### PR TITLE
Preserve contributor PRs until replacement merge

### DIFF
--- a/.github/workflows/close-superseded-pr.js
+++ b/.github/workflows/close-superseded-pr.js
@@ -1,0 +1,46 @@
+const TRUSTED_REPLACEMENT_AUTHORS = new Set([
+  "app/omni-resolve-agent",
+  "omni-resolve-agent",
+  "omni-resolve-agent[bot]",
+]);
+
+const supersededPRNumber = (body) => {
+  const match = String(body || "").match(/^Supersedes #(\d+)\b/im);
+  return match ? Number(match[1]) : null;
+};
+
+module.exports = async ({ context, github }) => {
+  const replacement = context.payload.pull_request;
+  if (!replacement?.merged) return;
+
+  const author = replacement.user?.login ?? "";
+  if (!TRUSTED_REPLACEMENT_AUTHORS.has(author)) return;
+
+  const oldNumber = supersededPRNumber(replacement.body);
+  if (!oldNumber || oldNumber === replacement.number) return;
+
+  const { owner, repo } = context.repo;
+  const { data: oldPR } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: oldNumber,
+  });
+  if (oldPR.state !== "open") return;
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: oldNumber,
+    body:
+      `Replacement #${replacement.number} has merged. Closing this PR now that ` +
+      "the credited replacement is on the default branch.",
+  });
+  await github.rest.pulls.update({
+    owner,
+    repo,
+    pull_number: oldNumber,
+    state: "closed",
+  });
+};
+
+module.exports.supersededPRNumber = supersededPRNumber;

--- a/.github/workflows/close-superseded-pr.test.js
+++ b/.github/workflows/close-superseded-pr.test.js
@@ -1,0 +1,72 @@
+const path = require("path");
+const script = require(
+  path.resolve(".github/workflows/close-superseded-pr.js"),
+);
+
+async function run({
+  merged = true,
+  author = "omni-resolve-agent[bot]",
+  body = "Supersedes #10",
+  oldState = "open",
+} = {}) {
+  const comments = [];
+  const closed = [];
+  const github = {
+    rest: {
+      pulls: {
+        get: async () => ({ data: { state: oldState } }),
+        update: async ({ pull_number, state }) =>
+          closed.push({ pull_number, state }),
+      },
+      issues: {
+        createComment: async ({ issue_number, body: comment }) =>
+          comments.push({ issue_number, body: comment }),
+      },
+    },
+  };
+  const context = {
+    repo: { owner: "omnigent-ai", repo: "omnigent" },
+    payload: {
+      pull_request: {
+        number: 20,
+        merged,
+        body,
+        user: { login: author },
+      },
+    },
+  };
+  await script({ context, github });
+  return { comments, closed };
+}
+
+function assert(name, condition, detail) {
+  console.log(
+    `${condition ? "PASS" : "FAIL"}  ${name}${detail ? ` -- ${detail}` : ""}`,
+  );
+  if (!condition) process.exitCode = 1;
+}
+
+(async () => {
+  let result = await run();
+  assert(
+    "closes contributor PR only after trusted replacement merges",
+    result.closed.length === 1 &&
+      result.closed[0].pull_number === 10 &&
+      result.comments.length === 1,
+    JSON.stringify(result),
+  );
+
+  for (const values of [
+    { merged: false },
+    { author: "human-contributor" },
+    { body: "Builds on #10" },
+    { oldState: "closed" },
+  ]) {
+    result = await run(values);
+    assert(
+      `does nothing for ${JSON.stringify(values)}`,
+      result.closed.length === 0 && result.comments.length === 0,
+      JSON.stringify(result),
+    );
+  }
+})();

--- a/.github/workflows/close-superseded-pr.yml
+++ b/.github/workflows/close-superseded-pr.yml
@@ -1,0 +1,30 @@
+name: Close Superseded PR
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  close-superseded:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+          sparse-checkout: .github/workflows/close-superseded-pr.js
+          sparse-checkout-cone-mode: false
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const script = require(".github/workflows/close-superseded-pr.js");
+            await script({ context, github });

--- a/.github/workflows/duplicate-prs-test.yml
+++ b/.github/workflows/duplicate-prs-test.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - .github/workflows/duplicate-prs.js
       - .github/workflows/duplicate-prs.test.js
+      - .github/workflows/close-superseded-pr.js
+      - .github/workflows/close-superseded-pr.test.js
   workflow_dispatch:
 
 permissions:
@@ -29,3 +31,5 @@ jobs:
           persist-credentials: false
       - name: Run duplicate-PR unit test
         run: node .github/workflows/duplicate-prs.test.js
+      - name: Run superseded-PR unit test
+        run: node .github/workflows/close-superseded-pr.test.js

--- a/.github/workflows/duplicate-prs.js
+++ b/.github/workflows/duplicate-prs.js
@@ -3,14 +3,19 @@
 // more than one such PR, the oldest PR is kept and the newer ones are closed,
 // labeled `duplicate`, and commented on. Maintainer PRs are included in
 // detection (so a maintainer's PR can be the kept "keeper") but are never
