### PR TITLE
Login screen using new UX

### DIFF
--- a/web/src/components/onboarding/AnimatedOmnigentPanel.css
+++ b/web/src/components/onboarding/AnimatedOmnigentPanel.css
@@ -64,6 +64,36 @@
   transform: translateX(-50%);
 }
 
+/* Auth-card variant: content-sized, translucent surface, logo centered (no
+   between-step shrink animation to clip it out the top). */
+.omnigent-panel-logo--centered {
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.omnigent-card--auto {
+  height: auto;
+  background: var(--card);
+}
+
+/* transparent, not var(--card): that token is translucent, so layering it over
+   the translucent card doubles the fill and the band reads brighter. */
+.dark .omnigent-card--auto .omnigent-animated-panel {
+  background: transparent;
+}
+
+/* On a short viewport the card clamps (max-height); let the band shrink and the
+   body scroll instead of overflowing. */
+.omnigent-card--auto .omnigent-animated-panel {
+  flex-shrink: 1;
+  min-height: 120px;
+}
+
+.omnigent-card--auto .omnigent-card-body {
+  min-height: 140px;
+  overflow-y: auto;
+}
+
 /* Card body (the current onboarding step) sits below the animated panel and
    fills the remaining card height. */
 .omnigent-card-body {

--- a/web/src/components/onboarding/AnimatedOmnigentPanel.tsx
+++ b/web/src/components/onboarding/AnimatedOmnigentPanel.tsx
@@ -19,10 +19,14 @@ const CARD_WIDTH = 440;
 const LOGO_SIZE = 56;
 
 export interface AnimatedOmnigentPanelProps {
-  /** Outer card height in px. */
+  /** Fixed outer card height in px. Ignored when `autoHeight` is set. */
   height?: number;
-  /** Animated pixel panel height in px. */
+  /** Animated pixel panel (canvas) height in px. */
   panelHeight?: number;
+  /** Size the card to its content instead of `height` (panel stays fixed). */
+  autoHeight?: boolean;
+  /** Center the logo in the panel instead of pinning it near the top. */
+  centeredLogo?: boolean;
   /** Card body rendered below the panel (the current onboarding step). */
   children?: ReactNode;
 }
@@ -30,6 +34,8 @@ export interface AnimatedOmnigentPanelProps {
 export function AnimatedOmnigentPanel({
   height = 560,
   panelHeight = 308,
+  autoHeight = false,
+  centeredLogo = false,
   children,
 }: AnimatedOmnigentPanelProps) {
   const reduceMotion =
@@ -37,8 +43,8 @@ export function AnimatedOmnigentPanel({
 
   return (
     <section
-      className="omnigent-card"
-      style={{ width: CARD_WIDTH, height }}
+      className={`omnigent-card${autoHeight ? " omnigent-card--auto" : ""}`}
+      style={{ width: CARD_WIDTH, ...(autoHeight ? {} : { height }) }}
       aria-label="Omnigent onboarding"
     >
       <div className="omnigent-animated-panel" style={{ height: panelHeight }}>
@@ -51,7 +57,7 @@ export function AnimatedOmnigentPanel({
         <img
           src={omnigentLogo}
           alt="Omnigent"
-          className="omnigent-panel-logo"
+          className={`omnigent-panel-logo${centeredLogo ? " omnigent-panel-logo--centered" : ""}`}
           style={{ width: LOGO_SIZE, height: LOGO_SIZE }}
         />
       </div>

--- a/web/src/components/onboarding/PixelBlast.tsx
+++ b/web/src/components/onboarding/PixelBlast.tsx
@@ -196,12 +196,18 @@ export default function PixelBlast({
       return;
     }
 
+    // A lost context (StrictMode's double-invoke reuses the canvas) fails to
+    // compile with a null info log — teardown noise, not a real failure.
+    if (gl.isContextLost()) return;
+
     let program: WebGLProgram;
     try {
       program = createProgram(gl);
     } catch (error) {
-      console.error("PixelBlast WebGL2 initialization failed:", error);
-      canvas.dataset.webglUnavailable = "true";
+      if (!gl.isContextLost()) {
+        console.error("PixelBlast WebGL2 initialization failed:", error);
+        canvas.dataset.webglUnavailable = "true";
+      }
       return;
     }
 
@@ -312,8 +318,8 @@ export default function PixelBlast({
       resizeObserver.disconnect();
       gl.deleteBuffer(positionBuffer);
       gl.deleteVertexArray(vertexArray);
-      gl.deleteProgram(program);
-      gl.getExtension("WEBGL_lose_context")?.loseContext();
+      // No loseContext(): it's idempotent per canvas and would poison re-init on
+      // StrictMode's remount; GC reclaims a truly unmounted canvas's context.
     };
   }, [color, patternDensity, patternScale, pixelSize, speed]);
 

--- a/web/src/lib/useLoginV2.ts
+++ b/web/src/lib/useLoginV2.ts
@@ -1,0 +1,30 @@
+// Sticky flag for the redesigned (v2) auth pages. `?login-v2=1`/`=0` toggles and
+// persists; with no param the stored value wins. Persisted because the accounts
+// 401→/login redirect drops the query string, so a param-only flag wouldn't stick.
+
+import { useSearchParams } from "@/lib/routing";
+
+const STORAGE_KEY = "omnigent.loginV2";
+
+function store(enabled: boolean): void {
+  try {
+    if (enabled) window.localStorage.setItem(STORAGE_KEY, "1");
+    else window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage can throw in sandboxed/blocked-cookies contexts.
+  }
+}
+
+export function useLoginV2(): boolean {
+  const raw = useSearchParams()[0].get("login-v2");
+  if (raw === "1" || raw === "0") {
+    const on = raw === "1";
+    store(on);
+    return on;
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -115,6 +115,58 @@ describe("LoginPage sanitizeReturnTo open-redirect defense", () => {
   });
 });
 
+describe("LoginPage v2 (?login-v2=1) flow", () => {
+  function renderLoginV2(extra = "") {
+    return render(
+      <MemoryRouter initialEntries={[`/login?login-v2=1${extra}`]}>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders the sign-in form inside the v2 card", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+    renderLoginV2();
+    expect(await screen.findByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeInTheDocument();
+  });
+
+  it("signs in and navigates on success", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+    vi.mocked(accountsApi.login).mockResolvedValue({
+      ok: true,
+      user: { id: "alice", is_admin: false },
+      token: "t",
+      expires_in: 3600,
+    });
+    renderLoginV2();
+    fireEvent.change(await screen.findByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "hunter2!" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(accountsApi.login).toHaveBeenCalledWith({ username: "alice", password: "hunter2!" }),
+    );
+    await waitFor(() => expect(hrefWrites[0]).toBe("/"));
+  });
+
+  it("shows the server error and does not navigate on failure", async () => {
+    vi.mocked(accountsApi.getMe).mockResolvedValue(null);
+    vi.mocked(accountsApi.login).mockResolvedValue({
+      ok: false,
+      error: "Invalid credentials",
+      status: 401,
+    });
+    renderLoginV2();
+    fireEvent.change(await screen.findByLabelText(/username/i), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: "wrongpass" } });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Invalid credentials");
+    expect(hrefWrites).toHaveLength(0);
+  });
+});
+
 describe("LoginPage forced re-auth (?reauth=1)", () => {
   it("does NOT auto-bounce an already-signed-in user — shows the form", async () => {
     // getMe resolves to an account (beforeEach default), which normally

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -25,9 +25,11 @@
  * reach the deploy.
  */
 
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { useSearchParams } from "@/lib/routing";
 import { useAppName } from "@/lib/branding";
+import { useLoginV2 } from "@/lib/useLoginV2";
+import { AuthCardShell } from "@/pages/onboarding/AuthCardShell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { getMe, login as loginRequest } from "@/lib/accountsApi";
@@ -54,6 +56,7 @@ function rememberUsername(value: string): void {
 
 export function LoginPage() {
   const appName = useAppName();
+  const loginV2 = useLoginV2();
   const [params] = useSearchParams();
   // `return_to` is set by both identity.ts (on 401 redirect) and the
   // server-side magic-redeem 302 fallback. Trust only same-origin
@@ -132,6 +135,91 @@ export function LoginPage() {
     setError(result.error);
   }
 
+  const heading = (
+    <div className="space-y-1 text-center">
+      <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+      <p className="text-ui text-muted-foreground">Welcome to {appName}.</p>
+    </div>
+  );
+
+  const body: ReactNode = (
+    <>
+      {heading}
+
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div className="space-y-1.5">
+          <label htmlFor="login-username" className="text-ui font-medium leading-none">
+            Username
+          </label>
+          <Input
+            id="login-username"
+            type="text"
+            autoComplete="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            disabled={submitting}
+            required
+          />
+          <p className="text-sm text-muted-foreground">
+            On a fresh install your username is your machine login (the output of{" "}
+            <code className="font-mono">whoami</code>), unless an admin set a different one.
+          </p>
+        </div>
+
+        <div className="space-y-1.5">
+          <label htmlFor="login-password" className="text-ui font-medium leading-none">
+            Password
+          </label>
+          <Input
+            id="login-password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={submitting}
+            required
+          />
+        </div>
+
+        {error !== null && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={submitting || password.length === 0}
+          componentId="login.sign_in"
+        >
+          {submitting ? "Signing in…" : "Sign in"}
+        </Button>
+      </form>
+
+      <p className="text-center text-sm text-muted-foreground">
+        On a fresh install you set the first admin's password yourself — no credential is
+        auto-generated. A brand-new instance shows a Create-admin form instead of this one; the
+        password can also be pre-seeded with{" "}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono">
+          OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD
+        </code>
+        .
+      </p>
+    </>
+  );
+
+  if (loginV2) {
+    return (
+      <AuthCardShell>
+        <div className="flex flex-col gap-6">{body}</div>
+      </AuthCardShell>
+    );
+  }
+
   return (
     <div
       className="flex min-h-screen items-center justify-center bg-background px-4"
@@ -142,76 +230,7 @@ export function LoginPage() {
         paddingBottom: "var(--omnigent-safe-bottom)",
       }}
     >
-      <div className="w-full max-w-sm space-y-6">
-        <div className="space-y-1 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
-          <p className="text-ui text-muted-foreground">Welcome to {appName}.</p>
-        </div>
-
-        <form onSubmit={onSubmit} className="space-y-4">
-          <div className="space-y-1.5">
-            <label htmlFor="login-username" className="text-ui font-medium leading-none">
-              Username
-            </label>
-            <Input
-              id="login-username"
-              type="text"
-              autoComplete="username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              disabled={submitting}
-              required
-            />
-            <p className="text-sm text-muted-foreground">
-              On a fresh install your username is your machine login (the output of{" "}
-              <code className="font-mono">whoami</code>), unless an admin set a different one.
-            </p>
-          </div>
-
-          <div className="space-y-1.5">
-            <label htmlFor="login-password" className="text-ui font-medium leading-none">
-              Password
-            </label>
-            <Input
-              id="login-password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              disabled={submitting}
-              required
-            />
-          </div>
-
-          {error !== null && (
-            <div
-              role="alert"
-              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui text-destructive"
-            >
-              {error}
-            </div>
-          )}
-
-          <Button
-            type="submit"
-            className="w-full"
-            disabled={submitting || password.length === 0}
-            componentId="login.sign_in"
-          >
-            {submitting ? "Signing in…" : "Sign in"}
-          </Button>
-        </form>
-
-        <p className="text-center text-sm text-muted-foreground">
-          On a fresh install you set the first admin's password yourself — no credential is
-          auto-generated. A brand-new instance shows a Create-admin form instead of this one; the
-          password can also be pre-seeded with{" "}
-          <code className="rounded bg-muted px-1 py-0.5 font-mono">
-            OMNIGENT_ACCOUNTS_INIT_ADMIN_PASSWORD
-          </code>
-          .
-        </p>
-      </div>
+      <div className="w-full max-w-sm space-y-6">{body}</div>
     </div>
   );
 }

--- a/web/src/pages/RegisterPage.test.tsx
+++ b/web/src/pages/RegisterPage.test.tsx
@@ -58,6 +58,13 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  // useLoginV2 persists ?login-v2 to localStorage — clear it so the v2 flag
+  // doesn't leak into the v1 tests (which assume the default-off state).
+  try {
+    window.localStorage.clear();
+  } catch {
+    /* jsdom localStorage always present, but be safe */
+  }
   Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
 });
 
@@ -122,5 +129,54 @@ describe("RegisterPage", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("invite expired");
     expect(hrefWrites).toHaveLength(0);
+  });
+});
+
+describe("RegisterPage v2 (?login-v2=1) flow", () => {
+  it("shows the 'Join your team' landing first, not the form", () => {
+    renderRegisterAt("?invite=tok123&login-v2=1");
+    expect(screen.getByRole("heading", { name: /join your team/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /accept invitation/i })).toBeInTheDocument();
+    // The form isn't rendered until the invite is accepted.
+    expect(screen.queryByLabelText(/username/i)).not.toBeInTheDocument();
+  });
+
+  it("advances to the form on Accept, then redeems and navigates home", async () => {
+    renderRegisterAt("?invite=tok123&login-v2=1");
+    fireEvent.click(screen.getByRole("button", { name: /accept invitation/i }));
+
+    // Form now shown; complete it.
+    fillForm("alice", "longenough", "longenough");
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() =>
+      expect(accountsApi.register).toHaveBeenCalledWith({
+        invite: "tok123",
+        username: "alice",
+        password: "longenough",
+      }),
+    );
+    await waitFor(() => expect(hrefWrites[0]).toBe("/"));
+  });
+
+  it("surfaces a redeem error after Accept and does not navigate", async () => {
+    vi.mocked(accountsApi.register).mockResolvedValue({
+      ok: false,
+      error: "invite expired",
+      status: 400,
+    });
+    renderRegisterAt("?invite=tok123&login-v2=1");
+    fireEvent.click(screen.getByRole("button", { name: /accept invitation/i }));
+    fillForm("alice", "longenough", "longenough");
+    fireEvent.click(screen.getByRole("button", { name: /create account/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("invite expired");
+    expect(hrefWrites).toHaveLength(0);
+  });
+
+  it("skips the landing and shows the invite-required error when the token is missing", () => {
+    renderRegisterAt("?login-v2=1");
+    expect(screen.queryByRole("button", { name: /accept invitation/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/invite token/i);
   });
 });

--- a/web/src/pages/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage.tsx
@@ -17,8 +17,11 @@
  * type a mixed-case value that the server then rejects.
  */
 
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { useSearchParams } from "@/lib/routing";
+import { useLoginV2 } from "@/lib/useLoginV2";
+import { AuthCardShell } from "@/pages/onboarding/AuthCardShell";
+import { JoinTeamStep } from "@/pages/onboarding/JoinTeamStep";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { register as registerRequest } from "@/lib/accountsApi";
@@ -26,6 +29,7 @@ import { register as registerRequest } from "@/lib/accountsApi";
 const MIN_PASSWORD_LENGTH = 8;
 
 export function RegisterPage() {
+  const loginV2 = useLoginV2();
   const [params] = useSearchParams();
   const invite = params.get("invite") ?? "";
 
@@ -34,6 +38,7 @@ export function RegisterPage() {
   const [confirm, setConfirm] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [accepted, setAccepted] = useState(false); // v2: invite landing accepted
 
   // Server rejects invites that are missing / expired / redeemed
   // with a generic 400. Surface the same generic UI in the
@@ -69,6 +74,115 @@ export function RegisterPage() {
     setError(result.error);
   }
 
+  const body: ReactNode = (
+    <>
+      <div className="space-y-1 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">Create your account</h1>
+        <p className="text-ui text-muted-foreground">
+          You were invited to join this Omnigent server.
+        </p>
+      </div>
+
+      {missingInvite ? (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui text-destructive"
+        >
+          This page needs an invite token in the URL — make sure you opened the link your admin sent
+          you.
+        </div>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <label htmlFor="register-username" className="text-ui font-medium leading-none">
+              Username
+            </label>
+            <Input
+              id="register-username"
+              type="text"
+              autoComplete="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value.toLowerCase())}
+              disabled={submitting}
+              required
+              pattern="[a-z0-9][a-z0-9._\-]{0,63}(@[a-z0-9.\-]+\.[a-z]{2,})?"
+              title="Lowercase letters, digits, dots, hyphens, underscores (or a lowercase email)"
+            />
+            <p className="text-sm text-muted-foreground">
+              Lowercase letters, digits, dots, hyphens, underscores — or a lowercase email.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="register-password" className="text-ui font-medium leading-none">
+              Password
+            </label>
+            <Input
+              id="register-password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={submitting}
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="register-confirm" className="text-ui font-medium leading-none">
+              Confirm password
+            </label>
+            <Input
+              id="register-confirm"
+              type="password"
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              disabled={submitting}
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+            />
+          </div>
+
+          {error !== null && (
+            <div
+              role="alert"
+              className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui text-destructive"
+            >
+              {error}
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={submitting || password.length < MIN_PASSWORD_LENGTH || username.length === 0}
+            componentId="register.create_account"
+          >
+            {submitting ? "Creating…" : "Create account"}
+          </Button>
+        </form>
+      )}
+    </>
+  );
+
+  // v2: a valid invite shows the "Join your team" landing first (Accept →
+  // form); a missing invite skips it. One shell across both steps so the panel
+  // isn't remounted (a fresh AnimatedOmnigentPanel re-inits its WebGL context).
+  if (loginV2) {
+    const showLanding = !missingInvite && !accepted;
+    return (
+      <AuthCardShell panelHeight={showLanding ? 340 : undefined}>
+        {showLanding ? (
+          <JoinTeamStep onAccept={() => setAccepted(true)} />
+        ) : (
+          <div className="flex flex-col gap-6">{body}</div>
+        )}
+      </AuthCardShell>
+    );
+  }
+
   return (
     <div
       className="flex min-h-screen items-center justify-center bg-background px-4"
@@ -79,98 +193,7 @@ export function RegisterPage() {
         paddingBottom: "var(--omnigent-safe-bottom)",
       }}
     >
-      <div className="w-full max-w-sm space-y-6">
-        <div className="space-y-1 text-center">
-          <h1 className="text-2xl font-semibold tracking-tight">Create your account</h1>
-          <p className="text-ui text-muted-foreground">
-            You were invited to join this Omnigent server.
-          </p>
-        </div>
-
-        {missingInvite ? (
-          <div
-            role="alert"
-            className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui text-destructive"
-          >
-            This page needs an invite token in the URL — make sure you opened the link your admin
-            sent you.
-          </div>
-        ) : (
-          <form onSubmit={onSubmit} className="space-y-4">
-            <div className="space-y-1.5">
-              <label htmlFor="register-username" className="text-ui font-medium leading-none">
-                Username
-              </label>
-              <Input
-                id="register-username"
-                type="text"
-                autoComplete="username"
-                value={username}
-                onChange={(e) => setUsername(e.target.value.toLowerCase())}
-                disabled={submitting}
-                required
-                pattern="[a-z0-9][a-z0-9._\-]{0,63}(@[a-z0-9.\-]+\.[a-z]{2,})?"
-                title="Lowercase letters, digits, dots, hyphens, underscores (or a lowercase email)"
-              />
-              <p className="text-sm text-muted-foreground">
-                Lowercase letters, digits, dots, hyphens, underscores — or a lowercase email.
-              </p>
-            </div>
-
-            <div className="space-y-1.5">
-              <label htmlFor="register-password" className="text-ui font-medium leading-none">
-                Password
-              </label>
-              <Input
-                id="register-password"
-                type="password"
-                autoComplete="new-password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                disabled={submitting}
-                required
-                minLength={MIN_PASSWORD_LENGTH}
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <label htmlFor="register-confirm" className="text-ui font-medium leading-none">
-                Confirm password
-              </label>
-              <Input
-                id="register-confirm"
-                type="password"
-                autoComplete="new-password"
-                value={confirm}
-                onChange={(e) => setConfirm(e.target.value)}
-                disabled={submitting}
-                required
-                minLength={MIN_PASSWORD_LENGTH}
-              />
-            </div>
-
-            {error !== null && (
-              <div
-                role="alert"
-                className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui text-destructive"
-              >
-                {error}
-              </div>
-            )}
-
-            <Button
-              type="submit"
-              className="w-full"
-              disabled={
-                submitting || password.length < MIN_PASSWORD_LENGTH || username.length === 0
-              }
-              componentId="register.create_account"
-            >
-              {submitting ? "Creating…" : "Create account"}
-            </Button>
-          </form>
-        )}
-      </div>
+      <div className="w-full max-w-sm space-y-6">{body}</div>
     </div>
   );
 }

--- a/web/src/pages/onboarding/AuthCardShell.tsx
+++ b/web/src/pages/onboarding/AuthCardShell.tsx
@@ -1,0 +1,66 @@
+// Card shell for the v2 auth pages: the onboarding AnimatedOmnigentPanel with
+// no drag strip. Desktop shows the animated card; mobile (<md) drops the chrome
+// and animation and lets the content flow.
+
+import type { CSSProperties, ReactNode } from "react";
+import { AnimatedOmnigentPanel } from "@/components/onboarding/AnimatedOmnigentPanel";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
+import omnigentLogo from "@/assets/omnigent-starfish-icon.png";
+
+const DEFAULT_PANEL_HEIGHT = 220;
+const MIN_PANEL_HEIGHT = 200;
+
+export function AuthCardShell({
+  panelHeight = DEFAULT_PANEL_HEIGHT,
+  children,
+}: {
+  panelHeight?: number;
+  children: ReactNode;
+}) {
+  const isMobile = useIsMobileViewport();
+
+  if (isMobile) {
+    // Base padding folded into the safe-area inset (an inline padding would
+    // override a Tailwind py-* class).
+    const padding = {
+      paddingTop: "calc(var(--omnigent-safe-top) + 3rem)",
+      paddingBottom: "calc(var(--omnigent-safe-bottom) + 3rem)",
+    } as CSSProperties;
+    return (
+      <div className="flex min-h-screen flex-col items-center bg-background px-4" style={padding}>
+        <div className="flex w-full max-w-sm flex-1 flex-col justify-center gap-6">
+          <img
+            src={omnigentLogo}
+            alt="Omnigent"
+            className="mx-auto size-14 object-contain"
+            aria-hidden="true"
+          />
+          {children}
+        </div>
+      </div>
+    );
+  }
+
+  const safeArea = {
+    paddingTop: "var(--omnigent-safe-top)",
+    paddingBottom: "var(--omnigent-safe-bottom)",
+  } as CSSProperties;
+  // my-auto (not items-center) so a card taller than the viewport scrolls from
+  // the top instead of being clipped.
+  return (
+    <div
+      className="flex min-h-screen justify-center overflow-y-auto bg-background p-6 [&>*]:my-auto"
+      style={safeArea}
+    >
+      <AnimatedOmnigentPanel
+        panelHeight={Math.max(panelHeight, MIN_PANEL_HEIGHT)}
+        autoHeight
+        centeredLogo
+      >
+        <div className="flex flex-col px-2 pb-2 pt-3">{children}</div>
+      </AnimatedOmnigentPanel>
+    </div>
+  );
+}
+
+export default AuthCardShell;

--- a/web/src/pages/onboarding/JoinTeamStep.tsx
+++ b/web/src/pages/onboarding/JoinTeamStep.tsx
@@ -1,0 +1,24 @@
+// Invite-accept landing shown before the register form in the v2 flow. Accept
+// just advances to the form — the account is created on form submit.
+
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function JoinTeamStep({ onAccept }: { onAccept: () => void }) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Join your team</h1>
+        <p className="text-ui text-muted-foreground">
+          Connect to their Omnigent server to start collaborating.
+        </p>
+      </div>
+      <Button className="w-full gap-1 py-5" onClick={onAccept} componentId="register.accept_invite">
+        Accept invitation
+        <ArrowRight className="size-4" aria-hidden />
+      </Button>
+    </div>
+  );
+}
+
+export default JoinTeamStep;


### PR DESCRIPTION
## Related issue

Closes https://linear.app/omnigent/issue/OMNI-5677/implement-new-omnigent-login-page

## Summary

Adds a redesigned (v2) look for the browser accounts pages — `/login` and the
invite `/register` — behind a sticky flag, reusing the onboarding
`AnimatedOmnigentPanel` (pixel-blast + starfish card) so the accounts flow
matches the ServerSelectorV2 experience.

- **Flag-gated, non-destructive.** `?login-v2=1` turns the new UI on and
  persists to localStorage (`?login-v2=0` off); default off. The existing v1
  pages are untouched when the flag is off — the form logic is shared, only the
  wrapper differs.
- **`AuthCardShell`** wraps the shared form body in the animated card (no
  Electron drag strip). Desktop shows the card; **mobile (<md) drops the chrome
  and animation** and lets the content flow.
- **`/register` gains a "Join your team" landing** (`JoinTeamStep`): a valid
  invite shows it first, Accept advances to the username/password form; a
  missing invite skips the landing and shows the existing error.
- **`AnimatedOmnigentPanel`** gains `autoHeight` + `centeredLogo` opt-ins for
  the static auth cards (onboarding keeps its fixed-height, pinned-logo
  behavior). CSS handles content-sizing, the dark translucent surface, and
  short-viewport shrink/scroll.
- **`PixelBlast`**: stop calling `loseContext()` on cleanup — it poisoned
  re-init on React StrictMode's dev remount (a lost context can't recompile);
  GC reclaims a truly unmounted canvas's context anyway.

**ELI5:** the sign-in and invite pages get the same animated card as the
onboarding flow, hidden behind `?login-v2=1` so nothing changes until we opt in.

## Test Plan

Automated (Vitest): `LoginPage.test.tsx` / `RegisterPage.test.tsx` cover both
v1 (existing) and the new v2 flows — happy and error paths:

- Login v2: form renders in the card; submit → `login()` → navigate; failure →
  alert, no navigation.
- Register v2: "Join your team" landing shows first; Accept → form → `register()`
  → navigate; redeem failure → alert, no navigation; missing invite → error,
  landing skipped.

All 764 `src/pages` tests pass; `tsc` and oxlint clean.

Manual (accounts-mode server, `?login-v2=1`):

- `/login?login-v2=1`, `/register?login-v2=1&invite=<token>` (landing → Accept →
  form), `/register?login-v2=1` (missing-invite error), `?login-v2=0` to revert.
- Verified light/dark, mobile (<md) free-flow, and short-viewport scroll —
  these (WebGL + CSS layout) aren't unit-testable, so they're manual.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change


https://github.com/user-attachments/assets/28285fec-25eb-43c9-a464-06140ca3b380



<img width="560" height="714" alt="Screenshot 2026-09-02 at 16 17 16" src="https://github.com/user-attachments/assets/7c372da7-3abc-4a77-8a2f-1e4a4a9324ee" />
<img width="640" height="794" alt="Screenshot 2026-09-02 at 16 17 02" src="https://github.com/user-attachments/assets/f9cf3b8f-bae3-4ba1-8ebd-722418873083" />


## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Vitest covers the v2 routing/gate/branch logic with `accountsApi` mocked (happy
+ error for both pages). The visual layer — WebGL pixel-blast, dark-mode
surface colors, mobile free-flow, and short-viewport clamp/scroll — depends on
real layout/GL that jsdom can't render, so it's verified manually per the Test
Plan.

## Changelog

New card-styled sign-in and invite pages, opt-in via `?login-v2=1`.
