### PR TITLE
Preserve agent-created hidden paths in trusted sandboxes

### DIFF
--- a/omnigent/inner/_cwd_scan.py
+++ b/omnigent/inner/_cwd_scan.py
@@ -163,6 +163,9 @@ def scan_cwd_mask_entries(
     - the entry is a symlink whose resolved target lies outside every
       path in *safe_roots*.
 
+    The explicit ``"*"`` allowlist entry disables dotpath masking for
+    trusted roots. Escaping symlinks remain masked.
+
     Walker termination is deterministic:
 
     - ``follow_symlinks=False`` on the recursion check ensures
@@ -246,6 +249,7 @@ def scan_cwd_mask_entries(
         return entries
 
     allow = set(allow_hidden)
+    allow_all_hidden = "*" in allow
     safe_root_list = list(safe_roots)
     cap_enabled = overflow != "unlimited"
     logger = logging.getLogger(logger_name) if logger_name else _LOGGER
@@ -289,7 +293,7 @@ def scan_cwd_mask_entries(
 
             child_path = Path(child.path)
             should_mask = False
-            if child.name.startswith(".") and child.name not in allow:
+            if child.name.startswith(".") and not allow_all_hidden and child.name not in allow:
                 should_mask = True
             elif child.is_symlink():
                 resolved_target = child_path.resolve(strict=False)

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -25,7 +25,8 @@ Default view inside the sandbox:
   ``write_paths: ["."]`` flips it to read-write. Top-level
   dotfiles / dotdirs in cwd are tmpfs-masked unless their name is
   in :data:`_DEFAULT_CWD_ALLOW_HIDDEN` (``.venv`` by default) or
-  :attr:`OSEnvSandboxSpec.cwd_allow_hidden`.
+  :attr:`OSEnvSandboxSpec.cwd_allow_hidden`; the explicit ``"*"``
+  entry allows every dotpath in trusted roots.
 - The per-helper scratch tmpdir created by
   :func:`omnigent.inner.sandbox.create_private_tmpdir` is
   bind-mounted read-write and surfaced via ``$TMPDIR``.

--- a/omnigent/inner/datamodel.py
+++ b/omnigent/inner/datamodel.py
@@ -577,6 +577,9 @@ class OSEnvSandboxSpec:
     # Matching is by basename, so an entry ``".venv"`` allows
     # ``cwd/.venv``,
     # ``cwd/services/api/.venv``, and ``<read_path>/.venv`` alike.
+    # The explicit entry ``"*"`` allows every dotpath while the
+    # escaping-symlink defense remains active. Use it only for trusted
+    # roots whose hidden files must persist across helper invocations.
     # ``None`` means "use the backend's documented default" (both
     # bwrap and seatbelt expand ``None`` to ``[".venv"]`` so a
     # typical Python project keeps working out of the box). An empty

--- a/omnigent/inner/sandbox.py
+++ b/omnigent/inner/sandbox.py
@@ -76,11 +76,9 @@ class SandboxPolicy:
     :param allow_network: ``True`` to share the host network namespace,
         ``False`` to isolate (bwrap adds ``--unshare-net``).
     :param cwd_allow_hidden: List of dotfile / dotdir basenames that
-        pass through the sandbox view at any depth under cwd. Only
-        consumed by the bwrap backend today (it tmpfs-masks every
-        dotfile whose basename is not in this list); other backends
-        ignore the field. ``None`` means the policy carries no
-        allowlist and the consuming backend applies its own default.
+        pass through the sandbox view at any depth under cwd. ``"*"``
+        explicitly allows every dotpath while retaining symlink escape
+        masking. ``None`` lets the backend apply its default.
     :param cwd_hidden_scan_max_entries: Cap on entries the bwrap
         backend's recursive cwd walker visits. Ignored by other
         backends. Pair with :attr:`cwd_hidden_scan_overflow` to

--- a/omnigent/inner/seatbelt_sandbox.py
+++ b/omnigent/inner/seatbelt_sandbox.py
@@ -61,7 +61,8 @@ Default view inside the sandbox:
   ``~/.ssh/id_rsa``, ``~/.gnupg``, etc. all return EPERM.
 - Top-level dotfiles / dotdirs anywhere under cwd are denied unless
   their basename is in :data:`_DEFAULT_CWD_ALLOW_HIDDEN` or the
-  spec's ``cwd_allow_hidden``. ``.venv`` is allowed by default.
+  spec's ``cwd_allow_hidden``. ``.venv`` is allowed by default; the
+  explicit ``"*"`` entry allows every dotpath in trusted roots.
 - The default network policy depends on egress and ``allow_network``:
 
   - egress active → ``network*`` denied except loopback to the

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -1032,11 +1032,9 @@ def _parse_cwd_allow_hidden(raw: object) -> list[str] | None:
     ``os_env.sandbox``.
 
     Each entry must be a single path component (no ``/``, ``\\``,
-    or ``.`` / ``..`` traversal) so a misconfigured spec can't punch
-    a hole through arbitrary subdirectories of cwd. The bwrap backend
-    looks each entry up in ``cwd.iterdir()`` directly; sanitising
-    here keeps the resolver simple and the failure mode loud at
-    parse time rather than at runtime.
+    or ``.`` / ``..`` traversal). The special entry ``"*"`` explicitly
+    disables dotpath masking for trusted roots while preserving escaping-
+    symlink masking.
 
     :param raw: Raw value from the YAML, e.g. ``[".venv", ".git"]``,
         or ``None`` when the field is absent.

--- a/tests/inner/test_cwd_scan.py
+++ b/tests/inner/test_cwd_scan.py
@@ -174,6 +174,27 @@ def test_allowlisted_dotdir_is_not_masked(tmp_path: Path) -> None:
     assert _entry_for(entries, venv) is None
 
 
+def test_wildcard_allows_created_dotpaths_but_still_masks_escape(
+    tmp_path: Path,
+) -> None:
+    """Trusted roots can preserve arbitrary dotpaths across helper calls."""
+    tools = tmp_path / ".otto-tools"
+    tools.mkdir()
+    nested = tools / "npm-global"
+    nested.mkdir()
+    secret = tmp_path / ".future-agent-cache"
+    secret.write_text("created during a prior helper invocation")
+    escaping = tmp_path / ".outward-link"
+    escaping.symlink_to("/etc/shadow")
+
+    entries = _scan(tmp_path, allow_hidden=["*"])
+
+    assert _entry_for(entries, tools) is None
+    assert _entry_for(entries, nested) is None
+    assert _entry_for(entries, secret) is None
+    assert _entry_for(entries, escaping) is not None
+
+
 def test_regular_file_is_not_masked(tmp_path: Path) -> None:
     """
     Non-dotfile content is never returned by the walker — the

--- a/tests/resources/examples/agent_with_os_env_bwrap.yaml
+++ b/tests/resources/examples/agent_with_os_env_bwrap.yaml
@@ -132,6 +132,8 @@ os_env:
     # ``git status`` / ``git log``; add ".gitignore" if it needs to
     # respect ignore rules. Entries must be plain names — no ``/``,
     # no ``..``, no absolute paths (validated at spec parse time).
+    # Use ["*"] only for a trusted root that must preserve arbitrary
+    # agent-created dotpaths across helper invocations.
     # cwd_allow_hidden: [".venv", ".git", ".gitignore"]
 
     # Optional: recurse into subdirectories when masking dotfiles /

--- a/tests/resources/examples/agent_with_os_env_seatbelt.yaml
+++ b/tests/resources/examples/agent_with_os_env_seatbelt.yaml
@@ -140,6 +140,8 @@ os_env:
     # Python project layouts keep working. Matching is by basename at
     # any depth. Entries must be plain names — no ``/``, no ``..``,
     # no absolute paths (validated at spec parse time).
+    # Use ["*"] only for a trusted root that must preserve arbitrary
+    # agent-created dotpaths across helper invocations.
     # cwd_allow_hidden: [".venv", ".git", ".gitignore"]
 
     # Optional: recurse into subdirectories when masking dotfiles /

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -1912,6 +1912,25 @@ def test_parse_os_env_sandbox_with_cwd_allow_hidden(tmp_path: Path) -> None:
     assert spec.os_env.sandbox.cwd_allow_hidden == [".venv", ".cache"]
 
 
+def test_parse_os_env_sandbox_cwd_allow_hidden_wildcard(tmp_path: Path) -> None:
+    """The explicit wildcard survives parsing for trusted workspaces."""
+    config = {
+        "spec_version": 1,
+        "name": "allow-all-hidden",
+        "os_env": {
+            "type": "caller_process",
+            "sandbox": {"type": "linux_bwrap", "cwd_allow_hidden": ["*"]},
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+
+    spec = parse(tmp_path)
+
+    assert spec.os_env is not None
+    assert spec.os_env.sandbox is not None
+    assert spec.os_env.sandbox.cwd_allow_hidden == ["*"]
+
+
 def test_parse_os_env_sandbox_cwd_allow_hidden_empty_list_preserved(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #6150

## Summary

- Add an explicit `cwd_allow_hidden: ["*"]` opt-in for trusted sandbox roots.
- Preserve arbitrary agent-created dotfiles and dot-directories across helper invocations while continuing to mask escaping symlinks.
- Document the trusted-root contract for both Bubblewrap and Seatbelt.

ELI5: the sandbox used to see a dot-directory created by one command and hide it from the next command. Trusted workspaces can now say “these hidden files are intentional” without turning off symlink escape protection.

`command 1 creates .tool-cache` → host workspace → `command 2 sees .tool-cache`

## Test Plan

- `uv run --extra tracing --group dev pytest -q tests/inner/test_cwd_scan.py tests/spec/test_parser.py -k 'cwd_allow_hidden or wildcard'`
- `uv run --extra tracing --group dev pytest -q tests/inner/test_bwrap_sandbox.py -k 'dotfile_masking'`
- Pre-commit on all changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression test creates `.otto-tools/npm-global` and another previously unknown dotfile, then verifies a subsequent sandbox scan leaves both visible while still masking an outward symlink.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The shared scanner test covers both Bubblewrap and Seatbelt decision logic. Existing backend tests verify mask emission from scanner results.

## Changelog

Trusted sandbox workspaces can preserve agent-created hidden files across commands.