### PR TITLE
feat: add Sprites as a managed sandbox provider

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -84,6 +84,9 @@ deploy/
 ├── blaxel/            ← Blaxel sandbox-provider guide + managed-host config;
 │   └── README.md         NOT a server deploy target.
 │
+├── sprites/           ← Sprites managed sandbox-provider guide (persistent
+│   └── README.md         filesystem + native bootstrap); NOT a server target.
+│
 ├── islo/              ← Islo sandbox-provider guide (gateway credential
 │   └── README.md         injection); NOT a server deploy target.
 │
@@ -281,7 +284,7 @@ omnigent sandbox connect --provider modal --sandbox-id <id> --server https://you
 > rather than a registry image — build it once first; see
 > [`e2b/README.md`](e2b/README.md).
 
-**Server-managed (Modal, Daytona, Blaxel, Islo, or E2B).** With *managed hosts*, creating a
+**Server-managed (Modal, Daytona, Sprites, Blaxel, Islo, or E2B).** With *managed hosts*, creating a
 session with `"host_type": "managed"` (e.g.
 `POST /v1/sessions {"agent_id": ..., "host_type": "managed"}`) makes the
 server provision a sandbox, start a host in it, and run the session there.
@@ -297,7 +300,7 @@ sandbox:
 
 Modal credentials come from the server's environment (`MODAL_TOKEN_ID` /
 `MODAL_TOKEN_SECRET`, or a mounted `~/.modal.toml`), not the config file.
-Daytona reads `DAYTONA_API_KEY`. Blaxel reads `BL_WORKSPACE` and `BL_API_KEY`. Islo reads `ISLO_API_KEY` and optional `ISLO_BASE_URL`. E2B reads `E2B_API_KEY` from the server environment.
+Daytona reads `DAYTONA_API_KEY`. Sprites reads `SPRITE_TOKEN`. Blaxel reads `BL_WORKSPACE` and `BL_API_KEY`. Islo reads `ISLO_API_KEY` and optional `ISLO_BASE_URL`. E2B reads `E2B_API_KEY` from the server environment.
 Each sandbox authenticates back with a server-minted, per-launch token, so
 no user credentials ever enter the sandbox.
 
@@ -318,6 +321,12 @@ sandbox:
 ```
 
 For private registries, set `OMNIGENT_MODAL_REGISTRY_SECRET` on the server to the name of a Modal secret holding `REGISTRY_USERNAME` and `REGISTRY_PASSWORD`. For CLI-launched sandboxes, `OMNIGENT_MODAL_HOST_IMAGE`, `OMNIGENT_DAYTONA_HOST_IMAGE`, `OMNIGENT_BLAXEL_HOST_IMAGE`, or `OMNIGENT_ISLO_HOST_IMAGE` overrides the image.
+
+Sprites are the exception: they do not accept a caller-supplied container
+image. Their persistent Ubuntu filesystem is bootstrapped once with OS tools,
+an isolated Omnigent install, and the coding-harness CLIs, then reused across
+wakes. See the [Sprites guide](sprites/README.md#why-there-is-no-custom-image)
+for the `install_spec` workflow and first-launch tradeoff.
 
 **LLM credentials for managed sessions.** A fresh sandbox has no API keys.
 Park your provider credentials in a [Modal secret](https://modal.com/secrets)
@@ -345,7 +354,7 @@ sandbox:
     secrets: [omnigent-llm]
 ```
 
