### PR TITLE
fix(claude-native): surface permission prompts the hook never delivered

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3453,6 +3453,7 @@ async def _attach_with_transcript_forwarder(
     # broadcast hazard this avoids.
     skip_existing_transcript = prepared.reattached or prepared.cold_resumed
     forwarder: asyncio.Task[None] | None = None
+    permission_mirror: asyncio.Task[None] | None = None
     if run_transcript_forwarder:
         forwarder = asyncio.create_task(
             supervise_forwarder(
@@ -3465,6 +3466,22 @@ async def _attach_with_transcript_forwarder(
                 auth=auth,
             ),
             name="claude-native-transcript-forwarder",
+        )
+        # Safety net for approval prompts the ``PermissionRequest`` hook
+        # failed to route to the web UI: without it the session blocks on a
+        # prompt only the terminal shows. Owned by whichever process runs
+        # the forwarder, for the same reason — one tailer per bridge.
+        from omnigent.claude_native_permissions import supervise_claude_permission_mirror
+
+        permission_mirror = asyncio.create_task(
+            supervise_claude_permission_mirror(
+                base_url=base_url,
+                headers=headers,
+                session_id=prepared.session_id,
+                bridge_dir=prepared.bridge_dir,
+                auth=auth,
+            ),
+            name="claude-native-permission-mirror",
         )
         startup_profiler.mark("transcript forwarder started")
     else:
@@ -3505,6 +3522,20 @@ async def _attach_with_transcript_forwarder(
                 close_attach_on_terminal_gone=attach is attach_local_terminal,
             )
     finally:
+        if permission_mirror is not None:
+            permission_mirror.cancel()
+            try:
+                await permission_mirror
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001 — cleanup must run regardless
+                # Same contract as the forwarder below: the mirror is a
+                # best-effort safety net, so a bug in it must not skip the
+                # terminal stop call.
+                _logger.warning(
+                    "claude-native permission mirror raised on shutdown",
+                    exc_info=True,
+                )
         if forwarder is not None:
             forwarder.cancel()
             try:

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -101,6 +101,16 @@ _TOOL_RELAY_FILE = "tool_relay.json"
 _TOOL_RELAY_ENV_FILE = "tool_relay.env"
 _TMUX_FILE = "tmux.json"
 _PERMISSION_HOOK_FILE = "permission_hook.json"
+# Append-only outcome trace for the ``PermissionRequest`` hook. The hook's
+# own diagnostics go to stderr, which Claude Code discards for a zero-exit
+# hook — so a prompt that failed to reach the web UI used to leave no trace
+# anywhere and the session just sat blocked. Every hook invocation records
+# its outcome here instead.
+_PERMISSION_TRACE_FILE = "permission_trace.jsonl"
+# Cap the trace so a long session cannot grow it without bound. Rewritten
+# (tail-kept) once it exceeds the cap; only the recent tail has diagnostic
+# value, and readers ask for the last few entries.
+_PERMISSION_TRACE_MAX_LINES = 500
 _CONTEXT_FILE = "context.json"
 _USER_CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 _MCP_SERVER_NAME = "omnigent"
@@ -229,15 +239,20 @@ _OCCUPIED_INPUT_DISMISS_RETRY_INTERVAL_S = 0.75
 SWITCH_MODEL_DIALOG_HINT = "Switch model?"
 EFFORT_DIALOG_HINT = "Change effort level?"
 _CONFIRM_DIALOG_HINTS = (SWITCH_MODEL_DIALOG_HINT, EFFORT_DIALOG_HINT)
+# Title every Claude Code tool permission prompt renders above its numbered
+# options ("Do you want to proceed?", "Do you want to make this edit to
+# x.py?"). Public because the runner-side permission mirror
+# (:mod:`omnigent.claude_native_permissions`) detects the same prompt from the
+# pane and must not re-spell the marker.
+PERMISSION_PROMPT_HINT = "Do you want to "
 # Surfaces a confirm Enter must never land on: they are never a slash command's
 # own confirmation, and their default answer commits something the person did
 # not ask for — the ``/model`` picker writes a new global default into
 # ``~/.claude/settings.json``, and a tool permission prompt approves the tool.
-# Every Claude Code permission prompt is titled "Do you want to …"; the second
-# signature catches the remembered-approval row of the wider ones.
+# The second signature catches the remembered-approval row of the wider prompts.
 _FOREIGN_DIALOG_HINTS = (
     _MODEL_PICKER_OPEN_HINT,
-    "Do you want to ",
+    PERMISSION_PROMPT_HINT,
     "Yes, and don't ask again",
 )
 # Seconds to wait for a confirmation dialog before concluding none appears.
@@ -1332,6 +1347,68 @@ def read_permission_hook_config(bridge_dir: Path) -> _JsonObject:
     """
     payload = _read_json_file(bridge_dir / _PERMISSION_HOOK_FILE)
     return payload if isinstance(payload, dict) else {}
+
+
+def record_permission_trace(bridge_dir: Path, outcome: str, **fields: object) -> None:
+    """
+    Append one ``PermissionRequest`` hook outcome to the bridge trace.
+
+    Best-effort and never raises: tracing must not turn a permission
+    prompt into a failed hook. Trimmed to the last
+    :data:`_PERMISSION_TRACE_MAX_LINES` entries.
+
+    :param bridge_dir: Bridge directory path.
+    :param outcome: Short outcome slug, e.g. ``"delivered"``,
+        ``"undelivered"``, ``"deferred"``, ``"no_server_url"``.
+    :param fields: Extra diagnostic fields to record alongside it, e.g.
+        ``tool_name="Bash"``. Never pass credentials.
+    :returns: None.
+    """
+    entry: _JsonObject = {"at": time.time(), "outcome": outcome, "pid": os.getpid()}
+    entry.update({key: value for key, value in fields.items() if value is not None})
+    path = bridge_dir / _PERMISSION_TRACE_FILE
+    # The bridge dir is created (and secured) at prep time; this only appends,
+    # so a missing dir simply fails the write. Swallowing everything is
+    # deliberate: the caller is blocking a live permission prompt, and no
+    # tracing failure may turn that into a failed hook.
+    try:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, separators=(",", ":"), default=str) + "\n")
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if len(lines) > _PERMISSION_TRACE_MAX_LINES:
+            path.write_text(
+                "\n".join(lines[-_PERMISSION_TRACE_MAX_LINES:]) + "\n", encoding="utf-8"
+            )
+    except Exception:  # noqa: BLE001 — tracing must never break the prompt
+        return
+
+
+def read_recent_permission_traces(bridge_dir: Path, limit: int = 5) -> list[_JsonObject]:
+    """
+    Read the most recent ``PermissionRequest`` hook outcomes, newest last.
+
+    Lets the runner-side permission mirror say *why* the web card is
+    missing (the hook never ran vs. it could not reach the server) in the
+    warning it logs before surfacing the prompt itself.
+
+    :param bridge_dir: Bridge directory path.
+    :param limit: Maximum number of trailing entries to return.
+    :returns: Parsed trace entries, oldest first; empty when absent or
+        unreadable.
+    """
+    try:
+        lines = (bridge_dir / _PERMISSION_TRACE_FILE).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    entries: list[_JsonObject] = []
+    for line in lines[-limit:] if limit > 0 else []:
+        try:
+            parsed = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(parsed, dict):
+            entries.append(parsed)
+    return entries
 
 
 def update_permission_hook_auth_headers(
@@ -3889,6 +3966,64 @@ def claude_pane_ready(bridge_dir: Path) -> bool:
     if any(text in pane for text in _CONFIRM_DIALOG_HINTS):
         return False
     return _claude_prompt_rendered(pane)
+
+
+def _pane_coordinates(bridge_dir: Path) -> tuple[str, str] | None:
+    """
+    Read the advertised tmux socket + pane target for a bridge dir.
+
+    :param bridge_dir: Bridge directory path holding ``tmux.json``.
+    :returns: ``(socket_path, tmux_target)``, or ``None`` when the pane
+        has not been advertised yet.
+    """
+    payload = _read_json_file(bridge_dir / _TMUX_FILE)
+    if not isinstance(payload, dict):
+        return None
+    socket_path = payload.get("socket_path")
+    tmux_target = payload.get("tmux_target")
+    if not isinstance(socket_path, str) or not isinstance(tmux_target, str):
+        return None
+    return socket_path, tmux_target
+
+
+def capture_claude_pane(bridge_dir: Path) -> str | None:
+    """
+    Return the visible Claude pane text, or ``None`` when no pane exists.
+
+    Used by the runner-side permission mirror
+    (:mod:`omnigent.claude_native_permissions`) to notice a permission
+    prompt that the ``PermissionRequest`` hook failed to route to the web
+    UI. ``None`` (no advertised tmux target) is distinct from ``""`` (a
+    live but torn capture); both mean "no prompt visible" to the caller.
+
+    :param bridge_dir: The claude-native bridge dir holding ``tmux.json``.
+    :returns: The captured pane text, or ``None`` when no live pane exists.
+    """
+    coordinates = _pane_coordinates(bridge_dir)
+    if coordinates is None:
+        return None
+    return _capture_pane(*coordinates)
+
+
+def send_claude_pane_keys(bridge_dir: Path, *keys: str) -> None:
+    """
+    Send one or more keys to the Claude pane (tmux ``send-keys``).
+
+    Used by the permission mirror to answer Claude's own prompt from a web
+    verdict, e.g. ``"1"`` for its "Yes" row. Each key is a tmux key
+    name/argument, so multi-byte keys like ``"Escape"`` are interpreted
+    rather than typed literally.
+
+    :param bridge_dir: The claude-native bridge dir holding ``tmux.json``.
+    :param keys: tmux key arguments, e.g. ``"1"`` or ``"Escape"``.
+    :returns: None.
+    :raises RuntimeError: If the pane is not advertised or send-keys fails.
+    """
+    coordinates = _pane_coordinates(bridge_dir)
+    if coordinates is None:
+        raise RuntimeError("claude-native tmux target not advertised")
+    socket_path, tmux_target = coordinates
+    _run_tmux(socket_path, "send-keys", "-t", tmux_target, *keys)
 
 
 def _restore_occupied_input(socket_path: str, tmux_target: str) -> None:

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -22,6 +22,7 @@ from omnigent.claude_native_bridge import (
     read_permission_hook_config,
     read_seen_claude_session_ids,
     record_hook_event,
+    record_permission_trace,
     transcript_has_forked_from_marker,
     transcript_has_recent_local_command,
     url_component,
@@ -837,24 +838,30 @@ def _main_permission_request(argv: list[str]) -> int:
     from omnigent.native_policy_hook import policy_hook_reauth
 
     args = _parse_permission_args(argv)
+    bridge_dir = Path(args.bridge_dir)
     raw = sys.stdin.read()
     try:
         payload = json.loads(raw or "{}")
     except json.JSONDecodeError as exc:
         print(f"omnigent claude permission hook: malformed JSON: {exc}", file=sys.stderr)
+        record_permission_trace(bridge_dir, "malformed_payload", detail=str(exc))
         return 0
     if not isinstance(payload, dict):
         print("omnigent claude permission hook: expected JSON object", file=sys.stderr)
+        record_permission_trace(bridge_dir, "malformed_payload", detail="not a JSON object")
         return 0
-    bridge_dir = Path(args.bridge_dir)
+    raw_tool_name = payload.get("tool_name")
+    tool_name = raw_tool_name if isinstance(raw_tool_name, str) else None
     session_id = read_active_session_id(bridge_dir)
     if not session_id:
         print("omnigent claude permission hook: active session missing", file=sys.stderr)
+        record_permission_trace(bridge_dir, "no_active_session", tool_name=tool_name)
         return 0
     config = read_permission_hook_config(bridge_dir)
     ap_server_url = args.omnigent_server_url or config.get("ap_server_url")
     if not isinstance(ap_server_url, str) or not ap_server_url:
         print("omnigent claude permission hook: Omnigent server URL missing", file=sys.stderr)
+        record_permission_trace(bridge_dir, "no_server_url", tool_name=tool_name)
         return 0
     headers = _parse_headers(args.omnigent_auth_headers_json)
     if not headers:
@@ -872,6 +879,7 @@ def _main_permission_request(argv: list[str]) -> int:
         f"{ap_server_url.rstrip('/')}/v1/sessions/"
         f"{url_component(session_id)}/hooks/permission-request"
     )
+    record_permission_trace(bridge_dir, "posting", tool_name=tool_name, session_id=session_id)
     resp = _post_hook_with_reattach(
         url,
         headers,
@@ -880,9 +888,18 @@ def _main_permission_request(argv: list[str]) -> int:
         reauth=policy_hook_reauth(ap_server_url, headers),
     )
     if resp is None:
+        # Out of retry budget or a hard rejection: the prompt is now the
+        # terminal's alone. Recorded so the runner-side mirror can say why
+        # it had to surface the pane prompt itself.
+        record_permission_trace(bridge_dir, "undelivered", tool_name=tool_name)
         return 0
     if resp.content:
+        record_permission_trace(bridge_dir, "delivered", tool_name=tool_name)
         sys.stdout.write(resp.text)
+        return 0
+    # Empty 2xx is the server's fail-ask: nobody answered in the web UI
+    # (timeout) or the prompt was resolved in the terminal.
+    record_permission_trace(bridge_dir, "deferred", tool_name=tool_name)
     return 0
 
 

--- a/omnigent/claude_native_permissions.py
+++ b/omnigent/claude_native_permissions.py
@@ -1,0 +1,504 @@
+"""Claude-native permission mirror (pane → web elicitation) — the safety net.
+
+Claude Code's own ``PermissionRequest`` hook is the primary route for getting
+a tool permission prompt into the Omnigent web UI: it fires just before the TUI
+renders the prompt, parks server-side for a day, and the web card and the
+terminal prompt then race (see :mod:`omnigent.claude_native_hook` and the
+``/hooks/permission-request`` route). Both surfaces are live by design and
+whichever is answered first wins.
+
+When that route fails, though, it fails *silently*. The hook exits 0 on every
+transport error so Claude keeps its own prompt, Claude Code discards a
+zero-exit hook's stderr, and a card that was published but never reached a
+subscriber leaves nothing behind either. The session then blocks on a prompt
+that exists only in the embedded terminal, with the web UI showing no card and
+no hint that anything is waiting — observed in the field as a turn stalled for
+nearly three hours.
+
+This watcher closes that hole:
+
+1. poll ``capture-pane`` and parse Claude's permission prompt — the block
+   titled by the gated tool ("Bash command") with a
+   ``Do you want to …?`` question and NUMBERED options (``❯ 1. Yes`` … ``3.
+   No``), where pressing the digit both selects and confirms,
+2. once the same prompt has been on screen for
+   :data:`_UNSURFACED_GRACE_S`, ask the server whether a prompt is already
+   pending for the session — the hook needs a moment to park, and a card it
+   parked must not be duplicated,
+3. only when the server reports nothing pending, POST the prompt to the
+   generic ``native-permission-request`` hook so a card renders, and send the
+   matching digit into the pane on the web verdict,
+4. if the prompt vanishes while our card is still parked (answered in the
+   terminal), POST ``external_elicitation_resolved`` so the card clears.
+
+The prompt in the pane always stays authoritative: this never dismisses it and
+never answers it without a web verdict, so a detection miss degrades to
+exactly the old behaviour. Mirrors :mod:`omnigent.hermes_native_permissions`.
+
+Deliberately narrow: only the plain ``Yes`` / ``No`` shape is mirrored. Prompts
+whose first option carries a rider ("Yes, and auto-accept edits", the
+``ExitPlanMode`` review) are left to the hook, which renders them as purpose-
+built cards with the full tool input rather than a scraped preview.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypedDict
+
+import httpx
+
+from omnigent.claude_native_bridge import (
+    PERMISSION_PROMPT_HINT,
+    capture_claude_pane,
+    read_recent_permission_traces,
+    send_claude_pane_keys,
+)
+
+
+class _PendingApproval(TypedDict):
+    elicitation_id: str
+    task: asyncio.Task[None]
+
+
+_logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL_S = 0.5
+# How long the same prompt must stay on screen before the mirror considers
+# stepping in. It only has to cover the hook's park round-trip (one local
+# POST), and a prompt still unsurfaced after this long is already a stall.
+_UNSURFACED_GRACE_S = 5.0
+# While a prompt stays up unsurfaced, how often to re-ask the server whether a
+# card exists. Covers a hook that parked first and gave up later (its retry
+# budget can run out mid-prompt), without polling the snapshot on every frame.
+_RECHECK_INTERVAL_S = 30.0
+# The hook parks server-side until a human answers; allow a day so this POST
+# never abandons a live prompt.
+_POST_TIMEOUT_S = 86400.0
+# Budget for the "is a card already pending?" snapshot read.
+_SNAPSHOT_TIMEOUT_S = 20.0
+
+# One numbered option row, e.g. "❯ 1. Yes" or "  3. No". Claude renders the
+# selection caret on the active row only.
+_OPTION_RE = re.compile(r"^\s*(?:❯\s*)?(?P<num>\d)\.\s+(?P<label>\S.*?)\s*$")
+# The rule Claude draws above the prompt block, which bounds the preview scan.
+_RULE_RE = re.compile(r"^[\s─]*─{8,}[\s─]*$")
+# Footer Claude renders under the options ("Esc to cancel · Tab to amend").
+# Required, not just used to end the option scan: it is what separates a live
+# prompt from Claude's own prose that happens to quote a question and an option
+# list. A false positive would put a stray digit in the composer.
+_FOOTER_HINT = "Esc to cancel"
+
+
+@dataclass(frozen=True)
+class ClaudePermissionPrompt:
+    """A Claude Code tool permission prompt parsed from the pane.
+
+    :param title: The prompt's own title, i.e. the gated tool as Claude
+        labels it, e.g. ``"Bash command"``.
+    :param question: The question row, e.g. ``"Do you want to proceed?"``.
+    :param preview: Compact preview of the gated call for the card.
+    :param accept_key: Digit that selects+confirms the plain "Yes" row.
+    :param decline_key: Digit that selects+confirms the "No" row.
+    :param signature: Stable hash of the prompt's visible content. Identifies
+        one prompt episode across re-renders, and distinguishes a *new* prompt
+        that replaced it without an intervening empty frame.
+    """
+
+    title: str
+    question: str
+    preview: str
+    accept_key: str
+    decline_key: str
+    signature: str
+
+
+def claude_permission_elicitation_id(session_id: str, signature: str) -> str:
+    """
+    Return the deterministic elicitation id for a mirrored pane prompt.
+
+    Keyed by the prompt's content signature rather than a counter so a
+    re-POST for the same on-screen prompt re-parks the same elicitation
+    instead of minting a second card.
+
+    :param session_id: Omnigent conversation id.
+    :param signature: The parsed prompt's :attr:`ClaudePermissionPrompt.signature`.
+    :returns: Elicitation id, e.g. ``"elicit_claude_pane_conv_x_ab12…"``.
+    """
+    return f"elicit_claude_pane_{session_id}_{signature}"
+
+
+def _prompt_preview_lines(lines: list[str], question_idx: int) -> list[str]:
+    """
+    Collect the prompt block's content rows above its question.
+
+    Scans up to the rule Claude draws above the block and drops its
+    "Tip: auto mode handles these prompts for you" advice (which wraps
+    onto a continuation line, hence skipping to the next blank row).
+
+    :param lines: The captured pane split into lines.
+    :param question_idx: Index of the ``Do you want to …`` row.
+    :returns: Content rows, in screen order, e.g.
+        ``["Bash command", "for d in a b; do echo $d; done"]``.
+    """
+    start = 0
+    for index in range(question_idx - 1, -1, -1):
+        if _RULE_RE.match(lines[index]):
+            start = index + 1
+            break
+    collected: list[str] = []
+    skipping_tip = False
+    for line in lines[start:question_idx]:
+        text = line.strip()
+        if not text:
+            skipping_tip = False
+            continue
+        if skipping_tip:
+            continue
+        if text.startswith("Tip:"):
+            skipping_tip = True
+            continue
+        collected.append(text)
+    return collected
+
+
+def parse_claude_permission_prompt(pane: str) -> ClaudePermissionPrompt | None:
+    """
+    Parse Claude Code's tool permission prompt from pane text.
+
+    Requires the whole live signature — a ``Do you want to …`` question, a
+    plain ``Yes`` row and a ``No`` row numbered *below* it, and the prompt's
+    own footer below those — so neither a transcript line quoting the question
+    nor a half-repainted frame is mistaken for a prompt awaiting an answer.
+
+    :param pane: Visible pane text from ``capture-pane -p``.
+    :returns: The parsed prompt, or ``None`` when no answerable prompt is
+        visible (including the option shapes this mirror leaves to the hook).
+    """
+    if not pane or PERMISSION_PROMPT_HINT not in pane:
+        return None
+    lines = pane.splitlines()
+    question_idx = next(
+        (
+            index
+            for index in range(len(lines) - 1, -1, -1)
+            if PERMISSION_PROMPT_HINT in lines[index]
+        ),
+        None,
+    )
+    if question_idx is None:
+        return None
+
+    accept_key: str | None = None
+    decline_key: str | None = None
+    options: list[str] = []
+    footer_seen = False
+    for line in lines[question_idx + 1 :]:
+        if _FOOTER_HINT in line:
+            footer_seen = True
+            break
+        match = _OPTION_RE.match(line)
+        if match is None:
+            continue
+        label = match.group("label")
+        options.append(f"{match.group('num')}. {label}")
+        folded = label.casefold()
+        if accept_key is None and folded == "yes":
+            accept_key = match.group("num")
+        elif decline_key is None and folded.startswith("no"):
+            decline_key = match.group("num")
+    if not footer_seen or accept_key is None or decline_key is None:
+        return None
+
+    content = _prompt_preview_lines(lines, question_idx)
+    title = content[0] if content else "tool call"
+    question = lines[question_idx].strip()
+    preview = " · ".join(content)[:1024]
+    signature = hashlib.sha256(
+        "\n".join([question, *content, *options]).encode("utf-8")
+    ).hexdigest()[:16]
+    return ClaudePermissionPrompt(
+        title=title,
+        question=question,
+        preview=preview or title,
+        accept_key=accept_key,
+        decline_key=decline_key,
+        signature=signature,
+    )
+
+
+async def _web_prompt_pending(client: httpx.AsyncClient, session_id: str) -> bool | None:
+    """
+    Report whether the session already has a prompt awaiting a web answer.
+
+    :param client: Server client for the runner's requests.
+    :param session_id: Omnigent conversation id.
+    :returns: ``True`` when the snapshot lists a pending elicitation,
+        ``False`` when it lists none, ``None`` when it could not be read
+        (callers stand down and retry rather than risk a duplicate card).
+    """
+    try:
+        response = await client.get(
+            f"/v1/sessions/{session_id}",
+            timeout=_SNAPSHOT_TIMEOUT_S,
+        )
+    except httpx.HTTPError:
+        _logger.debug(
+            "claude permission mirror: session snapshot unreadable; session=%s",
+            session_id,
+            exc_info=True,
+        )
+        return None
+    if response.status_code >= 400:
+        return None
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    if not isinstance(body, dict):
+        return None
+    pending = body.get("pending_elicitations")
+    return bool(pending) if isinstance(pending, list) else None
+
+
+async def supervise_claude_permission_mirror(
+    *,
+    base_url: str,
+    headers: dict[str, str],
+    session_id: str,
+    bridge_dir: Path,
+    auth: httpx.Auth | None = None,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+    grace_s: float = _UNSURFACED_GRACE_S,
+    recheck_interval_s: float = _RECHECK_INTERVAL_S,
+) -> None:
+    """
+    Watch the Claude pane and surface prompts the hook route never delivered.
+
+    Runs for the session's lifetime (cancelled on teardown). At most one
+    prompt is mirrored at a time. A prompt the hook already parked is left
+    alone: this only steps in once the server confirms the session has no
+    pending prompt, so the web UI cannot end up with two cards for one call.
+
+    :param base_url: Server base URL.
+    :param headers: Auth/routing headers for the runner's requests.
+    :param session_id: Omnigent conversation id.
+    :param bridge_dir: The claude-native bridge dir holding ``tmux.json``.
+    :param auth: Optional httpx auth for the runner's requests.
+    :param poll_interval_s: Pane poll cadence in seconds.
+    :param grace_s: How long a prompt must persist before stepping in.
+    :param recheck_interval_s: How often to re-ask the server about a prompt
+        that is still up and still unsurfaced.
+    :returns: None. Runs until cancelled.
+    """
+    from omnigent.cli_auth import open_server_client
+
+    active: _PendingApproval | None = None
+    # Signature of the prompt currently on screen, when it first appeared,
+    # and when the server was last asked about it.
+    visible_signature: str | None = None
+    visible_since = 0.0
+    last_checked_at = 0.0
+    timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
+
+    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
+        while True:
+            try:
+                pane = await asyncio.to_thread(capture_claude_pane, bridge_dir)
+                prompt = parse_claude_permission_prompt(pane) if pane else None
+                now = time.monotonic()
+
+                if prompt is None or prompt.signature != visible_signature:
+                    # Falling edge (or replaced by a different prompt): release
+                    # a card we parked, since the pane no longer awaits it.
+                    if active is not None:
+                        task = active["task"]
+                        if isinstance(task, asyncio.Task) and not task.done():
+                            await _post_external_elicitation_resolved(
+                                client, session_id, str(active["elicitation_id"])
+                            )
+                        active = None
+                    visible_signature = prompt.signature if prompt is not None else None
+                    visible_since = now
+                    last_checked_at = 0.0
+
+                if (
+                    prompt is not None
+                    and active is None
+                    and now - visible_since >= grace_s
+                    and now - last_checked_at >= recheck_interval_s
+                ):
+                    last_checked_at = now
+                    # Short-circuit: only re-read the pane when the server has
+                    # confirmed there is no card, so the common "hook owns it"
+                    # path costs one snapshot read and no extra tmux spawn.
+                    if await _web_prompt_pending(client, session_id) is False and (
+                        await asyncio.to_thread(_prompt_still_shown, bridge_dir, prompt.signature)
+                    ):
+                        _logger.warning(
+                            "claude permission prompt has no web card after %.0fs — "
+                            "surfacing it from the pane; session=%s title=%r "
+                            "hook_trace=%s",
+                            now - visible_since,
+                            session_id,
+                            prompt.title,
+                            [
+                                entry.get("outcome")
+                                for entry in read_recent_permission_traces(bridge_dir, limit=3)
+                            ],
+                        )
+                        elicitation_id = claude_permission_elicitation_id(
+                            session_id, prompt.signature
+                        )
+                        task = asyncio.create_task(
+                            _run_one_approval(
+                                client,
+                                session_id=session_id,
+                                bridge_dir=bridge_dir,
+                                prompt=prompt,
+                                elicitation_id=elicitation_id,
+                            ),
+                            name=f"claude-permission-{prompt.signature}",
+                        )
+                        active = {"elicitation_id": elicitation_id, "task": task}
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "claude permission mirror poll failed; session=%s bridge_dir=%s",
+                    session_id,
+                    bridge_dir,
+                )
+            await asyncio.sleep(poll_interval_s)
+
+
+def _prompt_still_shown(bridge_dir: Path, signature: str) -> bool:
+    """
+    Re-read the pane and confirm the same prompt is still awaiting an answer.
+
+    Spent at both points where acting on a stale read would misfire: before
+    minting a card (a prompt answered during the snapshot round-trip must not
+    raise one after the fact) and before sending a verdict digit (which at a
+    bare composer would be typed into the person's next message).
+
+    :param bridge_dir: The claude-native bridge dir holding ``tmux.json``.
+    :param signature: Signature of the prompt being acted on.
+    :returns: ``True`` when the same prompt is still on screen.
+    """
+    pane = capture_claude_pane(bridge_dir)
+    prompt = parse_claude_permission_prompt(pane) if pane else None
+    return prompt is not None and prompt.signature == signature
+
+
+async def _run_one_approval(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    prompt: ClaudePermissionPrompt,
+    elicitation_id: str,
+) -> None:
+    """
+    Park one pane-detected prompt on the server and send the verdict digit.
+
+    :param client: Server client for the runner's requests.
+    :param session_id: Omnigent conversation id.
+    :param bridge_dir: The claude-native bridge dir holding ``tmux.json``.
+    :param prompt: The parsed prompt being mirrored.
+    :param elicitation_id: Stable id the card is parked under.
+    :returns: None.
+    """
+    payload = {
+        "elicitation_id": elicitation_id,
+        "agent": "Claude Code",
+        "policy_name": "claude_native_permission",
+        "operation_type": prompt.title,
+        "message": f"Claude is waiting in the terminal: {prompt.question}",
+        "content_preview": prompt.preview,
+        # A decline is answered with the prompt's own "No" digit, which hands
+        # Claude a denial and lets the turn continue. Interrupting as well
+        # would abort the turn the person only meant to redirect.
+        "interrupt_on_decline": False,
+    }
+    try:
+        response = await client.post(
+            f"/v1/sessions/{session_id}/hooks/native-permission-request",
+            json=payload,
+        )
+    except httpx.HTTPError:
+        _logger.exception("claude permission mirror POST failed; session=%s", session_id)
+        return
+    if response.status_code >= 400:
+        _logger.warning(
+            "claude permission mirror rejected: status=%s body=%s",
+            response.status_code,
+            response.text[:512],
+        )
+        return
+    if not response.content:
+        # Empty 2xx → answered in the terminal, or timed out: no keystroke.
+        return
+    try:
+        result = response.json()
+    except ValueError:
+        _logger.warning("claude permission mirror got non-JSON: %s", response.text[:512])
+        return
+    action = result.get("action") if isinstance(result, dict) else None
+    if action == "accept":
+        key = prompt.accept_key
+    elif action in {"decline", "cancel"}:
+        key = prompt.decline_key
+    else:
+        return
+    # Only answer a prompt that is verifiably still the one on screen — a
+    # digit sent at a bare composer would be typed into the person's message.
+    if not await asyncio.to_thread(_prompt_still_shown, bridge_dir, prompt.signature):
+        _logger.info(
+            "claude permission prompt vanished before the web verdict landed; "
+            "session=%s action=%s",
+            session_id,
+            action,
+        )
+        return
+    try:
+        await asyncio.to_thread(send_claude_pane_keys, bridge_dir, key)
+    except RuntimeError:
+        _logger.exception(
+            "failed to send claude approval keystroke %r; session=%s", key, session_id
+        )
+
+
+async def _post_external_elicitation_resolved(
+    client: httpx.AsyncClient, session_id: str, elicitation_id: str
+) -> None:
+    """
+    Tell the server the terminal answered a prompt this mirror had parked.
+
+    :param client: Server client for the runner's requests.
+    :param session_id: Omnigent conversation id.
+    :param elicitation_id: Id of the card to release.
+    :returns: None.
+    """
+    try:
+        response = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "external_elicitation_resolved",
+                "data": {"elicitation_id": elicitation_id},
+            },
+            timeout=10.0,
+        )
+        if response.status_code >= 400:
+            _logger.warning(
+                "claude external_elicitation_resolved rejected: status=%s body=%s",
+                response.status_code,
+                response.text[:512],
+            )
+    except httpx.HTTPError:
+        _logger.exception("claude external_elicitation_resolved POST failed")

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -7040,8 +7040,25 @@ async def _auto_create_claude_terminal(
     # mirrors the CLI client's ``prepared.cold_resumed`` handling in
     # ``claude_native.py``.
     from omnigent.claude_native_forwarder import supervise_forwarder
+    from omnigent.claude_native_permissions import supervise_claude_permission_mirror
 
     async def _supervise_bridge() -> None:
+        # Safety net for approval prompts the ``PermissionRequest`` hook failed
+        # to route to the web UI, which would otherwise block the session on a
+        # prompt only the embedded terminal shows (see
+        # :mod:`omnigent.claude_native_permissions`). A sibling task rather
+        # than a ``gather`` arm so the forwarder still starts on this tick, and
+        # so a mirror crash can never take the transcript down with it.
+        permission_mirror = asyncio.create_task(
+            supervise_claude_permission_mirror(
+                base_url=server_url,
+                headers=_runner_headers,
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                auth=_runner_auth,
+            ),
+            name=f"claude-permission-mirror-{session_id}",
+        )
         try:
             await supervise_forwarder(
                 base_url=server_url,
@@ -7054,6 +7071,9 @@ async def _auto_create_claude_terminal(
                 auth=_runner_auth,
             )
         finally:
+            permission_mirror.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await permission_mirror
             await _shutdown_session_router_async(session_id, _subagent_router)
             await _shutdown_session_turn_router_async(session_id, _claude_turn_router)
 

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -1285,7 +1285,8 @@ def register_hooks_routes(
 
         :param request: FastAPI request carrying the detected prompt
             (``elicitation_id``, ``message``, ``content_preview``,
-            ``operation_type``, optional ``agent`` / ``policy_name``).
+            ``operation_type``, optional ``agent`` / ``policy_name`` /
+            ``interrupt_on_decline``).
         :param session_id: Omnigent conversation id from the URL path.
         :returns: An ``ElicitationResult`` (``{"action": …}``) on a web verdict,
             or ``200`` with empty body on TUI-resolution / timeout / disconnect.
@@ -1329,6 +1330,14 @@ def register_hooks_routes(
         policy_name = payload.get("policy_name")
         if not isinstance(policy_name, str) or not policy_name:
             policy_name = "native_permission"
+        # Whether a decline should also interrupt the native harness. True for
+        # the mirrors whose only lever is the verdict itself; False for one that
+        # answers the vendor's own prompt with a decline keystroke, where the
+        # harness continues from that denial and an interrupt would abort the
+        # turn the person only meant to redirect.
+        interrupt_on_decline = payload.get("interrupt_on_decline")
+        if not isinstance(interrupt_on_decline, bool):
+            interrupt_on_decline = True
         extras: dict[str, Any] = {}
         ask_user_question = payload.get("ask_user_question")
         if isinstance(ask_user_question, dict) and isinstance(
@@ -1358,7 +1367,7 @@ def register_hooks_routes(
         )
         if result is None:
             return Response(status_code=status.HTTP_200_OK)
-        if result.action == "decline":
+        if result.action == "decline" and interrupt_on_decline:
             # Explicit user decline: interrupt the native harness before
             # returning the decline so the abort signal arrives first.
             await _forward_session_change_to_runner(

--- a/tests/server/integration/test_sessions_permission_request_hook.py
+++ b/tests/server/integration/test_sessions_permission_request_hook.py
@@ -343,6 +343,72 @@ async def test_qwen_permission_request_hook_allow_round_trip(
     assert resp.json() == {"action": "accept"}
 
 
+async def test_native_permission_hook_decline_can_skip_the_interrupt(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    ``interrupt_on_decline: False`` returns the decline without interrupting.
+
+    A mirror that answers the vendor's own on-screen prompt (the claude-native
+    pane mirror sends its "No" digit) leaves the harness to continue from that
+    denial — so the route must not also interrupt the turn, which would abort
+    work the person only meant to redirect. Mirrors that have no such lever
+    (hermes/goose/qwen) omit the flag and keep the interrupt.
+
+    Catches: the flag being ignored (a redirected turn dies), and the default
+    silently flipping for the mirrors that rely on the interrupt.
+    """
+    from omnigent.server.routes.sessions import routes_hooks
+
+    interrupts: list[tuple[str, dict[str, Any]]] = []
+
+    async def _record_interrupt(session_id: str, _router: Any, change: dict[str, Any]) -> None:
+        interrupts.append((session_id, change))
+
+    monkeypatch.setattr(routes_hooks, "_forward_session_change_to_runner", _record_interrupt)
+
+    agent = await create_test_agent(client, "test-native-decline-no-interrupt")
+    session_id = await _create_session(client, agent["id"])
+
+    async def _decline(elicitation_id: str, payload: dict[str, Any]) -> httpx.Response:
+        drain_task = asyncio.create_task(_drain_until_elicitation(session_id))
+        await asyncio.sleep(0.05)
+        hook_task = asyncio.create_task(
+            client.post(
+                f"/v1/sessions/{session_id}/hooks/native-permission-request",
+                json=payload,
+            )
+        )
+        await drain_task
+        verdict = await _post_approval(client, session_id, elicitation_id, "decline")
+        assert verdict.status_code == 202, verdict.text
+        return await hook_task
+
+    base = {
+        "agent": "Claude Code",
+        "policy_name": "claude_native_permission",
+        "operation_type": "Bash command",
+        "message": "Claude is waiting in the terminal: Do you want to proceed?",
+        "content_preview": "for d in a b; do echo $d; done",
+    }
+
+    quiet_id = f"elicit_claude_pane_{session_id}_quiet"
+    resp = await _decline(
+        quiet_id, {**base, "elicitation_id": quiet_id, "interrupt_on_decline": False}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["action"] == "decline"
+    assert interrupts == []
+
+    # Same route, flag omitted → the interrupt still fires for the mirrors
+    # whose only lever is the verdict.
+    loud_id = f"elicit_claude_pane_{session_id}_loud"
+    resp = await _decline(loud_id, {**base, "elicitation_id": loud_id})
+    assert resp.status_code == 200, resp.text
+    assert [change for _session, change in interrupts] == [{"type": "interrupt"}]
+
+
 async def test_cursor_permission_request_hook_stamps_ask_user_question_extra(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/test_claude_native_permissions.py
+++ b/tests/test_claude_native_permissions.py
@@ -1,0 +1,427 @@
+"""Unit tests for the claude-native permission mirror.
+
+The mirror is the safety net for a permission prompt the
+``PermissionRequest`` hook failed to route to the web UI: it parses Claude's
+own prompt out of the pane and raises a card only once the server confirms
+none is pending, so the hook keeps ownership whenever it worked.
+
+``_REAL_PANE`` is a verbatim ``capture-pane -p`` of Claude Code v2.1.257 in an
+80x24 pane (the geometry omnigent launches), captured while it gated a Bash
+call its own analyzer flagged — the shape that stalled a session for ~3h.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import omnigent.claude_native_permissions as cp
+from omnigent.claude_native_bridge import (
+    read_recent_permission_traces,
+    record_permission_trace,
+)
+
+_RULE = "─" * 80
+
+_REAL_PANE = (
+    "\n"
+    "\n"
+    "❯ Run exactly this bash command and show its output: for d in a b; do echo $d;\n"
+    "  done\n"
+    "\n"
+    "  Looping over a and b echoing each\n"
+    "  ⎿  $ for d in a b; do echo $d; done\n"
+    "\n"
+    f"{_RULE}\n"
+    " Bash command\n"
+    ' Tip: auto mode handles these prompts for you — choose "switch to auto mode"\n'
+    " below\n"
+    "\n"
+    "   for d in a b; do echo $d; done\n"
+    "   Loop over a and b echoing each\n"
+    "\n"
+    " Contains simple_expansion\n"
+    "\n"
+    " Do you want to proceed?\n"
+    " ❯ 1. Yes\n"
+    "   2. Yes, and switch to auto mode · auto mode handles these prompts for you\n"
+    "   3. No\n"
+    "\n"
+    " Esc to cancel · Tab to amend\n"
+)
+
+# An edit prompt: the rider option sits between Yes and No, and the No row
+# carries a trailing clause.
+_EDIT_PANE = (
+    f"{_RULE}\n"
+    " Edit file\n"
+    "\n"
+    "   omnigent/cli.py\n"
+    "\n"
+    " Do you want to make this edit to cli.py?\n"
+    " ❯ 1. Yes\n"
+    "   2. Yes, and allow all edits during this session\n"
+    "   3. No, and tell Claude what to do differently\n"
+    "\n"
+    " Esc to cancel · Tab to amend\n"
+)
+
+# Plan review: every option carries a rider, so there is no plain "Yes" to
+# answer with. Left to the hook, which renders the full plan.
+_PLAN_PANE = (
+    f"{_RULE}\n"
+    " Ready to code?\n"
+    "\n"
+    " Do you want to proceed?\n"
+    " ❯ 1. Yes, and auto-accept edits\n"
+    "   2. Yes, and manually approve edits\n"
+    "   3. No, keep planning\n"
+    "\n"
+    " Esc to cancel\n"
+)
+
+
+def test_parses_the_real_prompt_and_reads_its_digits() -> None:
+    prompt = cp.parse_claude_permission_prompt(_REAL_PANE)
+    assert prompt is not None
+    assert prompt.title == "Bash command"
+    assert prompt.question == "Do you want to proceed?"
+    assert prompt.accept_key == "1"
+    assert prompt.decline_key == "3"
+    assert "for d in a b; do echo $d; done" in prompt.preview
+    # The tip advice and its wrapped continuation are not part of the preview.
+    assert "auto mode handles these prompts" not in prompt.preview
+    assert "below" not in prompt.preview
+    # Only the prompt block feeds the preview, not the transcript above the rule.
+    assert "Looping over a and b" not in prompt.preview
+
+
+def test_rider_option_is_never_mistaken_for_plain_yes() -> None:
+    prompt = cp.parse_claude_permission_prompt(_EDIT_PANE)
+    assert prompt is not None
+    assert prompt.title == "Edit file"
+    # "Yes, and allow all edits during this session" must not win accept, and
+    # the trailing clause on the No row must not stop it winning decline.
+    assert (prompt.accept_key, prompt.decline_key) == ("1", "3")
+
+
+def test_shapes_without_a_plain_yes_are_left_to_the_hook() -> None:
+    assert cp.parse_claude_permission_prompt(_PLAN_PANE) is None
+
+
+def test_question_without_live_options_is_not_a_prompt() -> None:
+    # Claude quoting the question in its own prose must not raise a card.
+    assert (
+        cp.parse_claude_permission_prompt(
+            "● I asked: Do you want to proceed? but you never answered.\n"
+        )
+        is None
+    )
+    # Options above the question (a stale frame) are not an answerable prompt.
+    assert (
+        cp.parse_claude_permission_prompt(" ❯ 1. Yes\n   3. No\n Do you want to proceed?\n")
+        is None
+    )
+    assert cp.parse_claude_permission_prompt("") is None
+
+
+def test_an_option_list_without_the_prompt_footer_is_prose() -> None:
+    # Claude enumerating choices in its own message must not raise a card —
+    # the stray digit a spurious verdict sends would land in the composer.
+    quoted = (
+        "● You have three options. Do you want to proceed?\n  1. Yes\n  3. No\n● Tell me which.\n"
+    )
+    assert cp.parse_claude_permission_prompt(quoted) is None
+    # The same block under Claude's real footer is a live prompt.
+    assert cp.parse_claude_permission_prompt(quoted + " Esc to cancel\n") is not None
+
+
+def test_signature_ignores_the_selection_caret_but_tracks_the_call() -> None:
+    moved = _REAL_PANE.replace(" ❯ 1. Yes", "   1. Yes").replace("   3. No", " ❯ 3. No")
+    first = cp.parse_claude_permission_prompt(_REAL_PANE)
+    second = cp.parse_claude_permission_prompt(moved)
+    assert first is not None and second is not None
+    # Moving the caret is a re-render of the same prompt, not a new one.
+    assert first.signature == second.signature
+    other = cp.parse_claude_permission_prompt(_REAL_PANE.replace("echo $d", "echo $DIFFERENT"))
+    assert other is not None
+    assert other.signature != first.signature
+
+
+def test_elicitation_id_is_keyed_by_signature() -> None:
+    prompt = cp.parse_claude_permission_prompt(_REAL_PANE)
+    assert prompt is not None
+    assert cp.claude_permission_elicitation_id("conv_x", prompt.signature) == (
+        f"elicit_claude_pane_conv_x_{prompt.signature}"
+    )
+
+
+class _Resp:
+    def __init__(self, status: int = 200, content: bytes = b'{"action":"accept"}', payload=None):
+        self.status_code = status
+        self.content = content
+        self._payload = payload if payload is not None else {"action": "accept"}
+        self.text = content.decode() if isinstance(content, bytes) else str(content)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, resp: _Resp, snapshot: _Resp | None = None) -> None:
+        self._resp = resp
+        self._snapshot = snapshot
+        self.posts: list[tuple[str, dict]] = []
+        self.gets: list[str] = []
+
+    async def post(self, url, json=None, **_kwargs):
+        self.posts.append((url, json or {}))
+        return self._resp
+
+    async def get(self, url, **_kwargs):
+        self.gets.append(url)
+        assert self._snapshot is not None, "unexpected snapshot read"
+        return self._snapshot
+
+
+def _prompt() -> cp.ClaudePermissionPrompt:
+    parsed = cp.parse_claude_permission_prompt(_REAL_PANE)
+    assert parsed is not None
+    return parsed
+
+
+async def test_accept_verdict_sends_the_yes_digit(tmp_path, monkeypatch) -> None:
+    sent: list[tuple] = []
+    monkeypatch.setattr(cp, "send_claude_pane_keys", lambda _bd, *keys: sent.append(keys))
+    monkeypatch.setattr(cp, "_prompt_still_shown", lambda _bd, _sig: True)
+    client = _FakeClient(_Resp(payload={"action": "accept"}))
+    await cp._run_one_approval(
+        client, session_id="c", bridge_dir=tmp_path, prompt=_prompt(), elicitation_id="e1"
+    )
+    assert sent == [("1",)]
+    url, body = client.posts[0]
+    assert url.endswith("/hooks/native-permission-request")
+    assert body["agent"] == "Claude Code"
+    assert body["elicitation_id"] == "e1"
+    # A decline is answered with the No digit, so the turn must not also be
+    # interrupted — Claude continues from its own denial.
+    assert body["interrupt_on_decline"] is False
+
+
+async def test_decline_verdict_sends_the_no_digit(tmp_path, monkeypatch) -> None:
+    sent: list[tuple] = []
+    monkeypatch.setattr(cp, "send_claude_pane_keys", lambda _bd, *keys: sent.append(keys))
+    monkeypatch.setattr(cp, "_prompt_still_shown", lambda _bd, _sig: True)
+    await cp._run_one_approval(
+        _FakeClient(_Resp(payload={"action": "decline"})),
+        session_id="c",
+        bridge_dir=tmp_path,
+        prompt=_prompt(),
+        elicitation_id="e1",
+    )
+    assert sent == [("3",)]
+
+
+async def test_no_keystroke_when_the_prompt_already_went_away(tmp_path, monkeypatch) -> None:
+    sent: list[tuple] = []
+    monkeypatch.setattr(cp, "send_claude_pane_keys", lambda _bd, *keys: sent.append(keys))
+    # Answered in the terminal while the web verdict was in flight: a digit now
+    # would be typed into the composer as a message.
+    monkeypatch.setattr(cp, "_prompt_still_shown", lambda _bd, _sig: False)
+    await cp._run_one_approval(
+        _FakeClient(_Resp(payload={"action": "accept"})),
+        session_id="c",
+        bridge_dir=tmp_path,
+        prompt=_prompt(),
+        elicitation_id="e1",
+    )
+    assert sent == []
+
+
+async def test_empty_2xx_and_error_send_nothing(tmp_path, monkeypatch) -> None:
+    sent: list[tuple] = []
+    monkeypatch.setattr(cp, "send_claude_pane_keys", lambda _bd, *keys: sent.append(keys))
+    monkeypatch.setattr(cp, "_prompt_still_shown", lambda _bd, _sig: True)
+    for resp in (_Resp(content=b""), _Resp(status=500, content=b"boom")):
+        await cp._run_one_approval(
+            _FakeClient(resp),
+            session_id="c",
+            bridge_dir=tmp_path,
+            prompt=_prompt(),
+            elicitation_id="e1",
+        )
+    assert sent == []
+
+
+async def test_external_elicitation_resolved_targets_events(tmp_path) -> None:
+    client = _FakeClient(_Resp(status=200, content=b""))
+    await cp._post_external_elicitation_resolved(client, "conv_z", "e9")
+    url, body = client.posts[0]
+    assert url == "/v1/sessions/conv_z/events"
+    assert body["type"] == "external_elicitation_resolved"
+    assert body["data"]["elicitation_id"] == "e9"
+
+
+def _drive_supervisor(monkeypatch, tmp_path, *, panes, snapshot, polls):
+    """Run the supervisor over a scripted pane sequence; return minted ids."""
+    seq = {"i": 0}
+
+    def _capture(_bd):
+        i = seq["i"]
+        seq["i"] += 1
+        return panes[i] if i < len(panes) else panes[-1]
+
+    monkeypatch.setattr(cp, "capture_claude_pane", _capture)
+    monkeypatch.setattr(cp, "_prompt_still_shown", lambda _bd, _sig: True)
+    created: list[str] = []
+
+    async def _fake_run_one(_client, *, session_id, bridge_dir, prompt, elicitation_id):
+        created.append(elicitation_id)
+
+    monkeypatch.setattr(cp, "_run_one_approval", _fake_run_one)
+
+    client = _FakeClient(_Resp(status=200, content=b""), snapshot=snapshot)
+
+    class _Ctx:
+        async def __aenter__(self):
+            return client
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    monkeypatch.setattr(cp, "open_server_client", lambda *_a, **_kw: _Ctx(), raising=False)
+    monkeypatch.setattr("omnigent.cli_auth.open_server_client", lambda *_a, **_kw: _Ctx())
+
+    sleeps = {"n": 0}
+
+    async def _sleep(_s):
+        sleeps["n"] += 1
+        if sleeps["n"] >= polls:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(cp.asyncio, "sleep", _sleep)
+    return created, client
+
+
+async def test_stands_down_while_the_hook_owns_the_prompt(tmp_path, monkeypatch) -> None:
+    # Server reports a parked elicitation → the hook route worked, so the
+    # mirror must not raise a second card for the same call.
+    created, client = _drive_supervisor(
+        monkeypatch,
+        tmp_path,
+        panes=[_REAL_PANE],
+        snapshot=_Resp(payload={"pending_elicitations": [{"elicitation_id": "elicit_claude_x"}]}),
+        polls=3,
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await cp.supervise_claude_permission_mirror(
+            base_url="http://x",
+            headers={},
+            session_id="c",
+            bridge_dir=tmp_path,
+            grace_s=0.0,
+            recheck_interval_s=0.0,
+        )
+    assert created == []
+    assert client.gets  # it did ask
+
+
+async def test_surfaces_the_prompt_when_no_card_is_pending(tmp_path, monkeypatch) -> None:
+    created, _client = _drive_supervisor(
+        monkeypatch,
+        tmp_path,
+        panes=[_REAL_PANE],
+        snapshot=_Resp(payload={"pending_elicitations": []}),
+        polls=3,
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await cp.supervise_claude_permission_mirror(
+            base_url="http://x",
+            headers={},
+            session_id="c",
+            bridge_dir=tmp_path,
+            grace_s=0.0,
+            recheck_interval_s=0.0,
+        )
+    prompt = _prompt()
+    # One card for the episode, keyed to the prompt, not one per poll.
+    assert created == [cp.claude_permission_elicitation_id("c", prompt.signature)]
+
+
+async def test_unreadable_snapshot_does_not_mint_a_card(tmp_path, monkeypatch) -> None:
+    # Cannot tell whether a card exists → stand down rather than duplicate.
+    created, _client = _drive_supervisor(
+        monkeypatch,
+        tmp_path,
+        panes=[_REAL_PANE],
+        snapshot=_Resp(status=503, content=b"nope", payload={}),
+        polls=3,
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await cp.supervise_claude_permission_mirror(
+            base_url="http://x",
+            headers={},
+            session_id="c",
+            bridge_dir=tmp_path,
+            grace_s=0.0,
+            recheck_interval_s=0.0,
+        )
+    assert created == []
+
+
+async def test_prompt_must_persist_past_the_grace_window(tmp_path, monkeypatch) -> None:
+    # A prompt answered before the grace window elapses is never surfaced. The
+    # clock is left real here so the window does not pass.
+    seq = {"i": 0}
+    panes = [_REAL_PANE, None]
+
+    def _capture(_bd):
+        i = seq["i"]
+        seq["i"] += 1
+        return panes[i] if i < len(panes) else None
+
+    monkeypatch.setattr(cp, "capture_claude_pane", _capture)
+    created: list[str] = []
+
+    async def _fake_run_one(_client, **_kwargs):
+        created.append("x")
+
+    monkeypatch.setattr(cp, "_run_one_approval", _fake_run_one)
+
+    class _Ctx:
+        async def __aenter__(self):
+            return _FakeClient(_Resp(status=200, content=b""))
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    monkeypatch.setattr("omnigent.cli_auth.open_server_client", lambda *_a, **_kw: _Ctx())
+    sleeps = {"n": 0}
+
+    async def _sleep(_s):
+        sleeps["n"] += 1
+        if sleeps["n"] >= 3:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(cp.asyncio, "sleep", _sleep)
+    with pytest.raises(asyncio.CancelledError):
+        await cp.supervise_claude_permission_mirror(
+            base_url="http://x", headers={}, session_id="c", bridge_dir=tmp_path
+        )
+    assert created == []
+
+
+def test_permission_trace_round_trips_and_is_capped(tmp_path) -> None:
+    record_permission_trace(tmp_path, "posting", tool_name="Bash")
+    record_permission_trace(tmp_path, "undelivered", tool_name="Bash")
+    entries = read_recent_permission_traces(tmp_path, limit=5)
+    assert [entry["outcome"] for entry in entries] == ["posting", "undelivered"]
+    assert entries[-1]["tool_name"] == "Bash"
+    assert isinstance(entries[-1]["pid"], int)
+
+
+def test_permission_trace_never_raises_on_an_unwritable_dir(tmp_path) -> None:
+    # Tracing must never turn a live permission prompt into a failed hook.
+    record_permission_trace(tmp_path / "missing" / "deeper", "undelivered")
+    assert read_recent_permission_traces(tmp_path / "missing" / "deeper") == []


### PR DESCRIPTION
## Related issue

None filed — reported directly from a stalled session rather than an issue. Happy to open one to link if the review queue needs the priority.

## Summary

A claude-native session can block **indefinitely** on a tool permission prompt that only the embedded terminal shows. Observed in the field as a turn stalled for **2h47m** with nothing at all in the chat view.

`PermissionRequest` is the primary route for mirroring that prompt into the web UI, and on any transport failure the hook exits 0 so Claude keeps its own prompt. Claude Code discards a zero-exit hook's stderr, so the failure left **no trace anywhere** — no card, no log line, just a session waiting on a prompt nobody was looking at. Note that both surfaces going live at once is the intended design (the route already has a terminal-resolved fast path), so the terminal prompt was never the problem — the missing card, and the silence about it, were.

Two missing pieces:

- **Traceability** — every `PermissionRequest` invocation records its outcome in `permission_trace.jsonl` in the bridge dir (`posting` / `delivered` / `deferred` / `undelivered` / …), so a card that never appears is diagnosable after the fact.
- **A safety net** — a runner-side pane mirror (`omnigent/claude_native_permissions.py`) parses Claude's own prompt out of the pane and, once it has stayed up 5s, asks the server whether a prompt is already pending. Only when none is does it raise one via the generic `native-permission-request` hook and answer the pane with the prompt's own digit on the web verdict.

The generic native-permission hook gains `interrupt_on_decline` (default `true`, so hermes/goose/qwen are unchanged): this mirror declines by sending the prompt's `No` digit, after which Claude continues from its own denial — an extra interrupt would abort the turn the person only meant to redirect.

### ELI5

Claude asks "may I run this?" in two places at once — the terminal and the web chat — and whichever you answer first wins. The web half was posting into a void with no error, so if it failed you saw nothing and the session just sat there. Now something watches the terminal and, if no card showed up, puts one in the chat itself.

```mermaid
flowchart TD
    A[Claude gates a tool call] --> B[PermissionRequest hook]
    B -->|POST ok| C[Web card parked]
    B -->|POST fails, exit 0| D[Terminal prompt only]
    C --> E[Answered in web UI]
    D --> F{Prompt up 5s?}
    F -->|yes| G[Mirror asks server:<br/>any card pending?]
    G -->|none| H[Mirror raises card,<br/>sends Yes/No digit]
    G -->|pending| I[Stand down —<br/>hook owns it]
    A --> J[Terminal prompt<br/>always authoritative]
```

The hook keeps ownership whenever it worked, so one call never gets two cards. Detection is deliberately narrow — question, plain `Yes` row, `No` row, and Claude's footer, all live — so prose quoting an option list cannot put a stray digit in the composer, and rider-only shapes (plan review) are left to the hook's purpose-built cards.

## Test Plan

**Automated** (all on this branch's base, `c0a919ffb`):

```
pytest tests/test_claude_native_permissions.py \
       tests/test_claude_native_hook.py \
       tests/test_claude_native_bridge.py \
       tests/server/integration/test_sessions_permission_request_hook.py
→ 414 passed

pytest tests/test_claude_native.py tests/test_claude_native_forwarder.py \
       tests/runner/test_app_sessions_native_terminals_autocreate.py \
       tests/runner/test_app_sessions_native_wake_forwarders.py
→ green apart from one pre-existing failure (below)
```

`ruff format`/`check` clean, `pyrefly` 0 errors, and the project lints (`no-global-asyncio-patch`, `no-skipped-tests`, `no-hardcoded-models`) pass.

The pane parser is tested against a **verbatim `capture-pane -p`** of Claude Code v2.1.257 in an 80x24 pane — the geometry omnigent launches — captured while it gated the exact call that stalled the reported session. Confirmed by probe that Claude Code does fire `PermissionRequest` for that prompt shape, so the mirror is genuinely a fallback and not a replacement.

`interrupt_on_decline` was verified prove-it-fails: reverting just the gate makes the new integration test fail on `assert interrupts == []`.

**Manual**

1. In a claude-native session, ask Claude to run `for d in a b; do echo $d; done`. Prompt appears in the terminal **and** as a card in the web chat; answering the card clears the terminal prompt. (Unchanged hook path.)
2. Point `permission_hook.json`'s `ap_server_url` at a dead port to force the hook to fail, then trigger the same prompt. Within ~5s the web UI shows *"Claude is waiting in the terminal: Do you want to proceed?"*; approving it runs the command. `permission_trace.jsonl` records `undelivered` and the runner log carries `claude permission prompt has no web card after …`.
3. Answer a prompt **in the terminal** while the mirror's card is up — the card clears itself rather than sticking.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

18 new unit tests cover the pane parser (real captured pane text, the rider-option and footer-absent false-positive guards, signature stability across caret moves), the verdict→keystroke paths, the stand-down-when-a-card-exists and stand-down-when-the-snapshot-is-unreadable branches, and the trace helpers. One new integration test covers `interrupt_on_decline` in both directions.

Manual verification is the three scenarios above, done against a live claude-native session — the failure being fixed is a cross-process race between Claude Code's TUI, a hook subprocess and the server, which no unit test reproduces end to end.

Two things reviewers should know:

- `tests/runner/.../test_auto_create_claude_terminal_registers_permission_hook` fails on this branch **and on pristine `main`** (`spec.command == 'isaac'`, not `'claude'`) — environmental, verified by setting the change aside and re-running. Not caused by this PR.
- The mirror is wired as a **sibling task** of the transcript forwarder, not a `gather` arm, deliberately: `gather` adds a scheduling hop that breaks four existing runner tests which assert the forwarder starts on the first tick.

The exact half of the original delivery failure (the hook's POST vs. a card published to no subscriber) could not be determined post-hoc — which is precisely why the trace exists. The mirror closes the stall either way.

## Changelog

Claude Code permission prompts can no longer strand a session in the terminal — if the approval card doesn't reach the web UI, Omnigent now surfaces the prompt itself
