### PR TITLE
feat: add provider-neutral runner activity leases

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -27,6 +27,7 @@ from fastapi import FastAPI
 from omnigent._platform import IS_WINDOWS
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.inner import _proc
+from omnigent.runner.activity_lease import activity_lease_from_env, run_activity_lease
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
 from omnigent.version import VERSION
 
@@ -1788,6 +1789,16 @@ async def _run_tunnel_from_env() -> None:
             ),
             name=f"runner-idle-monitor:{runner_id}",
         )
+    activity_lease = activity_lease_from_env(runner_id)
+    activity_lease_task: asyncio.Task[None] | None = None
+    if activity_lease is not None:
+        activity_lease_task = asyncio.create_task(
+            run_activity_lease(
+                lease=activity_lease,
+                has_active_work=_has_active_work,
+            ),
+            name=f"runner-activity-lease:{runner_id}",
+        )
     if parent_pid is not None:
 
         def _request_parent_death_shutdown() -> None:
@@ -1854,6 +1865,10 @@ async def _run_tunnel_from_env() -> None:
         if idle_task is not None:
             with contextlib.suppress(asyncio.CancelledError):
                 await idle_task
+        if activity_lease_task is not None:
+            activity_lease_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await activity_lease_task
         if direct_attach_listener is not None:
             with contextlib.suppress(Exception):
                 await direct_attach_listener.stop()

