### PR TITLE
Show selected provider status in New Chat

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -92,7 +92,7 @@ from omnigent.host.git_worktree import (
 from omnigent.host.identity import HostIdentity, load_or_create_host_identity
 from omnigent.host.runner_zygote import ZygoteManager, ZygoteRunnerProc, ZygoteUnavailable
 from omnigent.inner import _proc
-from omnigent.onboarding.ambient import detect_providers
+from omnigent.onboarding.ambient import detect_providers_noninteractive
 from omnigent.onboarding.harness_auth import (
     adopt_env_credential,
     detect_adoptable_credentials,
@@ -2539,14 +2539,18 @@ class HostProcess:
         :returns: Result frame with the non-secret credential descriptors.
         """
         try:
-            ambient = detect_providers()
+            ambient = detect_providers_noninteractive()
         except Exception:  # a status read must always settle
             _logger.exception("Failed to detect ambient providers")
             ambient = []
         detected = detect_adoptable_credentials(ambient)
         try:
             providers = [
-                entry.as_dict() for entry in build_provider_inventory(detected=list(ambient))
+                entry.as_dict()
+                for entry in build_provider_inventory(
+                    detected=list(ambient),
+                    harness_readiness=self._configured_harnesses,
+                )
             ]
         except Exception:  # malformed config must not hang the UI
             _logger.exception("Failed to build provider inventory")

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -92,6 +92,7 @@ from omnigent.host.git_worktree import (
 from omnigent.host.identity import HostIdentity, load_or_create_host_identity
 from omnigent.host.runner_zygote import ZygoteManager, ZygoteRunnerProc, ZygoteUnavailable
 from omnigent.inner import _proc
+from omnigent.onboarding.ambient import detect_providers
 from omnigent.onboarding.harness_auth import (
     adopt_env_credential,
     detect_adoptable_credentials,
@@ -108,6 +109,7 @@ from omnigent.onboarding.harness_readiness import (
     harness_is_configured,
 )
 from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, OPENAI_FAMILY
+from omnigent.onboarding.provider_inventory import build_provider_inventory
 from omnigent.process_logging import (
     LOG_TTY_FD_ENV_VAR,
     PROCESS_LOG_FILE_ENV_VAR,
@@ -2536,12 +2538,25 @@ class HostProcess:
         :param frame: The detect request (carries only a request id).
         :returns: Result frame with the non-secret credential descriptors.
         """
-        detected = detect_adoptable_credentials()
+        try:
+            ambient = detect_providers()
+        except Exception:  # a status read must always settle
+            _logger.exception("Failed to detect ambient providers")
+            ambient = []
+        detected = detect_adoptable_credentials(ambient)
+        try:
+            providers = [
+                entry.as_dict() for entry in build_provider_inventory(detected=list(ambient))
+            ]
+        except Exception:  # malformed config must not hang the UI
+            _logger.exception("Failed to build provider inventory")
+            providers = []
         return HostDetectCredentialsResultFrame(
             request_id=frame.request_id,
             credentials=[
                 {"family": d.family, "source": d.source, "env_var": d.env_var} for d in detected
             ],
+            providers=providers,
         )
 
     def _handle_fs_request(self, frame: HostFsRequestFrame) -> HostFsResultFrame:

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -785,10 +785,13 @@ class HostDetectCredentialsResultFrame:
     :param request_id: Correlates to the :class:`HostDetectCredentialsFrame`.
     :param credentials: List of ``{"family": ..., "source": ..., "env_var": ...}``
         dicts (non-secret). Empty when nothing adoptable was found.
+    :param providers: Sanitized provider inventory from the host's effective
+        Omnigent configuration. Empty for older hosts.
     """
 
     request_id: str
     credentials: list[dict[str, str | None]] = field(default_factory=list)
+    providers: list[_JsonObject] = field(default_factory=list)
 
 
 @dataclass
@@ -1300,6 +1303,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "kind": HostFrameKind.DETECT_CREDENTIALS_RESULT.value,
                 "request_id": frame.request_id,
                 "credentials": frame.credentials,
+                "providers": frame.providers,
             }
         )
     if isinstance(frame, HostFsRequestFrame):
@@ -1963,7 +1967,90 @@ def _decode_detect_credentials_result(msg: _JsonObject) -> HostDetectCredentials
     return HostDetectCredentialsResultFrame(
         request_id=_required_str(msg, "request_id"),
         credentials=creds,
+        providers=_decode_provider_inventory(msg.get("providers")),
     )
+
+
+_PROVIDER_CAPABILITY_VALUES = frozenset({"supported", "unsupported", "unknown"})
+
+
+def _decode_provider_inventory(raw: object) -> list[_JsonObject]:
+    """Allowlist non-secret fields from host-reported provider rows."""
+    if not isinstance(raw, list):
+        return []
+    providers: list[_JsonObject] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        required = (
+            "id",
+            "display_name",
+            "kind",
+            "origin",
+            "source",
+            "configuration_state",
+        )
+        if not all(isinstance(item.get(key), str) for key in required):
+            continue
+        if item.get("origin") not in {"configured", "detected"}:
+            continue
+        if item.get("configuration_state") not in {"valid", "invalid"}:
+            continue
+        string_lists: dict[str, list[str]] = {}
+        valid = True
+        for key in ("families", "surfaces", "default_for"):
+            value = item.get(key)
+            if not isinstance(value, list) or not all(isinstance(member, str) for member in value):
+                valid = False
+                break
+            string_lists[key] = list(value)
+        raw_models = item.get("default_models")
+        if not valid or not isinstance(raw_models, dict):
+            continue
+        default_models = {
+            key: value
+            for key, value in raw_models.items()
+            if isinstance(key, str) and isinstance(value, str)
+        }
+        if len(default_models) != len(raw_models):
+            continue
+        raw_capabilities = item.get("capabilities")
+        if not isinstance(raw_capabilities, dict):
+            continue
+        capability_names = (
+            "model_discovery",
+            "usage_status",
+            "multiple_profiles",
+            "interactive_cli",
+        )
+        capabilities: dict[str, str] = {}
+        for name in capability_names:
+            value = raw_capabilities.get(name)
+            if not isinstance(value, str) or value not in _PROVIDER_CAPABILITY_VALUES:
+                valid = False
+                break
+            capabilities[name] = value
+        if not valid:
+            continue
+        optional_strings: dict[str, str | None] = {}
+        for key in ("error", "cli", "profile", "model_provider"):
+            value = item.get(key)
+            if value is not None and not isinstance(value, str):
+                valid = False
+                break
+            optional_strings[key] = value
+        if not valid:
+            continue
+        providers.append(
+            {
+                **{key: item[key] for key in required},
+                **string_lists,
+                "default_models": default_models,
+                **optional_strings,
+                "capabilities": capabilities,
+            }
+        )
+    return providers
 
 
 def _decode_fs_request(msg: _JsonObject) -> HostFsRequestFrame:

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -2051,6 +2051,14 @@ def _decode_provider_inventory(raw: object) -> list[_JsonObject]:
             optional_strings[key] = value
         if not valid:
             continue
+        # Absent from hosts predating the pre-session picker: an empty list
+        # means "this host does not say", never "serves no harness".
+        raw_harnesses = item.get("default_for_harnesses")
+        default_for_harnesses = (
+            [name for name in raw_harnesses if isinstance(name, str)]
+            if isinstance(raw_harnesses, list)
+            else []
+        )
         raw_state = item.get("connection_state")
         state = raw_state if raw_state in _PROVIDER_CONNECTION_STATES else "unknown"
         raw_detail = item.get("connection_detail")
@@ -2068,6 +2076,7 @@ def _decode_provider_inventory(raw: object) -> list[_JsonObject]:
                 "capabilities": capabilities,
                 "connection_state": state,
                 "connection_detail": detail,
+                "default_for_harnesses": default_for_harnesses,
             }
         )
     return providers

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -1972,6 +1972,16 @@ def _decode_detect_credentials_result(msg: _JsonObject) -> HostDetectCredentials
 
 
 _PROVIDER_CAPABILITY_VALUES = frozenset({"supported", "unsupported", "unknown"})
+_PROVIDER_CONNECTION_STATES = frozenset(
+    {
+        "connected",
+        "authentication_required",
+        "misconfigured",
+        "unavailable",
+        "unknown",
+    }
+)
+_UNKNOWN_CONNECTION_DETAIL = "This host does not report provider connection state."
 
 
 def _decode_provider_inventory(raw: object) -> list[_JsonObject]:
@@ -2041,6 +2051,14 @@ def _decode_provider_inventory(raw: object) -> list[_JsonObject]:
             optional_strings[key] = value
         if not valid:
             continue
+        raw_state = item.get("connection_state")
+        state = raw_state if raw_state in _PROVIDER_CONNECTION_STATES else "unknown"
+        raw_detail = item.get("connection_detail")
+        detail = (
+            raw_detail
+            if isinstance(raw_detail, str) and raw_detail
+            else (_UNKNOWN_CONNECTION_DETAIL if state == "unknown" else "")
+        )
         providers.append(
             {
                 **{key: item[key] for key in required},
@@ -2048,6 +2066,8 @@ def _decode_provider_inventory(raw: object) -> list[_JsonObject]:
                 "default_models": default_models,
                 **optional_strings,
                 "capabilities": capabilities,
+                "connection_state": state,
+                "connection_detail": detail,
             }
         )
     return providers

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -567,7 +567,7 @@ def claude_managed_gateway_display_name(paths: tuple[Path, ...] | None = None) -
     return urlsplit(base_url).hostname or "Claude Code gateway"
 
 
-def _claude_login_detected() -> bool:
+def _claude_login_detected(*, allow_cli_auth_probe: bool = True) -> bool:
     """Return whether a usable Claude Code subscription login is present.
 
     File-first, with a macOS Keychain fallback. Claude Code stores its OAuth
@@ -598,7 +598,7 @@ def _claude_login_detected() -> bool:
     """
     if claude_auth_has_credential(_claude_credentials_path()):
         return True
-    if sys.platform == "darwin":
+    if allow_cli_auth_probe and sys.platform == "darwin":
         # macOS stores the Claude OAuth token in the Keychain, not the file
         # checked above. Ask the CLI itself (``claude auth status`` reads the
         # Keychain) rather than reimplement Keychain access here. Lazy import
@@ -710,7 +710,23 @@ def detect_providers() -> list[DetectedProvider]:
     return _detect_providers_now()
 
 
-def _detect_providers_now() -> list[DetectedProvider]:
+def detect_providers_noninteractive() -> list[DetectedProvider]:
+    """Detect providers without invoking a CLI or credential-store prompt.
+
+    This is the status-surface variant of :func:`detect_providers`. It keeps
+    structural evidence that can be inspected silently (environment presence,
+    credential/config files, managed settings, and the local Ollama socket),
+    but never consumes the interactive prewarm and never runs the macOS
+    ``claude auth status`` fallback that reads Keychain. A Keychain-only login
+    is therefore intentionally absent until a cached/provider-specific signal
+    can describe it as unknown.
+
+    :returns: Provider detections available without a CLI or secret-store read.
+    """
+    return _detect_providers_now(allow_cli_auth_probe=False)
+
+
+def _detect_providers_now(*, allow_cli_auth_probe: bool = True) -> list[DetectedProvider]:
     """Run the ambient-credential sweep (see :func:`detect_providers`)."""
     detected: list[DetectedProvider] = []
 
@@ -772,7 +788,7 @@ def _detect_providers_now() -> list[DetectedProvider]:
                 source="Claude Code managed settings",
             )
         )
-    elif _claude_login_detected():
+    elif _claude_login_detected(allow_cli_auth_probe=allow_cli_auth_probe):
         detected.append(
             DetectedProvider(
                 name="claude",

--- a/omnigent/onboarding/harness_auth.py
+++ b/omnigent/onboarding/harness_auth.py
@@ -23,8 +23,11 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Callable
-from typing import Literal, NamedTuple, Protocol
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol
+
+if TYPE_CHECKING:
+    from omnigent.onboarding.ambient import DetectedProvider
 
 from omnigent.onboarding.configure_models import (
     build_gateway_provider_entry,
@@ -260,7 +263,9 @@ class DetectedCredential(NamedTuple):
     env_var: str | None
 
 
-def detect_adoptable_credentials() -> list[DetectedCredential]:
+def detect_adoptable_credentials(
+    detected: Sequence[DetectedProvider] | None = None,
+) -> list[DetectedCredential]:
     """Return credentials already on the host the UI can offer to adopt.
 
     Wraps the existing ambient detection (:func:`ambient.detect_providers`),
@@ -270,13 +275,14 @@ def detect_adoptable_credentials() -> list[DetectedCredential]:
     and adopt it by reference. Never raises (a detection failure yields an empty
     list rather than crashing the readiness/adopt path).
     """
-    try:
-        from omnigent.onboarding.ambient import detect_providers
+    if detected is None:
+        try:
+            from omnigent.onboarding.ambient import detect_providers
 
-        detected = detect_providers()
-    except Exception:
-        _logger.debug("detect_adoptable_credentials: detection failed", exc_info=True)
-        return []
+            detected = detect_providers()
+        except Exception:
+            _logger.debug("detect_adoptable_credentials: detection failed", exc_info=True)
+            return []
 
     result: list[DetectedCredential] = []
     seen: set[tuple[str, str]] = set()

--- a/omnigent/onboarding/provider_inventory.py
+++ b/omnigent/onboarding/provider_inventory.py
@@ -2,24 +2,39 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 
+from omnigent.env_credentials import (
+    expand_envvars_with_omnigent_prefix,
+    getenv_nonempty_with_omnigent_prefix,
+)
+from omnigent.errors import OmnigentError
+from omnigent.harness_availability import (
+    HARNESS_BINARY_MISSING,
+    HARNESS_NEEDS_AUTH,
+    HARNESS_VERSION_TOO_LOW,
+    HarnessAvailability,
+)
 from omnigent.json_types import JsonObject
-from omnigent.onboarding.ambient import DetectedProvider, detect_providers
+from omnigent.onboarding.ambient import DetectedProvider, detect_providers_noninteractive
 from omnigent.onboarding.detected import effective_config_with_detected
 from omnigent.onboarding.provider_config import (
+    BEDROCK_KIND,
     CLI_CONFIG_KIND,
     DATABRICKS_KIND,
     GATEWAY_KIND,
     KEY_KIND,
     LOCAL_KIND,
     SUBSCRIPTION_KIND,
+    FamilyConfig,
     ProviderEntry,
     load_config,
     load_providers,
     provider_families,
 )
+from omnigent.spec.parser import check_unresolved_env_vars
 
 
 class CapabilitySupport(str, Enum):
@@ -49,6 +64,236 @@ class ProviderCapabilities:
         }
 
 
+class ConnectionState(str, Enum):
+    """How usable a provider is based on silent, local evidence."""
+
+    CONNECTED = "connected"
+    AUTHENTICATION_REQUIRED = "authentication_required"
+    MISCONFIGURED = "misconfigured"
+    UNAVAILABLE = "unavailable"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ProviderConnection:
+    """A settled local connection state and its non-secret explanation."""
+
+    state: ConnectionState
+    detail: str
+
+
+def _connection(state: ConnectionState, detail: str) -> ProviderConnection:
+    return ProviderConnection(state=state, detail=detail)
+
+
+_CLI_READINESS_HARNESS: dict[str, str] = {
+    "claude": "claude-native",
+    "codex": "codex-native",
+    "pi": "pi",
+}
+
+
+def _cli_connection(
+    provider: ProviderEntry,
+    readiness: Mapping[str, HarnessAvailability] | None,
+    *,
+    provider_detected: bool,
+) -> ProviderConnection:
+    """Describe a CLI provider without running the CLI's auth command.
+
+    Positive harness readiness is deliberately not treated as provider proof:
+    the harness map is aggregate and may be green because a different key or
+    gateway can launch the same harness. A safe ambient detection is
+    provider-specific, while cached negative binary/auth states remain useful.
+    """
+    cli = provider.cli
+    if cli is None:
+        return _connection(
+            ConnectionState.UNKNOWN,
+            "This provider does not name the CLI that carries its credential.",
+        )
+    availability = (
+        readiness.get(_CLI_READINESS_HARNESS.get(cli, cli)) if readiness is not None else None
+    )
+    if availability == HARNESS_VERSION_TOO_LOW:
+        return _connection(
+            ConnectionState.UNAVAILABLE,
+            f"The installed {cli} CLI is older than the version this harness requires.",
+        )
+    if availability is False or availability == HARNESS_BINARY_MISSING:
+        return _connection(
+            ConnectionState.UNAVAILABLE,
+            f"The {cli} CLI is not installed on this host.",
+        )
+    if provider_detected:
+        return _connection(
+            ConnectionState.CONNECTED,
+            f"A usable {cli} credential is configured locally; the vendor was not contacted.",
+        )
+    if provider.kind == SUBSCRIPTION_KIND and availability == HARNESS_NEEDS_AUTH:
+        return _connection(
+            ConnectionState.AUTHENTICATION_REQUIRED,
+            f"The {cli} CLI is installed but has no locally detected credential.",
+        )
+    if availability is True:
+        return _connection(
+            ConnectionState.UNKNOWN,
+            f"The {cli} harness is ready, but that readiness may come from another provider.",
+        )
+    return _connection(
+        ConnectionState.UNKNOWN,
+        f"This host has no provider-specific readiness evidence for the {cli} CLI.",
+    )
+
+
+def _reference_resolves(key: str, value: str) -> bool:
+    """Return whether environment references expand, without secret-store I/O."""
+    try:
+        expanded = expand_envvars_with_omnigent_prefix(value)
+        check_unresolved_env_vars(key, expanded)
+    except OmnigentError:
+        return False
+    return True
+
+
+def _family_connection(
+    provider_name: str,
+    family_name: str,
+    family: FamilyConfig,
+) -> ProviderConnection:
+    """Describe one inline family using only config and environment evidence."""
+    prefix = f"providers.{provider_name}.{family_name}"
+    if not _reference_resolves(f"{prefix}.base_url", family.base_url):
+        return _connection(
+            ConnectionState.MISCONFIGURED,
+            f"The {family_name} endpoint references an environment variable that is not set.",
+        )
+    if family.api_key is not None:
+        if not _reference_resolves(f"{prefix}.api_key", family.api_key):
+            return _connection(
+                ConnectionState.AUTHENTICATION_REQUIRED,
+                f"The {family_name} API key references an environment variable that is not set.",
+            )
+        return _connection(
+            ConnectionState.CONNECTED,
+            f"The {family_name} credential is configured locally; the vendor was not contacted.",
+        )
+    if family.api_key_ref is not None:
+        if family.api_key_ref.startswith("env:"):
+            env_var = family.api_key_ref[len("env:") :]
+            if getenv_nonempty_with_omnigent_prefix(env_var) is None:
+                return _connection(
+                    ConnectionState.AUTHENTICATION_REQUIRED,
+                    f"The {family_name} credential environment variable is not set.",
+                )
+            return _connection(
+                ConnectionState.CONNECTED,
+                f"The {family_name} credential is present in the environment; "
+                "the vendor was not contacted.",
+            )
+        if family.api_key_ref.startswith("keychain:"):
+            return _connection(
+                ConnectionState.UNKNOWN,
+                f"The {family_name} credential is stored in a protected secret store "
+                "that status reads do not open.",
+            )
+        return _connection(
+            ConnectionState.UNKNOWN,
+            f"The {family_name} credential uses a reference status reads do not resolve.",
+        )
+    if family.auth_command is not None:
+        return _connection(
+            ConnectionState.UNKNOWN,
+            f"The {family_name} credential comes from an auth command run only at launch.",
+        )
+    return _connection(
+        ConnectionState.MISCONFIGURED,
+        f"The {family_name} family declares no credential source.",
+    )
+
+
+_FAMILY_STATE_PRECEDENCE: tuple[ConnectionState, ...] = (
+    ConnectionState.MISCONFIGURED,
+    ConnectionState.AUTHENTICATION_REQUIRED,
+    ConnectionState.UNKNOWN,
+    ConnectionState.CONNECTED,
+)
+
+
+def _families_connection(provider: ProviderEntry) -> ProviderConnection:
+    results = [
+        _family_connection(provider.name, family, provider.families[family])
+        for family in sorted(provider.families)
+    ]
+    if not results:
+        return _connection(ConnectionState.MISCONFIGURED, "This provider serves no model family.")
+    for state in _FAMILY_STATE_PRECEDENCE:
+        for result in results:
+            if result.state is state:
+                return result
+    return results[0]
+
+
+def _databricks_connection(provider: ProviderEntry) -> ProviderConnection:
+    """Check profile declarations and package presence without authenticating."""
+    from omnigent.onboarding.databricks_config import (
+        databricks_sdk_installed,
+        list_databricks_profiles,
+    )
+
+    profile = provider.profile
+    if profile is None:
+        return _connection(ConnectionState.MISCONFIGURED, "This provider names no profile.")
+    if profile not in list_databricks_profiles():
+        return _connection(
+            ConnectionState.AUTHENTICATION_REQUIRED,
+            "The configured Databricks profile is not declared on this host.",
+        )
+    if not databricks_sdk_installed():
+        return _connection(
+            ConnectionState.UNAVAILABLE,
+            "The databricks extra is not installed on this host.",
+        )
+    return _connection(
+        ConnectionState.UNKNOWN,
+        "The Databricks profile and SDK are present, but status reads do not authenticate it.",
+    )
+
+
+def provider_connection_state(
+    provider: ProviderEntry,
+    *,
+    harness_readiness: Mapping[str, HarnessAvailability] | None = None,
+    provider_detected: bool = False,
+) -> ProviderConnection:
+    """Return a provider-specific state without reading a secret or running a CLI."""
+    try:
+        if provider.kind in (SUBSCRIPTION_KIND, CLI_CONFIG_KIND):
+            return _cli_connection(
+                provider,
+                harness_readiness,
+                provider_detected=provider_detected,
+            )
+        if provider.kind == DATABRICKS_KIND:
+            return _databricks_connection(provider)
+        if provider.kind in (KEY_KIND, GATEWAY_KIND, LOCAL_KIND):
+            return _families_connection(provider)
+        if provider.kind == BEDROCK_KIND:
+            return _connection(
+                ConnectionState.UNKNOWN,
+                "Bedrock credentials resolve from the AWS credential chain only at launch.",
+            )
+    except Exception:
+        return _connection(
+            ConnectionState.UNKNOWN,
+            "This provider's local status could not be checked without authenticating.",
+        )
+    return _connection(
+        ConnectionState.UNKNOWN,
+        f"Omnigent cannot check a {provider.kind} provider without authenticating.",
+    )
+
+
 @dataclass(frozen=True)
 class ProviderInventoryEntry:
     """A configured or ambient provider without credential material."""
@@ -68,6 +313,8 @@ class ProviderInventoryEntry:
     profile: str | None
     model_provider: str | None
     capabilities: ProviderCapabilities
+    connection_state: ConnectionState
+    connection_detail: str
 
     def as_dict(self) -> JsonObject:
         """Return the public API representation."""
@@ -87,6 +334,8 @@ class ProviderInventoryEntry:
             "profile": self.profile,
             "model_provider": self.model_provider,
             "capabilities": self.capabilities.as_dict(),
+            "connection_state": self.connection_state.value,
+            "connection_detail": self.connection_detail,
         }
 
 
@@ -137,12 +386,13 @@ def build_provider_inventory(
     config: dict[str, object] | None = None,
     *,
     detected: list[DetectedProvider] | None = None,
+    harness_readiness: Mapping[str, HarnessAvailability] | None = None,
 ) -> list[ProviderInventoryEntry]:
-    """Return configured plus ambient providers without resolving secrets."""
+    """Return providers and silent local status without resolving secrets."""
     if config is None:
         config = dict(load_config())
     if detected is None:
-        detected = detect_providers()
+        detected = detect_providers_noninteractive()
 
     explicit_raw = config.get("providers")
     explicit_names = set(explicit_raw) if isinstance(explicit_raw, dict) else set()
@@ -188,9 +438,35 @@ def build_provider_inventory(
                     profile=None,
                     model_provider=None,
                     capabilities=_unknown_capabilities(),
+                    connection_state=ConnectionState.MISCONFIGURED,
+                    connection_detail=(
+                        "This provider's configuration could not be parsed on this host."
+                    ),
                 )
             )
             continue
+        provider_detected = any(
+            item.kind == provider.kind
+            and (
+                item.name == provider.name
+                or (
+                    provider.kind == SUBSCRIPTION_KIND
+                    and provider.cli is not None
+                    and item.name == provider.cli
+                )
+                or (
+                    provider.kind == CLI_CONFIG_KIND
+                    and provider.model_provider is not None
+                    and item.model_provider == provider.model_provider
+                )
+            )
+            for item in detected
+        )
+        connection = provider_connection_state(
+            provider,
+            harness_readiness=harness_readiness,
+            provider_detected=provider_detected,
+        )
         surfaces = tuple(sorted(provider_families(provider)))
         families = tuple(surface for surface in surfaces if surface != "pi")
         default_models = {
@@ -215,6 +491,8 @@ def build_provider_inventory(
                 profile=provider.profile,
                 model_provider=provider.model_provider,
                 capabilities=provider_capabilities(provider),
+                connection_state=connection.state,
+                connection_detail=connection.detail,
             )
         )
     return inventory
@@ -222,8 +500,11 @@ def build_provider_inventory(
 
 __all__ = [
     "CapabilitySupport",
+    "ConnectionState",
     "ProviderCapabilities",
+    "ProviderConnection",
     "ProviderInventoryEntry",
     "build_provider_inventory",
     "provider_capabilities",
+    "provider_connection_state",
 ]

--- a/omnigent/onboarding/provider_inventory.py
+++ b/omnigent/onboarding/provider_inventory.py
@@ -30,6 +30,7 @@ from omnigent.onboarding.provider_config import (
     SUBSCRIPTION_KIND,
     FamilyConfig,
     ProviderEntry,
+    default_provider_for_harness,
     load_config,
     load_providers,
     provider_families,
@@ -315,6 +316,7 @@ class ProviderInventoryEntry:
     capabilities: ProviderCapabilities
     connection_state: ConnectionState
     connection_detail: str
+    default_for_harnesses: tuple[str, ...] = ()
 
     def as_dict(self) -> JsonObject:
         """Return the public API representation."""
@@ -336,6 +338,7 @@ class ProviderInventoryEntry:
             "capabilities": self.capabilities.as_dict(),
             "connection_state": self.connection_state.value,
             "connection_detail": self.connection_detail,
+            "default_for_harnesses": list(self.default_for_harnesses),
         }
 
 
@@ -382,6 +385,60 @@ def provider_capabilities(provider: ProviderEntry) -> ProviderCapabilities:
     )
 
 
+# Harnesses a pre-session picker asks about. Resolving each one host-side keeps
+# the harness→provider rule in the one function that owns it, instead of
+# re-deriving it from families in the web app.
+_PICKER_HARNESSES: tuple[str, ...] = (
+    "claude-native",
+    "claude-sdk",
+    "codex-native",
+    "codex",
+    "openai-agents",
+    "pi-native",
+    "pi",
+)
+
+
+def _default_harnesses_by_provider(config: dict[str, object]) -> dict[str, tuple[str, ...]]:
+    """Map each provider name to the harnesses it would serve by default.
+
+    Uses :func:`default_provider_for_harness`, the same resolver a launch uses,
+    so a status surface can name the provider that will actually run a session
+    rather than guessing from families.
+
+    :param config: The effective config, ambient detections included.
+    :returns: Provider name → harness ids, e.g. ``{"codex": ("codex-native",)}``.
+    """
+    raw_providers = config.get("providers")
+    if not isinstance(raw_providers, dict):
+        return {}
+
+    # The canonical resolver parses the whole provider table. Give it only the
+    # individually valid rows so one unrelated typo cannot hide every valid
+    # harness mapping from this read-only status surface.
+    valid_providers: dict[str, object] = {}
+    for raw_name, raw_provider in raw_providers.items():
+        name = str(raw_name)
+        try:
+            parsed = load_providers({"providers": {name: raw_provider}})
+        except Exception:
+            continue
+        if name in parsed:
+            valid_providers[name] = raw_provider
+
+    resolver_config = dict(config)
+    resolver_config["providers"] = valid_providers
+    by_provider: dict[str, list[str]] = {}
+    for harness in _PICKER_HARNESSES:
+        try:
+            provider = default_provider_for_harness(resolver_config, harness)
+        except Exception:  # a malformed default must not erase the whole map
+            continue
+        if provider is not None:
+            by_provider.setdefault(provider.name, []).append(harness)
+    return {name: tuple(harnesses) for name, harnesses in by_provider.items()}
+
+
 def build_provider_inventory(
     config: dict[str, object] | None = None,
     *,
@@ -405,6 +462,7 @@ def build_provider_inventory(
     if not isinstance(raw_providers, dict):
         return []
 
+    default_harnesses = _default_harnesses_by_provider(effective)
     inventory: list[ProviderInventoryEntry] = []
     for raw_name, raw_provider in raw_providers.items():
         name = str(raw_name)
@@ -493,6 +551,7 @@ def build_provider_inventory(
                 capabilities=provider_capabilities(provider),
                 connection_state=connection.state,
                 connection_detail=connection.detail,
+                default_for_harnesses=default_harnesses.get(provider.name, ()),
             )
         )
     return inventory

--- a/omnigent/onboarding/provider_inventory.py
+++ b/omnigent/onboarding/provider_inventory.py
@@ -1,0 +1,229 @@
+"""Non-secret provider inventory for host and UI status surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from omnigent.json_types import JsonObject
+from omnigent.onboarding.ambient import DetectedProvider, detect_providers
+from omnigent.onboarding.detected import effective_config_with_detected
+from omnigent.onboarding.provider_config import (
+    CLI_CONFIG_KIND,
+    DATABRICKS_KIND,
+    GATEWAY_KIND,
+    KEY_KIND,
+    LOCAL_KIND,
+    SUBSCRIPTION_KIND,
+    ProviderEntry,
+    load_config,
+    load_providers,
+    provider_families,
+)
+
+
+class CapabilitySupport(str, Enum):
+    """Whether Omnigent currently exposes a provider capability."""
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    """Provider-level features, kept separate from harness capabilities."""
+
+    model_discovery: CapabilitySupport
+    usage_status: CapabilitySupport
+    multiple_profiles: CapabilitySupport
+    interactive_cli: CapabilitySupport
+
+    def as_dict(self) -> JsonObject:
+        """Return a JSON-safe capability view."""
+        return {
+            "model_discovery": self.model_discovery.value,
+            "usage_status": self.usage_status.value,
+            "multiple_profiles": self.multiple_profiles.value,
+            "interactive_cli": self.interactive_cli.value,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderInventoryEntry:
+    """A configured or ambient provider without credential material."""
+
+    provider_id: str
+    display_name: str
+    kind: str
+    origin: str
+    source: str
+    configuration_state: str
+    error: str | None
+    families: tuple[str, ...]
+    surfaces: tuple[str, ...]
+    default_for: tuple[str, ...]
+    default_models: dict[str, str]
+    cli: str | None
+    profile: str | None
+    model_provider: str | None
+    capabilities: ProviderCapabilities
+
+    def as_dict(self) -> JsonObject:
+        """Return the public API representation."""
+        return {
+            "id": self.provider_id,
+            "display_name": self.display_name,
+            "kind": self.kind,
+            "origin": self.origin,
+            "source": self.source,
+            "configuration_state": self.configuration_state,
+            "error": self.error,
+            "families": list(self.families),
+            "surfaces": list(self.surfaces),
+            "default_for": list(self.default_for),
+            "default_models": dict(self.default_models),
+            "cli": self.cli,
+            "profile": self.profile,
+            "model_provider": self.model_provider,
+            "capabilities": self.capabilities.as_dict(),
+        }
+
+
+_DISCOVERABLE_KINDS = frozenset({KEY_KIND, GATEWAY_KIND, LOCAL_KIND, DATABRICKS_KIND})
+
+
+def _unknown_capabilities() -> ProviderCapabilities:
+    return ProviderCapabilities(
+        model_discovery=CapabilitySupport.UNKNOWN,
+        usage_status=CapabilitySupport.UNKNOWN,
+        multiple_profiles=CapabilitySupport.UNKNOWN,
+        interactive_cli=CapabilitySupport.UNKNOWN,
+    )
+
+
+def provider_capabilities(provider: ProviderEntry) -> ProviderCapabilities:
+    """Derive conservative capabilities from an existing provider entry."""
+    known_cli_discovery = (
+        provider.kind == SUBSCRIPTION_KIND and provider.cli in {"claude", "codex", "pi"}
+    ) or (provider.kind == CLI_CONFIG_KIND and provider.cli == "codex")
+    model_discovery = (
+        CapabilitySupport.SUPPORTED
+        if (provider.kind in _DISCOVERABLE_KINDS or known_cli_discovery)
+        else CapabilitySupport.UNKNOWN
+    )
+    interactive_cli = (
+        CapabilitySupport.SUPPORTED
+        if provider.kind in {SUBSCRIPTION_KIND, CLI_CONFIG_KIND}
+        else CapabilitySupport.UNSUPPORTED
+    )
+    if provider.kind == DATABRICKS_KIND:
+        multiple_profiles = CapabilitySupport.SUPPORTED
+    elif provider.kind == SUBSCRIPTION_KIND:
+        multiple_profiles = CapabilitySupport.UNSUPPORTED
+    else:
+        multiple_profiles = CapabilitySupport.UNKNOWN
+    return ProviderCapabilities(
+        model_discovery=model_discovery,
+        # Session token/cost accounting exists, but proactive provider quota
+        # status is not implemented by any provider integration today.
+        usage_status=CapabilitySupport.UNSUPPORTED,
+        multiple_profiles=multiple_profiles,
+        interactive_cli=interactive_cli,
+    )
+
+
+def build_provider_inventory(
+    config: dict[str, object] | None = None,
+    *,
+    detected: list[DetectedProvider] | None = None,
+) -> list[ProviderInventoryEntry]:
+    """Return configured plus ambient providers without resolving secrets."""
+    if config is None:
+        config = dict(load_config())
+    if detected is None:
+        detected = detect_providers()
+
+    explicit_raw = config.get("providers")
+    explicit_names = set(explicit_raw) if isinstance(explicit_raw, dict) else set()
+    detected_by_name = {item.name: item for item in detected}
+    try:
+        effective = effective_config_with_detected(config, detected)
+    except Exception:  # one malformed explicit entry must not erase every row
+        effective = config
+    raw_providers = effective.get("providers")
+    if not isinstance(raw_providers, dict):
+        return []
+
+    inventory: list[ProviderInventoryEntry] = []
+    for raw_name, raw_provider in raw_providers.items():
+        name = str(raw_name)
+        ambient = detected_by_name.get(name)
+        origin = "configured" if name in explicit_names else "detected"
+        source = ambient.source if origin == "detected" and ambient is not None else "config"
+        try:
+            parsed = load_providers({"providers": {name: raw_provider}})
+            provider = parsed.get(name)
+        except Exception:
+            provider = None
+        if provider is None:
+            inventory.append(
+                ProviderInventoryEntry(
+                    provider_id=name,
+                    display_name=name,
+                    kind=(
+                        str(raw_provider.get("kind", "unknown"))
+                        if isinstance(raw_provider, dict)
+                        else "unknown"
+                    ),
+                    origin=origin,
+                    source=source,
+                    configuration_state="invalid",
+                    error="Provider configuration is invalid. Reconfigure this provider.",
+                    families=(),
+                    surfaces=(),
+                    default_for=(),
+                    default_models={},
+                    cli=None,
+                    profile=None,
+                    model_provider=None,
+                    capabilities=_unknown_capabilities(),
+                )
+            )
+            continue
+        surfaces = tuple(sorted(provider_families(provider)))
+        families = tuple(surface for surface in surfaces if surface != "pi")
+        default_models = {
+            family: model
+            for family in families
+            if (model := provider.family_default_model(family)) is not None
+        }
+        inventory.append(
+            ProviderInventoryEntry(
+                provider_id=provider.name,
+                display_name=provider.display_name or provider.name,
+                kind=provider.kind,
+                origin=origin,
+                source=source,
+                configuration_state="valid",
+                error=None,
+                families=families,
+                surfaces=surfaces,
+                default_for=tuple(sorted(provider.default_families)),
+                default_models=default_models,
+                cli=provider.cli,
+                profile=provider.profile,
+                model_provider=provider.model_provider,
+                capabilities=provider_capabilities(provider),
+            )
+        )
+    return inventory
+
+
+__all__ = [
+    "CapabilitySupport",
+    "ProviderCapabilities",
+    "ProviderInventoryEntry",
+    "build_provider_inventory",
+    "provider_capabilities",
+]

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -722,7 +722,9 @@ async def _receive_loop(
         if isinstance(frame, HostDetectCredentialsResultFrame):
             detect_future = conn.pending_credential_detects.pop(frame.request_id, None)
             if detect_future is not None and not detect_future.done():
-                detect_future.set_result({"credentials": frame.credentials})
+                detect_future.set_result(
+                    {"credentials": frame.credentials, "providers": frame.providers}
+                )
             continue
 
         if isinstance(frame, HostFsResultFrame):

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -393,7 +393,7 @@ async def _proxy_detect_credentials(
 
     :param host_registry: Server-side registry; used to enqueue the frame.
     :param host_conn: Live host connection.
-    :returns: Dict with a ``credentials`` list of non-secret descriptors.
+    :returns: Dict with non-secret ``credentials`` and ``providers`` lists.
     :raises HTTPException: 504 on timeout, 502 on connection drop.
     """
     request_id = secrets.token_hex(8)
@@ -1523,6 +1523,38 @@ def create_hosts_router(
         return {
             "object": "detected_credentials",
             "credentials": result.get("credentials") or [],
+        }
+
+    @router.get("/hosts/{host_id}/providers")
+    async def list_host_providers(
+        request: Request,
+        host_id: str,
+    ) -> dict[str, Any]:
+        """List the connected host's configured and ambient providers.
+
+        Uses the same host-side provider parsing and ambient detection as Omni
+        Setup. The response contains only display metadata and conservative
+        capability states; credentials, secret references, and endpoints never
+        cross the tunnel.
+        """
+        if not flags.enabled(Feature.HARNESS_INSTALL):
+            raise HTTPException(status_code=404, detail="not found")
+
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise _host_absent_error(host)
+
+        result = await _proxy_detect_credentials(host_registry=host_registry, host_conn=conn)
+        return {
+            "object": "provider_inventory",
+            "providers": result.get("providers") or [],
         }
 
     @router.get("/hosts/{host_id}/worktrees")

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -1532,14 +1532,12 @@ def create_hosts_router(
     ) -> dict[str, Any]:
         """List the connected host's configured and ambient providers.
 
-        Uses the same host-side provider parsing and ambient detection as Omni
-        Setup. The response contains only display metadata and conservative
-        capability states; credentials, secret references, and endpoints never
-        cross the tunnel.
+        Uses the host's non-interactive provider parsing and ambient detection.
+        The response contains only display metadata and conservative capability
+        and connection states; credentials, secret references, and endpoints
+        never cross the tunnel. Unlike the mutation endpoints next to it, this
+        read-only inventory is always available.
         """
-        if not flags.enabled(Feature.HARNESS_INSTALL):
-            raise HTTPException(status_code=404, detail="not found")
-
         user_id = require_user(request, auth_provider)
         host = await asyncio.to_thread(host_store.get_host, host_id)
         if host is None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3032,14 +3032,14 @@ def test_handle_detect_credentials_returns_non_secret_descriptors(
 
     monkeypatch.setattr(
         connect,
-        "detect_providers",
+        "detect_providers_noninteractive",
         lambda: [SimpleNamespace(family="anthropic", kind="key", source="$ANTHROPIC_API_KEY")],
     )
     provider = {"id": "claude", "kind": "subscription"}
     monkeypatch.setattr(
         connect,
         "build_provider_inventory",
-        lambda *, detected: [SimpleNamespace(as_dict=lambda: provider)],
+        lambda *, detected, harness_readiness: [SimpleNamespace(as_dict=lambda: provider)],
     )
     host = _make_host_process()
     result = host._handle_detect_credentials(HostDetectCredentialsFrame(request_id="d1"))

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3029,12 +3029,17 @@ def test_handle_detect_credentials_returns_non_secret_descriptors(
 ) -> None:
     """The detect handler returns the core's descriptors as plain dicts."""
     import omnigent.host.connect as connect
-    from omnigent.onboarding.harness_auth import DetectedCredential
 
     monkeypatch.setattr(
         connect,
-        "detect_adoptable_credentials",
-        lambda: [DetectedCredential("anthropic", "$ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY")],
+        "detect_providers",
+        lambda: [SimpleNamespace(family="anthropic", kind="key", source="$ANTHROPIC_API_KEY")],
+    )
+    provider = {"id": "claude", "kind": "subscription"}
+    monkeypatch.setattr(
+        connect,
+        "build_provider_inventory",
+        lambda *, detected: [SimpleNamespace(as_dict=lambda: provider)],
     )
     host = _make_host_process()
     result = host._handle_detect_credentials(HostDetectCredentialsFrame(request_id="d1"))
@@ -3042,6 +3047,7 @@ def test_handle_detect_credentials_returns_non_secret_descriptors(
     assert result.credentials == [
         {"family": "anthropic", "source": "$ANTHROPIC_API_KEY", "env_var": "ANTHROPIC_API_KEY"}
     ]
+    assert result.providers == [provider]
 
 
 # --- Fail-loud on permanent tunnel failures ----------------------------

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -1533,6 +1533,7 @@ def test_detect_credentials_round_trip() -> None:
                 },
                 "connection_state": "authentication_required",
                 "connection_detail": "The claude CLI has no locally detected credential.",
+                "default_for_harnesses": ["claude-native"],
             }
         ],
     )
@@ -1657,6 +1658,15 @@ def test_provider_row_from_older_host_defaults_connection_state_to_unknown() -> 
 
     assert row["connection_state"] == "unknown"
     assert row["connection_detail"] == "This host does not report provider connection state."
+    assert row["default_for_harnesses"] == []
+
+
+def test_provider_row_keeps_only_string_harness_mappings() -> None:
+    [row] = _decode_providers(
+        _provider_row(default_for_harnesses=["codex-native", 7, None, "openai-agents"])
+    )
+
+    assert row["default_for_harnesses"] == ["codex-native", "openai-agents"]
 
 
 def test_provider_row_rejects_unknown_connection_state_without_dropping_row() -> None:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -1509,12 +1509,37 @@ def test_detect_credentials_round_trip() -> None:
         credentials=[
             {"family": "anthropic", "source": "$ANTHROPIC_API_KEY", "env_var": "ANTHROPIC_API_KEY"}
         ],
+        providers=[
+            {
+                "id": "claude",
+                "display_name": "Claude",
+                "kind": "subscription",
+                "origin": "detected",
+                "source": "claude CLI login",
+                "configuration_state": "valid",
+                "error": None,
+                "families": ["anthropic"],
+                "surfaces": ["anthropic"],
+                "default_for": ["anthropic"],
+                "default_models": {},
+                "cli": "claude",
+                "profile": None,
+                "model_provider": None,
+                "capabilities": {
+                    "model_discovery": "supported",
+                    "usage_status": "unsupported",
+                    "multiple_profiles": "unsupported",
+                    "interactive_cli": "supported",
+                },
+            }
+        ],
     )
     decoded = decode_host_frame(encode_host_frame(result))
     assert isinstance(decoded, HostDetectCredentialsResultFrame)
     assert decoded.credentials == [
         {"family": "anthropic", "source": "$ANTHROPIC_API_KEY", "env_var": "ANTHROPIC_API_KEY"}
     ]
+    assert decoded.providers == result.providers
 
 
 def test_detect_credentials_result_drops_malformed_entries() -> None:
@@ -1534,6 +1559,51 @@ def test_detect_credentials_result_drops_malformed_entries() -> None:
     decoded = decode_host_frame(encoded)
     assert isinstance(decoded, HostDetectCredentialsResultFrame)
     assert decoded.credentials == [{"family": "anthropic", "source": "$X", "env_var": "X"}]
+    assert decoded.providers == []
+
+
+def test_detect_credentials_result_drops_unknown_provider_fields() -> None:
+    """Provider rows are rebuilt from an allowlist, excluding credential material."""
+    provider = {
+        "id": "work",
+        "display_name": "Work",
+        "kind": "gateway",
+        "origin": "configured",
+        "source": "config",
+        "configuration_state": "valid",
+        "error": None,
+        "families": ["openai"],
+        "surfaces": ["openai", "pi"],
+        "default_for": ["openai"],
+        "default_models": {"openai": "model-a"},
+        "cli": None,
+        "profile": None,
+        "model_provider": None,
+        "capabilities": {
+            "model_discovery": "supported",
+            "usage_status": "unsupported",
+            "multiple_profiles": "unknown",
+            "interactive_cli": "unsupported",
+        },
+        "api_key": "must-not-cross-the-tunnel",
+        "base_url": "https://private.example",
+    }
+
+    decoded = decode_host_frame(
+        json.dumps(
+            {
+                "kind": "host.detect_credentials_result",
+                "request_id": "r2",
+                "credentials": [],
+                "providers": [provider],
+            }
+        )
+    )
+
+    assert isinstance(decoded, HostDetectCredentialsResultFrame)
+    assert len(decoded.providers) == 1
+    assert "api_key" not in decoded.providers[0]
+    assert "base_url" not in decoded.providers[0]
 
 
 def test_fs_request_round_trip() -> None:

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -1531,6 +1531,8 @@ def test_detect_credentials_round_trip() -> None:
                     "multiple_profiles": "unsupported",
                     "interactive_cli": "supported",
                 },
