### PR TITLE
feat(goose): make idle prompt and init timeouts configurable via env vars

### DIFF
--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -35,6 +35,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import math
 import os
 import secrets
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
@@ -131,9 +132,29 @@ _UPDATE_TOOL_CALL = "tool_call"
 _UPDATE_TOOL_CALL_UPDATE = "tool_call_update"
 _UPDATE_USAGE = "usage_update"
 
-# Idle (time-without-progress) timeouts in seconds.
-_PROMPT_TIMEOUT_SECONDS = 300.0
-_INIT_TIMEOUT_SECONDS = 30.0
+# Idle (time-without-progress) timeouts in seconds. Thinking-mode models emit
+# reasoning tokens that never reach us as ACP notifications, so a turn can look
+# idle for minutes; both deadlines are configurable. Parsing is import-time and
+# fail-loud: a malformed, non-positive, or non-finite value aborts goose at
+# startup.
+_PROMPT_TIMEOUT_ENV = "HARNESS_GOOSE_PROMPT_TIMEOUT_S"
+_INIT_TIMEOUT_ENV = "HARNESS_GOOSE_INIT_TIMEOUT_S"
+
+
+def _timeout_from_env(name: str, default: str) -> float:
+    """Read a positive, finite timeout in seconds from *name*, or *default*."""
+    err = f"{name} must be a positive finite number of seconds"
+    try:
+        value = float(os.environ.get(name, default))
+    except ValueError as exc:
+        raise ValueError(err) from exc
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(err)
+    return value
+
+
+_PROMPT_TIMEOUT_SECONDS = _timeout_from_env(_PROMPT_TIMEOUT_ENV, "300")
+_INIT_TIMEOUT_SECONDS = _timeout_from_env(_INIT_TIMEOUT_ENV, "30")
 
 # ACP protocol version this executor targets (Goose 1.38 → 1).
 _PROTOCOL_VERSION = 1

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -143,11 +143,14 @@ def _timeout_from_env(name: str, default: str) -> float:
     Thinking-mode models emit reasoning tokens that never reach us as ACP
     notifications, so a turn can look idle for minutes; both deadlines are
     configurable for that reason. Parsing is import-time and fail-loud: a