--- a/omnigent/runner/activity_lease.py
+++ b/omnigent/runner/activity_lease.py
@@ -1,0 +1,176 @@
+"""Provider-neutral activity leases for suspendable managed runners."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import os
+from collections.abc import Callable
+from typing import Protocol, TypeAlias
+
+ACTIVITY_LEASE_PROVIDER_ENV_VAR = "OMNIGENT_ACTIVITY_LEASE_PROVIDER"
+_DEFAULT_POLL_INTERVAL_S = 1.0
+_DEFAULT_REFRESH_INTERVAL_S = 60.0
+_DEFAULT_RELEASE_GRACE_S = 30.0
+_DEFAULT_RETRY_INTERVAL_S = 5.0
+
+logger = logging.getLogger(__name__)
+
+
+class ActivityLeaseError(Exception):
+    """A provider activity lease operation failed."""
+
+
+class ActivityLease(Protocol):
+    """Provider adapter that can refresh and release an activity hold."""
+
+    provider: str
+
+    async def refresh(self) -> None:
+        """Create or extend the provider's activity hold."""
+
+    async def release(self) -> None:
+        """Release the provider's activity hold if it exists."""
+
+    async def aclose(self) -> None:
+        """Close resources owned by the adapter."""
+
+
+ActivityLeaseFactory: TypeAlias = Callable[[str], ActivityLease]
+
+_ACTIVITY_LEASE_FACTORIES: dict[str, ActivityLeaseFactory] = {}
+_BUILTIN_LEASE_MODULES: dict[str, str] = {}
+
+
+def register_activity_lease_provider(provider: str, factory: ActivityLeaseFactory) -> None:
+    """Register a provider adapter factory with the runner lease framework.
+
+    Provider integrations own their adapter and registration. The shared
+    runner lifecycle resolves only the provider name and its lazily loaded
+    module; it never imports a concrete adapter eagerly.
+
+    :param provider: Environment-facing provider name, e.g. ``"acme"``.
+    :param factory: Callable that builds a lease for a stable runner id.
+    :raises ValueError: If *provider* is empty or already registered.
+    """
+    normalized = provider.strip().lower()
+    if not normalized:
+        raise ValueError("activity lease provider name must not be empty")
+    existing = _ACTIVITY_LEASE_FACTORIES.get(normalized)
+    if existing is not None and existing is not factory:
+        raise ValueError(f"activity lease provider {normalized!r} is already registered")
+    _ACTIVITY_LEASE_FACTORIES[normalized] = factory
+
+
+def activity_lease_from_env(runner_id: str) -> ActivityLease | None:
+    """Build the explicitly configured activity-lease backend, if any.
+
+    The runner never guesses from filesystem artifacts. A sandbox launcher
+    opts in by setting ``OMNIGENT_ACTIVITY_LEASE_PROVIDER`` in the host
+    service environment.
+
+    :param runner_id: Stable runner id used to namespace provider leases.
+    :returns: Configured lease adapter, or ``None`` when leasing is disabled.
+    :raises RuntimeError: If the configured backend is unsupported.
+    """
+    provider = os.environ.get(ACTIVITY_LEASE_PROVIDER_ENV_VAR)
+    if provider is None:
+        return None
+    provider = provider.strip().lower()
+    if not provider:
+        raise RuntimeError(f"{ACTIVITY_LEASE_PROVIDER_ENV_VAR} must not be empty")
+    factory = _ACTIVITY_LEASE_FACTORIES.get(provider)
+    module_name = _BUILTIN_LEASE_MODULES.get(provider)
+    if factory is None and module_name is not None:
+        module = importlib.import_module(module_name)
+        register = getattr(module, "register_activity_lease_provider", None)
+        if not callable(register):
+            raise RuntimeError(
+                f"activity lease module {module_name!r} does not expose "
+                "register_activity_lease_provider()"
+            )
+        register()
+        factory = _ACTIVITY_LEASE_FACTORIES.get(provider)
+    if factory is None:
+        raise RuntimeError(
+            f"unsupported activity lease provider {provider!r} in "
+            f"{ACTIVITY_LEASE_PROVIDER_ENV_VAR}"
+        )
+    return factory(runner_id)
+
+
+async def run_activity_lease(
+    *,
+    lease: ActivityLease,
+    has_active_work: Callable[[], bool],
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    refresh_interval_s: float = _DEFAULT_REFRESH_INTERVAL_S,
+    release_grace_s: float = _DEFAULT_RELEASE_GRACE_S,
+    retry_interval_s: float = _DEFAULT_RETRY_INTERVAL_S,
+) -> None:
+    """Hold a suspendable runner active only while work is outstanding.
+
+    Activity accounting is supplied by the runner and is independent of both
+    the selected harness and the sandbox provider. The adapter owns the
+    provider-specific acquire/release transport.
+
+    :param lease: Provider activity-lease adapter.
+    :param has_active_work: Callback reporting delivery-critical runner work.
+    :param poll_interval_s: Active-work polling interval.
+    :param refresh_interval_s: Successful lease refresh cadence.
+    :param release_grace_s: Idle grace before releasing a held lease.
+    :param retry_interval_s: Retry delay after a provider operation fails.
+    :returns: Never under normal operation; cancellation releases the lease.
+    """
+    held = False
+    next_refresh_at = 0.0
+    next_release_at = 0.0
+    loop = asyncio.get_running_loop()
+
+    try:
+        while True:
+            active = has_active_work()
+            now = loop.time()
+            if active:
+                next_release_at = 0.0
+                if now >= next_refresh_at:
+                    try:
+                        await lease.refresh()
+                    except ActivityLeaseError:
+                        logger.warning(
+                            "failed to refresh %s activity lease; active work may suspend",
+                            lease.provider,
+                            exc_info=True,
+                        )
+                        next_refresh_at = now + retry_interval_s
+                    else:
+                        held = True
+                        next_refresh_at = now + refresh_interval_s
+            elif held:
+                if next_release_at == 0.0:
+                    next_release_at = now + release_grace_s
+                if now >= next_release_at:
+                    try:
+                        await lease.release()
+                    except ActivityLeaseError:
+                        logger.warning(
+                            "failed to release %s activity lease",
+                            lease.provider,
+                            exc_info=True,
+                        )
+                        next_release_at = now + retry_interval_s
+                    else:
+                        held = False
+            await asyncio.sleep(poll_interval_s)
+    finally:
+        if held:
+            try:
+                await lease.release()
+            except ActivityLeaseError:
+                logger.debug(
+                    "failed to release %s activity lease during shutdown",
+                    lease.provider,
+                    exc_info=True,
+                )
+        await lease.aclose()

