### PR TITLE
fix: make interrupt completion authoritative

### DIFF
--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -852,7 +852,6 @@ def register_events_routes(
             return wake_conv, _client
 
         if body.type == _INTERRUPT_TYPE:
-            _publish_interrupted(session_id)
             # Fence the cancelled turn (see _interrupt_fenced_sessions).
             _interrupt_fenced_sessions.add(session_id)
             runner_client = await _get_runner_client(
@@ -878,6 +877,11 @@ def register_events_routes(
                 # The turn keeps running and nothing else lifts the fence —
                 # remove it so the turn's remaining output isn't dropped.
                 _interrupt_fenced_sessions.discard(session_id)
+                raise OmnigentError(
+                    f"Could not interrupt session {session_id!r}: no runner confirmed delivery.",
+                    code=ErrorCode.RUNNER_UNAVAILABLE,
+                )
+            _publish_interrupted(session_id)
             return {"queued": False}
         if body.type == _STOP_SESSION_TYPE:
             # Terminating the whole session (not just the current turn)

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4747,18 +4747,13 @@ async def test_post_interrupt_without_data_field_is_accepted(
         f"/v1/sessions/{session['id']}/events",
         json={"type": "interrupt"},
     )
-    # 202 (not 422) proves ``data`` defaults to ``{}`` at the schema
-    # layer; a 422 here means the pydantic default regressed and every
-    # deployed bare-control client breaks again.
-    assert resp.status_code == 202, resp.text
-    assert resp.json() == {"queued": False}
-    # The interrupt actually took effect (not just validated): the
-    # route published the cancellation signal for the web turn.
+    # A runner is not bound in this schema test. 503 (rather than 422) proves
+    # ``data`` defaulted to ``{}`` and routing reached delivery handling.
+    assert resp.status_code == 503, resp.text
+    # No runner is bound in this schema test, so the request is accepted but
+    # must not publish a terminal cancellation signal that did not land.
     interrupted = [e for _sid, e in published if e.get("type") == "session.interrupted"]
-    assert len(interrupted) == 1, (
-        f"expected one session.interrupted publish for a bare interrupt "
-        f"event, got types {[e.get('type') for _sid, e in published]!r}"
-    )
+    assert interrupted == []
 
 
 async def test_post_external_output_text_delta_carries_streaming_identifiers(
@@ -8180,17 +8175,11 @@ async def test_interrupt_on_claude_native_session_skips_idle_publish_on_runner_f
 ) -> None:
     """
     If the runner couldn't deliver the Escape (e.g. tmux pane gone),
-    Omnigent must NOT lie to the UI by publishing idle. The spinner spins
-    is the right signal — it tells the user the cancel didn't land.
+    Omnigent must not publish terminal interruption or idle state when the
+    runner rejected the request.
 
-    After the interrupt-unification refactor the Omnigent side no longer
-    publishes ``session.status: idle`` itself at all. Idle on a
-    claude-native interrupt now comes from the runner's PTY activity
-    watcher once the pane quiesces after the Escape (a failed Escape
-    naturally surfaces as "no idle" — the pane keeps changing). This
-    test acts as a regression guard against re-adding an AP-side idle
-    publish — if someone reintroduces the pre-refactor "publish idle on
-    2xx" logic, the 503 path here would start leaking idle.
+    The server publishes idle only after a runner 2xx confirms delivery. A
+    rejected Escape must return a retryable error and emit no terminal state.
     """
     from omnigent.runtime import session_stream, set_runner_client
 
@@ -8229,17 +8218,14 @@ async def test_interrupt_on_claude_native_session_skips_idle_publish_on_runner_f
             f"/v1/sessions/{session['id']}/events",
             json={"type": "interrupt", "data": {}},
         )
-        assert resp.status_code == 202, resp.text
+        assert resp.status_code == 503, resp.text
     finally:
         await fake_runner.aclose()
         set_runner_client(None)
 
-    # interrupted still fires (the UI marks the bubble cancelled);
-    # idle does not (the Escape didn't land).
+    # Neither terminal signal fires because the Escape did not land.
     interrupted = [e for e in published if e.get("type") == "session.interrupted"]
-    assert interrupted, (
-        f"session.interrupted should still publish on runner failure; got {published!r}"
-    )
+    assert not interrupted, f"failed interrupt must not publish completion; got {published!r}"
     idle_status = [
         e for e in published if e.get("type") == "session.status" and e.get("status") == "idle"
     ]
@@ -8598,9 +8584,7 @@ async def test_interrupt_forward_failure_lifts_stop_fence(
             f"/v1/sessions/{session_id}/events",
             json={"type": "interrupt", "data": {}},
         )
-        # Interrupt is best-effort and still ACKs (the UI already marked the
-        # bubble interrupted); the fence removal below is the fix under test.
-        assert resp.status_code == 202, resp.text
+        assert resp.status_code == 503, resp.text
         assert session_id not in _interrupt_fenced_sessions, (
             "a failed interrupt forward must remove the fence it installed — "
             "leaving it set drops the rest of the still-running turn"

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -3688,7 +3688,7 @@ describe("chatStore — stop", () => {
     expect(controller.signal.aborted).toBe(false);
   });
 
-  it("clears local working state immediately while the interrupt ack is pending", () => {
+  it("keeps working state until a confirmed interruption event arrives", () => {
     useChatStore.setState({
       conversationId: "conv_abc",
       pendingUserMessages: [
@@ -3706,21 +3706,18 @@ describe("chatStore — stop", () => {
     useChatStore.getState().stop();
 
     const state = useChatStore.getState();
-    expect(state.pendingUserMessages).toEqual([]);
-    expect(state.status).toBe("idle");
-    expect(state.sessionStatus).toBe("idle");
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.status).toBe("streaming");
+    expect(state.sessionStatus).toBe("running");
     expect(state.activeResponse).toEqual({
       responseId: "resp_1",
-      state: "cancelled",
+      state: "streaming",
       error: null,
     });
-    expect(readConversationRows()[0]?.status).toBe("idle");
+    expect(readConversationRows()[0]?.status).toBe("running");
   });
 
-  it("leaves a non-streaming activeResponse untouched on stop", () => {
-    // Pins the `state === "streaming"` guard: stop() still clears the working
-    // state, but must NOT overwrite a non-streaming activeResponse (dropping the
-    // guard would clobber a completed response with a cancelled decoration).
+  it("does not mutate a non-streaming activeResponse before confirmation", () => {
     useChatStore.setState({
       conversationId: "conv_abc",
       pendingUserMessages: [
@@ -3735,16 +3732,35 @@ describe("chatStore — stop", () => {
     useChatStore.getState().stop();
 
     const state = useChatStore.getState();
-    expect(state.pendingUserMessages).toEqual([]);
-    expect(state.status).toBe("idle");
-    expect(state.sessionStatus).toBe("idle");
-    // Untouched — the guard skipped the cancelled overwrite.
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.status).toBe("streaming");
+    expect(state.sessionStatus).toBe("running");
     expect(state.activeResponse).toEqual({
       responseId: "resp_1",
       state: "completed",
       error: null,
     });
-    expect(readConversationRows()[0]?.status).toBe("idle");
+    expect(readConversationRows()[0]?.status).toBe("running");
+  });
+
+  it("surfaces a failed interrupt without hiding the running turn", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("runner did not confirm delivery"));
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      status: "streaming",
+      sessionStatus: "running",
+    });
+
+    useChatStore.getState().stop();
+    await tick();
+
+    const state = useChatStore.getState();
+    expect(state.status).toBe("streaming");
+    expect(state.sessionStatus).toBe("running");
+    expect(state.blocks.at(-1)).toMatchObject({
+      type: "error",
+      message: "Stop failed: runner did not confirm delivery",
+    });
   });
 
   it("no-op when no session is bound", () => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1914,50 +1914,14 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
   stop: () => {
     const sessionId = get().conversationId;
     if (!sessionId) return;
-    // Fire-and-forget interrupt; the server emits session.interrupted
-    // + response.incomplete on the open stream, which the pump
-    // translates into the cancelled bubble decoration. We deliberately
-    // do NOT abort the local SSE stream — it remains open across
-    // turns; switchTo or tab unload is the only thing that tears it
-    // down.
-    void interruptSession(sessionId).catch(() => {
-      // Interrupt is best-effort. A network failure here means the
-      // user's cancel won't reach the server, but the local UI already
-      // reflects the user's stop request below.
+    // Keep the local stream open and let the server's confirmed
+    // session.interrupted event settle the turn for every viewer.
+    void interruptSession(sessionId).catch((err) => {
+      const { message, code } = describeSendFailure(err);
+      setterFor(sessionId)((s) => ({
+        blocks: [...s.blocks, makeClientErrorBlock(`Stop failed: ${message}`, code)],
+      }));
     });
-    setActive((s) => {
-      if (s.conversationId !== sessionId) return {};
-      const patch: Partial<ChatState> = {
-        pendingUserMessages: [],
-        status: "idle",
-        sessionStatus: "idle",
-        backgroundTaskCount: 0,
-        backgroundTasks: [],
-        blockedOn: null,
-      };
-      if (s.activeResponse?.state === "streaming") {
-        patch.activeResponse = {
-          ...s.activeResponse,
-          state: "cancelled",
-          error: null,
-        };
-      }
-      return patch;
-    });
-    // Optimistic, unbacked write: unlike the session.status SSE caller, no
-    // server event backs this, so a poll that interleaves while the turn is
-    // genuinely still running may briefly revert the sidebar dot — the helper's
-    // "never fights the poller" contract doesn't hold here. Self-corrects on the
-    // real idle event.
-    patchConversationStatusInCache(sessionId, "idle");
-    // Mirror the session.status handler: a sub-agent's row lives in its parent's
-    // child-sessions list, not the sidebar, so refresh the rail in lockstep.
-    const snapshot = queryClient?.getQueryData<Session>(["session", sessionId]);
-    if (snapshot?.parentSessionId) {
-      queryClient?.invalidateQueries({
-        queryKey: childSessionsQueryKey(snapshot.parentSessionId),
-      });
-    }
   },
 
   switchTo: async (conversationId) => {


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Make runner delivery authoritative for interrupt completion: the server publishes the stopped state only after the interrupt reaches the runner, and releases the stop fence if forwarding fails.
- Keep the web client in its active state until it receives the authoritative interruption event, so a failed stop request cannot make a still-running turn appear idle.
- Add focused backend and store regressions for success and failure paths.

**ELI5:** Pressing Stop now asks the running process to stop and waits for its confirmation. If that request fails, the app no longer pretends the work already stopped.

```text
Stop click -> interrupt request -> runner confirms -> interruption event -> UI settles
                              \-> forwarding fails -> turn remains active
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- `cd web && node_modules/.bin/vitest run src/store/chatStore.test.ts -t "chatStore — stop"` — 5 passed, 373 skipped.
- Focused backend handoff run on the final cancellation stack covered these first-PR nodes (7 parameterized cases passed):
  - `tests/server/integration/test_sessions_endpoints.py::test_post_interrupt_without_data_field_is_accepted`
  - `tests/server/integration/test_sessions_endpoints.py::test_interrupt_on_claude_native_session_skips_idle_publish_on_runner_failure`
  - `tests/server/integration/test_sessions_endpoints.py::test_interrupt_forward_failure_lifts_stop_fence`
  - `tests/server/integration/test_sessions_endpoints.py::test_interrupt_forward_success_keeps_stop_fence`
- Pytest reported all selected cases passed before the local sandbox blocked only the global leaked-process teardown reaper (`psutil` process enumeration), so the pytest process itself exited nonzero after the test results.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No visual artifact is attached yet. Before marking this PR ready for review, add a short recording showing that a failed Stop leaves the turn visibly running and a successful Stop settles only after confirmation. The focused automated evidence is in the Test Plan but does not replace that UI demo.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

The focused tests cover the client state transition and server forwarding success/failure behavior. No manual verification is claimed; the teardown limitation is recorded in the Test Plan.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Stopping a session now remains visibly in progress until the runner confirms the interruption.
