### PR TITLE
Fix flake in test_new_session_shows_first_prompt_optimistically

### DIFF
--- a/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
+++ b/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
@@ -147,9 +147,15 @@ def test_new_session_shows_first_prompt_optimistically(
 
     # Sanity: the real auto-send handoff ran (its POST was intercepted),
     # so a green run isn't a composer that silently never sent.
+    # Poll via `wait_for_timeout`, not `time.sleep`: `event_texts` is appended
+    # by the `handle_events` route callback, and Playwright's sync API only
+    # dispatches route/event callbacks while the test is inside a Playwright
+    # call. A bare `time.sleep` loop never yields to that dispatcher, so the
+    # POST stays paused and unrecorded until the loop exits — the auto-send
+    # already fired, but the assertion below can't see it (the observed flake).
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline and _PROMPT not in event_texts:
-        time.sleep(0.05)
+        page.wait_for_timeout(50)
     assert _PROMPT in event_texts, (
         f"the initial prompt was never POSTed to the session's /events "
         f"(observed: {event_texts}) — the auto-send path did not run"


### PR DESCRIPTION
## Related issue

N/A — this is a `Test / CI` change (no linked issue required per the template).

## Summary

`test_new_session_shows_first_prompt_optimistically` intermittently failed with
`the initial prompt was never POSTed to the session's /events (observed: [])`.

The bug is in the test, not the product. The loop that waits for the auto-send
used a bare `time.sleep`:

- `event_texts` is only appended inside the `handle_events` **route callback**.
- Playwright's sync API dispatches route/event callbacks *only while the test is
  inside a Playwright call*. A bare `time.sleep` loop never yields to that
  dispatcher, so the intercepted `POST /events` stays paused and unrecorded
  until the loop exits.
- The auto-send actually fired promptly; the assertion just couldn't observe it,
  and whether the dispatcher happened to get pumped mid-loop was
  timing/machine-dependent — hence the flake.

Fix: poll with `page.wait_for_timeout(50)` (which pumps the dispatcher) instead
of `time.sleep(0.05)`.

**ELI5:** the test was napping in a way that also put the mailman to sleep, so it
never noticed the letter that had already been delivered. Napping the Playwright
way keeps the mailman working.

## Test Plan

Reproduced and verified against a fresh SPA build + a spawned server/runner:

- **Before:** deterministic failure — `--count=8` → 8/8 failed. Instrumenting
  with a 45s ceiling showed the `POST /events` was only *recorded* at +45.01s —
  the moment the loop exited and the next Playwright call pumped the dispatcher.
- **After:** the same POST is recorded at **+0.14s**; `--count=10` → 10/10
  passed, ~1.3s per run.

```
uv run --no-sync pytest tests/e2e_ui/sessions/test_new_session_optimistic_title.py --ui-skip-build -q
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Ran the affected e2e test in a loop before and after the change (see Test Plan):
8/8 failures before, 10/10 passes after, with instrumentation confirming the
auto-send `POST /events` lands at +0.14s once the poll pumps Playwright's
dispatcher. No product code changed, so no new product coverage is warranted.

This pull request and its description were written by Isaac.
