### PR TITLE
feat(policies): add audit logs for admin policy API mutations

### DIFF
--- a/omnigent/server/routes/default_policies.py
+++ b/omnigent/server/routes/default_policies.py
@@ -15,6 +15,7 @@ session policies, with ``session_id IS NULL``.
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 import uuid
 from typing import Any
@@ -41,6 +42,15 @@ from omnigent.telemetry import emit as _tel_emit
 from omnigent.telemetry.events import PolicyDeletedEvent as _TelPolicyDeletedEvent
 from omnigent.telemetry.events import PolicyRegisteredEvent as _TelPolicyRegisteredEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
+
+_logger = logging.getLogger(__name__)
+
+
+def _redact_for_log(user_id: str) -> str:
+    """Truncate a user id for log lines to avoid full PII in aggregated logs."""
+    if len(user_id) <= 4:
+        return f"{user_id[:1]}***"
+    return f"{user_id[:3]}***(len={len(user_id)})"
 
 
 def _generate_default_policy_id() -> str:
@@ -225,6 +235,12 @@ def create_default_policies_router(
                 code=ErrorCode.CONFLICT,
             ) from exc
         invalidate_default_policy_specs_cache()
+        _logger.info(
+            "policies/create: user=%s created policy_id=%s handler=%s",
+            _redact_for_log(user_id) if user_id else "(single-user)",
+            policy.id,
+            policy.handler,
+        )
         try:
             import hashlib as _hashlib
 
