### PR TITLE
fix(web): bound session creation requests

### DIFF
--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   approve,
   bindOnlyOnlineRunner,
+  createBundledSession,
   createSession,
   fetchSessionItemsPage,
   forkSession,
@@ -188,6 +189,28 @@ describe("createSession", () => {
     await expect(createSession("missing")).rejects.toThrow(/404/);
   });
 
+  it("aborts and rejects when session creation never responds", async () => {
+    vi.useFakeTimers();
+    try {
+      let signal: AbortSignal | undefined;
+      fetchMock.mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        return new Promise<Response>(() => {});
+      });
+
+      const pending = createSession("agent_xyz");
+      const rejected = expect(pending).rejects.toThrow(
+        "Session creation timed out. Check the host or provider connection, then try again.",
+      );
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+
+      await rejected;
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("forward-compat: reads queued_items from the snapshot when present", async () => {
     const queued = [{ type: "message", data: { role: "user", content: [] } }];
     fetchMock.mockResolvedValueOnce(
@@ -260,6 +283,31 @@ describe("createSession", () => {
 
     const session = await createSession("agent_xyz");
     expect(session.activeResponseId).toBeNull();
+  });
+});
+
+describe("createBundledSession", () => {
+  it("aborts and rejects when multipart session creation never responds", async () => {
+    vi.useFakeTimers();
+    try {
+      let signal: AbortSignal | undefined;
+      fetchMock.mockImplementationOnce((_input: RequestInfo | URL, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        return new Promise<Response>(() => {});
+      });
+
+      const bundle = new File(["bundle"], "agent.tar.gz", { type: "application/gzip" });
+      const pending = createBundledSession(bundle);
+      const rejected = expect(pending).rejects.toThrow(
+        "Session creation timed out. Check the host or provider connection, then try again.",
+      );
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+
+      await rejected;
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -382,6 +382,39 @@ export class ApiError extends Error {
   }
 }
 
+// Session creation may wait for a host wake or runner initialization, but it
+// must eventually return control to New Chat. Browser fetch has no default
+// deadline, so a connection lost mid-request otherwise leaves it loading forever.
+const SESSION_CREATE_TIMEOUT_MS = 5 * 60 * 1_000;
+const SESSION_CREATE_TIMEOUT_MESSAGE =
+  "Session creation timed out. Check the host or provider connection, then try again.";
+
+async function withSessionCreateTimeout<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(SESSION_CREATE_TIMEOUT_MESSAGE));
+      controller.abort();
+    }, SESSION_CREATE_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([operation(controller.signal), timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/** Send a session-create request with the shared host-startup deadline. */
+export function createSessionRequest(
+  input: RequestInfo | URL,
+  init: RequestInit,
+): Promise<Response> {
+  return withSessionCreateTimeout((signal) => authenticatedFetch(input, { ...init, signal }));
+}
+
 /**
  * Build an {@link ApiError} from a non-OK response, preferring the
  * server's `error.message` / `error.code` over the bare status line.
@@ -486,7 +519,7 @@ export async function createSession(
   if (options.title !== undefined) {
     body.title = options.title;
   }
-  const res = await authenticatedFetch("/v1/sessions", {
+  const res = await createSessionRequest("/v1/sessions", {
     method: "POST",
     headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
     body: JSON.stringify(body),
@@ -577,7 +610,7 @@ export async function createBundledSession(
   const form = new FormData();
   form.append("metadata", JSON.stringify(metadata));
   form.append("bundle", bundle);
-  const res = await authenticatedFetch("/v1/sessions", {
+  const res = await createSessionRequest("/v1/sessions", {
     method: "POST",
     headers: { "X-Omnigent-Client": getClientSurface() },
     body: form,

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -79,7 +79,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { authenticatedFetch } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
@@ -246,7 +245,12 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { AgentRowTooltip } from "@/components/AgentHoverCard";
 import { CreateAgentDialog } from "./CreateAgentDialog";
 import { buildAgentBundle, type AgentBundleInput } from "@/lib/agentBundle";
-import { createBundledSession, importLocalSessions, launchRunner } from "@/lib/sessionsApi";
+import {
+  createBundledSession,
+  createSessionRequest,
+  importLocalSessions,
+  launchRunner,
+} from "@/lib/sessionsApi";
 
 // Short picker-row blurbs — the spec descriptions are long paragraphs that
 // truncate badly in the dropdown; other dialogs keep the server values.
@@ -4126,7 +4130,7 @@ export function NewChatLandingScreen() {
                 item.parent_session_id == null &&
                 item.agent_id === effectiveAgentId &&
                 item.host_id === selectedHostId;
-        const createRequest = authenticatedFetch("/v1/sessions", {
+        const createRequest = createSessionRequest("/v1/sessions", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Bound session creation requests to five minutes and abort the underlying fetch before showing an actionable timeout error.
- Apply the same timeout to all creation paths: JSON `createSession`, multipart bundled/custom-agent creation, and the direct New Chat JSON request.
- Keep the timeout helper responsible for timer cleanup so successful, failed, and aborted requests do not leave pending timers.

ELI5: if starting a session gets stuck, New Chat stops waiting after five minutes and tells the user to check the host or provider connection.

```text
JSON API -----------\
Bundled multipart ---+-> shared 5-minute timeout -> abort fetch -> actionable error
Direct New Chat ----/
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- `npm test -- src/lib/sessionsApi.test.ts` — 49 tests passed, including stalled JSON and multipart creation requests.
- Prettier and Oxlint passed for the three changed frontend files.
- TypeScript project build passed.
- Before marking ready for review, attach the visual timeout/error-state evidence described below.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Pending before ready for review: attach a screenshot or recording of New Chat surfacing the timeout message after a deliberately stalled create request. Include both a normal JSON session and a bundled/custom-agent session if practical.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

Fake-timer regressions verify timeout rejection and `AbortSignal` cancellation for JSON and multipart API helpers. The direct New Chat path shares the same tested helper and is covered by static checks; visual verification remains pending.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Stalled session starts now time out with an actionable error instead of waiting forever.