+                "connection_state": "authentication_required",
+                "connection_detail": "The claude CLI has no locally detected credential.",
             }
         ],
     )
@@ -1585,6 +1587,8 @@ def test_detect_credentials_result_drops_unknown_provider_fields() -> None:
             "multiple_profiles": "unknown",
             "interactive_cli": "unsupported",
         },
+        "connection_state": "connected",
+        "connection_detail": "A credential is configured locally.",
         "api_key": "must-not-cross-the-tunnel",
         "base_url": "https://private.example",
     }
@@ -1604,6 +1608,76 @@ def test_detect_credentials_result_drops_unknown_provider_fields() -> None:
     assert len(decoded.providers) == 1
     assert "api_key" not in decoded.providers[0]
     assert "base_url" not in decoded.providers[0]
+
+
+def _provider_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "id": "work",
+        "display_name": "Work",
+        "kind": "gateway",
+        "origin": "configured",
+        "source": "config",
+        "configuration_state": "valid",
+        "error": None,
+        "families": ["openai"],
+        "surfaces": ["openai"],
+        "default_for": ["openai"],
+        "default_models": {},
+        "cli": None,
+        "profile": None,
+        "model_provider": None,
+        "capabilities": {
+            "model_discovery": "supported",
+            "usage_status": "unsupported",
+            "multiple_profiles": "unknown",
+            "interactive_cli": "unsupported",
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def _decode_providers(*rows: dict[str, object]) -> list[dict[str, object]]:
+    decoded = decode_host_frame(
+        json.dumps(
+            {
+                "kind": "host.detect_credentials_result",
+                "request_id": "r3",
+                "credentials": [],
+                "providers": list(rows),
+            }
+        )
+    )
+    assert isinstance(decoded, HostDetectCredentialsResultFrame)
+    return decoded.providers
+
+
+def test_provider_row_from_older_host_defaults_connection_state_to_unknown() -> None:
+    [row] = _decode_providers(_provider_row())
+
+    assert row["connection_state"] == "unknown"
+    assert row["connection_detail"] == "This host does not report provider connection state."
+
+
+def test_provider_row_rejects_unknown_connection_state_without_dropping_row() -> None:
+    [row] = _decode_providers(
+        _provider_row(connection_state="future-state", connection_detail="future detail")
+    )
+
+    assert row["connection_state"] == "unknown"
+    assert row["connection_detail"] == "future detail"
+
+
+def test_provider_row_preserves_allowlisted_connection_state() -> None:
+    [row] = _decode_providers(
+        _provider_row(
+            connection_state="authentication_required",
+            connection_detail="Sign in on this host to use it.",
+        )
+    )
+
+    assert row["connection_state"] == "authentication_required"
+    assert row["connection_detail"] == "Sign in on this host to use it."
 
 
 def test_fs_request_round_trip() -> None:

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -19,6 +19,7 @@ from omnigent.onboarding import ambient
 from omnigent.onboarding.ambient import (
     DetectedProvider,
     detect_providers,
+    detect_providers_noninteractive,
 )
 
 # Every provider env var ambient may read — cleared in the base fixture so
@@ -933,6 +934,20 @@ def test_claude_cli_login_still_detected_without_managed_gateway(clean_env, monk
     monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", ())
     claude_rows = [d for d in detect_providers() if d.name == "claude"]
     assert [(d.kind, d.source) for d in claude_rows] == [("subscription", "claude CLI login")]
+
+
+def test_noninteractive_detection_never_runs_the_cli_auth_probe(clean_env, monkeypatch) -> None:
+    """Status reads must not invoke the macOS CLI/Keychain fallback."""
+    from omnigent.onboarding import harness_install
+
+    def _forbidden_cli_probe(key: str) -> bool:
+        raise AssertionError(f"status read probed {key!r} CLI authentication")
+
+    monkeypatch.setattr(harness_install, "harness_cli_logged_in", _forbidden_cli_probe)
+    monkeypatch.setattr(ambient.sys, "platform", "darwin")
+    monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", ())
+
+    assert detect_providers_noninteractive() == []
 
 
 def test_claude_managed_gateway_synthesizes_a_subscription_entry(clean_env, monkeypatch) -> None:

--- a/tests/onboarding/test_provider_inventory.py
+++ b/tests/onboarding/test_provider_inventory.py
@@ -65,6 +65,7 @@ def test_inventory_combines_configured_and_detected_providers_without_secrets() 
             "connection_detail": (
                 "A usable claude credential is configured locally; the vendor was not contacted."
             ),
+            "default_for_harnesses": ["claude-native", "claude-sdk"],
         },
         {
             "id": "work",
@@ -91,6 +92,7 @@ def test_inventory_combines_configured_and_detected_providers_without_secrets() 
             "connection_detail": (
                 "The openai credential is configured locally; the vendor was not contacted."
             ),
+            "default_for_harnesses": ["codex-native", "codex", "openai-agents", "pi-native", "pi"],
         },
     ]
     serialized = repr(rows)
