### PR TITLE
feat(web): complete skills from a "/" anywhere, and offer the host's own skills in the new-chat composer

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -74,6 +74,8 @@ from omnigent.host.frames import (
     HostRunnerExitedFrame,
     HostRunnerStatusFrame,
     HostRunnerStatusResultFrame,
+    HostSkillsFrame,
+    HostSkillsResultFrame,
     HostStatFrame,
     HostStatResultFrame,
     HostStopRunnerFrame,
@@ -144,6 +146,7 @@ from omnigent.runtime.websocket_metrics import (
     record_websocket_connected,
     record_websocket_disconnected,
 )
+from omnigent.spec.skill_sources import SkillSourceContext, resolve_harness_skills
 from omnigent.suspend_watch import watch_for_resume
 from omnigent.tls import client_ssl_context
 from omnigent.version import VERSION
@@ -2680,6 +2683,40 @@ class HostProcess:
         routable = list(config.routable_models) if config is not None else []
         return ModelOptionsResult(models=rows, routable_models=routable)
 
+    def _handle_skills(self, frame: HostSkillsFrame) -> HostSkillsResultFrame:
+        """Discover the skills a harness would expose on this machine.
+
+        The pre-launch counterpart to the runner's ``_resolve_session_skills``:
+        only the host can see ``~/.claude/skills``, the enabled Claude Code
+        plugins and the workspace's own ``.claude/skills``, so the new-session
+        composer's ``/`` menu asks the chosen host rather than guessing from
+        the agent's bundled skills alone.
+
+        Bundled skills are deliberately absent — the server already knows
+        those from the spec and merges them with what comes back.
+        """
+        harness = canonicalize_harness(frame.harness) or frame.harness
+        # The workspace is the only root: the bundle isn't materialized here
+        # (no session, so no runner workdir), which is also why bundle_dir is
+        # None — codex/cursor providers then read their home scope alone.
+        # Home stands in when no workspace is chosen yet: the generic walk
+        # discovers per-root, so an empty root tuple would find nothing at all
+        # rather than the user's own ~/.claude/skills.
+        home = Path.home()
+        roots = (Path(frame.path).expanduser().resolve(),) if frame.path else (home,)
+        ctx = SkillSourceContext(
+            roots=roots,
+            home=home,
+            skills_filter=frame.skills_filter,
+            bundle_dir=None,
+        )
+        skills = resolve_harness_skills(ctx, harness)
+        return HostSkillsResultFrame(
+            request_id=frame.request_id,
+            status="ok",
+            skills=[{"name": s.name, "description": s.description} for s in skills],
+        )
+
     async def _handle_model_options(
         self,
         frame: HostModelOptionsFrame,
@@ -3848,6 +3885,20 @@ class HostProcess:
             # off the event loop and reply when it completes.
             fs_result = await asyncio.to_thread(self._handle_fs_request, frame)
             await ws.send(encode_host_frame(fs_result))
+        elif isinstance(frame, HostSkillsFrame):
+            # Discovery walks the filesystem (and parses SKILL.md frontmatter),
+            # so keep it off the event loop; a crash becomes an honest failed
+            # frame so the server's request future settles.
+            try:
+                skills_result = await asyncio.to_thread(self._handle_skills, frame)
+            except Exception:
+                _logger.exception("Skill discovery crashed for %r", frame.harness)
+                skills_result = HostSkillsResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error=f"skill discovery crashed for {frame.harness!r}",
+                )
+            await ws.send(encode_host_frame(skills_result))
         elif isinstance(frame, HostModelOptionsFrame):
             # Every dispatched frame already runs on its own task (see
             # _start_frame_task), so a cold harness probe here cannot stall

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -77,6 +77,8 @@ class HostFrameKind(str, Enum):
     IMPORT_LOCAL = "host.import_local"
     IMPORT_LOCAL_SESSION = "host.import_local_session"
     IMPORT_LOCAL_DONE = "host.import_local_done"
+    SKILLS = "host.skills"
+    SKILLS_RESULT = "host.skills_result"
 
 
 # ── Frame dataclasses ────────────────────────────────────
@@ -946,6 +948,49 @@ class HostImportLocalDoneFrame:
     failed: int = 0
 
 
+@dataclass
+class HostSkillsFrame:
+    """Server → host: discover the skills a harness would expose here.
+
+    Answers the new-session composer's ``/`` menu before any runner
+    exists. Only the host can see ``~/.claude/skills``, the enabled Claude
+    Code plugins, ``~/.codex/skills`` and the workspace's own
+    ``.claude/skills`` — so the discovery runs there, the same way
+    ``host.model_options`` resolves a catalog on the machine that will run
+    it.
+
+    :param request_id: Unique ID for correlating the result, e.g.
+        ``"req_skills_1"``.
+    :param harness: Harness id (canonical or alias), e.g.
+        ``"claude-sdk"``. Selects the per-vendor discovery provider.
+    :param path: Workspace directory to walk, absolute or
+        tilde-prefixed. ``None`` discovers home/plugin-scope skills only
+        (the user hasn't chosen a workspace yet).
+    :param skills_filter: The agent spec's ``skills:`` filter —
+        ``"all"``, ``"none"``, or a list of names. A spec that opts out
+        must not have host skills offered on its behalf.
+    """
+
+    request_id: str
+    harness: str
+    path: str | None = None
+    skills_filter: str | list[str] = "all"
+
+
+@dataclass
+class HostSkillsResultFrame:
+    """Host → server: skills discovered on that machine.
+
+    :param skills: One entry per skill, ``{"name": …, "description": …}``,
+        namespaced as the harness names it (e.g. ``"plugin:skill"``).
+    """
+
+    request_id: str
+    status: str
+    skills: list[_JsonObject] = field(default_factory=list)
+    error: str | None = None
+
+
 HostFrame = (
     HostHelloFrame
     | HostConnectionErrorFrame
@@ -982,6 +1027,8 @@ HostFrame = (
     | HostImportLocalFrame
     | HostImportLocalSessionFrame
     | HostImportLocalDoneFrame
+    | HostSkillsFrame
+    | HostSkillsResultFrame
 )
 
 
@@ -1379,6 +1426,26 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "failed": frame.failed,
             }
         )
+    if isinstance(frame, HostSkillsFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.SKILLS.value,
+                "request_id": frame.request_id,
+                "harness": frame.harness,
+                "path": frame.path,
+                "skills_filter": frame.skills_filter,
+            }
+        )
+    if isinstance(frame, HostSkillsResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.SKILLS_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "skills": frame.skills,
+                "error": frame.error,
+            }
+        )
     raise TypeError(f"unknown host frame type: {type(frame).__name__}")
 
 
@@ -1513,6 +1580,10 @@ def _decode_known_host_frame(
             return _decode_import_local_session(msg)
         case HostFrameKind.IMPORT_LOCAL_DONE:
             return _decode_import_local_done(msg)
+        case HostFrameKind.SKILLS:
+            return _decode_skills(msg)
+        case HostFrameKind.SKILLS_RESULT:
+            return _decode_skills_result(msg)
     raise ValueError(f"unhandled host frame kind: {kind.value!r}")  # pragma: no cover
 
 
@@ -2086,6 +2157,40 @@ def _decode_import_local_done(msg: _JsonObject) -> HostImportLocalDoneFrame:
         error=_optional_nullable_str(msg, "error"),
         # Absent on older hosts; default to 0 so decode stays backward-compatible.
         failed=raw_failed if isinstance(raw_failed := msg.get("failed"), int) else 0,
+    )
+
+
+def _decode_skills(msg: _JsonObject) -> HostSkillsFrame:
+    """Decode a host.skills request frame."""
+    # Absent on an older server: "all" is the filter every spec without an
+    # explicit opt-out carries, and matches discover_host_skills' default.
+    raw_filter = msg.get("skills_filter", "all")
+    if isinstance(raw_filter, list):
+        if not all(isinstance(name, str) for name in raw_filter):
+            raise ValueError("frame field must be a list of strings: 'skills_filter'")
+        skills_filter: str | list[str] = list(raw_filter)
+    elif isinstance(raw_filter, str):
+        skills_filter = raw_filter
+    else:
+        raise ValueError("frame field must be a string or list of strings: 'skills_filter'")
+    return HostSkillsFrame(
+        request_id=_required_str(msg, "request_id"),
+        harness=_required_str(msg, "harness"),
+        path=_optional_nullable_str(msg, "path"),
+        skills_filter=skills_filter,
+    )
+
+
+def _decode_skills_result(msg: _JsonObject) -> HostSkillsResultFrame:
+    """Decode a host.skills_result frame."""
+    skills = msg.get("skills", [])
+    if not isinstance(skills, list) or not all(isinstance(skill, dict) for skill in skills):
+        raise ValueError("frame field must be a list of JSON objects: 'skills'")
+    return HostSkillsResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        skills=skills,
+        error=_optional_nullable_str(msg, "error"),
     )
 
 

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -259,6 +259,9 @@ class HostConnection:
         ``error_code``, and ``error``.
     :param pending_model_options: Per-``request_id`` futures for pre-launch
         model catalogs resolved by the selected host.
+    :param pending_skills: Per-``request_id`` futures for pre-launch host
+        skill discovery (``~/.claude/skills``, enabled plugins, the
+        workspace's own skills) resolved by the selected host.
     """
 
     workspace_id: int
@@ -313,6 +316,9 @@ class HostConnection:
         default_factory=dict,
     )
     pending_model_options: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
+    pending_skills: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
     # Import streams one session per frame, so the tunnel pushes each onto a

--- a/omnigent/server/routes/_host_skills.py
+++ b/omnigent/server/routes/_host_skills.py
@@ -1,0 +1,56 @@
+"""One round-trip helper for ``host.skills``.
+
+Mirrors :mod:`omnigent.server.routes._host_model_options`: the request-id /
+future / frame / timeout / cleanup shape lives here once so a caller only has
+to decide how to handle failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from typing import Any
+
+from omnigent.host.frames import HostSkillsFrame, encode_host_frame
+from omnigent.server.host_registry import HostConnection, HostRegistry
+
+
+async def request_host_skills(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    harness: str,
+    path: str | None,
+    skills_filter: str | list[str],
+    timeout_s: float,
+) -> dict[str, Any]:
+    """
+    Send a ``host.skills`` frame and await the host's result.
+
+    :param host_registry: Registry used to enqueue the outbound frame.
+    :param host_conn: Live host connection to query.
+    :param harness: Harness id, e.g. ``"claude-sdk"``.
+    :param path: Workspace directory to walk, or ``None`` for home scope only.
+    :param skills_filter: The agent spec's ``skills:`` filter.
+    :param timeout_s: Seconds to wait for the result frame.
+    :returns: The result payload, e.g. ``{"status": "ok", "skills": [...]}``.
+    :raises ConnectionError: The host connection dropped before the frame
+        could be enqueued.
+    :raises asyncio.TimeoutError: The host did not answer within *timeout_s*.
+    """
+    request_id = secrets.token_hex(8)
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+    host_conn.pending_skills[request_id] = future
+    frame = encode_host_frame(
+        HostSkillsFrame(
+            request_id=request_id,
+            harness=harness,
+            path=path,
+            skills_filter=skills_filter,
+        )
+    )
+    try:
+        host_registry.send_text(host_conn, frame)
+        return await asyncio.wait_for(future, timeout=timeout_s)
+    finally:
+        host_conn.pending_skills.pop(request_id, None)

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -45,6 +45,7 @@ from omnigent.host.frames import (
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
     HostRunnerStatusResultFrame,
+    HostSkillsResultFrame,
     HostStatResultFrame,
     HostStopRunnerResultFrame,
     HostStoreSecretResultFrame,
@@ -777,6 +778,18 @@ async def _receive_loop(
                         "done",
                         {"status": frame.status, "error": frame.error, "failed": frame.failed},
                     )
+                )
+            continue
+
+        if isinstance(frame, HostSkillsResultFrame):
+            skills_future = conn.pending_skills.pop(frame.request_id, None)
+            if skills_future is not None and not skills_future.done():
+                skills_future.set_result(
+                    {
+                        "status": frame.status,
+                        "skills": frame.skills,
+                        "error": frame.error,
+                    }
                 )
             continue
 

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -70,6 +70,10 @@ _LIST_DIR_MAX_LIMIT = 1000
 # for transient network slowness without making the picker feel hung.
 _CREATE_DIR_TIMEOUT_S = 5.0
 _MODEL_OPTIONS_TIMEOUT_S = 15.0
+# Per-call timeout for host.skills round-trips. Discovery scans a handful of
+# directories and parses each SKILL.md, so it sits above list_dir's 5s — but
+# well inside how long the composer's menu can wait.
+_SKILLS_TIMEOUT_S = 10.0
 # Per-call timeout for host.install_harness round-trips. The host runs
 # `npm install -g <pkg>` — install_harness_cli caps that subprocess at 300s —
 # then recomputes readiness and sends the result back over the tunnel. The
@@ -133,6 +137,41 @@ async def _proxy_model_options(
             detail=(
                 f"host '{host_conn.host_id}' did not resolve model options within "
                 f"{_MODEL_OPTIONS_TIMEOUT_S:.0f}s"
+            ),
+        ) from exc
+
+
+async def _proxy_skills(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    harness: str,
+    path: str | None,
+    skills_filter: str | list[str],
+) -> dict[str, Any]:
+    """Ask a host which skills a harness would expose there."""
+    from omnigent.server.routes._host_skills import request_host_skills
+
+    try:
+        return await request_host_skills(
+            host_registry=host_registry,
+            host_conn=host_conn,
+            harness=harness,
+            path=path,
+            skills_filter=skills_filter,
+            timeout_s=_SKILLS_TIMEOUT_S,
+        )
+    except ConnectionError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"host '{host_conn.host_id}' connection lost",
+        ) from exc
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"host '{host_conn.host_id}' did not resolve skills within "
+                f"{_SKILLS_TIMEOUT_S:.0f}s"
             ),
         ) from exc
 
