### PR TITLE
fix: gate Claude sandbox bypass confirmation

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -74,6 +74,8 @@ from omnigent.tools.base import Tool, ToolContext
 
 _logger = logging.getLogger(__name__)
 
+CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR = "OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING"
+_SANDBOX_ENV_VAR = "IS_SANDBOX"
 BRIDGE_DIR_ENV_VAR = "HARNESS_CLAUDE_NATIVE_BRIDGE_DIR"
 REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CLAUDE_NATIVE_REQUEST_SESSION_ID"
 BRIDGE_ID_LABEL_KEY = "omnigent.claude_native.bridge_id"
@@ -1410,10 +1412,10 @@ def build_hook_settings(
     api_key_helper: str | None = None,
     launch_model: str | None = None,
     launch_permission_mode: str | None = None,
-    launch_bypass_permissions: bool = False,
     launch_effort: str | None = None,
     subagent_router_dir: Path | None = None,
     turn_routing: bool = False,
+    accept_bypass_permissions_warning: bool = False,
 ) -> _JsonObject:
     """
     Build invocation-local Claude Code hook settings.
@@ -1440,11 +1442,6 @@ def build_hook_settings(
     :param launch_permission_mode: Effective launch permission mode from
         ``--permission-mode``. Mirrored into ``permissions.defaultMode``
         for the same re-exec hardening.
-    :param launch_bypass_permissions: ``True`` when this launch requests
-        bypass mode (``--dangerously-skip-permissions`` or
-        ``--permission-mode bypassPermissions``), which sets
-        ``skipDangerousModePermissionPrompt`` so the one-time acceptance
-        dialog never blocks a host-spawned terminal.
     :param launch_effort: Effective launch effort from ``--effort``.
         Mirrored into ``effortLevel`` for restart/re-exec parity.
     :param subagent_router_dir: Directory where the runner advertises its
@@ -1457,6 +1454,10 @@ def build_hook_settings(
         routing round trip (25s worst case on a degraded server) in front of
         every prompt of every native session, to be told every time that the
         session does not route.
+    :param accept_bypass_permissions_warning: Allow the invocation settings
+        to acknowledge Claude Code's one-time dangerous-mode warning. The
+        setting is emitted only when the effective launch mode is exactly
+        ``bypassPermissions``.
     :returns: JSON-serializable Claude settings fragment.
     """
     python = python_executable or sys.executable
