### PR TITLE
fix(spec): keep skills whose description contains a prose colon

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2379,8 +2379,15 @@ def _falsey_flag(raw: object) -> bool:
     return isinstance(raw, str) and raw.strip().lower() in _FALSEY_STRINGS
 
 
-# A top-level ``key: value`` frontmatter line with the value on the same line.
-_FRONTMATTER_SCALAR_RE = re.compile(r"\A(?P<key>[A-Za-z0-9_.-]+):[ \t]+(?P<value>\S.*)\Z")
+# The only line recovery rewrites: a top-level ``description:`` whose value
+# starts on the same line. Every other key keeps strict YAML semantics, so a
+# setting like ``user-invocable: false: internal only`` still fails loudly
+# instead of being read as a truthy string.
+_FRONTMATTER_DESCRIPTION_RE = re.compile(r"\Adescription:[ \t]+(?P<value>\S.*)\Z")
+
+# An indented ``key: value`` line is a mis-indented setting, not prose. Folding
+# it into the description would drop the setting it declares.
+_KEY_SHAPED_LINE_RE = re.compile(r"\A[ \t]+[A-Za-z0-9_.-]+:([ \t].*)?\Z")
 
 # Value openers that mean YAML structure (flow collection, block scalar, anchor,
 # alias, tag) or an already-quoted scalar. Quoting these would change what the
