### PR TITLE
Fix black screen when saved server is unreachable at launch

### DIFF
--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -137,14 +137,25 @@ function serverSelectorV2DevUrl() {
  * wizard gets HMR — it still runs in this window, keeping the omnigentSetup
  * bridge). If that server isn't running, loadURL rejects and we fall back to
  * the bundled file:// page. Prod always loads file://. Returns the load promise.
+ *
+ * Deferred to the next tick: this is often called from inside a `did-fail-load`
+ * handler (a dead saved server bouncing back to setup). Navigating a webContents
+ * synchronously while the failed load is still tearing down is unreliable —
+ * Electron can drop the new navigation and strand the window on the error page
+ * (seen in dev when BOTH the server and the Vite dev server are down). Letting
+ * the failing load settle first makes the fallback land every time.
  */
 function loadSetupPage(win, search = "") {
   const loadFile = () => win.loadFile(setupPagePath(), search ? { search } : undefined);
   const devUrl = serverSelectorV2DevUrl();
-  if (devUrl) {
-    return win.loadURL(search ? `${devUrl}?${search}` : devUrl).catch(loadFile);
-  }
-  return loadFile();
+  const run = () => {
+    if (win.isDestroyed()) return Promise.resolve();
+    if (devUrl) return win.loadURL(search ? `${devUrl}?${search}` : devUrl).catch(loadFile);
+    return loadFile();
+  };
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(run()), 0);
+  });
 }
 
 /** Absolute path to the bundled find-in-page bar page. */

--- a/web/electron/test/main.test.js
+++ b/web/electron/test/main.test.js
@@ -520,11 +520,15 @@ describe("navigation fallback wiring (src/main.js)", () => {
     harness.cleanup();
   });
 
