### PR TITLE
Preserve maintainer approval across Otto repairs

### DIFF
--- a/.github/scripts/maintainer_approval.py
+++ b/.github/scripts/maintainer_approval.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Evaluate maintainer approval, preserving it across trusted bot commits."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+DECISIVE_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}
+
+
+@dataclass(frozen=True)
+class ApprovalDecision:
+    approved: bool
+    reason: str
+
+
+def latest_decisive_reviews(reviews: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return each user's latest approval-changing review."""
+    latest: dict[str, tuple[tuple[str, str], dict[str, Any]]] = {}
+    for review in reviews:
+        user = review.get("user") or {}
+        login = str(user.get("login") or "").strip()
+        state = str(review.get("state") or "").upper()
+        if not login or state not in DECISIVE_REVIEW_STATES:
+            continue
+        ordering = (str(review.get("submitted_at") or ""), str(review.get("id") or ""))
+        if login not in latest or ordering >= latest[login][0]:
+            latest[login] = (ordering, review)
+    return {login: value[1] for login, value in latest.items()}
+
+
+def approval_decision(
+    *,
+    repository: str,
+    author: str,
+    head_repository: str,
+    head_sha: str,
+    maintainers: set[str],
+    trusted_successors: set[str],
+    reviews: list[dict[str, Any]],
+    commits: list[dict[str, Any]],
+) -> ApprovalDecision:
+    """Accept current approval or trusted same-repository successor commits."""
+    maintainers = {login.casefold() for login in maintainers}
+    trusted_successors = {login.casefold() for login in trusted_successors}
+    if author.casefold() in maintainers:
+        return ApprovalDecision(True, f"Author @{author} is a maintainer.")
+
+    commit_positions = {
+        str(commit.get("sha") or ""): index for index, commit in enumerate(commits)
+    }
+    same_repository = head_repository.casefold() == repository.casefold()
+    failures: list[str] = []
+    for login, review in latest_decisive_reviews(reviews).items():
+        if login.casefold() not in maintainers:
+            continue
+        if str(review.get("state") or "").upper() != "APPROVED":
+            continue
+        approved_sha = str(review.get("commit_id") or "")
+        if approved_sha == head_sha:
+            return ApprovalDecision(True, f"Current head approved by maintainer @{login}.")
+        if not same_repository:
+            failures.append(f"@{login}'s approval predates a fork-head update")
+            continue
+        position = commit_positions.get(approved_sha)
+        if position is None:
+            failures.append(f"@{login}'s approved commit is no longer in PR history")
+            continue
+        successors = commits[position + 1 :]
+        if not successors or str(successors[-1].get("sha") or "") != head_sha:
+            failures.append(f"@{login}'s approval does not reach the current head")
+            continue
+        untrusted = []
+        for commit in successors:
+            author_login = str((commit.get("author") or {}).get("login") or "").casefold()
+            committer_login = str((commit.get("committer") or {}).get("login") or "").casefold()
+            if author_login not in trusted_successors or committer_login not in trusted_successors:
+                untrusted.append(str(commit.get("sha") or "")[:9])
+        if not untrusted:
+            return ApprovalDecision(
+                True,
+                f"Maintainer @{login} approved {approved_sha[:9]}; only trusted "
+                f"automation committed through {head_sha[:9]}.",
+            )
+        failures.append(
+            f"@{login}'s approval predates untrusted commit(s): {', '.join(untrusted)}"
+        )
+
+    reason = "; ".join(failures) if failures else "awaiting approval from a maintainer"
+    return ApprovalDecision(False, reason)
+
+
+def gh_json(arguments: list[str]) -> Any:
+    completed = subprocess.run(["gh", *arguments], check=True, capture_output=True, text=True)
+    return json.loads(completed.stdout)
+
+
+def paginated(endpoint: str, request: Callable[[list[str]], Any] = gh_json) -> list[dict]:
+    items: list[dict] = []
+    separator = "&" if "?" in endpoint else "?"
+    page = 1
+    while True:
+        value = request(["api", f"{endpoint}{separator}per_page=100&page={page}"])
+        if not isinstance(value, list):
+            raise TypeError(f"expected list response, got {type(value).__name__}")
+        items.extend(value)
+        if len(value) < 100:
+            return items
+        page += 1
+
+
+def maintainers(repository: str) -> set[str]:
+    value = gh_json(["api", f"repos/{repository}/contents/.github/MAINTAINER?ref=main"])
+    content = base64.b64decode(value["content"]).decode()
+    return {
+        token.casefold()
+        for line in content.splitlines()
+        for token in line.partition("#")[0].split()
+        if token
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument("--trusted-successor", action="append", default=[])
+    args = parser.parse_args()
+
+    pull = gh_json(["api", f"repos/{args.repository}/pulls/{args.pr_number}"])
+    reviews = paginated(f"repos/{args.repository}/pulls/{args.pr_number}/reviews")
+    commits = paginated(f"repos/{args.repository}/pulls/{args.pr_number}/commits")
+    decision = approval_decision(
+        repository=args.repository,
+        author=str((pull.get("user") or {}).get("login") or ""),
+        head_repository=str(((pull.get("head") or {}).get("repo") or {}).get("full_name") or ""),
+        head_sha=str((pull.get("head") or {}).get("sha") or ""),
+        maintainers=maintainers(args.repository),
+        trusted_successors=set(args.trusted_successor),
+        reviews=reviews,
+        commits=commits,
+    )
+    if decision.approved:
+        print(decision.reason)
+        return 0
+    print(f"::error::{decision.reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/maintainer_approval_test.py
+++ b/.github/scripts/maintainer_approval_test.py
@@ -1,0 +1,100 @@
+from maintainer_approval import approval_decision, latest_decisive_reviews
+
+REPOSITORY = "omnigent-ai/omnigent"
+MAINTAINERS = {"maintainer"}
+TRUSTED = {"omni-resolve-agent[bot]"}
+
+
+def review(state: str, commit_id: str, *, submitted: str = "2026-09-01T00:00:00Z"):
+    return {
+        "id": 1,
+        "state": state,
+        "commit_id": commit_id,
+        "submitted_at": submitted,
+        "user": {"login": "maintainer"},
+    }
+
+
+def commit(sha: str, login: str = "omni-resolve-agent[bot]"):
+    return {
+        "sha": sha,
+        "author": {"login": login},
+        "committer": {"login": login},
+    }
+
+
+def decide(*, reviews, commits, head="new", head_repository=REPOSITORY):
+    return approval_decision(
+        repository=REPOSITORY,
+        author="contributor",
+        head_repository=head_repository,
+        head_sha=head,
+        maintainers=MAINTAINERS,
+        trusted_successors=TRUSTED,
+        reviews=reviews,
+        commits=commits,
+    )
+
+
+def test_current_head_approval_passes():
+    decision = decide(reviews=[review("APPROVED", "new")], commits=[commit("new")])
+    assert decision.approved
+    assert "Current head approved" in decision.reason
+
+
+def test_approval_survives_trusted_same_repo_successor_commits():
+    decision = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("new")],
+    )
+    assert decision.approved
+    assert "only trusted automation committed" in decision.reason
+
+
+def test_approval_does_not_survive_untrusted_or_fork_updates():
+    untrusted = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("new", "contributor")],
+    )
+    assert not untrusted.approved
+    assert "untrusted commit" in untrusted.reason
+
+    fork = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("new")],
+        head_repository="contributor/omnigent",
+    )
+    assert not fork.approved
+    assert "fork-head update" in fork.reason
+
+
+def test_approval_does_not_survive_rewritten_history():
+    decision = decide(
+        reviews=[review("APPROVED", "removed")],
+        commits=[commit("new")],
+    )
+    assert not decision.approved
+    assert "no longer in PR history" in decision.reason
+
+
+def test_later_changes_requested_supersedes_approval():
+    reviews = [
+        review("APPROVED", "old"),
+        review("CHANGES_REQUESTED", "new", submitted="2026-09-02T00:00:00Z"),
+    ]
+    assert latest_decisive_reviews(reviews)["maintainer"]["state"] == "CHANGES_REQUESTED"
+    assert not decide(reviews=reviews, commits=[commit("old"), commit("new")]).approved
+
+
+def test_maintainer_authored_pr_still_passes():
+    decision = approval_decision(
+        repository=REPOSITORY,
+        author="maintainer",
+        head_repository=REPOSITORY,
+        head_sha="new",
+        maintainers=MAINTAINERS,
+        trusted_successors=TRUSTED,
+        reviews=[],
+        commits=[commit("new", "maintainer")],
+    )
+    assert decision.approved

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -9,9 +9,9 @@ name: Maintainer Approval
 # Trigger is `pull_request_target`, so it runs from main with the base token
 # even for fork PRs: it isn't held behind the fork-PR-workflow approval gate
 # (reports immediately on open), and the PR-head copy never runs (a malicious PR
