### PR TITLE
Onboarding v2: terminal streaming

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -2782,7 +2782,15 @@ function registerIpc() {
     if (!cliPath) {
       return { ok: false, error: "The omnigent CLI was not found. Install it or set its path." };
     }
-    return serverManager.startLocalServer(cliPath);
+    // Stream the server's startup log lines to the setup page as it boots.
+    const onLine = (line) => {
+      try {
+        event.sender.send("omnigent:local-server-setup-log", { line });
+      } catch {
+        /* window torn down mid-start */
+      }
+    };
+    return serverManager.startLocalServer(cliPath, onLine);
   });
 
   // SPA → this machine's identity: is the CLI installed, and its host id. Both

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -665,7 +665,14 @@ async function tailLocalServerLog(onLine, opts = {}) {
   const sleep = (ms) =>
     new Promise((resolve) => {
       const t = setTimeout(resolve, ms);
-      signal?.addEventListener("abort", () => { clearTimeout(t); resolve(); }, { once: true });
+      signal?.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(t);
+          resolve();
+        },
+        { once: true },
+      );
     });
 
   // 1. Wait for the child's logfile to appear. It's created at spawn, so this

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -696,10 +696,21 @@ async function tailLocalServerLog(onLine, opts = {}) {
       if (size <= offset) return;
       const fd = fs.openSync(logPath, "r");
       try {
+        // readSync may return fewer bytes than requested (large append, pipe-
+        // backed fs); loop until the range up to `size` is drained, advancing
+        // `offset` only by bytes actually read so a short read can't emit
+        // uninitialized buffer or skip content.
         const buf = Buffer.alloc(size - offset);
-        fs.readSync(fd, buf, 0, buf.length, offset);
-        offset = size;
-        emit.push(buf.toString("utf8"));
+        let filled = 0;
+        while (offset + filled < size) {
+          const n = fs.readSync(fd, buf, filled, buf.length - filled, offset + filled);
+          if (n <= 0) break; // EOF (file truncated since stat) — emit what we have
+          filled += n;
+        }
+        if (filled > 0) {
+          offset += filled;
+          emit.push(buf.toString("utf8", 0, filled));
+        }
       } finally {
         fs.closeSync(fd);
       }

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -551,25 +551,55 @@ async function startLocalServer(cliPath) {
   };
 }
 