-For Daytona, Blaxel, and Islo, list server environment variable names under `sandbox.daytona.env`, `sandbox.blaxel.env`, or `sandbox.islo.env`. The launcher copies the current server values into each sandbox:
+For Daytona, Sprites, Blaxel, and Islo, list server environment variable names under the provider's `env` block. The launcher copies the current server values into each sandbox:
 
 ```yaml
 sandbox:
@@ -370,7 +379,7 @@ a Modal secret (GitLab: add `GIT_USERNAME=oauth2`). The host image's git
 credential helper picks it up for the clone and for the agent's later
 fetch/push.
 
-See the [`modal`](modal/README.md), [`daytona`](daytona/README.md), [`blaxel`](blaxel/README.md), and [`islo`](islo/README.md) guides for provider setup and troubleshooting.
+See the [`modal`](modal/README.md), [`daytona`](daytona/README.md), [`sprites`](sprites/README.md), [`blaxel`](blaxel/README.md), and [`islo`](islo/README.md) guides for provider setup and troubleshooting.
 
 ## Auth
 

--- a/deploy/sprites/README.md
+++ b/deploy/sprites/README.md
@@ -1,0 +1,157 @@
+# Omnigent on Sprites
+
+[Sprites](https://sprites.dev) are persistent Linux environments that
+hibernate when idle. Omnigent supports them as a **server-managed** sandbox:
+creating a session with `host_type: "managed"` provisions a Sprite, installs
+the host toolchain, clones the requested repository, and registers the host
+with the server. Deleting the session destroys the Sprite.
+
+The Sprites launcher is managed-only. It does not currently participate in
+the interactive `omnigent sandbox create` / `connect` CLI flow.
+
+## Prerequisites
+
+Install the optional SDK extra in the **server** environment and provide a
+Sprites organization token:
+
+```bash
+pip install 'omnigent[sprites]'
+export SPRITE_TOKEN=...
+```
+
+The server must have a public URL that a Sprite can reach.
+
+## Server configuration
+
+Add this block to the config passed to `omnigent server -c config.yaml` (or
+the server data directory's `config.yaml`):
+
+```yaml
+sandbox:
+  provider: sprites
+  server_url: https://omnigent.example.com
+  sprites:
+    env: [OPENAI_API_KEY, GIT_TOKEN]
+    allow_control_plane_credentials: true
+```
+
+`sandbox.sprites.env` contains environment variable **names**, not values.
+Each name must exist in the server process environment; the launcher copies
+its value into the Sprite service. The usual Omnigent runner forwarding rules
+then carry model credentials to agent processes. `GIT_TOKEN` enables cloning
+and later fetch/push for private HTTPS repositories.
+
+Because the Sprites Service API has no separate secret-reference primitive,
+these values cross the Sprites control plane and remain in the Service
+definition. Omnigent therefore rejects a non-empty `env` list unless
+`allow_control_plane_credentials: true` explicitly acknowledges that boundary.
+See [Credential boundary](#credential-boundary) below.
+
+Optional settings:
+
+```yaml
+sandbox:
+  provider: sprites
+  server_url: https://omnigent.example.com
+  sprites:
+    api_url: https://api.sprites.dev
+    runtime: default                 # default or dev
+    install_spec: omnigent==0.11.0   # any pip-compatible requirement
+    env: [OPENAI_API_KEY, GIT_TOKEN]
+    allow_control_plane_credentials: true
+```
+
+`SPRITES_API_URL` provides the API URL fallback when `api_url` is omitted.
+
+## Why there is no custom image
+
+Image-based providers start Omnigent from
+`ghcr.io/omnigent-ai/omnigent-host`. Sprites do not expose a caller-supplied
+container-image boot path; they provide a persistent Ubuntu filesystem
+instead. The launcher translates the host image's runtime contract into a
+one-time native bootstrap:
+
+1. Install the required OS tools (`git`, `tmux`, `procps`, `lsof`,
+   `bubblewrap`, `curl`, and certificates).
+2. Create a persistent virtual environment under
+   `~/.local/share/omnigent-host/venv`.
+3. Install the configured Omnigent package requirement.
+4. Install pinned Claude Code, Codex, and Pi coding CLIs under `~/.local`.
+5. Record a bootstrap marker only after every binary check succeeds.
+
+The Sprite filesystem survives hibernation, so later launches reuse that
+installation. The marker includes `install_spec` and every exact agent-CLI
+package version. Changing Omnigent or any CLI pin invalidates it and reruns the
+install, so Sprites provisioned at different times receive the same toolchain.
+The bootstrap is retry-safe after a partial failure; if initial provisioning
+fails, Omnigent destroys the incomplete Sprite.
+
+The default install requirement is the exact version running on the server
+(`omnigent==<version>`). For an unpublished development build, publish a wheel
+to an authenticated package source reachable from the Sprite or set
+`install_spec` to a reachable wheel URL:
+
+```yaml
+sprites:
+  install_spec: "omnigent @ https://artifacts.example.com/omnigent-dev.whl"
+```
+
+That requirement is the practical custom-image replacement for Python code.
+Additional system packages still require extending Omnigent's bootstrap (or a
+future configurable bootstrap hook); there is no Dockerfile escape hatch.
+New Sprites must provide Python 3, npm, and root or passwordless `sudo`.
+
+## Services, hibernation, and active turns
+
+The launcher creates an `omnigent-host` Sprite Service with the host identity,
+launch token, model/git environment, repository working directory, and
+augmented `PATH`. Services restart after a cold wake, so Omnigent refreshes
+the token and service definition whenever a managed host resumes.
+
+A Service alone does not protect an outbound WebSocket from suspension.
+During active work, Omnigent's provider-neutral runner lease tracks turns,
+native harness status, async tools, timers, and approvals. Its Sprites adapter
+uses the local Tasks API (`/.sprite/api.sock`) to upsert a five-minute activity
+task every minute. It deletes the task after work drains and a short grace
+period; if the runner crashes, expiry releases the hold. The accounting is
+shared across Claude Code, Codex, Pi, and other harnesses.
+
+An idle Sprite may appear offline after its tunnel is suspended. Resuming the
+managed host wakes it with an exec, refreshes its host token, and reapplies the
+Service definition without reinstalling the filesystem.
+
+## Credential boundary
+
+`SPRITE_TOKEN` stays in the Omnigent server and is used only by `sprites-py`.
+The Sprite receives a scoped Omnigent managed-host launch token so it can
+register with the server.
+
+Values named by `sandbox.sprites.env` are different: the Sprites Service API
+accepts environment values but has no secret-reference field. The current POC
+must send those values through the provider API and store them in the
+`omnigent-host` Service environment. To limit exposure:
+
+- Passthrough is disabled unless the operator explicitly enables
+  `allow_control_plane_credentials`.
+- Values are never interpolated into bootstrap or maintenance command strings.
+- Repository clone execs receive only `GIT_TOKEN` / `GIT_USERNAME`; model
+  credentials are not attached to those execs.
+- Operators should use narrowly scoped, revocable credentials and omit `env`
+  when the harness can authenticate another way.
+
+Avoiding provider-control-plane transit entirely requires a separate credential
+handoff: retain vendor credentials on the Omnigent server, authenticate the
+host with its managed launch token, and deliver short-lived credentials over
+the direct TLS connection between the host and Omnigent. That broker is not
+part of this POC and should be designed as a provider-neutral follow-up rather
+than hidden inside the Sprites launcher.
+
+## Operational notes
+
+- First provision is slower than an image-backed provider because apt, pip,
+  and npm run inside the Sprite. Warm/cold resumes skip this bootstrap.
+- The token is read only from `SPRITE_TOKEN`; do not store it in YAML.
+- Environment values listed in `sprites.env` cross the Sprites control plane.
+  Prefer narrowly scoped model and repository credentials.
+- Session deletion is destructive: it destroys the associated Sprite and its
+  persistent filesystem.

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -74,6 +74,8 @@ from omnigent.tools.base import Tool, ToolContext
 
 _logger = logging.getLogger(__name__)
 
+CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR = "OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING"
+_SANDBOX_ENV_VAR = "IS_SANDBOX"
 BRIDGE_DIR_ENV_VAR = "HARNESS_CLAUDE_NATIVE_BRIDGE_DIR"
 REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CLAUDE_NATIVE_REQUEST_SESSION_ID"
 BRIDGE_ID_LABEL_KEY = "omnigent.claude_native.bridge_id"
@@ -1402,10 +1404,10 @@ def build_hook_settings(
     api_key_helper: str | None = None,
     launch_model: str | None = None,
     launch_permission_mode: str | None = None,
-    launch_bypass_permissions: bool = False,
     launch_effort: str | None = None,
     subagent_router_dir: Path | None = None,
     turn_routing: bool = False,
+    accept_bypass_permissions_warning: bool = False,
 ) -> _JsonObject:
     """
     Build invocation-local Claude Code hook settings.
@@ -1432,11 +1434,6 @@ def build_hook_settings(
     :param launch_permission_mode: Effective launch permission mode from
         ``--permission-mode``. Mirrored into ``permissions.defaultMode``
         for the same re-exec hardening.
-    :param launch_bypass_permissions: ``True`` when this launch requests
-        bypass mode (``--dangerously-skip-permissions`` or
-        ``--permission-mode bypassPermissions``), which sets
-        ``skipDangerousModePermissionPrompt`` so the one-time acceptance
-        dialog never blocks a host-spawned terminal.
     :param launch_effort: Effective launch effort from ``--effort``.
         Mirrored into ``effortLevel`` for restart/re-exec parity.
     :param subagent_router_dir: Directory where the runner advertises its
@@ -1449,6 +1446,10 @@ def build_hook_settings(
         routing round trip (25s worst case on a degraded server) in front of
         every prompt of every native session, to be told every time that the
         session does not route.
+    :param accept_bypass_permissions_warning: Allow the invocation settings
+        to acknowledge Claude Code's one-time dangerous-mode warning. The
+        setting is emitted only when the effective launch mode is exactly
+        ``bypassPermissions``.
     :returns: JSON-serializable Claude settings fragment.
     """
     python = python_executable or sys.executable
@@ -1690,13 +1691,7 @@ def build_hook_settings(
         settings["model"] = launch_model
     if launch_permission_mode:
         settings["permissions"] = {"defaultMode": launch_permission_mode}
-    if launch_bypass_permissions:
-        # Bypass mode shows a one-time "Bypass Permissions mode" acceptance
-        # dialog. Like the trust/onboarding gates it fires no
-        # PermissionRequest hook, so a host-spawned terminal has nobody to
-        # answer it and the session hangs with a blank web UI. Claude checks
-        # the org policy (``disableBypassPermissionsMode``) BEFORE this
-        # consent gate, so a managed host still strips bypass regardless.
+    if accept_bypass_permissions_warning and launch_permission_mode == "bypassPermissions":
         settings["skipDangerousModePermissionPrompt"] = True
     if launch_effort and launch_effort in CLAUDE_EFFORTS:
         settings["effortLevel"] = launch_effort
@@ -1798,6 +1793,7 @@ def augment_claude_args(
     allowed_tools: tuple[str, ...] = (),
     subagent_router_dir: Path | None = None,
     turn_routing: bool = False,
+    accept_bypass_permissions_warning: bool = False,
 ) -> list[str]:
     """
     Return Claude CLI args with Omnigent MCP/hook/skill injection.
@@ -1846,6 +1842,9 @@ def augment_claude_args(
         Routing on, threaded to :func:`build_hook_settings` so the
         ``UserPromptSubmit`` first-message routing hook is registered.
         ``False`` keeps every prompt off the routing round trip.
+    :param accept_bypass_permissions_warning: Explicit sandbox-launcher opt-in
+        for Claude Code's one-time dangerous-mode warning. Non-bypass launches
+        ignore it.
     :returns: Augmented argument list for the terminal resource.
     """
     mcp_config = build_mcp_config(bridge_dir, python_executable=python_executable)
@@ -1857,10 +1856,10 @@ def augment_claude_args(
         api_key_helper=api_key_helper,
         launch_model=_arg_value(claude_args, "--model"),
         launch_permission_mode=_arg_value(claude_args, "--permission-mode"),
-        launch_bypass_permissions=_args_request_bypass_permissions(claude_args),
         launch_effort=_arg_value(claude_args, "--effort"),
         subagent_router_dir=subagent_router_dir,
         turn_routing=turn_routing,
+        accept_bypass_permissions_warning=accept_bypass_permissions_warning,
     )
     args = _merge_disallowed_tools(list(claude_args), _OMNIGENT_DISALLOWED_TOOLS)
     args = _merge_allowed_tools(args, allowed_tools)
@@ -1889,6 +1888,24 @@ def augment_claude_args(
     return args
 
 
+def sandbox_bypass_warning_acceptance_enabled(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether this process explicitly permits warning acceptance.
+
+    A generic sandbox marker is insufficient by itself. The sandbox launcher
+    must also opt in through the dedicated Claude setting.
+
+    :param environ: Environment mapping; ``None`` reads :data:`os.environ`.
+    :returns: ``True`` only when both gates are exactly ``"1"``.
+    """
+    values = os.environ if environ is None else environ
+    return (
+        values.get(_SANDBOX_ENV_VAR) == "1"
+        and values.get(CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR) == "1"
+    )
+
+
 def _arg_value(args: tuple[str, ...], flag: str) -> str | None:
     """Return the effective CLI flag value from ``args``.
 
@@ -1913,21 +1930,6 @@ def _arg_value(args: tuple[str, ...], flag: str) -> str | None:
             if candidate and not candidate.startswith("--"):
                 value = candidate
     return value
-
-
-def _args_request_bypass_permissions(args: tuple[str, ...]) -> bool:
-    """Return whether ``args`` launch Claude Code in bypass-permissions mode.
-
-    Both spellings count: the standalone ``--dangerously-skip-permissions``
-    flag, and ``--permission-mode bypassPermissions`` (the form
-    ``permission_mode: bypassPermissions`` in a worker bundle becomes).
-
-    :param args: Claude CLI args, e.g. ``("--dangerously-skip-permissions",)``.
-    :returns: ``True`` when this launch requests bypass mode.
-    """
-    return "--dangerously-skip-permissions" in args or (
-        _arg_value(args, "--permission-mode") == "bypassPermissions"
-    )
 
 
 def _merge_allowed_tools(args: list[str], extra: tuple[str, ...]) -> list[str]:

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -247,7 +247,11 @@ elif previous:
 """
 
 
-def render_host_config_write_command(host_config: dict[str, object]) -> str:
+def render_host_config_write_command(
+    host_config: dict[str, object],
+    *,
+    python_executable: str = "python3",
+) -> str:
     """
     Build the remote command that installs *host_config* into the
     sandbox's config directory before ``omnigent host`` starts. The directory
@@ -286,12 +290,15 @@ def render_host_config_write_command(host_config: dict[str, object]) -> str:
     :param host_config: The validated ``sandbox.host_config`` mapping
         (see :func:`omnigent.server.managed_hosts.parse_sandbox_config`),
         or ``{}`` to only remove previously injected entries.
+    :param python_executable: Python interpreter available in the sandbox.
+        Providers with an isolated host environment can point this at that
+        environment so the script sees Omnigent's PyYAML dependency.
     :returns: A ``python3 -c '<script>'`` shell command, safe to pass to
         :meth:`SandboxLauncher.run` or embed in a larger shell script.
     """
     payload = base64.b64encode(json.dumps(host_config).encode()).decode()
     script = _HOST_CONFIG_WRITE_SCRIPT.replace("__PAYLOAD__", repr(payload))
-    return f"python3 -c {shlex.quote(script)}"
+    return f"{shlex.quote(python_executable)} -c {shlex.quote(script)}"
 
 
 class SandboxCapabilityError(click.ClickException, _sandbox_types.SandboxError):

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -144,6 +144,11 @@ def _builtin_contribution() -> SandboxProviderContribution:
                 launcher_class="omnigent.onboarding.sandboxes.daytona:DaytonaSandboxLauncher",
                 managed_token_ttl_s=7 * 24 * 3600,
             ),
+            "sprites": SandboxProviderMetadata(
+                name="sprites",
+                launcher_class="omnigent.onboarding.sandboxes.sprites:SpritesSandboxLauncher",
+                managed_token_ttl_s=7 * 24 * 3600,
+            ),
             "blaxel": SandboxProviderMetadata(
                 name="blaxel",
                 launcher_class="omnigent.onboarding.sandboxes.blaxel:BlaxelSandboxLauncher",

--- a/omnigent/onboarding/sandboxes/sprites.py
+++ b/omnigent/onboarding/sandboxes/sprites.py
@@ -1,0 +1,529 @@
+"""
+Sprites sandbox launcher.
+
+Implements the server-managed subset of
+:class:`~omnigent.onboarding.sandboxes.base.SandboxLauncher` on top of
+`Sprites <https://sprites.dev>`_. Sprites boot a persistent Ubuntu filesystem
+rather than a caller-supplied container image, so provisioning installs the
+Omnigent host toolchain once and records a version marker. Subsequent warm/cold
+wakes reuse that filesystem and only refresh the ``omnigent-host`` service.
+
+The Sprites SDK is an optional dependency (``pip install 'omnigent[sprites]'``)
+and is imported lazily so base Omnigent installs do not require it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+from collections.abc import Sequence
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import click
+
+from omnigent.claude_native_bridge import CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR
+from omnigent.host.identity import HOST_ID_ENV_VAR, HOST_NAME_ENV_VAR, HOST_TOKEN_ENV_VAR
+from omnigent.onboarding.sandboxes import types as _sandbox_types
+from omnigent.onboarding.sandboxes.base import (
+    RemoteCommandResult,
+    SandboxLauncher,
+    render_host_config_write_command,
+)
+from omnigent.runner.activity_lease import ACTIVITY_LEASE_PROVIDER_ENV_VAR
+from omnigent.version import VERSION
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+TOKEN_ENV_VAR: str = "SPRITE_TOKEN"
+"""Sprites organization token read by the server-side launcher."""
+
+API_URL_ENV_VAR: str = "SPRITES_API_URL"
+"""Optional Sprites API base URL override."""
+
+INSTALL_SPEC_ENV_VAR: str = "OMNIGENT_SPRITES_INSTALL_SPEC"
+"""Optional package spec installed into new Sprites.
+
+The default is ``omnigent==<running server version>``. Development checkouts
+whose ``.dev`` version is not published can point this at a wheel URL or another
+pip-compatible artifact.
+"""
+
+SANDBOX_ENV_PASSTHROUGH_ENV_VAR: str = "OMNIGENT_SPRITES_SANDBOX_ENV"
+"""Comma-separated server env names injected into the host service."""
+
+ALLOW_CONTROL_PLANE_CREDENTIALS_ENV_VAR: str = "OMNIGENT_SPRITES_ALLOW_CONTROL_PLANE_CREDENTIALS"
+"""Explicit opt-in for credential values crossing the Sprites control plane."""
+
+_SERVICE_NAME: str = "omnigent-host"
+_BOOTSTRAP_SCHEMA_VERSION: int = 2
+# Keep these aligned with the native-harness versions exercised by CI in
+# ``.github/ci-deps/package.json``.
+_CLAUDE_CODE_VERSION: str = "2.1.212"
+_CODEX_VERSION: str = "0.139.0"
+_PI_VERSION: str = "0.84.2"
+_AGENT_CLI_SPECS: dict[str, str] = {
+    "claude": f"@anthropic-ai/claude-code@{_CLAUDE_CODE_VERSION}",
+    "codex": f"@openai/codex@{_CODEX_VERSION}",
+    "pi": f"@earendil-works/pi-coding-agent@{_PI_VERSION}",
+}
+_COMMAND_TIMEOUT_S: float = 15 * 60
+_SPRITE_NAME_MAX_LEN: int = 63
+_RUNNING_STATUS: str = "running"
+_DORMANT_STATUSES: frozenset[str] = frozenset({"warm", "cold", "stopped"})
+_ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def _ensure_sdk() -> None:
+    """Verify the optional Sprites SDK is importable."""
+    try:
+        import sprites  # type: ignore[import-not-found]  # noqa: F401
+    except ImportError as exc:
+        raise click.ClickException(
+            "The Sprites SDK is required for the 'sprites' sandbox provider. "
+            "Install it with `pip install 'omnigent[sprites]'`, then set "
+            f"{TOKEN_ENV_VAR}."
+        ) from exc
+
+
+def _managed_sprite_name(name: str) -> str:
+    """Return a DNS-safe, provider-prefixed Sprite name."""
+    slug = re.sub(r"[^a-z0-9-]+", "-", name.lower()).strip("-")
+    if not slug:
+        slug = "host"
+    return f"omnigent-{slug}"[:_SPRITE_NAME_MAX_LEN].rstrip("-")
+
+
+def _default_install_spec() -> str:
+    """Resolve the package artifact installed into newly created Sprites."""
+    return os.environ.get(INSTALL_SPEC_ENV_VAR) or f"omnigent=={VERSION}"
+
+
+def render_bootstrap_command(install_spec: str) -> str:
+    """
+    Build the idempotent shell bootstrap for a new Sprite.
+
+    Sprites persist their full filesystem, so this command translates the
+    runtime contract of Omnigent's ``host`` container target into a one-time
+    native install: required OS tools, an isolated Python environment, and the
+    Claude/Codex/Pi CLIs. A marker is written only after every verification
+    passes, making retries safe after partial failures.
+    """
+    marker_value = json.dumps(
+        {
+            "agent_clis": _AGENT_CLI_SPECS,
+            "install_spec": install_spec,
+            "schema": _BOOTSTRAP_SCHEMA_VERSION,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    q_marker_value = shlex.quote(marker_value)
+    q_install_spec = shlex.quote(install_spec)
+    return f"""\
+set -eu
+root="$HOME/.local/share/omnigent-host"
+venv="$root/venv"
+marker="$root/bootstrap-version"
+expected={q_marker_value}
+mkdir -p "$root" "$HOME/.local/bin"
+if [ -f "$marker" ] && [ "$(cat "$marker")" = "$expected" ] \
+  && [ -x "$venv/bin/omnigent" ] \
+  && command -v tmux >/dev/null 2>&1 \
+  && command -v bwrap >/dev/null 2>&1 \
+  && [ -x "$HOME/.local/bin/claude" ] \
+  && [ -x "$HOME/.local/bin/codex" ] \
+  && [ -x "$HOME/.local/bin/pi" ]; then
+  :
+else
+missing_os_tools=0
+for tool in python3 git tmux pgrep lsof bwrap curl; do
+  command -v "$tool" >/dev/null 2>&1 || missing_os_tools=1
+done
+venv_probe="$root/.venv-probe"
+if command -v python3 >/dev/null 2>&1; then
+  python3 -m venv "$venv_probe" >/dev/null 2>&1 || missing_os_tools=1
+  rm -rf "$venv_probe"
+fi
+if [ "$missing_os_tools" -ne 0 ]; then
+  if [ "$(id -u)" -eq 0 ]; then
+    apt-get update
+    apt-get install -y --no-install-recommends \
+      python3-venv git tmux procps lsof bubblewrap curl ca-certificates unzip
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo -n apt-get update
+    sudo -n apt-get install -y --no-install-recommends \
+      python3-venv git tmux procps lsof bubblewrap curl ca-certificates unzip
+  else
+    echo "Omnigent host bootstrap needs root or passwordless sudo to install OS tools" >&2
+    exit 1
+  fi
+fi
+command -v python3 >/dev/null 2>&1 || {{
+  echo "python3 is required in the Sprite runtime" >&2
+  exit 1
+}}
+command -v npm >/dev/null 2>&1 || {{
+  echo "npm is required in the Sprite runtime" >&2
+  exit 1
+}}
+python3 -m venv "$venv"
+"$venv/bin/python" -m pip install --disable-pip-version-check --upgrade pip
+"$venv/bin/python" -m pip install --disable-pip-version-check --upgrade {q_install_spec}
+install_npm_cli() {{
+  binary="$1"
+  package="$2"
+  # A broken user-local shim should not make npm fail with EEXIST.
+  rm -f "$HOME/.local/bin/$binary"
+  npm install --global --prefix "$HOME/.local" --no-audit --no-fund "$package"
+}}
+install_npm_cli claude {shlex.quote(_AGENT_CLI_SPECS["claude"])}
+install_npm_cli codex {shlex.quote(_AGENT_CLI_SPECS["codex"])}
+install_npm_cli pi {shlex.quote(_AGENT_CLI_SPECS["pi"])}
+git config --global credential.helper \
+  '!f() {{ [ "$1" = get ] || return 0; '\
+'[ -n "$GIT_TOKEN" ] || return 0; '\
+'printf "username=%s\\npassword=%s\\n" '\
+'"${{GIT_USERNAME:-x-access-token}}" "$GIT_TOKEN"; }}; f'
+test -x "$venv/bin/omnigent"
+test -x "$HOME/.local/bin/claude"
+test -x "$HOME/.local/bin/codex"
+test -x "$HOME/.local/bin/pi"
+printf %s "$expected" > "$marker"
+fi
+"""
+
+
+class SpritesSandboxLauncher(SandboxLauncher):
+    """Managed Omnigent hosts backed by persistent Sprites."""
+
+    provider: ClassVar[str] = "sprites"
+
+    @property
+    def capabilities(self) -> _sandbox_types.SandboxCapabilities:
+        """Declare the managed-only persistent lifecycle explicitly."""
+        return _sandbox_types.SandboxCapabilities(
+            managed_launch=True,
+            resume_stopped=True,
+            programmatic_terminate=True,
+        )
+
+    def __init__(
+        self,
+        *,
+        api_url: str | None = None,
+        env: Sequence[str] | None = None,
+        allow_control_plane_credentials: bool = False,
+        runtime: str | None = None,
+        install_spec: str | None = None,
+    ) -> None:
+        self._api_url = api_url
+        self._env_names = tuple(env) if env is not None else None
+        self._allow_control_plane_credentials = allow_control_plane_credentials or (
+            os.environ.get(ALLOW_CONTROL_PLANE_CREDENTIALS_ENV_VAR) == "1"
+        )
+        self._runtime = runtime
+        self._install_spec = install_spec
+        self._client: Any | None = None
+
+    def _sprites(self) -> Any:
+        """Return the lazily constructed SDK client."""
+        if self._client is None:
+            _ensure_sdk()
+            from sprites import SpritesClient  # type: ignore[import-not-found]
+
+            api_url = self._api_url or os.environ.get(API_URL_ENV_VAR)
+            if api_url:
+                self._client = SpritesClient(
+                    os.environ[TOKEN_ENV_VAR],
+                    base_url=api_url,
+                )
+            else:
+                self._client = SpritesClient(os.environ[TOKEN_ENV_VAR])
+        return self._client
+
+    def _sprite(self, sandbox_id: str) -> Any:
+        """Return an SDK handle for *sandbox_id* without a network lookup."""
+        return self._sprites().sprite(sandbox_id)
+
+    def _resolve_sandbox_env(self) -> dict[str, str]:
+        """Resolve configured server environment variables by name."""
+        if self._env_names is not None:
+            names: Sequence[str] = self._env_names
+        else:
+            names = [
+                name.strip()
+                for name in os.environ.get(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
+                if name.strip()
+            ]
+        if names and not self._allow_control_plane_credentials:
+            raise click.ClickException(
+                "sandbox.sprites.env sends credential values through the Sprites "
+                "control plane; set sandbox.sprites.allow_control_plane_credentials "
+                f"to true (or {ALLOW_CONTROL_PLANE_CREDENTIALS_ENV_VAR}=1) to "
+                "acknowledge this, or remove sandbox.sprites.env."
+            )
+        resolved: dict[str, str] = {}
+        for name in names:
+            if _ENV_NAME_RE.fullmatch(name) is None:
+                raise click.ClickException(
+                    f"sandbox.sprites.env contains invalid environment variable name {name!r}."
+                )
+            value = os.environ.get(name)
+            if value is None:
+                raise click.ClickException(
+                    f"sandbox env passthrough names '{name}' but it is not set "
+                    "in the server's environment — set it (or remove it from "
+                    "sandbox.sprites.env / "
+                    f"{SANDBOX_ENV_PASSTHROUGH_ENV_VAR})."
+                )
+            resolved[name] = value
+        return resolved
+
+    def prepare(self) -> None:
+        """Verify the SDK and server-side Sprites token."""
+        _ensure_sdk()
+        if not os.environ.get(TOKEN_ENV_VAR):
+            raise click.ClickException(
+                f"No Sprites credentials found. Create an organization token and set "
+                f"{TOKEN_ENV_VAR}."
+            )
+        self._resolve_sandbox_env()
+
+    def provision(self, name: str) -> str:
+        """Create and bootstrap a new persistent Sprite."""
+        from sprites.exceptions import SpriteError  # type: ignore[import-not-found]
+
+        sprite_name = _managed_sprite_name(name)
+        click.echo(f"▸ Creating Sprite '{sprite_name}'")
+        try:
+            sprite = self._sprites().create_sprite(
+                sprite_name,
+                labels=["omnigent-managed"],
+                wait_for_capacity=True,
+                runtime=self._runtime,
+            )
+        except SpriteError as exc:
+            raise click.ClickException(f"Sprite creation failed: {exc}") from exc
+        sandbox_id = str(sprite.name)
+        try:
+            install_spec = self._install_spec or _default_install_spec()
+            click.echo(f"  → bootstrapping Omnigent host ({install_spec})")
+            self.run(sandbox_id, render_bootstrap_command(install_spec))
+        except Exception:
+            with suppress(Exception):
+                sprite.destroy()
+            raise
+        click.echo(f"  → created {sandbox_id}")
+        return sandbox_id
+
+    def _run_remote(
+        self,
+        sandbox_id: str,
+        command: str,
+        *,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> RemoteCommandResult:
+        """Run a Sprite command without serializing credentials into its argv."""
+        from sprites.exceptions import SpriteError  # type: ignore[import-not-found]
+
+        try:
+            result = self._sprite(sandbox_id).run(
+                "bash",
+                "-lc",
+                command,
+                capture_output=True,
+                check=False,
+                env=env,
+                timeout=_COMMAND_TIMEOUT_S,
+            )
+        except SpriteError as exc:
+            raise click.ClickException(
+                f"Remote command failed to execute on Sprite '{sandbox_id}': {exc}"
+            ) from exc
+        stdout = (result.stdout or b"").decode("utf-8", errors="replace")
+        stderr = (result.stderr or b"").decode("utf-8", errors="replace")
+        if stdout:
+            click.echo(stdout, nl=not stdout.endswith("\n"))
+        if stderr:
+            click.echo(stderr, nl=not stderr.endswith("\n"), err=True)
+        if check and result.returncode != 0:
+            diagnostic = (stderr.strip() or stdout.strip())[-2000:]
+            suffix = f"\nRemote output tail:\n{diagnostic}" if diagnostic else ""
+            raise click.ClickException(
+                f"Remote command failed on Sprite '{sandbox_id}' "
+                f"(exit {result.returncode}).{suffix}"
+            )
+        return RemoteCommandResult(returncode=result.returncode, stdout=stdout, stderr=stderr)
+
+    def run(self, sandbox_id: str, command: str, *, check: bool = True) -> RemoteCommandResult:
+        """Run a shell command inside a Sprite and capture both streams."""
+        return self._run_remote(sandbox_id, command, check=check)
+
+    def materialize_workspace(
+        self,
+        sandbox_id: str,
+        *,
+        workspace: str,
+        repo_url: str,
+        repo_branch: str | None,
+        repo_name: str | None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """Clone a repository with only the configured Git credential env."""
+        if on_stage is not None:
+            on_stage("cloning")
+        clone_dir = f"{workspace}/{repo_name}"
+        branch_args = (
+            f"--branch {shlex.quote(repo_branch)} --single-branch "
+            if repo_branch is not None
+            else ""
+        )
+        workload_env = self._resolve_sandbox_env()
+        git_env = {
+            name: value
+            for name, value in workload_env.items()
+            if name in {"GIT_TOKEN", "GIT_USERNAME"}
+        }
+        try:
+            self._run_remote(
+                sandbox_id,
+                f"git clone {branch_args}-- {shlex.quote(repo_url)} {shlex.quote(clone_dir)}",
+                env=git_env or None,
+            )
+        except click.ClickException as exc:
+            raise click.ClickException(
+                f"failed to clone repository '{repo_url}'"
+                f"{f' (branch {repo_branch!r})' if repo_branch else ''}: {exc.message}"
+            ) from exc
+        return clone_dir
+
+    def start_host(
+        self,
+        sandbox_id: str,
+        *,
+        token: str,
+        host_id: str,
+        host_name: str,
+        server_url: str,
+        repo_url: str | None = None,
+        repo_branch: str | None = None,
+        repo_name: str | None = None,
+        host_config: dict[str, object] | None = None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """Create/update the cold-wake-safe ``omnigent-host`` service."""
+        from sprites.exceptions import SpriteError  # type: ignore[import-not-found]
+
+        home = self.run(sandbox_id, 'printf %s "$HOME"').stdout.strip()
+        if not home:
+            raise click.ClickException(f"could not resolve $HOME inside Sprite '{sandbox_id}'")
+        workspace = f"{home}/workspace"
+        self.run(sandbox_id, f"mkdir -p {shlex.quote(workspace)}")
+        if repo_url is not None:
+            workspace = self.materialize_workspace(
+                sandbox_id,
+                workspace=workspace,
+                repo_url=repo_url,
+                repo_branch=repo_branch,
+                repo_name=repo_name,
+                on_stage=on_stage,
+            )
+        if on_stage is not None:
+            on_stage("starting")
+        host_python = f"{home}/.local/share/omnigent-host/venv/bin/python"
+        self.run(
+            sandbox_id,
+            render_host_config_write_command(
+                host_config or {},
+                python_executable=host_python,
+            ),
+        )
+        base_path = self.run(sandbox_id, 'printf %s "$PATH"').stdout.strip()
+        service_env = {
+            **self._resolve_sandbox_env(),
+            "PATH": f"{home}/.local/bin:{base_path or '/usr/local/bin:/usr/bin:/bin'}",
+            "IS_SANDBOX": "1",
+            ACTIVITY_LEASE_PROVIDER_ENV_VAR: "sprites",
+            CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR: "1",
+            HOST_TOKEN_ENV_VAR: token,
+            HOST_ID_ENV_VAR: host_id,
+            HOST_NAME_ENV_VAR: host_name,
+        }
+        executable = f"{home}/.local/share/omnigent-host/venv/bin/omnigent"
+        click.echo(f"▸ Starting Omnigent host service on Sprite '{sandbox_id}'")
+        try:
+            stream = self._sprite(sandbox_id).create_service(
+                _SERVICE_NAME,
+                cmd=executable,
+                args=["host", "--server", server_url],
+                env=service_env,
+                dir=workspace,
+            )
+            for event in stream:
+                event_type = getattr(event, "type", "")
+                data = getattr(event, "data", None)
+                if event_type in {"stdout", "stderr", "info"} and data:
+                    click.echo(str(data), err=event_type == "stderr")
+                if event_type == "error":
+                    raise click.ClickException(
+                        f"Omnigent host service failed on Sprite '{sandbox_id}': "
+                        f"{data or getattr(event, 'error', 'unknown service error')}"
+                    )
+        except SpriteError as exc:
+            raise click.ClickException(
+                f"Could not start Omnigent host service on Sprite '{sandbox_id}': {exc}"
+            ) from exc
+        return workspace
+
+    def resume(self, sandbox_id: str) -> None:
+        """Wake a Sprite and remove the stale auto-started host service.
+
+        Sprites automatically restart persisted services when cold compute
+        wakes.  The existing ``omnigent-host`` definition still carries the
+        previous managed-host token, while :func:`resume_managed_host` mints a
+        new token before calling :meth:`start_host`.  If the old service is
+        left running, updating its definition does not reliably restart the
+        process and it reconnects with the revoked token (HTTP 403).
+
+        Delete the persisted definition after waking.  ``start_host`` then
+        recreates it with the fresh token and the workspace remains untouched.
+        """
+        click.echo(f"▸ Waking Sprite '{sandbox_id}'")
+        self.run(sandbox_id, "true")
+        sprite = self._sprite(sandbox_id)
+        services = sprite.list_services()
+        if any(getattr(service, "name", None) == _SERVICE_NAME for service in services):
+            sprite.delete_service(_SERVICE_NAME)
+
+    def is_running(self, sandbox_id: str) -> bool | None:
+        """Return whether Sprites reports this sandbox as actively running."""
+        from sprites.exceptions import NotFoundError, SpriteError  # type: ignore[import-not-found]
+
+        try:
+            status = str(self._sprites().get_sprite(sandbox_id).status or "").lower()
+        except NotFoundError:
+            return False
+        except SpriteError as exc:
+            raise click.ClickException(f"Could not inspect Sprite '{sandbox_id}': {exc}") from exc
+        if status == _RUNNING_STATUS:
+            return True
+        if status in _DORMANT_STATUSES:
+            return False
+        return None
+
+    def terminate(self, sandbox_id: str) -> None:
+        """Destroy a Sprite; missing Sprites are already terminated."""
+        from sprites.exceptions import NotFoundError, SpriteError  # type: ignore[import-not-found]
+
+        try:
+            self._sprites().destroy_sprite(sandbox_id)
+        except NotFoundError:
+            return
+        except SpriteError as exc:
+            raise click.ClickException(f"Could not destroy Sprite '{sandbox_id}': {exc}") from exc

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -27,6 +27,7 @@ from fastapi import FastAPI
 from omnigent._platform import IS_WINDOWS
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.inner import _proc
+from omnigent.runner.activity_lease import activity_lease_from_env, run_activity_lease
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
 from omnigent.version import VERSION
 
@@ -1788,6 +1789,16 @@ async def _run_tunnel_from_env() -> None:
             ),
             name=f"runner-idle-monitor:{runner_id}",
         )
+    activity_lease = activity_lease_from_env(runner_id)
+    activity_lease_task: asyncio.Task[None] | None = None
+    if activity_lease is not None:
+        activity_lease_task = asyncio.create_task(
+            run_activity_lease(
+                lease=activity_lease,
+                has_active_work=_has_active_work,
+            ),
+            name=f"runner-activity-lease:{runner_id}",
+        )
     if parent_pid is not None:
 
         def _request_parent_death_shutdown() -> None:
@@ -1854,6 +1865,10 @@ async def _run_tunnel_from_env() -> None:
         if idle_task is not None:
             with contextlib.suppress(asyncio.CancelledError):
                 await idle_task
+        if activity_lease_task is not None:
+            activity_lease_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await activity_lease_task
         if direct_attach_listener is not None:
             with contextlib.suppress(Exception):
                 await direct_attach_listener.stop()

--- a/omnigent/runner/activity_lease.py
+++ b/omnigent/runner/activity_lease.py
@@ -1,0 +1,176 @@
+"""Provider-neutral activity leases for suspendable managed runners."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import os
+from collections.abc import Callable
+from typing import Protocol, TypeAlias
+
+ACTIVITY_LEASE_PROVIDER_ENV_VAR = "OMNIGENT_ACTIVITY_LEASE_PROVIDER"
+_DEFAULT_POLL_INTERVAL_S = 1.0
+_DEFAULT_REFRESH_INTERVAL_S = 60.0
+_DEFAULT_RELEASE_GRACE_S = 30.0
+_DEFAULT_RETRY_INTERVAL_S = 5.0
+
+logger = logging.getLogger(__name__)
+
+
+class ActivityLeaseError(Exception):
+    """A provider activity lease operation failed."""
+
+
+class ActivityLease(Protocol):
+    """Provider adapter that can refresh and release an activity hold."""
+
+    provider: str
+
+    async def refresh(self) -> None:
+        """Create or extend the provider's activity hold."""
+
+    async def release(self) -> None:
+        """Release the provider's activity hold if it exists."""
+
+    async def aclose(self) -> None:
+        """Close resources owned by the adapter."""
+
+
+ActivityLeaseFactory: TypeAlias = Callable[[str], ActivityLease]
+
+_ACTIVITY_LEASE_FACTORIES: dict[str, ActivityLeaseFactory] = {}
+_BUILTIN_LEASE_MODULES: dict[str, str] = {}
+
+
+def register_activity_lease_provider(provider: str, factory: ActivityLeaseFactory) -> None:
+    """Register a provider adapter factory with the runner lease framework.
+
+    Provider integrations own their adapter and registration. The shared
+    runner lifecycle resolves only the provider name and its lazily loaded
+    module; it never imports a concrete adapter eagerly.
+
+    :param provider: Environment-facing provider name, e.g. ``"acme"``.
+    :param factory: Callable that builds a lease for a stable runner id.
+    :raises ValueError: If *provider* is empty or already registered.
+    """
+    normalized = provider.strip().lower()
+    if not normalized:
+        raise ValueError("activity lease provider name must not be empty")
+    existing = _ACTIVITY_LEASE_FACTORIES.get(normalized)
+    if existing is not None and existing is not factory:
+        raise ValueError(f"activity lease provider {normalized!r} is already registered")
+    _ACTIVITY_LEASE_FACTORIES[normalized] = factory
+
+
+def activity_lease_from_env(runner_id: str) -> ActivityLease | None:
+    """Build the explicitly configured activity-lease backend, if any.
+
+    The runner never guesses from filesystem artifacts. A sandbox launcher
+    opts in by setting ``OMNIGENT_ACTIVITY_LEASE_PROVIDER`` in the host
+    service environment.
+
+    :param runner_id: Stable runner id used to namespace provider leases.
+    :returns: Configured lease adapter, or ``None`` when leasing is disabled.
+    :raises RuntimeError: If the configured backend is unsupported.
+    """
+    provider = os.environ.get(ACTIVITY_LEASE_PROVIDER_ENV_VAR)
+    if provider is None:
+        return None
+    provider = provider.strip().lower()
+    if not provider:
+        raise RuntimeError(f"{ACTIVITY_LEASE_PROVIDER_ENV_VAR} must not be empty")
+    factory = _ACTIVITY_LEASE_FACTORIES.get(provider)
+    module_name = _BUILTIN_LEASE_MODULES.get(provider)
+    if factory is None and module_name is not None:
+        module = importlib.import_module(module_name)
+        register = getattr(module, "register_activity_lease_provider", None)
+        if not callable(register):
+            raise RuntimeError(
+                f"activity lease module {module_name!r} does not expose "
+                "register_activity_lease_provider()"
+            )
+        register()
+        factory = _ACTIVITY_LEASE_FACTORIES.get(provider)
+    if factory is None:
+        raise RuntimeError(
+            f"unsupported activity lease provider {provider!r} in "
+            f"{ACTIVITY_LEASE_PROVIDER_ENV_VAR}"
+        )
+    return factory(runner_id)
+
+
+async def run_activity_lease(
+    *,
+    lease: ActivityLease,
+    has_active_work: Callable[[], bool],
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    refresh_interval_s: float = _DEFAULT_REFRESH_INTERVAL_S,
+    release_grace_s: float = _DEFAULT_RELEASE_GRACE_S,
+    retry_interval_s: float = _DEFAULT_RETRY_INTERVAL_S,
+) -> None:
+    """Hold a suspendable runner active only while work is outstanding.
+
+    Activity accounting is supplied by the runner and is independent of both
+    the selected harness and the sandbox provider. The adapter owns the
+    provider-specific acquire/release transport.
+
+    :param lease: Provider activity-lease adapter.
+    :param has_active_work: Callback reporting delivery-critical runner work.
+    :param poll_interval_s: Active-work polling interval.
+    :param refresh_interval_s: Successful lease refresh cadence.
+    :param release_grace_s: Idle grace before releasing a held lease.
+    :param retry_interval_s: Retry delay after a provider operation fails.
+    :returns: Never under normal operation; cancellation releases the lease.
+    """
+    held = False
+    next_refresh_at = 0.0
+    next_release_at = 0.0
+    loop = asyncio.get_running_loop()
+
+    try:
+        while True:
+            active = has_active_work()
+            now = loop.time()
+            if active:
+                next_release_at = 0.0
+                if now >= next_refresh_at:
+                    try:
+                        await lease.refresh()
+                    except ActivityLeaseError:
+                        logger.warning(
+                            "failed to refresh %s activity lease; active work may suspend",
+                            lease.provider,
+                            exc_info=True,
+                        )
+                        next_refresh_at = now + retry_interval_s
+                    else:
+                        held = True
+                        next_refresh_at = now + refresh_interval_s
+            elif held:
+                if next_release_at == 0.0:
+                    next_release_at = now + release_grace_s
+                if now >= next_release_at:
+                    try:
+                        await lease.release()
+                    except ActivityLeaseError:
+                        logger.warning(
+                            "failed to release %s activity lease",
+                            lease.provider,
+                            exc_info=True,
+                        )
+                        next_release_at = now + retry_interval_s
+                    else:
+                        held = False
+            await asyncio.sleep(poll_interval_s)
+    finally:
+        if held:
+            try:
+                await lease.release()
+            except ActivityLeaseError:
+                logger.debug(
+                    "failed to release %s activity lease during shutdown",
+                    lease.provider,
+                    exc_info=True,
+                )
+        await lease.aclose()

--- a/omnigent/runner/activity_lease.py
+++ b/omnigent/runner/activity_lease.py
@@ -40,7 +40,9 @@ class ActivityLease(Protocol):
 ActivityLeaseFactory: TypeAlias = Callable[[str], ActivityLease]
 
 _ACTIVITY_LEASE_FACTORIES: dict[str, ActivityLeaseFactory] = {}
-_BUILTIN_LEASE_MODULES: dict[str, str] = {}
+_BUILTIN_LEASE_MODULES: dict[str, str] = {
+    "sprites": "omnigent.runner.activity_leases.sprites",
+}
 
 
 def register_activity_lease_provider(provider: str, factory: ActivityLeaseFactory) -> None:

--- a/omnigent/runner/activity_leases/__init__.py
+++ b/omnigent/runner/activity_leases/__init__.py
@@ -1,0 +1,1 @@
+"""Provider adapters for runner activity leases."""

--- a/omnigent/runner/activity_leases/sprites.py
+++ b/omnigent/runner/activity_leases/sprites.py
@@ -1,0 +1,80 @@
+"""Sprites Tasks API adapter for the provider-neutral activity lease."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import quote
+
+import httpx
+
+from omnigent.runner.activity_lease import (
+    ActivityLeaseError,
+)
+from omnigent.runner.activity_lease import (
+    register_activity_lease_provider as _register_activity_lease_provider,
+)
+
+_MANAGEMENT_SOCKET = Path("/.sprite/api.sock")
+_TASK_EXPIRE = "5m"
+
+
+def sprite_activity_task_name(runner_id: str) -> str:
+    """Return a Sprite Tasks API-compatible name for *runner_id*."""
+    normalized = re.sub(r"[^a-z0-9-]+", "-", runner_id.lower()).strip("-")
+    return f"omnigent-{normalized or 'runner'}"
+
+
+class SpriteActivityLease:
+    """Activity hold backed by the local Sprites Tasks API."""
+
+    provider = "sprites"
+
+    def __init__(self, task_name: str, *, client: httpx.AsyncClient | None = None) -> None:
+        self._task_path = f"/v1/tasks/{quote(task_name, safe='')}"
+        self._owns_client = client is None
+        self._client = client or httpx.AsyncClient(
+            base_url="http://sprite",
+            transport=httpx.AsyncHTTPTransport(uds=str(_MANAGEMENT_SOCKET)),
+            timeout=5.0,
+        )
+
+    @classmethod
+    def for_runner(cls, runner_id: str) -> SpriteActivityLease:
+        """Build a lease namespaced to a stable runner id."""
+        return cls(sprite_activity_task_name(runner_id))
+
+    async def refresh(self) -> None:
+        """Create or extend the local Sprite activity task."""
+        try:
+            response = await self._client.put(
+                self._task_path,
+                json={"expire": _TASK_EXPIRE},
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise ActivityLeaseError("Sprites activity task refresh failed") from exc
+
+    async def release(self) -> None:
+        """Delete the local Sprite activity task; absence is success."""
+        try:
+            response = await self._client.delete(self._task_path)
+            if response.status_code != 404:
+                response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise ActivityLeaseError("Sprites activity task release failed") from exc
+
+    async def aclose(self) -> None:
+        """Close an internally owned HTTP client."""
+        if self._owns_client:
+            await self._client.aclose()
+
+
+def _sprite_activity_lease_for_runner(runner_id: str) -> SpriteActivityLease:
+    """Build the registered Sprites adapter for a runner."""
+    return SpriteActivityLease.for_runner(runner_id)
+
+
+def register_activity_lease_provider() -> None:
+    """Register the Sprites adapter with the shared runner lease registry."""
+    _register_activity_lease_provider("sprites", _sprite_activity_lease_for_runner)

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2521,6 +2521,12 @@ def create_runner_app(
     def _has_active_work() -> bool:
         if _active_turns:
             return True
+        # Native harnesses publish ``running`` while terminal-owned work is
+        # active, including work that outlives the HTTP turn task. ``waiting``
+        # is the session-level turn-ended state; counting it here pins a
+        # suspendable provider's activity lease forever after a completed turn.
+        if any(status == "running" for status in _native_pane_status.values()):
+            return True
         if _has_live_async_tasks(_session_async_tasks):
             return True
         for timers in _session_timers.values():

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6340,6 +6340,7 @@ async def _auto_create_claude_terminal(
         augment_claude_args,
         ensure_claude_workspace_trusted,
         prepare_bridge_dir,
+        sandbox_bypass_warning_acceptance_enabled,
     )
     from omnigent.claude_native_forwarder import reset_transcript_forward_state
     from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
@@ -6881,6 +6882,7 @@ async def _auto_create_claude_terminal(
         # The route-turn hook is registered only when this session can
         # actually route; otherwise every submit would pay its round trip.
         turn_routing=_claude_turn_router is not None,
+        accept_bypass_permissions_warning=sandbox_bypass_warning_acceptance_enabled(),
     )
 
     # Apply the per-harness startup command/args override from config

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -32,7 +32,7 @@ stores into ``create_app``):
    ``<data_dir>/config.yaml``)::
 
        sandbox:
-         # lakebox|modal|daytona|blaxel|boxlite|cwsandbox|islo|e2b|openshell|kubernetes
+         # lakebox|modal|daytona|sprites|blaxel|boxlite|cwsandbox|islo|e2b|openshell|kubernetes
          provider: modal
          server_url: https://omnigent.example.com
          # For SEVERAL providers, replace `provider:` with a `providers:`
@@ -73,6 +73,12 @@ stores into ``create_app``):
            env: [OPENAI_API_KEY, GIT_TOKEN]  # SERVER env var NAMES whose
                                              # values are injected as
                                              # sandbox env
+         sprites:                 # optional block (provider: sprites)
+           env: [ANTHROPIC_API_KEY, GIT_TOKEN]  # SERVER env var NAMES injected
+           allow_control_plane_credentials: true  # required when env is non-empty
+           runtime: default       # optional: default|dev
+           install_spec: omnigent==0.11.0  # optional pip requirement
+           api_url: https://api.sprites.dev  # optional API override
          blaxel:                  # optional block (provider: blaxel)
            image: blaxel/omnigent-host:TAG  # optional fixed tag override
            env: [OPENAI_API_KEY, GIT_TOKEN]  # SERVER env var NAMES
@@ -108,7 +114,8 @@ stores into ``create_app``):
    (12-factor): the Modal launcher reads ``MODAL_TOKEN_ID`` /
    ``MODAL_TOKEN_SECRET`` (or ``~/.modal.toml``) and the Daytona
    launcher reads ``DAYTONA_API_KEY`` (plus optional
-   ``DAYTONA_API_URL`` / ``DAYTONA_TARGET``), and the Islo launcher
+   ``DAYTONA_API_URL`` / ``DAYTONA_TARGET``), the Sprites launcher reads
+   ``SPRITE_TOKEN`` (plus optional ``SPRITES_API_URL``), and the Islo launcher
    reads ``ISLO_API_KEY`` (plus optional ``ISLO_BASE_URL``) from the
    server process environment. The Blaxel launcher reads ``BL_WORKSPACE``
    and ``BL_API_KEY`` or the local ``bl login`` profile. The OpenShell
@@ -117,7 +124,7 @@ stores into ``create_app``):
    select`` (``$OPENSHELL_GATEWAY`` / ``~/.config/openshell/active_gateway``,
    or ``sandbox.openshell.cluster``), so the server process needs
    OpenShell gateway access. ``modal``, ``daytona``, ``blaxel``, ``cwsandbox``,
-   ``islo``, and ``openshell`` have managed-launch support; ``lakebox``
+   ``sprites``, ``islo``, and ``openshell`` have managed-launch support; ``lakebox``
    parses but rejects at launch.
 
 2. **Direct construction** (embedding deployments): build
@@ -173,6 +180,7 @@ SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
         "lakebox",
         "modal",
         "daytona",
+        "sprites",
         "blaxel",
         "boxlite",
         "cwsandbox",
@@ -186,6 +194,7 @@ PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
     {
         "modal",
         "daytona",
+        "sprites",
         "blaxel",
         "boxlite",
         "cwsandbox",
@@ -220,6 +229,10 @@ MODAL_MANAGED_TOKEN_TTL_S = 25 * 3600
 # session past 7 days going through the dead-host relaunch path) mints
 # a fresh token.
 DAYTONA_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
+
+# Sprites preserve their filesystem and service definitions across warm/cold
+# transitions. Each resume mints and installs a fresh host token.
+SPRITES_MANAGED_TOKEN_TTL_S = 7 * 24 * 3600
 
 # The blaxel launch-token TTL is NOT a constant: Blaxel reaps a sandbox at its
 # configured max age (sandbox.blaxel.ttl, 24h by default), so the TTL is derived
@@ -838,6 +851,30 @@ def _modal_launcher_factory(
     return _build
 
 
+def _sprites_launcher_factory(
+    *,
+    api_url: str | None,
+    env: list[str] | None,
+    allow_control_plane_credentials: bool,
+    runtime: str | None,
+    install_spec: str | None,
+) -> Callable[[], SandboxHostLauncher]:
+    """Build the launcher factory for the YAML ``provider: sprites`` path."""
+
+    def _build() -> SandboxHostLauncher:
+        from omnigent.onboarding.sandboxes.sprites import SpritesSandboxLauncher
+
+        return SpritesSandboxLauncher(
+            api_url=api_url,
+            env=env,
+            allow_control_plane_credentials=allow_control_plane_credentials,
+            runtime=runtime,
+            install_spec=install_spec,
+        )
+
+    return _build
+
+
 def _community_sandbox_providers() -> frozenset[str]:
     """Provider names contributed by packages, excluding every built-in.
 
@@ -1157,6 +1194,39 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
             _parse_daytona_image(raw), _parse_daytona_env(raw)
         )
         token_ttl_s = DAYTONA_MANAGED_TOKEN_TTL_S
+    elif provider == "sprites":
+        section = _parse_provider_section(raw, "sprites")
+        if section is not None:
+            _reject_unknown_keys(
+                section,
+                {
+                    "api_url",
+                    "env",
+                    "allow_control_plane_credentials",
+                    "runtime",
+                    "install_spec",
+                },
+                "sandbox.sprites",
+            )
+        sprites_env = _parse_provider_env(raw, "sprites")
+        allow_control_plane_credentials = (
+            _parse_provider_bool(raw, "sprites", "allow_control_plane_credentials") or False
+        )
+        if sprites_env and not allow_control_plane_credentials:
+            raise ValueError(
+                "server config 'sandbox.sprites.env' sends credential values through "
+                "the Sprites control plane; set "
+                "'sandbox.sprites.allow_control_plane_credentials: true' to acknowledge "
+                "that boundary, or remove 'sandbox.sprites.env'"
+            )
+        launcher_factory = _sprites_launcher_factory(
+            api_url=_parse_provider_string(raw, "sprites", "api_url"),
+            env=sprites_env,
+            allow_control_plane_credentials=allow_control_plane_credentials,
+            runtime=_parse_sprites_runtime(raw),
+            install_spec=_parse_provider_string(raw, "sprites", "install_spec"),
+        )
+        token_ttl_s = SPRITES_MANAGED_TOKEN_TTL_S
     elif provider == "blaxel":
         from omnigent.onboarding.sandboxes.blaxel import managed_token_ttl_s
 
@@ -2094,6 +2164,14 @@ def _parse_provider_string(raw: dict[str, object], provider: str, key: str) -> s
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"server config 'sandbox.{provider}.{key}' must be a non-empty string")
     return value.strip()
+
+
+def _parse_sprites_runtime(raw: dict[str, object]) -> str | None:
+    """Extract and validate the optional Sprites runtime channel."""
+    runtime = _parse_provider_string(raw, "sprites", "runtime")
+    if runtime is not None and runtime not in {"default", "dev"}:
+        raise ValueError("server config 'sandbox.sprites.runtime' must be 'default' or 'dev'")
+    return runtime
 
 
 def _parse_provider_positive_int(raw: dict[str, object], provider: str, key: str) -> int | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,9 @@ modal = ["modal>=1.0,<2"]
 # server-managed `sandbox.provider: daytona`).
 # Same lazy-import posture as the modal extra. Pre-1.0 SDK: pin minor.
 daytona = ["daytona>=0.180,<1"]
+# Sprites managed sandbox launcher. The launcher module ships in the base
+# package and imports the SDK lazily; only Sprites deployments need it.
+sprites = ["sprites-py>=0.5,<1"]
 # Blaxel sandbox launcher (`omnigent sandbox --provider blaxel` and
 # server-managed `sandbox.provider: blaxel`).
 blaxel = ["blaxel>=0.4.1,<0.5"]

--- a/tests/onboarding/sandboxes/test_sprites.py
+++ b/tests/onboarding/sandboxes/test_sprites.py
@@ -1,0 +1,456 @@
+"""Tests for the managed Sprites sandbox launcher."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import click
+import pytest
+
+from omnigent.claude_native_bridge import CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR
+from omnigent.onboarding.sandboxes import sprites as sprites_sandbox
+from omnigent.onboarding.sandboxes.sprites import (
+    API_URL_ENV_VAR,
+    TOKEN_ENV_VAR,
+    SpritesSandboxLauncher,
+    _managed_sprite_name,
+    render_bootstrap_command,
+)
+from omnigent.runner.activity_lease import ACTIVITY_LEASE_PROVIDER_ENV_VAR
+
+
+class FakeSpriteError(Exception):
+    """Fake SDK provider error."""
+
+
+class FakeNotFoundError(FakeSpriteError):
+    """Fake SDK missing-resource error."""
+
+
+@dataclass
+class FakeResult:
+    """Minimal subprocess-like SDK result."""
+
+    returncode: int = 0
+    stdout: bytes = b""
+    stderr: bytes = b""
+
+
+class FakeSprite:
+    """Recording Sprite handle."""
+
+    def __init__(self, name: str, *, status: str = "running") -> None:
+        self.name = name
+        self.status = status
+        self.run_calls: list[tuple[tuple[str, ...], dict[str, object]]] = []
+        self.service_calls: list[dict[str, object]] = []
+        self.services: list[object] = []
+        self.deleted_services: list[str] = []
+        self.destroyed = False
+        self.fail_commands_containing: str | None = None
+        self.service_events: list[object] = []
+
+    def run(self, *args: str, **kwargs: object) -> FakeResult:
+        """Record and answer shell commands used by the launcher."""
+        self.run_calls.append((args, kwargs))
+        command = args[-1]
+        if self.fail_commands_containing and self.fail_commands_containing in command:
+            return FakeResult(returncode=12, stderr=b"boom")
+        if 'printf %s "$HOME"' in command:
+            return FakeResult(stdout=b"/home/sprite")
+        if 'printf %s "$PATH"' in command:
+            return FakeResult(stdout=b"/usr/local/bin:/usr/bin:/bin")
+        return FakeResult()
+
+    def create_service(
+        self,
+        service_name: str,
+        *,
+        cmd: str,
+        args: list[str],
+        env: dict[str, str],
+        dir: str,
+    ) -> list[object]:
+        """Record the merged service definition and return its event stream."""
+        self.service_calls.append(
+            {
+                "service_name": service_name,
+                "cmd": cmd,
+                "args": args,
+                "env": env,
+                "dir": dir,
+            }
+        )
+        return self.service_events
+
+    def list_services(self) -> list[object]:
+        """Return the configured fake service definitions."""
+        return self.services
+
+    def delete_service(self, service_name: str) -> None:
+        """Record removal of a stale service definition."""
+        self.deleted_services.append(service_name)
+
+    def destroy(self) -> None:
+        """Record direct cleanup after failed provisioning."""
+        self.destroyed = True
+
+
+class FakeClient:
+    """Recording Sprites client."""
+
+    def __init__(self) -> None:
+        self.sprites: dict[str, FakeSprite] = {}
+        self.create_calls: list[dict[str, object]] = []
+        self.destroy_calls: list[str] = []
+        self.missing: set[str] = set()
+
+    def create_sprite(self, name: str, **kwargs: object) -> FakeSprite:
+        """Create a recording Sprite."""
+        self.create_calls.append({"name": name, **kwargs})
+        sprite = FakeSprite(name)
+        self.sprites[name] = sprite
+        return sprite
+
+    def sprite(self, name: str) -> FakeSprite:
+        """Return a handle without a provider lookup."""
+        return self.sprites[name]
+
+    def get_sprite(self, name: str) -> FakeSprite:
+        """Return status or simulate a missing Sprite."""
+        if name in self.missing:
+            raise FakeNotFoundError(name)
+        return self.sprites[name]
+
+    def destroy_sprite(self, name: str) -> None:
+        """Record deletion or simulate an already-missing Sprite."""
+        if name in self.missing:
+            raise FakeNotFoundError(name)
+        self.destroy_calls.append(name)
+
+
+@pytest.fixture(autouse=True)
+def fake_sprites_sdk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install a minimal SDK module tree for lazy imports."""
+    sprites_module = ModuleType("sprites")
+    sprites_module.SpritesClient = object  # type: ignore[attr-defined]
+    exceptions_module = ModuleType("sprites.exceptions")
+    exceptions_module.SpriteError = FakeSpriteError  # type: ignore[attr-defined]
+    exceptions_module.NotFoundError = FakeNotFoundError  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sprites", sprites_module)
+    monkeypatch.setitem(sys.modules, "sprites.exceptions", exceptions_module)
+
+
+def launcher_with(client: FakeClient, **kwargs: Any) -> SpritesSandboxLauncher:
+    """Construct a launcher with its network client replaced by a fake."""
+    launcher = SpritesSandboxLauncher(**kwargs)
+    launcher._client = client
+    return launcher
+
+
+def test_prepare_requires_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing organization token fails before provisioning."""
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    with pytest.raises(click.ClickException, match=TOKEN_ENV_VAR):
+        SpritesSandboxLauncher().prepare()
+
+
+def test_prepare_validates_env_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Named sandbox secrets must exist in the server environment."""
+    monkeypatch.setenv(TOKEN_ENV_VAR, "sprite-token")
+    monkeypatch.delenv("MISSING_API_KEY", raising=False)
+    with pytest.raises(click.ClickException, match="MISSING_API_KEY"):
+        SpritesSandboxLauncher(
+            env=["MISSING_API_KEY"],
+            allow_control_plane_credentials=True,
+        ).prepare()
+
+
+def test_prepare_requires_explicit_control_plane_credential_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Naming secrets is insufficient without acknowledging their transport."""
+    monkeypatch.setenv(TOKEN_ENV_VAR, "sprite-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "secret")
+    with pytest.raises(click.ClickException, match="allow_control_plane_credentials"):
+        SpritesSandboxLauncher(env=["OPENAI_API_KEY"]).prepare()
+
+
+def test_prepare_rejects_invalid_env_passthrough_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Environment names cannot inject shell syntax into remote commands."""
+    monkeypatch.setenv(TOKEN_ENV_VAR, "sprite-token")
+    with pytest.raises(click.ClickException, match="invalid environment variable name"):
+        SpritesSandboxLauncher(
+            env=["SAFE; touch /tmp/injected"],
+            allow_control_plane_credentials=True,
+        ).prepare()
+
+
+def test_sdk_client_honors_api_url_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The server token and configured API endpoint reach the SDK constructor."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    class RecordingClient:
+        def __init__(self, token: str, **kwargs: object) -> None:
+            calls.append((token, kwargs))
+
+    sys.modules["sprites"].SpritesClient = RecordingClient  # type: ignore[attr-defined]
+    monkeypatch.setenv(TOKEN_ENV_VAR, "sprite-token")
+    monkeypatch.setenv(API_URL_ENV_VAR, "https://env.example.test")
+    launcher = SpritesSandboxLauncher(api_url="https://config.example.test")
+    launcher._sprites()
+    assert calls == [("sprite-token", {"base_url": "https://config.example.test"})]
+
+
+def test_provision_bootstraps_persistent_sprite() -> None:
+    """Provisioning creates the expected Sprite and installs the native runtime."""
+    client = FakeClient()
+    launcher = launcher_with(
+        client,
+        runtime="dev",
+        install_spec="omnigent @ https://example.test/omnigent.whl",
+    )
+    sandbox_id = launcher.provision("Alice's Feature Branch")
+    assert sandbox_id == "omnigent-alice-s-feature-branch"
+    assert client.create_calls == [
+        {
+            "name": sandbox_id,
+            "labels": ["omnigent-managed"],
+            "wait_for_capacity": True,
+            "runtime": "dev",
+        }
+    ]
+    command = client.sprites[sandbox_id].run_calls[0][0][-1]
+    assert "bootstrap-version" in command
+    assert "python3 -m venv" in command
+    assert "https://example.test/omnigent.whl" in command
+    assert "@anthropic-ai/claude-code@2.1.212" in command
+    assert "@openai/codex@0.139.0" in command
+    assert "@earendil-works/pi-coding-agent@0.84.2" in command
+    assert '[ -x "$HOME/.local/bin/$binary" ] && return' not in command
+    assert "exit 0" not in command
+
+
+def test_agent_cli_pin_change_invalidates_bootstrap_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing a pinned CLI spec changes both installation and cache identity."""
+    original = render_bootstrap_command("omnigent==1.2.3")
+    monkeypatch.setitem(
+        sprites_sandbox._AGENT_CLI_SPECS,
+        "codex",
+        "@openai/codex@0.140.0",
+    )
+    updated = render_bootstrap_command("omnigent==1.2.3")
+
+    assert original != updated
+    assert "@openai/codex@0.139.0" in original
+    assert "@openai/codex@0.140.0" in updated
+
+
+def test_provision_destroys_sprite_when_bootstrap_fails() -> None:
+    """A partial native install never strands a billable managed Sprite."""
+    client = FakeClient()
+    sprite = FakeSprite("omnigent-broken")
+    sprite.fail_commands_containing = "bootstrap-version"
+
+    def create_sprite(name: str, **_: object) -> FakeSprite:
+        assert name == sprite.name
+        client.sprites[name] = sprite
+        return sprite
+
+    client.create_sprite = create_sprite  # type: ignore[method-assign]
+    launcher = launcher_with(client)
+    with pytest.raises(click.ClickException, match="exit 12"):
+        launcher.provision("broken")
+    assert sprite.destroyed is True
+
+
+def test_run_keeps_workload_credentials_out_of_command_execs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Routine provider commands never contain or inherit workload secrets."""
+    monkeypatch.setenv("OPENAI_API_KEY", "secret with spaces")
+    client = FakeClient()
+    sprite = FakeSprite("sb")
+    client.sprites["sb"] = sprite
+    launcher = launcher_with(
+        client,
+        env=["OPENAI_API_KEY"],
+        allow_control_plane_credentials=True,
+    )
+
+    result = launcher.run("sb", "printf ok", check=False)
+    assert result.returncode == 0
+    args, kwargs = sprite.run_calls[-1]
+    assert args[-1] == "printf ok"
+    assert kwargs["env"] is None
+    assert "secret with spaces" not in args[-1]
+
+    sprite.fail_commands_containing = "false"
+    with pytest.raises(click.ClickException, match="exit 12"):
+        launcher.run("sb", "false")
+
+
+def test_run_failure_includes_remote_output_tail() -> None:
+    """Managed launch errors retain the actionable end of remote output."""
+    client = FakeClient()
+    sprite = FakeSprite("sb")
+    sprite.fail_commands_containing = "bootstrap"
+    client.sprites["sb"] = sprite
+    launcher = launcher_with(client)
+
+    with pytest.raises(click.ClickException, match="boom"):
+        launcher.run("sb", "bootstrap")
+
+
+def test_repository_clone_receives_only_git_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clone execs do not receive unrelated model credentials."""
+    monkeypatch.setenv("GIT_TOKEN", "git-secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
+    client = FakeClient()
+    sprite = FakeSprite("sb")
+    client.sprites["sb"] = sprite
+    launcher = launcher_with(
+        client,
+        env=["GIT_TOKEN", "OPENAI_API_KEY"],
+        allow_control_plane_credentials=True,
+    )
+
+    clone_dir = launcher.materialize_workspace(
+        "sb",
+        workspace="/home/sprite/workspace",
+        repo_url="https://github.com/example/project",
+        repo_branch="main",
+        repo_name="project",
+    )
+
+    assert clone_dir == "/home/sprite/workspace/project"
+    args, kwargs = sprite.run_calls[-1]
+    assert "git-secret" not in args[-1]
+    assert "model-secret" not in args[-1]
+    assert kwargs["env"] == {"GIT_TOKEN": "git-secret"}
+
+
+def test_start_host_creates_cold_wake_safe_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repository, host identity, credentials, and cwd reach the service API."""
+    monkeypatch.setenv("OPENAI_API_KEY", "llm-secret")
+    client = FakeClient()
+    sprite = FakeSprite("sb")
+    sprite.service_events = [SimpleNamespace(type="info", data="service updated")]
+    client.sprites["sb"] = sprite
+    launcher = launcher_with(
+        client,
+        env=["OPENAI_API_KEY"],
+        allow_control_plane_credentials=True,
+    )
+    stages: list[str] = []
+
+    workspace = launcher.start_host(
+        "sb",
+        token="host-token",
+        host_id="host-123",
+        host_name="managed-123",
+        server_url="https://server.example.test",
+        repo_url="https://github.com/example/project",
+        repo_branch="main",
+        repo_name="project",
+        host_config={"providers": {}},
+        on_stage=stages.append,
+    )
+
+    assert workspace == "/home/sprite/workspace/project"
+    assert stages == ["cloning", "starting"]
+    commands = [call[0][-1] for call in sprite.run_calls]
+    assert any(
+        "git clone --branch main --single-branch -- "
+        "https://github.com/example/project /home/sprite/workspace/project" in command
+        for command in commands
+    )
+    assert any(
+        "/home/sprite/.local/share/omnigent-host/venv/bin/python -c" in command
+        for command in commands
+    )
+    service = sprite.service_calls[0]
+    assert service["service_name"] == "omnigent-host"
+    assert service["cmd"] == ("/home/sprite/.local/share/omnigent-host/venv/bin/omnigent")
+    assert service["args"] == [
+        "host",
+        "--server",
+        "https://server.example.test",
+    ]
+    assert service["dir"] == "/home/sprite/workspace/project"
+    assert service["env"] == {
+        "OPENAI_API_KEY": "llm-secret",
+        "PATH": "/home/sprite/.local/bin:/usr/local/bin:/usr/bin:/bin",
+        "IS_SANDBOX": "1",
+        ACTIVITY_LEASE_PROVIDER_ENV_VAR: "sprites",
+        CLAUDE_BYPASS_WARNING_ACCEPT_ENV_VAR: "1",
+        "OMNIGENT_HOST_TOKEN": "host-token",
+        "OMNIGENT_HOST_ID": "host-123",
+        "OMNIGENT_HOST_NAME": "managed-123",
+    }
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("running", True),
+        ("warm", False),
+        ("cold", False),
+        ("starting", None),
+    ],
+)
+def test_is_running_maps_sprite_status(status: str, expected: bool | None) -> None:
+    """Provider lifecycle states map to the launcher tri-state contract."""
+    client = FakeClient()
+    client.sprites["sb"] = FakeSprite("sb", status=status)
+    assert launcher_with(client).is_running("sb") is expected
+
+
+def test_missing_sprite_is_stopped_and_termination_is_idempotent() -> None:
+    """A provider 404 behaves like an already-terminated sandbox."""
+    client = FakeClient()
+    client.missing.add("gone")
+    launcher = launcher_with(client)
+    assert launcher.is_running("gone") is False
+    launcher.terminate("gone")
+    assert client.destroy_calls == []
+
+
+def test_resume_wakes_sprite_with_exec() -> None:
+    """Wake removes the stale auto-started host before token refresh."""
+    client = FakeClient()
+    sprite = FakeSprite("sb", status="cold")
+    sprite.services = [SimpleNamespace(name="omnigent-host")]
+    client.sprites["sb"] = sprite
+    launcher_with(client).resume("sb")
+    assert sprite.run_calls[-1][0][-1] == "true"
+    assert sprite.deleted_services == ["omnigent-host"]
+
+
+def test_resume_tolerates_missing_host_service() -> None:
+    """A partial first launch can wake without a persisted service."""
+    client = FakeClient()
+    sprite = FakeSprite("sb", status="cold")
+    client.sprites["sb"] = sprite
+    launcher_with(client).resume("sb")
+    assert sprite.deleted_services == []
+
+
+def test_bootstrap_and_names_are_shell_safe() -> None:
+    """Install specs are quoted and provider names remain bounded/DNS-safe."""
+    command = render_bootstrap_command("omnigent @ https://e.test/a b.whl")
+    assert "'omnigent @ https://e.test/a b.whl'" in command
+    name = _managed_sprite_name(" !!! ")
+    assert name == "omnigent-host"
+    assert len(_managed_sprite_name("X" * 100)) <= 63

