### PR TITLE
feat(ios): enable iPad support

### DIFF
--- a/tests/e2e_ui/mobile/test_ios_ipad_safe_layout.py
+++ b/tests/e2e_ui/mobile/test_ios_ipad_safe_layout.py
@@ -1,0 +1,71 @@
+"""E2E: the iOS shell applies safe-area and keyboard layout at iPad widths."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+_IPAD_VIEWPORT = {"width": 1024, "height": 768}
+_IPAD_SAFE_AREA = {"top": 24, "left": 0, "bottom": 20, "right": 0}
+_KEYBOARD_TOP = 500
+
+_IOS_SHELL_INIT_SCRIPT = """
+window.omnigentNative = {
+  kind: "ios",
+  setBadgeCount: function () {},
+  notify: function () { return Promise.resolve(false); },
+  onNotificationActivated: function () { return function () {}; },
+  onOpenPath: function () { return function () {}; },
+  onNativeInsets: function () { return function () {}; },
+  onSidebarDrag: function () { return function () {}; },
+  onViewModeChanged: function () { return function () {}; },
+  setViewMode: function () {},
+  setServerSwitcherHidden: function () {},
+  setSidebarOpen: function () {},
+};
+"""
+
+
+def test_ios_ipad_keeps_header_and_composer_in_visible_viewport(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Keep floating controls below the status bar and the composer above the keyboard."""
+    base_url, session_id = seeded_session
+    page.set_viewport_size(_IPAD_VIEWPORT)
+    page.add_init_script(_IOS_SHELL_INIT_SCRIPT)
+    cdp = page.context.new_cdp_session(page)
+    cdp.send("Emulation.setSafeAreaInsetsOverride", {"insets": _IPAD_SAFE_AREA})
+
+    page.goto(f"{base_url}/c/{session_id}")
+    app_shell = page.locator(".app-shell")
+    expect(app_shell).to_have_attribute("data-ios-native", "true")
+
+    close_sidebar = page.get_by_role("button", name="Close sidebar", exact=True)
+    expect(close_sidebar).to_be_visible()
+    close_sidebar.click()
+    open_sidebar = page.get_by_role("button", name="Open sidebar", exact=True)
+    expect(open_sidebar).to_be_visible()
+
+    toggle_box = open_sidebar.bounding_box()
+    assert toggle_box is not None
+    assert toggle_box["y"] >= _IPAD_SAFE_AREA["top"], (
+        f"sidebar toggle starts at y={toggle_box['y']:.0f}, inside the "
+        f"{_IPAD_SAFE_AREA['top']}px iPad status-bar safe area"
+    )
+
+    composer = page.locator('textarea[aria-label="Message the agent"]')
+    expect(composer).to_be_visible(timeout=15_000)
+    page.evaluate(
+        "height => document.documentElement.style"
+        ".setProperty('--omnigent-viewport-height', `${height}px`)",
+        _KEYBOARD_TOP,
+    )
+    expect(app_shell).to_have_css("height", f"{_KEYBOARD_TOP}px")
+
+    composer_box = composer.bounding_box()
+    assert composer_box is not None
+    composer_bottom = composer_box["y"] + composer_box["height"]
+    assert composer_bottom <= _KEYBOARD_TOP + 1, (
+        f"composer bottom is y={composer_bottom:.0f}, behind the simulated "
+        f"keyboard starting at y={_KEYBOARD_TOP}"
+    )

--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -556,7 +556,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -587,7 +587,7 @@
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -610,7 +610,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Omnigent.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Omnigent";
 			};
 			name = Debug;
@@ -634,7 +634,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Omnigent.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Omnigent";
 			};
 			name = Release;
@@ -657,7 +657,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Omnigent;
 			};
 			name = Debug;
@@ -680,7 +680,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Omnigent;
 			};
 			name = Release;

--- a/web/ios/Omnigent/Info-Debug.plist
+++ b/web/ios/Omnigent/Info-Debug.plist
@@ -56,5 +56,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/web/ios/Omnigent/Info-Release.plist
+++ b/web/ios/Omnigent/Info-Release.plist
@@ -51,5 +51,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>