@@ -282,3 +284,61 @@ def test_databricks_profile_presence_does_not_claim_authenticated(
 
     assert connection.state is ConnectionState.UNKNOWN
     assert "do not authenticate" in connection.detail
+
+
+def test_rows_name_the_harnesses_they_would_serve() -> None:
+    # The picker must not re-derive harness→provider from families itself.
+    config: dict[str, object] = {
+        "providers": {
+            "claude": {"kind": "subscription", "cli": "claude", "default": "anthropic"},
+            "work": {
+                "kind": "gateway",
+                "default": "openai",
+                "openai": {"base_url": "https://gateway.example/v1", "api_key": "k"},
+            },
+        }
+    }
+
+    rows = {row.provider_id: row for row in build_provider_inventory(config, detected=[])}
+
+    assert rows["claude"].default_for_harnesses == ("claude-native", "claude-sdk")
+    assert "codex-native" in rows["work"].default_for_harnesses
+    assert "claude-native" not in rows["work"].default_for_harnesses
+
+
+def test_a_provider_that_is_nobodys_default_names_no_harness() -> None:
+    config: dict[str, object] = {
+        "providers": {
+            "spare": {
+                "kind": "gateway",
+                "openai": {"base_url": "https://spare.example/v1", "api_key": "k"},
+            }
+        }
+    }
+
+    [row] = build_provider_inventory(config, detected=[])
+
+    assert row.default_for_harnesses == ()
+
+
+def test_malformed_unrelated_provider_does_not_erase_valid_harness_mapping() -> None:
+    config: dict[str, object] = {
+        "providers": {
+            "broken": {
+                "kind": "gateway",
+                "default": "anthropic",
+                "anthropic": "not a provider family configuration",
+            },
+            "work": {
+                "kind": "gateway",
+                "default": "openai",
+                "openai": {"base_url": "https://gateway.example/v1", "api_key": "k"},
+            },
+        }
+    }
+
+    rows = {row.provider_id: row for row in build_provider_inventory(config, detected=[])}
+
+    assert rows["broken"].configuration_state == "invalid"
+    assert "codex-native" in rows["work"].default_for_harnesses
+    assert "openai-agents" in rows["work"].default_for_harnesses

--- a/tests/onboarding/test_provider_inventory.py
+++ b/tests/onboarding/test_provider_inventory.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
+
 from omnigent.onboarding.ambient import DetectedProvider
-from omnigent.onboarding.provider_config import ProviderEntry
-from omnigent.onboarding.provider_inventory import build_provider_inventory, provider_capabilities
+from omnigent.onboarding.provider_config import FamilyConfig, ProviderEntry
+from omnigent.onboarding.provider_inventory import (
+    ConnectionState,
+    build_provider_inventory,
+    provider_capabilities,
+    provider_connection_state,
+)
 
 
 def test_inventory_combines_configured_and_detected_providers_without_secrets() -> None:
@@ -54,6 +61,10 @@ def test_inventory_combines_configured_and_detected_providers_without_secrets() 
                 "multiple_profiles": "unsupported",
                 "interactive_cli": "supported",
             },
