### PR TITLE
fix(logging): redact token-like strings from log sinks

### DIFF
--- a/omnigent/cli_diagnostics.py
+++ b/omnigent/cli_diagnostics.py
@@ -28,7 +28,6 @@ import contextlib
 import io
 import logging
 import os
-import re
 import sys
 import time
 from dataclasses import dataclass
@@ -38,12 +37,16 @@ from typing import cast
 
 from omnigent.cli_invocation import cli_invocation
 from omnigent.process_logging import (
-    TerminalLogFormatter,
+    RedactingLogFormatter,
     effective_log_level,
     env_truthy,
     process_log_dir,
+    redact_log_text,
     terminal_supports_color,
 )
+
+_RedactingFormatter = RedactingLogFormatter
+_redact = redact_log_text
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -103,65 +106,6 @@ class _LoggingStreamSnapshot:
 
 
 _redirected_logging_streams: list[_LoggingStreamSnapshot] = []
-
-# ---------------------------------------------------------------------------
-# Secret redaction filter
-# ---------------------------------------------------------------------------
-
-#: Patterns that match values likely to be secrets.  Applied to every
-#: log record's formatted message before it hits the file.
-_SECRET_PATTERNS: list[re.Pattern[str]] = [
-    # Header values: "Authorization: Bearer xxx" or "bearer xxx"
-    re.compile(r"(?i)(authorization\s*[:=]\s*)\S+"),
-    re.compile(r"(?i)(bearer\s+)\S+"),
-    # Env-var style keys: FOO_TOKEN=xxx, FOO_API_KEY=xxx, ...
-    re.compile(r"(?i)(\b\w*(?:token|api_key|secret|password)\s*[:=]\s*)\S+"),
-    # Anthropic / OpenAI style keys
-    re.compile(r"\bsk-[A-Za-z0-9_-]{10,}\b"),
-    # Databricks PATs
-    re.compile(r"\bdapi[A-Za-z0-9]{10,}\b"),
-]
-_REDACTED = "[REDACTED]"
-
-
-def _redact(text: str) -> str:
-    """
-    Replace secret-shaped substrings in *text* with :data:`_REDACTED`.
-
-    :param text: Arbitrary log text (may include tracebacks).
-    :returns: Scrubbed text.
-    """
-    for pat in _SECRET_PATTERNS:
-        text = pat.sub(
-            lambda m: m.group(1) + _REDACTED if m.lastindex else _REDACTED,
-            text,
-        )
-    return text
-
-
-class _RedactingFormatter(TerminalLogFormatter):
-    """
-    Formatter that scrubs obvious secrets from the *final* formatted
-    output — after ``%``-interpolation of ``record.args`` and after
-    traceback rendering.
-
-    A ``logging.Filter`` on ``record.msg`` would run *before*
-    formatting, so secrets passed as ``logger.info("key=%s", secret)``
-    or appearing in exception tracebacks would slip through.
-    Overriding :meth:`format` is the correct interception point
-    because the base class returns the fully-assembled string
-    (message + traceback) and nothing downstream mutates it before
-    the handler writes.
-    """
-
-    def format(self, record: logging.LogRecord) -> str:
-        """
-        Format *record* then redact secrets from the result.
-
-        :param record: The log record to format.
-        :returns: Formatted, redacted string ready for the handler.
-        """
-        return _redact(super().format(record))
 
 
 class _RedactingStderr(io.TextIOBase):

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 
 import httpx
 
+from omnigent.process_logging import redact_log_text
 from omnigent.version import VERSION
 
 # ── environment contract ────────────────────────────────────────────────────
@@ -421,8 +422,9 @@ def _attributes(record: logging.LogRecord) -> dict[str, str]:
     raw = getattr(record, "attributes", None)
     if not isinstance(raw, dict):
         return {}
-    # The target column is MAP<STRING,STRING>; coerce values and drop nulls.
-    return {str(k): str(v) for k, v in raw.items() if v is not None}
+    # The target column is MAP<STRING,STRING>; coerce values, redact them, and
+    # drop nulls. Event attributes share the same privacy boundary as messages.
+    return {str(k): redact_log_text(str(v)) for k, v in raw.items() if v is not None}
 
 
 def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