@@ -725,6 +764,92 @@ def create_hosts_router(
         if isinstance(error, str) and error:
             payload["error"] = error
         return payload
+
+    @router.get("/hosts/{host_id}/agents/{agent_id}/skills")
+    async def get_host_agent_skills(
+        request: Request,
+        host_id: str,
+        agent_id: str,
+        path: str | None = Query(
+            default=None,
+            description="Workspace directory to walk; omit for home-scope skills only.",
+        ),
+    ) -> dict[str, list[dict[str, str]]]:
+        """Return the host-discovered skills an agent would gain on this host.
+
+        The new-session composer's ``/`` menu knows an agent's *bundled* skills
+        from ``GET /v1/agents``, but the ones a user actually reaches for often
+        live on their machine — ``~/.claude/skills``, enabled Claude Code
+        plugins, ``~/.codex/skills``, or the workspace's own ``.claude/skills``.
+        Only the host can see those, so it resolves them under the agent's
+        ``skills:`` filter and the server drops anything already bundled.
+
+        A preview, not a binding snapshot: the session's own merged list
+        arrives on the snapshot once a runner binds.
+        """
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise _host_absent_error(host)
+
+        # Harness picks the discovery provider and ``skills_filter`` decides
+        # what may surface, so both come from the spec — an agent declaring
+        # ``skills: none`` must not have host skills offered on its behalf. A
+        # spec that won't load leaves the harness unknown, which the host reads
+        # as the generic host walk rather than a vendor's own mechanism.
+        harness: str | None = None
+        skills_filter: str | list[str] = "all"
+        bundled: set[str] = set()
+        if agent_store is not None and agent_cache is not None:
+            agent = await asyncio.to_thread(agent_store.get, agent_id)
+            if agent is None:
+                raise HTTPException(status_code=404, detail="agent not found")
+            if agent.bundle_location is not None:
+                try:
+                    loaded = await asyncio.to_thread(
+                        agent_cache.load, agent.id, agent.bundle_location
+                    )
+                except (OmnigentError, OSError):
+                    _logger.warning(
+                        "host skills: spec load failed for agent=%s", agent_id, exc_info=True
+                    )
+                else:
+                    harness = canonicalize_harness(loaded.spec.executor.harness_kind)
+                    skills_filter = loaded.spec.skills_filter
+                    bundled = {sk.name for sk in loaded.spec.skills}
+
+        result = await _proxy_skills(
+            host_registry=host_registry,
+            host_conn=conn,
+            harness=harness or "",
+            path=path,
+            skills_filter=skills_filter,
+        )
+        if result.get("status") != "ok":
+            raise HTTPException(
+                status_code=502,
+                detail=str(result.get("error") or "host skill discovery failed"),
+            )
+        raw = result.get("skills")
+        skills: list[dict[str, str]] = []
+        seen = set(bundled)
+        for entry in raw if isinstance(raw, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str) or name in seen:
+                continue
+            seen.add(name)
+            description = entry.get("description")
+            skills.append(
+                {"name": name, "description": description if isinstance(description, str) else ""}
+            )
+        return {"skills": skills}
 
     @router.post("/hosts/{host_id}/runners")
     async def launch_runner(

--- a/openapi.json
+++ b/openapi.json
@@ -8444,6 +8444,86 @@
         ]
       }
     },
