### PR TITLE
fix: harden managed sandbox wake and reconnect handoff

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2623,6 +2623,7 @@ def create_app(
         """
         from omnigent.server.routes.sessions import (
             RUNNER_DISCONNECT_GRACE_S,
+            _managed_wake_sessions,
             _mark_runner_sessions_offline,
         )
         from omnigent.server.schemas import ErrorDetail
@@ -2650,6 +2651,7 @@ def create_app(
         affected = await asyncio.to_thread(
             conversation_store.list_conversations_by_runner_id, runner_id
         )
+        affected = [conv for conv in affected if conv.id not in _managed_wake_sessions]
         _logger.warning(
             "Runner %s disconnected; reconciling %d bound session(s)",
             runner_id,
@@ -2781,6 +2783,7 @@ def create_app(
         )
         from omnigent.server.routes.sessions import (
             _ensure_runner_relay,
+            _managed_wake_sessions,
             _publish_runner_recovered_status,
             _publish_sandbox_status,
             prefetch_session_routing_catalogs,
@@ -2808,6 +2811,14 @@ def create_app(
             len(convs),
         )
         for conv in convs:
+            if conv.id in _managed_wake_sessions:
+                _logger.info(
+                    "_on_runner_connect: ignoring transient runner %s for "
+                    "managed-waking session %s",
+                    runner_id,
+                    conv.id,
+                )
+                continue
             _logger.info(
                 "_on_runner_connect: matched %s (agent=%s)",
                 conv.id,

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -499,6 +499,9 @@ _interrupt_fenced_sessions: set[str] = set()
 _intentional_stop_sessions: set[str] = set()
 
 
+_managed_wake_sessions: set[str] = set()
+
+
 _TERMINAL_RESPONSE_EVENT_TYPES: frozenset[str] = frozenset(
     {
         "response.completed",
@@ -968,6 +971,7 @@ __all__ = [
     "_interrupt_fenced_sessions",
     "_logger",
     "_managed_launch_tasks",
+    "_managed_wake_sessions",
     "_model_options_cache",
     "_model_options_inflight",
     "_model_options_stale",

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -167,6 +167,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _interrupt_fenced_sessions,
     _logger,
     _managed_launch_tasks,
+    _managed_wake_sessions,
     _MirroredToolCall,
     _model_options_cache,
     _model_options_inflight,
@@ -3178,10 +3179,19 @@ async def _maybe_wake_stale_resumable_managed_sandbox(
     ):
         return False
 
-    if host_registry is not None:
-        host_registry.deregister(conv.host_id)
-    if tunnel_registry is not None and conv.runner_id is not None:
-        tunnel_registry.deregister(conv.runner_id)
+    # The stale tunnel and its relay are intentionally replaced during a
+    # managed wake. Mark the handoff before deregistration so those expected
+    # disconnects do not become a user-visible task failure.
+    _managed_wake_sessions.add(session_id)
+    try:
+        await _retire_runner_relay_for_managed_wake(session_id)
+        if host_registry is not None:
+            host_registry.deregister(conv.host_id)
+        if tunnel_registry is not None and conv.runner_id is not None:
+            tunnel_registry.deregister(conv.runner_id)
+    except BaseException:
+        _managed_wake_sessions.discard(session_id)
+        raise
 
     _logger.info(
         "Managed host %s for session %s needs wake before reusing tunnels "
@@ -3195,12 +3205,34 @@ async def _maybe_wake_stale_resumable_managed_sandbox(
         runner_tunnel_stale,
         extra={"session_id": session_id},
     )
-    return await _maybe_relaunch_managed_sandbox(
-        session_id=session_id,
-        conv=conv,
-        app_state=app_state,
-        conversation_store=conversation_store,
+    try:
+        started = await _maybe_relaunch_managed_sandbox(
+            session_id=session_id,
+            conv=conv,
+            app_state=app_state,
+            conversation_store=conversation_store,
+        )
+    except BaseException:
+        _managed_wake_sessions.discard(session_id)
+        raise
+    if not started:
+        _managed_wake_sessions.discard(session_id)
+    return started
+
+
+async def _retire_runner_relay_for_managed_wake(session_id: str) -> None:
+    """Cancel the relay bound to the runner a managed wake will replace."""
+    stale_relay = _runner_relay_tasks.get(session_id)
+    if stale_relay is None or stale_relay.task.done():
+        return
+    _logger.info(
+        "Managed wake: retiring stale runner relay for session %s (runner %s)",
+        session_id,
+        stale_relay.runner_id,
     )
+    stale_relay.task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await stale_relay.task
 
 
 async def ensure_runner_connected(
@@ -3549,11 +3581,12 @@ def _kick_managed_wake_impl(
         session_id,
         extra={"session_id": session_id},
     )
+    _managed_wake_sessions.add(session_id)
     tracker.begin(session_id)
     # Seed the progress indicator immediately — the user is watching the
     # session page when the wake fires (the composer let them send into a
     # host_asleep session).
-    _publish_sandbox_status(session_id, "provisioning")
+    _publish_sandbox_status(session_id, "waking")
     wake_task = asyncio.create_task(
         _run_managed_wake(
             session_id=session_id,
@@ -3617,6 +3650,7 @@ async def _run_managed_wake(
         reason = "managed session has no host binding"
         tracker.fail(session_id, reason)
         _publish_sandbox_status(session_id, "failed", reason)
+        _managed_wake_sessions.discard(session_id)
         return
 
     def _on_stage(stage: str) -> None:
@@ -3631,6 +3665,7 @@ async def _run_managed_wake(
         _publish_sandbox_status(session_id, stage)
 
     try:
+        await _retire_runner_relay_for_managed_wake(session_id)
         # Wake the same sandbox in place; resume_managed_host is single-flight
         # per host and a no-op if it's already online.
         await resume_managed_host(
@@ -3723,6 +3758,8 @@ async def _run_managed_wake(
         )
         tracker.fail(session_id, "internal error during managed host wake")
         _publish_sandbox_status(session_id, "failed", "internal error during managed host wake")
+    finally:
+        _managed_wake_sessions.discard(session_id)
 
 
 async def _ensure_runner_session_initialized(
@@ -5924,6 +5961,12 @@ async def _relay_runner_stream(
             return
         except _RelayTransportLost as lost:
             now = loop.time()
+            if session_id in _managed_wake_sessions:
+                _logger.info(
+                    "Relay: suppressing expected managed-wake disconnect for session=%s",
+                    session_id,
+                )
+                return
             # An attempt that streamed longer than the grace was a live
             # tunnel dropping anew — give the new outage a fresh window.
             if deadline is None or now - started > RUNNER_DISCONNECT_GRACE_S:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -5980,6 +5980,17 @@ async def _relay_runner_stream(
                 )
                 await asyncio.sleep(_RELAY_RETRY_INTERVAL_S)
                 continue
+            if not lost.intentional and _session_status_cache.get(session_id) == "idle":
+                _logger.info(
+                    "Relay: suppressing disconnect after idle for session=%s",
+                    session_id,
+                )
+                await _persist_session_status_error_labels(
+                    session_id,
+                    None,
+                    conversation_store,
+                )
+                return
             _logger.warning(
                 "Relay: runner transport lost for session=%s",
                 session_id,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -3179,19 +3179,22 @@ async def _maybe_wake_stale_resumable_managed_sandbox(
     ):
         return False
 
-    # The stale tunnel and its relay are intentionally replaced during a
-    # managed wake. Mark the handoff before deregistration so those expected
-    # disconnects do not become a user-visible task failure.
-    _managed_wake_sessions.add(session_id)
+    # Suppress only the stale-tunnel handoff here. A newly kicked wake owns its
+    # longer-lived marker in ``_kick_managed_wake_impl``; keeping this temporary
+    # marker through tracker rendezvous can leak it when another launch is
+    # already unsettled and no new wake task is created.
+    already_waking = session_id in _managed_wake_sessions
+    if not already_waking:
+        _managed_wake_sessions.add(session_id)
     try:
         await _retire_runner_relay_for_managed_wake(session_id)
         if host_registry is not None:
             host_registry.deregister(conv.host_id)
         if tunnel_registry is not None and conv.runner_id is not None:
             tunnel_registry.deregister(conv.runner_id)
-    except BaseException:
-        _managed_wake_sessions.discard(session_id)
-        raise
+    finally:
+        if not already_waking:
+            _managed_wake_sessions.discard(session_id)
 
     _logger.info(
         "Managed host %s for session %s needs wake before reusing tunnels "
@@ -3205,19 +3208,12 @@ async def _maybe_wake_stale_resumable_managed_sandbox(
         runner_tunnel_stale,
         extra={"session_id": session_id},
     )
-    try:
-        started = await _maybe_relaunch_managed_sandbox(
-            session_id=session_id,
-            conv=conv,
-            app_state=app_state,
-            conversation_store=conversation_store,
-        )
-    except BaseException:
-        _managed_wake_sessions.discard(session_id)
-        raise
-    if not started:
-        _managed_wake_sessions.discard(session_id)
-    return started
+    return await _maybe_relaunch_managed_sandbox(
+        session_id=session_id,
+        conv=conv,
+        app_state=app_state,
+        conversation_store=conversation_store,
+    )
 
 
 async def _retire_runner_relay_for_managed_wake(session_id: str) -> None:
@@ -3665,6 +3661,9 @@ async def _run_managed_wake(
         _publish_sandbox_status(session_id, stage)
 
     try:
+        # Idempotent by design: stale-tunnel detection may retire this relay
+        # before kicking the wake, while a direct host-asleep wake first
+        # reaches the relay here.
         await _retire_runner_relay_for_managed_wake(session_id)
         # Wake the same sandbox in place; resume_managed_host is single-flight
         # per host and a no-op if it's already online.
@@ -5966,6 +5965,9 @@ async def _relay_runner_stream(
                     "Relay: suppressing expected managed-wake disconnect for session=%s",
                     session_id,
                 )
+                # Managed wakes are message-triggered. The parked dispatch
+                # resumes after the wake tracker settles and establishes the
+                # replacement relay; this obsolete relay must not race it.
                 return
             # An attempt that streamed longer than the grace was a live
             # tunnel dropping anew — give the new outage a fresh window.

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -306,6 +306,7 @@ from omnigent.server.routes._sessions.common import (
     _interrupt_fenced_sessions as _interrupt_fenced_sessions,
     _logger as _logger,
     _managed_launch_tasks as _managed_launch_tasks,
+    _managed_wake_sessions as _managed_wake_sessions,
     _model_options_cache as _model_options_cache,
     _model_options_inflight as _model_options_inflight,
     _model_options_stale as _model_options_stale,

--- a/omnigent/server/routes/terminal_attach.py
+++ b/omnigent/server/routes/terminal_attach.py
@@ -74,6 +74,8 @@ from typing import Final
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect, WebSocketException
 from starlette import status
+from websockets.exceptions import ProtocolError
+from websockets.frames import Close
 
 from omnigent.debug_logging import debug_event
 from omnigent.errors import OmnigentError
@@ -98,6 +100,17 @@ _logger = logging.getLogger(__name__)
 _WS_CLOSE_TERMINAL_NOT_FOUND: Final[int] = WS_CLOSE_TERMINAL_NOT_FOUND
 _WS_CLOSE_INTERNAL_ERROR: Final[int] = WS_CLOSE_INTERNAL_ERROR
 _WS_CLOSE_WRONG_REPLICA: Final[int] = WS_CLOSE_WRONG_REPLICA
+
+
+def _safe_browser_close_code(code: int | None) -> int:
+    """Return a sendable WebSocket close code for the browser connection."""
+    if code is None:
+        return _WS_CLOSE_INTERNAL_ERROR
+    try:
+        Close(code, "").check()
+    except ProtocolError:
+        return _WS_CLOSE_INTERNAL_ERROR
+    return code
 
 
 def create_terminal_attach_router(
@@ -215,11 +228,7 @@ def create_terminal_attach_router(
                     async with runner_cm as runner_ws:
                         await _shuttle_ws_frames(websocket, runner_ws)
             except _RunnerWSClosed as closed:
-                code = (
-                    closed.code
-                    if closed.code and closed.code >= 1000
-                    else _WS_CLOSE_INTERNAL_ERROR
-                )
+                code = _safe_browser_close_code(closed.code)
                 with contextlib.suppress(RuntimeError):
                     await websocket.close(
                         code=code,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1737,13 +1737,12 @@ class SessionLabelsResponse(BaseModel):
     labels: dict[str, str] = Field(default_factory=dict)
 
 
-# Stages of a managed-sandbox launch, in pipeline order: the sandbox
-# is provisioned, the repository workspace is cloned into it (skipped
-# when the session has no repo workspace), the in-sandbox host starts
-# and registers, and the agent runner is launched on it. ``ready`` and
-# ``failed`` are terminal.
+# Stages of a managed-sandbox launch or resume. New sandboxes move from
+# provisioning through clone/start/connect; resumed sandboxes move from
+# waking to connect. ``ready`` and ``failed`` are terminal.
 SandboxLaunchStage = Literal[
     "provisioning",
+    "waking",
     "cloning",
     "starting",
     "connecting",
@@ -1761,13 +1760,15 @@ class SandboxStatus(BaseModel):
     for sessions without a managed launch and once the launch
     succeeds (the session then looks like any host-bound session).
 
-    :param stage: Current launch stage, e.g. ``"provisioning"`` —
+    :param stage: Current launch stage, e.g. ``"provisioning"`` or
+        ``"waking"`` —
         one of :data:`SandboxLaunchStage`, in pipeline order:
         ``provisioning`` (creating the sandbox) → ``cloning``
         (cloning the repository workspace; skipped when the session
         has none) → ``starting`` (starting the in-sandbox host) →
         ``connecting`` (launching the agent runner) → ``ready`` /
-        ``failed``.
+        ``failed``. A resumed sandbox begins at ``waking`` and then
+        joins the same ``connecting`` → ``ready`` / ``failed`` tail.
     :param error: Failure detail when ``stage == "failed"``, e.g.
         ``"managed sandbox launch failed: spend limit reached"``.
         ``None`` otherwise.

--- a/openapi.json
+++ b/openapi.json
@@ -3961,9 +3961,10 @@
             "title": "Error"
           },
           "stage": {
-            "description": "Current launch stage, e.g. `\"provisioning\"` \u2014 one of `SandboxLaunchStage`, in pipeline order: `provisioning` (creating the sandbox) \u2192 `cloning` (cloning the repository workspace; skipped when the session has none) \u2192 `starting` (starting the in-sandbox host) \u2192 `connecting` (launching the agent runner) \u2192 `ready` / `failed`.",
+            "description": "Current launch stage, e.g. `\"provisioning\"` or `\"waking\"` \u2014 one of `SandboxLaunchStage`, in pipeline order: `provisioning` (creating the sandbox) \u2192 `cloning` (cloning the repository workspace; skipped when the session has none) \u2192 `starting` (starting the in-sandbox host) \u2192 `connecting` (launching the agent runner) \u2192 `ready` / `failed`. A resumed sandbox begins at `waking` and then joins the same `connecting` \u2192 `ready` / `failed` tail.",
             "enum": [
               "provisioning",
+              "waking",
               "cloning",
               "starting",
               "connecting",
@@ -6330,6 +6331,7 @@
             "description": "The launch stage just entered, e.g. `\"provisioning\"` \u2014 see `SandboxStatus` for the full pipeline order.",
             "enum": [
               "provisioning",
+              "waking",
               "cloning",
               "starting",
               "connecting",

--- a/tests/e2e_ui/chat/test_managed_sandbox_wake.py
+++ b/tests/e2e_ui/chat/test_managed_sandbox_wake.py
@@ -1,0 +1,202 @@
+"""Browser regressions for managed wake status and missed consumed events.
+
+Drive the real SPA and server-backed history, controlling only the session's
+HTTP/SSE boundary. No live sandbox or native agent credentials are required.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import httpx
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.chat.test_initial_history_loading import _seed_message
+from tests.e2e_ui.chat.test_queued_message_lifecycle import _send, _user_bubble
+from tests.e2e_ui.conftest import fetch_with_retry
+
+_STREAM_CONTROLLER = """
+(() => {
+  const sessionId = __SESSION_ID__;
+  const originalFetch = window.fetch.bind(window);
+  window.__wakeStreams = [];
+  window.fetch = (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    if (new URL(url, window.location.origin).pathname ===
+        `/v1/sessions/${sessionId}/stream`) {
+      const body = new ReadableStream({
+        start(controller) {
+          window.__wakeStreams.push(controller);
+          init?.signal?.addEventListener("abort", () => {
+            try { controller.error(new DOMException("Aborted", "AbortError")); }
+            catch { /* Already closed by the test. */ }
+          }, { once: true });
+        },
+      });
+      return Promise.resolve(new Response(body, {
+        status: 200, headers: { "content-type": "text/event-stream" },
+      }));
+    }
+    return originalFetch(input, init);
+  };
+})()
+"""
+
+
+def _install_stream(page: Page, session_id: str) -> None:
+    page.add_init_script(_STREAM_CONTROLLER.replace("__SESSION_ID__", json.dumps(session_id)))
+
+
+def _push_sse(page: Page, event: str, payload: dict) -> None:
+    page.wait_for_function("window.__wakeStreams.length > 0")
+    page.evaluate(
+        """({ event, payload }) => {
+          const frame = `event: ${event}\\ndata: ${JSON.stringify(payload)}\\n\\n`;
+          window.__wakeStreams.at(-1).enqueue(new TextEncoder().encode(frame));
+        }""",
+        {"event": event, "payload": payload},
+    )
+
+
+@pytest.mark.parametrize("from_snapshot", [False, True], ids=["live-event", "snapshot"])
+def test_managed_wake_indicator_advances_and_clears(
+    page: Page, seeded_session: tuple[str, str], from_snapshot: bool
+) -> None:
+    """A wake is not a new provision; ready removes the progress indicator."""
+    base_url, session_id = seeded_session
+    _install_stream(page, session_id)
+
+    def patch_snapshot(route: Route) -> None:
+        if route.request.method != "GET":
+            route.continue_()
+            return
+        response = fetch_with_retry(route)
+        payload = response.json()
+        payload["sandbox_status"] = {"stage": "waking"} if from_snapshot else None
+        route.fulfill(response=response, json=payload)
+
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), patch_snapshot)
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_label("Message the agent")).to_be_visible(timeout=15_000)
+
+    def stage(value: str) -> None:
+        _push_sse(
+            page,
+            "session.sandbox_status",
+            {"type": "session.sandbox_status", "conversation_id": session_id, "stage": value},
+        )
+
+    if not from_snapshot:
+        expect(page.get_by_role("heading", name="What should we work on?")).to_be_visible()
+        stage("waking")
+    indicator = page.get_by_test_id("runner-starting-indicator")
+    expect(indicator).to_contain_text("Waking sandbox")
+    expect(page.get_by_text("Provisioning sandbox", exact=False)).to_have_count(0)
+    expect(page.get_by_test_id("disconnected-indicator")).to_have_count(0)
+
+    stage("connecting")
+    expect(indicator).to_contain_text("Starting agent")
+    stage("ready")
+    expect(indicator).to_have_count(0)
+    expect(page.get_by_test_id("sandbox-failed-indicator")).to_have_count(0)
+    expect(page.get_by_label("Message the agent")).to_be_enabled()
+
+
+@pytest.mark.parametrize("queued_duplicate", [False, True], ids=["consumed", "still-queued"])
+@pytest.mark.parametrize("wrapper", ["claude-code-native-ui", "codex-native-ui"])
+def test_rebind_reconciles_a_missed_consumed_event(
+    page: Page, seeded_session: tuple[str, str], queued_duplicate: bool, wrapper: str
+) -> None:
+    """Drop a stale optimistic copy, but keep an identical server-queued send."""
+    base_url, session_id = seeded_session
+    prompt = "wake-rebind original prompt"
+    follow_up = "wake-rebind follow up"
+    pending_inputs: list[dict] = []
+    posts: list[dict] = []
+    _install_stream(page, session_id)
+
+    def patch_snapshot(route: Route) -> None:
+        if route.request.method != "GET":
+            route.continue_()
+            return
+        response = fetch_with_retry(route)
+        payload = response.json()
+        payload["labels"] = {**(payload.get("labels") or {}), "omnigent.wrapper": wrapper}
+        payload["pending_inputs"] = pending_inputs
+        route.fulfill(response=response, json=payload)
+
+    def accept_message(route: Route) -> None:
+        if route.request.method != "POST":
+            route.continue_()
+            return
+        body = route.request.post_data_json
+        if body.get("type") != "message":
+            route.continue_()
+            return
+        posts.append(body)
+        # Native message acceptance precedes transcript persistence/consumption.
+        route.fulfill(status=202, json={"queued": True, "pending_id": f"pending_{len(posts)}"})
+
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), patch_snapshot)
+    page.route(f"**/v1/sessions/{session_id}/events", accept_message)
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_label("Message the agent")).to_be_visible(timeout=15_000)
+
+    with page.expect_response(f"**/v1/sessions/{session_id}/events"):
+        _send(page, prompt)
+    expect(_user_bubble(page, prompt)).to_have_count(1)
+    if queued_duplicate:
+        _push_sse(
+            page,
+            "session.status",
+            {"type": "session.status", "conversation_id": session_id, "status": "idle"},
+        )
+        expect(page.get_by_label("Message the agent")).to_have_attribute(
+            "placeholder", "Send a message…"
+        )
+        with page.expect_response(f"**/v1/sessions/{session_id}/events"):
+            _send(page, prompt)
+        expect(_user_bubble(page, prompt)).to_have_count(2)
+        pending_inputs.append(
+            {"pending_id": "pending_2", "content": [{"type": "input_text", "text": prompt}]}
+        )
+
+    # Persist the accepted prompt and answer while withholding consumed SSE.
+    with httpx.Client(base_url=base_url, timeout=30.0) as client:
+        _seed_message(client, session_id, response_id="resp_wake", role="user", text=prompt)
+        _seed_message(
+            client,
+            session_id,
+            response_id="resp_wake",
+            role="assistant",
+            text="The original task completed.",
+        )
+    _push_sse(
+        page,
+        "session.status",
+        {"type": "session.status", "conversation_id": session_id, "status": "idle"},
+    )
+    # Native idle edges must not clear the optimistic copies before rebind.
+    expect(page.get_by_label("Message the agent")).to_have_attribute(
+        "placeholder", "Send a message…"
+    )
+    expect(_user_bubble(page, prompt)).to_have_count(2 if queued_duplicate else 1)
+    # End the subscription; the next send must rebind and read durable history.
+    page.evaluate(
+        """() => {
+          const stream = window.__wakeStreams.at(-1);
+          stream.enqueue(new TextEncoder().encode("data: [DONE]\\n\\n"));
+          stream.close();
+        }"""
+    )
+    with page.expect_response(f"**/v1/sessions/{session_id}/events"):
+        _send(page, follow_up)
+    page.wait_for_function("window.__wakeStreams.length === 2")
+    expect(page.get_by_text("The original task completed.", exact=True)).to_be_visible()
+    expect(_user_bubble(page, prompt)).to_have_count(2 if queued_duplicate else 1)
+    expect(_user_bubble(page, follow_up)).to_have_count(1)
+    assert [post["data"]["content"][0]["text"] for post in posts] == (
+        [prompt, prompt, follow_up] if queued_duplicate else [prompt, follow_up]
+    )

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -1317,6 +1317,7 @@ async def test_resumable_managed_wake_drops_fresh_local_tunnels_when_provider_pa
     assert calls == ["wake"]
     assert host_deregistered == ["055e31f38d07908f171ebad4ff5cbe9c"]
     assert runner_deregistered == ["runner_stale_tunnel"]