-  it("registers navigation fallbacks when createWindow builds a window", () => {
+  it("registers navigation fallbacks when createWindow builds a window", async () => {
     const harness = loadNavigationHarness({ registerFallbacks: false });
 
     const win = harness.api.createWindow("https://host.example/ml/omnigents");
     harness.emit("did-navigate", "https://host.example/ml/omnigents/", 503, "Unavailable");
+    // loadSetupPage defers its navigation a tick (see main.js loadSetupPage).
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     assert.equal(win, harness.win);
     assert.equal(harness.hasListener("did-fail-load"), true);
@@ -835,11 +839,19 @@ describe("deep-link ingestion wiring (src/main.js)", () => {
 // carries httpResponseCode for main-frame navigations — fall back to setup
 // with ?error=&url= the same way the net-error path does.
 describe("HTTP error status fallback (src/main.js)", () => {
-  it("routes a 404 to the setup error surface with the mounted server URL", (t) => {
+  // loadSetupPage defers its navigation to the next tick (see main.js), so the
+  // fallback's loadFile lands a macrotask after the event is emitted.
+  const flush = () =>
+    new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+  it("routes a 404 to the setup error surface with the mounted server URL", async (t) => {
     const harness = loadNavigationHarness();
     t.after(harness.cleanup);
 
     harness.emit("did-navigate", "https://host.example/ml/omnigents/health", 404, "Not Found");
+    await flush();
 
     assert.equal(harness.calls.loadFile.length, 1);
     assert.equal(harness.calls.loadFile[0][0], harness.api.SETUP_PAGE);
@@ -848,11 +860,12 @@ describe("HTTP error status fallback (src/main.js)", () => {
     assert.equal(params.get("url"), "https://host.example/ml/omnigents");
   });
 
-  it("routes a 503 to the same setup error surface", (t) => {
+  it("routes a 503 to the same setup error surface", async (t) => {
     const harness = loadNavigationHarness();
     t.after(harness.cleanup);
 
     harness.emit("did-navigate", "https://host.example/ml/omnigents/", 503, "Service Unavailable");
+    await flush();
 
     assert.equal(harness.calls.loadFile.length, 1);
     const params = new URLSearchParams(harness.calls.loadFile[0][1].search);
@@ -860,17 +873,18 @@ describe("HTTP error status fallback (src/main.js)", () => {
     assert.equal(params.get("url"), "https://host.example/ml/omnigents");
   });
 
-  it("does not fall back for successful or redirect navigations", (t) => {
+  it("does not fall back for successful or redirect navigations", async (t) => {
     const harness = loadNavigationHarness();
     t.after(harness.cleanup);
 
     harness.emit("did-navigate", "https://host.example/ml/omnigents/", 200, "OK");
     harness.emit("did-navigate", "https://host.example/ml/omnigents/login", 302, "Found");
+    await flush();
 
     assert.deepEqual(harness.calls.loadFile, []);
   });
 
-  it("ignores a duplicate failure after the first fallback unpins the window", (t) => {
+  it("ignores a duplicate failure after the first fallback unpins the window", async (t) => {
     const harness = loadNavigationHarness();
     t.after(harness.cleanup);
 
@@ -880,11 +894,12 @@ describe("HTTP error status fallback (src/main.js)", () => {
     assert.equal(harness.api.windows.get(harness.win).origin, null);
     // Unpinning makes the origin guard reject re-entry.
     harness.emit("did-navigate", failedUrl, 503, "Service Unavailable");
+    await flush();
 
     assert.equal(harness.calls.loadFile.length, 1);
   });
 
-  it("keeps the network-error fallback and ignores ERR_ABORTED", (t) => {
+  it("keeps the network-error fallback and ignores ERR_ABORTED", async (t) => {
     const harness = loadNavigationHarness();
     t.after(harness.cleanup);
 
@@ -895,11 +910,13 @@ describe("HTTP error status fallback (src/main.js)", () => {
       "https://host.example/ml/omnigents/",
       true,
     );
+    await flush();
     assert.equal(harness.calls.loadFile.length, 1);
 
     const aborted = loadNavigationHarness();
     t.after(aborted.cleanup);
     aborted.emit("did-fail-load", -3, "ABORTED", "https://host.example/ml/omnigents/", true);
+    await flush();
     assert.deepEqual(aborted.calls.loadFile, []);
   });
 });


### PR DESCRIPTION
## Related issue

Closes #

## Summary

When a saved server is unreachable at launch, the `did-fail-load` handler
bounces the window back to the setup page via `loadSetupPage`. That call
navigated the webContents **synchronously from inside the failure callback**,
while the failed load was still tearing down — which Electron handles
unreliably: it drops the new navigation and strands the window on Chromium's
raw error page.

This bit twice in dev: the dead server bounces to setup, then the setup page's
own Vite dev-server URL (`localhost:5174`) is also down, so `loadSetupPage`'s
Vite→file:// fallback is itself a nested navigation from the failure handler and
gets dropped too — leaving a black screen showing
`Failed to load URL: http://localhost:5174/server-selector-v2.html … ERR_CONNECTION_REFUSED`.
"Change Server…" from the native menu worked around it because it fires from a
**settled** page, not from within a failing load's callback.

Fix: defer `loadSetupPage`'s navigation to the next tick (`setTimeout(0)`) so the
failing load settles first; the Vite→file:// fallback then lands every time,
from every caller. The deferred run is guarded with `isDestroyed()` since a tick
now elapses before it navigates.

**ELI5:** the app tried to jump to the setup screen at the exact instant the
previous page was crashing, and the browser engine sometimes ignored the jump —
so you were stuck on a black error screen. Waiting one beat before jumping makes
it work every time.

Scope: the black-screen symptom is dev-only (packaged builds skip the Vite URL
and load file:// directly), but navigating out of a `did-fail-load` handler was
fragile regardless of Vite, so this also hardens the production fallback path.

## Test Plan

Automated (`node --test` in `web/electron/`): the navigation-fallback tests now
`await` a macrotask before asserting the fallback's `loadFile` (the navigation
is deferred a tick). All electron tests pass; oxlint clean.

Manual (the exact repro):

1. Stop the omnigent server **and** don't run `pnpm dev:onboarding-wizard` (Vite
   down), then launch the Electron app with the wizard flag.
2. Before: black screen with `ERR_CONNECTION_REFUSED http://localhost:5174/...`.
   After: lands on the bundled file:// setup page with the connection error
   shown, same as the old (non-v2) flow.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing `did-fail-load` / `did-navigate` fallback tests in `main.test.js`
were updated to await the now-deferred navigation and continue to assert the
setup page loads. The nested-navigation timing this fixes depends on a real
Electron webContents tearing down a failed load, which the unit layer mocks —
so the end-to-end black-screen repro (server + Vite both down) is verified
manually per the Test Plan.

## Changelog

Fixed a black screen at launch when the saved server was unreachable and the
app couldn't immediately reach its setup page.