@@ -1698,13 +1699,7 @@ def build_hook_settings(
         settings["model"] = launch_model
     if launch_permission_mode:
         settings["permissions"] = {"defaultMode": launch_permission_mode}
-    if launch_bypass_permissions:
-        # Bypass mode shows a one-time "Bypass Permissions mode" acceptance
-        # dialog. Like the trust/onboarding gates it fires no
-        # PermissionRequest hook, so a host-spawned terminal has nobody to
-        # answer it and the session hangs with a blank web UI. Claude checks
-        # the org policy (``disableBypassPermissionsMode``) BEFORE this
-        # consent gate, so a managed host still strips bypass regardless.
+    if accept_bypass_permissions_warning and launch_permission_mode == "bypassPermissions":
         settings["skipDangerousModePermissionPrompt"] = True
     if launch_effort and launch_effort in CLAUDE_EFFORTS:
         settings["effortLevel"] = launch_effort
@@ -1806,6 +1801,7 @@ def augment_claude_args(
     allowed_tools: tuple[str, ...] = (),
     subagent_router_dir: Path | None = None,
     turn_routing: bool = False,
+    accept_bypass_permissions_warning: bool = False,
 ) -> list[str]:
     """
     Return Claude CLI args with Omnigent MCP/hook/skill injection.
@@ -1854,6 +1850,9 @@ def augment_claude_args(
         Routing on, threaded to :func:`build_hook_settings` so the
         ``UserPromptSubmit`` first-message routing hook is registered.
         ``False`` keeps every prompt off the routing round trip.
+    :param accept_bypass_permissions_warning: Explicit sandbox-launcher opt-in
+        for Claude Code's one-time dangerous-mode warning. Non-bypass launches
+        ignore it.
     :returns: Augmented argument list for the terminal resource.
     """
     mcp_config = build_mcp_config(bridge_dir, python_executable=python_executable)
@@ -1865,10 +1864,10 @@ def augment_claude_args(
         api_key_helper=api_key_helper,
         launch_model=_arg_value(claude_args, "--model"),
         launch_permission_mode=_arg_value(claude_args, "--permission-mode"),
-        launch_bypass_permissions=_args_request_bypass_permissions(claude_args),
         launch_effort=_arg_value(claude_args, "--effort"),
         subagent_router_dir=subagent_router_dir,
         turn_routing=turn_routing,
+        accept_bypass_permissions_warning=accept_bypass_permissions_warning,
     )
     args = _merge_disallowed_tools(list(claude_args), _OMNIGENT_DISALLOWED_TOOLS)
     args = _merge_allowed_tools(args, allowed_tools)
@@ -1897,6 +1896,24 @@ def augment_claude_args(
     return args
 
 
+def sandbox_bypass_warning_acceptance_enabled(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether this process explicitly permits warning acceptance.
+
+    A generic sandbox marker is insufficient by itself. The sandbox launcher
+    must also opt in through the dedicated Claude setting.
+
+    :param environ: Environment mapping; ``None`` reads :data:`os.environ`.
+    :returns: ``True`` only when both gates are exactly ``"1"``.
+    """
+    values = os.environ if environ is None else environ
+    return (
+        values.get(_SANDBOX_ENV_VAR) == "1"
+        and values.get(CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR) == "1"
+    )
+
+
 def _arg_value(args: tuple[str, ...], flag: str) -> str | None:
     """Return the effective CLI flag value from ``args``.
 
@@ -1921,21 +1938,6 @@ def _arg_value(args: tuple[str, ...], flag: str) -> str | None:
             if candidate and not candidate.startswith("--"):
                 value = candidate
     return value
-
-
-def _args_request_bypass_permissions(args: tuple[str, ...]) -> bool:
-    """Return whether ``args`` launch Claude Code in bypass-permissions mode.
-
-    Both spellings count: the standalone ``--dangerously-skip-permissions``
-    flag, and ``--permission-mode bypassPermissions`` (the form
-    ``permission_mode: bypassPermissions`` in a worker bundle becomes).
-
-    :param args: Claude CLI args, e.g. ``("--dangerously-skip-permissions",)``.
-    :returns: ``True`` when this launch requests bypass mode.
-    """
-    return "--dangerously-skip-permissions" in args or (
-        _arg_value(args, "--permission-mode") == "bypassPermissions"
-    )
 
 
 def _merge_allowed_tools(args: list[str], extra: tuple[str, ...]) -> list[str]:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6340,6 +6340,7 @@ async def _auto_create_claude_terminal(
         augment_claude_args,
         ensure_claude_workspace_trusted,
         prepare_bridge_dir,
+        sandbox_bypass_warning_acceptance_enabled,
     )
     from omnigent.claude_native_forwarder import reset_transcript_forward_state
     from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
@@ -6881,6 +6882,7 @@ async def _auto_create_claude_terminal(
         # The route-turn hook is registered only when this session can
         # actually route; otherwise every submit would pay its round trip.
         turn_routing=_claude_turn_router is not None,
+        accept_bypass_permissions_warning=sandbox_bypass_warning_acceptance_enabled(),
     )
 
     # Apply the per-harness startup command/args override from config

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2847,20 +2847,15 @@ def test_augment_claude_args_mirrors_launch_overrides_into_settings(
     ],
     ids=["skip-flag", "mode-spaced", "mode-joined"],
 )
-def test_augment_claude_args_preaccepts_bypass_dialog(
+def test_augment_claude_args_does_not_preaccept_bypass_dialog_without_opt_in(
     bypass_args: tuple[str, ...],
     tmp_path: Path,
 ) -> None:
     """
-    A bypass launch pre-accepts Claude's one-time bypass consent dialog.
+    A bypass launch alone cannot acknowledge Claude's dangerous-mode warning.
 
-    Claude shows a blocking "Bypass Permissions mode / 1. No, exit /
-    2. Yes, I accept" dialog before the first bypass launch. It fires no
-    PermissionRequest hook, so a host-spawned worker has nobody to answer it
-    and hangs forever producing no output. Setting
-    ``skipDangerousModePermissionPrompt`` in the invocation-local settings
-    sidecar clears the gate without touching the user's own config. Both
-    spellings that reach the CLI must be recognised.
+    Managed sandbox providers must opt in separately, so ordinary local and
+    unmanaged launches preserve Claude's confirmation gate.
     """
     args = augment_claude_args(
         bypass_args,
@@ -2869,9 +2864,9 @@ def test_augment_claude_args_preaccepts_bypass_dialog(
     )
 
     settings = _load_invocation_settings(args)
-    assert settings.get("skipDangerousModePermissionPrompt") is True, (
-        "bypass launches must set skipDangerousModePermissionPrompt; without it a "
-        f"headless worker hangs on the acceptance dialog. args={bypass_args!r}"
+    assert "skipDangerousModePermissionPrompt" not in settings, (
+        "bypass launches must preserve the confirmation gate without an explicit "
+        f"sandbox-provider opt-in. args={bypass_args!r}"
     )
 
 
@@ -2922,6 +2917,66 @@ def test_augment_claude_args_mirrors_joined_model_arg_into_settings(
     assert settings["model"] == "claude-sonnet-5"
     assert "permissions" not in settings
     assert "effortLevel" not in settings
+
+
+@pytest.mark.parametrize(
+    ("permission_mode", "accepted", "expected"),
+    [
+        ("bypassPermissions", True, True),
+        ("bypassPermissions", False, False),
+        ("default", True, False),
+        (None, True, False),
+    ],
+)
+def test_bypass_warning_acceptance_requires_bypass_launch_and_caller_opt_in(
+    tmp_path: Path,
+    permission_mode: str | None,
+    accepted: bool,
+    expected: bool,
+) -> None:
+    """The dangerous-mode acknowledgement is never a blanket sandbox setting."""
+    claude_args = ("--permission-mode", permission_mode) if permission_mode is not None else ()
+    args = augment_claude_args(
+        claude_args,
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+        accept_bypass_permissions_warning=accepted,
+    )
+
+    settings = _load_invocation_settings(args)
+    assert (settings.get("skipDangerousModePermissionPrompt") is True) is expected
+
+
+@pytest.mark.parametrize(
+    ("environ", "expected"),
+    [
+        ({}, False),
+        ({"IS_SANDBOX": "1"}, False),
+        ({"OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING": "1"}, False),
+        (
+            {
+                "IS_SANDBOX": "1",
+                "OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING": "1",
+            },
+            True,
+        ),
+        (
+            {
+                "IS_SANDBOX": "true",
+                "OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING": "1",
+            },
+            False,
+        ),
+    ],
+)
+def test_sandbox_bypass_warning_gate_requires_two_exact_opt_ins(
+    environ: dict[str, str],
+    expected: bool,
+) -> None:
+    """Neither a generic sandbox marker nor the dedicated flag works alone."""
+    from omnigent.claude_native_bridge import sandbox_bypass_warning_acceptance_enabled
+
+    assert sandbox_bypass_warning_acceptance_enabled(environ) is expected
 
 
 def test_augment_claude_args_uses_last_repeated_launch_override(


### PR DESCRIPTION
## Related issue

Part of #5115. This isolates the shared Claude permissions change requested in the maintainer discussion; the draft Sprites provider PR #6219 depends on this PR and will close the feature request.

## Summary

- Limit automatic acknowledgement of Claude Code's one-time bypass-permissions warning to explicitly opted-in managed sandbox launches. The runner requires both `IS_SANDBOX=1` and `OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING=1`.
- Write `skipDangerousModePermissionPrompt` only when the caller opts in and the effective `--permission-mode` is exactly `bypassPermissions`. Other modes, ordinary local launches, and the standalone skip-permissions flag without an explicit mode do not qualify.
- Reconcile with current main's newly added blanket bypass-warning acknowledgement: this PR intentionally narrows that behavior. It does not enable bypass mode itself or modify the user's global Claude settings.

In plain language: an unattended sandbox may acknowledge this startup warning only when its launcher explicitly authorizes it; merely requesting bypass mode is not enough.

```text
IS_SANDBOX=1 + dedicated opt-in=1
                |
                v
caller opt-in + effective mode=bypassPermissions
                |
                v
invocation-local warning acknowledgement
```

Deployment note: providers that need unattended bypass startup must explicitly set both environment gates and request `bypassPermissions`. Without that configuration, Claude retains its confirmation prompt.

## Test Plan

On the rebased branch (base `4e41d4fb2`):

```bash
uv run pytest -p no:rerunfailures tests/test_claude_native_bridge.py -k 'bypass_dialog or bypass_consent or bypass_warning_acceptance or sandbox_bypass_warning_gate'
uv run pre-commit run --from-ref upstream/main --to-ref HEAD
```

16 focused tests passed; all applicable pre-commit checks passed. The complete bridge test file also passed as part of the composed Sprites branch's 598-test run.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — invocation settings and environment gating, covered by the test matrix above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [x] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests exercise emitted invocation settings and exact environment values. This intentionally changes current main's automatic acknowledgement behavior; existing unattended bypass deployments may need explicit launcher configuration. No live model invocation was run for this rebase.

## Changelog

Claude Code's bypass-permissions startup warning is automatically acknowledged only by explicitly opted-in managed sandbox launches.
