### PR TITLE
fix(ci): preserve auto-dismissed Otto approvals

### DIFF
--- a/.github/scripts/maintainer_approval.py
+++ b/.github/scripts/maintainer_approval.py
@@ -45,6 +45,7 @@ def approval_decision(
     trusted_successors: set[str],
     reviews: list[dict[str, Any]],
     commits: list[dict[str, Any]],
+    timeline: list[dict[str, Any]] | None = None,
 ) -> ApprovalDecision:
     """Accept current approval or trusted same-repository successor commits."""
     maintainers = {login.casefold() for login in maintainers}
@@ -60,10 +61,11 @@ def approval_decision(
     for login, review in latest_decisive_reviews(reviews).items():
         if login.casefold() not in maintainers:
             continue
-        if str(review.get("state") or "").upper() != "APPROVED":
+        review_state = str(review.get("state") or "").upper()
+        if review_state not in {"APPROVED", "DISMISSED"}:
             continue
         approved_sha = str(review.get("commit_id") or "")
-        if approved_sha == head_sha:
+        if review_state == "APPROVED" and approved_sha == head_sha:
             return ApprovalDecision(True, f"Current head approved by maintainer @{login}.")
         if not same_repository:
             failures.append(f"@{login}'s approval predates a fork-head update")
@@ -83,6 +85,16 @@ def approval_decision(
             if author_login not in trusted_successors or committer_login not in trusted_successors:
                 untrusted.append(str(commit.get("sha") or "")[:9])
         if not untrusted:
+            if review_state == "DISMISSED" and not trusted_automatic_dismissal(
+                review=review,
+                successor_shas={str(commit.get("sha") or "") for commit in successors},
+                trusted_successors=trusted_successors,
+                timeline=timeline or [],
+            ):
+                failures.append(
+                    f"@{login}'s approval was not auto-dismissed by trusted automation"
+                )
+                continue
             return ApprovalDecision(
                 True,
                 f"Maintainer @{login} approved {approved_sha[:9]}; only trusted "
@@ -94,6 +106,31 @@ def approval_decision(
 
     reason = "; ".join(failures) if failures else "awaiting approval from a maintainer"
     return ApprovalDecision(False, reason)
+
+
+def trusted_automatic_dismissal(
+    *,
+    review: dict[str, Any],
+    successor_shas: set[str],
+    trusted_successors: set[str],
+    timeline: list[dict[str, Any]],
+) -> bool:
+    review_id = str(review.get("id") or "")
+    for event in timeline:
+        dismissed = event.get("dismissed_review") or {}
+        actor = event.get("actor") or {}
+        if str(event.get("event") or "") != "review_dismissed":
+            continue
+        if str(dismissed.get("review_id") or "") != review_id:
+            continue
+        if str(dismissed.get("state") or "").upper() != "APPROVED":
+            continue
+        if str(actor.get("login") or "").casefold() not in trusted_successors:
+            continue
+        if str(dismissed.get("dismissal_commit_id") or "") not in successor_shas:
+            continue
+        return True
+    return False
 
 
 def gh_json(arguments: list[str]) -> Any:
@@ -136,6 +173,7 @@ def main() -> int:
     pull = gh_json(["api", f"repos/{args.repository}/pulls/{args.pr_number}"])
     reviews = paginated(f"repos/{args.repository}/pulls/{args.pr_number}/reviews")
     commits = paginated(f"repos/{args.repository}/pulls/{args.pr_number}/commits")
+    timeline = paginated(f"repos/{args.repository}/issues/{args.pr_number}/timeline")
     decision = approval_decision(
         repository=args.repository,
         author=str((pull.get("user") or {}).get("login") or ""),
@@ -145,6 +183,7 @@ def main() -> int:
         trusted_successors=set(args.trusted_successor),
         reviews=reviews,
         commits=commits,
+        timeline=timeline,
     )
     if decision.approved:
         print(decision.reason)

--- a/.github/scripts/maintainer_approval_test.py
+++ b/.github/scripts/maintainer_approval_test.py
@@ -23,7 +23,19 @@ def commit(sha: str, login: str = "omni-resolve-agent[bot]"):
     }
 
 
-def decide(*, reviews, commits, head="new", head_repository=REPOSITORY):
+def dismissal_event(*, review_id=1, actor="omni-resolve-agent[bot]", commit_id="new"):
+    return {
+        "event": "review_dismissed",
+        "actor": {"login": actor},
+        "dismissed_review": {
+            "review_id": review_id,
+            "state": "approved",
+            "dismissal_commit_id": commit_id,
+        },
+    }
+
+
+def decide(*, reviews, commits, timeline=None, head="new", head_repository=REPOSITORY):
     return approval_decision(
         repository=REPOSITORY,
         author="contributor",
@@ -33,6 +45,7 @@ def decide(*, reviews, commits, head="new", head_repository=REPOSITORY):
         trusted_successors=TRUSTED,
         reviews=reviews,
         commits=commits,
+        timeline=timeline or [],
     )
 
 
@@ -49,6 +62,31 @@ def test_approval_survives_trusted_same_repo_successor_commits():
     )
     assert decision.approved
     assert "only trusted automation committed" in decision.reason
+
+
+def test_auto_dismissed_approval_survives_the_trusted_push_that_dismissed_it():
+    decision = decide(
+        reviews=[review("DISMISSED", "old")],
+        commits=[commit("old"), commit("new")],
+        timeline=[dismissal_event()],
+    )
+    assert decision.approved
+    assert "only trusted automation committed" in decision.reason
+
+
+def test_dismissed_approval_requires_a_trusted_matching_dismissal_event():
+    manual = decide(
+        reviews=[review("DISMISSED", "old")],
+        commits=[commit("old"), commit("new")],
+        timeline=[dismissal_event(actor="maintainer")],
+    )
+    wrong_commit = decide(
+        reviews=[review("DISMISSED", "old")],
+        commits=[commit("old"), commit("new")],
+        timeline=[dismissal_event(commit_id="other")],
+    )
+    assert not manual.approved
+    assert not wrong_commit.approved
 
 
 def test_approval_does_not_survive_untrusted_or_fork_updates():


### PR DESCRIPTION
## Related issue

N/A — CI gate correction.

## Summary

- Preserve a maintainer approval when GitHub auto-dismisses it because trusted Otto automation pushed a same-repository successor commit.
- Require the dismissal timeline event to identify the trusted bot and the exact successor commit that caused the dismissal.
- Continue rejecting manual dismissals, fork updates, rewritten history, untrusted commits, and later change requests.

ELI5: Otto may need to resolve a conflict after approval. GitHub can relabel that approval as dismissed when Otto pushes the repair. The gate now checks who caused the dismissal and only keeps the approval when the trusted bot made the verified follow-up commit.

```text
maintainer approval -> trusted Otto commit -> automatic dismissal event -> approval remains valid
maintainer approval -> anyone else/manual dismissal/fork rewrite        -> approval is invalid
```

## Test Plan

- `uv run --with pytest pytest .github/scripts/maintainer_approval_test.py -q`
- `uv run --with pre-commit pre-commit run --files .github/scripts/maintainer_approval.py .github/scripts/maintainer_approval_test.py`
- Replayed the review, commit, and timeline payloads from PR #6157 at head `4756fb056`; the decision passes only with its trusted automatic dismissal event.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The real PR #6157 API payload was replayed locally to cover GitHub's mutation of the original review from `APPROVED` to `DISMISSED` and the associated `review_dismissed` timeline event.