+            "connection_state": "connected",
+            "connection_detail": (
+                "A usable claude credential is configured locally; the vendor was not contacted."
+            ),
         },
         {
             "id": "work",
@@ -76,6 +87,10 @@ def test_inventory_combines_configured_and_detected_providers_without_secrets() 
                 "multiple_profiles": "unknown",
                 "interactive_cli": "unsupported",
             },
+            "connection_state": "connected",
+            "connection_detail": (
+                "The openai credential is configured locally; the vendor was not contacted."
+            ),
         },
     ]
     serialized = repr(rows)
@@ -83,7 +98,17 @@ def test_inventory_combines_configured_and_detected_providers_without_secrets() 
     assert "gateway.example" not in serialized
 
 
-def test_databricks_inventory_exposes_profile_name_and_profile_capability() -> None:
+def test_databricks_inventory_exposes_profile_name_and_profile_capability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_databricks_profiles",
+        lambda: ["staging"],
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.databricks_sdk_installed",
+        lambda: True,
+    )
     config: dict[str, object] = {
         "providers": {
             "analytics": {
@@ -97,6 +122,7 @@ def test_databricks_inventory_exposes_profile_name_and_profile_capability() -> N
     [row] = [entry.as_dict() for entry in build_provider_inventory(config, detected=[])]
 
     assert row["profile"] == "staging"
+    assert row["connection_state"] == "unknown"
     assert row["capabilities"] == {
         "model_discovery": "supported",
         "usage_status": "unsupported",
@@ -124,5 +150,135 @@ def test_inventory_keeps_malformed_entries_as_explicit_invalid_state() -> None:
     assert [row["id"] for row in rows] == ["broken", "codex"]
     assert rows[0]["configuration_state"] == "invalid"
     assert rows[0]["error"] == "Provider configuration is invalid. Reconfigure this provider."
+    assert rows[0]["connection_state"] == "misconfigured"
     assert rows[1]["configuration_state"] == "valid"
     assert "do-not-expose" not in repr(rows)
+
+
+def _subscription(cli: str = "codex") -> ProviderEntry:
+    return ProviderEntry(name=cli, kind="subscription", cli=cli)
+
+
+def _gateway(family: FamilyConfig, *, name: str = "work") -> ProviderEntry:
+    return ProviderEntry(name=name, kind="gateway", families={"openai": family})
+
+
+@pytest.mark.parametrize(
+    ("availability", "expected"),
+    [
+        ("needs-auth", ConnectionState.AUTHENTICATION_REQUIRED),
+        ("binary-missing", ConnectionState.UNAVAILABLE),
+        (False, ConnectionState.UNAVAILABLE),
+        ("version-too-low", ConnectionState.UNAVAILABLE),
+    ],
+)
+def test_cli_provider_uses_cached_negative_readiness(
+    availability: object, expected: ConnectionState
+) -> None:
+    connection = provider_connection_state(
+        _subscription(),
+        harness_readiness={"codex-native": availability},  # type: ignore[dict-item]
+    )
+
+    assert connection.state is expected
+    assert connection.detail
+
+
+def test_aggregate_cli_readiness_is_not_provider_specific_proof() -> None:
+    connection = provider_connection_state(
+        _subscription(),
+        harness_readiness={"codex-native": True},
+    )
+
+    assert connection.state is ConnectionState.UNKNOWN
+    assert "another provider" in connection.detail
+
+
+def test_safe_provider_detection_is_provider_specific_proof() -> None:
+    connection = provider_connection_state(
+        _subscription(),
+        harness_readiness={"codex-native": True},
+        provider_detected=True,
+    )
+
+    assert connection.state is ConnectionState.CONNECTED
+    assert "vendor was not contacted" in connection.detail
+
+
+def test_keychain_reference_is_unknown_without_resolving_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import omnigent.onboarding.provider_inventory as provider_inventory_module
+
+    def _forbidden_secret_resolution(ref: str) -> str:
+        raise AssertionError(f"status read resolved secret {ref!r}")
+
+    assert not hasattr(provider_inventory_module, "resolve_secret")
+    monkeypatch.setattr(
+        "omnigent.onboarding.provider_config.resolve_secret",
+        _forbidden_secret_resolution,
+    )
+    provider = _gateway(
+        FamilyConfig(base_url="https://gateway.example/v1", api_key_ref="keychain:openai")
+    )
+
+    connection = provider_connection_state(provider)
+
+    assert connection.state is ConnectionState.UNKNOWN
+    assert "protected secret store" in connection.detail
+
+
+def test_env_reference_uses_presence_without_leaking_the_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OMNIGENT_TEST_PROVIDER_KEY", "sk-do-not-expose")
+    provider = _gateway(
+        FamilyConfig(
+            base_url="https://gateway.example/v1",
+            api_key_ref="env:OMNIGENT_TEST_PROVIDER_KEY",
+        )
+    )
+
+    connection = provider_connection_state(provider)
+
+    assert connection.state is ConnectionState.CONNECTED
+    assert "sk-do-not-expose" not in connection.detail
+
+
+def test_missing_env_reference_needs_authentication(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OMNIGENT_TEST_PROVIDER_KEY", raising=False)
+    provider = _gateway(
+        FamilyConfig(
+            base_url="https://gateway.example/v1",
+            api_key_ref="env:OMNIGENT_TEST_PROVIDER_KEY",
+        )
+    )
+
+    assert provider_connection_state(provider).state is ConnectionState.AUTHENTICATION_REQUIRED
+
+
+def test_auth_command_is_unknown_because_status_reads_never_run_it() -> None:
+    provider = _gateway(
+        FamilyConfig(base_url="https://gateway.example/v1", auth_command="print-token")
+    )
+
+    assert provider_connection_state(provider).state is ConnectionState.UNKNOWN
+
+
+def test_databricks_profile_presence_does_not_claim_authenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.list_databricks_profiles",
+        lambda: ["staging"],
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.databricks_sdk_installed",
+        lambda: True,
+    )
+    provider = ProviderEntry(name="analytics", kind="databricks", profile="staging")
+
+    connection = provider_connection_state(provider)
+
+    assert connection.state is ConnectionState.UNKNOWN
+    assert "do not authenticate" in connection.detail

--- a/tests/onboarding/test_provider_inventory.py
+++ b/tests/onboarding/test_provider_inventory.py
@@ -1,0 +1,128 @@
+"""Tests for the non-secret provider inventory."""
+
+from __future__ import annotations
+
+from omnigent.onboarding.ambient import DetectedProvider
+from omnigent.onboarding.provider_config import ProviderEntry
+from omnigent.onboarding.provider_inventory import build_provider_inventory, provider_capabilities
+
+
+def test_inventory_combines_configured_and_detected_providers_without_secrets() -> None:
+    config: dict[str, object] = {
+        "providers": {
+            "work": {
+                "kind": "gateway",
+                "default": "openai",
+                "openai": {
+                    "base_url": "https://gateway.example/v1",
+                    "api_key": "top-secret-value",
+                    "models": {"default": "company-model"},
+                },
+            }
+        }
+    }
+    detected = [
+        DetectedProvider(
+            name="claude",
+            kind="subscription",
+            family="anthropic",
+            source="claude CLI login",
+        )
+    ]
+
+    rows = [entry.as_dict() for entry in build_provider_inventory(config, detected=detected)]
+
+    assert rows == [
+        {
+            "id": "claude",
+            "display_name": "claude",
+            "kind": "subscription",
+            "origin": "detected",
+            "source": "claude CLI login",
+            "configuration_state": "valid",
+            "error": None,
+            "families": ["anthropic"],
+            "surfaces": ["anthropic"],
+            "default_for": ["anthropic"],
+            "default_models": {},
+            "cli": "claude",
+            "profile": None,
+            "model_provider": None,
+            "capabilities": {
+                "model_discovery": "supported",
+                "usage_status": "unsupported",
+                "multiple_profiles": "unsupported",
+                "interactive_cli": "supported",
+            },
+        },
+        {
+            "id": "work",
+            "display_name": "work",
+            "kind": "gateway",
+            "origin": "configured",
+            "source": "config",
+            "configuration_state": "valid",
+            "error": None,
+            "families": ["openai"],
+            "surfaces": ["openai", "pi"],
+            "default_for": ["openai"],
+            "default_models": {"openai": "company-model"},
+            "cli": None,
+            "profile": None,
+            "model_provider": None,
+            "capabilities": {
+                "model_discovery": "supported",
+                "usage_status": "unsupported",
+                "multiple_profiles": "unknown",
+                "interactive_cli": "unsupported",
+            },
+        },
+    ]
+    serialized = repr(rows)
+    assert "top-secret-value" not in serialized
+    assert "gateway.example" not in serialized
+
+
+def test_databricks_inventory_exposes_profile_name_and_profile_capability() -> None:
+    config: dict[str, object] = {
+        "providers": {
+            "analytics": {
+                "kind": "databricks",
+                "profile": "staging",
+                "default": "openai",
+            }
+        }
+    }
+
+    [row] = [entry.as_dict() for entry in build_provider_inventory(config, detected=[])]
+
+    assert row["profile"] == "staging"
+    assert row["capabilities"] == {
+        "model_discovery": "supported",
+        "usage_status": "unsupported",
+        "multiple_profiles": "supported",
+        "interactive_cli": "unsupported",
+    }
+
+
+def test_bedrock_inventory_does_not_claim_unimplemented_discovery() -> None:
+    provider = ProviderEntry(name="aws", kind="bedrock")
+
+    assert provider_capabilities(provider).as_dict()["model_discovery"] == "unknown"
+
+
+def test_inventory_keeps_malformed_entries_as_explicit_invalid_state() -> None:
+    config: dict[str, object] = {
+        "providers": {
+            "broken": {"kind": "gateway", "api_key": "do-not-expose"},
+            "codex": {"kind": "subscription", "cli": "codex"},
+        }
+    }
+
+    rows = [entry.as_dict() for entry in build_provider_inventory(config, detected=[])]
+
+    assert [row["id"] for row in rows] == ["broken", "codex"]
+    assert rows[0]["configuration_state"] == "invalid"
+    assert rows[0]["error"] == "Provider configuration is invalid. Reconfigure this provider."
+    assert rows[1]["configuration_state"] == "valid"
+    assert "do-not-expose" not in repr(rows)

--- a/tests/server/integration/test_hosts_store_credential.py
+++ b/tests/server/integration/test_hosts_store_credential.py
@@ -50,6 +50,28 @@ pytestmark = [
 
 _HOST_ID = "a1b2c3d4e5f60718293a4b5c6d7e8f90"
 _HOST_NAME = "credential-test-laptop"
+_PROVIDER = {
+    "id": "claude",
+    "display_name": "Claude",
+    "kind": "subscription",
+    "origin": "detected",
+    "source": "claude CLI login",
+    "configuration_state": "valid",
+    "error": None,
+    "families": ["anthropic"],
+    "surfaces": ["anthropic"],
+    "default_for": ["anthropic"],
+    "default_models": {},
+    "cli": "claude",
+    "profile": None,
+    "model_provider": None,
+    "capabilities": {
+        "model_discovery": "supported",
+        "usage_status": "unsupported",
+        "multiple_profiles": "unsupported",
+        "interactive_cli": "supported",
+    },
+}
 
 
 @pytest.fixture(autouse=True)
@@ -161,6 +183,7 @@ async def cred_setup(
                                         "env_var": "ANTHROPIC_API_KEY",
                                     }
                                 ],
+                                providers=[_PROVIDER],
                             )
                         ),
                     }
@@ -572,4 +595,20 @@ async def test_detect_credentials_hidden_when_flag_off(
     )
     async with AsyncClient(transport=ASGITransport(app=off_app), base_url="http://test") as client:
         resp = await client.get(f"/v1/hosts/{_HOST_ID}/credentials/detected")
+        providers_resp = await client.get(f"/v1/hosts/{_HOST_ID}/providers")
     assert resp.status_code == 404
+    assert providers_resp.status_code == 404
+
+
+async def test_provider_inventory_returns_host_configuration(
+    cred_setup: tuple[
+        FastAPI, HostRegistry, list[HostStoreSecretFrame], dict[str, dict[str, Any]]
+    ],
+) -> None:
+    """The provider route reuses the host's non-secret setup inventory."""
+    app, _reg, _received, _replies = cred_setup
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(f"/v1/hosts/{_HOST_ID}/providers")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"object": "provider_inventory", "providers": [_PROVIDER]}

