### PR TITLE
fix(sandbox): tear down a managed sandbox when its launch fails after the host is online

### DIFF
--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -208,6 +208,16 @@ _JOB_BACKOFF_LIMIT: int = 6
 # launch-token TTL.
 _JOB_ACTIVE_DEADLINE_S: int = 7 * 24 * 3600
 
+# How long a Job's objects (and its terminated Pod) stick around after the
+# Job itself reaches a terminal state (Complete or Failed), before the
+# cluster garbage-collects them. Backstop for the case where nothing ever
+# calls terminate() on a Job that ends on its own — a crash-loop exhausting
+# backoffLimit, or activeDeadlineSeconds finally expiring — so a
+# credential-bearing Pod object doesn't linger indefinitely just because
+# application-level cleanup never ran. 24h leaves a window to inspect a
+# failed Job's status/logs before it's swept.
+_JOB_TTL_SECONDS_AFTER_FINISHED: int = 24 * 3600
+
 # Lines of container log tail surfaced in a start-failure message (e.g. the git
 # clone error from the init container).
 _LOG_TAIL_LINES: int = 20
@@ -564,6 +574,7 @@ def build_job_manifest(
     agent_name: str | None = None,
     backoff_limit: int = _JOB_BACKOFF_LIMIT,
     active_deadline_seconds: int = _JOB_ACTIVE_DEADLINE_S,
+    ttl_seconds_after_finished: int = _JOB_TTL_SECONDS_AFTER_FINISHED,
     runtime_class: str | None = None,
 ) -> dict[str, object]:
     """
@@ -577,10 +588,14 @@ def build_job_manifest(
     ``restartPolicy: OnFailure`` so the kubelet automatically restarts a
     crashed host container with exponential backoff (10 s, 20 s, 40 s, …
     capped at 5 min).  The Job's ``backoffLimit`` caps the total retry count,
-    and ``activeDeadlineSeconds`` enforces a hard lifetime.  Because
-    ``OnFailure`` restarts the SAME Pod in place, the Pod name is stable
-    across retries — the token Secret ``secretKeyRef`` keeps resolving and the
-    ``sandbox_id`` tracking in the managed-host machinery is unaffected.
+    and ``activeDeadlineSeconds`` enforces a hard lifetime.
+    ``ttlSecondsAfterFinished`` is a backstop on top of both: once a Job
+    reaches a terminal state on its own, the cluster garbage-collects it
+    even if this launcher's own ``terminate()`` never runs or never lands.
+    Because ``OnFailure`` restarts the SAME Pod in place, the Pod name is
+    stable across retries — the token Secret ``secretKeyRef`` keeps
+    resolving and the ``sandbox_id`` tracking in the managed-host machinery
+    is unaffected.
 
     The host's existing WebSocket reconnect logic (exponential backoff in
     ``omnigent/host/connect.py``) re-registers the tunnel automatically after
@@ -846,6 +861,7 @@ def build_job_manifest(
         "spec": {
             "backoffLimit": backoff_limit,
             "activeDeadlineSeconds": active_deadline_seconds,
+            "ttlSecondsAfterFinished": ttl_seconds_after_finished,
             "template": {
                 "metadata": {"labels": labels},
                 "spec": pod_spec,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2866,6 +2866,7 @@ async def _run_managed_launch(
         host_store=host_store,
         host_registry=host_registry,
         tunnel_registry=tunnel_registry,
+        relaunch_host=relaunch_host,
     )
 
 
@@ -2879,6 +2880,7 @@ async def _bind_and_launch_managed_runner(
     host_store: HostStore,
     host_registry: HostRegistry | None,
     tunnel_registry: TunnelRegistry | None,
+    relaunch_host: Host | None = None,
 ) -> None:
     """
     Bind a provisioned managed host to its session and launch a runner.
