### PR TITLE
polish(web): rework the "+" shell menu for discoverability [OMNI-5864]

### DIFF
--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -443,10 +443,10 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     await waitFor(() => expect(screen.queryByRole("menuitem", { name: /shell/i })).toBeNull());
   });
 
-  it("launches the default shell directly when several are declared (type selection is optional)", async () => {
-    // Multiple declared terminals → "Shell" nests a submenu to pick a type, but
-    // clicking it directly launches the default (declared[0]) without forcing a
-    // selection.
+  it("launches the default shell from the top 'Shell' item when several are declared", async () => {
+    // Multiple declared terminals → a top "Shell" item launches the default
+    // (declared[0] with no prior pick); the types live in the "More shells"
+    // flyout below.
     useSessionAgentMock.mockReturnValue({
       data: { terminals: ["zsh", "bash", "fish"] },
     } as unknown as ReturnType<typeof useSessionAgent>);
@@ -462,16 +462,15 @@ describe('WorkspacePanel "+" new-tab menu', () => {
 
     const { openTerminalTab } = renderWorkspace({ showBrowserTab: false });
 
-    // Open the "+" menu and click the "Shell" submenu trigger directly.
+    // Open the "+" menu and click the top "Shell" item (not "More shells").
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: /shell/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^shell$/i }));
 
     // Launches the default (first-declared) shell without a further pick.
     expect(mutate).toHaveBeenCalledWith("zsh", expect.any(Object));
     expect(openTerminalTab).toHaveBeenCalledWith("terminal:terminal_zsh_s1");
 
-    // The menu closes on its own — the submenu trigger's preventDefault would
-    // otherwise leave it stuck open, needing a second click to dismiss.
+    // The menu closes on its own after the launch.
     await waitFor(() => expect(screen.queryByRole("menuitem", { name: /shell/i })).toBeNull());
 
     // Focus is not restored to the "+" trigger on close — that focus return is
@@ -479,7 +478,7 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     expect(screen.getByRole("button", { name: "Open new" })).not.toHaveFocus();
   });
 
-  it("remembers the picked shell type as the new default (persisted + check-marked)", async () => {
+  it("remembers the flyout-picked shell type as the new default (persisted)", async () => {
     window.localStorage.removeItem("omnigent:preferred-shell");
     useSessionAgentMock.mockReturnValue({
       data: { terminals: ["zsh", "bash", "fish"] },
@@ -493,18 +492,18 @@ describe('WorkspacePanel "+" new-tab menu', () => {
 
     renderWorkspace({ showBrowserTab: false });
 
-    // Open the submenu (ArrowRight — a plain click on "Shell" launches the
-    // default instead) and pick "bash", which persists as the preferred type.
+    // Open the "More shells" flyout (ArrowRight) and pick "bash", which persists
+    // as the preferred type under the app-global key.
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    const shellTrigger = await screen.findByRole("menuitem", { name: /shell/i });
-    shellTrigger.focus();
-    fireEvent.keyDown(shellTrigger, { key: "ArrowRight" });
+    const moreShells = await screen.findByRole("menuitem", { name: /more shells/i });
+    moreShells.focus();
+    fireEvent.keyDown(moreShells, { key: "ArrowRight" });
     fireEvent.click(await screen.findByRole("menuitem", { name: /^bash$/i }));
     expect(mutate).toHaveBeenCalledWith("bash", expect.any(Object));
     expect(window.localStorage.getItem("omnigent:preferred-shell")).toBe("bash");
 
-    // A fresh menu seeds its default from the persisted pick — clicking "Shell"
-    // now launches bash without opening the submenu.
+    // A fresh menu seeds its default from the persisted pick — the top "Shell"
+    // item now launches bash.
     cleanup();
     mutate.mockClear();
     useSessionAgentMock.mockReturnValue({
@@ -512,7 +511,7 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     } as unknown as ReturnType<typeof useSessionAgent>);
     renderWorkspace({ showBrowserTab: false });
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: /shell/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: /^shell$/i }));
     expect(mutate).toHaveBeenCalledWith("bash", expect.any(Object));
 
     window.localStorage.removeItem("omnigent:preferred-shell");

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -1,6 +1,5 @@
 import {
   BotIcon,
-  CheckIcon,
   FileIcon,
   FolderTreeIcon,
   FileDiffIcon,
@@ -8,6 +7,7 @@ import {
   Loader2Icon,
   MaximizeIcon,
   MinimizeIcon,
+  MoreHorizontalIcon,
   PlusIcon,
   TerminalIcon,
   XIcon,
@@ -83,11 +83,12 @@ function readPreferredShell(): string | null {
 
 // ---------------------------------------------------------------------------
 // NewTabMenu — the "+" affordance in the tab strip. Opens a small dropdown
-// ("Open new") to spin up a Shell as a rail tab. When the agent declares a
-// single terminal, "Shell" launches it directly; when several are declared,
-// "Shell" nests a submenu so the user picks which type to launch — the last
-// pick is remembered (check-marked, and launched on a plain "Shell" click).
-// Gated on the agent's spec declaring terminal access — renders nothing else.
+// ("Open new") to spin up a Shell as a rail tab. A top "Shell" item launches
+// the remembered default (the last-picked type, else the first declared name);
+// when several types are declared, a "More shells" flyout lists them all so the
+// user can pick a specific one (remembered as the new default). The flyout
+// trigger only reveals the submenu — it never launches. Gated on the agent's
+// spec declaring terminal access — renders nothing else.
 //
 // The "Shell" item also reflects the session's liveness so opening a shell on
 // a disconnected session isn't a silent 502:
@@ -150,10 +151,7 @@ function NewTabMenu({
   // Remembered shell type, persisted across remounts/reloads. Seeded from
   // localStorage so the "+" in either strip spot agrees on the current pick.
   const [preferred, setPreferred] = useState<string | null>(() => readPreferredShell());
-  // Controlled so a launch can force the menu closed. The submenu "Shell"
-  // trigger preventDefaults its click (to launch the default without toggling
-  // the submenu), which also suppresses Radix's auto-close — leaving the menu
-  // stuck open until a second click. Closing here fixes that.
+  // Controlled so a launch can force the menu closed on select.
   const [menuOpen, setMenuOpen] = useState(false);
   // Shell access mirrors NewTerminalButton's gate: the agent's spec must
   // declare a non-empty ``terminals:`` block.
@@ -192,8 +190,8 @@ function NewTabMenu({
     launchShell(name);
   };
 
-  // One declared shell → a direct "Shell" action. Several → a nested submenu
-  // so the user picks which type to launch (mirrors NewTerminalButton's picker).
+  // One declared shell → just the "Shell" item. Several → a "More shells"
+  // flyout to pick a specific type.
   const multipleShells = declaredTerminals.length > 1;
 
   // Liveness-derived affordance for the "Shell" item. A create in flight on a
@@ -201,8 +199,8 @@ function NewTabMenu({
   // an offline session disables the item since the browser can't reconnect it.
   const isReconnecting = create.isPending && connectState === "wakeable";
   const shellDisabled = create.isPending || connectState === "offline";
-  // Icon + label + trailing hint, shared by the single-item and submenu-trigger
-  // renders so both reflect the same connect state.
+  // Icon + label + trailing hint for the "Shell" item, reflecting the connect
+  // state.
   const shellItemContent = (
     <>
       {isReconnecting ? (
@@ -246,21 +244,18 @@ function NewTabMenu({
             paint over the dropdown (#3980). Only this rail menu needs it. */}
         <SuppressBrowserView />
         <DropdownMenuLabel>Open new</DropdownMenuLabel>
-        {multipleShells ? (
+        {/* Remembered default shell — the direct-launch item. */}
+        <DropdownMenuItem onSelect={() => launchShell(defaultShell)} disabled={shellDisabled}>
+          {shellItemContent}
+        </DropdownMenuItem>
+        {/* Other declared types live behind a flyout whose trigger only reveals
+            the submenu — it never launches, so the type list stays discoverable.
+            Picking one launches it and remembers it as the new default. */}
+        {multipleShells && (
           <DropdownMenuSub>
-            {/* Clicking "Shell" launches the remembered default immediately —
-                the type selection is optional. Hover/right-arrow still opens the
-                submenu to pick a specific type. onClick fires the default and
-                lets the menu close on its own; preventDefault stops the click
-                from only toggling the submenu open. */}
-            <DropdownMenuSubTrigger
-              disabled={shellDisabled}
-              onClick={(e) => {
-                e.preventDefault();
-                launchShell(defaultShell);
-              }}
-            >
-              {shellItemContent}
+            <DropdownMenuSubTrigger disabled={shellDisabled}>
+              <MoreHorizontalIcon className="size-4" />
+              <span className="whitespace-nowrap">More shells</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {declaredTerminals.map((name) => (
@@ -269,21 +264,11 @@ function NewTabMenu({
                   onSelect={() => pickShell(name)}
                   disabled={shellDisabled}
                 >
-                  <CheckIcon
-                    className={cn("size-4", name === defaultShell ? "opacity-100" : "opacity-0")}
-                  />
                   {name}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-        ) : (
-          <DropdownMenuItem
-            onSelect={() => launchShell(declaredTerminals[0])}
-            disabled={shellDisabled}
-          >
-            {shellItemContent}
-          </DropdownMenuItem>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -245,7 +245,11 @@ function NewTabMenu({
         <SuppressBrowserView />
         <DropdownMenuLabel>Open new</DropdownMenuLabel>
         {/* Remembered default shell — the direct-launch item. */}
-        <DropdownMenuItem onSelect={() => launchShell(defaultShell)} disabled={shellDisabled}>
+        <DropdownMenuItem
+          onSelect={() => launchShell(defaultShell)}
+          disabled={shellDisabled}
+          className="cursor-pointer"
+        >
           {shellItemContent}
         </DropdownMenuItem>
         {/* Other declared types live behind a flyout whose trigger only reveals
@@ -263,6 +267,7 @@ function NewTabMenu({
                   key={name}
                   onSelect={() => pickShell(name)}
                   disabled={shellDisabled}
+                  className="cursor-pointer"
                 >
                   {name}
                 </DropdownMenuItem>


### PR DESCRIPTION
## Related issue

Linear: [OMNI-5864 — Polish Shells UX](https://linear.app/omnigent/issue/OMNI-5864/polish-shells-ux)

<!-- No GitHub issue; tracked in Linear. The branch name carries the OMNI-5864 identifier so Linear auto-links this PR. -->

## Summary

Restyles the workspace **"+ → Open new"** shell menu. **Dropdown layout only — the shell-selection logic is unchanged from main.**

- The menu now leads with a single **"Shell"** item that launches the remembered default (the last-picked type, else the first declared shell).
- When several types are declared, they move behind a **"More shells"** flyout with a three-dot (⋯) trigger.
- The flyout trigger is **non-actionable** — it only opens the submenu, never launches — so the type list stays discoverable. Previously the "Shell" submenu trigger launched the default on click, hiding the picker behind that click.

No changes to the preferred-shell memoization (`readPreferredShell` / `useState` / `pickShell` / the `omnigent:preferred-shell` key) — only the JSX/layout and the two tests that asserted the old structure.

Before → after (multi-shell session):

```
before                            after
Open new                          Open new
  Shell  ▸  (click launches;        Shell             ← launches remembered default
    ✓ zsh    picker hidden)         More shells  ⋯ ▸  ← reveals types (never launches)
       bash                            zsh
       fish                            bash
                                       fish
```

## Test Plan

- `vitest run src/shell/WorkspacePanel.test.tsx` — 39 pass. The two tests for the old submenu were updated to the new layout: the top "Shell" launches the default, and the "More shells" flyout picks a type and persists it under `omnigent:preferred-shell` (unchanged key).
- `tsc -b`, `oxlint --deny-warnings`, `prettier --check` — clean on the changed files.
- Manual (for the reviewer): session with 2+ declared shells (e.g. the `polly` example: `shell` + `zsh`). Open **"+ → Open new"** → the top **"Shell"** launches directly; **"More shells" (⋯)** opens the type list; the flyout trigger only opens it. Pick a type → it's remembered as the default the top "Shell" launches next time. A single-shell session shows just "Shell", no flyout.

## Demo

- [x] Visual demo attached below

ASCII schematic in **Summary** above. A short screen recording of the flow should be attached before merge — recorded demos aren't capturable from this environment.

<img width="359" height="201" alt="Screenshot 2026-09-02 at 09 46 10" src="https://github.com/user-attachments/assets/6d639791-e4f7-4ade-b82f-6b93d924585d" />
<img width="409" height="216" alt="Screenshot 2026-09-02 at 09 46 03" src="https://github.com/user-attachments/assets/9442fd95-1908-4322-9f19-c253a8c6f5c2" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests in `WorkspacePanel.test.tsx` cover the menu structure; the purely visual affordances (three-dot icon, flyout hover) are best confirmed via the manual steps in the Test Plan.

## Changelog

Restyled the workspace "+ → Open new" shell menu — a single "Shell" launches your default shell, with the other types behind a "More shells" flyout.

---
This pull request and its description were written by Isaac.
