### PR TITLE
fix(packaging): stage legal files for standalone packages

### DIFF
--- a/.github/workflows/release-omnigent.yml
+++ b/.github/workflows/release-omnigent.yml
@@ -127,8 +127,8 @@ jobs:
       - name: Build sdists + wheels
         run: |
           uv build --out-dir dist
-          uv build sdks/python-client --out-dir dist
-          uv build sdks/ui --out-dir dist
+          uv run --no-project python scripts/build_subpackages.py \
+            --out-dir dist omnigent-client omnigent-ui-sdk
           ls -la dist/
 
       # 4. Metadata sanity check (long-description renders, fields valid).

--- a/.github/workflows/release-omnigent.yml
+++ b/.github/workflows/release-omnigent.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Build sdists + wheels
         run: |
           uv build --out-dir dist
-          uv run --no-project python scripts/build_subpackages.py \
+          uv run --no-project --with build python scripts/build_subpackages.py \
             --out-dir dist omnigent-client omnigent-ui-sdk
           ls -la dist/
 

--- a/integrations/slack/pyproject.toml
+++ b/integrations/slack/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,6 +7,7 @@ name = "omnigent-slack"
 version = "0.13.0.dev0"
 description = "Slack Socket Mode bot that drives Omnigent sessions."
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
     "aiosqlite>=0.21.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,8 @@ lint = [
 ]
 test = [
     "pytest>=7.0",
+    # PEP 517 frontend used by the standalone-package artifact checks.
+    "build>=1.2",
     # These clients are optional product capabilities, but their tests import
     # and execute the real packages against mocks.
     "hindsight-client>=0.4.0",

--- a/scripts/build_subpackages.py
+++ b/scripts/build_subpackages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import shutil
 import subprocess
+import sys
 import tempfile
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
@@ -55,9 +56,10 @@ def build_packages(package_names: Sequence[str], out_dir: Path, *, wheel_only: b
     output.mkdir(parents=True, exist_ok=True)
     for package_name in package_names:
         with staged_package(PACKAGE_DIRS[package_name]) as staged:
-            command = ["uv", "build", str(staged), "--out-dir", str(output)]
+            command = [sys.executable, "-m", "build", "--outdir", str(output)]
             if wheel_only:
                 command.append("--wheel")
+            command.append(str(staged))
             subprocess.run(command, cwd=REPO_ROOT, check=True)
 
 

--- a/scripts/build_subpackages.py
+++ b/scripts/build_subpackages.py
@@ -1,0 +1,80 @@
+"""Build standalone Python packages with the repository's legal files."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LEGAL_FILES = ("LICENSE", "NOTICE")
+LICENSE_FILES_DECLARATION = 'license-files = ["LICENSE", "NOTICE"]'
+PACKAGE_DIRS = {
+    "omnigent-client": Path("sdks/python-client"),
+    "omnigent-ui-sdk": Path("sdks/ui"),
+    "omnigent-slack": Path("integrations/slack"),
+}
+
+
+@contextmanager
+def staged_package(package_dir: Path) -> Iterator[Path]:
+    """Stage a package beside its source and add the canonical legal files."""
+    source = (REPO_ROOT / package_dir).resolve()
+    with tempfile.TemporaryDirectory(prefix=f".{source.name}-build-", dir=source.parent) as tmp:
+        staged = Path(tmp)
+        shutil.copytree(
+            source,
+            staged,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns(".venv", "__pycache__", ".pytest_cache", "dist"),
+        )
+        for filename in LEGAL_FILES:
+            shutil.copy2(REPO_ROOT / filename, staged / filename)
+        _declare_license_files(staged / "pyproject.toml")
+        yield staged
+
+
+def _declare_license_files(pyproject: Path) -> None:
+    """Declare the legal files that exist only in the staged project."""
+    source = pyproject.read_text(encoding="utf-8")
+    anchor = 'license = "Apache-2.0"\n'
+    if source.count(anchor) != 1:
+        raise ValueError(f"expected one Apache-2.0 license declaration in {pyproject}")
+    pyproject.write_text(
+        source.replace(anchor, f"{anchor}{LICENSE_FILES_DECLARATION}\n"), encoding="utf-8"
+    )
+
+
+def build_packages(package_names: Sequence[str], out_dir: Path, *, wheel_only: bool) -> None:
+    """Build selected packages from temporary, self-contained source trees."""
+    output = out_dir.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    for package_name in package_names:
+        with staged_package(PACKAGE_DIRS[package_name]) as staged:
+            command = ["uv", "build", str(staged), "--out-dir", str(output)]
+            if wheel_only:
+                command.append("--wheel")
+            subprocess.run(command, cwd=REPO_ROOT, check=True)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package", nargs="+", choices=PACKAGE_DIRS)
+    parser.add_argument("--out-dir", type=Path, default=Path("dist"))
+    parser.add_argument("--wheel", action="store_true", help="Build wheels without sdists")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Build the requested standalone packages."""
+    args = parse_args(argv)
+    build_packages(args.package, args.out_dir, wheel_only=args.wheel)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,6 +7,7 @@ name = "omnigent-client"
 version = "0.13.0.dev0"
 description = "Python client SDK for the omnigent server API"
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
     # Sibling package — provides the SessionStreamEventType /

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,6 +7,7 @@ name = "omnigent-ui-sdk"
 version = "0.13.0.dev0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.12"
 dependencies = [
     # Version-locked (==) with the sibling client SDK; released together

--- a/tests/e2e/test_subpackage_license_artifacts_e2e.py
+++ b/tests/e2e/test_subpackage_license_artifacts_e2e.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import tarfile
+import zipfile
+from email import message_from_bytes
+from email.message import Message
+from pathlib import Path
+
+import pytest
+
+from scripts.build_subpackages import LEGAL_FILES, PACKAGE_DIRS, REPO_ROOT, build_packages
+
+
+@pytest.mark.parametrize("package_name", PACKAGE_DIRS)
+def test_subpackage_artifacts_contain_canonical_legal_files(
+    tmp_path: Path, package_name: str
+) -> None:
+    build_packages([package_name], tmp_path, wheel_only=False)
+
+    wheel_prefix = package_name.replace("-", "_")
+    wheel_path = next(tmp_path.glob(f"{wheel_prefix}-*.whl"))
+    with zipfile.ZipFile(wheel_path) as wheel:
+        metadata_path = next(
+            path for path in wheel.namelist() if path.endswith(".dist-info/METADATA")
+        )
+        metadata = message_from_bytes(wheel.read(metadata_path))
+        _assert_license_metadata(metadata)
+
+        dist_info = metadata_path.rsplit("/", 1)[0]
+        for filename in LEGAL_FILES:
+            archived = f"{dist_info}/licenses/{filename}"
+            assert wheel.read(archived) == (REPO_ROOT / filename).read_bytes()
+
+    sdist_path = next(tmp_path.glob(f"{wheel_prefix}-*.tar.gz"))
+    with tarfile.open(sdist_path, "r:gz") as sdist:
+        pkg_info = next(name for name in sdist.getnames() if name.endswith("/PKG-INFO"))
+        pkg_info_file = sdist.extractfile(pkg_info)
+        assert pkg_info_file is not None
+        _assert_license_metadata(message_from_bytes(pkg_info_file.read()))
+
+        archive_root = pkg_info.rsplit("/", 1)[0]
+        for filename in LEGAL_FILES:
+            archived_file = sdist.extractfile(f"{archive_root}/{filename}")
+            assert archived_file is not None
+            assert archived_file.read() == (REPO_ROOT / filename).read_bytes()
+
+
+def _assert_license_metadata(metadata: Message) -> None:
+    assert metadata["License-Expression"] == "Apache-2.0"
+    assert metadata.get_all("License-File") == list(LEGAL_FILES)

--- a/tests/test_subpackage_legal_files.py
+++ b/tests/test_subpackage_legal_files.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+import tomllib
+
+from scripts.build_subpackages import (
+    LEGAL_FILES,
+    PACKAGE_DIRS,
+    REPO_ROOT,
+    staged_package,
+)
+
+
+@pytest.mark.parametrize("package_name", PACKAGE_DIRS)
+def test_subpackage_stages_canonical_legal_files(package_name: str) -> None:
+    package_dir = PACKAGE_DIRS[package_name]
+    project = tomllib.loads((REPO_ROOT / package_dir / "pyproject.toml").read_text())["project"]
+
+    assert project["license"] == "Apache-2.0"
+    assert "license-files" not in project
+    assert all(not (REPO_ROOT / package_dir / filename).exists() for filename in LEGAL_FILES)
+
+    with staged_package(package_dir) as staged:
+        staged_project = tomllib.loads((staged / "pyproject.toml").read_text())["project"]
+        assert staged_project["license-files"] == list(LEGAL_FILES)
+        for filename in LEGAL_FILES:
+            assert (staged / filename).read_bytes() == (REPO_ROOT / filename).read_bytes()
+
+
+def test_staging_preserves_package_depth_for_relative_paths() -> None:
+    with staged_package(PACKAGE_DIRS["omnigent-client"]) as staged:
+        assert staged.parent == REPO_ROOT / "sdks"
+        assert (staged / "../..").resolve() == REPO_ROOT

--- a/uv.lock
+++ b/uv.lock
@@ -444,6 +444,20 @@ wheels = [
 ]
 
 [[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt' or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-cwsandbox') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-databricks') or (extra == 'extra-8-omnigent-antigravity' and extra == 'extra-8-omnigent-modal') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-dev') or (extra == 'extra-8-omnigent-antigravity' and extra == 'group-8-omnigent-lint')" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3274,6 +3288,7 @@ vertex = [
 [package.dev-dependencies]
 dev = [
     { name = "boto3" },
+    { name = "build" },
     { name = "filelock" },
     { name = "grpcio-tools" },
     { name = "hindsight-client" },
@@ -3302,6 +3317,7 @@ lint = [
 ]
 test = [
     { name = "boto3" },
+    { name = "build" },
     { name = "filelock" },
     { name = "hindsight-client" },
     { name = "moto", extra = ["s3"] },
@@ -3415,6 +3431,7 @@ provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "kms", "s3",
 [package.metadata.requires-dev]
 dev = [
     { name = "boto3", specifier = ">=1.30,<2" },
+    { name = "build", specifier = ">=1.2" },
     { name = "filelock", specifier = ">=3.0" },
     { name = "grpcio-tools", specifier = ">=1.68,<=1.81.1" },
     { name = "hindsight-client", specifier = ">=0.4.0" },
@@ -3443,6 +3460,7 @@ lint = [
 ]
 test = [
     { name = "boto3", specifier = ">=1.30,<2" },
+    { name = "build", specifier = ">=1.2" },
     { name = "filelock", specifier = ">=3.0" },
     { name = "hindsight-client", specifier = ">=0.4.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5,<6" },
@@ -4641,6 +4659,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

Closes #5890

Supersedes #5892.

## Summary

Standalone package artifacts need Apache-2.0 metadata and legal text, but keeping copies in every package directory would let them drift from the repository source of truth.

- Declares the Apache-2.0 SPDX expression for `omnigent-client`, `omnigent-ui-sdk`, and `omnigent-slack`.
- Stages the root `LICENSE` and `NOTICE` only while building each standalone package, and declares them as PEP 639 license files in that temporary project.
- Uses the staging helper in the source-repo fallback workflow and verifies both wheel and sdist contents. The central secure-release workflow must call the same helper before this PR is ready.

ELI5: each published archive gets its own real copy of the legal files, but Git tracks only the canonical root files.

```text
root LICENSE + NOTICE
          |
          v
temporary package source -> self-contained sdist -> wheel .dist-info/licenses/
```

Required companion substitutions in the central `omnigent.yml` workflow:

```text
python scripts/build_subpackages.py --out-dir dist-omnigent-client omnigent-client
python scripts/build_subpackages.py --out-dir dist-omnigent-ui-sdk omnigent-ui-sdk
python scripts/build_subpackages.py --out-dir dist-omnigent-slack omnigent-slack
```

## Test Plan

- `uv run --no-sync pytest tests/test_subpackage_legal_files.py tests/e2e/test_subpackage_license_artifacts_e2e.py -q` — 7 passed.
- `pre-commit run --all-files` — all hooks passed.
- Built wheel and sdist pairs for all three packages with `scripts/build_subpackages.py`; `twine check` passed for all six artifacts.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test checks that source directories contain no duplicate legal files and that staging uses the canonical bytes. The artifact test builds each normal sdist-plus-wheel pair and checks its PEP 639 metadata and embedded `LICENSE`/`NOTICE` contents byte-for-byte. Manual verification repeated the release-style build and ran `twine check` on every artifact.

## Changelog

Standalone SDK and Slack distributions now include Apache-2.0 LICENSE and NOTICE metadata.
