### PR TITLE
feat(harness): add MiniMax Code ACP harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ Using OpenClaw? See the [OpenClaw integration guide](docs/openclaw.md) to import
 its coding agents or drive a live OpenClaw Gateway session over ACP.
 
 <details>
-<summary>Grok Build and Devin</summary>
+<summary>Grok Build, Devin, and MiniMax Code</summary>
 
-Two more coding agents are built in but have no `omnigent <name>` launcher of
+Three more coding agents are built in but have no `omnigent <name>` launcher of
 their own, because each ships a CLI that holds its own login. Install the vendor
 CLI, log in with it, then name the harness:
 
@@ -292,20 +292,27 @@ omnigent run --harness grok           # 'grok-build' also works
 curl -fsSL https://cli.devin.ai/install.sh | bash
 devin auth login
 omnigent run --harness devin
+
+# MiniMax Code
+curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash
+mcode login
+omnigent run --harness minimax        # 'mcode' and 'minimax-code' also work
 ```
 
-Both speak the [Agent Client Protocol](https://agentclientprotocol.com) over
-stdio, and Omnigent stores no credential for either — each CLI reads back the
-login it wrote to disk. That also means `--model` is refused rather than
-silently dropped: both run their account-default model. To pin one, configure an
-`acp:` agent whose command passes the vendor's own model flag.
+All three speak the [Agent Client Protocol](https://agentclientprotocol.com) over
+stdio, and Omnigent stores no credential for any of them — each CLI reads its own
+saved configuration. That also means `--model` is refused rather than silently
+dropped: model selection stays with the vendor CLI. To pass a vendor model flag,
+configure an `acp:` agent whose command includes it.
 
-Use the vendor login rather than an API key. A builtin ACP row has no
+Use the vendor's own credential command rather than expecting an ambient API
+key. A builtin ACP row has no
 `env_passthrough` of its own, and `XAI_API_KEY` is not in the host-to-runner
 credential allowlist, so exporting it in your shell does not reach the agent.
 If you need the key route, pass it explicitly with
 `OMNIGENT_RUNNER_ENV_PASSTHROUGH=XAI_API_KEY`, or configure an `acp:` agent that
-declares the passthrough.
+declares the passthrough. For a MiniMax custom provider or API key, run
+`mcode provider`; MiniMax Code reads that saved configuration itself.
 
 </details>
 

--- a/docs/AGENT_YAML_SPEC.md
+++ b/docs/AGENT_YAML_SPEC.md
@@ -177,6 +177,22 @@ executor:
 CLI flags such as `--harness qwen` and `--model <id>` can override or supply
 missing executor values.
 
+## MiniMax Code
+
+`harness: minimax` runs [MiniMax Code](https://www.minimax.io/) through its
+ACP stdio server (`mcode acp`). Install the CLI with
+`curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash`, then
+authenticate once with `mcode login`.
+
+```yaml
+executor:
+  harness: minimax            # aliases: mcode, minimax-code
+```
+
+MiniMax Code owns its authentication and model selection, so Omnigent stores no
+credential and rejects a `--model` override instead of silently dropping it.
+Run `mcode provider` to configure a custom provider or API key in MiniMax Code.
+
 ## Custom ACP agents
 
 `harness: acp:<slug>` runs any configured Agent Client Protocol server command.

--- a/omnigent/acp_cli_harnesses.py
+++ b/omnigent/acp_cli_harnesses.py
@@ -115,4 +115,18 @@ ACP_CLI_HARNESSES: dict[str, AcpCliHarness] = {
         args=("agent", "stdio"),
         aliases=("grok-build",),
     ),
+    # MiniMax Code drives ``mcode acp`` and reads the credentials written by
+    # ``mcode login``; Omnigent stores no credential or model selection.
+    "minimax": AcpCliHarness(
+        install=HarnessInstallSpec(
+            "MiniMax Code",
+            "mcode",
+            None,
+            login_args=("login",),
+            install_hint="curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash",
+            auth_hint="run `mcode login` (MiniMax Code manages its own credentials)",
+        ),
+        args=("acp",),
+        aliases=("mcode", "minimax-code"),
+    ),
 }

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1748,6 +1748,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         # ACP-family builtin, sorted by id, before the non-ACP harnesses.
         "Devin",
         "Grok Build",
+        "MiniMax Code",
         "Copilot",
         "Kiro",
         "Kimi Code",
@@ -1911,7 +1912,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1933,7 +1934,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1950,7 +1951,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2141,14 +2142,15 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
         ("5", "_manage_hermes_harness"),
         ("8", "_manage_qwen_harness"),
         ("9", "_manage_goose_harness"),
-        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
-        # every row after them shifted down by two when that block landed.
+        # 10-12 are the builtin ACP CLI rows (Devin, Grok Build, MiniMax Code —
+        # sorted by id); every row after them follows that derived block.
         ("10", "_show_acp_cli_harness"),
         ("11", "_show_acp_cli_harness"),
-        ("12", "_manage_copilot_harness"),
-        ("13", "_manage_kiro_harness"),
-        ("14", "_manage_kimi_harness"),
-        ("16", "_add_acp_agent"),
+        ("12", "_show_acp_cli_harness"),
+        ("13", "_manage_copilot_harness"),
+        ("14", "_manage_kiro_harness"),
+        ("15", "_manage_kimi_harness"),
+        ("17", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(

--- a/tests/e2e/test_minimax_acp_harness_e2e.py
+++ b/tests/e2e/test_minimax_acp_harness_e2e.py
@@ -1,0 +1,99 @@
+"""Hermetic e2e for the MiniMax Code builtin ACP harness."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.acp_harness import _build_acp_executor
+from omnigent.inner.executor import ExecutorError, TextChunk, TurnComplete
+from omnigent.runtime.workflow import _build_acp_cli_spawn_env
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+_MARKER = "MINIMAX_ACP_E2E_OK"
+_FAKE_MCODE = rf"""#!/usr/bin/env python3
+import json
+import sys
+
+if sys.argv[1:] != ["acp"]:
+    raise SystemExit(f"expected 'acp', got {{sys.argv[1:]!r}}")
+
+def send(message):
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    message = json.loads(line)
+    request_id = message.get("id")
+    method = message.get("method")
+    if method == "initialize":
+        send({{"jsonrpc": "2.0", "id": request_id, "result": {{
+            "protocolVersion": 1,
+            "agentCapabilities": {{"promptCapabilities": {{"image": False}}}},
+        }}}})
+    elif method == "session/new":
+        send({{"jsonrpc": "2.0", "id": request_id,
+              "result": {{"sessionId": "minimax-e2e-session"}}}})
+    elif method == "session/prompt":
+        session_id = message["params"]["sessionId"]
+        send({{"jsonrpc": "2.0", "method": "session/update", "params": {{
+            "sessionId": session_id,
+            "update": {{
+                "sessionUpdate": "agent_message_chunk",
+                "content": {{"type": "text", "text": "{_MARKER}"}},
+            }},
+        }}}})
+        send({{"jsonrpc": "2.0", "id": request_id, "result": {{
+            "stopReason": "end_turn",
+            "usage": {{"inputTokens": 1, "outputTokens": 1, "totalTokens": 2}},
+        }}}})
+"""
+
+
+@pytest.mark.asyncio
+async def test_minimax_catalog_launches_mcode_acp_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public MiniMax harness row launches ``mcode acp`` and streams a turn."""
+    fake_mcode = tmp_path / "mcode"
+    fake_mcode.write_text(_FAKE_MCODE, encoding="utf-8")
+    fake_mcode.chmod(0o755)
+    monkeypatch.setenv("OMNIGENT_MINIMAX_PATH", str(fake_mcode))
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="minimax-e2e",
+        instructions="Test MiniMax Code.",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "minimax"}),
+    )
+    spawn_env = _build_acp_cli_spawn_env(spec, harness="minimax", cwd=tmp_path)
+    assert shlex.split(spawn_env["HARNESS_ACP_COMMAND"]) == [str(fake_mcode), "acp"]
+    assert spawn_env["HARNESS_ACP_NAME"] == "MiniMax Code"
+    for name, value in spawn_env.items():
+        monkeypatch.setenv(name, value)
+
+    executor = _build_acp_executor()
+    events = []
+    try:
+        async for event in executor.run_turn(
+            [{"role": "user", "content": "Reply with the marker."}],
+            tools=[],
+            system_prompt="You are a test agent.",
+        ):
+            events.append(event)
+    finally:
+        await executor.close()
+
+    errors = [event for event in events if isinstance(event, ExecutorError)]
+    assert not errors
+    assert "".join(event.text for event in events if isinstance(event, TextChunk)) == _MARKER
+    completions = [event for event in events if isinstance(event, TurnComplete)]
+    assert len(completions) == 1
+    assert completions[0].usage == {
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "total_tokens": 2,
+    }


### PR DESCRIPTION
## Related issue

Closes #6193

## Summary

- Add MiniMax Code as a first-class declarative ACP CLI harness, launched with `mcode acp`.
- Surface the official installer and `mcode login` in setup, and document the `minimax`, `mcode`, and `minimax-code` names.
- Update setup-menu coverage and add a hermetic ACP round-trip test without vendor credentials or network access.

ELI5: Omnigent already knows how to speak ACP; this change adds MiniMax Code's executable and launch command to the existing catalog instead of creating a vendor-specific adapter.

```text
omnigent run --harness minimax
              |
              v
          mcode acp
              |
          ACP over stdio
              |
              v
         MiniMax Code
