### PR TITLE
Increase harness idle watchdog to one hour

### DIFF
--- a/omnigent/runtime/harnesses/_scaffold.py
+++ b/omnigent/runtime/harnesses/_scaffold.py
@@ -120,7 +120,10 @@ _TURN_CONTEXT_DESYNC_CODE = "runner_turn_context_desync"
 # exceed the old 240s cap, tripping the watchdog and wedging the session
 # in a "Prompt is too long" → compaction → 240s-timeout loop.
 # Env var name kept for the ops knob; ``<= 0`` disables.
-_TURN_IDLE_TIMEOUT_S = float(os.environ.get("HARNESS_TURN_TIMEOUT_S", "600"))
+_DEFAULT_TURN_IDLE_TIMEOUT_S = 3600.0
+_TURN_IDLE_TIMEOUT_S = float(
+    os.environ.get("HARNESS_TURN_TIMEOUT_S", _DEFAULT_TURN_IDLE_TIMEOUT_S)
+)
 
 # Absolute per-turn ceiling on TOTAL turn duration. Progress-aware when
 # the idle watchdog is enabled: every real progress event extends the

--- a/tests/e2e/omnigent/test_codex_gateway_auth_error.py
+++ b/tests/e2e/omnigent/test_codex_gateway_auth_error.py
@@ -125,7 +125,7 @@ def test_codex_gateway_auth_failure_exits_with_actionable_error(
     assert "https://example.test/ai-gateway/codex/v1/responses" in output
     assert "auth likely expired/misconfigured" in output
     assert "wedged LLM" not in output
-    assert "600s harness idle watchdog" not in output
+    assert "harness idle watchdog" not in output
 
     requests = [json.loads(line) for line in request_log.read_text().splitlines()]
     assert any(

--- a/tests/runtime/harnesses/test_scaffold.py
+++ b/tests/runtime/harnesses/test_scaffold.py
@@ -54,6 +54,12 @@ _TEST_HARNESS_MODULE = "tests.runtime.harnesses._test_scaffold_harnesses"
 _TRUNCATION_MARKER = "[output truncated by omnigent:"
 
 
+def test_default_idle_watchdog_allows_one_hour_progress_free_calls() -> None:
+    from omnigent.runtime.harnesses import _scaffold
+
+    assert _scaffold._DEFAULT_TURN_IDLE_TIMEOUT_S == 3600.0
+
+
 @dataclass
 class _ParsedSSEEvent:
     """


### PR DESCRIPTION
## Summary
- increase the public harness idle-watchdog default from 600 seconds to 3600 seconds
- retain the environment override and ability to disable the watchdog
- add regression coverage for the new default
- make the gateway-auth regression independent of the configured timeout value

## Why
Long-running test commands are a single progress-free harness await: the tool-call start event is emitted immediately, but no further event is emitted until the command returns. Legitimate test runs can exceed ten minutes. The watchdog still protects against genuinely wedged LLM/tool calls and failed event forwarding, but now allows one hour without progress by default.

## Test plan
- `uv run pytest -q tests/runtime/harnesses/test_scaffold.py::test_default_idle_watchdog_allows_one_hour_progress_free_calls tests/e2e/omnigent/test_codex_gateway_auth_error.py`
- `uv run pytest -q tests/runtime/harnesses/test_scaffold.py::test_per_turn_watchdog_fails_wedged_turn tests/runtime/harnesses/test_scaffold.py::test_per_turn_watchdog_allows_active_turn_past_window tests/runtime/harnesses/test_scaffold.py::test_per_turn_watchdog_ignores_heartbeats`
- `uv run --with ruff ruff check omnigent/runtime/harnesses/_scaffold.py tests/runtime/harnesses/test_scaffold.py tests/e2e/omnigent/test_codex_gateway_auth_error.py`
- `git diff --check`