### PR TITLE
Fix overlapping bubblewrap read/write grants

### DIFF
--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -475,7 +475,11 @@ class BwrapSandboxBackend(SandboxBackend):
         # letting the last mount win.
         if policy.read_roots is not None:
             for root in policy.read_roots:
-                if any(_is_same_path(root, write_root) for write_root in policy.write_roots):
+                # Read roots only expand visibility; they never restrict an
+                # overlapping cwd or explicit write grant.
+                if _is_same_path(root, cwd_resolved) or any(
+                    _is_same_path(root, write_root) for write_root in policy.write_roots
+                ):
                     continue
                 bwrap_args += ["--ro-bind-try", str(root), str(root)]
 

--- a/omnigent/inner/bwrap_sandbox.py
+++ b/omnigent/inner/bwrap_sandbox.py
@@ -470,6 +470,15 @@ class BwrapSandboxBackend(SandboxBackend):
         if target is not None:
             bwrap_args += _ensure_executable_visible([target], cwd_resolved)
 
+        # Extra read roots beyond the default toolchain bind set. These
+        # mounts precede write grants because bwrap resolves overlaps by
+        # letting the last mount win.
+        if policy.read_roots is not None:
+            for root in policy.read_roots:
+                if any(_is_same_path(root, write_root) for write_root in policy.write_roots):
+                    continue
+                bwrap_args += ["--ro-bind-try", str(root), str(root)]
+
         # cwd bind: writable iff a write_root resolves to cwd.
         cwd_writable = any(_is_same_path(root, cwd_resolved) for root in policy.write_roots)
         bwrap_args += [
@@ -491,11 +500,6 @@ class BwrapSandboxBackend(SandboxBackend):
         # caller also added the parent to read_paths or write_paths).
         for fpath in policy.write_files:
             bwrap_args += ["--bind-try", str(fpath), str(fpath)]
-
-        # Extra read roots beyond the default toolchain bind set.
-        if policy.read_roots is not None:
-            for root in policy.read_roots:
-                bwrap_args += ["--ro-bind-try", str(root), str(root)]
 
         # Mask dotfiles anywhere under cwd OR under any ``read_paths`` /
         # ``write_paths`` root that aren't on the allowlist, plus any

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -538,6 +538,22 @@ def test_wrap_launcher_argv_write_grant_wins_exact_read_overlap(
     assert mounts == ["--bind"]
 
 
+def test_wrap_launcher_argv_deduplicates_read_only_cwd(tmp_path: Path) -> None:
+    """An explicit read grant for read-only cwd does not duplicate its mount."""
+    backend = _make_backend()
+    root = tmp_path.resolve(strict=False)
+    policy = _make_policy(tmp_path, read_roots=[root])
+
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+
+    mounts = [
+        argv[i]
+        for i in range(len(argv) - 2)
+        if argv[i + 1] == str(root) and argv[i + 2] == str(root)
+    ]
+    assert mounts == ["--ro-bind"]
+
+
 def test_wrap_launcher_argv_nested_write_mount_follows_read_parent(
     tmp_path: Path,
 ) -> None:

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -520,6 +520,43 @@ def test_wrap_launcher_argv_cwd_read_only_by_default(tmp_path: Path) -> None:
     assert "--bind" not in bind_verbs
 
 
+def test_wrap_launcher_argv_write_grant_wins_exact_read_overlap(
+    tmp_path: Path,
+) -> None:
+    """An exact read/write overlap emits only the authoritative RW mount."""
+    backend = _make_backend()
+    root = tmp_path.resolve(strict=False)
+    policy = _make_policy(tmp_path, read_roots=[root], write_roots=[root])
+
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+
+    mounts = [
+        argv[i]
+        for i in range(len(argv) - 2)
+        if argv[i + 1] == str(root) and argv[i + 2] == str(root)
+    ]
+    assert mounts == ["--bind"]
+
+
+def test_wrap_launcher_argv_nested_write_mount_follows_read_parent(
+    tmp_path: Path,
+) -> None:
+    """A writable child overlays its read-only parent rather than vice versa."""
+    backend = _make_backend()
+    parent = (tmp_path / "parent").resolve(strict=False)
+    child = parent / "child"
+    child.mkdir(parents=True)
+    policy = _make_policy(tmp_path, read_roots=[parent], write_roots=[child])
+
+    argv = backend.wrap_launcher_argv([sys.executable, "-c", "pass"], policy, tmp_path)
+
+    read_index = _index_of_triple(argv, "--ro-bind-try", str(parent), str(parent))
+    write_index = _index_of_triple(argv, "--bind-try", str(child), str(child))
+    assert read_index is not None
+    assert write_index is not None
+    assert read_index < write_index
+
+
 def test_wrap_launcher_argv_masks_denied_unix_socket_after_write_root(
     tmp_path: Path,
 ) -> None:
@@ -1507,6 +1544,70 @@ def test_s5_read_paths_dedup_skips_paths_under_cwd(tmp_path: Path) -> None:
 pytestmark_bwrap = pytest.mark.skipif(
     not BWRAP_AVAILABLE, reason="bwrap not installed on this host"
 )
+
+
+@pytestmark_bwrap
+def test_overlapping_read_write_root_remains_writable(tmp_path: Path) -> None:
+    """End-to-end: an exact read/write overlap keeps the shared root writable."""
+    root = (tmp_path / "shared").resolve(strict=False)
+    root.mkdir()
+    output = root / "created.txt"
+    policy = _make_policy(tmp_path, read_roots=[root], write_roots=[root])
+    probe = f"from pathlib import Path; Path({str(output)!r}).write_text('ok'); print('WROTE')"
+
+    result = _run_helper_probe(tmp_path, probe, policy=policy)
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == "WROTE"
+    assert output.read_text() == "ok"
+
+
+@pytestmark_bwrap
+def test_read_only_root_rejects_writes(tmp_path: Path) -> None:
+    """End-to-end: a root without a write grant remains read-only."""
+    root = (tmp_path / "readonly").resolve(strict=False)
+    root.mkdir()
+    output = root / "blocked.txt"
+    policy = _make_policy(tmp_path, read_roots=[root])
+    probe = (
+        "import errno; from pathlib import Path; "
+        f"p=Path({str(output)!r}); "
+        "\ntry: p.write_text('bad')\n"
+        "except OSError as exc: print(exc.errno)\n"
+        "else: print('WROTE')"
+    )
+
+    result = _run_helper_probe(tmp_path, probe, policy=policy)
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == str(errno.EROFS)
+    assert not output.exists()
+
+
+@pytestmark_bwrap
+def test_nested_write_root_overlays_read_only_parent(tmp_path: Path) -> None:
+    """End-to-end: a child write grant stays scoped within a read-only parent."""
+    parent = (tmp_path / "parent").resolve(strict=False)
+    child = parent / "child"
+    child.mkdir(parents=True)
+    parent_output = parent / "blocked.txt"
+    child_output = child / "created.txt"
+    policy = _make_policy(tmp_path, read_roots=[parent], write_roots=[child])
+    probe = (
+        "import errno; from pathlib import Path; "
+        f"parent=Path({str(parent_output)!r}); child=Path({str(child_output)!r}); "
+        "child.write_text('ok'); "
+        "\ntry: parent.write_text('bad')\n"
+        "except OSError as exc: print(exc.errno)\n"
+        "else: print('PARENT_WROTE')"
+    )
+
+    result = _run_helper_probe(tmp_path, probe, policy=policy)
+
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == str(errno.EROFS)
+    assert child_output.read_text() == "ok"
+    assert not parent_output.exists()
 
 
 @pytestmark_bwrap


### PR DESCRIPTION
## Related issue

Related to OMNI-5939.

## Summary

- Emit explicit read-only roots before writable cwd/root/file overlays so write grants win overlapping bubblewrap mounts.
- Skip redundant exact read/write root overlaps.
- Add argv and real-bubblewrap regressions for exact overlap, read-only roots, nested writable children, and mask ordering.

**ELI5:** Bubblewrap uses the last overlapping mount. We previously put the read-only mount last, accidentally locking a workspace that was also explicitly writable. This reverses that layering while keeping deny masks last.

```text
read-only parent/root
        ↓
writable cwd/child/file
        ↓
dotfile/socket masks
```

## Test Plan

- `uv run --group dev pytest tests/inner/test_bwrap_sandbox.py -q -k 'write_grant_wins_exact_read_overlap or nested_write_mount_follows_read_parent or overlapping_read_write_root_remains_writable or read_only_root_rejects_writes or nested_write_root_overlays_read_only_parent or socket_mask_after_write_root'`
- `uv run --extra all --group dev pre-commit run --files omnigent/inner/bwrap_sandbox.py tests/inner/test_bwrap_sandbox.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Real bubblewrap subprocess tests verify filesystem behavior, not only argv shape.
