### PR TITLE
feat(harness): add headless genie CLI harness (Databricks codex fork)

### DIFF
--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -3538,6 +3538,7 @@ def _run_configure_harnesses_interactive() -> None:
     from omnigent.onboarding.harness_install import (
         COPILOT_KEY,
         CURSOR_KEY,
+        GENIE_KEY,
         GOOSE_KEY,
         HERMES_KEY,
         KIMI_KEY,
@@ -3608,6 +3609,12 @@ def _run_configure_harnesses_interactive() -> None:
     # / ``kimi provider add`` → ~/.kimi-code/config.toml), so it dispatches to its
     # own drill-in rather than ``_manage_harness_providers``.
     _KIMI = "\x00kimi"
+    # Sentinel marking the Genie row — Databricks' fork of the Codex CLI. It has
+    # its own ``genie`` binary but no credential of its own: it authenticates
+    # through the shared OpenAI-family provider (Databricks AI Gateway), same as
+    # Codex. So it is not a provider family; selecting it manages that shared
+    # OpenAI-family provider.
+    _GENIE = "\x00genie"
     # Sentinels for the generic-ACP rows. Each configured agent gets its own row
     # (``_ACP_AGENT_PREFIX + slug`` → per-agent remove drill-in); import/add rows
     # jump straight into those flows. Not a provider family — each ACP agent owns
@@ -3697,6 +3704,46 @@ def _run_configure_harnesses_interactive() -> None:
         rows: list[tuple[str, str, str, str, str]] = []
         rows.append(_family_row(ANTHROPIC_FAMILY))
         rows.append(_family_row(OPENAI_FAMILY))
+
+        # Genie — Databricks' fork of the Codex CLI. It wraps its own ``genie``
+        # binary but authenticates through the shared OpenAI-family provider
+        # (Databricks AI Gateway), so the row gates on the genie binary and
+        # reflects the OpenAI-family credential. Selecting it manages that same
+        # shared provider as Codex.
+        if not harness_cli_installed(GENIE_KEY):
+            rows.append(
+                (
+                    _GENIE,
+                    "Genie",
+                    "CLI not installed",
+                    "missing",
+                    _install_hint(harness_install_display(GENIE_KEY)),
+                )
+            )
+        else:
+            genie_default = surface_default_provider(config, OPENAI_FAMILY)
+            if genie_default is None:
+                rows.append(
+                    (
+                        _GENIE,
+                        "Genie",
+                        "Not configured",
+                        "warn",
+                        "Open to add a Databricks/OpenAI credential (shared with Codex).",
+                    )
+                )
+            else:
+                rows.append(
+                    (
+                        _GENIE,
+                        "Genie",
+                        _family_credential_label(
+                            config, OPENAI_FAMILY, genie_default.name, genie_default
+                        ),
+                        "ready",
+                        "",
+                    )
+                )
 
         # Cursor setup covers both surfaces, but readiness prioritizes the CLI
         # used by the built-in web agent. An SDK key never hides a CLI problem.
@@ -4120,6 +4167,9 @@ def _run_configure_harnesses_interactive() -> None:
             _manage_copilot_harness()
         elif isinstance(selected_target, str) and selected_target in families:
             _manage_harness_providers(selected_target)
+        elif selected_target == _GENIE:
+            # Genie shares the OpenAI-family provider with Codex — manage it there.
+            _manage_harness_providers(OPENAI_FAMILY)
         elif selected_target == _ANTIGRAVITY:
             _manage_antigravity_harness()
         elif selected_target == _QWEN:

--- a/omnigent/harness_availability.py
+++ b/omnigent/harness_availability.py
@@ -19,7 +19,7 @@ HarnessAvailability = Literal[
 
 # Readiness and model-family checks must agree on every Codex spelling.
 CODEX_CANONICAL_HARNESSES: Final[frozenset[str]] = frozenset(
-    {"codex", "codex-native", "native-codex"}
+    {"codex", "codex-native", "native-codex", "genie"}
 )
 
 

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -541,6 +541,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         subagents=False,
         interrupt=True,
         streaming=True,
+        instruction_delivery=_ID.COMPOSED_PER_TURN,
     ),
     "pi": _C(
         _IM.CLI_SUBPROCESS,

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -529,6 +529,19 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         streaming=True,
         instruction_delivery=_ID.COMPOSED_PER_TURN,
     ),
+    # Genie is Databricks' fork of the codex CLI, driven over the identical
+    # app-server protocol; same capabilities as codex.
+    "genie": _C(
+        _IM.CLI_SUBPROCESS,
+        _EL.JSONRPC,
+        _RS.WARM_REATTACH,
+        _EF.OPENAI,
+        _MF.GPT,
+        _AU.OMNIGENT_CREDENTIAL,
+        subagents=False,
+        interrupt=True,
+        streaming=True,
+    ),
     "pi": _C(
         _IM.CLI_SUBPROCESS,
         _EL.NONE,
@@ -700,6 +713,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "copilot",
             "cursor",
             "cursor-native",
+            "genie",
             "goose",
             "goose-native",
             "hermes",
@@ -735,6 +749,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "copilot": "omnigent.inner.copilot_harness",
         "cursor": "omnigent.inner.cursor_harness",
         "cursor-native": "omnigent.inner.cursor_native_harness",
+        "genie": "omnigent.inner.genie_harness",
         "goose": "omnigent.inner.goose_harness",
         "goose-native": "omnigent.inner.goose_native_harness",
         "hermes": "omnigent.inner.hermes_harness",
@@ -827,6 +842,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "codex": "HARNESS_CODEX_MODEL",
         "copilot": "HARNESS_COPILOT_MODEL",
         "cursor": "HARNESS_CURSOR_MODEL",
+        "genie": "HARNESS_GENIE_MODEL",
         "goose": "HARNESS_GOOSE_MODEL",
         "hermes": "HARNESS_HERMES_MODEL",
         "kimi": "HARNESS_KIMI_MODEL",
@@ -848,6 +864,9 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "codex-native": BackgroundTitleGeneratorSpec(
             "omnigent.runner.background_titles.codex_native:generate_background_title"
         ),
+        "genie": BackgroundTitleGeneratorSpec(
+            "omnigent.runner.background_titles.sdk:generate_background_title"
+        ),
     },
     harness_labels={
         "antigravity": "Antigravity",
@@ -855,6 +874,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "codex": "Codex",
         "copilot": "Copilot",
         "cursor": "Cursor",
+        "genie": "Genie",
         "hermes": "Hermes",
         # openai-agents is intentionally omitted from the picker catalog: it
         # stays a valid harness for YAML specs (and the credential-free

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -2351,9 +2351,7 @@ class _CodexAppServerSession:
         # definitions) from ``$CODEX_HOME``; without this step a freshly-
         # created temp dir has neither, causing 401 Unauthorized errors
         # for subscription-authenticated users.
-        config_source = _codex_home_config_source_from_env(
-            self._home_env_var, self._home_dir_name
-        )
+        config_source = _codex_home_config_source_from_env(self._home_env_var, self._home_dir_name)
         # When the runner advertises a subagent-routing endpoint, the user's
         # hooks.json is merged into a generated file registering the routing
         # hooks instead of being symlinked in untouched. Only an auto-harness

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -410,6 +410,13 @@ def _find_codex_cli() -> str | None:
     return resolve_cli_binary("codex", env_var=_CODEX_PATH_ENV)
 
 
+# Default on-disk home spelling for the codex CLI. Genie (a Databricks fork of
+# codex, driven by :class:`~omnigent.inner.genie_executor.GenieExecutor`) reads
+# ``GENIE_HOME`` / ``~/.genie`` instead — see :class:`_CodexHomeSpec`.
+_DEFAULT_HOME_ENV_VAR = "CODEX_HOME"
+_DEFAULT_HOME_DIR_NAME = ".codex"
+
+
 async def _codex_cli_version(codex_path: str) -> tuple[int, int, int] | None:
     """
     Return the codex CLI version as a ``(major, minor, patch)`` tuple.
@@ -773,7 +780,10 @@ def _resolve_codex_home_config_source(source_dir: Path, home_codex_home: Path) -
     return source_dir
 
 
-def _codex_home_config_source_from_env() -> Path:
+def _codex_home_config_source_from_env(
+    home_env_var: str = _DEFAULT_HOME_ENV_VAR,
+    home_dir_name: str = _DEFAULT_HOME_DIR_NAME,
+) -> Path:
     """
     Return the Codex home whose auth/config should be bridged.
 
@@ -783,12 +793,16 @@ def _codex_home_config_source_from_env() -> Path:
     can inherit a parent private home, so this resolver maps that specific
     inherited session-state home back to the user's default ``~/.codex``.
 
+    :param home_env_var: The env var naming the user's source home, e.g.
+        ``"CODEX_HOME"`` (codex) or ``"GENIE_HOME"`` (the genie fork).
+    :param home_dir_name: The default home dir under ``~`` when the env var is
+        unset, e.g. ``".codex"`` or ``".genie"``.
     :returns: Host Codex home to read ``auth.json`` and ``config.toml`` from,
         e.g. ``Path.home() / ".codex"`` or an explicit user ``CODEX_HOME``.
     """
-    home_codex_home = Path.home() / ".codex"
+    home_codex_home = Path.home() / home_dir_name
     return _resolve_codex_home_config_source(
-        Path(os.environ.get("CODEX_HOME") or str(home_codex_home)),
+        Path(os.environ.get(home_env_var) or str(home_codex_home)),
         home_codex_home,
     )
 
@@ -2242,6 +2256,8 @@ class _CodexAppServerSession:
         disable_native_tools: bool = False,
         bundle_dir: Path | None = None,
         skills_filter: str | list[str] = "all",
+        home_env_var: str = _DEFAULT_HOME_ENV_VAR,
+        home_dir_name: str = _DEFAULT_HOME_DIR_NAME,
     ) -> None:
         self._codex_path = codex_path
         self._cwd = cwd
@@ -2252,6 +2268,13 @@ class _CodexAppServerSession:
         self._disable_native_tools = disable_native_tools
         self._bundle_dir = bundle_dir
         self._skills_filter = skills_filter
+        # Home-dir spelling for the wrapped CLI. Codex reads ``CODEX_HOME`` /
+        # ``~/.codex``; the genie fork reads ``GENIE_HOME`` / ``~/.genie``. The
+        # tag (``codex`` / ``genie``) also names the private temp home so both
+        # forms are legible on disk and never collide.
+        self._home_env_var = home_env_var
+        self._home_dir_name = home_dir_name
+        self._home_tag = home_dir_name.lstrip(".") or "codex"
         self._proc: asyncio.subprocess.Process | None = None
         self._reader_task: asyncio.Task[None] | None = None
         self._stderr_task: asyncio.Task[None] | None = None
@@ -2299,7 +2322,7 @@ class _CodexAppServerSession:
         codex_home_root = Path(tempfile.gettempdir())
         if self._cwd and self._cwd != "/":
             try:
-                codex_home_root = Path(self._cwd) / ".codex-tmp"
+                codex_home_root = Path(self._cwd) / f".{self._home_tag}-tmp"
                 codex_home_root.mkdir(parents=True, exist_ok=True)
             except OSError:
                 # The cwd may be on a read-only filesystem — e.g. macOS
@@ -2308,7 +2331,7 @@ class _CodexAppServerSession:
                 # system temp directory so the codex home is still writable.
                 codex_home_root = Path(tempfile.gettempdir())
         self._codex_home_dir = Path(
-            tempfile.mkdtemp(prefix="omnigent-codex-home-", dir=str(codex_home_root))
+            tempfile.mkdtemp(prefix=f"omnigent-{self._home_tag}-home-", dir=str(codex_home_root))
         )
         # Populate the per-conversation CODEX_HOME's ``skills/`` subdir
         # based on the spec's ``skills:`` field. Codex auto-discovers
@@ -2328,7 +2351,9 @@ class _CodexAppServerSession:
         # definitions) from ``$CODEX_HOME``; without this step a freshly-
         # created temp dir has neither, causing 401 Unauthorized errors
         # for subscription-authenticated users.
-        config_source = _codex_home_config_source_from_env()
+        config_source = _codex_home_config_source_from_env(
+            self._home_env_var, self._home_dir_name
+        )
         # When the runner advertises a subagent-routing endpoint, the user's
         # hooks.json is merged into a generated file registering the routing
         # hooks instead of being symlinked in untouched. Only an auto-harness
@@ -2367,10 +2392,11 @@ class _CodexAppServerSession:
                 session_id=codex_router_session_id(self._env),
                 user_hooks_source=config_source / _CODEX_HOOKS_FILENAME,
             )
-        # Override CODEX_HOME so Codex stores its data (including conversation
-        # history) in a private temp directory rather than the user's ~/.codex/.
-        # This prevents subagent sessions from polluting the user's Codex history.
-        proc_env = {**self._env, "CODEX_HOME": str(self._codex_home_dir)}
+        # Override the home env var so the CLI stores its data (including
+        # conversation history) in a private temp directory rather than the
+        # user's ~/.codex/ (or ~/.genie/ for the fork). This prevents subagent
+        # sessions from polluting the user's real history.
+        proc_env = {**self._env, self._home_env_var: str(self._codex_home_dir)}
         try:
             argv = [self._codex_path, "app-server"]
             for override in self._codex_config_overrides:
@@ -3275,6 +3301,8 @@ class _AppSessionFactory(Protocol):
         disable_native_tools: bool,
         bundle_dir: Path | None,
         skills_filter: str | list[str],
+        home_env_var: str,
+        home_dir_name: str,
     ) -> _CodexAppServerSession: ...
 
 
@@ -3289,6 +3317,8 @@ def _default_app_session_factory(
     disable_native_tools: bool,
     bundle_dir: Path | None,
     skills_filter: str | list[str],
+    home_env_var: str,
+    home_dir_name: str,
 ) -> _CodexAppServerSession:
     return _CodexAppServerSession(
         codex_path=codex_path,
@@ -3300,6 +3330,8 @@ def _default_app_session_factory(
         disable_native_tools=disable_native_tools,
         bundle_dir=bundle_dir,
         skills_filter=skills_filter,
+        home_env_var=home_env_var,
+        home_dir_name=home_dir_name,
     )
 
 
@@ -3325,6 +3357,8 @@ class CodexExecutor(Executor):
         bundle_dir: Path | None = None,
         agent_name: str | None = None,
         skills_filter: str | list[str] = "all",
+        home_env_var: str = _DEFAULT_HOME_ENV_VAR,
+        home_dir_name: str = _DEFAULT_HOME_DIR_NAME,
     ) -> None:
         """Create a CodexExecutor.
 
@@ -3415,13 +3449,15 @@ class CodexExecutor(Executor):
         self._bundle_dir = bundle_dir
         self._agent_name = agent_name
         self._skills_filter = skills_filter
-        resolved_codex = codex_path or _find_codex_cli()
+        # Home-dir spelling for the wrapped CLI (codex: ``CODEX_HOME`` /
+        # ``~/.codex``; genie fork: ``GENIE_HOME`` / ``~/.genie``), threaded
+        # into each per-session app-server so the private temp home uses the
+        # right env var. See :class:`~omnigent.inner.genie_executor.GenieExecutor`.
+        self._home_env_var = home_env_var
+        self._home_dir_name = home_dir_name
+        resolved_codex = codex_path or self._find_cli()
         if not resolved_codex:
-            raise ImportError(
-                "CodexExecutor requires the 'codex' CLI on PATH. If codex is "
-                "installed on a PATH the host daemon didn't inherit (e.g. an "
-                f"nvm-managed bin dir), set {_CODEX_PATH_ENV}=/path/to/codex."
-            )
+            raise ImportError(self._cli_missing_message())
         self._codex_path = resolved_codex
         self._env = _clean_codex_env(declared_passthrough(self._os_env_spec))
         # Retry policy → OpenAI SDK env vars (Codex uses the OpenAI
@@ -3537,6 +3573,25 @@ class CodexExecutor(Executor):
             else _default_app_session_factory
         )
 
+    def _find_cli(self) -> str | None:
+        """Resolve the wrapped CLI binary when no explicit path was given.
+
+        Overridden by :class:`~omnigent.inner.genie_executor.GenieExecutor` to
+        search for ``genie`` instead of ``codex``.
+        """
+        return _find_codex_cli()
+
+    def _cli_missing_message(self) -> str:
+        """Error text when the wrapped CLI cannot be resolved.
+
+        Overridden by :class:`~omnigent.inner.genie_executor.GenieExecutor`.
+        """
+        return (
+            "CodexExecutor requires the 'codex' CLI on PATH. If codex is "
+            "installed on a PATH the host daemon didn't inherit (e.g. an "
+            f"nvm-managed bin dir), set {_CODEX_PATH_ENV}=/path/to/codex."
+        )
+
     def supports_streaming(self) -> bool:
         return True
 
@@ -3621,6 +3676,8 @@ class CodexExecutor(Executor):
             disable_native_tools=self._disable_native_tools,
             bundle_dir=self._bundle_dir,
             skills_filter=self._skills_filter,
+            home_env_var=self._home_env_var,
+            home_dir_name=self._home_dir_name,
         )
         state.app_session = app_session
         state.signature = signature