-    malformed, non-positive, or non-finite value aborts goose at startup.
+    malformed, non-positive, or non-finite value aborts goose at startup. A
+    set-but-empty value (e.g. a bare ``export FOO=``) falls back to *default*
+    like every other env var this harness reads, rather than crashing.
     """
     err = f"{name} must be a positive finite number of seconds"
+    raw = (os.environ.get(name) or "").strip() or default
     try:
-        value = float(os.environ.get(name, default))
+        value = float(raw)
     except ValueError as exc:
         raise ValueError(err) from exc
     if not math.isfinite(value) or value <= 0:

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -132,17 +132,19 @@ _UPDATE_TOOL_CALL = "tool_call"
 _UPDATE_TOOL_CALL_UPDATE = "tool_call_update"
 _UPDATE_USAGE = "usage_update"
 
-# Idle (time-without-progress) timeouts in seconds. Thinking-mode models emit
-# reasoning tokens that never reach us as ACP notifications, so a turn can look
-# idle for minutes; both deadlines are configurable. Parsing is import-time and
-# fail-loud: a malformed, non-positive, or non-finite value aborts goose at
-# startup.
+# Idle (time-without-progress) timeouts in seconds, configurable via env vars.
 _PROMPT_TIMEOUT_ENV = "HARNESS_GOOSE_PROMPT_TIMEOUT_S"
 _INIT_TIMEOUT_ENV = "HARNESS_GOOSE_INIT_TIMEOUT_S"
 
 
 def _timeout_from_env(name: str, default: str) -> float:
-    """Read a positive, finite timeout in seconds from *name*, or *default*."""
+    """Read a positive, finite timeout in seconds from *name*, or *default*.
+
+    Thinking-mode models emit reasoning tokens that never reach us as ACP
+    notifications, so a turn can look idle for minutes; both deadlines are
+    configurable for that reason. Parsing is import-time and fail-loud: a
+    malformed, non-positive, or non-finite value aborts goose at startup.
+    """
     err = f"{name} must be a positive finite number of seconds"
     try:
         value = float(os.environ.get(name, default))

--- a/omnigent/inner/goose_harness.py
+++ b/omnigent/inner/goose_harness.py
@@ -32,6 +32,12 @@ Env vars read at startup:
   (``--with-builtin``). ``None`` defaults to ``developer`` (shell + editor).
 - ``HARNESS_GOOSE_OS_ENV``: JSON-encoded :class:`OSEnvSpec`. When unset, falls
   back to ``caller_process`` + ``sandbox=none``.
+- ``HARNESS_GOOSE_PROMPT_TIMEOUT_S``: idle (time-without-progress) deadline for
+  a prompt turn, in seconds. Defaults to ``300``. Raise it for thinking-mode
+  models that deliberate for minutes before their first ACP notification.
+- ``HARNESS_GOOSE_INIT_TIMEOUT_S``: idle deadline for the ACP handshake
+  (``initialize`` / ``session/new``), in seconds. Defaults to ``30``. Raise it
+  when many MCP servers are bridged.
 """
 
 from __future__ import annotations

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -1138,10 +1138,14 @@ async def test_ensure_session_uses_server_assigned_id_and_caches() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(15)
 async def test_ensure_initialized_times_out_at_init_deadline(monkeypatch) -> None:
     """The ``initialize`` handshake is bounded by the module's init-timeout
-    constant, not left to hang forever against a stuck goose subprocess."""
+    constant. Checks elapsed time too, so a regression back to _rpc's
+    def-time-bound default (~30s) fails fast instead of passing silently.
+    """
+    import time
+
     from omnigent.inner import goose_executor
 
     monkeypatch.setattr(goose_executor, "_INIT_TIMEOUT_SECONDS", 0.05)
@@ -1154,9 +1158,16 @@ async def test_ensure_initialized_times_out_at_init_deadline(monkeypatch) -> Non
 
     executor._send = fake_send  # type: ignore[method-assign]
 
+    start = time.monotonic()
     with pytest.raises(asyncio.TimeoutError):
         await executor._ensure_initialized()
+    elapsed = time.monotonic() - start
+
     assert executor._initialized is False
+    # Comfortably above the 0.05s patched deadline plus scheduling slack, and
+    # comfortably below the real 30.0s default a dropped-kwarg regression
+    # would fall back to.
+    assert elapsed < 10.0
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -828,8 +828,15 @@ async def test_run_turn_streams_text_and_usage() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(30)
 async def test_run_turn_times_out_at_prompt_deadline(monkeypatch) -> None:
-    """run_turn bounds an idle turn by the module's prompt-timeout constant."""
+    """run_turn bounds an idle turn by the module's prompt-timeout constant.
+
+    Fails fast on a 30s cap and checks wall-clock elapsed, so a regression to
+    the real 300s default is an assertion failure, not a multi-minute hang.
+    """
+    import time
+
     from omnigent.inner import goose_executor
 
     monkeypatch.setattr(goose_executor, "_PROMPT_TIMEOUT_SECONDS", 0.05)
@@ -846,13 +853,18 @@ async def test_run_turn_times_out_at_prompt_deadline(monkeypatch) -> None:
 
     executor._send = fake_send  # type: ignore[method-assign]
 
+    start = time.monotonic()
     events = [e async for e in executor.run_turn([{"role": "user", "content": "hi"}], [], "")]
+    elapsed = time.monotonic() - start
 
     errors = [e for e in events if isinstance(e, ExecutorError)]
     assert len(errors) == 1
     assert errors[0].message == "Timeout waiting for goose response"
     assert errors[0].retryable is True
     assert not any(isinstance(e, TurnComplete) for e in events)
+    # Comfortably above the 0.05s patched deadline plus scheduling slack, and
+    # comfortably below the real 300s default a regression would fall back to.
+    assert elapsed < 10.0
 
 
 def test_history_prefix_serializes_prior_turns() -> None:
@@ -1123,6 +1135,28 @@ async def test_ensure_session_uses_server_assigned_id_and_caches() -> None:
     executor._rpc.reset_mock()
     assert await executor._ensure_session() == "20260623_7"
     executor._rpc.assert_not_called()  # cached
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_ensure_initialized_times_out_at_init_deadline(monkeypatch) -> None:
+    """The ``initialize`` handshake is bounded by the module's init-timeout
+    constant, not left to hang forever against a stuck goose subprocess."""
+    from omnigent.inner import goose_executor
+
+    monkeypatch.setattr(goose_executor, "_INIT_TIMEOUT_SECONDS", 0.05)
+
+    executor = GooseExecutor()
+
+    async def fake_send(msg: dict) -> None:
+        # Goose never replies: the handshake hangs until the deadline.
+        return None
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    with pytest.raises(asyncio.TimeoutError):
+        await executor._ensure_initialized()
+    assert executor._initialized is False
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -827,6 +827,34 @@ async def test_run_turn_streams_text_and_usage() -> None:
     assert completes[0].usage == {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10}
 
 
+@pytest.mark.asyncio
+async def test_run_turn_times_out_at_prompt_deadline(monkeypatch) -> None:
+    """run_turn bounds an idle turn by the module's prompt-timeout constant."""
+    from omnigent.inner import goose_executor
+
+    monkeypatch.setattr(goose_executor, "_PROMPT_TIMEOUT_SECONDS", 0.05)
+
+    executor = GooseExecutor()
+    executor._initialized = True
+    executor._session_id = "20260623_1"
+    executor._proc = MagicMock()
+    executor._proc.returncode = None
+
+    async def fake_send(msg: dict) -> None:
+        # Idle from the start: never resolve the pending future, never enqueue.
+        return None
+
+    executor._send = fake_send  # type: ignore[method-assign]
+
+    events = [e async for e in executor.run_turn([{"role": "user", "content": "hi"}], [], "")]
+
+    errors = [e for e in events if isinstance(e, ExecutorError)]
+    assert len(errors) == 1
+    assert errors[0].message == "Timeout waiting for goose response"
+    assert errors[0].retryable is True
+    assert not any(isinstance(e, TurnComplete) for e in events)
+
+
 def test_history_prefix_serializes_prior_turns() -> None:
     """_history_prefix renders prior turns as labeled role: content lines."""
     prior = [

--- a/tests/inner/test_goose_executor_timeout_config.py
+++ b/tests/inner/test_goose_executor_timeout_config.py
@@ -78,6 +78,43 @@ def test_timeout_rejects_non_positive_or_non_finite(env_var: str, value: str) ->
     assert env_var in result.stderr.strip().splitlines()[-1]
 
 
+@pytest.mark.parametrize("env_var", [_PROMPT_TIMEOUT_ENV, _INIT_TIMEOUT_ENV])
+def test_timeout_set_but_empty_falls_back_to_default(env_var: str) -> None:
+    """A bare ``export FOO=`` (set-but-empty) must not crash the harness."""
+    result = _run(_subprocess_env(**{env_var: ""}))
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["300.0", "30.0"]
+
+
+@pytest.mark.parametrize("env_var", [_PROMPT_TIMEOUT_ENV, _INIT_TIMEOUT_ENV])
+def test_timeout_whitespace_only_falls_back_to_default(env_var: str) -> None:
+    result = _run(_subprocess_env(**{env_var: "   "}))
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["300.0", "30.0"]
+
+
+@pytest.mark.parametrize(
+    ("env_var", "override", "expected"),
+    [
+        (_PROMPT_TIMEOUT_ENV, " 600 ", "600.0"),
+        (_INIT_TIMEOUT_ENV, " 600 ", "600.0"),
+    ],
+)
+def test_timeout_surrounding_whitespace_is_stripped(
+    env_var: str, override: str, expected: str
+) -> None:
+    result = _run(_subprocess_env(**{env_var: override}))
+
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.strip().splitlines()
+    if env_var == _PROMPT_TIMEOUT_ENV:
+        assert lines[0] == expected
+    else:
+        assert lines[1] == expected
+
+
 def test_timeouts_are_independent() -> None:
     result = _run(_subprocess_env(**{_PROMPT_TIMEOUT_ENV: "600"}))
     assert result.returncode == 0, result.stderr

--- a/tests/inner/test_goose_executor_timeout_config.py
+++ b/tests/inner/test_goose_executor_timeout_config.py
@@ -1,0 +1,88 @@
+"""Tests for Goose executor timeout configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_PROMPT_TIMEOUT_ENV = "HARNESS_GOOSE_PROMPT_TIMEOUT_S"
+_INIT_TIMEOUT_ENV = "HARNESS_GOOSE_INIT_TIMEOUT_S"
+
+_PRINT_TIMEOUTS = (
+    "from omnigent.inner.goose_executor import ("
+    "_PROMPT_TIMEOUT_SECONDS, _INIT_TIMEOUT_SECONDS); "
+    "print(_PROMPT_TIMEOUT_SECONDS); print(_INIT_TIMEOUT_SECONDS)"
+)
+
+
+def _subprocess_env(**overrides: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop(_PROMPT_TIMEOUT_ENV, None)
+    env.pop(_INIT_TIMEOUT_ENV, None)
+    env.update(overrides)
+    return env
+
+
+def _run(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", _PRINT_TIMEOUTS],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_timeouts_default_when_unset() -> None:
+    result = _run(_subprocess_env())
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["300.0", "30.0"]
+
+
+@pytest.mark.parametrize(
+    ("env_var", "override", "expected"),
+    [
+        (_PROMPT_TIMEOUT_ENV, "600", "600.0"),
+        (_INIT_TIMEOUT_ENV, "60", "60.0"),
+    ],
+)
+def test_timeout_override_honored(env_var: str, override: str, expected: str) -> None:
+    result = _run(_subprocess_env(**{env_var: override}))
+
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.strip().splitlines()
+    if env_var == _PROMPT_TIMEOUT_ENV:
+        assert lines[0] == expected
+    else:
+        assert lines[1] == expected
+
+
+@pytest.mark.parametrize("env_var", [_PROMPT_TIMEOUT_ENV, _INIT_TIMEOUT_ENV])
+def test_timeout_malformed_value_fails_loud(env_var: str) -> None:
+    result = _run(_subprocess_env(**{env_var: "not-a-number"}))
+
+    assert result.returncode != 0
+    assert env_var in result.stderr.strip().splitlines()[-1]
+
+
+@pytest.mark.parametrize("env_var", [_PROMPT_TIMEOUT_ENV, _INIT_TIMEOUT_ENV])
+@pytest.mark.parametrize("value", ["0", "-1", "nan", "inf"])
+def test_timeout_rejects_non_positive_or_non_finite(env_var: str, value: str) -> None:
+    result = _run(_subprocess_env(**{env_var: value}))
+
+    assert result.returncode != 0
+    assert env_var in result.stderr.strip().splitlines()[-1]
+
+
+def test_timeouts_are_independent() -> None:
+    result = _run(_subprocess_env(**{_PROMPT_TIMEOUT_ENV: "600"}))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["600.0", "30.0"]
+
+    result = _run(_subprocess_env(**{_INIT_TIMEOUT_ENV: "60"}))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines() == ["300.0", "60.0"]


### PR DESCRIPTION
## Related issue

Closes #6201

## Summary

The Goose ACP executor hard-coded two idle (time-without-progress) deadlines:
`_PROMPT_TIMEOUT_SECONDS = 300.0` (the per-turn deadline in `_run_prompt_stream`) and
`_INIT_TIMEOUT_SECONDS = 30.0` (the `initialize` / `session/new` handshake deadline).

Hybrid thinking-mode models (DeepSeek V4 Think High/Max, GLM 5.2 with `reasoning_effort: max`,
Kimi K3) emit `reasoning_content` that never surfaces as an ACP `session/update` notification.
With 34+ bridged tools and a long history, such a model can deliberate 4–6 minutes before its
first notification — so the idle deadline never resets and the turn dies with
`ExecutorError("Timeout waiting for goose response", retryable=True)`. The same applies to
`session/new` against 30s when many MCP servers are bridged. The only workaround was patching
the installed package, which `uv tool upgrade omnigent` erases every release.

Both deadlines are now configurable, with the current values as defaults:

- `HARNESS_GOOSE_PROMPT_TIMEOUT_S` (default `300`)
- `HARNESS_GOOSE_INIT_TIMEOUT_S` (default `30`)

Unset means byte-identical behavior to today.

**Naming note:** the issue proposed `OMNIGENT_GOOSE_*`, but this uses `HARNESS_GOOSE_*` to match
the sibling `HARNESS_ACP_PROMPT_TIMEOUT_S` in `acp_executor.py` and the existing
`HARNESS_GOOSE_MODEL` / `_PROVIDER` / `_CWD` / `_BUILTINS` knobs this harness already reads.

```python
_PROMPT_TIMEOUT_ENV = "HARNESS_GOOSE_PROMPT_TIMEOUT_S"
_INIT_TIMEOUT_ENV = "HARNESS_GOOSE_INIT_TIMEOUT_S"


def _timeout_from_env(name: str, default: str) -> float:
    err = f"{name} must be a positive finite number of seconds"
    raw = (os.environ.get(name) or "").strip() or default
    try:
        value = float(raw)
    except ValueError as exc:
        raise ValueError(err) from exc
    if not math.isfinite(value) or value <= 0:
        raise ValueError(err)
    return value


_PROMPT_TIMEOUT_SECONDS = _timeout_from_env(_PROMPT_TIMEOUT_ENV, "300")
_INIT_TIMEOUT_SECONDS = _timeout_from_env(_INIT_TIMEOUT_ENV, "30")
```

Parsing is import-time and fail-loud, mirroring `acp_executor.py`: a malformed, non-positive, or
non-finite value raises `ValueError` so the goose child aborts at startup rather than silently
running with a default the user thought they had overridden. No call site changed, so the five
existing references to both constants are untouched.

### Two deliberate decisions worth a reviewer's eye

**A set-but-empty value falls back to the default rather than crashing.** `os.environ.get(name, default)`
returns `""` for a set-but-empty var, and `float("")` raises — so a bare `export HARNESS_GOOSE_PROMPT_TIMEOUT_S=`,
or `environment: - HARNESS_GOOSE_PROMPT_TIMEOUT_S=` in a compose/k8s manifest, would have bricked every
goose session at spawn. Every other env var this harness reads treats empty as unset
(`goose_harness.py:107-111` uses `.strip() or None`), so this follows the local convention.
Genuinely malformed values still fail loud.

**No upper bound.** `HARNESS_GOOSE_PROMPT_TIMEOUT_S=999999` really is unbounded. A ceiling would risk
re-creating this exact bug for someone with a legitimately slower model, and the wait sits in a
cancellable `asyncio.wait_for(..., min(remaining, 2.0))`, so Stop always works. Recorded as a decision,
not an oversight.

### The same latent bug exists in two sibling files — not fixed here

Out of scope for this issue, but verified and worth follow-ups:

- **`omnigent/inner/qwen_executor.py:132-133`** has the identical hard-coded pair
  (`_PROMPT_TIMEOUT_SECONDS = 300.0` / `_INIT_TIMEOUT_SECONDS = 30.0`), used the same way at
  lines 565/630/663 and 1427/1551. Goose is documented as "mirroring the qwen wrap", so the
  thinking-model failure in this issue applies to qwen unchanged.
- **`omnigent/inner/acp_executor.py:158`** still hard-codes `_INIT_TIMEOUT_SECONDS = 30.0`, so the
  "many MCP servers slow `session/new`" half of this issue applies to the generic ACP wrap that
  backs every `ACP_CLI_HARNESSES` row.
- **`omnigent/inner/acp_executor.py:151`** carries the same set-but-empty crash fixed here:
  `float(os.environ.get(_PROMPT_TIMEOUT_ENV, "300"))` means `HARNESS_ACP_PROMPT_TIMEOUT_S=` aborts
  that harness at import.

These were left alone deliberately to keep a P2 fix off two other harnesses. Happy to follow up in a
separate PR if maintainers prefer.

## Test Plan

`.venv/bin/python -m pytest tests/inner/test_goose_executor.py tests/inner/test_goose_executor_timeout_config.py -q`
→ **94 passed** (10 new tests). `ruff format` / `ruff check` clean via `pre-commit`.

Ten new tests across two files:

- `tests/inner/test_goose_executor_timeout_config.py` (new, 8 tests) — parse and validation, driven
  through real subprocess imports because the parse is import-time and `monkeypatch.setenv` cannot
  reach it. Covers: defaults when unset; overrides honored; malformed values fail loud; `0` / `-1` /
  `nan` / `inf` rejected; set-but-empty and whitespace-only fall back to the default; surrounding
  whitespace tolerated; and the two vars are independent. Each subprocess pops *both* vars from
  `os.environ.copy()` first, so a developer with either exported in their shell cannot get a false pass.
- `tests/inner/test_goose_executor.py` (2 tests) — behavioral proof that each constant actually bounds
  its deadline, so neither override sets a dead constant.
  `test_run_turn_times_out_at_prompt_deadline` patches the constant to 0.05s with an inert `_send` and
  asserts exactly one `ExecutorError("Timeout waiting for goose response", retryable=True)` and no
  `TurnComplete`. `test_ensure_initialized_times_out_at_init_deadline` does the same for the handshake.
  Both carry a `pytest.mark.timeout` and a wall-clock elapsed assertion, so a regression fails in
  seconds instead of hanging for the full default.

Both behavioral tests were validated by falsification: with `_run_prompt_stream` altered to ignore the
constant, and separately with the explicit `timeout=_INIT_TIMEOUT_SECONDS` kwarg stripped from
`_ensure_initialized`, each test fails; both probes were reverted and the source diff confirmed empty.

Manual verification of the user-facing behavior:

```console
$ env -u HARNESS_GOOSE_PROMPT_TIMEOUT_S -u HARNESS_GOOSE_INIT_TIMEOUT_S python -c '...'
prompt=300.0 init=30.0                     # unchanged for existing users

$ HARNESS_GOOSE_PROMPT_TIMEOUT_S=600 HARNESS_GOOSE_INIT_TIMEOUT_S=60 python -c '...'
prompt=600.0 init=60.0                     # the issue's workaround, now config

$ HARNESS_GOOSE_PROMPT_TIMEOUT_S= HARNESS_GOOSE_INIT_TIMEOUT_S= python -c '...'
prompt=300.0 init=30.0                     # set-but-empty no longer crashes

$ HARNESS_GOOSE_PROMPT_TIMEOUT_S=abc python -c "import omnigent.inner.goose_harness"
ValueError: HARNESS_GOOSE_PROMPT_TIMEOUT_S must be a positive finite number of seconds
```

Note: `pre-commit`'s `pyrefly` hook reports 13 errors, all pre-existing on the base commit and all in
`cursor_executor.py`, `copilot_executor.py`, and `kubernetes.py` — none in the files this PR touches.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the four user-facing paths shown in the Test Plan: unset (defaults
preserved), override honored, set-but-empty falling back instead of crashing, and a malformed value
aborting the harness child with a legible message and non-zero exit.

Not covered automatically: a live end-to-end run against a real thinking-mode model over a slow
`session/new`. That needs a configured Goose install plus a DeepSeek/GLM/Kimi endpoint, so the
timeout path is proven at the executor level with the deadline constant patched down rather than by
waiting out a real 300s stall.

## Changelog

Goose harness idle timeouts are now configurable via `HARNESS_GOOSE_PROMPT_TIMEOUT_S` (default 300s) and `HARNESS_GOOSE_INIT_TIMEOUT_S` (default 30s), for thinking-mode models that deliberate for minutes before their first response

🤖 Generated with [Claude Code](https://claude.com/claude-code)
