### PR TITLE
feat(desktop): run internal local hosts through isaac omni

### DIFF
--- a/web/electron/setup/index.html
+++ b/web/electron/setup/index.html
@@ -433,6 +433,9 @@
       <div class="modal" role="dialog" aria-modal="true" aria-label="Omnigent CLI settings">
         <p class="modal-title">Omnigent CLI</p>
         <p class="cli-note" id="cli-status"></p>
+        <p class="cli-note" id="cli-managed" hidden>
+          Managed by your organization. Host enrollment uses <code>isaac omni</code>.
+        </p>
         <div id="cli-install" hidden>
           <p>
             <a
@@ -446,7 +449,7 @@
           <button type="button" id="cli-redetect">Re-detect</button>
         </div>
         <p id="cli-path-label">Path to the Omnigent CLI</p>
-        <div class="path-row">
+        <div class="path-row" id="cli-path-row">
           <input
             id="cli-path"
             type="text"
@@ -626,14 +629,17 @@
       const cliModalClose = document.getElementById("cli-modal-close");
       const cliModalNewUX = document.getElementById("cli-modal-new-ux");
       const cliStatus = document.getElementById("cli-status");
+      const cliManaged = document.getElementById("cli-managed");
       const cliInstall = document.getElementById("cli-install");
       const cliRedetect = document.getElementById("cli-redetect");
       const cliPathInput = document.getElementById("cli-path");
       const cliBrowse = document.getElementById("cli-browse");
       const cliPathNote = document.getElementById("cli-path-note");
-      // Tracks the last resolved install state so the Start-locally click can
-      // open settings (instead of failing) when the CLI isn't available.
+      // Tracks the last resolved install/policy state so Start locally can
+      // either open customization (public) or explain why it is unavailable
+      // (MDM-managed internal mode).
       let cliInstalled = false;
+      let cliCustomizationDisabled = false;
 
       async function refreshCliStatus() {
         let status;
@@ -644,19 +650,35 @@
         }
         const installed = Boolean(status.installed);
         cliInstalled = installed;
-        // Modal contents: install one-liner only when missing. The resolved /
+        cliCustomizationDisabled = status.customizationDisabled === true;
+        // The gear always opens the status dialog. MDM internal mode explains
+        // that customization is organization-managed and hides its controls;
+        // main-process IPC enforces the same policy.
+        cliGear.hidden = false;
+        cliManaged.hidden = !cliCustomizationDisabled;
+        // Keep the resolved path visible for context, but make customization
+        // controls explicitly inert in managed mode. `disabled` is preferable
+        // to `hidden`: it communicates policy without implying the CLI/path
+        // vanished, and the main-process IPC independently enforces it.
+        cliPathInput.disabled = cliCustomizationDisabled;
+        cliBrowse.disabled = cliCustomizationDisabled;
+        cliRedetect.disabled = cliCustomizationDisabled;
+        cliPathNote.hidden = cliCustomizationDisabled;
+        // Modal contents: install one-liner only when missing AND customization
+        // is allowed. The resolved /
         // auto-detected path is shown as the field's PLACEHOLDER (the value
         // stays empty until the user types an override), so the field reads as
         // "auto" by default.
-        cliInstall.hidden = installed;
+        cliInstall.hidden = installed || cliCustomizationDisabled;
         cliStatus.textContent = installed
           ? status.version
             ? `Found: ${status.version}`
             : "Omnigent CLI found."
           : "Omnigent CLI not found.";
         cliPathInput.placeholder = status.path || "/path/to/omni";
-        // Draw the eye to the (otherwise quiet) gear when the CLI is missing.
-        cliGear.classList.toggle("attention", !installed);
+        // Draw the eye to the (otherwise quiet) gear when the CLI is missing,
+        // unless policy disabled the gear entirely.
+        cliGear.classList.toggle("attention", !cliCustomizationDisabled && !installed);
       }
 
       // Validate + persist the typed path. Returns true when there's nothing to