-# can't weaken the check). Safe because the job checks out nothing and runs no PR
-# code — it reads .github/MAINTAINER from main's tip (so a PR can't self-grant by
-# adding its author) and queries the API.
+# can't weaken the check). Safe because the job checks out only the evaluator
+# from main and runs no PR code. The evaluator reads .github/MAINTAINER from
+# main's tip (so a PR can't self-grant by adding its author) and queries the API.
 #
 # `pull_request_target` doesn't fire on reviews, so maintainer-approval-rerun.yml
 # + -rerun-run.yml re-run this workflow on an approving review to flip it green.
@@ -37,58 +37,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      - name: Check out approval evaluator
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          sparse-checkout: .github/scripts/maintainer_approval.py
+          sparse-checkout-cone-mode: false
+
       - name: Require maintainer approval
         env:
           GH_TOKEN: ${{ github.token }}
           REPO:     ${{ github.repository }}
           PR:       ${{ github.event.pull_request.number }}
         run: |
-          # --- Load maintainers from .github/MAINTAINER at main's tip ---
-          set +e
-          CONTENT_B64=$(gh api "repos/$REPO/contents/.github/MAINTAINER?ref=main" --jq '.content' 2>/dev/null)
-          RC=$?
-          set -e
-          if [[ $RC -ne 0 || -z "$CONTENT_B64" ]]; then
-            echo "::error::.github/MAINTAINER not found on main"
-            exit 1
-          fi
-
-          CONTENT=$(echo "$CONTENT_B64" | base64 -d)
-          # Strip comments/blanks to a space-separated list. `grep -v` exits 1
-          # on no matches; wrap with `|| true` so pipefail reaches the empty branch.
-          MAINTAINERS=$(echo "$CONTENT" | sed -E 's/#.*$//' | tr -s '[:space:]' '\n' | { grep -v '^$' || true; } | tr '\n' ' ')
-          MAINTAINERS_LC=$(echo "$MAINTAINERS" | tr '[:upper:]' '[:lower:]')
-          if [[ -z "${MAINTAINERS_LC// /}" ]]; then
-            echo "::error::.github/MAINTAINER on main has no entries"
-            exit 1
-          fi
-
-          AUTHOR=$(gh pr view "$PR" --repo "$REPO" --json author --jq '.author.login')
-          AUTHOR_LC=$(echo "$AUTHOR" | tr '[:upper:]' '[:lower:]')
-
-          # Case 1: author is a maintainer.
-          for m in $MAINTAINERS_LC; do
-            if [[ "$m" == "$AUTHOR_LC" ]]; then
-              echo "Author @$AUTHOR is a maintainer."
-              exit 0
-            fi
-          done
-
-          # Case 2: latest non-COMMENTED review state of some maintainer
-          # is APPROVED. Matches GitHub's UI semantics (COMMENTED does
-          # not supersede APPROVED; CHANGES_REQUESTED and DISMISSED do).
-          APPROVERS=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-            --jq '[.[] | select(.state != "COMMENTED")] | group_by(.user.login) | map(max_by(.submitted_at)) | .[] | select(.state == "APPROVED") | .user.login')
-          for u in $APPROVERS; do
-            u_lc=$(echo "$u" | tr '[:upper:]' '[:lower:]')
-            for m in $MAINTAINERS_LC; do
-              if [[ "$m" == "$u_lc" ]]; then
-                echo "Approved by maintainer @$u."
-                exit 0
-              fi
-            done
-          done
-
-          # Case 3: nothing yet -- fail the check so merge stays blocked.
-          echo "::error::Awaiting approval from a maintainer (one of: $MAINTAINERS)."
-          exit 1
+          python3 .github/scripts/maintainer_approval.py \
+            --repository "$REPO" \
+            --pr-number "$PR" \
+            --trusted-successor 'omni-resolve-agent[bot]'


### PR DESCRIPTION
## Summary
- preserve human maintainer approval across same-repository commits made only by the trusted resolve bot
- reject fork updates, rewritten history, untrusted successor commits, and later changes-requested reviews
- run the hardened evaluator from the protected base branch

## Validation
- `uv run --with pytest pytest -q .github/scripts/maintainer_approval_test.py`
- `uv run --with ruff ruff check .github/scripts/maintainer_approval.py .github/scripts/maintainer_approval_test.py`
- validated against the real commit chain from PR #6087