-// auto-closed: a maintainer duplicate instead gets a softer heads-up comment
-// and the `duplicate` label (no close). Originally ported from mlflow/mlflow's
-// .github/workflows/duplicate-prs.js, with the maintainer skip narrowed from
-// detection to closing only.
+// auto-closed. Trusted resolve-agent replacement PRs are excluded entirely;
+// their contributor PR remains open until a post-merge workflow closes it.
+// Originally ported from mlflow/mlflow's .github/workflows/duplicate-prs.js,
+// with the maintainer skip narrowed from detection to closing only.
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DAYS_TO_CONSIDER = 14;
 const DUPLICATE_LABEL = "duplicate";
+const TRUSTED_REPLACEMENT_AUTHORS = new Set([
+  "app/omni-resolve-agent",
+  "omni-resolve-agent",
+  "omni-resolve-agent[bot]",
+]);
 
 const duplicateMessage = (author, issueNumber, keeperPR) =>
   `@${author} This PR appears to reference the same issue (#${issueNumber}) as #${keeperPR} (opened earlier). Closing as a duplicate. ` +
@@ -54,13 +59,15 @@ const MAINTAINER_ASSOCIATIONS = ["MEMBER", "OWNER", "COLLABORATOR"];
 // Maintainer PRs participate in detection (so they can be the kept "keeper"
 // that makes a community duplicate closeable) but are never themselves closed.
 const isMaintainerPR = (pr) => MAINTAINER_ASSOCIATIONS.includes(pr.authorAssociation);
+const isTrustedReplacementPR = (pr) =>
+  TRUSTED_REPLACEMENT_AUTHORS.has(pr.author?.login ?? "");
 
 // Whether a PR should be considered at all when grouping by issue. Already
 // labeled-duplicate PRs are skipped (already handled); everything else --
 // community and maintainer alike -- is considered.
 const shouldConsiderPR = (pr) => {
   const labels = pr.labels?.nodes?.map((l) => l.name) ?? [];
-  return !labels.includes(DUPLICATE_LABEL);
+  return !labels.includes(DUPLICATE_LABEL) && !isTrustedReplacementPR(pr);
 };
 
 // Whether a duplicate PR is eligible to be auto-closed: only community PRs.

--- a/.github/workflows/duplicate-prs.test.js
+++ b/.github/workflows/duplicate-prs.test.js
@@ -153,4 +153,19 @@ function assert(name, cond, detail) {
     pr({ number: 2, createdAt: "2026-06-02T00:00:00Z", issues: [] }),
   ]);
   assert("PR with no issue reference is ignored", r.closed.length === 0, JSON.stringify(r));
+
+  // 8. Resolve-agent replacement PRs are exempt. The contributor PR remains
+  //    open until a separate post-merge workflow closes it after replacement.
+  r = await run([
+    pr({ number: 1, createdAt: "2026-06-01T00:00:00Z", issues: [9] }),
+    pr({
+      number: 2,
+      createdAt: "2026-06-02T00:00:00Z",
+      author: "omni-resolve-agent[bot]",
+      issues: [9],
+    }),
+  ]);
+  assert("trusted replacement PR is exempt while contributor PR stays open",
+    r.closed.length === 0 && r.labeled.length === 0 && r.commented.length === 0,
+    JSON.stringify(r));
 })();

--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -3,10 +3,10 @@ name: Duplicate PRs
 # Closes duplicate community PRs that reference the same issue: when more than
 # one open PR (created in the last 14 days) closes the same issue, the oldest is
 # kept and the newer ones are closed, labeled `duplicate`, and commented on.
-# Maintainer-authored PRs are never touched. Runs every 4 hours (and on demand)
-# rather than per-PR, so a freshly opened PR is only flagged once a real
-# duplicate exists. Never checks out or runs PR code -- it reads PR metadata via
-# the API using only the default-branch script. See duplicate-prs.js.
+# Maintainer-authored PRs are never closed, and trusted resolve-agent replacement
+# PRs are exempt so the contributor's original stays open until the replacement
+# merges. Runs every 4 hours (and on demand) rather than per-PR. Never checks out
+# or runs PR code -- it reads PR metadata via the default-branch script.
 
 on:
   schedule:

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -351,19 +351,12 @@ comment-only outcome. Say precisely why the existing approach won't do (in a
 review comment on that PR, so the author knows), then **switch to the author path
 (Step 2B) and open your own PR** that resolves the bug correctly. In your PR,
 reference the existing one and summarize why a fresh approach was warranted.
