### PR TITLE
fix(host): mirror structured logs in foreground terminals

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -117,6 +117,7 @@ from omnigent.process_logging import (
     env_truthy,
     open_process_log_file,
     process_log_dir,
+    should_log_to_stderr,
 )
 from omnigent.runner._zygote import ZYGOTE_ENABLED_ENV_VAR
 from omnigent.runner.identity import (
@@ -3897,7 +3898,10 @@ def run_host_process(
         loopback server that is gone). The actionable cause is printed
         to stderr first.
     """
-    host_log_path = configure_process_logging("host")
+    host_log_path = configure_process_logging(
+        "host",
+        log_to_stderr=should_log_to_stderr() or sys.stderr.isatty(),
+    )
     # Initialize tracing so the host daemon exports its own spans
     # (e.g. handling launch_runner / stat / list_dir frames) into the
     # same distributed trace as the server that requested them. The

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -7,6 +7,7 @@ import contextlib
 import errno
 import logging
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -3948,6 +3949,26 @@ async def test_run_host_process_invalid_host_id_exits_actionably(
     assert "Could not start host" in err
     assert "OMNIGENT_HOST_ID" in err
     assert "not-a-uuid" in err
+
+
+def test_run_host_process_mirrors_structured_logs_on_foreground_tty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Foreground ``omnigent host`` mirrors logs like ``omnigent server``."""
+    monkeypatch.delenv("OMNIGENT_LOG_TO_STDERR", raising=False)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+    _patch_connect(monkeypatch, _ConnectSpy([asyncio.CancelledError()]))
+
+    with patch(
+        "omnigent.host.connect.configure_process_logging",
+        return_value=tmp_path / "host.log",
+    ) as configure_logging:
+        run_host_process(
+            server_url="https://app.example.databricks.com",
+            config_path=tmp_path / "config.yaml",
+        )
+
+    configure_logging.assert_called_once_with("host", log_to_stderr=True)
 
 
 def test_run_host_process_announces_session_log_dir_on_start(


### PR DESCRIPTION
## Related issue

Resolves [OMNI-2523](https://linear.app/omnigent/issue/OMNI-2523/fix-logging-format-in-omni-host)

## Summary

- Make foreground `omni host` mirror structured process logs when stderr is a TTY, matching `omni server`.
- Preserve file-only logging for detached and non-interactive hosts unless stderr mirroring is explicitly enabled.

## Test Plan

- `uv run pytest tests/host/test_connect.py::test_run_host_process_mirrors_structured_logs_on_foreground_tty tests/host/test_connect.py::test_run_host_process_announces_session_log_dir_on_start`
- `uv run pytest tests/cli/test_cli.py::test_server_uvicorn_log_config_mirrors_foreground_tty_by_default tests/cli/test_cli.py::test_server_uvicorn_log_config_keeps_noninteractive_default_file_only tests/cli/test_cli.py::test_server_uvicorn_log_config_standardizes_timestamp_and_color tests/test_process_logging.py::test_terminal_log_formatter_colors_level_name tests/test_process_logging.py::test_terminal_log_formatter_abbreviates_warning_and_source`
- `uv run ruff check omnigent/host/connect.py tests/host/test_connect.py`
- `uv run ruff format --check omnigent/host/connect.py tests/host/test_connect.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Foreground host logging is covered by the new TTY regression test; the existing server and formatter tests confirm the shared output format.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit test covers host TTY detection, while existing tests cover server routing and structured terminal formatting.

## Changelog

`omni host` now shows structured logs in foreground terminals, matching `omni server`.
