### PR TITLE
fix(compaction): surface harness-owned compaction failures

### DIFF
--- a/omnigent/inner/executor.py
+++ b/omnigent/inner/executor.py
@@ -239,6 +239,15 @@ class CompactionStarted(ExecutorEvent):
 
 
 @dataclass
+class CompactionFailed(ExecutorEvent):
+    """The harness attempted to compact its context but could not.
+
+    The current turn may still complete successfully. Clients use this event
+    to clear compaction progress and expose the failed recovery attempt.
+    """
+
+
+@dataclass
 class CompactionComplete(ExecutorEvent):
     """The harness compacted its internal context.
 

--- a/omnigent/inner/openai_agents_sdk_executor.py
+++ b/omnigent/inner/openai_agents_sdk_executor.py
@@ -680,6 +680,9 @@ class _AgentsSessionState:
     :param rollback_to_item_count: When non-``None``, the next
         ``run_turn`` rewinds the SDK session to this length
         before starting. Set by :meth:`interrupt_session`.
+    :param compaction_failed: Set when the SDK's harness-owned compaction
+        request fails. The next executor event drain publishes a terminal
+        compaction-failed event and clears this flag.
     """
 
     sdk_session: _SDKSession
@@ -694,6 +697,7 @@ class _AgentsSessionState:
     history_cursor: int = 0
     run_item_count_before: int | None = None
     rollback_to_item_count: int | None = None
+    compaction_failed: bool = False
 
 
 # ``_sanitize_replay_item`` walks replay values recursively. At the
@@ -1147,7 +1151,7 @@ class OpenAIAgentsSDKExecutor(Executor):
             return state
 
         underlying = _SanitizingSession(agents_sdk.SQLiteSession(session_key))
-        sdk_session: _SDKSession = underlying
+        state = _AgentsSessionState(sdk_session=underlying)
         # Wrap with compaction session when the client targets a real
         # HTTP endpoint. Skip for bare object() clients in unit tests
         # that lack base_url.
@@ -1175,13 +1179,14 @@ class OpenAIAgentsSDKExecutor(Executor):
                         try:
                             await super().run_compaction(args)
                         except Exception:  # noqa: BLE001