@@ -451,6 +453,7 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
     null on the managed service.
     """
     workspace_id, app_name = _process_identity()
+    stack_trace = _stack_trace(record)
     return {
         "session_id": (
             getattr(record, "session_id", None)
@@ -461,13 +464,13 @@ def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:
         "source": source,
         "event_name": getattr(record, "event_name", None),
         "level": record.levelname,
-        "message": record.getMessage(),
+        "message": redact_log_text(record.getMessage()),
         "client_time": int(record.created * 1_000_000),
         "hostname": _HOSTNAME,
         "logger_name": record.name,
         "func_name": record.funcName,
         "app_version": VERSION,
-        "stack_trace": _stack_trace(record),
+        "stack_trace": redact_log_text(stack_trace) if stack_trace is not None else None,
         "attributes": _attributes(record),
         "log_id": uuid.uuid4().hex,
         "user_id": getattr(record, "user_id", None) or current_user_id(),

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -6,6 +6,7 @@ import atexit
 import contextlib
 import logging
 import os
+import re
 import sys
 import threading
 from collections.abc import Callable, Iterator, Sequence
@@ -103,6 +104,61 @@ _LEVEL_COLORS = {
     logging.ERROR: "\x1b[31m",
     logging.CRITICAL: "\x1b[91m",
 }
+_REDACTED = "[REDACTED]"
+_QUOTED_OR_NONSPACE_VALUE = r'(?:"[^"\r\n]*"|\'[^\'\r\n]*\'|\S+)'
+_AUTHORIZATION_VALUE = r'(?:(?:"[^"\r\n]*"|\'[^\'\r\n]*\')|(?:bearer\s+)?\S+)'
+_AUTHORIZATION_PATTERN = re.compile(
+    rf"(?i)(\bauthorization\b[\"']?\s*[:=]\s*)({_AUTHORIZATION_VALUE})"
+)
+_NAMED_SECRET_PATTERN = re.compile(
+    rf"(?i)(\b[\w.-]*(?:token|api[_-]?key|secret|password|credential)"
+    rf"\b[\"']?\s*[:=]\s*)({_QUOTED_OR_NONSPACE_VALUE})"
+)
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Keep the broad standalone-bearer behavior: short or punctuation-heavy
+    # credentials are still secrets.
+    re.compile(r"(?i)(\bbearer\s+)\S+"),
+    # Common provider-specific token shapes.
+    re.compile(r"\bsk-[A-Za-z0-9_-]{10,}\b"),
+    re.compile(r"\bdapi[A-Za-z0-9]{10,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+    re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b"),
+    # JWTs and long mixed-case opaque values are token-like even without a
+    # nearby label. Requiring lower, upper, and numeric characters avoids
+    # treating UUIDs, hashes, and normal lower-case identifiers as secrets.
+    re.compile(r"\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b"),
+    re.compile(
+        r"(?<![A-Za-z0-9_])"
+        r"(?=[A-Za-z0-9_]{32,}(?![A-Za-z0-9_]))"
+        r"(?=[A-Za-z0-9_]*[a-z])"
+        r"(?=[A-Za-z0-9_]*[A-Z])"
+        r"(?=[A-Za-z0-9_]*[0-9])"
+        r"[A-Za-z0-9_]{32,}"
+        r"(?![A-Za-z0-9_])"
+    ),
+)
+
+
+def _replace_named_secret(match: re.Match[str]) -> str:
+    value = match.group(2)
+    if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+        replacement = f"{value[0]}{_REDACTED}{value[0]}"
+    else:
+        replacement = _REDACTED
+    return match.group(1) + replacement
+
+
+def redact_log_text(text: str) -> str:
+    """Replace secret- and token-shaped substrings in log text."""
+    text = _AUTHORIZATION_PATTERN.sub(_replace_named_secret, text)
+    text = _NAMED_SECRET_PATTERN.sub(_replace_named_secret, text)
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(
+            lambda match: match.group(1) + _REDACTED if match.lastindex else _REDACTED,
+            text,
+        )
+    return text
 
 
 def format_log_level_name(levelno: int, levelname: str, *, use_colors: bool) -> str:
@@ -199,6 +255,13 @@ class TerminalLogFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         with log_record_display_fields(record, use_colors=self._use_colors):
             return super().format(record)
+
+
+class RedactingLogFormatter(TerminalLogFormatter):
+    """Format a complete record, then remove token-like strings from it."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        return redact_log_text(super().format(record))
 
 
 def data_dir() -> Path:
@@ -391,7 +454,7 @@ def terminal_stream_handler() -> logging.Handler:
 
 def terminal_log_formatter() -> logging.Formatter:
     """Return the formatter used by mirrored terminal process logs."""
-    return TerminalLogFormatter(use_colors=terminal_supports_color())
+    return RedactingLogFormatter(use_colors=terminal_supports_color())
 
 
 def _unlink_if_empty(path: Path) -> None:
@@ -436,7 +499,7 @@ def configure_process_logging(
     path.parent.mkdir(parents=True, exist_ok=True)
     _current_process_log_path = path
 
-    formatter = TerminalLogFormatter(use_colors=False)
+    formatter = RedactingLogFormatter(use_colors=False)
     handlers: list[logging.Handler] = []
 
     file_handler = _ProcessLogFileHandler(path, encoding="utf-8")

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -115,6 +115,36 @@ def test_record_to_row_shape_and_coercions() -> None:
     }
 
 
+def test_record_to_row_redacts_token_like_text_fields() -> None:
+    secret = "aB3" + "xY7" * 12
+    try:
+        raise ValueError(f"credential={secret}")
+    except ValueError:
+        import sys
+
+        record = logging.LogRecord(
+            "omnigent.runner",
+            logging.ERROR,
+            __file__,
+            10,
+            "request failed: %s",
+            (secret,),
+            sys.exc_info(),
+            func="do_it",
+        )
+    record.attributes = {"upstream_response": secret, "attempt": 3}
+
+    row = dl.record_to_row(record, source="runner")
+
+    attributes = row["attributes"]
+    assert isinstance(attributes, dict)
+    assert secret not in str(row["message"])
+    assert secret not in str(row["stack_trace"])
+    assert secret not in attributes["upstream_response"]
+    assert attributes["attempt"] == "3"
+    assert "[REDACTED]" in str(row)
+
+
 def test_record_to_row_reads_session_id_from_extra(monkeypatch: pytest.MonkeyPatch) -> None:
     # session_id is passed explicitly at the callsite via extra= and read off
     # the record. There is deliberately no ambient request-scoped fallback; an

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 import os
 import re
