### PR TITLE
fix(codex-native): ignore housekeeping thread rotations

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -2014,11 +2014,9 @@ async def _maybe_rotate_session_on_thread_started(
     # its own Omnigent child session by ``_handle_event``.
     if _thread_started_is_subagent(event):
         return False
-    # Codex CLI 0.150.1 emits a second ``thread/started`` mid-turn for an
-    # internal system/housekeeping thread (``ephemeral=true``, ``path=null``).
-    # That thread is never persistable and cannot host goals; rotating onto it
-    # strands the real turn's output as stale. Ignore all ephemeral threads.
-    if _thread_started_is_ephemeral(event):
+    # Codex emits non-user housekeeping threads during startup and mid-turn.
+    # They cannot host the session and must never be treated as ``/clear``.
+    if _thread_started_is_housekeeping(event):
         return False
     old_delta_coalescer = target.delta_coalescer
     await old_delta_coalescer.flush()
@@ -7003,6 +7001,28 @@ def _thread_started_is_ephemeral(event: CodexMessage) -> bool:
     if not isinstance(thread, dict):
         return False
     return thread.get("ephemeral") is True
+
+
+def _thread_started_is_housekeeping(event: CodexMessage) -> bool:
+    """Return whether ``thread/started`` announces an internal Codex thread.
+
+    Codex 0.150 marks mid-turn housekeeping threads as ephemeral. Codex 0.151
+    also labels startup title-generation threads with ``threadSource=system``.
+    Neither represents a user ``/clear`` and neither may own the Omnigent
+    session.
+
+    :param event: Codex app-server notification envelope.
+    :returns: ``True`` for an ephemeral or system-owned started thread.
+    """
+    if _thread_started_is_ephemeral(event):
+        return True
+    if event.get("method") != "thread/started":
+        return False
+    params = event.get("params")
+    if not isinstance(params, dict):
+        return False
+    thread = params.get("thread")
+    return isinstance(thread, dict) and thread.get("threadSource") == "system"
 
 
 async def wait_for_thread_started(

--- a/tests/e2e/test_codex_ephemeral_thread_rotation_e2e.py
+++ b/tests/e2e/test_codex_ephemeral_thread_rotation_e2e.py
@@ -327,3 +327,19 @@ async def test_rotation_preserves_workspace_cwd(tmp_path: Path) -> None:
     assert state is not None
     assert state.thread_id == "0195dddd-real-clear-thread"
     assert state.cwd == workspace
+
+
+async def test_system_title_thread_does_not_rotate_without_ephemeral_flag(tmp_path: Path) -> None:
+    """Codex startup title generation is internal even if its flag changes."""
+    ap = _RecordingAP()
+    bridge_dir = _seed_bridge(tmp_path)
+    target = _make_target(ap)
+    thread = _ephemeral_system_thread()
+    thread["ephemeral"] = False
+
+    rotated = await _rotate(ap, target, bridge_dir, _thread_started(thread))
+
+    assert rotated is False
+    assert ap.created_sessions() == []
+    assert target.session_id == PARENT_SESSION
+    assert target.thread_id == PARENT_THREAD

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -3297,3 +3297,52 @@ def test_thread_started_is_ephemeral_false_for_missing_thread() -> None:
     """Event with params but no thread is not ephemeral."""
     event = {"method": "thread/started", "params": {}}
     assert fwd._thread_started_is_ephemeral(event) is False
+
+
+_CODEX_0151_STARTUP_TITLE_THREAD = {
+    "id": "01a051a0-e5dc-79e3-bdd3-cceeda4b6a16",
+    "ephemeral": True,
+    "historyMode": "legacy",
+    "path": None,
+    "cliVersion": "0.151.0",
+    "source": "vscode",
+    "threadSource": "system",
+    "status": {"type": "idle"},
+    "turns": [],
+}
+
+
+def test_housekeeping_true_for_captured_codex_0151_startup_thread() -> None:
+    """The captured startup title thread cannot rotate the user session."""
+    assert fwd._thread_started_is_housekeeping(
+        _make_thread_started(dict(_CODEX_0151_STARTUP_TITLE_THREAD))
+    )
+
+
+def test_housekeeping_true_for_system_thread_without_ephemeral_marker() -> None:
+    """The system ownership marker remains sufficient if Codex changes flags."""
+    thread = dict(_CODEX_0151_STARTUP_TITLE_THREAD)
+    thread["ephemeral"] = False
+    assert fwd._thread_started_is_housekeeping(_make_thread_started(thread))
+
+
+def test_housekeeping_false_for_real_user_thread() -> None:
+    """A persistent user thread still represents a genuine ``/clear``."""
+    event = _make_thread_started(
+        {
+            "id": "01a051a0-ddda-78c0-a62c-71af8c6ae60d",
+            "ephemeral": False,
+            "path": "/sessions/rollout-user.jsonl",
+            "threadSource": "user",
+        }
+    )
+    assert fwd._thread_started_is_housekeeping(event) is False
+
+
+def test_housekeeping_false_for_non_started_event() -> None:
+    """Only thread-start notifications participate in rotation filtering."""
+    event = {
+        "method": "thread/updated",
+        "params": {"thread": {"id": "system", "threadSource": "system"}},
+    }
+    assert fwd._thread_started_is_housekeeping(event) is False


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Recognize Codex startup/title housekeeping threads by their event semantics instead of relying only on the ephemeral flag.
- Ignore those housekeeping rotations so they do not replace the real active thread or create ghost sessions.
- Preserve genuine user-driven thread rotation and cover both paths with focused forwarder and end-to-end regressions.

**ELI5:** Codex creates tiny internal threads while starting up and naming work. The forwarder now ignores those bookkeeping threads but still follows real conversation changes.

```text
thread/started -> housekeeping event? -- yes --> ignore rotation
                         |
                         no
                         v
                  rotate active thread
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- Focused handoff run on the final Codex rotation stack covered the 5 cases belonging to this PR: four forwarder housekeeping/real-thread unit cases and `tests/e2e/test_codex_native_session_lifecycle.py::test_system_title_thread_does_not_rotate_without_ephemeral_flag`; all 5 passed.
- The combined Codex rotation run reported all 11 selected cases passed before the local sandbox blocked only the global leaked-process teardown reaper (`psutil` process enumeration), so the pytest process itself exited nonzero after the test results.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No visual artifact is attached: this changes Codex-native event routing. Focused forwarder and lifecycle evidence is in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

The focused cases distinguish startup/title housekeeping threads from genuine user and non-startup rotations. No manual verification is claimed; the teardown limitation is recorded in the Test Plan.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Codex startup housekeeping threads no longer create ghost replacement sessions.