@@ -322,7 +338,7 @@ def create_default_policies_router(
         :raises OmnigentError: 401/403 if the user lacks admin
             privileges, or 404 if the policy is not found.
         """
-        await _require_admin(request, auth_provider, permission_store)
+        user_id = await _require_admin(request, auth_provider, permission_store)
         # Validate handler against the existing policy's type.
         if body.handler is not None:
             existing = store.get_default(policy_id)
@@ -362,6 +378,11 @@ def create_default_policies_router(
         if policy is None:
             raise OmnigentError("Policy not found", code=ErrorCode.NOT_FOUND)
         invalidate_default_policy_specs_cache()
+        _logger.info(
+            "policies/update: user=%s updated policy_id=%s",
+            _redact_for_log(user_id) if user_id else "(single-user)",
+            policy_id,
+        )
         return _entity_to_response(policy)
 
     @router.delete("/policies/{policy_id}")
@@ -385,6 +406,11 @@ def create_default_policies_router(
         user_id = await _require_admin(request, auth_provider, permission_store)
         store.delete_default(policy_id)
         invalidate_default_policy_specs_cache()
+        _logger.info(
+            "policies/delete: user=%s deleted policy_id=%s",
+            _redact_for_log(user_id) if user_id else "(single-user)",
+            policy_id,
+        )
         try:
             import hashlib as _hashlib
 

--- a/omnigent/server/routes/default_policies.py
+++ b/omnigent/server/routes/default_policies.py
@@ -46,13 +46,6 @@ from omnigent.telemetry.installation_id import get_installation_id as _get_insta
 _logger = logging.getLogger(__name__)
 
 
-def _redact_for_log(user_id: str) -> str:
-    """Truncate a user id for log lines to avoid full PII in aggregated logs."""
-    if len(user_id) <= 4:
-        return f"{user_id[:1]}***"
-    return f"{user_id[:3]}***(len={len(user_id)})"
-
-
 def _generate_default_policy_id() -> str:
     """Generate a unique default policy identifier.
 
@@ -237,7 +230,7 @@ def create_default_policies_router(
         invalidate_default_policy_specs_cache()
         _logger.info(
             "policies/create: user=%s created policy_id=%s handler=%s",
-            _redact_for_log(user_id) if user_id else "(single-user)",
+            user_id or "(single-user)",
             policy.id,
             policy.handler,
         )
@@ -380,7 +373,7 @@ def create_default_policies_router(
         invalidate_default_policy_specs_cache()
         _logger.info(
             "policies/update: user=%s updated policy_id=%s",
-            _redact_for_log(user_id) if user_id else "(single-user)",
+            user_id or "(single-user)",
             policy_id,
         )
         return _entity_to_response(policy)
@@ -408,7 +401,7 @@ def create_default_policies_router(
         invalidate_default_policy_specs_cache()
         _logger.info(
             "policies/delete: user=%s deleted policy_id=%s",
-            _redact_for_log(user_id) if user_id else "(single-user)",
+            user_id or "(single-user)",
             policy_id,
         )
         try:

--- a/tests/server/routes/test_default_policies.py
+++ b/tests/server/routes/test_default_policies.py
@@ -337,3 +337,54 @@ async def test_create_default_policy_no_telemetry_on_error(
         resp = await policy_client.post("/v1/policies", json=_policy_payload(name="dup"))
     assert resp.status_code == 409
     mock_emit.assert_not_called()
+
+
+# ── Audit logging ─────────────────────────────────────────────────────
+
+
+async def test_create_default_policy_logs_audit(
+    policy_client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``POST /v1/policies`` emits an audit log line with policy_id and handler."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="omnigent.server.routes.default_policies"):
+        resp = await policy_client.post("/v1/policies", json=_policy_payload())
+    assert resp.status_code == 200
+    pid = resp.json()["id"]
+    assert "policies/create" in caplog.text
+    assert pid in caplog.text
+    assert _REGISTERED_HANDLER in caplog.text
+
+
+async def test_update_default_policy_logs_audit(
+    policy_client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``PATCH /v1/policies/{id}`` emits an audit log line with the policy_id."""
+    import logging
+
+    create_resp = await policy_client.post("/v1/policies", json=_policy_payload())
+    pid = create_resp.json()["id"]
+    with caplog.at_level(logging.INFO, logger="omnigent.server.routes.default_policies"):
+        resp = await policy_client.patch(f"/v1/policies/{pid}", json={"name": "renamed"})
+    assert resp.status_code == 200
+    assert "policies/update" in caplog.text
+    assert pid in caplog.text
+
+
+async def test_delete_default_policy_logs_audit(
+    policy_client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``DELETE /v1/policies/{id}`` emits an audit log line with the policy_id."""
+    import logging
+
+    create_resp = await policy_client.post("/v1/policies", json=_policy_payload())
+    pid = create_resp.json()["id"]
+    with caplog.at_level(logging.INFO, logger="omnigent.server.routes.default_policies"):
+        resp = await policy_client.delete(f"/v1/policies/{pid}")
+    assert resp.status_code == 200
+    assert "policies/delete" in caplog.text
+    assert pid in caplog.text

--- a/tests/server/routes/test_default_policies.py
+++ b/tests/server/routes/test_default_policies.py
@@ -15,10 +15,12 @@ import httpx
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
+from starlette.requests import HTTPConnection
 
 from omnigent.runtime import get_caps
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.server.app import create_app
+from omnigent.server.auth import AuthProvider
 from omnigent.spec.types import FunctionPolicySpec, FunctionRef
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
@@ -30,6 +32,14 @@ from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
 from omnigent.stores.policy_store.sqlalchemy_store import SqlAlchemyPolicyStore
 
 _REGISTERED_HANDLER = "omnigent.policies.builtins.safety.ask_on_os_tools"
+_TEST_USER_ID = "alice@example.com"
+
+
+class _FixedAuthProvider(AuthProvider):
+    """Auth provider that always returns a fixed user ID, for audit log tests."""
+
+    def get_user_id(self, request: HTTPConnection) -> str | None:
+        return _TEST_USER_ID
 
 
 @pytest.fixture()
@@ -50,12 +60,41 @@ def policy_app(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
     )
 
 
+@pytest.fixture()
+def policy_app_with_auth(runtime_init: None, db_uri: str, tmp_path: Path) -> FastAPI:
+    """Policy-enabled app with a fixed auth provider for audit log tests."""
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        policy_store=SqlAlchemyPolicyStore(db_uri),
+        auth_provider=_FixedAuthProvider(),
+    )
+
+
 @pytest_asyncio.fixture()
 async def policy_client(
     policy_app: FastAPI,
 ) -> AsyncIterator[httpx.AsyncClient]:
     """HTTP client wired to the policy-enabled app."""
     transport = httpx.ASGITransport(app=policy_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture()
+async def authed_policy_client(
+    policy_app_with_auth: FastAPI,
+) -> AsyncIterator[httpx.AsyncClient]:
+    """HTTP client wired to the auth-enabled policy app."""
+    transport = httpx.ASGITransport(app=policy_app_with_auth)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
         yield c
 
@@ -356,6 +395,7 @@ async def test_create_default_policy_logs_audit(
     assert "policies/create" in caplog.text
     assert pid in caplog.text
     assert _REGISTERED_HANDLER in caplog.text
+    assert "(single-user)" in caplog.text
 
 
 async def test_update_default_policy_logs_audit(
@@ -372,6 +412,7 @@ async def test_update_default_policy_logs_audit(
     assert resp.status_code == 200
     assert "policies/update" in caplog.text
     assert pid in caplog.text
+    assert "(single-user)" in caplog.text
 
 
 async def test_delete_default_policy_logs_audit(
@@ -388,3 +429,22 @@ async def test_delete_default_policy_logs_audit(
     assert resp.status_code == 200
     assert "policies/delete" in caplog.text
     assert pid in caplog.text
+    assert "(single-user)" in caplog.text
+
+
+async def test_audit_logs_include_caller_user_id(
+    authed_policy_client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Audit log lines include the full caller user ID (not redacted)."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="omnigent.server.routes.default_policies"):
+        create_resp = await authed_policy_client.post(
+            "/v1/policies", json=_policy_payload(name="uid_test")
+        )
+        pid = create_resp.json()["id"]
+        await authed_policy_client.patch(f"/v1/policies/{pid}", json={"name": "uid_test_renamed"})
+        await authed_policy_client.delete(f"/v1/policies/{pid}")
+
+    assert caplog.text.count(_TEST_USER_ID) == 3  # create, update, delete


### PR DESCRIPTION
## Summary

- `POST /v1/policies`, `PATCH /v1/policies/{id}`, and `DELETE /v1/policies/{id}` now emit `INFO`-level audit log lines via the standard Python logger (`omnigent.server.routes.default_policies`)
- Each line includes: operation (`policies/create|update|delete`), the **full caller user ID** (intentionally unredacted — audit logs exist for accountability), and the `policy_id`; `create` additionally logs the handler
- In single-user mode (no auth provider), `(single-user)` is logged as the identity
- In `update_policy` the return value of `_require_admin` was previously discarded — this is now captured so the caller identity is available for the log line

## Test Plan

- Added `test_create_default_policy_logs_audit`, `test_update_default_policy_logs_audit`, and `test_delete_default_policy_logs_audit` — use `caplog.at_level` to capture audit lines and assert the operation keyword, `policy_id`, and `(single-user)` sentinel all appear
- Added `test_audit_logs_include_caller_user_id` with a `_FixedAuthProvider` stub — asserts the raw user ID appears exactly 3 times (once per mutation) and is not truncated
- All 23 tests in the file pass: `python -m pytest tests/server/routes/test_default_policies.py -x -q`

## Demo

N/A — no UI change

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage notes

N/A