### PR TITLE
fix(claude-native): serialize pane writes across processes

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -43,7 +43,7 @@ import tempfile
 import threading
 import time
 import urllib.parse
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterator, Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from http import HTTPStatus
@@ -51,6 +51,11 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from urllib import error, request
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows has no flock.
+    fcntl = None  # type: ignore[assignment]
 
 from omnigent._platform import stable_user_id
 from omnigent.claude_model_vocabulary import MODEL_VOCABULARY_ENV_VARS
@@ -133,6 +138,15 @@ _MAX_CONCURRENT_MCP_REQUESTS = 64
 # tails it and shells out to tmux.
 _TMUX_READY_TIMEOUT_S = 30.0
 _TMUX_SEND_TIMEOUT_S = 5.0
+# Cross-process mutex for the pane's keyboard. The harness executor and the
+# runner both type into this pane from different processes, so an in-process
+# lock cannot order them, and every injector below is a multi-step sequence
+# that corrupts if interleaved.
+_PANE_LOCK_FILE = "pane.lock"
+# Above the longest single injection (paste-commit + submit-verify) so a queued
+# writer waits its turn instead of failing while the holder is progressing.
+_PANE_LOCK_TIMEOUT_S = 30.0
+_PANE_LOCK_POLL_INTERVAL_S = 0.05
 # Claude Code renders this prompt glyph in its input box once the TUI
 # is interactive. We poll ``capture-pane`` for it before injecting the
 # first message so keystrokes typed during Claude's boot aren't dropped.
