### PR TITLE
fix(codex-native): preserve sub-agent lineage on thread rotation

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -2014,11 +2014,9 @@ async def _maybe_rotate_session_on_thread_started(
     # its own Omnigent child session by ``_handle_event``.
     if _thread_started_is_subagent(event):
         return False
-    # Codex CLI 0.150.1 emits a second ``thread/started`` mid-turn for an
-    # internal system/housekeeping thread (``ephemeral=true``, ``path=null``).
-    # That thread is never persistable and cannot host goals; rotating onto it
-    # strands the real turn's output as stale. Ignore all ephemeral threads.
-    if _thread_started_is_ephemeral(event):
+    # Codex emits non-user housekeeping threads during startup and mid-turn.
+    # They cannot host the session and must never be treated as ``/clear``.
+    if _thread_started_is_housekeeping(event):
         return False
     old_delta_coalescer = target.delta_coalescer
     await old_delta_coalescer.flush()
@@ -7003,6 +7001,28 @@ def _thread_started_is_ephemeral(event: CodexMessage) -> bool:
     if not isinstance(thread, dict):
         return False
     return thread.get("ephemeral") is True
+
+
+def _thread_started_is_housekeeping(event: CodexMessage) -> bool:
+    """Return whether ``thread/started`` announces an internal Codex thread.
+
+    Codex 0.150 marks mid-turn housekeeping threads as ephemeral. Codex 0.151
+    also labels startup title-generation threads with ``threadSource=system``.
+    Neither represents a user ``/clear`` and neither may own the Omnigent
+    session.
+
+    :param event: Codex app-server notification envelope.
+    :returns: ``True`` for an ephemeral or system-owned started thread.
+    """
+    if _thread_started_is_ephemeral(event):
+        return True
+    if event.get("method") != "thread/started":
+        return False
+    params = event.get("params")
+    if not isinstance(params, dict):
+        return False
+    thread = params.get("thread")
+    return isinstance(thread, dict) and thread.get("threadSource") == "system"
 
 
 async def wait_for_thread_started(

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -2049,6 +2049,47 @@ async def _maybe_rotate_session_on_thread_started(
     return True
 
 
+def _replacement_session_lineage(old: _JsonObject) -> _JsonObject:
+    """Build trusted create fields that preserve a rotated session's identity.
+
+    ``POST /v1/sessions`` derives ``kind`` from ``parent_session_id``. A
+    replacement created without it silently demotes a sub-agent to a top-level
+    session, leaving its parent waiting on an abandoned child.
+
+    ``host_id`` is intentionally omitted because the existing runner is bound
+    after creation; including a host would launch a second runner. Named
+    sub-agents also omit stored terminal arguments because the server derives
+    those from the trusted sub-agent specification.
+
+    :param old: Session snapshot being rotated away from.
+    :returns: Valid ``SessionCreateRequest`` fields to carry to the replacement.
+    """
+    body: _JsonObject = {}
+    parent_session_id = old.get("parent_session_id")
+    if isinstance(parent_session_id, str) and parent_session_id:
+        body["parent_session_id"] = parent_session_id
+    sub_agent_name = old.get("sub_agent_name")
+    if "parent_session_id" in body and isinstance(sub_agent_name, str) and sub_agent_name:
+        body["sub_agent_name"] = sub_agent_name
+    workspace = old.get("workspace")
+    if isinstance(workspace, str) and workspace:
+        body["workspace"] = workspace
+    if "sub_agent_name" not in body:
+        launch_args = old.get("terminal_launch_args")
+        if isinstance(launch_args, list) and all(isinstance(arg, str) for arg in launch_args):
+            body["terminal_launch_args"] = launch_args
+    for key in (
+        "model_override",
+        "reasoning_effort",
+        "cost_control_mode_override",
+        "subagent_routing_override",
+    ):
+        value = old.get(key)
+        if isinstance(value, str) and value:
+            body[key] = value
+    return body
+
+
 async def _create_thread_replacement_session(
     *,
     client: httpx.AsyncClient,
@@ -2091,13 +2132,9 @@ async def _create_thread_replacement_session(
     if CODEX_NATIVE_BRIDGE_ID_LABEL_KEY not in labels:
         labels[CODEX_NATIVE_BRIDGE_ID_LABEL_KEY] = old_session_id
 
-    create_resp = await client.post(
-        "/v1/sessions",
-        json={
-            "agent_id": agent_id,
-            "labels": labels,
-        },
-    )
+    create_body: _JsonObject = {"agent_id": agent_id, "labels": labels}
+    create_body.update(_replacement_session_lineage(old))
+    create_resp = await client.post("/v1/sessions", json=create_body)
     create_resp.raise_for_status()
     created = create_resp.json()
     new_session_id = created.get("id")

--- a/tests/e2e/test_codex_ephemeral_thread_rotation_e2e.py
+++ b/tests/e2e/test_codex_ephemeral_thread_rotation_e2e.py
@@ -327,3 +327,19 @@ async def test_rotation_preserves_workspace_cwd(tmp_path: Path) -> None:
     assert state is not None
     assert state.thread_id == "0195dddd-real-clear-thread"
     assert state.cwd == workspace
+
+
+async def test_system_title_thread_does_not_rotate_without_ephemeral_flag(tmp_path: Path) -> None:
+    """Codex startup title generation is internal even if its flag changes."""
+    ap = _RecordingAP()
+    bridge_dir = _seed_bridge(tmp_path)
+    target = _make_target(ap)
+    thread = _ephemeral_system_thread()
+    thread["ephemeral"] = False
+
+    rotated = await _rotate(ap, target, bridge_dir, _thread_started(thread))
+
+    assert rotated is False
+    assert ap.created_sessions() == []
+    assert target.session_id == PARENT_SESSION
+    assert target.thread_id == PARENT_THREAD

--- a/tests/e2e/test_codex_ephemeral_thread_rotation_e2e.py
+++ b/tests/e2e/test_codex_ephemeral_thread_rotation_e2e.py
@@ -64,10 +64,16 @@ class _RecordingAP:
     assert whether a rotation was performed at all.
     """
 
-    def __init__(self) -> None:
-        """Initialize with empty POST/PATCH records."""
+    def __init__(self, snapshot: dict | None = None) -> None:
+        """Initialize with empty records and an optional session snapshot."""
         self.posts: list[tuple[str, dict]] = []
         self.patches: list[tuple[str, dict]] = []
+        self.snapshot = snapshot or {
+            "id": PARENT_SESSION,
+            "agent_id": "ag_codex_native",
+            "runner_id": "runner_1",
+            "labels": {},
+        }
 
     async def get(self, url: str) -> httpx.Response:
         """Return the parent session snapshot for any GET.
@@ -77,12 +83,7 @@ class _RecordingAP:
         """
         return httpx.Response(
             200,
-            json={
-                "id": PARENT_SESSION,
-                "agent_id": "ag_codex_native",
-                "runner_id": "runner_1",
-                "labels": {},
-            },
+            json=self.snapshot,
             request=httpx.Request("GET", url),
         )
 
@@ -343,3 +344,73 @@ async def test_system_title_thread_does_not_rotate_without_ephemeral_flag(tmp_pa
     assert ap.created_sessions() == []
     assert target.session_id == PARENT_SESSION
     assert target.thread_id == PARENT_THREAD
+
+
+async def test_rotated_subagent_replacement_stays_a_subagent(tmp_path: Path) -> None:
+    """A genuine thread rotation preserves the sub-agent's parent lineage."""
+    ap = _RecordingAP(
+        snapshot={
+            "id": "conv_child",
+            "agent_id": "ag_polly",
+            "runner_id": "runner_1",
+            "labels": {"omnigent.wrapper": "codex-native-ui"},
+            "kind": "sub_agent",
+            "parent_session_id": "conv_orchestrator",
+            "sub_agent_name": "codex",
+            "workspace": "/workspace/project",
+            "model_override": "gpt-5.1-codex-max",
+            "reasoning_effort": "high",
+        }
+    )
+    bridge_dir = _seed_bridge(tmp_path)
+    target = _make_target(ap)
+    event = _thread_started(
+        {
+            "id": "0195dddd-subagent-clear-thread",
+            "ephemeral": False,
+            "path": "/rollout/0195dddd.jsonl",
+            "threadSource": "user",
+        }
+    )
+
+    assert await _rotate(ap, target, bridge_dir, event) is True
+    body = ap.created_sessions()[0]
+    assert body["parent_session_id"] == "conv_orchestrator"
+    assert body["sub_agent_name"] == "codex"
+    assert body["workspace"] == "/workspace/project"
+    assert body["model_override"] == "gpt-5.1-codex-max"
+    assert body["reasoning_effort"] == "high"
+    assert "kind" not in body
+    assert "host_id" not in body
+
+
+async def test_rotated_top_level_session_does_not_invent_parent(tmp_path: Path) -> None:
+    """A top-level rotation remains top-level and keeps its launch arguments."""
+    ap = _RecordingAP(
+        snapshot={
+            "id": PARENT_SESSION,
+            "agent_id": "ag_codex_native",
+            "runner_id": "runner_1",
+            "labels": {},
+            "kind": "default",
+            "parent_session_id": None,
+            "sub_agent_name": None,
+            "terminal_launch_args": ["--dangerously-bypass-approvals-and-sandbox"],
+        }
+    )
+    bridge_dir = _seed_bridge(tmp_path)
+    target = _make_target(ap)
+    event = _thread_started(
+        {
+            "id": "0195eeee-top-level-clear",
+            "ephemeral": False,
+            "path": "/rollout/0195eeee.jsonl",
+            "threadSource": "user",
+        }
+    )
+
+    assert await _rotate(ap, target, bridge_dir, event) is True
+    body = ap.created_sessions()[0]
+    assert "parent_session_id" not in body
+    assert "sub_agent_name" not in body
+    assert body["terminal_launch_args"] == ["--dangerously-bypass-approvals-and-sandbox"]

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -3297,3 +3297,52 @@ def test_thread_started_is_ephemeral_false_for_missing_thread() -> None:
     """Event with params but no thread is not ephemeral."""
     event = {"method": "thread/started", "params": {}}
     assert fwd._thread_started_is_ephemeral(event) is False
+
+
+_CODEX_0151_STARTUP_TITLE_THREAD = {
+    "id": "01a051a0-e5dc-79e3-bdd3-cceeda4b6a16",
+    "ephemeral": True,
+    "historyMode": "legacy",
+    "path": None,
+    "cliVersion": "0.151.0",
+    "source": "vscode",
+    "threadSource": "system",
+    "status": {"type": "idle"},
+    "turns": [],
+}
+
+
+def test_housekeeping_true_for_captured_codex_0151_startup_thread() -> None:
+    """The captured startup title thread cannot rotate the user session."""
+    assert fwd._thread_started_is_housekeeping(
+        _make_thread_started(dict(_CODEX_0151_STARTUP_TITLE_THREAD))
+    )
+
+
+def test_housekeeping_true_for_system_thread_without_ephemeral_marker() -> None:
+    """The system ownership marker remains sufficient if Codex changes flags."""
+    thread = dict(_CODEX_0151_STARTUP_TITLE_THREAD)
+    thread["ephemeral"] = False
+    assert fwd._thread_started_is_housekeeping(_make_thread_started(thread))
+
+
+def test_housekeeping_false_for_real_user_thread() -> None:
+    """A persistent user thread still represents a genuine ``/clear``."""
+    event = _make_thread_started(
+        {
+            "id": "01a051a0-ddda-78c0-a62c-71af8c6ae60d",
+            "ephemeral": False,
+            "path": "/sessions/rollout-user.jsonl",
+            "threadSource": "user",
+        }
+    )
+    assert fwd._thread_started_is_housekeeping(event) is False
+
+
+def test_housekeeping_false_for_non_started_event() -> None:
+    """Only thread-start notifications participate in rotation filtering."""
+    event = {
+        "method": "thread/updated",
+        "params": {"thread": {"id": "system", "threadSource": "system"}},
+    }
+    assert fwd._thread_started_is_housekeeping(event) is False

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -3346,3 +3346,63 @@ def test_housekeeping_false_for_non_started_event() -> None:
         "params": {"thread": {"id": "system", "threadSource": "system"}},
     }
     assert fwd._thread_started_is_housekeeping(event) is False
+
+
+def test_replacement_lineage_preserves_subagent_parent_and_name() -> None:
+    """A rotated sub-agent remains attached to the parent that spawned it."""
+    lineage = fwd._replacement_session_lineage(
+        {
+            "kind": "sub_agent",
+            "parent_session_id": "conv_orchestrator",
+            "sub_agent_name": "codex",
+            "workspace": "/workspace/project",
+            "model_override": "gpt-5.1-codex-max",
+            "reasoning_effort": "high",
+        }
+    )
+    assert lineage == {
+        "parent_session_id": "conv_orchestrator",
+        "sub_agent_name": "codex",
+        "workspace": "/workspace/project",
+        "model_override": "gpt-5.1-codex-max",
+        "reasoning_effort": "high",
+    }
+
+
+def test_replacement_lineage_omits_untrusted_or_server_derived_fields() -> None:
+    """Rotation must not launch another runner or replay stored child arguments."""
+    lineage = fwd._replacement_session_lineage(
+        {
+            "kind": "sub_agent",
+            "parent_session_id": "conv_orchestrator",
+            "sub_agent_name": "codex",
+            "host_id": "host_123",
+            "git_branch": "fix/thing",
+            "title": "codex:worker",
+            "terminal_launch_args": ["--dangerously-bypass-approvals-and-sandbox"],
+        }
+    )
+    assert lineage == {
+        "parent_session_id": "conv_orchestrator",
+        "sub_agent_name": "codex",
+    }
+
+
+def test_replacement_lineage_keeps_top_level_launch_args() -> None:
+    """A top-level replacement keeps the terminal arguments it owns."""
+    assert fwd._replacement_session_lineage(
+        {"terminal_launch_args": ["--dangerously-bypass-approvals-and-sandbox"]}
+    ) == {"terminal_launch_args": ["--dangerously-bypass-approvals-and-sandbox"]}
+
+
+def test_replacement_lineage_ignores_malformed_values() -> None:
+    """Malformed snapshot fields are not reflected into a create request."""
+    assert fwd._replacement_session_lineage(
+        {
+            "parent_session_id": 17,
+            "sub_agent_name": "codex",
+            "workspace": None,
+            "terminal_launch_args": ["--ok", 3],
+            "reasoning_effort": "high",
+        }
+    ) == {"reasoning_effort": "high"}


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

> **Stacked draft:** GitHub base is `main`, but the conceptual parent is `review/fix-codex-ghost-thread-rotation` at `c25979881f987774915efe562d4ebf2833dda735`. Review the isolated lineage diff after that parent merges.

- Preserve trusted sub-agent launch lineage when a genuine Codex thread rotation creates a replacement session, including parent, name, workspace, model, and reasoning settings.
- Keep top-level replacements top-level and avoid copying server-derived or otherwise untrusted fields into the new launch request.
- Add focused unit and lifecycle coverage for both sub-agent and top-level rotation.

**ELI5:** If Codex moves a helper agent onto a replacement thread, the helper still belongs to the same parent instead of reappearing as an unrelated top-level task.

```text
sub-agent thread rotates -> replacement session -> same trusted parent/name/settings
top-level thread rotates -> replacement session -> remains top-level
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- Focused handoff run on the final Codex rotation stack covered the 6 cases belonging to this PR: four replacement-lineage unit cases and two lifecycle cases for rotated sub-agent/top-level sessions; all 6 passed.
- The combined Codex rotation run reported all 11 selected cases passed before the local sandbox blocked only the global leaked-process teardown reaper (`psutil` process enumeration), so the pytest process itself exited nonzero after the test results.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No visual artifact is attached: this changes Codex-native replacement-session metadata. Focused unit and lifecycle evidence is in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

The focused cases cover trusted lineage propagation and ensure top-level replacements do not acquire synthetic parents. No manual verification is claimed; the teardown limitation is recorded in the Test Plan.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Codex sub-agents keep their parent lineage when a thread rotates.
