### PR TITLE
fix(web): make keyboard shortcuts platform-exact (⌘ vs Ctrl)

### DIFF
--- a/tests/e2e_ui/sessions/test_command_palette.py
+++ b/tests/e2e_ui/sessions/test_command_palette.py
@@ -11,12 +11,12 @@ the *other* seeded session from the palette's list and assert the route changes
 to it.
 
 Two more chord-ownership cases live here because they are about who gets ⌘K
-and ⌘↑/↓ when another surface is focused:
+and the session-switch brackets when another surface is focused:
 
 - ``test_command_palette_chord_with_a_terminal_focused``: ⌘K opens the palette
-  over a focused terminal, while Ctrl+K stays with the PTY.
-- ``test_session_switch_chord_yields_to_the_open_palette``: with the palette
-  open, the switch chord moves *its* highlight and does not navigate behind it.
+  over a focused terminal on macOS, while Ctrl+K stays with the PTY.
+- ``test_session_switch_chord_does_not_navigate_behind_open_palette``: with the
+  palette open, the switch chord does not navigate behind it.
 
 No LLM turn is needed — this is pure client-side keyboard + routing — so it
 skips the nightly/real-agent markers the approval suites carry. Two runner-bound
@@ -33,6 +33,7 @@ same open → select → navigate path deterministically.
 from __future__ import annotations
 
 import re
+import sys
 
 import httpx
 from playwright.sync_api import Page, expect