--- a/tests/onboarding/sandboxes/test_sprites_live.py
+++ b/tests/onboarding/sandboxes/test_sprites_live.py
@@ -1,0 +1,70 @@
+"""Opt-in live bootstrap coverage for the managed Sprites provider."""
+
+from __future__ import annotations
+
+import json
+import os
+from uuid import uuid4
+
+import pytest
+
+from omnigent.onboarding.sandboxes.sprites import (
+    _AGENT_CLI_SPECS,
+    _BOOTSTRAP_SCHEMA_VERSION,
+    TOKEN_ENV_VAR,
+    SpritesSandboxLauncher,
+    render_bootstrap_command,
+)
+
+_RUN_LIVE_ENV_VAR = "OMNIGENT_RUN_SPRITES_LIVE_TEST"
+_LIVE_INSTALL_SPEC_ENV_VAR = "OMNIGENT_SPRITES_LIVE_INSTALL_SPEC"
+
+
+def test_live_sprite_bootstrap_is_versioned_and_idempotent() -> None:
+    """Provision a real Sprite and verify exact native harness versions."""
+    if os.environ.get(_RUN_LIVE_ENV_VAR) != "1":
+        pytest.skip(f"set {_RUN_LIVE_ENV_VAR}=1 to run the live Sprites test")
+    if not os.environ.get(TOKEN_ENV_VAR):
+        pytest.fail(f"{TOKEN_ENV_VAR} is required when {_RUN_LIVE_ENV_VAR}=1")
+    install_spec = os.environ.get(_LIVE_INSTALL_SPEC_ENV_VAR)
+    if not install_spec:
+        pytest.fail(
+            f"{_LIVE_INSTALL_SPEC_ENV_VAR} must name a Sprite-reachable Omnigent "
+            "artifact when the live test is enabled"
+        )
+
+    launcher = SpritesSandboxLauncher(install_spec=install_spec)
+    sandbox_id: str | None = None
+    try:
+        launcher.prepare()
+        sandbox_id = launcher.provision(f"live-bootstrap-{uuid4().hex[:10]}")
+
+        package_tree = json.loads(
+            launcher.run(
+                sandbox_id,
+                'npm list --global --prefix "$HOME/.local" --depth=0 --json',
+            ).stdout
+        )
+        installed = package_tree["dependencies"]
+        for spec in _AGENT_CLI_SPECS.values():
+            package, expected_version = spec.rsplit("@", 1)
+            assert installed[package]["version"] == expected_version
+
+        marker_path = "$HOME/.local/share/omnigent-host/bootstrap-version"
+        marker = json.loads(launcher.run(sandbox_id, f'cat "{marker_path}"').stdout)
+        assert marker == {
+            "agent_clis": _AGENT_CLI_SPECS,
+            "install_spec": install_spec,
+            "schema": _BOOTSTRAP_SCHEMA_VERSION,
+        }
+
+        launcher.run(sandbox_id, f'touch -d @1 "{marker_path}"')
+        launcher.run(sandbox_id, render_bootstrap_command(install_spec))
+        marker_mtime = launcher.run(
+            sandbox_id,
+            f'stat -c %Y "{marker_path}"',
+        ).stdout.strip()
+        assert marker_mtime == "1"
+    finally:
+        if sandbox_id is not None:
+            launcher.terminate(sandbox_id)