@@ -2388,21 +2395,22 @@ _FRONTMATTER_SCALAR_RE = re.compile(r"\A(?P<key>[A-Za-z0-9_.-]+):[ \t]+(?P<value
 _YAML_VALUE_INDICATORS = ("'", '"', "[", "{", "|", ">", "&", "*", "!", "?", "%", "@", "`")
 
 
-def _quote_frontmatter_values_with_colons(frontmatter_str: str) -> str:
+def _quote_description_with_colon(frontmatter_str: str) -> str:
     """
-    Quote plain frontmatter scalars whose value carries a ``": "``.
+    Quote a plain ``description:`` scalar whose value carries a ``": "``.
 
     Skill authors write prose in ``description:`` and prose contains colons,
     which YAML reads as a nested mapping and rejects. Claude Code accepts those
     files, so rejecting them drops a skill the user has installed. Rewriting
-    only the offending line and re-parsing keeps every other malformed
-    frontmatter loud: a value opening a flow collection, block scalar, or quote
-    is left alone, as is one carrying a `` #`` comment, since quoting either
-    would change its meaning rather than recover it.
+    only that one line and re-parsing keeps every other malformed frontmatter
+    loud: no other key is touched, a value opening a flow collection, block
+    scalar, or quote is left alone, and so is one carrying a `` #`` comment,
+    since quoting any of those would change what the frontmatter says rather
+    than recover it.
 
     :param frontmatter_str: Raw frontmatter block, e.g.
         ``"name: x\ndescription: does y: and z\n"``.
-    :returns: The block with colon-bearing plain scalars double-quoted.
+    :returns: The block with a colon-bearing description double-quoted.
     """
     lines = frontmatter_str.split("\n")
     out: list[str] = []
@@ -2410,7 +2418,7 @@ def _quote_frontmatter_values_with_colons(frontmatter_str: str) -> str:
     while index < len(lines):
         line = lines[index]
         index += 1
-        match = _FRONTMATTER_SCALAR_RE.match(line)
+        match = _FRONTMATTER_DESCRIPTION_RE.match(line)
         value = match.group("value").rstrip() if match else ""
         if (
             match is None
@@ -2421,12 +2429,18 @@ def _quote_frontmatter_values_with_colons(frontmatter_str: str) -> str:
             out.append(line)
             continue
         # A plain scalar folds its indented continuation lines into one value
-        # with single spaces, so absorb them before quoting the whole thing.
-        while index < len(lines) and lines[index][:1] in (" ", "\t") and lines[index].strip():
+        # with single spaces, so absorb a wrapped description. A key-shaped
+        # line ends the run: it is left in place for the re-parse to reject.
+        while (
+            index < len(lines)
+            and lines[index][:1] in (" ", "\t")
+            and lines[index].strip()
+            and not _KEY_SHAPED_LINE_RE.match(lines[index])
+        ):
             value = f"{value} {lines[index].strip()}"
             index += 1
         escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-        out.append(f'{match.group("key")}: "{escaped}"')
+        out.append(f'description: "{escaped}"')
     return "\n".join(out)
 
 
@@ -2471,7 +2485,7 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
         # the ORIGINAL error if that still fails so the message names the real
         # complaint rather than the rewrite's.
         try:
-            frontmatter = yaml.safe_load(_quote_frontmatter_values_with_colons(frontmatter_str))
+            frontmatter = yaml.safe_load(_quote_description_with_colon(frontmatter_str))
         except yaml.YAMLError:
             raise OmnigentError(
                 f"SKILL.md has invalid YAML frontmatter: {skill_md}: {exc}",

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2379,6 +2379,57 @@ def _falsey_flag(raw: object) -> bool:
     return isinstance(raw, str) and raw.strip().lower() in _FALSEY_STRINGS
 
 
+# A top-level ``key: value`` frontmatter line with the value on the same line.
+_FRONTMATTER_SCALAR_RE = re.compile(r"\A(?P<key>[A-Za-z0-9_.-]+):[ \t]+(?P<value>\S.*)\Z")
+
+# Value openers that mean YAML structure (flow collection, block scalar, anchor,
+# alias, tag) or an already-quoted scalar. Quoting these would change what the
+# frontmatter says, so they are left for the strict parse to accept or reject.
+_YAML_VALUE_INDICATORS = ("'", '"', "[", "{", "|", ">", "&", "*", "!", "?", "%", "@", "`")
+
+
+def _quote_frontmatter_values_with_colons(frontmatter_str: str) -> str:
+    """
+    Quote plain frontmatter scalars whose value carries a ``": "``.
+
+    Skill authors write prose in ``description:`` and prose contains colons,
+    which YAML reads as a nested mapping and rejects. Claude Code accepts those
+    files, so rejecting them drops a skill the user has installed. Rewriting
+    only the offending line and re-parsing keeps every other malformed
+    frontmatter loud: a value opening a flow collection, block scalar, or quote
+    is left alone, as is one carrying a `` #`` comment, since quoting either
+    would change its meaning rather than recover it.
+
+    :param frontmatter_str: Raw frontmatter block, e.g.
+        ``"name: x\ndescription: does y: and z\n"``.
+    :returns: The block with colon-bearing plain scalars double-quoted.
+    """
+    lines = frontmatter_str.split("\n")
+    out: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        match = _FRONTMATTER_SCALAR_RE.match(line)
+        value = match.group("value").rstrip() if match else ""
+        if (
+            match is None
+            or value.startswith(_YAML_VALUE_INDICATORS)
+            or " #" in value
+            or (": " not in value and not value.endswith(":"))
+        ):
+            out.append(line)
+            continue
+        # A plain scalar folds its indented continuation lines into one value
+        # with single spaces, so absorb them before quoting the whole thing.
+        while index < len(lines) and lines[index][:1] in (" ", "\t") and lines[index].strip():
+            value = f"{value} {lines[index].strip()}"
+            index += 1
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        out.append(f'{match.group("key")}: "{escaped}"')
+    return "\n".join(out)
+
+
 def _parse_skill(skill_md: Path) -> SkillSpec:
     """
     Parse a single ``SKILL.md`` file into a :class:`SkillSpec`.
@@ -2416,10 +2467,16 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
     try:
         frontmatter = yaml.safe_load(frontmatter_str)
     except yaml.YAMLError as exc:
-        raise OmnigentError(
-            f"SKILL.md has invalid YAML frontmatter: {skill_md}: {exc}",
-            code=ErrorCode.INVALID_INPUT,
-        ) from exc
+        # Retry with colon-bearing prose quoted before giving up, and report
+        # the ORIGINAL error if that still fails so the message names the real
+        # complaint rather than the rewrite's.
+        try:
+            frontmatter = yaml.safe_load(_quote_frontmatter_values_with_colons(frontmatter_str))
+        except yaml.YAMLError:
+            raise OmnigentError(
+                f"SKILL.md has invalid YAML frontmatter: {skill_md}: {exc}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
     if not isinstance(frontmatter, dict):
         raise OmnigentError(
             f"SKILL.md frontmatter must be a YAML mapping: {skill_md}",

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 
 from omnigent.errors import OmnigentError
-from omnigent.spec.parser import discover_host_skills, parse
+from omnigent.spec.parser import _parse_skill, discover_host_skills, parse
 from omnigent.spec.types import ApiKeyAuth, DatabricksAuth, ProviderAuth, SharePolicy
 
 
@@ -679,6 +679,63 @@ _UPSTREAM_BAD_ARGUMENT_HINT = (
 )
 
 
+# The literal ``description:`` line from the ``dev-productivity`` plugin's
+# ``simplify`` skill. Claude Code loads it; strict YAML rejects it because a
+# plain scalar may not contain ``": "`` — so every user with that plugin
+# installed silently lost the skill from Omnigent's menus.
+_UPSTREAM_COLON_IN_DESCRIPTION = (
+    "description: Refines already-working code for clarity, consistency, and "
+    "maintainability while preserving behavior. Targets code the user wants "
+    "cleaned up, not code that was just written: finishing an implementation, "
+    "bug fix, or refactor does not call for this skill."
+)
+
+
+def test_parse_skill_accepts_unquoted_colon_in_description(
+    tmp_path: Path,
+) -> None:
+    """
+    A description carrying an unquoted ``": "`` still yields a skill.
+
+    Authors write prose in ``description:`` without quoting it, and prose
+    contains colons. Claude Code accepts that; if Omnigent insists on strict
+    YAML the skill vanishes from its menus with only a log line to say why.
+    """
+    skill_dir = tmp_path / "simplify"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(f"---\nname: simplify\n{_UPSTREAM_COLON_IN_DESCRIPTION}\n---\nContent.")
+
+    skill = _parse_skill(skill_md)
+
+    assert skill.name == "simplify"
+    # The whole line survives verbatim — the text after the colon is part of
+    # the description, not a nested mapping.
+    assert skill.description == _UPSTREAM_COLON_IN_DESCRIPTION.removeprefix("description: ")
+    assert skill.content == "Content."
+
+
+def test_parse_skill_colon_recovery_keeps_other_yaml_errors_loud(
+    tmp_path: Path,
+) -> None:
+    """
+    Recovery is scoped to the colon case; other malformed YAML still raises.
+
+    ``argument-hint: [industry] [--rows N]`` breaks on the flow sequence, not
+    on a colon. Quoting must not paper over it, or a genuinely broken
+    frontmatter would be read as prose and its fields silently misparsed.
+    """
+    skill_dir = tmp_path / "bad-yaml"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        f"---\nname: bad-yaml\ndescription: x\n{_UPSTREAM_BAD_ARGUMENT_HINT}\n---\nContent."
+    )
+
+    with pytest.raises(OmnigentError, match=r"invalid YAML frontmatter"):
+        _parse_skill(skill_md)
+
+
 def test_parse_skill_invalid_yaml_frontmatter_in_bundle_raises(
     agent_dir: Path,
 ) -> None:
@@ -1036,8 +1093,13 @@ def test_discover_host_skills_skips_yaml_syntax_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """
-    Host skills whose frontmatter contains invalid YAML (e.g.
-    unquoted colons) are skipped gracefully.
+    Host skills whose frontmatter contains invalid YAML are skipped
+    gracefully.
+
+    Uses the flow-sequence case rather than an unquoted colon: prose colons
+    are recovered now (see
+    ``test_parse_skill_accepts_unquoted_colon_in_description``), so they no
+    longer exercise the skip path.
 
     :param tmp_path: Temporary directory for test fixtures.
     :param monkeypatch: Pytest monkeypatch for isolating ``Path.home()``.
@@ -1052,9 +1114,8 @@ def test_discover_host_skills_skips_yaml_syntax_error(
     skills_dir = fake_home / ".claude" / "skills"
     broken = skills_dir / "broken-yaml"
     broken.mkdir(parents=True)
-    # Unquoted colon in description triggers yaml.scanner.ScannerError.
     (broken / "SKILL.md").write_text(
-        "---\nname: broken-yaml\ndescription: TRIGGER when: code imports foo\n---\nContent."
+        f"---\nname: broken-yaml\ndescription: x\n{_UPSTREAM_BAD_ARGUMENT_HINT}\n---\nContent."
     )
 
     agent_root = tmp_path / "project"

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -736,6 +736,76 @@ def test_parse_skill_colon_recovery_keeps_other_yaml_errors_loud(
         _parse_skill(skill_md)
 
 
+def test_parse_skill_colon_recovery_leaves_other_keys_alone(
+    tmp_path: Path,
+) -> None:
+    """
+    A colon in a non-description key still raises, keeping the skill hidden.
+
+    ``user-invocable: false: internal only`` is invalid YAML. Quoting it would
+    make the value the truthy string ``"false: internal only"``, so a skill its
+    author marked internal would appear in the user's ``/`` menu. Recovery is
+    scoped to ``description`` precisely so that cannot happen.
+    """
+    skill_dir = tmp_path / "internal-skill"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: internal-skill\ndescription: orchestrates\n"
+        "user-invocable: false: internal only\n---\nContent."
+    )
+
+    with pytest.raises(OmnigentError, match=r"invalid YAML frontmatter"):
+        _parse_skill(skill_md)
+
+
+def test_parse_skill_colon_recovery_does_not_absorb_indented_keys(
+    tmp_path: Path,
+) -> None:
+    """
+    A mis-indented setting is not folded into a recovered description.
+
+    Continuation lines fold into a plain scalar, but an indented
+    ``user-invocable: false`` is a mis-indented setting, not prose. Absorbing
+    it would drop the flag and publish an internal skill, so the run stops
+    there and the file is rejected instead.
+    """
+    skill_dir = tmp_path / "indented-key"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: indented-key\ndescription: orchestrates things: internally\n"
+        "  user-invocable: false\n---\nContent."
+    )
+
+    with pytest.raises(OmnigentError, match=r"invalid YAML frontmatter"):
+        _parse_skill(skill_md)
+
+
+def test_parse_skill_colon_recovery_folds_wrapped_prose(
+    tmp_path: Path,
+) -> None:
+    """
+    A wrapped description recovers, and later keys keep their own meaning.
+
+    The continuation line is prose, so it folds with a single space the way a
+    YAML plain scalar would; ``user-invocable`` is a sibling key rather than
+    part of the description and still parses as a boolean.
+    """
+    skill_dir = tmp_path / "wrapped"
+    skill_dir.mkdir()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: wrapped\ndescription: Use when foo: bar\n"
+        "  and also when baz qux\nuser-invocable: false\n---\nContent."
+    )
+
+    skill = _parse_skill(skill_md)
+
+    assert skill.description == "Use when foo: bar and also when baz qux"
+    assert skill.user_invocable is False
+
+
 def test_parse_skill_invalid_yaml_frontmatter_in_bundle_raises(
     agent_dir: Path,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

A skill whose `description:` contains an unquoted colon was silently dropped from every Omnigent menu — even though **Claude Code, which the file was written for, loads it fine**.

Skill authors write `description:` as prose, and prose contains colons. YAML reads `": "` inside a plain scalar as a nested mapping and rejects the whole frontmatter:

```
Skipping skill with bad frontmatter: .../xxx-skill/1.23.5/skills/simplify/SKILL.md:
  SKILL.md has invalid YAML frontmatter: mapping values are not allowed here
  in "<unicode string>", line 2, column 255:
     ... , not code that was just written: finishing an implementation, b ...
                                         ^
```

The user's symptom is an installed skill that just isn't in the `/` menu, with only a runner log line to explain it.

- `_parse_skill` now retries once with colon-bearing plain scalars quoted before giving up.
- **Recovery is deliberately narrow.** A value opening a flow collection, block scalar, anchor/alias/tag, or quote is left alone, as is one carrying a ` #` comment — quoting either would change what the frontmatter *says* rather than recover it. Valid YAML never goes through the rewrite at all (it only runs after `yaml.safe_load` raises), so existing semantics are untouched, and any other malformed frontmatter still raises with the **original** YAML error so the message names the real complaint.
- Continuation lines fold with single spaces, matching YAML plain-scalar semantics, so a wrapped description recovers too.

```
frontmatter ── yaml.safe_load ──✔──▶ spec                    (unchanged path)
                    │
                   ✘ YAMLError
                    │
                    ├─ value opens [ { | > & * ! ' " , or has " #"  ──▶ raise (original error)
                    │
                    └─ value has ": " ──▶ quote it, fold continuations
                                            └─ safe_load ──✔──▶ spec
                                                          ──✘──▶ raise (original error)
```

## Test Plan

Prove-it-fails, then fix:

```bash
# 1. On main, the real upstream description reproduces the production failure:
.venv/bin/pytest tests/spec/test_parser.py -k colon -p no:randomly -q
# OmnigentError: SKILL.md has invalid YAML frontmatter: ...:
#   mapping values are not allowed here

# 2. With the fix — recovery + the still-loud case both pass:
.venv/bin/pytest tests/spec/test_parser.py -p no:randomly -q
# 240 passed

# 3. Whole spec suite, nothing else moved:
.venv/bin/pytest tests/spec/ -p no:randomly -q
# 589 passed
```

Verified against the real production shapes and the edge cases the narrowness depends on:

| frontmatter value | result |
|---|---|
| `description: ... just written: finishing ...` (real `simplify`) | recovered verbatim |
| colon on line 1 + indented continuation line | folded with a space, `user-invocable: false` still parses as bool |
| `metadata:` with nested `type: user`, `tags: [a, b]` | untouched, still a nested mapping |
| `description: a: b # note` | left alone → still raises (comment semantics preserved) |
| `argument-hint: [industry] [--rows N]` | left alone → still raises |
| `description: he said "hi": then left` | recovered, inner quotes escaped |

Manual check for a reviewer: drop a `SKILL.md` into `~/.claude/skills/colon-test/` whose description contains `something: like this`, then run `omnigent --harness codex` (or open the new-session composer's `/` menu). Before: the skill is absent and the runner logs `Skipping skill with bad frontmatter`. After: it appears, description intact.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The production log line is quoted in the Summary; the failing-before / passing-after runs and the edge-case matrix are in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two new tests: `test_parse_skill_accepts_unquoted_colon_in_description` uses the literal upstream `simplify` description and fails on `main` with the same error as production; `test_parse_skill_colon_recovery_keeps_other_yaml_errors_loud` pins that the flow-sequence case still raises, so recovery can't quietly widen.

`test_discover_host_skills_skips_yaml_syntax_error` had used an unquoted colon to reach the tolerant-skip path — that input is now recovered, so it switches to `_UPSTREAM_BAD_ARGUMENT_HINT` (the flow-sequence case already canonical in this file), which is still genuinely unrecoverable. The strict-bundle test and the multi-bad-skill test are unchanged.

Manual verification covers the edge-case matrix in the Test Plan, which was run against the real parser rather than only through pytest.

## Changelog

Skills whose description contains a colon now load instead of being silently skipped.
