### PR TITLE
feat(server): reap inactive managed sandboxes

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -293,6 +293,10 @@ config (`omnigent server -c config.yaml`, or `<data_dir>/config.yaml`):
 sandbox:
   provider: modal
   server_url: https://your-host        # public URL sandboxes dial back to
+  reaper:                              # optional, disabled by default
+    enabled: true
+    terminate_after_offline_days: 30   # default: 30 days
+    sweep_interval_s: 86400            # default: 1 day
 ```
 
 Modal credentials come from the server's environment (`MODAL_TOKEN_ID` /
@@ -300,6 +304,14 @@ Modal credentials come from the server's environment (`MODAL_TOKEN_ID` /
 Daytona reads `DAYTONA_API_KEY`. Blaxel reads `BL_WORKSPACE` and `BL_API_KEY`. Islo reads `ISLO_API_KEY` and optional `ISLO_BASE_URL`. E2B reads `E2B_API_KEY` from the server environment.
 Each sandbox authenticates back with a server-minted, per-launch token, so
 no user credentials ever enter the sandbox.
+
+The optional reaper runs once for the whole `sandbox:` deployment, including
+multi-provider configurations. It queries managed host rows directly and
+detaches a sandbox generation only after its host has stayed offline past
+`terminate_after_offline_days`. Provider termination failures remain recorded
+for a later sweep, while the session history and durable host binding stay
+available for a fresh sandbox generation. Both
+`terminate_after_offline_days` and `sweep_interval_s` must be positive integers.
 
 **The host image.** Most sandboxes boot from the official prebaked host image (`ghcr.io/omnigent-ai/omnigent-host:latest`, published by CI from the `host` target of [`docker/Dockerfile`](docker/Dockerfile)), so the host starts in seconds instead of installing Omnigent at boot. The image ships the coding-harness CLIs (`claude`, `codex`, `pi`, `kiro-cli`). Blaxel uses `blaxel/omnigent-host:latest`, which combines this host runtime with Blaxel's required `sandbox-api`. E2B uses its provider template. To use a custom image instead, build the same `host` target and point the provider config at it:
 

--- a/docs/extending/sandbox_providers.md
+++ b/docs/extending/sandbox_providers.md
@@ -131,11 +131,31 @@ server's `sandbox:` config:
 sandbox:
   provider: acme
   server_url: https://your-host
+  reaper:
+    enabled: true
+    terminate_after_offline_days: 30  # optional; defaults to 30 days
+    sweep_interval_s: 86400           # optional; defaults to 1 day
 ```
 
 The server resolves the provider through the registry and calls
 `prepare()` → `provision()` → `start_host()` → wait for online registration.
 Each managed sandbox authenticates back with a server-minted per-launch token.
+
+`sandbox.reaper` is deployment-wide: configure it next to `provider` or
+`providers`, never inside one provider entry. One configurable loop covers every
+configured provider and dispatches termination through the provider recorded on
+each managed host. Reaping keeps the session and durable host binding so the
+next message can launch a fresh sandbox generation.
+
+The loop discovers workspaces with active or pending managed sandboxes, then
+queries stale managed hosts within each workspace. Before calling the provider,
+it atomically detaches the stale sandbox id from the active host generation.
+Failed terminations stay pending and are retried by later sweeps; providers must
+therefore make `terminate()` succeed when the sandbox is already absent.
+
+The reaper reuses one launcher per workspace and provider. Override
+`reaper_identity(workspace_id)` when background termination needs a scoped
+credential context; the default context is a no-op.
 
 ## Provider capabilities
 

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1316,6 +1316,10 @@ class SqlHost(OmnigentBase):
     :param sandbox_id: Provider-assigned id of the sandbox currently
         backing the host, e.g. ``"sb-a1b2c3"`` — what termination is
         issued against. ``NULL`` for external hosts.
+    :param terminating_sandbox_id: Provider-assigned id detached from the
+        active host generation and awaiting successful provider termination.
+        A fresh generation may be registered in ``sandbox_id`` while this
+        cleanup remains pending.
     :param configured_harnesses: JSON-encoded per-harness readiness map
         reported in the host's last ``host.hello`` frame, e.g.
         ``'{"claude-sdk": true, "codex": false}'``. ``NULL`` when the
@@ -1349,6 +1353,7 @@ class SqlHost(OmnigentBase):
     token_expires_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     sandbox_provider: Mapped[str | None] = mapped_column(String(32), nullable=True)
     sandbox_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    terminating_sandbox_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
     # Opaque; never SQL-filtered — stored compressed (CompressedText).
     configured_harnesses: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
 