--- a/tests/runner/test_activity_lease.py
+++ b/tests/runner/test_activity_lease.py
@@ -1,0 +1,208 @@
+"""Provider-neutral runner activity lease tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
+
+from omnigent.runner import activity_lease as activity_lease_module
+from omnigent.runner.activity_lease import (
+    _ACTIVITY_LEASE_FACTORIES,
+    _BUILTIN_LEASE_MODULES,
+    ACTIVITY_LEASE_PROVIDER_ENV_VAR,
+    ActivityLeaseError,
+    activity_lease_from_env,
+    register_activity_lease_provider,
+    run_activity_lease,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class RecordingLease:
+    """Controllable lease adapter for state-machine tests."""
+
+    provider = "test"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.fail_release = False
+
+    async def refresh(self) -> None:
+        self.calls.append("refresh")
+
+    async def release(self) -> None:
+        self.calls.append("release")
+        if self.fail_release:
+            self.fail_release = False
+            raise ActivityLeaseError("transient release failure")
+
+    async def aclose(self) -> None:
+        self.calls.append("close")
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError("timed out waiting for activity lease operation")
+
+
+async def test_backend_requires_explicit_provider_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Filesystem artifacts alone never activate a provider lease."""
+    monkeypatch.delenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, raising=False)
+    assert activity_lease_from_env("runner-123") is None
+
+
+async def test_registered_backend_is_selected_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The configured provider selects its registered adapter factory."""
+    lease = RecordingLease()
+
+    def factory(runner_id: str) -> RecordingLease:
+        assert runner_id == "runner-123"
+        return lease
+
+    register_activity_lease_provider("test", factory)
+    monkeypatch.setenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, "test")
+    try:
+        assert activity_lease_from_env("runner-123") is lease
+    finally:
+        _ACTIVITY_LEASE_FACTORIES.pop("test", None)
+
+
+async def test_configured_builtin_module_is_loaded_lazily(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the provider named by the environment imports its adapter module."""
+    lease = RecordingLease()
+    imported: list[str] = []
+
+    def register() -> None:
+        register_activity_lease_provider("lazy", lambda runner_id: lease)
+
+    def import_module(module_name: str) -> object:
+        imported.append(module_name)
+        return SimpleNamespace(register_activity_lease_provider=register)
+
+    monkeypatch.setitem(_BUILTIN_LEASE_MODULES, "lazy", "example.lazy_lease")
+    monkeypatch.setattr(activity_lease_module.importlib, "import_module", import_module)
+    monkeypatch.setenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, "lazy")
+    try:
+        assert activity_lease_from_env("runner-123") is lease
+        assert imported == ["example.lazy_lease"]
+    finally:
+        _ACTIVITY_LEASE_FACTORIES.pop("lazy", None)
+
+
+@pytest.mark.parametrize("provider", ["", "unknown"])
+async def test_invalid_backend_configuration_fails_loud(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    """A typo cannot silently disable hibernation protection."""
+    monkeypatch.setenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, provider)
+    with pytest.raises(RuntimeError, match=r"activity lease provider|must not be empty"):
+        activity_lease_from_env("runner-123")
+
+
+async def test_active_work_refreshes_then_releases_lease() -> None:
+    """Work holds the provider lease and draining releases it."""
+    active = True
+    lease = RecordingLease()
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: active,
+            poll_interval_s=0.005,
+            refresh_interval_s=60,
+            release_grace_s=0,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    active = False
+    await _wait_until(lambda: "release" in lease.calls)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "close"]
+
+
+async def test_idle_grace_survives_a_transient_status_gap() -> None:
+    """A brief gap between turn and terminal work does not drop the hold."""
+    active = True
+    lease = RecordingLease()
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: active,
+            poll_interval_s=0.005,
+            refresh_interval_s=60,
+            release_grace_s=0.05,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    active = False
+    await asyncio.sleep(0.02)
+    active = True
+    await asyncio.sleep(0.02)
+    assert "release" not in lease.calls
+
+    active = False
+    await _wait_until(lambda: "release" in lease.calls)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "close"]
+
+
+async def test_release_failure_retries_without_losing_held_state() -> None:
+    """A transient provider failure retries release until it succeeds."""
+    active = True
+    lease = RecordingLease()
+    lease.fail_release = True
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: active,
+            poll_interval_s=0.005,
+            refresh_interval_s=60,
+            release_grace_s=0,
+            retry_interval_s=0.01,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    active = False
+    await _wait_until(lambda: lease.calls.count("release") == 2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "release", "close"]
+
+
+async def test_cancellation_releases_a_live_lease() -> None:
+    """Orderly runner shutdown drops the provider hold immediately."""
+    lease = RecordingLease()
+    task = asyncio.create_task(
+        run_activity_lease(
+            lease=lease,
+            has_active_work=lambda: True,
+            poll_interval_s=0.005,
+        )
+    )
+    await _wait_until(lambda: "refresh" in lease.calls)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert lease.calls == ["refresh", "release", "close"]

