### PR TITLE
fix(web): make text selection theme-aware and legible

### DIFF
--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -50,7 +50,11 @@ export function terminalTheme(isDark: boolean): ITheme {
         foreground: "#e4e4e7",
         cursor: "#22d3ee",
         cursorAccent: bg,
-        selectionBackground: "#22d3ee33",
+        // Solid (not the prior translucent wash) so selected text stays
+        // legible regardless of what's underneath; selectionForeground
+        // guarantees contrast instead of leaving the original glyph color.
+        selectionBackground: "#1e9aae",
+        selectionForeground: "#111318",
         black: "#09090b",
         brightBlack: "#71717a",
       }
@@ -59,7 +63,8 @@ export function terminalTheme(isDark: boolean): ITheme {
         foreground: "#18181b",
         cursor: "#0891b2",
         cursorAccent: bg,
-        selectionBackground: "#0891b233",
+        selectionBackground: "#0891b2",
+        selectionForeground: "#111318",
         black: "#18181b",
         brightBlack: "#e4e4e7",
         // CLIs that assume a dark terminal paint primary text with ANSI

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -955,11 +955,15 @@ aside[aria-label="Workspace"][data-maximized] {
   .xterm {
     font-family: var(--font-mono);
   }
-  /* Text selection mirrors the sidebar's active-item treatment in every
-   * palette and color mode. */
+  /* Selection needs solid, high-contrast palette tokens rather than the
+   * sidebar's low-alpha active-item wash. */
   ::selection {
-    background: var(--sidebar-active);
-    color: var(--sidebar-active-foreground);
+    background: var(--selection-background);
+    color: var(--selection-foreground);
+  }
+  ::-moz-selection {
+    background: var(--selection-background);
+    color: var(--selection-foreground);
   }
 }
 

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TooltipProvider } from "./components/ui/tooltip";
 import type * as UseTerminalsModule from "./hooks/useTerminals";
+import { themePalettes } from "./lib/themePalette";
 import { UI_FONT_SIZE_DEFAULT, UI_FONT_SIZE_MAX, UI_FONT_SIZE_MIN } from "./lib/uiFontPreferences";
 import { WorkspacePanel } from "./shell/WorkspacePanel";
 
@@ -837,13 +838,30 @@ describe("index.css mobile sidebar glass chip opacity", () => {
 });
 
 describe("index.css text selection colors", () => {
-  const selectionRule = cssSource.match(/::selection\s*\{([^}]*)\}/)?.[1];
+  // The sidebar's low-alpha active-item wash was barely visible as selection.
+  // Selection now uses dedicated palette tokens.
+  const selectionRule = cssSource.match(/(?<!-moz-)::selection\s*\{([^}]*)\}/)?.[1];
+  const mozSelectionRule = cssSource.match(/::-moz-selection\s*\{([^}]*)\}/)?.[1];
 
-  it("matches the active sidebar item in every color mode", () => {
-    expect(selectionRule).toContain("background: var(--sidebar-active)");
-    expect(selectionRule).toContain("color: var(--sidebar-active-foreground)");
-    expect(selectionRule).not.toContain("--brand-accent");
-    expect(cssSource).not.toContain(".dark ::selection");
+  it("uses the dedicated selection tokens, not the sidebar-active wash", () => {
+    expect(selectionRule).toContain("background: var(--selection-background)");
+    expect(selectionRule).toContain("color: var(--selection-foreground)");
+    expect(selectionRule).not.toContain("--sidebar-active");
+  });
+
+  it("defines a matching ::-moz-selection rule (Firefox ignores unprefixed ::selection)", () => {
+    expect(mozSelectionRule).toBeTruthy();
+    expect(mozSelectionRule).toContain("background: var(--selection-background)");
+    expect(mozSelectionRule).toContain("color: var(--selection-foreground)");
+  });
+
+  it("defines --selection-background/--selection-foreground for every palette, in both light and dark", () => {
+    // Count every built-in plus Custom in light and dark modes.
+    const expectedRuleCount = (themePalettes.length + 1) * 2;
+    const backgroundCount = cssSource.split("--selection-background:").length - 1;
+    const foregroundCount = cssSource.split("--selection-foreground:").length - 1;
+    expect(backgroundCount).toBe(expectedRuleCount);
+    expect(foregroundCount).toBe(expectedRuleCount);
   });
 });
 

