### PR TITLE
fix(desktop): avoid macOS fullscreen letterboxing

### DIFF
--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -87,7 +87,8 @@
       "entitlementsInherit": "signing/entitlements.mac.inherit.plist",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Omnigent uses the microphone for voice dictation in the message composer.",
-        "CFBundleIconName": "AppIcon"
+        "CFBundleIconName": "AppIcon",
+        "NSPrefersDisplaySafeAreaCompatibilityMode": false
       },
       "gatekeeperAssess": false,
       "notarize": false,

--- a/web/electron/test/mac_packaging.test.js
+++ b/web/electron/test/mac_packaging.test.js
@@ -1,0 +1,13 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const packageConfig = require("../package.json");
+
+describe("macOS packaging", () => {
+  it("opts out of camera housing compatibility mode", () => {
+    assert.equal(
+      packageConfig.build.mac.extendInfo.NSPrefersDisplaySafeAreaCompatibilityMode,
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Related issue

https://linear.app/omnigent/issue/OMNI-4243/desktop-app-full-screen-macos-looks-odd

## Summary

- Opt the packaged macOS app out of camera-housing compatibility mode so native fullscreen is not letterboxed below the notch.
- Add a packaging regression test that requires the Info.plist setting to remain a Boolean `false`.

## Test Plan

- `node --test web/electron/test/mac_packaging.test.js`
- `uv run pre-commit run --files web/electron/package.json web/electron/test/mac_packaging.test.js`

## Demo

<img width="2056" height="1329" alt="image" src="https://github.com/user-attachments/assets/aff7d066-211f-4cee-9706-ab964480e711" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The automated test covers the packaged Info.plist configuration. Final visual verification requires entering native fullscreen on a notched MacBook.

## Changelog

Desktop fullscreen on notched Macs no longer leaves a black band above the app.