--- a/omnigent/db/migrations/versions/gb1b2c3d4e5f_add_terminating_sandbox_id.py
+++ b/omnigent/db/migrations/versions/gb1b2c3d4e5f_add_terminating_sandbox_id.py
@@ -1,0 +1,35 @@
+"""Add pending managed sandbox termination to hosts.
+
+Revision ID: gb1b2c3d4e5f
+Revises: ga1b2c3d4e5f
+Create Date: 2026-09-03 00:00:00.000000
+
+The managed sandbox reaper detaches a stale provider id from the active host
+generation before making the external termination call. Persisting that id on
+the host row makes failed cleanup retryable while allowing a fresh generation
+to launch under the durable host identity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "gb1b2c3d4e5f"
+down_revision: str | None = "ga1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the retryable pending-termination slot."""
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.add_column(sa.Column("terminating_sandbox_id", sa.String(256), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove the pending-termination slot."""
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.drop_column("terminating_sandbox_id")

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -23,7 +23,7 @@ import json
 import secrets
 import shlex
 from abc import ABC, abstractmethod
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
@@ -543,7 +543,9 @@ class SandboxLifecycle(ABC):
         Optional capability: the default implementation raises
         :class:`SandboxCapabilityError` — providers whose SDK exposes
         programmatic termination override it. Used by the server's
-        managed-host cleanup when a managed session is deleted.
+        managed-host cleanup when a managed session is deleted. Implementations
+        must treat an already-absent sandbox as success so cleanup can retry
+        safely after a crash or database failure.
 
         :param sandbox_id: The sandbox to terminate, e.g.
             ``"sb-a1b2c3"``.
@@ -801,6 +803,10 @@ class SandboxHostLauncher(SandboxLifecycle):
     Kubernetes) inherit this class directly and override :meth:`start_host`
     without needing any exec transport.
     """
+
+    def reaper_identity(self, workspace_id: int) -> AbstractContextManager[None]:
+        """Bind credentials needed for background cleanup in one workspace."""
+        return nullcontext()
 
     @abstractmethod
     def start_host(

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -60,6 +60,7 @@ from omnigent.server.background_session_titles import (
 )
 from omnigent.server.feature_flags import Feature, FeatureFlags, resolve_feature_flags
 from omnigent.server.managed_hosts import ManagedSandboxDeployment
+from omnigent.server.managed_sandbox_reaper import ManagedSandboxReaper
 from omnigent.server.mcp_pool import ServerMcpPool
 from omnigent.server.performance_metrics import (
     ServerMetricsOtelPublisher,
@@ -1443,9 +1444,26 @@ def create_app(
             # endpoints (see routes/scheduled_tasks.py); there is no startup
             # sweep and no periodic reconcile.
 
+        managed_sandbox_reaper: ManagedSandboxReaper | None = None
+        if sandbox_config is not None and sandbox_config.reaper.enabled:
+            if host_store is None:
+                _logger.warning(
+                    "Managed sandbox reaper is enabled but no host store is configured; "
+                    "the reaper will not run"
+                )
+            else:
+                managed_sandbox_reaper = ManagedSandboxReaper(
+                    host_store=host_store,
+                    sandbox_config=sandbox_config,
+                )
+                app_inst.state.managed_sandbox_reaper = managed_sandbox_reaper
+                await managed_sandbox_reaper.start()
+
         try:
             yield
         finally:
+            if managed_sandbox_reaper is not None:
+                await managed_sandbox_reaper.shutdown()
             # Run completion is event-driven (the _publish_status hook) plus a
             # lazy-on-read stale backstop — there is no run-reconciler task to
             # cancel. Only the per-job scheduler holds timers that need stopping.

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -38,6 +38,10 @@ stores into ``create_app``):
          # For SEVERAL providers, replace `provider:` with a `providers:`
          # list (mutually exclusive); a create picks one by name via
          # `sandbox_provider`, else the first. See parse_sandbox_config.
+         reaper:                  # optional; deployment-wide, not per-provider
+           enabled: true          # default: false
+           terminate_after_offline_days: 30  # default: 30 days
+           sweep_interval_s: 86400            # default: 1 day
          host_config:             # optional; provider-agnostic. Verbatim
                                   # in-sandbox ~/.omnigent/config.yaml content,
                                   # installed before `omnigent host` starts
@@ -148,6 +152,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import TYPE_CHECKING, cast
 
 import click
@@ -518,6 +523,23 @@ class ManagedSandboxConfig:
     host_config: dict[str, object] | None = None
 
 
+@dataclass(frozen=True)
+class ManagedSandboxReaperConfig:
+    """Deployment-wide managed sandbox reaper settings.
+
+    :param enabled: Whether the server lifespan starts the reaper loop.
+        Disabled by default because terminating user compute is destructive.
+    :param terminate_after_offline_days: Minimum number of days since the
+        managed host's last heartbeat/disconnect before its current sandbox
+        generation may be terminated.
+    :param sweep_interval_s: Seconds between complete deployment-wide sweeps.
+    """
+
+    enabled: bool = False
+    terminate_after_offline_days: int = 30
+    sweep_interval_s: int = 24 * 60 * 60
+
+
 @dataclass
 class ManagedSandboxDeployment:
     """
@@ -537,9 +559,14 @@ class ManagedSandboxDeployment:
     :param configs: One single-provider config per offered provider, in
         configured order. Never empty. The first is the deployment
         default a request that names no provider gets.
+    :param reaper: One deployment-wide reaper policy shared by every
+        configured provider.
     """
 
     configs: tuple[ManagedSandboxConfig, ...]
+    reaper: ManagedSandboxReaperConfig = dataclass_field(
+        default_factory=ManagedSandboxReaperConfig
+    )
 
     def __post_init__(self) -> None:
         # Enforce the "never empty" invariant the accessors rely on
@@ -550,7 +577,12 @@ class ManagedSandboxDeployment:
             raise ValueError("ManagedSandboxDeployment requires at least one provider config")
 
     @classmethod
-    def single(cls, config: ManagedSandboxConfig) -> ManagedSandboxDeployment:
+    def single(
+        cls,
+        config: ManagedSandboxConfig,
+        *,
+        reaper: ManagedSandboxReaperConfig | None = None,
+    ) -> ManagedSandboxDeployment:
         """
         Wrap one provider config as a one-provider deployment.
 
@@ -559,9 +591,10 @@ class ManagedSandboxDeployment:
         deployment uniformly.
 
         :param config: The single provider's config.
+        :param reaper: Optional deployment-wide reaper policy.
         :returns: A deployment offering exactly *config*.
         """
-        return cls(configs=(config,))
+        return cls(configs=(config,), reaper=reaper or ManagedSandboxReaperConfig())
 
     @property
     def default(self) -> ManagedSandboxConfig:
@@ -1068,12 +1101,63 @@ def parse_sandbox_config(raw: object) -> ManagedSandboxDeployment | None:
         return None
     if not isinstance(raw, dict):
         raise ValueError("server config 'sandbox' must be a mapping")
+    reaper = _parse_managed_sandbox_reaper_config(raw)
     if "providers" in raw:
-        return _parse_multi_provider_sandbox_config(raw)
-    return ManagedSandboxDeployment.single(_parse_single_provider_sandbox_config(raw))
+        return _parse_multi_provider_sandbox_config(raw, reaper=reaper)
+    return ManagedSandboxDeployment.single(
+        _parse_single_provider_sandbox_config(raw),
+        reaper=reaper,
+    )
 
 
-def _parse_multi_provider_sandbox_config(raw: dict[str, object]) -> ManagedSandboxDeployment:
+def _parse_managed_sandbox_reaper_config(
+    raw: dict[str, object],
+) -> ManagedSandboxReaperConfig:
+    """Parse the deployment-wide ``sandbox.reaper`` block."""
+    reaper_raw = raw.get("reaper")
+    if reaper_raw is None:
+        return ManagedSandboxReaperConfig()
+    if not isinstance(reaper_raw, dict):
+        raise ValueError("server config 'sandbox.reaper' must be a mapping")
+    _reject_unknown_keys(
+        reaper_raw,
+        {"enabled", "terminate_after_offline_days", "sweep_interval_s"},
+        "sandbox.reaper",
+    )
+    enabled = reaper_raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        raise ValueError("server config 'sandbox.reaper.enabled' must be a boolean")
+    terminate_after_offline_days = reaper_raw.get("terminate_after_offline_days", 30)
+    if (
+        not isinstance(terminate_after_offline_days, int)
+        or isinstance(terminate_after_offline_days, bool)
+        or terminate_after_offline_days <= 0
+    ):
+        raise ValueError(
+            "server config 'sandbox.reaper.terminate_after_offline_days' "
+            "must be a positive integer"
+        )
+    sweep_interval_s = reaper_raw.get("sweep_interval_s", 24 * 60 * 60)
+    if (
+        not isinstance(sweep_interval_s, int)
+        or isinstance(sweep_interval_s, bool)
+        or sweep_interval_s <= 0
+    ):
+        raise ValueError(
+            "server config 'sandbox.reaper.sweep_interval_s' must be a positive integer"
+        )
+    return ManagedSandboxReaperConfig(
+        enabled=enabled,
+        terminate_after_offline_days=terminate_after_offline_days,
+        sweep_interval_s=sweep_interval_s,
+    )
+
+
+def _parse_multi_provider_sandbox_config(
+    raw: dict[str, object],
+    *,
+    reaper: ManagedSandboxReaperConfig,
+) -> ManagedSandboxDeployment:
     """
     Parse the ``sandbox.providers`` list shape into a deployment.
 
@@ -1098,7 +1182,9 @@ def _parse_multi_provider_sandbox_config(raw: dict[str, object]) -> ManagedSandb
         )
     # Shared keys describe THIS server, so they ride into every entry
     # instead of being repeated per entry.
-    shared = {key: value for key, value in raw.items() if key not in {"providers", "provider"}}
+    shared = {
+        key: value for key, value in raw.items() if key not in {"providers", "provider", "reaper"}
+    }
     parsed: list[ManagedSandboxConfig] = []
     seen: set[str] = set()
     for index, entry in enumerate(entries):
@@ -1111,6 +1197,11 @@ def _parse_multi_provider_sandbox_config(raw: dict[str, object]) -> ManagedSandb
             raise ValueError(
                 f"server config 'sandbox.providers[{index}]' must not nest 'providers'"
             )
+        if "reaper" in entry:
+            raise ValueError(
+                "server config 'sandbox.reaper' is deployment-wide and must be set "
+                "next to 'providers', not inside a provider entry"
+            )
         config = _parse_single_provider_sandbox_config({**shared, **entry})
         # Always a str: the single-provider parser rejects anything else.
         name = str(config.provider)
@@ -1118,7 +1209,7 @@ def _parse_multi_provider_sandbox_config(raw: dict[str, object]) -> ManagedSandb
             raise ValueError(f"server config 'sandbox.providers' lists {name!r} more than once")
         seen.add(name)
         parsed.append(config)
-    return ManagedSandboxDeployment(configs=tuple(parsed))
+    return ManagedSandboxDeployment(configs=tuple(parsed), reaper=reaper)
 
 
 def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSandboxConfig:
@@ -2705,7 +2796,7 @@ async def launch_managed_host(
             status_code=502,
             detail=f"managed sandbox launch failed: {exc.message}",
         ) from exc
-    workspace = await _arm_and_start_host(
+    workspace = await _register_and_start_host(
         launcher=launcher,
         config=entry,
         host_store=host_store,
@@ -2758,7 +2849,7 @@ async def relaunch_managed_host(
         re-stamped as the new runner Pod's ``omnigent.ai/agent`` classifier
         (Kubernetes only), or ``None`` to leave it unstamped.
     :param on_stage: Progress observer forwarded to
-        :func:`_arm_and_start_host`; see :func:`launch_managed_host`.
+        :func:`_register_and_start_host`; see :func:`launch_managed_host`.
         ``None`` disables progress reporting.
     :returns: The (unchanged) host id + fresh in-sandbox workspace.
     :raises HTTPException: 400 when the host's recorded provider no
@@ -2780,7 +2871,8 @@ async def relaunch_managed_host(
     # The old generation is normally already dead (that is why we are
     # here), but terminate defensively so a transient tunnel outage
     # can never leave two live sandboxes claiming one host identity.
-    await _terminate_sandbox_best_effort(launcher, host)
+    if host.sandbox_id is not None:
+        await _terminate_sandbox_best_effort(launcher, host, host.sandbox_id)
     try:
         await asyncio.to_thread(launcher.prepare)
         sandbox_id = await asyncio.to_thread(launcher.provision, host.name)
@@ -2789,19 +2881,25 @@ async def relaunch_managed_host(
             status_code=502,
             detail=f"managed sandbox relaunch failed: {exc.message}",
         ) from exc
-    workspace = await _arm_and_start_host(
-        launcher=launcher,
-        config=entry,
-        host_store=host_store,
-        host_id=host.host_id,
-        host_name=host.name,
-        owner=host.user_id,
-        sandbox_id=sandbox_id,
-        repo=repo,
-        agent_name=agent_name,
-        on_stage=on_stage,
-        keep_host_on_failure=True,
-    )
+    try:
+        workspace = await _register_and_start_host(
+            launcher=launcher,
+            config=entry,
+            host_store=host_store,
+            host_id=host.host_id,
+            host_name=host.name,
+            owner=host.user_id,
+            sandbox_id=sandbox_id,
+            repo=repo,
+            agent_name=agent_name,
+            on_stage=on_stage,
+            keep_host_on_failure=True,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"managed sandbox relaunch conflicted with pending cleanup: {exc}",
+        ) from exc
     return ManagedHostLaunch(host_id=host.host_id, workspace=workspace)
 
 
@@ -2898,7 +2996,7 @@ async def _start_sandbox_host(
     )
 
 
-async def _arm_and_start_host(
+async def _register_and_start_host(
     *,
     launcher: SandboxHostLauncher,
     config: ManagedSandboxConfig,
@@ -2991,7 +3089,7 @@ async def _arm_and_start_host(
         # cap. Cleanup-then-reraise at a system boundary, not a
         # swallow: every path below re-raises as an HTTPException.
         if keep_host_on_failure:
-            await _terminate_sandbox_best_effort(launcher, record)
+            await _terminate_sandbox_best_effort(launcher, record, sandbox_id)
             await asyncio.to_thread(host_store.revoke_launch_token, host_id)
         else:
             # The row was just armed with THIS single-provider config, so a
@@ -3165,7 +3263,7 @@ async def resume_managed_host(
     :param on_stage: Progress observer forwarded to the launcher's
         ``start_host`` (via :func:`_start_sandbox_host`), so a wake reports the
         launch-pipeline ``"starting"`` stage to the caller's progress surface
-        exactly like a fresh launch (:func:`_arm_and_start_host`) — without it a
+        exactly like a fresh launch (:func:`_register_and_start_host`) — without it a
         wake shows a single frozen ``"provisioning"`` band for its whole
         duration. ``None`` disables progress reporting.
     :raises HTTPException: 502 when the resume or host restart fails.
@@ -3176,24 +3274,34 @@ async def resume_managed_host(
     # registry alone. Cheap gate before taking the lock.
     if not force and await asyncio.to_thread(host_store.is_online, host_id):
         return
-    host = await asyncio.to_thread(host_store.get_host, host_id)
-    if host is None:
-        return
-    # Provider-matched launcher (None if config dropped / provider changed).
-    # Resume needs a reattachable volume; others (e.g. Modal) fall through to
-    # the caller's host-offline path (the user starts a new session).
-    launcher = _launcher_for_teardown(host, config)
-    if launcher is None or not launcher.capabilities.resume_stopped or host.sandbox_id is None:
-        return
-    # Re-arm with the recorded provider's own TTL / host_config.
-    entry = config.recorded(host.sandbox_provider)
-    sandbox_id = host.sandbox_id
     # Single-flight per host (see _resume_locks).
     resume_lock = _resume_locks.setdefault(host_id, asyncio.Lock())
     async with resume_lock:
         # Re-check under the lock: a concurrent waker may have brought the host
         # online while we waited.
         if not force and await asyncio.to_thread(host_store.is_online, host_id):
+            return
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            return
+        # Provider-matched launcher (None if config dropped / provider changed).
+        # Resume needs a reattachable volume; others (e.g. Modal) fall through
+        # to the caller's fresh relaunch path.
+        launcher = _launcher_for_teardown(host, config)
+        if launcher is None or not launcher.capabilities.resume_stopped or host.sandbox_id is None:
+            return
+        entry = config.recorded(host.sandbox_provider)
+        sandbox_id = host.sandbox_id
+        token = secrets.token_urlsafe(32)
+        armed = await asyncio.to_thread(
+            host_store.rearm_managed_host,
+            host.host_id,
+            sandbox_id=sandbox_id,
+            expected_updated_at=host.updated_at,
+            token=token,
+            token_expires_at=now_epoch() + entry.token_ttl_s,
+        )
+        if armed is None:
             return
         _logger.info(
             "Waking dormant managed host %s (sandbox %s, provider %s)",
@@ -3203,20 +3311,6 @@ async def resume_managed_host(
         )
         try:
             await asyncio.to_thread(launcher.resume, sandbox_id)
-            # Mint a fresh token: the old one died with the host process's env
-            # (only its hash persists). register_managed_host's relaunch branch
-            # overwrites it in place, keeping the host_id's session bindings.
-            token = secrets.token_urlsafe(32)
-            await asyncio.to_thread(
-                host_store.register_managed_host,
-                host_id=host.host_id,
-                name=host.name,
-                user_id=host.user_id,
-                token=token,
-                provider=launcher.provider,
-                sandbox_id=sandbox_id,
-                token_expires_at=now_epoch() + entry.token_ttl_s,
-            )
             await _start_sandbox_host(
                 launcher,
                 sandbox_id,
@@ -3258,57 +3352,44 @@ async def terminate_managed_host(
     and the caller (session delete / launch-failure cleanup) must not
     be blocked by provider hiccups.
 
-    :param host: The managed host to tear down (``sandbox_provider`` /
-        ``sandbox_id`` set; callers guard on that).
+    :param host: The managed host to tear down. Active and pending sandbox ids
+        are both terminated when present.
     :param host_store: Store holding the host row.
     :param config: The deployment's current sandbox config (supplies
         the launcher for the provider-side terminate), or ``None``
         when managed hosts are no longer configured.
     """
     launcher = _launcher_for_teardown(host, config)
-    await _terminate_sandbox_best_effort(launcher, host)
+    sandbox_ids = dict.fromkeys((host.sandbox_id, host.terminating_sandbox_id))
+    for sandbox_id in sandbox_ids:
+        if sandbox_id is not None:
+            await _terminate_sandbox_best_effort(launcher, host, sandbox_id)
     await asyncio.to_thread(host_store.delete_host, host.host_id)
 
 
 async def _terminate_sandbox_best_effort(
     launcher: SandboxHostLauncher | None,
     host: Host,
-) -> None:
-    """
-    Terminate a managed host's sandbox without touching its row.
-
-    Best-effort by design: termination failures (or a
-    missing/mismatched launcher after a config change) are logged, not
-    raised — the provider's lifetime cap reaps stragglers, and callers
-    (session delete, launch-failure cleanup, relaunch) must not be
-    blocked by provider hiccups.
-
-    :param launcher: Provider-matched launcher from
-        :func:`_launcher_for_teardown`, or ``None`` when no matching
-        launcher is available (logged, nothing terminated).
-    :param host: The host whose ``sandbox_id`` names the sandbox.
-    """
-    if launcher is not None and host.sandbox_id is not None:
-        try:
-            await asyncio.to_thread(launcher.terminate, host.sandbox_id)
-        except Exception:  # noqa: BLE001 — deliberate broad catch: this is a
-            # provider-API boundary on a cleanup path. The provider SDK can
-            # fail here in many shapes (auth/config ClickException, network
-            # errors, SDK-internal exceptions), the sandbox may already be
-            # gone past its lifetime cap, and NONE of those may block the
-            # caller's remaining cleanup (deleting the host row / revoking
-            # the launch token), which only we can do.
-            _logger.warning(
-                "Failed to terminate managed sandbox %s (provider=%s) for host %s",
-                host.sandbox_id,
-                host.sandbox_provider,
-                host.host_id,
-                exc_info=True,
-            )
-    else:
+    sandbox_id: str,
+) -> bool:
+    """Terminate one explicit provider sandbox id without touching its row."""
+    if launcher is None:
         _logger.warning(
             "No launcher available for managed sandbox provider %s; "
             "sandbox %s must be deleted with the provider's own tooling",
             host.sandbox_provider,
-            host.sandbox_id,
+            sandbox_id,
         )
+        return False
+    try:
+        await asyncio.to_thread(launcher.terminate, sandbox_id)
+        return True
+    except Exception:  # noqa: BLE001 — provider cleanup must remain best-effort.
+        _logger.warning(
+            "Failed to terminate managed sandbox %s (provider=%s) for host %s",
+            sandbox_id,
+            host.sandbox_provider,
+            host.host_id,
+            exc_info=True,
+        )
+        return False

--- a/omnigent/server/managed_sandbox_reaper.py
+++ b/omnigent/server/managed_sandbox_reaper.py
@@ -1,0 +1,209 @@
+"""Periodic cleanup of stale and pending server-managed sandboxes."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from contextlib import suppress
+
+from omnigent.db.db_models import workspace_scope
+from omnigent.db.utils import now_epoch
+from omnigent.server.managed_hosts import (
+    ManagedSandboxDeployment,
+    _launcher_for_teardown,
+)
+from omnigent.stores.host_store import Host, HostStore, host_is_live
+
+_logger = logging.getLogger(__name__)
+
+_SECONDS_PER_DAY = 24 * 60 * 60
+
+
+class ManagedSandboxReaper:
+    """Reap stale generations and retry pending provider cleanup.
+
+    Each loop covers the whole configured deployment. A sweep discovers every
+    workspace containing an active or pending managed sandbox, then queries
+    candidates within that workspace. Offline age comes from the host heartbeat
+    row, which is the persisted source of truth for when the sandbox was last
+    online.
+
+    Reaping detaches only the stale provider generation. The session transcript
+    and durable host row remain, allowing a fresh sandbox to launch while failed
+    provider cleanup stays pending for a later sweep.
+    """
+
+    def __init__(
+        self,
+        *,
+        host_store: HostStore,
+        sandbox_config: ManagedSandboxDeployment,
+        clock: Callable[[], int] = now_epoch,
+    ) -> None:
+        self._host_store = host_store
+        self._sandbox_config = sandbox_config
+        self._clock = clock
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start this server process's deployment-wide reaper loop."""
+        if self._task is not None and not self._task.done():
+            return
+        self._task = asyncio.create_task(
+            self._run(),
+            name="managed-sandbox-reaper",
+        )
+
+    async def shutdown(self) -> None:
+        """Stop the reaper loop and wait for cancellation to settle."""
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    async def sweep_once(self, *, now: int | None = None) -> int:
+        """Run one complete cross-workspace sweep and return the reap count."""
+        reference_time = self._clock() if now is None else now
+        workspace_ids = await asyncio.to_thread(
+            self._host_store.list_managed_sandbox_workspace_ids
+        )
+        reaped = 0
+        for workspace_id in workspace_ids:
+            try:
+                reaped += await self._sweep_current_workspace(
+                    workspace_id,
+                    reference_time,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "Managed sandbox reaper failed for workspace %s; continuing",
+                    workspace_id,
+                )
+        return reaped
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                reaped = await self.sweep_once()
+                if reaped:
+                    _logger.info("Managed sandbox reaper terminated %s generation(s)", reaped)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception("Managed sandbox reaper sweep failed; retrying later")
+            await asyncio.sleep(self._sandbox_config.reaper.sweep_interval_s)
+
+    async def _sweep_current_workspace(self, workspace_id: int, now: int) -> int:
+        cutoff = now - self._sandbox_config.reaper.terminate_after_offline_days * _SECONDS_PER_DAY
+        hosts = await asyncio.to_thread(
+            self._list_stale_managed_sandbox_hosts,
+            workspace_id,
+            cutoff,
+        )
+        grouped: dict[str, list[Host]] = {}
+        for host in hosts:
+            if not self._is_reap_candidate(host, cutoff=cutoff, now=now):
+                continue
+            assert host.sandbox_provider is not None
+            grouped.setdefault(host.sandbox_provider, []).append(host)
+
+        reaped = 0
+        for provider, candidates in grouped.items():
+            try:
+                reaped += await asyncio.to_thread(
+                    self._reap_group,
+                    workspace_id,
+                    provider,
+                    candidates,
+                    cutoff,
+                    now,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _logger.exception(
+                    "Managed sandbox reaper failed for provider %s in workspace %s; continuing",
+                    provider,
+                    workspace_id,
+                )
+        return reaped
+
+    def _list_stale_managed_sandbox_hosts(
+        self,
+        workspace_id: int,
+        cutoff: int,
+    ) -> list[Host]:
+        with workspace_scope(workspace_id):
+            return self._host_store.list_stale_managed_sandbox_hosts(cutoff)
+
+    def _reap_group(
+        self,
+        workspace_id: int,
+        provider: str,
+        candidates: list[Host],
+        cutoff: int,
+        now: int,
+    ) -> int:
+        with workspace_scope(workspace_id):
+            launcher = _launcher_for_teardown(candidates[0], self._sandbox_config)
+            if launcher is None:
+                _logger.warning(
+                    "No launcher available for managed sandbox provider %s; "
+                    "skipping %s candidate(s)",
+                    provider,
+                    len(candidates),
+                )
+                return 0
+
+            reaped = 0
+            with launcher.reaper_identity(workspace_id):
+                for candidate in candidates:
+                    try:
+                        sandbox_id = candidate.terminating_sandbox_id
+                        if sandbox_id is None:
+                            if not self._is_reap_candidate(candidate, cutoff=cutoff, now=now):
+                                continue
+                            sandbox_id = candidate.sandbox_id
+                            assert sandbox_id is not None
+                            if not self._host_store.detach_stale_managed_sandbox(
+                                candidate.host_id,
+                                sandbox_id=sandbox_id,
+                                expected_updated_at=candidate.updated_at,
+                            ):
+                                continue
+                        elif candidate.sandbox_id == sandbox_id:
+                            _logger.error(
+                                "Managed sandbox host %s has the same active and pending "
+                                "sandbox id; skipping termination",
+                                candidate.host_id,
+                            )
+                            continue
+                        launcher.terminate(sandbox_id)
+                        if self._host_store.mark_terminating_sandbox_terminated(
+                            candidate.host_id,
+                            sandbox_id=sandbox_id,
+                        ):
+                            reaped += 1
+                    except Exception:
+                        _logger.exception(
+                            "Managed sandbox reaper failed for host %s; continuing",
+                            candidate.host_id,
+                        )
+            return reaped
+
+    @staticmethod
+    def _is_reap_candidate(host: Host, *, cutoff: int, now: int) -> bool:
+        return host.sandbox_provider is not None and (
+            host.terminating_sandbox_id is not None
+            or (
+                host.sandbox_id is not None
+                and not host_is_live(host, now=now)
+                and host.updated_at <= cutoff
+            )
+        )

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -282,6 +282,7 @@ def create_host_tunnel_router(
                 user_id=tunnel_owner,
                 allow_host_id_reown=allow_host_id_reown,
                 configured_harnesses=frame.configured_harnesses,
+                managed_token=managed_token,
             )
             host_persisted = True
 

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -2322,7 +2322,7 @@ def register_events_routes(
         host_store_for_managed = getattr(request.app.state, "host_store", None)
         if conv.host_id is not None and host_store_for_managed is not None:
             bound_host = await asyncio.to_thread(host_store_for_managed.get_host, conv.host_id)
-            if bound_host is not None and bound_host.sandbox_id is not None:
+            if bound_host is not None and bound_host.sandbox_provider is not None:
                 from omnigent.server.managed_hosts import terminate_managed_host
 
                 await terminate_managed_host(

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -16,9 +16,11 @@ import hmac
 import json
 import logging
 from dataclasses import dataclass
+from typing import cast
 
-from sqlalchemy import Engine, select, update
+from sqlalchemy import Engine, and_, or_, select, update
 from sqlalchemy import delete as sql_delete
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -67,9 +69,14 @@ class Host:
         host (``host_type="managed"`` sessions), e.g. ``"modal"``.
         ``None`` for external (user-connected) hosts — non-``None``
         marks the host as server-managed.
-    :param sandbox_id: Provider-assigned id of the sandbox currently
-        backing a managed host, e.g. ``"sb-a1b2c3"`` — what
-        termination is issued against. ``None`` for external hosts.
+    :param sandbox_id: Provider-assigned id of the sandbox generation
+        currently backing a managed host, e.g. ``"sb-a1b2c3"`` — what
+        termination is issued against. ``None`` for external hosts and
+        managed hosts whose prior generation was reaped while the durable
+        host/session binding remains available for relaunch.
+    :param terminating_sandbox_id: Provider-assigned id detached from the
+        active generation and awaiting provider termination. A newly launched
+        generation may coexist in ``sandbox_id`` while this cleanup retries.
     :param configured_harnesses: Per-harness readiness reported in the
         host's last ``host.hello`` frame, e.g.
         ``{"claude-sdk": True, "codex": False}``. ``None`` when the
@@ -86,6 +93,7 @@ class Host:
     sandbox_provider: str | None = None
     sandbox_id: str | None = None
     configured_harnesses: dict[str, HarnessAvailability] | None = None
+    terminating_sandbox_id: str | None = None
 
 
 def host_is_live(host: Host, now: int | None = None) -> bool:
@@ -153,6 +161,7 @@ def _row_to_host(row: SqlHost) -> Host:
         updated_at=row.updated_at,
         sandbox_provider=row.sandbox_provider,
         sandbox_id=row.sandbox_id,
+        terminating_sandbox_id=row.terminating_sandbox_id,
         configured_harnesses=_parse_configured_harnesses(row.configured_harnesses),
     )
 
@@ -202,6 +211,7 @@ class HostStore:
         *,
         allow_host_id_reown: bool = False,
         configured_harnesses: dict[str, HarnessAvailability] | None = None,
+        managed_token: str | None = None,
     ) -> Host:
         """
         Register or update a host on WebSocket connect.
@@ -241,6 +251,9 @@ class HostStore:
             Written on every connect — including ``None`` from an older
             host that doesn't report it, which correctly resets any
             stale value back to "unknown".
+        :param managed_token: Raw launch token for a managed host. When set,
+            registration atomically revalidates the current credential instead
+            of performing the external-host upsert path.
         :returns: The upserted :class:`Host`.
         """
         now = now_epoch()
@@ -248,6 +261,35 @@ class HostStore:
             json.dumps(configured_harnesses) if configured_harnesses is not None else None
         )
         with self._session("upsert_host_on_connect") as session:
+            if managed_token is not None:
+                result = cast(
+                    CursorResult[tuple[object]],
+                    session.execute(
+                        update(SqlHost)
+                        .where(
+                            SqlHost.workspace_id == current_workspace_id(),
+                            SqlHost.host_id == host_id,
+                            SqlHost.user_id == user_id,
+                            SqlHost.token_hash == hash_host_launch_token(managed_token),
+                            SqlHost.token_expires_at.is_not(None),
+                            SqlHost.token_expires_at >= now,
+                            SqlHost.sandbox_id.is_not(None),
+                        )
+                        .values(
+                            name=name,
+                            status=encode_host_status("online"),
+                            updated_at=now,
+                            configured_harnesses=harnesses_json,
+                        )
+                    ),
+                )
+                if result.rowcount != 1:
+                    raise ValueError("managed host launch token is no longer valid")
+                managed_row = session.get(SqlHost, (current_workspace_id(), host_id))
+                if managed_row is None:
+                    raise ValueError("managed host registration disappeared")
+                return _row_to_host(managed_row)
+
             # Primary lookup: by (workspace_id, host_id) — the new PK.
             row = session.get(SqlHost, (current_workspace_id(), host_id))
             if row is not None:
@@ -357,6 +399,7 @@ class HostStore:
         token_expires_at = row.token_expires_at
         sandbox_provider = row.sandbox_provider
         sandbox_id = row.sandbox_id
+        terminating_sandbox_id = row.terminating_sandbox_id
 
         bound_ids = list(
             session.execute(
@@ -398,6 +441,7 @@ class HostStore:
             token_expires_at=token_expires_at,
             sandbox_provider=sandbox_provider,
             sandbox_id=sandbox_id,
+            terminating_sandbox_id=terminating_sandbox_id,
             configured_harnesses=harnesses_json,
         )
         session.add(new_row)
@@ -635,6 +679,58 @@ class HostStore:
             )
             return [_row_to_host(row) for row in rows]
 
+    def list_managed_sandbox_workspace_ids(self) -> list[int]:
+        """List workspaces with active or pending managed sandbox generations.
+
+        This is the privileged discovery query used by the server-wide managed
+        sandbox reaper. Unlike normal request-path store methods, it
+        intentionally spans workspace partitions; the reaper immediately enters
+        each returned :func:`workspace_scope` before reading sessions or hosts.
+
+        :returns: Workspace ids in ascending order.
+        """
+        with self._session("list_managed_sandbox_workspaces") as session:
+            return list(
+                session.execute(
+                    select(SqlHost.workspace_id)
+                    .where(
+                        SqlHost.sandbox_provider.is_not(None),
+                        or_(
+                            SqlHost.sandbox_id.is_not(None),
+                            SqlHost.terminating_sandbox_id.is_not(None),
+                        ),
+                    )
+                    .distinct()
+                    .order_by(SqlHost.workspace_id.asc())
+                ).scalars()
+            )
+
+    def list_stale_managed_sandbox_hosts(self, older_than_epoch: int) -> list[Host]:
+        """List stale active and pending managed sandboxes in this workspace.
+
+        :param older_than_epoch: Latest included host heartbeat timestamp.
+        :returns: Stale generations ordered from oldest to newest.
+        """
+        with self._session("list_stale_managed_sandbox_hosts") as session:
+            rows = (
+                session.query(SqlHost)
+                .filter(
+                    SqlHost.workspace_id == current_workspace_id(),
+                    SqlHost.sandbox_provider.is_not(None),
+                    or_(
+                        SqlHost.terminating_sandbox_id.is_not(None),
+                        and_(
+                            SqlHost.terminating_sandbox_id.is_(None),
+                            SqlHost.sandbox_id.is_not(None),
+                            SqlHost.updated_at <= older_than_epoch,
+                        ),
+                    ),
+                )
+                .order_by(SqlHost.updated_at.asc(), SqlHost.host_id.asc())
+                .all()
+            )
+            return [_row_to_host(row) for row in rows]
+
     def get_host(self, host_id: str) -> Host | None:
         """
         Fetch a single host by ID.
@@ -696,17 +792,17 @@ class HostStore:
         :param token_expires_at: Unix epoch seconds after which the
             token no longer authenticates.
         :returns: The registered :class:`Host`.
-        :raises ValueError: If a row for *host_id* exists under a
-            DIFFERENT user_id — a relaunch may only re-credential a host
-            the same user owns.
+        :raises ValueError: If a row for *host_id* belongs to another user,
+            changes provider while cleanup is pending, or tries to re-arm the
+            exact sandbox id still awaiting termination.
         """
         now = now_epoch()
         token_hash = hash_host_launch_token(token)
         with self._session("register_managed_host") as session:
             existing = session.execute(
-                select(SqlHost).where(
-                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
-                )
+                select(SqlHost)
+                .where(SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id)
+                .with_for_update()
             ).scalar_one_or_none()
             if existing is not None:
                 if existing.user_id != user_id:
@@ -719,6 +815,18 @@ class HostStore:
                     raise ValueError(
                         f"host {host_id!r} is registered to a different user; "
                         "refusing to re-credential it"
+                    )
+                if (
+                    existing.terminating_sandbox_id is not None
+                    and existing.sandbox_provider != provider
+                ):
+                    raise ValueError(
+                        "cannot change managed sandbox provider while termination is pending"
+                    )
+                if existing.terminating_sandbox_id == sandbox_id:
+                    raise ValueError(
+                        f"sandbox {sandbox_id!r} is still pending termination; "
+                        "refusing to re-arm it"
                     )
                 existing.token_hash = token_hash
                 existing.token_expires_at = token_expires_at
@@ -740,6 +848,52 @@ class HostStore:
             )
             session.add(row)
             return _row_to_host(row)
+
+    def rearm_managed_host(
+        self,
+        host_id: str,
+        *,
+        sandbox_id: str,
+        expected_updated_at: int,
+        token: str,
+        token_expires_at: int,
+    ) -> Host | None:
+        """Atomically re-arm the exact active generation before resuming it.
+
+        The compare-and-update races against reaper detachment and tunnel
+        heartbeats. Cleanup of a different, older generation does not block the
+        active generation. A missing result means the caller's snapshot is no
+        longer current and the provider must not be asked to resume that sandbox id.
+        """
+        now = now_epoch()
+        with self._session("rearm_managed_host") as session:
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlHost)
+                    .where(
+                        SqlHost.workspace_id == current_workspace_id(),
+                        SqlHost.host_id == host_id,
+                        SqlHost.sandbox_id == sandbox_id,
+                        SqlHost.updated_at == expected_updated_at,
+                        SqlHost.sandbox_provider.is_not(None),
+                        or_(
+                            SqlHost.terminating_sandbox_id.is_(None),
+                            SqlHost.terminating_sandbox_id != sandbox_id,
+                        ),
+                    )
+                    .values(
+                        token_hash=hash_host_launch_token(token),
+                        token_expires_at=token_expires_at,
+                        status=encode_host_status("offline"),
+                        updated_at=now,
+                    )
+                ),
+            )
+            if result.rowcount != 1:
+                return None
+            row = session.get(SqlHost, (current_workspace_id(), host_id))
+            return _row_to_host(row) if row is not None else None
 
     def resolve_launch_token(self, host_id: str, token: str) -> Host | None:
         """
@@ -809,6 +963,76 @@ class HostStore:
                     SqlHost.host_id == host_id,
                 )
             )
+
+    def detach_stale_managed_sandbox(
+        self,
+        host_id: str,
+        *,
+        sandbox_id: str,
+        expected_updated_at: int,
+    ) -> bool:
+        """Atomically detach one stale generation before provider termination.
+
+        The sandbox id and heartbeat timestamp form the stale snapshot. A
+        reconnect, resume, or relaunch changes one of them and wins the race.
+        Detachment revokes the old token immediately and leaves the cleanup id
+        persisted for later retries.
+
+        :param host_id: Durable managed host identifier.
+        :param sandbox_id: Provider id of the stale active generation.
+        :param expected_updated_at: Heartbeat timestamp observed by the sweep.
+        :returns: ``True`` when that exact stale generation was detached.
+        """
+        with self._session("detach_stale_managed_sandbox") as session:
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlHost)
+                    .where(
+                        SqlHost.workspace_id == current_workspace_id(),
+                        SqlHost.host_id == host_id,
+                        SqlHost.sandbox_id == sandbox_id,
+                        SqlHost.updated_at == expected_updated_at,
+                        SqlHost.sandbox_provider.is_not(None),
+                        SqlHost.terminating_sandbox_id.is_(None),
+                    )
+                    .values(
+                        token_hash=None,
+                        token_expires_at=None,
+                        sandbox_id=None,
+                        terminating_sandbox_id=sandbox_id,
+                        status=encode_host_status("offline"),
+                    )
+                ),
+            )
+            return result.rowcount == 1
+
+    def mark_terminating_sandbox_terminated(
+        self,
+        host_id: str,
+        *,
+        sandbox_id: str,
+    ) -> bool:
+        """Clear one successfully terminated pending sandbox id.
+
+        :param host_id: Durable managed host identifier.
+        :param sandbox_id: Exact pending provider id that was terminated.
+        :returns: ``True`` when that pending id was cleared.
+        """
+        with self._session("mark_terminating_sandbox_terminated") as session:
+            result = cast(
+                CursorResult[tuple[object]],
+                session.execute(
+                    update(SqlHost)
+                    .where(
+                        SqlHost.workspace_id == current_workspace_id(),
+                        SqlHost.host_id == host_id,
+                        SqlHost.terminating_sandbox_id == sandbox_id,
+                    )
+                    .values(terminating_sandbox_id=None)
+                ),
+            )
+            return result.rowcount == 1
 
     def revoke_launch_token(self, host_id: str) -> None:
         """