-/** Path of the log-path sidecar the background server writes on startup. */
-function localServerLogRefPath() {
-  return path.join(localDataDir(), "local_server.logpath");
+/** Directory the background server writes its per-run logfile into. Mirrors
+ * `open_process_log_file("server", root=<data_dir>/logs)` in local_server.py:
+ * files are named `server-<timestamp>.log` and created at spawn time. */
+function localServerLogDir() {
+  return path.join(localDataDir(), "logs", "server");
 }
 
 /**
- * Read the absolute logfile path the background server recorded, or null. The
- * detached child writes this *after* it starts, so callers must retry until it
- * appears. Mirrors `_read_local_server_log_path()` in local_server.py.
+ * Find the background server's CURRENT-run logfile by scanning the server log
+ * dir for the newest `server-*.log` created at/after `startedAtMs`.
  *
- * @returns {string | null}
+ * Why not the `local_server.logpath` sidecar: that sidecar is written only
+ * AFTER the server is healthy (local_server.py records it post-`/health`), so
+ * during boot it doesn't exist yet — tailing it can't stream the startup, and a
+ * stale sidecar from a prior crashed run would stream old content. The child's
+ * real logfile, by contrast, is created the moment it spawns. The `startedAtMs`
+ * floor rejects a previous run's log so a failed start never tails stale lines.
+ *
+ * @param {number} startedAtMs Only consider files modified at/after this (ms).
+ * @returns {string | null} Absolute path of the freshest matching log, or null.
  */
-function readLocalServerLogPath() {
+function findLiveServerLog(startedAtMs) {
+  const dir = localServerLogDir();
+  let entries;
   try {
-    const p = fs.readFileSync(localServerLogRefPath(), "utf8").trim();
-    return p || null;
+    entries = fs.readdirSync(dir);
   } catch {
-    return null;
+    return null; // dir not created yet (child hasn't spawned)
   }
+  let best = null;
+  let bestMtime = -1;
+  // A small floor tolerance: the child may open its log a beat before our
+  // recorded start, and mtime resolution is coarse on some filesystems.
+  const floor = startedAtMs - 2000;
+  for (const name of entries) {
+    if (!/^server-.*\.log$/.test(name)) continue;
+    const full = path.join(dir, name);
+    try {
+      const st = fs.statSync(full);
+      const mtime = st.mtimeMs;
+      if (mtime >= floor && mtime > bestMtime) {
+        best = full;
+        bestMtime = mtime;
+      }
+    } catch {
+      // Racing file removal — skip it.
+    }
+  }
+  return best;
 }
 
 /**
@@ -610,39 +640,48 @@ function makeLineSplitter(onLine) {
 }
 
 /**
- * Tail the background server's logfile, forwarding each new line to `onLine`,
- * until `/health` is ready (or a timeout). Does NOT own the server process — it
- * only reads the logfile the detached daemon writes, keeping the daemon model
- * intact. The logfile appears late (the child writes the sidecar after it
- * starts), so we poll for the sidecar+file before tailing. Naive read-from-
- * offset on `fs.watch` change events — no tail library, no external deps.
+ * Tail the background server's boot logfile, forwarding each new line to
+ * `onLine`, until the caller signals stop (its `omnigent server --background`
+ * resolved — success or failure) or a discovery timeout elapses. Does NOT own
+ * the server process nor decide readiness — it only reads the logfile the
+ * detached child writes, keeping the daemon model intact.
+ *
+ * Discovery uses {@link findLiveServerLog} (the child's real logfile, created
+ * at spawn) rather than the post-health `local_server.logpath` sidecar — so
+ * lines stream DURING boot, and a prior run's stale log is never adopted. Naive
+ * read-from-offset driven by `fs.watch` + a poll fallback; no tail library.
  *
  * @param {(line: string) => void} onLine
- * @param {{ readyTimeoutMs?: number, sidecarTimeoutMs?: number, pollMs?: number }} [opts]
- * @returns {Promise<void>} resolves when tailing stops (ready or timed out).
+ * @param {{ signal?: AbortSignal, startedAtMs?: number, discoverTimeoutMs?: number, pollMs?: number }} [opts]
+ *   `signal` stops the tail (the caller aborts it once the start resolves);
+ *   `startedAtMs` floors log discovery so stale logs are ignored (default: now).
+ * @returns {Promise<void>} resolves when tailing stops (aborted, timed out, or
+ *   the log couldn't be found).
  */
 async function tailLocalServerLog(onLine, opts = {}) {
-  const { readyTimeoutMs = 60000, sidecarTimeoutMs = 15000, pollMs = 200 } = opts;
+  const { signal, startedAtMs = Date.now(), discoverTimeoutMs = 15000, pollMs = 200 } = opts;
   const emit = makeLineSplitter((line) => onLine(stripAnsi(line)));
-  const deadline = Date.now() + readyTimeoutMs;
-  const sidecarDeadline = Date.now() + sidecarTimeoutMs;
-  const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+  const aborted = () => signal?.aborted === true;
+  const sleep = (ms) =>
+    new Promise((resolve) => {
+      const t = setTimeout(resolve, ms);
+      signal?.addEventListener("abort", () => { clearTimeout(t); resolve(); }, { once: true });
+    });
 
-  // 1. Wait for the sidecar + logfile to exist (detached child writes them).
+  // 1. Wait for the child's logfile to appear. It's created at spawn, so this
+  //    is a short wait — bounded so a start that never writes a log can't hang.
+  const discoverDeadline = Date.now() + discoverTimeoutMs;
   let logPath = null;
-  while (Date.now() < sidecarDeadline) {
-    const p = readLocalServerLogPath();
-    if (p && fs.existsSync(p)) {
-      logPath = p;
-      break;
-    }
-    // eslint-disable-next-line no-await-in-loop -- sequential poll for a file that appears over time
+  while (!aborted() && Date.now() < discoverDeadline) {
+    logPath = findLiveServerLog(startedAtMs);
+    if (logPath) break;
+    // eslint-disable-next-line no-await-in-loop -- sequential poll for a file that appears at spawn
     await sleep(pollMs);
   }
-  if (!logPath) return; // No logfile to tail — the caller still reports ready/fail via status.
+  if (!logPath) return; // No logfile found — the caller still reports ready/fail.
 
-  // 2. Read the file from the start, then follow appended bytes. fs.watch can
-  //    miss rapid writes, so we also re-check on each poll tick until ready.
+  // 2. Read from the start, then follow appended bytes. fs.watch can miss rapid
+  //    writes, so a poll tick also drains until the caller aborts.
   let offset = 0;
   const readNew = () => {
     try {
@@ -658,7 +697,7 @@ async function tailLocalServerLog(onLine, opts = {}) {
         fs.closeSync(fd);
       }
     } catch {
-      // File rotated/removed mid-tail — stop reading; readiness poll still runs.
+      // File rotated/removed mid-tail — stop reading; the caller drives the end.
     }
   };
 
@@ -670,16 +709,12 @@ async function tailLocalServerLog(onLine, opts = {}) {
   }
   try {
     readNew();
-    while (Date.now() < deadline) {
-      // eslint-disable-next-line no-await-in-loop -- sequential poll: tick, drain new bytes, re-check readiness
+    while (!aborted()) {
+      // eslint-disable-next-line no-await-in-loop -- sequential poll: tick, drain, until aborted
       await sleep(pollMs);
       readNew();
-      // eslint-disable-next-line no-await-in-loop -- must await this tick's health before the next
-      if (await localServerHealthy(1000)) {
-        readNew(); // final drain of the readiness lines
-        return;
-      }
     }
+    readNew(); // final drain of any lines written just before the abort
   } finally {
     if (watcher) watcher.close();
   }
@@ -1080,7 +1115,7 @@ module.exports = {
   getCliStatus,
   getServerStatus,
   startLocalServer,
-  readLocalServerLogPath,
+  findLiveServerLog,
   makeLineSplitter,
   stripAnsi,
   tailLocalServerLog,

--- a/web/electron/src/omnigent_cli.js
+++ b/web/electron/src/omnigent_cli.js
@@ -551,6 +551,140 @@ async function startLocalServer(cliPath) {
   };
 }
 
+/** Path of the log-path sidecar the background server writes on startup. */
+function localServerLogRefPath() {
+  return path.join(localDataDir(), "local_server.logpath");
+}
+
+/**
+ * Read the absolute logfile path the background server recorded, or null. The
+ * detached child writes this *after* it starts, so callers must retry until it
+ * appears. Mirrors `_read_local_server_log_path()` in local_server.py.
+ *
+ * @returns {string | null}
+ */
+function readLocalServerLogPath() {
+  try {
+    const p = fs.readFileSync(localServerLogRefPath(), "utf8").trim();
+    return p || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strip ANSI SGR/escape sequences so log lines render as plain text in the
+ * setup terminal (uvicorn/app logs may be colorized).
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+function stripAnsi(s) {
+  return s.replace(ANSI_RE, "");
+}
+
+/**
+ * Split a growing byte stream into whole lines across chunk boundaries. Feed
+ * each chunk to `push`; complete lines (newline-terminated) are emitted via
+ * `onLine`, and a trailing partial line is buffered until its newline arrives.
+ * The classic bug this avoids: emitting a half line when a chunk splits mid-line.
+ *
+ * @param {(line: string) => void} onLine
+ * @returns {{ push: (chunk: string) => void }}
+ */
+function makeLineSplitter(onLine) {
+  let buf = "";
+  return {
+    push(chunk) {
+      buf += chunk;
+      let nl;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        // Trim a trailing \r for CRLF logs; keep other content verbatim.
+        onLine(buf.slice(0, nl).replace(/\r$/, ""));
+        buf = buf.slice(nl + 1);
+      }
+    },
+  };
+}
+
+/**
+ * Tail the background server's logfile, forwarding each new line to `onLine`,
+ * until `/health` is ready (or a timeout). Does NOT own the server process — it
+ * only reads the logfile the detached daemon writes, keeping the daemon model
+ * intact. The logfile appears late (the child writes the sidecar after it
+ * starts), so we poll for the sidecar+file before tailing. Naive read-from-
+ * offset on `fs.watch` change events — no tail library, no external deps.
+ *
+ * @param {(line: string) => void} onLine
+ * @param {{ readyTimeoutMs?: number, sidecarTimeoutMs?: number, pollMs?: number }} [opts]
+ * @returns {Promise<void>} resolves when tailing stops (ready or timed out).
+ */
+async function tailLocalServerLog(onLine, opts = {}) {
+  const { readyTimeoutMs = 60000, sidecarTimeoutMs = 15000, pollMs = 200 } = opts;
+  const emit = makeLineSplitter((line) => onLine(stripAnsi(line)));
+  const deadline = Date.now() + readyTimeoutMs;
+  const sidecarDeadline = Date.now() + sidecarTimeoutMs;
+  const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+  // 1. Wait for the sidecar + logfile to exist (detached child writes them).
+  let logPath = null;
+  while (Date.now() < sidecarDeadline) {
+    const p = readLocalServerLogPath();
+    if (p && fs.existsSync(p)) {
+      logPath = p;
+      break;
+    }
+    // eslint-disable-next-line no-await-in-loop -- sequential poll for a file that appears over time
+    await sleep(pollMs);
+  }
+  if (!logPath) return; // No logfile to tail — the caller still reports ready/fail via status.
+
+  // 2. Read the file from the start, then follow appended bytes. fs.watch can
+  //    miss rapid writes, so we also re-check on each poll tick until ready.
+  let offset = 0;
+  const readNew = () => {
+    try {
+      const size = fs.statSync(logPath).size;
+      if (size <= offset) return;
+      const fd = fs.openSync(logPath, "r");
+      try {
+        const buf = Buffer.alloc(size - offset);
+        fs.readSync(fd, buf, 0, buf.length, offset);
+        offset = size;
+        emit.push(buf.toString("utf8"));
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      // File rotated/removed mid-tail — stop reading; readiness poll still runs.
+    }
+  };
+
+  let watcher = null;
+  try {
+    watcher = fs.watch(logPath, { persistent: false }, readNew);
+  } catch {
+    // fs.watch unsupported here — the poll loop below still drains new bytes.
+  }
+  try {
+    readNew();
+    while (Date.now() < deadline) {
+      // eslint-disable-next-line no-await-in-loop -- sequential poll: tick, drain new bytes, re-check readiness
+      await sleep(pollMs);
+      readNew();
+      // eslint-disable-next-line no-await-in-loop -- must await this tick's health before the next
+      if (await localServerHealthy(1000)) {
+        readNew(); // final drain of the readiness lines
+        return;
+      }
+    }
+  } finally {
+    if (watcher) watcher.close();
+  }
+}
+
 /**
  * Stop the local background server (and its attached host daemon).
  *
@@ -946,6 +1080,10 @@ module.exports = {
   getCliStatus,
   getServerStatus,
   startLocalServer,
+  readLocalServerLogPath,
+  makeLineSplitter,
+  stripAnsi,
+  tailLocalServerLog,
   stopLocalServer,
   stopHost,
   serverAuthed,

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -461,4 +461,15 @@ contextBridge.exposeInMainWorld("omnigentSetup", {
    * caller then connects to `url` via setServerUrl.
    */
   startLocalServer: () => ipcRenderer.invoke("omnigent:start-local-server"),
+  /**
+   * Subscribe to the local server's startup log lines (streamed while it boots
+   * during startLocalServer). Returns an unsubscribe function. Absent on older
+   * shells → the setup page falls back to phase-only display.
+   * @param {(line: string) => void} callback
+   */
+  onLocalServerSetupLog: (callback) => {
+    const listener = (_event, payload) => callback(payload?.line ?? "");
+    ipcRenderer.on("omnigent:local-server-setup-log", listener);
+    return () => ipcRenderer.removeListener("omnigent:local-server-setup-log", listener);
+  },
 });

--- a/web/electron/src/server_manager.js
+++ b/web/electron/src/server_manager.js
@@ -383,10 +383,15 @@ function stopChild(child) {
  * *we* actually start it — a server that was already running is left to its
  * own lifecycle.
  *
+ * When `onLine` is given, forward the fresh server's startup log lines to it
+ * while it boots (Option B: tail the daemon's own logfile — we don't own the
+ * process). A reused server has no fresh startup, so it gets one status line.
+ *
  * @param {string} cliPath
+ * @param {(line: string) => void} [onLine]
  * @returns {Promise<{ ok: boolean, url?: string, alreadyRunning?: boolean, error?: string }>}
  */
-async function startLocalServer(cliPath) {
+async function startLocalServer(cliPath, onLine) {
   // Reuse a server that's already running — but health-verify it (pidfile +
   // pid + /health), not just pid-liveness, since we're about to navigate the
   // window to this URL: a stale pidfile (dead/reused pid, hung server) must NOT
@@ -395,9 +400,17 @@ async function startLocalServer(cliPath) {
   // ownership claim.
   const existing = await cli.localServerHealthy();
   if (existing) {
+    if (onLine) onLine("Server already running — connecting…");
     return { ok: true, url: existing.url, alreadyRunning: true };
   }
+  // Tail the daemon's logfile alongside the start so lines stream as it boots.
+  // The tail stops itself on /health-ready or timeout; a tail failure must not
+  // fail the start, so it's fire-and-forget and awaited only for cleanup.
+  const tail = onLine
+    ? cli.tailLocalServerLog(onLine).catch(() => {})
+    : Promise.resolve();
   const res = await cli.startLocalServer(cliPath);
+  await tail;
   if (res.ok) {
     ownedLocalServer = { url: res.url, port: res.port, pid: res.pid };
     return { ok: true, url: res.url };

--- a/web/electron/src/server_manager.js
+++ b/web/electron/src/server_manager.js
@@ -403,19 +403,29 @@ async function startLocalServer(cliPath, onLine) {
     if (onLine) onLine("Server already running — connecting…");
     return { ok: true, url: existing.url, alreadyRunning: true };
   }
-  // Tail the daemon's logfile alongside the start so lines stream as it boots.
-  // The tail stops itself on /health-ready or timeout; a tail failure must not
-  // fail the start, so it's fire-and-forget and awaited only for cleanup.
-  const tail = onLine
-    ? cli.tailLocalServerLog(onLine).catch(() => {})
+  // Tail the daemon's boot logfile alongside the start so lines stream live as
+  // it boots. `omnigent server --background` blocks until the server is healthy
+  // or fails, so it IS the authoritative "boot finished" signal: abort the tail
+  // the moment it resolves rather than letting the tail poll on its own. This
+  // keeps a failed start from waiting on the tail (no ~60s stall), and the
+  // startedAt floor makes the tail ignore any stale log from a prior crash. A
+  // tail failure must never fail the start, so it's isolated with catch.
+  const startedAtMs = Date.now();
+  const controller = onLine ? new AbortController() : null;
+  const tail = controller
+    ? cli.tailLocalServerLog(onLine, { signal: controller.signal, startedAtMs }).catch(() => {})
     : Promise.resolve();
-  const res = await cli.startLocalServer(cliPath);
-  await tail;
-  if (res.ok) {
-    ownedLocalServer = { url: res.url, port: res.port, pid: res.pid };
-    return { ok: true, url: res.url };
+  try {
+    const res = await cli.startLocalServer(cliPath);
+    if (res.ok) {
+      ownedLocalServer = { url: res.url, port: res.port, pid: res.pid };
+      return { ok: true, url: res.url };
+    }
+    return { ok: false, error: res.error };
+  } finally {
+    controller?.abort();
+    await tail; // let it drain the final lines and close its watcher
   }
-  return { ok: false, error: res.error };
 }
 
 /**

--- a/web/electron/test/local_server_log_tail.test.js
+++ b/web/electron/test/local_server_log_tail.test.js
@@ -1,12 +1,17 @@
 // Tests for the setup-terminal log tail helpers (src/omnigent_cli.js), run with
 // `node --test`. Focus: the line splitter's partial-line buffering across chunk
 // boundaries (the classic tail bug — never emit a half line), CRLF trimming,
-// and ANSI stripping so streamed uvicorn/app logs render as plain text.
+// ANSI stripping, live-log discovery (freshest file, stale rejected), and the
+// tail streaming during boot then stopping on abort.
 
-const { describe, it } = require("node:test");
+const { describe, it, before, after, beforeEach } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 
-const { makeLineSplitter, stripAnsi } = require("../src/omnigent_cli");
+const { makeLineSplitter, stripAnsi, findLiveServerLog, tailLocalServerLog } =
+  require("../src/omnigent_cli");
 
 describe("makeLineSplitter", () => {
   it("emits whole lines and buffers a trailing partial across chunks", () => {
@@ -53,5 +58,129 @@ describe("stripAnsi", () => {
   });
   it("leaves plain text untouched", () => {
     assert.equal(stripAnsi("plain line"), "plain line");
+  });
+});
+
+// findLiveServerLog + tailLocalServerLog read from <OMNIGENT_DATA_DIR>/logs/server,
+// so point the env var at a temp dir and lay out server-*.log files.
+describe("findLiveServerLog", () => {
+  let dataDir;
+  let logDir;
+  const prevEnv = process.env.OMNIGENT_DATA_DIR;
+
+  before(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omnigent-logtail-"));
+    process.env.OMNIGENT_DATA_DIR = dataDir;
+    logDir = path.join(dataDir, "logs", "server");
+    fs.mkdirSync(logDir, { recursive: true });
+  });
+  after(() => {
+    if (prevEnv === undefined) delete process.env.OMNIGENT_DATA_DIR;
+    else process.env.OMNIGENT_DATA_DIR = prevEnv;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+  beforeEach(() => {
+    for (const f of fs.readdirSync(logDir)) fs.rmSync(path.join(logDir, f));
+  });
+
+  const write = (name, mtimeMs) => {
+    const full = path.join(logDir, name);
+    fs.writeFileSync(full, "");
+    const s = mtimeMs / 1000;
+    fs.utimesSync(full, s, s);
+    return full;
+  };
+
+  it("returns null when the log dir has no matching file", () => {
+    assert.equal(findLiveServerLog(Date.now()), null);
+  });
+
+  it("picks the newest server-*.log at/after the start floor", () => {
+    const now = Date.now();
+    write("server-old.log", now + 1000);
+    const newer = write("server-new.log", now + 5000);
+    assert.equal(findLiveServerLog(now), newer);
+  });
+
+  it("rejects a stale log written before the start floor (prior crash)", () => {
+    const now = Date.now();
+    // Well before the floor (which is startedAt - 2000ms tolerance).
+    write("server-stale.log", now - 60_000);
+    assert.equal(findLiveServerLog(now), null);
+  });
+
+  it("ignores non-server files in the dir", () => {
+    const now = Date.now();
+    write("runner-x.log", now + 5000);
+    write("notes.txt", now + 5000);
+    const s = write("server-y.log", now + 1000);
+    assert.equal(findLiveServerLog(now), s);
+  });
+});
+
+describe("tailLocalServerLog", () => {
+  let dataDir;
+  let logDir;
+  const prevEnv = process.env.OMNIGENT_DATA_DIR;
+
+  before(() => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omnigent-logtail-run-"));
+    process.env.OMNIGENT_DATA_DIR = dataDir;
+    logDir = path.join(dataDir, "logs", "server");
+    fs.mkdirSync(logDir, { recursive: true });
+  });
+  after(() => {
+    if (prevEnv === undefined) delete process.env.OMNIGENT_DATA_DIR;
+    else process.env.OMNIGENT_DATA_DIR = prevEnv;
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+  beforeEach(() => {
+    for (const f of fs.readdirSync(logDir)) fs.rmSync(path.join(logDir, f));
+  });
+
+  it("streams lines appended DURING boot, then stops on abort", async () => {
+    const now = Date.now();
+    const logFile = path.join(logDir, "server-boot.log");
+    fs.writeFileSync(logFile, "INFO starting\n");
+    fs.utimesSync(logFile, (now + 100) / 1000, (now + 100) / 1000);
+
+    const lines = [];
+    const controller = new AbortController();
+    const done = tailLocalServerLog((l) => lines.push(l), {
+      signal: controller.signal,
+      startedAtMs: now,
+      pollMs: 10,
+    });
+
+    // Append more lines after the tail has started — these must stream, not be
+    // dumped only at the end (the bug: sidecar discovery streamed nothing live).
+    await new Promise((r) => {
+      setTimeout(r, 40);
+    });
+    fs.appendFileSync(logFile, "INFO migrating\nINFO Uvicorn running\n");
+    await new Promise((r) => {
+      setTimeout(r, 40);
+    });
+
+    controller.abort();
+    await done;
+
+    assert.deepEqual(lines, ["INFO starting", "INFO migrating", "INFO Uvicorn running"]);
+  });
+
+  it("returns promptly on abort when no logfile ever appears (failed start)", async () => {
+    const controller = new AbortController();
+    const started = Date.now();
+    const done = tailLocalServerLog(() => {}, {
+      signal: controller.signal,
+      startedAtMs: started,
+      pollMs: 10,
+      // A large discover timeout would hang if abort weren't honored.
+      discoverTimeoutMs: 60_000,
+    });
+    controller.abort();
+    await done;
+    // Aborting during discovery must not wait out discoverTimeoutMs.
+    assert.ok(Date.now() - started < 1000);
   });
 });

--- a/web/electron/test/local_server_log_tail.test.js
+++ b/web/electron/test/local_server_log_tail.test.js
@@ -10,8 +10,12 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-const { makeLineSplitter, stripAnsi, findLiveServerLog, tailLocalServerLog } =
-  require("../src/omnigent_cli");
+const {
+  makeLineSplitter,
+  stripAnsi,
+  findLiveServerLog,
+  tailLocalServerLog,
+} = require("../src/omnigent_cli");
 
 describe("makeLineSplitter", () => {
   it("emits whole lines and buffers a trailing partial across chunks", () => {

--- a/web/electron/test/local_server_log_tail.test.js
+++ b/web/electron/test/local_server_log_tail.test.js
@@ -1,0 +1,57 @@
+// Tests for the setup-terminal log tail helpers (src/omnigent_cli.js), run with
+// `node --test`. Focus: the line splitter's partial-line buffering across chunk
+// boundaries (the classic tail bug — never emit a half line), CRLF trimming,
+// and ANSI stripping so streamed uvicorn/app logs render as plain text.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const { makeLineSplitter, stripAnsi } = require("../src/omnigent_cli");
+
+describe("makeLineSplitter", () => {
+  it("emits whole lines and buffers a trailing partial across chunks", () => {
+    const out = [];
+    const s = makeLineSplitter((line) => out.push(line));
+    s.push("hello\nwor");
+    assert.deepEqual(out, ["hello"]); // "wor" is buffered, not emitted
+    s.push("ld\n");
+    assert.deepEqual(out, ["hello", "world"]);
+  });
+
+  it("splits a line that arrives one byte at a time", () => {
+    const out = [];
+    const s = makeLineSplitter((line) => out.push(line));
+    for (const ch of "ab\ncd\n") s.push(ch);
+    assert.deepEqual(out, ["ab", "cd"]);
+  });
+
+  it("handles multiple newlines in one chunk", () => {
+    const out = [];
+    const s = makeLineSplitter((line) => out.push(line));
+    s.push("a\nb\nc\n");
+    assert.deepEqual(out, ["a", "b", "c"]);
+  });
+
+  it("trims a trailing CR (CRLF logs)", () => {
+    const out = [];
+    const s = makeLineSplitter((line) => out.push(line));
+    s.push("line\r\nnext\r\n");
+    assert.deepEqual(out, ["line", "next"]);
+  });
+
+  it("does not emit a final unterminated line", () => {
+    const out = [];
+    const s = makeLineSplitter((line) => out.push(line));
+    s.push("no newline here");
+    assert.deepEqual(out, []);
+  });
+});
+
+describe("stripAnsi", () => {
+  it("removes SGR color codes, keeps text", () => {
+    assert.equal(stripAnsi("\x1b[32mINFO\x1b[0m ready"), "INFO ready");
+  });
+  it("leaves plain text untouched", () => {
+    assert.equal(stripAnsi("plain line"), "plain line");
+  });
+});

--- a/web/src/pages/onboarding/ServerSelectorV2.tsx
+++ b/web/src/pages/onboarding/ServerSelectorV2.tsx
@@ -49,6 +49,10 @@ export interface ServerSelectorV2Setup {
    *  outcome so the terminal step can show ready/failed (on success the window
    *  navigates away, so it resolves only on failure in practice). */
   onStartLocal: () => Promise<{ ok: boolean; error?: string }>;
+  /** Subscribe to the local server's startup log lines while it boots; returns
+   *  an unsubscribe. Absent on older shells / browser preview → the terminal
+   *  step shows the coarse phases only. */
+  onSetupLog?: (cb: (line: string) => void) => () => void;
   /** Remove a recent server from the saved list, if the shell supports it. */
   onRemoveServer?: (url: string) => void;
   /** Copy text to the clipboard via the shell's native bridge. */
@@ -74,7 +78,7 @@ const CARD: Record<Step, { height: number; panelHeight: number }> = {
   landing: { height: 560, panelHeight: 308 },
   mode: { height: 560, panelHeight: 96 },
   server: { height: 600, panelHeight: 64 },
-  terminal: { height: 560, panelHeight: 96 },
+  terminal: { height: 560, panelHeight: 240 },
 };
 
 export function ServerSelectorV2({ setup }: { setup: ServerSelectorV2Setup }) {
@@ -125,7 +129,11 @@ export function ServerSelectorV2({ setup }: { setup: ServerSelectorV2Setup }) {
           />
         )}
         {step === "terminal" && (
-          <SetupTerminalStep onStartLocal={setup.onStartLocal} onBack={() => setStep("mode")} />
+          <SetupTerminalStep
+            onStartLocal={setup.onStartLocal}
+            onSetupLog={setup.onSetupLog}
+            onBack={() => setStep("mode")}
+          />
         )}
         {step === "server" && (
           <ServerSelectStep

--- a/web/src/pages/onboarding/SetupTerminalStep.test.tsx
+++ b/web/src/pages/onboarding/SetupTerminalStep.test.tsx
@@ -29,6 +29,28 @@ describe("SetupTerminalStep", () => {
     expect(await screen.findByText("Server ready")).toBeInTheDocument();
   });
 
+  it("renders streamed log lines from onSetupLog and unsubscribes on unmount", async () => {
+    const unsubscribe = vi.fn();
+    let emit: ((line: string) => void) | undefined;
+    const onSetupLog = vi.fn((cb: (line: string) => void) => {
+      emit = cb;
+      return unsubscribe;
+    });
+    const onStartLocal = vi.fn().mockResolvedValue({ ok: true });
+    const { unmount } = render(
+      <SetupTerminalStep onStartLocal={onStartLocal} onSetupLog={onSetupLog} onBack={vi.fn()} />,
+    );
+
+    expect(onSetupLog).toHaveBeenCalledOnce();
+    emit?.("Starting omnigent server on 127.0.0.1:6767");
+    emit?.("Uvicorn running on http://127.0.0.1:6767");
+    expect(await screen.findByText("Uvicorn running on http://127.0.0.1:6767")).toBeInTheDocument();
+    expect(screen.getByText("Starting omnigent server on 127.0.0.1:6767")).toBeInTheDocument();
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
   it("fires onBack from Back on the failure screen", async () => {
     const onBack = vi.fn();
     render(

--- a/web/src/pages/onboarding/SetupTerminalStep.tsx
+++ b/web/src/pages/onboarding/SetupTerminalStep.tsx
@@ -1,35 +1,55 @@
 // Onboarding step: start the local server, shown as a small terminal-styled
-// status log. Phases reflect what the shell actually observes — the local
-// server daemonizes (omnigent server --background), so there is no live install
-// stream to tail; we show the real start → ready/failed lifecycle, not
-// fabricated install steps. On success the window navigates to the server and
-// this page is replaced, so "Ready" is only ever briefly visible.
+// status log. The local server daemonizes (omnigent server --background); the
+// shell tails its logfile and streams the real startup lines here via
+// onSetupLog. We frame those streamed lines with a phase heading + progress bar
+// and the real start → ready/failed lifecycle, not fabricated install steps.
+// When no stream is available (older shell / browser preview) the log shows a
+// single "Starting…" line until ready. On success the window navigates to the
+// server and this page is replaced, so "Ready" is only ever briefly visible.
 
 import { useEffect, useRef, useState } from "react";
-import { CircleCheck, CircleX, LoaderCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 type Phase = "starting" | "ready" | "failed";
 
 export function SetupTerminalStep({
   onStartLocal,
+  onSetupLog,
   onBack,
 }: {
   onStartLocal: () => Promise<{ ok: boolean; error?: string }>;
+  onSetupLog?: (cb: (line: string) => void) => () => void;
   onBack: () => void;
 }) {
   const [phase, setPhase] = useState<Phase>("starting");
   const [error, setError] = useState<string | undefined>();
+  const [lines, setLines] = useState<string[]>([]);
   // Bump to re-run the start effect on retry.
   const [attempt, setAttempt] = useState(0);
   // Guard against a resolve landing after unmount (window navigated away).
   const alive = useRef(true);
+  const logBox = useRef<HTMLDivElement>(null);
   useEffect(
     () => () => {
       alive.current = false;
     },
     [],
   );
+
+  // Subscribe to the streamed startup log lines (if the shell exposes them).
+  useEffect(() => {
+    if (!onSetupLog) return;
+    setLines([]);
+    const unsubscribe = onSetupLog((line) => {
+      if (alive.current) setLines((prev) => [...prev, line]);
+    });
+    return unsubscribe;
+  }, [onSetupLog, attempt]);
+
+  // Keep the newest line in view as the stream grows.
+  useEffect(() => {
+    if (logBox.current) logBox.current.scrollTop = logBox.current.scrollHeight;
+  }, [lines]);
 
   useEffect(() => {
     setPhase("starting");
@@ -44,15 +64,49 @@ export function SetupTerminalStep({
     });
   }, [onStartLocal, attempt]);
 
-  return (
-    <div className="flex h-full flex-col px-2 pb-1 pt-3">
-      <h1 className="mb-3 pt-1 text-center text-sm text-foreground">Starting Omnigent</h1>
+  const streamed = lines.length > 0;
+  const phaseLabel =
+    phase === "ready"
+      ? "Omnigent is ready"
+      : phase === "failed"
+        ? "Couldn't start Omnigent"
+        : "Starting Omnigent";
 
-      <div className="flex-1 rounded-lg border border-border bg-muted/40 p-3 font-mono text-xs">
-        <Line state={phase === "starting" ? "running" : "done"} text="Starting the local server…" />
-        {phase === "ready" && <Line state="done" text="Server ready" />}
+  return (
+    <div className="flex h-full flex-col px-2 pb-1 pt-1">
+      <div className="mb-2 text-sm font-medium text-foreground">{phaseLabel}</div>
+      <div className="mb-3 h-[6px] w-full overflow-hidden rounded-full bg-foreground/[0.06]">
+        <div
+          className={`h-full rounded-full transition-all duration-300 ease-linear ${
+            phase === "failed" ? "bg-destructive/60" : "bg-foreground/25"
+          } ${phase === "starting" ? "animate-pulse" : ""}`}
+          style={{ width: phase === "starting" ? "60%" : "100%" }}
+        />
+      </div>
+
+      <div
+        ref={logBox}
+        className="min-h-0 flex-1 overflow-y-auto text-[13px] leading-4"
+        style={{ fontFamily: '"SF Mono", Monaco, Consolas, monospace' }}
+      >
+        {streamed ? (
+          lines.map((line, i) => (
+            // Streamed log lines have no stable id; index is fine (append-only).
+            // eslint-disable-next-line react/no-array-index-key
+            <LogLine key={i} text={line} />
+          ))
+        ) : (
+          <div className="text-foreground/25">Starting the local server…</div>
+        )}
+        {phase === "ready" && (
+          <div className="text-[rgb(34,197,94)]">
+            <span className="select-none">✓</span> Server ready
+          </div>
+        )}
         {phase === "failed" && (
-          <Line state="error" text={error ?? "Could not start the local server."} />
+          <div className="text-destructive">
+            <span className="select-none">✕</span> {error ?? "Could not start the local server."}
+          </div>
         )}
       </div>
 
@@ -70,22 +124,17 @@ export function SetupTerminalStep({
   );
 }
 
-function Line({ state, text }: { state: "running" | "done" | "error"; text: string }) {
-  return (
-    <div className="flex items-start gap-2 py-0.5">
-      {state === "running" && (
-        <LoaderCircle
-          className="mt-0.5 size-3.5 shrink-0 animate-spin text-muted-foreground"
-          aria-hidden
-        />
-      )}
-      {state === "done" && (
-        <CircleCheck className="mt-0.5 size-3.5 shrink-0 text-success" aria-hidden />
-      )}
-      {state === "error" && (
-        <CircleX className="mt-0.5 size-3.5 shrink-0 text-destructive" aria-hidden />
-      )}
-      <span className={state === "error" ? "text-destructive" : "text-foreground"}>{text}</span>
-    </div>
-  );
+// One raw streamed log line, styled as a terminal row. Raw uvicorn/app logs have
+// no command/pending/success structure, so we color by a light severity
+// heuristic: errors red, warnings amber, "ready/complete" green, else normal.
+function LogLine({ text }: { text: string }) {
+  const t = text.trim();
+  const color = /\b(error|traceback|exception|fatal|failed)\b/i.test(t)
+    ? "text-destructive"
+    : /\b(warn|warning)\b/i.test(t)
+      ? "text-[rgb(180,120,0)]"
+      : /\b(ready|complete|listening|running on|started)\b/i.test(t)
+        ? "text-[rgb(34,197,94)]"
+        : "text-foreground/80";
+  return <div className={`whitespace-pre-wrap break-words ${color}`}>{text}</div>;
 }

--- a/web/src/server-selector-v2.tsx
+++ b/web/src/server-selector-v2.tsx
@@ -28,6 +28,7 @@ interface OmnigentSetup {
   setServerSelectorV2?: (enabled: boolean) => Promise<unknown>;
   getCliStatus: () => Promise<{ installed?: boolean }>;
   startLocalServer: () => Promise<{ ok?: boolean; url?: string; error?: string }>;
+  onLocalServerSetupLog?: (cb: (line: string) => void) => () => void;
 }
 
 function setupBridge(): OmnigentSetup | undefined {
@@ -107,6 +108,11 @@ function SetupApp() {
         return { ok: false, error: e instanceof Error ? e.message : String(e) };
       }
     },
+    // Live startup-log stream from the shell, if this shell exposes it (older
+    // shells / browser preview omit it → the terminal step shows phases only).
+    onSetupLog: setupBridge()?.onLocalServerSetupLog
+      ? (cb) => setupBridge()?.onLocalServerSetupLog?.(cb) ?? (() => {})
+      : undefined,
     // Only offered when the shell exposes the forget method (newer shells).
     onRemoveServer: setupBridge()?.forgetRecentServer
       ? (url) => {


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Streams the local server's real startup log lines into the onboarding wizard's
"Starting Omnigent" step, instead of the coarse Starting → Ready/Failed phase
indicator. When a new user picks **Local** and clicks **Begin**, the shell tails
the daemon's boot logfile and forwards each line to the terminal-styled step,
so the user sees the server actually come up (uvicorn boot, DB migrations, app
startup) rather than a spinner.

- **No Python changes.** The server still daemonizes via `omnigent server
  --background`; the shell only *reads* the logfile the detached child writes,
  so the daemon lifecycle model is untouched (we don't own the process).
- Line splitter (partial-line buffering across chunks), ANSI stripping, and an
  offset-based tail (`fs.watch` + poll fallback) live in `omnigent_cli.js`;
  lines reach the renderer over a sender-validated IPC channel
  (`omnigent:local-server-setup-log`) exposed through the `omnigentSetup`
  preload bridge.
- The React step subscribes on mount, appends + auto-scrolls, and falls back to
  the phase-only display on an older shell / browser preview (no bridge).

**ELI5:** the app used to show a spinner while the local server started. Now it
shows the server's own log scrolling by, like watching a terminal, so you can
see what it's doing and spot a failure instead of staring at a spinner.

### How it works

```
Begin ─▶ main.js  omnigent:start-local-server (sender-validated)
           │
           ├─▶ server_manager.startLocalServer(cliPath, onLine)
           │      ├─ tailLocalServerLog(onLine, {signal, startedAtMs})  ── tails ──┐
           │      │     discovers <data_dir>/logs/server/server-*.log             │
           │      └─ omnigent server --background  (blocks until healthy/failed)  │
           │            └─ on resolve: controller.abort() ── stops the tail ◀──────┘
           │
           └─▶ each line ─▶ webContents.send("omnigent:local-server-setup-log")
                              └─▶ preload onLocalServerSetupLog ─▶ SetupTerminalStep
```

Two review findings (from Polly's cross-vendor review) were addressed in the
`address feedback` commit — both about sidecar timing, not code hygiene:

1. **Live streaming during boot.** The `local_server.logpath` sidecar is written
   only *after* the server is healthy, so tailing it dumped every line at once
   right before navigation. Discovery now scans `<data_dir>/logs/server/` for the
   child's real logfile (`findLiveServerLog`), which is created at spawn — so
   lines stream as the server boots.
2. **No stale content / no ~60s block on failure.** A `startedAtMs` floor makes
   discovery reject a prior crashed run's log, and the tail no longer polls
   `/health` on its own — `omnigent server --background` is the authoritative
   "boot finished" signal, so `server_manager` aborts the tail (via
   `AbortController`) the instant it resolves. A failed start ends the tail
   immediately instead of stalling the failure screen.

## Test Plan

Automated (`node --test` in `web/electron/`, Vitest in `web/`):

- `local_server_log_tail.test.js` — line splitter (partial lines across chunks,
  one-byte-at-a-time, CRLF, no unterminated tail), ANSI strip, `findLiveServerLog`
  (freshest file, stale-log rejection, non-`server-*` filtering), and
  `tailLocalServerLog` (streams lines appended *during* boot; returns promptly on
  abort when no logfile appears).
- `SetupTerminalStep.test.tsx` — renders streamed lines from `onSetupLog` and
  unsubscribes on unmount.

Manual (Electron wizard, two terminals):

```bash
# web/:          pnpm dev:onboarding-wizard
# web/electron/: OMNIGENT_ONBOARDING_WIZARD=1 pnpm dev
```

1. `omnigent server stop` first (so there's a fresh boot to stream), then Get
   started → Local → Begin → real log lines stream in and it navigates on ready.
2. Reused healthy server → shows "Server already running — connecting…", no tail.
3. Failed start (e.g. CLI missing) → failure screen appears without delay + Retry.
4. Browser preview (no bridge) → phase-only fallback still renders.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<!-- Attach a screen recording of Get started → Local → Begin showing the log stream. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the pure/IO helpers (splitter, ANSI, log discovery, tail
streaming + abort) and the React subscribe/unsubscribe. The end-to-end wizard
flow (real `omnigent server --background`, live tail, navigate-on-ready) and the
theme/scroll appearance are verified manually per the Test Plan above — they
depend on a real Electron window and a live daemon that the unit layer mocks.

## Changelog

The onboarding "Starting Omnigent" step now streams the local server's real
startup logs instead of a spinner.
