### PR TITLE
fix(pi-native): clamp model maxTokens to serving endpoint output cap

### DIFF
--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -34,6 +34,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import subprocess
 import threading
 from dataclasses import dataclass, field, replace
@@ -1327,6 +1328,76 @@ def fetch_databricks_model_service_entries(
             )
         )
     return tuple(models)
+
+
+# A value no endpoint will honor, so the request trips the output-token
+# validator before the model generates anything.
+_PROBE_OUTPUT_TOKENS = 100_000_000
+
+# Databricks serving endpoints report an exceeded output limit in one of two
+# shapes: "max_tokens (N) cannot exceed CAP" or "max_new_tokens N cannot be
+# greater than max_output_tokens CAP". Capture CAP from either.
+_OUTPUT_CAP_RE = re.compile(r"cannot exceed (\d+)|max_output_tokens\D*?(\d+)")
+
+
+def probe_output_token_cap(
+    base_url: str,
+    token: str,
+    model_id: str,
+    *,
+    api_type: str = "openai-completions",
+    transport: httpx.BaseTransport | None = None,
+) -> int | None:
+    """Discover a serving endpoint's enforced per-request output-token cap.
+
+    The Unity Catalog model-services listing carries no token limits, and a
+    model's native ceiling (its catalog ``max_output_tokens``) can exceed what
+    the Databricks serving endpoint accepts — requesting the native value then
+    fails at runtime. Sending an oversized request trips the endpoint's
+    validator, which names the real cap in its 400 body. The model never
+    generates, so this is a single cheap round-trip that also tracks any future
+    increase to the cap.
+
+    :param base_url: Surface base, e.g. ``https://ws/ai-gateway/mlflow/v1``.
+    :param token: Workspace bearer token.
+    :param model_id: Served model id, e.g. ``system.ai.kimi-k3``.
+    :param api_type: ``"openai-responses"`` or ``"openai-completions"`` —
+        selects the request shape and path.
+    :param transport: Optional httpx transport override for tests.
+    :returns: The cap in tokens, or ``None`` when the endpoint accepts the
+        probe (no cap below it) or the limit cannot be read (network/parse
+        failure). ``None`` means "keep the catalog value".
+    """
+    if api_type == "openai-responses":
+        path = "/responses"
+        body: dict[str, object] = {
+            "model": model_id,
+            "input": "cap probe",
+            "max_output_tokens": _PROBE_OUTPUT_TOKENS,
+        }
+    else:
+        path = "/chat/completions"
+        body = {
+            "model": model_id,
+            "messages": [{"role": "user", "content": "cap probe"}],
+            "max_tokens": _PROBE_OUTPUT_TOKENS,
+        }
+    try:
+        with httpx.Client(transport=transport, timeout=_HTTP_TIMEOUT_S) as client:
+            resp = client.post(
+                f"{base_url.rstrip('/')}{path}",
+                headers={"Authorization": f"Bearer {token}"},
+                json=body,
+            )
+    except httpx.HTTPError:
+        return None
+    if resp.status_code < 400:
+        return None
+    match = _OUTPUT_CAP_RE.search(resp.text or "")
+    if match is None:
+        return None
+    cap = match.group(1) or match.group(2)
+    return int(cap) if cap else None
 
 
 def _models_url(base_url: str) -> str:

--- a/omnigent/pi_native_credentials.py
+++ b/omnigent/pi_native_credentials.py
@@ -26,6 +26,7 @@ import re
 import shlex
 import subprocess
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple, NotRequired, TypeAlias, TypedDict, TypeGuard
@@ -625,6 +626,43 @@ def _run_auth_command(auth_command: str, *, timeout: float = 15.0) -> str | None
         return None
 
 