--- a/web/ios/OmnigentTests/ServerURLTests.swift
+++ b/web/ios/OmnigentTests/ServerURLTests.swift
@@ -51,6 +51,30 @@ final class ServerURLTests: XCTestCase {
   }
 }
 
+final class AppDeviceSupportTests: XCTestCase {
+  func testAppSupportsIPhoneAndIPad() throws {
+    let deviceFamilies = try XCTUnwrap(
+      Bundle.main.object(forInfoDictionaryKey: "UIDeviceFamily") as? [Int])
+
+    XCTAssertEqual(deviceFamilies, [1, 2])
+  }
+
+  func testIPadSupportsAllOrientations() throws {
+    let orientations = try XCTUnwrap(
+      Bundle.main.object(forInfoDictionaryKey: "UISupportedInterfaceOrientations~ipad")
+        as? [String])
+
+    XCTAssertEqual(
+      Set(orientations),
+      Set([
+        "UIInterfaceOrientationPortrait",
+        "UIInterfaceOrientationPortraitUpsideDown",
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight",
+      ]))
+  }
+}
+
 final class AppPrivacyInfoTests: XCTestCase {
   func testPrivacyUsageDescriptionsArePresent() throws {
     for key in [

--- a/web/ios/README.md
+++ b/web/ios/README.md
@@ -1,12 +1,13 @@
 # Omnigent iOS
 
-Thin SwiftUI/WKWebView shell for Omnigent. Like the Electron app, this target
-loads the server-served web UI instead of shipping a duplicate copy of the SPA.
+Thin SwiftUI/WKWebView shell for Omnigent on iPhone and iPad. Like the Electron
+app, this target loads the server-served web UI instead of shipping a duplicate
+copy of the SPA.
 
 ## Development
 
 Open `Omnigent.xcodeproj` in Xcode 26 or newer and run the `Omnigent` scheme on
-an iOS 26 simulator.
+an iOS 26 iPhone or iPad simulator.
 
 Debug builds allow `http://` web content for local development by enabling
 `NSAllowsArbitraryLoadsInWebContent`. Release builds keep App Transport

--- a/web/ios/RELEASE.md
+++ b/web/ios/RELEASE.md
@@ -70,10 +70,11 @@ the latest uploaded TestFlight build and uploads `fastlane/metadata` plus
 ## Other commands
 
 - `bundle exec fastlane tests` — run the `OmnigentTests` unit suite.
-- `bundle exec fastlane screenshots` — build and capture App Store screenshots
-  into `fastlane/screenshots` using the `OmnigentUITests` snapshot target. The
-  lane rebuilds the web UI, starts an isolated local Omnigent server via `uv` on
-  a non-6767 port, and connects the simulator to that server automatically.
+- `bundle exec fastlane screenshots` — build and capture iPhone and iPad App
+  Store screenshots into `fastlane/screenshots` using the `OmnigentUITests`
+  snapshot target. The lane rebuilds the web UI, starts an isolated local
+  Omnigent server via `uv` on a non-6767 port, and connects each simulator to
+  that server automatically.
 - `bundle exec fastlane release` — upload a new binary to App Store Connect
   without submitting it for review. Prefer `prod` after a TestFlight build is
   already uploaded.

--- a/web/ios/fastlane/Fastfile
+++ b/web/ios/fastlane/Fastfile
@@ -139,10 +139,10 @@ platform :ios do
 
     app_path = File.join(build_dir, "Build/Products/Debug-iphonesimulator/Omnigent.app")
 
-    # Boot, install, and launch
-    sh("xcrun simctl boot '#{device}' || true") # || true so already-booted is fine
-    sh("xcrun simctl install booted '#{app_path}'")
-    sh("xcrun simctl launch booted ai.omnigent.ios")
+    # Wait for the selected simulator rather than racing its boot process.
+    sh("xcrun simctl bootstatus '#{device}' -b")
+    sh("xcrun simctl install '#{device}' '#{app_path}'")
+    sh("xcrun simctl launch '#{device}' ai.omnigent.ios")
 
     UI.success("Launched on #{device}")
   end

--- a/web/ios/fastlane/Snapfile
+++ b/web/ios/fastlane/Snapfile
@@ -5,7 +5,8 @@ only_testing(["OmnigentUITests/OmnigentUITests/testLocalServerSnapshot"])
 configuration("Debug")
 
 devices([
-  "iPhone 17 Pro Max"
+  "iPhone 17 Pro Max",
+  "iPad Pro 13-inch (M5)"
 ])
 
 languages([

--- a/web/ios/fastlane/metadata/en-US/description.txt
+++ b/web/ios/fastlane/metadata/en-US/description.txt
@@ -1,6 +1,6 @@
 Omnigent is the mobile companion for your Omnigent server: an open-source workspace for supervising AI agents across coding, research, automation, and other technical workflows.
 
-Connect to a server you run, sign in, and continue the same sessions you use from desktop or browser. Follow agent work from your phone, send messages, review outputs, and switch between sessions without losing context.
+Connect to a server you run, sign in, and continue the same sessions you use from desktop or browser. Follow agent work from your iPhone or iPad, send messages, review outputs, and switch between sessions without losing context.
 
 Use Omnigent to:
 

--- a/web/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/web/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Connect your iPhone to Omnigent and keep agent sessions, chats, files, and terminals within reach wherever your server is running.
+Connect your iPhone or iPad to Omnigent and keep agent sessions, chats, files, and terminals within reach wherever your server is running.

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -666,28 +666,30 @@ aside[aria-label="Workspace"][data-maximized] {
   display: none;
 }
 
-/* iOS native shell (SwiftUI/WKWebView) runs the webview full-screen under the
- * system status bar and home indicator. Keep the web app visually full-bleed,
- * but move interactive mobile chrome out of unsafe areas. Scoped to the native
- * bridge marker so normal iOS Safari keeps its existing browser-safe layout. */
-@media (width < 48rem) {
-  [data-ios-native].app-shell {
-    /* Lock the shell to the live visual viewport so the soft keyboard can never
-       pan the whole document (which hides the header). --omnigent-viewport-
-       height is published by useIOSViewportLock from visualViewport.height; it
-       shrinks when the keyboard opens so inputs stay above it and only inner
-       panes scroll. Falls back to the large viewport before JS runs / on older
-       WebKit. The two-line pattern keeps the lvh fallback for browsers without
-       the var. */
-    height: 100lvh;
-    height: var(--omnigent-viewport-height, 100lvh);
-    min-height: 100lvh;
-    min-height: var(--omnigent-viewport-height, 100lvh);
-    max-height: 100lvh;
-    max-height: var(--omnigent-viewport-height, 100lvh);
-    overflow: hidden;
-  }
+/* The iOS WKWebView runs full-screen under the keyboard at every responsive
+ * width. Lock the shell to the visual viewport published by
+ * useIOSViewportLock so flow content, including the composer, stays visible. */
+[data-ios-native].app-shell {
+  height: 100lvh;
+  height: var(--omnigent-viewport-height, 100lvh);
+  min-height: 100lvh;
+  min-height: var(--omnigent-viewport-height, 100lvh);
+  max-height: 100lvh;
+  max-height: var(--omnigent-viewport-height, 100lvh);
+  overflow: hidden;
+}
 
+/* Native shells render beneath the status bar at every width. Keep floating
+ * chat controls and the pinned Plan tracker below its safe area. */
+:is([data-ios-native], [data-android-native]) .chat-header {
+  top: max(0px, calc(var(--omnigent-safe-top) - 0.5rem));
+}
+:is([data-ios-native], [data-android-native]) .chat-plan-accordion {
+  margin-top: calc(var(--omnigent-header-height) + max(0px, var(--omnigent-safe-top) - 0.5rem));
+}
+
+/* Remaining native-shell adjustments are specific to the mobile layout. */
+@media (width < 48rem) {
   /* Slide animation for the mobile drawer. Covers BOTH paths that move the
      panel: the edge-swipe drag settles via an inline `transform`, while the
      button toggle (and the drag's resting open/closed state) is driven by
@@ -721,24 +723,6 @@ aside[aria-label="Workspace"][data-maximized] {
 
   [data-ios-native] :is(input, textarea, select, [contenteditable="true"]) {
     font-size: 16px;
-  }
-
-  /* `--omnigent-safe-top` (not raw env()) so this works on Android too, where
-     env(safe-area-inset-top) is 0 in the WebView and the OS inset arrives via
-     the native-injected `--omnigent-android-safe-area-top`. On iOS the var folds
-     down to env(), so the iOS result is unchanged. */
-  [data-ios-native] .chat-header,
-  [data-android-native] .chat-header {
-    top: max(0px, calc(var(--omnigent-safe-top) - 0.5rem));
-  }
-
-  /* The pinned Plan tracker clears the floating header with a fixed mt-14
-     tuned for the web header at top: 0. Native shells shift the header down
-     by the rule above, so fold the same offset into the tracker's margin or
-     the header's floating controls land on top of the Plan bar. */
-  [data-ios-native] .chat-plan-accordion,
-  [data-android-native] .chat-plan-accordion {
-    margin-top: calc(var(--omnigent-header-height) + max(0px, var(--omnigent-safe-top) - 0.5rem));
   }
 
   [data-ios-native] .chat-conversation-content,

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -174,6 +174,29 @@ describe("index.css app-shell viewport lock", () => {
   });
 });
 
+const allWidthNativeLayoutRules = [
+  ["iOS keyboard viewport", "[data-ios-native].app-shell", "--omnigent-viewport-height"],
+  ["native chat header", ".chat-header", "--omnigent-safe-top"],
+  ["native Plan tracker", ".chat-plan-accordion", "--omnigent-safe-top"],
+] as const;
+
+describe("index.css native tablet layout", () => {
+  it.each(allWidthNativeLayoutRules)(
+    "keeps the %s rule outside width media queries",
+    (_, selector, value) => {
+      const matches = cssBlocks.filter(
+        ([block]) => block.includes(selector) && block.includes(value),
+      );
+      expect(matches, `missing the all-width ${selector} rule`).toHaveLength(1);
+
+      const before = cssSource.slice(0, matches[0].index!);
+      const opens = (before.match(/\{/g) ?? []).length;
+      const closes = (before.match(/\}/g) ?? []).length;
+      expect(opens - closes, `${selector} must not sit inside an at-rule`).toBe(0);
+    },
+  );
+});
+
 /* The unified native-panel rule: one ungated :is() list covering the
  * Workspace rail, the conversations sidebar, and every push panel / rail-tab
  * drawer. The assertions below apply it verbatim — media-stripping a gated


### PR DESCRIPTION
## Related issue

[OMNI-5719](https://linear.app/omnigent/issue/OMNI-5719/enable-ipad)

## Summary

- Make the native iOS shell available as a universal iPhone and iPad app, with all iPad orientations required for multitasking.
- Cover the processed device metadata with focused tests and include iPad in screenshot automation, release docs, and App Store copy.

## Test Plan

- `xcodebuild test -project web/ios/Omnigent.xcodeproj -scheme Omnigent -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M5)' -only-testing:OmnigentTests/AppDeviceSupportTests`
- `xcodebuild build -quiet -project web/ios/Omnigent.xcodeproj -scheme Omnigent -configuration Release -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M5)'`
- `plutil -lint web/ios/Omnigent/Info-Debug.plist web/ios/Omnigent/Info-Release.plist`

## Demo

https://github.com/user-attachments/assets/1849e35a-dedf-4b12-b892-eb101dcb6872



## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused unit tests verify the built app's device-family and orientation metadata on an iPad simulator.

## Changelog

Use the native Omnigent app on iPad in portrait, landscape, and multitasking layouts.
