### PR TITLE
fix(store): don't bump conversations.updated_at on runner/host rebind

### DIFF
--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1318,6 +1318,10 @@ class ConversationStore(ABC):
         method; internal sub-agent code also uses it to keep child
         conversations on the parent's current runner.
 
+        Runner/host binding is live state, not conversation activity, so
+        this must NOT bump ``updated_at`` (it drives sidebar ordering
+        and the unread dot).
+
         :param conversation_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.
         :param runner_id: Runner identifier to bind to,
@@ -1337,6 +1341,10 @@ class ConversationStore(ABC):
         Counterpart to :meth:`replace_runner_id` for the 1:1
         session↔runner invariant — /clear and /switch unbind the old
         session before binding the runner to the new one.
+
+        Runner/host binding is live state, not conversation activity, so
+        this must NOT bump ``updated_at`` (it drives sidebar ordering
+        and the unread dot).
 
         :param conversation_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.
@@ -1365,6 +1373,10 @@ class ConversationStore(ABC):
         ``workspace`` together never violates
         ``ck_conversations_workspace_required_for_host`` (workspace
         is only required while ``host_id`` is set).
+
+        Runner/host binding is live state, not conversation activity, so
+        this must NOT bump ``updated_at`` (it drives sidebar ordering
+        and the unread dot).
 
         :param conversation_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.
@@ -1411,6 +1423,10 @@ class ConversationStore(ABC):
         Used when the server asks a host to spawn a runner for
         an existing session. Last-write-wins semantics (like
         :meth:`replace_runner_id`).
+
+        Runner/host binding is live state, not conversation activity, so
+        this must NOT bump ``updated_at`` (it drives sidebar ordering
+        and the unread dot).
 
         :param conversation_id: Session/conversation identifier,
             e.g. ``"conv_abc123"``.

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3077,7 +3077,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
                 )
-            ap_row.updated_at = now_epoch()
             labels = _fetch_labels(ap_sess, conversation_id)
         return _to_conversation(ap_row, meta, labels)
 
@@ -3104,7 +3103,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
                 )
-            ap_row.updated_at = now_epoch()
             labels = _fetch_labels(ap_sess, conversation_id)
         return _to_conversation(ap_row, meta, labels)
 
@@ -3139,7 +3137,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
                 )
-            ap_row.updated_at = now_epoch()
             labels = _fetch_labels(ap_sess, conversation_id)
         return _to_conversation(ap_row, meta, labels)
 
@@ -3249,7 +3246,6 @@ class SqlAlchemyConversationStore(ConversationStore):
                 raise ConversationNotFoundError(
                     f"conversation {conversation_id!r} does not exist",
                 )
-            ap_row.updated_at = now_epoch()
             labels = _fetch_labels(ap_sess, conversation_id)
         return _to_conversation(ap_row, meta, labels)
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -2088,6 +2088,52 @@ def test_update_title_bumps_updated_at(
     )
 
 
+@pytest.mark.parametrize(
+    "rebind",
+    ["replace_runner_id", "clear_runner_id", "clear_host_binding", "set_host_id"],
+)
+def test_runner_host_rebind_does_not_bump_updated_at(
+    conversation_store: SqlAlchemyConversationStore,
+    monkeypatch: pytest.MonkeyPatch,
+    db_uri: str,
+    rebind: str,
+) -> None:
+    """
+    Runner/host binding is live state, so it must leave updated_at alone.
+
+    The sidebar lights its unread dot when ``updated_at`` exceeds the viewer's
+    last-seen baseline, so a rebind that stamped ``now`` would flag a
+    long-quiet conversation as unread with nothing new to read.
+    """
+    import omnigent.stores.conversation_store.sqlalchemy_store as store_mod
+
+    host_id = "292dfcdf8a31f1319b469f4fa179ac6b"
+    _register_host(db_uri, host_id)
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 1000)
+    conv = conversation_store.create_conversation(
+        workspace="/Users/corey/projects/myapp",
+    )
+    assert conv.updated_at == 1000
+
+    # Three days later, with no new conversation content at all.
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 1000 + 3 * 86_400)
+    if rebind == "replace_runner_id":
+        conversation_store.replace_runner_id(conv.id, "runner_abc123")
+    elif rebind == "clear_runner_id":
+        conversation_store.clear_runner_id(conv.id)
+    elif rebind == "clear_host_binding":
+        conversation_store.clear_host_binding(conv.id)
+    else:
+        conversation_store.set_host_id(conv.id, host_id)
+
+    fetched = conversation_store.get_conversation(conv.id)
+    assert fetched is not None
+    assert fetched.updated_at == 1000, (
+        f"{rebind} bumped updated_at to {fetched.updated_at} with no new "
+        "content; that lights the sidebar unread dot on a quiet conversation."
+    )
+
+
 # ── sort_by=updated_at ────────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #6130

