### PR TITLE
feat(web): label new sessions with their first prompt optimistically

### DIFF
--- a/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
+++ b/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
@@ -1,0 +1,169 @@
+"""Browser e2e for the optimistic first-prompt label on new sessions.
+
+Drives the real landing flow (create POST, pending-prompt handoff,
+client-side navigate) and asserts the sidebar row flips to the typed
+prompt with provisional styling, then that a server-side rename
+supersedes it over the live update stream with no reload. The /events
+POST is stubbed so no turn runs and no seed title races the assertions.
+
+Two setup constraints, both non-obvious:
+
+- The fake create returns session A but the app boots on B. ChatPage's
+  initial-prompt consume memoizes per session, so booting on A would
+  cache a null consume and the post-create navigate back to A would
+  never pick up the held prompt (production create returns a fresh id).
+- The recent-workspace seed must land via evaluate AFTER boot (an init
+  script is cleared at app boot) so the working-directory chip
+  auto-fills and Send enables.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+
+import httpx
+from playwright.sync_api import Page, Route, expect
+
+_PROMPT = "e2e sentinel optimistic label 9f4c2d"
+_SETTLED_TITLE = "e2e settled server title"
+
+# Bare create endpoint: ``/v1/sessions`` with an optional query, but NOT
+# ``/v1/sessions/{id}/...`` — so reads pass through to the real server
+# while only the composer's create POST is faked.
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+
+
+def _fulfill_json(route: Route, body: dict) -> None:
+    route.fulfill(status=200, content_type="application/json", body=json.dumps(body))
+
+
+def test_new_session_shows_first_prompt_optimistically(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """The landing flow labels the new row with the prompt, provisionally.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session_pair: ``(base_url, session_a, session_b)`` —
+        two pre-created runner-bound sessions with no titles. The fake
+        create returns A; the app boots on B (see module docstring).
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    event_texts: list[str] = []
+
+    def handle_events(route: Route) -> None:
+        # The first-turn send never reaches the server: no turn runs and
+        # no seed title is written, so the optimistic label can't be
+        # superseded mid-assertion. Recording the text proves the real
+        # auto-send path ran.
+        body = route.request.post_data_json
+        event_texts.append(body["data"]["content"][0]["text"])
+        _fulfill_json(route, {"queued": True, "item_id": "ci_e2e"})
+
+    def handle_hosts(route: Route) -> None:
+        # One online host so the composer can pick a host (the directly
+        # tunneled harness registers no host).
+        _fulfill_json(
+            route,
+            {
+                "hosts": [
+                    {"host_id": "host_e2e", "name": "e2e-host", "owner": "e2e", "status": "online"}
+                ]
+            },
+        )
+
+    def handle_agents(route: Route) -> None:
+        # The composer's available-agent catalog (GET /v1/agents).
+        _fulfill_json(
+            route,
+            {
+                "data": [
+                    {
+                        "id": "ag_e2e",
+                        "name": "hello_world",
+                        "display_name": "Hello World",
+                        "description": None,
+                        "harness": None,
+                    }
+                ]
+            },
+        )
+
+    def handle_sessions(route: Route) -> None:
+        # Fake ONLY the composer's create POST, returning pre-seeded
+        # session A so the real handoff targets a real, untitled
+        # session. Reads (the list, per-session) pass through.
+        if route.request.method == "POST":
+            _fulfill_json(route, {"id": session_a})
+        else:
+            route.continue_()
+
+    page.route("**/v1/sessions/*/events", handle_events)
+    page.route("**/v1/hosts", handle_hosts)
+    page.route("**/v1/agents", handle_agents)
+    page.route(_SESSIONS_RE, handle_sessions)
+
+    # Boot on session B's chat (full reload is fine — the flow below is
+    # client-side from here).
+    page.goto(f"{base_url}/c/{session_b}")
+
+    # Seed a recent workspace for the stubbed host AFTER boot: the
+    # landing's working-directory chip auto-fills from this when the
+    # composer mounts, and Send only enables with a valid workspace (the
+    # file browser has its own tests).
+    page.evaluate(
+        """() => localStorage.setItem(
+            "omnigent:recent-workspaces",
+            JSON.stringify({ host_e2e: ["/tmp"] }),
+        )"""
+    )
+
+    # Open the landing composer via the sidebar button: the route change
+    # mounts a fresh composer, which reads the seeded recents.
+    page.get_by_test_id("new-chat-button").click()
+
+    label_span = page.locator(f'a[href="/c/{session_a}"]').locator("span.relative")
+
+    # Pre-state: session A is untitled, so its row reads as the generic
+    # fallback — the flip below must come from the landing flow.
+    expect(label_span).to_contain_text("New session")
+
+    prompt_input = page.get_by_test_id("new-chat-landing-input")
+    prompt_input.wait_for(state="visible", timeout=15_000)
+    prompt_input.fill(_PROMPT)
+    # Playwright auto-waits for Send to be actionable (enabled): it
+    # enables only once message + host + agent + workspace are all set,
+    # so this also confirms the seeded workspace chip auto-filled.
+    page.get_by_test_id("new-chat-landing-submit").click()
+
+    page.wait_for_url(re.compile(rf"/c/{re.escape(session_a)}"))
+
+    # The row flips to the typed prompt IMMEDIATELY — before any server
+    # round-trip could have titled the session — styled provisionally.
+    expect(label_span).to_contain_text(_PROMPT)
+    expect(label_span).to_have_class(re.compile(r"\bitalic\b"))
+
+    # Sanity: the real auto-send handoff ran (its POST was intercepted),
+    # so a green run isn't a composer that silently never sent.
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline and _PROMPT not in event_texts:
+        time.sleep(0.05)
+    assert _PROMPT in event_texts, (
+        f"the initial prompt was never POSTed to the session's /events "
+        f"(observed: {event_texts}) — the auto-send path did not run"
+    )
+
+    # A real server title supersedes the optimistic label: PATCH one via
+    # the rename endpoint and the row flips on the live update stream —
+    # no reload, so the in-memory optimistic entry is still present and
+    # MUST lose, provisional styling and all.
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_a}",
+        json={"title": _SETTLED_TITLE},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    expect(label_span).to_contain_text(_SETTLED_TITLE, timeout=15_000)
+    expect(label_span).not_to_have_class(re.compile(r"\bitalic\b"))