+# Entries at or below this need no probe: Pi's own default ceiling is lower, so
+# they cannot exceed any observed serving cap. Skipping them keeps launch fast.
+_CAP_PROBE_FLOOR = 16384
+_CAP_PROBE_WORKERS = 8
+
+
+def _clamp_entries_to_output_caps(
+    workspace_url: str,
+    token: str,
+    entries: list[_PiModelEntry],
+) -> None:
+    """Lower each entry's ``maxTokens`` to the serving endpoint's real cap.
+
+    Omnigent's catalog reports a model's native output ceiling, but a Databricks
+    serving endpoint may enforce a lower per-request cap; Pi would then send the
+    native value and every call fails with 400. The cap is a model property, so
+    a single probe on the MLflow chat surface yields it regardless of which
+    surface the model is finally served on. Best-effort and parallel: any probe
+    failure leaves the catalog value untouched, so a network blip never blocks
+    launch. Re-probing each launch picks up a cap that is later raised.
+    """
+    # ponytail: re-probes every launch; cache by the model-services etag to skip
+    # unchanged endpoints once that field is plumbed through the listing.
+    base_url = f"{workspace_url.rstrip('/')}/ai-gateway/mlflow/v1"
+    targets = [e for e in entries if (e.get("maxTokens") or 0) > _CAP_PROBE_FLOOR]
+    if not targets:
+        return
+
+    def clamp(entry: _PiModelEntry) -> None:
+        cap = model_catalog.probe_output_token_cap(base_url, token, entry["id"])
+        if cap is not None:
+            entry["maxTokens"] = min(entry.get("maxTokens", cap), cap)
+
+    with ThreadPoolExecutor(max_workers=_CAP_PROBE_WORKERS) as pool:
+        list(pool.map(clamp, targets))
+
+
 def _fetch_pi_model_lists(
     workspace_url: str,
     token: str,
@@ -708,6 +746,10 @@ def _fetch_pi_model_lists(
             "pi-native: Unity Catalog model-services returned no LLM models; "
             "Pi will show only the selected model"
         )
+
+    # Claude entries keep their catalog ceiling (already within serving caps);
+    # the OSS/GPT/Gemini surfaces carry the oversized values that 400 at runtime.
+    _clamp_entries_to_output_caps(workspace_url, token, [*gpt_responses, *completions, *gemini])
 
     return claude, gpt_responses, completions, gemini
 

--- a/tests/test_pi_native_output_cap.py
+++ b/tests/test_pi_native_output_cap.py
@@ -1,0 +1,73 @@
+"""Endpoint output-token cap discovery and clamping for Pi-native config."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from omnigent import model_catalog
+from omnigent import pi_native_credentials as pnc
+
+
+def _transport(status: int, text: str) -> httpx.MockTransport:
+    return httpx.MockTransport(lambda request: httpx.Response(status, text=text))
+
+
+def test_probe_parses_cannot_exceed_format() -> None:
+    t = _transport(400, '{"message":"max_tokens (1048576) cannot exceed 65536."}')
+    cap = model_catalog.probe_output_token_cap(
+        "https://ws/ai-gateway/mlflow/v1", "tok", "system.ai.kimi-k3", transport=t
+    )
+    assert cap == 65536
+
+
+def test_probe_parses_max_output_tokens_format() -> None:
+    t = _transport(
+        400, "max_new_tokens 99999999 cannot be greater than max_output_tokens 25000.\n"
+    )
+    cap = model_catalog.probe_output_token_cap(
+        "https://ws/ai-gateway/mlflow/v1", "tok", "system.ai.gpt-oss-120b", transport=t
+    )
+    assert cap == 25000
+
+
+def test_probe_returns_none_when_accepted() -> None:
+    t = _transport(200, '{"choices":[]}')
+    assert model_catalog.probe_output_token_cap("https://ws/x", "tok", "m", transport=t) is None
+
+
+def test_probe_returns_none_on_unparseable_error() -> None:
+    t = _transport(400, '{"message":"some unrelated validation error"}')
+    assert model_catalog.probe_output_token_cap("https://ws/x", "tok", "m", transport=t) is None
+
+
+def test_clamp_lowers_oversized_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(model_catalog, "probe_output_token_cap", lambda *a, **k: 65536)
+    entries = [{"id": "system.ai.kimi-k3", "maxTokens": 1048576}]
+    pnc._clamp_entries_to_output_caps("https://ws", "tok", entries)
+    assert entries[0]["maxTokens"] == 65536
+
+
+def test_clamp_keeps_smaller_catalog_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(model_catalog, "probe_output_token_cap", lambda *a, **k: 131072)
+    entries = [{"id": "m", "maxTokens": 65536}]
+    pnc._clamp_entries_to_output_caps("https://ws", "tok", entries)
+    assert entries[0]["maxTokens"] == 65536
+
+
+def test_clamp_skips_small_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    probed: list[str] = []
+    monkeypatch.setattr(
+        model_catalog, "probe_output_token_cap", lambda *a, **k: probed.append(a) or 100
+    )
+    entries = [{"id": "m", "maxTokens": 8000}]
+    pnc._clamp_entries_to_output_caps("https://ws", "tok", entries)
+    assert entries[0]["maxTokens"] == 8000
+    assert probed == []
+
+
+def test_clamp_keeps_value_when_probe_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(model_catalog, "probe_output_token_cap", lambda *a, **k: None)
+    entries = [{"id": "m", "maxTokens": 131072}]
+    pnc._clamp_entries_to_output_caps("https://ws", "tok", entries)
+    assert entries[0]["maxTokens"] == 131072


### PR DESCRIPTION
## Related issue

<!-- No tracking issue; small bug fix surfaced while running Pi against a Databricks workspace. -->
Closes #

## Summary

When Pi runs in Databricks gateway mode, `_fetch_pi_model_lists` writes each
model's catalog `max_output_tokens` into the generated `models.json` as
`maxTokens`. That value is the model's **native** output ceiling, but a
Databricks serving endpoint often enforces a **lower per-request cap**. Pi then
sends the native value as `max_output_tokens` and every call fails:

```
OpenAI API error (400): max_tokens (1048576) cannot exceed 65536
```

**ELI5:** the model says "I can write a million words," the endpoint says "not
here, 65k max," and we were telling Pi to always ask for a million.

```
catalog max_output_tokens (native)        e.g. kimi-k3 = 1,048,576
        │
        ▼
 generated models.json  ──►  Pi requests max_output_tokens = 1,048,576
        │                                       │
 serving endpoint cap = 65,536  ◄───────────────┘   400: cannot exceed 65,536

 fix:  probe endpoint for the real cap  ──►  maxTokens = min(catalog, cap)
```

The cap isn't exposed by the Unity Catalog model-services listing, so we
discover it the only way available: send one oversized request that trips the
endpoint's validator (the model never generates) and read the cap from the 400
body. Two message shapes are handled (`cannot exceed N` and
`... max_output_tokens N`). Probing runs in parallel, is best-effort (any
failure keeps the catalog value, so a network blip never blocks launch), and
skips small entries. Re-probing each launch means a **future increase to the
cap is picked up automatically** — nothing is hardcoded.

Follow-up (noted in a `ponytail:` comment): cache the cap by the model-services
`etag` to avoid re-probing unchanged endpoints, once that field is plumbed
through the listing.

## Test Plan

- New unit tests (`tests/test_pi_native_output_cap.py`, 8 cases): both 400
  message formats parse; a 200 or unparseable body yields `None`; the clamp
  lowers oversized entries, keeps a smaller catalog value (`min`), skips
  sub-floor entries, and preserves the value when the probe fails.

  ```
  uv run --extra databricks --group test pytest tests/test_pi_native_output_cap.py
  # 8 passed
  ```

- Live probe against a real workspace (unmocked, via this branch's code):

  | model | discovered cap |
  |---|---|
  | `system.ai.kimi-k3` | 65536 |
  | `system.ai.glm-5-3-flash` | 65536 |
  | `system.ai.gpt-oss-120b` | 25000 |
  | `system.ai.qwen3-next-80b-a3b-instruct` | 10000 |
  | `system.ai.claude-opus-5` | None (accepted → keeps catalog value) |

  Before this change, launching Pi and sending "hi" to kimi-k3 / glm-5-3-flash
  returned `400 (no body)`; after clamping, the generated `maxTokens` is within
  the endpoint cap and the calls succeed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests mock the endpoint (httpx `MockTransport`) to cover both error
formats and every clamp branch. Manual verification ran the real
`probe_output_token_cap` against a live Databricks workspace for the models in
the Test Plan table and confirmed the discovered caps match the endpoints'
enforced limits.

## Changelog

Pi on Databricks no longer 400s on models whose native output limit exceeds the serving endpoint's per-request cap


---
This pull request and its description were written by Isaac.