--- a/omnigent/runner/activity_leases/__init__.py
+++ b/omnigent/runner/activity_leases/__init__.py
@@ -1,0 +1,1 @@
+"""Provider adapters for runner activity leases."""

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2549,7 +2549,12 @@ def create_runner_app(
 
     app.state.drain_session_streams = _drain_session_streams
 
-    def _publish_event(session_id: str, event: Mapping[str, object]) -> None:
+    def _publish_event(
+        session_id: str,
+        event: Mapping[str, object],
+        *,
+        local_status: str | None = None,
+    ) -> None:
         event_body = cast(_JsonObject, event)
         queue = _session_event_queues.get(session_id)
         if queue is None:
@@ -2557,7 +2562,9 @@ def create_runner_app(
             _session_event_queues[session_id] = queue
         queue.put_nowait(event_body)
         if event_body.get("type") == "session.status":
-            _status_value = event_body.get("status")
+            # Legacy servers receive ``running`` for ``waiting``; that wire
+            # fallback must not turn completed local work into an activity pin.
+            _status_value = local_status if local_status is not None else event_body.get("status")
             if isinstance(_status_value, str):
                 _native_pane_status[session_id] = _status_value
         _fan_out_child_delta_to_parent(session_id, event_body)
@@ -4531,6 +4538,7 @@ def create_runner_app(
         status: str,
         error: Mapping[str, object] | None = None,
     ) -> None:
+        local_status = status
         if status == "waiting" and not (
             _server_version is not None and _version_supports_waiting_status(_server_version)
         ):
@@ -4562,7 +4570,7 @@ def create_runner_app(
                 error,
                 extra={"session_id": conv_id},
             )
-        _publish_event(conv_id, event)
+        _publish_event(conv_id, event, local_status=local_status)
 
     def _is_native_harness(conv_id: str) -> bool:
         return is_native_harness(_session_harness_name(conv_id))

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2521,6 +2521,12 @@ def create_runner_app(
     def _has_active_work() -> bool:
         if _active_turns:
             return True
+        # Native harnesses publish ``running`` while terminal-owned work is
+        # active, including work that outlives the HTTP turn task. ``waiting``
+        # is the session-level turn-ended state; counting it here pins a
+        # suspendable provider's activity lease forever after a completed turn.
+        if any(status == "running" for status in _native_pane_status.values()):
+            return True
         if _has_live_async_tasks(_session_async_tasks):
             return True
         for timers in _session_timers.values():

--- a/tests/runner/test_activity_lease.py
+++ b/tests/runner/test_activity_lease.py
@@ -1,0 +1,208 @@
+"""Provider-neutral runner activity lease tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
+
+from omnigent.runner import activity_lease as activity_lease_module
+from omnigent.runner.activity_lease import (
+    _ACTIVITY_LEASE_FACTORIES,
+    _BUILTIN_LEASE_MODULES,
+    ACTIVITY_LEASE_PROVIDER_ENV_VAR,
+    ActivityLeaseError,
+    activity_lease_from_env,
+    register_activity_lease_provider,
+    run_activity_lease,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class RecordingLease:
+    """Controllable lease adapter for state-machine tests."""
+
+    provider = "test"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.fail_release = False
+
+    async def refresh(self) -> None:
+        self.calls.append("refresh")
+
+    async def release(self) -> None:
+        self.calls.append("release")
+        if self.fail_release:
+            self.fail_release = False
+            raise ActivityLeaseError("transient release failure")
+
+    async def aclose(self) -> None:
+        self.calls.append("close")
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError("timed out waiting for activity lease operation")
+
+
+async def test_backend_requires_explicit_provider_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filesystem artifacts alone never activate a provider lease."""
+    monkeypatch.delenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, raising=False)
+    assert activity_lease_from_env("runner-123") is None
+
+
+async def test_registered_backend_is_selected_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The configured provider selects its registered adapter factory."""
+    lease = RecordingLease()
+
+    def factory(runner_id: str) -> RecordingLease:
+        assert runner_id == "runner-123"
+        return lease
+
+    register_activity_lease_provider("test", factory)
+    monkeypatch.setenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, "test")
+    try:
+        assert activity_lease_from_env("runner-123") is lease
+    finally:
+        _ACTIVITY_LEASE_FACTORIES.pop("test", None)
+
+
+async def test_configured_builtin_module_is_loaded_lazily(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the provider named by the environment imports its adapter module."""
+    lease = RecordingLease()
+    imported: list[str] = []
+
+    def register() -> None:
+        register_activity_lease_provider("lazy", lambda runner_id: lease)
+
+    def import_module(module_name: str) -> object:
+        imported.append(module_name)
+        return SimpleNamespace(register_activity_lease_provider=register)
+
+    monkeypatch.setitem(_BUILTIN_LEASE_MODULES, "lazy", "example.lazy_lease")
+    monkeypatch.setattr(activity_lease_module.importlib, "import_module", import_module)
+    monkeypatch.setenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, "lazy")
+    try:
+        assert activity_lease_from_env("runner-123") is lease
+        assert imported == ["example.lazy_lease"]
+    finally:
+        _ACTIVITY_LEASE_FACTORIES.pop("lazy", None)
+
+
+@pytest.mark.parametrize("provider", ["", "unknown"])
+async def test_invalid_backend_configuration_fails_loud(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    """A typo cannot silently disable hibernation protection."""
+    monkeypatch.setenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, provider)
+    with pytest.raises(RuntimeError, match=r"activity lease provider|must not be empty"):
+        activity_lease_from_env("runner-123")
+
+
+async def test_active_work_refreshes_then_releases_lease() -> None:
+    """Work holds the provider lease and draining releases it."""
+    active = True
+    lease = RecordingLease()
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: active,
+            poll_interval_s=0.005,
+            refresh_interval_s=60,
+            release_grace_s=0,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    active = False
+    await _wait_until(lambda: "release" in lease.calls)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "close"]
+
+
+async def test_idle_grace_survives_a_transient_status_gap() -> None:
+    """A brief gap between turn and terminal work does not drop the hold."""
+    active = True
+    lease = RecordingLease()
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: active,
+            poll_interval_s=0.005,
+            refresh_interval_s=60,
+            release_grace_s=0.05,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    active = False
+    await asyncio.sleep(0.02)
+    active = True
+    await asyncio.sleep(0.02)
+    assert "release" not in lease.calls
+
+    active = False
+    await _wait_until(lambda: "release" in lease.calls)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "close"]
+
+
+async def test_release_failure_retries_without_losing_held_state() -> None:
+    """A transient provider failure retries release until it succeeds."""
+    active = True
+    lease = RecordingLease()
+    lease.fail_release = True
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: active,
+            poll_interval_s=0.005,
+            refresh_interval_s=60,
+            release_grace_s=0,
+            retry_interval_s=0.01,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    active = False
+    await _wait_until(lambda: lease.calls.count("release") == 2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "release", "close"]
+
+
+async def test_cancellation_releases_a_live_lease() -> None:
+    """Orderly runner shutdown drops the provider hold immediately."""
+    lease = RecordingLease()
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: True,
+            poll_interval_s=0.005,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "close"]

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -1969,7 +1969,10 @@ async def test_parent_idle_with_stuck_wake_flag_and_drained_inbox_clears_flag() 
 
 
 @pytest.mark.asyncio