--- a/web/src/lib/optimisticTitles.test.ts
+++ b/web/src/lib/optimisticTitles.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearOptimisticTitles,
+  getOptimisticTitle,
+  recordOptimisticTitle,
+  synthesizeOptimisticTitle,
+} from "./optimisticTitles";
+
+afterEach(() => {
+  clearOptimisticTitles();
+});
+
+describe("synthesizeOptimisticTitle", () => {
+  it("collapses whitespace and newlines into one line", () => {
+    expect(synthesizeOptimisticTitle("  read the README\n\nand   refactor\tit ")).toBe(
+      "read the README and refactor it",
+    );
+  });
+
+  it("drops attachment-marker lines so paths never become the title", () => {
+    expect(
+      synthesizeOptimisticTitle(
+        "[Attached: /tmp/notes.md]\n[Attached file: /tmp/x.png]\nsummarize",
+      ),
+    ).toBe("summarize");
+    expect(synthesizeOptimisticTitle("[Attachment foo.png could not be loaded]\ndescribe it")).toBe(
+      "describe it",
+    );
+  });
+
+  it("returns null when no usable text remains", () => {
+    expect(synthesizeOptimisticTitle("   \n\t ")).toBeNull();
+    expect(synthesizeOptimisticTitle("[Attached: /tmp/only.md]")).toBeNull();
+  });
+
+  it("keeps titles at or under the limit untouched", () => {
+    const exact = "x".repeat(60);
+    expect(synthesizeOptimisticTitle(exact)).toBe(exact);
+  });
+
+  it("truncates beyond the limit with an ellipsis at 60 chars total", () => {
+    const title = synthesizeOptimisticTitle("a".repeat(70));
+    expect(title).toBe("a".repeat(59) + "…");
+    expect([...(title ?? "")]).toHaveLength(60);
+  });
+
+  it("trims trailing whitespace before the ellipsis", () => {
+    // 58 letters + 2 spaces + more text: the raw cut lands mid-gap, and the
+    // server rstrips before appending the ellipsis.
+    const title = synthesizeOptimisticTitle(`${"a".repeat(58)}  ${"b".repeat(10)}`);
+    expect(title).toBe("a".repeat(58) + "…");
+  });
+
+  it("counts code points, not UTF-16 units, so emoji don't split", () => {
+    const title = synthesizeOptimisticTitle("🚀".repeat(70));
+    expect([...(title ?? "")]).toHaveLength(60);
+    expect(title?.endsWith("…")).toBe(true);
+  });
+});
+
+describe("recordOptimisticTitle", () => {
+  it("stores the synthesized title under the conversation id", () => {
+    recordOptimisticTitle("conv_1", "  fix the flaky test  ");
+    expect(getOptimisticTitle("conv_1")).toBe("fix the flaky test");
+  });
+
+  it("records nothing when the prompt has no usable text", () => {
+    recordOptimisticTitle("conv_2", "  \n ");
+    recordOptimisticTitle("conv_3", "[Attached: /tmp/only.md]");
+    expect(getOptimisticTitle("conv_2")).toBeUndefined();
+    expect(getOptimisticTitle("conv_3")).toBeUndefined();
+  });
+
+  it("clears all entries at once", () => {
+    recordOptimisticTitle("conv_1", "one");
+    recordOptimisticTitle("conv_2", "two");
+    clearOptimisticTitles();
+    expect(getOptimisticTitle("conv_1")).toBeUndefined();
+    expect(getOptimisticTitle("conv_2")).toBeUndefined();
+  });
+});