--- a/omnigent/inner/genie_executor.py
+++ b/omnigent/inner/genie_executor.py
@@ -1,0 +1,70 @@
+"""Executor for the ``genie`` harness — Databricks' fork of the codex CLI.
+
+Genie (`databricks-eng/genie-code-codex`) is codex with Databricks branding, a
+`~/.genie` home (``GENIE_HOME``), OpenAI phone-home disabled, and the Databricks
+AI Gateway (Codex Responses API at ``/ai-gateway/codex/v1``) as its default
+provider. Its ``app-server`` speaks the identical JSON-RPC protocol codex does,
+so :class:`~omnigent.inner.codex_executor.CodexExecutor` already drives it: the
+gateway base URL, ``databricks auth token`` auth command, model, and profile
+are all shared behavior. Genie differs from codex in exactly two ways that this
+subclass encodes:
+
+1. **Binary** — resolve/run ``genie`` (``OMNIGENT_GENIE_PATH``) rather than
+   ``codex``.
+2. **Home** — ``GENIE_HOME`` / ``~/.genie`` rather than ``CODEX_HOME`` /
+   ``~/.codex`` (the fork ignores ``CODEX_HOME``, so a per-session private home
+   must be handed to it under the right env var).
+
+Keeping this a thin subclass — rather than a fork of the executor — is
+deliberate: genie's interaction surface is codex's today, and this is the seam
+where genie-native behavior can grow (one method at a time) if that changes,
+without touching the shared codex driver.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from omnigent._platform import resolve_cli_binary
+from omnigent.inner.codex_executor import CodexExecutor
+
+# Env override for an explicit genie binary, mirroring codex's
+# ``OMNIGENT_CODEX_PATH``. Set this when genie lives on a PATH the host daemon
+# doesn't inherit.
+_GENIE_PATH_ENV = "OMNIGENT_GENIE_PATH"
+
+GENIE_HOME_ENV_VAR = "GENIE_HOME"
+GENIE_HOME_DIR_NAME = ".genie"
+
+
+def _find_genie_cli() -> str | None:
+    """Resolve the ``genie`` CLI binary (override → ``PATH`` → global dirs)."""
+    return resolve_cli_binary("genie", env_var=_GENIE_PATH_ENV)
+
+
+class GenieExecutor(CodexExecutor):
+    """Drive the genie CLI's ``app-server`` over the shared codex protocol.
+
+    Identical to :class:`CodexExecutor` except it runs ``genie`` and isolates
+    per-session state under ``GENIE_HOME`` / ``~/.genie``. All gateway routing
+    (base URL, ``databricks auth token`` auth command, model, profile) is
+    inherited unchanged.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        # Force the genie home spelling regardless of what a caller passed, so
+        # the per-session private home is handed to genie under the env var it
+        # actually reads.
+        kwargs["home_env_var"] = GENIE_HOME_ENV_VAR
+        kwargs["home_dir_name"] = GENIE_HOME_DIR_NAME
+        super().__init__(**kwargs)
+
+    def _find_cli(self) -> str | None:
+        return _find_genie_cli()
+
+    def _cli_missing_message(self) -> str:
+        return (
+            "GenieExecutor requires the 'genie' CLI on PATH. If genie is "
+            "installed on a PATH the host daemon didn't inherit, set "
+            f"{_GENIE_PATH_ENV}=/path/to/genie."
+        )