+import time
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,7 @@ from omnigent.process_logging import (
     LOG_TO_STDERR_ENV_VAR,
     LOG_TTY_FD_ENV_VAR,
     PROCESS_LOG_FILE_ENV_VAR,
+    RedactingLogFormatter,
     TerminalLogFormatter,
     _debug_sink_target_loggers,
     _log_once_seen,
@@ -28,6 +30,7 @@ from omnigent.process_logging import (
     log_once,
     process_log_dir_reference,
     process_log_reference,
+    redact_log_text,
     terminal_stream_handler,
     terminal_supports_color,
 )
@@ -106,6 +109,85 @@ def test_terminal_log_formatter_colors_level_name() -> None:
     assert record.levelname == "INFO"
     assert "source_name" not in record.__dict__
     assert "func_name" not in record.__dict__
+
+
+def test_redact_log_text_filters_labeled_and_unlabeled_token_shapes() -> None:
+    """Secrets are removed even when they have no provider-specific prefix."""
+    opaque = "aB3" + "xY7" * 12
+    labeled = "lowercase123" * 4
+    jwt = ".".join(("eyJ" + "HeaderA1" * 2, "PayloadB2" * 2, "SignatureC3" * 2))
+    provider_key = "sk-" + "TestKey123" * 2
+    workspace_pat = "dapi" + "Test1234567890"
+
+    samples = (
+        (f"Authorization: Bearer {labeled}", labeled),
+        (f'headers={{"token": "{labeled}"}}', labeled),
+        ("bearer abc:def", "abc:def"),
+        ("password=;supersecret", ";supersecret"),
+        ("password=p@ss,word", "p@ss,word"),
+        ('{"password":"p@ss,word"}', "p@ss,word"),
+        (f"response contained {opaque}", opaque),
+        (f"session credential {jwt}", jwt),
+        (f"provider key {provider_key}", provider_key),
+        (f"workspace PAT {workspace_pat}", workspace_pat),
+    )
+
+    for sample, secret in samples:
+        redacted = redact_log_text(sample)
+        assert "[REDACTED]" in redacted
+        assert secret not in redacted
+        assert redact_log_text(redacted) == redacted
+
+
+def test_redact_log_text_handles_large_non_token_input_in_linear_time() -> None:
+    """Punctuation-heavy log lines do not trigger quadratic regex backtracking."""
+    text = "+" * 20_000
+
+    started = time.perf_counter()
+    output = redact_log_text(text)
+    elapsed = time.perf_counter() - started
+
+    assert output == text
+    assert elapsed < 0.5
+
+
+def test_redact_log_text_preserves_normal_identifiers() -> None:
+    """UUIDs, session IDs, hashes, and ordinary prose remain useful in logs."""
+    values = (
+        "conv_0123456789abcdef0123456789abcdef",
+        "123e4567-e89b-12d3-a456-426614174000",
+        "0123456789abcdef0123456789abcdef01234567",
+        "claude-sonnet-4-20250514",
+    )
+
+    for value in values:
+        assert redact_log_text(value) == value
+
+
+def test_redacting_log_formatter_scrubs_interpolated_args_and_tracebacks() -> None:
+    """Redaction runs after message interpolation and exception rendering."""
+    secret = "aB3" + "xY7" * 12
+    formatter = RedactingLogFormatter(use_colors=False)
+    try:
+        raise ValueError(f"token={secret}")
+    except ValueError:
+        import sys
+
+        record = logging.LogRecord(
+            "omnigent.example",
+            logging.ERROR,
+            __file__,
+            1,
+            "request failed for %s",
+            (secret,),
+            sys.exc_info(),
+            "send",
+        )
+
+    output = formatter.format(record)
+
+    assert secret not in output
+    assert output.count("[REDACTED]") >= 2
 
 
 def test_terminal_log_formatter_abbreviates_warning_and_source() -> None:


### PR DESCRIPTION
## Related issue

[OMNI-2910](https://linear.app/omnigent/issue/OMNI-2910/logger-should-filter-out-token-like-strings-privacy-safe)

## Summary

- Prevent credentials and opaque token-like values from leaking through process logs, terminal mirrors, CLI diagnostics, tracebacks, and uploaded debug-log rows.
- Centralize redaction in `omnigent.process_logging`, including labeled secrets, bearer tokens, common provider formats, JWTs, and high-entropy opaque values while preserving normal identifiers.
- Add regression coverage for formatted messages, exception text, structured attributes, and false-positive-prone identifiers.

**ELI5:** Every supported log destination now passes potentially sensitive text through the same privacy screen before storing or displaying it.

```text
LogRecord ──> shared redaction ──> process file / terminal / CLI diagnostics
        └──> structured redaction ──> debug-log message / traceback / attributes
```

## Test Plan

- `uv run pytest -q tests/test_process_logging.py::test_redact_log_text_filters_labeled_and_unlabeled_token_shapes tests/test_process_logging.py::test_redact_log_text_preserves_normal_identifiers tests/test_process_logging.py::test_redacting_log_formatter_scrubs_interpolated_args_and_tracebacks tests/test_debug_logging.py::test_record_to_row_redacts_token_like_text_fields tests/cli/test_cli_diagnostics.py::test_redirect_stderr_to_log_redacts_direct_stderr_writes`
- Targeted existing formatter, process logging, debug-row serialization, traceback, and CLI setup tests.
- `just typecheck-python`
- `uv run ruff check omnigent/process_logging.py omnigent/cli_diagnostics.py omnigent/debug_logging.py tests/test_process_logging.py tests/test_debug_logging.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Token-shaped values are replaced with `[REDACTED]`; UUIDs, session IDs, hashes, and model identifiers remain unchanged, as covered by the targeted tests above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests exercise each new redaction path and verify representative normal identifiers are retained. Existing logging tests cover formatter output and CLI diagnostics setup.

## Changelog

Logs now redact token-like credentials consistently before writing or uploading them.
