### PR TITLE
New selector experience needs key now

### DIFF
--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -286,16 +286,20 @@
         margin: 0 0 4px;
       }
       .modal-switch-to-new-experience {
-        margin-top: 14px;
         padding: 9px 12px;
         font-weight: 500;
-        border: none;
         border: 1px solid var(--border);
         background: var(--background);
         color: var(--foreground);
+        /* Alt/Option-only affordance: reserves its space always so the modal
+           doesn't reflow, but stays invisible until revealed (see .is-visible). */
+        visibility: hidden;
       }
-      .modal-switch-to-new-experienc:hover {
-        border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
+      .modal-switch-to-new-experience.is-visible {
+        visibility: visible;
+      }
+      .modal-switch-to-new-experience:hover {
+        color: color-mix(in srgb, var(--foreground) 80%, transparent);
       }
       .modal-close {
         margin-top: 14px;
@@ -685,12 +689,33 @@
         return false;
       }
 
+      // The "Switch to new experience" button is an Alt/Option-only affordance:
+      // hidden until the user holds Alt while the CLI modal is open. Listeners
+      // are scoped to the modal being open so nothing lingers globally.
+      // visibility (not the `hidden` attribute): reserves layout space so the
+      // modal doesn't reflow when it toggles, and — being visibility:hidden —
+      // it's non-interactive (no clicks, no pointer/cursor) while concealed.
+      const setNewUxVisible = (visible) => {
+        cliModalNewUX.classList.toggle("is-visible", visible);
+      };
+      const onAltKey = (e) => {
+        if (e.key === "Alt") setNewUxVisible(e.type === "keydown");
+      };
       function openCliModal() {
         cliModal.hidden = false;
+        setNewUxVisible(false); // reset: revealed only while Alt is held
+        window.addEventListener("keydown", onAltKey);
+        window.addEventListener("keyup", onAltKey);
+        // Releasing Alt outside the window (focus loss) never fires keyup, so
+        // re-hide when the window is blurred to avoid a stuck-visible button.
+        window.addEventListener("blur", () => setNewUxVisible(false), { once: true });
         void refreshCliStatus();
       }
       function closeCliModal() {
         cliModal.hidden = true;
+        window.removeEventListener("keydown", onAltKey);
+        window.removeEventListener("keyup", onAltKey);
+        setNewUxVisible(false);
       }
 
       if (setup.getCliStatus) {


### PR DESCRIPTION
## Related issue

Closes #

<!-- No linked issue — small follow-up to the server-selector feature. Add one
or mark Refactor/chore if none applies. -->

## Summary

Gate the classic setup page's **"Switch to new experience (experimental)"**
button behind the Alt/Option key, so it's a deliberate opt-in rather than an
always-visible experimental control.

- The button (in the CLI settings modal, `web/electron/setup/index.html`) now
  starts `hidden` and only appears while **Alt/⌥ is held** with the modal open.
- Keydown/keyup listeners are scoped to the modal being open (added in
  `openCliModal`, removed in `closeCliModal`) so nothing lingers globally; a
  window `blur` re-hides it, since releasing Alt outside the window never fires
  a keyup. Its click behavior (`setServerSelectorV2(true)`) is unchanged.
- Also fixes a stale selector typo in the same block
  (`.modal-switch-to-new-experienc` → `…experience`) so its hover state applies.

## Test Plan

Manual, in the Electron shell:

- Open the setup page → click the gear → the "Switch to new experience" button
  is **not** shown.
- Hold **⌥/Alt** → it appears; release → it disappears.
- Hold Alt, then click away / blur the window → the button re-hides (no stuck
  state); reopening the modal resets it to hidden.
- Clicking it while visible still switches to the new server selector.
- Extracted the page's inline script and `node --check`'d it (syntax clean).

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

https://github.com/user-attachments/assets/5bab1fb2-eb3e-405e-8252-5504af159b26

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Not applicable

## Coverage notes

The static setup page (`web/electron/setup/index.html`) has no automated test
harness — verified manually in the shell (steps above) plus a `node --check` of
its inline script. The change is a visibility toggle on one button; its click
action is unchanged.

## Changelog

The classic setup page's "Switch to new experience" button now appears only while Alt/Option is held.
