### PR TITLE
fix(server): serialize AgentCache calls without blocking requests

### DIFF
--- a/omnigent/runtime/agent_cache.py
+++ b/omnigent/runtime/agent_cache.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import weakref
+from _thread import LockType
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from threading import Lock
 
 from omnigent.entities import LoadedAgent
 from omnigent.spec import AgentSpec
@@ -47,6 +52,20 @@ class AgentCache:
         self._artifact_store = artifact_store
         self._cache_dir = cache_dir
         self._specs: dict[str, AgentSpec] = {}
+
+        self._locks_guard = Lock()
+        self._locks: weakref.WeakValueDictionary[str, LockType] = weakref.WeakValueDictionary()
+
+    @contextmanager
+    def _lock(self, agent_id: str) -> Iterator[None]:
+        """Serialize one agent's cache operations without retaining idle locks."""
+        with self._locks_guard:
+            lock = self._locks.get(agent_id)
+            if lock is None:
+                lock = Lock()
+                self._locks[agent_id] = lock
+        with lock:
+            yield
 
     def _cache_path(self, agent_id: str, *, suffix: str = "") -> Path:
         """Return a direct child of the cache root for an agent id."""
@@ -99,6 +118,12 @@ class AgentCache:
         :returns: A LoadedAgent with the parsed spec and the
             on-disk working directory.
         """
+        with self._lock(agent_id):
+            return self._load_locked(agent_id, bundle_location, expand_env=expand_env)
+
+    def _load_locked(
+        self, agent_id: str, bundle_location: str, *, expand_env: bool
+    ) -> LoadedAgent:
         workdir = self._cache_path(agent_id)
 
         # Tier 1: in-memory spec. The cached spec was parsed with the
@@ -130,10 +155,9 @@ class AgentCache:
         """
         Warm-swap an agent's cached spec and disk directory.
 
-        Extracts the new bundle to a temp directory, swaps the
-        in-memory spec entry, renames into the cache location, and
-        cleans up the old directory. Concurrent readers see either
-        the old spec or the new spec, never an empty cache.
+        Extracts the new bundle, replaces the disk directory, then publishes
+        the matching spec. Same-agent cache calls wait for the swap;
+        previously returned workdirs are not immutable snapshots.
 
         :param agent_id: Unique agent identifier,
             e.g. ``"ag_abc123"``.
@@ -150,6 +174,14 @@ class AgentCache:
         :returns: A LoadedAgent with the new spec and working
             directory.
         """
+        with self._lock(agent_id):
+            return self._replace_locked(
+                agent_id, bundle_location, bundle_bytes, expand_env=expand_env
+            )
+
+    def _replace_locked(
+        self, agent_id: str, bundle_location: str, bundle_bytes: bytes, *, expand_env: bool
+    ) -> LoadedAgent:
         workdir = self._cache_path(agent_id)
         staging_dir = self._cache_path(agent_id, suffix="_staging")
 
@@ -168,13 +200,11 @@ class AgentCache:
         finally:
             tmp_path.unlink()
 
-        # Swap in-memory entry (atomic dict assignment)
-        self._specs[agent_id] = spec
-
         # Replace disk directory: remove old, rename staging into place
         if workdir.is_dir():
             shutil.rmtree(workdir)
         staging_dir.rename(workdir)
+        self._specs[agent_id] = spec
 
         return LoadedAgent(spec=spec, workdir=workdir)
 
@@ -186,6 +216,10 @@ class AgentCache:
         :param agent_id: Unique agent identifier,
             e.g. ``"ag_abc123"``.
         """
+        with self._lock(agent_id):
+            return self._evict_locked(agent_id)
+
+    def _evict_locked(self, agent_id: str) -> None:
         workdir = self._cache_path(agent_id)
         self._specs.pop(agent_id, None)
         if workdir.is_dir():

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1818,6 +1818,11 @@ def _resolve_harness(*args: Any, **kwargs: Any) -> str | None:
     return _facade._resolve_harness(*args, **kwargs)
 
 