```

## Test Plan

- `uv run --no-sync pytest tests/test_acp_cli_harnesses.py tests/cli/test_configure_models.py tests/e2e/test_minimax_acp_harness_e2e.py -q` — 143 passed
- `uv run --no-sync pytest tests/test_harness_plugins.py tests/test_harness_capabilities.py tests/onboarding/test_harness_readiness.py tests/onboarding/test_harness_install.py tests/onboarding/test_acp_auth.py -q` — 240 passed
- `uv run --no-sync pytest tests/server/test_app.py -k 'acp or harness_catalog or builtin' -q` — 8 passed
- `uv run --no-sync pyrefly check` — 0 errors
- `uv run --no-sync pre-commit run --all-files` — passed
- Manual probe with MiniMax Code 0.2.7: `mcode acp` returned an ACP v1 `initialize` response with the expected capabilities.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The new e2e test exercises catalog resolution, spawn environment construction, ACP initialization, session creation, prompt streaming, and turn completion. The live CLI probe verified that the documented `mcode acp` command speaks ACP over stdio; no credentials or response content are included.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The hermetic e2e uses a fake `mcode` executable but follows the real catalog → spawn-env → generic ACP executor path. A separate manual probe confirmed MiniMax Code 0.2.7 supports the same ACP v1 handshake. No MiniMax account, token, network call, or new dependency is required by the automated test.

## Changelog

MiniMax Code can now be selected as a built-in ACP harness with `minimax`, `mcode`, or `minimax-code`.