### PR TITLE
fix(kimi): confirm interrupts actually stop the process

### DIFF
--- a/omnigent/inner/kimi_executor.py
+++ b/omnigent/inner/kimi_executor.py
@@ -85,6 +85,10 @@ from omnigent.inner.executor import (
 
 _logger = logging.getLogger(__name__)
 
+# Keep both grace periods inside the adapter's interrupt slice so reap still runs.
+_INTERRUPT_TERM_GRACE_S = 1.5
+_INTERRUPT_KILL_GRACE_S = 0.5
+
 # Per-line cap for the stdout StreamReader. Kimi emits whole messages (not
 # deltas), so a single JSONL line can be large; 16 MiB keeps a big file-read
 # tool result or long assistant message from overrunning asyncio's 64 KiB
@@ -565,20 +569,40 @@ class KimiExecutor(Executor):
         """
         self._session_id = None
 
-    async def interrupt_session(self, session_key: str) -> bool:  # noqa: ARG002 — best-effort process terminate
-        """Terminate the active kimi process, if any.
+    async def interrupt_session(self, session_key: str) -> bool:  # noqa: ARG002 — per-turn subprocess model
+        """Stop the active kimi process, and confirm that it stopped.
 
-        Returns True when a process was actually signalled. The next
-        ``run_turn`` will start a fresh process (and a fresh ``-S``
-        resume if the cached id is still valid).
+        Signalling is not stopping: a process that ignores ``SIGTERM`` keeps
+        producing the turn while its stream reader waits for more output, so
+        reporting success on the signal alone would claim a cancellation that
+        never happened. This waits for the exit, escalates to ``SIGKILL``, and
+        returns whether the process is actually gone. The whole sequence fits
+        inside the adapter's interrupt budget (``_INTERRUPT_SLICE_S``).
+
+        :param session_key: Inner session key (unused — the per-turn
+            subprocess model keeps one active process per executor).
+        :returns: ``True`` when no process is running any more, ``False`` when
+            one survived even the kill, so the caller can surface an
+            unconfirmed interrupt instead of a false idle.
         """
         process = self._active_process
         if process is None or process.returncode is not None:
             return False
         with contextlib.suppress(ProcessLookupError):
             process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_INTERRUPT_TERM_GRACE_S)
             return True
