### PR TITLE
perf(tests): seed sqlite test databases from a migrated template

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,12 +567,37 @@ def _worker_db_uri() -> Generator[str, None, None]:
     root_engine2.dispose()
 
 
+@pytest.fixture(scope="session")
+def _sqlite_schema_template(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Build one migrated SQLite template per pytest worker process.
+
+    The function-scoped ``db_uri`` fixture previously replayed the full Alembic
+    chain for every SQLite test. Copying this template preserves a private file
+    per test at the same Alembic head revision as a fresh migration. Because
+    the copied file carries its ``alembic_version`` stamp, its first
+    ``get_or_create_engine`` call takes the already-at-head verification path.
+    """
+    template = tmp_path_factory.mktemp("schema-template") / "template.db"
+    uri = f"sqlite:///{template}"
+    engine = get_or_create_engine(uri)
+    with _engine_lock:
+        _engine_cache.pop(uri, None)
+    engine.dispose()
+    return str(template)
+
+
 @pytest.fixture()
-def db_uri(tmp_path: Path, _worker_db_uri: str) -> Generator[str, None, None]:
+def db_uri(
+    tmp_path: Path,
+    _worker_db_uri: str,
+    request: pytest.FixtureRequest,
+) -> Generator[str, None, None]:
     """
     Per-test database URI.
 
-    * **SQLite** (default): fresh file per test, fully isolated.
+    * **SQLite** (default): fresh file per test, copied from the session
+      schema template so the Alembic chain runs once per worker rather than
+      once per test. Still fully isolated.
     * **Postgres / MySQL** (``OMNIGENT_TEST_DB_URI`` set): reuses the
       session-scoped worker database and truncates all non-alembic tables
       between tests so each test starts clean without re-migrating.
@@ -580,8 +605,10 @@ def db_uri(tmp_path: Path, _worker_db_uri: str) -> Generator[str, None, None]:
     import sqlalchemy as _sa
 
     if not _worker_db_uri:
-        # SQLite: per-test file.
+        # SQLite: per-test file, seeded from the migrated template.
+        template = request.getfixturevalue("_sqlite_schema_template")
         db_path = tmp_path / "test.db"
+        shutil.copyfile(template, db_path)
         uri = f"sqlite:///{db_path}"
         engine = get_or_create_engine(uri)
         yield uri

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import shutil
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -15,6 +16,8 @@ from omnigent.db.utils import (
     _LAKEBASE_POOL_RECYCLE_SECONDS,
     _SERVER_POOL_RECYCLE_SECONDS,
     _build_alembic_config,
+    _engine_cache,
+    _engine_lock,
     _get_current_db_revision,
     _get_head_db_revision,
     _initialize_or_verify_schema,
@@ -423,6 +426,65 @@ def test_initialize_or_verify_schema_no_op_when_at_head(
         assert _get_current_db_revision(engine) == head
     finally:
         engine.dispose()
+
+
+def test_copied_sqlite_template_migrates_once_and_remains_isolated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Copied test databases stay at head without replaying migrations."""
+    migration_uris: list[str] = []
+
+    def _counting_run_migrations(engine: Any, db_uri: str) -> None:
+        migration_uris.append(db_uri)
+        _run_migrations(engine, db_uri)
+
+    monkeypatch.setattr(
+        "omnigent.db.utils._run_migrations",
+        _counting_run_migrations,
+    )
+
+    template_path = tmp_path / "template.db"
+    template_uri = f"sqlite:///{template_path}"
+    template_engine = get_or_create_engine(template_uri)
+    try:
+        assert _get_current_db_revision(template_engine) == _get_head_db_revision(template_uri)
+    finally:
+        with _engine_lock:
+            _engine_cache.pop(template_uri, None)
+        template_engine.dispose()
+
+    copy_uris: list[str] = []
+    copy_engines: list[Any] = []
+    try:
+        for name in ("first.db", "second.db"):
+            copy_path = tmp_path / name
+            shutil.copyfile(template_path, copy_path)
+            copy_uri = f"sqlite:///{copy_path}"
+            copy_uris.append(copy_uri)
+            copy_engines.append(get_or_create_engine(copy_uri))
+
+        assert all(
+            _get_current_db_revision(engine) == _get_head_db_revision(uri)
+            for uri, engine in zip(copy_uris, copy_engines, strict=True)
+        )
+        assert migration_uris == [template_uri]
+
+        for engine in copy_engines:
+            with engine.begin() as conn:
+                conn.execute(text("CREATE TABLE isolation_probe (value TEXT)"))
+        with copy_engines[0].begin() as conn:
+            conn.execute(text("INSERT INTO isolation_probe (value) VALUES ('first')"))
+        with copy_engines[0].connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM isolation_probe")).scalar() == 1
+        with copy_engines[1].connect() as conn:
+            assert conn.execute(text("SELECT count(*) FROM isolation_probe")).scalar() == 0
+    finally:
+        with _engine_lock:
+            for uri in copy_uris:
+                _engine_cache.pop(uri, None)
+        for engine in copy_engines:
+            engine.dispose()
 
 
 def test_initialize_or_verify_schema_auto_migrates_when_stale(

--- a/tests/db/test_utils.py
+++ b/tests/db/test_utils.py
@@ -487,6 +487,51 @@ def test_copied_sqlite_template_migrates_once_and_remains_isolated(
             engine.dispose()
 
 
+@pytest.mark.parametrize("marker", ["first", "second"])
+def test_db_uri_uses_template_without_replaying_migrations(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    marker: str,
+) -> None:
+    """The real SQLite ``db_uri`` path copies an at-head template."""
+    # Resolve the session template before installing the spy. Its one migration
+    # is expected; acquiring a per-test copy must not run another migration.
+    request.getfixturevalue("_sqlite_schema_template")
+    migration_uris: list[str] = []
+
+    def _counting_run_migrations(engine: Any, db_uri: str) -> None:
+        migration_uris.append(db_uri)
+        _run_migrations(engine, db_uri)
+
+    monkeypatch.setattr(
+        "omnigent.db.utils._run_migrations",
+        _counting_run_migrations,
+    )
+
+    db_uri = request.getfixturevalue("db_uri")
+    engine = get_or_create_engine(db_uri)
+    assert migration_uris == []
+    assert _get_current_db_revision(engine) == _get_head_db_revision(db_uri)
+
+    # Two parametrized fixture acquisitions must each start from the pristine
+    # template. Reusing a prior test database would expose this marker table.
+    with engine.begin() as conn:
+        existing = conn.execute(
+            text(
+                "SELECT count(*) FROM sqlite_master "
+                "WHERE type = 'table' AND name = 'fixture_isolation_probe'"
+            )
+        ).scalar()
+        assert existing == 0
+        conn.execute(text("CREATE TABLE fixture_isolation_probe (value TEXT)"))
+        conn.execute(
+            text("INSERT INTO fixture_isolation_probe (value) VALUES (:marker)"),
+            {"marker": marker},
+        )
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT value FROM fixture_isolation_probe")).scalar() == marker
+
+
 def test_initialize_or_verify_schema_auto_migrates_when_stale(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Related issue

<!-- Test / CI change — no issue required per CONTRIBUTING.md -->

N/A — `Test / CI` change.

## Summary

`get_or_create_engine()` runs the Alembic chain to head on first engine creation. On the SQLite path (the default, when `OMNIGENT_TEST_DB_URI` is unset) the `db_uri` fixture handed it a brand-new empty file **per test**, so every db-using test replayed all ~96 migrations — including the `batch_alter_table` rebuilds that copy whole tables under `PRAGMA foreign_keys=OFF`. The cost scaled with migration count, so it quietly got worse every time a migration was added.

This migrates **once per pytest session / xdist worker** into a template file, and `db_uri` copies that template per test. A copied SQLite file already carries its `alembic_version` stamp, so the per-test `get_or_create_engine()` call takes the already-at-head verification path instead of migrating.

- **`tests/stores`: 272.89s → 36.06s (7.6x)**, identical results
- Isolation unchanged: each test still gets its own private file, at the same Alembic head revision as a fresh migration
- No production code touched, no new dependencies, test-only diff

### ELI5

Every test was rebuilding the same database from 96 sequential blueprints. Now we build it once, then photocopy it.

```
before:  test 1 ──> replay 96 migrations ──> db   (~0.48s each)
         test 2 ──> replay 96 migrations ──> db
         ...      (x ~180 db-using tests)

after:   session ──> replay 96 migrations ──> template.db   (once)
         test 1  ──> copyfile ──────────────> db   (~0.014s)
         test 2  ──> copyfile ──────────────> db
```

## Test Plan

All runs on a clean `uv sync --all-groups` worktree, `-p no:randomly`, base `origin/main @ 4858cccbf`.

| Suite | Result | Time |
|---|---|---|
| `tests/stores` | 614 passed, 1 skipped | **36.06s** (was 272.89s) |
| `tests/db` | 391 passed, 1 skipped | 81.25s |
| `tests/server` | 4045 passed, 8 skipped, 3 xfailed | 486.39s |
| `tests/onboarding` | 1249 passed | 16.09s |
| `tests/stores -n 4` | 614 passed, 1 skipped | 20.52s |
| `tests/db -n 4` | 391 passed, 1 skipped | 40.30s |
| `ruff check` / `ruff format --check` | clean | — |

**No behaviour change:** `tests/stores` collects **615 tests both before and after** — the speedup is not from running fewer tests.

**Determinism:** `tests/db` run 3x under randomized ordering (no `-p no:randomly`): 54 passed each time. The new guard asserts *zero additional* migrations rather than an exact count, so it is not order-dependent against the shared session fixture.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

### Mutation evidence — the guard genuinely fails

A performance guard that cannot fail is worthless, so both directions were verified. Replacing the fixture's `shutil.copyfile(template, db_path)` with `db_path.touch()` kills the optimization while leaving every test functionally green:

```
mutated fixture:   tests/stores  614 passed, 1 skipped in 303.85s   <- 8.4x regression, all green
                   new guard     2 failed                          <- caught it
                   assert migration_uris == []
                   AssertionError: assert ['sqlite:////.../test.db'] == []

restored:          new guard     2 passed
                   tests/stores  614 passed, 1 skipped in 36.06s
```

An earlier iteration of this PR had a guard that only tested a *re-implementation* of the copy logic rather than the real `db_uri` fixture — it stayed green under the mutation above. Review caught it; the guard now resolves the real fixture via `request.getfixturevalue("db_uri")` so it executes the production path.

### Broken migrations still surface

The template is built by running the real Alembic chain, so a broken migration fails template construction rather than being silently skipped. Verified by injecting `raise RuntimeError` into a migration's `upgrade()`: tests errored immediately; restoring made them pass. This is why the template is migrated rather than built with `Base.metadata.create_all()`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two guards were added to `tests/db/test_utils.py`:

1. `test_copied_sqlite_template_migrates_once_and_remains_isolated` — mechanism level. Spies on `_run_migrations`, asserts it runs exactly once for the template and never for copies, both copies report `current_revision == head`, and a row written to one copy is absent from the other.
2. `test_db_uri_uses_template_without_replaying_migrations` — fixture level. Resolves the real `_sqlite_schema_template` and `db_uri` fixtures, then asserts acquiring a per-test database triggers **zero additional** migrations and lands at head. Parameterized twice with a marker table to prove each acquisition starts from a pristine copy.

**Manual verification** covers the two mutation experiments above (fixture mutation → guard fails; broken migration → tests error), since neither is appropriate to leave as a permanent test.

Deliberately out of scope: two independently freshly-migrated SQLite databases differ from each other in `CHECK`-constraint *emission order* (same constraints, same semantics). That non-determinism is pre-existing in the migration chain and unrelated to this change — which is why the invariant documented here is "same Alembic head revision", not byte identity. Split-DB tests (`test_conversation_store_split_db.py`, `test_agent_store.py`) intentionally construct their own URIs and so do not use the template; that is by design.

## Changelog

<!-- Test-only change, no user-facing impact — section intentionally left without a line. -->