@@ -2957,108 +2971,112 @@ def inject_user_message(
     :returns: None.
     :raises RuntimeError: If the tmux target is not advertised in time,
         if Claude's input prompt never renders, if a ``tmux send-keys``
-        invocation fails, or if the draft never leaves the input box
-        after repeated submit Enters (message not delivered).
+        invocation fails, if another pane write holds the keyboard too
+        long, or if the draft never leaves the input box after repeated
+        submit Enters (message not delivered).
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    # A ctrl+r history search or hand-opened /model picker left covering
-    # the composer swallows everything typed below — and can hide the
-    # prompt glyph, wedging the readiness gate — so reclaim the input box
-    # before waiting on it.
-    _restore_occupied_input(info["socket_path"], info["tmux_target"])
-    # tmux.json only means the tmux session exists; Claude Code's input
-    # box mounts a few seconds later. Block until the prompt renders so
-    # the first message isn't typed into a still-booting TUI and dropped.
-    _wait_for_claude_prompt_ready(
-        info["socket_path"],
-        info["tmux_target"],
-        timeout_s=timeout_s,
-    )
-    # Clear any leftover text in Claude's input field before typing.
-    # After Escape-cancel, Claude Code re-populates the prompt area
-    # with the previous input for re-editing. Without this clear,
-    # the new message appends to the stale buffer (e.g.
-    # "old promptnew prompt" with no separator).
-    # Ctrl-A (Home) + Ctrl-K (kill-to-end) is the safest pair —
-    # Ctrl-U only clears backwards from cursor.
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-a")
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-k")
-    # Escape unsupported slash commands (e.g. ``/help``, ``/exit``) so the
-    # Claude Code TUI treats them as user text instead of invoking a state
-    # that Omnigent cannot drive. Allowed commands (``/clear``,
-    # ``/model``, ``/fork``, skills, etc.) pass through unchanged.
-    injected_text = _escape_unsupported_slash_command(content)
-    # Trailing newline absorbs a trailing "\" so it can't escape the submit Enter.
-    # Delivered through a tmux buffer, NOT ``send-keys`` argv: tmux caps one
-    # client→server command at ~16KB, so per-byte hex argv blew up with
-    # "command too long" on large payloads (a PR diff in a sub-agent
-    # dispatch). ``load-buffer`` streams the file without that cap, and
-    # ``paste-buffer -p`` wraps it in the same bracketed-paste markers so
-    # interior newlines (mapped to CR below) stay data instead of becoming
-    # per-line submits. See anthropics/claude-code#52126.
-    with tempfile.NamedTemporaryFile(
-        dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
-    ) as paste_file:
-        paste_file.write(_paste_payload_bytes(injected_text + "\n"))
-        paste_path = paste_file.name
-    try:
-        _run_tmux(info["socket_path"], "load-buffer", "-b", "omnigent-paste", paste_path)
-        _run_tmux(
+    with _pane_write_lock(bridge_dir, what="the web message"):
+        # A ctrl+r history search or hand-opened /model picker left covering
+        # the composer swallows everything typed below — and can hide the
+        # prompt glyph, wedging the readiness gate — so reclaim the input box
+        # before waiting on it.
+        _restore_occupied_input(info["socket_path"], info["tmux_target"])
+        # tmux.json only means the tmux session exists; Claude Code's input
+        # box mounts a few seconds later. Block until the prompt renders so
+        # the first message isn't typed into a still-booting TUI and dropped.
+        _wait_for_claude_prompt_ready(
             info["socket_path"],
-            "paste-buffer",
-            "-p",  # bracketed-paste markers — the TUI keeps newlines as data
-            "-d",  # drop the buffer after pasting (no stale copies server-side)
-            "-b",
-            "omnigent-paste",
-            "-t",
             info["tmux_target"],
+            timeout_s=timeout_s,
         )
-    finally:
-        with contextlib.suppress(OSError):
-            os.unlink(paste_path)
-    # Wait until the TUI has visibly committed the paste into its input
-    # box before submitting. Claude Code coalesces rapid stdin bursts
-    # into a paste; an Enter that arrives while it is still consuming
-    # the paste becomes a newline inside the draft instead of a submit,
-    # and the message sits unsent. A fixed sleep raced this (lost under
-    # load / large payloads); polling is deterministic. Best-effort:
-    # when the draft never becomes identifiable (e.g. whitespace-only
-    # first line, custom statusline containing the glyph), fall through
-    # after the timeout and submit blind, matching the old behavior.
-    needle = _submit_needle(content)
-    draft_seen = False
-    deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
-    while time.monotonic() < deadline:
-        if _draft_in_input_box(_capture_pane(info["socket_path"], info["tmux_target"]), needle):
-            draft_seen = True
-            break
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    time.sleep(_PASTE_SETTLE_S)
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-    if not draft_seen:
-        # The draft was never observed, so its absence proves nothing —
-        # verification would trivially "pass". Submit blind as before.
-        return
-    # Verify the submit took: a successful Enter clears the input box.
-    # If the draft is still sitting there the Enter was swallowed into
-    # the paste burst as a newline — re-send it (the retry lands well
-    # after the burst, so it submits). Each Enter only fires while the
-    # draft is verifiably still present, so a retry can never hit an
-    # empty prompt or a permission dialog of the started turn.
-    deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
-    last_enter = time.monotonic()
-    while time.monotonic() < deadline:
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-        pane = _capture_pane(info["socket_path"], info["tmux_target"])
-        if not _draft_in_input_box(pane, needle):
+        # Clear any leftover text in Claude's input field before typing.
+        # After Escape-cancel, Claude Code re-populates the prompt area
+        # with the previous input for re-editing. Without this clear,
+        # the new message appends to the stale buffer (e.g.
+        # "old promptnew prompt" with no separator).
+        # Ctrl-A (Home) + Ctrl-K (kill-to-end) is the safest pair —
+        # Ctrl-U only clears backwards from cursor.
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-a")
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "C-k")
+        # Escape unsupported slash commands (e.g. ``/help``, ``/exit``) so the
+        # Claude Code TUI treats them as user text instead of invoking a state
+        # that Omnigent cannot drive. Allowed commands (``/clear``,
+        # ``/model``, ``/fork``, skills, etc.) pass through unchanged.
+        injected_text = _escape_unsupported_slash_command(content)
+        # Trailing newline absorbs a trailing "\" so it can't escape the submit Enter.
+        # Delivered through a tmux buffer, NOT ``send-keys`` argv: tmux caps one
+        # client→server command at ~16KB, so per-byte hex argv blew up with
+        # "command too long" on large payloads (a PR diff in a sub-agent
+        # dispatch). ``load-buffer`` streams the file without that cap, and
+        # ``paste-buffer -p`` wraps it in the same bracketed-paste markers so
+        # interior newlines (mapped to CR below) stay data instead of becoming
+        # per-line submits. See anthropics/claude-code#52126.
+        with tempfile.NamedTemporaryFile(
+            dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
+        ) as paste_file:
+            paste_file.write(_paste_payload_bytes(injected_text + "\n"))
+            paste_path = paste_file.name
+        try:
+            _run_tmux(info["socket_path"], "load-buffer", "-b", "omnigent-paste", paste_path)
+            _run_tmux(
+                info["socket_path"],
+                "paste-buffer",
+                "-p",  # bracketed-paste markers — the TUI keeps newlines as data
+                "-d",  # drop the buffer after pasting (no stale copies server-side)
+                "-b",
+                "omnigent-paste",
+                "-t",
+                info["tmux_target"],
+            )
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(paste_path)
+        # Wait until the TUI has visibly committed the paste into its input
+        # box before submitting. Claude Code coalesces rapid stdin bursts
+        # into a paste; an Enter that arrives while it is still consuming
+        # the paste becomes a newline inside the draft instead of a submit,
+        # and the message sits unsent. A fixed sleep raced this (lost under
+        # load / large payloads); polling is deterministic. Best-effort:
+        # when the draft never becomes identifiable (e.g. whitespace-only
+        # first line, custom statusline containing the glyph), fall through
+        # after the timeout and submit blind, matching the old behavior.
+        needle = _submit_needle(content)
+        draft_seen = False
+        deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if _draft_in_input_box(
+                _capture_pane(info["socket_path"], info["tmux_target"]), needle
+            ):
+                draft_seen = True
+                break
+            time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+        time.sleep(_PASTE_SETTLE_S)
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+        if not draft_seen:
+            # The draft was never observed, so its absence proves nothing —
+            # verification would trivially "pass". Submit blind as before.
             return
-        if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
-            _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-            last_enter = time.monotonic()
-    raise RuntimeError(
-        f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
-        "(the draft is still in the input box). The message was not delivered."
-    )
+        # Verify the submit took: a successful Enter clears the input box.
+        # If the draft is still sitting there the Enter was swallowed into
+        # the paste burst as a newline — re-send it (the retry lands well
+        # after the burst, so it submits). Each Enter only fires while the
+        # draft is verifiably still present, so a retry can never hit an
+        # empty prompt or a permission dialog of the started turn.
+        deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
+        last_enter = time.monotonic()
+        while time.monotonic() < deadline:
+            time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+            pane = _capture_pane(info["socket_path"], info["tmux_target"])
+            if not _draft_in_input_box(pane, needle):
+                return
+            if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
+                _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+                last_enter = time.monotonic()
+        raise RuntimeError(
+            f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
+            "(the draft is still in the input box). The message was not delivered."
+        )
 
 
 def inject_interrupt(
@@ -3086,8 +3104,9 @@ def inject_interrupt(
         time, or if the ``tmux send-keys`` invocation fails.
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    # No ``-l``: tmux must interpret ``Escape`` as a key name.
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
+    with _pane_write_lock(bridge_dir, what="the interrupt"):
+        # No ``-l``: tmux must interpret ``Escape`` as a key name.
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Escape")
 
 
 # Option-1 label in Claude Code's plan-review dialog: proof that dialog is
@@ -3129,11 +3148,12 @@ def inject_plan_verdict(
     if key is None:
         raise ValueError(f"unknown plan verdict {verdict!r}")
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    if _PLAN_DIALOG_MARKER not in _capture_pane(info["socket_path"], info["tmux_target"]):
-        return False
-    # No ``-l``: tmux must read ``Escape`` as a key name, not literal text.
-    _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], key)
-    return True
+    with _pane_write_lock(bridge_dir, what="the plan verdict"):
+        if _PLAN_DIALOG_MARKER not in _capture_pane(info["socket_path"], info["tmux_target"]):
+            return False
+        # No ``-l``: tmux must read ``Escape`` as a key name, not literal text.
+        _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], key)
+        return True
 
 
 def kill_session(
@@ -3211,8 +3231,9 @@ def inject_slash_command(
         ``/``, contains a newline, or *auto_confirm* is set without a
         *confirm_hint*.
     :raises RuntimeError: If the tmux target is not advertised in
-        time, if a ``tmux send-keys`` invocation fails, or if the typed
-        command verifiably never left the input box (submit swallowed).
+        time, if a ``tmux send-keys`` invocation fails, if another pane
+        write holds the keyboard too long, or if the typed command
+        verifiably never left the input box (submit swallowed).
     """
     if not command or not command.startswith("/"):
         raise ValueError(f"slash command must start with '/'; got {command!r}")
@@ -3224,58 +3245,59 @@ def inject_slash_command(
             raise ValueError("auto_confirm needs the confirm_hint its dialog renders")
         dialog_hint = confirm_hint
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
-    socket_path = info["socket_path"]
-    tmux_target = info["tmux_target"]
-    # Same reclaim as inject_user_message: a ctrl+r search or hand-opened
-    # /model picker left covering the composer would swallow the C-u and
-    # the typed command.
-    _restore_occupied_input(socket_path, tmux_target)
-    # ``C-u`` clears any draft the user is mid-typing; otherwise the
-    # paste below concatenates with their text and Enter submits
-    # ``<their-draft>/effort high`` as a turn. Unlike Escape it does
-    # not interrupt an in-flight generation.
-    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-u")
-    # ``-l`` pastes ``/`` and spaces literally; trailing Enter submits.
-    _run_tmux(socket_path, "send-keys", "-l", "-t", tmux_target, command)
-    # Same delivery hazards as inject_user_message: a coalesced or dropped
-    # Enter leaves the command drafted while the persisted session value
-    # claims it applied. Wait for the command to render, submit, verify it
-    # left the box; an unidentifiable draft falls through to a blind submit.
-    needle = _submit_needle(command)
-    draft_seen = False
-    deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
-    while time.monotonic() < deadline:
-        if _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
-            draft_seen = True
-            break
-        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    time.sleep(_PASTE_SETTLE_S)
-    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
-    if draft_seen:
-        # Re-send only while the command verifiably still sits in the box —
-        # a one-poll-stale retry can at worst hit the empty composer (no-op)
-        # or our own confirm dialog (the intended answer), never a foreign
-        # surface. The command leaving the box is the submit signal; the
-        # dialog replacing the composer counts, since submission pops it.
-        deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
-        last_enter = time.monotonic()
-        submitted = False
+    with _pane_write_lock(bridge_dir, what="the slash command"):
+        socket_path = info["socket_path"]
+        tmux_target = info["tmux_target"]
+        # Same reclaim as inject_user_message: a ctrl+r search or hand-opened
+        # /model picker left covering the composer would swallow the C-u and
+        # the typed command.
+        _restore_occupied_input(socket_path, tmux_target)
+        # ``C-u`` clears any draft the user is mid-typing; otherwise the
+        # paste below concatenates with their text and Enter submits
+        # ``<their-draft>/effort high`` as a turn. Unlike Escape it does
+        # not interrupt an in-flight generation.
+        _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-u")
+        # ``-l`` pastes ``/`` and spaces literally; trailing Enter submits.
+        _run_tmux(socket_path, "send-keys", "-l", "-t", tmux_target, command)
+        # Same delivery hazards as inject_user_message: a coalesced or dropped
+        # Enter leaves the command drafted while the persisted session value
+        # claims it applied. Wait for the command to render, submit, verify it
+        # left the box; an unidentifiable draft falls through to a blind submit.
+        needle = _submit_needle(command)
+        draft_seen = False
+        deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
         while time.monotonic() < deadline:
-            time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-            if not _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
-                submitted = True
+            if _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
+                draft_seen = True
                 break
-            if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
-                _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
-                last_enter = time.monotonic()
-        if not submitted:
-            raise RuntimeError(
-                f"Claude Code did not accept the slash command within "
-                f"{_SUBMIT_VERIFY_TIMEOUT_S}s (the command is still in the "
-                "input box). The command was not delivered."
-            )
-    if dialog_hint is not None:
-        _confirm_tui_dialog(socket_path, tmux_target, hint=dialog_hint)
+            time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+        time.sleep(_PASTE_SETTLE_S)
+        _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+        if draft_seen:
+            # Re-send only while the command verifiably still sits in the box —
+            # a one-poll-stale retry can at worst hit the empty composer (no-op)
+            # or our own confirm dialog (the intended answer), never a foreign
+            # surface. The command leaving the box is the submit signal; the
+            # dialog replacing the composer counts, since submission pops it.
+            deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
+            last_enter = time.monotonic()
+            submitted = False
+            while time.monotonic() < deadline:
+                time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+                if not _draft_in_input_box(_capture_pane(socket_path, tmux_target), needle):
+                    submitted = True
+                    break
+                if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
+                    _run_tmux(socket_path, "send-keys", "-t", tmux_target, "Enter")
+                    last_enter = time.monotonic()
+            if not submitted:
+                raise RuntimeError(
+                    f"Claude Code did not accept the slash command within "
+                    f"{_SUBMIT_VERIFY_TIMEOUT_S}s (the command is still in the "
+                    "input box). The command was not delivered."
+                )
+        if dialog_hint is not None:
+            _confirm_tui_dialog(socket_path, tmux_target, hint=dialog_hint)
 
 
 def _confirm_tui_dialog(
@@ -3492,6 +3514,55 @@ def post_tools_changed(
                 raise RuntimeError(f"tools-changed POST failed with HTTP {resp.status}")
     except error.URLError as exc:
         raise RuntimeError(f"failed to notify Claude tool list change: {exc}") from exc
+
+
+@contextlib.contextmanager
+def _pane_write_lock(
+    bridge_dir: Path,
+    *,
+    what: str,
+    timeout_s: float = _PANE_LOCK_TIMEOUT_S,
+) -> Iterator[None]:
+    """
+    Hold the pane's keyboard for one whole keystroke sequence.
+
+    An exclusive ``flock`` on ``<bridge_dir>/pane.lock`` — what orders the
+    harness process against the runner process, neither of which can see the
+    other's in-process locks. Held for the whole sequence (draft clear →
+    paste → Enter → verify), since that is what must be atomic. Polls
+    ``LOCK_NB`` so a wedged holder times out instead of hanging a request
+    handler; a no-op where ``fcntl`` is unavailable (Windows).
+
+    :param bridge_dir: Bridge directory path, e.g.
+        ``/tmp/omnigent/claude-native/<digest>``.
+    :param what: Short description of the sequence being serialized, used
+        in the timeout message, e.g. ``"/compact"``.
+    :param timeout_s: Seconds to wait for the keyboard, e.g. ``30.0``.
+    :yields: None, with the lock held.
+    :raises RuntimeError: If the keyboard is not free within *timeout_s*.
+    """
+    if fcntl is None:
+        yield
+        return
+    _ensure_secure_dir(bridge_dir)
+    fd = os.open(bridge_dir / _PANE_LOCK_FILE, os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        deadline = time.monotonic() + timeout_s
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        f"another Claude pane write is still in flight after {timeout_s}s; "
+                        f"{what} was not delivered"
+                    ) from None
+                time.sleep(_PANE_LOCK_POLL_INTERVAL_S)
+        yield
+    finally:
+        # Closing the descriptor releases the flock.
+        os.close(fd)
 
 
 def _run_tmux(socket_path: str, *args: str) -> None:

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -62,10 +62,12 @@ class ClaudeNativeExecutor(Executor):
         # conversation), and ``inject_user_message`` is not atomic — it
         # issues several ``tmux send-keys`` calls. Without this lock the
         # two paths interleave their keystrokes and combine messages
-        # (e.g. "1" and "2" land as a single "12" prompt). See
-        # designs/NATIVE_INJECTION_SERIALIZATION.md. Relies on the
+        # (e.g. "1" and "2" land as a single "12" prompt). Relies on the
         # adapter caching one executor per conversation; per-turn
         # construction would regress the lock to per-turn scope.
+        # Orders writers inside this process only; the runner types into
+        # the same pane from its own, so the bridge also holds a
+        # cross-process flock per injection (``_pane_write_lock``).
         self._inject_lock = asyncio.Lock()
         # The model the pane is currently on, so a routing turn only types
         # ``/model`` when the model actually changes. Seeded lazily from the

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -7934,3 +7934,172 @@ async def test_curl_evaluate_policy_command_round_trips(
     output = json.loads(result.stdout)
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert output["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def _stub_idle_pane_tmux(
+    recorded: list[tuple[str, list[str]]],
+    pane: dict[str, str],
+    lock: threading.Lock,
+    step_delay: float = 0.02,
+) -> Any:
+    """
+    Build a ``subprocess.run`` stub that simulates Claude's input box.
+
+    ``send-keys -l`` drafts the literal text into the simulated box and
+    ``Enter`` clears it, so the paste-committed and submit-verified gates
+    both resolve on the first poll. Every delivery call is recorded with
+    the name of the thread that made it, which is what lets a test assert
+    two concurrent injections did not interleave.
+
+    :param recorded: Accumulator of ``(thread_name, argv)`` for delivery
+        calls. ``capture-pane`` polls are not recorded.
+    :param pane: Single-entry dict holding the simulated pane text —
+        shared across threads, exactly like the real pane.
+    :param lock: Guards ``recorded``/``pane`` against the test's own
+        threads, so a torn list is never mistaken for interleaving.
+    :param step_delay: Seconds to stall inside each call, widening the
+        window an unserialized writer would interleave in.
+    :returns: A callable suitable for ``monkeypatch.setattr``.
+    """
+
+    staged: dict[str, str] = {"draft": ""}
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        del kwargs
+        if "capture-pane" in cmd:
+            with lock:
+                return SimpleNamespace(returncode=0, stdout=pane["text"], stderr="")
+        name = threading.current_thread().name
+        with lock:
+            recorded.append((name, list(cmd)))
+            if "load-buffer" in cmd:
+                # The message path pastes via a tmux buffer; remember the
+                # payload's first line so paste-buffer can draft it.
+                payload = Path(cmd[-1]).read_bytes().decode("utf-8", "replace")
+                staged["draft"] = payload.replace("\r", "\n").split("\n")[0]
+            elif "paste-buffer" in cmd:
+                pane["text"] = f"❯ {staged['draft']}"
+            elif "-l" in cmd:
+                # The slash-command path types the text literally.
+                pane["text"] = f"❯ {cmd[-1]}"
+            elif cmd[-1] == "Enter":
+                pane["text"] = "❯ "
+        time.sleep(step_delay)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return _fake_run
+
+
+def test_concurrent_pane_writes_do_not_interleave_keystrokes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Two concurrent injections each own the pane for their whole sequence.
+
+    The harness process delivers web turns while the runner process types
+    ``/compact`` / ``/effort`` / ``/model`` into the same tmux pane, so the
+    executor's in-process ``asyncio.Lock`` cannot order them. Each
+    injection is a multi-step sequence (clear the draft, type, Enter,
+    verify); interleaving two of them merges their keystrokes, which is
+    how a ``/compact`` ends up submitted as part of someone's message.
+
+    Fails if :func:`_pane_write_lock` stops covering the whole sequence:
+    without it the recorded argv stream alternates between the two
+    threads instead of showing one contiguous block each.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/example/tmux.sock"),
+        tmux_target="claude:0.0",
+    )
+
+    recorded: list[tuple[str, list[str]]] = []
+    pane = {"text": "❯ "}
+    guard = threading.Lock()
+    monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_SETTLE_S", 0.01)
+    monkeypatch.setattr("subprocess.run", _stub_idle_pane_tmux(recorded, pane, guard))
+
+    def _deliver_message() -> None:
+        inject_user_message(bridge_dir, content="the web message")
+
+    def _deliver_compact() -> None:
+        claude_native_bridge.inject_slash_command(bridge_dir, command="/compact")
+
+    threads = [
+        threading.Thread(target=_deliver_message, name="harness"),
+        threading.Thread(target=_deliver_compact, name="runner"),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+    assert not any(thread.is_alive() for thread in threads)
+
+    with guard:
+        owners = [name for name, _ in recorded]
+    assert set(owners) == {"harness", "runner"}
+    # One contiguous run per writer: collapse consecutive duplicates and
+    # exactly two blocks must remain. Three or more means the sequences
+    # interleaved on the shared pane.
+    blocks = [name for index, name in enumerate(owners) if index == 0 or owners[index - 1] != name]
+    assert len(blocks) == 2, f"pane writes interleaved: {owners}"
+
+
+def test_pane_write_lock_times_out_when_another_process_holds_the_keyboard(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A lock held by another *process* blocks delivery and fails loud.
+
+    The flock is what orders the runner against the harness, so a holder
+    outside this interpreter must be respected. Holding the same lock
+    file on an independent descriptor is exactly what the other process
+    looks like to the kernel. Failing with ``RuntimeError`` keeps the
+    existing contract — the runner's endpoints map it to a 503 and the
+    executor to an ``ExecutorError`` — rather than hanging the caller.
+    """
+    pytest.importorskip("fcntl")
+    import fcntl as _fcntl
+
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    holder = os.open(bridge_dir / "pane.lock", os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        _fcntl.flock(holder, _fcntl.LOCK_EX)
+        with pytest.raises(RuntimeError, match="another Claude pane write"):
+            with claude_native_bridge._pane_write_lock(bridge_dir, what="/compact", timeout_s=0.3):
+                pass
+    finally:
+        _fcntl.flock(holder, _fcntl.LOCK_UN)
+        os.close(holder)
+
+    # Released: the next writer gets the keyboard immediately.
+    with claude_native_bridge._pane_write_lock(bridge_dir, what="/compact"):
+        pass
+
+
+def test_pane_write_lock_is_a_noop_without_fcntl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Where ``fcntl`` is unavailable (Windows) the lock degrades to a no-op.
+
+    Matches the other flock helpers in the codebase: the platform without
+    ``flock`` keeps the old unserialized behavior rather than losing the
+    ability to type into the pane at all.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.claude_native_bridge.fcntl", None)
+    bridge_dir = tmp_path / "bridge"
+    with claude_native_bridge._pane_write_lock(bridge_dir, what="/compact"):
+        pass
+    # No lock file is created when the mechanism is unavailable.
+    assert not (bridge_dir / "pane.lock").exists()


### PR DESCRIPTION
## Related issue

None. This is latent hardening found while investigating a user report —
it is **not** the cause of that report. The reported symptom (a `/compact`
rendering an earlier message's text) is fixed by #6117, in the web store's
optimistic-bubble reconciliation. Filed separately because this race is
real and worth closing on its own.

## Summary

Two processes type into the same Claude Code tmux pane with nothing ordering them, so their multi-step keystroke sequences can interleave — merging keystrokes from a web message with those of a `/compact`, `/effort` or `/model`.

To be clear about provenance: this was found while chasing a user report, but it does **not** explain that report — a corrupted `/compact` would never have parsed as the command, and the user's Claude answered it cleanly. The race is nonetheless real and reproducible (see Test Plan). The user's actual bug is #6117.

Every injector in `claude_native_bridge` is a *multi-step* keystroke sequence — clear the draft (`C-a`/`C-k` or `C-u`), paste or type, `Enter`, then poll `capture-pane` to verify the draft left the box. It is the **sequence**, not each individual `send-keys`, that must be atomic.

The harness executor already held an `asyncio.Lock` around its two writers, but that only orders writers *within its own process*. The runner is a **separate process** — `runner/app.py:1` spawns the harness as a subprocess — and types into the same pane independently: `/compact`, `/effort`, `/model`, plan verdicts, and interrupts. Nothing ordered those against a web turn being delivered, so the two sequences interleaved keystroke by keystroke.

```
        harness process                    runner process
   inject_user_message("test")        inject_slash_command("/compact")
        C-a, C-k  ──────────┐         ┌────────  C-u
        paste-buffer  ──────┼─────────┼────────  send-keys -l "/compact"
        Enter  ─────────────┘         └────────  Enter
                     one shared tmux pane
                  → keystrokes merge, both corrupt
```

**Fix:** take an exclusive `flock` on `<bridge_dir>/pane.lock` for the whole sequence, *inside the bridge* — the one module both processes go through, so no writer can bypass it. It polls `LOCK_NB` against a deadline instead of blocking in `LOCK_EX`, so a wedged holder surfaces as the `RuntimeError` callers already map to a 503 / `ExecutorError` rather than hanging a request handler. No-ops where `fcntl` is unavailable, matching the other flock helpers in the codebase (`filesystem_registry`, `codex_native_process_registry`).

The executor's in-process lock is kept — it's cheaper for the common case. Its comment pointed at `designs/NATIVE_INJECTION_SERIALIZATION.md`, which was never committed; it now points at the real mechanism.

**ELI5:** two people were typing into the same keyboard at once. Each now has to pick the keyboard up, finish their sentence, and put it down.

## Test Plan

Three new tests in `tests/test_claude_native_bridge.py`:

- `test_concurrent_pane_writes_do_not_interleave_keystrokes` — drives a web message and a `/compact` concurrently against one simulated pane and asserts each writer's argv block is contiguous. **Verified it fails without the fix**: neutering the lock reproduces the bug exactly — `['harness', 'runner', 'harness', 'runner', 'harness', 'runner', ...]` (7 blocks instead of 2).
- `test_pane_write_lock_times_out_when_another_process_holds_the_keyboard` — holds the same lock file on an independent fd (what another process looks like to the kernel) and asserts `RuntimeError`, then that the next writer proceeds once released.
- `test_pane_write_lock_is_a_noop_without_fcntl` — Windows fallback.

```
pytest tests/test_claude_native_bridge.py          # 235 passed
pytest tests/inner/test_claude_native_executor.py  # 21 passed
pytest tests/test_claude_native_forwarder.py       # passed
pre-commit run --files <the 3 changed files>       # ruff format + ruff check pass
```

Two failures in `tests/test_claude_native.py` (`..._ambient_key`, `..._ambient_prefixed_key`) are pre-existing and environmental — they assert `ANTHROPIC_BASE_URL == https://api.anthropic.com` but this dev box's Databricks profile routes through its ai-gateway. That file is not touched by this PR.

### Manual verification

Reviewers can reproduce the original symptom and confirm the fix in a native Claude session:

1. `just dev`, then open a `claude-native` session in the web UI and let it boot.
2. Send a multi-line message from the web composer and, without waiting, immediately trigger `/compact` (and/or switch model/effort) from the UI.
3. Before this change the pane shows merged/fragmented input — partial messages on stray `❯` prompt rows, and `/compact` answering "Not enough messages to compact". After it, each action completes as one intact prompt, in order.

## Demo

N/A — no visual/frontend change; the fix is in keystroke sequencing. The user-visible effect is the *absence* of the corrupted pane shown in the Summary.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The concurrency test is the load-bearing one and was confirmed to fail without the fix (see Test Plan), so it genuinely pins the regression rather than passing vacuously. The cross-process half is covered by taking the real `flock` on a second descriptor; a true two-process test would need a live tmux pane and Claude Code binary, which is the domain of the `cli-setup-verify` / native e2e harnesses rather than a unit test — hence the manual steps above.

## Changelog

Messages sent from the web UI to a native Claude session can no longer have their keystrokes merged with a concurrent `/compact`, model switch, or interrupt.
