### PR TITLE
fix(triage): bump wheel version to invalidate cache

### DIFF
--- a/.github/triage_v2/pyproject.toml
+++ b/.github/triage_v2/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "omnigent-issue-prioritization"
-version = "0.2.0"
+version = "0.2.1"
 description = "Deterministic issue-prioritization pipeline for Omnigent"
 requires-python = ">=3.12"
 dependencies = ["databricks-sdk>=0.56.0,<1", "PyJWT[crypto]>=2.8,<3"]

--- a/uv.lock
+++ b/uv.lock
@@ -3479,7 +3479,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-issue-prioritization"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = ".github/triage_v2" }
 dependencies = [
     { name = "databricks-sdk", version = "0.67.0", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-8-omnigent-antigravity'" },


### PR DESCRIPTION
## Related issue

N/A — operational regression in the scheduled issue-prioritization job.

## Summary

- Bump the issue-prioritization package from 0.2.0 to 0.2.1.
- Force the Databricks bundle to publish a new wheel URL so serverless jobs stop loading cached pre-#5913 code.

ELI5: Databricks remembered the old wheel because the repaired wheel had the same filename. The new version gives it a new filename.

```text
0.2.0 URL (cached old code) -> 0.2.1 URL -> fresh environment -> Arrow fix runs
```

## Test Plan

- `uv run --frozen pytest` in `.github/triage_v2` — 107 passed.
- `uv build` produced `omnigent_issue_prioritization-0.2.1-py3-none-any.whl`.
- Verified the failed Databricks stack executes old line 40, while main contains the fixed `.drop("state")` implementation.
- Pre-commit checks passed except repository-wide `pyrefly`, which could not resolve unrelated optional integrations absent from the clean worktree environment.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The deployed job currently references `omnigent_issue_prioritization-0.2.0-py3-none-any.whl`. After deploying this PR, the dependency should reference version 0.2.1.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The package contents are unchanged from tested main; this PR changes only the distribution version. Production verification is to deploy the bundle, confirm the dependency URL contains 0.2.1, and run the job once in dry-run mode.