--- a/tests/db/test_migration_connections.py
+++ b/tests/db/test_migration_connections.py
@@ -34,7 +34,7 @@ def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
 def test_single_alembic_head() -> None:
     script = ScriptDirectory.from_config(_build_alembic_config("sqlite://"))
     heads = script.get_heads()
-    assert heads == ["ga1b2c3d4e5f"], f"expected a single head, got {heads!r}"
+    assert heads == ["gb1b2c3d4e5f"], f"expected a single head, got {heads!r}"
 
 
 def test_upgrade_creates_table_downgrade_drops_it(tmp_path: Path) -> None:

--- a/tests/db/test_migration_managed_sandbox_reaper.py
+++ b/tests/db/test_migration_managed_sandbox_reaper.py
@@ -1,0 +1,49 @@
+"""Tests for the managed sandbox pending-termination migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+
+from omnigent.db.utils import _build_alembic_config, clear_engine_cache
+
+
+def _migrate(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as connection:
+        config.attributes["connection"] = connection
+        command.upgrade(config, revision)
+
+
+def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as connection:
+        config.attributes["connection"] = connection
+        command.downgrade(config, revision)
+
+
+def test_upgrade_adds_pending_termination_column_and_downgrade_removes_it(
+    tmp_path: Path,
+) -> None:
+    uri = f"sqlite:///{tmp_path / 'managed-sandbox-reaper.db'}"
+    engine = sa.create_engine(uri)
+
+    _migrate(uri, engine, "ga1b2c3d4e5f")
+    assert "terminating_sandbox_id" not in {
+        column["name"] for column in sa.inspect(engine).get_columns("hosts")
+    }
+
+    _migrate(uri, engine, "gb1b2c3d4e5f")
+    columns = {column["name"]: column for column in sa.inspect(engine).get_columns("hosts")}
+    assert columns["terminating_sandbox_id"]["nullable"] is True
+    assert columns["terminating_sandbox_id"]["type"].length == 256
+
+    _downgrade(uri, engine, "ga1b2c3d4e5f")
+    assert "terminating_sandbox_id" not in {
+        column["name"] for column in sa.inspect(engine).get_columns("hosts")
+    }
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
+++ b/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
@@ -149,7 +149,7 @@ def test_new_session_shows_first_prompt_optimistically(
     # so a green run isn't a composer that silently never sent.
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline and _PROMPT not in event_texts:
-        time.sleep(0.05)
+        page.wait_for_timeout(50)
     assert _PROMPT in event_texts, (
         f"the initial prompt was never POSTed to the session's /events "
         f"(observed: {event_texts}) — the auto-send path did not run"

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -1547,3 +1547,40 @@ async def test_managed_session_deleted_during_provision_terminates_sandbox(
     # don't surface as unretrieved-exception noise after the test.
     for future in host_futures:
         future.cancel()
+
+
+async def test_delete_reaped_managed_session_removes_durable_host(
+    managed_session_env: ManagedSessionEnv,
+) -> None:
+    """Deleting a reaped session removes its provider-marked durable host row."""
+    env = managed_session_env
+    host = env.host_store.register_managed_host(
+        host_id="8e616af6da4245de923023927b2f36d7",
+        name="managed-reaped-delete",
+        user_id=RESERVED_USER_LOCAL,
+        token="managed-reaped-delete-token",
+        provider="modal",
+        sandbox_id="sb-reaped-delete",
+        token_expires_at=int(time.time()) + 3600,
+    )
+    assert env.host_store.detach_stale_managed_sandbox(
+        host.host_id,
+        sandbox_id="sb-reaped-delete",
+        expected_updated_at=host.updated_at,
+    )
+    assert env.host_store.mark_terminating_sandbox_terminated(
+        host.host_id,
+        sandbox_id="sb-reaped-delete",
+    )
+    agent = await create_test_agent(env.client, name="managed-reaped-delete-agent")
+    conversation = env.conv_store.create_conversation(
+        agent_id=agent["id"],
+        host_id=host.host_id,
+        workspace="/tmp/managed-reaped-delete",
+    )
+
+    response = await env.client.delete(f"/v1/sessions/{conversation.id}")
+
+    assert response.status_code == 200, response.text
+    assert env.conv_store.get_conversation(conversation.id) is None
+    assert env.host_store.get_host(host.host_id) is None

--- a/tests/server/integration/test_host_tunnel_route.py
+++ b/tests/server/integration/test_host_tunnel_route.py
@@ -803,6 +803,40 @@ async def test_managed_token_authenticates_as_record_owner(
     assert host.sandbox_id == "sb-tunnel-1"
 
 
+async def test_managed_token_is_revalidated_after_websocket_accept(
+    host_app: tuple[FastAPI, HostRegistry, HostStore],
+) -> None:
+    """Detaching after handshake auth still blocks final host registration."""
+    app, registry, store = host_app
+    _register_managed(store, host_id=_HOST_ID, token="tunnel-token-race")
+    registered = store.get_host(_HOST_ID)
+    assert registered is not None
+
+    communicator = ApplicationCommunicator(app, _managed_scope(_TUNNEL_PATH, "tunnel-token-race"))
+    await communicator.send_input({"type": "websocket.connect"})
+    accepted = await communicator.receive_output(timeout=1.0)
+    assert accepted["type"] == "websocket.accept"
+
+    assert store.detach_stale_managed_sandbox(
+        _HOST_ID,
+        sandbox_id="sb-tunnel-1",
+        expected_updated_at=registered.updated_at,
+    )
+    await communicator.send_input(
+        {"type": "websocket.receive", "text": _make_hello(name=f"managed-{_HOST_ID}")},
+    )
+    response = await communicator.receive_output(timeout=1.0)
+    if response["type"] == "websocket.send":
+        response = await communicator.receive_output(timeout=1.0)
+    assert response["type"] == "websocket.close"
+    assert registry.get(_HOST_ID) is None
+    detached = store.get_host(_HOST_ID)
+    assert detached is not None
+    assert detached.status == "offline"
+    assert detached.sandbox_id is None
+    assert detached.terminating_sandbox_id == "sb-tunnel-1"
+
+
 @pytest.mark.parametrize(
     ("record_host_id", "token", "presented_token", "expires_in_s"),
     [

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -56,11 +56,12 @@ from omnigent.server.managed_hosts import (
     resume_managed_host,
     terminate_managed_host,
 )
+from omnigent.server.managed_sandbox_reaper import ManagedSandboxReaper
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.artifact_store.local import LocalArtifactStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
-from omnigent.stores.host_store import HostStore
+from omnigent.stores.host_store import Host, HostStore
 from tests.server.helpers import (
     FakeSandboxLauncher,
     HostStartInvocation,
@@ -150,6 +151,81 @@ class _StubAgentStore:
 def test_parse_absent_section_disables_managed_hosts() -> None:
     """No ``sandbox:`` section → managed hosts simply not configured."""
     assert parse_sandbox_config(None) is None
+
+
+def test_parse_reaper_defaults_disabled_with_thirty_day_cutoff() -> None:
+    """Managed sandbox cleanup is opt-in and defaults to a 30-day age."""
+    config = parse_sandbox_config({"provider": "modal", "server_url": "https://s.example.com"})
+    assert config is not None
+    assert config.reaper.enabled is False
+    assert config.reaper.terminate_after_offline_days == 30
+    assert config.reaper.sweep_interval_s == 86400
+
+
+def test_parse_reaper_is_one_deployment_wide_policy_for_multiple_providers() -> None:
+    """One top-level reaper config applies across every offered provider."""
+    config = parse_sandbox_config(
+        {
+            "server_url": "https://s.example.com",
+            "reaper": {
+                "enabled": True,
+                "terminate_after_offline_days": 7,
+                "sweep_interval_s": 1234,
+            },
+            "providers": [
+                {"provider": "modal"},
+                {"provider": "e2b"},
+            ],
+        }
+    )
+    assert config is not None
+    assert config.reaper.enabled is True
+    assert config.reaper.terminate_after_offline_days == 7
+    assert config.reaper.sweep_interval_s == 1234
+    assert [entry.provider for entry in config.offered()] == ["modal", "e2b"]
+
+
+@pytest.mark.parametrize(
+    ("reaper", "expected_fragment"),
+    [
+        (True, "must be a mapping"),
+        ({"enabled": "yes"}, "enabled.*boolean"),
+        ({"terminate_after_offline_days": 0}, "positive integer"),
+        ({"terminate_after_offline_days": True}, "positive integer"),
+        ({"terminate_after_offline_days": "30d"}, "positive integer"),
+        ({"sweep_interval_s": 0}, "positive integer"),
+        ({"sweep_interval_s": True}, "positive integer"),
+        ({"sweep_interval_s": "1d"}, "positive integer"),
+        ({"offline_after_s": 60}, "unknown key"),
+    ],
+)
+def test_parse_reaper_rejects_malformed_config(
+    reaper: object,
+    expected_fragment: str,
+) -> None:
+    """Reaper typos fail server startup instead of silently disabling cleanup."""
+    with pytest.raises(ValueError, match=expected_fragment):
+        parse_sandbox_config(
+            {
+                "provider": "modal",
+                "server_url": "https://s.example.com",
+                "reaper": reaper,
+            }
+        )
+
+
+def test_parse_reaper_rejects_per_provider_override() -> None:
+    """The reaper loop is configured once, never independently per provider."""
+    with pytest.raises(ValueError, match="deployment-wide"):
+        parse_sandbox_config(
+            {
+                "server_url": "https://s.example.com",
+                "providers": [
+                    {"provider": "modal", "reaper": {"enabled": True}},
+                    {"provider": "e2b"},
+                ],
+            }
+        )
 
 
 def test_parse_valid_modal_config_builds_image_parameterized_factory(
@@ -1659,6 +1735,8 @@ def _capability_probe_app(
     db_uri: str,
     tmp_path: Path,
     sandbox_config: ManagedSandboxDeployment | None,
+    *,
+    host_store: HostStore | None = None,
 ) -> FastAPI:
     """
     Build a real app wired with *sandbox_config* to probe ``GET /v1/info``.