@@ -76,9 +77,15 @@ def test_command_palette_opens_and_switches_session(
     expect(composer).to_be_visible()
     composer.click()
 
-    # Open the palette. CI runs Linux chromium → Control; the hook also accepts
-    # Cmd via metaKey on macOS.
-    page.keyboard.press("Control+k")
+    # The opposite platform modifier and a combined Cmd+Ctrl chord are inert.
+    modifier = "Meta" if sys.platform == "darwin" else "Control"
+    wrong_modifier = "Control" if sys.platform == "darwin" else "Meta"
+    page.keyboard.press(f"{wrong_modifier}+k")
+    expect(page.get_by_test_id("command-palette-input")).to_have_count(0)
+    page.keyboard.press("Meta+Control+k")
+    expect(page.get_by_test_id("command-palette-input")).to_have_count(0)
+
+    page.keyboard.press(f"{modifier}+k")
 
     dialog = page.get_by_role("dialog")
     expect(dialog).to_be_visible(timeout=10_000)
@@ -119,28 +126,24 @@ def test_command_palette_chord_with_a_terminal_focused(
     # (a container click doesn't reliably focus the canvas in headless).
     terminal_view.locator("textarea.xterm-helper-textarea").focus()
 
-    # Ctrl+K belongs to the PTY — the palette must leave it alone.
+    # Ctrl+K belongs to the PTY, while a non-platform modifier is inert.
     page.keyboard.press("Control+k")
     expect(page.get_by_placeholder(_PALETTE_INPUT)).to_have_count(0)
 
-    # Cmd+K reaches nothing else, so the palette claims it.
+    # On macOS Cmd+K reaches nothing else, so the palette claims it. On
+    # Windows/Linux Meta is not the command modifier and remains inert.
     page.keyboard.press("Meta+k")
-    expect(page.get_by_placeholder(_PALETTE_INPUT)).to_be_visible(timeout=10_000)
+    if sys.platform == "darwin":
+        expect(page.get_by_placeholder(_PALETTE_INPUT)).to_be_visible(timeout=10_000)
+    else:
+        expect(page.get_by_placeholder(_PALETTE_INPUT)).to_have_count(0)
 
 
-def test_session_switch_chord_yields_to_the_open_palette(
+def test_session_switch_chord_does_not_navigate_behind_open_palette(
     page: Page,
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """With the palette open, the switch chord moves its highlight, nothing more.
-
-    ``useSessionSwitchHotkey`` yields on ``defaultPrevented`` rather than on
-    "focus is in a text field", so the guard only holds while cmdk really does
-    claim this chord (it binds Cmd/Ctrl+↑/↓ to jump to the first/last row).
-    Asserting the highlight *moved* is what pins that: a cmdk upgrade that
-    stopped binding these chords would fail here rather than silently start
-    navigating the app behind the open palette.
-    """
+    """The session-switch bracket chord cannot navigate behind the palette."""
     base_url, session_a, session_b = seeded_session_pair
     _set_title(base_url, session_a, "e2e-yield-a")
     _set_title(base_url, session_b, "e2e-yield-b")
@@ -151,18 +154,8 @@ def test_session_switch_chord_yields_to_the_open_palette(
     page.keyboard.press("ControlOrMeta+k")
     palette_input = page.get_by_placeholder(_PALETTE_INPUT)
     expect(palette_input).to_be_visible(timeout=10_000)
-    # cmdk highlights a row as soon as its list renders; the chord below has
-    # nothing to move until it does.
-    selected = page.locator("[cmdk-item][data-selected=true]")
-    expect(selected).to_have_count(1, timeout=10_000)
-    before_row = selected.inner_text()
+    page.keyboard.press("ControlOrMeta+BracketRight")
 
-    page.keyboard.press("ControlOrMeta+ArrowDown")
-
-    # cmdk consumed it: the highlight moved to the last row...
-    expect(page.locator("[cmdk-item][data-selected=true]")).not_to_have_text(
-        before_row, timeout=10_000
-    )
-    # ...and the app did NOT navigate behind the still-open palette.
+    # The app did not navigate behind the still-open palette.
     expect(palette_input).to_be_visible()
     assert page.url.endswith(f"/c/{session_a}"), f"route moved behind the palette: {page.url}"

--- a/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
+++ b/tests/e2e_ui/sessions/test_composer_session_switch_hotkey.py
@@ -1,24 +1,21 @@
-"""E2E: Cmd/Ctrl+Arrow switches sessions, composer focus included.
+"""E2E: Cmd/Ctrl+bracket switches sessions, composer focus included.
 
 ``useSessionSwitchHotkey`` (window keydown) steps the sidebar's ordered
-sessions on Cmd/Ctrl+Up/Down. It used to bail whenever the keydown target sat
-in an editable field, which killed the chord in the composer — the one place
-users spend their time, and the exact case the hotkey was meant to serve (the
-composer already declines modified arrows so this window hook can have them).
-It now yields on ``defaultPrevented`` instead, so a widget that genuinely
-claimed the chord for its own list navigation still wins.
+sessions on Cmd/Ctrl+[ and Cmd/Ctrl+]. Brackets carry no composer caret
+behavior, so the global shortcut can work while a draft is focused. Terminals
+and Monaco remain excluded because they own these chords.
 
 This exercises the contract through the real chain the unit tests mock out:
 live session list -> sidebar render order -> window keydown handler ->
 client-side navigation to ``/c/{id}``.
 
-- ``test_ctrl_arrow_switches_session_from_focused_composer``: focus the
-  composer, leave a draft, press Ctrl+Down, and assert the route moved, the
+- ``test_command_bracket_switches_session_from_focused_composer``: focus the
+  composer, leave a draft, press Command/Ctrl+], and assert the route moved, the
   inactive row gains its draft indicator, and the draft survives the round
   trip. A regression that restored the editable-field guard would stay put
   here.
-- ``test_ctrl_arrow_still_switches_session_from_body_focus``: blur the
-  composer so the keydown targets the body, press Ctrl+Down, and assert the
+- ``test_command_bracket_still_switches_session_from_body_focus``: blur the
+  composer so the keydown targets the body, press Command/Ctrl+], and assert the
   route leaves the current session.
 
 No LLM turn is needed — pure client-side keyboard + routing — so this skips the
@@ -28,6 +25,8 @@ sidebar's "Sessions" group, so both are in the hotkey's ordered list.
 """
 
 from __future__ import annotations
+
+import sys
 
 import httpx
 from playwright.sync_api import Page, expect
@@ -45,11 +44,11 @@ def _set_title(base_url: str, session_id: str, title: str) -> None:
     resp.raise_for_status()
 
 
-def test_ctrl_arrow_switches_session_from_focused_composer(
+def test_command_bracket_switches_session_from_focused_composer(
     page: Page,
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """Typing in the composer, then Ctrl+↓, still moves to another session."""
+    """Typing in the composer, then Command/Ctrl+], moves to another session."""
     base_url, session_a, session_b = seeded_session_pair
     _set_title(base_url, session_a, "e2e-switch-a")
     _set_title(base_url, session_b, "e2e-switch-b")
@@ -72,9 +71,17 @@ def test_ctrl_arrow_switches_session_from_focused_composer(
     # row does not need a redundant draft marker.
     expect(draft_indicator).to_have_count(0)
 
+    # The non-platform modifier must not navigate (Control on macOS, Meta
+    # elsewhere), and holding both modifiers must not bypass that exclusivity.
+    wrong_modifier = "Control" if sys.platform == "darwin" else "Meta"
+    page.keyboard.press(f"{wrong_modifier}+BracketRight")
+    assert page.url == f"{base_url}/c/{session_a}"
+    page.keyboard.press("Meta+Control+BracketRight")
+    assert page.url == f"{base_url}/c/{session_a}"
+
     # ControlOrMeta maps to the real platform modifier (Cmd on macOS, Ctrl
-    # elsewhere); CI runs Linux chromium, so this is Ctrl+Down.
-    page.keyboard.press("ControlOrMeta+ArrowDown")
+    # elsewhere); CI runs Linux chromium, so this is Ctrl+].
+    page.keyboard.press("ControlOrMeta+BracketRight")
 
     # Assert "switched away" rather than a hard-coded target: the suite shares
     # one server, so the sidebar may hold sessions beyond this pair.
@@ -88,7 +95,7 @@ def test_ctrl_arrow_switches_session_from_focused_composer(
     # Drafts are per-session, so the composer we landed on is a different one;
     # stepping back restores the draft, proving the chord navigated rather than
     # clobbering composer state.
-    page.keyboard.press("ControlOrMeta+ArrowUp")
+    page.keyboard.press("ControlOrMeta+BracketLeft")
     expect(page).to_have_url(f"{base_url}/c/{session_a}", timeout=10_000)
     expect(page.get_by_placeholder(_COMPOSER)).to_have_value(
         "an unsent draft that must survive the switch"
@@ -96,11 +103,11 @@ def test_ctrl_arrow_switches_session_from_focused_composer(
     expect(draft_indicator).to_have_count(0)
 
 
-def test_ctrl_arrow_still_switches_session_from_body_focus(
+def test_command_bracket_still_switches_session_from_body_focus(
     page: Page,
     seeded_session_pair: tuple[str, str, str],
 ) -> None:
-    """With focus outside the composer, Ctrl+↓ still steps to a neighbor."""
+    """With focus outside the composer, Command/Ctrl+] steps to a neighbor."""
     base_url, session_a, session_b = seeded_session_pair
     _set_title(base_url, session_a, "e2e-switch-a")
     _set_title(base_url, session_b, "e2e-switch-b")
@@ -119,7 +126,7 @@ def test_ctrl_arrow_still_switches_session_from_body_focus(
 
     # Dispatch the chord at the body; the keydown bubbles to the window hook
     # and we navigate to a neighbor.
-    page.locator("body").press("ControlOrMeta+ArrowDown")
+    page.locator("body").press("ControlOrMeta+BracketRight")
 
     # Assert we left session_a for another /c/ route. We check "switched away"
     # rather than a hard-coded target id: the suite shares one server across

--- a/web/src/components/KeyboardShortcut.tsx
+++ b/web/src/components/KeyboardShortcut.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from "react";
+
 import { TooltipContent } from "@/components/ui/tooltip";
+import { isMacPlatform } from "@/lib/hotkeys";
 import { cn } from "@/lib/utils";
 
-const IS_MAC =
-  typeof navigator !== "undefined" &&
-  /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent || "");
+const IS_MAC = isMacPlatform();
 
 export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl";
 export const ALT_KEY = IS_MAC ? "⌥" : "Alt";

--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -86,6 +86,8 @@ describe("KeyboardShortcutsDialog", () => {
     expect(screen.getByText("Send message")).toBeTruthy();
     expect(screen.getByText("Recall previous prompt")).toBeTruthy();
     expect(screen.getByText("Previous session")).toBeTruthy();
+    expect(keysFor("Previous session")).toEqual(["Ctrl", "["]);
+    expect(keysFor("Next session")).toEqual(["Ctrl", "]"]);
     expect(screen.getByText("Toggle conversations sidebar")).toBeTruthy();
     expect(screen.getByText("Open a new shell")).toBeTruthy();
     expect(screen.getByText("Navigate suggestions")).toBeTruthy();

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -29,6 +29,7 @@ import {
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
+import { hasCommandModifier } from "@/lib/hotkeys";
 import { isNativeShell } from "@/lib/nativeBridge";
 
 // Custom event the dialog listens for, so non-adjacent surfaces (e.g. the
@@ -44,6 +45,8 @@ export function openKeyboardShortcuts(): void {
 // Glyphs match the in-app tooltips (e.g. UserMessageNav's "⌘⌥↑").
 const UP = "↑";
 const DOWN = "↓";
+const BRACKET_LEFT = "[";
+const BRACKET_RIGHT = "]";
 
 interface Shortcut {
   label: string;
@@ -83,8 +86,8 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
   {
     title: "Navigation",
     items: [
-      { label: "Previous session", keys: [MOD_KEY, UP] },
-      { label: "Next session", keys: [MOD_KEY, DOWN] },
+      { label: "Previous session", keys: [MOD_KEY, BRACKET_LEFT] },
+      { label: "Next session", keys: [MOD_KEY, BRACKET_RIGHT] },
     ],
   },
   {
@@ -196,8 +199,9 @@ export function KeyboardShortcutsDialog() {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       // ⌘/Ctrl + / toggles the panel. Plain `/` is the composer's slash-menu
-      // trigger, so require the modifier and no Shift/Alt to avoid clashing.
-      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key === "/") {
+      // trigger, so require the platform command modifier and no Shift/Alt to
+      // avoid clashing (only ⌘/ on macOS, only Ctrl+/ on Win/Linux).
+      if (hasCommandModifier(e) && !e.altKey && !e.shiftKey && e.key === "/") {
         e.preventDefault();
         setOpen((prev) => !prev);
       }

--- a/web/src/components/chat/Transcript.tsx
+++ b/web/src/components/chat/Transcript.tsx
@@ -9,6 +9,7 @@ import { Message, MessageContent } from "@/components/ai-elements/message";
 import { ElicitationCard } from "@/components/blocks/ApprovalCard";
 import { cn } from "@/lib/utils";
 import { getCurrentAuthorId } from "@/lib/identity";
+import { hasCommandModifier } from "@/lib/hotkeys";
 import {
   type Bubble,
   type BubbleCache,
@@ -197,7 +198,7 @@ function TranscriptImpl({
   // Cmd+Alt+↑/↓ (Ctrl+Alt on win/linux) user-turn navigation.
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || !e.altKey) return;
+      if (!hasCommandModifier(e) || !e.altKey) return;
       if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
       if (e.defaultPrevented) return;
       e.preventDefault();

--- a/web/src/hooks/useApproveHotkey.test.tsx
+++ b/web/src/hooks/useApproveHotkey.test.tsx
@@ -1,6 +1,7 @@
 // Cmd/Ctrl+Enter accepts the newest pending accept/decline prompt; skips
 // already-responded prompts and AskUserQuestion (which needs an explicit
-// choice); ignores bare Enter and Alt/Shift-modified Enter.
+// choice); platform-aware (only ⌘ on macOS, only Ctrl on Win/Linux); ignores
+// bare Enter and Alt/Shift-modified Enter.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -47,7 +48,7 @@ describe("useApproveHotkey", () => {
     // keystroke that accepts anyway walks around that gate and sends the
     // server none of what it asked for.
     blocks = [{ ...pending, requestedSchema: FIELD_SCHEMA }];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press();
     expect(submitApproval).not.toHaveBeenCalled();
   });
@@ -59,30 +60,37 @@ describe("useApproveHotkey", () => {
       { type: "elicitation", elicitationId: "old", status: "pending" },
       { ...pending, elicitationId: "form", requestedSchema: FIELD_SCHEMA },
     ];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press();
     expect(submitApproval).not.toHaveBeenCalled();
   });
 
   it("still accepts a bare consent prompt that names no fields", () => {
     blocks = [{ ...pending, requestedSchema: { type: "object" } }];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press();
     expect(submitApproval).toHaveBeenCalledWith("e1", "accept");
   });
 
-  it("Cmd+Enter accepts the pending approval", () => {
+  it("Cmd+Enter accepts the pending approval (macOS)", () => {
     blocks = [pending];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press();
     expect(submitApproval).toHaveBeenCalledWith("e1", "accept");
   });
 
-  it("Ctrl+Enter also accepts (Win/Linux)", () => {
+  it("Ctrl+Enter accepts on Windows/Linux", () => {
     blocks = [pending];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(false));
     press({ ctrlKey: true });
     expect(submitApproval).toHaveBeenCalledWith("e1", "accept");
+  });
+
+  it("ignores Ctrl+Enter on macOS (only ⌘↵ fires there)", () => {
+    blocks = [pending];
+    renderHook(() => useApproveHotkey(true));
+    press({ ctrlKey: true });
+    expect(submitApproval).not.toHaveBeenCalled();
   });
 
   it("accepts the most recent pending approval", () => {
@@ -91,28 +99,28 @@ describe("useApproveHotkey", () => {
       { type: "text" },
       { type: "elicitation", elicitationId: "new", status: "pending" },
     ];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press();
     expect(submitApproval).toHaveBeenCalledWith("new", "accept");
   });
 
   it("ignores already-responded prompts", () => {
     blocks = [{ type: "elicitation", elicitationId: "e1", status: "responded" }];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press();
     expect(submitApproval).not.toHaveBeenCalled();
   });
 
   it("skips AskUserQuestion (needs an explicit choice)", () => {
     blocks = [{ type: "elicitation", elicitationId: "q1", status: "pending", askUserQuestion: {} }];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press();
     expect(submitApproval).not.toHaveBeenCalled();
   });
 
   it("ignores bare Enter and Alt/Shift-modified Enter", () => {
     blocks = [pending];
-    renderHook(() => useApproveHotkey());
+    renderHook(() => useApproveHotkey(true));
     press({}); // bare Enter
     press({ metaKey: true, shiftKey: true });
     press({ metaKey: true, altKey: true });

--- a/web/src/hooks/useApproveHotkey.ts
+++ b/web/src/hooks/useApproveHotkey.ts
@@ -18,14 +18,16 @@
 import { useEffect } from "react";
 
 import { schemaFields } from "@/components/blocks/ElicitationSchemaForm";
+import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
 import type { ElicitationBlock } from "@/lib/blocks";
 import { useChatStore } from "@/store/chatStore";
 
-export function useApproveHotkey(): void {
+export function useApproveHotkey(isMac = isMacPlatform()): void {
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Cmd/Ctrl, not Alt/Shift (mirrors the session-switch hotkey's guard).
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
+      // Platform command modifier, not Alt/Shift (mirrors the session-switch guard):
+      // only ⌘↵ on macOS and only Ctrl+↵ on Win/Linux.
+      if (!hasCommandModifier(e, isMac) || e.altKey || e.shiftKey) return;
       if (e.key !== "Enter") return;
 
       const { blocks, submitApproval } = useChatStore.getState();
@@ -51,5 +53,5 @@ export function useApproveHotkey(): void {
 
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, []);
+  }, [isMac]);
 }

--- a/web/src/hooks/useCommandPaletteHotkey.test.tsx
+++ b/web/src/hooks/useCommandPaletteHotkey.test.tsx
@@ -8,51 +8,45 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
+function event(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
 function press(init: KeyboardEventInit): KeyboardEvent {
-  const e = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+  const e = event(init);
   window.dispatchEvent(e);
   return e;
 }
 
 describe("isCommandPaletteHotkey", () => {
-  it("matches Cmd+K and Ctrl+K", () => {
-    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "k", metaKey: true }))).toBe(
-      true,
-    );
-    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "k", ctrlKey: true }))).toBe(
-      true,
-    );
+  it("uses Cmd on macOS and Ctrl on other platforms", () => {
+    expect(isCommandPaletteHotkey(event({ key: "k", metaKey: true }), true)).toBe(true);
+    expect(isCommandPaletteHotkey(event({ key: "k", ctrlKey: true }), true)).toBe(false);
+    expect(isCommandPaletteHotkey(event({ key: "k", ctrlKey: true }), false)).toBe(true);
+    expect(isCommandPaletteHotkey(event({ key: "k", metaKey: true }), false)).toBe(false);
     // Uppercase (some layouts report "K" with the modifier).
-    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "K", metaKey: true }))).toBe(
-      true,
-    );
+    expect(isCommandPaletteHotkey(event({ key: "K", metaKey: true }), true)).toBe(true);
   });
 
   it("rejects plain k, and k with Alt or Shift held", () => {
-    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "k" }))).toBe(false);
-    expect(
-      isCommandPaletteHotkey(
-        new KeyboardEvent("keydown", { key: "k", metaKey: true, altKey: true }),
-      ),
-    ).toBe(false);
-    expect(
-      isCommandPaletteHotkey(
-        new KeyboardEvent("keydown", { key: "k", ctrlKey: true, shiftKey: true }),
-      ),
-    ).toBe(false);
+    expect(isCommandPaletteHotkey(event({ key: "k" }), true)).toBe(false);
+    expect(isCommandPaletteHotkey(event({ key: "k", metaKey: true, altKey: true }), true)).toBe(
+      false,
+    );
+    expect(isCommandPaletteHotkey(event({ key: "k", ctrlKey: true, shiftKey: true }), false)).toBe(
+      false,
+    );
   });
 
   it("rejects other keys with the modifier", () => {
-    expect(isCommandPaletteHotkey(new KeyboardEvent("keydown", { key: "j", metaKey: true }))).toBe(
-      false,
-    );
+    expect(isCommandPaletteHotkey(event({ key: "j", metaKey: true }), true)).toBe(false);
   });
 });
 
 describe("useCommandPaletteHotkey", () => {
   it("toggles on Cmd+K and prevents the browser default", () => {
     const onToggle = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
 
     const e = press({ key: "k", metaKey: true });
 
@@ -60,9 +54,29 @@ describe("useCommandPaletteHotkey", () => {
     expect(e.defaultPrevented).toBe(true);
   });
 
+  it("leaves Ctrl+K alone on macOS (emacs kill-to-end-of-line keeps working)", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
+
+    const e = press({ key: "k", ctrlKey: true });
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("fires on Ctrl+K on Windows/Linux", () => {
+    const onToggle = vi.fn();
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, false));
+
+    const e = press({ key: "k", ctrlKey: true });
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
   it("ignores auto-repeat", () => {
     const onToggle = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
 
     press({ key: "k", metaKey: true, repeat: true });
 
@@ -71,7 +85,7 @@ describe("useCommandPaletteHotkey", () => {
 
   it("does nothing when disabled", () => {
     const onToggle = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle, false));
+    renderHook(() => useCommandPaletteHotkey(onToggle, false, true));
 
     const e = press({ key: "k", metaKey: true });
 
@@ -97,7 +111,7 @@ describe("useCommandPaletteHotkey", () => {
     // window would never reach document listeners regardless).
     const onToggle = vi.fn();
     const hostListener = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
     document.addEventListener("keydown", hostListener);
     const deep = document.createElement("div");
     document.body.appendChild(deep);
@@ -114,7 +128,7 @@ describe("useCommandPaletteHotkey", () => {
   it("lets the chord through to host-page listeners when a focused surface owns it", () => {
     const onToggle = vi.fn();
     const hostListener = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
     document.addEventListener("keydown", hostListener);
     focusInside("monaco-editor");
 
@@ -130,7 +144,7 @@ describe("useCommandPaletteHotkey", () => {
 
   it("bails on Ctrl+K in a terminal — xterm sends it to the PTY as ^K", () => {
     const onToggle = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, false));
     focusInside("xterm");
 
     press({ key: "k", ctrlKey: true });
@@ -140,7 +154,7 @@ describe("useCommandPaletteHotkey", () => {
 
   it("claims Cmd+K in a terminal — xterm drops Cmd chords, so nothing owns it", () => {
     const onToggle = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
     focusInside("xterm");
 
     press({ key: "k", metaKey: true });
@@ -148,20 +162,19 @@ describe("useCommandPaletteHotkey", () => {
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
-  it("bails on both variants inside the code editor (⌘K is a chord prefix)", () => {
+  it("bails on the platform command variant inside the code editor", () => {
     const onToggle = vi.fn();
-    renderHook(() => useCommandPaletteHotkey(onToggle));
+    renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
     focusInside("monaco-editor");
 
     press({ key: "k", metaKey: true });
-    press({ key: "k", ctrlKey: true });
 
     expect(onToggle).not.toHaveBeenCalled();
   });
 
   it("unbinds on unmount", () => {
     const onToggle = vi.fn();
-    const { unmount } = renderHook(() => useCommandPaletteHotkey(onToggle));
+    const { unmount } = renderHook(() => useCommandPaletteHotkey(onToggle, true, true));
     unmount();
 
     press({ key: "k", metaKey: true });

--- a/web/src/hooks/useCommandPaletteHotkey.ts
+++ b/web/src/hooks/useCommandPaletteHotkey.ts
@@ -1,16 +1,19 @@
 // ⌘K (Ctrl+K on Win/Linux) toggles the global command palette. Sibling to the
-// session-switch (⌘↑/↓) and sidebar-toggle (⌘⌥[ / ⌘⌥]) hotkeys; like them it's
-// bound ONCE at the app shell, where the palette's open-state lives.
+// session-switch (⌘[ / ⌘]) and sidebar-toggle (⌘⌥[ / ⌘⌥]) hotkeys; like them
+// it's bound ONCE at the app shell, where the palette's open-state lives.
 //
 // Why ⌘K: it's the de-facto command-palette key across developer tools, and
 // issue #1059 / PR #1064 deliberately reserved it for this (PR #1064 took ⌘⇧F
 // for sidebar search precisely to leave ⌘K free). The browser binds Ctrl+K to
 // the address bar, so we preventDefault to claim it.
 //
+// Platform-aware: only ⌘K fires on macOS and only Ctrl+K on Win/Linux.
 // Focused surfaces can still own the chord, but only the variant they actually
 // consume — see `focusOwnsHotkey`.
 
 import { useEffect, useRef } from "react";
+
+import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
 
 /** Monaco: ⌘K and Ctrl+K are both chord prefixes, on every platform. */
 const CHORD_PREFIX_SURFACE = ".monaco-editor";
@@ -18,9 +21,13 @@ const CHORD_PREFIX_SURFACE = ".monaco-editor";
 /** xterm: forwards the CONTROL variant to the PTY as ^K (kill-to-end-of-line). */
 const PTY_SURFACE = ".xterm";
 
-/** True when the event is the command-palette chord: Cmd/Ctrl+K, no Alt/Shift. */
-export function isCommandPaletteHotkey(e: globalThis.KeyboardEvent): boolean {
-  if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return false;
+/** True when the event is the command-palette chord: the platform command
+ *  modifier + K, no Alt/Shift. */
+export function isCommandPaletteHotkey(
+  e: globalThis.KeyboardEvent,
+  isMac: boolean = isMacPlatform(),
+): boolean {
+  if (!hasCommandModifier(e, isMac) || e.altKey || e.shiftKey) return false;
   // AltGr reports as Ctrl+Alt on some layouts; the altKey check above already
   // rejects it, but guard explicitly so intl typing never triggers the palette.
   if (e.getModifierState("AltGraph")) return false;
@@ -50,7 +57,11 @@ function focusOwnsHotkey(e: globalThis.KeyboardEvent): boolean {
  * @param enabled  Pass `false` to disable the hotkey (e.g. embedded in a real
  *   host page, where ⌘K belongs to the host). Defaults to enabled.
  */
-export function useCommandPaletteHotkey(onToggle: () => void, enabled = true): void {
+export function useCommandPaletteHotkey(
+  onToggle: () => void,
+  enabled = true,
+  isMac = isMacPlatform(),
+): void {
   // Held in a ref so the bound handler always calls the latest closure without
   // re-registering on every render.
   const latest = useRef(onToggle);
@@ -61,7 +72,7 @@ export function useCommandPaletteHotkey(onToggle: () => void, enabled = true): v
     const handler = (e: globalThis.KeyboardEvent): void => {
       // Ignore auto-repeat: holding the chord would flap the palette.
       if (e.repeat) return;
-      if (!isCommandPaletteHotkey(e)) return;
+      if (!isCommandPaletteHotkey(e, isMac)) return;
       // Leave the chord to a surface that actually consumes it.
       if (focusOwnsHotkey(e)) return;
       // Claim the chord: preventDefault drops the browser default (Ctrl+K
@@ -78,5 +89,5 @@ export function useCommandPaletteHotkey(onToggle: () => void, enabled = true): v
     // propagation, so Monaco/terminal chords still flow to their surfaces.
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [enabled]);
+  }, [enabled, isMac]);
 }

--- a/web/src/hooks/useNewSessionHotkey.ts
+++ b/web/src/hooks/useNewSessionHotkey.ts
@@ -1,18 +1,13 @@
 import { useEffect } from "react";
 
+import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
 import { useNavigate } from "@/lib/routing";
-
-function isMacPlatform(): boolean {
-  if (typeof navigator === "undefined") return false;
-  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
-  const platform = uaData?.platform ?? navigator.platform ?? navigator.userAgent ?? "";
-  return /Mac|iPhone|iPad|iPod/i.test(platform);
-}
 
 /** True for Cmd+N on Apple platforms or Ctrl+N elsewhere, without extra modifiers. */
 export function isNewSessionHotkey(e: globalThis.KeyboardEvent, isMac = isMacPlatform()): boolean {
-  const platformModifier = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
-  if (!platformModifier || e.altKey || e.shiftKey || e.getModifierState("AltGraph")) return false;
+  if (!hasCommandModifier(e, isMac) || e.altKey || e.shiftKey || e.getModifierState("AltGraph")) {
+    return false;
+  }
   return e.key === "n" || e.key === "N";
 }
 

--- a/web/src/hooks/usePinnedSessionHotkeys.test.tsx
+++ b/web/src/hooks/usePinnedSessionHotkeys.test.tsx
@@ -1,7 +1,8 @@
 // Numeric pinned-session jump to the Nth pinned session: 1–9 → indices 0–8,
 // 0 → 10th. Platform-aware chord — plain Cmd/Ctrl+digit in the Electron shell,
 // Cmd/Ctrl+Alt+digit in the browser (matched on e.code there, since Alt rewrites
-// e.key). Fires inside text fields; out-of-range and already-active are no-ops.
+// e.key). Only ⌘ fires on macOS, only Ctrl on Win/Linux. Fires inside text
+// fields; out-of-range and already-active are no-ops.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -35,6 +36,11 @@ function press(
   return e;
 }
 
+/** Render on macOS (⌘) by default; pass isMac=false for the Ctrl (Win/Linux) path. */
+function render(ids: readonly string[], activeId: string | undefined, isMac = true) {
+  return renderHook(() => usePinnedSessionHotkeys(ids, activeId, isMac));
+}
+
 beforeEach(() => {
   navigate.mockClear();
   isNativeShell.mockReturnValue(true);
@@ -52,57 +58,63 @@ describe("usePinnedSessionHotkeys", () => {
   });
 
   it("Cmd+1 opens the first pinned session", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     press("1");
     expect(navigate).toHaveBeenCalledWith("/c/a");
   });
 
   it("Cmd+3 opens the third pinned session", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     press("3");
     expect(navigate).toHaveBeenCalledWith("/c/c");
   });
 
   it("Cmd+0 opens the tenth pinned session", () => {
     const ten = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
-    renderHook(() => usePinnedSessionHotkeys(ten, undefined));
+    render(ten, undefined);
     press("0");
     expect(navigate).toHaveBeenCalledWith("/c/j");
   });
 
   it("Cmd+9 opens the ninth pinned session", () => {
     const ten = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
-    renderHook(() => usePinnedSessionHotkeys(ten, undefined));
+    render(ten, undefined);
     press("9");
     expect(navigate).toHaveBeenCalledWith("/c/i");
   });
 
-  it("Ctrl+1 also works (Windows/Linux)", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+  it("Ctrl+1 works on Windows/Linux", () => {
+    render(ids, undefined, false);
     press("1", { ctrlKey: true });
     expect(navigate).toHaveBeenCalledWith("/c/a");
   });
 
+  it("ignores Ctrl+1 on macOS (only ⌘ fires there)", () => {
+    render(ids, undefined, true);
+    press("1", { ctrlKey: true });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it("ignores a bare digit with no Cmd/Ctrl", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     press("1", {});
     expect(navigate).not.toHaveBeenCalled();
   });
 
   it("ignores Alt+digit (reserved for message navigation discipline)", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     press("1", { metaKey: true, altKey: true });
     expect(navigate).not.toHaveBeenCalled();
   });
 
   it("ignores Shift+digit", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     press("1", { metaKey: true, shiftKey: true });
     expect(navigate).not.toHaveBeenCalled();
   });
 
   it("fires while a text field is focused", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     const ta = document.createElement("textarea");
     document.body.appendChild(ta);
     press("2", { metaKey: true }, ta);
@@ -110,42 +122,42 @@ describe("usePinnedSessionHotkeys", () => {
   });
 
   it("does nothing when no pinned session exists at that index", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     const e = press("5"); // only 3 pinned
     expect(navigate).not.toHaveBeenCalled();
     expect(e.defaultPrevented).toBe(false); // leaves the native event alone
   });
 
   it("does not navigate when the digit points at the already-active session", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, "a"));
+    render(ids, "a");
     const e = press("1");
     expect(navigate).not.toHaveBeenCalled();
     expect(e.defaultPrevented).toBe(true); // but still suppresses native tab-switch
   });
 
   it("prevents the browser's native tab-switch when it navigates", () => {
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     const e = press("1");
     expect(e.defaultPrevented).toBe(true);
   });
 
   it("only maps the first ten: an 11th pinned session has no shortcut", () => {
     const eleven = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"];
-    renderHook(() => usePinnedSessionHotkeys(eleven, undefined));
+    render(eleven, undefined);
     // No digit maps to index 10, so "k" is unreachable; 0 still lands on the 10th.
     press("0");
     expect(navigate).toHaveBeenCalledWith("/c/j");
   });
 
   it("does nothing when the list is empty", () => {
-    renderHook(() => usePinnedSessionHotkeys([], undefined));
+    render([], undefined);
     press("1");
     expect(navigate).not.toHaveBeenCalled();
   });
 
   it("browser: leaves plain Cmd+digit to the native tab-switch", () => {
     isNativeShell.mockReturnValue(false);
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     const e = press("1", { metaKey: true }, document.body, "Digit1");
     expect(navigate).not.toHaveBeenCalled();
     // Plain Cmd+1 is the browser's own tab-switch — left alone.
@@ -154,7 +166,7 @@ describe("usePinnedSessionHotkeys", () => {
 
   it("browser: Cmd+Alt+Digit1 opens the first pinned session", () => {
     isNativeShell.mockReturnValue(false);
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined);
     // Alt rewrites e.key on macOS (⌥1 → "¡"), so the hook matches e.code.
     const e = press("¡", { metaKey: true, altKey: true }, document.body, "Digit1");
     expect(navigate).toHaveBeenCalledWith("/c/a");
@@ -163,7 +175,7 @@ describe("usePinnedSessionHotkeys", () => {
 
   it("browser: Ctrl+Alt+Digit3 opens the third (Windows/Linux)", () => {
     isNativeShell.mockReturnValue(false);
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined, false);
     press("3", { ctrlKey: true, altKey: true }, document.body, "Digit3");
     expect(navigate).toHaveBeenCalledWith("/c/c");
   });
@@ -172,11 +184,11 @@ describe("usePinnedSessionHotkeys", () => {
     // AltGr reports as Ctrl+Alt on Windows/Linux — typing AltGr+2 must
     // compose the character (event untouched), not navigate to a session.
     isNativeShell.mockReturnValue(false);
-    renderHook(() => usePinnedSessionHotkeys(ids, undefined));
+    render(ids, undefined, false);
     const altGraph = vi
       .spyOn(KeyboardEvent.prototype, "getModifierState")
       .mockImplementation((keyArg) => keyArg === "AltGraph");
-    const e = press("\u00b2", { ctrlKey: true, altKey: true }, document.body, "Digit2");
+    const e = press("²", { ctrlKey: true, altKey: true }, document.body, "Digit2");
     expect(navigate).not.toHaveBeenCalled();
     expect(e.defaultPrevented).toBe(false);
     altGraph.mockRestore();
@@ -185,7 +197,7 @@ describe("usePinnedSessionHotkeys", () => {
   it("browser: Cmd+Alt+Digit0 opens the tenth pinned session", () => {
     isNativeShell.mockReturnValue(false);
     const ten = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"];
-    renderHook(() => usePinnedSessionHotkeys(ten, undefined));
+    render(ten, undefined);
     press("º", { metaKey: true, altKey: true }, document.body, "Digit0");
     expect(navigate).toHaveBeenCalledWith("/c/j");
   });

--- a/web/src/hooks/usePinnedSessionHotkeys.ts
+++ b/web/src/hooks/usePinnedSessionHotkeys.ts
@@ -1,7 +1,8 @@
 // Cmd+1..9/0 (Ctrl on Win/Linux) jumps to the Nth pinned sidebar session:
 // 1–9 → the first nine, 0 → the tenth (browser-tab-style mapping). Sibling to
-// useSessionSwitchHotkey — same once-bound, ref-backed, metaKey||ctrlKey shape.
-// Fires even in a focused text field so you can jump mid-compose. Bind ONCE.
+// useSessionSwitchHotkey — same once-bound, ref-backed, platform-aware shape
+// (only ⌘ fires on macOS, only Ctrl on Win/Linux). Fires even in a focused text
+// field so you can jump mid-compose. Bind ONCE.
 //
 // Platform-aware chord: a browser tab reserves plain Cmd/Ctrl+digit for native
 // tab-switching, so in the browser the binding adds Alt (Cmd/Ctrl+Alt+digit) to
@@ -11,6 +12,7 @@
 // native path matches on e.key. The shortcuts-dialog row mirrors the same split.
 
 import { useEffect, useRef } from "react";
+import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
 import { useNavigate } from "@/lib/routing";
 import { isNativeShell } from "@/lib/nativeBridge";
 
@@ -42,6 +44,7 @@ export const PINNED_HOTKEY_CODES = [
 export function usePinnedSessionHotkeys(
   orderedPinnedIds: readonly string[],
   activeId: string | undefined,
+  isMac = isMacPlatform(),
 ): void {
   const navigate = useNavigate();
   // Bound once; the ref keeps the handler reading the live list/route.
@@ -50,8 +53,8 @@ export function usePinnedSessionHotkeys(
 
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Cmd/Ctrl required; Shift left to other bindings.
-      if (e.shiftKey || !(e.metaKey || e.ctrlKey)) return;
+      // Platform command modifier required; Shift left to other bindings.
+      if (e.shiftKey || !hasCommandModifier(e, isMac)) return;
 
       let index: number;
       if (isNativeShell()) {
@@ -82,5 +85,5 @@ export function usePinnedSessionHotkeys(
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [navigate]);
+  }, [navigate, isMac]);
 }

--- a/web/src/hooks/useSessionSwitchHotkey.test.tsx
+++ b/web/src/hooks/useSessionSwitchHotkey.test.tsx
@@ -136,6 +136,16 @@ describe("useSessionSwitchHotkey", () => {
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  it("does not navigate behind an open command palette", () => {
+    render(ids, "a");
+    const input = document.createElement("input");
+    input.setAttribute("cmdk-input", "");
+    document.body.appendChild(input);
+    input.focus();
+    press("BracketRight", { metaKey: true }, input);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it("yields when a focused widget already claimed the chord", () => {
     render(ids, "a");
     const menu = document.createElement("div");

--- a/web/src/hooks/useSessionSwitchHotkey.test.tsx
+++ b/web/src/hooks/useSessionSwitchHotkey.test.tsx
@@ -1,7 +1,7 @@
-// Cmd/Ctrl+↓/↑ steps next/prev with wrap; off-list ↓ enters at top, ↑ at
-// bottom; fires inside editable fields (the composer is where users type, and
-// the chord carries a modifier) but yields to a widget that already claimed it;
-// ignores Alt/Shift/bare arrows; a no-op step (same id) doesn't navigate.
+// Cmd/Ctrl+] / [ steps next/prev with wrap; off-list ] enters at top, [ at
+// bottom; platform-aware (only ⌘ on macOS, only Ctrl elsewhere); fires while the
+// composer is focused but bails inside terminals / the code editor; ignores
+// Alt/Shift/bare brackets; a no-op step (same id) doesn't navigate.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,17 +12,23 @@ vi.mock("@/lib/routing", () => ({
   useNavigate: () => navigate,
 }));
 
-/** Dispatch a keydown that bubbles to window from `target` (default: body). */
+/** Dispatch a bracket keydown that bubbles to window from `target` (default:
+ *  body, ⌘ held → macOS). */
 function press(
-  key: "ArrowUp" | "ArrowDown",
+  code: "BracketLeft" | "BracketRight",
   mods: Partial<Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey" | "shiftKey">> = {
     metaKey: true,
   },
   target: HTMLElement = document.body,
-): void {
-  target.dispatchEvent(
-    new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...mods }),
-  );
+): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { code, bubbles: true, cancelable: true, ...mods });
+  target.dispatchEvent(e);
+  return e;
+}
+
+/** Render on macOS (⌘) by default; pass isMac=false for the Ctrl (Win/Linux) path. */
+function render(ids: readonly string[], activeId: string | undefined, isMac = true) {
+  return renderHook(() => useSessionSwitchHotkey(ids, activeId, isMac));
 }
 
 beforeEach(() => {
@@ -36,102 +42,124 @@ afterEach(() => {
 describe("useSessionSwitchHotkey", () => {
   const ids = ["a", "b", "c"];
 
-  it("Cmd+↓ opens the next conversation", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "b"));
-    press("ArrowDown");
+  it("Cmd+] opens the next conversation", () => {
+    render(ids, "b");
+    press("BracketRight");
     expect(navigate).toHaveBeenCalledWith("/c/c");
   });
 
-  it("Cmd+↑ opens the previous conversation", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "b"));
-    press("ArrowUp");
+  it("Cmd+[ opens the previous conversation", () => {
+    render(ids, "b");
+    press("BracketLeft");
     expect(navigate).toHaveBeenCalledWith("/c/a");
   });
 
-  it("wraps: ↓ from the last goes to the first, ↑ from the first to the last", () => {
-    const { rerender } = renderHook(({ active }) => useSessionSwitchHotkey(ids, active), {
+  it("wraps: ] from the last goes to the first, [ from the first to the last", () => {
+    const { rerender } = renderHook(({ active }) => useSessionSwitchHotkey(ids, active, true), {
       initialProps: { active: "c" },
     });
-    press("ArrowDown");
+    press("BracketRight");
     expect(navigate).toHaveBeenLastCalledWith("/c/a");
 
     rerender({ active: "a" });
-    press("ArrowUp");
+    press("BracketLeft");
     expect(navigate).toHaveBeenLastCalledWith("/c/c");
   });
 
-  it("off-list: ↓ enters at the top, ↑ at the bottom", () => {
-    const { rerender } = renderHook(({ active }) => useSessionSwitchHotkey(ids, active), {
+  it("off-list: ] enters at the top, [ at the bottom", () => {
+    const { rerender } = renderHook(({ active }) => useSessionSwitchHotkey(ids, active, true), {
       initialProps: { active: undefined as string | undefined },
     });
-    press("ArrowDown");
+    press("BracketRight");
     expect(navigate).toHaveBeenLastCalledWith("/c/a");
 
     rerender({ active: undefined });
-    press("ArrowUp");
+    press("BracketLeft");
     expect(navigate).toHaveBeenLastCalledWith("/c/c");
   });
 
-  it("Ctrl+↓ also works (Windows/Linux)", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "a"));
-    press("ArrowDown", { ctrlKey: true });
+  it("Ctrl+] also works (Windows/Linux)", () => {
+    render(ids, "a", false);
+    press("BracketRight", { ctrlKey: true });
     expect(navigate).toHaveBeenCalledWith("/c/b");
   });
 
-  it("ignores Alt+chord (reserved for message navigation)", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "a"));
-    press("ArrowDown", { metaKey: true, altKey: true });
+  it("ignores Ctrl+] on macOS (only ⌘ fires there)", () => {
+    render(ids, "a", true);
+    press("BracketRight", { ctrlKey: true });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("ignores Alt+chord (reserved for the sidebar-toggle hotkey)", () => {
+    render(ids, "a");
+    press("BracketRight", { metaKey: true, altKey: true });
     expect(navigate).not.toHaveBeenCalled();
   });
 
   it("ignores Shift+chord", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "a"));
-    press("ArrowDown", { metaKey: true, shiftKey: true });
+    render(ids, "a");
+    press("BracketRight", { metaKey: true, shiftKey: true });
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("ignores a bare arrow with no Cmd/Ctrl", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "a"));
-    press("ArrowDown", {});
+  it("ignores a bare bracket with no Cmd/Ctrl", () => {
+    render(ids, "a");
+    press("BracketRight", {});
     expect(navigate).not.toHaveBeenCalled();
   });
 
-  it("switches while a textarea is focused (composer editing)", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+  it("switches while a textarea is focused (brackets carry no caret command)", () => {
+    render(ids, "a");
     const ta = document.createElement("textarea");
     document.body.appendChild(ta);
-    press("ArrowDown", { metaKey: true }, ta);
+    press("BracketRight", { metaKey: true }, ta);
     expect(navigate).toHaveBeenCalledWith("/c/b");
   });
 
   it("switches while an input is focused", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "a"));
+    render(ids, "a");
     const input = document.createElement("input");
     document.body.appendChild(input);
-    press("ArrowDown", { metaKey: true }, input);
+    press("BracketRight", { metaKey: true }, input);
     expect(navigate).toHaveBeenCalledWith("/c/b");
   });
 
-  it("yields when a focused widget already claimed the chord", () => {
-    renderHook(() => useSessionSwitchHotkey(ids, "a"));
-    // Stands in for the command palette / mention menu, which preventDefault
-    // on Cmd+↑/↓ to move their own selection before this listener runs.
-    const menu = document.createElement("div");
-    document.body.appendChild(menu);
-    menu.addEventListener("keydown", (e) => e.preventDefault());
-    press("ArrowDown", { metaKey: true }, menu);
+  it.each(["xterm", "monaco-editor"])("bails inside a %s surface", (className) => {
+    render(ids, "a");
+    const surface = document.createElement("div");
+    surface.className = className;
+    const inner = document.createElement("textarea");
+    surface.appendChild(inner);
+    document.body.appendChild(surface);
+    inner.focus();
+    press("BracketRight", { metaKey: true }, inner);
     expect(navigate).not.toHaveBeenCalled();
   });
 
+  it("yields when a focused widget already claimed the chord", () => {
+    render(ids, "a");
+    const menu = document.createElement("div");
+    document.body.appendChild(menu);
+    menu.addEventListener("keydown", (e) => e.preventDefault());
+    press("BracketRight", { metaKey: true }, menu);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("claims the event (suppresses the browser Back/Forward gesture)", () => {
+    render(ids, "a");
+    const e = press("BracketRight");
+    expect(e.defaultPrevented).toBe(true);
+  });
+
   it("does nothing when the list is empty", () => {
-    renderHook(() => useSessionSwitchHotkey([], "a"));
-    press("ArrowDown");
+    render([], "a");
+    press("BracketRight");
     expect(navigate).not.toHaveBeenCalled();
   });
 
   it("does not navigate when the step lands on the already-active id", () => {
-    renderHook(() => useSessionSwitchHotkey(["only"], "only"));
-    press("ArrowDown");
+    render(["only"], "only");
+    press("BracketRight");
     expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/web/src/hooks/useSessionSwitchHotkey.ts
+++ b/web/src/hooks/useSessionSwitchHotkey.ts
@@ -1,11 +1,21 @@
-// Cmd+↑/↓ (Ctrl+↑/↓ on Win/Linux) opens the previous / next sidebar session,
-// wrapping at the ends. Sibling to ChatPage's Cmd+Alt+↑/↓ message nav; they
-// don't collide (that one requires Alt, this one requires Alt up). Fires while
-// the composer has focus — that is where users spend their time, and the chord
-// carries a modifier so it can't be mistaken for typing. Bind ONCE.
+// Cmd+[ / Cmd+] (Ctrl+[ / Ctrl+] on Win/Linux) opens the previous / next
+// sidebar session, wrapping at the ends. Sibling to the sidebar-toggle
+// (⌘⌥[ / ⌘⌥]) hotkey — they don't collide, that one requires Alt and this one
+// requires Alt up. Bind ONCE.
+//
+// Why brackets: they read as "step back / forward" (matching the browser's
+// ⌘[ / ⌘] Back/Forward, which we claim), and unlike the old ⌘↑/↓ they carry no
+// text-editing meaning, so the hotkey can fire while the composer is focused
+// without stealing a caret-to-start/end. It still bails inside surfaces that
+// bind ⌘[ / ⌘] themselves (Monaco outdents/indents; xterm forwards to the PTY).
 
 import { useEffect, useRef } from "react";
+
+import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
 import { useNavigate } from "@/lib/routing";
+
+/** Selector for surfaces that own ⌘[ / ⌘] and must keep them (terminals, editor). */
+const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor";
 
 /**
  * @param orderedIds Conversation ids in sidebar render order, visible sections
@@ -16,6 +26,7 @@ import { useNavigate } from "@/lib/routing";
 export function useSessionSwitchHotkey(
   orderedIds: readonly string[],
   activeId: string | undefined,
+  isMac = isMacPlatform(),
 ): void {
   const navigate = useNavigate();
   // Bound once; the ref keeps the handler reading the live list/route.
@@ -24,23 +35,29 @@ export function useSessionSwitchHotkey(
 
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Cmd/Ctrl, not Alt (Alt+arrow is the message hotkey); Shift left to selection.
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      // Ignore auto-repeat: holding the chord would race through sessions.
+      if (e.repeat) return;
+      // Cmd/Ctrl only — no Alt (that's the sidebar-toggle chord) or Shift.
+      if (!hasCommandModifier(e, isMac) || e.altKey || e.shiftKey) return;
+      // Match the physical bracket key (e.code is layout/modifier-stable), the
+      // same way the sidebar-toggle sibling does.
+      const dir = e.code === "BracketRight" ? 1 : e.code === "BracketLeft" ? -1 : 0;
+      if (dir === 0) return;
 
-      // Yield to a focused widget that already claimed this chord for its own
-      // list navigation — the command palette (cmdk binds Cmd+↑/↓ to jump to
-      // the first/last row) and the composer's mention / slash menus all
-      // preventDefault before this window listener runs.
+      // Yield when a focused widget claimed the chord before this window listener.
       if (e.defaultPrevented) return;
+
+      // Leave the chord to terminals / the code editor that bind it themselves.
+      const el = document.activeElement;
+      if (el instanceof Element && el.closest(HOTKEY_OWNING_SURFACES)) return;
 
       const { orderedIds: ids, activeId: active } = latest.current;
       if (ids.length === 0) return;
 
-      e.preventDefault(); // also suppresses the native caret-to-start/end in fields
-      const dir = e.key === "ArrowDown" ? 1 : -1;
+      e.preventDefault(); // suppress the browser's ⌘[ / ⌘] Back/Forward gesture
+      e.stopPropagation();
       const current = active ? ids.indexOf(active) : -1;
-      // Off-list: ↓ enters at the top, ↑ at the bottom. Otherwise step + wrap.
+      // Off-list: ] enters at the top, [ at the bottom. Otherwise step + wrap.
       const next =
         current === -1
           ? dir === 1
@@ -54,5 +71,5 @@ export function useSessionSwitchHotkey(
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [navigate]);
+  }, [navigate, isMac]);
 }

--- a/web/src/hooks/useSessionSwitchHotkey.ts
+++ b/web/src/hooks/useSessionSwitchHotkey.ts
@@ -14,8 +14,8 @@ import { useEffect, useRef } from "react";
 import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
 import { useNavigate } from "@/lib/routing";
 
-/** Selector for surfaces that own ⌘[ / ⌘] and must keep them (terminals, editor). */
-const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor";
+/** Surfaces that keep bracket chords or must not navigate behind an overlay. */
+const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor, [cmdk-input]";
 
 /**
  * @param orderedIds Conversation ids in sidebar render order, visible sections

--- a/web/src/hooks/useSidebarToggleHotkeys.test.tsx
+++ b/web/src/hooks/useSidebarToggleHotkeys.test.tsx
@@ -1,7 +1,8 @@
-// ⌘⌥[ toggles the left sidebar, ⌘⌥] the right; matches the physical bracket
-// keys (not the glyph ⌥ produces), ignores the bare keys / missing-Alt / Shift
-// variants / auto-repeat / AltGraph, fully claims the event, and unbinds on
-// unmount.
+// ⌘⌥[ toggles the left sidebar, ⌘⌥] the right (Ctrl+Alt on Win/Linux); matches
+// the physical bracket keys (not the glyph ⌥ produces), is platform-aware (only
+// ⌘ fires on macOS, only Ctrl on Win/Linux), ignores the bare keys / missing-Alt
+// / Shift variants / auto-repeat / AltGraph, fully claims the event, and unbinds
+// on unmount.
 
 import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -23,61 +24,72 @@ function press(
 
 afterEach(() => vi.restoreAllMocks());
 
-function setup() {
+/** Render for the Ctrl (Win/Linux) path by default; pass isMac=true for ⌘. */
+function setup(isMac = false) {
   const onToggleLeft = vi.fn();
   const onToggleRight = vi.fn();
-  const utils = renderHook(() => useSidebarToggleHotkeys({ onToggleLeft, onToggleRight }));
+  const utils = renderHook(() => useSidebarToggleHotkeys({ onToggleLeft, onToggleRight }, isMac));
   return { onToggleLeft, onToggleRight, ...utils };
 }
 
 describe("useSidebarToggleHotkeys", () => {
-  it("Ctrl+Alt+[ toggles only the left sidebar", () => {
-    const { onToggleLeft, onToggleRight } = setup();
+  it("Ctrl+Alt+[ toggles only the left sidebar (Win/Linux)", () => {
+    const { onToggleLeft, onToggleRight } = setup(false);
     press({ ctrlKey: true, altKey: true }, "BracketLeft");
     expect(onToggleLeft).toHaveBeenCalledTimes(1);
     expect(onToggleRight).not.toHaveBeenCalled();
   });
 
-  it("Ctrl+Alt+] toggles only the right sidebar", () => {
-    const { onToggleLeft, onToggleRight } = setup();
+  it("Ctrl+Alt+] toggles only the right sidebar (Win/Linux)", () => {
+    const { onToggleLeft, onToggleRight } = setup(false);
     press({ ctrlKey: true, altKey: true }, "BracketRight");
     expect(onToggleRight).toHaveBeenCalledTimes(1);
     expect(onToggleLeft).not.toHaveBeenCalled();
   });
 
-  it("Cmd variants also fire (macOS)", () => {
-    const { onToggleLeft, onToggleRight } = setup();
+  it("Cmd+Alt+[ / ] fire on macOS", () => {
+    const { onToggleLeft, onToggleRight } = setup(true);
     press({ metaKey: true, altKey: true }, "BracketLeft");
     press({ metaKey: true, altKey: true }, "BracketRight");
     expect(onToggleLeft).toHaveBeenCalledTimes(1);
     expect(onToggleRight).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores Ctrl+Alt on macOS and Cmd+Alt on Win/Linux (wrong modifier)", () => {
+    const mac = setup(true);
+    press({ ctrlKey: true, altKey: true }, "BracketLeft");
+    expect(mac.onToggleLeft).not.toHaveBeenCalled();
+
+    const other = setup(false);
+    press({ metaKey: true, altKey: true }, "BracketLeft");
+    expect(other.onToggleLeft).not.toHaveBeenCalled();
+  });
+
   it("ignores the bare keys, missing-Alt, and Shift variants", () => {
-    const { onToggleLeft, onToggleRight } = setup();
+    const { onToggleLeft, onToggleRight } = setup(false);
     press({}, "BracketLeft"); // bare [
-    press({ ctrlKey: true }, "BracketLeft"); // ⌘[ alone = browser Back, not ours
-    press({ metaKey: true, altKey: true, shiftKey: true }, "BracketRight");
+    press({ ctrlKey: true }, "BracketLeft"); // Ctrl+[ alone = browser Back, not ours
+    press({ ctrlKey: true, altKey: true, shiftKey: true }, "BracketRight");
     expect(onToggleLeft).not.toHaveBeenCalled();
     expect(onToggleRight).not.toHaveBeenCalled();
   });
 
   it("ignores other keys held with the modifiers", () => {
-    const { onToggleLeft, onToggleRight } = setup();
+    const { onToggleLeft, onToggleRight } = setup(false);
     press({ ctrlKey: true, altKey: true }, "Backslash");
-    press({ metaKey: true, altKey: true }, "Period");
+    press({ ctrlKey: true, altKey: true }, "Period");
     expect(onToggleLeft).not.toHaveBeenCalled();
     expect(onToggleRight).not.toHaveBeenCalled();
   });
 
   it("ignores auto-repeat (holding the chord doesn't flap the panel)", () => {
-    const { onToggleLeft } = setup();
+    const { onToggleLeft } = setup(false);
     press({ ctrlKey: true, altKey: true, repeat: true }, "BracketLeft");
     expect(onToggleLeft).not.toHaveBeenCalled();
   });
 
   it("ignores AltGraph chords (Ctrl+Alt produced by intl layouts)", () => {
-    const { onToggleLeft, onToggleRight } = setup();
+    const { onToggleLeft, onToggleRight } = setup(false);
     const altGraph = vi
       .spyOn(KeyboardEvent.prototype, "getModifierState")
       .mockImplementation((keyArg) => keyArg === "AltGraph");
@@ -89,7 +101,7 @@ describe("useSidebarToggleHotkeys", () => {
   });
 
   it("still fires when getModifierState is unavailable (no throw)", () => {
-    const { onToggleLeft } = setup();
+    const { onToggleLeft } = setup(false);
     const ev = new KeyboardEvent("keydown", {
       code: "BracketLeft",
       ctrlKey: true,
@@ -105,7 +117,7 @@ describe("useSidebarToggleHotkeys", () => {
   });
 
   it("claims the event (preventDefault + stopPropagation)", () => {
-    setup();
+    setup(false);
     const ev = new KeyboardEvent("keydown", {
       code: "BracketLeft",
       ctrlKey: true,
@@ -120,7 +132,7 @@ describe("useSidebarToggleHotkeys", () => {
   });
 
   it("unbinds on unmount", () => {
-    const { onToggleLeft, unmount } = setup();
+    const { onToggleLeft, unmount } = setup(false);
     unmount();
     press({ ctrlKey: true, altKey: true }, "BracketLeft");
     expect(onToggleLeft).not.toHaveBeenCalled();

--- a/web/src/hooks/useSidebarToggleHotkeys.ts
+++ b/web/src/hooks/useSidebarToggleHotkeys.ts
@@ -1,7 +1,8 @@
 // ⌘⌥[ / ⌘⌥] (Ctrl+Alt+[ / Ctrl+Alt+] on Win/Linux) toggle the left
 // (Conversations) and right (Workspace) sidebars. Siblings to the session-switch
-// (⌘↑/↓) and approve (⌘↵) hotkeys; like them they fire even inside a focused
-// text field, so a panel can be collapsed mid-compose.
+// (⌘[ / ⌘]) and approve (⌘↵) hotkeys; like them they fire even inside a focused
+// text field, so a panel can be collapsed mid-compose. Platform-aware: only the
+// ⌘ chord fires on macOS and only the Ctrl chord on Win/Linux.
 //
 // Why this chord: the bare ⌘[ / ⌘] are the browser's Back/Forward gestures, and
 // single ⌘+punctuation combos (e.g. ⌘\) get swallowed by global hotkey utilities
@@ -12,6 +13,8 @@
 
 import { useEffect, useRef } from "react";
 
+import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
+
 export interface SidebarToggleHandlers {
   /** Flip the left (Conversations) sidebar. Bound to ⌘/Ctrl + ⌥/Alt + [. */
   onToggleLeft: () => void;
@@ -19,7 +22,10 @@ export interface SidebarToggleHandlers {
   onToggleRight: () => void;
 }
 
-export function useSidebarToggleHotkeys(handlers: SidebarToggleHandlers): void {
+export function useSidebarToggleHotkeys(
+  handlers: SidebarToggleHandlers,
+  isMac = isMacPlatform(),
+): void {
   // Held in a ref so the bound handler always calls the latest closures without
   // re-registering each render.
   const latest = useRef(handlers);
@@ -27,9 +33,9 @@ export function useSidebarToggleHotkeys(handlers: SidebarToggleHandlers): void {
 
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent): void => {
-      // Require Cmd/Ctrl AND Alt (the ⌘⌥ message-nav chord) and additionally
-      // reject Shift, so ⌘⌥⇧ combos stay free for future bindings.
-      if (!(e.metaKey || e.ctrlKey) || !e.altKey || e.shiftKey) return;
+      // Require the platform command modifier AND Alt (the ⌘⌥ message-nav chord)
+      // and additionally reject Shift, so ⌘⌥⇧ combos stay free for future bindings.
+      if (!hasCommandModifier(e, isMac) || !e.altKey || e.shiftKey) return;
       // AltGr often reports as Ctrl+Alt; ignore it so intl-layout typing doesn't
       // accidentally toggle sidebars while focused in an editor/composer. Guard
       // the call: not every environment implements getModifierState, and an
@@ -54,5 +60,5 @@ export function useSidebarToggleHotkeys(handlers: SidebarToggleHandlers): void {
 
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, []);
+  }, [isMac]);
 }

--- a/web/src/hooks/useVoiceDictationHotkey.test.tsx
+++ b/web/src/hooks/useVoiceDictationHotkey.test.tsx
@@ -15,37 +15,48 @@ function press(init: KeyboardEventInit): KeyboardEvent {
 }
 
 describe("isVoiceDictationHotkey", () => {
-  it("matches Cmd+Alt+V and Ctrl+Alt+V by physical code", () => {
+  it("uses Cmd+Alt+V on macOS and Ctrl+Alt+V elsewhere, by physical code", () => {
     expect(
       isVoiceDictationHotkey(
         new KeyboardEvent("keydown", { code: "KeyV", metaKey: true, altKey: true }),
+        true,
       ),
     ).toBe(true);
     expect(
       isVoiceDictationHotkey(
         new KeyboardEvent("keydown", { code: "KeyV", ctrlKey: true, altKey: true }),
+        false,
       ),
     ).toBe(true);
+    // Wrong modifier for the platform.
+    expect(
+      isVoiceDictationHotkey(
+        new KeyboardEvent("keydown", { code: "KeyV", ctrlKey: true, altKey: true }),
+        true,
+      ),
+    ).toBe(false);
     // ⌥ rewrites the character to "√" on macOS, but e.code stays "KeyV".
     expect(
       isVoiceDictationHotkey(
         new KeyboardEvent("keydown", { code: "KeyV", key: "√", metaKey: true, altKey: true }),
+        true,
       ),
     ).toBe(true);
   });
 
   it("rejects the chord without Alt, and with Shift held", () => {
     expect(
-      isVoiceDictationHotkey(new KeyboardEvent("keydown", { code: "KeyV", metaKey: true })),
+      isVoiceDictationHotkey(new KeyboardEvent("keydown", { code: "KeyV", metaKey: true }), true),
     ).toBe(false);
     expect(
       isVoiceDictationHotkey(
         new KeyboardEvent("keydown", { code: "KeyV", metaKey: true, altKey: true, shiftKey: true }),
+        true,
       ),
     ).toBe(false);
     // Alt+V without a Cmd/Ctrl modifier.
     expect(
-      isVoiceDictationHotkey(new KeyboardEvent("keydown", { code: "KeyV", altKey: true })),
+      isVoiceDictationHotkey(new KeyboardEvent("keydown", { code: "KeyV", altKey: true }), true),
     ).toBe(false);
   });
 
@@ -53,6 +64,7 @@ describe("isVoiceDictationHotkey", () => {
     expect(
       isVoiceDictationHotkey(
         new KeyboardEvent("keydown", { code: "KeyK", metaKey: true, altKey: true }),
+        true,
       ),
     ).toBe(false);
   });
@@ -61,7 +73,7 @@ describe("isVoiceDictationHotkey", () => {
 describe("useVoiceDictationHotkey", () => {
   it("toggles on Cmd+Alt+V and prevents the browser default", () => {
     const onToggle = vi.fn();
-    renderHook(() => useVoiceDictationHotkey(onToggle));
+    renderHook(() => useVoiceDictationHotkey(onToggle, true, true));
 
     const e = press({ code: "KeyV", metaKey: true, altKey: true });
 
@@ -71,7 +83,7 @@ describe("useVoiceDictationHotkey", () => {
 
   it("ignores auto-repeat", () => {
     const onToggle = vi.fn();
-    renderHook(() => useVoiceDictationHotkey(onToggle));
+    renderHook(() => useVoiceDictationHotkey(onToggle, true, true));
 
     press({ code: "KeyV", metaKey: true, altKey: true, repeat: true });
 
@@ -80,7 +92,7 @@ describe("useVoiceDictationHotkey", () => {
 
   it("does nothing when disabled", () => {
     const onToggle = vi.fn();
-    renderHook(() => useVoiceDictationHotkey(onToggle, false));
+    renderHook(() => useVoiceDictationHotkey(onToggle, false, true));
 
     const e = press({ code: "KeyV", metaKey: true, altKey: true });
 
@@ -90,7 +102,7 @@ describe("useVoiceDictationHotkey", () => {
 
   it("bails when focus sits inside a terminal or code editor", () => {
     const onToggle = vi.fn();
-    renderHook(() => useVoiceDictationHotkey(onToggle));
+    renderHook(() => useVoiceDictationHotkey(onToggle, true, true));
 
     const term = document.createElement("div");
     term.className = "xterm";
@@ -107,7 +119,7 @@ describe("useVoiceDictationHotkey", () => {
 
   it("unbinds on unmount", () => {
     const onToggle = vi.fn();
-    const { unmount } = renderHook(() => useVoiceDictationHotkey(onToggle));
+    const { unmount } = renderHook(() => useVoiceDictationHotkey(onToggle, true, true));
     unmount();
 
     press({ code: "KeyV", metaKey: true, altKey: true });

--- a/web/src/hooks/useVoiceDictationHotkey.ts
+++ b/web/src/hooks/useVoiceDictationHotkey.ts
@@ -11,14 +11,20 @@
 
 import { useEffect, useRef } from "react";
 
+import { hasCommandModifier, isMacPlatform } from "@/lib/hotkeys";
+
 /** Selector for surfaces that own their keystrokes (terminals, code editor). */
 const HOTKEY_OWNING_SURFACES = ".xterm, .monaco-editor";
 
-/** True when the event is the voice-dictation chord: Cmd/Ctrl+Alt+V, no Shift. */
-export function isVoiceDictationHotkey(e: globalThis.KeyboardEvent): boolean {
-  // Require Cmd/Ctrl AND Alt (the browser-safe ⌘⌥ chord) and reject Shift, so
-  // ⌘⌥⇧ combos stay free for future bindings.
-  if (!(e.metaKey || e.ctrlKey) || !e.altKey || e.shiftKey) return false;
+/** True when the event is the voice-dictation chord: the platform command
+ *  modifier + Alt + V, no Shift. */
+export function isVoiceDictationHotkey(
+  e: globalThis.KeyboardEvent,
+  isMac: boolean = isMacPlatform(),
+): boolean {
+  // Require the platform command modifier AND Alt (the browser-safe ⌘⌥ chord)
+  // and reject Shift, so ⌘⌥⇧ combos stay free for future bindings.
+  if (!hasCommandModifier(e, isMac) || !e.altKey || e.shiftKey) return false;
   // AltGr often reports as Ctrl+Alt; ignore it so intl-layout typing doesn't
   // trigger dictation. Guard the call: not every environment implements
   // getModifierState, and an unguarded call there would throw.
@@ -41,7 +47,11 @@ function focusOwnsHotkey(): boolean {
  * @param enabled  Pass `false` to skip binding (e.g. the secondary composer in
  *   the New Chat dialog, so two mics don't fight for the device). Defaults on.
  */
-export function useVoiceDictationHotkey(onToggle: () => void, enabled = true): void {
+export function useVoiceDictationHotkey(
+  onToggle: () => void,
+  enabled = true,
+  isMac = isMacPlatform(),
+): void {
   // Held in a ref so the bound handler always calls the latest closure without
   // re-registering on every render (onToggle changes as listening state flips).
   const latest = useRef(onToggle);
@@ -52,7 +62,7 @@ export function useVoiceDictationHotkey(onToggle: () => void, enabled = true): v
     const handler = (e: globalThis.KeyboardEvent): void => {
       // Ignore auto-repeat: holding the chord would flap dictation on/off.
       if (e.repeat) return;
-      if (!isVoiceDictationHotkey(e)) return;
+      if (!isVoiceDictationHotkey(e, isMac)) return;
       if (focusOwnsHotkey()) return;
       e.preventDefault();
       e.stopPropagation();
@@ -60,5 +70,5 @@ export function useVoiceDictationHotkey(onToggle: () => void, enabled = true): v
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [enabled]);
+  }, [enabled, isMac]);
 }

--- a/web/src/lib/hotkeys.test.ts
+++ b/web/src/lib/hotkeys.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { hasCommandModifier } from "./hotkeys";
+
+describe("hasCommandModifier", () => {
+  it("requires Meta exclusively on macOS", () => {
+    expect(hasCommandModifier({ metaKey: true, ctrlKey: false }, true)).toBe(true);
+    expect(hasCommandModifier({ metaKey: false, ctrlKey: true }, true)).toBe(false);
+    expect(hasCommandModifier({ metaKey: true, ctrlKey: true }, true)).toBe(false);
+  });
+
+  it("requires Control exclusively on Windows and Linux", () => {
+    expect(hasCommandModifier({ metaKey: false, ctrlKey: true }, false)).toBe(true);
+    expect(hasCommandModifier({ metaKey: true, ctrlKey: false }, false)).toBe(false);
+    expect(hasCommandModifier({ metaKey: true, ctrlKey: true }, false)).toBe(false);
+  });
+});

--- a/web/src/lib/hotkeys.ts
+++ b/web/src/lib/hotkeys.ts
@@ -1,0 +1,32 @@
+// Platform-aware command-modifier detection shared by every global hotkey hook.
+//
+// On Apple platforms the command modifier is ⌘ (metaKey); everywhere else it's
+// Ctrl. Detecting the platform — instead of accepting `metaKey || ctrlKey` on
+// all platforms — keeps each shortcut "what you see is what you get": the
+// shortcuts dialog shows ⌘K on macOS, so only ⌘K fires there, leaving the
+// Ctrl-based emacs/readline bindings (Ctrl+K, Ctrl+A, …) that users rely on in
+// the composer untouched. On Windows/Linux the dialog shows Ctrl and only Ctrl
+// fires.
+
+/** True on Apple platforms (⌘ is the command modifier); false elsewhere (Ctrl). */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  const platform = uaData?.platform ?? navigator.platform ?? navigator.userAgent ?? "";
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+/**
+ * True when the platform's command modifier is held *exclusively*: ⌘ (and not
+ * Ctrl) on macOS, Ctrl (and not ⌘) elsewhere. Callers layer Alt/Shift on top.
+ *
+ * Rejecting the opposite modifier matters on macOS: Ctrl+K there is a real
+ * text-editing binding (kill-to-end-of-line), so treating Ctrl as a ⌘ stand-in
+ * would swallow it. `isMac` is injectable so hooks and tests can pin a platform.
+ */
+export function hasCommandModifier(
+  e: Pick<globalThis.KeyboardEvent, "metaKey" | "ctrlKey">,
+  isMac: boolean = isMacPlatform(),
+): boolean {
+  return isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+}

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1831,7 +1831,7 @@ describe("Workspace rail maximize", () => {
     renderShell("/settings");
 
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
-    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    fireEvent.keyDown(document, { code: "BracketLeft", ctrlKey: true, altKey: true });
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
   });
 
@@ -1877,8 +1877,8 @@ describe("Workspace rail maximize", () => {
     renderShell("/settings");
 
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
-    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
-    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    fireEvent.keyDown(document, { code: "BracketLeft", ctrlKey: true, altKey: true });
+    fireEvent.keyDown(document, { code: "BracketLeft", ctrlKey: true, altKey: true });
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
   });
 
@@ -1908,7 +1908,7 @@ describe("Workspace rail maximize", () => {
     mockConversations([{ id: "conv_abc", permission_level: null }]);
     renderShell("/c/conv_abc");
 
-    fireEvent.keyDown(document, { code: "BracketLeft", metaKey: true, altKey: true });
+    fireEvent.keyDown(document, { code: "BracketLeft", ctrlKey: true, altKey: true });
     expect(screen.getByTestId("sidebar")).toHaveAttribute("data-open", "true");
 
     fireEvent.click(screen.getByTestId("nav-settings"));


### PR DESCRIPTION
## Related issue

N/A — reported via internal Slack (Ctrl+K stealing the emacs kill-line binding in the composer). No tracked issue.

## Summary

- Every global hotkey hook except new-session matched `e.metaKey || e.ctrlKey` on **all** platforms. On macOS that meant **Ctrl+<key> silently fired shortcuts the dialog only advertises as ⌘** — most visibly `Ctrl+K` opening the command palette (clobbering emacs kill-to-end-of-line in the composer), and the same for `Ctrl+↵` (approve), `Ctrl+⌥V` (voice), `Ctrl+⌥[/]` (sidebars). What the shortcuts panel showed was not what fired.
- Extracted the platform check new-session already used into `web/src/lib/hotkeys.ts` — `isMacPlatform()` + `hasCommandModifier()`, which requires the command modifier **exclusively** (⌘ and *not* Ctrl on macOS, Ctrl and *not* ⌘ elsewhere) — and routed every hook through it: command palette, session switch, sidebar toggle, approve, voice dictation, pinned sessions, and ChatPage message nav. The shortcuts dialog derives its glyph from the same check, so it now shows exactly the modifier that fires (WYSIWYG).
- Moved session switching from `⌘↑/↓` to **`⌘[` / `⌘]`** (Ctrl+[ / Ctrl+] on Win/Linux): `[` = previous, `]` = next, mirroring the browser Back/Forward we claim. Unlike the arrows, brackets carry no caret command, so the hotkey now fires while the composer is focused (it still bails inside terminals / the Monaco editor, which bind `⌘[` / `⌘]` themselves).

## Test Plan

- `pnpm run test` (web) — full suite green: 5876 passed, 3 expected-fail, 1 skipped. Rewrote the six hotkey hook suites + the dialog to assert the per-platform contract (only ⌘ fires on macOS, only Ctrl elsewhere), and updated the AppShell sidebar-toggle integration tests to the jsdom (non-mac) Ctrl path.
- `pnpm run type-check` and `pnpm run lint` (oxlint) — both clean.
- Manual repro (macOS): in the composer, `Ctrl+K` now deletes to end of line (emacs) instead of opening the palette; `⌘K` still opens it. `⌘[` / `⌘]` step between conversations. The Keyboard shortcuts panel shows `⌘[` / `⌘]` for Previous/Next session.

## Demo

Keyboard-only behavior; the sole visual change is the shortcuts panel now listing `⌘[` / `⌘]` (Ctrl+[ / Ctrl+]) for Previous/Next session instead of the arrows. To verify: open the shortcuts panel (`⌘/`), then in the composer confirm `Ctrl+K` no longer opens the palette on macOS while `⌘K` still does. (Happy to add a screen recording if a reviewer wants one.)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Every hotkey hook has a unit suite asserting the platform-exact contract (⌘ fires on macOS, Ctrl elsewhere, and the opposite modifier does not). Manual verification on macOS confirmed Ctrl+K no longer opens the palette in the composer and `⌘[` / `⌘]` switch sessions.

## Changelog

Keyboard shortcuts now use ⌘ on macOS and Ctrl elsewhere exactly as shown (Ctrl+K no longer opens the command palette on macOS), and switching conversations moved to ⌘[ / ⌘]