## Summary

- The sidebar unread dot fires when `conversations.updated_at` exceeds the viewer's last-seen baseline. `replace_runner_id`, `clear_runner_id`, `clear_host_binding` and `set_host_id` each stamped `updated_at = now_epoch()` unconditionally for purely operational runner/host rebinding, so a conversation quiet for hours or days grew a red dot with nothing new to read.
- Drop those four writes. Runner and host binding is live state, not conversation activity, which is what the store already specifies for its other live-state writes (`touch_runner_liveness`, `clear_runner_liveness`, `set_session_live_status`, `set_pending_elicitation_count` all say "must NOT bump `updated_at`"). `set_runner_id` already complied and `set_external_session_id` guards its bump behind a change check, so this brings the remaining four in line.
- State the contract on the four abstract methods so it isn't reintroduced.

ELI5: the sidebar treats "row timestamp moved" as "someone said something new". Reattaching a runner moved the timestamp without anyone saying anything, so the chat claimed to be unread.

How a quiet chat lit up (`/switch` moving a runner to another session):

```
user runs /switch        ->  PATCH /v1/sessions/{A} runner_id:""
                         ->  clear_runner_id(A)
                         ->  conversations.updated_at = now      <- no new content
web sidebar poll         ->  updated_at > last_seen  ->  red dot on A
```

## Test Plan

New parametrized regression test, `test_runner_host_rebind_does_not_bump_updated_at`, covering all four methods: create a conversation at `t=1000`, advance the clock three days, rebind, assert `updated_at` is still `1000`.

```
$ pytest tests/stores/test_conversation_store.py -k rebind_does_not_bump
4 passed, 193 deselected
```

Confirmed the test catches the bug by reverting the fix in `sqlalchemy_store.py` and rerunning:

```
AssertionError: replace_runner_id bumped updated_at to 260200 with no new content; that lights the sidebar unread dot on a quiet conversation.
AssertionError: clear_runner_id bumped updated_at to 260200 ...
AssertionError: clear_host_binding bumped updated_at to 260200 ...
AssertionError: set_host_id bumped updated_at to 260200 ...
```

Neighbouring store tests still pass:

```
$ pytest tests/stores/test_conversation_store.py -k "runner_id or host_id or host_binding or updated_at"
25 passed, 172 deselected
```

`ruff format` and `ruff check` pass on the changed files. No existing test asserted the old bump (checked the rebind tests under `tests/server/integration/` and `tests/stores/` for `updated_at` assertions).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The failing-before / passing-after assertion output is in the Test Plan above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

No frontend files change here. The user-visible effect is in the web sidebar, but the defect and the fix are both server side.

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A, automated coverage added above.

## Changelog

Chats no longer show a false unread dot after their runner or host is rebound

---

Scope note: there is a second, independent cause of spontaneous unread dots that this PR deliberately does not touch. `isConversationUnseen` suppresses the dot while `status === "running"` instead of resolving it, so an owed dot stays hidden until the status stops reading `running` (a disconnect finally observed, a stale `failed` cleared on reconnect, or a sidebar poll landing on a replica whose in-memory `_session_status_cache` disagrees with the persisted `live_status`). That needs a separate fix and is tracked separately.

This pull request and its description were written by Isaac.