@@ -1670,6 +1748,7 @@ def _capability_probe_app(
     :param tmp_path: Per-test scratch dir for artifact/cache stores.
     :param sandbox_config: The sandbox config under test, or ``None``
         when managed hosts are not configured.
+    :param host_store: Optional managed-host store for lifespan tests.
     :returns: The assembled FastAPI app.
     """
     artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
@@ -1679,8 +1758,46 @@ def _capability_probe_app(
         conversation_store=SqlAlchemyConversationStore(db_uri),
         artifact_store=artifact_store,
         agent_cache=AgentCache(artifact_store=artifact_store, cache_dir=tmp_path / "cache"),
+        host_store=host_store,
         sandbox_config=sandbox_config,
     )
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+async def test_lifespan_gates_one_deployment_wide_managed_sandbox_reaper(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+    enabled: bool,
+) -> None:
+    """One lifespan task covers all providers and obeys the global enable flag."""
+    config = parse_sandbox_config(
+        {
+            "server_url": "https://s.example.com",
+            "reaper": {"enabled": enabled},
+            "providers": [{"provider": "modal"}, {"provider": "e2b"}],
+        }
+    )
+    assert config is not None
+    app = _capability_probe_app(
+        db_uri,
+        tmp_path,
+        config,
+        host_store=HostStore(db_uri),
+    )
+
+    async with app.router.lifespan_context(app):
+        reaper = getattr(app.state, "managed_sandbox_reaper", None)
+        if enabled:
+            assert isinstance(reaper, ManagedSandboxReaper)
+            assert reaper._sandbox_config is config
+            assert reaper._task is not None
+            assert not reaper._task.done()
+        else:
+            assert reaper is None
+
+    if enabled:
+        assert reaper._task is None
 
 
 @pytest.mark.parametrize(
@@ -1904,6 +2021,7 @@ async def test_launch_materializes_host_config_before_host_start(db_uri: str) ->
             host_id=invocation.host_id,
             name=invocation.host_name,
             user_id=_OWNER,
+            managed_token=invocation.token,
         )
 
     fake = FakeSandboxLauncher(on_host_start=_register)
@@ -1923,7 +2041,7 @@ async def test_launch_materializes_host_config_before_host_start(db_uri: str) ->
 async def test_resume_rematerializes_host_config_before_host_restart(db_uri: str) -> None:
     """
     Waking a dormant sandbox re-runs the config write before re-execing the
-    host — resume_managed_host bypasses _arm_and_start_host, so this is a
+    host — resume_managed_host bypasses _register_and_start_host, so this is a
     distinct wiring point, and re-materializing is what lets an operator's
     host_config change land on the next wake without a new sandbox.
     """
@@ -2381,6 +2499,67 @@ async def test_launch_entrypoint_provider_cleans_up_on_launch_failure(db_uri: st
 # ── relaunch_managed_host ───────────────────────────────────
 
 
+class _ReusedIdFakeLauncher(FakeSandboxLauncher):
+    provider: ClassVar[str] = "blaxel"
+
+    def provision(self, name: str) -> str:
+        self.provisioned_names.append(name)
+        return name
+
+
+async def test_relaunch_rejects_pending_reused_id_then_allows_retry(db_uri: str) -> None:
+    host_store = HostStore(db_uri)
+
+    def _register(invocation: HostStartInvocation) -> None:
+        host_store.upsert_on_connect(
+            host_id=invocation.host_id,
+            name=invocation.host_name,
+            user_id=_OWNER,
+        )
+
+    fake = _ReusedIdFakeLauncher(on_host_start=_register)
+    config = _injected_config(fake)
+    first = await launch_managed_host(config=config, owner=_OWNER, host_store=host_store)
+    active = host_store.get_host(first.host_id)
+    assert active is not None
+    assert active.sandbox_id is not None
+    assert host_store.detach_stale_managed_sandbox(
+        active.host_id,
+        sandbox_id=active.sandbox_id,
+        expected_updated_at=active.updated_at,
+    )
+    pending = host_store.get_host(active.host_id)
+    assert pending is not None
+
+    with pytest.raises(HTTPException) as exc:
+        await relaunch_managed_host(config=config, host=pending, host_store=host_store)
+
+    assert exc.value.status_code == 409
+    assert "pending cleanup" in exc.value.detail
+    assert len(fake.host_starts) == 1
+    assert fake.terminated == []
+    still_pending = host_store.get_host(active.host_id)
+    assert still_pending is not None
+    assert still_pending.sandbox_id is None
+    assert still_pending.terminating_sandbox_id == active.name
+
+    reaper = ManagedSandboxReaper(host_store=host_store, sandbox_config=config)
+    assert await reaper.sweep_once() == 1
+    assert fake.terminated == [active.name]
+    cleared = host_store.get_host(active.host_id)
+    assert cleared is not None
+    assert cleared.sandbox_id is None
+    assert cleared.terminating_sandbox_id is None
+
+    relaunched = await relaunch_managed_host(config=config, host=cleared, host_store=host_store)
+    assert relaunched.host_id == active.host_id
+    current = host_store.get_host(active.host_id)
+    assert current is not None
+    assert current.status == "online"
+    assert current.sandbox_id == active.name
+    assert current.terminating_sandbox_id is None
+
+
 async def test_relaunch_rolls_sandbox_generation_under_same_host(db_uri: str) -> None:
     """
     A relaunch terminates the dead generation, provisions a fresh
@@ -2592,7 +2771,7 @@ async def test_resume_managed_host_wakes_same_sandbox_and_refreshes_token(db_uri
 async def test_resume_managed_host_forwards_on_stage(db_uri: str) -> None:
     """A wake reports launch-pipeline stages through ``on_stage``.
 
-    Parity with the fresh-launch path (``_arm_and_start_host``): base
+    Parity with the fresh-launch path (``_register_and_start_host``): base
     ``start_host`` emits ``"starting"`` before it execs the host, so a wake
     with an observer must surface at least that stage rather than leaving the
     caller on a single frozen ``"provisioning"`` band for the whole resume.
@@ -2621,6 +2800,15 @@ async def test_resume_managed_host_forwards_on_stage(db_uri: str) -> None:
 async def test_resume_managed_host_force_wakes_fresh_online_row(db_uri: str) -> None:
     """A local missing-tunnel wake can bypass stale cross-replica DB freshness."""
     host_store = HostStore(db_uri)
+
+    def _register(invocation: HostStartInvocation) -> None:
+        host_store.upsert_on_connect(
+            host_id=invocation.host_id,
+            name=invocation.host_name,
+            user_id=_OWNER,
+            managed_token=invocation.token,
+        )
+
     host_store.register_managed_host(
         host_id="62d4405ba38711fe34bebfeb5a7adaf2",
         name="managed-resume-force",
@@ -2636,7 +2824,7 @@ async def test_resume_managed_host_force_wakes_fresh_online_row(db_uri: str) -> 
         user_id=_OWNER,
     )
     assert host_store.is_online("62d4405ba38711fe34bebfeb5a7adaf2") is True
-    fake = _IsloFakeLauncher(can_resume=True)
+    fake = _IsloFakeLauncher(on_host_start=_register, can_resume=True)
 
     await resume_managed_host(
         "62d4405ba38711fe34bebfeb5a7adaf2", host_store, _injected_config(fake), force=True
@@ -2684,8 +2872,8 @@ async def test_resume_managed_host_noops_for_non_resumable_provider(db_uri: str)
     )
 
 
-async def test_resume_managed_host_failure_preserves_existing_row_and_token(db_uri: str) -> None:
-    """A failed wake leaves the dormant host retryable."""
+async def test_resume_managed_host_failure_preserves_existing_row(db_uri: str) -> None:
+    """A failed wake leaves the dormant host generation retryable."""
     host_store = HostStore(db_uri)
     host_store.register_managed_host(
         host_id="efbef7dede7be6577770cbb1287992f2",
@@ -2712,8 +2900,59 @@ async def test_resume_managed_host_failure_preserves_existing_row_and_token(db_u
     assert host.sandbox_id == "sb-resume-fail"
     assert (
         host_store.resolve_launch_token("efbef7dede7be6577770cbb1287992f2", "tok-resume-fail")
-        is not None
+        is None
     )
+
+
+async def test_resume_managed_host_does_not_resume_detached_generation(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reaper detach that wins the CAS prevents the provider resume call."""
+    host_store = HostStore(db_uri)
+    host_id = "ade43acaaaf44af59388dc2109a8557f"
+    host_store.register_managed_host(
+        host_id=host_id,
+        name="managed-resume-race",
+        user_id=_OWNER,
+        token="tok-resume-race",
+        provider="islo",
+        sandbox_id="sb-resume-race",
+        token_expires_at=now_epoch() + 3600,
+    )
+    original_rearm = host_store.rearm_managed_host
+
+    def _detach_before_rearm(
+        requested_host_id: str,
+        *,
+        sandbox_id: str,
+        expected_updated_at: int,
+        token: str,
+        token_expires_at: int,
+    ) -> Host | None:
+        assert host_store.detach_stale_managed_sandbox(
+            requested_host_id,
+            sandbox_id=sandbox_id,
+            expected_updated_at=expected_updated_at,
+        )
+        return original_rearm(
+            requested_host_id,
+            sandbox_id=sandbox_id,
+            expected_updated_at=expected_updated_at,
+            token=token,
+            token_expires_at=token_expires_at,
+        )
+
+    monkeypatch.setattr(host_store, "rearm_managed_host", _detach_before_rearm)
+    fake = _IsloFakeLauncher(can_resume=True)
+
+    await resume_managed_host(host_id, host_store, _injected_config(fake))
+
+    assert fake.resumed == []
+    detached = host_store.get_host(host_id)
+    assert detached is not None
+    assert detached.sandbox_id is None
+    assert detached.terminating_sandbox_id == "sb-resume-race"
 
 
 # ── terminate_managed_host ──────────────────────────────────
@@ -2744,6 +2983,43 @@ async def test_terminate_managed_host_terminates_and_deletes_row(db_uri: str) ->
     assert (
         host_store.resolve_launch_token("62a91eb065624754c6a6dfb5869dd7e8", "tok-term-1") is None
     )
+
+
+async def test_terminate_managed_host_cleans_active_and_pending_generations(db_uri: str) -> None:
+    """Full host teardown best-effort terminates both persisted sandbox ids."""
+    fake = FakeSandboxLauncher()
+    host_store = HostStore(db_uri)
+    host_id = "b63810fdd86a4f04988b3e53a930ad08"
+    original = host_store.register_managed_host(
+        host_id=host_id,
+        name="managed-term-both",
+        user_id=_OWNER,
+        token="tok-term-old",
+        provider="modal",
+        sandbox_id="sb-term-old",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert host_store.detach_stale_managed_sandbox(
+        host_id,
+        sandbox_id="sb-term-old",
+        expected_updated_at=original.updated_at,
+    )
+    host_store.register_managed_host(
+        host_id=host_id,
+        name="managed-term-both",
+        user_id=_OWNER,
+        token="tok-term-new",
+        provider="modal",
+        sandbox_id="sb-term-new",
+        token_expires_at=now_epoch() + 3600,
+    )
+    host = host_store.get_host(host_id)
+    assert host is not None
+
+    await terminate_managed_host(host, host_store, _injected_config(fake))
+
+    assert fake.terminated == ["sb-term-new", "sb-term-old"]
+    assert host_store.get_host(host_id) is None
 
 
 async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(

--- a/tests/server/test_managed_sandbox_reaper.py
+++ b/tests/server/test_managed_sandbox_reaper.py
@@ -1,0 +1,475 @@
+"""Tests for :mod:`omnigent.server.managed_sandbox_reaper`."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Callable, Iterator
+from dataclasses import replace
+
+import pytest
+
+from omnigent.db.db_models import current_workspace_id
+from omnigent.server.managed_hosts import (
+    ManagedSandboxConfig,
+    ManagedSandboxDeployment,
+    ManagedSandboxReaperConfig,
+)
+from omnigent.server.managed_sandbox_reaper import ManagedSandboxReaper
+from omnigent.stores.host_store import Host
+
+pytestmark = pytest.mark.asyncio
+
+_DAY_S = 24 * 60 * 60
+
+
+class _RecordingLauncher:
+    def __init__(
+        self,
+        provider: str,
+        *,
+        fail: bool = False,
+        identity_fail: bool = False,
+        on_terminate: Callable[[str], None] | None = None,
+    ) -> None:
+        self.provider = provider
+        self.fail = fail
+        self.identity_fail = identity_fail
+        self.on_terminate = on_terminate
+        self.factory_calls = 0
+        self.identity_entries: list[int] = []
+        self.identity_threads: list[int] = []
+        self.terminated: list[str] = []
+        self.termination_threads: list[int] = []
+
+    @contextlib.contextmanager
+    def reaper_identity(self, workspace_id: int) -> Iterator[None]:
+        self.identity_entries.append(workspace_id)
+        self.identity_threads.append(threading.get_ident())
+        if self.identity_fail:
+            raise RuntimeError(f"{self.provider} identity unavailable")
+        yield
+
+    def terminate(self, sandbox_id: str) -> None:
+        self.termination_threads.append(threading.get_ident())
+        if self.on_terminate is not None:
+            self.on_terminate(sandbox_id)
+        if self.fail:
+            raise RuntimeError(f"{self.provider} unavailable")
+        self.terminated.append(sandbox_id)
+
+
+class _FakeHostStore:
+    def __init__(self, hosts: dict[int, list[Host]]) -> None:
+        self.hosts = {
+            workspace_id: {host.host_id: host for host in workspace_hosts}
+            for workspace_id, workspace_hosts in hosts.items()
+        }
+        self.detached: list[tuple[int, str, str]] = []
+        self.cleared: list[tuple[int, str, str]] = []
+        self.refresh_on_detach: set[str] = set()
+        self.stale_queries: list[tuple[int, int]] = []
+
+    def list_managed_sandbox_workspace_ids(self) -> list[int]:
+        return sorted(
+            workspace_id
+            for workspace_id, hosts in self.hosts.items()
+            if any(
+                host.sandbox_provider is not None
+                and (host.sandbox_id is not None or host.terminating_sandbox_id is not None)
+                for host in hosts.values()
+            )
+        )
+
+    def list_stale_managed_sandbox_hosts(self, older_than_epoch: int) -> list[Host]:
+        workspace_id = current_workspace_id()
+        self.stale_queries.append((workspace_id, older_than_epoch))
+        hosts = [
+            host
+            for host in self.hosts[workspace_id].values()
+            if host.sandbox_provider is not None
+            and (
+                host.terminating_sandbox_id is not None
+                or (host.sandbox_id is not None and host.updated_at <= older_than_epoch)
+            )
+        ]
+        return sorted(hosts, key=lambda host: (host.updated_at, host.host_id))
+
+    def detach_stale_managed_sandbox(
+        self,
+        host_id: str,
+        *,
+        sandbox_id: str,
+        expected_updated_at: int,
+    ) -> bool:
+        workspace_id = current_workspace_id()
+        workspace_hosts = self.hosts[current_workspace_id()]
+        host = workspace_hosts.get(host_id)
+        if host is not None and host_id in self.refresh_on_detach:
+            host = replace(host, status="online", updated_at=4_000_000)
+            workspace_hosts[host_id] = host
+            self.refresh_on_detach.remove(host_id)
+        if (
+            host is None
+            or host.sandbox_id != sandbox_id
+            or host.updated_at != expected_updated_at
+            or host.terminating_sandbox_id is not None
+        ):
+            return False
+        workspace_hosts[host_id] = replace(
+            host,
+            status="offline",
+            sandbox_id=None,
+            terminating_sandbox_id=sandbox_id,
+        )
+        self.detached.append((workspace_id, host_id, sandbox_id))
+        return True
+
+    def mark_terminating_sandbox_terminated(
+        self,
+        host_id: str,
+        *,
+        sandbox_id: str,
+    ) -> bool:
+        workspace_id = current_workspace_id()
+        host = self.hosts[workspace_id].get(host_id)
+        if host is None or host.terminating_sandbox_id != sandbox_id:
+            return False
+        self.hosts[workspace_id][host_id] = replace(
+            host,
+            terminating_sandbox_id=None,
+        )
+        self.cleared.append((workspace_id, host_id, sandbox_id))
+        return True
+
+
+def _host(
+    host_id: str,
+    *,
+    provider: str,
+    sandbox_id: str | None,
+    updated_at: int,
+    status: str = "offline",
+    terminating_sandbox_id: str | None = None,
+) -> Host:
+    return Host(
+        host_id=host_id,
+        name=host_id,
+        user_id="alice@example.com",
+        status=status,
+        created_at=updated_at - 100,
+        updated_at=updated_at,
+        sandbox_provider=provider,
+        sandbox_id=sandbox_id,
+        terminating_sandbox_id=terminating_sandbox_id,
+    )
+
+
+def _deployment(
+    launchers: list[_RecordingLauncher],
+    *,
+    terminate_after_offline_days: int = 1,
+    sweep_interval_s: int = 86400,
+) -> ManagedSandboxDeployment:
+    configs = []
+    for launcher in launchers:
+
+        def launcher_factory(launcher: _RecordingLauncher = launcher) -> _RecordingLauncher:
+            launcher.factory_calls += 1
+            return launcher
+
+        configs.append(
+            ManagedSandboxConfig(
+                server_url="https://s.example.com",
+                launcher_factory=launcher_factory,
+                token_ttl_s=3600,
+                provider=launcher.provider,
+            )
+        )
+    return ManagedSandboxDeployment(
+        configs=tuple(configs),
+        reaper=ManagedSandboxReaperConfig(
+            enabled=True,
+            terminate_after_offline_days=terminate_after_offline_days,
+            sweep_interval_s=sweep_interval_s,
+        ),
+    )
+
+
+async def test_sweep_reaps_stale_host_rows_without_scanning_sessions() -> None:
+    now = 4_000_000
+    modal = _RecordingLauncher("modal")
+    e2b = _RecordingLauncher("e2b")
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_recent",
+                    provider="modal",
+                    sandbox_id="sb-recent",
+                    updated_at=now - _DAY_S + 1,
+                ),
+                _host(
+                    "host_modal",
+                    provider="modal",
+                    sandbox_id="sb-modal",
+                    updated_at=now - _DAY_S - 1,
+                ),
+                _host(
+                    "host_modal_2",
+                    provider="modal",
+                    sandbox_id="sb-modal-2",
+                    updated_at=now - 2 * _DAY_S,
+                ),
+            ],
+            9: [
+                _host(
+                    "host_e2b",
+                    provider="e2b",
+                    sandbox_id="sb-e2b",
+                    updated_at=now - 2 * _DAY_S,
+                    status="online",
+                )
+            ],
+        }
+    )
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal, e2b]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 3
+
+    assert modal.terminated == ["sb-modal-2", "sb-modal"]
+    assert e2b.terminated == ["sb-e2b"]
+    assert hosts.detached == [
+        (7, "host_modal_2", "sb-modal-2"),
+        (7, "host_modal", "sb-modal"),
+        (9, "host_e2b", "sb-e2b"),
+    ]
+    assert hosts.cleared == hosts.detached
+    assert modal.factory_calls == 1
+    assert modal.identity_entries == [7]
+    assert e2b.factory_calls == 1
+    assert e2b.identity_entries == [9]
+    assert hosts.hosts[7]["host_modal"].sandbox_id is None
+    assert hosts.hosts[7]["host_modal"].terminating_sandbox_id is None
+    assert hosts.hosts[7]["host_recent"].sandbox_id == "sb-recent"
+    assert hosts.stale_queries == [(7, now - _DAY_S), (9, now - _DAY_S)]
+
+
+async def test_provider_failure_does_not_stop_other_sandboxes() -> None:
+    now = 4_000_000
+    modal = _RecordingLauncher("modal", fail=True)
+    e2b = _RecordingLauncher("e2b")
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_modal",
+                    provider="modal",
+                    sandbox_id="sb-modal",
+                    updated_at=now - 2 * _DAY_S,
+                ),
+                _host(
+                    "host_e2b",
+                    provider="e2b",
+                    sandbox_id="sb-e2b",
+                    updated_at=now - 2 * _DAY_S,
+                ),
+            ]
+        }
+    )
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal, e2b]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 1
+    assert hosts.hosts[7]["host_modal"].sandbox_id is None
+    assert hosts.hosts[7]["host_modal"].terminating_sandbox_id == "sb-modal"
+    assert hosts.hosts[7]["host_e2b"].sandbox_id is None
+    assert e2b.terminated == ["sb-e2b"]
+
+
+async def test_provider_identity_failure_does_not_stop_other_sandboxes() -> None:
+    now = 4_000_000
+    modal = _RecordingLauncher("modal", identity_fail=True)
+    e2b = _RecordingLauncher("e2b")
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_modal",
+                    provider="modal",
+                    sandbox_id="sb-modal",
+                    updated_at=now - 2 * _DAY_S,
+                ),
+                _host(
+                    "host_e2b",
+                    provider="e2b",
+                    sandbox_id="sb-e2b",
+                    updated_at=now - 2 * _DAY_S,
+                ),
+            ]
+        }
+    )
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal, e2b]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 1
+    assert modal.terminated == []
+    assert e2b.terminated == ["sb-e2b"]
+    assert hosts.hosts[7]["host_modal"].sandbox_id == "sb-modal"
+    assert hosts.hosts[7]["host_e2b"].sandbox_id is None
+
+
+async def test_reaper_rereads_liveness_before_termination() -> None:
+    now = 4_000_000
+    modal = _RecordingLauncher("modal")
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_modal",
+                    provider="modal",
+                    sandbox_id="sb-modal",
+                    updated_at=now - 2 * _DAY_S,
+                )
+            ]
+        }
+    )
+    hosts.refresh_on_detach.add("host_modal")
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 0
+    assert modal.terminated == []
+    assert hosts.hosts[7]["host_modal"].sandbox_id == "sb-modal"
+
+
+async def test_successful_termination_preserves_new_active_generation() -> None:
+    now = 4_000_000
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_modal",
+                    provider="modal",
+                    sandbox_id="sb-modal",
+                    updated_at=now - 2 * _DAY_S,
+                )
+            ]
+        }
+    )
+
+    def _launch_new_generation(sandbox_id: str) -> None:
+        assert sandbox_id == "sb-modal"
+        current = hosts.hosts[7]["host_modal"]
+        assert current.sandbox_id is None
+        assert current.terminating_sandbox_id == "sb-modal"
+        hosts.hosts[7]["host_modal"] = replace(
+            current,
+            sandbox_id="sb-modal-new",
+            status="online",
+            updated_at=now,
+        )
+
+    modal = _RecordingLauncher("modal", on_terminate=_launch_new_generation)
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 1
+    assert modal.terminated == ["sb-modal"]
+    assert hosts.hosts[7]["host_modal"].sandbox_id == "sb-modal-new"
+    assert hosts.hosts[7]["host_modal"].terminating_sandbox_id is None
+
+
+async def test_pending_termination_retries_without_detaching_active_generation() -> None:
+    now = 4_000_000
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_modal",
+                    provider="modal",
+                    sandbox_id="sb-modal-new",
+                    terminating_sandbox_id="sb-modal-old",
+                    updated_at=now,
+                    status="online",
+                )
+            ]
+        }
+    )
+    modal = _RecordingLauncher("modal")
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 1
+    assert modal.terminated == ["sb-modal-old"]
+    assert hosts.detached == []
+    assert hosts.hosts[7]["host_modal"].sandbox_id == "sb-modal-new"
+    assert hosts.hosts[7]["host_modal"].terminating_sandbox_id is None
+
+
+async def test_pending_id_equal_to_active_id_is_not_terminated() -> None:
+    now = 4_000_000
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_blaxel",
+                    provider="blaxel",
+                    sandbox_id="managed-host_blaxel",
+                    terminating_sandbox_id="managed-host_blaxel",
+                    updated_at=now,
+                    status="online",
+                )
+            ]
+        }
+    )
+    blaxel = _RecordingLauncher("blaxel")
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([blaxel]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 0
+    assert blaxel.terminated == []
+    current = hosts.hosts[7]["host_blaxel"]
+    assert current.sandbox_id == "managed-host_blaxel"
+    assert current.terminating_sandbox_id == "managed-host_blaxel"
+
+
+async def test_identity_and_termination_run_off_event_loop_thread() -> None:
+    now = 4_000_000
+    event_loop_thread = threading.get_ident()
+    modal = _RecordingLauncher("modal")
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_modal",
+                    provider="modal",
+                    sandbox_id="sb-modal",
+                    updated_at=now - 2 * _DAY_S,
+                )
+            ]
+        }
+    )
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 1
+    assert modal.identity_threads == modal.termination_threads
+    assert modal.identity_threads[0] != event_loop_thread

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 
-from omnigent.db.db_models import SqlHost
+from omnigent.db.db_models import SqlHost, workspace_scope
 from omnigent.db.utils import get_or_create_engine, now_epoch
 from omnigent.stores.host_store import (
     HOST_LIVENESS_TTL_S,
@@ -815,6 +815,7 @@ def test_managed_columns_survive_connect(db_uri: str) -> None:
         host_id="d55a61010459cea88ed2af0fe916139b",
         name="managed-m4",
         user_id="alice@example.com",
+        managed_token="raw-launch-token-4",
     )
 
     assert connected.status == "online"
@@ -853,6 +854,271 @@ def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
     assert store.list_hosts("alice@example.com") == []
     # Second delete is a no-op, not an error.
     store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
+
+
+def test_managed_sandbox_reaper_queries_and_compare_clear_span_workspaces(
+    db_uri: str,
+) -> None:
+    """The reaper discovers workspaces, scopes stale reads, and clears one generation."""
+    store = HostStore(db_uri)
+    host_11 = "d6cb45e67d3d4bdbbff1b45d5c408e11"
+    host_22 = "60a41477758b4b4c9f3072dd47009522"
+    with workspace_scope(11):
+        store.register_managed_host(
+            host_id=host_11,
+            name="managed-11",
+            user_id="alice@example.com",
+            token="token-11",
+            provider="modal",
+            sandbox_id="sb-11",
+            token_expires_at=now_epoch() + 3600,
+        )
+    with workspace_scope(22):
+        store.register_managed_host(
+            host_id=host_22,
+            name="managed-22",
+            user_id="bob@example.com",
+            token="token-22",
+            provider="e2b",
+            sandbox_id="sb-22",
+            token_expires_at=now_epoch() + 3600,
+        )
+
+    assert store.list_managed_sandbox_workspace_ids() == [11, 22]
+    with workspace_scope(11):
+        assert store.list_stale_managed_sandbox_hosts(0) == []
+        listed = store.list_stale_managed_sandbox_hosts(now_epoch() + 1)
+        assert [host.host_id for host in listed] == [host_11]
+        last_seen_at = listed[0].updated_at
+        assert (
+            store.detach_stale_managed_sandbox(
+                host_11,
+                sandbox_id="sb-other",
+                expected_updated_at=last_seen_at,
+            )
+            is False
+        )
+        assert (
+            store.detach_stale_managed_sandbox(
+                host_11,
+                sandbox_id="sb-11",
+                expected_updated_at=last_seen_at,
+            )
+            is True
+        )
+        detached = store.get_host(host_11)
+        assert detached is not None
+        assert detached.status == "offline"
+        assert detached.updated_at == last_seen_at
+        assert detached.sandbox_provider == "modal"
+        assert detached.sandbox_id is None
+        assert detached.terminating_sandbox_id == "sb-11"
+        assert store.resolve_launch_token(host_11, "token-11") is None
+        assert store.list_managed_sandbox_workspace_ids() == [11, 22]
+        assert (
+            store.mark_terminating_sandbox_terminated(
+                host_11,
+                sandbox_id="sb-other",
+            )
+            is False
+        )
+        assert (
+            store.mark_terminating_sandbox_terminated(
+                host_11,
+                sandbox_id="sb-11",
+            )
+            is True
+        )
+        reaped = store.get_host(host_11)
+        assert reaped is not None
+        assert reaped.sandbox_id is None
+        assert reaped.terminating_sandbox_id is None
+
+    assert store.list_managed_sandbox_workspace_ids() == [22]
+    with workspace_scope(22):
+        listed = store.list_stale_managed_sandbox_hosts(now_epoch() + 1)
+        assert [host.host_id for host in listed] == [host_22]
+
+
+def test_detach_and_resume_rearm_are_atomic_competitors(db_uri: str) -> None:
+    store = HostStore(db_uri)
+    host_id = "2bc4d1fa28934f579ae62b6d40b23e53"
+    store.register_managed_host(
+        host_id=host_id,
+        name="managed-race",
+        user_id="alice@example.com",
+        token="old-token",
+        provider="modal",
+        sandbox_id="sb-race",
+        token_expires_at=now_epoch() + 3600,
+    )
+    _set_updated_at(db_uri, host_id, 100)
+    stale = store.get_host(host_id)
+    assert stale is not None
+
+    armed = store.rearm_managed_host(
+        host_id,
+        sandbox_id="sb-race",
+        expected_updated_at=stale.updated_at,
+        token="resume-token",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert armed is not None
+    assert armed.status == "offline"
+    assert (
+        store.detach_stale_managed_sandbox(
+            host_id,
+            sandbox_id="sb-race",
+            expected_updated_at=stale.updated_at,
+        )
+        is False
+    )
+    assert store.resolve_launch_token(host_id, "resume-token") is not None
+
+    current = store.get_host(host_id)
+    assert current is not None
+    assert (
+        store.detach_stale_managed_sandbox(
+            host_id,
+            sandbox_id="sb-race",
+            expected_updated_at=current.updated_at,
+        )
+        is True
+    )
+    assert (
+        store.rearm_managed_host(
+            host_id,
+            sandbox_id="sb-race",
+            expected_updated_at=current.updated_at,
+            token="too-late-token",
+            token_expires_at=now_epoch() + 3600,
+        )
+        is None
+    )
+    assert store.resolve_launch_token(host_id, "too-late-token") is None
+
+
+def test_pending_cleanup_rejects_reused_active_sandbox_id(db_uri: str) -> None:
+    store = HostStore(db_uri)
+    host_id = "97d1c9ac65124fb8ba452f6ba5269d0c"
+    registered = store.register_managed_host(
+        host_id=host_id,
+        name="managed-reused-id",
+        user_id="alice@example.com",
+        token="old-generation-token",
+        provider="blaxel",
+        sandbox_id="managed-reused-id",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert store.detach_stale_managed_sandbox(
+        host_id,
+        sandbox_id="managed-reused-id",
+        expected_updated_at=registered.updated_at,
+    )
+
+    with pytest.raises(ValueError, match="still pending termination"):
+        store.register_managed_host(
+            host_id=host_id,
+            name="managed-reused-id",
+            user_id="alice@example.com",
+            token="new-generation-token",
+            provider="blaxel",
+            sandbox_id="managed-reused-id",
+            token_expires_at=now_epoch() + 3600,
+        )
+
+    current = store.get_host(host_id)
+    assert current is not None
+    assert current.sandbox_id is None
+    assert current.terminating_sandbox_id == "managed-reused-id"
+    assert store.resolve_launch_token(host_id, "new-generation-token") is None
+
+
+def test_pending_cleanup_does_not_block_rearming_new_generation(db_uri: str) -> None:
+    store = HostStore(db_uri)
+    host_id = "ae83022f168b4897a72933734a2d0c3d"
+    old = store.register_managed_host(
+        host_id=host_id,
+        name="managed-rearm-new",
+        user_id="alice@example.com",
+        token="old-generation-token",
+        provider="modal",
+        sandbox_id="sb-old",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert store.detach_stale_managed_sandbox(
+        host_id,
+        sandbox_id="sb-old",
+        expected_updated_at=old.updated_at,
+    )
+    current = store.register_managed_host(
+        host_id=host_id,
+        name="managed-rearm-new",
+        user_id="alice@example.com",
+        token="new-generation-token",
+        provider="modal",
+        sandbox_id="sb-new",
+        token_expires_at=now_epoch() + 3600,
+    )
+
+    rearmed = store.rearm_managed_host(
+        host_id,
+        sandbox_id="sb-new",
+        expected_updated_at=current.updated_at,
+        token="resume-new-generation-token",
+        token_expires_at=now_epoch() + 3600,
+    )
+
+    assert rearmed is not None
+    assert rearmed.sandbox_id == "sb-new"
+    assert rearmed.terminating_sandbox_id == "sb-old"
+    assert store.resolve_launch_token(host_id, "resume-new-generation-token") is not None
+
+
+def test_managed_connect_revalidates_token_after_detach(db_uri: str) -> None:
+    store = HostStore(db_uri)
+    host_id = "769e5fd3b45a47a79cadad2dfeab3c8c"
+    registered = store.register_managed_host(
+        host_id=host_id,
+        name="managed-connect-race",
+        user_id="alice@example.com",
+        token="old-connect-token",
+        provider="modal",
+        sandbox_id="sb-connect-old",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert store.detach_stale_managed_sandbox(
+        host_id,
+        sandbox_id="sb-connect-old",
+        expected_updated_at=registered.updated_at,
+    )
+
+    with pytest.raises(ValueError, match="no longer valid"):
+        store.upsert_on_connect(
+            host_id=host_id,
+            name="managed-connect-race",
+            user_id="alice@example.com",
+            managed_token="old-connect-token",
+        )
+
+    store.register_managed_host(
+        host_id=host_id,
+        name="managed-connect-race",
+        user_id="alice@example.com",
+        token="new-connect-token",
+        provider="modal",
+        sandbox_id="sb-connect-new",
+        token_expires_at=now_epoch() + 3600,
+    )
+    connected = store.upsert_on_connect(
+        host_id=host_id,
+        name="managed-connect-race",
+        user_id="alice@example.com",
+        managed_token="new-connect-token",
+    )
+    assert connected.status == "online"
+    assert connected.sandbox_id == "sb-connect-new"
+    assert connected.terminating_sandbox_id == "sb-connect-old"
 
 
 def test_revoke_launch_token_keeps_row_but_stops_resolution(db_uri: str) -> None:


### PR DESCRIPTION
## Related issue

N/A — requested directly; no tracking issue.

## Summary

- Add one opt-in `sandbox.reaper` policy shared by every configured sandbox provider.
- Configure sandbox cleanup with `terminate_after_offline_days` (default: 30 days) and `sweep_interval_s` (default: 1 day).
- Use a direct host-driven sweep: discover workspaces containing managed sandboxes, query stale managed hosts in each workspace, group them by provider, and terminate through the provider recorded on each host.
- Atomically detach a stale sandbox generation before the provider call by moving its ID into `terminating_sandbox_id` and revoking its launch credential. Failed provider termination remains pending for a later sweep; successful termination clears the pending ID.
- Allow a fresh active sandbox generation to coexist with one older generation awaiting cleanup, while preventing a detached generation from reconnecting or being resumed.
- Reject re-arming a provider ID that is still pending termination, so deterministic ID reuse cannot turn cleanup of an old generation into deletion of a live one.
- Keep managed-session relaunch UX outside this PR.

ELI5: the server periodically finds managed sandbox compute that has stayed offline too long and shuts it down without deleting the conversation. If shutdown fails, it remembers the old sandbox and retries later.

```text
periodic loop
  -> managed-sandbox workspaces
  -> stale managed hosts
  -> group by provider
  -> atomically detach stale generation
  -> terminate provider sandbox
  -> clear pending generation on success
  -> retry pending generation on failure
```

## Test Plan

- `uv run --frozen pytest -q tests/server/test_managed_sandbox_reaper.py tests/server/test_managed_hosts.py tests/stores/test_host_store.py tests/server/integration/test_host_tunnel_route.py`
  - 341 passed
- `uv run --frozen pre-commit run --files omnigent/server/managed_hosts.py omnigent/server/managed_sandbox_reaper.py tests/server/test_managed_hosts.py tests/server/test_managed_sandbox_reaper.py deploy/README.md docs/extending/sandbox_providers.md`
  - all applicable hooks passed, including Ruff and Pyrefly

### Local live E2E validation

Validated with a temporary process-backed dummy provider against a real local Uvicorn server. The harness launched actual `omnigent host` and runner subprocesses, connected them through the normal WebSocket tunnel routes, and exercised the public session APIs.

Covered:
- Managed session creation and real host/runner registration
- Reaping an offline sandbox after backdating its heartbeat past the configured age
- Persisting a provider termination failure and retrying it on the next sweep
- Launching a fresh sandbox generation through `retry_session` after reaping
- A real host reconnect winning the stale-detach CAS race without termination
- A managed resume winning the stale-detach CAS race without termination
- Final session deletion terminating active compute and removing the host row

The run completed with `LIVE E2E PASS`. The temporary harness was removed after validation.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes configuration validation, deployment-wide multi-provider behavior, stale workspace and host discovery, provider failure isolation, atomic generation detachment, retrying pending cleanup, preserving a newer active generation, managed-token revalidation, and resume-versus-reaper race handling, and deterministic provider-ID reuse.

## Changelog

Servers can automatically terminate managed sandbox compute after it remains offline for a configured number of days.