@@ -2888,6 +2890,14 @@ async def _bind_and_launch_managed_runner(
     ``ConversationNotFoundError``, and the fresh sandbox is torn down
     (the delete route could not see the host binding yet). Settles
     the tracker on every path.
+
+    A launch failure after the host is online also tears the sandbox
+    down — UNLESS *relaunch_host* is set: that means ``managed.host_id``
+    is an existing, persistent host identity getting a new sandbox
+    generation, not a fresh one minted for this launch, so a failed
+    generation is left alone (same reasoning as a failed wake: the
+    identity is the user's, not this attempt's to destroy) rather than
+    torn down.
 
     :param session_id: Session/conversation identifier.
     :param managed: The provision result (host id + workspace).
@@ -2900,6 +2910,9 @@ async def _bind_and_launch_managed_runner(
     :param tunnel_registry: Runner-tunnel registry used to await the
         launched runner's connection. ``None`` in minimal test
         wirings (the rendezvous then settles at frame-send).
+    :param relaunch_host: Existing managed host row being relaunched, or
+        ``None`` for a first launch (a fresh host identity was just
+        minted for ``managed.host_id``).
     """
     from omnigent.server.managed_hosts import terminate_managed_host
 
@@ -2948,7 +2961,15 @@ async def _bind_and_launch_managed_runner(
                 # host refuses, fail the launch loudly (mirroring the
                 # delete-during-provisioning path) rather than waiting out
                 # the connect timeout for a runner that will never appear.
+                # A first launch's fresh Job that will never serve this
+                # session shouldn't outlive the launch that provisioned it;
+                # a relaunch generation on an existing host leaves the
+                # identity alone, same as a failed wake.
                 reason = launch_attempt.error or "harness not configured on the sandbox host"
+                if relaunch_host is None:
+                    host = await asyncio.to_thread(host_store.get_host, managed.host_id)
+                    if host is not None:
+                        await terminate_managed_host(host, host_store, sandbox_config)
                 tracker.fail(session_id, reason)
                 _publish_sandbox_status(session_id, "failed", reason)
                 return
@@ -2961,6 +2982,13 @@ async def _bind_and_launch_managed_runner(
             tracker,
         )
         if not connected:
+            # The runner never connected its tunnel; _wait_for_managed_runner_tunnel
+            # already settled the tracker and published the failure. Same
+            # first-launch-vs-relaunch reasoning as the branch above.
+            if relaunch_host is None:
+                host = await asyncio.to_thread(host_store.get_host, managed.host_id)
+                if host is not None:
+                    await terminate_managed_host(host, host_store, sandbox_config)
             return
     tracker.finish(session_id)
     _publish_sandbox_status(session_id, "ready")

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -1386,17 +1386,28 @@ async def test_managed_wake_fails_when_runner_never_reconnects(
 async def test_managed_launch_fails_when_runner_never_connects(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Initial managed launch settlement also depends on the runner tunnel."""
+    """Initial managed launch settlement also depends on the runner tunnel.
+
+    A launch that fails here — after the host is already online — must tear
+    the fresh sandbox down, not just settle the tracker and leave the Job
+    running with a live launch token and no one who will ever use it.
+    """
     from omnigent.server.routes import sessions as sessions_module
 
     session_id = "1a41e11887aca4570e42c0be40f24833"
+    host_id = "3c8cdcdb61903904849174c864620a5c"
     conv = SimpleNamespace(id=session_id)
     tracker = ManagedLaunchTracker()
     tracker.begin(session_id)
     stages: list[tuple[str, str | None]] = []
+    terminated: list[object] = []
+    sentinel_host = object()
 
     async def _launch_runner(*_args: object, **_kwargs: object) -> object:
         return sessions_module._HostLaunchAttempt(runner_id="runner_never_connects")
+
+    async def _fake_terminate(host: object, *_args: object, **_kwargs: object) -> None:
+        terminated.append(host)
 
     class _HostRegistry:
         def get(self, _host_id: str) -> object:
@@ -1406,17 +1417,23 @@ async def test_managed_launch_fails_when_runner_never_connects(
         async def wait_for_runner(self, _runner_id: str, *, timeout_s: float) -> None:
             del timeout_s
 
+    class _HostStore:
+        def get_host(self, requested_id: str) -> object:
+            assert requested_id == host_id
+            return sentinel_host
+
     monkeypatch.setattr(sessions_module, "_launch_runner_on_host", _launch_runner)
     monkeypatch.setattr(
         sessions_module,
         "_publish_sandbox_status",
         lambda _sid, stage, error=None: stages.append((stage, error)),
     )
+    monkeypatch.setattr("omnigent.server.managed_hosts.terminate_managed_host", _fake_terminate)
 
     await sessions_module._bind_and_launch_managed_runner(
         session_id=session_id,
         managed=ManagedHostLaunch(
-            host_id="3c8cdcdb61903904849174c864620a5c",
+            host_id=host_id,
             workspace="/root/workspace",
         ),
         sandbox_config=ManagedSandboxDeployment.single(
@@ -1430,7 +1447,7 @@ async def test_managed_launch_fails_when_runner_never_connects(
         conversation_store=SimpleNamespace(
             set_host_id=lambda _sid, _host_id, _workspace: conv,
         ),
-        host_store=SimpleNamespace(),
+        host_store=_HostStore(),  # type: ignore[arg-type]
         host_registry=_HostRegistry(),  # type: ignore[arg-type]
         tunnel_registry=_TunnelRegistry(),  # type: ignore[arg-type]
     )
@@ -1440,6 +1457,151 @@ async def test_managed_launch_fails_when_runner_never_connects(
     assert launch.settled.is_set()
     assert launch.error == "managed runner did not connect after launch"
     assert stages[-1] == ("failed", "managed runner did not connect after launch")
+    assert terminated == [sentinel_host]
+
+
+async def test_managed_launch_fails_and_tears_down_when_harness_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host that refuses the harness is a fresh sandbox that will never
+    serve this session, so it must be torn down the same as the
+    delete-during-provisioning branch already is.
+    """
+    from omnigent.server.routes import sessions as sessions_module
+
+    session_id = "3f3aa440b7274531a889fa4c25f4bb1b"
+    host_id = "b4e372ad19634c62966a2c56aab8cfab"
+    conv = SimpleNamespace(id=session_id)
+    tracker = ManagedLaunchTracker()
+    tracker.begin(session_id)
+    stages: list[tuple[str, str | None]] = []
+    terminated: list[object] = []
+    sentinel_host = object()
+
+    async def _launch_runner(*_args: object, **_kwargs: object) -> object:
+        return sessions_module._HostLaunchAttempt(
+            runner_id="runner_refused_harness",
+            error_code=sessions_module._HARNESS_NOT_CONFIGURED_ERROR_CODE,
+            error="harness not configured on the sandbox host",
+        )
+
+    async def _fake_terminate(host: object, *_args: object, **_kwargs: object) -> None:
+        terminated.append(host)
+
+    class _HostRegistry:
+        def get(self, _host_id: str) -> object:
+            return object()
+
+    class _HostStore:
+        def get_host(self, requested_id: str) -> object:
+            assert requested_id == host_id
+            return sentinel_host
+
+    monkeypatch.setattr(sessions_module, "_launch_runner_on_host", _launch_runner)
+    monkeypatch.setattr(
+        sessions_module,
+        "_publish_sandbox_status",
+        lambda _sid, stage, error=None: stages.append((stage, error)),
+    )
+    monkeypatch.setattr("omnigent.server.managed_hosts.terminate_managed_host", _fake_terminate)
+
+    await sessions_module._bind_and_launch_managed_runner(
+        session_id=session_id,
+        managed=ManagedHostLaunch(
+            host_id=host_id,
+            workspace="/root/workspace",
+        ),
+        sandbox_config=ManagedSandboxDeployment.single(
+            ManagedSandboxConfig(
+                server_url="https://managed-test.example.com",
+                launcher_factory=lambda: FakeSandboxLauncher(),
+                token_ttl_s=3600,
+            )
+        ),
+        tracker=tracker,
+        conversation_store=SimpleNamespace(
+            set_host_id=lambda _sid, _host_id, _workspace: conv,
+        ),
+        host_store=_HostStore(),  # type: ignore[arg-type]
+        host_registry=_HostRegistry(),  # type: ignore[arg-type]
+        tunnel_registry=None,
+    )
+
+    launch = tracker.get(session_id)
+    assert launch is not None
+    assert launch.settled.is_set()
+    assert launch.error == "harness not configured on the sandbox host"
+    assert stages[-1] == ("failed", "harness not configured on the sandbox host")
+    assert terminated == [sentinel_host]
+
+
+async def test_managed_relaunch_failure_leaves_the_host_identity_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed runner connect on a RELAUNCH generation must not tear down
+    the host row: unlike a first launch, ``managed.host_id`` here is an
+    existing, persistent identity, not something freshly minted for this
+    attempt. Deleting it on a slow connect would destroy the user's host
+    binding, not just clean up an orphaned Job.
+    """
+    from omnigent.server.routes import sessions as sessions_module
+
+    session_id = "d3a6e13f0dbf4b6ea4b6e37f4a76f2a9"
+    host_id = "9e6cf6f52ebb4a2c9c9a1a5f8e8f5f42"
+    conv = SimpleNamespace(id=session_id)
+    tracker = ManagedLaunchTracker()
+    tracker.begin(session_id)
+    terminated: list[object] = []
+
+    async def _launch_runner(*_args: object, **_kwargs: object) -> object:
+        return sessions_module._HostLaunchAttempt(runner_id="runner_never_connects")
+
+    async def _fake_terminate(host: object, *_args: object, **_kwargs: object) -> None:
+        terminated.append(host)
+
+    class _HostRegistry:
+        def get(self, _host_id: str) -> object:
+            return object()
+
+    class _TunnelRegistry:
+        async def wait_for_runner(self, _runner_id: str, *, timeout_s: float) -> None:
+            del timeout_s
+
+    class _HostStore:
+        def get_host(self, _requested_id: str) -> object:
+            # Should never be called: relaunch_host being set must short-circuit
+            # before the lookup, not just before the terminate call.
+            raise AssertionError("get_host should not be called for a relaunch failure")
+
+    monkeypatch.setattr(sessions_module, "_launch_runner_on_host", _launch_runner)
+    monkeypatch.setattr(sessions_module, "_publish_sandbox_status", lambda *_a, **_kw: None)
+    monkeypatch.setattr("omnigent.server.managed_hosts.terminate_managed_host", _fake_terminate)
+
+    await sessions_module._bind_and_launch_managed_runner(
+        session_id=session_id,
+        managed=ManagedHostLaunch(host_id=host_id, workspace="/root/workspace"),
+        sandbox_config=ManagedSandboxDeployment.single(
+            ManagedSandboxConfig(
+                server_url="https://managed-test.example.com",
+                launcher_factory=lambda: FakeSandboxLauncher(),
+                token_ttl_s=3600,
+            )
+        ),
+        tracker=tracker,
+        conversation_store=SimpleNamespace(
+            set_host_id=lambda _sid, _host_id, _workspace: conv,
+        ),
+        host_store=_HostStore(),  # type: ignore[arg-type]
+        host_registry=_HostRegistry(),  # type: ignore[arg-type]
+        tunnel_registry=_TunnelRegistry(),  # type: ignore[arg-type]
+        relaunch_host=object(),  # type: ignore[arg-type]
+    )
+
+    launch = tracker.get(session_id)
+    assert launch is not None
+    assert launch.settled.is_set()
+    assert launch.error == "managed runner did not connect after launch"
+    assert terminated == []
 
 
 async def test_cancel_managed_launch_tasks_returns_while_provision_parked(

--- a/tests/server/integration/test_managed_launch_failure_teardown.py
+++ b/tests/server/integration/test_managed_launch_failure_teardown.py
@@ -1,0 +1,425 @@
+"""Managed-sandbox teardown when the runner launch fails after the host is online.
+
+A ``host_type="managed"`` session whose launch fails AFTER the sandbox
+host has registered must not leave the sandbox running. Two failure
+branches of the post-online launch stage are exercised:
+
+- the host refuses the runner launch (harness not configured), and
+- the launched runner never connects its tunnel within the connect
+  grace.
+
+In both cases the launch settles as ``failed`` on the session snapshot.
+The provider-side terminate must then fire and the managed host row
+(which holds the sandbox's launch token) must be deleted — the same
+teardown the delete-during-provisioning branch already performs. A
+regression here leaks a running, credential-bearing sandbox whose only
+reaper is the provider's lifetime cap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from asgiref.testing import ApplicationCommunicator
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from omnigent.host.frames import (
+    HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    HostHelloFrame,
+    HostLaunchRunnerFrame,
+    HostLaunchRunnerResultFrame,
+    decode_host_frame,
+    encode_host_frame,
+)
+from omnigent.runner.identity import token_bound_runner_id
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.managed_hosts import parse_sandbox_config
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+from omnigent.stores.host_store import HostStore
+from tests.server.helpers import (
+    FakeSandboxLauncher,
+    HostStartInvocation,
+    create_test_agent,
+    install_fake_modal_launcher,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _websocket_scope(path: str) -> dict[str, object]:
+    """Build an ASGI WebSocket scope.
+
+    :param path: WebSocket path.
+    :returns: Minimal ASGI WebSocket scope.
+    """
+    return {
+        "type": "websocket",
+        "asgi": {"version": "3.0"},
+        "scheme": "ws",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("testserver", 80),
+        "subprotocols": [],
+    }
+
+
+@dataclass
+class _Env:
+    """Assembled managed-session test environment.
+
+    :param app: The full FastAPI app under test.
+    :param client: HTTP client bound to *app*.
+    :param host_store: The app's host store (also holds the managed
+        credential/sandbox columns).
+    :param conv_store: The app's conversation store.
+    """
+
+    app: FastAPI
+    client: AsyncClient
+    host_store: HostStore
+    conv_store: SqlAlchemyConversationStore
+
+
+@pytest_asyncio.fixture()
+async def teardown_env(
+    runtime_init: None,
+    db_uri: str,
+    tmp_path: Path,
+) -> AsyncIterator[_Env]:
+    """Full app wired for managed-host sessions (no real sandbox).
+
+    Builds the production ``create_app`` with host + managed-host
+    stores and a modal ``sandbox:`` config, so a ``host_type="managed"``
+    create exercises the real route, tunnel, and store paths end to
+    end. Only the sandbox itself is fake.
+
+    :param runtime_init: Ensures runtime singletons are initialized.
+    :param db_uri: SQLite URI shared by every store in the app.
+    :param tmp_path: Per-test scratch dir for artifact/cache stores.
+    :returns: The assembled environment.
+    """
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    host_store = HostStore(db_uri)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    app = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=conv_store,
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache",
+        ),
+        comment_store=SqlAlchemyCommentStore(db_uri),
+        host_store=host_store,
+        sandbox_config=parse_sandbox_config(
+            {
+                "provider": "modal",
+                "server_url": "https://managed-test.example.com",
+                "modal": {"image": "docker.io/test/omnigent-host:latest"},
+            }
+        ),
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield _Env(app=app, client=client, host_store=host_store, conv_store=conv_store)
+
+
+async def _sandbox_host(
+    app: FastAPI,
+    host_id: str,
+    host_name: str,
+    token: str,
+    *,
+    refuse_launch: bool,
+) -> ApplicationCommunicator:
+    """Act as the host process inside the (fake) sandbox.
+
+    Connects to the app's real host tunnel authenticating only with
+    the launch token (exactly what a sandbox has), sends hello with
+    the server-injected host name, then answers the launch frame —
+    refusing it as harness-not-configured when *refuse_launch* is
+    set, confirming a launched runner (that never connects) otherwise.
+
+    :param app: The app whose tunnel to dial.
+    :param host_id: Server-chosen host identity from the launch env.
+    :param host_name: Server-chosen host name from the launch env.
+    :param token: Raw launch token from the launch env.
+    :param refuse_launch: Answer the launch frame with a structured
+        harness-not-configured refusal instead of a launched result.
+    :returns: The live tunnel communicator. The CALLER must keep it
+        referenced for as long as the host should stay online.
+    """
+    scope = _websocket_scope(f"/v1/hosts/{host_id}/tunnel")
+    scope["headers"] = [(b"x-omnigent-host-token", token.encode("ascii"))]
+    comm = ApplicationCommunicator(app, scope)
+    await comm.send_input({"type": "websocket.connect"})
+    accepted = await comm.receive_output(timeout=5.0)
+    assert accepted["type"] == "websocket.accept", f"tunnel refused: {accepted!r}"
+    hello = encode_host_frame(
+        HostHelloFrame(
+            version="0.1.0-test",
+            frame_protocol_version=1,
+            name=host_name,
+            runners=[],
+        )
+    )
+    await comm.send_input({"type": "websocket.receive", "text": hello})
+    # Serve frames until the launch request arrives, then answer it.
+    for _ in range(50):
+        output = await comm.receive_output(timeout=10.0)
+        if output["type"] != "websocket.send":
+            continue
+        try:
+            frame = decode_host_frame(output["text"])
+        except ValueError:
+            # Runner-encoded ping frames share the socket; skip them.
+            continue
+        if isinstance(frame, HostLaunchRunnerFrame):
+            if refuse_launch:
+                result = HostLaunchRunnerResultFrame(
+                    request_id=frame.request_id,
+                    status="failed",
+                    error="harness is not configured on the sandbox host",
+                    error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
+                )
+            else:
+                result = HostLaunchRunnerResultFrame(
+                    request_id=frame.request_id,
+                    status="launched",
+                    runner_id=token_bound_runner_id(frame.binding_token),
+                )
+            await comm.send_input(
+                {"type": "websocket.receive", "text": encode_host_frame(result)},
+            )
+            return comm
+    raise AssertionError("fake sandbox host never received a launch frame")
+
+
+async def _wait_for_failed_launch(
+    env: _Env,
+    session_id: str,
+    *,
+    timeout_s: float = 15.0,
+) -> dict[str, Any]:
+    """Poll the session snapshot until the launch settles as failed.
+
+    The same observation a client makes via ``GET /v1/sessions/{id}``:
+    a failed managed launch is retained on the snapshot's
+    ``sandbox_status`` field.
+
+    :param env: The managed-session test environment.
+    :param session_id: The created session's id.
+    :param timeout_s: Poll budget.
+    :returns: The failed ``sandbox_status`` payload.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while asyncio.get_running_loop().time() < deadline:
+        snapshot = await env.client.get(f"/v1/sessions/{session_id}")
+        assert snapshot.status_code == 200, snapshot.text
+        status = snapshot.json()["sandbox_status"]
+        if status is not None and status["stage"] == "failed":
+            return status
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"managed launch for session {session_id} never settled as failed")
+
+
+async def _wait_for_sandbox_teardown(
+    env: _Env,
+    fake: FakeSandboxLauncher,
+    host_id: str,
+    *,
+    timeout_s: float = 5.0,
+) -> None:
+    """Wait for the failed launch's sandbox teardown to land.
+
+    Teardown means both halves of ``terminate_managed_host``: the
+    provider-side terminate fired for the sandbox, and the managed
+    host row (whose existence keeps the launch token resolvable) is
+    deleted. The launch-settled status precedes the teardown by a
+    scheduling beat, so poll rather than assert immediately.
+
+    :param env: The managed-session test environment.
+    :param fake: The fake launcher recording terminations.
+    :param host_id: The managed host bound to the failed session.
+    :param timeout_s: Poll budget before declaring the sandbox leaked.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while asyncio.get_running_loop().time() < deadline:
+        if fake.terminated and env.host_store.get_host(host_id) is None:
+            return
+        await asyncio.sleep(0.05)
+    host = env.host_store.get_host(host_id)
+    raise AssertionError(
+        "managed sandbox leaked after the launch settled as failed: "
+        f"provider terminations={fake.terminated!r} (expected the failed "
+        "launch to terminate the sandbox), host row="
+        f"{'present — launch token still resolvable' if host is not None else 'deleted'}"
+    )
+
+
+async def test_harness_refusal_failure_tears_down_managed_sandbox(
+    teardown_env: _Env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A managed launch the host refuses (harness not configured) settles
+    as ``failed`` — and must tear its sandbox down.
+
+    The sandbox host registers over the real tunnel, so the sandbox is
+    live and holds its launch token when the refusal lands. Before the
+    teardown existed, this branch only published the failed status and
+    returned: the sandbox kept running with no code path left to ever
+    delete it.
+    """
+    env = teardown_env
+    # A healthy fake host registers in well under a second; shrink the
+    # online-poll budget so a registration regression fails in seconds.
+    monkeypatch.setattr("omnigent.server.managed_hosts.MANAGED_HOST_ONLINE_TIMEOUT_S", 10)
+    loop = asyncio.get_running_loop()
+    host_futures: list[asyncio.Future[ApplicationCommunicator]] = []
+    launched_host_ids: list[str] = []
+
+    def _start_fake_sandbox_host(invocation: HostStartInvocation) -> None:
+        """Spawn the refusing fake sandbox host when the launcher 'starts' it."""
+        launched_host_ids.append(invocation.host_id)
+        future = asyncio.run_coroutine_threadsafe(
+            _sandbox_host(
+                env.app,
+                invocation.host_id,
+                invocation.host_name,
+                invocation.token,
+                refuse_launch=True,
+            ),
+            loop,
+        )
+        host_futures.append(asyncio.wrap_future(future, loop=loop))
+
+    fake = FakeSandboxLauncher(on_host_start=_start_fake_sandbox_host)
+    install_fake_modal_launcher(monkeypatch, fake)
+
+    agent = await create_test_agent(env.client, name="managed-refusal-teardown-agent")
+    resp = await env.client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "host_type": "managed"},
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = resp.json()["id"]
+
+    # The host's structured refusal settles the launch as failed, and
+    # the reason reaches the snapshot a reloading client cold-loads.
+    status = await _wait_for_failed_launch(env, session_id)
+    assert "not configured" in (status["error"] or ""), status
+
+    # Keep the fake host's tunnel alive (referenced) through the
+    # teardown assertions — the sandbox is genuinely live when the
+    # refusal lands, exactly the leaked state.
+    tunnels = [await future for future in host_futures]
+    assert len(tunnels) == 1
+
+    # The session row survives (the operator keeps the transcript of
+    # why the launch failed). The host binding is deliberately NOT read
+    # off the conversation row here: deleting the host row (the
+    # teardown under test) also clears the session's binding to it, so
+    # the sandbox's host id comes from the launch invocation instead.
+    conv = env.conv_store.get_conversation(session_id)
+    assert conv is not None, "failed launch must not delete the session row"
+    assert len(launched_host_ids) == 1, "exactly one sandbox launch expected"
+
+    # A launch that settles as failed leaves no running sandbox: the
+    # provider terminate fires and the host row (launch token) goes.
+    await _wait_for_sandbox_teardown(env, fake, launched_host_ids[0])
+    assert fake.terminated == ["sb-fake-1"]
+    del tunnels
+
+
+async def test_runner_connect_timeout_failure_tears_down_managed_sandbox(
+    teardown_env: _Env,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A managed launch whose runner never connects settles as ``failed``
+    after the connect grace — and must tear its sandbox down.
+
+    The host confirms the launch but no runner tunnel ever arrives
+    (a cold or overloaded node does this on its own). Before the
+    teardown existed, the connect timeout only published the failed
+    status and returned: the sandbox kept running with no code path
+    left to ever delete it.
+    """
+    env = teardown_env
+    monkeypatch.setattr("omnigent.server.managed_hosts.MANAGED_HOST_ONLINE_TIMEOUT_S", 10)
+    # No runner ever connects in this test by design; shrink the
+    # connect grace so the launch settles in milliseconds, not 30s.
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._HOST_RELAUNCH_RUNNER_CONNECT_TIMEOUT_S", 0.2
+    )
+    loop = asyncio.get_running_loop()
+    host_futures: list[asyncio.Future[ApplicationCommunicator]] = []
+    launched_host_ids: list[str] = []
+
+    def _start_fake_sandbox_host(invocation: HostStartInvocation) -> None:
+        """Spawn the confirming fake sandbox host when the launcher 'starts' it."""
+        launched_host_ids.append(invocation.host_id)
+        future = asyncio.run_coroutine_threadsafe(
+            _sandbox_host(
+                env.app,
+                invocation.host_id,
+                invocation.host_name,
+                invocation.token,
+                refuse_launch=False,
+            ),
+            loop,
+        )
+        host_futures.append(asyncio.wrap_future(future, loop=loop))
+
+    fake = FakeSandboxLauncher(on_host_start=_start_fake_sandbox_host)
+    install_fake_modal_launcher(monkeypatch, fake)
+
+    agent = await create_test_agent(env.client, name="managed-connect-timeout-agent")
+    resp = await env.client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "host_type": "managed"},
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = resp.json()["id"]
+
+    # The connect grace expires and the launch settles as failed with
+    # the connect-timeout reason on the snapshot.
+    status = await _wait_for_failed_launch(env, session_id)
+    assert "did not connect" in (status["error"] or ""), status
+
+    tunnels = [await future for future in host_futures]
+    assert len(tunnels) == 1
+
+    # Same as the refusal test: the sandbox's host id comes from the
+    # launch invocation, because a correct teardown clears the
+    # conversation's host binding along with the host row.
+    conv = env.conv_store.get_conversation(session_id)
+    assert conv is not None, "failed launch must not delete the session row"
+    assert len(launched_host_ids) == 1, "exactly one sandbox launch expected"
+
+    # A launch that settles as failed leaves no running sandbox: the
+    # provider terminate fires and the host row (launch token) goes.
+    await _wait_for_sandbox_teardown(env, fake, launched_host_ids[0])
+    assert fake.terminated == ["sb-fake-1"]
+    del tunnels


### PR DESCRIPTION
## Related issue

Closes #6063

## Summary

A managed Kubernetes sandbox whose launch fails after the host is already online was leaking. `_bind_and_launch_managed_runner` has three failure branches after that point; only one (session deleted mid-provision) tore the sandbox down. The other two — the host refusing the harness, and the runner never connecting its tunnel — settled the tracker and published the failure, then just returned, leaving a credential-bearing Pod running until `activeDeadlineSeconds` (7 days) finally expired.

This PR ships the two smallest fixes from the issue's own proposed list:
- **(a)** Tear the sandbox down in the two missing branches, the same as the branch that already does it correctly.
- **(c)** Add `ttlSecondsAfterFinished` (24h) to the Job spec as a backstop, so a Job that reaches a terminal state on its own gets garbage-collected by the cluster even if application-level cleanup never runs.

The issue's third option, **(b)** — a periodic reconciler catching orphaned sandboxes regardless of cause, including a server-restart-mid-launch that the in-memory launch tracker simply forgets — is a different shape of change (a new subsystem with its own design questions: poll interval, what counts as "orphaned," multi-replica locking), not a bug fix. Filing it as a separate follow-up rather than bundling it in, so it stays tracked and visible instead of stalling review of these two clean fixes.

**Caught a real regression along the way, worth flagging explicitly:** `_bind_and_launch_managed_runner` is shared between a first launch (fresh host identity, safe to fully tear down on failure) and a message-triggered relaunch of an *existing*, persistent host (a new sandbox generation on the same identity). My first pass tore down unconditionally, which the existing `test_message_relaunches_dead_managed_sandbox` integration test caught immediately — it would have deleted the user's host identity the moment a relaunch's runner was merely slow to connect, not just cleaned up an orphaned Job. Threaded `relaunch_host` through so the new teardown only fires on a first launch; a failed relaunch generation is left alone, matching the same principle `_run_managed_wake` already uses for a failed wake.

## Test Plan

New unit coverage for both previously-missing teardown branches, and a dedicated test locking in that a relaunch failure does *not* tear down the host identity. All three: reverted just the source, confirmed they fail; restored it, confirmed they pass.

Running the **full** existing `test_host_session_binding.py` suite (not just the new tests) is what caught the relaunch-vs-first-launch regression above before it shipped — `test_message_relaunches_dead_managed_sandbox` failed with the naive unconditional-teardown version and passes with the `relaunch_host`-gated one. 337 tests across `tests/onboarding/sandboxes/test_kubernetes.py` and `tests/server/test_managed_hosts.py` stay green.

Verified live against a real Kubernetes cluster (OrbStack): built the actual Job manifest through `build_job_manifest` and applied it with both `--dry-run=server` and a real create against the live API server — `ttlSecondsAfterFinished`, `backoffLimit`, and `activeDeadlineSeconds` all persisted correctly, confirming the field name and type are accepted by the real API, not just a plain-dict unit test.

`ruff check`, `ruff format --check`, `pyrefly check`, and the full `pre-commit` hook set are all clean on the touched files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Live cluster check, the actual manifest our code builds, applied for real:

```
$ kubectl apply -f manifest.json
job.batch/e2e-ttl-check created
$ kubectl get job e2e-ttl-check -o jsonpath='{.spec.ttlSecondsAfterFinished} {.spec.backoffLimit} {.spec.activeDeadlineSeconds}'
86400 6 604800
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: the live `kubectl apply` against a real OrbStack cluster shown above, confirming the Job spec change is accepted by the real Kubernetes API server rather than only a plain-dict unit test. The teardown fix itself is covered by the new integration tests in `test_host_session_binding.py`, which exercise the real FastAPI app, DB, and host-tunnel WebSocket simulation rather than isolated mocks — that's also what surfaced the relaunch regression described above.

## Changelog

A managed Kubernetes sandbox is now torn down if its launch fails after the host comes online (harness refusal or a runner that never connects), instead of leaking until its 7-day lifetime cap expires; Jobs also get a 24h `ttlSecondsAfterFinished` backstop as defense in depth

## Issues

Resolves [OMNI-5905](https://linear.app/omnigent/issue/OMNI-5905/managed-sandbox-leaks-when-the-runner-launch-fails-after-the-host-is)