--- a/web/src/lib/customTheme.ts
+++ b/web/src/lib/customTheme.ts
@@ -414,6 +414,8 @@ function rebaseVariant(
     sidebarActiveForeground: base.sidebarActiveForeground,
     sidebarBackground: base.sidebarBackground,
     shellBackground: base.shellBackground,
+    selectionBackground: base.selectionBackground,
+    selectionForeground: base.selectionForeground,
   };
 }
 

--- a/web/src/lib/themePalette.test.ts
+++ b/web/src/lib/themePalette.test.ts
@@ -14,6 +14,19 @@ import {
 
 const STORAGE_KEY = "omnigent:ui-theme-palette";
 
+function contrastRatio(first: string, second: string): number {
+  const luminance = (hex: string) => {
+    const channel = (offset: number) => {
+      const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+      return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+    };
+    return channel(1) * 0.2126 + channel(3) * 0.7152 + channel(5) * 0.0722;
+  };
+  const lighter = Math.max(luminance(first), luminance(second));
+  const darker = Math.min(luminance(first), luminance(second));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
 afterEach(() => {
   localStorage.clear();
   setEmbedScopeRoot(null);
@@ -117,6 +130,16 @@ describe("themePalette", () => {
       expect(palette.dark.bg).toMatch(/^#|rgb/);
       expect(palette.tokens.light.shellBackground.length).toBeGreaterThan(0);
       expect(palette.tokens.dark.shellBackground.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps text selection at WCAG AA contrast in every palette", () => {
+    for (const palette of PALETTES) {
+      for (const tokens of [palette.tokens.light, palette.tokens.dark]) {
+        expect(
+          contrastRatio(tokens.selectionBackground, tokens.selectionForeground),
+        ).toBeGreaterThanOrEqual(4.5);
+      }
     }
   });
 });

--- a/web/src/lib/themePalette.ts
+++ b/web/src/lib/themePalette.ts
@@ -95,6 +95,8 @@ export interface PaletteTokens {
   sidebarActiveForeground: string;
   sidebarBackground: string;
   shellBackground: string;
+  selectionBackground: string;
+  selectionForeground: string;
 }
 
 export const PALETTE_TOKEN_CSS_NAMES = {
@@ -133,6 +135,8 @@ export const PALETTE_TOKEN_CSS_NAMES = {
   sidebarActiveForeground: "sidebar-active-foreground",
   sidebarBackground: "sidebar-background",
   shellBackground: "shell-background",
+  selectionBackground: "selection-background",
+  selectionForeground: "selection-foreground",
 } as const satisfies Record<keyof PaletteTokens, string>;
 
 type PaletteTokenInput = Pick<
@@ -154,6 +158,8 @@ type PaletteTokenInput = Pick<
   | "ring"
   | "sidebar"
   | "shellBackground"
+  | "selectionBackground"
+  | "selectionForeground"
 > &
   Partial<PaletteTokens>;
 
@@ -238,6 +244,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebarActiveForeground: "#651249",
         sidebarBackground: "linear-gradient(90deg, #fffefe, #fcf6fa)",
         shellBackground: "var(--background)",
+        selectionBackground: "#e5639d",
+        selectionForeground: "#111318",
       }),
       dark: paletteTokens({
         background: "#0e1013",
@@ -273,6 +281,8 @@ export const PALETTES: readonly PaletteMeta[] = [
           "linear-gradient(transparent 35%, rgba(92, 48, 108, 0.2)), linear-gradient(135deg, rgba(255, 255, 255, 0.04), transparent 60%)",
         shellBackground:
           "radial-gradient(rgba(100, 40, 180, 0.12), transparent 50%), radial-gradient(at 80% 20%, rgba(80, 30, 140, 0.08), transparent 45%), linear-gradient(145deg, #1a0e2d, #0e1418, #130e1b)",
+        selectionBackground: "#a02f63",
+        selectionForeground: "#ffffff",
       }),
     },
   },
@@ -308,6 +318,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         brandAccent: "#d6409f",
         sidebar: "#f3f0fa",
         shellBackground: "linear-gradient(160deg, #faf8ff 0%, #f5f1fd 50%, #f3eefb 100%)",
+        selectionBackground: "#dd64b2",
+        selectionForeground: "#111318",
       }),
       dark: paletteTokens({
         background: "#282a36",
@@ -330,6 +342,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebar: "rgba(33, 34, 44, 0.8)",
         shellBackground:
           "radial-gradient(ellipse at 20% 40%, rgba(189, 147, 249, 0.14) 0%, transparent 50%), radial-gradient(ellipse at 80% 20%, rgba(255, 121, 198, 0.1) 0%, transparent 45%), linear-gradient(160deg, #2a2c3a 0%, #282a36 55%, #21222c 100%)",
+        selectionBackground: "#94527e",
+        selectionForeground: "#ffffff",
       }),
     },
   },