-Record `mode: "authored_fix"` and put the reviewed PR's number in your prose so
-the two are linked. **Close the superseded PR the instant yours is open — before
-you emit the interim handoff (Step 3.5) and before you start Step 4** (same reason
-as the fork take-over: two open PRs on one issue trip the duplicate-PR automation,
-which auto-closes the newer one — yours, and a cleanup left for the end of Step 4
-is what a mid-turn SSE drop strands): `gh pr comment <old> --body 'Superseded by
-#<yours> — a different approach was needed; see there.'` then `gh pr close <old>`.
-Closing a PR is a base-repo operation (it flips `state` on the PR object in
-`omnigent-ai/omnigent`), so `pull_requests: write` covers it **even for a
-contributor's fork PR** — expect the close to succeed; run it. Only if it returns
-a real error, record that error in `maintainer_review` and ask the maintainer to
-close it — never leave both open. Use this escape hatch deliberately, not for
-style preferences — a working,
+Record `mode: "authored_fix"`, put `Supersedes #<old>` on its own line in the new
+PR body, and keep the reviewed PR open while the replacement is under review.
+The trusted post-merge workflow closes the old PR only after the replacement
+actually merges. Comment on the old PR immediately with the replacement link so
+the contributor understands the handoff, but **do not close it yourself**. Use
+this escape hatch deliberately, not for style preferences — a working,
 root-cause-sound PR should be reviewed and improved in place, not replaced.
 
 When you keep the PR, you drive it to landable per Step 4 — pushing fixes directly
@@ -685,10 +678,10 @@ Once the set is genuinely green:
      CI-green gate (see 4.1); label it now so the preview builds while you drive
      Step 4. (Review-path fork PRs still wait for green — 4.1.)
    - **If you opened this PR to supersede another** (fork take-over, or the
-     "approach is wrong" escape hatch), you already commented on and closed that PR
-     *before* this handoff — see Step 4's fork-take-over and Step 2A's escape hatch.
-     Set `reviewed_pr_url` to the superseded PR here so the workflow can verify it's
-     closed as a backstop.
+     "approach is wrong" escape hatch), you already commented on that PR but left
+     it open. Ensure the replacement body contains `Supersedes #<old>` on its own
+     line, and set `reviewed_pr_url` so workflow reconciliation can preserve and
+     inform the original PR until the replacement merges.
 6. You do **not** merge. Opening the PR is not the finish line — go to Step 4 and
    drive it to a green, reviewed, ready-for-a-human state.
 
@@ -740,29 +733,17 @@ can land a fix depends on where its branch lives:
       then replay onto your branch, or `git cherry-pick`), then add your fix on top.
     - Credit the original author on the commits (`Co-authored-by: <name> <email>`,
       read from `gh pr view <pr> --json commits`).
-    - In your PR body, link the fork PR (`Builds on #<pr> by @<author>`) and say
-      why you re-opened it (couldn't push to the fork).
-    - **Close the fork PR the instant yours is open — before anything else.**
-      Two open PRs that fix the same issue trip the repo's duplicate-PR automation,
-      which will auto-close the **newer** one — i.e. *yours*. So the moment
-      `gh pr create` returns your PR number, comment on the fork PR pointing to
-      yours and close it **as the very next commands — before you emit the interim
-      handoff (Step 3.5) and before you start driving Step 4**:
+    - In your PR body, put `Supersedes #<pr>` on its own line, credit
+      `@<author>`, and say why you re-opened it (couldn't push to the fork). The
+      duplicate-PR workflow exempts trusted resolve-agent replacement PRs.
+    - Comment on the fork PR as soon as yours opens, but leave it open while the
+      replacement is being reviewed:
       ```
-      gh pr comment <fork-pr> --body 'Superseded by #<your-pr> — I took this over to add a fix because maintainer fork updates were unavailable. Your commits are carried over with credit. Thanks @<author>!'
-      gh pr close <fork-pr>
+      gh pr comment <fork-pr> --body 'Replacement #<your-pr> is open because maintainer fork updates were unavailable. Your commits are carried over with credit. This PR will remain open until the replacement merges. Thanks @<author>!'
       ```
-      Do **not** defer this to the end of Step 4: the session can drop mid-turn
-      (the `--server` SSE stream ends the Run step abruptly), and a cleanup left for
-      last is exactly what gets lost — stranding two open PRs. Close first, then
-      hand off. This both keeps the contributor informed and stops the dedup bot
-      from closing your PR as the duplicate. Closing a PR is a base-repo operation
-      (it flips `state` on the PR object in `omnigent-ai/omnigent`), so
-      `pull_requests: write` covers it **even though the head branch is on a fork**
-      — the fork-push restriction does not apply to a close. Expect it to succeed;
-      run it. Only if the close returns a real error, **record that error in
-      `maintainer_review`** and ask the maintainer to close `#<fork-pr>` in favor of
-      yours — never leave both silently open.
+      The trusted post-merge workflow reads the `Supersedes #<pr>` marker and
+      closes the contributor PR only after your replacement is merged. Never
+      close a contributor PR merely because a replacement was opened.
     - Set `mode: "authored_fix"`, record the fork PR's number in `reviewed_pr_url`,
       and drive **your** PR through the rest of Step 4 (you can push to it).
   - **If the fork PR needs no fix** (repro passes against it, CI green, review


### PR DESCRIPTION
## Summary
- exempt trusted resolve-agent replacement PRs from duplicate auto-closure
- keep the contributor PR open while the replacement is reviewed
- close the contributor PR through a trusted workflow only after the replacement merges
- update resolve-agent instructions to use an explicit `Supersedes #N` marker

## Validation
- `node .github/workflows/duplicate-prs.test.js`
- `node .github/workflows/close-superseded-pr.test.js`
- workflow YAML parsing