-                            logger.debug(
+                            state.compaction_failed = True
+                            logger.warning(
                                 "Compaction call failed (endpoint may not support "
                                 "responses.compact), continuing without compaction",
                                 exc_info=True,
                             )
 
-                sdk_session = cast(
+                state.sdk_session = cast(
                     _SDKSession,
                     _SafeCompactionSession(
                         session_id=session_key,
@@ -1194,7 +1199,6 @@ class OpenAIAgentsSDKExecutor(Executor):
                     "Compaction session setup failed, falling back to plain session: %s",
                     exc,
                 )
-        state = _AgentsSessionState(sdk_session=sdk_session)
         self._session_states[session_key] = state
         return state
 
@@ -1883,6 +1887,12 @@ class OpenAIAgentsSDKExecutor(Executor):
                 if cached_tok:
                     turn_usage["cache_read_input_tokens"] = cached_tok
         _notify_usage_from_dict(model=model, usage=turn_usage)
+
+        if state.compaction_failed:
+            from omnigent.inner.executor import CompactionFailed
+
+            state.compaction_failed = False
+            yield CompactionFailed()
 
         # Emit CompactionComplete if the SDK compacted this turn.
         if result is not None:

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -24,6 +24,7 @@ from fastapi import Response
 from omnigent.errors import ElicitationDeclinedError
 from omnigent.inner.executor import (
     CompactionComplete,
+    CompactionFailed,
     CompactionStarted,
     Executor,
     ExecutorConfig,
@@ -826,6 +827,14 @@ class ExecutorAdapter(HarnessApp):
             ctx.emit(
                 CompactionInProgressEvent(
                     type="response.compaction.in_progress",
+                )
+            )
+        elif isinstance(event, CompactionFailed):
+            from omnigent.server.schemas import CompactionFailedEvent
+
+            ctx.emit(
+                CompactionFailedEvent(
+                    type="response.compaction.failed",
                 )
             )
         elif isinstance(event, CompactionComplete):

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -2405,8 +2405,7 @@ def _prepare_messages(
     Build system instructions and Responses API input items.
 
     Resolves content references and counts system token budget.
-    Extracted from ``_call_llm_maybe_compact`` for reuse by the
-    executor path.
+    Shared by the executor and explicit compaction paths.
 
     :param spec: The parsed AgentSpec.
     :param llm_config: LLM configuration.

--- a/omnigent/spec/types.py
+++ b/omnigent/spec/types.py
@@ -647,14 +647,15 @@ class CompactionConfig:
     """
     Context compaction configuration.
 
-    Controls when the agent compacts its conversation history to
-    stay within the LLM's context window. Compaction is layered:
+    Controls server-side compaction of persisted conversation history.
+    Stateful harnesses own automatic compaction of their live context;
+    this configuration applies to the explicit server compaction path.
+    Compaction is layered:
     (1) clear tool result bodies, (2) LLM summarization, (3)
     truncation as emergency fallback.
 
-    :param trigger_threshold: Fraction of the model's context window
-        at which proactive compaction fires, e.g. ``0.8`` means fire
-        at 80% of the window.
+    :param trigger_threshold: Fraction of the model's context window used
+        to calculate the explicit compaction target budget, e.g. ``0.8``.
     :param recent_window: Number of recent LLM iterations to protect
         from compaction. Items within this window are never cleared or
         summarized — the agent always has verbatim access to its most

--- a/tests/inner/test_openai_agents_sdk_executor.py
+++ b/tests/inner/test_openai_agents_sdk_executor.py
@@ -7,6 +7,7 @@ import types
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -3183,5 +3184,67 @@ def test_no_compaction_item_no_compaction_event() -> None:
 
         compaction_events = [e for e in events if isinstance(e, CompactionComplete)]
         assert len(compaction_events) == 0
+
+    _run(_t())
+
+
+def test_compaction_failure_is_observable_and_non_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A rejected responses.compact call is surfaced without killing the turn."""
+    from agents.memory import OpenAIResponsesCompactionSession
+
+    from omnigent.inner.executor import CompactionFailed
+
+    async def _fail_compaction(self: object, args: object = None) -> None:
+        del self, args
+        raise RuntimeError("responses.compact unavailable")
+
+    monkeypatch.setattr(
+        OpenAIResponsesCompactionSession,
+        "run_compaction",
+        _fail_compaction,
+    )
+
+    async def _t() -> None:
+        executor = OpenAIAgentsSDKExecutor(
+            client=SimpleNamespace(base_url="https://gateway.example/v1")
+        )
+        sdk = _fake_agents_sdk()
+        state = executor._get_or_create_session_state(sdk, "s_compact_fail")
+
+        with caplog.at_level("WARNING"):
+            await state.sdk_session.run_compaction()
+
+        assert state.compaction_failed
+        assert "continuing without compaction" in caplog.text
+
+        _FakeRunner.next_result = _FakeResult(
+            events=[],
+            final_output="turn still completed",
+            raw_responses=[_nonempty_raw_response()],
+        )
+        with patch(
+            "omnigent.inner.openai_agents_sdk_executor._ensure_agents_sdk",
+            return_value=sdk,
+        ):
+            events = await _collect(
+                executor.run_turn(
+                    [
+                        {
+                            "role": "user",
+                            "content": "hi",
+                            "session_id": "s_compact_fail",
+                        }
+                    ],
+                    [],
+                    "Be helpful.",
+                )
+            )
+
+        assert len([event for event in events if isinstance(event, CompactionFailed)]) == 1
+        assert len([event for event in events if isinstance(event, TurnComplete)]) == 1
+        assert not state.compaction_failed
 
     _run(_t())

--- a/tests/runtime/harnesses/test_executor_adapter.py
+++ b/tests/runtime/harnesses/test_executor_adapter.py
@@ -1048,6 +1048,20 @@ class _RecordingTurnContext:
         self.emitted.append(event)
 
 
+def test_translate_compaction_failed_emits_terminal_sse() -> None:
+    """Harness compaction failures reach clients as the existing failed event."""
+    from omnigent.inner.executor import CompactionFailed
+    from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+    adapter = ExecutorAdapter(executor_factory=lambda: _StubExecutor())
+    ctx = _RecordingTurnContext()
+
+    adapter._translate_event(CompactionFailed(), ctx)  # type: ignore[arg-type]
+
+    assert len(ctx.emitted) == 1
+    assert ctx.emitted[0].type == "response.compaction.failed"
+
+
 def test_translate_event_mcp_tool_call_request_emits_observed_with_bare_name() -> None:
     """
     A ``ToolCallRequest`` carrying an MCP-prefixed name emits


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Surface OpenAI Agents SDK compaction rejections as the existing `response.compaction.failed` event instead of silently logging them at debug level.
- Preserve the current turn: the failure is recorded on session state, drained once, and translated by the executor adapter without turning a recoverable compaction failure into a failed response.
- Update stale workflow/spec documentation that still described runner-owned compaction.

ELI5: if the provider cannot compact a long conversation, Omnigent now tells the client what happened instead of quietly disabling recovery.

```text
SDK compaction rejection
        -> session records failure
        -> CompactionFailed executor event
        -> response.compaction.failed SSE event
        -> current turn continues
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- `python -m pytest -q tests/inner/test_openai_agents_sdk_executor.py tests/runtime/harnesses/test_executor_adapter.py` — 133 tests and 2 subtests passed.
- Ruff format and lint checks passed for all seven changed Python files.
- Scoped Pyrefly passed for the five changed production Python files with the project Python 3.12 interpreter.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The focused regression tests verify that an SDK compaction rejection produces one observable failure event and remains non-fatal to the turn.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

The added regression covers recording, draining, adapter translation, and the non-fatal turn behavior; the existing executor suites cover adjacent event handling.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Compaction failures are now reported instead of silently disabling long-session recovery.