-async def test_repeat_identical_recovery_wake_is_suppressed() -> None:
+@pytest.mark.parametrize("server_version", [None, "0.2.0", "0.3.0"])
+async def test_repeat_identical_recovery_wake_is_suppressed(
+    monkeypatch: pytest.MonkeyPatch, server_version: str | None
+) -> None:
     """
     A recovery wake identical to the previous one is skipped, not re-posted.
 
@@ -2001,6 +2004,7 @@ async def test_repeat_identical_recovery_wake_is_suppressed() -> None:
     """
     from omnigent.runner import app as runner_app
 
+    monkeypatch.setattr(runner_app, "_server_version", server_version)
     parent_id = "b3d5c9f1a26e4708b1f0c4d29e7a6f13"
     child_a = "5f2a1c8b90d34e6fa7c1b2d3e4f50617"
     child_b = "6a3b2d9c81e45f70b8d2c3e4f5061728"
@@ -2099,6 +2103,14 @@ async def test_repeat_identical_recovery_wake_is_suppressed() -> None:
             assert "sub-agent gp/fanout finished (completed)" in recovery_text
             assert "2 results waiting in inbox" in recovery_text
             await _wait_turn_idle()
+            # A legacy wire fallback must not pin activity after T1 finishes.
+            assert app.state.native_pane_status[parent_id] == "waiting"
+            statuses = [
+                event["status"]
+                for event in _drain_session_event_queue(app.state.session_event_queues[parent_id])
+                if event.get("type") == "session.status"
+            ]
+            assert statuses[-1] == ("waiting" if server_version == "0.3.0" else "running")
 
             # 4. Start T2 (clears the flag). Drain one inbox item, then child C
             #    completes mid-T2 — the count returns to 2, so C's completion

