### PR TITLE
Persist resolved models reported by SDK harnesses

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -111,9 +111,10 @@ class Conversation:
     :param reported_model: The model the harness last REPORTED the
         session is actually on, verbatim in the harness's own
         spelling, e.g. ``"claude-opus-4-8[1m]"``. Written only by
-        harness reports (``external_model_change``); never by user
-        picks. The only model value UI surfaces display. ``None``
-        means no report has arrived yet.
+        harness reports (native ``external_model_change`` events or
+        SDK terminal-response usage); never by user picks. The only
+        model value UI surfaces display. ``None`` means no report has
+        arrived yet.
     :param model_override: Per-session LLM model override — the user's
         REQUEST, e.g. ``"claude-opus-4-7"``. ``None`` means use the
         agent default from the spec's ``llm.model``. Mutable via

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1360,6 +1360,37 @@ def _accumulate_session_usage(
     return _priced_cost_for_display(new_current)
 
 
+async def _persist_relay_reported_model(
+    resp_obj: dict[str, Any],
+    session_id: str,
+    conversation_store: ConversationStore,
+) -> None:
+    """Persist the concrete model reported by an SDK harness response."""
+    usage_obj = resp_obj.get("usage")
+    if not isinstance(usage_obj, dict):
+        return
+    raw_model = usage_obj.get("model")
+    if not isinstance(raw_model, str) or not raw_model.strip():
+        return
+    model = raw_model.strip()
+    conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
+    if conv is None or conv.reported_model == model:
+        return
+    await asyncio.to_thread(
+        conversation_store.update_conversation,
+        session_id,
+        reported_model=model,
+    )
+    session_stream.publish(
+        session_id,
+        SessionModelEvent(
+            type="session.model",
+            conversation_id=session_id,
+            model=model,
+        ).model_dump(exclude_none=True),
+    )
+
+
 def _persist_native_cumulative_usage(
     session_id: str,
     data: dict[str, Any],
@@ -6358,6 +6389,14 @@ async def _relay_runner_stream_once(
                     # Accumulate LLM token usage from the harness
                     # response so policy callables can read
                     # event["context"]["usage"]["total_cost_usd"].
+                    if evt_type in _TERMINAL_RESPONSE_EVENT_TYPES:
+                        _terminal_response = event.get("response")
+                        if isinstance(_terminal_response, dict):
+                            await _persist_relay_reported_model(
+                                _terminal_response,
+                                session_id,
+                                conversation_store,
+                            )
                     if evt_type == "response.completed":
                         # Persist the turn's usage (cost + token buckets) so
                         # policy callables can read
@@ -6374,10 +6413,9 @@ async def _relay_runner_stream_once(
                         if _turn_start_s is not None:
                             _latency_ms = (time.monotonic() - _turn_start_s) * 1000
                         _turn_start_s = None
+                        _response = event.get("response")
                         _resp_usage = (
-                            event.get("response", {}).get("usage") or {}
-                            if evt_type == "response.completed"
-                            else {}
+                            _response.get("usage") or {} if isinstance(_response, dict) else {}
                         )
                         _turn_in = _resp_usage.get("input_tokens")
                         _turn_out = _resp_usage.get("output_tokens")

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2989,12 +2989,11 @@ class SessionUsageEvent(_SSEEventBase):
 
 class SessionModelEvent(_SSEEventBase):
     """
-    Active-model report from a terminal-backed integration.
+    Active-model report from a harness integration.
 
     Emitted after an ``external_model_change`` POST from a native
-    forwarder — the launch's own model report, or a switch made inside
-    the pane (a ``/model`` command or the in-TUI picker). Every surface
-    re-renders its model display from this.
+    forwarder or when an SDK relay reports its concrete model in terminal
+    response usage. Every surface re-renders its model display from this.
 
     :param type: Always ``"session.model"``.
     :param conversation_id: Session identifier, e.g. ``"conv_abc123"``.

--- a/openapi.json
+++ b/openapi.json
@@ -5327,7 +5327,7 @@
         "type": "object"
       },
       "SessionModelEvent": {
-        "description": "Active-model report from a terminal-backed integration.\n\nEmitted after an `external_model_change` POST from a native\nforwarder \u2014 the launch's own model report, or a switch made inside\nthe pane (a `/model` command or the in-TUI picker). Every surface\nre-renders its model display from this.",
+        "description": "Active-model report from a harness integration.\n\nEmitted after an `external_model_change` POST from a native\nforwarder or when an SDK relay reports its concrete model in terminal\nresponse usage. Every surface re-renders its model display from this.",
         "properties": {
           "conversation_id": {
             "description": "Session identifier, e.g. `\"conv_abc123\"`.",

--- a/tests/e2e_ui/chat/test_cursor_native_list_models_row.py
+++ b/tests/e2e_ui/chat/test_cursor_native_list_models_row.py
@@ -324,6 +324,10 @@ def test_cursor_native_worker_row_not_source_none(
     expect(
         page.locator(_ASSISTANT, has_text=f"Catalog reported. Marker: {chat.routing_token}").first
     ).to_be_visible(timeout=_TURN_TIMEOUT_MS)
+    # The final text item can render just before the terminal response settles
+    # the turn and folds its tool calls. Wait for the authoritative session
+    # status UI to go idle so the trigger cannot be replaced mid-click.
+    expect(page.get_by_test_id("working-indicator")).to_be_hidden(timeout=30_000)
 
     # Put the catalog on screen the way a user reads it (and the video shows it).
     _expand_list_models_tool_call(page)

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -163,14 +163,16 @@ class _ConversationStore:
 
         :param conversation_id: Conversation id to update.
         :param title: Optional title to set.
-        :param kwargs: Extra store fields ignored by this test stub.
+        :param kwargs: Additional conversation fields used by relay tests.
         :returns: Updated conversation, or ``None`` if absent.
         """
-        del kwargs
         conv = self._conversations.get(conversation_id)
         if conv is None:
             return None
-        conv.title = title
+        if title is not None:
+            conv.title = title
+        if "reported_model" in kwargs:
+            conv.reported_model = kwargs["reported_model"]
         return conv
 
     def set_labels(
@@ -4324,6 +4326,56 @@ async def test_relay_skips_malformed_resource_created_from_runner() -> None:
 
     events = [i for i in store.appended_items if i.type == "resource_event"]
     assert events == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_type", ["response.completed", "response.failed"])
+async def test_relay_persists_harness_reported_model(
+    terminal_type: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SDK terminal usage records the concrete model on the session snapshot."""
+    from omnigent.server.routes.sessions import _relay_runner_stream
+
+    session_id = "79b22ebd2309e48fdeb450c65611d51b"
+    published: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda _session_id, event: published.append(event),
+    )
+    store = _ConversationStore()
+    client = _FakeStreamingRunnerClient(
+        [
+            _sse_frame(
+                {
+                    "type": terminal_type,
+                    "response": {
+                        "id": "resp_model",
+                        "model": "repro_agent",
+                        "usage": {
+                            "input_tokens": 0,
+                            "output_tokens": 0,
+                            "total_tokens": 0,
+                            "model": "claude-opus-4-8",
+                        },
+                    },
+                }
+            ),
+            "data: [DONE]\n\n",
+        ]
+    )
+
+    await _relay_runner_stream(session_id, client, store)  # type: ignore[arg-type]
+
+    assert store.get_conversation(session_id).reported_model == "claude-opus-4-8"  # type: ignore[union-attr]
+    model_events = [event for event in published if event.get("type") == "session.model"]
+    assert model_events == [
+        {
+            "type": "session.model",
+            "conversation_id": session_id,
+            "model": "claude-opus-4-8",
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

N/A — follow-up to the CI model-resolution incident; no public issue was filed.

## Summary

- Persist the concrete model reported in SDK harness terminal-response usage into the existing `reported_model` session field.
- Publish the existing `session.model` event when that reported model changes, including on failed turns.
- Include failed-terminal usage in turn telemetry instead of discarding its model and token metadata.

ELI5: the runner already said which model answered, but the server used that value only for pricing and forgot it afterward. The server now saves and broadcasts it.

```text
SDK response.usage.model
          |
          v
conversation.reported_model ---> GET /v1/sessions/{id}.llm_model
          |
          +---------------------> session.model SSE
```

## Test Plan

- `uv run --extra tracing --group dev pytest -q tests/server/routes/test_session_resources.py -k 'relay_persists_harness_reported_model'`
- `uv run --extra tracing --group dev pytest -q tests/server/integration/test_sessions_endpoints.py -k 'external_model_change or accumulate_session_usage'`
- `uv run --extra tracing --group dev pre-commit run --files omnigent/entities/conversation.py omnigent/server/schemas.py omnigent/server/routes/_sessions/orchestration.py tests/server/routes/test_session_resources.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The new relay regression covers both `response.completed` and `response.failed`, asserting that the reported model is persisted and a typed `session.model` event is emitted.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The relay test uses the real SSE relay logic with an in-memory conversation store. Existing integration tests cover snapshot projection from `reported_model`, model-event semantics, and per-model usage persistence.

## Changelog

Session metadata now records the concrete model reported by SDK-based agent harnesses.