+async def _resolve_harness_async(*args: Any, **kwargs: Any) -> str | None:
+    """Resolve a harness without blocking the Server event loop."""
+    return await asyncio.to_thread(_resolve_harness, *args, **kwargs)
+
+
 def _resolve_harness_impl(
     conv: Conversation | None,
     *,
@@ -5410,7 +5415,7 @@ async def _launch_runner_on_host_locked(
             # Canonical harness (see _resolve_harness) so the host runs the
             # same configuration check it does at create-time launch. None
             # (agent not resolvable) skips the host-side check — fail open.
-            harness=_resolve_harness(conv),
+            harness=await _resolve_harness_async(conv),
         )
     )
     try:
@@ -9885,15 +9890,13 @@ async def _handle_advise_models_mcp(
         agent_obj = await asyncio.to_thread(agent_store.get, conv.agent_id)
         if agent_obj is not None:
             try:
-                spec = (
-                    get_agent_cache()
-                    .load(
-                        agent_obj.id,
-                        agent_obj.bundle_location,
-                        expand_env=agent_obj.session_id is None,
-                    )
-                    .spec
+                loaded = await asyncio.to_thread(
+                    get_agent_cache().load,
+                    agent_obj.id,
+                    agent_obj.bundle_location,
+                    expand_env=agent_obj.session_id is None,
                 )
+                spec = loaded.spec
             except Exception:  # noqa: BLE001
                 _logger.debug(
                     "_handle_advise_models_mcp: failed to load spec for agent=%s", conv.agent_id
@@ -10734,6 +10737,7 @@ __all__ = [
     "_reset_runner_resources_after_switch",
     "_reset_runner_resources_after_switch_impl",
     "_resolve_harness",
+    "_resolve_harness_async",
     "_resolve_llm_model",
     "_resolve_skill_meta_text_via_runner",
     "_resolve_subagent_spec",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -301,6 +301,7 @@ from omnigent.server.routes._sessions.helpers import (
     _require_declared_subagent,
     _require_external_status_forward,
     _resolve_harness,
+    _resolve_harness_async,
     _resolve_llm_model,
     _resolve_subagent_spec,
     _resource_event_item_from_sse,
@@ -4128,7 +4129,7 @@ async def _ensure_native_terminal_ready(
     :returns: The probe outcome — a definitive ``error`` when the terminal
         could not start, else ``error=None``.
     """
-    display_name, _, harness = _native_terminal_runtime(conv)
+    display_name, _, harness = await asyncio.to_thread(_native_terminal_runtime, conv)
     terminal_name = _native_terminal_name_for_harness(harness)
     try:
         resp = await runner_client.post(
@@ -4478,8 +4479,13 @@ async def _forward_native_terminal_message(
     :raises HTTPException: 502 when the runner or harness rejects
         the injection request.
     """
-    display_name, _, harness = _native_terminal_runtime(conv)
-    event = _build_native_terminal_message_event(conv, body, model_override=model_override)
+    display_name, _, harness = await asyncio.to_thread(_native_terminal_runtime, conv)
+    event = await asyncio.to_thread(
+        _build_native_terminal_message_event,
+        conv,
+        body,
+        model_override=model_override,
+    )
     _logger.info(
         "%s terminal message forward starting: session=%s block_types=%s model_override=%s",
         display_name,
@@ -4833,7 +4839,7 @@ def _unavailable_routing_card(reason: str) -> tuple[str, dict[str, Any]]:
     return _UNAVAILABLE_ROUTED_MODEL, {"rationale": reason, "applied": False}
 
 
-def _native_pane_harness(conv: Conversation) -> str | None:
+async def _native_pane_harness(conv: Conversation) -> str | None:
     """The native harness a pane actually runs, past the ``"auto"`` sentinel.
 
     A forced-auto child keeps ``harness_override="auto"`` until its first
@@ -4846,10 +4852,10 @@ def _native_pane_harness(conv: Conversation) -> str | None:
     :returns: The canonical native harness, e.g. ``"claude-native"``, or
         ``None`` when it cannot be resolved.
     """
-    harness = _resolve_harness(conv)
+    harness = await _resolve_harness_async(conv)
     if harness is not None and harness != "auto":
         return harness
-    native = _native_coding_agent_for_session(conv)
+    native = await asyncio.to_thread(_native_coding_agent_for_session, conv)
     return native.harness if native is not None else harness
 
 
@@ -5336,7 +5342,7 @@ async def _forward_event_to_runner(
                 # brain's claude family and a claude worker the codex family;
                 # under an auto parent it dropped the restriction entirely, so
                 # a pi child could be handed a codex verdict it then ran pi on.
-                _child_harness = _resolve_harness(conv)
+                _child_harness = await _resolve_harness_async(conv)
                 _child_pinned = _child_harness is not None and _child_harness != "auto"
                 _child_family = harness_family(_child_harness) if _child_pinned else None
                 # A single-harness candidate set is the honest offer for a
@@ -5408,7 +5414,7 @@ async def _forward_event_to_runner(
                 # Top-level sessions: model-only routing (harness already fixed by spec).
                 from omnigent.server.smart_routing import route_turn_or_decline
 
-                _harness = _resolve_harness(conv)
+                _harness = await _resolve_harness_async(conv)
                 # A turn cannot change harness, so only this session's own
                 # family has to be gateway-backed for the workspace router.
                 _turn_backed = _gateway_backed(
@@ -5587,13 +5593,14 @@ async def _forward_event_to_runner(
                 and _bare_model_id(_attempted_override) != _bare_model_id(_routed_model)
                 else None
             )
+            _decision_harness = _routed_harness or await _resolve_harness_async(conv)
             _decision_id = await _emit_server_routing_decision(
                 session_id,
                 conversation_store,
                 _routed_model,
                 _verdict,
                 scope=_decision_scope,
-                harness=_routed_harness or _resolve_harness(conv),
+                harness=_decision_harness,
                 attempted_override=_overridden,
             )
             if not _route_failed:
@@ -5614,7 +5621,7 @@ async def _forward_event_to_runner(
                     _verdict,
                     agent=agent_name or "",
                     scope=_decision_scope,
-                    harness=_routed_harness or _resolve_harness(conv),
+                    harness=_decision_harness,
                     decision_id=_decision_id,
                     attempted_override=_overridden,
                 )
@@ -5871,11 +5878,11 @@ async def _dispatch_session_event_to_runner_impl(
         persisted item id (non-native) or the pending-input id
         (claude-native message bypass).
     """
-    if body.type == "message" and _is_native_terminal_session(conv):
+    if body.type == "message" and await asyncio.to_thread(_is_native_terminal_session, conv):
         # Validate before touching the runner. The ensure probe is only
         # for syntactically valid user messages; assistant/system-shaped
         # inputs should still fail locally without creating terminals.
-        _build_native_terminal_message_event(conv, body)
+        await asyncio.to_thread(_build_native_terminal_message_event, conv, body)
         ensure_outcome = (
             _NativeTerminalEnsureOutcome(error=None)
             if native_terminal_ready
@@ -5963,15 +5970,18 @@ async def _dispatch_session_event_to_runner_impl(
         ):
             from omnigent.server.smart_routing import route_turn_or_decline
 
-            _harness = _native_pane_harness(conv)
+            _harness = await _native_pane_harness(conv)
             _user_text = _extract_user_text_for_routing(body)
             # Cross-family spawns belong to auto-harness sessions: a pinned
             # session's children stay in its family (the rule the in-harness
             # spawn gate applies via ``candidate_models(cross_harness=False)``).
             # This pane already runs another family's CLI, so the parent's
             # family has no candidate for it and nothing is routed.
-            _native_out_of_family = _out_of_family_spawn_notice(
-                conv, _native_parent_conv, _harness
+            _native_out_of_family = await asyncio.to_thread(
+                _out_of_family_spawn_notice,
+                conv,
+                _native_parent_conv,
+                _harness,
             )
             if _user_text and _native_out_of_family is not None:
                 _native_routed_model, _native_verdict = _unavailable_routing_card(
@@ -6067,13 +6077,14 @@ async def _dispatch_session_event_to_runner_impl(
         if _native_routed_model is not None and _native_verdict is not None:
             if _native_applied_model is None and not _native_route_failed:
                 _native_verdict = _unapplied_routed_verdict(_native_routed_model, _native_verdict)
+            _native_decision_harness = await _resolve_harness_async(conv)
             _native_decision_id = await _emit_server_routing_decision(
                 session_id,
                 conversation_store,
                 _native_routed_model,
                 _native_verdict,
                 scope=_native_scope,
-                harness=_resolve_harness(conv),
+                harness=_native_decision_harness,
             )
             if not _native_route_failed:
                 # The label is the route-once gate, so a failed call must not
@@ -6090,7 +6101,7 @@ async def _dispatch_session_event_to_runner_impl(
                     _native_verdict,
                     agent=agent_name or "",
                     scope=_native_scope,
-                    harness=_resolve_harness(conv),
+                    harness=_native_decision_harness,
                     decision_id=_native_decision_id,
                 )
         return _SessionEventDispatchResult(item_id=None, pending_id=pending_id)
@@ -6751,7 +6762,8 @@ async def _relay_runner_stream_once(
                         # policy callables can read
                         # event["context"]["usage"]["total_cost_usd"] and the
                         # subtree roll-up below sees the new totals.
-                        _accumulate_session_usage(
+                        await asyncio.to_thread(
+                            _accumulate_session_usage,
                             event.get("response", {}),
                             session_id,
                             conversation_store,
@@ -8528,8 +8540,9 @@ async def _create_session_from_existing_agent(
         # rather than created and declined afterwards. Auto parents are
         # unaffected (the router owns their family) and so is a parent that
         # routes no spawns — neither resolves the child's harness at all.
-        if _pinned_spawn_family(_parent_for_routing) is not None:
-            _reject_out_of_family_child(
+        if await asyncio.to_thread(_pinned_spawn_family, _parent_for_routing) is not None:
+            await asyncio.to_thread(
+                _reject_out_of_family_child,
                 _parent_for_routing,
                 await asyncio.to_thread(
                     _create_resolved_harness, agent, body.harness_override, agent_cache
@@ -8677,7 +8690,8 @@ async def _create_session_from_existing_agent(
     # opt-ins only, never the headless worker default bypass.
     sub_spec: AgentSpec | None = None
     if body.sub_agent_name:
-        sub_spec = _resolve_subagent_spec(
+        sub_spec = await asyncio.to_thread(
+            _resolve_subagent_spec,
             agent=agent,
             sub_agent_name=body.sub_agent_name,
             agent_cache=agent_cache,
@@ -8868,7 +8882,8 @@ async def _create_session_from_existing_agent(
         body.sub_agent_name is None
         and body.host_id is not None
         and (
-            _repl_labels := _repl_terminal_ui_labels(
+            _repl_labels := await asyncio.to_thread(
+                _repl_terminal_ui_labels,
                 agent=agent,
                 agent_cache=agent_cache,
                 harness_override=harness_override,
@@ -8989,7 +9004,8 @@ async def _create_session_from_existing_agent(
             elif conv.harness_override:
                 _tel_harness = conv.harness_override
             elif agent_cache is not None:
-                _tel_loaded = agent_cache.load(
+                _tel_loaded = await asyncio.to_thread(
+                    agent_cache.load,
                     agent.id,
                     agent.bundle_location,
                     expand_env=agent.session_id is None,
@@ -10127,7 +10143,13 @@ async def _get_session_snapshot(
         host_for_resume = await asyncio.to_thread(host_store.get_host, conv.host_id)
         if host_for_resume is not None:
             host_resumable = host_resume_supported(host_for_resume, sandbox_config)
-    return _build_session_response(
+    pending_elicitation_events = await asyncio.to_thread(
+        _pending_elicitation_snapshot_for_session,
+        conv_store,
+        conv,
+    )
+    return await asyncio.to_thread(
+        _build_session_response,
         conv,
         items,
         status,
@@ -10144,11 +10166,7 @@ async def _get_session_snapshot(
         runner_online=runner_online,
         host_online=host_online,
         host_resumable=host_resumable,
-        pending_elicitation_events=await asyncio.to_thread(
-            _pending_elicitation_snapshot_for_session,
-            conv_store,
-            conv,
-        ),
+        pending_elicitation_events=pending_elicitation_events,
         subtree_usage=subtree_usage,
         viewer_id=viewer_id,
         agent_store=agent_store,

--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -20,6 +20,7 @@ through session creation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, Query, Request
@@ -159,12 +160,16 @@ def create_builtin_agents_router(
         :returns: A :class:`PaginatedList` of built-in agents.
         """
         _require_user(request, auth_provider)
-        page = agent_store.list(limit=limit, after=after, before=before, order=order)
-        return PaginatedList(
-            data=[_to_agent_object(a, agent_cache) for a in page.data],
-            first_id=page.first_id,
-            last_id=page.last_id,
-            has_more=page.has_more,
-        )
+
+        def _load_page() -> PaginatedList:
+            page = agent_store.list(limit=limit, after=after, before=before, order=order)
+            return PaginatedList(
+                data=[_to_agent_object(a, agent_cache) for a in page.data],
+                first_id=page.first_id,
+                last_id=page.last_id,
+                has_more=page.has_more,
+            )
+
+        return await asyncio.to_thread(_load_page)
 
     return router

--- a/omnigent/server/routes/sessions/routes_agent.py
+++ b/omnigent/server/routes/sessions/routes_agent.py
@@ -131,7 +131,7 @@ def register_agent_routes(
                 f"Agent not found: {conv.agent_id!r}",
                 code=ErrorCode.NOT_FOUND,
             )
-        return _to_agent_object(agent, agent_cache)
+        return await asyncio.to_thread(_to_agent_object, agent, agent_cache)
 
     @router.get(
         "/sessions/{session_id}/agent/contents",
@@ -293,7 +293,7 @@ def register_agent_routes(
 
         # Idempotency: same bundle content = no-op
         if new_loc == agent.bundle_location:
-            return _to_agent_object(agent, agent_cache)
+            return await asyncio.to_thread(_to_agent_object, agent, agent_cache)
 
         if artifact_store is None:
             raise OmnigentError(
@@ -312,11 +312,15 @@ def register_agent_routes(
             # Only operator-authored template agents
             # (session_id is None) may expand ${VAR} against the server
             # env; tenant session-scoped bundles must not.
-            agent_cache.replace(
-                agent.id, new_loc, bundle_bytes, expand_env=agent.session_id is None
+            await asyncio.to_thread(
+                agent_cache.replace,
+                agent.id,
+                new_loc,
+                bundle_bytes,
+                expand_env=agent.session_id is None,
             )
 
-        return _to_agent_object(updated, agent_cache)
+        return await asyncio.to_thread(_to_agent_object, updated, agent_cache)
 
     # ── POST /sessions/{session_id}/mcp ──────────────────────────────────
     # MCP Streamable HTTP proxy endpoint. Only registered when a

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2334,7 +2334,7 @@ def register_core_routes(
             # polly/debby also carry) — see _persist_model_change_note for the
             # full rationale. live_forward (== not silent) already excludes
             # bind-time auto-applies, so only an explicit /model lands a note.
-            if _is_native_terminal_session(updated):
+            if await asyncio.to_thread(_is_native_terminal_session, updated):
                 # The injection is the only thing that moves a LIVE native
                 # pane's model, so a forward its runner refused must not pass as
                 # applied. A stopped session reaches no runner and stays quiet —
@@ -2952,7 +2952,8 @@ def register_core_routes(
             order="desc",
         )
         level = await _get_permission_level(user_id, new_conv.id, permission_store)
-        return _build_session_response(
+        return await asyncio.to_thread(
+            _build_session_response,
             new_conv,
             list(reversed(fork_items.data)),
             "idle",
@@ -3183,7 +3184,8 @@ def register_core_routes(
 
         items = await asyncio.to_thread(conversation_store.list_items, session_id, limit=10000)
         level = await _get_permission_level(user_id, session_id, permission_store)
-        return _build_session_response(
+        return await asyncio.to_thread(
+            _build_session_response,
             updated,
             items.data,
             "idle",

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -358,7 +358,7 @@ async def _recover_retry_session(
             require_success=True,
         )
 
-    if _is_native_terminal_session(conv):
+    if await asyncio.to_thread(_is_native_terminal_session, conv):
         if not terminal_ready_from_init:
             terminal_outcome = await _ensure_native_terminal_ready(
                 runner_client,
@@ -1230,7 +1230,9 @@ def register_events_routes(
             # session (runner_asleep / host_asleep) should wake and compact
             # just like sending a message does, so relaunch the runner the same
             # way the message-dispatch path does, then retry the forward once.
-            if runner_result is None and _is_native_terminal_session(conv):
+            if runner_result is None and await asyncio.to_thread(
+                _is_native_terminal_session, conv
+            ):
                 conv, woke_client = await _wake_bound_runner_for_control(conv)
                 if woke_client is not None:
                     # Same TUI-inject budget as the initial forward: a
@@ -1778,7 +1780,9 @@ def register_events_routes(
                 # the runner must initialize the child's terminal session.
                 # For SDK/non-native sub-agents the parent runner already
                 # holds the child's state — no re-initialization needed.
-                _runner_needs_session_init = _is_native_terminal_session(conv)
+                _runner_needs_session_init = await asyncio.to_thread(
+                    _is_native_terminal_session, conv
+                )
         if runner_client is None and conv.host_id is not None:
             _tunnel_registry = getattr(request.app.state, "tunnel_registry", None)
             _grace_host_reg = cast(
@@ -1936,7 +1940,9 @@ def register_events_routes(
             # harness). Other event types and non-native sessions still
             # raise: their message would replay to a relaunched runner, so
             # persisting now WOULD desync the store from harness state.
-            if body.type == "message" and _is_native_terminal_session(conv):
+            if body.type == "message" and await asyncio.to_thread(
+                _is_native_terminal_session, conv
+            ):
                 exit_cause = (
                     runner_exit_reports.get(conv.runner_id)
                     if runner_exit_reports is not None and conv.runner_id is not None

--- a/omnigent/server/routes/sessions/routes_hooks.py
+++ b/omnigent/server/routes/sessions/routes_hooks.py
@@ -759,8 +759,11 @@ def register_hooks_routes(
                 media_type="application/json",
             )
 
-        loaded = _sf.get_agent_cache().load(
-            agent.id, agent.bundle_location, expand_env=agent.session_id is None
+        loaded = await asyncio.to_thread(
+            _sf.get_agent_cache().load,
+            agent.id,
+            agent.bundle_location,
+            expand_env=agent.session_id is None,
         )
 
         _caps = _sf.get_caps()
@@ -1633,7 +1636,7 @@ def register_hooks_routes(
             decision_scope,
             resolve_turn_route,
         )
-        from omnigent.server.routes._sessions.helpers import _resolve_harness
+        from omnigent.server.routes._sessions.helpers import _resolve_harness_async
         from omnigent.server.routes._sessions.orchestration import (
             _native_turn_catalog,
             _publish_routed_model,
@@ -1772,6 +1775,7 @@ def register_hooks_routes(
             await _stamp_routing_decision_label(session_id, conversation_store, decision_id)
             return True
 
+        parent_harness = await _resolve_harness_async(parent) if parent is not None else None
         decision = await resolve_turn_route(
             session_id,
             route_request,
@@ -1779,7 +1783,7 @@ def register_hooks_routes(
             parent=parent,
             # A pinned routed parent confines its spawns to its own family, so
             # the pane's own family is not the only one that matters.
-            parent_harness=_resolve_harness(parent) if parent is not None else None,
+            parent_harness=parent_harness,
             route_turn=_route,
             reuse_create_route=_reuse_create_route,
             pin=_pin,

--- a/tests/runtime/test_agent_cache.py
+++ b/tests/runtime/test_agent_cache.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import io
 import tarfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -493,3 +495,97 @@ def test_replace_swaps_spec(
     # Subsequent load() returns the new spec from memory cache
     loaded_again = agent_cache.load("agent-5", loc_v2)
     assert loaded_again.spec is loaded_v2.spec
+
+
+@pytest.mark.parametrize("operation", ["miss", "replace", "evict"])
+def test_same_agent_waits_while_other_agent_progresses(
+    agent_cache: AgentCache,
+    artifact_store: LocalArtifactStore,
+    cache_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    """A cache call cannot observe another call's incomplete disk work."""
+    import shutil
+
+    location = "agent-1/v1"
+    bundle = _store_bundle(artifact_store, location)
+    _store_bundle(artifact_store, "agent-2/v1")
+    if operation != "miss":
+        agent_cache.load("agent-1", location)
+    started, release = threading.Event(), threading.Event()
+    reader_started, reader_done = threading.Event(), threading.Event()
+    downloads = 0
+    original_get = artifact_store.get
+    original_rename = Path.rename
+    original_rmtree = shutil.rmtree
+
+    def pause() -> None:
+        started.set()
+        assert release.wait(5), "test did not release cache operation"
+
+    def get(key: str) -> bytes:
+        nonlocal downloads
+        if key == location:
+            downloads += 1
+            if operation == "miss":
+                pause()
+        return original_get(key)
+
+    def rename(source: Path, target: Path) -> Path:
+        if source == cache_dir / "agent-1_staging":
+            pause()
+        return original_rename(source, target)
+
+    def rmtree(path: Path) -> None:
+        if path == cache_dir / "agent-1":
+            pause()
+        original_rmtree(path)
+
+    def read():  # type: ignore[no-untyped-def]
+        reader_started.set()
+        try:
+            return agent_cache.load("agent-1", location)
+        finally:
+            reader_done.set()
+
+    monkeypatch.setattr(artifact_store, "get", get)
+    if operation == "replace":
+        monkeypatch.setattr(Path, "rename", rename)
+    elif operation == "evict":
+        monkeypatch.setattr(shutil, "rmtree", rmtree)
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        if operation == "miss":
+            writing = pool.submit(agent_cache.load, "agent-1", location)
+        elif operation == "replace":
+            writing = pool.submit(agent_cache.replace, "agent-1", location, bundle)
+        else:
+            writing = pool.submit(agent_cache.evict, "agent-1")
+        try:
+            assert started.wait(5)
+            reading = pool.submit(read)
+            assert reader_started.wait(5)
+            other = pool.submit(agent_cache.load, "agent-2", "agent-2/v1").result(5)
+            assert (other.workdir / "config.yaml").is_file()
+            assert not reader_done.wait(0.1)
+        finally:
+            release.set()
+        writing.result(5)
+        loaded = reading.result(5)
+    assert (loaded.workdir / "config.yaml").is_file()
+    assert loaded.spec is agent_cache.load("agent-1", location).spec
+    if operation == "miss":
+        assert downloads == 1
+
+
+def test_cache_lock_released_after_error(
+    agent_cache: AgentCache, artifact_store: LocalArtifactStore
+) -> None:
+    with pytest.raises(KeyError):
+        agent_cache.load("agent-1", "agent-1/missing")
+    _store_bundle(artifact_store, "agent-1/v1")
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        loaded = pool.submit(agent_cache.load, "agent-1", "agent-1/v1").result(5)
+    assert (loaded.workdir / "config.yaml").is_file()
+    assert not agent_cache._locks

--- a/tests/server/integration/test_agent_cache_responsiveness.py
+++ b/tests/server/integration/test_agent_cache_responsiveness.py
@@ -1,0 +1,107 @@
+"""Event-loop coverage for Server routes that mutate the agent cache."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runtime import get_conversation_store
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.routes._sessions.orchestration import _native_pane_harness
+from tests.server.helpers import build_agent_bundle, create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+@asynccontextmanager
+async def cache_pause(monkeypatch: pytest.MonkeyPatch, method: str) -> AsyncIterator[None]:
+    """Let the loop release a blocked cache call; direct calls time out."""
+    started, release = threading.Event(), threading.Event()
+    original = getattr(AgentCache, method)
+
+    def blocked(self: AgentCache, *args: Any, **kwargs: Any):  # type: ignore[no-untyped-def]
+        started.set()
+        assert release.wait(timeout=2), "cache work blocked the event loop"
+        return original(self, *args, **kwargs)
+
+    async def heartbeat() -> None:
+        try:
+            assert await asyncio.to_thread(started.wait, 2)
+            await asyncio.sleep(0)
+        finally:
+            release.set()
+
+    monkeypatch.setattr(AgentCache, method, blocked)
+    pulse = asyncio.create_task(heartbeat())
+    try:
+        yield
+        await pulse
+    finally:
+        release.set()
+        await pulse
+
+
+async def test_update_agent_cache_waits_do_not_block_event_loop(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contended replacement and response loading both yield to the event loop."""
+    agent = await create_test_agent(
+        client,
+        name="cache-responsive-agent",
+        description="original",
+    )
+    updated_bundle = build_agent_bundle(
+        name="cache-responsive-agent",
+        description="updated",
+    )
+    async with cache_pause(monkeypatch, "replace"), cache_pause(monkeypatch, "load"):
+        response = await client.put(
+            f"/v1/sessions/{agent['_session_id']}/agent",
+            files={"bundle": ("agent.tar.gz", updated_bundle, "application/gzip")},
+        )
+    assert response.status_code == 200, response.text
+    assert response.json()["id"] == agent["id"]
+
+
+async def test_no_override_native_pane_resolution_does_not_block_event_loop(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native-pane routing resolves its bound harness without blocking."""
+    agent = await create_test_agent(
+        client,
+        name="harness-responsive-agent",
+        executor={"type": "omnigent", "config": {"harness": "codex-native"}},
+    )
+    conversation_store = get_conversation_store()
+    conv = await asyncio.to_thread(
+        conversation_store.get_conversation,
+        agent["_session_id"],
+    )
+    assert conv is not None
+    assert conv.harness_override is None
+
+    async with cache_pause(monkeypatch, "load"):
+        assert await _native_pane_harness(conv) == "codex-native"
+
+
+async def test_patch_model_override_non_native_check_does_not_block_event_loop(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The PATCH route's no-override SDK classification yields during cache load."""
+    agent = await create_test_agent(client, name="sdk-classification-responsive-agent")
+    async with cache_pause(monkeypatch, "load"):
+        response = await client.patch(
+            f"/v1/sessions/{agent['_session_id']}",
+            json={"model_override": "databricks-gpt-5-4"},
+        )
+    assert response.status_code == 200, response.text
+    assert response.json()["model_override"] == "databricks-gpt-5-4"


### PR DESCRIPTION
## Related issue

Closes #6166

## Summary

- Serialize same-Agent cache loads, replacements and evictions so memory hits cannot return during an unfinished disk swap and concurrent misses extract only once.
- Move cache-backed request work onto worker threads before introducing lock waits; unrelated Agents and unrelated Server requests remain responsive.
- Preserve upstream cache-path validation and environment-expansion provenance.

ELI5: each Agent's cache finishes changing before it is read, without freezing other requests.

```mermaid
flowchart LR
  Request[Async request] --> Worker[Worker thread]
  Worker --> Lock[Per-Agent lock]
  Lock --> Cache[Complete cache operation]
  Other[Other requests / Agents] --> Progress[Independent progress]
```

## Review stack and integration scope

This existing PR now carries the complete top-of-stack implementation at `99f01e2f2d9c7b035d6107bd805274ea7b085926`, rather than only the offload prefix. Both incremental review PRs are available together in the fork:

1. [Event-loop offload — +211/-61, 272 lines](https://github.com/pandalaohe/omnigent/pull/6)
2. [Per-Agent serialization — +137/-7, 144 lines](https://github.com/pandalaohe/omnigent/pull/7)

The fork PRs form a native review stack rooted at a clean upstream snapshot. This PR remains the official integration owner; the fork stack is not an upstream-native stack and its checks do not replace this PR's checks.

**Aggregate carrier diff: +348/-68 = 416 lines across 10 files.** This PR carries exactly the two review layers listed above, with no additional hunks. Each incremental layer is below the 300-line baseline (272 and 144, including its regression tests). The stack total has no 300-line cap; this carrier is not an additional review layer. No additional upstream PR or duplicate issue is introduced.

## Test Plan

Fixed baseline: `88194b59154d8cfa0299c4ebf52ed8bdcefaa52f`. Full candidate head: `99f01e2f2d9c7b035d6107bd805274ea7b085926`.

- `python -m pytest -q tests/runtime/test_agent_cache.py tests/server/integration/test_agent_cache_responsiveness.py`: 50 passed on Windows and Linux. The three event-loop cases also pass on the offload prefix alone.
- Selected Agent/session routes: 130 passed on Windows.
- Selected native routing, snapshot and smart-routing matrix: 356 passed on Windows; eight optional-SDK cases reran successfully on Linux after Windows reported the missing dependency. Total distinct selected cases with passing evidence: 544.
- Six negative controls fail on unmodified upstream: three same-Agent races and three event-loop responsiveness cases.
- Canonical pre-commit passed for all 10 changed files, including full Linux Pyrefly in a lint dependency environment matching the workflow's capability selection. Installing the additional Databricks SDK exposes one existing type error in the unchanged OpenCode provider; that extra-capability result is recorded separately.
- Request-path call-graph inspection and `git diff --check` passed. New hosted checks and maintainer approval must evaluate this new complete head; the former head's green checks are not reused as acceptance.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Controlled threads pause real cache operations while other calls or an ASGI event loop must progress. The synchronization is scoped to one cache instance; failed-swap filesystem rollback, cross-process coordination and immutable returned workdir snapshots are not introduced. All fixtures are synthetic; no live model calls, screenshots or deployed-platform claims are needed.

## Changelog

Concurrent Agent loading and updates keep cache results consistent while unrelated Server requests remain responsive.

## Issues

Resolves [OMNI-5959](https://linear.app/omnigent/issue/OMNI-5959/bug-concurrent-agentcache-operations-can-expose-a-partially-replaced)
