### PR TITLE
feat(policies): add audit logs for session policy API mutations

### DIFF
--- a/omnigent/server/routes/session_policies.py
+++ b/omnigent/server/routes/session_policies.py
@@ -10,6 +10,7 @@ view. Spec policies have ``id=None`` and cannot be patched or deleted.
 
 from __future__ import annotations
 
+import logging
 import re
 import uuid
 from typing import Any
@@ -42,6 +43,8 @@ from omnigent.telemetry import emit as _tel_emit
 from omnigent.telemetry.events import PolicyDeletedEvent as _TelPolicyDeletedEvent
 from omnigent.telemetry.events import PolicyRegisteredEvent as _TelPolicyRegisteredEvent
 from omnigent.telemetry.installation_id import get_installation_id as _get_installation_id
+
+_logger = logging.getLogger(__name__)
 
 
 def _generate_policy_id() -> str:
@@ -212,6 +215,13 @@ def create_session_policies_router(
                 code=ErrorCode.CONFLICT,
             ) from exc
         invalidate_session_policy_specs_cache(session_id)
+        _logger.info(
+            "session_policies/create: user=%s created policy_id=%s session_id=%s handler=%s",
+            user_id or "(single-user)",
+            policy.id,
+            session_id,
+            policy.handler,
+        )
         try:
             import hashlib as _hashlib
 
@@ -373,6 +383,12 @@ def create_session_policies_router(
         if policy is None:
             raise OmnigentError("Policy not found", code=ErrorCode.NOT_FOUND)
         invalidate_session_policy_specs_cache(session_id)
+        _logger.info(
+            "session_policies/update: user=%s updated policy_id=%s session_id=%s",
+            user_id or "(single-user)",
+            policy_id,
+            session_id,
+        )
         return _entity_to_response(policy)
 
     @router.delete("/sessions/{session_id}/policies/{policy_id}")
@@ -403,6 +419,12 @@ def create_session_policies_router(
             )
         store.delete(policy_id, session_id)
         invalidate_session_policy_specs_cache(session_id)
+        _logger.info(
+            "session_policies/delete: user=%s deleted policy_id=%s session_id=%s",
+            user_id or "(single-user)",
+            policy_id,
+            session_id,
+        )
         try:
             import hashlib as _hashlib
 

--- a/tests/server/routes/test_session_policies_crud.py
+++ b/tests/server/routes/test_session_policies_crud.py
@@ -296,3 +296,64 @@ async def test_create_session_policy_no_telemetry_on_error(
         )
     assert resp.status_code == 409
     mock_emit.assert_not_called()
+
+
+# ── Audit logging ─────────────────────────────────────────────────────
+
+
+async def test_create_session_policy_logs_audit(
+    client: httpx.AsyncClient,
+    session_id: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``POST /v1/sessions/{id}/policies`` emits an audit log line."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="omnigent.server.routes.session_policies"):
+        resp = await client.post(f"/v1/sessions/{session_id}/policies", json=_policy_payload())
+    assert resp.status_code == 200
+    pid = resp.json()["id"]
+    assert "session_policies/create" in caplog.text
+    assert pid in caplog.text
+    assert session_id in caplog.text
+    assert "(single-user)" in caplog.text
+
+
+async def test_update_session_policy_logs_audit(
+    client: httpx.AsyncClient,
+    session_id: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``PATCH /v1/sessions/{id}/policies/{pid}`` emits an audit log line."""
+    import logging
+
+    create_resp = await client.post(f"/v1/sessions/{session_id}/policies", json=_policy_payload())
+    pid = create_resp.json()["id"]
+    with caplog.at_level(logging.INFO, logger="omnigent.server.routes.session_policies"):
+        resp = await client.patch(
+            f"/v1/sessions/{session_id}/policies/{pid}", json={"name": "renamed"}
+        )
+    assert resp.status_code == 200
+    assert "session_policies/update" in caplog.text
+    assert pid in caplog.text
+    assert session_id in caplog.text
+    assert "(single-user)" in caplog.text
+
+
+async def test_delete_session_policy_logs_audit(
+    client: httpx.AsyncClient,
+    session_id: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``DELETE /v1/sessions/{id}/policies/{pid}`` emits an audit log line."""
+    import logging
+
+    create_resp = await client.post(f"/v1/sessions/{session_id}/policies", json=_policy_payload())
+    pid = create_resp.json()["id"]
+    with caplog.at_level(logging.INFO, logger="omnigent.server.routes.session_policies"):
+        resp = await client.delete(f"/v1/sessions/{session_id}/policies/{pid}")
+    assert resp.status_code == 200
+    assert "session_policies/delete" in caplog.text
+    assert pid in caplog.text
+    assert session_id in caplog.text
+    assert "(single-user)" in caplog.text


### PR DESCRIPTION
## Summary

- `POST /v1/sessions/{id}/policies`, `PATCH /v1/sessions/{id}/policies/{pid}`, and `DELETE /v1/sessions/{id}/policies/{pid}` now emit `INFO`-level audit log lines via the standard Python logger (`omnigent.server.routes.session_policies`)
- Each line includes: operation (`session_policies/create|update|delete`), the full caller user ID, `policy_id`, and `session_id`; `create` additionally logs the handler
- In single-user mode (no auth provider), `(single-user)` is logged as the identity
- Matches the pattern introduced for admin policy mutations in #6126

## Test Plan

- Added `test_create_session_policy_logs_audit`, `test_update_session_policy_logs_audit`, and `test_delete_session_policy_logs_audit` in `tests/server/routes/test_session_policies_crud.py`
- Each test uses `caplog.at_level` to assert the operation keyword, `policy_id`, and `session_id` all appear in the log
- All 18 tests in the file pass: `python -m pytest tests/server/routes/test_session_policies_crud.py -x -q`

## Demo

N/A — no UI change

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Test coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual verification completed
- [ ] Not applicable

## Coverage notes

N/A