### PR TITLE
fix(runner): detect source changes before zygote forks

### DIFF
--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -54,7 +54,6 @@ import threading
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from types import ModuleType
 from typing import Any, cast
 
 from omnigent.process_logging import LOG_TTY_FD_ENV_VAR, env_truthy
@@ -87,11 +86,10 @@ _ZYGOTE_TEST_CHILD_SLEEP_ENV_VAR = "OMNIGENT_RUNNER_ZYGOTE_TEST_CHILD_SLEEP"
 
 @dataclass(frozen=True)
 class _SourceFileStamp:
-    """Metadata identifying one imported package file."""
+    """Metadata identifying one package source file."""
 
     path: Path
     modified_ns: int
-    changed_ns: int
     size: int
     inode: int
 
@@ -101,7 +99,7 @@ class _GraphStamp:
     """Build and source state backing the zygote's imported graph."""
 
     build: tuple[float, str] | None
-    sources: tuple[_SourceFileStamp, ...]
+    sources: tuple[_SourceFileStamp, ...] | None
 
 
 def _disk_build_stamp(package_dir: Path | None = None) -> tuple[float, str] | None:
@@ -137,19 +135,22 @@ def _disk_build_stamp(package_dir: Path | None = None) -> tuple[float, str] | No
         return None
 
 
-def _source_file_stamps(paths: Iterable[Path]) -> tuple[_SourceFileStamp, ...]:
-    """Capture stable metadata for existing source files in *paths*."""
+def _source_file_stamps(paths: Iterable[Path]) -> tuple[_SourceFileStamp, ...] | None:
+    """Capture file metadata, returning ``None`` if the baseline is incomplete."""
     stamps: list[_SourceFileStamp] = []
-    for path in sorted(set(paths)):
+    try:
+        unique_paths = sorted(set(paths))
+    except OSError:
+        return None
+    for path in unique_paths:
         try:
             stat = path.stat()
         except OSError:
-            continue
+            return None
         stamps.append(
             _SourceFileStamp(
                 path=path,
                 modified_ns=stat.st_mtime_ns,
-                changed_ns=stat.st_ctime_ns,
                 size=stat.st_size,
                 inode=stat.st_ino,
             )
@@ -157,40 +158,18 @@ def _source_file_stamps(paths: Iterable[Path]) -> tuple[_SourceFileStamp, ...]:
     return tuple(stamps)
 
 
-def _module_file(module: ModuleType) -> Path | None:
-    """Return a module's source path, preferring ``.py`` over cached bytecode."""
-    raw_path = getattr(module, "__file__", None)
-    if not isinstance(raw_path, str):
-        return None
-    path = Path(raw_path)
-    if path.suffix in {".pyc", ".pyo"}:
-        with contextlib.suppress(ValueError):
-            source = Path(importlib.util.source_from_cache(str(path)))
-            if source.exists():
-                path = source
-    with contextlib.suppress(OSError):
-        return path.resolve()
-    return None
-
-
-def _loaded_source_stamps(package_dir: Path | None = None) -> tuple[_SourceFileStamp, ...]:
-    """Fingerprint imported ``omnigent`` files inside the active package tree."""
+def _package_source_stamps(
+    package_dir: Path | None = None,
+) -> tuple[_SourceFileStamp, ...] | None:
+    """Fingerprint all Python sources, including modules imported lazily later."""
     package_root = (package_dir or Path(__file__).resolve().parents[1]).resolve()
-    paths: set[Path] = set()
-    for name, module in tuple(sys.modules.items()):
-        if name != "omnigent" and not name.startswith("omnigent."):
-            continue
-        if not isinstance(module, ModuleType):
-            continue
-        path = _module_file(module)
-        if path is None or not path.is_relative_to(package_root):
-            continue
-        paths.add(path)
-    return _source_file_stamps(paths)
+    return _source_file_stamps(package_root.rglob("*.py"))
 
 
-def _source_files_match(stamps: tuple[_SourceFileStamp, ...]) -> bool:
-    """Return whether every imported package file still matches its boot metadata."""
+def _source_files_match(stamps: tuple[_SourceFileStamp, ...] | None) -> bool:
+    """Return whether every package source still matches its boot metadata."""
+    if stamps is None:
+        return False
     if not stamps:
         return True
     return _source_file_stamps(stamp.path for stamp in stamps) == stamps
@@ -388,8 +367,8 @@ class _ZygoteServer:
     thread per connection.
 
     :param control_sock: The daemon control socket (role ``"daemon"``).
-    :param graph_stamp: Build and imported-source state captured after the
-        zygote imported its graph. Both runner and harness forks are refused
+    :param graph_stamp: Build and package-source state captured before the
+        zygote imports its graph. Both runner and harness forks are refused
         once either changes on disk: the child would otherwise resolve lazy
         imports from new files against the old in-memory graph.
     """
@@ -602,7 +581,7 @@ class _ZygoteServer:
             conn,
             {
                 "error": (
-                    "omnigent was upgraded on disk after the zygote imported its "
+                    "omnigent changed on disk after the zygote imported its "
                     f"graph; refusing to fork a mixed-version {kind}"
                 )
             },
@@ -749,11 +728,12 @@ def main() -> None:
 
     control_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=control_fd)
 
-    _import_runner_graph()
+    # A source update during graph import must make later forks fail closed.
     graph_stamp = _GraphStamp(
         build=_disk_build_stamp(),
-        sources=_loaded_source_stamps(),
+        sources=_package_source_stamps(),
     )
+    _import_runner_graph()
     # The import graph is now static; move it out of GC's tracked set so cyclic
     # collections stay cheap and don't dirty shared pages in forked children.
     gc.freeze()

--- a/omnigent/runner/_zygote.py
+++ b/omnigent/runner/_zygote.py
@@ -51,7 +51,10 @@ import selectors
 import socket
 import sys
 import threading
+from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 from typing import Any, cast
 
 from omnigent.process_logging import LOG_TTY_FD_ENV_VAR, env_truthy
@@ -80,6 +83,25 @@ _ZYGOTE_TEST_CHILD_RAISE_ENV_VAR = "OMNIGENT_RUNNER_ZYGOTE_TEST_CHILD_RAISE"
 # genuinely alive) instead of exiting, so a test can kill the zygote out from
 # under a live child and assert the crash-recovery path. Never set in prod.
 _ZYGOTE_TEST_CHILD_SLEEP_ENV_VAR = "OMNIGENT_RUNNER_ZYGOTE_TEST_CHILD_SLEEP"
+
+
+@dataclass(frozen=True)
+class _SourceFileStamp:
+    """Metadata identifying one imported package file."""
+
+    path: Path
+    modified_ns: int
+    changed_ns: int
+    size: int
+    inode: int
+
+
+@dataclass(frozen=True)
+class _GraphStamp:
+    """Build and source state backing the zygote's imported graph."""
+
+    build: tuple[float, str] | None
+    sources: tuple[_SourceFileStamp, ...]
 
 
 def _disk_build_stamp(package_dir: Path | None = None) -> tuple[float, str] | None:
@@ -115,6 +137,65 @@ def _disk_build_stamp(package_dir: Path | None = None) -> tuple[float, str] | No
         return None
 
 
+def _source_file_stamps(paths: Iterable[Path]) -> tuple[_SourceFileStamp, ...]:
+    """Capture stable metadata for existing source files in *paths*."""
+    stamps: list[_SourceFileStamp] = []
+    for path in sorted(set(paths)):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        stamps.append(
+            _SourceFileStamp(
+                path=path,
+                modified_ns=stat.st_mtime_ns,
+                changed_ns=stat.st_ctime_ns,
+                size=stat.st_size,
+                inode=stat.st_ino,
+            )
+        )
+    return tuple(stamps)
+
+
+def _module_file(module: ModuleType) -> Path | None:
+    """Return a module's source path, preferring ``.py`` over cached bytecode."""
+    raw_path = getattr(module, "__file__", None)
+    if not isinstance(raw_path, str):
+        return None
+    path = Path(raw_path)
+    if path.suffix in {".pyc", ".pyo"}:
+        with contextlib.suppress(ValueError):
+            source = Path(importlib.util.source_from_cache(str(path)))
+            if source.exists():
+                path = source
+    with contextlib.suppress(OSError):
+        return path.resolve()
+    return None
+
+
+def _loaded_source_stamps(package_dir: Path | None = None) -> tuple[_SourceFileStamp, ...]:
+    """Fingerprint imported ``omnigent`` files inside the active package tree."""
+    package_root = (package_dir or Path(__file__).resolve().parents[1]).resolve()
+    paths: set[Path] = set()
+    for name, module in tuple(sys.modules.items()):
+        if name != "omnigent" and not name.startswith("omnigent."):
+            continue
+        if not isinstance(module, ModuleType):
+            continue
+        path = _module_file(module)
+        if path is None or not path.is_relative_to(package_root):
+            continue
+        paths.add(path)
+    return _source_file_stamps(paths)
+
+
+def _source_files_match(stamps: tuple[_SourceFileStamp, ...]) -> bool:
+    """Return whether every imported package file still matches its boot metadata."""
+    if not stamps:
+        return True
+    return _source_file_stamps(stamp.path for stamp in stamps) == stamps
+
+
 def _import_runner_graph() -> None:
     """Eagerly import the heavy runner graph so the ~120MB lands once.
 
@@ -128,6 +209,11 @@ def _import_runner_graph() -> None:
     already holds, so this adds little resident cost).
     """
     from omnigent.runner import _entry, app, native  # noqa: F401
+    from omnigent.runner.background_titles import (  # noqa: F401
+        claude_native,
+        codex_native,
+        sdk,
+    )
     from omnigent.runtime.harnesses import _runner as _harness_runner  # noqa: F401
 
 
@@ -302,18 +388,16 @@ class _ZygoteServer:
     thread per connection.
 
     :param control_sock: The daemon control socket (role ``"daemon"``).
-    :param graph_stamp: The on-disk build stamp captured when the zygote
-        imported its graph, or ``None`` when unknown (unbuilt checkout).
-        Both runner and harness forks are refused once the on-disk stamp no
-        longer matches: the child would resolve its lazily-imported modules
-        from the *new* files against the *old* pre-imported graph, breaking
-        on any cross-version import.
+    :param graph_stamp: Build and imported-source state captured after the
+        zygote imported its graph. Both runner and harness forks are refused
+        once either changes on disk: the child would otherwise resolve lazy
+        imports from new files against the old in-memory graph.
     """
 
     def __init__(
         self,
         control_sock: socket.socket,
-        graph_stamp: tuple[float, str] | None = None,
+        graph_stamp: _GraphStamp | None = None,
     ) -> None:
         self._graph_stamp = graph_stamp
         self._sel = selectors.DefaultSelector()
@@ -508,7 +592,11 @@ class _ZygoteServer:
             in the error so operator logs say which launch fell back.
         :returns: ``True`` when the request was refused (caller must return).
         """
-        if self._graph_stamp is None or _disk_build_stamp() == self._graph_stamp:
+        stamp = self._graph_stamp
+        if stamp is None:
+            return False
+        build_matches = stamp.build is None or _disk_build_stamp() == stamp.build
+        if build_matches and _source_files_match(stamp.sources):
             return False
         _send(
             conn,
@@ -661,10 +749,11 @@ def main() -> None:
 
     control_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=control_fd)
 
-    # Capture the disk stamp of the graph about to be imported, so harness
-    # forks can detect an in-place upgrade landing after this point.
-    graph_stamp = _disk_build_stamp()
     _import_runner_graph()
+    graph_stamp = _GraphStamp(
+        build=_disk_build_stamp(),
+        sources=_loaded_source_stamps(),
+    )
     # The import graph is now static; move it out of GC's tracked set so cyclic
     # collections stay cheap and don't dirty shared pages in forked children.
     gc.freeze()

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -33,7 +33,9 @@ from omnigent.runner._zygote import (
     _ZYGOTE_TEST_CHILD_SLEEP_ENV_VAR,
     _disk_build_stamp,
     _GraphStamp,
+    _package_source_stamps,
     _source_file_stamps,
+    _source_files_match,
     _ZygoteServer,
 )
 
@@ -523,6 +525,36 @@ def test_disk_build_stamp_resolves_package_dir_without_top_level_file(monkeypatc
     assert probed == [Path(_zygote.__file__).resolve().parents[1] / "_build_info.py"]
 
 
+def test_package_source_stamps_include_lazy_modules(tmp_path) -> None:
+    """The source baseline covers modules that the imported graph has not loaded."""
+    package_dir = tmp_path / "omnigent"
+    lazy_module = package_dir / "provider" / "lazy.py"
+    lazy_module.parent.mkdir(parents=True)
+    lazy_module.write_text("VALUE = 1\n")
+
+    stamps = _package_source_stamps(package_dir)
+
+    assert stamps is not None
+    assert [stamp.path for stamp in stamps] == [lazy_module]
+
+
+def test_source_stamps_ignore_metadata_only_changes(tmp_path) -> None:
+    """Permission changes do not force direct spawning when source is unchanged."""
+    source = tmp_path / "module.py"
+    source.write_text("VALUE = 1\n")
+    stamps = _source_file_stamps([source])
+    assert stamps is not None
+
+    source.chmod(source.stat().st_mode ^ 0o100)
+
+    assert _source_files_match(stamps)
+
+
+def test_source_stamp_capture_fails_closed_for_missing_file(tmp_path) -> None:
+    """An unreadable baseline is represented as incomplete rather than omitted."""
+    assert _source_file_stamps([tmp_path / "missing.py"]) is None
+
+
 def _dispatch_fork(
     server: _ZygoteServer, conn: socket.socket, peer: socket.socket, cmd: str
 ) -> dict:
@@ -565,7 +597,7 @@ def test_fork_refused_after_in_place_upgrade(monkeypatch, cmd, kind) -> None:
     monkeypatch.setattr(os, "fork", lambda: pytest.fail(f"must not fork a mixed-version {kind}"))
     try:
         reply = _dispatch_fork(server, conn, peer, cmd)
-        assert "upgraded on disk" in reply["error"]
+        assert "changed on disk" in reply["error"]
         assert kind in reply["error"]
         assert server._live == set()
     finally:
@@ -606,7 +638,7 @@ def test_fork_proceeds_while_disk_stamp_matches(monkeypatch, cmd) -> None:
 def test_fork_refused_after_source_change_with_stale_build_info(
     monkeypatch, tmp_path, cmd, kind
 ) -> None:
-    """Changed imported source refuses a fork even when build metadata is stale."""
+    """Changed package source refuses a fork even when build metadata is stale."""
     source = tmp_path / "service.py"
     source.write_text("old = True\n")
     graph_stamp = _GraphStamp(
@@ -622,7 +654,29 @@ def test_fork_refused_after_source_change_with_stale_build_info(
     monkeypatch.setattr(os, "fork", lambda: pytest.fail(f"must not fork a mixed-version {kind}"))
     try:
         reply = _dispatch_fork(server, conn, peer, cmd)
-        assert "upgraded on disk" in reply["error"]
+        assert "changed on disk" in reply["error"]
+        assert kind in reply["error"]
+        assert server._live == set()
+    finally:
+        server._sel.close()
+        for sock in (daemon, daemon_peer, conn, peer):
+            sock.close()
+
+
+@pytest.mark.parametrize(("cmd", "kind"), [("fork", "runner"), ("fork_harness", "harness")])
+def test_fork_refused_when_source_baseline_is_incomplete(monkeypatch, cmd, kind) -> None:
+    """An incomplete initial source baseline fails closed onto direct spawning."""
+    daemon, daemon_peer = socket.socketpair()
+    conn, peer = socket.socketpair()
+    server = _ZygoteServer(
+        daemon,
+        graph_stamp=_GraphStamp(build=(1000.0, "sha"), sources=None),
+    )
+    monkeypatch.setattr(_zygote, "_disk_build_stamp", lambda: (1000.0, "sha"))
+    monkeypatch.setattr(os, "fork", lambda: pytest.fail(f"must not fork a mixed-version {kind}"))
+    try:
+        reply = _dispatch_fork(server, conn, peer, cmd)
+        assert "changed on disk" in reply["error"]
         assert kind in reply["error"]
         assert server._live == set()
     finally:

--- a/tests/host/test_runner_zygote.py
+++ b/tests/host/test_runner_zygote.py
@@ -32,6 +32,8 @@ from omnigent.runner._zygote import (
     _ZYGOTE_TEST_CHILD_EXIT_ENV_VAR,
     _ZYGOTE_TEST_CHILD_SLEEP_ENV_VAR,
     _disk_build_stamp,
+    _GraphStamp,
+    _source_file_stamps,
     _ZygoteServer,
 )
 
@@ -95,10 +97,16 @@ def test_import_graph_is_single_threaded() -> None:
     probe = "\n".join(
         [
             "from omnigent.runner._zygote import _import_runner_graph",
+            "import sys",
             "import threading",
             "_import_runner_graph()",
             "print(threading.active_count())",
             "print([t.name for t in threading.enumerate()])",
+            "print(all(name in sys.modules for name in (",
+            "    'omnigent.runner.background_titles.claude_native',",
+            "    'omnigent.runner.background_titles.codex_native',",
+            "    'omnigent.runner.background_titles.sdk',",
+            ")))",
         ]
     )
     result = subprocess.run(
@@ -108,8 +116,9 @@ def test_import_graph_is_single_threaded() -> None:
         timeout=120,
     )
     assert result.returncode == 0, result.stderr
-    first_line = result.stdout.strip().splitlines()[0]
-    assert first_line == "1", result.stdout
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == "1", result.stdout
+    assert lines[-1] == "True", result.stdout
 
 
 def test_manager_starts_and_pings(manager: ZygoteManager) -> None:
@@ -548,7 +557,10 @@ def test_fork_refused_after_in_place_upgrade(monkeypatch, cmd, kind) -> None:
     """
     daemon, daemon_peer = socket.socketpair()
     conn, peer = socket.socketpair()
-    server = _ZygoteServer(daemon, graph_stamp=(1000.0, "oldsha"))
+    server = _ZygoteServer(
+        daemon,
+        graph_stamp=_GraphStamp(build=(1000.0, "oldsha"), sources=()),
+    )
     monkeypatch.setattr(_zygote, "_disk_build_stamp", lambda: (2000.0, "newsha"))
     monkeypatch.setattr(os, "fork", lambda: pytest.fail(f"must not fork a mixed-version {kind}"))
     try:
@@ -574,13 +586,45 @@ def test_fork_proceeds_while_disk_stamp_matches(monkeypatch, cmd) -> None:
     """
     daemon, daemon_peer = socket.socketpair()
     conn, peer = socket.socketpair()
-    server = _ZygoteServer(daemon, graph_stamp=(1000.0, "sha"))
+    server = _ZygoteServer(
+        daemon,
+        graph_stamp=_GraphStamp(build=(1000.0, "sha"), sources=()),
+    )
     monkeypatch.setattr(_zygote, "_disk_build_stamp", lambda: (1000.0, "sha"))
     monkeypatch.setattr(os, "fork", lambda: 4242)
     try:
         reply = _dispatch_fork(server, conn, peer, cmd)
         assert reply == {"pid": 4242}
         assert 4242 in server._live
+    finally:
+        server._sel.close()
+        for sock in (daemon, daemon_peer, conn, peer):
+            sock.close()
+
+
+@pytest.mark.parametrize(("cmd", "kind"), [("fork", "runner"), ("fork_harness", "harness")])
+def test_fork_refused_after_source_change_with_stale_build_info(
+    monkeypatch, tmp_path, cmd, kind
+) -> None:
+    """Changed imported source refuses a fork even when build metadata is stale."""
+    source = tmp_path / "service.py"
+    source.write_text("old = True\n")
+    graph_stamp = _GraphStamp(
+        build=(1000.0, "stale-sha"),
+        sources=_source_file_stamps([source]),
+    )
+    source.write_text("new = True\n")
+
+    daemon, daemon_peer = socket.socketpair()
+    conn, peer = socket.socketpair()
+    server = _ZygoteServer(daemon, graph_stamp=graph_stamp)
+    monkeypatch.setattr(_zygote, "_disk_build_stamp", lambda: (1000.0, "stale-sha"))
+    monkeypatch.setattr(os, "fork", lambda: pytest.fail(f"must not fork a mixed-version {kind}"))
+    try:
+        reply = _dispatch_fork(server, conn, peer, cmd)
+        assert "upgraded on disk" in reply["error"]
+        assert kind in reply["error"]
+        assert server._live == set()
     finally:
         server._sel.close()
         for sock in (daemon, daemon_peer, conn, peer):


### PR DESCRIPTION
## Related issue

N/A — reproduced locally while the host daemon remained running across a source update.

## Summary

- Detect changes to every Omnigent Python source file even when the generated wheel build stamp remains stale in an editable checkout, including provider modules imported lazily after a runner forks.
- Reuse the existing safe fallback: refuse the mixed-version zygote fork and directly spawn a coherent runner without terminating existing sessions.
- Capture the source baseline before importing the runner graph and eagerly import built-in background-title generators for defense in depth.

ELI5: the zygote is a photocopy of Python code kept in memory. Previously, after a Git pull, a new runner could combine pages from the old photocopy with pages from the updated checkout. The zygote now checks its copied source tree before making a runner and declines when it changed.

```text
Before: old cached graph + new lazy imports -> mixed runner -> title failure
After:  source mismatch -> refuse fork -> fresh direct spawn -> coherent runner
```

## Test Plan

- `python -m pytest tests/host/test_runner_zygote.py -q` — 46 passed.
- `pre-commit run --all-files` — all hooks passed.
- Regression coverage verifies lazy modules are fingerprinted, metadata-only changes are ignored, incomplete baselines fail closed, and both runner and harness forks are refused after source changes with stale `_build_info.py`.

## Demo

N/A — non-visual runner lifecycle change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression tests cover package-wide source changes with stale build metadata for both runner and harness fork paths. The existing subprocess test also verifies the preloaded graph stays single-threaded.

## Changelog

Local development sessions keep generating automatic titles after the Omnigent source checkout changes.