--- a/omnigent/inner/genie_harness.py
+++ b/omnigent/inner/genie_harness.py
@@ -1,0 +1,189 @@
+"""
+``harness: genie`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the shared
+:mod:`omnigent.runtime.harnesses._runner` invokes after the parent process
+resolves ``"genie"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Mirrors :mod:`omnigent.inner.codex_harness` (genie is Databricks' fork of the
+codex CLI); it instantiates an
+:class:`omnigent.inner.genie_executor.GenieExecutor` (a thin
+:class:`~omnigent.inner.codex_executor.CodexExecutor` subclass) from env vars
+the parent process sets before spawning. Genie always routes through the
+Databricks AI Gateway (Codex Responses API at ``/ai-gateway/codex/v1``), so the
+gateway path defaults on; the base URL and ``databricks auth token`` auth
+command are derived from the profile by the shared executor.
+
+Env vars read at startup:
+
+- ``HARNESS_GENIE_MODEL``: model identifier, e.g.
+  ``"databricks-gpt-5-4-mini"``. ``None`` falls back to the catalog default.
+- ``HARNESS_GENIE_GATEWAY``: ``"1"`` / ``"true"`` (default) to route through the
+  Databricks AI gateway. ``"0"`` lets genie use its own ``~/.genie/config.toml``
+  provider instead.
+- ``HARNESS_GENIE_DATABRICKS_PROFILE``: ``~/.databrickscfg`` profile used to
+  derive the gateway host / base URL and mint the bearer token.
+- ``HARNESS_GENIE_GATEWAY_HOST`` / ``HARNESS_GENIE_GATEWAY_BASE_URL`` /
+  ``HARNESS_GENIE_GATEWAY_AUTH_COMMAND`` /
+  ``HARNESS_GENIE_GATEWAY_AUTH_REFRESH_INTERVAL_MS``: explicit gateway transport
+  overrides (written by the Omnigent workflow layer); when unset the executor
+  derives them from the Databricks profile.
+- ``HARNESS_GENIE_CWD``: working directory the executor launches genie in.
+  ``None`` falls back to ``OMNIGENT_RUNNER_WORKSPACE`` then the inherited cwd.
+- ``OMNIGENT_GENIE_PATH``: absolute path to a ``genie`` CLI binary. ``None``
+  searches ``PATH``.
+- ``HARNESS_GENIE_ENABLE_WEB_SEARCH`` / ``HARNESS_GENIE_DISABLE_NATIVE_TOOLS`` /
+  ``HARNESS_GENIE_OS_ENV`` / ``HARNESS_GENIE_RETRY_POLICY`` /
+  ``HARNESS_GENIE_SKILLS_FILTER`` / ``HARNESS_GENIE_BUNDLE_DIR`` /
+  ``HARNESS_GENIE_AGENT_NAME``: same semantics as their ``HARNESS_CODEX_*``
+  counterparts (see :mod:`omnigent.inner.codex_harness`).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from omnigent.harness_startup_config import resolve_harness_path
+from omnigent.inner.codex_harness import _parse_truthy
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.inner.genie_executor import GenieExecutor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+from omnigent.spec.types import RetryPolicy
+
+_logger = logging.getLogger(__name__)
+
+_ENV_MODEL = "HARNESS_GENIE_MODEL"
+_ENV_GATEWAY = "HARNESS_GENIE_GATEWAY"
+_ENV_DATABRICKS_PROFILE = "HARNESS_GENIE_DATABRICKS_PROFILE"
+_ENV_MODEL_PROVIDER = "HARNESS_GENIE_MODEL_PROVIDER"
+_ENV_GATEWAY_HOST = "HARNESS_GENIE_GATEWAY_HOST"
+_ENV_CWD = "HARNESS_GENIE_CWD"
+_ENV_ENABLE_WEB_SEARCH = "HARNESS_GENIE_ENABLE_WEB_SEARCH"
+_ENV_DISABLE_NATIVE_TOOLS = "HARNESS_GENIE_DISABLE_NATIVE_TOOLS"
+_ENV_OS_ENV = "HARNESS_GENIE_OS_ENV"
+_ENV_RETRY_POLICY = "HARNESS_GENIE_RETRY_POLICY"
+_ENV_SKILLS_FILTER = "HARNESS_GENIE_SKILLS_FILTER"
+_ENV_BUNDLE_DIR = "HARNESS_GENIE_BUNDLE_DIR"
+_ENV_AGENT_NAME = "HARNESS_GENIE_AGENT_NAME"
+_ENV_GATEWAY_BASE_URL = "HARNESS_GENIE_GATEWAY_BASE_URL"
+_ENV_GATEWAY_AUTH_COMMAND = "HARNESS_GENIE_GATEWAY_AUTH_COMMAND"
+_ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_GENIE_GATEWAY_AUTH_REFRESH_INTERVAL_MS"
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    """Resolve the inner-executor :class:`OSEnvSpec` from :data:`_ENV_OS_ENV`.
+
+    Decodes the JSON-encoded :class:`OSEnvSpec` dict Omnigent serialized; on a
+    missing/malformed value falls back to ``caller_process + sandbox=none`` so
+    genie's natives stay enabled (matches the codex wrap's default).
+    """
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env", _ENV_OS_ENV, exc
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    return OSEnvSpec(
+        type="caller_process", cwd=None, sandbox=OSEnvSandboxSpec(type="none"), fork=False
+    )
+
+
+def _resolve_retry_policy() -> RetryPolicy:
+    """Resolve the :class:`RetryPolicy` from :data:`_ENV_RETRY_POLICY`.
+
+    Falls back to ``RetryPolicy()`` when unset; a parse error degrades to the
+    default with a warning rather than crashing.
+    """
+    raw = os.environ.get(_ENV_RETRY_POLICY, "").strip()
+    if not raw:
+        return RetryPolicy()
+    try:
+        return RetryPolicy.from_json(raw)
+    except ValueError as exc:
+        _logger.warning(
+            "%s could not be parsed (%s); falling back to default RetryPolicy",
+            _ENV_RETRY_POLICY,
+            exc,
+        )
+        return RetryPolicy()
+
+
+def _resolve_skills_filter() -> str | list[str]:
+    """Resolve ``skills_filter`` from :data:`_ENV_SKILLS_FILTER` (default ``"all"``)."""
+    raw = os.environ.get(_ENV_SKILLS_FILTER, "").strip()
+    if not raw:
+        return "all"
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _logger.warning("%s is not valid JSON (%s); falling back to 'all'", _ENV_SKILLS_FILTER, exc)
+        return "all"
+    if isinstance(decoded, str) and decoded in ("all", "none"):
+        return decoded
+    if isinstance(decoded, list) and all(isinstance(s, str) for s in decoded):
+        return decoded
+    _logger.warning(
+        "%s decoded to unsupported shape %r; falling back to 'all'", _ENV_SKILLS_FILTER, decoded
+    )
+    return "all"
+
+
+def _build_genie_executor() -> Executor:
+    """Construct a :class:`GenieExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first turn.
+
+    :raises ImportError: If the ``genie`` CLI isn't resolvable.
+    :raises OSError: If the gateway is enabled but credentials are missing.
+    """
+    bundle_dir_raw = os.environ.get(_ENV_BUNDLE_DIR, "").strip()
+    bundle_dir = Path(bundle_dir_raw) if bundle_dir_raw else None
+    agent_name = os.environ.get(_ENV_AGENT_NAME, "").strip() or None
+    return GenieExecutor(
+        cwd=os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE") or None,
+        os_env=_resolve_os_env(),
+        model=os.environ.get(_ENV_MODEL),
+        codex_path=resolve_harness_path("genie"),
+        # Genie is the Databricks-gateway CLI; default the gateway path on.
+        gateway=_parse_truthy(_ENV_GATEWAY, default=True),
+        databricks_profile=os.environ.get(_ENV_DATABRICKS_PROFILE),
+        model_provider_override=os.environ.get(_ENV_MODEL_PROVIDER) or None,
+        gateway_host=os.environ.get(_ENV_GATEWAY_HOST) or None,
+        enable_web_search=_parse_truthy(_ENV_ENABLE_WEB_SEARCH, default=True),
+        disable_native_tools=_parse_truthy(_ENV_DISABLE_NATIVE_TOOLS, default=False),
+        base_url_override=os.environ.get(_ENV_GATEWAY_BASE_URL) or None,
+        gateway_auth_command=os.environ.get(_ENV_GATEWAY_AUTH_COMMAND) or None,
+        gateway_auth_refresh_interval_ms=os.environ.get(_ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS)
+        or None,
+        retry_policy=_resolve_retry_policy(),
+        bundle_dir=bundle_dir,
+        agent_name=agent_name,
+        skills_filter=_resolve_skills_filter(),
+    )
+
+
+def create_app() -> FastAPI:
+    """Build the genie harness's FastAPI app (see the codex wrap's ``create_app``)."""
+    adapter = ExecutorAdapter(executor_factory=_build_genie_executor)
+    return adapter.build()

--- a/omnigent/inner/genie_harness.py
+++ b/omnigent/inner/genie_harness.py
@@ -137,7 +137,9 @@ def _resolve_skills_filter() -> str | list[str]:
     try:
         decoded = json.loads(raw)
     except json.JSONDecodeError as exc:
-        _logger.warning("%s is not valid JSON (%s); falling back to 'all'", _ENV_SKILLS_FILTER, exc)
+        _logger.warning(
+            "%s is not valid JSON (%s); falling back to 'all'", _ENV_SKILLS_FILTER, exc
+        )
         return "all"
     if isinstance(decoded, str) and decoded in ("all", "none"):
         return decoded

--- a/omnigent/inner/genie_harness.py
+++ b/omnigent/inner/genie_harness.py
@@ -59,6 +59,8 @@ from omnigent.spec.types import RetryPolicy
 
 _logger = logging.getLogger(__name__)
 
+_AGENT_NAME = "genie"
+
 _ENV_MODEL = "HARNESS_GENIE_MODEL"
 _ENV_GATEWAY = "HARNESS_GENIE_GATEWAY"
 _ENV_DATABRICKS_PROFILE = "HARNESS_GENIE_DATABRICKS_PROFILE"
@@ -183,6 +185,35 @@ def _build_genie_executor() -> Executor:
         agent_name=agent_name,
         skills_filter=_resolve_skills_filter(),
     )
+
+
+def _materialize_genie_agent_spec(tmpdir: Path) -> Path:
+    """
+    Write the headless session agent spec used by Genie in the web UI picker.
+
+    :param tmpdir: Temporary directory for the generated YAML file.
+    :returns: Path to a generated YAML spec.
+    """
+    yaml_path = tmpdir / "genie.yaml"
+    raw = {
+        "name": _AGENT_NAME,
+        "prompt": (
+            "Genie is running as a headless coding agent through Omnigent. "
+            "Web UI messages are forwarded to the Genie CLI."
+        ),
+        "executor": {
+            "harness": "genie",
+            # Conservative default; genie will negotiate the actual window
+            # size via its API responses.
+            "context_window": 200_000,
+        },
+    }
+    # Write minimal YAML without external dependencies
+    import yaml
+
+    with open(yaml_path, "w") as f:
+        yaml.dump(raw, f, default_flow_style=False)
+    return yaml_path
 
 
 def create_app() -> FastAPI:

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -154,6 +154,11 @@ HERMES_KEY = "hermes"
 
 _HERMES_INSTALL_HINT = "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash"
 
+# Genie is Databricks' fork of the Codex CLI. Like Codex, it wraps a binary
+# called ``genie`` with no separate login command (authenticates via Databricks
+# profile / AI Gateway). Binary-only readiness; no npm package.
+GENIE_KEY = "genie"
+
 # Anthropic recommends its native installer over ``npm install -g``: it writes
 # to a user-writable ``~/.local/bin`` and self-updates, so it sidesteps the
 # EACCES failure on a root-owned npm global prefix.
@@ -312,6 +317,13 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         install_command=("bash", "-c", _HERMES_INSTALL_HINT),
         min_version=_HERMES_MIN_VERSION,
     ),
+    GENIE_KEY: HarnessInstallSpec(
+        "Genie",
+        "genie",
+        package=None,
+        login_args=None,
+        install_hint="Genie is Databricks' fork of Codex. Install via the Databricks internal package manager.",
+    ),
 }
 
 
@@ -377,6 +389,9 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     # gates on the same binary.
     "hermes-native": HERMES_KEY,
     "native-hermes": HERMES_KEY,
+    # Genie is Databricks' fork of Codex. The headless ``genie`` harness wraps
+    # the ``genie`` CLI and gates on the same binary as any future genie-native TUI.
+    GENIE_KEY: GENIE_KEY,
 }
 
 

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -459,6 +459,13 @@ def _cli_family_availability(canonical: str, install_key: str) -> HarnessAvailab
 
 def _harness_availability(canonical: str) -> HarnessAvailability:
     """Return picker-facing availability for one canonical harness spelling."""
+    if canonical == "genie":
+        # Genie is Databricks' fork of Codex: it uses the genie binary and
+        # authenticates via Databricks profile / AI Gateway, not Codex's
+        # subscription path. Gate readiness on the genie binary only.
+        from omnigent.onboarding.harness_install import GENIE_KEY
+
+        return _installer_only_availability(GENIE_KEY)
     if _is_codex_family_harness(canonical):
         from omnigent.codex_native import _codex_auth_unavailable_reason
 

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -174,6 +174,9 @@ _HARNESS_FAMILY: dict[str, str] = {
     "codex": OPENAI_FAMILY,
     "codex-native": OPENAI_FAMILY,
     "native-codex": OPENAI_FAMILY,
+    # Genie is Databricks' codex fork; it consumes GPT models over the
+    # openai-compatible Codex Responses gateway.
+    "genie": OPENAI_FAMILY,
     "openai-agents": OPENAI_FAMILY,
     # The workflow's AgentHarnessType spells this "openai-agents-sdk" and
     # normally maps it down via _provider_harness_name; accept both spellings

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -147,7 +147,15 @@ _logger = logging.getLogger(__name__)
 
 
 AgentHarnessType = Literal[
-    "claude-sdk", "codex", "genie", "pi", "openai-agents-sdk", "antigravity", "kimi", "qwen", "goose"
+    "claude-sdk",
+    "codex",
+    "genie",
+    "pi",
+    "openai-agents-sdk",
+    "antigravity",
+    "kimi",
+    "qwen",
+    "goose",
 ]
 
 

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -147,7 +147,7 @@ _logger = logging.getLogger(__name__)
 
 
 AgentHarnessType = Literal[
-    "claude-sdk", "codex", "pi", "openai-agents-sdk", "antigravity", "kimi", "qwen", "goose"
+    "claude-sdk", "codex", "genie", "pi", "openai-agents-sdk", "antigravity", "kimi", "qwen", "goose"
 ]
 
 
@@ -201,6 +201,20 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         host_key="HARNESS_CODEX_GATEWAY_HOST",
         auth_key="HARNESS_CODEX_GATEWAY_AUTH_COMMAND",
         refresh_key="HARNESS_CODEX_GATEWAY_AUTH_REFRESH_INTERVAL_MS",
+        catalog_family="openai",
+    ),
+    # Genie is Databricks' codex fork; same gateway transport as codex, its
+    # own ``HARNESS_GENIE_*`` env vars. ``agent_name="genie"`` means a host
+    # with no ucode ``genie`` agent simply skips ucode enrichment.
+    "genie": UcodeHarnessConfig(
+        agent_name="genie",
+        model_key="HARNESS_GENIE_MODEL",
+        base_url_key="HARNESS_GENIE_GATEWAY_BASE_URL",
+        base_url_family="codex",
+        base_urls_key=None,
+        host_key="HARNESS_GENIE_GATEWAY_HOST",
+        auth_key="HARNESS_GENIE_GATEWAY_AUTH_COMMAND",
+        refresh_key="HARNESS_GENIE_GATEWAY_AUTH_REFRESH_INTERVAL_MS",
         catalog_family="openai",
     ),
     "pi": UcodeHarnessConfig(
@@ -395,6 +409,7 @@ def _inject_ucode_agent_state(
 _PROVIDER_HARNESS_FAMILY: dict[AgentHarnessType, str] = {
     "claude-sdk": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
+    "genie": OPENAI_FAMILY,
     "openai-agents-sdk": OPENAI_FAMILY,
     # Antigravity is Gemini-native but routes generic-provider traffic over
     # the OpenAI-compatible wire (OpenRouter / LiteLLM / Databricks gateway),
@@ -413,6 +428,7 @@ _PROVIDER_HARNESS_FAMILY: dict[AgentHarnessType, str] = {
 _HARNESS_GATEWAY_FLAG: dict[AgentHarnessType, str] = {
     "claude-sdk": "HARNESS_CLAUDE_SDK_GATEWAY",
     "codex": "HARNESS_CODEX_GATEWAY",
+    "genie": "HARNESS_GENIE_GATEWAY",
     "pi": "HARNESS_PI_GATEWAY",
     "qwen": "HARNESS_QWEN_GATEWAY",
 }
@@ -433,6 +449,7 @@ _PI_FAMILY_KEY: dict[str, str] = {
 _HARNESS_DATABRICKS_PROFILE: dict[AgentHarnessType, str] = {
     "claude-sdk": "HARNESS_CLAUDE_SDK_DATABRICKS_PROFILE",
     "codex": "HARNESS_CODEX_DATABRICKS_PROFILE",
+    "genie": "HARNESS_GENIE_DATABRICKS_PROFILE",
     "pi": "HARNESS_PI_DATABRICKS_PROFILE",
     "openai-agents-sdk": "HARNESS_OPENAI_AGENTS_DATABRICKS_PROFILE",
     "qwen": "HARNESS_QWEN_DATABRICKS_PROFILE",

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -675,6 +675,7 @@ def _ensure_default_agents(
     _ensure_default_acp_agents(agent_store, artifact_store, agent_cache)
     _ensure_default_debby_agent(agent_store, artifact_store, agent_cache)
     _ensure_default_polly_agent(agent_store, artifact_store, agent_cache)
+    _ensure_default_genie_agent(agent_store, artifact_store, agent_cache)
     _ensure_extra_builtin_agents(agent_store, artifact_store, agent_cache)
 
 
@@ -1056,6 +1057,43 @@ def _ensure_default_polly_agent(
         agent_cache,
         name=_POLLY_AGENT_NAME,
         bundle_bytes=_build_polly_bundle(),
+    )
+
+
+def _ensure_default_genie_agent(
+    agent_store: AgentStore,
+    artifact_store: ArtifactStore,
+    agent_cache: Any,
+) -> None:
+    """
+    Register the headless Genie agent.
+
+    Genie is a headless CLI-driven coding agent (Databricks' fork of Codex).
+    Seeding it lets the Web UI's new-session picker offer Genie as a
+    host-launchable card next to Claude Code and Codex. Unlike polly and debby,
+    Genie's spec is materialized on-the-fly since it's a built-in harness with
+    no external bundle.
+
+    :param agent_store: Store for agent metadata.
+    :param artifact_store: Store for agent bundles.
+    :param agent_cache: Cache for loaded agent specs.
+    """
+    import tempfile
+
+    from omnigent.inner.genie_harness import _materialize_genie_agent_spec
+    from omnigent.spec import materialize_bundle
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        spec_path = _materialize_genie_agent_spec(Path(tmpdir))
+        bundle_dir = materialize_bundle(spec_path, Path(tmpdir) / "bundle")
+        bundle_bytes = _tar_gz_dir(bundle_dir)
+
+    _ensure_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_cache,
+        name="genie",
+        bundle_bytes=bundle_bytes,
     )
 
 

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -11,10 +11,10 @@ add/set-default/remove write paths surfaces here rather than silently.
 ``configure harnesses`` is a **three-level** picker. Level 1 shows every
 harness on a single compact row — the name on the left, then an aligned
 ``✓``/``✗`` status column — in 0.3 priority order: ``1=Claude``,
-``2=Codex``, ``3=Cursor``, ``4=OpenCode``, ``5=Hermes``, ``6=Pi``,
-``7=Antigravity``, ``8=Qwen Code``, ``9=Goose``, ``10=Copilot``, ``11=Kiro``,
-``12=Kimi Code``, ``13=Import from OpenClaw``, ``14=Custom ACP agent``,
-``15=Quit``. There is no "More" folding — every harness is visible at once —
+``2=Codex``, ``3=Genie``, ``4=Cursor``, ``5=OpenCode``, ``6=Hermes``, ``7=Pi``,
+``8=Antigravity``, ``9=Qwen Code``, ``10=Goose``, ``11=Copilot``, ``12=Kiro``,
+``13=Kimi Code``, ``14=Import from OpenClaw``, ``15=Custom ACP agent``,
+``16=Quit``. There is no "More" folding — every harness is visible at once —
 and the actionable hint (install command / next step)
 renders only for the highlighted row, as the selector's description line.
 Selecting a harness drills into level 2 — its configured credentials, then ``+ Add a
@@ -135,6 +135,16 @@ def _harnesses_installed(monkeypatch):
     monkeypatch.setattr(
         "omnigent.onboarding.harness_install.harness_cli_logged_in",
         lambda family: True,
+    )
+    # Mock databricks_sdk_installed to return True since it's now an optional
+    # extra and may not be installed in the test environment.
+    monkeypatch.setattr(
+        "omnigent.onboarding.databricks_config.databricks_sdk_installed",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.configure_models.databricks_sdk_installed",
+        lambda: True,
     )
 
 
@@ -651,9 +661,13 @@ def test_add_menu_databricks_option_gated_on_extra(monkeypatch) -> None:
         "Requires the Databricks extra — select for the install command."
     )
 
-    # With the SDK present (the dev/CI env — no patch), the description
-    # explains the routing instead of demanding an install.
-    monkeypatch.undo()
+    # With the SDK present, the description explains the routing instead of
+    # demanding an install. Explicitly mock to return True since the SDK might
+    # not be installed in the test environment (it's now an optional extra).
+    monkeypatch.setattr(
+        "omnigent.onboarding.configure_models.databricks_sdk_installed",
+        lambda: True,
+    )
     options = add_menu_options()
     databricks = next(o for o in options if o.label.endswith("Databricks — workspace"))
     assert "Unity AI Gateway" in databricks.description
@@ -1737,6 +1751,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
     expected = [
         "Claude",
         "Codex",
+        "Genie",
         "Cursor",
         "OpenCode",
         "Hermes",
@@ -1771,6 +1786,27 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
     for row in expected:
         assert row in rendered
     assert "more" not in rendered.lower()
+
+
+def test_overview_genie_row_appears_at_position_3(isolated_config, monkeypatch) -> None:
+    """The Genie row appears at position 3 (right after Codex) in the overview.
+
+    Genie is Databricks' fork of the Codex CLI, shares the OpenAI-family
+    provider, and drilling into it manages that shared provider (same as Codex).
+    This test verifies the row appears in the correct position and that selecting
+    it routes to the OpenAI-family provider manager.
+    """
+    called: list[str] = []
+    monkeypatch.setattr(
+        "omnigent.cli_config._manage_harness_providers",
+        lambda *a, **k: called.append(a[0] if a else None),
+    )
+
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="3\nq\n")
+    assert result.exit_code == 0, result.output
+    # Selecting position 3 (Genie) routes to _manage_harness_providers with
+    # OPENAI_FAMILY, the shared provider family with Codex.
+    assert called == ["openai"], f"Expected ['openai'] but got {called}"
 
 
 def test_overview_lists_configured_acp_agents_as_rows(isolated_config, monkeypatch) -> None:
@@ -1911,7 +1947,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1933,7 +1969,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1950,7 +1986,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2034,7 +2070,7 @@ def test_missing_cursor_cli_drillin_shows_install_and_login(isolated_config, mon
         lambda key: key != "cursor",
     )
 
-    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="3\n1\nq\nq\n")
+    result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input="4\n1\nq\nq\n")
 
     assert result.exit_code == 0, result.output
     assert "curl https://cursor.com/install -fsS | bash" in result.output
@@ -2137,18 +2173,18 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
 @pytest.mark.parametrize(
     "choice,manager_attr",
     [
-        ("4", "_manage_opencode_harness"),
-        ("5", "_manage_hermes_harness"),
-        ("8", "_manage_qwen_harness"),
-        ("9", "_manage_goose_harness"),
-        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
+        ("5", "_manage_opencode_harness"),
+        ("6", "_manage_hermes_harness"),
+        ("9", "_manage_qwen_harness"),
+        ("10", "_manage_goose_harness"),
+        # 11-12 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
         # every row after them shifted down by two when that block landed.
-        ("10", "_show_acp_cli_harness"),
         ("11", "_show_acp_cli_harness"),
-        ("12", "_manage_copilot_harness"),
-        ("13", "_manage_kiro_harness"),
-        ("14", "_manage_kimi_harness"),
-        ("16", "_add_acp_agent"),
+        ("12", "_show_acp_cli_harness"),
+        ("13", "_manage_copilot_harness"),
+        ("14", "_manage_kiro_harness"),
+        ("15", "_manage_kimi_harness"),
+        ("17", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(
@@ -2439,9 +2475,9 @@ def test_configure_harnesses_pi_page_sets_explicit_pi_default(isolated_config) -
             f,
         )
 
-    # L1 6=Pi → L2 (1=anthropic 2=openai 3=+Add): select openai (2) → L3
+    # L1 7=Pi → L2 (1=anthropic 2=openai 3=+Add): select openai (2) → L3
     # 1=Make default for Pi → back to L2 q=back → L1 q=exit.
-    stdin = "\n".join(["6", "2", "1", "q", "q"]) + "\n"
+    stdin = "\n".join(["7", "2", "1", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2491,9 +2527,9 @@ def test_configure_harnesses_pi_page_excludes_subscription_rows(isolated_config)
             f,
         )
 
-    # L1 6=Pi → L2 renders its rows → q=back → L1 q=exit. The L2 frame is
+    # L1 7=Pi → L2 renders its rows → q=back → L1 q=exit. The L2 frame is
     # cleared on exit under a TTY but the numbered fallback echoes options.
-    stdin = "\n".join(["6", "q", "q"]) + "\n"
+    stdin = "\n".join(["7", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2539,8 +2575,8 @@ def test_configure_harnesses_add_databricks_under_pi_scopes_to_pi(
     # Databricks position within the Pi add menu, computed live.
     pi_opts = add_menu_options_for_family(PI_SURFACE)
     db = next(i for i, o in enumerate(pi_opts) if o.kind == DATABRICKS_KIND) + 1
-    # L1 6=Pi → L2 1=+Add → add menu <db>=Databricks → URL → q → q.
-    stdin = "\n".join(["6", "1", str(db), "https://example.cloud.databricks.com", "q", "q"]) + "\n"
+    # L1 7=Pi → L2 1=+Add → add menu <db>=Databricks → URL → q → q.
+    stdin = "\n".join(["7", "1", str(db), "https://example.cloud.databricks.com", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2792,7 +2828,7 @@ def test_cursor_set_api_key_paste_writes_block_and_secret(
     config) and the config references it via ``keychain:cursor``.
     """
     # L1 Cursor → Cursor SDK → Set API key → paste key → back through both menus.
-    stdin = "\n".join(["3", "2", "1", "crsr_test_key_123", "q", "q", "q"]) + "\n"
+    stdin = "\n".join(["4", "2", "1", "crsr_test_key_123", "q", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2813,7 +2849,7 @@ def test_cursor_adopt_env_api_key_writes_env_ref(
     """
     monkeypatch.setenv("CURSOR_API_KEY", "crsr_env_key_456")
     # L1 Cursor → Cursor SDK → Set API key → adopt detected env key → back.
-    stdin = "\n".join(["3", "2", "1", "y", "q", "q", "q"]) + "\n"
+    stdin = "\n".join(["4", "2", "1", "y", "q", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2833,7 +2869,7 @@ def test_cursor_remove_api_key_drops_block_and_secret(
         yaml.safe_dump({"cursor": {"api_key_ref": "keychain:cursor"}}, f)
 
     # L1 Cursor → Cursor SDK → Remove → back through both menus.
-    stdin = "\n".join(["3", "2", "2", "q", "q", "q"]) + "\n"
+    stdin = "\n".join(["4", "2", "2", "q", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2851,7 +2887,7 @@ def test_cursor_set_api_key_non_crsr_declined_is_not_stored(
     both the secret store and the config untouched.
     """
     # L1 Cursor → Cursor SDK → Set → decline the non-crsr_ warning → back.
-    stdin = "\n".join(["3", "2", "1", "sk-not-a-cursor-key", "n", "q", "q", "q"]) + "\n"
+    stdin = "\n".join(["4", "2", "1", "sk-not-a-cursor-key", "n", "q", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2904,7 +2940,7 @@ def test_cursor_drillin_offers_install_when_sdk_missing(
     through to the key menu, then backs out.
     """
     # Cursor → Cursor SDK → show command → back through both menus.
-    stdin = "\n".join(["3", "2", "3", "q", "q", "q"]) + "\n"
+    stdin = "\n".join(["4", "2", "3", "q", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
     out = result.output
@@ -2920,7 +2956,7 @@ def test_cursor_key_settable_when_sdk_missing(isolated_config, _cursor_sdk_absen
     choice 2), then sets the key — which must persist as it does with the SDK.
     """
     # Cursor → Cursor SDK → set key anyway → Set → paste key → back.
-    stdin = "\n".join(["3", "2", "2", "1", "crsr_key_no_sdk", "q", "q", "q"]) + "\n"
+    stdin = "\n".join(["4", "2", "2", "1", "crsr_key_no_sdk", "q", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2950,7 +2986,7 @@ def test_cursor_install_now_invokes_runner_without_index(
     monkeypatch.setattr("omnigent.onboarding.cursor_auth.subprocess.run", _run)
 
     # Cursor → Cursor SDK → install now → back through both menus.
-    stdin = "\n".join(["3", "2", "1", "q", "q", "q"]) + "\n"
+    stdin = "\n".join(["4", "2", "1", "q", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -2996,9 +3032,9 @@ def test_antigravity_set_api_key_paste_writes_block_and_secret(
     Proves the api-key path: the secret lands in the store (never plaintext in
     config) and the config references it via ``keychain:antigravity``.
     """
-    # L1 7=Antigravity → antigravity menu 1=Set API key →
+    # L1 8=Antigravity → antigravity menu 1=Set API key →
     # paste key (AIza → no warn) → antigravity menu q=back → L1 q=quit.
-    stdin = "\n".join(["7", "1", "AIza_test_key_123", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "AIza_test_key_123", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3018,9 +3054,9 @@ def test_antigravity_adopt_env_api_key_writes_env_ref(
     at the live environment variable so the key never leaves the user's shell.
     """
     monkeypatch.setenv("GEMINI_API_KEY", "AIza_env_key_456")
-    # L1 7=Antigravity → 1=Set API key →
+    # L1 8=Antigravity → 1=Set API key →
     # "y" adopt detected $GEMINI_API_KEY → q back → q quit.
-    stdin = "\n".join(["7", "1", "y", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "y", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3036,11 +3072,11 @@ def test_antigravity_sign_in_runs_agy_auth_service(
     login = Mock(return_value=True)
     monkeypatch.setattr("omnigent.onboarding.harness_install.harness_login", login)
 
-    # L1 7=Antigravity → 2=Sign in → q back → q quit.
+    # L1 8=Antigravity → 2=Sign in → q back → q quit.
     result = CliRunner().invoke(
         cli,
         ["setup", "--no-internal-beta"],
-        input="\n".join(["7", "2", "q", "q"]) + "\n",
+        input="\n".join(["8", "2", "q", "q"]) + "\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -3061,7 +3097,7 @@ def test_antigravity_sign_in_skips_sdk_install_prompt(isolated_config, monkeypat
     result = CliRunner().invoke(
         cli,
         ["setup", "--no-internal-beta"],
-        input="\n".join(["7", "2", "q", "q"]) + "\n",
+        input="\n".join(["8", "2", "q", "q"]) + "\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -3079,9 +3115,9 @@ def test_antigravity_remove_api_key_drops_block_and_secret(
     with open(config_path, "w") as f:
         yaml.safe_dump({"antigravity": {"api_key_ref": "keychain:antigravity"}}, f)
 
-    # L1 7=Antigravity → antigravity menu (key set:
+    # L1 8=Antigravity → antigravity menu (key set:
     # 1=Replace 2=Remove 3=Back) → 2=Remove → q back → q quit.
-    stdin = "\n".join(["7", "2", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "2", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3106,9 +3142,9 @@ def test_antigravity_remove_does_not_delete_foreign_keychain_secret(
     with open(config_path, "w") as f:
         yaml.safe_dump({"antigravity": {"api_key_ref": "keychain:shared-gemini"}}, f)
 
-    # L1 7=Antigravity → antigravity menu 2=Remove →
+    # L1 8=Antigravity → antigravity menu 2=Remove →
     # q back → q quit.
-    stdin = "\n".join(["7", "2", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "2", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3126,9 +3162,9 @@ def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(
     The soft prefix check warns and asks to store anyway; declining must leave
     both the secret store and the config untouched.
     """
-    # L1 7=Antigravity → 1=Set API key →
+    # L1 8=Antigravity → 1=Set API key →
     # paste non-AIza key → "n" decline warning → q back → q quit.
-    stdin = "\n".join(["7", "1", "sk-not-a-gemini-key", "n", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "sk-not-a-gemini-key", "n", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3223,17 +3259,17 @@ def test_copilot_overview_install_command_is_selection_only(
     "choice,sdk_probe,unexpected_header",
     [
         (
-            "3\n2",
+            "4\n2",
             "omnigent.onboarding.cursor_auth.cursor_sdk_installed",
             "Cursor — no API key yet",
         ),
         (
-            "7",
+            "8",
             "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed",
             "Antigravity — no Gemini API key yet",
         ),
         (
-            "10",
+            "13",
             "omnigent.onboarding.copilot_auth.copilot_sdk_installed",
             "Copilot — no GitHub token yet",
         ),
@@ -3265,9 +3301,9 @@ def test_antigravity_drillin_offers_install_when_sdk_missing(
     The user picks "show the command" (choice 3), which prints the command and falls
     through to the key menu, then backs out.
     """
-    # L1 7=Antigravity → install offer 3=show command →
+    # L1 8=Antigravity → install offer 3=show command →
     # key menu q=back → L1 q.
-    stdin = "\n".join(["7", "3", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "3", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
     out = result.output
@@ -3284,9 +3320,9 @@ def test_antigravity_key_settable_when_sdk_missing(
     gate key management on it. The user declines ("set the key anyway" = choice 2),
     then sets the key, which must persist as it does with the SDK present.
     """
-    # L1 7=Antigravity → install offer 2=set key anyway →
+    # L1 8=Antigravity → install offer 2=set key anyway →
     # key menu 1=Set → paste AIza key → key menu q=back → L1 q=quit.
-    stdin = "\n".join(["7", "2", "1", "AIza_key_no_sdk", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "2", "1", "AIza_key_no_sdk", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3315,9 +3351,9 @@ def test_antigravity_install_now_invokes_runner_without_index(
     monkeypatch.setattr("omnigent.onboarding.extra_install.shutil.which", lambda name: None)
     monkeypatch.setattr("omnigent.onboarding.antigravity_auth.subprocess.run", _run)
 
-    # L1 7=Antigravity → install offer 1=install now →
+    # L1 8=Antigravity → install offer 1=install now →
     # key menu q=back → L1 q.
-    stdin = "\n".join(["7", "1", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3371,8 +3407,8 @@ def test_configure_harnesses_add_other_key_no_remaining_providers_aborts_cleanly
     monkeypatch.setattr("omnigent.onboarding.configure_models.other_key_providers", list)
 
     other = _other_key_add_menu_index(PI_SURFACE)
-    # L1 6=Pi → L2 1=+Add → add menu <other>=Other provider — API key → L2 q=back → L1 q=exit.
-    stdin = "\n".join(["6", "1", str(other), "q", "q"]) + "\n"
+    # L1 7=Pi → L2 1=+Add → add menu <other>=Other provider — API key → L2 q=back → L1 q=exit.
+    stdin = "\n".join(["7", "1", str(other), "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     # Pre-fix this exited non-zero with a ValueError; the guard makes it graceful.

--- a/tests/inner/test_codex_hooks_generation.py
+++ b/tests/inner/test_codex_hooks_generation.py
@@ -257,7 +257,9 @@ def _start_app_server(
         return _MODEL_CATALOG
 
     monkeypatch.setattr(codex_executor, "populate_codex_skills_from_bundle", lambda *a, **k: None)
-    monkeypatch.setattr(codex_executor, "_codex_home_config_source_from_env", lambda: source)
+    monkeypatch.setattr(
+        codex_executor, "_codex_home_config_source_from_env", lambda *a, **k: source
+    )
     monkeypatch.setattr(codex_executor, "_create_subprocess_exec", fake_exec)
     # Never shell out to a real ``codex debug models`` from a unit test, and
     # never let one session's cached catalog answer another's probe count.
@@ -480,7 +482,9 @@ def test_an_old_codex_cli_keeps_the_sdk_harness_hooks_symlinked(
         raise RuntimeError("stop")
 
     monkeypatch.setattr(codex_executor, "populate_codex_skills_from_bundle", lambda *a, **k: None)
-    monkeypatch.setattr(codex_executor, "_codex_home_config_source_from_env", lambda: source)
+    monkeypatch.setattr(
+        codex_executor, "_codex_home_config_source_from_env", lambda *a, **k: source
+    )
     monkeypatch.setattr(codex_executor, "_create_subprocess_exec", fake_exec)
     session = codex_executor._CodexAppServerSession(
         codex_path="/bin/echo",

--- a/tests/inner/test_genie_executor.py
+++ b/tests/inner/test_genie_executor.py
@@ -1,0 +1,103 @@
+"""Tests for GenieExecutor and the genie harness registration.
+
+Genie is Databricks' fork of the codex CLI; :class:`GenieExecutor` is a thin
+:class:`CodexExecutor` subclass that only swaps the binary (``genie``) and the
+on-disk home (``GENIE_HOME`` / ``~/.genie``). These tests pin those two seams
+and the gateway-config inheritance, plus the ``genie`` harness registry entry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner.codex_executor import CodexExecutor
+from omnigent.inner.genie_executor import (
+    GENIE_HOME_DIR_NAME,
+    GENIE_HOME_ENV_VAR,
+    GenieExecutor,
+    _find_genie_cli,
+)
+
+
+def _genie_executor(**overrides: object) -> GenieExecutor:
+    """Build a GenieExecutor with the genie binary resolution stubbed."""
+    with patch(
+        "omnigent.inner.genie_executor._find_genie_cli",
+        return_value="/usr/bin/genie",
+    ):
+        return GenieExecutor(**overrides)  # type: ignore[arg-type]
+
+
+class TestGenieExecutor:
+    def test_is_codex_executor_subclass(self) -> None:
+        # The whole design: reuse the codex app-server driver, don't fork it.
+        assert issubclass(GenieExecutor, CodexExecutor)
+
+    def test_forces_genie_home(self) -> None:
+        ex = _genie_executor()
+        assert ex._home_env_var == GENIE_HOME_ENV_VAR == "GENIE_HOME"
+        assert ex._home_dir_name == GENIE_HOME_DIR_NAME == ".genie"
+
+    def test_home_override_cannot_be_smuggled_in(self) -> None:
+        # Even if a caller passes codex's home, genie forces its own.
+        ex = _genie_executor(home_env_var="CODEX_HOME", home_dir_name=".codex")
+        assert ex._home_env_var == "GENIE_HOME"
+        assert ex._home_dir_name == ".genie"
+
+    def test_resolves_genie_binary(self) -> None:
+        with patch(
+            "omnigent.inner.genie_executor._find_genie_cli",
+            return_value="/opt/genie",
+        ):
+            ex = GenieExecutor()
+        assert ex._codex_path == "/opt/genie"
+
+    def test_missing_binary_raises_with_genie_hint(self) -> None:
+        with patch("omnigent.inner.genie_executor._find_genie_cli", return_value=None):
+            with pytest.raises(ImportError, match="OMNIGENT_GENIE_PATH"):
+                GenieExecutor()
+
+    def test_find_genie_cli_uses_genie_name_and_env(self) -> None:
+        with patch("omnigent.inner.genie_executor.resolve_cli_binary") as resolve:
+            resolve.return_value = "/usr/bin/genie"
+            assert _find_genie_cli() == "/usr/bin/genie"
+        resolve.assert_called_once_with("genie", env_var="OMNIGENT_GENIE_PATH")
+
+    def test_inherits_databricks_gateway_config(self) -> None:
+        # Genie routes through the same Databricks Codex Responses gateway
+        # (/ai-gateway/codex/v1) as codex; the gateway -c overrides come from
+        # the shared CodexExecutor path unchanged.
+        ex = _genie_executor(
+            gateway=True,
+            databricks_profile="eng-ml-agent-platform",
+            base_url_override="https://example.databricks.com/ai-gateway/codex/v1",
+            gateway_auth_command="printf token",
+            model="databricks-gpt-5-4-mini",
+        )
+        joined = "\n".join(ex._codex_config_overrides)
+        assert "/ai-gateway/codex/v1" in joined
+        assert 'model="databricks-gpt-5-4-mini"' in joined
+
+
+class TestGenieRegistration:
+    def test_registered_as_valid_harness(self) -> None:
+        from omnigent import harness_plugins as hp
+
+        assert "genie" in hp.valid_harnesses()
+        assert hp.harness_modules()["genie"] == "omnigent.inner.genie_harness"
+        assert hp.model_env_keys()["genie"] == "HARNESS_GENIE_MODEL"
+
+    def test_consumes_openai_family(self) -> None:
+        from omnigent.onboarding.provider_config import _HARNESS_FAMILY, OPENAI_FAMILY
+
+        assert _HARNESS_FAMILY["genie"] == OPENAI_FAMILY
+
+    def test_workflow_gateway_and_profile_maps(self) -> None:
+        from omnigent.runtime import workflow as w
+
+        assert w._HARNESS_GATEWAY_FLAG["genie"] == "HARNESS_GENIE_GATEWAY"
+        assert w._HARNESS_DATABRICKS_PROFILE["genie"] == "HARNESS_GENIE_DATABRICKS_PROFILE"
+        assert w._PROVIDER_HARNESS_FAMILY["genie"] == "openai"
+        assert "genie" in w._UCODE_HARNESS_CONFIGS

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -311,6 +311,7 @@ def test_configured_harness_map_covers_all_spellings(
         "codex",
         "codex-native",
         "native-codex",
+        "genie",
         "openai-agents",
         "openai-agents-sdk",
         "open-responses",
@@ -428,10 +429,12 @@ def test_configured_harness_map_gates_only_cli_harnesses(
     # this group — it is now auth-aware like the other native CLI harnesses, so
     # its missing binary surfaces as ``"binary-missing"`` too. Pi is also here —
     # it reports the credential axis (no CLI login; its credential is a provider).
+    # Genie is binary-gated like codex (but with the genie binary, not codex's).
     for missing in (
         "codex",
         "codex-native",
         "native-codex",
+        "genie",
         "claude-native",
         "native-claude",
         "opencode-native",

--- a/web/src/lib/agentGrouping.ts
+++ b/web/src/lib/agentGrouping.ts
@@ -93,6 +93,26 @@ export function sortAgentsForDisplay<T extends AvailableAgent>(agents: readonly 
   );
 }
 
+// Headless CLI-subprocess harnesses that should appear in the picker's
+// "Harnesses" group alongside native TUIs and ACP harnesses (user experience
+// groups all "pick a harness" rows together, separate from "pick a composed agent").
+// Genie is a headless Codex fork; others may follow this pattern.
+const HEADLESS_CLI_HARNESSES = new Set(["genie"]);
+
+/**
+ * Whether an agent is a headless CLI-subprocess harness — like genie (a Codex
+ * fork). These belong in the picker's "Harnesses" group with native CLIs and ACP
+ * harnesses, not the "Agents" group. They run a harness, not a composed agent.
+ *
+ * @param agent - Agent to classify (only `harness` is read).
+ */
+export function isHeadlessCliHarness(
+  agent: Pick<AvailableAgent, "harness"> | null | undefined,
+): boolean {
+  if (agent == null || agent.harness == null) return false;
+  return HEADLESS_CLI_HARNESSES.has(agent.harness);
+}
+
 // Hidden from session-creation pickers. `nessie` is superseded by polly.
 // `kimi` / `kimi-code` are the headless SDK harness (kept for sub-agent /
 // `run --harness kimi` use) — pickers offer only the native TUI

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -149,6 +149,7 @@ import {
 import { CLAUDE_NATIVE_MODELS } from "@/lib/claudeNativeModels";
 import {
   isAcpHarnessAgent,
+  isHeadlessCliHarness,
   partitionAgentsByKind,
   selectableSessionAgents,
 } from "@/lib/agentGrouping";
@@ -1217,7 +1218,12 @@ export function AgentHarnessPicker({
       // The preference hides harnesses that can't launch here — it outranks
       // both support level and recency, but never buries the active pick.
       if (!selected && hideUnconfigured && harnessUnconfiguredOnHost(a.harness, host)) continue;
-      if (selected || isFullySupportedNativeCodingAgent(a) || isRecentHarness(a, recentHarnesses)) {
+      if (
+        selected ||
+        isFullySupportedNativeCodingAgent(a) ||
+        isHeadlessCliHarness(a) ||
+        isRecentHarness(a, recentHarnesses)
+      ) {
         ready.push(a);
       } else more.push(a);
     }
@@ -2292,11 +2298,21 @@ export function NewChatLandingScreen() {
   // split: Polly & Debby are built-ins but are composed agents, so they stay
   // under "Agents". ACP agents aren't native, so they fold into "More".
   const harnessEntries = useMemo(
-    () => agentList.filter((a) => isNativeCodingAgent(a) || isAcpHarnessAgent(a)),
+    () =>
+      agentList.filter(
+        (a) =>
+          isNativeCodingAgent(a) || isAcpHarnessAgent(a) || isHeadlessCliHarness(a),
+      ),
     [agentList],
   );
   const agentEntries = useMemo(
-    () => agentList.filter((a) => !isNativeCodingAgent(a) && !isAcpHarnessAgent(a)),
+    () =>
+      agentList.filter(
+        (a) =>
+          !isNativeCodingAgent(a) &&
+          !isAcpHarnessAgent(a) &&
+          !isHeadlessCliHarness(a),
+      ),
     [agentList],
   );
 


### PR DESCRIPTION
## Summary

Adds a **headless `genie` harness** — genie is Databricks' fork of the codex CLI (`databricks-eng/genie-code-codex`): same `app-server` JSON-RPC protocol, but a `~/.genie` home (`GENIE_HOME`), OpenAI phone-home disabled, and the Databricks AI Gateway (Codex Responses API at `/ai-gateway/codex/v1`) as its provider.

Because the app-server wire protocol is byte-identical to codex's, `CodexExecutor` already drives it. Genie differs in exactly two ways, encoded here:
- **binary**: resolve/run `genie` (`OMNIGENT_GENIE_PATH`) instead of `codex`
- **home**: `GENIE_HOME` / `~/.genie` instead of `CODEX_HOME` / `~/.codex`

Rather than fork the executor, **`GenieExecutor` is a thin `CodexExecutor` subclass** and `codex_executor.py`'s home-dir spelling is parameterized (codex behavior unchanged — defaults stay `CODEX_HOME` / `~/.codex`). The shared app-server driver, gateway routing, and `databricks auth token` auth command remain one code path, leaving a clean seam for genie-native behavior to grow if its surface ever diverges.

Registers `genie` across `harness_plugins.py`, `onboarding/provider_config.py` (openai family), and `runtime/workflow.py` so a `databricks`-kind provider routes genie exactly as it routes codex.

**Scope:** headless app-server only; no native TUI harness.

```text
session -> GenieExecutor (subclass of CodexExecutor) -> `genie app-server` (stdio JSON-RPC)
             |  GENIE_HOME + genie binary                 |  thread/start -> turn/start -> stream
             \-> Databricks AI Gateway /ai-gateway/codex/v1 (databricks auth token)
