### PR TITLE
fix(repl): reconcile reused subagent status

### DIFF
--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -225,6 +225,11 @@ _LIST_ITEMS_PAGE_SIZE = 100
 # session's direct children) while sub-agents are active.
 _MAX_SUBAGENT_TREE_DEPTH = 3
 _SUBAGENT_POLL_SECONDS = 2.0
+# A reused child can become busy without publishing a fresh update on an idle
+# parent's SSE stream.  Keep the fast poll asleep for settled trees, but
+# periodically reconcile retained child handles so stale ``Idle`` state is
+# bounded rather than permanent (issue #6162).
+_SUBAGENT_SETTLED_RECONCILE_SECONDS = 30.0
 
 
 def _load_startup_theme() -> TerminalTheme:
@@ -3392,6 +3397,10 @@ async def run_repl(
     # (new turn begins) so the idle-event local-estimate fallback fires
     # on every turn for harnesses that never report usage (e.g. codex).
     _context_ring_state: list[bool] = [False]  # [last_completed_had_usage]
+    # A parent entering ``waiting`` has commonly just delegated work.  Request
+    # an immediate child-tree snapshot on the next poll tick; the event handler
+    # is defined before the poll loop, so a mutable cell bridges the closures.
+    _subagent_reconcile_requested: list[bool] = [False]
 
     def _flush_inflight_assistant_text() -> list[FormattedItem]:
         """
@@ -3542,6 +3551,9 @@ async def run_repl(
                 _spawn_metadata_refresh()
             elif event.status in ("idle", "waiting", "failed"):
                 from omnigent_client import TextDone
+
+                if event.status == "waiting":
+                    _subagent_reconcile_requested[0] = True
 
                 # A SETUP-phase failure (spec resolution, spawn-env
                 # build) ends the turn before the LLM stream starts, so
@@ -4382,6 +4394,7 @@ async def run_repl(
     # session that already has children, with no fresh SSE to seed them) even
     # though no sub-agents are registered yet — see ``_subagent_poll_loop``.
     polled_root: list[str | None] = [None]
+    last_subagent_reconcile_at: list[float] = [0.0]
 
     def _sync_subagent_root() -> None:
         # Track the live top-level session id while we're at the top. While
@@ -4419,10 +4432,10 @@ async def run_repl(
         # just changed (the discovery poll that repopulates the selector after a
         # resume / ``/switch`` into a session that already has children, which
         # would otherwise never poll: no SSE, no nodes yet). It deliberately
-        # goes quiet once everything settles at the top level: a finished
-        # sub-agent's status no longer changes, so polling retained-but-terminal
-        # nodes forever is pure waste; a child that later resumes re-arms the
-        # poll via the active stream's ``session.child_session.updated``.
+        # drops to a 30-second reconciliation once everything settles at the
+        # top level. A parent ``waiting`` edge requests an immediate snapshot;
+        # the low-frequency fallback covers reused children whose parent stream
+        # emits no fresh ``session.child_session.updated`` event.
         while True:
             try:
                 _sync_subagent_root()
@@ -4430,14 +4443,22 @@ async def run_repl(
                 observing_subagent = getattr(session, "_readonly_view", False) or getattr(
                     session, "_interactive_child", False
                 )
+                now = asyncio.get_running_loop().time()
+                settled_reconcile_due = _subagent_reconcile_requested[0] or (
+                    host.has_any_subagents()
+                    and now - last_subagent_reconcile_at[0] >= _SUBAGENT_SETTLED_RECONCILE_SECONDS
+                )
                 if _should_discover_subagents(
                     root_id,
                     has_active_subagents=host.has_active_subagents(),
                     observing_subagent=observing_subagent,
                     last_polled_root=polled_root[0],
+                    settled_reconcile_due=settled_reconcile_due,
                 ):
                     await _refresh_subagents()
                     polled_root[0] = root_id
+                    last_subagent_reconcile_at[0] = now
+                    _subagent_reconcile_requested[0] = False
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001 — best-effort background poll; never crash the REPL
@@ -6510,6 +6531,7 @@ def _should_discover_subagents(
     has_active_subagents: bool,
     observing_subagent: bool,
     last_polled_root: str | None,
+    settled_reconcile_due: bool = False,
 ) -> bool:
     """Decide whether the background loop should (re-)fetch the sub-agent tree.
 
@@ -6525,26 +6547,35 @@ def _should_discover_subagents(
       the badge) fresh while chatting; or
     * ``last_polled_root != root_id`` — the root just changed: a one-shot
       discovery that repopulates the selector for a resumed / ``/switch``-ed
-      session that already has children (no fresh SSE to seed them).
+      session that already has children (no fresh SSE to seed them); or
+    * ``settled_reconcile_due`` — a retained, apparently idle tree is due for
+      its low-frequency snapshot reconciliation.  This catches a reused child
+      becoming busy when the idle parent's stream emits no fresh child update.
 
     Deliberately keyed on *active* work, NOT merely "any node exists": finished
     sub-agents are retained in the selector indefinitely (web parity), but a
-    terminal child's status no longer changes, so polling it forever is pure
-    waste. Once everything settles at the top level the loop goes quiet; a child
-    that later resumes does so on the active (root) stream, whose SSE
-    ``session.child_session.updated`` re-arms ``has_active_subagents`` and the
-    poll wakes again.
+    terminal child's status normally no longer changes, so the 2-second poll
+    goes quiet once everything settles.  Retained handles are reconciled at a
+    much lower frequency because reuse is allowed and does not always publish a
+    fresh child update on the parent stream.
 
     :param root_id: The current tree root (top-level session id), or ``None``.
     :param has_active_subagents: Whether any sub-agent is still running.
     :param observing_subagent: Whether the user is currently viewing/co-driving
         a child (so the parent-rooted poll is what keeps that child fresh).
     :param last_polled_root: The root the loop last ran discovery for.
+    :param settled_reconcile_due: Whether the low-frequency reconciliation for
+        a retained settled tree is due.
     :returns: ``True`` to fetch the tree this tick.
     """
     if root_id is None:
         return False
-    return has_active_subagents or observing_subagent or last_polled_root != root_id
+    return (
+        has_active_subagents
+        or observing_subagent
+        or last_polled_root != root_id
+        or settled_reconcile_due
+    )
 
 
 def _apply_child_session_event(

--- a/tests/repl/test_subagent_chat.py
+++ b/tests/repl/test_subagent_chat.py
@@ -144,15 +144,32 @@ def test_should_discover_polls_while_active_or_observing() -> None:
     )
 
 
-def test_should_stop_polling_when_idle_at_top_level() -> None:
-    """Once everything settles at the top level the loop goes quiet — retained
-    finished sub-agents no longer change status, so polling them is pure waste.
-    A child that later resumes re-arms the poll via the active stream's SSE."""
+def test_should_pause_fast_polling_when_idle_at_top_level() -> None:
+    """A settled top-level tree pauses the fast poll between reconciliations."""
     assert not _should_discover_subagents(
         "conv_main",
         has_active_subagents=False,
         observing_subagent=False,
         last_polled_root="conv_main",
+        settled_reconcile_due=False,
+    )
+
+
+def test_should_periodically_reconcile_retained_idle_children() -> None:
+    """A low-frequency snapshot can notice a reused child becoming busy.
+
+    Reusing an existing child handle does not always emit a fresh
+    ``session.child_session.updated`` event on an idle parent's stream.  The
+    fast poll is still disabled while the retained tree appears settled, but a
+    due reconciliation must re-fetch it so stale ``Idle`` state cannot persist
+    forever.
+    """
+    assert _should_discover_subagents(
+        "conv_main",
+        has_active_subagents=False,
+        observing_subagent=False,
+        last_polled_root="conv_main",
+        settled_reconcile_due=True,
     )
 
 

--- a/tests/repl/test_subagent_registry.py
+++ b/tests/repl/test_subagent_registry.py
@@ -269,3 +269,7 @@ def test_run_repl_wires_subagent_plumbing() -> None:
         "existing children won't repopulate the selector without fresh SSE, "
         "or the poll no longer gates on active work and spins forever idle."
     )
