### PR TITLE
fix(sessions): keep a /clear rotation on the machine it happened on

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -3085,9 +3085,14 @@ async def _rotate_session_for_cascade(
        the rewritten bridge state below, not via a later ``--resume``. (The old code
        PATCHed it, which 400'd on the auto-cold-started session's already-set,
        set-once-immutable field and looped the rotation — see the module header.)
-    5. Rewrite agy bridge state in ``bridge_dir`` with the new session id + new
+    5. PATCH ``inherit_host_from_session_id`` so the replacement row carries the
+       old session's host / workspace: the same agy process on the same machine
+       keeps serving it, and a host-less row routes to the default replica and
+       resumes on whichever machine the user is looking at (best-effort — an
+       older server rejects the field, which must not cost us the rotation).
+    6. Rewrite agy bridge state in ``bridge_dir`` with the new session id + new
        conversation id (the reader re-reads this on rebind to bind the new cascade).
-    6. PATCH the old session's ``runner_id`` to ``""`` to release it (best-effort;
+    7. PATCH the old session's ``runner_id`` to ``""`` to release it (best-effort;
        a failure is logged, not raised — the new session is already live).
 
     Best-effort: ANY failure (snapshot, create, bind, transfer, state write) is
@@ -3159,6 +3164,35 @@ async def _rotate_session_for_cascade(
             exc,
         )
         return None
+
+    # Same machine the /clear was typed on (best-effort): the replacement keeps
+    # running in this agy process on this host, so its row must say so or it
+    # routes to the default replica and a later resume defaults to whichever
+    # machine the user is looking at. Kept OUT of the rotation try above — a
+    # server predating the field rejects the body (the request model forbids
+    # extras), and the rotation must not be lost over a missing nicety.
+    try:
+        affinity_resp = await client.patch(
+            f"/v1/sessions/{url_component(new_session_id)}",
+            json={"inherit_host_from_session_id": old_session_id},
+        )
+        if affinity_resp.status_code >= 400:
+            _logger.warning(
+                "agy /clear rotation: failed to inherit the host binding; "
+                "old_session=%s new_session=%s status=%s body=%s",
+                old_session_id,
+                new_session_id,
+                affinity_resp.status_code,
+                affinity_resp.text,
+            )
+    except httpx.HTTPError:
+        _logger.warning(
+            "agy /clear rotation: error inheriting the host binding; "
+            "old_session=%s new_session=%s",
+            old_session_id,
+            new_session_id,
+            exc_info=True,
+        )
 
     # The new session is live + bound; commit bridge state so the reader's rebind
     # discovers the new cascade. Done last so a mid-sequence failure above never

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -2232,6 +2232,25 @@ async def _create_clear_replacement_session(
         )
         bind_resp.raise_for_status()
 