+    "/v1/hosts/{host_id}/agents/{agent_id}/skills": {
+      "get": {
+        "description": "Return the host-discovered skills an agent would gain on this host.\n\nThe new-session composer's `/` menu knows an agent's *bundled* skills\nfrom `GET /v1/agents`, but the ones a user actually reaches for often\nlive on their machine \u2014 `~/.claude/skills`, enabled Claude Code\nplugins, `~/.codex/skills`, or the workspace's own `.claude/skills`.\nOnly the host can see those, so it resolves them under the agent's\n`skills:` filter and the server drops anything already bundled.\n\nA preview, not a binding snapshot: the session's own merged list\narrives on the snapshot once a runner binds.",
+        "operationId": "get_host_agent_skills_v1_hosts__host_id__agents__agent_id__skills_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "host_id",
+            "required": true,
+            "schema": {
+              "title": "Host Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace directory to walk; omit for home-scope skills only.",
+            "in": "query",
+            "name": "path",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Workspace directory to walk; omit for home-scope skills only.",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Host Agent Skills V1 Hosts  Host Id  Agents  Agent Id  Skills Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Host Agent Skills",
+        "tags": [
+          "hosts"
+        ]
+      }
+    },
     "/v1/hosts/{host_id}/credentials/detected": {
       "get": {
         "description": "List adoptable credentials already present on a connected host.\n\nBacks the setup dialog's \"adopt an existing credential\" affordance: the\nhost reports which UI-auth-family credentials it already has as\nNON-secret descriptors (family + source label + env var name), so the UI\ncan offer a one-click \"Use it\". Owner-scoped and flag-gated like the\ncredential-write route (404 when disabled). Never returns a secret value.\n\n**Returns:** `{\"object\": \"detected_credentials\", \"credentials\": [...]}`.\n\n**Raises**\n\n- `HTTPException` \u2014 404 when disabled or host unknown, 403 when not the owner, 409 when offline, 502/504 on host failure/timeout.",

--- a/tests/e2e_ui/chat/test_composer_lists_host_skills_before_runner_binds.py
+++ b/tests/e2e_ui/chat/test_composer_lists_host_skills_before_runner_binds.py
@@ -1,0 +1,127 @@
+"""E2E regression guard: fresh composer must list host-discovered skills.
+
+Bug: the web composer's slash-command menu is missing host-discovered
+skills on a fresh session. The menu is built from the session snapshot's
+``skills`` field (``buildSlashCommandMap`` in ``web/src/pages/ChatPage.tsx``),
+which the server populates from ``_fetch_runner_skills``
+(``omnigent/server/routes/_sessions/orchestration.py``). That helper returns
+``[]`` when no runner is bound (``runner_client is None``), and a runner binds
+only once the first turn is dispatched. So on the landing / freshly created
+session, a skill sitting in the workspace's ``.claude/skills/`` — the kind of
+skill a user reaches for with ``/`` — is absent from the menu until they have
+already sent a message.
+
+User journey reproduced here:
+
+1. A host skill exists under the session workspace's ``.claude/skills/``.
+2. Start a fresh session in the web UI (no message sent, so no runner bound).
+3. Open the composer's ``/`` menu before sending anything.
+4. The host-discovered skill should be listed — it is the whole point of the
+   ``/`` menu — but on the buggy build it is missing (only built-ins/bundled
+   commands appear).
+
+This test asserts the **expected** behavior (the host skill IS offered in the
+fresh composer), so it fails on a build with the bug and is the fail->pass
+target for the fix. ``/help`` (an unconditional built-in) is asserted first as
+a control: it proves the ``/`` menu itself rendered, so the host skill's
+absence is specifically the missing-skills bug and not a menu that never
+opened.
+
+Selectors mirror the component: rows are
+``data-testid="slash-menu-item-<name-sans-slash>"`` (see
+``web/src/components/SlashCommandMenu.tsx`` and
+``tests/e2e_ui/chat/test_slash_command_menu_matching.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import _build_hello_world_bundle
+
+# The host-library skill seeded under the workspace's ``.claude/skills/``.
+# Name matches ``SkillSpec.name`` (``[a-z0-9-]+``); the composer row testid is
+# ``slash-menu-item-<name>``.
+_HOST_SKILL = "host-lib-skill"
+
+
+def _seed_host_skill(workspace: Path, name: str) -> None:
+    """Write a discoverable host skill into ``<workspace>/.claude/skills/``.
+
+    ``discover_host_skills`` (walked by the runner's
+    ``_resolve_session_skills``) picks up any ``<dir>/SKILL.md`` under a
+    ``.claude/skills/`` directory on the session workspace — exactly the
+    "skill in your own library" that must be offered in the menu.
+
+    :param workspace: The session workspace directory.
+    :param name: The skill name (its frontmatter ``name`` and dir).
+    """
+    skill_dir = workspace / ".claude" / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: A skill from the user's host library.\n---\n\n"
+        "Say HOST-LIB.\n"
+    )
+
+
+def test_fresh_composer_lists_host_discovered_skill(
+    page: Page,
+    live_server: str,
+    tmp_path: Path,
+) -> None:
+    """A fresh session's ``/`` menu must offer a host-discovered skill.
+
+    Creates a session bound to a workspace that has a host skill under
+    ``.claude/skills/`` but deliberately does **not** bind a runner (the
+    fresh, pre-first-turn state the user lands in). Navigates to the session
+    and opens the composer's ``/`` menu.
+
+    * ``/help`` (an unconditional built-in) must appear — proves the menu
+      rendered on a runnerless session.
+    * The host skill must appear — this is the expected behavior the fix
+      restores. On a buggy build it is absent, so this assertion fails until
+      host-discovered skills are surfaced independent of runner binding.
+
+    :param page: Playwright page (fresh context per test).
+    :param live_server: Base URL of the spawned server serving the SPA.
+    :param tmp_path: Per-test temp dir used for the session workspace.
+    """
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    _seed_host_skill(workspace, _HOST_SKILL)
+
+    # Create a fresh session bound to the seeded workspace. No PATCH to
+    # ``runner_id`` — this mirrors the landing/new-chat state before the first
+    # turn dispatches (and thus before any runner binds).
+    bundle = _build_hello_world_bundle()
+    create_resp = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({"workspace": str(workspace)})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+
+    try:
+        page.goto(f"{live_server}/c/{session_id}")
+
+        composer = page.get_by_label("Message the agent")
+        expect(composer).to_be_visible(timeout=30_000)
+
+        # Open the slash-command menu.
+        composer.fill("/")
+
+        # Control: the menu opened (an always-present built-in is listed).
+        expect(page.get_by_test_id("slash-menu-item-help")).to_be_visible(timeout=15_000)
+
+        # The bug: the host-discovered skill is expected here but missing on
+        # the buggy build. Fails until the fix surfaces host skills before a
+        # runner binds; passes after.
+        expect(page.get_by_test_id(f"slash-menu-item-{_HOST_SKILL}")).to_be_visible(timeout=20_000)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)

--- a/tests/e2e_ui/chat/test_skill_autocomplete.py
+++ b/tests/e2e_ui/chat/test_skill_autocomplete.py
@@ -42,19 +42,26 @@ def _fulfill(route: Route, body: dict[str, object]) -> None:
 
 
 def _stub_landing(
-    page: Page, *, bundled: list[dict[str, str]], host: list[dict[str, str]]
+    page: Page,
+    *,
+    bundled: list[dict[str, str]],
+    host: list[dict[str, str]],
+    harness: str = "claude-sdk",
+    agent_name: str = "helper",
 ) -> None:
     """Stub the landing screen's edges: one host, one agent, its skills.
 
-    ``harness: "claude-sdk"`` keeps the ``/`` menu enabled (native-terminal
-    agents suppress it, since their CLI owns slash commands) and makes the
-    agent auto-select as the only row. The session list is stubbed empty so no
-    agent discovered by the ``kind=any`` scan sorts ahead and steals that
-    auto-selection.
+    The agent is the only row, so it auto-selects. The session list is stubbed
+    empty so no agent discovered by the ``kind=any`` scan sorts ahead and
+    steals that auto-selection.
 
     :param page: The Playwright page to install routes on.
     :param bundled: Skills reported by ``GET /v1/agents`` for the agent.
     :param host: Skills the host reports for it (the pre-launch endpoint).
+    :param harness: The agent's harness — drives whether the frontend treats it
+        as a native terminal agent.
+    :param agent_name: The agent's name, which the native-agent mapping also
+        keys on.
     """
     page.route(
         "**/v1/hosts",
@@ -80,10 +87,10 @@ def _stub_landing(
                 "data": [
                     {
                         "id": "ag_helper_e2e",
-                        "name": "helper",
+                        "name": agent_name,
                         "display_name": "Helper",
                         "description": "A helper agent",
-                        "harness": "claude-sdk",
+                        "harness": harness,
                         "skills": bundled,
                     }
                 ]
@@ -157,6 +164,44 @@ def test_landing_composer_lists_a_skill_only_the_host_can_see(
     expect(host_row).to_have_attribute("data-active", "true")
 
     landing_input.press("Tab")
+    expect(landing_input).to_have_value("/dev-productivity:deslop ")
+
+
+def test_landing_composer_offers_skills_for_a_native_terminal_agent(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Claude Code — what auto-selects for most people — offers its skills too.
+
+    The landing menu used to suppress itself for every native terminal agent on
+    the theory that the vendor CLI owns slash commands. But the host-discovered
+    skills *are* that CLI's own commands, and the in-session composer never
+    gated on the harness — so the new-chat screen was the one place a Claude
+    Code user's own skills were invisible.
+
+    :param page: Playwright page (fresh context per test).
+    :param live_server: Base URL of the spawned server serving the SPA.
+    """
+    _stub_landing(
+        page,
+        bundled=[],
+        host=[_HOST_SKILL],
+        harness="claude-native",
+        agent_name="claude-native-ui",
+    )
+    page.goto(f"{live_server}/")
+    landing_input = page.get_by_test_id("new-chat-landing-input")
+    expect(landing_input).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+        "Claude Code", timeout=30_000
+    )
+
+    landing_input.fill("/deslop")
+    host_row = page.get_by_test_id("slash-menu-item-dev-productivity:deslop")
+    expect(host_row).to_be_visible(timeout=15_000)
+
+    landing_input.press("Tab")
+    # Completing the name is all this does — the CLI interprets it from there.
     expect(landing_input).to_have_value("/dev-productivity:deslop ")
 
 

--- a/tests/e2e_ui/chat/test_skill_autocomplete.py
+++ b/tests/e2e_ui/chat/test_skill_autocomplete.py
@@ -1,0 +1,210 @@
+"""E2E: completing a skill from a ``/`` typed anywhere, and host-discovered skills.
+
+Two user-facing behaviors, driven through the real SPA in a browser:
+
+- **A ``/`` mid-draft opens the menu and completes in place.** The menu used
+  to require the draft to *start* with a slash and carry no space, so a skill
+  could only be named as the very first thing typed — reaching for one
+  mid-sentence ("please run /desl…") got nothing. Both composers now read the
+  token at the caret (``detectSlashTokenAt``) and rewrite only that token
+  (``spliceSlashToken``), so the words around it survive.
+- **The new-chat menu lists skills the chosen host discovered.** Before, the
+  landing composer knew only the agent's *bundled* skills, so a user's own
+  ``~/.claude/skills`` entry wasn't completable until a runner had bound.
+  ``GET /v1/hosts/{id}/agents/{id}/skills`` asks the host for them.
+
+Selectors mirror the component: rows are
+``data-testid="slash-menu-item-<name-sans-slash>"`` and the highlighted row
+carries ``data-active="true"`` (see ``SlashCommandMenu.tsx``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+# Bundled skill on the stubbed landing agent.
+_BUNDLED_SKILL = {"name": "code-review", "description": "Review a pull request"}
+# A skill only the host can see (the user's own ~/.claude/skills), namespaced
+# the way an enabled Claude Code plugin's skills are.
+_HOST_SKILL = {"name": "dev-productivity:deslop", "description": "Remove AI slop"}
+_HOST_ID = "host_skills_e2e"
+# The pre-launch skill endpoint, with or without its ``?path=`` query.
+_HOST_SKILLS_RE = re.compile(r"/v1/hosts/[^/]+/agents/[^/]+/skills")
+
+
+def _fulfill(route: Route, body: dict[str, object]) -> None:
+    """Answer *route* with *body* as JSON."""
+    route.fulfill(status=200, content_type="application/json", body=json.dumps(body))
+
+
+def _stub_landing(
+    page: Page, *, bundled: list[dict[str, str]], host: list[dict[str, str]]
+) -> None:
+    """Stub the landing screen's edges: one host, one agent, its skills.
+
+    ``harness: "claude-sdk"`` keeps the ``/`` menu enabled (native-terminal
+    agents suppress it, since their CLI owns slash commands) and makes the
+    agent auto-select as the only row. The session list is stubbed empty so no
+    agent discovered by the ``kind=any`` scan sorts ahead and steals that
+    auto-selection.
+
+    :param page: The Playwright page to install routes on.
+    :param bundled: Skills reported by ``GET /v1/agents`` for the agent.
+    :param host: Skills the host reports for it (the pre-launch endpoint).
+    """
+    page.route(
+        "**/v1/hosts",
+        lambda r: _fulfill(
+            r,
+            {
+                "hosts": [
+                    {
+                        "host_id": _HOST_ID,
+                        "name": "e2e-host",
+                        "owner": "e2e",
+                        "status": "online",
+                    }
+                ]
+            },
+        ),
+    )
+    page.route(
+        "**/v1/agents",
+        lambda r: _fulfill(
+            r,
+            {
+                "data": [
+                    {
+                        "id": "ag_helper_e2e",
+                        "name": "helper",
+                        "display_name": "Helper",
+                        "description": "A helper agent",
+                        "harness": "claude-sdk",
+                        "skills": bundled,
+                    }
+                ]
+            },
+        ),
+    )
+    page.route(_HOST_SKILLS_RE, lambda r: _fulfill(r, {"skills": host}))
+    page.route(
+        "**/v1/sessions", lambda r: _fulfill(r, {"object": "list", "data": [], "has_more": False})
+    )
+
+
+def _open_landing(page: Page, base_url: str) -> None:
+    """Load the landing screen and wait for the stubbed agent to auto-select."""
+    page.goto(f"{base_url}/")
+    expect(page.get_by_test_id("new-chat-landing-input")).to_be_visible(timeout=30_000)
+    # The menu's command map is fed by the selected agent, so wait for the
+    # pick to settle before typing.
+    expect(page.get_by_test_id("new-chat-landing-agent-select")).to_contain_text(
+        "Helper", timeout=30_000
+    )
+
+
+def test_landing_composer_completes_a_skill_typed_mid_draft(
+    page: Page,
+    live_server: str,
+) -> None:
+    """A ``/`` inside a sentence opens the menu, and Tab completes it in place.
+
+    Under the old whole-draft check this draft was invisible to the menu twice
+    over: the slash isn't leading, and the draft already carries a space.
+
+    :param page: Playwright page (fresh context per test).
+    :param live_server: Base URL of the spawned server serving the SPA.
+    """
+    _stub_landing(page, bundled=[_BUNDLED_SKILL], host=[])
+    _open_landing(page, live_server)
+
+    landing_input = page.get_by_test_id("new-chat-landing-input")
+    # ``fill`` leaves the caret at the end, i.e. on the "/revi" token.
+    landing_input.fill("please run /revi")
+    skill_row = page.get_by_test_id("slash-menu-item-code-review")
+    expect(skill_row).to_be_visible()
+    expect(skill_row).to_have_attribute("data-active", "true")
+
+    landing_input.press("Tab")
+    # Only the token is rewritten — the words before it are still there.
+    expect(landing_input).to_have_value("please run /code-review ")
+
+
+def test_landing_composer_lists_a_skill_only_the_host_can_see(
+    page: Page,
+    live_server: str,
+) -> None:
+    """A skill from the host (not the bundle) is offered and completes.
+
+    The agent bundles nothing, so this row can only come from the pre-launch
+    host lookup — the gap this closes is that a user's own skill was
+    uncompletable on the first message.
+
+    :param page: Playwright page (fresh context per test).
+    :param live_server: Base URL of the spawned server serving the SPA.
+    """
+    _stub_landing(page, bundled=[], host=[_HOST_SKILL])
+    _open_landing(page, live_server)
+
+    landing_input = page.get_by_test_id("new-chat-landing-input")
+    landing_input.fill("/deslop")
+    host_row = page.get_by_test_id("slash-menu-item-dev-productivity:deslop")
+    expect(host_row).to_be_visible(timeout=15_000)
+    expect(host_row).to_have_attribute("data-active", "true")
+
+    landing_input.press("Tab")
+    expect(landing_input).to_have_value("/dev-productivity:deslop ")
+
+
+def test_in_session_composer_completes_a_skill_typed_mid_draft(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The in-session ``/`` menu completes a skill named inside a sentence.
+
+    The session's skills come from its snapshot, so the real ``GET
+    /v1/sessions/{id}`` response is patched with one rather than faked
+    wholesale — everything else about the session stays real.
+
+    Built-ins are deliberately absent mid-draft (they act on the session,
+    which completing a word in a sentence cannot do), so the assertion also
+    pins that only the skill is offered there.
+
+    :param page: Playwright page (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` from the fixture.
+    """
+    base_url, session_id = seeded_session
+
+    def handle_session(route: Route) -> None:
+        request = route.request
+        if urlparse(request.url).path != f"/v1/sessions/{session_id}" or request.method != "GET":
+            route.continue_()
+            return
+        response = route.fetch()
+        payload = response.json()
+        payload["skills"] = [_BUNDLED_SKILL]
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route(f"**/v1/sessions/{session_id}**", handle_session)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("take a look and /revi")
+
+    skill_row = page.get_by_test_id("slash-menu-item-code-review")
+    expect(skill_row).to_be_visible(timeout=15_000)
+    # Mid-draft the menu is skills-only: a built-in that a leading "/" would
+    # offer (and that "revi" doesn't narrow away) must not be reachable here.
+    expect(page.get_by_test_id("slash-menu-item-context")).to_have_count(0)
+
+    composer.press("Tab")
+    expect(composer).to_have_value("take a look and /code-review ")

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -48,6 +48,8 @@ from omnigent.host.frames import (
     HostRunnerExitedFrame,
     HostRunnerStatusFrame,
     HostRunnerStatusResultFrame,
+    HostSkillsFrame,
+    HostSkillsResultFrame,
     HostStatFrame,
     HostStatResultFrame,
     HostStopRunnerFrame,
@@ -103,6 +105,129 @@ def _no_real_zygote(monkeypatch: pytest.MonkeyPatch) -> None:
     from omnigent.runner._zygote import ZYGOTE_ENABLED_ENV_VAR
 
     monkeypatch.setenv(ZYGOTE_ENABLED_ENV_VAR, "0")
+
+
+def _write_host_skill(skills_dir: Path, name: str) -> None:
+    """Write a minimal ``<skills_dir>/<name>/SKILL.md`` with valid frontmatter."""
+    d = skills_dir / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: {name} desc\n---\nbody\n")
+
+
+async def test_handle_skills_discovers_workspace_and_home_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The composer's pre-launch menu sees both scopes only the host can read."""
+    home = tmp_path / "home"
+    _write_host_skill(home / ".claude" / "skills", "home-skill")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    workspace = tmp_path / "ws"
+    _write_host_skill(workspace / ".claude" / "skills", "ws-skill")
+    host = _make_host_process()
+
+    result = await asyncio.to_thread(
+        host._handle_skills,
+        HostSkillsFrame(request_id="req_1", harness="claude-sdk", path=str(workspace)),
+    )
+
+    assert result.request_id == "req_1"
+    assert result.status == "ok"
+    assert {s["name"] for s in result.skills} == {"ws-skill", "home-skill"}
+    assert {s["description"] for s in result.skills} == {"ws-skill desc", "home-skill desc"}
+    _cleanup_host(host)
+
+
+async def test_handle_skills_honors_the_specs_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An agent declaring ``skills: none`` gets no host skills offered for it.
+
+    The filter rides on the frame precisely so a hermetic spec can't have the
+    user's local skill library surfaced on its behalf by the new-chat menu.
+    """
+    home = tmp_path / "home"
+    _write_host_skill(home / ".claude" / "skills", "home-skill")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    workspace = tmp_path / "ws"
+    _write_host_skill(workspace / ".claude" / "skills", "ws-skill")
+    _write_host_skill(workspace / ".claude" / "skills", "other-skill")
+    host = _make_host_process()
+
+    hermetic = await asyncio.to_thread(
+        host._handle_skills,
+        HostSkillsFrame(
+            request_id="req_1",
+            harness="claude-sdk",
+            path=str(workspace),
+            skills_filter="none",
+        ),
+    )
+    assert hermetic.skills == []
+
+    named = await asyncio.to_thread(
+        host._handle_skills,
+        HostSkillsFrame(
+            request_id="req_2",
+            harness="claude-sdk",
+            path=str(workspace),
+            skills_filter=["ws-skill"],
+        ),
+    )
+    assert [s["name"] for s in named.skills] == ["ws-skill"]
+    _cleanup_host(host)
+
+
+async def test_handle_skills_without_a_workspace_reads_home_scope_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No workspace chosen yet still answers with the user's own skills."""
+    home = tmp_path / "home"
+    _write_host_skill(home / ".claude" / "skills", "home-skill")
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    host = _make_host_process()
+
+    result = await asyncio.to_thread(
+        host._handle_skills,
+        HostSkillsFrame(request_id="req_1", harness="claude-sdk", path=None),
+    )
+
+    assert [s["name"] for s in result.skills] == ["home-skill"]
+    _cleanup_host(host)
+
+
+async def test_skills_frame_reply_survives_a_discovery_crash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crash becomes a failed frame, so the server's future can't hang.
+
+    The route awaits a future keyed by request_id; without the reply the
+    composer would sit on a 10s timeout instead of falling back to the
+    agent's bundled skills.
+    """
+    host = _make_host_process()
+    monkeypatch.setattr(
+        "omnigent.host.connect.resolve_harness_skills",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            sent.append(text)
+
+    await host._dispatch_host_frame(
+        _FakeWs(),  # type: ignore[arg-type]
+        HostSkillsFrame(request_id="req_1", harness="claude-sdk", path=None),
+    )
+
+    assert len(sent) == 1
+    reply = decode_host_frame(sent[0])
+    assert isinstance(reply, HostSkillsResultFrame)
+    assert reply.request_id == "req_1"
+    assert reply.status == "failed"
+    assert reply.skills == []
+    assert reply.error is not None and "claude-sdk" in reply.error
+    _cleanup_host(host)
 
 
 async def test_handle_model_options_serves_the_claude_catalog(

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -39,6 +39,8 @@ from omnigent.host.frames import (
     HostRunnerExitedFrame,
     HostRunnerStatusFrame,
     HostRunnerStatusResultFrame,
+    HostSkillsFrame,
+    HostSkillsResultFrame,
     HostStatFrame,
     HostStatResultFrame,
     HostStopRunnerFrame,
@@ -161,6 +163,79 @@ def test_model_options_frames_round_trip() -> None:
         "system.ai.claude-opus-5",
         "system.ai.claude-opus-4-8",
     ]
+
+
+def test_skills_frames_round_trip() -> None:
+    """Pre-launch skill discovery survives both directions of the host tunnel."""
+    request = decode_host_frame(
+        encode_host_frame(
+            HostSkillsFrame(
+                request_id="req_skills",
+                harness="claude-sdk",
+                path="/Users/corey/proj",
+                skills_filter=["deslop", "review-pr"],
+            ),
+        )
+    )
+    assert request == HostSkillsFrame(
+        request_id="req_skills",
+        harness="claude-sdk",
+        path="/Users/corey/proj",
+        skills_filter=["deslop", "review-pr"],
+    )
+
+    # No workspace chosen yet, and the spec's default filter: home/plugin
+    # scope only, everything allowed.
+    home_scope = decode_host_frame(
+        encode_host_frame(HostSkillsFrame(request_id="req_skills", harness="codex"))
+    )
+    assert home_scope == HostSkillsFrame(
+        request_id="req_skills",
+        harness="codex",
+        path=None,
+        skills_filter="all",
+    )
+
+    result = decode_host_frame(
+        encode_host_frame(
+            HostSkillsResultFrame(
+                request_id="req_skills",
+                status="ok",
+                skills=[{"name": "dev-productivity:deslop", "description": "Remove slop"}],
+            )
+        )
+    )
+    assert isinstance(result, HostSkillsResultFrame)
+    assert result.skills == [{"name": "dev-productivity:deslop", "description": "Remove slop"}]
+    assert result.error is None
+
+    failed = decode_host_frame(
+        encode_host_frame(
+            HostSkillsResultFrame(
+                request_id="req_skills",
+                status="failed",
+                error="skill discovery crashed for 'claude-sdk'",
+            )
+        )
+    )
+    assert isinstance(failed, HostSkillsResultFrame)
+    assert failed.status == "failed"
+    assert failed.skills == []
+    assert failed.error == "skill discovery crashed for 'claude-sdk'"
+
+
+def test_skills_frame_rejects_malformed_filter() -> None:
+    """A non-string filter entry is refused rather than silently coerced."""
+    payload = json.dumps(
+        {
+            "kind": "host.skills",
+            "request_id": "req_skills",
+            "harness": "claude-sdk",
+            "skills_filter": ["deslop", 7],
+        }
+    )
+    with pytest.raises(ValueError, match="skills_filter"):
+        decode_host_frame(payload)
 
 
 def test_encode_injects_traceparent_under_active_span() -> None:

--- a/tests/server/integration/test_hosts_skills.py
+++ b/tests/server/integration/test_hosts_skills.py
@@ -1,0 +1,386 @@
+"""
+Integration tests for ``GET /v1/hosts/{id}/agents/{agent_id}/skills``.
+
+Wires up a real host tunnel + REST router pair, drives a fake host that
+auto-replies to ``host.skills`` frames, and exercises the endpoint's
+contract end-to-end. The new-session composer's ``/`` menu knows an
+agent's *bundled* skills from ``GET /v1/agents``; the ones on the user's
+own machine are visible only to the host, so this route asks it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from asgiref.testing import ApplicationCommunicator
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from httpx import ASGITransport, AsyncClient
+
+from omnigent.errors import OmnigentError
+from omnigent.host.frames import (
+    HostHelloFrame,
+    HostSkillsFrame,
+    HostSkillsResultFrame,
+    decode_host_frame,
+    encode_host_frame,
+)
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.host_registry import HostRegistry
+from omnigent.server.routes.host_tunnel import create_host_tunnel_router
+from omnigent.server.routes.hosts import create_hosts_router
+from omnigent.stores import AgentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.host_store import HostStore
+
+# Mirrors test_hosts_filesystem: a mock host tunnel can flake with a 409
+# ("host is offline") under parallel CI load when the mock WS is starved and
+# the connection deregistered. Tests here are sub-second.
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.flaky(reruns=2, reruns_delay=1),
+]
+
+_HOST_ID = "4f3c2b1a09d8e7f6a5b4c3d2e1f00998"
+_HOST_NAME = "skills-test-laptop"
+_AGENT_ID = "ag_skilled"
+
+
+def _websocket_scope(path: str) -> dict[str, object]:
+    """Build a minimal ASGI WebSocket scope."""
+    return {
+        "type": "websocket",
+        "asgi": {"version": "3.0"},
+        "scheme": "ws",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("testserver", 80),
+        "subprotocols": [],
+    }
+
+
+def _fake_agent_deps(
+    *,
+    harness: str = "claude-sdk",
+    skills_filter: str | list[str] = "all",
+    bundled: tuple[str, ...] = (),
+    bundle_location: str | None = "bundle://skilled",
+) -> tuple[AgentStore, AgentCache]:
+    """
+    Minimal agent store + cache doubles for the route's spec lookup.
+
+    The route reads exactly three spec fields — harness (which discovery
+    provider), ``skills_filter`` (what may surface), and the bundled names
+    (what to drop) — so a namespace carrying those is enough, and keeps the
+    test off a materialized bundle on disk.
+    """
+    agent = SimpleNamespace(id=_AGENT_ID, bundle_location=bundle_location)
+    spec = SimpleNamespace(
+        executor=SimpleNamespace(harness_kind=harness),
+        skills_filter=skills_filter,
+        skills=[SimpleNamespace(name=name) for name in bundled],
+    )
+    store = SimpleNamespace(get=lambda agent_id: agent if agent_id == _AGENT_ID else None)
+    cache = SimpleNamespace(load=lambda _id, _loc: SimpleNamespace(spec=spec))
+    return cast(AgentStore, store), cast(AgentCache, cache)
+
+
+def _build_app(
+    db_uri: str,
+    agent_deps: tuple[AgentStore, AgentCache] | None,
+) -> tuple[FastAPI, HostRegistry, HostStore]:
+    """App with host tunnel + REST routes for skill-discovery tests."""
+    registry = HostRegistry()
+    host_store = HostStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    app = FastAPI()
+    app.include_router(create_host_tunnel_router(registry, host_store), prefix="/v1")
+    app.include_router(
+        create_hosts_router(
+            registry,
+            host_store,
+            conv_store,
+            agent_store=None if agent_deps is None else agent_deps[0],
+            agent_cache=None if agent_deps is None else agent_deps[1],
+        ),
+        prefix="/v1",
+    )
+
+    @app.exception_handler(OmnigentError)
+    async def _handle_omnigent_error(request: Request, exc: OmnigentError) -> JSONResponse:
+        """Convert application errors to structured JSON responses."""
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    return app, registry, host_store
+
+
+class _SkillsHost:
+    """A connected mock host that auto-replies to ``host.skills`` frames."""
+
+    def __init__(self, comm: ApplicationCommunicator) -> None:
+        self._comm = comm
+        self._stop = asyncio.Event()
+        self.received: list[HostSkillsFrame] = []
+        # What to answer with; tests overwrite before calling the endpoint.
+        self.reply: dict[str, Any] = {"status": "ok", "skills": []}
+        self.task: asyncio.Task[None] | None = None
+
+    async def drain(self) -> None:
+        """Forward each outbound skills frame back as a configured result."""
+        while not self._stop.is_set():
+            try:
+                output = await self._comm.receive_output(timeout=0.5)
+            except asyncio.TimeoutError:
+                continue
+            if output.get("type") != "websocket.send":
+                continue
+            text = output.get("text")
+            if not isinstance(text, str):
+                continue
+            frame = decode_host_frame(text)
+            if not isinstance(frame, HostSkillsFrame):
+                continue
+            self.received.append(frame)
+            await self._comm.send_input(
+                {
+                    "type": "websocket.receive",
+                    "text": encode_host_frame(
+                        HostSkillsResultFrame(
+                            request_id=frame.request_id,
+                            status=self.reply.get("status", "ok"),
+                            skills=self.reply.get("skills", []),
+                            error=self.reply.get("error"),
+                        )
+                    ),
+                }
+            )
+
+    def stop(self) -> None:
+        """Signal the drain loop to finish."""
+        self._stop.set()
+
+
+async def _connect_host(app: FastAPI, registry: HostRegistry) -> _SkillsHost:
+    """Connect a mock host tunnel and start its auto-replier."""
+    comm = ApplicationCommunicator(app, _websocket_scope(f"/v1/hosts/{_HOST_ID}/tunnel"))
+    await comm.send_input({"type": "websocket.connect"})
+    accepted = await comm.receive_output(timeout=1.0)
+    assert accepted["type"] == "websocket.accept"
+    await comm.send_input(
+        {
+            "type": "websocket.receive",
+            "text": encode_host_frame(
+                HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name=_HOST_NAME)
+            ),
+        }
+    )
+    while registry.get(_HOST_ID) is None:
+        await asyncio.sleep(0.01)
+    host = _SkillsHost(comm)
+    host.task = asyncio.create_task(host.drain())
+    return host
+
+
+@pytest.fixture()
+async def skills_setup(db_uri: str) -> AsyncIterator[tuple[FastAPI, _SkillsHost]]:
+    """App + connected mock host, with a spec declaring one bundled skill."""
+    app, registry, _host_store = _build_app(db_uri, _fake_agent_deps(bundled=("review-pr",)))
+    host = await _connect_host(app, registry)
+    try:
+        yield app, host
+    finally:
+        host.stop()
+        if host.task is not None:
+            try:
+                await asyncio.wait_for(host.task, timeout=1.0)
+            except asyncio.TimeoutError:
+                host.task.cancel()
+
+
+async def _get_skills(app: FastAPI, query: str = "") -> Any:
+    """Call the endpoint and return the response object."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.get(f"/v1/hosts/{_HOST_ID}/agents/{_AGENT_ID}/skills{query}")
+
+
+# ── Happy path ──────────────────────────────────────────
+
+
+async def test_returns_host_skills_and_drops_bundled_duplicates(
+    skills_setup: tuple[FastAPI, _SkillsHost],
+) -> None:
+    """Host skills reach the composer; a name the bundle already claims doesn't.
+
+    The menu concatenates this onto the agent's bundled skills, so a name
+    present in both would render twice — and the bundle's own description is
+    the one the picker already shows.
+    """
+    app, host = skills_setup
+    host.reply = {
+        "status": "ok",
+        "skills": [
+            {"name": "dev-productivity:deslop", "description": "Remove slop"},
+            {"name": "my-own-skill", "description": "Something local"},
+            # Already bundled (see the fixture's spec) — must not come back.
+            {"name": "review-pr", "description": "A host copy"},
+        ],
+    }
+
+    resp = await _get_skills(app)
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "skills": [
+            {"name": "dev-productivity:deslop", "description": "Remove slop"},
+            {"name": "my-own-skill", "description": "Something local"},
+        ]
+    }
+
+
+async def test_frame_carries_the_specs_harness_filter_and_the_workspace(
+    db_uri: str,
+) -> None:
+    """Discovery is scoped by the agent's own spec, not by defaults.
+
+    The harness selects the per-vendor provider and the filter decides what
+    may surface at all, so both must ride the frame — a spec pinning
+    ``skills: [deslop]`` must not have the user's whole library offered.
+    """
+    app, registry, _hs = _build_app(
+        db_uri,
+        _fake_agent_deps(harness="codex-native", skills_filter=["deslop"]),
+    )
+    host = await _connect_host(app, registry)
+    try:
+        resp = await _get_skills(app, "?path=/Users/corey/proj")
+    finally:
+        host.stop()
+        if host.task is not None:
+            await asyncio.wait_for(host.task, timeout=1.0)
+
+    assert resp.status_code == 200
+    assert len(host.received) == 1
+    sent = host.received[0]
+    assert sent.harness == "codex-native"
+    assert sent.skills_filter == ["deslop"]
+    assert sent.path == "/Users/corey/proj"
+
+
+async def test_omitting_the_path_asks_for_home_scope_only(
+    skills_setup: tuple[FastAPI, _SkillsHost],
+) -> None:
+    """No workspace chosen yet still answers, with no directory to walk."""
+    app, host = skills_setup
+
+    resp = await _get_skills(app)
+
+    assert resp.status_code == 200
+    assert host.received[0].path is None
+
+
+async def test_without_an_agent_store_the_generic_walk_is_requested(
+    db_uri: str,
+) -> None:
+    """A server with no agent deps degrades to the harness-agnostic walk.
+
+    The host reads an empty harness as "no vendor mechanism I can enumerate"
+    and falls back to ``discover_host_skills``, which is the honest answer
+    when the spec can't be consulted.
+    """
+    app, registry, _hs = _build_app(db_uri, None)
+    host = await _connect_host(app, registry)
+    try:
+        resp = await _get_skills(app)
+    finally:
+        host.stop()
+        if host.task is not None:
+            await asyncio.wait_for(host.task, timeout=1.0)
+
+    assert resp.status_code == 200
+    assert host.received[0].harness == ""
+    assert host.received[0].skills_filter == "all"
+
+
+# ── Failure modes ───────────────────────────────────────
+
+
+async def test_host_failure_is_a_502(
+    skills_setup: tuple[FastAPI, _SkillsHost],
+) -> None:
+    """A failed discovery surfaces the host's reason, not an empty success."""
+    app, host = skills_setup
+    host.reply = {"status": "failed", "error": "skill discovery crashed for 'claude-sdk'"}
+
+    resp = await _get_skills(app)
+
+    assert resp.status_code == 502
+    assert "crashed" in resp.json()["detail"]
+
+
+async def test_unknown_agent_returns_404(
+    skills_setup: tuple[FastAPI, _SkillsHost],
+) -> None:
+    """An agent id the store doesn't know is a client error, not an empty list."""
+    app, _host = skills_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/v1/hosts/{_HOST_ID}/agents/ag_nope/skills")
+    assert resp.status_code == 404
+
+
+async def test_unknown_host_returns_404(db_uri: str) -> None:
+    """An unregistered host is 404 — it must not confirm other hosts exist."""
+    app, _reg, _hs = _build_app(db_uri, _fake_agent_deps())
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/v1/hosts/{_HOST_ID}/agents/{_AGENT_ID}/skills")
+    assert resp.status_code == 404
+
+
+async def test_offline_host_returns_409(db_uri: str) -> None:
+    """Discovery needs a live tunnel, so an offline host is a conflict."""
+    app, _reg, host_store = _build_app(db_uri, _fake_agent_deps())
+    host_store.upsert_on_connect(host_id=_HOST_ID, name="offline-host", user_id="local")
+    host_store.set_offline(_HOST_ID)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/v1/hosts/{_HOST_ID}/agents/{_AGENT_ID}/skills")
+    assert resp.status_code == 409
+
+
+async def test_unloadable_spec_still_answers(db_uri: str) -> None:
+    """A spec that won't parse must not break the menu.
+
+    The composer falls back to bundled skills alone if this 500s; degrading to
+    the generic walk keeps the request useful and the dialog usable.
+    """
+    agent = SimpleNamespace(id=_AGENT_ID, bundle_location="bundle://broken")
+
+    def _raise(_id: str, _loc: str) -> Any:
+        raise OmnigentError("bad spec")
+
+    store = cast(
+        AgentStore,
+        SimpleNamespace(get=lambda agent_id: agent if agent_id == _AGENT_ID else None),
+    )
+    cache = cast(AgentCache, SimpleNamespace(load=_raise))
+    app, registry, _hs = _build_app(db_uri, (store, cache))
+    host = await _connect_host(app, registry)
+    try:
+        resp = await _get_skills(app)
+    finally:
+        host.stop()
+        if host.task is not None:
+            await asyncio.wait_for(host.task, timeout=1.0)
+
+    assert resp.status_code == 200
+    assert host.received[0].harness == ""

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   useDetectedCredentials,
+  useHostAgentSkills,
   useHostModelOptions,
   useHosts,
   useInstallHarness,
@@ -394,6 +395,59 @@ describe("useHostModelOptions", () => {
     renderHook(() => useHostModelOptions(null, "claude-native"), { wrapper });
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useHostAgentSkills", () => {
+  it("loads the host-discovered skills for an agent and workspace", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        skills: [{ name: "dev-productivity:deslop", description: "Remove AI slop" }],
+      }),
+    );
+
+    const { result } = renderHook(
+      () => useHostAgentSkills("host_1", "ag_1", "/Users/corey/my repo"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The workspace rides as a query param, encoded — a path with a space
+    // would otherwise break the URL.
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/v1/hosts/host_1/agents/ag_1/skills?path=%2FUsers%2Fcorey%2Fmy%20repo",
+    );
+    expect(result.current.data).toEqual([
+      { name: "dev-productivity:deslop", description: "Remove AI slop" },
+    ]);
+  });
+
+  it("omits the path param when no workspace is chosen", async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ skills: [] }));
+
+    const { result } = renderHook(() => useHostAgentSkills("host_1", "ag_1", null), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/hosts/host_1/agents/ag_1/skills");
+  });
+
+  it("does not fetch without a host, an agent, or when disabled", async () => {
+    renderHook(() => useHostAgentSkills(null, "ag_1", null), { wrapper });
+    renderHook(() => useHostAgentSkills("host_1", null, null), { wrapper });
+    renderHook(() => useHostAgentSkills("host_1", "ag_1", null, false), { wrapper });
+    await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a server that omits the field", async () => {
+    // An older server (or one whose host answered nothing) must leave the
+    // menu with the agent's bundled skills, not an undefined crash.
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+
+    const { result } = renderHook(() => useHostAgentSkills("host_1", "ag_1", null), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
   });
 });
 

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -119,6 +119,73 @@ export function useHostModelOptions(hostId: string | null, harness: string, enab
   });
 }
 