+    assert conv.id not in sessions_module._managed_wake_sessions
 
 
 async def test_managed_wake_fails_when_runner_never_reconnects(

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -737,6 +737,51 @@ async def test_relay_suppresses_disconnect_error_on_intentional_stop() -> None:
 
 
 @pytest.mark.asyncio
+async def test_relay_suppresses_disconnect_after_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dormant runner dropping after a completed turn stays quietly idle."""
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    monkeypatch.setattr(
+        "omnigent.server.routes._sessions.orchestration.RUNNER_DISCONNECT_GRACE_S",
+        0.0,
+    )
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _TunnelCloseRunnerClient(gate)
+    store = _RecordingLabelStore()
+    session_id = "e8d9c0b1a2f34567890123456789abcd"
+
+    try:
+        sessions_module._session_status_cache[session_id] = "idle"
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_idle_disconnect",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        assert sessions_module._session_status_cache[session_id] == "idle"
+        assert sessions_module._last_task_error_from_labels(store.labels[session_id]) is None
+    finally:
+        gate.set()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)
+
+
+@pytest.mark.asyncio
 async def test_relay_suppresses_disconnect_error_during_managed_wake() -> None:
     """Replacing a dormant managed runner does not surface as a task failure."""
     from omnigent.runtime import session_stream

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -736,6 +736,50 @@ async def test_relay_suppresses_disconnect_error_on_intentional_stop() -> None:
         session_stream.close(session_id)
 
 
+@pytest.mark.asyncio
+async def test_relay_suppresses_disconnect_error_during_managed_wake() -> None:
+    """Replacing a dormant managed runner does not surface as a task failure."""
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    gate = asyncio.Event()
+    fake_runner = _TunnelCloseRunnerClient(gate)
+    store = _RecordingLabelStore()
+    session_id = "930bf92183da4fe7a7d83e05e7f43a12"
+
+    try:
+        sessions_module._session_status_cache[session_id] = "idle"
+        sessions_module._managed_wake_sessions.add(session_id)
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_managed_wake",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+
+        gate.set()
+        await asyncio.wait_for(handle.task, timeout=2.0)
+
+        assert sessions_module._session_status_cache[session_id] == "idle"
+        assert session_id not in store.labels
+        # The wake coordinator owns this marker and clears it only after the
+        # replacement runner is ready; a relay exit must not consume it.
+        assert session_id in sessions_module._managed_wake_sessions
+    finally:
+        gate.set()
+        sessions_module._managed_wake_sessions.discard(session_id)
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=1.0)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)
+
+
 class _ScriptedThenDropStreamResponse:
     """Async stream that emits scripted SSE frames, then raises ``ConnectionError``.
 

--- a/tests/server/routes/test_terminal_attach.py
+++ b/tests/server/routes/test_terminal_attach.py
@@ -617,6 +617,29 @@ async def test_attach_terminal_runner_close_propagates_close_code(
     assert exc_info.value.code == 4404
 
 
+async def test_attach_terminal_reserved_runner_close_uses_internal_error(
+    app: FastAPI,
+) -> None:
+    """A reserved runner close code is not mirrored onto the browser socket."""
+    from websockets.exceptions import ConnectionClosedError
+    from websockets.frames import Close
+
+    class _ImmediateCloseConn(_FakeRunnerWSConn):
+        async def recv(self) -> bytes | str:
+            raise ConnectionClosedError(Close(1006, ""), None, None)
+
+    factory = _FakeRunnerWSFactory(_ImmediateCloseConn())
+    set_runner_ws_factory(factory)
+
+    with TestClient(app).websocket_connect(
+        "/v1/sessions/conv_ws/resources/terminals/terminal_bash_missing/attach"
+    ) as ws:
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            ws.receive_bytes()
+
+    assert exc_info.value.code == 4500
+
+
 # ── WS attach: local fallback when no ws factory ─────────
 
 

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -1037,3 +1037,11 @@ def test_session_response_status_rejects_unknown_value() -> None:
 
     with pytest.raises(ValidationError):
         SessionResponse(id="conv_x", agent_id="ag_x", status="launching", created_at=0)
+
+
+def test_sandbox_status_accepts_waking_resume_stage() -> None:
+    """A managed resume has distinct progress from fresh provisioning."""
+    from omnigent.server.schemas import SandboxStatus
+
+    status = SandboxStatus(stage="waking")
+    assert status.model_dump() == {"stage": "waking", "error": None}

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -642,9 +642,9 @@ export interface SessionTerminalPendingEvent {
 }
 
 /**
- * `session.sandbox_status` — the session's managed-sandbox launch
- * advanced a stage (provision → clone → host start → runner connect),
- * settled successfully (`ready`), or failed (`failed` + `error`).
+ * `session.sandbox_status` — the session's managed-sandbox launch or
+ * resume advanced a stage, settled successfully (`ready`), or failed
+ * (`failed` + `error`).
  * Drives the provisioning indicator on the session page so the
  * background launch reads as live progress instead of a dead chat.
  */

--- a/web/src/lib/sessionEvents.test.ts
+++ b/web/src/lib/sessionEvents.test.ts
@@ -1350,6 +1350,16 @@ describe("session.sandbox_status (FLAT envelope)", () => {
     expect(out).toEqual([]);
   });
 
+  it("parses a managed sandbox wake stage", () => {
+    const out = parse("session.sandbox_status", {
+      type: "session.sandbox_status",
+      conversation_id: "conv_abc",
+      stage: "waking",
+    });
+    expect(out).toHaveLength(1);
+    expect((out[0] as SessionSandboxStatusEvent).stage).toBe("waking");
+  });
+
   it("rejects missing conversation_id", () => {
     const out = parse("session.sandbox_status", {
       type: "session.sandbox_status",

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -747,6 +747,7 @@ export function parseEvent(rawType: string, data: Record<string, unknown>): Stre
     // step — the snapshot re-seeds the indicator on the next load.
     if (
       stage !== "provisioning" &&
+      stage !== "waking" &&
       stage !== "cloning" &&
       stage !== "starting" &&
       stage !== "connecting" &&

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -512,13 +512,13 @@ export interface Session {
 }
 
 /**
- * Stages of a managed-sandbox launch, in pipeline order. `cloning`
- * only occurs when the session requested a repository workspace;
- * `ready` and `failed` are terminal (`ready` is delivered via SSE
- * only — the snapshot field clears to null on success).
+ * Stages of a managed-sandbox launch or resume. New sandboxes move
+ * through provision/clone/start/connect; resumed sandboxes move from
+ * waking to connect. `ready` and `failed` are terminal (`ready` is
+ * delivered via SSE only — the snapshot field clears to null on success).
  */
 export type SandboxLaunchStage =
-  "provisioning" | "cloning" | "starting" | "connecting" | "ready" | "failed";
+  "provisioning" | "waking" | "cloning" | "starting" | "connecting" | "ready" | "failed";
 
 /**
  * Managed-sandbox launch progress — mirrors

--- a/web/src/pages/ChatIndicators.tsx
+++ b/web/src/pages/ChatIndicators.tsx
@@ -11,8 +11,8 @@ import { CHAT_COLUMN_WIDTH } from "./chatLayout";
 
 /**
  * Band copy for each in-flight managed-sandbox launch stage, in
- * pipeline order: provisioning → cloning (repo workspaces only) →
- * starting → connecting. `starting` is the in-sandbox host booting
+ * launch and resume order: provisioning/waking → cloning (repo workspaces
+ * only) → starting → connecting. `starting` is the in-sandbox host booting
  * and dialing back to the server (so it reads "Connecting host");
  * `connecting` is the agent runner being launched on that host
  * (so it reads "Starting agent"). Terminal stages are absent on
@@ -21,6 +21,7 @@ import { CHAT_COLUMN_WIDTH } from "./chatLayout";
  */
 const SANDBOX_STAGE_LABELS: Record<string, string | undefined> = {
   provisioning: "Provisioning sandbox",
+  waking: "Waking sandbox",
   cloning: "Cloning repository",
   starting: "Connecting host",
   connecting: "Starting agent",

--- a/web/src/pages/RunnerStartingIndicator.test.tsx
+++ b/web/src/pages/RunnerStartingIndicator.test.tsx
@@ -91,6 +91,12 @@ describe("RunnerStartingIndicator", () => {
     },
   );
 
+  it.each(["hero", "row"] as const)("%s: names a managed resume as waking", (variant) => {
+    useChatStore.setState({ sandboxStatus: { stage: "waking", error: null } });
+    renderWithContext(variant, makeCtx({ isTerminalFirst: false, terminalStartingUp: false }));
+    expect(screen.getByTestId("runner-starting-indicator")).toHaveTextContent(/waking sandbox/i);
+  });
+
   it.each(["hero", "row"] as const)(
     "%s: renders nothing for a non-terminal-first session (no terminal context)",
     (variant) => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2069,6 +2069,30 @@ describe("chatStore — send (first-send ordering)", () => {
     expect(useChatStore.getState().pendingUserMessages).toHaveLength(1);
   });
 
+  it("rebind drops a posted optimistic bubble whose message already committed", async () => {
+    seedSession("conv_existing", [userMessage("resp_committed", "initial prompt")]);
+    useChatStore.setState({
+      conversationId: "conv_existing",
+      abortController: null,
+      pendingUserMessages: [
+        {
+          tempId: "pend_stale",
+          content: [{ type: "input_text", text: "initial prompt" }],
+          posted: true,
+        },
+      ],
+    });
+
+    await useChatStore.getState().send("follow up", "agent_xyz");
+
+    const state = useChatStore.getState();
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.pendingUserMessages[0]?.content).toEqual([
+      { type: "input_text", text: "follow up" },
+    ]);
+    expect(state.blocks.filter((b) => b.type === "user_message")).toHaveLength(1);
+  });
+
   it("tears the old pump down before rebinding after a failed snapshot", async () => {
     // A snapshot failure leaves `conversationLoadError` set while the pump it
     // opened is STILL RUNNING — `bindStream` catches the error without aborting

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -3266,11 +3266,22 @@ async function bindStream(
         content: p.content,
         ...(p.createdBy !== undefined ? { author: p.createdBy } : {}),
       });
+      const serverPending = (session.pendingInputs ?? []).map(toPending);
+      const pendingStillOnServer = new Set<string>();
       let candidatePending: PendingUserMessage[];
       if (!hydratePending) {
         candidatePending = state.pendingUserMessages;
+        // A reconnect can miss the consumed event that normally promotes an
+        // optimistic bubble. Preserve server-known entries; allow a posted
+        // entry that already committed to reconcile against the snapshot.
+        const unmatchedServer = serverPending.map((p) => contentKeyOf(p.content));
+        for (const pending of candidatePending) {
+          const i = unmatchedServer.indexOf(contentKeyOf(pending.content));
+          if (i === -1) continue;
+          pendingStillOnServer.add(pending.tempId);
+          unmatchedServer.splice(i, 1);
+        }
       } else {
-        const serverPending = (session.pendingInputs ?? []).map(toPending);
         // One-to-one consumption so two identical queued sends still match
         // pairwise. Content (not text) equality so image-only messages
         // correlate too.
@@ -3300,12 +3311,26 @@ async function bindStream(
       // (The old baseline arithmetic existed only because `switchTo` used to
       // destroy state and restore bubbles from a stash, which could collide
       // with an older identical message in history.)
-      const dedupePending = hydratePending && candidatePending.length > 0;
+      const dedupePending =
+        candidatePending.length > 0 &&
+        (hydratePending ||
+          candidatePending.some(
+            (p) =>
+              !pendingStillOnServer.has(p.tempId) &&
+              (p.posted === true || !p.tempId.startsWith("pend_")),
+          ));
       const committedUserTexts = dedupePending ? committedUserTextsOf(allBlocks) : [];
       const countEndsWith = (texts: string[], suffix: string): number =>
         texts.reduce((n, c) => (c.endsWith(suffix) ? n + 1 : n), 0);
       const snapshotPending: PendingUserMessage[] = dedupePending
         ? candidatePending.filter((p) => {
+            if (
+              !hydratePending &&
+              (pendingStillOnServer.has(p.tempId) ||
+                (p.posted !== true && p.tempId.startsWith("pend_")))
+            ) {
+              return true;
+            }
             const text = messageContentText(p.content);
             if (text === "") return true;
             return countEndsWith(committedUserTexts, text) === 0;


### PR DESCRIPTION
## Related issue

Part of #5115. These provider-neutral wake/reconnect fixes are separated from the Sprites implementation and can be reviewed independently; the draft provider PR #6219 will close the feature request. This branch is not bundled into #6219.

## Summary

- Treat waking a resumable managed sandbox as a handoff: retire the stale relay, temporarily suppress stale disconnect/reconnect binding, and let the parked message dispatch establish the replacement relay. Bound suppression to the wake lifetime, including when another launch already owns the tracker entry.
- Report `waking` / "Waking sandbox" instead of provisioning, avoid unexpected-disconnect errors after an already-completed idle turn, and reconcile an optimistic message with the server snapshot when reconnect misses its consumed event.
- Sanitize proxied terminal WebSocket close codes so reserved/invalid codes are not forwarded to the browser. Preserve genuine active-turn failures. No Sprites-specific code or deployment configuration is added.

In plain language: resuming a sleeping sandbox should look like a brief wake-up, not a failed session or a second copy of the user's prompt.

```text
follow-up -> retire stale relay -> wake + reconnect -> dispatch parked input
                |                     |
                +-- bounded expected-disconnect suppression --+
```

## Test Plan

On the rebased branch (base `4e41d4fb2`):

```bash
uv run pytest -p no:rerunfailures tests/server/routes/test_sessions_runner_relay.py tests/server/routes/test_terminal_attach.py tests/server/test_schemas.py tests/server/integration/test_host_session_binding.py
uv run pytest -p no:rerunfailures tests/server/test_openapi_drift.py
uv run pytest -p no:rerunfailures tests/e2e_ui/chat/test_managed_sandbox_wake.py tests/e2e_ui/chat/test_queued_message_lifecycle.py
cd web
pnpm exec vitest run src/lib/sessionEvents.test.ts src/pages/RunnerStartingIndicator.test.tsx src/store/chatStore.test.ts
cd ..
uv run pre-commit run --from-ref upstream/main --to-ref HEAD
```

159 backend tests (including the OpenAPI drift checks) and 521 focused frontend tests passed; all applicable pre-commit checks, including TypeScript, passed. A broader web run had 6,502 passing tests and three `NewChatDialog.test.tsx` failures; the identical three failures reproduced on untouched upstream `4e41d4fb2`.

New browser regressions exercise the real SPA with server-backed history and a controlled HTTP/SSE boundary: wake status from both snapshots and live events, advancement to ready, and missed-consumed-event reconciliation for both Claude-native and Codex-native session contracts, including preservation of a genuinely queued identical prompt. These tests do not launch real native CLIs or provision a live sandbox.

All 6 new browser cases and the 3 existing optimistic-message lifecycle tests passed (9 total). Negative-control validation: temporarily disabling live `waking` parsing and rebind deduplication produced the expected missing-indicator failure and duplicate-prompt failures in all 4 native-session cases. Restoring the fixes and rebuilding returned the browser suite to green.

Manual lifecycle check: send a follow-up to a sleeping managed sandbox. Expect "Waking sandbox", one copy of the submitted prompt, and a normal reply without a stale-host error. After a completed turn, an idle disconnect must not become an execution error. This full live check was not rerun on the rebased branch.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Actual `RunnerStartingIndicator` rendered from this branch with simulated `sandboxStatus.stage = "waking"`. The surrounding message is fixture content. This is a component screenshot, not evidence of a live Sprite lifecycle run.

![Managed sandbox wake indicator component preview](https://raw.githubusercontent.com/superfly/omnigent/3c7f1a566416c0c33a9224196c423e4be52c4800/docs/pr-demos/managed-wake-preview.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification here is limited to visually inspecting the actual wake-indicator component screenshot. Backend tests cover wake-marker cleanup, expected versus unexpected relay loss, terminal close-code validation, and host binding. Frontend unit and browser tests cover wake-stage handling and optimistic-message reconciliation. Full live end-to-end validation on this rebase remains outstanding.

## Changelog

Managed sandbox resumes show a wake-up indicator and avoid stale disconnect errors and duplicate prompts during reconnect.
