### PR TITLE
New server selector: improve handling of nav and errors

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -2601,7 +2601,11 @@ function registerIpc() {
     const ephemeral = windows.get(win)?.ephemeral === true;
     pinWindow(win, null); // back on the setup page → no trusted origin
     setWindowServerUrl(win, null);
-    void loadSetupPage(win, ephemeral ? "ephemeral=1" : "");
+    // "Connect to new server…" from a connected window goes straight to the
+    // server list, skipping the landing/mode intro (that's for first run).
+    const params = new URLSearchParams({ step: "server" });
+    if (ephemeral) params.set("ephemeral", "1");
+    void loadSetupPage(win, params.toString());
   });
 
   // Find bar → run/continue a search in its parent window. Empty text

--- a/web/src/pages/onboarding/ServerSelectStep.tsx
+++ b/web/src/pages/onboarding/ServerSelectStep.tsx
@@ -214,13 +214,21 @@ export function ServerSelectStep({
 
       {(error || invalid || unconfirmedUrl || connectError) && (
         <div role="alert" className="mb-2 text-base text-destructive">
-          {invalid
-            ? "Enter a valid http(s) server URL."
-            : connectError
-              ? connectError
-              : unconfirmedUrl
-                ? "This doesn't look like an Omnigent server. Click Join again to connect anyway."
-                : error}
+          {invalid ? (
+            "Enter a valid http(s) server URL."
+          ) : connectError ? (
+            <>
+              <span className="font-medium">Couldn&apos;t connect to the server: </span>
+              {connectError}
+            </>
+          ) : unconfirmedUrl ? (
+            "This doesn't look like an Omnigent server. Click Join again to connect anyway."
+          ) : (
+            <>
+              <span className="font-medium">Couldn&apos;t connect to the server: </span>
+              {error}
+            </>
+          )}
         </div>
       )}
 

--- a/web/src/pages/onboarding/ServerSelectorV2.tsx
+++ b/web/src/pages/onboarding/ServerSelectorV2.tsx
@@ -34,6 +34,9 @@ export interface ConnectResult {
 export interface ServerSelectorV2Setup {
   /** Initial server URL to prefill (saved / failed / default). */
   initialUrl: string;
+  /** Step to open on. "server" jumps straight to the server list ("Connect to
+   *  new server…" from a connected window); default is the first-run landing. */
+  initialStep?: "server";
   /** Optional error banner (from the shell's ?error=&url= params). */
   error?: string;
   /** Recently-connected server URLs (most recent first). */
@@ -81,7 +84,10 @@ export function ServerSelectorV2({ setup }: { setup: ServerSelectorV2Setup }) {
   // A failed connect reloads the wizard with an error (from ?error=&url=). That
   // only ever comes from the server-select flow, so open there — otherwise the
   // error banner renders on a step that isn't mounted and stays invisible.
-  const [step, setStep] = useState<Step>(setup.error ? "server" : "landing");
+  // "Connect to new server…" also opens the list directly (initialStep).
+  const [step, setStep] = useState<Step>(
+    setup.error || setup.initialStep === "server" ? "server" : "landing",
+  );
   const { height, panelHeight } = CARD[step];
 
   return (

--- a/web/src/server-selector-v2.tsx
+++ b/web/src/server-selector-v2.tsx
@@ -39,6 +39,9 @@ function SetupApp() {
   const failedUrl = params.get("url");
   const error = params.get("error") ?? undefined;
   const isEphemeral = params.get("ephemeral") === "1";
+  // "Connect to new server…" opens straight on the server list (?step=server),
+  // skipping the first-run landing/mode intro.
+  const initialStep = params.get("step") === "server" ? ("server" as const) : undefined;
 
   // Prefill: the URL that just failed (retry is the common next step), else the
   // saved server, else the default — except in ephemeral mode, where the whole
@@ -68,6 +71,7 @@ function SetupApp() {
 
   const setup: ServerSelectorV2Setup = {
     initialUrl,
+    initialStep,
     error,
     recentServers,
     managedServers,


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Two small UX fixes to the new (v2) server selector:

- **Connect to new server → server list.** The sidebar picker's "Connect to new
  server…" action reopened the wizard on the first-run **landing** page, forcing
  a connected user back through the intro to reach the server list. It now jumps
  straight to the server-select step. The shell passes `?step=server` to the
  setup page (`main.js`), which `SetupApp` reads into a new optional
  `initialStep` prop that opens `ServerSelectorV2` directly on the list. First
  run (no saved server) still opens on the landing page.
- **Labeled connection errors.** A failed connect showed a bare error string
  (e.g. `ERR_CONNECTION_REFUSED (-102)`) under the "Join an existing server…"
  heading with no context. The real connection-failure cases (the `?error=` from
  a failed navigate, and an in-page `connectError`) now render with a bold
  **"Couldn't connect to the server: "** label before the message. The two
  validation messages ("Enter a valid http(s) server URL." and the "doesn't look
  like an Omnigent server" confirm prompt) are left unlabeled — they're already
  self-explanatory instructions, not connection failures.

**ELI5:** clicking "Connect to new server" used to dump you on the welcome screen
instead of the server list, and connection errors showed a cryptic code with no
label. Both are fixed.

## Test Plan

Manual (Electron wizard, two terminals):

```bash
# web/:          pnpm dev:onboarding-wizard
# web/electron/: OMNIGENT_ONBOARDING_WIZARD=1 pnpm dev
```

1. Connect to a server, then sidebar picker → **Connect to new server…** → lands
   directly on the server list (not the landing page).
2. First run with no saved server → still opens on the landing page.
3. Trigger a failed connect (dead URL) → error reads **"Couldn't connect to the
   server: ERR_CONNECTION_REFUSED (-102)"** under the heading.
4. Enter an invalid URL → still shows "Enter a valid http(s) server URL." (no
   "Couldn't connect" label).

Typecheck (`tsc --noEmit`) and existing onboarding Vitest suites pass.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<img width="528" height="623" alt="Screenshot 2026-09-02 at 13 29 09" src="https://github.com/user-attachments/assets/cdf55b5d-9c45-49b9-8783-a09bc5478639" />

https://github.com/user-attachments/assets/1fa0bdc3-837f-4936-99d3-cf71c94f69c7

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both changes are UI wiring: an added query-param/prop that selects the initial
wizard step, and a copy/label change on the error banner. Verified manually per
the Test Plan; the existing onboarding component tests continue to pass and the
change carries no new logic worth a dedicated unit test.

## Changelog

"Connect to new server…" now opens the server list directly, and connection
failures are shown with a clear "Couldn't connect to the server:" label.