+    # Same machine the /clear was typed on. Sent as its own best-effort PATCH
+    # rather than folded into the bind above: a server predating the field
+    # rejects the whole body (the request model forbids extras), and losing the
+    # rotation over a missing nicety is far worse than losing the affinity.
+    affinity_resp = await client.patch(
+        f"/v1/sessions/{url_component(new_session_id)}",
+        json={"inherit_host_from_session_id": old_session_id},
+    )
+    if affinity_resp.status_code >= 400:
+        _logger.warning(
+            "Failed to inherit the host binding for the /clear replacement session; "
+            "old_session=%s new_session=%s status=%s body=%s",
+            old_session_id,
+            new_session_id,
+            affinity_resp.status_code,
+            affinity_resp.text,
+            extra={"session_id": new_session_id},
+        )
+
     terminal_id = terminal_resource_id("claude", "main")
     transfer_resp = await client.post(
         (

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -514,6 +514,23 @@ def _create_clear_replacement_session(
         )
         bind_resp.raise_for_status()
 
+    # Same machine the /clear was typed on. Sent as its own best-effort PATCH
+    # rather than folded into the bind above: a server predating the field
+    # rejects the whole body (the request model forbids extras), and losing the
+    # rotation over a missing nicety is far worse than losing the affinity.
+    affinity_resp = client.patch(
+        f"{ap_server_url}/v1/sessions/{url_component(new_session_id)}",
+        json={"inherit_host_from_session_id": old_session_id},
+    )
+    if affinity_resp.status_code >= 400:
+        print(
+            (
+                "omnigent claude clear hook: failed to inherit host binding: "
+                f"{affinity_resp.status_code} {affinity_resp.text}"
+            ),
+            file=sys.stderr,
+        )
+
     from omnigent.entities.session_resources import terminal_resource_id
 
     terminal_id = terminal_resource_id("claude", "main")

--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -2119,6 +2119,25 @@ async def _create_thread_replacement_session(
     )
     external_resp.raise_for_status()
 
+    # Same machine the /clear was typed on. Sent as its own best-effort PATCH
+    # rather than folded into a bind above: a server predating the field
+    # rejects the whole body (the request model forbids extras), and losing the
+    # rotation over a missing nicety is far worse than losing the affinity.
+    affinity_resp = await client.patch(
+        f"/v1/sessions/{url_component(new_session_id)}",
+        json={"inherit_host_from_session_id": old_session_id},
+    )
+    if affinity_resp.status_code >= 400:
+        _logger.warning(
+            "Failed to inherit the host binding for the codex thread replacement "
+            "session; old_session=%s new_session=%s status=%s body=%s",
+            old_session_id,
+            new_session_id,
+            affinity_resp.status_code,
+            affinity_resp.text,
+            extra={"session_id": new_session_id},
+        )
+
     terminal_id = terminal_resource_id("codex", "main")
     transfer_resp = await client.post(
         (

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -203,6 +203,75 @@ from omnigent.stores.project_store import ProjectStore
 from omnigent.version import VERSION
 
 
+async def _inherit_host_binding(
+    *,
+    user_id: str | None,
+    session_id: str,
+    source_session_id: str,
+    conversation_store: ConversationStore,
+    permission_store: PermissionStore | None,
+) -> None:
+    """
+    Copy a session's machine binding onto the session that continues it.
+
+    A native ``/clear`` rotation mints a fresh Omnigent session that keeps
+    running in the same terminal, on the same host, in the same directory.
+    Without this the replacement row is host-less: it routes to the default
+    replica instead of the one holding its host's tunnel, and a later resume
+    defaults to whichever machine the user is looking at rather than the one
+    the rotation happened on.
+
+    Affinity is read from the source row, so no caller-supplied host id or
+    path reaches the DB and nothing needs re-validating — the values were
+    validated when the source session was bound.
+
+    :param user_id: Authenticated caller, e.g. ``"alice@example.com"``, or
+        ``None`` when auth is disabled.
+    :param session_id: Session to bind, e.g. ``"conv_new"``. The caller's
+        ownership of it is already checked by the route.
+    :param source_session_id: Session to read affinity from, e.g.
+        ``"conv_old"``.
+    :param conversation_store: Store holding both rows.
+    :param permission_store: Session permission store, or ``None`` when
+        auth is disabled.
+    :returns: None. A source with no host binding is a no-op, as is a
+        target already bound to the same host.
+    :raises OmnigentError: 404 if either session is missing (or invisible
+        to the caller); 403 if the caller does not own the source; 409 if
+        the target is already bound to a different host.
+    """
+    await _require_access(
+        user_id, source_session_id, LEVEL_OWNER, permission_store, conversation_store
+    )
+    source = await asyncio.to_thread(conversation_store.get_conversation, source_session_id)
+    if source is None:
+        raise _session_not_found()
+    if source.host_id is None or source.workspace is None:
+        # A CLI-local session never had a machine binding to hand over.
+        return
+    target = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+    if target is None:
+        raise _session_not_found()
+    if target.host_id == source.host_id:
+        return
+    if target.host_id is not None:
+        raise OmnigentError(
+            f"Session {session_id!r} is already bound to host {target.host_id!r}; "
+            "a bound session cannot inherit a different host.",
+            code=ErrorCode.CONFLICT,
+        )
+    try:
+        await asyncio.to_thread(
+            conversation_store.set_host_id,
+            session_id,
+            source.host_id,
+            source.workspace,
+            source.git_branch,
+        )
+    except ConversationNotFoundError as exc:
+        raise _session_not_found() from exc
+
+
 def register_core_routes(
     router: APIRouter,
     *,
@@ -1636,12 +1705,15 @@ def register_core_routes(
         #   session may pin it — including a read-only collaborator on a session
         #   shared with them. Only when the pinned label is the request's ONLY
         #   mutation.
-        # * OWNER — archiving/unarchiving or filing into a project. Both are
+        # * OWNER — archiving/unarchiving, filing into a project, or
+        #   inheriting another session's machine binding. The first two are
         #   owner-only: projects are owner-private (an editor must not move a
         #   session between them), and archive pairs with a client-driven,
         #   owner-gated stop (an editor must not hide/stop a session they can't
         #   issue that stop for). Presence is the signal for project (``""``
         #   unfiles), so gate on model_fields_set, not a non-None value.
+        #   Inheriting a host decides which machine the session runs on, so it
+        #   sits with the runner attach below rather than plain metadata.
         # * EDIT — every other field.
         #
         # Owner implies edit, so a single check at the resolved level gates all
@@ -1652,7 +1724,11 @@ def register_core_routes(
         }
         if pin_only:
             required_level = LEVEL_READ
-        elif body.archived is not None or set_project:
+        elif (
+            body.archived is not None
+            or set_project
+            or body.inherit_host_from_session_id is not None
+        ):
             required_level = LEVEL_OWNER
         else:
             required_level = LEVEL_EDIT
@@ -1833,6 +1909,18 @@ def register_core_routes(
                 f"invalid terminal_launch_args: {exc}",
                 code=ErrorCode.INVALID_INPUT,
             ) from exc
+
+        # Machine affinity before the runner bind: the bind resolves a runner
+        # client and restarts the relay, both of which read the row's host to
+        # classify a missing runner, so the host must already be there.
+        if body.inherit_host_from_session_id is not None:
+            await _inherit_host_binding(
+                user_id=user_id,
+                session_id=session_id,
+                source_session_id=body.inherit_host_from_session_id,
+                conversation_store=conversation_store,
+                permission_store=permission_store,
+            )
 
         if body.runner_id is not None:
             # Empty string is the clear sentinel (None = leave unchanged);

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2248,6 +2248,20 @@ class UpdateSessionRequest(BaseModel):
         owner-private, only the session owner may file it, and only into a
         project they own — the server verifies both. Independent of the
         legacy ``omni_project`` label, which is set via ``labels``.
+    :param inherit_host_from_session_id: Copy another session's machine
+        binding (``host_id`` / ``workspace`` / ``git_branch``) onto this
+        one, e.g. ``"conv_old"``. This is the affinity half of a native
+        session rotation: a Claude ``/clear`` mints a fresh Omnigent
+        session that keeps running in the SAME terminal on the SAME host,
+        so the replacement must land on the machine the rotation was
+        triggered on rather than looking host-less (which strands it on
+        the default replica and makes a later resume default to whichever
+        machine the user happens to be on). The server reads the affinity
+        from the named session — the caller never supplies a host id or
+        path, so nothing needs re-validating. Owner-level on BOTH
+        sessions. A source with no host binding is a no-op; a target
+        already bound to a DIFFERENT host is rejected (409) rather than
+        migrated. ``None`` leaves the binding unchanged.
     """
 
     runner_id: str | None = None
@@ -2263,6 +2277,7 @@ class UpdateSessionRequest(BaseModel):
     terminal_launch_args: list[str] | None = None
     archived: bool | None = None
     project_id: str | None = None
+    inherit_host_from_session_id: str | None = None
     silent: bool = False
 
     model_config = ConfigDict(extra="forbid")

--- a/openapi.json
+++ b/openapi.json
@@ -7639,6 +7639,18 @@
             "description": "Runtime-native session id captured by a wrapper bridge (e.g. Claude Code's session uuid for `omnigent claude` sessions). Idempotent on same-value writes; the server rejects attempts to overwrite an already-set different value with `invalid_input` to surface programmer errors. `None` leaves unchanged.",
             "title": "External Session Id"
           },
+          "inherit_host_from_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Copy another session's machine binding (`host_id` / `workspace` / `git_branch`) onto this one, e.g. `\"conv_old\"`. This is the affinity half of a native session rotation: a Claude `/clear` mints a fresh Omnigent session that keeps running in the SAME terminal on the SAME host, so the replacement must land on the machine the rotation was triggered on rather than looking host-less (which strands it on the default replica and makes a later resume default to whichever machine the user happens to be on). The server reads the affinity from the named session \u2014 the caller never supplies a host id or path, so nothing needs re-validating. Owner-level on BOTH sessions. A source with no host binding is a no-op; a target already bound to a DIFFERENT host is rejected (409) rather than migrated. `None` leaves the binding unchanged.",
+            "title": "Inherit Host From Session Id"
+          },
           "labels": {
             "anyOf": [
               {

--- a/tests/server/routes/test_sessions_crud.py
+++ b/tests/server/routes/test_sessions_crud.py
@@ -22,6 +22,11 @@ from omnigent.stores.conversation_store.sqlalchemy_store import (
     SqlAlchemyConversationStore,
 )
 
+# Host ids are stored as uuids (the ``host_`` prefix is stripped on write), so
+# the rotation tests use the canonical form the store reads back.
+_HOST_A = "329c39d03aad39ccf2f8597d596676bd"
+_HOST_B = "77599b2c44934910b00cfdfda3ba21fc"
+
 
 @pytest_asyncio.fixture()
 async def session_id(db_uri: str) -> str:
@@ -337,6 +342,120 @@ async def test_patch_session_not_found(client: httpx.AsyncClient) -> None:
         headers={"Content-Type": "application/json"},
     )
     assert resp.status_code == 404
+
+
+# ── PATCH inherit_host_from_session_id ───────────────────────────────
+
+
+async def test_patch_inherits_the_source_session_machine(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    A rotation replacement lands on the machine the rotation happened on.
+
+    A native ``/clear`` mints a fresh session that keeps running in the same
+    terminal on the same host. Without inheritance the replacement row is
+    host-less, so it routes to the default replica and a later resume
+    defaults to whichever machine the user is looking at.
+    """
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    agent_id = generate_agent_id()
+    agent_store.create(agent_id, name="rotation-agent", bundle_location="test:///bundle")
+    old = conv_store.create_conversation(
+        agent_id=agent_id,
+        host_id=_HOST_A,
+        workspace="/home/dev/universe",
+        git_branch="feature/login",
+    )
+    new = conv_store.create_conversation(agent_id=agent_id)
+
+    resp = await client.patch(
+        f"/v1/sessions/{new.id}",
+        json={"inherit_host_from_session_id": old.id},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["host_id"] == _HOST_A
+    assert resp.json()["workspace"] == "/home/dev/universe"
+    rebound = conv_store.get_conversation(new.id)
+    assert rebound is not None
+    assert rebound.host_id == _HOST_A
+    assert rebound.workspace == "/home/dev/universe"
+    assert rebound.git_branch == "feature/login"
+
+
+async def test_patch_inherit_host_is_a_noop_for_a_hostless_source(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A CLI-local source has no machine to hand over — no error, no change."""
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    agent_id = generate_agent_id()
+    agent_store.create(agent_id, name="rotation-agent", bundle_location="test:///bundle")
+    old = conv_store.create_conversation(agent_id=agent_id)
+    new = conv_store.create_conversation(agent_id=agent_id)
+
+    resp = await client.patch(
+        f"/v1/sessions/{new.id}",
+        json={"inherit_host_from_session_id": old.id},
+    )
+
+    assert resp.status_code == 200, resp.text
+    rebound = conv_store.get_conversation(new.id)
+    assert rebound is not None
+    assert rebound.host_id is None
+
+
+async def test_patch_inherit_host_refuses_to_migrate_a_bound_session(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    Inheritance binds an unbound session; it never moves a bound one.
+
+    Rebinding a live session to another machine would strand its runner, so
+    a target already on a different host is a conflict rather than a
+    silent migration.
+    """
+    agent_store = SqlAlchemyAgentStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    agent_id = generate_agent_id()
+    agent_store.create(agent_id, name="rotation-agent", bundle_location="test:///bundle")
+    old = conv_store.create_conversation(
+        agent_id=agent_id,
+        host_id=_HOST_A,
+        workspace="/home/dev/universe",
+    )
+    new = conv_store.create_conversation(
+        agent_id=agent_id,
+        host_id=_HOST_B,
+        workspace="/home/dev/other",
+    )
+
+    resp = await client.patch(
+        f"/v1/sessions/{new.id}",
+        json={"inherit_host_from_session_id": old.id},
+    )
+
+    assert resp.status_code == 409, resp.text
+    rebound = conv_store.get_conversation(new.id)
+    assert rebound is not None
+    assert rebound.host_id == _HOST_B
+
+
+async def test_patch_inherit_host_from_missing_session_is_404(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> None:
+    """An unknown source session cannot be inherited from."""
+    resp = await client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"inherit_host_from_session_id": "4fe12335002377c209e501c3fe3bcffc"},
+    )
+    assert resp.status_code == 404, resp.text
 
 
 # ── GET /v1/sessions/projects ────────────────────────────────────────

--- a/tests/server/routes/test_sessions_shared_projects.py
+++ b/tests/server/routes/test_sessions_shared_projects.py
@@ -136,3 +136,32 @@ def test_shared_session_still_visible_in_flat_list(db_uri: str) -> None:
     assert conv_id in items
     # Below LEVEL_OWNER, so the frontend files it under "Shared with me".
     assert items[conv_id]["permission_level"] < LEVEL_OWNER
+
+
+def test_read_shared_session_cannot_hand_its_host_to_another_session(db_uri: str) -> None:
+    """
+    Only the owner of a session may hand its machine to another session.
+
+    ``inherit_host_from_session_id`` copies a host binding, so a collaborator
+    with mere read access must not be able to stamp someone else's machine
+    onto a session of their own — that would route their traffic at another
+    user's replica.
+    """
+    shared_id = _seed_shared_project_session(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    perms = SqlAlchemyPermissionStore(db_uri)
+    conv_store.set_host_id(shared_id, "329c39d03aad39ccf2f8597d596676bd", "/home/bob/repo")
+    alices = conv_store.create_conversation(agent_id="087b7cb7ac30abf4debfaa578d052ec6")
+    perms.grant(ALICE, alices.id, LEVEL_OWNER)
+
+    app = _multi_user_app(db_uri)
+    resp = TestClient(app).patch(
+        f"/v1/sessions/{alices.id}",
+        json={"inherit_host_from_session_id": shared_id},
+        headers={"X-Forwarded-Email": ALICE},
+    )
+
+    assert resp.status_code == 403, resp.text
+    rebound = conv_store.get_conversation(alices.id)
+    assert rebound is not None
+    assert rebound.host_id is None

--- a/tests/test_antigravity_native_reader.py
+++ b/tests/test_antigravity_native_reader.py
@@ -3895,7 +3895,7 @@ async def test_rotate_session_for_cascade_mirrors_claude_sequence(
 
     assert new_session_id == "conv_new"
     # The exact ordered API sequence (method, path) mirroring claude rotation —
-    # ONE PATCH on the new session (runner_id bind), then transfer, then release.
+    # runner_id bind, transfer, host-affinity inherit, then release.
     methods_paths = [(m, p) for (m, p, _b) in calls]
     assert methods_paths == [
         ("GET", f"/v1/sessions/{_SESSION_ID}"),
@@ -3905,6 +3905,7 @@ async def test_rotate_session_for_cascade_mirrors_claude_sequence(
             "POST",
             f"/v1/sessions/{_SESSION_ID}/resources/terminals/terminal_antigravity_main/transfer",
         ),
+        ("PATCH", "/v1/sessions/conv_new"),  # inherit the old session's host
         ("PATCH", f"/v1/sessions/{_SESSION_ID}"),  # release old runner
     ]
     # No external_session_id PATCH is made anywhere (the loop-bug source): every
@@ -3922,8 +3923,11 @@ async def test_rotate_session_for_cascade_mirrors_claude_sequence(
     assert calls[2][2] == {"runner_id": "runner_abc"}
     # The terminal transfer targeted the new session (the SAME agy moves over).
     assert calls[3][2] == {"target_session_id": "conv_new"}
+    # The replacement inherited the old session's machine, so it stays on the
+    # host the /clear was typed on instead of looking host-less.
+    assert calls[4][2] == {"inherit_host_from_session_id": _SESSION_ID}
     # Old runner released.
-    assert calls[4][2] == {"runner_id": ""}
+    assert calls[5][2] == {"runner_id": ""}
     # Bridge state was rewritten to the new session + new cascade (the reader
     # rebinds to the new cascade on the SAME agy via this shared bridge_dir).
     state = read_bridge_state(bridge_dir)

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -328,7 +328,10 @@ async def test_clear_hook_rotates_active_session_without_reprocessing(
             }
             return httpx.Response(201, json={"id": "conv_new"})
         if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_new":
-            assert body == {"runner_id": "runner_one"}
+            assert body in (
+                {"runner_id": "runner_one"},
+                {"inherit_host_from_session_id": "conv_old"},
+            )
             return httpx.Response(200, json={"id": "conv_new"})
         if (
             request.method == "POST"
@@ -389,6 +392,9 @@ async def test_clear_hook_rotates_active_session_without_reprocessing(
             },
         ),
         ("PATCH", "/v1/sessions/conv_new", {"runner_id": "runner_one"}),
+        # Machine affinity: the replacement must land on the host the /clear
+        # was typed on, not wherever the next resume happens to look.
+        ("PATCH", "/v1/sessions/conv_new", {"inherit_host_from_session_id": "conv_old"}),
         (
             "POST",
             "/v1/sessions/conv_old/resources/terminals/terminal_claude_main/transfer",
@@ -454,7 +460,10 @@ async def test_clear_hook_rotation_survives_old_runner_clear_failure(
             create_count += 1
             return httpx.Response(201, json={"id": "conv_new"})
         if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_new":
-            assert body == {"runner_id": "runner_one"}
+            assert body in (
+                {"runner_id": "runner_one"},
+                {"inherit_host_from_session_id": "conv_old"},
+            )
             return httpx.Response(200, json={"id": "conv_new"})
         if (
             request.method == "POST"

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -318,6 +318,11 @@ def test_clear_session_start_hook_rotates_before_printing_conversation_url(
         ),
         ("PATCH", "http://127.0.0.1:8787/v1/sessions/conv_new", {"runner_id": "runner_one"}),
         (
+            "PATCH",
+            "http://127.0.0.1:8787/v1/sessions/conv_new",
+            {"inherit_host_from_session_id": "conv_old"},
+        ),
+        (
             "POST",
             (
                 "http://127.0.0.1:8787/v1/sessions/conv_old/resources/"


### PR DESCRIPTION
## Related issue

Closes #

## Summary

A native `/clear` mints a fresh Omnigent session that keeps running in the **same terminal, on the same host, in the same directory** — but the rotation created that replacement row with only `agent_id` + `labels`, then bound the old runner to it. The row was left **host-less**, and that has two visible consequences:

- **Wrong replica.** Session-scoped traffic gets its slice key from `host_id` (`web/src/lib/sessionHost.ts`, `chat.py`'s `set_session_host`). With no host, both fall back to "leave routing to the default" — so turn dispatch and terminal attach land on the default replica instead of the one holding that host's runner tunnel.
- **Wrong machine on resume.** With nothing to prefill, `ResumeWithDirectoryDialog` does what its docstring says for a host-less session: *"defaults the host to the caller's current online machine"* — whichever machine the user happens to be looking at, not the one they typed `/clear` on.

`PATCH /v1/sessions/{id}` gains **`inherit_host_from_session_id`**. The server copies `host_id` / `workspace` / `git_branch` off the named session, so the caller passes a session id and never a host id or path — nothing needs re-validating, because those values were validated when the source session was bound. Owner-level on **both** sessions; a host-less source is a no-op, and a target already bound to a *different* host is a 409 rather than a silent migration.

All three native harnesses share the same `create → bind runner → transfer terminal` rotation, so all three now inherit: claude (both the synchronous hook and the forwarder fallback), the codex thread rotation, and the agy cascade rotation.

**ELI5:** the replacement session forgot which computer it was running on, so anything that needed to find that computer later guessed — and sometimes guessed the one you were sitting in front of instead of the one the agent was actually on.

```
BEFORE                                  AFTER
POST /v1/sessions {agent, labels}       POST /v1/sessions {agent, labels}
PATCH new {runner_id}                   PATCH new {runner_id}
                                        PATCH new {inherit_host_from_session_id: old}
POST old/…/transfer                     POST old/…/transfer
PATCH old {runner_id: ""}               PATCH old {runner_id: ""}

new row: host_id=NULL  ← host-less      new row: host_id=<same host>
         workspace=NULL                          workspace=<same dir>
```

Each client sends it as its **own** best-effort PATCH rather than folding it into the runner bind: `UpdateSessionRequest` sets `extra="forbid"`, so a combined body would make a newer client's rotation fail outright against a server that predates the field. A 4xx here is logged and the rotation continues.

## Test Plan

Automated:

```bash
pytest tests/server/routes/test_sessions_crud.py -k inherit          # 4 new server tests
pytest tests/server/routes/test_sessions_shared_projects.py          # + owner-gate test
pytest tests/test_claude_native_hook.py tests/test_claude_native_forwarder.py \
       tests/test_antigravity_native_reader.py                       # 313 passed
pytest tests/test_codex_native.py tests/test_codex_native_forwarder.py  # 361 passed
pytest tests/server/routes                                           # 1048 passed
python scripts/dump_openapi.py --check                               # spec in sync
pre-commit run --files <changed files>                               # ruff format/check clean
```

The three rotation-sequence tests assert the new PATCH by position, so they fail if a harness drops it.

Manual check a reviewer can run — this is the behaviour the fix is about, and it needs **two** registered hosts:

1. `omnigent host` on machine A and on machine B, then open the web UI.
2. Start a claude-native chat on **machine A** (New chat → host A → a directory), send a message.
3. In that chat's terminal, type `/clear`. The banner links to a new session and the pane keeps running.
4. Open the new session's details in the sidebar: it should show **host A** and A's directory (before this change: no host).
5. Now stop the runner (`omnigent host stop` on A, or just let it idle out) and send a message in the cleared-to session **from a browser on machine B**. The resume dialog should prefill **host A** and A's directory, not B's. Before the fix it prefilled B — that is the "different machine" report.
6. Repeat step 3–4 for codex (`omnigent codex`, `/clear`) and antigravity (`omnigent antigravity`, `/clear`) to cover the two sibling rotations.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New server-side tests cover the four PATCH outcomes (inherit, host-less-source no-op, 409 on a bound target, 404 on a missing source) plus the owner gate via a read-shared session. The three harness rotation tests pin the request sequence, so a dropped affinity PATCH fails them.

Manual verification so far covered the automated paths and the OpenAPI regeneration; the **two-host** walkthrough above (the part that actually reproduces "different machine") needs two registered hosts and has not been run on real hardware — a reviewer with a laptop plus a dev box is the right person for steps 4–6.

Not changed, deliberately: Claude's `/fork` rotation (`_create_fork_replacement_session`) has the same host-less replacement row, but `POST /v1/sessions/{id}/fork` documents "forks do not inherit workspace or worktree settings" on purpose — the fork dialog picks the directory. Teaching fork to inherit needs an opt-in flag and its own reasoning about worktrees, so it is left out rather than bundled in here.

## Changelog

A native `/clear` now keeps the new session on the machine it was typed on, instead of leaving it machine-less and resuming on whichever computer you happen to be using.

This pull request and its description were written by Isaac.
