### PR TITLE
fix(sessions): interrupt sub-agent descendants

### DIFF
--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -129,6 +129,7 @@ from omnigent.server.routes._sessions.helpers import (
     _background_task_delivery_status,
     _build_actor,
     _build_skill_slash_command_policy_body,
+    _collect_descendant_conversation_ids,
     _dispatch_skill_slash_command_to_runner,
     _evaluate_output_policy,
     _forward_session_change_to_runner,
@@ -224,6 +225,85 @@ _retry_recovery_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
     weakref.WeakValueDictionary()
 )
 _retry_recovery_tasks: dict[str, asyncio.Task[dict[str, bool | str]]] = {}
+
+
+async def _forward_interrupt(
+    session_id: str,
+    runner_router: RunnerRouter | None,
+) -> bool:
+    """Forward one interrupt and publish it only after confirmed delivery.
+
+    :param session_id: Session receiving the interrupt.
+    :param runner_router: Router used to resolve the session's runner.
+    :returns: Whether a runner accepted the interrupt.
+    """
+    _interrupt_fenced_sessions.add(session_id)
+    runner_client = await _get_runner_client(session_id, runner_router)
+    interrupt_delivered = False
+    if runner_client is not None:
+        try:
+            interrupt_resp = await runner_client.post(
+                f"/v1/sessions/{session_id}/events",
+                json={"type": "interrupt"},
+                timeout=5.0,
+            )
+            interrupt_delivered = interrupt_resp.status_code < 400
+        except (httpx.HTTPError, ConnectionError):
+            # WSTunnelTransport raises bare ConnectionError on tunnel close.
+            _logger.exception(
+                "Interrupt forward failed for %r",
+                session_id,
+            )
+    if not interrupt_delivered:
+        # The turn keeps running and nothing else lifts the fence — remove it
+        # so the turn's remaining output isn't dropped.
+        _interrupt_fenced_sessions.discard(session_id)
+    else:
+        _publish_interrupted(session_id)
+    return interrupt_delivered
+
+
+async def _interrupt_descendants(
+    session_id: str,
+    conversation_store: ConversationStore,
+    runner_router: RunnerRouter | None,
+) -> None:
+    """Best-effort interrupt every sub-agent below a session.
+
+    The parent interrupt is attempted before this function runs, which normally
+    prevents new children while the descendant snapshot is collected. If that
+    attempt failed, existing descendants are still interrupted best-effort.
+
+    :param session_id: Root session whose descendants should stop.
+    :param conversation_store: Store used to walk the sub-agent tree.
+    :param runner_router: Router used to resolve each descendant runner.
+    """
+    try:
+        descendant_ids = await _collect_descendant_conversation_ids(
+            conversation_store,
+            session_id,
+        )
+    except Exception:
+        _logger.exception(
+            "Could not enumerate sub-agent descendants while interrupting %r",
+            session_id,
+        )
+        return
+
+    async def _best_effort_interrupt(descendant_id: str) -> None:
+        try:
+            await _forward_interrupt(descendant_id, runner_router)
+        except Exception:
+            _interrupt_fenced_sessions.discard(descendant_id)
+            _logger.exception(
+                "Could not interrupt sub-agent descendant %r of %r",
+                descendant_id,
+                session_id,
+            )
+
+    await asyncio.gather(
+        *(_best_effort_interrupt(descendant_id) for descendant_id in descendant_ids)
+    )
 
 
 def _retry_recovery_lock(session_id: str) -> asyncio.Lock:
@@ -852,36 +932,17 @@ def register_events_routes(
             return wake_conv, _client
 
         if body.type == _INTERRUPT_TYPE:
-            # Fence the cancelled turn (see _interrupt_fenced_sessions).
-            _interrupt_fenced_sessions.add(session_id)
-            runner_client = await _get_runner_client(
+            interrupt_delivered = await _forward_interrupt(session_id, runner_router)
+            await _interrupt_descendants(
                 session_id,
+                conversation_store,
                 runner_router,
             )
-            interrupt_delivered = False
-            if runner_client is not None:
-                try:
-                    interrupt_resp = await runner_client.post(
-                        f"/v1/sessions/{session_id}/events",
-                        json={"type": "interrupt"},
-                        timeout=5.0,
-                    )
-                    interrupt_delivered = interrupt_resp.status_code < 400
-                except (httpx.HTTPError, ConnectionError):
-                    # WSTunnelTransport raises bare ConnectionError on tunnel close.
-                    _logger.exception(
-                        "Interrupt forward failed for %r",
-                        session_id,
-                    )
             if not interrupt_delivered:
-                # The turn keeps running and nothing else lifts the fence —
-                # remove it so the turn's remaining output isn't dropped.
-                _interrupt_fenced_sessions.discard(session_id)
                 raise OmnigentError(
                     f"Could not interrupt session {session_id!r}: no runner confirmed delivery.",
                     code=ErrorCode.RUNNER_UNAVAILABLE,
                 )
-            _publish_interrupted(session_id)
             return {"queued": False}
         if body.type == _STOP_SESSION_TYPE:
             # Terminating the whole session (not just the current turn)

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -852,7 +852,6 @@ def register_events_routes(
             return wake_conv, _client
 
         if body.type == _INTERRUPT_TYPE:
-            _publish_interrupted(session_id)
             # Fence the cancelled turn (see _interrupt_fenced_sessions).
             _interrupt_fenced_sessions.add(session_id)
             runner_client = await _get_runner_client(
@@ -878,6 +877,11 @@ def register_events_routes(
                 # The turn keeps running and nothing else lifts the fence —
                 # remove it so the turn's remaining output isn't dropped.
                 _interrupt_fenced_sessions.discard(session_id)
+                raise OmnigentError(
+                    f"Could not interrupt session {session_id!r}: no runner confirmed delivery.",
+                    code=ErrorCode.RUNNER_UNAVAILABLE,
+                )
+            _publish_interrupted(session_id)
             return {"queued": False}
         if body.type == _STOP_SESSION_TYPE:
             # Terminating the whole session (not just the current turn)

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4756,6 +4756,93 @@ async def test_post_interrupt_without_data_field_is_accepted(
     assert interrupted == []
 
 
+async def test_post_interrupt_reaches_nested_and_concurrently_spawned_subagents(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopping a parent interrupts its complete sub-agent tree.
+
+    The runner creates one last child while accepting the parent's interrupt,
+    exercising the spawn-vs-cancel race. Descendant discovery must happen after
+    the parent receives cancellation so that child is included alongside an
+    already-running child and grandchild.
+    """
+    from omnigent.server.routes.sessions import _interrupt_fenced_sessions, routes_events
+
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    store = SqlAlchemyConversationStore(db_uri)
+    child = store.create_conversation(
+        kind="sub_agent",
+        title="child",
+        parent_conversation_id=parent["id"],
+        agent_id=agent["id"],
+    )
+    grandchild = store.create_conversation(
+        kind="sub_agent",
+        title="grandchild",
+        parent_conversation_id=child.id,
+        agent_id=agent["id"],
+    )
+    forwarded: list[tuple[str, dict[str, Any]]] = []
+    late_child_id: str | None = None
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal late_child_id
+        target_id = request.url.path.split("/")[3]
+        forwarded.append((target_id, json.loads(request.content)))
+        if target_id == parent["id"] and late_child_id is None:
+            late_child_id = store.create_conversation(
+                kind="sub_agent",
+                title="late-child",
+                parent_conversation_id=parent["id"],
+                agent_id=agent["id"],
+            ).id
+        return httpx.Response(202)
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+
+    async def _fake_get_runner_client(
+        session_id: str,
+        runner_router: object,
+    ) -> httpx.AsyncClient | None:
+        del runner_router
+        # One unavailable direct child must not shield its running child or
+        # sibling from the subtree interrupt.
+        return None if session_id == child.id else fake_runner
+
+    published: list[str] = []
+    monkeypatch.setattr(routes_events, "_get_runner_client", _fake_get_runner_client)
+    monkeypatch.setattr(
+        routes_events,
+        "_publish_interrupted",
+        lambda session_id, response_id=None: published.append(session_id),
+    )
+    try:
+        response = await client.post(
+            f"/v1/sessions/{parent['id']}/events",
+            json={"type": "interrupt", "data": {}},
+        )
+        assert response.status_code == 202, response.text
+        assert late_child_id is not None
+        expected_ids = {parent["id"], child.id, grandchild.id, late_child_id}
+        delivered_ids = expected_ids - {child.id}
+        assert {session_id for session_id, _body in forwarded} == delivered_ids
+        assert set(published) == delivered_ids
+        assert all(body == {"type": "interrupt"} for _session_id, body in forwarded)
+        assert delivered_ids <= _interrupt_fenced_sessions
+        assert child.id not in _interrupt_fenced_sessions
+    finally:
+        _interrupt_fenced_sessions.difference_update(
+            {parent["id"], child.id, grandchild.id, late_child_id}
+        )
+        await fake_runner.aclose()
+
+
 async def test_post_external_output_text_delta_carries_streaming_identifiers(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4747,18 +4747,13 @@ async def test_post_interrupt_without_data_field_is_accepted(
         f"/v1/sessions/{session['id']}/events",
         json={"type": "interrupt"},
     )
-    # 202 (not 422) proves ``data`` defaults to ``{}`` at the schema
-    # layer; a 422 here means the pydantic default regressed and every
-    # deployed bare-control client breaks again.
-    assert resp.status_code == 202, resp.text
-    assert resp.json() == {"queued": False}
-    # The interrupt actually took effect (not just validated): the
-    # route published the cancellation signal for the web turn.
+    # A runner is not bound in this schema test. 503 (rather than 422) proves
+    # ``data`` defaulted to ``{}`` and routing reached delivery handling.
+    assert resp.status_code == 503, resp.text
+    # No runner is bound in this schema test, so the request is accepted but
+    # must not publish a terminal cancellation signal that did not land.
     interrupted = [e for _sid, e in published if e.get("type") == "session.interrupted"]
-    assert len(interrupted) == 1, (
-        f"expected one session.interrupted publish for a bare interrupt "
-        f"event, got types {[e.get('type') for _sid, e in published]!r}"
-    )
+    assert interrupted == []
 
 
 async def test_post_external_output_text_delta_carries_streaming_identifiers(
@@ -8180,17 +8175,11 @@ async def test_interrupt_on_claude_native_session_skips_idle_publish_on_runner_f
 ) -> None:
     """
     If the runner couldn't deliver the Escape (e.g. tmux pane gone),
-    Omnigent must NOT lie to the UI by publishing idle. The spinner spins
-    is the right signal — it tells the user the cancel didn't land.
+    Omnigent must not publish terminal interruption or idle state when the
+    runner rejected the request.
 
-    After the interrupt-unification refactor the Omnigent side no longer
-    publishes ``session.status: idle`` itself at all. Idle on a
-    claude-native interrupt now comes from the runner's PTY activity
-    watcher once the pane quiesces after the Escape (a failed Escape
-    naturally surfaces as "no idle" — the pane keeps changing). This
-    test acts as a regression guard against re-adding an AP-side idle
-    publish — if someone reintroduces the pre-refactor "publish idle on
-    2xx" logic, the 503 path here would start leaking idle.
+    The server publishes idle only after a runner 2xx confirms delivery. A
+    rejected Escape must return a retryable error and emit no terminal state.
     """
     from omnigent.runtime import session_stream, set_runner_client
 
@@ -8229,17 +8218,14 @@ async def test_interrupt_on_claude_native_session_skips_idle_publish_on_runner_f
             f"/v1/sessions/{session['id']}/events",
             json={"type": "interrupt", "data": {}},
         )
-        assert resp.status_code == 202, resp.text
+        assert resp.status_code == 503, resp.text
     finally:
         await fake_runner.aclose()
         set_runner_client(None)
 
-    # interrupted still fires (the UI marks the bubble cancelled);
-    # idle does not (the Escape didn't land).
+    # Neither terminal signal fires because the Escape did not land.
     interrupted = [e for e in published if e.get("type") == "session.interrupted"]
-    assert interrupted, (
-        f"session.interrupted should still publish on runner failure; got {published!r}"
-    )
+    assert not interrupted, f"failed interrupt must not publish completion; got {published!r}"
     idle_status = [
         e for e in published if e.get("type") == "session.status" and e.get("status") == "idle"
     ]
@@ -8598,9 +8584,7 @@ async def test_interrupt_forward_failure_lifts_stop_fence(
             f"/v1/sessions/{session_id}/events",
             json={"type": "interrupt", "data": {}},
         )
-        # Interrupt is best-effort and still ACKs (the UI already marked the
-        # bubble interrupted); the fence removal below is the fix under test.
-        assert resp.status_code == 202, resp.text
+        assert resp.status_code == 503, resp.text
         assert session_id not in _interrupt_fenced_sessions, (
             "a failed interrupt forward must remove the fence it installed — "
             "leaving it set drops the rest of the still-running turn"

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -3688,7 +3688,7 @@ describe("chatStore — stop", () => {
     expect(controller.signal.aborted).toBe(false);
   });
 
-  it("clears local working state immediately while the interrupt ack is pending", () => {
+  it("keeps working state until a confirmed interruption event arrives", () => {
     useChatStore.setState({
       conversationId: "conv_abc",
       pendingUserMessages: [
@@ -3706,21 +3706,18 @@ describe("chatStore — stop", () => {
     useChatStore.getState().stop();
 
     const state = useChatStore.getState();
-    expect(state.pendingUserMessages).toEqual([]);
-    expect(state.status).toBe("idle");
-    expect(state.sessionStatus).toBe("idle");
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.status).toBe("streaming");
+    expect(state.sessionStatus).toBe("running");
     expect(state.activeResponse).toEqual({
       responseId: "resp_1",
-      state: "cancelled",
+      state: "streaming",
       error: null,
     });
-    expect(readConversationRows()[0]?.status).toBe("idle");
+    expect(readConversationRows()[0]?.status).toBe("running");
   });
 
-  it("leaves a non-streaming activeResponse untouched on stop", () => {
-    // Pins the `state === "streaming"` guard: stop() still clears the working
-    // state, but must NOT overwrite a non-streaming activeResponse (dropping the
-    // guard would clobber a completed response with a cancelled decoration).
+  it("does not mutate a non-streaming activeResponse before confirmation", () => {
     useChatStore.setState({
       conversationId: "conv_abc",
       pendingUserMessages: [
@@ -3735,16 +3732,35 @@ describe("chatStore — stop", () => {
     useChatStore.getState().stop();
 
     const state = useChatStore.getState();
-    expect(state.pendingUserMessages).toEqual([]);
-    expect(state.status).toBe("idle");
-    expect(state.sessionStatus).toBe("idle");
-    // Untouched — the guard skipped the cancelled overwrite.
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.status).toBe("streaming");
+    expect(state.sessionStatus).toBe("running");
     expect(state.activeResponse).toEqual({
       responseId: "resp_1",
       state: "completed",
       error: null,
     });
-    expect(readConversationRows()[0]?.status).toBe("idle");
+    expect(readConversationRows()[0]?.status).toBe("running");
+  });
+
+  it("surfaces a failed interrupt without hiding the running turn", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("runner did not confirm delivery"));
+    useChatStore.setState({
+      conversationId: "conv_abc",
+      status: "streaming",
+      sessionStatus: "running",
+    });
+
+    useChatStore.getState().stop();
+    await tick();
+
+    const state = useChatStore.getState();
+    expect(state.status).toBe("streaming");
+    expect(state.sessionStatus).toBe("running");
+    expect(state.blocks.at(-1)).toMatchObject({
+      type: "error",
+      message: "Stop failed: runner did not confirm delivery",
+    });
   });
 
   it("no-op when no session is bound", () => {

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1914,50 +1914,14 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
   stop: () => {
     const sessionId = get().conversationId;
     if (!sessionId) return;
-    // Fire-and-forget interrupt; the server emits session.interrupted
-    // + response.incomplete on the open stream, which the pump
-    // translates into the cancelled bubble decoration. We deliberately
-    // do NOT abort the local SSE stream — it remains open across
-    // turns; switchTo or tab unload is the only thing that tears it
-    // down.
-    void interruptSession(sessionId).catch(() => {
-      // Interrupt is best-effort. A network failure here means the
-      // user's cancel won't reach the server, but the local UI already
-      // reflects the user's stop request below.
+    // Keep the local stream open and let the server's confirmed
+    // session.interrupted event settle the turn for every viewer.
+    void interruptSession(sessionId).catch((err) => {
+      const { message, code } = describeSendFailure(err);
+      setterFor(sessionId)((s) => ({
+        blocks: [...s.blocks, makeClientErrorBlock(`Stop failed: ${message}`, code)],
+      }));
     });
-    setActive((s) => {
-      if (s.conversationId !== sessionId) return {};
-      const patch: Partial<ChatState> = {
-        pendingUserMessages: [],
-        status: "idle",
-        sessionStatus: "idle",
-        backgroundTaskCount: 0,
-        backgroundTasks: [],
-        blockedOn: null,
-      };
-      if (s.activeResponse?.state === "streaming") {
-        patch.activeResponse = {
-          ...s.activeResponse,
-          state: "cancelled",
-          error: null,
-        };
-      }
-      return patch;
-    });
-    // Optimistic, unbacked write: unlike the session.status SSE caller, no
-    // server event backs this, so a poll that interleaves while the turn is
-    // genuinely still running may briefly revert the sidebar dot — the helper's
-    // "never fights the poller" contract doesn't hold here. Self-corrects on the
-    // real idle event.
-    patchConversationStatusInCache(sessionId, "idle");
-    // Mirror the session.status handler: a sub-agent's row lives in its parent's
-    // child-sessions list, not the sidebar, so refresh the rail in lockstep.
-    const snapshot = queryClient?.getQueryData<Session>(["session", sessionId]);
-    if (snapshot?.parentSessionId) {
-      queryClient?.invalidateQueries({
-        queryKey: childSessionsQueryKey(snapshot.parentSessionId),
-      });
-    }
   },
 
   switchTo: async (conversationId) => {


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

> **Stacked draft:** GitHub base is `main`, but the conceptual parent is `review/fix-cancellation-authoritative-state` at `b3eee1cce741fa0632d7ce1fe5b8a21c9886c5e1`. Review the isolated descendant-interrupt diff after that parent merges.

- Extend session interruption from the selected session to its full active sub-agent tree.
- Re-scan while interrupting so nested or concurrently spawned descendants cannot escape the stop request.
- Add a focused integration regression for nested and concurrently created sub-agents.

**ELI5:** Stopping a parent task now also stops every helper it started, including helpers created while the stop is being processed.

```text
interrupt parent -> snapshot descendants -> interrupt children -> rescan
                                                        ^          |
                                                        +----------+
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- Focused backend handoff run on the final cancellation stack: `tests/server/integration/test_sessions_endpoints.py::test_post_interrupt_reaches_nested_and_concurrently_spawned_subagents` — 1 passed.
- The combined cancellation run reported all 8 selected cases passed before the local sandbox blocked only the global leaked-process teardown reaper (`psutil` process enumeration), so the pytest process itself exited nonzero after the test results.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No visual artifact is attached: this is runtime interruption propagation. The nested/concurrent integration evidence is in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

The focused integration test exercises both nested descendants and descendants spawned concurrently with interruption. No manual verification is claimed; the teardown limitation is recorded in the Test Plan.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Stopping a session now interrupts its nested and newly spawned sub-agents too.