+    assert "_subagent_reconcile_requested" in src, (
+        "a parent waiting edge no longer requests a child-tree snapshot — "
+        "reused children can remain falsely Idle until the slow fallback poll."
+    )


### PR DESCRIPTION
## Related issue

Closes #6162

## Summary

- Reconcile the retained sub-agent tree immediately when the parent enters `waiting`, which commonly follows delegation.
- Add a 30-second fallback reconciliation for settled retained children, so reusing a child handle cannot leave the TUI permanently showing `ready` when the REST snapshot says it is busy.
- Preserve the existing 2-second active poll and avoid restoring the expensive 2-second forever-poll for fully settled trees.

ELI5: the TUI previously stopped checking an old child after it looked finished. If that same child started working again without sending a fresh notification, the TUI stayed stale forever. It now checks immediately at delegation and occasionally while retained children are idle.

```text
parent waiting ───────────────> reconcile on next 2s tick
missed parent/child SSE ──────> reconcile within 30s
snapshot says child busy ─────> resume normal 2s active polling
all children settle ──────────> return to low-frequency fallback
```

## Test Plan

- `uv run pytest tests/repl/test_subagent_chat.py tests/repl/test_subagent_registry.py tests/frontends/sdk/test_terminal_host.py -q` — 88 passed.
- `uv run pre-commit run --files omnigent/repl/_repl.py tests/repl/test_subagent_chat.py tests/repl/test_subagent_registry.py` — all hooks passed, including ruff and pyrefly.
- `git diff --check` — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The live reproduction and exact REST/TUI evidence are recorded in #6162. The regression test demonstrates that an apparently settled retained tree remains quiet between checks but is fetched once reconciliation is due, allowing a reused `in_progress` child to re-arm the active poll.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change extends the existing #445 poll-decision seam and keeps the terminal host's public active-subagent behavior covered by the existing SDK tests.

## Changelog

The TUI now detects reused sub-agents that resume work without a fresh parent-stream update instead of remaining incorrectly `ready`.