--- a/web/src/lib/optimisticTitles.ts
+++ b/web/src/lib/optimisticTitles.ts
@@ -1,0 +1,88 @@
+// Optimistic sidebar labels for newly created sessions: the client's copy
+// of the first prompt, shown until the server's title lands.
+//
+// Never sent to the server — a create-body title would persist as a USER
+// title, which rename-wins pins forever. Derivation mirrors the server's
+// synthesize_conversation_title so the swap is invisible.
+
+import { useSyncExternalStore } from "react";
+
+// Keep in sync with _ATTACHMENT_MARKER_RE in omnigent/entities/conversation.py
+// and the preamble buildMentionPreamble emits in composerMentions.ts.
+const ATTACHMENT_MARKER_RE =
+  /^(?:\[Attached(?: file)?: .+\]|\[Attachment [^\]]+ could not be loaded\])$/;
+
+// Same default limit as synthesize_conversation_title.
+export const OPTIMISTIC_TITLE_LIMIT = 60;
+
+/**
+ * Derive the same one-line title the server seed would produce for a first
+ * message: attachment-marker lines dropped, whitespace collapsed, truncated
+ * with an ellipsis. Returns ``null`` when no usable text remains.
+ */
+export function synthesizeOptimisticTitle(
+  text: string,
+  limit: number = OPTIMISTIC_TITLE_LIMIT,
+): string | null {
+  const keptLines = text.split("\n").filter((line) => !ATTACHMENT_MARKER_RE.test(line.trim()));
+  const collapsed = keptLines.join(" ").split(/\s+/).filter(Boolean).join(" ");
+  if (!collapsed) return null;
+  // Code points, not UTF-16 units, so the cap matches Python's len() and
+  // never splits a surrogate pair.
+  const chars = [...collapsed];
+  if (chars.length <= limit) return collapsed;
+  return (
+    chars
+      .slice(0, Math.max(0, limit - 1))
+      .join("")
+      .trimEnd() + "…"
+  );
+}
+
+const optimisticTitles = new Map<string, string>();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function notifyListeners(): void {
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Stash the label for a session the user just created. ``promptText`` is the
+ * exact first message handed to the chat (mention preamble included); empty
+ * or attachment-only prompts record nothing.
+ */
+export function recordOptimisticTitle(conversationId: string, promptText: string): void {
+  const title = synthesizeOptimisticTitle(promptText);
+  if (title === null) return;
+  optimisticTitles.set(conversationId, title);
+  notifyListeners();
+}
+
+/**
+ * The stashed label for a session, if any. Read reactively via
+ * ``useOptimisticTitle``; this plain getter serves non-component callers
+ * (e.g. conversationDisplayLabel).
+ */
+export function getOptimisticTitle(conversationId: string): string | undefined {
+  return optimisticTitles.get(conversationId);
+}
+
+/** The stashed label, reactive — re-renders when it is recorded or cleared. */
+export function useOptimisticTitle(conversationId: string): string | undefined {
+  return useSyncExternalStore(
+    subscribe,
+    () => getOptimisticTitle(conversationId),
+    () => undefined,
+  );
+}
+
+/** Clear all stashed labels — for logout/reset flows and isolated tests. */
+export function clearOptimisticTitles(): void {
+  optimisticTitles.clear();
+  notifyListeners();
+}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { authenticatedFetch } from "@/lib/identity";
+import { clearOptimisticTitles, getOptimisticTitle } from "@/lib/optimisticTitles";
 import type { Host } from "@/hooks/useHosts";
 import { useHostModelOptions, useHosts } from "@/hooks/useHosts";
 import type { AvailableAgent } from "@/hooks/useAvailableAgents";
@@ -267,6 +268,7 @@ beforeEach(() => {
   // Clear the module-level landing draft so a base branch (or other field)
   // left behind by an unmounting test doesn't seed the next one.
   resetLandingDraft();
+  clearOptimisticTitles();
   localStorage.clear();
   vi.mocked(useHostModelOptions).mockReturnValue({
     data: [
@@ -573,6 +575,26 @@ describe("NewChatLandingScreen create flow", () => {
         skill: null,
         files: [],
       }),
+    );
+    expect(navigateMock).toHaveBeenCalledWith("/c/conv_new");
+  });
+
+  it("stashes the first prompt as the session's optimistic label", async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("  read the README\nand refactor  ");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    // The sidebar reads this while the server's seed title is still in
+    // flight — same whitespace-collapsed text the seed will carry, so the
+    // swap is invisible.
+    await waitFor(() =>
+      expect(getOptimisticTitle("conv_new")).toBe("read the README and refactor"),
     );
     expect(navigateMock).toHaveBeenCalledWith("/c/conv_new");
   });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -83,6 +83,7 @@ import { authenticatedFetch } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
+import { recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { HarnessSetupDialog } from "@/shell/HarnessSetupDialog";
@@ -4350,6 +4351,8 @@ export function NewChatLandingScreen() {
           : matchSkillInvocation(initialPrompt, agent?.skills ?? []),
         files,
       });
+      // Label the new row with the prompt until the server's seed title lands.
+      recordOptimisticTitle(data.id, initialPrompt);
       // Scope the recall entry to the new session id so ArrowUp surfaces it in
       // the freshly-opened chat (whose composer reads the same per-conversation
       // key). Sanitized text so recall reproduces exactly what was sent.

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 import { FALLBACK_SERVER_INFO, type ServerInfo } from "@/lib/capabilities";
+import { clearOptimisticTitles, recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { clearSessionDrafts, setSessionDraft } from "@/lib/sessionDrafts";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 
@@ -269,6 +270,7 @@ beforeEach(() => {
   useHostsMock.mockReturnValue({ data: [] });
   localStorage.clear();
   clearSessionDrafts();
+  clearOptimisticTitles();
   projectsMock.length = 0;
   moveToProjectSpy.mockReset();
   deleteProjectSpy.mockReset();
@@ -296,6 +298,26 @@ describe("Sidebar session list", () => {
 
     expect(screen.getByText("No sessions")).toHaveClass("text-ui");
     expect(screen.getByText("No sessions")).not.toHaveClass("text-sm");
+  });
+
+  it("flips a just-created session's row to its provisional first-prompt label", () => {
+    mockConversations([
+      conv("conv_opt", "Claude Code", {
+        title: null,
+        labels: { "omnigent.wrapper": "claude-code-native-ui" },
+      }),
+    ]);
+    renderSidebar();
+
+    // Before the landing form's stash lands (and for sessions born
+    // elsewhere), the row reads as the wrapper name.
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+
+    act(() => recordOptimisticTitle("conv_opt", "debug the login redirect"));
+
+    const label = screen.getByText("debug the login redirect");
+    expect(label).toHaveClass("italic", "text-muted-foreground");
+    expect(screen.queryByText("Claude Code")).not.toBeInTheDocument();
   });
 
   it("uses the interface text token for session-list errors", () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -151,6 +151,7 @@ import { isSessionStoppable } from "@/lib/sessionStop";
 import { getCurrentUserId, resolveIdentity } from "@/lib/identity";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { useHasSessionDraft } from "@/lib/sessionDrafts";
+import { useOptimisticTitle } from "@/lib/optimisticTitles";
 import { getSessionState, type SessionState } from "@/hooks/useSessionState";
 import { useChatStore } from "@/store/chatStore";
 import {
@@ -3431,6 +3432,11 @@ function ConversationRow({
   }, [conversation.title, pendingTitle, rename.isSuccess, rename.isError]);
 
   const label = pendingTitle ?? conversationDisplayLabel(conversation);
+  // Subscribed so the just-recorded optimistic label flips the row
+  // immediately instead of at the next conversations poll.
+  const optimisticTitle = useOptimisticTitle(conversation.id);
+  const isProvisionalLabel =
+    pendingTitle === null && conversation.title == null && optimisticTitle !== undefined;
   const hasDraft = useHasSessionDraft(conversation.id);
   // Recompute unseen state the moment the last-seen map changes (e.g. the
   // user picks "Mark as unread" on this row) rather than waiting for the
@@ -3699,7 +3705,14 @@ function ConversationRow({
       {/* Row 1: the session name. Working, needs-approval, unseen, and draft
           markers render in the shared trailing indicator slot below. */}
       <div className="flex w-full items-center gap-1.5">
-        <span className="relative min-w-0 truncate">
+        <span
+          className={cn(
+            "relative min-w-0 truncate",
+            // The optimistic first-prompt label is a placeholder until the
+            // server's title lands — dim it so it doesn't read as final.
+            isProvisionalLabel && "italic text-muted-foreground",
+          )}
+        >
           {label}
           {hasUnseenMessages && <span className="sr-only"> (unread)</span>}
         </span>

--- a/web/src/shell/sidebarNav.test.ts
+++ b/web/src/shell/sidebarNav.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Conversation } from "@/hooks/useConversations";
+import { clearOptimisticTitles, recordOptimisticTitle } from "@/lib/optimisticTitles";
 import {
   type ActiveChatOverride,
   bareConversationId,
@@ -399,6 +400,67 @@ describe("conversationDisplayLabel", () => {
         ),
       ),
     ).toBe("investigate the regression");
+  });
+
+  it("shows the optimistic first-prompt label while the title is unset", () => {
+    recordOptimisticTitle("conv_abcdefghijklmnopqrstuvwxyz", "debug the login redirect");
+    try {
+      expect(
+        conversationDisplayLabel(
+          conversation("conv_abcdefghijklmnopqrstuvwxyz", null, new Date(2026, 4, 14, 9), {
+            labels: { "omnigent.wrapper": "claude-code-native-ui" },
+          }),
+        ),
+      ).toBe("debug the login redirect");
+    } finally {
+      clearOptimisticTitles();
+    }
+  });
+
+  it("lets the real title supersede the optimistic label once it lands", () => {
+    recordOptimisticTitle("conv_abcdefghijklmnopqrstuvwxyz", "debug the login redirect");
+    try {
+      expect(
+        conversationDisplayLabel(
+          conversation(
+            "conv_abcdefghijklmnopqrstuvwxyz",
+            "debug the login redirect",
+            new Date(2026, 4, 14, 9),
+            {
+              labels: { "omnigent.wrapper": "claude-code-native-ui" },
+            },
+          ),
+        ),
+      ).toBe("debug the login redirect");
+      // A server title — the seed, a generated title, or a rename — always
+      // wins over the stashed prompt.
+      expect(
+        conversationDisplayLabel(
+          conversation(
+            "conv_abcdefghijklmnopqrstuvwxyz",
+            "Login redirect loop",
+            new Date(2026, 4, 14, 9),
+            {
+              labels: { "omnigent.wrapper": "claude-code-native-ui" },
+            },
+          ),
+        ),
+      ).toBe("Login redirect loop");
+    } finally {
+      clearOptimisticTitles();
+    }
+  });
+
+  it("falls back to the wrapper name when no optimistic label was stashed", () => {
+    // Sessions born outside the landing form (forks, CLI, imports) never
+    // record one.
+    expect(
+      conversationDisplayLabel(
+        conversation("conv_abcdefghijklmnopqrstuvwxyz", null, new Date(2026, 4, 14, 9), {
+          labels: { "omnigent.wrapper": "claude-code-native-ui" },
+        }),
+      ),
+    ).toBe("Claude Code");
   });
 });
 

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -1,5 +1,6 @@
 import type { Conversation } from "@/hooks/useConversations";
 import { nativeCodingAgentForWrapper, WRAPPER_LABEL_KEY } from "@/lib/nativeCodingAgents";
+import { getOptimisticTitle } from "@/lib/optimisticTitles";
 import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
 
 export const PINNED_CONVERSATION_IDS_STORAGE_KEY = "omnigent:pinned-conversation-ids";
@@ -157,6 +158,9 @@ export function getConversationAgentType(conversation: Conversation): string {
 
 export function conversationDisplayLabel(conversation: Conversation): string {
   if (conversation.title) return conversation.title;
+  // Just-created session: its first prompt stands in until a real title lands.
+  const optimistic = getOptimisticTitle(conversation.id);
+  if (optimistic !== undefined) return optimistic;
   const label = nativeWrapperLabel(conversation);
   if (label !== null) return label;
   return UNTITLED_CONVERSATION_LABEL;


### PR DESCRIPTION
## Related issue

No tracking issue — small UX polish spotted while dogfooding against a remote (managed) server.

## Summary

A session created from the landing form is born untitled, so its sidebar row reads as the bare wrapper name ("Claude Code") until the server's deterministic seed title lands — a window of one or more server round-trips that is especially visible against a remote server.

ELI5: the browser already knows your first prompt at submit time, so it shows that as the session's label immediately (dimmed/italic = "not final yet") instead of staring at "Claude Code" while the server catches up.

- New in-memory `optimisticTitles` store (`web/src/lib/optimisticTitles.ts`) mirrors the server's `synthesize_conversation_title` (attachment lines dropped, whitespace collapsed, 60-char ellipsis, code-point safe) so the swap to the real seed title is invisible.
- `conversationDisplayLabel` prefers `title ?? optimistic ?? wrapper fallback`, so every surface (sidebar, command palette, inbox, header) shows the prompt immediately; the sidebar row renders it provisionally (`italic text-muted-foreground`).
- Deliberately client-only: a title sent in the create body would persist as a *user* title, which rename-wins pins forever — the background title would never replace it. The optimistic label is never sent to the server and is superseded by the first real title (seed, generated, or rename).

```
submit ──► row shows first prompt (italic, muted)        t=0, zero RTT
              │
              ▼
         seed title lands (same string — invisible swap) t≈1 RTT
              │
              ▼
         background title lands (semantic)               t≈seconds
```

## Test Plan

- `npx vitest run src/lib/optimisticTitles.test.ts src/shell/sidebarNav.test.ts src/shell/Sidebar.test.tsx src/shell/NewChatDialog.flow.test.tsx` — 203 passed (13 new: synthesize parity with the server rules, label precedence, provisional styling, landing submit records the label).
- `pre-commit run` clean for the touched files (prettier, tsc). `web oxlint` fails repo-wide on untouched files (`ChatPage.tsx`, `Sidebar.tsx` react-compiler rules) — verified identical on clean `upstream/main`.
- Manual: three-process dev stack; created sessions from the landing in dark and light themes. The row never showed "Claude Code" — prompt label instantly, then the seed, then the generated title. Sessions born elsewhere (CLI, forks) still fall back to the wrapper name.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Screen recording (two captured frames, light theme):

1. **Provisional** — t≈0, before any server round-trip: the row shows the typed prompt, DOM-verified `italic text-muted-foreground`.
2. **Settled** — the server’s title now carries the row; provisional styling gone.

https://github.com/user-attachments/assets/acca0c9f-16f0-4d0f-8cfc-d2c3a64e510d

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the live create → provisional → seed → generated-title sequence in dark and light themes on a local dev stack (see Demo). Automated coverage: the optimistic-titles store + its parity with the server's title synthesis, `conversationDisplayLabel` precedence, the sidebar row's provisional styling and reactive flip, and a landing-flow test asserting the label is recorded at submit.

## Changelog

New sessions show their first prompt as the sidebar label right away instead of "Claude Code" while the server title is on its way