--- a/tests/runner/test_runner_idle_active_work.py
+++ b/tests/runner/test_runner_idle_active_work.py
@@ -294,6 +294,31 @@ async def test_done_approval_future_does_not_pin_runner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_running_native_harness_blocks_idle_shutdown() -> None:
+    """Terminal-owned work remains active after the HTTP turn slot clears."""
+    app = _scaffold_app()
+    app.state.native_pane_status["conv_native"] = "running"
+    assert app.state.has_active_work() is True
+
+    async def _release() -> None:
+        app.state.native_pane_status["conv_native"] = "idle"
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=app.state.has_active_work,
+        release=_release,
+    )
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.parametrize("status", ["waiting", "idle", "error"])
+def test_inactive_native_harness_status_does_not_pin_runner(status: str) -> None:
+    """Only the cross-harness running state counts as active work."""
+    app = _scaffold_app()
+    app.state.native_pane_status["conv_native"] = status
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
 async def test_drain_session_streams_enqueues_done_sentinel() -> None:
     """Graceful shutdown signals end-of-stream to every open session stream.
 


### PR DESCRIPTION
## Related issue

Part of #5115. This is the provider- and harness-neutral prerequisite requested in the maintainer discussion; the draft Sprites provider PR #6219 depends on this PR and will close the feature request.

## Summary

- Suspendable sandbox providers need to know when a runner has delivery-critical work. Add an opt-in `ActivityLease` protocol, adapter registry/lazy-loader, and refresh/release loop without adding a concrete provider adapter.
- Reuse runner activity accounting across harnesses, including native `running` work that outlives the HTTP turn task. Native `waiting` is a turn-ended state and must not keep the sandbox awake indefinitely.
- Retry provider failures, allow a short idle grace, and release/close the lease during shutdown. Lease acquisition stays disabled unless the launcher sets `OMNIGENT_ACTIVITY_LEASE_PROVIDER`; a concrete backend is added separately by the Sprites PR. The shared idle monitor also recognizes native `running` work.
- Preserve the true local `waiting` status when sending the backward-compatible `running` value to older servers, so completed turns cannot hold an activity lease indefinitely.

In plain language: keep the sandbox awake while the agent is working, then stop holding it awake after work drains.

```text
runner work -> provider-neutral lease loop -> selected adapter
               refresh while active
               release after idle grace / on shutdown
```

## Test Plan

On the rebased branch (base `4e41d4fb2`):

```bash
uv run pytest -p no:rerunfailures tests/runner/test_activity_lease.py tests/runner/test_runner_idle_active_work.py tests/runner/test_app_sessions_native_supervision.py tests/runner/test_waiting_status_compat.py
env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u DATABRICKS_TOKEN uv run pytest -p no:rerunfailures tests/e2e/omnigent/test_repl_session_lifecycle.py
uv run pre-commit run --files omnigent/runner/app.py tests/runner/test_app_sessions_native_supervision.py
```

66 focused runner tests and all 4 mock REPL lifecycle E2E tests passed; all applicable pre-commit checks passed. Coverage includes explicit opt-in, lazy loading, refresh/release, retry behavior, shutdown cleanup, active native work, inactive native states, and activity accounting with unknown, legacy, and current server versions.

The full runner group was also run locally: 1,849 passed, 1 skipped, 4 expected failures, and 5 environment failures (4 missing the optional Databricks SDK, 1 requiring Linux bubblewrap on macOS). All five environment failures were reproduced on unchanged base `4e41d4fb2`. The updated [Linux `Pytest (runner-app)` CI check](https://github.com/omnigent-ai/omnigent/actions/runs/33677850953/job/100407129013) passes on commit `08d46bb77`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — runner lifecycle change; deterministic test evidence is above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Provider-specific live behavior is deliberately outside this prerequisite. No live infrastructure was provisioned for this rebase.

## Changelog

Managed sandbox providers can opt into activity leases that keep active agent work awake and release the hold when it finishes.
