### PR TITLE
Require Linear writeback for PR remediation

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -102,7 +102,9 @@ and candidate-PR discovery instructions below.
    review, or merge.
 7. Skip reproduction handoff recovery, fail-before proof, recording generation,
    candidate-fix discovery, new-PR creation, UI-preview setup unless already
-   required by the PR, and Linear-specific write-back.
+   required by the PR. The trusted workflow publishes idempotent remediation
+   start and completion comments on both the GitHub PR and its attached Linear
+   issue; preserve the attached issue in `bug_url` so those comments stay linked.
 8. Finish with the normal handoff using `mode: "review_remediation"`. Set
    `bug_url` to an attached bug when one is clear, otherwise `""`; set
    `reviewed_pr_url` and `pr_url` to `review_pr`; include the review fingerprint,


### PR DESCRIPTION
## Summary
- correct the Resolve-agent review-remediation contract
- require trusted workflow start and completion comments on both GitHub and the attached Linear issue
- preserve the attached issue URL in the remediation handoff

The workflow implementation is in the dependent omnigent-internal PR.

## Validation
- `git diff --check`