@@ -364,6 +378,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         ring: "#0969da",
         sidebar: "#f6f8fa",
         shellBackground: "linear-gradient(180deg, #fbfcfd 0%, #f6f8fa 100%)",
+        selectionBackground: "#5094e4",
+        selectionForeground: "#111318",
       }),
       dark: paletteTokens({
         background: "#0d1117",
@@ -385,6 +401,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebar: "rgba(13, 17, 23, 0.75)",
         sidebarPrimaryForeground: "#0d1117",
         shellBackground: "linear-gradient(160deg, #0d1117 0%, #0a0e14 100%)",
+        selectionBackground: "#3a6aa2",
+        selectionForeground: "#ffffff",
       }),
     },
   },
@@ -420,6 +438,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         brandAccent: "#ea76cb",
         sidebar: "#e6e9ef",
         shellBackground: "linear-gradient(160deg, #f2f3f7 0%, #eff1f5 60%, #e9ecf2 100%)",
+        selectionBackground: "#a770f1",
+        selectionForeground: "#111318",
       }),
       dark: paletteTokens({
         background: "#1e1e2e",
@@ -441,6 +461,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebar: "rgba(24, 24, 37, 0.8)",
         shellBackground:
           "radial-gradient(ellipse at 20% 30%, rgba(203, 166, 247, 0.12) 0%, transparent 55%), radial-gradient(ellipse at 80% 20%, rgba(245, 194, 231, 0.08) 0%, transparent 45%), linear-gradient(160deg, #232336 0%, #1e1e2e 60%, #181825 100%)",
+        selectionBackground: "#746292",
+        selectionForeground: "#ffffff",
       }),
     },
   },
@@ -475,6 +497,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         ring: "#d65d0e",
         sidebar: "#f4e8bc",
         shellBackground: "linear-gradient(160deg, #fbf3cd 0%, #fbf1c7 55%, #f7ecbb 100%)",
+        selectionBackground: "#e18946",
+        selectionForeground: "#111318",
       }),
       dark: paletteTokens({
         background: "#282828",
@@ -496,6 +520,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebar: "rgba(29, 32, 33, 0.8)",
         shellBackground:
           "radial-gradient(ellipse at 20% 30%, rgba(254, 128, 25, 0.1) 0%, transparent 55%), radial-gradient(ellipse at 80% 20%, rgba(250, 189, 47, 0.07) 0%, transparent 45%), linear-gradient(160deg, #32302f 0%, #282828 60%, #1d2021 100%)",
+        selectionBackground: "#935420",
+        selectionForeground: "#ffffff",
       }),
     },
   },
@@ -531,6 +557,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebar: "#e5e9f0",
         sidebarAccent: "#d8dee9",
         shellBackground: "linear-gradient(160deg, #eceff4 0%, #e5e9f0 55%, #d8dee9 100%)",