@@ -719,9 +741,9 @@
       }
 
       if (setup.getCliStatus) {
-        // The gear is the only entry point to the CLI settings — hidden by
-        // default, revealed once we know the bridge exists.
-        cliGear.hidden = false;
+        // The gear opens CLI status/customization. It starts hidden and is
+        // revealed by refreshCliStatus; managed mode keeps it visible but
+        // replaces customization controls with a policy explanation.
         cliGear.addEventListener("click", openCliModal);
         // "Done" commits the typed path (it isn't applied on every keystroke).
         // On an invalid path, keep the modal open so the error stays visible.
@@ -756,9 +778,15 @@
           await refreshCliStatus();
         });
         startLocalBtn.addEventListener("click", async () => {
-          // No CLI yet → open settings (install / set path) rather than fail.
+          // No CLI yet → open settings (install / set path) when policy allows
+          // it; MDM internal mode deliberately disables custom paths.
           if (!cliInstalled) {
-            openCliModal();
+            if (cliCustomizationDisabled) {
+              err.textContent =
+                "The Omnigent CLI was not found. CLI customization is disabled by your organization.";
+            } else {
+              openCliModal();
+            }
             return;
           }
           err.textContent = "";

--- a/web/electron/src/isaac.js
+++ b/web/electron/src/isaac.js
@@ -1,0 +1,63 @@
+"use strict";
+
+/**
+ * Locate Databricks' internal `isaac` launcher for desktop host enrollment.
+ * GUI-launched Electron inherits a minimal PATH, so mirror the Omnigent/Arca
+ * resolver pattern: PATH first, then well-known macOS install locations.
+ */
+
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+/** @returns {string[]} */
+function candidatePaths() {
+  const home = os.homedir();
+  return [
+    "/usr/local/bin/isaac",
+    "/opt/homebrew/bin/isaac",
+    path.join(home, ".local", "bin", "isaac"),
+  ];
+}
+
+/** @param {string} value @returns {boolean} */
+function isExecutableFile(value) {
+  try {
+    if (!fs.statSync(value).isFile()) return false;
+    fs.accessSync(value, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** @returns {string | null} */
+function whichIsaac() {
+  try {
+    const out = execFileSync("/bin/sh", ["-c", "command -v isaac"], { encoding: "utf8" });
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {{
+ *   isExecutableFile?: (value: string) => boolean,
+ *   whichIsaac?: () => string | null,
+ *   candidatePaths?: () => string[],
+ * }} [deps]
+ * @returns {string | null}
+ */
+function resolveIsaacPath(deps = {}) {
+  const isExec = deps.isExecutableFile || isExecutableFile;
+  const onPath = (deps.whichIsaac || whichIsaac)();
+  if (onPath && isExec(onPath)) return onPath;
+  for (const candidate of (deps.candidatePaths || candidatePaths)()) {
+    if (isExec(candidate)) return candidate;
+  }
+  return null;
+}
+
+module.exports = { candidatePaths, resolveIsaacPath };

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -62,6 +62,7 @@ const {
   getManagedServerUrls,
 } = require("./managed_preferences");
 const arca = require("./arca");
+const isaac = require("./isaac");
 const { createArcaConnectFlow } = require("./arca_connect_window");
 const { registerSessionExpiryReload } = require("./session-expiry");
 const { decideWindowOpen, stripCrossOriginOpenerHeaders, WEB_SCHEMES } = require("./popupPolicy");
@@ -946,6 +947,28 @@ function resolvedCliPath() {
   const resolved = omnigentCli.resolveCliPath(configured);
   cachedCli = { configuredPath: configured, path: resolved ? resolved.path : null };
   return cachedCli.path;
+}
+
+/**
+ * CLI command for desktop host enrollment on `serverUrl`. Databricks-internal
+ * windows use `isaac omni` behind the same effective gate as Arca (MDM flag +
+ * Databricks-managed HTTPS server); every other window keeps the configured /
+ * auto-detected public Omnigent CLI. Returns null when the selected launcher
+ * is unavailable.
+ *
+ * @param {string | null | undefined} serverUrl
+ * @returns {string | {
+ *   executable: string,
+ *   prefixArgs: string[],
+ *   displayName: string,
+ * } | null}
+ */
+function hostCliCommand(serverUrl) {
+  const useIsaac = databricksInternalFeaturesEnabled() && isDatabricksManagedServerUrl(serverUrl);
+  if (!useIsaac) return resolvedCliPath();
+  const isaacPath = isaac.resolveIsaacPath();
+  if (!isaacPath) return null;
+  return { executable: isaacPath, prefixArgs: ["omni"], displayName: "isaac omni" };
 }
 
 /**
@@ -2787,7 +2810,10 @@ function registerIpc() {
     if (!isSetupPageSender(event)) {
       throw new Error("get-cli-status is only available to the setup page");
     }
-    return omnigentCli.getCliStatus(loadSettings().omnigent_path);
+    return {
+      ...(await omnigentCli.getCliStatus(loadSettings().omnigent_path)),
+      customizationDisabled: databricksInternalFeaturesEnabled(),
+    };
   });
 
   // Setup page → set an explicit path to the `omnigent` binary. Persisted only
@@ -2798,6 +2824,13 @@ function registerIpc() {
     if (!isSetupPageSender(event)) {
       throw new Error("set-cli-path is only available to the setup page");
     }
+    if (databricksInternalFeaturesEnabled()) {
+      return {
+        ...(await omnigentCli.getCliStatus(loadSettings().omnigent_path)),
+        customizationDisabled: true,
+        accepted: false,
+      };
+    }
     return applyCliPath(configuredPath);
   });
 
@@ -2807,6 +2840,7 @@ function registerIpc() {
     if (!isSetupPageSender(event)) {
       throw new Error("browse-cli-path is only available to the setup page");
     }
+    if (databricksInternalFeaturesEnabled()) return null;
     const win = BrowserWindow.fromWebContents(event.sender) ?? activeWindow();
     const result = await dialog.showOpenDialog(win ?? undefined, {
       title: "Locate the Omnigent CLI binary",
@@ -2838,7 +2872,10 @@ function registerIpc() {
       console.warn("[omnigent] host-get-identity from untrusted sender dropped");
       return null;
     }
-    return { cliInstalled: Boolean(resolvedCliPath()), hostId: omnigentCli.localHostId() };
+    return {
+      cliInstalled: Boolean(hostCliCommand(senderServerUrl(event))),
+      hostId: omnigentCli.localHostId(),
+    };
   });
 
   // SPA (in-app Settings → Local CLI) → is the CLI installed and runnable,
@@ -2848,7 +2885,10 @@ function registerIpc() {
       console.warn("[omnigent] cli-get-status from untrusted sender dropped");
       return null;
     }
-    return omnigentCli.getCliStatus(loadSettings().omnigent_path);
+    return {
+      ...(await omnigentCli.getCliStatus(loadSettings().omnigent_path)),
+      customizationDisabled: databricksInternalFeaturesEnabled(),
+    };
   });
 
   // SPA → reset to auto-detected (clear the override). Chooses no path itself,
@@ -2860,6 +2900,12 @@ function registerIpc() {
   ipcMain.handle("omnigent:cli-reset-path", async (event) => {
     if (!isPinnedOriginSender(event)) {
       throw new Error("cli-reset-path is only available to a connected server page");
+    }
+    if (databricksInternalFeaturesEnabled()) {
+      return {
+        ...(await omnigentCli.getCliStatus(loadSettings().omnigent_path)),
+        customizationDisabled: true,
+      };
     }
     return clearCliPath();
   });
@@ -2890,9 +2936,16 @@ function registerIpc() {
     }
     const serverUrl = senderServerUrl(event);
     if (!serverUrl) return { ok: false, error: "this window is not connected to a server" };
-    const cliPath = resolvedCliPath();
-    if (!cliPath) {
-      return { ok: false, error: "The omnigent CLI was not found. Install it or set its path." };
+    const cliCommand = hostCliCommand(serverUrl);
+    if (!cliCommand) {
+      const internal =
+        databricksInternalFeaturesEnabled() && isDatabricksManagedServerUrl(serverUrl);
+      return {
+        ok: false,
+        error: internal
+          ? "The isaac CLI was not found. Install it before connecting this machine."
+          : "The omnigent CLI was not found. Install it or set its path.",
+      };
     }
     let result;
     if (action === "start" || action === "restart") {
@@ -2909,13 +2962,13 @@ function registerIpc() {
       }
       // Ensure the CLI is authenticated for a remote server first (local needs
       // none) — otherwise the host connect would just fail on a 401.
-      const auth = await serverManager.ensureServerAuth(cliPath, serverUrl);
+      const auth = await serverManager.ensureServerAuth(cliCommand, serverUrl);
       if (!auth.ok) result = { ok: false, error: auth.error, authError: auth.authError };
       else if (action === "start")
-        result = await serverManager.ensureHostConnected(cliPath, serverUrl);
-      else result = await serverManager.restartHost(cliPath, serverUrl);
+        result = await serverManager.ensureHostConnected(cliCommand, serverUrl);
+      else result = await serverManager.restartHost(cliCommand, serverUrl);
     } else if (action === "stop") {
-      result = await serverManager.disconnectHost(cliPath, serverUrl);
+      result = await serverManager.disconnectHost(cliCommand, serverUrl);
     } else {
       result = { ok: false, error: `unknown host action '${action}'` };
     }

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -376,23 +376,67 @@ function resolveCliPath(configuredPath, deps = {}) {
 }
 
 /**
- * Run an `omnigent` subcommand and resolve with its captured output. Never
+ * Normalize a CLI invocation. Public paths pass a string (`/path/omnigent`);
+ * Databricks-internal host enrollment passes an executable + fixed argv prefix
+ * (`/usr/local/bin/isaac`, `["omni"]`). Both stay shell-free.
+ *
+ * @param {string | {
+ *   executable: string,
+ *   prefixArgs?: string[],
+ *   displayName?: string,
+ * }} command
+ * @returns {{ executable: string, prefixArgs: string[], displayName: string }}
+ */
+function cliCommandParts(command) {
+  if (typeof command === "string" && command !== "") {
+    return { executable: command, prefixArgs: [], displayName: "omnigent" };
+  }
+  if (
+    command &&
+    typeof command === "object" &&
+    typeof command.executable === "string" &&
+    command.executable !== "" &&
+    (command.prefixArgs === undefined ||
+      (Array.isArray(command.prefixArgs) &&
+        command.prefixArgs.every((arg) => typeof arg === "string")))
+  ) {
+    const prefixArgs = command.prefixArgs ?? [];
+    return {
+      executable: command.executable,
+      prefixArgs,
+      displayName:
+        typeof command.displayName === "string" && command.displayName !== ""
+          ? command.displayName
+          : [path.basename(command.executable), ...prefixArgs].join(" "),
+    };
+  }
+  throw new TypeError("invalid CLI command");
+}
+
+/**
+ * Run an Omnigent CLI subcommand and resolve with its captured output. Never
  * rejects — a failure surfaces as a non-zero `code` plus stderr so callers can
  * decide. `execFile` (no shell) avoids quoting pitfalls.
  *
- * @param {string} cliPath
+ * @param {Parameters<typeof cliCommandParts>[0]} command
  * @param {string[]} args
  * @param {{ timeoutMs?: number }} [opts]
  * @returns {Promise<{ code: number, stdout: string, stderr: string }>}
  */
-function runCli(cliPath, args, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+function runCli(command, args, { timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const { executable, prefixArgs } = cliCommandParts(command);
   return new Promise((resolve) => {
-    execFile(cliPath, args, { timeout: timeoutMs, encoding: "utf8" }, (err, stdout, stderr) => {
-      // execFile sets err.code to the numeric exit code on a normal non-zero
-      // exit, or a string errno (e.g. "ENOENT") when the spawn itself failed.
-      const code = err ? (typeof err.code === "number" ? err.code : 1) : 0;
-      resolve({ code, stdout: stdout || "", stderr: stderr || "" });
-    });
+    execFile(
+      executable,
+      [...prefixArgs, ...args],
+      { timeout: timeoutMs, encoding: "utf8" },
+      (err, stdout, stderr) => {
+        // execFile sets err.code to the numeric exit code on a normal non-zero
+        // exit, or a string errno (e.g. "ENOENT") when the spawn itself failed.
+        const code = err ? (typeof err.code === "number" ? err.code : 1) : 0;
+        resolve({ code, stdout: stdout || "", stderr: stderr || "" });
+      },
+    );
   });
 }
 
@@ -941,6 +985,7 @@ module.exports = {
   isExecutableFile,
   whichOmnigent,
   resolveCliPath,
+  cliCommandParts,
   runCli,
   parseJsonLoose,
   getCliStatus,

--- a/web/electron/src/server_manager.js
+++ b/web/electron/src/server_manager.js
@@ -122,24 +122,29 @@ function ownsLiveHost(key) {
  * (or fails / times out). On success the child keeps running; the caller
  * registers it. Never rejects.
  *
- * @param {string} cliPath
+ * @param {Parameters<typeof cli.cliCommandParts>[0]} cliCommand
  * @param {string} serverUrl
  * @returns {Promise<{ ok: boolean, child: import("child_process").ChildProcess, holder: {text: string}, error?: string }>}
  */
-function spawnHostChild(cliPath, serverUrl) {
+function spawnHostChild(cliCommand, serverUrl) {
   return new Promise((resolve) => {
     const holder = { text: "" };
     let child;
     try {
+      const { executable, prefixArgs } = cli.cliCommandParts(cliCommand);
       // `--non-interactive`: the desktop owns the sign-in step (ensureServerAuth
       // runs `omnigent login` first), so the host daemon must never try its own
       // interactive login. Without the flag, an unauthed connect relies on the
       // spawned child's stdin not being a TTY to bail — with it, the CLI raises a
       // deterministic "run `omnigent login`" error that `isAuthError` classifies,
       // so any residual auth gap becomes a fast, surfaced authError, not a hang.
-      child = spawn(cliPath, ["host", "--server", serverUrl, "--non-interactive"], {
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      child = spawn(
+        executable,
+        [...prefixArgs, "host", "--server", serverUrl, "--non-interactive"],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
     } catch (err) {
       resolve({ ok: false, child: null, holder, error: err.message });
       return;
@@ -191,11 +196,11 @@ function spawnHostChild(cliPath, serverUrl) {
  * error on the conflict, and we must not kill a daemon we didn't start. Adopted
  * connections report ownedByDesktop:false.
  *
- * @param {string} cliPath
+ * @param {Parameters<typeof cli.cliCommandParts>[0]} cliCommand
  * @param {string} serverUrl
  * @returns {Promise<{ ok: boolean, ownedByDesktop: boolean, adopted?: boolean, error?: string }>}
  */
-async function ensureHostConnected(cliPath, serverUrl) {
+async function ensureHostConnected(cliCommand, serverUrl) {
   const key = cli.normalizeServerUrl(serverUrl);
   if (key === "") return { ok: false, ownedByDesktop: false, error: "missing server URL" };
   if (ownsLiveHost(key)) return { ok: true, ownedByDesktop: true };
@@ -204,7 +209,7 @@ async function ensureHostConnected(cliPath, serverUrl) {
   // two `omnigent host` processes for one target.
   const inflight = connectingHosts.get(key);
   if (inflight) return inflight;
-  const op = connectHost(cliPath, serverUrl, key);
+  const op = connectHost(cliCommand, serverUrl, key);
   connectingHosts.set(key, op);
   // Ping the renderer right away so it re-reads (e.g. refetches the server's
   // host list), then again once the connect settles.
@@ -221,12 +226,12 @@ async function ensureHostConnected(cliPath, serverUrl) {
  * The actual connect: adopt a daemon already serving this target, else spawn
  * and track one. Serialized per target by ensureHostConnected.
  *
- * @param {string} cliPath
+ * @param {Parameters<typeof cli.cliCommandParts>[0]} cliCommand
  * @param {string} serverUrl
  * @param {string} key Normalized server URL.
  * @returns {Promise<{ ok: boolean, ownedByDesktop: boolean, adopted?: boolean, error?: string }>}
  */
-async function connectHost(cliPath, serverUrl, key) {
+async function connectHost(cliCommand, serverUrl, key) {
   // Adopt only a daemon we can VERIFY is connected (live process + an online
   // tunnel, via the fast disk-read + single HTTP probe — not the slow `omnigent
   // host status` subprocess). PID-liveness alone is not enough: a stale registry
@@ -239,7 +244,7 @@ async function connectHost(cliPath, serverUrl, key) {
     return { ok: true, ownedByDesktop: false, adopted: true };
   }
 
-  const spawned = await spawnHostChild(cliPath, serverUrl);
+  const spawned = await spawnHostChild(cliCommand, serverUrl);
   if (!spawned.ok) {
     // Connect failed or timed out. Await the child's termination — escalating to
     // SIGKILL after the grace period — rather than firing a single SIGTERM and
@@ -280,11 +285,11 @@ async function connectHost(cliPath, serverUrl, key) {
  * daemon we merely adopted is asked to stop via the CLI (the user explicitly
  * toggled off, so honoring that is correct even for an adopted daemon).
  *
- * @param {string} cliPath
+ * @param {Parameters<typeof cli.cliCommandParts>[0]} cliCommand
  * @param {string} serverUrl
  * @returns {Promise<{ ok: boolean, error?: string }>}
  */
-async function disconnectHost(cliPath, serverUrl) {
+async function disconnectHost(cliCommand, serverUrl) {
   const key = cli.normalizeServerUrl(serverUrl);
   const entry = hostChildren.get(key);
   if (entry) {
@@ -295,7 +300,7 @@ async function disconnectHost(cliPath, serverUrl) {
     return { ok: true };
   }
   // No desktop-owned child: ask the CLI to stop a daemon we'd adopted.
-  const res = await cli.stopHost(cliPath, serverUrl);
+  const res = await cli.stopHost(cliCommand, serverUrl);
   return { ok: res.ok, error: res.ok ? undefined : res.output };
 }
 
@@ -315,17 +320,17 @@ async function disconnectHost(cliPath, serverUrl) {
  * login failure returns `{ ok:false, authError:true, error }` so the UI can
  * offer a sign-in/retry affordance instead of a generic failure.
  *
- * @param {string} cliPath
+ * @param {Parameters<typeof cli.cliCommandParts>[0]} cliCommand
  * @param {string} serverUrl
  * @returns {Promise<{ ok: boolean, authError?: boolean, error?: string }>}
  */
-async function ensureServerAuth(cliPath, serverUrl) {
+async function ensureServerAuth(cliCommand, serverUrl) {
   if (cli.isLoopbackServer(serverUrl)) return { ok: true };
   const probe = await cli.probeServerAuth(serverUrl);
   // Already authed, or unreachable — in the unreachable case skip a doomed login
   // and let the connect attempt surface the real (connectivity) error.
   if (probe.authed || !probe.reachable) return { ok: true };
-  const res = await cli.loginServer(cliPath, serverUrl);
+  const res = await cli.loginServer(cliCommand, serverUrl);
   if (res.ok) return { ok: true };
   // Deliberately a fixed, generic message — NOT `res.output`. `omnigent login`
   // stdout on the OIDC path contains the login-ticket URL
@@ -335,7 +340,7 @@ async function ensureServerAuth(cliPath, serverUrl) {
   return {
     ok: false,
     authError: true,
-    error: `Sign-in to ${serverUrl} didn't complete. A browser window should have opened — finish signing in and try again (or run \`omnigent login ${serverUrl}\` in a terminal).`,
+    error: `Sign-in to ${serverUrl} didn't complete. A browser window should have opened — finish signing in and try again (or run \`${cli.cliCommandParts(cliCommand).displayName} login ${serverUrl}\` in a terminal).`,
   };
 }
 
@@ -343,13 +348,13 @@ async function ensureServerAuth(cliPath, serverUrl) {
  * Restart this machine's host connection: stop (awaiting the daemon down), then
  * reconnect.
  *
- * @param {string} cliPath
+ * @param {Parameters<typeof cli.cliCommandParts>[0]} cliCommand
  * @param {string} serverUrl
  * @returns {Promise<{ ok: boolean, ownedByDesktop: boolean, error?: string }>}
  */
-async function restartHost(cliPath, serverUrl) {
-  await disconnectHost(cliPath, serverUrl);
-  return ensureHostConnected(cliPath, serverUrl);
+async function restartHost(cliCommand, serverUrl) {
+  await disconnectHost(cliCommand, serverUrl);
+  return ensureHostConnected(cliCommand, serverUrl);
 }
 
 /**

--- a/web/electron/test/isaac.test.js
+++ b/web/electron/test/isaac.test.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { resolveIsaacPath } = require("../src/isaac");
+
+describe("isaac binary resolution", () => {
+  it("prefers PATH, then well-known locations, and fails closed", () => {
+    assert.equal(
+      resolveIsaacPath({
+        whichIsaac: () => "/from/path/isaac",
+        isExecutableFile: (value) => value === "/from/path/isaac",
+        candidatePaths: () => ["/usr/local/bin/isaac"],
+      }),
+      "/from/path/isaac",
+    );
+    assert.equal(
+      resolveIsaacPath({
+        whichIsaac: () => null,
+        isExecutableFile: (value) => value === "/usr/local/bin/isaac",
+        candidatePaths: () => ["/usr/local/bin/isaac"],
+      }),
+      "/usr/local/bin/isaac",
+    );
+    assert.equal(
+      resolveIsaacPath({
+        whichIsaac: () => null,
+        isExecutableFile: () => false,
+        candidatePaths: () => ["/usr/local/bin/isaac"],
+      }),
+      null,
+    );
+  });
+});

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -307,6 +307,47 @@ describe("managed server preference wiring", () => {
   });
 });
 
+describe("Databricks-internal local-host CLI wiring", () => {
+  it("selects isaac omni only behind the internal flag and Databricks server gate", () => {
+    assert.match(
+      liveCode,
+      /function hostCliCommand\(serverUrl\)[\s\S]{0,300}databricksInternalFeaturesEnabled\(\)[\s\S]{0,120}isDatabricksManagedServerUrl\(serverUrl\)[\s\S]{0,300}prefixArgs:\s*\["omni"\]/,
+    );
+  });
+
+  it("uses the selected command for identity availability and every host action", () => {
+    assert.match(
+      liveCode,
+      /host-get-identity[\s\S]{0,350}Boolean\(hostCliCommand\(senderServerUrl\(event\)\)\)/,
+    );
+    assert.match(
+      liveCode,
+      /host-control[\s\S]{0,450}const cliCommand = hostCliCommand\(serverUrl\)[\s\S]{0,1400}ensureServerAuth\(cliCommand, serverUrl\)[\s\S]{0,400}ensureHostConnected\(cliCommand, serverUrl\)[\s\S]{0,300}disconnectHost\(cliCommand, serverUrl\)/,
+    );
+  });
+
+  it("disables CLI customization in main and explains managed policy in the setup dialog", () => {
+    assert.match(
+      liveCode,
+      /omnigent:set-cli-path[\s\S]{0,300}databricksInternalFeaturesEnabled\(\)[\s\S]{0,250}customizationDisabled:\s*true[\s\S]{0,80}accepted:\s*false/,
+    );
+    assert.match(
+      liveCode,
+      /omnigent:browse-cli-path[\s\S]{0,250}databricksInternalFeaturesEnabled\(\)\) return null/,
+    );
+    assert.match(
+      liveCode,
+      /omnigent:cli-reset-path[\s\S]{0,250}databricksInternalFeaturesEnabled\(\)[\s\S]{0,250}customizationDisabled:\s*true/,
+    );
+    assert.match(setupSource, /cliGear\.hidden = false/);
+    assert.match(setupSource, /cliManaged\.hidden = !cliCustomizationDisabled/);
+    assert.match(setupSource, /cliPathInput\.disabled = cliCustomizationDisabled/);
+    assert.match(setupSource, /cliBrowse\.disabled = cliCustomizationDisabled/);
+    assert.match(setupSource, /cliRedetect\.disabled = cliCustomizationDisabled/);
+    assert.match(setupSource, /Managed by your organization/);
+  });
+});
+
 describe("production developer-mode wiring (src/main.js)", () => {
   it("uses the same opt-in to enable the shell window's DevTools capability", () => {
     assert.match(liveCode, /webPreferences:\s*\{[\s\S]{0,400}devTools:\s*developerModeEnabled\(\)/);

--- a/web/electron/test/omnigent_cli.test.js
+++ b/web/electron/test/omnigent_cli.test.js
@@ -15,6 +15,7 @@ const {
   parseLocalServerPidfile,
   candidatePaths,
   resolveCliPath,
+  cliCommandParts,
   parseJsonLoose,
   matchesServer,
   parseDaemonRecord,
@@ -23,6 +24,34 @@ const {
   probeServerAuth,
   localHostId,
 } = require("../src/omnigent_cli");
+
+describe("cliCommandParts", () => {
+  it("keeps public CLI paths bare and adds fixed isaac argv without a shell", () => {
+    assert.deepEqual(cliCommandParts("/bin/omnigent"), {
+      executable: "/bin/omnigent",
+      prefixArgs: [],
+      displayName: "omnigent",
+    });
+    assert.deepEqual(
+      cliCommandParts({
+        executable: "/usr/local/bin/isaac",
+        prefixArgs: ["omni"],
+        displayName: "isaac omni",
+      }),
+      {
+        executable: "/usr/local/bin/isaac",
+        prefixArgs: ["omni"],
+        displayName: "isaac omni",
+      },
+    );
+  });
+
+  it("rejects malformed descriptors", () => {
+    assert.throws(() => cliCommandParts(null));
+    assert.throws(() => cliCommandParts({ executable: "", prefixArgs: ["omni"] }));
+    assert.throws(() => cliCommandParts({ executable: "/bin/isaac", prefixArgs: "omni" }));
+  });
+});
 
 describe("normalizeServerUrl", () => {
   it("strips trailing slashes and trims", () => {

--- a/web/electron/test/server_manager.test.js
+++ b/web/electron/test/server_manager.test.js
@@ -70,6 +70,24 @@ describe("ensureServerAuth", () => {
     assert.deepEqual(login.mock.calls[0].arguments, [CLI_PATH, SERVER]);
   });
 
+  it("passes an isaac omni descriptor through login and names it in the safe error", async () => {
+    mock.method(cli, "isLoopbackServer", () => false);
+    mock.method(cli, "probeServerAuth", async () => ({ authed: false, reachable: true }));
+    const login = mock.method(cli, "loginServer", async () => ({ ok: false, output: "SECRET" }));
+    const command = {
+      executable: "/usr/local/bin/isaac",
+      prefixArgs: ["omni"],
+      displayName: "isaac omni",
+    };
+
+    const res = await ensureServerAuth(command, SERVER);
+
+    assert.deepEqual(login.mock.calls[0].arguments, [command, SERVER]);
+    assert.equal(res.authError, true);
+    assert.match(res.error, /isaac omni login https:\/\/app\.example\.com/);
+    assert.doesNotMatch(res.error, /SECRET/);
+  });
+
   it("returns an authError with a generic message and does NOT surface raw login output", async () => {
     mock.method(cli, "isLoopbackServer", () => false);
     mock.method(cli, "probeServerAuth", async () => ({ authed: false, reachable: true }));

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -247,6 +247,8 @@ export interface CliStatus {
   installCommand: string;
   /** Whether a just-submitted path was accepted (present on pick/set results). */
   accepted?: boolean;
+  /** MDM policy disables set/browse/reset of custom CLI paths. */
+  customizationDisabled?: boolean;
 }
 
 /** This machine's identity, read from local config (fast — no subprocess). */

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1665,18 +1665,26 @@ function LocalCliSection() {
             </div>
           )}
 
-          <p className="text-sm text-muted-foreground">
-            For security, a custom path can only be set from the connect screen — this prevents a
-            connected server from pointing the app at a different binary. Open it from the Server
-            menu (Change Server…) and use the settings gear.
-          </p>
+          {status.customizationDisabled ? (
+            <p className="text-sm text-muted-foreground">
+              Managed by your organization. Host enrollment uses <code>isaac omni</code>.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                For security, a custom path can only be set from the connect screen — this prevents
+                a connected server from pointing the app at a different binary. Open it from the
+                Server menu (Change Server…) and use the settings gear.
+              </p>
 
-          {status.source === "configured" && (
-            <div>
-              <Button variant="ghost" size="sm" disabled={busy} onClick={() => void onReset()}>
-                Reset to auto-detected
-              </Button>
-            </div>
+              {status.source === "configured" && (
+                <div>
+                  <Button variant="ghost" size="sm" disabled={busy} onClick={() => void onReset()}>
+                    Reset to auto-detected
+                  </Button>
+                </div>
+              )}
+            </>
           )}
         </div>
       )}


### PR DESCRIPTION
## Related issue

N/A — Databricks-internal follow-up to #5779.

## Summary

- When the effective Databricks-internal gate is true (the MDM flag from #5779 **and** a Databricks-managed HTTPS server), desktop **Run on this machine** now invokes `isaac omni host ...` instead of a directly resolved `omnigent` binary.
- Introduces a shell-free CLI command descriptor (`executable` + fixed `prefixArgs`) and threads it through host authentication, start, restart, adopted-host stop, and availability detection. The internal command is `/path/isaac`, `["omni", ...args]`; the existing public command remains `/path/omnigent`, `args`.
- Resolves `isaac` from PATH plus GUI-safe well-known locations and reports an internal-specific error if it is unavailable. Sign-in remediation correctly says `isaac omni login ...` without exposing raw login output.
- Local server start/stop remains on the resolved public Omnigent binary; only desktop host enrollment switches launchers.
- When the raw MDM flag is on, CLI path customization is policy-disabled end to end: the legacy setup gear opens a managed-policy dialog with concise copy ("Managed by your organization. Host enrollment uses `isaac omni`.") and visibly disabled path/Browse/Re-detect controls, setup set/browse IPC is rejected, in-app reset is a no-op, and Settings → Local CLI explains that internal host enrollment uses `isaac omni`. Existing saved overrides are preserved (not destructively cleared) and may still supply local-server commands.

```text
Run on this machine
        │
        ├─ MDM internal flag + Databricks-managed server
        │      └─ /path/isaac omni {login|host|host stop} ...
        │
        └─ otherwise
               └─ /path/omnigent {login|host|host stop} ...
```

## Test Plan

- `cd web/electron && node --test` — 377 tests pass, including new Isaac path-resolution tests, CLI descriptor validation, `isaac omni` auth argument propagation/safe error copy, main-process wiring guards for identity/start/restart/stop, and defense-in-depth CLI-customization policy guards.
- `cd web && npm run lint && npm run type-check`.
- `pre-commit run --files <changed files>` — all applicable hooks pass.

## Demo

N/A — command-routing change with no visual UI changes.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The command descriptor and conditional main-process wiring are unit tested. A live internal host enrollment requires the MDM flag, a Databricks-managed server, and the internal `isaac` launcher.

## Changelog

Desktop: Databricks-internal local host enrollment now uses `isaac omni`, with custom CLI paths disabled by the managed internal-feature policy.
Signed-off-by: Zeyi (Rice) Fan <zeyi.f@databricks.com>