+/** A skill the host would expose, in the shape the composer menu wants. */
+export interface HostSkill {
+  name: string;
+  description: string;
+}
+
+/** An error carrying the HTTP status, so the retry predicate can read it. */
+interface StatusError extends Error {
+  status?: number;
+}
+
+async function fetchHostAgentSkills(
+  hostId: string,
+  agentId: string,
+  path: string | null,
+): Promise<HostSkill[]> {
+  const query = path === null ? "" : `?path=${encodeURIComponent(path)}`;
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/agents/${encodeURIComponent(agentId)}/skills${query}`,
+  );
+  if (!res.ok) {
+    const err: StatusError = new Error(`${res.status} ${res.statusText}`);
+    err.status = res.status;
+    throw err;
+  }
+  const body = (await res.json()) as { skills?: HostSkill[] };
+  return body.skills ?? [];
+}
+
+/**
+ * Skills the chosen host would add to an agent, before any session exists.
+ *
+ * The agent's *bundled* skills come from `GET /v1/agents`; the ones on the
+ * user's machine (`~/.claude/skills`, enabled Claude Code plugins,
+ * `~/.codex/skills`, the workspace's own `.claude/skills`) are only visible to
+ * the host, so the new-chat composer asks it. Bundled names are already
+ * filtered out server-side, so the caller can concatenate.
+ *
+ * @param hostId Host the session will launch on; `null` disables the query.
+ * @param agentId Agent whose spec supplies the harness and `skills:` filter;
+ *   `null` disables the query.
+ * @param path Workspace directory to walk, or `null` for home scope only.
+ * @param enabled Caller-side gate (e.g. the menu is hidden for this agent).
+ */
+export function useHostAgentSkills(
+  hostId: string | null,
+  agentId: string | null,
+  path: string | null,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ["host-agent-skills", hostId, agentId, path],
+    queryFn: () => fetchHostAgentSkills(hostId as string, agentId as string, path),
+    enabled: enabled && hostId !== null && agentId !== null,
+    // Skills change when the user edits a SKILL.md or toggles a plugin — rare
+    // within one visit to the dialog, so a minute of cache spares the tunnel a
+    // round-trip per agent/workspace switch.
+    staleTime: 60_000,
+    // Any HTTP answer here is final: an offline host (409), a missing agent
+    // (404), and a host that didn't reply (502/504 — including a host too old
+    // to know the frame) all mean "no host skills", and the menu falls back to
+    // the bundled ones. Only a network-level failure (no status) is worth one
+    // retry — retrying the rest would just spend 30s on a settled answer.
+    retry: (failureCount, error) => (error as StatusError).status === undefined && failureCount < 1,
+  });
+}
+
 interface InstallHarnessResult {
   object: "harness_install";
   harness: string;

--- a/web/src/lib/composerSlash.test.ts
+++ b/web/src/lib/composerSlash.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { detectSlashTokenAt, spliceSlashToken } from "@/lib/composerSlash";
+
+// These tests pin *where* the "/" menu may open. The composer reads the token
+// from the caret, so completion has to work mid-draft — while text that merely
+// contains a slash (paths, "and/or", dates) must never trigger it.
+describe("detectSlashTokenAt", () => {
+  it("detects a bare leading slash", () => {
+    expect(detectSlashTokenAt("/", 1)).toEqual({
+      query: "",
+      start: 0,
+      end: 1,
+      leading: true,
+    });
+  });
+
+  it("detects a partially typed leading command", () => {
+    expect(detectSlashTokenAt("/des", 4)).toEqual({
+      query: "des",
+      start: 0,
+      end: 4,
+      leading: true,
+    });
+  });
+
+  it("detects a token typed mid-sentence and marks it non-leading", () => {
+    const text = "please run /des";
+    expect(detectSlashTokenAt(text, text.length)).toEqual({
+      query: "des",
+      start: 11,
+      end: 15,
+      leading: false,
+    });
+  });
+
+  it("detects a token after a newline and marks it non-leading", () => {
+    const text = "context first\n/des";
+    expect(detectSlashTokenAt(text, text.length)).toEqual({
+      query: "des",
+      start: 14,
+      end: 18,
+      leading: false,
+    });
+  });
+
+  it("treats leading whitespace as still leading", () => {
+    // The composer trims for submit routing, so "  /x" invokes just like "/x";
+    // the menu must agree or the two surfaces disagree on what's a command.
+    expect(detectSlashTokenAt("  /x", 4)?.leading).toBe(true);
+  });
+
+  it("closes on the space that ends the token", () => {
+    expect(detectSlashTokenAt("/deslop ", 8)).toBeNull();
+  });
+
+  it("reads the token at the caret, not at the end of the draft", () => {
+    // Caret parked just after "/des" while "hello" trails it: the user is
+    // editing the command name, so the menu must reopen on that token.
+    const text = "/des hello";
+    expect(detectSlashTokenAt(text, 4)).toEqual({
+      query: "des",
+      start: 0,
+      end: 4,
+      leading: true,
+    });
+  });
+
+  it("ignores a slash glued to the previous word", () => {
+    expect(detectSlashTokenAt("and/or", 6)).toBeNull();
+    expect(detectSlashTokenAt("2026/09", 7)).toBeNull();
+  });
+
+  it("stops matching once a path's second slash is typed", () => {
+    // "/etc" alone reads as a command shape (and harmlessly yields no
+    // matches); the second slash makes it unambiguously a path.
+    expect(detectSlashTokenAt("/etc", 4)?.query).toBe("etc");
+    expect(detectSlashTokenAt("/etc/hosts", 10)).toBeNull();
+    expect(detectSlashTokenAt("see /etc/hosts", 14)).toBeNull();
+  });
+
+  it("keeps namespaced plugin skill names in one token", () => {
+    expect(detectSlashTokenAt("/dev-productivity:simpl", 23)?.query).toBe("dev-productivity:simpl");
+  });
+});
+
+describe("spliceSlashToken", () => {
+  it("replaces a leading token in place", () => {
+    const token = detectSlashTokenAt("/des", 4)!;
+    expect(spliceSlashToken("/des", token, "/deslop")).toEqual({
+      text: "/deslop ",
+      caret: 8,
+    });
+  });
+
+  it("preserves text on both sides of a mid-draft token", () => {
+    const text = "run /des on this file";
+    // Caret sits at the end of the token, not the end of the draft.
+    const token = detectSlashTokenAt(text, 8)!;
+    expect(spliceSlashToken(text, token, "/deslop")).toEqual({
+      text: "run /deslop  on this file",
+      caret: 12,
+    });
+  });
+
+  it("leaves a caret positioned for an argument", () => {
+    const token = detectSlashTokenAt("/", 1)!;
+    const { text, caret } = spliceSlashToken("/", token, "/deep-research");
+    expect(text.slice(caret)).toBe("");
+    // The trailing space closes the menu — a finished token no longer matches.
+    expect(detectSlashTokenAt(text, caret)).toBeNull();
+  });
+});

--- a/web/src/lib/composerSlash.ts
+++ b/web/src/lib/composerSlash.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure ``/``-slash-token utilities shared by the in-session composer
+ * (``ChatPage``) and the new-session launcher (``NewChatDialog``). The sibling
+ * of ``composerMentions`` for the "/" trigger: kept free of React/state so both
+ * surfaces decide *where* a command token starts identically — and so the
+ * trigger logic is unit-testable without rendering.
+ *
+ * Ranking and filtering of the matches live in ``components/SlashCommandMenu``
+ * (which the menu itself needs); only token detection and splicing are here.
+ */
+
+/** An active ``/`` token being typed in a composer. */
+export interface SlashTokenState {
+  /** Text typed after the ``/`` (no whitespace, no further ``/``). */
+  query: string;
+  /** Index of the ``/`` character in the textarea value. */
+  start: number;
+  /** Caret index (one past the last query char) — end of the token. */
+  end: number;
+  /**
+   * True when this ``/`` opens the whole draft (nothing but whitespace
+   * before it). Only a leading token can *invoke* something: the composer
+   * routes a leading ``/cmd`` to a built-in or a ``slash_command`` event,
+   * whereas a token typed mid-sentence is plain text the agent reads. Callers
+   * use it to decide whether built-ins join the menu and whether selecting a
+   * row may execute.
+   */
+  leading: boolean;
+}
+
+// Token preceding the caret: a "/" at the start of the inspected string or
+// after whitespace, followed by a run with no whitespace and no further "/".
+// (``^`` anchors to the start of the sliced ``before`` text, not a line — a
+// mid-string "/" still matches because the newline before it counts as the
+// ``\s``.) Excluding "/" from the run is what makes paths self-closing:
+// "/etc/hosts" stops matching the moment the second slash is typed, and
+// "and/or" never matches since its "/" follows a letter.
+const SLASH_TOKEN_RE = /(?:^|\s)\/([^\s/]*)$/;
+
+/**
+ * Detect an in-progress ``/`` token immediately before the caret.
+ *
+ * Looks only at ``text`` up to ``caret`` so a trailing space (token finished)
+ * closes the menu. Returns ``null`` when there is no active token.
+ *
+ * :param text: The full textarea value.
+ * :param caret: The caret offset (``selectionStart``).
+ * :returns: The active :class:`SlashTokenState`, or ``null``.
+ */
+export function detectSlashTokenAt(text: string, caret: number): SlashTokenState | null {
+  const before = text.slice(0, caret);
+  const m = SLASH_TOKEN_RE.exec(before);
+  if (!m) return null;
+  const query = m[1];
+  // ``m.index`` points at the matched whitespace (or -1+1=0 at line start);
+  // the "/" sits just before the captured query.
+  const start = caret - query.length - 1;
+  return { query, start, end: caret, leading: text.slice(0, start).trim() === "" };
+}
+
+/**
+ * Replace an active token with the selected command name plus a trailing
+ * space, leaving the rest of the draft untouched.
+ *
+ * The trailing space both closes the menu (a finished token no longer matches)
+ * and puts the caret where an argument would go.
+ *
+ * :param text: The full textarea value.
+ * :param token: The token being completed.
+ * :param name: Slash-prefixed command name, e.g. ``"/deslop"``.
+ * :returns: The rewritten text and the caret offset to restore.
+ */
+export function spliceSlashToken(
+  text: string,
+  token: SlashTokenState,
+  name: string,
+): { text: string; caret: number } {
+  const inserted = `${name} `;
+  return {
+    text: text.slice(0, token.start) + inserted + text.slice(token.end),
+    caret: token.start + inserted.length,
+  };
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -498,6 +498,136 @@ describe("Composer slash-command menu", () => {
   });
 });
 
+describe("Composer mid-draft skill completion", () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      conversationId: "conv_test",
+      skills: [
+        { name: "deep-research", description: "Run a deep research sweep" },
+        { name: "deslop", description: "Remove AI slop" },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  /** Type `value` with the caret parked at `caret` (default: end of value). */
+  function type(ta: HTMLTextAreaElement, value: string, caret = value.length) {
+    fireEvent.change(ta, { target: { value, selectionStart: caret } });
+  }
+
+  it("opens the menu for a slash typed mid-sentence", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    type(ta, "please run /des");
+    expect(activeRow()?.textContent).toContain("/deslop");
+  });
+
+  it("offers skills only mid-draft, since built-ins can't act on a word in a sentence", () => {
+    render(<Composer {...composerProps({ isNativeWrapper: true })} />);
+    const ta = textarea();
+    // Leading "/" lists the built-ins…
+    type(ta, "/");
+    expect(screen.getByTestId("slash-menu-item-compact")).toBeInTheDocument();
+    expect(screen.getByTestId("slash-menu-item-deslop")).toBeInTheDocument();
+    // …the same "/" mid-draft lists the skills alone.
+    type(ta, "use /");
+    expect(screen.queryByTestId("slash-menu-item-compact")).toBeNull();
+    expect(screen.queryByTestId("slash-menu-item-context")).toBeNull();
+    expect(screen.getByTestId("slash-menu-item-deslop")).toBeInTheDocument();
+  });
+
+  it("Tab completes in place, keeping the text around the token", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    type(ta, "please run /des");
+    fireEvent.keyDown(ta, { key: "Tab" });
+    expect(ta.value).toBe("please run /deslop ");
+  });
+
+  it("completes a token the caret sits on without disturbing the tail", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    // Caret parked at the end of "/des", with the rest of the sentence after
+    // it — the re-editing case that the whole-draft prefix check never saw.
+    type(ta, "/des this file please", 4);
+    expect(activeRow()?.textContent).toContain("/deslop");
+    fireEvent.keyDown(ta, { key: "Tab" });
+    expect(ta.value).toBe("/deslop  this file please");
+  });
+
+  it("Enter completes mid-draft instead of sending", () => {
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    const ta = textarea();
+    type(ta, "run /des");
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(ta.value).toBe("run /deslop ");
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("never executes a built-in from a mid-draft completion", () => {
+    // /compact is a no-arg built-in: selecting it from the leading menu runs
+    // it. It must not be reachable (nor runnable) from inside a sentence.
+    const compact = vi.fn();
+    useChatStore.setState({ compact });
+    render(<Composer {...composerProps({ isNativeWrapper: true })} />);
+    const ta = textarea();
+    type(ta, "now /compact");
+    // No menu at all: /compact isn't a skill, so nothing matches mid-draft.
+    expect(activeRow()).toBeNull();
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(compact).not.toHaveBeenCalled();
+  });
+
+  it("Escape closes the menu but keeps a mid-draft sentence", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    type(ta, "please run /des");
+    expect(activeRow()).not.toBeNull();
+
+    fireEvent.keyDown(ta, { key: "Escape" });
+    expect(activeRow()).toBeNull();
+    expect(ta.value).toBe("please run /des");
+
+    // Typing on brings the suggestions back.
+    type(ta, "please run /desl");
+    expect(activeRow()?.textContent).toContain("/deslop");
+  });
+
+  it("Escape still clears a draft that is nothing but the command", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    type(ta, "/des");
+    fireEvent.keyDown(ta, { key: "Escape" });
+    expect(ta.value).toBe("");
+  });
+
+  it("stays closed for slashes that read as paths or prose", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    type(ta, "look at /etc/hosts");
+    expect(activeRow()).toBeNull();
+    type(ta, "deslop and/or simplify");
+    expect(activeRow()).toBeNull();
+  });
+
+  it("sends a mid-draft skill mention as plain text", () => {
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    const ta = textarea();
+    type(ta, "run /des");
+    fireEvent.keyDown(ta, { key: "Tab" });
+    // The completed draft doesn't read as a command (the "/" isn't leading),
+    // so it goes out as an ordinary message, not a slash_command event.
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("run /deslop", undefined);
+  });
+});
+
 describe("Composer slash-command submit routing", () => {
   // Several tests below swap the store's setModel for a vi.fn(); restore
   // the real action after each test so the mock can't bleed into later

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -136,6 +136,7 @@ import {
   parseMentionToken,
   rankMentionEntries,
 } from "@/lib/composerMentions";
+import { detectSlashTokenAt, spliceSlashToken } from "@/lib/composerSlash";
 import { useMentionBrowser } from "@/hooks/useMentionBrowser";
 import { getSessionDraft, setSessionDraft } from "@/lib/sessionDrafts";
 // Re-exported so existing tests importing these from "./ChatPage" keep working
@@ -4332,6 +4333,15 @@ export function Composer({
   // opens with matches the reset logic below pre-selects the first item (0)
   // so Tab/Enter complete it immediately.
   const [menuIndex, setMenuIndex] = useState(-1);
+  // Where the user last typed, so the "/" menu can read the token at the caret
+  // rather than only the one that opens the draft. ``null`` means "not known
+  // yet" — a value set from outside the composer (draft restore, history
+  // recall, a queued message pulled back for editing) — and reads at the end
+  // of the draft, which is where the caret lands.
+  const [slashCaret, setSlashCaret] = useState<number | null>(null);
+  // Escape / blur close the menu without touching the draft. Cleared on the
+  // next keystroke, so typing on brings the suggestions back.
+  const [slashDismissed, setSlashDismissed] = useState(false);
   // Active "@"-file-mention being typed, plus its highlighted row and the
   // workspace paths the user has already tagged. ``@``-mention is wired for
   // the native coding-agent sessions (see ``mentionEnabled``): those harnesses
@@ -4545,18 +4555,35 @@ export function Composer({
     [skills, showEffort, showModel],
   );
 
-  // Suggestions menu is open while the user is still typing the command
-  // name — i.e. the value starts with "/" with no spaces yet (once a
-  // space appears the command name is done and args follow) and no second
-  // "/" (guards against file-path-like strings).
-  const trimmedValue = value.trimStart();
-  const menuOpen =
-    trimmedValue.startsWith("/") &&
-    !trimmedValue.slice(1).includes("/") &&
-    !trimmedValue.includes(" ") &&
-    files.length === 0;
-  // Query = what the user typed after the leading "/".
-  const menuQuery = menuOpen ? trimmedValue.slice(1) : "";
+  // Skills only, for a "/" typed mid-draft: built-ins act on the session
+  // (compact it, switch its model), which completing a word inside a sentence
+  // cannot do, so offering them there would promise something selection can't
+  // deliver. A skill name is just text the agent reads, so it completes
+  // anywhere.
+  const skillCommands = useMemo(
+    () => Object.fromEntries(skills.map((s) => [`/${s.name}`, s.description])),
+    [skills],
+  );
+  // Derived from the value (so a submit clear or a recall closes the menu on
+  // its own) but read at the caret. The offset is clamped because a value set
+  // from outside the composer can be shorter than where the user last typed.
+  const slashToken = useMemo(
+    () =>
+      slashDismissed
+        ? null
+        : detectSlashTokenAt(value, Math.min(slashCaret ?? value.length, value.length)),
+    [slashDismissed, slashCaret, value],
+  );
+  // Suggestions menu is open while the user is still typing a command name at
+  // the caret: a "/" at the start of the draft or after whitespace, with no
+  // space (the name is done, args follow) and no second "/" (a file path) —
+  // see ``detectSlashTokenAt``.
+  const menuOpen = slashToken !== null && files.length === 0;
+  // Query = what the user typed after that "/".
+  const menuQuery = slashToken?.query ?? "";
+  // A leading token can invoke (built-ins execute, skills route as a
+  // ``slash_command``); one typed mid-sentence completes as plain text.
+  const menuCommands = slashToken !== null && !slashToken.leading ? skillCommands : slashCommands;
   // Tint the `/skill` token blue while the draft reads as a slash command, so
   // the command shape is signalled as the user types it.
   const composerIsCommand = files.length === 0 && isSlashCommandText(value);
@@ -4575,7 +4602,7 @@ export function Composer({
   };
   // Filtered matches — kept in sync with what SlashCommandMenu renders so
   // keyboard nav indexes into the same list.
-  const menuMatches = menuOpen ? rankedSlashCommandNames(slashCommands, menuQuery) : [];
+  const menuMatches = menuOpen ? rankedSlashCommandNames(menuCommands, menuQuery) : [];
 
   // Pre-select the first match whenever the filtered list changes — both
   // when the menu first opens (matches go [] → non-empty) and as the query
@@ -4833,20 +4860,36 @@ export function Composer({
 
   /**
    * Called when the user selects a suggestion from the menu (keyboard or
-   * click). Commands that need an argument (``SLASH_COMMANDS_WITH_ARGS``)
-   * fill in the text with a trailing space so the user can type the arg.
-   * All other commands execute immediately.
+   * click). Commands that need an argument (``SLASH_COMMANDS_WITH_ARGS``) —
+   * and every token typed mid-draft, which can't invoke anything — complete
+   * into the text with a trailing space so the user can type the arg. All
+   * other commands execute immediately.
    */
   const applyMenuSelection = (cmd: string) => {
     setMenuIndex(-1);
-    if (slashCommandsWithArgs.has(cmd)) {
-      // Fill in "cmd " and let the user type the argument.
-      setValue(cmd + " ");
+    const token = slashToken;
+    const completesAsText = slashCommandsWithArgs.has(cmd) || (token !== null && !token.leading);
+    if (completesAsText) {
+      // Rewrite just the token, so a mid-sentence completion keeps the words
+      // around it and a leading one keeps any args already typed after it.
+      const next =
+        token !== null
+          ? spliceSlashToken(value, token, cmd)
+          : { text: `${cmd} `, caret: cmd.length + 1 };
+      setValue(next.text);
       dirtyRef.current = true;
-      textareaRef.current?.focus();
+      setSlashCaret(next.caret);
+      // Restore the caret after React applies the value; without this the
+      // browser leaves it where the shorter token ended, i.e. mid-word.
+      queueMicrotask(() => {
+        const ta = textareaRef.current;
+        ta?.setSelectionRange(next.caret, next.caret);
+        ta?.focus();
+      });
     } else {
       // Execute immediately — no argument needed.
       setValue("");
+      setSlashCaret(null);
       setCommandError(null);
       executeSlashCommand(cmd, "");
     }
@@ -5102,8 +5145,11 @@ export function Composer({
       }
       if (e.key === "Escape") {
         e.preventDefault();
-        // Dismiss the menu by clearing the input so the user can start fresh.
-        setValue("");
+        // A leading token IS the whole draft, so clearing the input is the
+        // fastest way back to an empty composer. Mid-draft, only the menu
+        // closes — the sentence being written has to survive.
+        if (slashToken === null || slashToken.leading) setValue("");
+        setSlashDismissed(true);
         setMenuIndex(-1);
         return;
       }
@@ -5256,7 +5302,7 @@ export function Composer({
             query={menuQuery}
             activeIndex={menuIndex}
             onSelect={applyMenuSelection}
-            commands={slashCommands}
+            commands={menuCommands}
           />
         )}
         {/* "@"-file-mention browser — native coding-agent sessions only.
@@ -5333,14 +5379,13 @@ export function Composer({
               if (attachmentError !== null) setAttachmentError(null);
               // Recompute the active "@"-mention from the caret on every
               // keystroke (native coding-agent sessions — ``mentionEnabled``).
-              setMention(
-                mentionEnabled
-                  ? detectMentionAt(
-                      e.target.value,
-                      e.target.selectionStart ?? e.target.value.length,
-                    )
-                  : null,
-              );
+              const caret = e.target.selectionStart ?? e.target.value.length;
+              setMention(mentionEnabled ? detectMentionAt(e.target.value, caret) : null);
+              // Same for the "/" token, so the menu follows the caret rather
+              // than only opening on a draft that starts with a slash. Typing
+              // also lifts an earlier Escape.
+              setSlashCaret(caret);
+              setSlashDismissed(false);
               // Treat user-driven changes as exiting recall mode. Recall-
               // driven setValue toggles `recallingRef` first so we skip the
               // reset for that one tick.
@@ -5366,6 +5411,7 @@ export function Composer({
               // keeps focus and does NOT blur — this only fires for genuine
               // focus-out, where the lingering menu would otherwise float.
               dismissMention();
+              setSlashDismissed(true);
             }}
             onPaste={handlePaste}
             onScroll={(e) => {

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { authenticatedFetch } from "@/lib/identity";
 import type { Host } from "@/hooks/useHosts";
-import { useHostModelOptions, useHosts } from "@/hooks/useHosts";
+import { useHostAgentSkills, useHostModelOptions, useHosts } from "@/hooks/useHosts";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { NewChatLandingScreen, resetLandingDraft, sanitizeInitialPrompt } from "./NewChatDialog";
@@ -83,6 +83,9 @@ vi.mock("@/hooks/useHosts", () => ({
       { id: "haiku", displayName: "Haiku" },
     ],
   })),
+  // The landing composer asks the chosen host for its own skills; these flows
+  // assert routing of the first message, so an empty answer is enough.
+  useHostAgentSkills: vi.fn(() => ({ data: [] })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));
@@ -276,6 +279,11 @@ beforeEach(() => {
     ],
     isLoading: false,
   } as unknown as ReturnType<typeof useHostModelOptions>);
+  // Reset per-test host-skill overrides: a leaked skill would make a later
+  // test's "/name" route as an invocation instead of plain text.
+  vi.mocked(useHostAgentSkills).mockReturnValue({
+    data: [],
+  } as unknown as ReturnType<typeof useHostAgentSkills>);
   // Seed host_1's recent so the working directory pre-fills deterministically
   // (the create body must carry SEEDED_WORKSPACE through).
   localStorage.setItem(RECENT_KEY, JSON.stringify({ host_1: [SEEDED_WORKSPACE] }));
@@ -646,9 +654,9 @@ describe("NewChatLandingScreen create flow", () => {
 
     renderLanding();
     await waitForWorkspaceSeed();
-    // Not a bundled skill — e.g. a typo or a host-discovered skill the
-    // server can't know pre-session. Falls through to plain text, same as
-    // the in-session composer's unknown-command path.
+    // Matches no skill the agent can resolve — neither bundled nor
+    // host-discovered (a typo). Falls through to plain text, same as the
+    // in-session composer's unknown-command path.
     typeMessage("/typo do something");
     fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
 
@@ -656,6 +664,33 @@ describe("NewChatLandingScreen create flow", () => {
       expect(setPendingInitialPromptMock).toHaveBeenCalledWith("conv_new", {
         text: "/typo do something",
         skill: null,
+        files: [],
+      }),
+    );
+  });
+
+  it("invokes a host-discovered skill as a slash command, not plain text", async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    // Not in the bundle — it lives in the user's own ~/.claude/skills, which
+    // only the chosen host can see. The composer offers it in the "/" menu, so
+    // completing one has to actually invoke it rather than send literal text.
+    vi.mocked(useHostAgentSkills).mockReturnValue({
+      data: [{ name: "my-own-skill", description: "Something local" }],
+    } as unknown as ReturnType<typeof useHostAgentSkills>);
+    setAgents([agent({ skills: [] })]);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("/my-own-skill on the auth module");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() =>
+      expect(setPendingInitialPromptMock).toHaveBeenCalledWith("conv_new", {
+        text: "/my-own-skill on the auth module",
+        skill: { name: "my-own-skill", args: "on the auth module" },
         files: [],
       }),
     );

--- a/web/src/shell/NewChatDialog.projectCreate.test.tsx
+++ b/web/src/shell/NewChatDialog.projectCreate.test.tsx
@@ -53,6 +53,9 @@ vi.mock("@/components/ui/toast", async (importOriginal) => ({
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(() => ({ data: [] })),
+  // The landing composer asks the chosen host for its own skills; an empty
+  // answer leaves the "/" menu on the agent's bundled skills.
+  useHostAgentSkills: vi.fn(() => ({ data: [] })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(() => ({ data: [] })),
+  useHostAgentSkills: vi.fn(() => ({ data: [] })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2873,6 +2873,32 @@ describe("NewChatLandingScreen skills menu", () => {
     expect(screen.queryByText("Review a pull request")).toBeNull();
   });
 
+  it("opens the menu for a slash typed mid-draft and completes it in place", () => {
+    mockAgents([skilledAgent()]);
+    renderLanding();
+    const input = screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement;
+    // Same trigger the in-session composer uses: the "/" token at the caret,
+    // not just one that opens the draft.
+    fireEvent.change(input, {
+      target: { value: "start with /rev", selectionStart: 15 },
+    });
+    expect(screen.getByTestId("slash-menu-item-review-pr")).toBeTruthy();
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect(input.value).toBe("start with /review-pr ");
+  });
+
+  it("Escape mid-draft closes the menu without discarding the draft", () => {
+    mockAgents([skilledAgent()]);
+    renderLanding();
+    const input = screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement;
+    fireEvent.change(input, {
+      target: { value: "start with /rev", selectionStart: 15 },
+    });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByTestId("slash-menu-item-review-pr")).toBeNull();
+    expect(input.value).toBe("start with /rev");
+  });
+
   it("shows no menu for native terminal agents even if skills are listed", () => {
     // A native agent with (hypothetical) bundled skills: the gate is the
     // agent kind, not an empty skill list — the vendor CLI interprets

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2939,33 +2939,12 @@ describe("NewChatLandingScreen skills menu", () => {
     );
   });
 
-  it("does not ask the host for a native terminal agent", () => {
-    // The vendor CLI owns slash commands there, so the web menu stays hidden
-    // — and a request whose answer can't be shown is pure round-trip.
-    mockAgents([
-      {
-        id: "a_native",
-        name: "claude-native-ui",
-        display_name: "Claude Code",
-        description: null,
-        harness: "claude-native",
-        skills: [],
-      },
-    ]);
-    renderLanding();
-    // Last arg is the `enabled` gate — false keeps the query from firing.
-    expect(useHostAgentSkillsMock).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      false,
-    );
-  });
-
-  it("shows no menu for native terminal agents even if skills are listed", () => {
-    // A native agent with (hypothetical) bundled skills: the gate is the
-    // agent kind, not an empty skill list — the vendor CLI interprets
-    // slash commands itself, so the web menu must stay out of the way.
+  it("offers skills for native terminal agents too, completing the name only", () => {
+    // Claude Code is what auto-selects for most people, and its
+    // host-discovered skills ARE its own slash commands — so the landing menu
+    // lists them, matching the in-session composer (which never gated on the
+    // harness). The first message reaches the CLI as text, which interprets
+    // the completed "/name" itself.
     mockAgents([
       {
         id: "a1",
@@ -2976,9 +2955,38 @@ describe("NewChatLandingScreen skills menu", () => {
         skills: [{ name: "review-pr", description: "Review a pull request" }],
       },
     ]);
+    useHostAgentSkillsMock.mockReturnValue({
+      data: [{ name: "dev-productivity:deslop", description: "Remove AI slop" }],
+    } as unknown as ReturnType<typeof useHostAgentSkills>);
     renderLanding();
     typeMessage("/");
-    expect(screen.queryByTestId("slash-menu-item-review-pr")).toBeNull();
+    expect(screen.getByTestId("slash-menu-item-review-pr")).toBeTruthy();
+    expect(screen.getByTestId("slash-menu-item-dev-productivity:deslop")).toBeTruthy();
+    fireEvent.keyDown(screen.getByTestId("new-chat-landing-input"), { key: "Tab" });
+    expect((screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement).value).toBe(
+      "/review-pr ",
+    );
+  });
+
+  it("asks the host for a native terminal agent's skills as well", () => {
+    mockAgents([
+      {
+        id: "a1",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    // Last arg is the `enabled` gate — the harness no longer suppresses it.
+    expect(useHostAgentSkillsMock).toHaveBeenLastCalledWith(
+      "host_1",
+      "a1",
+      "/Users/corey/repo",
+      true,
+    );
   });
 });
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -31,6 +31,7 @@ import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 import type { ServerInfo } from "@/lib/capabilities";
 import { authenticatedFetch } from "@/lib/identity";
 import {
+  useHostAgentSkills,
   useHostModelOptions,
   useHosts,
   useInstallHarness,
@@ -74,6 +75,7 @@ vi.mock("@/lib/nativeBridge", async (importOriginal) => ({
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(),
+  useHostAgentSkills: vi.fn(),
   // The setup dialog mounts these; default to inert so tests that don't
   // exercise install / credential-write don't need to wire them up.
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
@@ -188,6 +190,7 @@ const CODEX_MODEL_OPTIONS_RESULT = {
 };
 
 const useHostModelOptionsMock = vi.mocked(useHostModelOptions);
+const useHostAgentSkillsMock = vi.mocked(useHostAgentSkills);
 const useAvailableAgentsMock = vi.mocked(useAvailableAgents);
 const useHostFilesystemMock = vi.mocked(useHostFilesystem);
 const useHostWorktreesMock = vi.mocked(useHostWorktrees);
@@ -701,6 +704,12 @@ function setupLandingMocks() {
   authenticatedFetchMock.mockReset();
   useHostsMock.mockReset();
   useHostModelOptionsMock.mockReset();
+  useHostAgentSkillsMock.mockReset();
+  // Default: the host reports no extra skills, so the menu shows the agent's
+  // bundled ones alone (what every test predating host discovery expects).
+  useHostAgentSkillsMock.mockReturnValue({
+    data: undefined,
+  } as unknown as ReturnType<typeof useHostAgentSkills>);
   useAvailableAgentsMock.mockReset();
   useHostFilesystemMock.mockReset();
   useHostWorktreesMock.mockReset();
@@ -2897,6 +2906,60 @@ describe("NewChatLandingScreen skills menu", () => {
     fireEvent.keyDown(input, { key: "Escape" });
     expect(screen.queryByTestId("slash-menu-item-review-pr")).toBeNull();
     expect(input.value).toBe("start with /rev");
+  });
+
+  it("lists host-discovered skills alongside the bundled ones", () => {
+    // The user's own ~/.claude/skills and enabled plugins live on the host, so
+    // before this the first message couldn't complete them at all — they only
+    // appeared once a runner had bound and pushed a session snapshot.
+    mockAgents([skilledAgent()]);
+    useHostAgentSkillsMock.mockReturnValue({
+      data: [
+        { name: "dev-productivity:deslop", description: "Remove AI slop" },
+        { name: "my-own-skill", description: "Something local" },
+      ],
+    } as unknown as ReturnType<typeof useHostAgentSkills>);
+    renderLanding();
+    typeMessage("/");
+    expect(screen.getByTestId("slash-menu-item-review-pr")).toBeTruthy();
+    expect(screen.getByTestId("slash-menu-item-dev-productivity:deslop")).toBeTruthy();
+    expect(screen.getByTestId("slash-menu-item-my-own-skill")).toBeTruthy();
+  });
+
+  it("asks the chosen host, scoped to the agent and workspace", () => {
+    mockAgents([skilledAgent()]);
+    renderLanding();
+    // Host + agent + workspace identify the answer; the seeded recent
+    // workspace (see setupLandingMocks) supplies the path.
+    expect(useHostAgentSkillsMock).toHaveBeenCalledWith(
+      "host_1",
+      "ag_skilled",
+      "/Users/corey/repo",
+      true,
+    );
+  });
+
+  it("does not ask the host for a native terminal agent", () => {
+    // The vendor CLI owns slash commands there, so the web menu stays hidden
+    // — and a request whose answer can't be shown is pure round-trip.
+    mockAgents([
+      {
+        id: "a_native",
+        name: "claude-native-ui",
+        display_name: "Claude Code",
+        description: null,
+        harness: "claude-native",
+        skills: [],
+      },
+    ]);
+    renderLanding();
+    // Last arg is the `enabled` gate — false keeps the query from firing.
+    expect(useHostAgentSkillsMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      false,
+    );
   });
 
   it("shows no menu for native terminal agents even if skills are listed", () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3588,8 +3588,16 @@ export function NewChatLandingScreen() {
   // Slash-command suggestions for the chosen agent's skills. Mirrors the
   // in-session composer's menu mechanics (open on the "/" token at the caret,
   // wherever in the draft it sits), but lists skills only — built-ins like
-  // /model need a live session. Hidden for native-terminal agents (their CLI
-  // owns slash commands) and for agents with no skills at all.
+  // /model need a live session.
+  //
+  // Native terminal agents are included: their host-discovered skills ARE the
+  // vendor CLI's own slash commands (~/.claude/skills and enabled plugins are
+  // exactly what Claude Code registers), and the first message reaches that CLI
+  // as text, so it interprets the completed "/name" itself. The in-session
+  // composer has never gated on the harness either — hiding them here only on
+  // the landing screen made the default agent look like it had no skills.
+  // Completing a name is all this does; `matchSkillInvocation` still declines to
+  // route natives as a `slash_command` (see handleCreate).
   const [slashMenuIndex, setSlashMenuIndex] = useState(-1);
   // Skills the chosen host would add on top of the bundled ones —
   // ~/.claude/skills, enabled Claude Code plugins, the workspace's own
@@ -3604,17 +3612,16 @@ export function NewChatLandingScreen() {
     sandboxSelected ? null : selectedHostId,
     skillsAgentId,
     workspaceValid ? workspaceTrimmed : null,
-    !isNativeTerminalAgent && skillsAgentId !== null,
+    skillsAgentId !== null,
   );
   const skillCommands = useMemo(() => {
-    if (isNativeTerminalAgent) return {};
     const m: Record<string, string> = {};
     for (const s of selectedAgent?.skills ?? []) m[`/${s.name}`] = s.description;
     // Host skills come after the bundled ones (the endpoint already drops
     // names the bundle claims), so a bundled skill keeps its own description.
     for (const s of hostSkills ?? []) m[`/${s.name}`] ??= s.description;
     return m;
-  }, [selectedAgent, isNativeTerminalAgent, hostSkills]);
+  }, [selectedAgent, hostSkills]);
   // Caret offset + dismissal, exactly as the in-session composer tracks them:
   // ``null`` reads the token at the end of the draft (a prefilled message the
   // user hasn't typed into yet), Escape/blur closes without editing the draft.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -103,6 +103,7 @@ import {
   rankedSlashCommandNames,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
+import { detectSlashTokenAt, spliceSlashToken } from "@/lib/composerSlash";
 import { setPendingInitialPrompt } from "@/store/chatStore";
 import { markSessionCreated } from "@/store/interactionTelemetry";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
@@ -3585,12 +3586,11 @@ export function NewChatLandingScreen() {
   // Sandbox creates need no host or path workspace — the server
   // provisions both; only the message, agent, and (optional) repo
   // inputs gate the submit.
-  // Slash-command suggestions for the chosen agent's bundled skills.
-  // Mirrors the in-session composer's menu mechanics (open while the
-  // command name is still being typed: leading "/", no second "/", no
-  // space yet), but lists skills only — built-ins like /model need a
-  // live session. Hidden for native-terminal agents (their CLI owns
-  // slash commands) and for agents without bundled skills.
+  // Slash-command suggestions for the chosen agent's skills. Mirrors the
+  // in-session composer's menu mechanics (open on the "/" token at the caret,
+  // wherever in the draft it sits), but lists skills only — built-ins like
+  // /model need a live session. Hidden for native-terminal agents (their CLI
+  // owns slash commands) and for agents with no skills at all.
   const [slashMenuIndex, setSlashMenuIndex] = useState(-1);
   const skillCommands = useMemo(() => {
     if (isNativeTerminalAgent) return {};
@@ -3598,12 +3598,20 @@ export function NewChatLandingScreen() {
     for (const s of selectedAgent?.skills ?? []) m[`/${s.name}`] = s.description;
     return m;
   }, [selectedAgent, isNativeTerminalAgent]);
-  const trimmedMessage = message.trimStart();
-  const slashMenuOpen =
-    trimmedMessage.startsWith("/") &&
-    !trimmedMessage.slice(1).includes("/") &&
-    !trimmedMessage.includes(" ");
-  const slashMenuQuery = slashMenuOpen ? trimmedMessage.slice(1) : "";
+  // Caret offset + dismissal, exactly as the in-session composer tracks them:
+  // ``null`` reads the token at the end of the draft (a prefilled message the
+  // user hasn't typed into yet), Escape/blur closes without editing the draft.
+  const [slashCaret, setSlashCaret] = useState<number | null>(null);
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  const slashToken = useMemo(
+    () =>
+      slashDismissed
+        ? null
+        : detectSlashTokenAt(message, Math.min(slashCaret ?? message.length, message.length)),
+    [slashDismissed, slashCaret, message],
+  );
+  const slashMenuOpen = slashToken !== null;
+  const slashMenuQuery = slashToken?.query ?? "";
   // Kept in sync with what SlashCommandMenu renders so keyboard nav
   // indexes into the same list.
   const slashMenuMatches = slashMenuOpen
@@ -3621,12 +3629,22 @@ export function NewChatLandingScreen() {
     setSlashMenuIndex(slashMenuMatches.length > 0 ? 0 : -1);
   }
 
-  // Selecting a skill fills "/name " and leaves the caret ready for the
-  // argument — skills never auto-execute from the menu.
+  // Selecting a skill rewrites just the token to "/name " and leaves the caret
+  // ready for the argument — skills never auto-execute from the menu, and a
+  // completion mid-draft keeps the words around it.
   function applySlashSelection(cmd: string) {
     setSlashMenuIndex(-1);
-    setMessage(cmd + " ");
-    textareaRef.current?.focus();
+    const next =
+      slashToken !== null
+        ? spliceSlashToken(message, slashToken, cmd)
+        : { text: `${cmd} `, caret: cmd.length + 1 };
+    setMessage(next.text);
+    setSlashCaret(next.caret);
+    queueMicrotask(() => {
+      const ta = textareaRef.current;
+      ta?.setSelectionRange(next.caret, next.caret);
+      ta?.focus();
+    });
   }
 
   // Always-visible skill pills for the allowlisted orchestrators, fed by
@@ -4491,14 +4509,13 @@ export function NewChatLandingScreen() {
                   if (attachmentError !== null) setAttachmentError(null);
                   // Recompute the active "@"-mention from the caret each keystroke
                   // (native terminal agents with a workspace — ``mentionEnabled``).
-                  setMention(
-                    mentionEnabled
-                      ? detectMentionAt(
-                          e.target.value,
-                          e.target.selectionStart ?? e.target.value.length,
-                        )
-                      : null,
-                  );
+                  const caret = e.target.selectionStart ?? e.target.value.length;
+                  setMention(mentionEnabled ? detectMentionAt(e.target.value, caret) : null);
+                  // Same for the "/" token, so the menu follows the caret rather
+                  // than only opening on a draft that starts with a slash. Typing
+                  // also lifts an earlier Escape.
+                  setSlashCaret(caret);
+                  setSlashDismissed(false);
                 }}
                 onFocus={() => {
                   // From here the textarea's caret is one the user placed, so
@@ -4509,6 +4526,7 @@ export function NewChatLandingScreen() {
                   // Dismiss the mention menu when focus leaves the textarea; menu
                   // rows preventDefault on mousedown so selecting one doesn't blur.
                   dismissMention();
+                  setSlashDismissed(true);
                 }}
                 onCompositionStart={() => {
                   isComposingRef.current = true;
@@ -4573,9 +4591,11 @@ export function NewChatLandingScreen() {
                     }
                     if (e.key === "Escape") {
                       e.preventDefault();
-                      // Dismiss the menu by clearing the draft so the user can
-                      // start fresh.
-                      setMessage("");
+                      // A leading token IS the whole draft, so clearing it is the
+                      // fastest way back to an empty composer. Mid-draft, only
+                      // the menu closes — the sentence being written survives.
+                      if (slashToken === null || slashToken.leading) setMessage("");
+                      setSlashDismissed(true);
                       setSlashMenuIndex(-1);
                       return;
                     }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -184,7 +184,7 @@ import {
   CURSOR_NATIVE_DEFAULT_EXEC_MODE,
   CURSOR_NATIVE_EXEC_MODES,
 } from "@/lib/nativeHarnessModes";
-import { useHostModelOptions, useHosts, type Host } from "@/hooks/useHosts";
+import { useHostAgentSkills, useHostModelOptions, useHosts, type Host } from "@/hooks/useHosts";
 import {
   controlHost,
   getHostIdentity,
@@ -791,22 +791,21 @@ export function deriveRepoName(url: string): string | null {
 }
 
 /**
- * Match a first message against an agent's bundled skills.
+ * Match a first message against the skills the chosen agent can invoke.
  *
  * Uses the in-session composer's shared command-shape guard
  * (:func:`isSlashCommandText`): the first token must read as ``/name``
  * (file paths like ``/etc/hosts`` never match), while the args after it
  * may carry anything — including paths and URLs, e.g.
- * ``"/review-pr https://github.com/..."``. The command name must
- * exactly match a bundled skill. Anything else — including
- * host-discovered skills the server can't know before a runner boots —
- * is sent as plain text, the same fall-through the in-session composer
- * uses for unknown commands.
+ * ``"/review-pr https://github.com/..."``. The command name must exactly
+ * match one of *skills*. Anything else is sent as plain text, the same
+ * fall-through the in-session composer uses for unknown commands.
  *
  * @param text The sanitized first message, e.g. ``"/review-pr 123"``.
- * @param skills The chosen agent's bundled skills from GET /v1/agents.
+ * @param skills Skills the agent can resolve — bundled ones from
+ *   GET /v1/agents plus what the host discovered for it.
  * @returns The skill name and argument string, or ``null`` when the
- *   text is not an invocation of a bundled skill.
+ *   text is not an invocation of a known skill.
  */
 export function matchSkillInvocation(
   text: string,
@@ -3592,12 +3591,30 @@ export function NewChatLandingScreen() {
   // /model need a live session. Hidden for native-terminal agents (their CLI
   // owns slash commands) and for agents with no skills at all.
   const [slashMenuIndex, setSlashMenuIndex] = useState(-1);
+  // Skills the chosen host would add on top of the bundled ones —
+  // ~/.claude/skills, enabled Claude Code plugins, the workspace's own
+  // .claude/skills. Only the host can see those, so before this a user's own
+  // skill wasn't completable until a runner had bound and pushed a snapshot.
+  // A pending agent (an upload still being described) has no registered spec
+  // for the server to read a harness and filter from; a sandbox has no host to
+  // ask. Both leave the menu on bundled skills alone.
+  const skillsAgentId =
+    selectedAgent !== undefined && selectedAgent.id !== PENDING_AGENT_ID ? selectedAgent.id : null;
+  const { data: hostSkills } = useHostAgentSkills(
+    sandboxSelected ? null : selectedHostId,
+    skillsAgentId,
+    workspaceValid ? workspaceTrimmed : null,
+    !isNativeTerminalAgent && skillsAgentId !== null,
+  );
   const skillCommands = useMemo(() => {
     if (isNativeTerminalAgent) return {};
     const m: Record<string, string> = {};
     for (const s of selectedAgent?.skills ?? []) m[`/${s.name}`] = s.description;
+    // Host skills come after the bundled ones (the endpoint already drops
+    // names the bundle claims), so a bundled skill keeps its own description.
+    for (const s of hostSkills ?? []) m[`/${s.name}`] ??= s.description;
     return m;
-  }, [selectedAgent, isNativeTerminalAgent]);
+  }, [selectedAgent, isNativeTerminalAgent, hostSkills]);
   // Caret offset + dismissal, exactly as the in-session composer tracks them:
   // ``null`` reads the token at the end of the draft (a prefilled message the
   // user hasn't typed into yet), Escape/blur closes without editing the draft.
@@ -4356,16 +4373,17 @@ export function NewChatLandingScreen() {
       // loads from the session id and never reads the sidebar cache.
       void queryClient.refetchQueries({ queryKey: ["conversations"] });
       void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
-      // A first message matching one of the agent's bundled skills is
-      // handed off as a structured invocation so ChatPage auto-sends it
-      // as a `slash_command` event (server resolves the skill) instead
-      // of plain text the agent would see as a literal "/name". Native
+      // A first message matching one of the agent's skills is handed off as a
+      // structured invocation so ChatPage auto-sends it as a `slash_command`
+      // event (server resolves the skill) instead of plain text the agent
+      // would see as a literal "/name". Host-discovered skills count too —
+      // the menu offers them, so completing one has to invoke it. Native
       // terminal agents keep plain text — their CLI owns slash commands.
       setPendingInitialPrompt(data.id, {
         text: initialPrompt,
         skill: isNativeTerminalAgent
           ? null
-          : matchSkillInvocation(initialPrompt, agent?.skills ?? []),
+          : matchSkillInvocation(initialPrompt, [...(agent?.skills ?? []), ...(hostSkills ?? [])]),
         files,
       });
       // Scope the recall entry to the new session id so ArrowUp surfaces it in

--- a/web/src/shell/NewChatLandingScreen.mobileChrome.test.tsx
+++ b/web/src/shell/NewChatLandingScreen.mobileChrome.test.tsx
@@ -31,6 +31,9 @@ vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
 vi.mock("@/hooks/useHosts", () => ({
   useHosts: vi.fn(),
   useHostModelOptions: vi.fn(() => ({ data: [] })),
+  // The landing composer asks the chosen host for its own skills; an empty
+  // answer leaves the "/" menu on the agent's bundled skills.
+  useHostAgentSkills: vi.fn(() => ({ data: [] })),
   useInstallHarness: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
 }));


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Skill autocomplete in the web UI had two gaps that both left the user typing a
name from memory:

- **The `/` menu only opened on a draft that *started* with a slash** and
  carried no space, so a skill could be named only as the very first thing
  typed. Reaching for one mid-sentence ("please run /desl…"), or going back to
  fix a command name in a draft that already had args, got nothing. Both
  composers now read the token **at the caret** and rewrite only that token, so
  the words around it survive. A token typed mid-draft lists skills only and
  never executes — built-ins act on the session, which completing a word inside
  a sentence cannot do.
- **The new-chat composer hid the menu entirely for native terminal agents.**
  It returned an empty command map for Claude Code / Codex / Cursor / pi / agy,
  so with the default agent selected, typing `/` showed nothing at all. The
  in-session composer never gated on the harness, so the same session offered
  those skills the moment it opened — the landing screen was the one place a
  user's own skills were invisible. The original rationale (the vendor CLI owns
  slash commands) argues for not intercepting the *invocation*, not for hiding
  the *names*: a native agent's host-discovered skills are that CLI's own
  commands, and the first message reaches it as text. Submit routing is
  untouched — a native's first message still goes out as plaintext.
- **The new-chat composer knew only an agent's *bundled* skills.** The ones
  users actually reach for live on their machine (`~/.claude/skills`, enabled
  Claude Code plugins, `~/.codex/skills`, the workspace's own `.claude/skills`),
  and only the host can see those — so they weren't completable until a runner
  had bound and pushed a session snapshot. A new `host.skills` tunnel frame +
  `GET /v1/hosts/{id}/agents/{id}/skills` asks the chosen host for them, under
  the agent's own `skills:` filter. Completing one on the first message now
  routes as a `slash_command` (it invokes) rather than literal text.

### ELI5

Typing `/` used to only work as the first character of your message, and the
new-chat box only knew the skills that shipped inside the agent. Now `/` works
anywhere in what you're writing, and the new-chat box also offers your own
skills from your machine.

```
                     BEFORE                          AFTER
draft: "please run /desl"    no menu     "please run /desl"    menu → skills
draft: "/desl args"          no menu     "/desl| args"         menu (caret token)
new chat, "/"          bundled skills    "/"        bundled + host-discovered
new chat + Claude Code       no menu     "/"        its own CLI skills (75 here)

  new-chat "/" menu ──▶ GET /v1/hosts/{id}/agents/{id}/skills?path=<workspace>
                             │  server: reads the agent's harness + skills: filter
                             ▼
                        host.skills frame ──▶ host: resolve_harness_skills()
                             │                  ~/.claude/skills, plugins,
                             ▼                  <workspace>/.claude/skills
                        host.skills_result ──▶ server drops bundled names
```

## Test Plan

Automated (all green locally):

- `web/src/lib/composerSlash.test.ts` — new: token detection at the caret
  (mid-sentence, after a newline, path/prose rejection, namespaced names) and
  splicing.
- `web/src/pages/ChatPage.composer.test.tsx` — new `Composer mid-draft skill
  completion` block (10 tests). 7 of them fail against the pre-change ChatPage;
  the other 3 are guards.
- `web/src/shell/NewChatDialog.test.tsx` — mid-draft open/complete, Escape
  keeps the draft, host skills merged into the menu, request scoping.
- `web/src/shell/NewChatDialog.flow.test.tsx` — a host-discovered skill on the
  first message routes as a `slash_command`, not plain text (fails without the
  submit-path merge).
- `web/src/hooks/useHosts.test.tsx` — the new hook's URL, `?path=` encoding,
  disabled cases, and a server that omits the field.
- `tests/host/test_frames.py` / `tests/host/test_connect.py` — frame round-trip
  and malformed-filter rejection; host-side discovery of workspace + home
  scope, `skills: none` / named-filter behavior, and a crash still replying a
  failed frame so the server's future can't hang.
- `tests/server/integration/test_hosts_skills.py` — new (9 tests): the route
  end-to-end over a real tunnel, bundled-name dedupe, harness/filter/path
  passthrough, 404/409/502 paths, and an unloadable spec degrading rather than
  erroring.
- `tests/e2e_ui/chat/test_skill_autocomplete.py` — new (4 tests, real browser):
  mid-draft completion in both composers, a host-only skill offered and completed
  in the new-chat menu, and a `claude-native` agent's skills offered there too.
  The first 3 fail against the pre-change composers
  (`Locator expected to be visible … element(s) not found` — no menu row
  appears); the two pre-existing `test_slash_command_menu_matching.py` tests
  still pass, so the leading-slash behavior is unchanged.

Full suites run on the rebased branch: `pnpm vitest run` (6420 passed),
`pnpm type-check`,
`pnpm lint`, `pre-commit` (only pre-existing pyrefly `opentelemetry.sdk`
missing-import errors in `omnigent/runtime/telemetry.py`, a local venv gap),
`pytest tests/host tests/server/integration`.

Manual check for a reviewer (not run here — this branch was verified by the
suites above, which include the browser-driven e2e UI tests):

1. `just dev`, open the web UI.
2. In the new-chat box pick a non-native agent (e.g. a `claude-sdk` one) and a
   host, then type `/` — your own `~/.claude/skills` entries and enabled Claude
   Code plugin skills now appear under **Skills**, not just the agent's bundled
   ones. Tab-complete one and send it: it runs as a skill invocation.
3. In an open session, type `please run /` mid-sentence — the menu opens on that
   token and lists skills only. Tab completes it in place, leaving
   `please run /<skill> ` with the rest of your sentence intact.
4. Type `look at /etc/hosts` and `deslop and/or simplify` — no menu (paths and
   prose stay closed).
5. With the menu open mid-sentence, press Escape — the menu closes and your
   draft survives. On a draft that is only `/foo`, Escape still clears it.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The change is a menu trigger plus extra rows in the existing `/` menu. Evidence
is the browser-driven e2e UI suite (`tests/e2e_ui/chat/test_skill_autocomplete.py`),
which drives the real SPA and asserts the rendered menu and the resulting draft
text — including the before/after proof that all 3 tests fail on the pre-change
composers:

```
$ pytest tests/e2e_ui/chat/test_skill_autocomplete.py   # pre-change composers
E  AssertionError: Locator expected to be visible
E  Actual value: - complementary "Conversations":
E  Error: element(s) not found
3 failed in 55.83s

$ pytest tests/e2e_ui/chat/test_skill_autocomplete.py \
    tests/e2e_ui/chat/test_slash_command_menu_matching.py   # this branch
5 passed in 19.93s
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The prove-it-fails discipline was applied to both behavioral halves: the
mid-draft ChatPage tests were re-run against the pre-change file (7 failed), and
the first-message routing test against the pre-change submit path (failed).

The lifted native gate was checked against a live local stack, not only in
tests: `GET /v1/hosts/{id}/agents/{id}/skills` returns 75 skills for the Claude
Code agent on this repo (including plugin-namespaced ones like
`/dev-productivity:debug-ci`), none of which the new-chat menu could offer
before. The test that pinned the old suppression was rewritten to assert the new
behavior rather than deleted.

One gap worth naming: no test drives the *whole* host-skills path against a real
`omnigent host` process. It is covered in two halves instead — the route over a
real tunnel with a fake host (`test_hosts_skills.py`) and the host's own
discovery against real `SKILL.md` files on disk (`test_connect.py`) — with the
e2e UI test stubbing the endpoint to pin the menu. The manual steps above close
that seam if a reviewer wants to see it live.

## Changelog

Skills autocomplete from a `/` anywhere in your message, and the new-chat
composer now offers the skills on your own machine — including for Claude Code
and the other terminal agents, which previously showed no menu there at all.

## Issues

Closes #6280
Resolves [OMNI-6052](https://linear.app/omnigent/issue/OMNI-6052/web-composer-slash-command-menu-is-missing-host-discovered-skills)