+        selectionBackground: "#89a2c2",
+        selectionForeground: "#111318",
       }),
       dark: paletteTokens({
         background: "#2e3440",
@@ -552,6 +580,8 @@ export const PALETTES: readonly PaletteMeta[] = [
         sidebar: "rgba(46, 52, 64, 0.8)",
         shellBackground:
           "radial-gradient(ellipse at 20% 30%, rgba(136, 192, 208, 0.12) 0%, transparent 55%), radial-gradient(ellipse at 80% 20%, rgba(94, 129, 172, 0.08) 0%, transparent 45%), linear-gradient(160deg, #434c5e 0%, #2e3440 60%, #2e3440 100%)",
+        selectionBackground: "#526c7a",
+        selectionForeground: "#ffffff",
       }),
     },
   },

--- a/web/src/shell/MarkdownRichTextViewer.tsx
+++ b/web/src/shell/MarkdownRichTextViewer.tsx
@@ -501,7 +501,7 @@ function MarkdownRichTextViewerInner({
         )}
         <EditorContent
           editor={editor}
-          className="outline-none max-w-none text-ui text-foreground [&_*::selection]:bg-blue-300/40 [&_*::selection]:text-foreground [&::selection]:bg-blue-300/40 [&::selection]:text-foreground tiptap-md-content"
+          className="outline-none max-w-none text-ui text-foreground tiptap-md-content"
         />
       </div>
       {canEdit && editor && (

--- a/web/src/shell/pdfViewer.css
+++ b/web/src/shell/pdfViewer.css
@@ -1,15 +1,10 @@
-/* Browser-only highlight overlays for PDF comment anchors. Colors mirror the
-   Monaco/Shiki comment decorations (yellow wash). */
+/* Browser-only highlight overlays for PDF comment anchors. */
 
 .pdf-viewer .textLayer *::selection {
-  /* pdf.js text spans are transparent; keep selection yellow so it doesn't
-     clash with the app-wide brand-accent ::selection styling. */
-  background: rgba(250, 204, 21, 0.4);
-  color: transparent;
-}
-
-.dark .pdf-viewer .textLayer *::selection {
-  background: rgba(250, 204, 21, 0.35);
+  /* pdf.js text spans are transparent (the visible glyphs are baked into the
+     rendered page image), so selection can only show as a translucent wash
+     over that image — a solid --selection-background would blot it out. */
+  background: color-mix(in srgb, var(--selection-background) 40%, transparent);
   color: transparent;
 }
 

--- a/web/src/themePalettes.generated.css
+++ b/web/src/themePalettes.generated.css
@@ -34,6 +34,8 @@
   --sidebar-ring: #2272b4;
   --sidebar-active: rgba(240, 1, 150, 0.1);
   --sidebar-active-foreground: #651249;
+  --selection-background: #e5639d;
+  --selection-foreground: #111318;
 }
 
 :root:not(.dark):not([data-theme]) .app-shell {
@@ -78,6 +80,8 @@
   --sidebar-ring: oklch(0.92 0.003 240 / 0.4);
   --sidebar-active: rgba(240, 1, 150, 0.15);
   --sidebar-active-foreground: #f472b6;
+  --selection-background: #a02f63;
+  --selection-foreground: #ffffff;
 }
 
 .dark:not([data-theme]) .app-shell {
@@ -127,6 +131,8 @@
   --sidebar-ring: #7c3aed;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #dd64b2;
+  --selection-foreground: #111318;
 }
 
 :root:not(.dark)[data-theme="dracula"] .app-shell {
@@ -171,6 +177,8 @@
   --sidebar-ring: #bd93f9;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #94527e;
+  --selection-foreground: #ffffff;
 }
 
 .dark[data-theme="dracula"] .app-shell {
@@ -218,6 +226,8 @@
   --sidebar-ring: #0969da;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #5094e4;
+  --selection-foreground: #111318;
 }
 
 :root:not(.dark)[data-theme="github"] .app-shell {
@@ -262,6 +272,8 @@
   --sidebar-ring: #58a6ff;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #3a6aa2;
+  --selection-foreground: #ffffff;
 }
 
 .dark[data-theme="github"] .app-shell {
@@ -306,6 +318,8 @@
   --sidebar-ring: #8839ef;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #a770f1;
+  --selection-foreground: #111318;
 }
 
 :root:not(.dark)[data-theme="catppuccin"] .app-shell {
@@ -350,6 +364,8 @@
   --sidebar-ring: #cba6f7;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #746292;
+  --selection-foreground: #ffffff;
 }
 
 .dark[data-theme="catppuccin"] .app-shell {
@@ -397,6 +413,8 @@
   --sidebar-ring: #d65d0e;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #e18946;
+  --selection-foreground: #111318;
 }
 
 :root:not(.dark)[data-theme="gruvbox"] .app-shell {
@@ -441,6 +459,8 @@
   --sidebar-ring: #fe8019;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #935420;
+  --selection-foreground: #ffffff;
 }
 
 .dark[data-theme="gruvbox"] .app-shell {
@@ -488,6 +508,8 @@
   --sidebar-ring: #5e81ac;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #89a2c2;
+  --selection-foreground: #111318;
 }
 
 :root:not(.dark)[data-theme="nord"] .app-shell {
@@ -532,6 +554,8 @@
   --sidebar-ring: #88c0d0;
   --sidebar-active: color-mix(in srgb, var(--sidebar-foreground) 7%, var(--sidebar));
   --sidebar-active-foreground: var(--sidebar-foreground);
+  --selection-background: #526c7a;
+  --selection-foreground: #ffffff;
 }
 
 .dark[data-theme="nord"] .app-shell {
@@ -579,6 +603,8 @@
   --sidebar-ring: var(--custom-light-sidebar-ring);
   --sidebar-active: var(--custom-light-sidebar-active);
   --sidebar-active-foreground: var(--custom-light-sidebar-active-foreground);
+  --selection-background: var(--custom-light-selection-background);
+  --selection-foreground: var(--custom-light-selection-foreground);
 }
 
 :root:not(.dark)[data-theme="custom"] .app-shell {
@@ -623,6 +649,8 @@
   --sidebar-ring: var(--custom-dark-sidebar-ring);
   --sidebar-active: var(--custom-dark-sidebar-active);
   --sidebar-active-foreground: var(--custom-dark-sidebar-active-foreground);
+  --selection-background: var(--custom-dark-selection-background);
+  --selection-foreground: var(--custom-dark-selection-foreground);
 }
 
 .dark[data-theme="custom"] .app-shell {


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

N/A — no linked issue

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

- Add dedicated selection background/foreground tokens for every built-in palette and custom themes, with contrast coverage for both light and dark modes.
- Use those tokens for global and Firefox selection, inherit them in rich text, preserve translucent PDF text-layer highlighting, and give xterm an explicit high-contrast selection foreground/background.
- Leave Monaco and the comment-highlight bridge unchanged because they use separate selection systems.

ELI5: selected text now remains clearly readable in every theme instead of reusing a faint sidebar-hover color.

```text
theme palette tokens
  |-> global ::selection / ::-moz-selection
  |-> rich text inheritance
  |-> translucent PDF text-layer highlight
  `-> explicit terminal selection colors
```

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

- Focused Vitest run across 10 theme, terminal, and rich-text test files — 240 tests passed.
- Theme palette generation consistency check passed.
- Prettier and Oxlint passed for all changed frontend source files.
- TypeScript project build passed.
- Before marking ready for review, attach light/dark visual evidence described below.

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Pending before ready for review: attach before/after screenshots of selected text in at least one light and one dark palette. Include terminal selection and PDF/rich-text selection where practical.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

Automated coverage verifies both selection tokens exist for every palette/mode and meet the intended wiring. Manual visual evidence is still required before the PR is ready.

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

Selected text is now legible and theme-aware across the app, terminal, rich text, and PDF viewer.
