### PR TITLE
Ensure Otto agents bypass permission prompts

### DIFF
--- a/dev/repro-agent/config.yaml
+++ b/dev/repro-agent/config.yaml
@@ -55,6 +55,7 @@ executor:
   reasoning_effort: xhigh
   config:
     harness: claude-sdk
+    permission_mode: bypassPermissions
 
 # The full operating procedure lives in AGENTS.md, read at startup.
 instructions: AGENTS.md

--- a/dev/resolve-agent/config.yaml
+++ b/dev/resolve-agent/config.yaml
@@ -67,6 +67,7 @@ executor:
   reasoning_effort: xhigh
   config:
     harness: claude-sdk
+    permission_mode: bypassPermissions
 
 # The full operating procedure lives in AGENTS.md, read at startup.
 instructions: AGENTS.md

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -8753,6 +8753,16 @@ def _create_session_from_bundle(
         )
         metadata = metadata.model_copy(update={"reasoning_effort": seeded_effort})
 
+    if metadata.parent_session_id is not None:
+        try:
+            terminal_launch_args = _derive_terminal_launch_args_from_spec(spec)
+        except ValueError as exc:
+            raise OmnigentError(
+                f"invalid terminal_launch_args in bundled child spec: {exc}",
+                code=ErrorCode.INVALID_INPUT,
+            ) from exc
+        metadata = metadata.model_copy(update={"terminal_launch_args": terminal_launch_args})
+
     agent_id = generate_agent_id()
     agent_bundle_location = bundle_location(agent_id, bundle_bytes)
     try:

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1663,6 +1663,47 @@ async def test_multipart_create_with_parent_links_child(
     assert child_id in listed_ids
 
 
+@pytest.mark.parametrize(
+    "harness,config,expected_args",
+    [
+        (
+            "codex-native",
+            {"yolo": True},
+            ["--dangerously-bypass-approvals-and-sandbox"],
+        ),
+        (
+            "claude-native",
+            {"permission_mode": "bypassPermissions"},
+            ["--permission-mode", "bypassPermissions"],
+        ),
+    ],
+)
+async def test_multipart_child_derives_native_bypass_args_from_uploaded_spec(
+    client: httpx.AsyncClient,
+    harness: str,
+    config: dict[str, Any],
+    expected_args: list[str],
+) -> None:
+    """A config-path child persists the uploaded agent's bypass stance."""
+    parent = await _create_parent_session(client, agent_name=f"bundle-yolo-parent-{harness}")
+    child_bundle = build_agent_bundle(
+        name=f"bundle-yolo-child-{harness}",
+        executor={"type": "omnigent", "config": {"harness": harness, **config}},
+        include_llm=False,
+    )
+
+    resp = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"parent_session_id": parent["id"]})},
+        files={"bundle": ("agent.tar.gz", child_bundle, "application/gzip")},
+    )
+
+    assert resp.status_code == 201, resp.text
+    child = await client.get(f"/v1/sessions/{resp.json()['session_id']}")
+    assert child.status_code == 200, child.text
+    assert child.json()["terminal_launch_args"] == expected_args
+
+
 async def test_multipart_create_with_unknown_parent_404s(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/spec/test_otto_agent_permissions.py
+++ b/tests/spec/test_otto_agent_permissions.py
@@ -1,0 +1,24 @@
+"""Contract tests for unattended Otto agent permission modes."""
+
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _executor_config(relative_path: str) -> dict[str, object]:
+    config = yaml.safe_load((_ROOT / relative_path).read_text())
+    return config["executor"]["config"]
+
+
+def test_repro_agent_fully_bypasses_sdk_permission_prompts() -> None:
+    assert _executor_config("dev/repro-agent/config.yaml")["permission_mode"] == (
+        "bypassPermissions"
+    )
+
+
+def test_resolve_agent_fully_bypasses_sdk_permission_prompts() -> None:
+    assert _executor_config("dev/resolve-agent/config.yaml")["permission_mode"] == (
+        "bypassPermissions"
+    )


### PR DESCRIPTION
## Related issue

N/A — production incident in resolve session `5852a42b64e6444a8a900d9f41de7b2c`.

## Summary

- Derive native permission launch arguments for agents uploaded as child bundles through `sys_session_create(config_path=...)`, matching the existing named-subagent path.
- Pin the unattended repro and resolve Claude SDK agents to `bypassPermissions` instead of relying on the generic `auto` default.
- Add contract and integration coverage for Claude and Codex child bypass behavior.

**ELI5:** the reviewer config already said “don’t ask,” but the upload path dropped that setting before launching it. This carries the setting through and makes Otto’s parent agents explicit too.

```text
config.yaml (yolo / bypassPermissions)
              |
              v
multipart child create -> terminal_launch_args -> native CLI full bypass
```

## Test Plan

- `uv run pytest -q tests/spec/test_otto_agent_permissions.py tests/server/routes/test_sessions_yolo_launch_args.py tests/server/integration/test_sessions_child_sessions.py -k 'otto_agent_permissions or yolo or multipart_child_derives_native_bypass_args_from_uploaded_spec'`
- `uv run pre-commit run --files dev/repro-agent/config.yaml dev/resolve-agent/config.yaml omnigent/server/routes/_sessions/orchestration.py tests/server/integration/test_sessions_child_sessions.py tests/spec/test_otto_agent_permissions.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Production evidence showed the uploaded Codex child had `terminal_launch_args: null`; the new integration test asserts the same upload path persists `--dangerously-bypass-approvals-and-sandbox` (and the Claude-native equivalent).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration test exercises the real multipart bundled-child create route used by `sys_session_create(config_path=...)`.

## Changelog

Unattended child agents now preserve full permission bypass instead of pausing for human approval.
