### PR TITLE
fix(web): open Cmd+F find-in-file on the file viewer's Monaco surfaces

### DIFF
--- a/web/src/components/ProjectIconPicker.tsx
+++ b/web/src/components/ProjectIconPicker.tsx
@@ -6,10 +6,10 @@
 //     hover-revealed edit/remove affordances (the OMNI-3742 design).
 
 import { type CSSProperties, lazy, Suspense, useState } from "react";
-import { useTheme } from "next-themes";
 import { FolderIcon, Loader2Icon, PencilIcon, Trash2Icon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { useUpdateProjectConfig } from "@/hooks/useConversations";
 import type { ProjectConfig } from "@/lib/projectsApi";
@@ -23,13 +23,13 @@ const loadEmojiData = async () => (await import("@emoji-mart/data")).default;
 
 /** A themed emoji-mart picker. Calls `onSelect` with the chosen unicode glyph. */
 export function EmojiPicker({ onSelect }: { onSelect: (native: string) => void }) {
-  const { resolvedTheme } = useTheme();
+  const mode = useResolvedThemeMode();
   return (
     <Suspense fallback={<div className="h-[420px] w-[352px]" aria-hidden />}>
       <Picker
         data={loadEmojiData}
         onEmojiSelect={(emoji: { native: string }) => onSelect(emoji.native)}
-        theme={resolvedTheme === "dark" ? "dark" : "light"}
+        theme={mode}
         navPosition="top"
         previewPosition="none"
         skinTonePosition="none"

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -10,7 +10,7 @@
 
 import { Loader2Icon } from "lucide-react";
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
-import { useTheme } from "next-themes";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { copyText } from "@/lib/clipboard";
@@ -186,7 +186,7 @@ export function TerminalView({
   // Lets the close handler tell "stable connection finally dropped"
   // (reset the budget) from "re-dial died straight away" (burn it).
   const connectedAtRef = useRef<number | null>(null);
-  const { resolvedTheme } = useTheme();
+  const resolvedMode = useResolvedThemeMode();
   // Terminal theme is independent of the app theme: "auto" follows the app's
   // resolved appearance, while "light"/"dark" pin the terminal. Reading the
   // pref as state (seeded at mount, updated via the pub/sub) lets a Settings
@@ -195,7 +195,7 @@ export function TerminalView({
     readTerminalThemeMode(),
   );
   useEffect(() => subscribeTerminalTheme(setTerminalMode), []);
-  const isDark = resolveTerminalIsDark(terminalMode, resolvedTheme === "dark");
+  const isDark = resolveTerminalIsDark(terminalMode, resolvedMode === "dark");
   // Stable ref so the theme-update effect can reach the live session
   // without adding isDark to the attachSession deps (which would
   // reconnect the WebSocket on every theme change).

--- a/web/src/components/theme/useResolvedThemeMode.test.tsx
+++ b/web/src/components/theme/useResolvedThemeMode.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useResolvedThemeMode } from "./useResolvedThemeMode";
+
+// Controllable next-themes stub: each test sets what useTheme() returns.
+let themeReturn: { resolvedTheme?: string; forcedTheme?: string } = {};
+vi.mock("next-themes", () => ({ useTheme: () => themeReturn }));
+
+afterEach(() => {
+  themeReturn = {};
+});
+
+describe("useResolvedThemeMode", () => {
+  it("uses forcedTheme when resolvedTheme is unset (the embed case)", () => {
+    // The embed sets forcedTheme but next-themes leaves resolvedTheme unset —
+    // the exact managed regression: without the hook this normalized to light.
+    themeReturn = { forcedTheme: "dark", resolvedTheme: undefined };
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("dark");
+  });
+
+  it("prefers forcedTheme over a conflicting resolvedTheme", () => {
+    themeReturn = { forcedTheme: "dark", resolvedTheme: "light" };
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("dark");
+  });
+
+  it("falls back to resolvedTheme when no theme is forced (standalone)", () => {
+    themeReturn = { forcedTheme: undefined, resolvedTheme: "dark" };
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("dark");
+  });
+
+  it("normalizes to light when neither is set", () => {
+    themeReturn = {};
+    const { result } = renderHook(() => useResolvedThemeMode());
+    expect(result.current).toBe("light");
+  });
+});

--- a/web/src/components/theme/useResolvedThemeMode.ts
+++ b/web/src/components/theme/useResolvedThemeMode.ts
@@ -1,0 +1,20 @@
+import { useTheme } from "next-themes";
+import { normalizeResolvedTheme, type ResolvedThemeMode } from "./themeMode";
+
+/**
+ * The concrete light/dark palette the app is rendering, honoring a forced theme.
+ *
+ * The managed/embedded island drives its palette with next-themes'
+ * `forcedTheme` (see `embed.tsx`), which — unlike a normal selection —
+ * does NOT feed back into `resolvedTheme`; there `resolvedTheme` stays
+ * unset and normalizes to light. Editor/terminal/3D themes that read
+ * `resolvedTheme` alone therefore render light on a dark embed. Prefer
+ * `forcedTheme` when present; standalone never sets it, so this is identical
+ * to reading `resolvedTheme` there.
+ *
+ * @returns Concrete `"light"` or `"dark"` mode to theme non-CSS surfaces with.
+ */
+export function useResolvedThemeMode(): ResolvedThemeMode {
+  const { resolvedTheme, forcedTheme } = useTheme();
+  return normalizeResolvedTheme(forcedTheme ?? resolvedTheme);
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -114,12 +114,8 @@ import { absoluteTime } from "@/lib/relativeTime";
 import { useNavigate } from "@/lib/routing";
 import { useSettingsRoute } from "@/shell/settingsNav";
 import { ImportSessionsPanel } from "@/shell/ImportSessionsPanel";
-import {
-  isThemeMode,
-  normalizeResolvedTheme,
-  normalizeThemeMode,
-  type ThemeMode,
-} from "@/components/theme/themeMode";
+import { isThemeMode, normalizeThemeMode, type ThemeMode } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import {
   applyDesktopUiFontSize,
   applyUiFontFamily,
@@ -539,9 +535,9 @@ function WorkspacePanelDefaultControl() {
 }
 
 function ColorThemeControl() {
-  // Render each chip in the currently-resolved mode so it matches the app now.
-  const { resolvedTheme } = useTheme();
-  const isDark = normalizeResolvedTheme(resolvedTheme) === "dark";
+  // Render each chip in the currently-resolved mode so it matches the app now
+  // (honoring the embed's forced theme, not just next-themes' resolvedTheme).
+  const isDark = useResolvedThemeMode() === "dark";
   const [selection, setSelection] = useState<ThemeSelection>(() => readThemePalette());
   const [customTheme, setCustomTheme] = useState<CustomTheme>(() => readCustomTheme());
   const labelId = useId();

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -1650,6 +1650,32 @@ describe("FileViewer Cmd+F opens find on Monaco surfaces", () => {
     expect(searchOpenOf("code-viewer")).toBe("true");
     document.body.removeChild(chatArea);
   });
+
+  it.each(["pic.png", "doc.pdf", "widget.stl", "blob.bin"])(
+    "does NOT claim Cmd+F on non-Monaco viewers (%s)",
+    (path) => {
+      // Images, PDFs, 3D models, and binary files render CodeViewer's own
+      // viewers / "preview not available" notice, not Monaco — there is no find
+      // widget, so Cmd+F must fall through to the browser's find-in-page.
+      renderViewer({ open: true, path });
+      fireEvent.keyDown(window, { key: "f", metaKey: true });
+      expect(searchOpenOf("code-viewer")).toBe("false");
+    },
+  );
+
+  it("re-seeds the active surface when the viewer reopens the same path", () => {
+    const { rerender } = renderViewer({ open: true, path: "file1.py" });
+    // User clicks into the chat → the viewer is no longer the active surface.
+    const chatArea = document.createElement("div");
+    document.body.appendChild(chatArea);
+    fireEvent.mouseDown(chatArea);
+    // Close, then reopen the SAME path (no path change to re-seed on).
+    rerender(viewerTree({ open: false, path: "file1.py" }));
+    rerender(viewerTree({ open: true, path: "file1.py" }));
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("true");
+    document.body.removeChild(chatArea);
+  });
 });
 
 describe("FileViewer Escape closes the active tab", () => {

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -14,7 +14,7 @@
 //  12. Comments are marked seen (inbox-clearing registry) only while the
 //      comments panel is open — never from merely opening the file.
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useSearchParams } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -29,12 +29,18 @@ vi.mock("./CodeViewer", () => ({
   // (onDirtyChange) so the mode-switch / navigation guard can be exercised.
   CodeViewer: ({
     viewMode,
+    searchOpen,
     onDirtyChange,
   }: {
     viewMode: string;
+    searchOpen?: boolean;
     onDirtyChange?: (dirty: boolean) => void;
   }) => (
-    <div data-testid="code-viewer" data-view-mode={viewMode}>
+    <div
+      data-testid="code-viewer"
+      data-view-mode={viewMode}
+      data-search-open={String(!!searchOpen)}
+    >
       <button type="button" aria-label="make dirty" onClick={() => onDirtyChange?.(true)} />
     </div>
   ),
@@ -80,14 +86,17 @@ vi.mock("./MonacoDiffViewer", () => ({
   MonacoDiffViewer: ({
     wrapLines,
     hideWhitespace,
+    searchOpen,
   }: {
     wrapLines?: boolean;
     hideWhitespace?: boolean;
+    searchOpen?: boolean;
   }) => (
     <div
       data-testid="diff-viewer"
       data-wrap-lines={String(!!wrapLines)}
       data-hide-whitespace={String(!!hideWhitespace)}
+      data-search-open={String(!!searchOpen)}
     />
   ),
 }));
@@ -1542,6 +1551,104 @@ describe("FileViewer keyboard shortcut — Alt+← / Alt+→", () => {
     expect(onNavigateTo).not.toHaveBeenCalled();
 
     document.body.removeChild(input);
+  });
+});
+
+describe("FileViewer Cmd+F opens find on Monaco surfaces", () => {
+  // The Monaco-backed surfaces (code source/editor and the diff view) open
+  // find via the shared `searchOpen` toggle rather than Monaco's own Cmd+F
+  // keybinding — the keybinding needs editor focus and doesn't fire inside the
+  // managed same-root embed, so cmd+f silently did nothing there. These assert
+  // that a Cmd/Ctrl+F flips the toggle FileViewer hands each surface.
+  beforeEach(() => {
+    useCommentsMock.mockReturnValue(makeCommentsQuery([]));
+  });
+
+  const searchOpenOf = (testId: string) =>
+    screen.getByTestId(testId).getAttribute("data-search-open");
+
+  it("opens find on the code (source) surface with Cmd+F", () => {
+    renderViewer({ open: true, path: "file1.py" });
+    expect(searchOpenOf("code-viewer")).toBe("false");
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("true");
+  });
+
+  it("opens find on the code surface with Ctrl+F (Windows/Linux)", () => {
+    renderViewer({ open: true, path: "file1.py" });
+    fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("true");
+  });
+
+  it("opens find in the diff view with Cmd+F", async () => {
+    renderViewer({ open: true, path: "file1.py", initialSearch: "diff=1" });
+    // Diff view renders MonacoDiffViewer, not CodeViewer.
+    expect(await screen.findByTestId("diff-viewer")).toBeInTheDocument();
+    expect(searchOpenOf("diff-viewer")).toBe("false");
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(searchOpenOf("diff-viewer")).toBe("true");
+  });
+
+  it("does not intercept Cmd+Shift+F (leaves other chords alone)", () => {
+    renderViewer({ open: true, path: "file1.py" });
+    fireEvent.keyDown(window, { key: "f", metaKey: true, shiftKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("false");
+  });
+
+  it("leaves the markdown editor surface to CodeViewer's own find handler", () => {
+    // Markdown defaults to the rich-text editor — a non-Monaco surface whose
+    // Cmd+F is owned by CodeViewer, so FileViewer's handler must stay inert
+    // (the mocked CodeViewer never flips searchOpen on its own).
+    renderViewer({ open: true, path: "notes.md" });
+    expect(screen.getByTestId("code-viewer").getAttribute("data-view-mode")).toBe("editor");
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("false");
+  });
+
+  const insideButton = () =>
+    within(screen.getByTestId("file-viewer")).getByRole("button", { name: "make dirty" });
+
+  it("opens find when the last interaction was inside the file viewer", () => {
+    renderViewer({ open: true, path: "file1.py" });
+    fireEvent.mouseDown(insideButton());
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("true");
+  });
+
+  it("does NOT open file find when focus moves to the chat composer (outside the viewer)", () => {
+    renderViewer({ open: true, path: "file1.py" });
+    // The viewer stays mounted beside the chat; focusing the composer must leave
+    // Cmd+F to the browser's find-in-page, not the file's find.
+    const composer = document.createElement("textarea");
+    document.body.appendChild(composer);
+    composer.focus();
+    fireEvent.keyDown(composer, { key: "f", metaKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("false");
+    document.body.removeChild(composer);
+  });
+
+  it("does NOT open file find after the user clicks a non-focusable chat area", () => {
+    renderViewer({ open: true, path: "file1.py" });
+    // Clicking a non-focusable region of the chat page drops focus to <body>,
+    // but the click marks the chat as the active surface — the exact case that
+    // used to still open the file's find.
+    const chatArea = document.createElement("div");
+    document.body.appendChild(chatArea);
+    fireEvent.mouseDown(chatArea);
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("false");
+    document.body.removeChild(chatArea);
+  });
+
+  it("re-claims Cmd+F after the user clicks back into the viewer", () => {
+    renderViewer({ open: true, path: "file1.py" });
+    const chatArea = document.createElement("div");
+    document.body.appendChild(chatArea);
+    fireEvent.mouseDown(chatArea); // leave the viewer
+    fireEvent.mouseDown(insideButton()); // click back into the viewer
+    fireEvent.keyDown(window, { key: "f", metaKey: true });
+    expect(searchOpenOf("code-viewer")).toBe("true");
+    document.body.removeChild(chatArea);
   });
 });
 

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -90,6 +90,7 @@ import {
   MONACO_SPLIT_BREAKPOINT,
   type SaveStatus,
   detectLang,
+  isBinaryPath,
   isImageFile,
   isModelFile,
   isNotebookPath,
@@ -653,6 +654,9 @@ function FileViewerBody({
   // they have no meaningful source/diff/preview text representation, so diff is
   // suppressed and they always resolve to the (viewer-owning) source surface.
   const isModel = isModelFile(path, fileQuery.data?.content_type);
+  // Binary/base64 files render CodeViewer's "Preview not available" notice, not
+  // Monaco — mirrors CodeViewer's own base64/binary-path check.
+  const isBinary = fileQuery.data?.encoding === "base64" || isBinaryPath(path);
   // Show Δ button only when the file appears in the session's changed-files list.
   const isDiffAvailable =
     !isImage &&
@@ -754,7 +758,14 @@ function FileViewerBody({
   // instead, matching how the Shiki/markdown surfaces (handled by their own
   // window listeners in CodeViewer) already open find. Gated to the Monaco
   // surfaces so it never double-handles the CodeViewer-owned ones.
-  const isMonacoFindSurface = diffViewActive || (lang !== "markdown" && viewMode !== "preview");
+  // The find toggle only reaches a Monaco surface: the diff view, or a non-diff
+  // file that CodeViewer renders in Monaco. Exclude the surfaces CodeViewer
+  // returns *before* the Monaco block — markdown (rich editor / its own find
+  // bar), previews, and the image/PDF/model/binary viewers — otherwise Cmd+F
+  // would swallow the browser's find-in-page with no find widget to show.
+  const isMonacoFindSurface =
+    diffViewActive ||
+    (lang !== "markdown" && viewMode !== "preview" && !isImage && !isPdf && !isModel && !isBinary);
   // Cmd+F must open find-in-file only while the file viewer is the surface the
   // user is working in. The viewer stays mounted beside the chat, so `open`
   // alone can't tell them apart, and reading `document.activeElement` at
@@ -765,9 +776,11 @@ function FileViewerBody({
   // works in the chat/composer, Cmd+F falls through to the browser's find.
   const viewerIsActiveSurfaceRef = useRef(true);
   useEffect(() => {
-    // Opening (or switching to) a file makes the viewer the active surface.
-    viewerIsActiveSurfaceRef.current = true;
-  }, [path]);
+    // Opening the viewer (or switching files within it) makes it the active
+    // surface again. Keyed on `open` too, so reopening the same path after the
+    // user had clicked into the chat re-seeds the ref instead of staying stale.
+    if (open) viewerIsActiveSurfaceRef.current = true;
+  }, [open, path]);
   useEffect(() => {
     if (!open) return;
     const track = (e: Event) => {

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -405,6 +405,13 @@ function FileViewerBody({
   // null = not yet measured (or zero, e.g. jsdom) — treat as "wide enough" so
   // the toggle shows by default and only hides once a real narrow width lands.
   const contentAreaRef = useRef<HTMLDivElement | null>(null);
+  // The viewer's outer element, used to scope Cmd+F to when focus is inside the
+  // file viewer (vs the chat/composer, which owns find-in-page). Callback ref so
+  // one handle serves both the framed <aside> and the frameless <div> root.
+  const viewerRootRef = useRef<HTMLElement | null>(null);
+  const setViewerRoot = useCallback((el: HTMLElement | null) => {
+    viewerRootRef.current = el;
+  }, []);
   const [contentWidth, setContentWidth] = useState<number | null>(null);
   // Tracks the in-progress comment textarea body. Used by MarkdownCommentPlugin
   // to decide whether to preserve the pending mark when the user clicks away.
@@ -738,6 +745,66 @@ function FileViewerBody({
   const viewMode: "editor" | "preview" | "source" | "diff" =
     diffActive && isDiffAvailable ? "diff" : fileViewMode;
   const diffViewActive = viewMode === "diff";
+
+  // Cmd/Ctrl+F opens find-in-file on the Monaco-backed surfaces (code
+  // source/editor and the diff view). Those surfaces would otherwise rely on
+  // Monaco's own Cmd+F keybinding, which needs editor DOM focus and does not
+  // fire inside the managed (same-root embed) host — so cmd+f silently did
+  // nothing there. Driving `searchOpen` runs Monaco's find action imperatively
+  // instead, matching how the Shiki/markdown surfaces (handled by their own
+  // window listeners in CodeViewer) already open find. Gated to the Monaco
+  // surfaces so it never double-handles the CodeViewer-owned ones.
+  const isMonacoFindSurface = diffViewActive || (lang !== "markdown" && viewMode !== "preview");
+  // Cmd+F must open find-in-file only while the file viewer is the surface the
+  // user is working in. The viewer stays mounted beside the chat, so `open`
+  // alone can't tell them apart, and reading `document.activeElement` at
+  // keypress time is unreliable — clicking a non-focusable chat area drops focus
+  // to <body>, which reads the same as "nothing focused yet". Instead we track
+  // the last surface the user interacted with: seeded to the viewer (opening a
+  // file makes it active) and flipped by clicks / focus moves. When the user
+  // works in the chat/composer, Cmd+F falls through to the browser's find.
+  const viewerIsActiveSurfaceRef = useRef(true);
+  useEffect(() => {
+    // Opening (or switching to) a file makes the viewer the active surface.
+    viewerIsActiveSurfaceRef.current = true;
+  }, [path]);
+  useEffect(() => {
+    if (!open) return;
+    const track = (e: Event) => {
+      const root = viewerRootRef.current;
+      const target = e.target;
+      if (root !== null && target instanceof Node) {
+        viewerIsActiveSurfaceRef.current = root.contains(target);
+      }
+    };
+    window.addEventListener("mousedown", track, true);
+    window.addEventListener("focusin", track, true);
+    return () => {
+      window.removeEventListener("mousedown", track, true);
+      window.removeEventListener("focusin", track, true);
+    };
+  }, [open]);
+  useEffect(() => {
+    if (!open || !isMonacoFindSurface) return;
+    const handler = (e: KeyboardEvent) => {
+      if (!((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key === "f")) return;
+      if (!viewerIsActiveSurfaceRef.current) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setSearchOpen(true);
+    };
+    // Capture phase so the embed claims Cmd+F ahead of the host page's own
+    // listeners and the browser's native find (which would search the whole
+    // host page, not the file).
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [open, isMonacoFindSurface, setSearchOpen]);
+
+  // Reset the toggle when find is closed from inside Monaco (Escape or the
+  // widget's ✕) so the next Cmd+F re-opens it instead of no-opping. Shared by
+  // the diff view; the non-diff CodeViewer resets its own copy internally.
+  const handleSearchHandled = useCallback(() => setSearchOpen(false), [setSearchOpen]);
+
   // Persist where the reader was in the content area (markdown source, plain
   // text). The view mode is part of the key because each mode renders a
   // different height, so sharing one offset across modes would drop the reader
@@ -1455,6 +1522,8 @@ function FileViewerBody({
                   activeSelection={activeSelection}
                   onSetActiveSelection={handleSetActiveSelection}
                   pendingBodyRef={pendingBodyRef}
+                  searchOpen={searchOpen}
+                  onSearchHandled={handleSearchHandled}
                 />
               </Suspense>
             )
@@ -1580,6 +1649,7 @@ function FileViewerBody({
   if (frameless) {
     return (
       <div
+        ref={setViewerRoot}
         data-testid="file-viewer"
         className="flex flex-col flex-1 min-h-0 overflow-hidden bg-card"
       >
@@ -1590,6 +1660,7 @@ function FileViewerBody({
 
   return (
     <aside
+      ref={setViewerRoot}
       data-testid="file-viewer"
       style={{ width: panelWidth, paddingBottom: keyboardInset || undefined }}
       className={cn(

--- a/web/src/shell/ModelViewer.tsx
+++ b/web/src/shell/ModelViewer.tsx
@@ -10,14 +10,13 @@
 // geometry, materials, renderer, the animation frame, and the WebGL context are
 // all released so repeatedly opening model files can't leak GPU memory.
 
-import { useTheme } from "next-themes";
 import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js";
 import { ThreeMFLoader } from "three/examples/jsm/loaders/3MFLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
-import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { type FileContentResponse, fileContentToBlob } from "@/hooks/useFileContent";
 import {
   type ModelFormat,
@@ -228,8 +227,7 @@ export function ModelViewer({ data, path }: { data: FileContentResponse; path: s
   // Theme comes from the app's shared next-themes source (same hook Monaco and
   // the terminal use). `mode` is a stable "light"|"dark" string, so the theme
   // effect below re-runs only on an actual toggle.
-  const { resolvedTheme } = useTheme();
-  const mode = normalizeResolvedTheme(resolvedTheme);
+  const mode = useResolvedThemeMode();
 
   // The live scene, so the theme effect can recolor it without a rebuild, and
   // the latest theme, so the build effect can seed it without depending on the

--- a/web/src/shell/MonacoCodeEditor.tsx
+++ b/web/src/shell/MonacoCodeEditor.tsx
@@ -17,9 +17,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Editor, type EditorProps, type OnChange, type OnMount } from "@monaco-editor/react";
-import { useTheme } from "next-themes";
 import { AlertTriangleIcon, MessageSquareOffIcon } from "lucide-react";
-import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import {
   codeFontFamilyForEditor,
   readCodeFont,
@@ -220,8 +219,7 @@ function MonacoCodeEditorInner({
   pendingBodyRef,
 }: InnerProps) {
   const lang = detectLang(path);
-  const { resolvedTheme } = useTheme();
-  const monacoTheme = resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  const monacoTheme = resolvedThemeToMonaco(useResolvedThemeMode());
 
   // Gate rendering until Shiki has registered the github themes + this file's
   // grammar, so the editor never flashes Monaco's default 'vs' theme.

--- a/web/src/shell/MonacoDiffViewer.test.tsx
+++ b/web/src/shell/MonacoDiffViewer.test.tsx
@@ -63,6 +63,8 @@ function renderDiff(props: {
   layout: "unified" | "split";
   hideWhitespace?: boolean;
   wrapLines?: boolean;
+  searchOpen?: boolean;
+  onSearchHandled?: () => void;
 }) {
   return render(
     <MonacoDiffViewer
@@ -76,8 +78,45 @@ function renderDiff(props: {
       comments={[]}
       activeSelection={null}
       onSetActiveSelection={() => {}}
+      searchOpen={props.searchOpen}
+      onSearchHandled={props.onSearchHandled}
     />,
   );
+}
+
+// Fake modified-side editor with the find slice the search wiring drives:
+// getAction("actions.find").run() and getContribution(findController).
+function makeFindController() {
+  let listener: ((e: { isRevealed: boolean }) => void) | null = null;
+  const controller = {
+    isRevealed: false,
+    run: vi.fn(() => {
+      controller.isRevealed = true;
+    }),
+    closeFindWidget: vi.fn(() => {
+      controller.isRevealed = false;
+    }),
+    getState: () => ({
+      get isRevealed() {
+        return controller.isRevealed;
+      },
+      onFindReplaceStateChange: (l: (e: { isRevealed: boolean }) => void) => {
+        listener = l;
+        return { dispose: () => {} };
+      },
+    }),
+    fireStateChange: (e: { isRevealed: boolean }) => listener?.(e),
+  };
+  return controller;
+}
+
+function makeFindableModified(controller: ReturnType<typeof makeFindController>) {
+  return {
+    getModel: () => ({ setEOL: vi.fn() }),
+    ...scrollStubs(),
+    getAction: (id: string) => (id === "actions.find" ? { run: controller.run } : undefined),
+    getContribution: () => controller,
+  };
 }
 
 // The modified editor's scroll API, used by the viewer to persist the reader's
@@ -86,6 +125,10 @@ function scrollStubs() {
   return {
     setScrollTop: vi.fn(),
     onDidScrollChange: vi.fn(() => ({ dispose: () => {} })),
+    // The find effects call these on mount; the search-specific tests below
+    // swap in a real controller. Undefined is a valid "no find widget open".
+    getAction: () => undefined,
+    getContribution: () => undefined,
   };
 }
 
@@ -166,7 +209,10 @@ describe("MonacoDiffViewer", () => {
     // getModifiedEditor() → modifiedEditorRef wiring — not a mock echo.
     act(() => {
       h.onMount?.(
-        { getModifiedEditor: () => fakeModified } as unknown as Parameters<DiffOnMount>[0],
+        {
+          getModifiedEditor: () => fakeModified,
+          getOriginalEditor: () => ({ getModel: () => null }),
+        } as unknown as Parameters<DiffOnMount>[0],
         {
           editor: { EndOfLineSequence: { LF: 0, CRLF: 1 } },
         } as unknown as Parameters<DiffOnMount>[1],
@@ -193,13 +239,18 @@ describe("MonacoDiffViewer", () => {
       setScrollTop,
       onDidScrollChange,
       getDomNode: () => document.createElement("div"),
+      getAction: () => undefined,
+      getContribution: () => undefined,
     };
     renderDiff({ before: "a", after: "b", layout: "split" });
     await waitFor(() => expect(h.onMount).not.toBeNull());
 
     act(() => {
       h.onMount?.(
-        { getModifiedEditor: () => fakeModified } as unknown as Parameters<DiffOnMount>[0],
+        {
+          getModifiedEditor: () => fakeModified,
+          getOriginalEditor: () => ({ getModel: () => null }),
+        } as unknown as Parameters<DiffOnMount>[0],
         {
           editor: { EndOfLineSequence: { LF: 0, CRLF: 1 } },
         } as unknown as Parameters<DiffOnMount>[1],
@@ -226,13 +277,18 @@ describe("MonacoDiffViewer", () => {
       setScrollTop,
       onDidScrollChange,
       getDomNode: () => document.createElement("div"),
+      getAction: () => undefined,
+      getContribution: () => undefined,
     };
     renderDiff({ before: "a", after: "b", layout: "split" });
     await waitFor(() => expect(h.onMount).not.toBeNull());
 
     act(() => {
       h.onMount?.(
-        { getModifiedEditor: () => fakeModified } as unknown as Parameters<DiffOnMount>[0],
+        {
+          getModifiedEditor: () => fakeModified,
+          getOriginalEditor: () => ({ getModel: () => null }),
+        } as unknown as Parameters<DiffOnMount>[0],
         {
           editor: { EndOfLineSequence: { LF: 0, CRLF: 1 } },
         } as unknown as Parameters<DiffOnMount>[1],
@@ -256,7 +312,11 @@ describe("MonacoDiffViewer", () => {
   it("re-fonts the mounted diff editor when the code-font preference changes", async () => {
     const updateOptions = vi.fn();
     const fakeModified = { getModel: () => ({ setEOL: vi.fn() }), ...scrollStubs() };
-    const fakeDiff = { getModifiedEditor: () => fakeModified, updateOptions };
+    const fakeDiff = {
+      getModifiedEditor: () => fakeModified,
+      getOriginalEditor: () => ({ getModel: () => null }),
+      updateOptions,
+    };
     renderDiff({ before: "a", after: "b", layout: "split" });
     await waitFor(() => expect(h.onMount).not.toBeNull());
 
@@ -281,5 +341,106 @@ describe("MonacoDiffViewer", () => {
       fontFamily: codeFontFamilyForEditor(""),
       fontWeight: "400",
     });
+  });
+
+  it("runs Monaco's find action on the modified side when searchOpen is set", async () => {
+    const controller = makeFindController();
+    const fakeModified = makeFindableModified(controller);
+    renderDiff({ before: "a", after: "b", layout: "split", searchOpen: true });
+    await waitFor(() => expect(h.onMount).not.toBeNull());
+
+    act(() => {
+      h.onMount?.(
+        {
+          getModifiedEditor: () => fakeModified,
+          getOriginalEditor: () => ({ getModel: () => null }),
+        } as unknown as Parameters<DiffOnMount>[0],
+        {
+          editor: { EndOfLineSequence: { LF: 0, CRLF: 1 } },
+        } as unknown as Parameters<DiffOnMount>[1],
+      );
+    });
+
+    // searchOpen=true opens Monaco's native find on the modified editor — the
+    // path Cmd+F drives in the managed embed, where the keybinding won't fire.
+    expect(controller.run).toHaveBeenCalledTimes(1);
+    expect(controller.closeFindWidget).not.toHaveBeenCalled();
+  });
+
+  it("reports back via onSearchHandled when find is closed from within Monaco", async () => {
+    const controller = makeFindController();
+    const fakeModified = makeFindableModified(controller);
+    const onSearchHandled = vi.fn();
+    renderDiff({ before: "a", after: "b", layout: "split", searchOpen: true, onSearchHandled });
+    await waitFor(() => expect(h.onMount).not.toBeNull());
+
+    act(() => {
+      h.onMount?.(
+        {
+          getModifiedEditor: () => fakeModified,
+          getOriginalEditor: () => ({ getModel: () => null }),
+        } as unknown as Parameters<DiffOnMount>[0],
+        {
+          editor: { EndOfLineSequence: { LF: 0, CRLF: 1 } },
+        } as unknown as Parameters<DiffOnMount>[1],
+      );
+    });
+
+    // Simulate Escape / the widget's ✕: Monaco flips isRevealed false and fires
+    // a change whose isRevealed flag marks that field as changed.
+    controller.isRevealed = false;
+    act(() => {
+      controller.fireStateChange({ isRevealed: true });
+    });
+    expect(onSearchHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the widget model and disposes both text models on unmount", async () => {
+    // @monaco-editor/react disposes the models before the diff widget, which the
+    // bundled Monaco rejects. We take disposal over (keepCurrent*) and tear down
+    // in the safe order: detach the widget's model, then dispose both models.
+    const originalModel = { dispose: vi.fn() };
+    const modifiedModel = { dispose: vi.fn(), setEOL: vi.fn() };
+    const setModel = vi.fn();
+    const fakeModified = {
+      getModel: () => modifiedModel,
+      ...scrollStubs(),
+    };
+    const fakeDiff = {
+      getModifiedEditor: () => fakeModified,
+      getOriginalEditor: () => ({ getModel: () => originalModel }),
+      setModel,
+    };
+    const { unmount } = renderDiff({ before: "a", after: "b", layout: "split" });
+    await waitFor(() => expect(h.onMount).not.toBeNull());
+    act(() => {
+      h.onMount?.(
+        fakeDiff as unknown as Parameters<DiffOnMount>[0],
+        {
+          editor: { EndOfLineSequence: { LF: 0, CRLF: 1 } },
+        } as unknown as Parameters<DiffOnMount>[1],
+      );
+    });
+
+    act(() => unmount());
+
+    // The widget's model is detached before the models are disposed, so a model
+    // is never disposed while still attached to the diff widget.
+    expect(setModel).toHaveBeenCalledWith(null);
+    expect(originalModel.dispose).toHaveBeenCalledTimes(1);
+    expect(modifiedModel.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes keepCurrent* so the library does not dispose the models itself", async () => {
+    renderDiff({ before: "a", after: "b", layout: "split" });
+    await waitFor(() => expect(h.diffProps).not.toBeNull());
+    // Without these, @monaco-editor/react disposes the text models before the
+    // diff widget on unmount and Monaco throws.
+    const props = h.diffProps as {
+      keepCurrentOriginalModel?: boolean;
+      keepCurrentModifiedModel?: boolean;
+    };
+    expect(props.keepCurrentOriginalModel).toBe(true);
+    expect(props.keepCurrentModifiedModel).toBe(true);
   });
 });

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -8,8 +8,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DiffEditor, type DiffEditorProps, type DiffOnMount } from "@monaco-editor/react";
-import { useTheme } from "next-themes";
-import { normalizeResolvedTheme } from "@/components/theme/themeMode";
+import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import {
   codeFontFamilyForEditor,
   readCodeFont,
@@ -73,8 +72,7 @@ export function MonacoDiffViewer({
 }: MonacoDiffViewerProps) {
   const canEdit = useCanEdit(conversationId);
   const lang = detectLang(path);
-  const { resolvedTheme } = useTheme();
-  const monacoTheme = resolvedThemeToMonaco(normalizeResolvedTheme(resolvedTheme));
+  const monacoTheme = resolvedThemeToMonaco(useResolvedThemeMode());
 
   // Gate rendering until Shiki has registered the github themes + this file's
   // grammar (so the diff never flashes Monaco's default 'vs' theme); surface an

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -25,7 +25,23 @@ import {
 } from "./monacoSetup";
 import { useMonacoCommentLayer, type CodeEditorInstance } from "./useMonacoCommentLayer";
 import { attachEditorScrollRestore } from "./useScrollRestore";
+import type { monaco } from "./monacoSetup";
 import "./monacoCodeEditor.css";
+
+// Monaco's find contribution isn't a public export, so we reach it by its
+// registered id and describe only the slice we drive: whether the find widget
+// is open, close it, and subscribe to open/close changes. Mirrors
+// MonacoCodeEditor's wiring, applied to the diff's modified-side editor.
+const FIND_CONTROLLER_ID = "editor.contrib.findController";
+interface FindController extends monaco.editor.IEditorContribution {
+  getState: () => {
+    readonly isRevealed: boolean;
+    onFindReplaceStateChange: (listener: (e: { isRevealed: boolean }) => void) => {
+      dispose: () => void;
+    };
+  };
+  closeFindWidget: () => void;
+}
 
 interface MonacoDiffViewerProps {
   /** File content before this session (null = new file). */
@@ -47,6 +63,19 @@ interface MonacoDiffViewerProps {
   onSetActiveSelection: (sel: ActiveSelection | null) => void;
   /** In-progress comment body; clicking away won't clear an active draft. */
   pendingBodyRef?: React.RefObject<string>;
+  /**
+   * Toolbar / Cmd+F "Find in file" toggle. The diff mirrors Monaco's native
+   * find widget (on the modified side) to it: true opens find, false closes it.
+   * Cmd+F is driven through this flag rather than Monaco's own keybinding so it
+   * fires even when the editor lacks DOM focus — the case that breaks in the
+   * managed (same-root embed) host.
+   */
+  searchOpen?: boolean;
+  /**
+   * Called when the find widget is closed from within Monaco (Escape or the
+   * widget's ✕) so the owning toggle resets and the next Cmd+F re-opens it.
+   */
+  onSearchHandled?: () => void;
 }
 
 /**
@@ -69,6 +98,8 @@ export function MonacoDiffViewer({
   activeSelection,
   onSetActiveSelection,
   pendingBodyRef,
+  searchOpen,
+  onSearchHandled,
 }: MonacoDiffViewerProps) {
   const canEdit = useCanEdit(conversationId);
   const lang = detectLang(path);
@@ -103,6 +134,10 @@ export function MonacoDiffViewer({
   // The diff editor itself — its updateOptions propagates the code font to both
   // panes (per-pane updateOptions would only re-font one side).
   const diffEditorRef = useRef<Parameters<DiffOnMount>[0] | null>(null);
+  // The two text models, captured on mount so we can dispose them ourselves on
+  // unmount (see the teardown effect and keepCurrent* on <DiffEditor>).
+  const originalModelRef = useRef<ReturnType<CodeEditorInstance["getModel"]>>(null);
+  const modifiedModelRef = useRef<ReturnType<CodeEditorInstance["getModel"]>>(null);
   const [mounted, setMounted] = useState(false);
 
   // The diff scrolls inside Monaco, so its offset is cached per conversation +
@@ -116,6 +151,9 @@ export function MonacoDiffViewer({
       diffEditorRef.current = diffEditor;
       const modified = diffEditor.getModifiedEditor();
       modifiedEditorRef.current = modified;
+      // Capture both models so the teardown effect can dispose them itself.
+      originalModelRef.current = diffEditor.getOriginalEditor().getModel();
+      modifiedModelRef.current = modified.getModel();
       // Align the modified model's offsets with the raw "after" char offsets that
       // comment anchors use (CRLF files would otherwise be counted as LF).
       modified
@@ -139,11 +177,65 @@ export function MonacoDiffViewer({
 
   useEffect(
     () => () => {
+      // @monaco-editor/react's DiffEditor disposes the text models before the
+      // diff widget on unmount, which the bundled Monaco rejects with "TextModel
+      // got disposed before DiffEditorWidget model got reset". We take model
+      // disposal over via keepCurrent* on <DiffEditor>: detach the widget's
+      // model first, then dispose the two models here. Guarded because our
+      // cleanup and the library's own run in an unspecified order.
+      try {
+        diffEditorRef.current?.setModel(null);
+      } catch {
+        // Widget already disposed by the library — nothing to reset.
+      }
+      try {
+        originalModelRef.current?.dispose();
+      } catch {
+        // Already disposed.
+      }
+      try {
+        modifiedModelRef.current?.dispose();
+      } catch {
+        // Already disposed.
+      }
       modifiedEditorRef.current = null;
       diffEditorRef.current = null;
+      originalModelRef.current = null;
+      modifiedModelRef.current = null;
     },
     [],
   );
+
+  // Mirror the "Find in file" toggle to Monaco's native find widget on the
+  // modified side. Gated on `mounted` so a Cmd+F pressed while the lazy chunk
+  // was still loading isn't dropped. `searchOpen` true opens find; false closes
+  // it. The controller drives the close directly so re-toggling is a real close,
+  // not a second open.
+  useEffect(() => {
+    if (!mounted) return;
+    const editor = modifiedEditorRef.current;
+    if (!editor) return;
+    if (searchOpen) {
+      editor.getAction("actions.find")?.run();
+    } else {
+      const controller = editor.getContribution<FindController>(FIND_CONTROLLER_ID);
+      if (controller?.getState().isRevealed) controller.closeFindWidget();
+    }
+  }, [mounted, searchOpen]);
+
+  // Reflect a find close initiated inside Monaco (Escape or the widget's ✕) back
+  // to the owning toggle, so its state matches the visible widget and the next
+  // Cmd+F re-opens instead of no-opping.
+  useEffect(() => {
+    if (!mounted) return;
+    const controller =
+      modifiedEditorRef.current?.getContribution<FindController>(FIND_CONTROLLER_ID);
+    if (!controller) return;
+    const sub = controller.getState().onFindReplaceStateChange((e) => {
+      if (e.isRevealed && !controller.getState().isRevealed) onSearchHandled?.();
+    });
+    return () => sub.dispose();
+  }, [mounted, onSearchHandled]);
 
   // Apply live code-font changes to both diff panes. Monaco is a fixed-pixel
   // widget with no CSS-variable path like the chrome font, so the new
@@ -226,6 +318,11 @@ export function MonacoDiffViewer({
             modified={after ?? ""}
             options={options}
             onMount={handleMount}
+            // We dispose the models ourselves on unmount, in the correct order
+            // (see the teardown effect). Without this the library disposes them
+            // before the diff widget and Monaco throws.
+            keepCurrentOriginalModel
+            keepCurrentModifiedModel
           />
         )}
       </div>

--- a/web/src/shell/MonacoDiffViewer.tsx
+++ b/web/src/shell/MonacoDiffViewer.tsx
@@ -152,7 +152,7 @@ export function MonacoDiffViewer({
       const modified = diffEditor.getModifiedEditor();
       modifiedEditorRef.current = modified;
       // Capture both models so the teardown effect can dispose them itself.
-      originalModelRef.current = diffEditor.getOriginalEditor().getModel();
+      originalModelRef.current = diffEditor.getOriginalEditor()?.getModel() ?? null;
       modifiedModelRef.current = modified.getModel();
       // Align the modified model's offsets with the raw "after" char offsets that
       // comment anchors use (CRLF files would otherwise be counted as LF).


### PR DESCRIPTION
## Related issue

No filed issue — this is a managed/embedded parity bug found while testing embedded omnigent. Happy to link one if a maintainer prefers.

## Summary

In managed (embedded) omnigent, <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+F did nothing in the code viewer and the diff view; it worked in the standalone app. Those surfaces relied on Monaco's own Cmd+F keybinding, which needs editor DOM focus and doesn't behave the same inside the same-root embed. The Shiki/markdown surfaces already open find through a window listener that flips a shared `searchOpen` toggle, so this routes the Monaco surfaces through that same imperative path.

- **FileViewer**: a capture-phase Cmd+F handler for the Monaco-backed surfaces (code source/editor and diff) that opens find via `searchOpen`. It's scoped to when the file viewer is the surface the user is working in — tracked via clicks/focus, seeded to the viewer when a file opens — so it never hijacks the browser's find-in-page while the user is in the chat/composer (the viewer stays mounted beside the chat).
- **MonacoDiffViewer**: wires find (previously unwired) by mirroring Monaco's native find widget to `searchOpen` on the modified side.
- **MonacoDiffViewer**: fixes a pre-existing `@monaco-editor/react` `DiffEditor` teardown crash — `TextModel got disposed before DiffEditorWidget model got reset` — hit when switching diff → non-diff. The library disposes the text models before the diff widget; this takes disposal over via `keepCurrentOriginalModel`/`keepCurrentModifiedModel` and disposes the models itself in the safe order (detach the widget's model first).

## Test Plan

- `pnpm exec tsc -p tsconfig.app.json --noEmit`, `pnpm exec oxlint`, and `pnpm exec vitest run` for the touched files all pass (110 tests + 1 pre-existing expected-fail).
- New unit tests: Cmd+F/Ctrl+F opening find on the code surface; opening it in the diff view; not intercepting Cmd+Shift+F; leaving the markdown editor to its own handler; not opening file find when focus is in the chat composer or after clicking a non-focusable chat area; re-claiming after clicking back into the viewer; the diff view's find wiring; and the diff teardown resetting the widget model and disposing both text models.
- Manual: built the embedded bundle and drove managed omnigent in the dev-proxy. Cmd+F opens find in the code and diff views; leaves find-in-page to the browser when focused in the chat; switching diff → non-diff no longer throws.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Behavior is embedded-host specific (hard to capture in the standalone app); see the Test Plan for the managed dev-proxy verification and unit coverage.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was done in the embedded (managed) host via the dev-proxy, because the bug is specific to the same-root embed and doesn't reproduce in the standalone app. Unit tests cover the surface-scoping logic, the diff find wiring, and the diff-editor teardown/disposal order.

## Changelog

Cmd+F opens find-in-file in the code and diff viewers (and no longer steals find-in-page while you're in the chat)

This pull request and its description were written by Isaac.