-        return False
+        except asyncio.TimeoutError:
+            _logger.warning("kimi executor: process ignored SIGTERM; escalating to SIGKILL")
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_INTERRUPT_KILL_GRACE_S)
+        except asyncio.TimeoutError:
+            _logger.error("kimi executor: process survived SIGKILL; interrupt unconfirmed")
+            return False
+        return True
 
     async def enqueue_session_message(
         self,

--- a/tests/inner/test_kimi_harness.py
+++ b/tests/inner/test_kimi_harness.py
@@ -815,3 +815,93 @@ def test_run_turn_warns_once_when_tools_declared(
 
     warnings = [rec for rec in caplog.records if "tool-injection bridge" in rec.message]
     assert len(warnings) == 1, "should warn exactly once across both turns"
+
+
+# ---------------------------------------------------------------------------
+# Interrupt: signalling is not stopping
+# ---------------------------------------------------------------------------
+
+
+class _InterruptibleProcess:
+    """A subprocess stub whose exit can be withheld, like a wedged CLI."""
+
+    def __init__(self, *, exits_on: str | None) -> None:
+        self._exits_on = exits_on
+        self.returncode: int | None = None
+        self.signals: list[str] = []
+        self._exited = asyncio.Event()
+
+    def terminate(self) -> None:
+        self.signals.append("SIGTERM")
+        if self._exits_on == "SIGTERM":
+            self.returncode = -15
+            self._exited.set()
+
+    def kill(self) -> None:
+        self.signals.append("SIGKILL")
+        if self._exits_on == "SIGKILL":
+            self.returncode = -9
+            self._exited.set()
+
+    async def wait(self) -> int | None:
+        await self._exited.wait()
+        return self.returncode
+
+
+def _interrupt(process: _InterruptibleProcess) -> bool:
+    ex = KimiExecutor(binary_path="kimi")
+    ex._active_process = process  # type: ignore[assignment]
+    return asyncio.run(ex.interrupt_session("s1"))
+
+
+def test_interrupt_confirms_the_process_actually_exited() -> None:
+    process = _InterruptibleProcess(exits_on="SIGTERM")
+
+    assert _interrupt(process) is True
+    assert process.signals == ["SIGTERM"]
+
+
+def test_interrupt_escalates_to_kill_when_sigterm_is_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A process that ignores SIGTERM keeps producing the turn; without the
+    # escalation the interrupt would report success while the work continued.
+    monkeypatch.setattr(kimi_executor, "_INTERRUPT_TERM_GRACE_S", 0.01)
+    process = _InterruptibleProcess(exits_on="SIGKILL")
+
+    assert _interrupt(process) is True
+    assert process.signals == ["SIGTERM", "SIGKILL"]
+
+
+def test_interrupt_reports_failure_when_the_process_survives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No fake cancellation: an unkillable process must not read as stopped.
+    monkeypatch.setattr(kimi_executor, "_INTERRUPT_TERM_GRACE_S", 0.01)
+    monkeypatch.setattr(kimi_executor, "_INTERRUPT_KILL_GRACE_S", 0.01)
+    process = _InterruptibleProcess(exits_on=None)
+
+    assert _interrupt(process) is False
+    assert process.signals == ["SIGTERM", "SIGKILL"]
+
+
+def test_interrupt_without_a_running_process_is_a_no_op() -> None:
+    ex = KimiExecutor(binary_path="kimi")
+
+    assert asyncio.run(ex.interrupt_session("s1")) is False
+
+    finished = _InterruptibleProcess(exits_on=None)
+    finished.returncode = 0
+    ex._active_process = finished  # type: ignore[assignment]
+    assert asyncio.run(ex.interrupt_session("s1")) is False
+    assert finished.signals == []
+
+
+def test_the_escalation_fits_the_adapter_interrupt_budget() -> None:
+    # The adapter gives an interrupt _INTERRUPT_SLICE_S before it moves on to
+    # the reap; an escalation that outlived that budget would be cut off
+    # mid-way and leave the process running.
+    from omnigent.runtime.harnesses._executor_adapter import _INTERRUPT_SLICE_S
+
+    total = kimi_executor._INTERRUPT_TERM_GRACE_S + kimi_executor._INTERRUPT_KILL_GRACE_S
+    assert total < _INTERRUPT_SLICE_S


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Make Kimi interruption report success only after the child process has actually exited.
- Wait after `SIGTERM`, escalate to `SIGKILL` when necessary, and return `false` if the process survives both bounded waits.
- Pin the escalation budget below the executor adapter's interrupt slice so future timeout changes cannot silently truncate cleanup.

ELI5: pressing stop now waits to confirm Kimi stopped; if it ignores the polite request, Omnigent force-stops it and reports failure if even that does not work.

```text
SIGTERM -> wait 1.5s -> exited? yes -> success
                         no
                         -> SIGKILL -> wait 0.5s -> exited? success : failure
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- `python -m pytest -q tests/inner/test_kimi_harness.py` — 62 tests passed.
- Ruff format and lint checks passed for both changed Python files.
- Scoped Pyrefly passed for `omnigent/inner/kimi_executor.py` with the project Python 3.12 interpreter.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The focused suite covers normal exit, ignored `SIGTERM`, `SIGKILL` escalation, surviving processes, and the adapter timeout-budget relationship.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

Process exit and escalation behavior is deterministic under mocked process handles; the existing Kimi harness tests cover the surrounding lifecycle.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Stopping a Kimi session now confirms that its process actually exited.