```

## Test Plan

**Live end-to-end (real Databricks AI Gateway):** stood up an isolated `omnigent server` + host daemon and ran genie sessions end-to-end through the full stack (server → daemon → runner → `GenieExecutor` → `genie app-server` → gateway). Profile `eng-ml-agent-platform`, model `databricks-gpt-5-4-mini`. 6 sessions completed real turns, e.g.:
- *"Say hello and state your model name"* → **"Hello! I'm Genie, powered by GPT-5.6"**
- *"what is 2 + 2?"* → "2 + 2 equals 4"; a git-commit explanation; etc.
- Sessions persist with `agent_name=genie`, `status=idle`.

(Model note: genie's codex-specific `databricks-gpt-5-2-codex` isn't pay-per-token on that workspace, and `-nano` rejects genie's `tool_search` tool, so `databricks-gpt-5-4-mini` is the validated model.)

**Protocol parity:** dumped `genie app-server generate-json-schema` — the wire methods are identical to what `CodexExecutor` drives (`thread/start|started|resume`, `turn/start|started|completed|interrupt|steer`, `item/started|completed`). A stdio JSON-RPC smoke client reproduced `initialize → thread/start → turn/start → item/agentMessage/delta → turn/completed`.

**Unit tests (this PR):** `tests/inner/test_genie_executor.py` — 10 passed. Pins the home/binary seams, gateway-config inheritance, and registry/provider/workflow entries.

**Regression (codex unchanged):**
- `tests/inner/test_codex_executor.py` + `tests/test_harness_plugins.py` — **130 passed**
- `tests/harness_bench` — **178 passed, 19 skipped, 0 failures**
- `tests/server/test_app.py` (server surface, incl. harness-catalog seeding) — **60 passed**

**`verify-omnigent` skill (#6003):** ran `verify.sh` against this diff (`OMNIGENT_VERIFY_REPO_ROOT`). It correctly selected the `quality-gates, server, harness-client, cli` lanes. **`server` lane passed** (60 tests). The `harness-client` lane's underlying `tests/harness_bench` pytest passed (178/0), but the lane wrapper is reported failed only because it expects the `report.py` `schema_version:1` contract that #6003 itself introduces and is **not in this PR's `origin/main` base** — a base/skill version skew, not a genie defect. `quality-gates`/`cli` block under `auto` on a child-env `pre-commit` probe quirk in the sandbox (their doctors pass when run directly).

**Lint:** pre-commit content hooks pass on the changed files (ruff format/lint, no-hardcoded-model-ids, EOF/whitespace, etc.). `pyrefly` reports only `opentelemetry.*` missing-import noise from an ad-hoc venv without the otel extras — **zero errors in any changed file**.

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added / updated
- [x] Manual verification completed (live gateway, full stack)
- [x] Existing tests cover this change (codex regression suites green)
