### PR TITLE
Fix active sandbox file reads for writable roots

### DIFF
--- a/omnigent/inner/os_env.py
+++ b/omnigent/inner/os_env.py
@@ -997,7 +997,7 @@ def _handle_helper_request(
         path = _resolve_path(cwd, raw_path)
         try:
             _assert_within_reach(cwd, sandbox, path, need_write=False)
-            _assert_read_allowed(sandbox, path)
+            _assert_read_allowed(sandbox, path, cwd)
         except PermissionError as exc:
             return {"error": str(exc)}
         offset_raw = request.get("offset", 1)
@@ -1039,7 +1039,7 @@ def _handle_helper_request(
         path = _resolve_path(cwd, raw_path)
         try:
             _assert_within_reach(cwd, sandbox, path, need_write=True)
-            _assert_read_allowed(sandbox, path)
+            _assert_read_allowed(sandbox, path, cwd)
             _assert_write_allowed(sandbox, path)
         except PermissionError as exc:
             return {"error": str(exc)}
@@ -1183,11 +1183,15 @@ def _assert_within_reach(
     )
 
 
-def _assert_read_allowed(policy: SandboxPolicy, path: Path) -> None:
+def _assert_read_allowed(policy: SandboxPolicy, path: Path, cwd: Path) -> None:
     roots = policy.read_roots
     if not policy.active or roots is None:
         return
-    if any(_is_within(path, root) for root in roots):
+    if _is_within(path, cwd):
+        return
+    if any(_is_within(path, root) for root in (*roots, *policy.write_roots)):
+        return
+    if any(path == allowed for allowed in policy.write_files):
         return
     raise PermissionError(f"Read access to '{path}' is blocked by sandbox.")
 

--- a/tests/inner/test_os_env_grant_reach.py
+++ b/tests/inner/test_os_env_grant_reach.py
@@ -208,6 +208,33 @@ def test_write_grant_permits_write_edit_and_read(tmp_path: Path) -> None:
     assert target.read_text() == "bye"
 
 
+def test_active_policy_reads_workspace_and_write_grants(tmp_path: Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    workspace_file = workspace / "workspace.txt"
+    workspace_file.write_text("workspace")
+    read_grant = tmp_path / "ro"
+    read_grant.mkdir()
+    write_grant = tmp_path / "rw"
+    write_grant.mkdir()
+    write_file = tmp_path / "single.txt"
+    write_file.write_text("single")
+    write_target = write_grant / "target.txt"
+    write_target.write_text("target")
+    policy = SandboxPolicy(
+        backend_type="linux_bwrap",
+        active=True,
+        read_roots=[read_grant.resolve()],
+        write_roots=[workspace.resolve(), write_grant.resolve()],
+        write_files=[write_file.resolve()],
+        allow_network=False,
+    )
+
+    assert _req("read", workspace_file, workspace, policy).get("content") == "workspace"
+    assert _req("read", write_target, workspace, policy).get("content") == "target"
+    assert _req("read", write_file, workspace, policy).get("content") == "single"
+
+
 def test_write_files_grant_is_file_scoped(tmp_path: Path) -> None:
     """A single-file write grant covers exactly that file, not its siblings."""
     workspace = tmp_path / "ws"


### PR DESCRIPTION
## Related issue

Closes #6152

## Summary

- Let active-sandbox file reads access the session workspace.
- Treat directory and single-file write grants as readable, matching the existing reach contract and filesystem behavior.
- Keep paths outside the workspace and all declared grants blocked.

ELI5: if the sandbox lets an agent write a file, the file-reading tool should be able to read that same file. Previously, adding any external read-only path could accidentally make the reading tool forget about the workspace.

`workspace/write grant -> readable + writable`
`read grant            -> readable only`
`everything else       -> blocked`

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_os_env_grant_reach.py tests/inner/test_os_env.py` (45 passed)
- `uv run --no-sync pre-commit run --files omnigent/inner/os_env.py tests/inner/test_os_env_grant_reach.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

An active-policy regression now reads a workspace file, a file under `write_paths`, and an exact `write_files` target while preserving the existing denial tests.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new test covers the active-sandbox gap; the surrounding grant-reach suite continues to verify that ungranted paths remain inaccessible.

## Changelog

Sandboxed file tools can read the workspace and other paths they are allowed to write.