--- a/tests/server/integration/test_hosts_store_credential.py
+++ b/tests/server/integration/test_hosts_store_credential.py
@@ -50,7 +50,7 @@ pytestmark = [
 
 _HOST_ID = "a1b2c3d4e5f60718293a4b5c6d7e8f90"
 _HOST_NAME = "credential-test-laptop"
-_PROVIDER = {
+_PROVIDER: dict[str, object] = {
     "id": "claude",
     "display_name": "Claude",
     "kind": "subscription",
@@ -71,6 +71,8 @@ _PROVIDER = {
         "multiple_profiles": "unsupported",
         "interactive_cli": "supported",
     },
+    "connection_state": "connected",
+    "connection_detail": "A usable claude credential is configured locally.",
 }
 
 
@@ -578,11 +580,15 @@ async def test_detect_credentials_returns_non_secret_descriptors(
     ]
 
 
-async def test_detect_credentials_hidden_when_flag_off(
+async def test_mutation_helpers_stay_hidden_but_provider_inventory_is_available_when_flag_off(
+    cred_setup: tuple[
+        FastAPI, HostRegistry, list[HostStoreSecretFrame], dict[str, dict[str, Any]]
+    ],
     cred_app: tuple[FastAPI, HostRegistry, HostStore, SqlAlchemyConversationStore],
 ) -> None:
-    """With the flag off the detect route is 404."""
-    _app, registry, host_store, conv_store = cred_app
+    """The mutation flag does not hide the read-only provider inventory."""
+    _app, registry, _received, _replies = cred_setup
+    _original_app, _same_registry, host_store, conv_store = cred_app
     off_app = FastAPI()
     off_app.include_router(
         create_hosts_router(
@@ -597,7 +603,8 @@ async def test_detect_credentials_hidden_when_flag_off(
         resp = await client.get(f"/v1/hosts/{_HOST_ID}/credentials/detected")
         providers_resp = await client.get(f"/v1/hosts/{_HOST_ID}/providers")
     assert resp.status_code == 404
-    assert providers_resp.status_code == 404
+    assert providers_resp.status_code == 200
+    assert providers_resp.json() == {"object": "provider_inventory", "providers": [_PROVIDER]}
 
 
 async def test_provider_inventory_returns_host_configuration(

--- a/tests/server/integration/test_hosts_store_credential.py
+++ b/tests/server/integration/test_hosts_store_credential.py
@@ -73,6 +73,7 @@ _PROVIDER: dict[str, object] = {
     },
     "connection_state": "connected",
     "connection_detail": "A usable claude credential is configured locally.",
+    "default_for_harnesses": ["claude-native", "claude-sdk"],
 }
 
 

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -528,6 +528,8 @@ describe("useProviderInventory", () => {
         multiple_profiles: "unsupported",
         interactive_cli: "supported",
       },
+      connection_state: "connected",
+      connection_detail: "A usable claude credential is configured locally.",
     };
     fetchMock.mockResolvedValueOnce(mockResponse({ providers: [provider] }));
 

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -9,6 +9,7 @@ import {
   useHosts,
   useInstallHarness,
   useInstallingHarnesses,
+  useProviderInventory,
   useStoreCredential,
 } from "./useHosts";
 
@@ -498,6 +499,51 @@ describe("useDetectedCredentials", () => {
     const disabled = renderHook(() => useDetectedCredentials("host_1", false), { wrapper });
     const noHost = renderHook(() => useDetectedCredentials(null, true), { wrapper });
     await Promise.resolve();
+    expect(fetchMock).not.toHaveBeenCalled();
+    disabled.unmount();
+    noHost.unmount();
+  });
+});
+
+describe("useProviderInventory", () => {
+  it("fetches the host provider inventory without background polling", async () => {
+    const provider = {
+      id: "claude",
+      display_name: "Claude",
+      kind: "subscription",
+      origin: "detected",
+      source: "claude CLI login",
+      configuration_state: "valid",
+      error: null,
+      families: ["anthropic"],
+      surfaces: ["anthropic"],
+      default_for: ["anthropic"],
+      default_models: {},
+      cli: "claude",
+      profile: null,
+      model_provider: null,
+      capabilities: {
+        model_discovery: "supported",
+        usage_status: "unsupported",
+        multiple_profiles: "unsupported",
+        interactive_cli: "supported",
+      },
+    };
+    fetchMock.mockResolvedValueOnce(mockResponse({ providers: [provider] }));
+
+    const { result } = renderHook(() => useProviderInventory("host_1", true), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/v1/hosts/host_1/providers");
+    expect(result.current.data).toEqual([provider]);
+  });
+
+  it("does not fetch while closed or without a host", async () => {
+    const disabled = renderHook(() => useProviderInventory("host_1", false), { wrapper });
+    const noHost = renderHook(() => useProviderInventory(null, true), { wrapper });
+    await Promise.resolve();
+
     expect(fetchMock).not.toHaveBeenCalled();
     disabled.unmount();
     noHost.unmount();

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -318,6 +318,11 @@ export interface ProviderInventoryEntry {
   profile: string | null;
   model_provider: string | null;
   capabilities: ProviderCapabilities;
+  /**
+   * Harnesses this provider would serve by default, resolved host-side by the
+   * same canonical function a launch uses. Optional for older hosts.
+   */
+  default_for_harnesses?: string[];
   /** Conservative status derived from silent, provider-specific local evidence. */
   connection_state: ProviderConnectionState;
   /** Non-secret explanation; never implies a live vendor check occurred. */

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -277,6 +277,7 @@ export function useStoreCredential(hostId: string) {
       );
       // A written/adopted credential changes what's adoptable — refetch it.
       void queryClient.invalidateQueries({ queryKey: ["detected-credentials", hostId] });
+      void queryClient.invalidateQueries({ queryKey: ["provider-inventory", hostId] });
     },
   });
 }
@@ -286,6 +287,52 @@ export interface DetectedCredential {
   family: string;
   source: string;
   env_var: string | null;
+}
+
+export type ProviderCapabilitySupport = "supported" | "unsupported" | "unknown";
+
+export interface ProviderCapabilities {
+  model_discovery: ProviderCapabilitySupport;
+  usage_status: ProviderCapabilitySupport;
+  multiple_profiles: ProviderCapabilitySupport;
+  interactive_cli: ProviderCapabilitySupport;
+}
+
+/** Non-secret provider metadata reported by the selected host. */
+export interface ProviderInventoryEntry {
+  id: string;
+  display_name: string;
+  kind: string;
+  origin: "configured" | "detected";
+  source: string;
+  configuration_state: "valid" | "invalid";
+  error: string | null;
+  families: string[];
+  surfaces: string[];
+  default_for: string[];
+  default_models: Record<string, string>;
+  cli: string | null;
+  profile: string | null;
+  model_provider: string | null;
+  capabilities: ProviderCapabilities;
+}
+
+/** Fetch provider configuration on demand; no background CLI polling. */
+export function useProviderInventory(hostId: string | null | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ["provider-inventory", hostId],
+    queryFn: async (): Promise<ProviderInventoryEntry[]> => {
+      const res = await authenticatedFetch(
+        `/v1/hosts/${encodeURIComponent(hostId ?? "")}/providers`,
+      );
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const body = (await res.json()) as { providers?: ProviderInventoryEntry[] };
+      return Array.isArray(body.providers) ? body.providers : [];
+    },
+    enabled: enabled && !!hostId,
+    staleTime: 60_000,
+    refetchInterval: false,
+  });
 }
 
 /**

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -291,6 +291,9 @@ export interface DetectedCredential {
 
 export type ProviderCapabilitySupport = "supported" | "unsupported" | "unknown";
 
+export type ProviderConnectionState =
+  "connected" | "authentication_required" | "misconfigured" | "unavailable" | "unknown";
+
 export interface ProviderCapabilities {
   model_discovery: ProviderCapabilitySupport;
   usage_status: ProviderCapabilitySupport;
@@ -315,6 +318,10 @@ export interface ProviderInventoryEntry {
   profile: string | null;
   model_provider: string | null;
   capabilities: ProviderCapabilities;
+  /** Conservative status derived from silent, provider-specific local evidence. */
+  connection_state: ProviderConnectionState;
+  /** Non-secret explanation; never implies a live vendor check occurred. */
+  connection_detail: string;
 }
 
 /** Fetch provider configuration on demand; no background CLI polling. */

--- a/web/src/pages/ProvidersSection.tsx
+++ b/web/src/pages/ProvidersSection.tsx
@@ -1,0 +1,350 @@
+import { useState, type ReactNode } from "react";
+import {
+  AlertTriangleIcon,
+  CableIcon,
+  CircleAlertIcon,
+  CircleCheckIcon,
+  CircleDashedIcon,
+  Loader2Icon,
+  RefreshCwIcon,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useHosts,
+  useProviderInventory,
+  type ProviderCapabilitySupport,
+  type ProviderConnectionState,
+  type ProviderInventoryEntry,
+} from "@/hooks/useHosts";
+import { useHarnessSetupSteps } from "@/lib/agentLabels";
+import { HarnessSetupDialog } from "@/shell/HarnessSetupDialog";
+
+/** CLI-backed rows reuse the existing host setup checklist when available. */
+function providerManageHarness(
+  provider: ProviderInventoryEntry,
+  setupStepsByHarness: Record<string, unknown>,
+): string | null {
+  if (!provider.cli) return null;
+  return setupStepsByHarness[provider.cli] ? provider.cli : null;
+}
+
+function CapabilityChip({ label, state }: { label: string; state: ProviderCapabilitySupport }) {
+  const Icon =
+    state === "supported"
+      ? CircleCheckIcon
+      : state === "unknown"
+        ? CircleDashedIcon
+        : CircleAlertIcon;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs ${
+        state === "supported" ? "text-foreground" : "text-muted-foreground"
+      }`}
+      data-testid={`provider-capability-${label.toLowerCase().replace(/\s+/g, "-")}`}
+      title={
+        state === "supported"
+          ? "Supported"
+          : state === "unknown"
+            ? "Unknown — Omnigent cannot determine this locally"
+            : "Not supported by this provider integration"
+      }
+    >
+      <Icon
+        className={`size-3.5 shrink-0 ${
+          state === "supported" ? "text-emerald-600 dark:text-emerald-500" : ""
+        }`}
+      />
+      {label}
+      {state === "unknown" ? " (?)" : ""}
+    </span>
+  );
+}
+
+const CONNECTION_PRESENTATION: Record<
+  ProviderConnectionState,
+  { label: string; className: string; iconClassName: string }
+> = {
+  connected: {
+    label: "Credential available locally",
+    className: "text-emerald-700 dark:text-emerald-400",
+    iconClassName: "text-emerald-600 dark:text-emerald-500",
+  },
+  authentication_required: {
+    label: "Authentication required",
+    className: "text-amber-700 dark:text-amber-400",
+    iconClassName: "text-amber-600 dark:text-amber-500",
+  },
+  misconfigured: {
+    label: "Misconfigured",
+    className: "text-amber-700 dark:text-amber-400",
+    iconClassName: "text-amber-600 dark:text-amber-500",
+  },
+  unavailable: {
+    label: "Unavailable on this host",
+    className: "text-destructive",
+    iconClassName: "text-destructive",
+  },
+  unknown: {
+    label: "Status unknown",
+    className: "text-muted-foreground",
+    iconClassName: "text-muted-foreground",
+  },
+};
+
+function ProviderConnectionStatus({ provider }: { provider: ProviderInventoryEntry }) {
+  const presentation = CONNECTION_PRESENTATION[provider.connection_state];
+  const Icon =
+    provider.connection_state === "connected"
+      ? CircleCheckIcon
+      : provider.connection_state === "unknown"
+        ? CircleDashedIcon
+        : CircleAlertIcon;
+  return (
+    <div className="mt-2" data-testid={`provider-connection-${provider.id}`}>
+      <div className={`flex items-center gap-1.5 text-sm font-medium ${presentation.className}`}>
+        <Icon className={`size-4 shrink-0 ${presentation.iconClassName}`} />
+        <span>{presentation.label}</span>
+      </div>
+      <p className="mt-0.5 text-sm text-muted-foreground">{provider.connection_detail}</p>
+    </div>
+  );
+}
+
+function ProviderRow({
+  provider,
+  manageHarness,
+  onManage,
+}: {
+  provider: ProviderInventoryEntry;
+  manageHarness: string | null;
+  onManage: (harness: string) => void;
+}) {
+  const valid = provider.configuration_state === "valid";
+  return (
+    <div
+      data-testid={`provider-row-${provider.id}`}
+      className="rounded-lg border border-border bg-card px-4 py-3"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <CableIcon className="ui-icon shrink-0 text-muted-foreground" />
+            <span className="font-medium">{provider.display_name}</span>
+            <Badge variant="secondary" className="lowercase">
+              {provider.kind}
+            </Badge>
+            {provider.origin === "detected" && <Badge variant="outline">Detected</Badge>}
+          </div>
+
+          <ProviderConnectionStatus provider={provider} />
+
+          {!valid && (
+            <div className="mt-2 text-sm text-amber-700 dark:text-amber-400">
+              <div className="flex items-center gap-1.5 font-medium">
+                <CircleAlertIcon className="size-4 shrink-0" />
+                <span>Configuration invalid</span>
+              </div>
+              {provider.error && <p className="mt-0.5 text-muted-foreground">{provider.error}</p>}
+            </div>
+          )}
+
+          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+            {provider.families.length > 0 && (
+              <span>
+                Families:{" "}
+                {provider.families
+                  .map(
+                    (family) =>
+                      `${family}${provider.default_models[family] ? ` (${provider.default_models[family]})` : ""}`,
+                  )
+                  .join(", ")}
+              </span>
+            )}
+            {provider.cli && <span>CLI: {provider.cli}</span>}
+            {provider.profile && <span>Profile: {provider.profile}</span>}
+            {provider.model_provider && <span>Gateway: {provider.model_provider}</span>}
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1">
+            <CapabilityChip label="Model discovery" state={provider.capabilities.model_discovery} />
+            <CapabilityChip
+              label="Multiple profiles"
+              state={provider.capabilities.multiple_profiles}
+            />
+            <CapabilityChip label="Interactive CLI" state={provider.capabilities.interactive_cli} />
+          </div>
+        </div>
+        {manageHarness && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={() => onManage(manageHarness)}
+            data-testid={`provider-manage-${provider.id}`}
+          >
+            Manage
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProvidersSectionShell({ children }: { children: ReactNode }) {
+  return (
+    <section>
+      <h1 className="text-2xl font-semibold">Providers</h1>
+      <p className="mt-1 text-ui text-muted-foreground">
+        Provider configuration and local credential evidence for the selected host. Opening this
+        page never contacts a remote provider or opens a protected credential store.
+      </p>
+      <div className="mt-6">{children}</div>
+    </section>
+  );
+}
+
+/** Read-only provider inventory for the selected connected host. */
+export function ProvidersSection() {
+  const { data: hosts, isLoading: hostsLoading } = useHosts();
+  const hostsList = hosts ?? [];
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
+  const host = hostsList.find((candidate) => candidate.host_id === selectedHostId) ?? hostsList[0];
+  const inventory = useProviderInventory(host?.host_id, !!host);
+  const setupStepsByHarness = useHarnessSetupSteps();
+  const [manageHarness, setManageHarness] = useState<string | null>(null);
+
+  if (hostsLoading) {
+    return (
+      <ProvidersSectionShell>
+        <p className="flex items-center gap-2 text-muted-foreground">
+          <Loader2Icon className="size-4 animate-spin" />
+          Loading hosts…
+        </p>
+      </ProvidersSectionShell>
+    );
+  }
+
+  if (hostsList.length === 0) {
+    return (
+      <ProvidersSectionShell>
+        <p className="text-muted-foreground">
+          No host is connected yet. Start one with <code>omnigent host</code> to see its providers
+          here.
+        </p>
+      </ProvidersSectionShell>
+    );
+  }
+
+  const providers = inventory.data ?? [];
+
+  return (
+    <ProvidersSectionShell>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-2">
+          {hostsList.length > 1 && (
+            <Select
+              value={host?.host_id ?? ""}
+              onValueChange={(id) => {
+                setManageHarness(null);
+                setSelectedHostId(id);
+              }}
+              name="provider-host"
+            >
+              <SelectTrigger data-testid="provider-host-select" className="w-56" aria-label="Host">
+                <SelectValue placeholder="Host" />
+              </SelectTrigger>
+              <SelectContent>
+                {hostsList.map((candidate) => (
+                  <SelectItem key={candidate.host_id} value={candidate.host_id}>
+                    {candidate.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {hostsList.length === 1 && (
+            <span className="text-sm text-muted-foreground">Host: {host?.name}</span>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => void inventory.refetch()}
+            disabled={inventory.isFetching}
+            data-testid="provider-refresh"
+          >
+            <RefreshCwIcon className={`size-3.5 ${inventory.isFetching ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
+
+        {inventory.isLoading && (
+          <p
+            className="flex items-center gap-2 text-muted-foreground"
+            data-testid="provider-loading"
+          >
+            <Loader2Icon className="size-4 animate-spin" />
+            Loading providers…
+          </p>
+        )}
+
+        {inventory.isError && (
+          <div
+            className="rounded-lg border border-border bg-card px-4 py-3 text-sm"
+            data-testid="provider-error"
+          >
+            <div className="flex items-center gap-1.5">
+              <AlertTriangleIcon className="size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+              <span>Couldn&apos;t load providers.</span>
+            </div>
+            <p className="mt-1 text-muted-foreground">
+              {inventory.error instanceof Error ? inventory.error.message : "Unknown error"}
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              onClick={() => void inventory.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {!inventory.isLoading && !inventory.isError && providers.length === 0 && (
+          <p className="text-muted-foreground" data-testid="provider-empty">
+            No providers configured or detected on this host yet. Run <code>omni setup</code> to
+            configure one.
+          </p>
+        )}
+
+        {!inventory.isError &&
+          providers.map((provider) => (
+            <ProviderRow
+              key={provider.id}
+              provider={provider}
+              manageHarness={providerManageHarness(provider, setupStepsByHarness)}
+              onManage={setManageHarness}
+            />
+          ))}
+      </div>
+
+      <HarnessSetupDialog
+        open={manageHarness !== null}
+        onOpenChange={(open) => {
+          if (!open) setManageHarness(null);
+        }}
+        agentName={manageHarness ?? undefined}
+        harness={manageHarness}
+        host={host}
+      />
+    </ProvidersSectionShell>
+  );
+}

--- a/web/src/pages/SettingsPage.providers.test.tsx
+++ b/web/src/pages/SettingsPage.providers.test.tsx
@@ -1,0 +1,353 @@
+// Tests for the Providers settings section — the read-only provider inventory
+// (per host) that reuses Omni Setup's detection. Covers row rendering with
+// honest status, capability chips, the host picker, error/empty/loading
+// states, and the Manage affordance that reuses the harness setup dialog.
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type * as AgentLabelsModule from "@/lib/agentLabels";
+import type { Host, ProviderInventoryEntry } from "@/hooks/useHosts";
+
+const mocks = vi.hoisted(() => ({
+  hostsLoading: false,
+  hosts: [] as Host[],
+  inventoryHostId: undefined as string | null | undefined,
+  inventoryEnabled: undefined as boolean | undefined,
+  inventoryLoading: false,
+  inventoryError: false,
+  inventoryErrorObj: null as Error | null,
+  providers: [] as ProviderInventoryEntry[],
+  refetch: vi.fn(),
+  setupSteps: {} as Record<string, unknown[]>,
+  lastSetupProps: null as { harness: string | null; host: Host | null | undefined } | null,
+}));
+
+vi.mock("@/lib/CapabilitiesContext", () => ({
+  useServerInfo: () => ({
+    accounts_enabled: false,
+    login_url: null,
+    single_user: false,
+  }),
+}));
+vi.mock("@/hooks/useHosts", () => ({
+  useHosts: () => ({ data: mocks.hosts, isLoading: mocks.hostsLoading }),
+  useProviderInventory: (hostId: string | null | undefined, enabled: boolean) => {
+    mocks.inventoryHostId = hostId;
+    mocks.inventoryEnabled = enabled;
+    return {
+      data: mocks.providers,
+      isLoading: mocks.inventoryLoading,
+      isError: mocks.inventoryError,
+      error: mocks.inventoryErrorObj,
+      isFetching: false,
+      refetch: mocks.refetch,
+    };
+  },
+}));
+vi.mock("@/lib/agentLabels", async (importOriginal) => {
+  const original = await importOriginal<typeof AgentLabelsModule>();
+  return {
+    ...original,
+    useHarnessSetupSteps: () => mocks.setupSteps,
+  };
+});
+vi.mock("@/shell/HarnessSetupDialog", () => ({
+  HarnessSetupDialog: (props: {
+    open: boolean;
+    harness: string | null;
+    host: Host | null | undefined;
+  }) => {
+    if (props.open) mocks.lastSetupProps = { harness: props.harness, host: props.host };
+    return props.open ? (
+      <div data-testid="harness-setup-stub">{`${props.harness}@${props.host?.host_id ?? ""}`}</div>
+    ) : null;
+  },
+}));
+// Radix Select portals + pointer events can't be driven in jsdom; stub to a
+// native <select> (lifts the trigger's data-testid), same as SettingsPage.test.
+vi.mock("@/components/ui/select", async () => {
+  const { Children, isValidElement } = await import("react");
+  const SelectTrigger = ({ children }: { children?: ReactNode }) => children;
+  const Select = ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children: ReactNode;
+  }) => {
+    const kids = Children.toArray(children);
+    const trigger = kids.find((c) => isValidElement(c) && c.type === SelectTrigger);
+    const testId =
+      isValidElement(trigger) && trigger.props && typeof trigger.props === "object"
+        ? (trigger.props as Record<string, unknown>)["data-testid"]
+        : undefined;
+    return (
+      <select
+        data-testid={typeof testId === "string" ? testId : undefined}
+        value={value}
+        onChange={(e) => onValueChange(e.target.value)}
+      >
+        {kids.filter((c) => !(isValidElement(c) && c.type === SelectTrigger))}
+      </select>
+    );
+  };
+  return {
+    Select,
+    SelectTrigger,
+    SelectValue: () => null,
+    SelectContent: ({ children }: { children: ReactNode }) => children,
+    SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
+      <option value={value}>{children}</option>
+    ),
+  };
+});
+
+import { SettingsPage } from "./SettingsPage";
+
+function host(id: string, name: string): Host {
+  return {
+    host_id: id,
+    name,
+    owner: "jakob",
+    status: "online",
+  };
+}
+
+function provider(partial: Partial<ProviderInventoryEntry>): ProviderInventoryEntry {
+  return {
+    id: "prov",
+    display_name: "Prov",
+    kind: "subscription",
+    origin: "configured",
+    source: "config",
+    configuration_state: "valid",
+    error: null,
+    families: [],
+    surfaces: [],
+    default_for: [],
+    default_models: {},
+    cli: null,
+    profile: null,
+    model_provider: null,
+    capabilities: {
+      model_discovery: "supported",
+      usage_status: "unsupported",
+      multiple_profiles: "unknown",
+      interactive_cli: "supported",
+    },
+    connection_state: "connected",
+    connection_detail: "A usable credential is configured locally; the vendor was not contacted.",
+    ...partial,
+  };
+}
+
+function renderPage(path = "/settings/providers") {
+  return render(
+    <TooltipProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <SettingsPage />
+      </MemoryRouter>
+    </TooltipProvider>,
+  );
+}
+
+beforeEach(() => {
+  mocks.hostsLoading = false;
+  mocks.hosts = [host("host_1", "MacBook")];
+  mocks.inventoryLoading = false;
+  mocks.inventoryError = false;
+  mocks.inventoryErrorObj = null;
+  mocks.providers = [];
+  mocks.refetch.mockReset();
+  mocks.setupSteps = {};
+  mocks.lastSetupProps = null;
+});
+afterEach(cleanup);
+
+describe("ProvidersSection", () => {
+  it("renders provider rows with honest status and metadata", () => {
+    mocks.providers = [
+      provider({
+        id: "codex",
+        display_name: "Codex",
+        cli: "codex",
+        families: ["openai"],
+        default_models: { openai: "gpt-5.4" },
+      }),
+      provider({
+        id: "broken",
+        display_name: "Broken Gateway",
+        kind: "gateway",
+        origin: "detected",
+        configuration_state: "invalid",
+        error: "Provider configuration is invalid. Reconfigure this provider.",
+        connection_state: "misconfigured",
+        connection_detail: "This provider's configuration could not be parsed on this host.",
+        capabilities: {
+          model_discovery: "unknown",
+          usage_status: "unknown",
+          multiple_profiles: "unknown",
+          interactive_cli: "unsupported",
+        },
+      }),
+    ];
+    renderPage();
+
+    const codex = screen.getByTestId("provider-row-codex");
+    expect(within(codex).getByText("Codex")).toBeInTheDocument();
+    expect(within(codex).getByText("Credential available locally")).toBeInTheDocument();
+    expect(within(codex).getByText(/vendor was not contacted/)).toBeInTheDocument();
+    expect(within(codex).getByText(/Families: openai \(gpt-5\.4\)/)).toBeInTheDocument();
+    expect(within(codex).getByText("CLI: codex")).toBeInTheDocument();
+    expect(within(codex).queryByText("Detected")).toBeNull();
+
+    const broken = screen.getByTestId("provider-row-broken");
+    expect(within(broken).getByText("Configuration invalid")).toBeInTheDocument();
+    expect(within(broken).getByText("Misconfigured")).toBeInTheDocument();
+    expect(
+      within(broken).getByText("Provider configuration is invalid. Reconfigure this provider."),
+    ).toBeInTheDocument();
+    expect(within(broken).getByText("Detected")).toBeInTheDocument();
+  });
+
+  it("renders capability chips with per-state indication", () => {
+    mocks.providers = [provider({ id: "codex", display_name: "Codex" })];
+    renderPage();
+
+    expect(screen.getByTestId("provider-capability-model-discovery")).toHaveTextContent(
+      "Model discovery",
+    );
+    expect(screen.queryByTestId("provider-capability-usage-status")).toBeNull();
+    expect(screen.getByTestId("provider-capability-multiple-profiles")).toHaveTextContent(
+      "Multiple profiles (?)",
+    );
+    expect(screen.getByTestId("provider-capability-interactive-cli")).toHaveTextContent(
+      "Interactive CLI",
+    );
+  });
+
+  it("distinguishes every conservative connection state without claiming a vendor check", () => {
+    mocks.providers = [
+      provider({ id: "local", connection_state: "connected" }),
+      provider({
+        id: "auth",
+        connection_state: "authentication_required",
+        connection_detail: "The CLI has no locally detected credential.",
+      }),
+      provider({
+        id: "bad",
+        connection_state: "misconfigured",
+        connection_detail: "The endpoint variable is not set.",
+      }),
+      provider({
+        id: "missing",
+        connection_state: "unavailable",
+        connection_detail: "The CLI is not installed on this host.",
+      }),
+      provider({
+        id: "opaque",
+        connection_state: "unknown",
+        connection_detail: "The protected credential store was not opened.",
+      }),
+    ];
+    renderPage();
+
+    expect(screen.getByTestId("provider-connection-local")).toHaveTextContent(
+      "Credential available locally",
+    );
+    expect(screen.getByTestId("provider-connection-auth")).toHaveTextContent(
+      "Authentication required",
+    );
+    expect(screen.getByTestId("provider-connection-bad")).toHaveTextContent("Misconfigured");
+    expect(screen.getByTestId("provider-connection-missing")).toHaveTextContent(
+      "Unavailable on this host",
+    );
+    expect(screen.getByTestId("provider-connection-opaque")).toHaveTextContent("Status unknown");
+    expect(screen.queryByText(/^Connected$/)).toBeNull();
+  });
+
+  it("shows the empty state when the host reports no providers", () => {
+    renderPage();
+    expect(screen.getByTestId("provider-empty")).toHaveTextContent(/No providers/);
+  });
+
+  it("shows a retryable error instead of an indefinite spinner", () => {
+    mocks.inventoryError = true;
+    mocks.inventoryErrorObj = new Error("host unreachable");
+    renderPage();
+
+    expect(screen.getByTestId("provider-error")).toHaveTextContent("host unreachable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(mocks.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers Manage only for CLI providers the setup catalog knows", () => {
+    mocks.setupSteps = { codex: [] };
+    mocks.providers = [
+      provider({ id: "codex", display_name: "Codex", cli: "codex" }),
+      provider({ id: "gateway", display_name: "Work Gateway", kind: "gateway" }),
+      provider({ id: "mystery", display_name: "Mystery CLI", cli: "unknown-cli" }),
+    ];
+    renderPage();
+
+    expect(screen.getByTestId("provider-manage-codex")).toBeInTheDocument();
+    expect(screen.queryByTestId("provider-manage-gateway")).toBeNull();
+    expect(screen.queryByTestId("provider-manage-mystery")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("provider-manage-codex"));
+    expect(screen.getByTestId("harness-setup-stub")).toHaveTextContent("codex@host_1");
+  });
+
+  it("switches hosts through the picker when several are connected", () => {
+    mocks.hosts = [host("host_1", "MacBook"), host("host_2", "Studio")];
+    renderPage();
+
+    // Single-host label is replaced by the picker; inventory targets host_1.
+    expect(screen.queryByText("Host: MacBook")).toBeNull();
+    expect(mocks.inventoryHostId).toBe("host_1");
+
+    const picker = screen.getByTestId("provider-host-select") as HTMLSelectElement;
+    expect(picker.value).toBe("host_1");
+    fireEvent.change(picker, { target: { value: "host_2" } });
+    expect(mocks.inventoryHostId).toBe("host_2");
+  });
+
+  it("closes a provider management dialog when switching hosts", () => {
+    mocks.hosts = [host("host_1", "MacBook"), host("host_2", "Studio")];
+    mocks.setupSteps = { codex: [] };
+    mocks.providers = [provider({ id: "codex", cli: "codex" })];
+    renderPage();
+
+    fireEvent.click(screen.getByTestId("provider-manage-codex"));
+    expect(screen.getByTestId("harness-setup-stub")).toHaveTextContent("codex@host_1");
+
+    fireEvent.change(screen.getByTestId("provider-host-select"), {
+      target: { value: "host_2" },
+    });
+    expect(screen.queryByTestId("harness-setup-stub")).toBeNull();
+  });
+
+  it("explains what to do when no host is connected", () => {
+    mocks.hosts = [];
+    renderPage();
+    expect(screen.getByText(/No host is connected yet/)).toBeInTheDocument();
+  });
+
+  it("shows loading states for hosts and inventory", () => {
+    mocks.hostsLoading = true;
+    const { unmount } = renderPage();
+    expect(screen.getByText("Loading hosts…")).toBeInTheDocument();
+
+    unmount();
+    cleanup();
+    mocks.hostsLoading = false;
+    mocks.inventoryLoading = true;
+    renderPage();
+    expect(screen.getByTestId("provider-loading")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -14,6 +14,9 @@
  *   default transcript view, Workspace panel default, and UI/code font controls.
  * - **Git** — Git behavior: the global "always use a random worktree" default
  *   and the default base branch pre-filled when naming a new worktree branch.
+ * - **Providers** — the model providers configured on or safely detected for
+ *   the selected host, with conservative local connection evidence and a
+ *   Manage affordance that reuses the harness setup checklist for CLI rows.
  * - **Keyboard shortcuts** — the full shortcuts reference, shown inline.
  * - **Account** — only when the accounts auth provider is active. Absorbs
  *   the old sidebar AccountMenu: signed-in identity, change password, and
@@ -114,6 +117,7 @@ import { absoluteTime } from "@/lib/relativeTime";
 import { useNavigate } from "@/lib/routing";
 import { useSettingsRoute } from "@/shell/settingsNav";
 import { ImportSessionsPanel } from "@/shell/ImportSessionsPanel";
+import { ProvidersSection } from "@/pages/ProvidersSection";
 import { isThemeMode, normalizeThemeMode, type ThemeMode } from "@/components/theme/themeMode";
 import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import {
@@ -304,6 +308,7 @@ export function SettingsPage() {
       {section === "appearance" && <AppearanceSection />}
       {section === "general" && <GeneralSection />}
       {section === "git" && <GitSection />}
+      {section === "providers" && <ProvidersSection />}
       {section === "shortcuts" && <ShortcutsSection />}
       {section === "import" && <ImportSection />}
       {section === "account" && hasAuthSession && <AccountSection />}

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -35,7 +35,9 @@ import {
   useHosts,
   useInstallHarness,
   useInstallingHarnesses,
+  useProviderInventory,
   type Host,
+  type ProviderInventoryEntry,
 } from "@/hooks/useHosts";
 import { useAvailableAgents, type AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useHostFilesystem, type HostFilesystemEntry } from "@/hooks/useHostFilesystem";
@@ -80,6 +82,9 @@ vi.mock("@/hooks/useHosts", () => ({
   useInstallingHarnesses: vi.fn(() => new Set<string>()),
   useStoreCredential: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useDetectedCredentials: vi.fn(() => ({ data: [] })),
+  // The config modal names the provider that will serve the agent; inert by
+  // default so tests that don't exercise it need no wiring.
+  useProviderInventory: vi.fn(() => ({ data: [], isLoading: false, isError: false })),
 }));
 // The setup dialog's copyable command rows call copyText; stub it so a click
 // can be asserted without touching the real clipboard.
@@ -168,6 +173,7 @@ vi.mock("@/store/chatStore", async (importOriginal) => ({
 
 const authenticatedFetchMock = vi.mocked(authenticatedFetch);
 const useHostsMock = vi.mocked(useHosts);
+const useProviderInventoryMock = vi.mocked(useProviderInventory);
 /** Stable per-harness model-catalog results (identity matters: effects key on them). */
 const CLAUDE_MODEL_OPTIONS_RESULT = {
   data: [
@@ -680,6 +686,37 @@ function host(status: "online" | "offline", i = 1): Host {
   return { host_id: `host_${i}`, name: `machine-${i}`, owner: "me", status };
 }
 
+function providerInventoryEntry(
+  partial: Partial<ProviderInventoryEntry> = {},
+): ProviderInventoryEntry {
+  return {
+    id: "claude",
+    display_name: "Claude",
+    kind: "subscription",
+    origin: "configured",
+    source: "config",
+    configuration_state: "valid",
+    error: null,
+    families: ["anthropic"],
+    surfaces: ["anthropic"],
+    default_for: ["anthropic"],
+    default_models: {},
+    cli: "claude",
+    profile: null,
+    model_provider: null,
+    capabilities: {
+      model_discovery: "supported",
+      usage_status: "unsupported",
+      multiple_profiles: "unsupported",
+      interactive_cli: "supported",
+    },
+    default_for_harnesses: ["claude-native"],
+    connection_state: "unknown",
+    connection_detail: "No provider-specific local credential proof is available.",
+    ...partial,
+  };
+}
+
 function mockHosts(hosts: Host[], queryState: Partial<ReturnType<typeof useHosts>> = {}) {
   useHostsMock.mockReturnValue({
     data: hosts,
@@ -700,6 +737,12 @@ function mockAgents(agents: AvailableAgent[]) {
 function setupLandingMocks() {
   authenticatedFetchMock.mockReset();
   useHostsMock.mockReset();
+  useProviderInventoryMock.mockReset();
+  useProviderInventoryMock.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useProviderInventory>);
   useHostModelOptionsMock.mockReset();
   useAvailableAgentsMock.mockReset();
   useHostFilesystemMock.mockReset();
@@ -3357,6 +3400,21 @@ describe("NewChatLandingScreen agent picker + config gear", () => {
     fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
     expect(screen.getByTestId("new-chat-landing-config-modal")).toBeTruthy();
     expect(screen.getByTestId("new-chat-landing-config-permission")).toBeTruthy();
+  });
+
+  it("routes the selected host and harness to the read-only provider row", () => {
+    useProviderInventoryMock.mockReturnValue({
+      data: [providerInventoryEntry()],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useProviderInventory>);
+    renderLanding();
+
+    fireEvent.click(screen.getByTestId("new-chat-landing-config-gear"));
+
+    expect(useProviderInventoryMock).toHaveBeenLastCalledWith("host_1", true);
+    expect(screen.getByTestId("new-chat-provider-status")).toHaveTextContent("Claude");
+    expect(screen.getByTestId("new-chat-provider-status")).toHaveTextContent("Status unknown");
   });
 
   it("summarizes the current settings in the gear tooltip on hover", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -67,6 +67,7 @@ import {
   defaultModelLabel,
   nativeModelLabel,
 } from "@/components/HarnessConfigControls";
+import { NewChatProviderStatus } from "@/shell/NewChatProviderStatus";
 import { ProjectLandingIcon } from "@/components/ProjectIconPicker";
 import {
   DropdownMenu,
@@ -1658,6 +1659,7 @@ function HarnessConfigModal({
         </DialogHeader>
 
         <div className="flex flex-col gap-5 py-1">
+          <NewChatProviderStatus host={host} harness={draftHarness ?? entryHarness} open={open} />
           {!autoRouting && hasModelPicker && !hasPermission && (
             <>
               <ConfigRow label="Model" description="Underlying LLM" controlClassName="sm:w-80">

--- a/web/src/shell/NewChatProviderStatus.test.tsx
+++ b/web/src/shell/NewChatProviderStatus.test.tsx
@@ -1,0 +1,168 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Host, ProviderConnectionState, ProviderInventoryEntry } from "@/hooks/useHosts";
+
+const mocks = vi.hoisted(() => ({
+  providers: [] as ProviderInventoryEntry[],
+  isLoading: false,
+  isError: false,
+  inventoryArgs: [] as [string | null | undefined, boolean][],
+}));
+
+vi.mock("@/hooks/useHosts", () => ({
+  useProviderInventory: (hostId: string | null | undefined, enabled: boolean) => {
+    mocks.inventoryArgs.push([hostId, enabled]);
+    return { data: mocks.providers, isLoading: mocks.isLoading, isError: mocks.isError };
+  },
+}));
+
+const { NewChatProviderStatus, providerForHarness } = await import("./NewChatProviderStatus");
+
+function providerRow(partial: Partial<ProviderInventoryEntry> = {}): ProviderInventoryEntry {
+  return {
+    id: "codex",
+    display_name: "Codex",
+    kind: "subscription",
+    origin: "configured",
+    source: "config",
+    configuration_state: "valid",
+    error: null,
+    families: ["openai"],
+    surfaces: ["openai"],
+    default_for: ["openai"],
+    default_models: {},
+    cli: "codex",
+    profile: null,
+    model_provider: null,
+    capabilities: {
+      model_discovery: "supported",
+      usage_status: "unsupported",
+      multiple_profiles: "unsupported",
+      interactive_cli: "supported",
+    },
+    default_for_harnesses: ["codex-native"],
+    connection_state: "connected",
+    connection_detail:
+      "A credential reference is configured locally; the provider was not contacted.",
+    ...partial,
+  };
+}
+
+const HOST_ONE = { host_id: "host_1", name: "MacBook" } as Host;
+const HOST_TWO = { host_id: "host_2", name: "Workstation" } as Host;
+
+beforeEach(() => {
+  mocks.providers = [];
+  mocks.isLoading = false;
+  mocks.isError = false;
+  mocks.inventoryArgs = [];
+});
+
+afterEach(cleanup);
+
+describe("providerForHarness", () => {
+  it("uses the host's canonical mapping rather than guessing from provider families", () => {
+    const rows = [
+      providerRow({ id: "work", display_name: "Work", default_for_harnesses: ["pi-native"] }),
+      providerRow(),
+    ];
+
+    expect(providerForHarness(rows, "codex-native")?.id).toBe("codex");
+    expect(providerForHarness(rows, "pi-native")?.id).toBe("work");
+    expect(providerForHarness(rows, "claude-native")).toBeNull();
+  });
+
+  it("does not invent an answer for an older host or an absent harness", () => {
+    const legacy = providerRow();
+    delete legacy.default_for_harnesses;
+
+    expect(providerForHarness([legacy], "codex-native")).toBeNull();
+    expect(providerForHarness(undefined, "codex-native")).toBeNull();
+    expect(providerForHarness([providerRow()], null)).toBeNull();
+  });
+});
+
+describe("NewChatProviderStatus", () => {
+  it("shows the serving provider with conservative local evidence", () => {
+    mocks.providers = [providerRow()];
+    render(<NewChatProviderStatus host={HOST_ONE} harness="codex-native" open />);
+
+    const status = screen.getByTestId("new-chat-provider-status");
+    expect(status).toHaveAttribute("data-state", "connected");
+    expect(status).toHaveTextContent("Codex");
+    expect(status).toHaveTextContent("Credential available locally");
+    expect(status).toHaveTextContent("the provider was not contacted");
+    expect(screen.getByText("Provider")).toBeInTheDocument();
+  });
+
+  it.each<[ProviderConnectionState, string]>([
+    ["authentication_required", "Authentication required"],
+    ["misconfigured", "Misconfigured"],
+    ["unavailable", "Unavailable on this host"],
+    ["unknown", "Status unknown"],
+  ])("presents %s without claiming vendor connectivity", (connectionState, label) => {
+    mocks.providers = [
+      providerRow({
+        connection_state: connectionState,
+        connection_detail: "This conclusion uses local evidence only.",
+      }),
+    ];
+
+    render(<NewChatProviderStatus host={HOST_ONE} harness="codex-native" open />);
+
+    expect(screen.getByTestId("new-chat-provider-status")).toHaveAttribute(
+      "data-state",
+      connectionState,
+    );
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByText("This conclusion uses local evidence only.")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["missing mapping", HOST_ONE, "claude-native", false, false],
+    ["sandbox", null, "codex-native", false, false],
+    ["missing harness", HOST_ONE, null, false, false],
+    ["closed dialog", HOST_ONE, "codex-native", false, false],
+    ["loading", HOST_ONE, "codex-native", true, false],
+    ["error", HOST_ONE, "codex-native", false, true],
+  ])("renders no outer row while %s", (_case, host, harness, loading, error) => {
+    mocks.providers = [providerRow()];
+    mocks.isLoading = loading;
+    mocks.isError = error;
+    const open = _case !== "closed dialog";
+
+    const { container } = render(
+      <NewChatProviderStatus host={host as Host | null} harness={harness} open={open} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText("Provider")).toBeNull();
+  });
+
+  it("performs only the noninteractive inventory read when the dialog opens", () => {
+    mocks.providers = [providerRow()];
+
+    render(<NewChatProviderStatus host={HOST_ONE} harness="codex-native" open />);
+
+    expect(mocks.inventoryArgs.at(-1)).toEqual(["host_1", true]);
+  });
+
+  it("clears the old row while a newly selected host loads", () => {
+    mocks.providers = [providerRow()];
+    const { rerender } = render(
+      <NewChatProviderStatus host={HOST_ONE} harness="codex-native" open />,
+    );
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+
+    mocks.isLoading = true;
+    rerender(<NewChatProviderStatus host={HOST_TWO} harness="codex-native" open />);
+    expect(screen.queryByText("Provider")).toBeNull();
+    expect(mocks.inventoryArgs.at(-1)).toEqual(["host_2", true]);
+
+    mocks.isLoading = false;
+    mocks.providers = [providerRow({ id: "work", display_name: "Work Gateway" })];
+    rerender(<NewChatProviderStatus host={HOST_TWO} harness="codex-native" open />);
+    expect(screen.getByText("Work Gateway")).toBeInTheDocument();
+  });
+});

--- a/web/src/shell/NewChatProviderStatus.tsx
+++ b/web/src/shell/NewChatProviderStatus.tsx
@@ -1,0 +1,96 @@
+/** Read-only provider status for the New Chat configuration dialog. */
+import { AlertTriangleIcon, CircleCheckIcon, CircleDashedIcon } from "lucide-react";
+
+import { ConfigRow } from "@/components/HarnessConfigControls";
+import {
+  useProviderInventory,
+  type Host,
+  type ProviderConnectionState,
+  type ProviderInventoryEntry,
+} from "@/hooks/useHosts";
+
+interface StatePresentation {
+  label: string;
+  className: string;
+  icon: typeof CircleCheckIcon;
+}
+
+const STATE_PRESENTATION: Record<ProviderConnectionState, StatePresentation> = {
+  connected: {
+    label: "Credential available locally",
+    className: "text-emerald-600 dark:text-emerald-500",
+    icon: CircleCheckIcon,
+  },
+  authentication_required: {
+    label: "Authentication required",
+    className: "text-amber-600 dark:text-amber-500",
+    icon: AlertTriangleIcon,
+  },
+  misconfigured: {
+    label: "Misconfigured",
+    className: "text-destructive",
+    icon: AlertTriangleIcon,
+  },
+  unavailable: {
+    label: "Unavailable on this host",
+    className: "text-destructive",
+    icon: AlertTriangleIcon,
+  },
+  unknown: {
+    label: "Status unknown",
+    className: "text-muted-foreground",
+    icon: CircleDashedIcon,
+  },
+};
+
+/** Return the host-selected provider for a harness, without guessing by family. */
+export function providerForHarness(
+  providers: readonly ProviderInventoryEntry[] | undefined,
+  harness: string | null,
+): ProviderInventoryEntry | null {
+  if (!harness || !providers) return null;
+  return providers.find((provider) => provider.default_for_harnesses?.includes(harness)) ?? null;
+}
+
+/**
+ * Name the local provider that would serve the selected harness.
+ *
+ * The row is absent until the host supplies a complete answer. This prevents
+ * an empty configuration row during host changes and for sandbox sessions.
+ */
+export function NewChatProviderStatus({
+  host,
+  harness,
+  open,
+}: {
+  host: Host | null | undefined;
+  harness: string | null;
+  open: boolean;
+}) {
+  const hostId = host?.host_id ?? null;
+  const inventory = useProviderInventory(hostId, open && !!hostId && !!harness);
+
+  if (!open || !hostId || !harness || inventory.isLoading || inventory.isError) return null;
+
+  const provider = providerForHarness(inventory.data, harness);
+  if (!provider) return null;
+
+  const presentation = STATE_PRESENTATION[provider.connection_state];
+  const Icon = presentation.icon;
+  return (
+    <ConfigRow
+      label="Provider"
+      description="Selected locally for this harness"
+      controlClassName="sm:w-80"
+    >
+      <div data-testid="new-chat-provider-status" data-state={provider.connection_state}>
+        <div className="flex flex-wrap items-center gap-1.5 text-ui">
+          <Icon className={`size-4 shrink-0 ${presentation.className}`} />
+          <span className="font-medium">{provider.display_name}</span>
+          <span className={`text-sm ${presentation.className}`}>{presentation.label}</span>
+        </div>
+        <p className="mt-0.5 text-sm text-muted-foreground">{provider.connection_detail}</p>
+      </div>
+    </ConfigRow>
+  );
+}

--- a/web/src/shell/settingsNav.test.tsx
+++ b/web/src/shell/settingsNav.test.tsx
@@ -75,6 +75,14 @@ describe("settingsNavGroups", () => {
     });
   });
 
+  it("includes Providers in the General settings navigation", () => {
+    const general = settingsNavGroups(false, false).find((group) => group.title === "General");
+
+    expect(general?.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "providers", label: "Providers" })]),
+    );
+  });
+
   it("flags Keyboard shortcuts as hidden on mobile, but not the other items", () => {
     const items = settingsNavGroups(false, false).flatMap((g) => g.items);
     const shortcuts = items.find((i) => i.id === "shortcuts");
@@ -312,6 +320,13 @@ describe("useSettingsRoute", () => {
     );
     return renderHook(() => useSettingsRoute(), { wrapper: w }).result.current;
   }
+
+  it("resolves /settings/providers as the Providers section", () => {
+    expect(routeHook("/settings/providers")).toEqual({
+      inSettings: true,
+      section: "providers",
+    });
+  });
 
   it("treats /settings/members and /settings/policies as in-settings sections on an accounts deploy", () => {
     // The core of the fix: Members / Policies now live UNDER /settings, so the

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -14,6 +14,7 @@ import {
   GitBranchIcon,
   KeyboardIcon,
   PaletteIcon,
+  PlugIcon,
   SettingsIcon,
   Share2Icon,
   ShieldCheckIcon,
@@ -34,6 +35,7 @@ export type SettingsSectionId =
   | "appearance"
   | "general"
   | "git"
+  | "providers"
   | "shortcuts"
   | "import"
   | "account"
@@ -48,6 +50,7 @@ const SECTION_IDS: readonly SettingsSectionId[] = [
   "appearance",
   "general",
   "git",
+  "providers",
   "shortcuts",
   "import",
   "account",
@@ -91,6 +94,9 @@ export function settingsNavGroups(
     { id: "general", label: "General", icon: SettingsIcon },
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
     { id: "git", label: "Git", icon: GitBranchIcon },
+    // Providers sits next to Git because it answers the same "what is Omnigent
+    // wired up to" question — for model backends instead of repositories.
+    { id: "providers", label: "Providers", icon: PlugIcon },
     { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
     { id: "import", label: "Import sessions", icon: DownloadIcon },
   ];


### PR DESCRIPTION
<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

N/A — no linked issue

## Summary

- Show the provider that canonically serves the selected host and harness in New Chat’s Configure view.
- ELI5: before starting a chat, users can see which configured account or gateway the chosen harness will actually use.
- GitHub base is `main`. This is a stacked draft whose conceptual parent is `review/feat-provider-management-ui-safe` at `118d4e0cb748884395a9d2c88739a55f180a34f4`; after that parent merges, GitHub’s diff shrinks to this PR’s isolated change.

```text
selected host + harness → canonical serving-harness mapping → safe provider status
```

The component handles older hosts, absent mappings, malformed unrelated rows, host changes, loading, and errors conservatively. It uses the noninteractive inventory only—no quota, vendor, protected-store, or CLI-auth probe. The provider picker is intentionally a later PR.

## Test Plan

- `NewChatProviderStatus`: 15 passed.
- `NewChatDialog` integration case: 1 passed.
- Focused Python inventory/frame selection: 10 passed under normal repository configuration.
- Ruff, Pyrefly, TypeScript type-check, Oxlint, and Prettier passed.
- The final restack onto current `upstream/main` was patch-equivalent by `git range-diff`.

Manual follow-up: switch hosts and harnesses, then verify mapped, missing, unknown, loading, and failed inventory states.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Attachment required before ready-for-review: show a mapped provider, host/harness switching, and an unknown or unavailable state.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Frontend behavior and backend mapping contracts are covered. Visual/network manual verification remains outstanding.

## Changelog

New Chat now shows the provider serving the selected host and harness.