--- a/tests/runner/test_runner_idle_active_work.py
+++ b/tests/runner/test_runner_idle_active_work.py
@@ -294,6 +294,31 @@ async def test_done_approval_future_does_not_pin_runner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_running_native_harness_blocks_idle_shutdown() -> None:
+    """Terminal-owned work remains active after the HTTP turn slot clears."""
+    app = _scaffold_app()
+    app.state.native_pane_status["conv_native"] = "running"
+    assert app.state.has_active_work() is True
+
+    async def _release() -> None:
+        app.state.native_pane_status["conv_native"] = "idle"
+
+    await _assert_monitor_blocked_then_shuts_down(
+        has_active_work=app.state.has_active_work,
+        release=_release,
+    )
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.parametrize("status", ["waiting", "idle", "error"])
+def test_inactive_native_harness_status_does_not_pin_runner(status: str) -> None:
+    """Only the cross-harness running state counts as active work."""
+    app = _scaffold_app()
+    app.state.native_pane_status["conv_native"] = status
+    assert app.state.has_active_work() is False
+
+
+@pytest.mark.asyncio
 async def test_drain_session_streams_enqueues_done_sentinel() -> None:
     """Graceful shutdown signals end-of-stream to every open session stream.
 

--- a/tests/runner/test_sprite_activity_lease.py
+++ b/tests/runner/test_sprite_activity_lease.py
@@ -1,0 +1,91 @@
+"""Sprites adapter tests for the runner activity lease."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from omnigent.runner.activity_lease import (
+    _ACTIVITY_LEASE_FACTORIES,
+    ACTIVITY_LEASE_PROVIDER_ENV_VAR,
+    ActivityLeaseError,
+    activity_lease_from_env,
+)
+from omnigent.runner.activity_leases.sprites import (
+    SpriteActivityLease,
+    sprite_activity_task_name,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_registration_selects_sprites_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The provider layer registers its adapter with the shared framework."""
+    monkeypatch.setenv(ACTIVITY_LEASE_PROVIDER_ENV_VAR, "sprites")
+    try:
+        lease = activity_lease_from_env("runner-123")
+        assert isinstance(lease, SpriteActivityLease)
+        await lease.aclose()
+    finally:
+        _ACTIVITY_LEASE_FACTORIES.pop("sprites", None)
+
+
+async def test_task_name_sanitizes_runner_id() -> None:
+    """Delegated runner ids become valid Sprite task names."""
+    assert sprite_activity_task_name("runner_token_34D104") == "omnigent-runner-token-34d104"
+
+
+async def test_refresh_and_release_use_sprite_tasks_api() -> None:
+    """The adapter translates generic lease operations to local task calls."""
+    requests: list[tuple[str, str, object | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else None
+        requests.append((request.method, request.url.path, body))
+        return httpx.Response(204 if request.method == "DELETE" else 200)
+
+    async with httpx.AsyncClient(
+        base_url="http://sprite",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        lease = SpriteActivityLease("omnigent-runner-123", client=client)
+        await lease.refresh()
+        await lease.release()
+        await lease.aclose()
+
+    assert requests == [
+        ("PUT", "/v1/tasks/omnigent-runner-123", {"expire": "5m"}),
+        ("DELETE", "/v1/tasks/omnigent-runner-123", None),
+    ]
+
+
+async def test_missing_task_is_already_released() -> None:
+    """A task that expired independently makes release idempotent."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(
+        base_url="http://sprite",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        await SpriteActivityLease("missing", client=client).release()
+
+
+async def test_provider_transport_failure_is_normalized() -> None:
+    """HTTP failures surface through the provider-neutral exception."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+
+    async with httpx.AsyncClient(
+        base_url="http://sprite",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        lease = SpriteActivityLease("broken", client=client)
+        with pytest.raises(ActivityLeaseError, match="refresh"):
+            await lease.refresh()

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -42,6 +42,7 @@ from omnigent.server.managed_hosts import (
     KUBERNETES_MANAGED_TOKEN_TTL_S,
     MODAL_MANAGED_TOKEN_TTL_S,
     OPENSHELL_MANAGED_TOKEN_TTL_S,
+    SPRITES_MANAGED_TOKEN_TTL_S,
     ManagedLaunch,
     ManagedLaunchTracker,
     ManagedSandboxConfig,
@@ -278,6 +279,76 @@ def test_parse_daytona_without_section_defaults(
     assert cfg.launcher_factory() is fake
     assert fake.image is None
     assert fake.env is None
+
+
+async def test_parse_valid_sprites_config_builds_parameterized_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The documented Sprites block reaches the managed launcher intact."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "sprites",
+            "server_url": "https://srv.example.com/",
+            "sprites": {
+                "api_url": "https://api.example.test",
+                "env": ["ANTHROPIC_API_KEY", "GIT_TOKEN"],
+                "allow_control_plane_credentials": True,
+                "runtime": "dev",
+                "install_spec": "omnigent @ https://example.test/omnigent.whl",
+            },
+        }
+    )
+    assert cfg is not None
+    parsed = cfg.default
+    assert parsed.server_url == "https://srv.example.com"
+    assert parsed.token_ttl_s == SPRITES_MANAGED_TOKEN_TTL_S
+    assert parsed.managed_launch_supported is True
+    assert parsed.provider == "sprites"
+
+    captured: dict[str, object] = {}
+
+    def _ctor(**kwargs: object) -> FakeSandboxLauncher:
+        captured.update(kwargs)
+        fake = FakeSandboxLauncher()
+        fake.provider = "sprites"
+        return fake
+
+    monkeypatch.setattr(
+        "omnigent.onboarding.sandboxes.sprites.SpritesSandboxLauncher",
+        _ctor,
+    )
+    assert parsed.launcher_factory().provider == "sprites"
+    assert captured == {
+        "api_url": "https://api.example.test",
+        "env": ["ANTHROPIC_API_KEY", "GIT_TOKEN"],
+        "allow_control_plane_credentials": True,
+        "runtime": "dev",
+        "install_spec": "omnigent @ https://example.test/omnigent.whl",
+    }
+
+
+async def test_parse_sprites_rejects_unknown_config_key() -> None:
+    """Operator typos in the provider block fail during server startup."""
+    with pytest.raises(ValueError, match=r"sandbox\.sprites"):
+        parse_sandbox_config(
+            {
+                "provider": "sprites",
+                "server_url": "https://srv.example.com",
+                "sprites": {"enb": ["ANTHROPIC_API_KEY"]},
+            }
+        )
+
+
+async def test_parse_sprites_requires_control_plane_credential_opt_in() -> None:
+    """Credential passthrough must be acknowledged before server startup."""
+    with pytest.raises(ValueError, match="allow_control_plane_credentials"):
+        parse_sandbox_config(
+            {
+                "provider": "sprites",
+                "server_url": "https://srv.example.com",
+                "sprites": {"env": ["ANTHROPIC_API_KEY"]},
+            }
+        )
 
 
 def test_parse_valid_blaxel_config_builds_parameterized_factory(

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2847,20 +2847,15 @@ def test_augment_claude_args_mirrors_launch_overrides_into_settings(
     ],
     ids=["skip-flag", "mode-spaced", "mode-joined"],
 )
-def test_augment_claude_args_preaccepts_bypass_dialog(
+def test_augment_claude_args_does_not_preaccept_bypass_dialog_without_opt_in(
     bypass_args: tuple[str, ...],
     tmp_path: Path,
 ) -> None:
     """
-    A bypass launch pre-accepts Claude's one-time bypass consent dialog.
+    A bypass launch alone cannot acknowledge Claude's dangerous-mode warning.
 
-    Claude shows a blocking "Bypass Permissions mode / 1. No, exit /
-    2. Yes, I accept" dialog before the first bypass launch. It fires no
-    PermissionRequest hook, so a host-spawned worker has nobody to answer it
-    and hangs forever producing no output. Setting
-    ``skipDangerousModePermissionPrompt`` in the invocation-local settings
-    sidecar clears the gate without touching the user's own config. Both
-    spellings that reach the CLI must be recognised.
+    Managed sandbox providers must opt in separately, so ordinary local and
+    unmanaged launches preserve Claude's confirmation gate.
     """
     args = augment_claude_args(
         bypass_args,
@@ -2869,9 +2864,9 @@ def test_augment_claude_args_preaccepts_bypass_dialog(
     )
 
     settings = _load_invocation_settings(args)
-    assert settings.get("skipDangerousModePermissionPrompt") is True, (
-        "bypass launches must set skipDangerousModePermissionPrompt; without it a "
-        f"headless worker hangs on the acceptance dialog. args={bypass_args!r}"
+    assert "skipDangerousModePermissionPrompt" not in settings, (
+        "bypass launches must preserve the confirmation gate without an explicit "
+        f"sandbox-provider opt-in. args={bypass_args!r}"
     )
 
 
@@ -2922,6 +2917,66 @@ def test_augment_claude_args_mirrors_joined_model_arg_into_settings(
     assert settings["model"] == "claude-sonnet-5"
     assert "permissions" not in settings
     assert "effortLevel" not in settings
+
+
+@pytest.mark.parametrize(
+    ("permission_mode", "accepted", "expected"),
+    [
+        ("bypassPermissions", True, True),
+        ("bypassPermissions", False, False),
+        ("default", True, False),
+        (None, True, False),
+    ],
+)
+def test_bypass_warning_acceptance_requires_bypass_launch_and_caller_opt_in(
+    tmp_path: Path,
+    permission_mode: str | None,
+    accepted: bool,
+    expected: bool,
+) -> None:
+    """The dangerous-mode acknowledgement is never a blanket sandbox setting."""
+    claude_args = ("--permission-mode", permission_mode) if permission_mode is not None else ()
+    args = augment_claude_args(
+        claude_args,
+        bridge_dir=tmp_path,
+        python_executable="/venv/bin/python",
+        accept_bypass_permissions_warning=accepted,
+    )
+
+    settings = _load_invocation_settings(args)
+    assert (settings.get("skipDangerousModePermissionPrompt") is True) is expected
+
+
+@pytest.mark.parametrize(
+    ("environ", "expected"),
+    [
+        ({}, False),
+        ({"IS_SANDBOX": "1"}, False),
+        ({"OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING": "1"}, False),
+        (
+            {
+                "IS_SANDBOX": "1",
+                "OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING": "1",
+            },
+            True,
+        ),
+        (
+            {
+                "IS_SANDBOX": "true",
+                "OMNIGENT_CLAUDE_AUTO_ACCEPT_BYPASS_WARNING": "1",
+            },
+            False,
+        ),
+    ],
+)
+def test_sandbox_bypass_warning_gate_requires_two_exact_opt_ins(
+    environ: dict[str, str],
+    expected: bool,
+) -> None:
+    """Neither a generic sandbox marker nor the dedicated flag works alone."""
+    from omnigent.claude_native_bridge import sandbox_bypass_warning_acceptance_enabled
+
+    assert sandbox_bypass_warning_acceptance_enabled(environ) is expected
 
 
 def test_augment_claude_args_uses_last_repeated_launch_override(

--- a/uv.lock
+++ b/uv.lock
@@ -687,6 +687,15 @@ wheels = [
 ]
 
 [[package]]
+name = "client-signals"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/dd/5002f106210ebb4772171e80f206c395e1ac38532c7d601a883903b9b7e6/client_signals-0.4.4.tar.gz", hash = "sha256:1fc1846b9992706349a10c10886f0f326bc56eeedd9af612c41cf9ff1a89562d", size = 3851, upload-time = "2026-08-05T14:46:53.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/76/e8f0947c8a26ec9fd0ccc960ed3875aec55035afb19bd6c08e9eac574861/client_signals-0.4.4-py3-none-any.whl", hash = "sha256:672551d797c004cfc9d5ae87ed0dca4ba5a64fc35d1edcf1218cc11f12fdfb25", size = 4347, upload-time = "2026-08-05T14:46:52.186Z" },
+]
+
+[[package]]
 name = "cloudpickle"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3256,6 +3265,9 @@ s3 = [
 slack = [
     { name = "omnigent-slack" },
 ]
+sprites = [
+    { name = "sprites-py" },
+]
 tracing = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -3401,6 +3413,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14,<15" },
     { name = "sherpa-onnx", marker = "extra == 'dictation'", specifier = ">=1.13,<2" },
     { name = "sherpa-onnx-core", marker = "extra == 'dictation'", specifier = ">=1.13,<2" },
+    { name = "sprites-py", marker = "extra == 'sprites'", specifier = ">=0.5,<1" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "starlette", specifier = ">=1.0.1,<2" },
     { name = "tiktoken", specifier = ">=0.7,<1" },
@@ -3410,7 +3423,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=10.4,<15" },
     { name = "zstandard", specifier = ">=0.22,<1" },
 ]
-provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "kms", "s3", "vertex", "modal", "daytona", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "vault", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "nimble", "slack", "databricks", "loadtest"]
+provides-extras = ["claude-sdk", "openai-agents", "all", "bedrock", "kms", "s3", "vertex", "modal", "daytona", "sprites", "blaxel", "boxlite", "cwsandbox", "e2b", "islo", "openshell", "kubernetes", "vault", "tracing", "agents-sdk", "antigravity", "copilot", "dictation", "cursor", "hindsight", "nimble", "slack", "databricks", "loadtest"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -5590,6 +5603,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sprites-py"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "client-signals" },
+    { name = "httpx" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/06/e36e15391f39f30b61871ea8aef753e4b696599545f1d7f13507705db409/sprites_py-0.5.1.tar.gz", hash = "sha256:8b15db9d6d88c461e54191c12e68d93a46d56a513d200d6d8044181dea6c85e2", size = 52765, upload-time = "2026-08-26T13:11:40.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/c8/e334645ebc5a382afc9ffc4bddcac3351c476c55d9369d658c8ea44fadda/sprites_py-0.5.1-py3-none-any.whl", hash = "sha256:d98cab60d94d32a4f7d6ffed8b5893c915827f6864c98ad3d4c2fd2112e6cb38", size = 46317, upload-time = "2026-08-26T13:11:39.657Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related issue

Closes #5115.

Depends on #6216 (provider-neutral activity leases) and #6217 (Claude bypass-confirmation gate). This draft includes those two prerequisite commits so it is runnable; after they merge, I will rebase and remove the duplicated prerequisite diff. The separate managed wake/reconnect improvements in #6218 are not included and are not an import-level dependency.

## Summary

- Add Sprites as a core, server-managed sandbox provider using the optional `sprites-py` SDK: create, bootstrap, register an `omnigent-host` Service, wake/reconnect, and delete. This does not add Sprites to the interactive sandbox CLI flow.
- Replace the custom-image assumption with native, retry-safe bootstrap in the persistent filesystem. Pin Claude Code 2.1.212, Codex 0.139.0, and Pi 0.84.2 to match current Omnigent CI. The idempotency marker includes the Omnigent install requirement and every exact CLI package version.
- Add the lazily loaded Sprites activity-lease adapter and explicit credential-boundary checks. The shared runner entry point does not eagerly import Sprites. The SDK is resolved to 0.5.1 in the lockfile.

In plain language: selecting Sprites creates a persistent Linux workspace for an agent. Omnigent installs its host once, holds the Sprite awake while work is active, and reuses the workspace after it sleeps.

```text
Omnigent server -> Sprites API: create + native bootstrap + Service
       ^                              |
       +--------- host tunnel --------+
                                      |
                   runner work -> local activity lease -> idle release
                   follow-up -> wake same Sprite -> resume workspace
                   session deletion -> destroy Sprite
```

Deployment: install `omnigent[sprites]` on the server, provide `SPRITE_TOKEN` in its environment, and configure a server URL reachable from the Sprite. Unpublished builds need a Sprite-reachable wheel URL via `install_spec`; by default the runner installs the exact server version. Initial bootstrap is slower than image startup. Session deletion destroys the Sprite and its filesystem.

```yaml
sandbox:
  provider: sprites
  server_url: https://omnigent.example.com
  sprites:
    env: [ANTHROPIC_API_KEY]
    allow_control_plane_credentials: true
```

Credential boundary: the launcher uses the organization token on the server. Explicitly selected workload environment values cross the Sprites control plane and are stored in the Service definition; a nonempty passthrough list is rejected without the opt-in above. Maintenance execs receive no workload credentials, and repository clone execs receive only configured Git credentials. A short-lived credential broker that avoids this transit is not implemented by this POC and remains a provider-neutral follow-up. See `deploy/sprites/README.md` for the full operational contract.

## Test Plan

On the rebased composition (base `4e41d4fb2`):

```bash
uv sync --group dev --extra sprites --extra tracing
uv run pytest -p no:rerunfailures tests/onboarding/sandboxes/test_sprites.py tests/runner/test_activity_lease.py tests/runner/test_runner_idle_active_work.py tests/runner/test_sprite_activity_lease.py tests/server/test_managed_hosts.py tests/test_claude_native_bridge.py
uv run pre-commit run --from-ref upstream/main --to-ref HEAD
```

598 affected Python tests passed. After aligning the Pi pin with current CI, the 20 provider tests and all applicable pre-commit checks passed again.

Opt-in live bootstrap regression (provisions a real Sprite and deletes it in cleanup): set `SPRITE_TOKEN` and `OMNIGENT_SPRITES_LIVE_INSTALL_SPEC` to a Sprite-reachable Omnigent artifact, then run:

```bash
OMNIGENT_RUN_SPRITES_LIVE_TEST=1 uv run --extra sprites pytest -p no:rerunfailures tests/onboarding/sandboxes/test_sprites_live.py
```

The earlier version of this live test passed in 152 seconds, verifying exact CLI versions, the bootstrap marker, and unchanged marker mtime on a repeated bootstrap. It has not been rerun after this rebase/Pi pin update. Earlier POC Claude tests exercised fresh provisioning, a three-minute foreground task, idle release, wake, and filesystem persistence; those are historical results, not validation of the current head. Live Codex/Pi agent turns are not claimed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — no provider-specific frontend changes. Bootstrap and lifecycle evidence and reproduction steps are above; the wake-indicator screenshot belongs to #6218.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new opt-in live test covers real bootstrap and idempotency, not a full agent conversation. Fresh live bootstrap and lifecycle validation on the current head remain outstanding, along with merging the two prerequisite PRs. This PR is intentionally a draft until those steps and the credential-boundary review are complete.

## Changelog

Run managed agent sessions in persistent Sprites sandboxes with native bootstrap, activity-aware hibernation, and workspace reuse after wake.
