### PR TITLE
fix(server): mirror child status edges onto the parent stream

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -244,6 +244,7 @@ from omnigent.server.schemas import (
     ResponseObject,
     RetryErrorDetail,
     SandboxStatus,
+    SessionChildSessionUpdatedEvent,
     SessionCollaborationModeEvent,
     SessionCreatedEvent,
     SessionCreateMetadata,
@@ -4094,6 +4095,55 @@ def _require_permission_mode_forward(
     return settled if isinstance(settled, str) and settled else mode
 
 
+def _publish_child_status_to_parent(session_id: str, status: str) -> None:
+    """
+    Mirror a status transition onto the session's parent stream.
+
+    A sub-agent's ``busy`` / ``current_task_status`` on the parent's Agents
+    rail comes from ``session.child_session.updated`` events. The runner
+    fans those out only for children it registered in-process, so a child
+    reused after a runner restart, or driven directly rather than through
+    its parent, changes status without the parent's stream ever hearing of
+    it. The server sees every transition in ``_session_status_cache``, so
+    it republishes the child's current summary to the parent from here; a
+    top-level session (no parent) publishes nothing.
+
+    The store reads run on the ordered live-state worker so a ``running``
+    → ``idle`` pair can never fan out reversed, and the event-loop caller
+    only pays a queue put.
+
+    :param session_id: Session whose cached status just changed,
+        e.g. ``"conv_child123"``.
+    :param status: The new status, e.g. ``"running"``. Captured here rather
+        than re-read on the worker so each edge fans out its own value.
+    """
+    store = session_live_state.conversation_store()
+    if store is None:
+        return
+
+    def _fan_out() -> None:
+        conv = store.get_conversation(session_id)
+        if conv is None or conv.parent_conversation_id is None:
+            return
+        parent_id = conv.parent_conversation_id
+        items_by_child = store.list_latest_message_items_for_conversations([conv.id], 10)
+        summary = _child_session_summary_from_conversation(
+            conv,
+            parent_id,
+            _latest_message_preview(items_by_child.get(conv.id, [])),
+            cached_status=status,
+        )
+        event = SessionChildSessionUpdatedEvent(
+            type="session.child_session.updated",
+            conversation_id=parent_id,
+            child_session_id=conv.id,
+            child=summary.model_dump(mode="json"),
+        )
+        session_stream.publish(parent_id, event.model_dump())
+
+    session_live_state.submit("child_status_fanout", _fan_out)
+
+
 def _publish_status(
     session_id: str,
     status: str,
@@ -4148,7 +4198,10 @@ def _publish_status(
         # snapshot to reopen a streaming bubble.
         _session_active_response_cache.pop(session_id, None)
         return
+    previous_status = _session_status_cache.get(session_id)
     _session_status_cache[session_id] = status
+    if previous_status != status:
+        _publish_child_status_to_parent(session_id, status)
     # Mirror the transition onto the conversation row (best-effort,
     # deduplicated, off-loop) so replicas that don't hold this session's
     # runner tunnel serve the same sidebar status.
@@ -9179,6 +9232,8 @@ def _child_session_summary_from_conversation(
     conv: Conversation,
     parent_session_id: str,
     last_message_preview: str | None,
+    *,
+    cached_status: str | None = None,
 ) -> ChildSessionSummary:
     """
     Build a :class:`ChildSessionSummary` from a child conversation.
@@ -9207,6 +9262,11 @@ def _child_session_summary_from_conversation(
         be missing.
     :param last_message_preview: Preview text derived from a batched
         child-message lookup, or ``None`` when no visible message exists.
+    :param cached_status: Session status to derive ``busy`` /
+        ``current_task_status`` from, e.g. ``"running"``. ``None`` reads the
+        live ``_session_status_cache``; a status-edge publisher passes the
+        edge's own value so a burst of transitions fans out one summary per
+        edge instead of the latest status repeated.
     :returns: A populated :class:`ChildSessionSummary`.
     """
     display_title = title_without_closed_marker(conv.title)
@@ -9240,7 +9300,8 @@ def _child_session_summary_from_conversation(
         session_name = None
 
     # Derive busy from the relay-fed cache; tasks table is gone.
-    cached_status = _session_status_cache.get(conv.id)
+    if cached_status is None:
+        cached_status = _session_status_cache.get(conv.id)
     if cached_status in ("running", "waiting"):
         busy = True
     else:

--- a/omnigent/server/session_live_state.py
+++ b/omnigent/server/session_live_state.py
@@ -94,11 +94,21 @@ def configure(
     _last_pending.clear()
 
 
-def _submit(description: str, fn, *args, on_failure=None) -> None:  # type: ignore[no-untyped-def]
+def conversation_store() -> ConversationStore | None:
     """
-    Run one store write on the ordered background worker.
+    Return the conversation store wired by :func:`configure`.
 
-    The write runs inside a snapshot of the *caller's* ``contextvars``
+    :returns: The server's conversation store, or ``None`` when live-state
+        persistence is disabled (tests / non-server processes).
+    """
+    return _store
+
+
+def submit(description: str, fn, *args, on_failure=None) -> None:  # type: ignore[no-untyped-def]
+    """
+    Run one store-backed task on the ordered background worker.
+
+    The task runs inside a snapshot of the *caller's* ``contextvars``
     (``copy_context().run``). The store filters every query on
     ``current_workspace_id()``, a ``ContextVar`` the multi-tenant request
     middleware binds per request via ``workspace_scope``; a bare
@@ -173,7 +183,7 @@ def persist_live_status(session_id: str, status: str) -> None:
         if _last_status.get(session_id) == status:
             _last_status.pop(session_id, None)
 
-    _submit("live_status", _store.set_session_live_status, session_id, status, on_failure=_evict)
+    submit("live_status", _store.set_session_live_status, session_id, status, on_failure=_evict)
 
 
 def persist_scheduled_run_completion(
@@ -234,7 +244,7 @@ def persist_scheduled_run_completion(
             error_code=error_code,
         )
 
-    _submit("scheduled_run_completion", _transition)
+    submit("scheduled_run_completion", _transition)
 
 
 def persist_pending_count(conversation_id: str, count: int) -> None:
@@ -257,7 +267,7 @@ def persist_pending_count(conversation_id: str, count: int) -> None:
         if _last_pending.get(conversation_id) == count:
             _last_pending.pop(conversation_id, None)
 
-    _submit(
+    submit(
         "pending_count",
         _store.set_pending_elicitation_count,
         conversation_id,
@@ -283,7 +293,7 @@ def touch_runner_liveness(runner_ids: list[str]) -> None:
     """
     if _store is None or not runner_ids:
         return
-    _submit("runner_liveness", _store.touch_runner_liveness, list(runner_ids), int(time.time()))
+    submit("runner_liveness", _store.touch_runner_liveness, list(runner_ids), int(time.time()))
 
 
 def clear_runner_liveness(runner_id: str) -> None:
@@ -298,4 +308,4 @@ def clear_runner_liveness(runner_id: str) -> None:
     """
     if _store is None:
         return
-    _submit("runner_liveness_clear", _store.clear_runner_liveness, runner_id)
+    submit("runner_liveness_clear", _store.clear_runner_liveness, runner_id)

--- a/tests/e2e/test_repl_subagent_panel_events_e2e.py
+++ b/tests/e2e/test_repl_subagent_panel_events_e2e.py
@@ -10,32 +10,51 @@ fed by two server-side sources, both exercised here against a real LLM:
   the recursive tree poll reads for deeper levels.
 
 If the server stops emitting either, the CLI panel goes blank even while
-sub-agents are running. A terminal UI can't be driven from e2e, so this test
-asserts the data the panel consumes, not the rendering (covered by the
-``tests/frontends/sdk`` unit tests).
+sub-agents are running. The first test asserts that data contract against a
+real LLM. The second drives the real CLI under a PTY against the mock LLM and
+reads the rendered toolbar, for the case the runner's own fan-out cannot
+cover: a child whose status changes without its parent's runner knowing.
 
 Excluded from default ``pytest`` runs via ``--ignore=tests/e2e``. Invoke::
 
     pytest tests/e2e/test_repl_subagent_panel_events_e2e.py \\
         --llm-api-key "$(cat /tmp/mykey)" -v
+    pytest tests/e2e/test_repl_subagent_panel_events_e2e.py -k toolbar -v
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import os
+import re
+import sys
 import threading
+import time
+import uuid
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 from omnigent_client._sessions import SessionsNamespace
 
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
 from tests.e2e.conftest import (
+    configure_mock_llm,
     create_runner_bound_session,
+    lookup_agent_id,
     poll_session_until_terminal,
+    release_mock_gate,
+    reset_mock_llm,
     send_user_message_to_session,
 )
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+# Wide enough that the right-aligned ``state:`` badge fits after the hint
+# row; at 120 columns it falls off the edge and never reaches the PTY.
+_REPL_DIMENSIONS = (40, 200)
 
 
 def _iter_sse(response: httpx.Response):
@@ -205,3 +224,172 @@ def test_parent_stream_and_child_sessions_expose_subagents(
         "child updates carried no current_task_status — the menu's per-agent "
         "status word would be blank."
     )
+
+
+def _attach_repl_env(tmp_home: Path) -> dict[str, str]:
+    """Build the env for spawning ``omnigent attach`` under a PTY.
+
+    An isolated ``HOME`` / config home keeps the developer's real config out
+    of the run, and the persisted theme skips the interactive theme picker
+    that would otherwise stand in for the prompt.
+
+    :param tmp_home: Per-test directory to use as ``HOME``.
+    :returns: The subprocess environment.
+    """
+    from tests.e2e.omnigent._pexpect_harness import ensure_repl_test_theme_env
+
+    config_home = tmp_home / ".omnigent"
+    config_home.mkdir(parents=True, exist_ok=True)
+    (config_home / "config.yaml").write_text(
+        "auto_open_conversation: false\ntui:\n  theme: dark\n",
+    )
+    sdk_paths = [
+        str(_REPO_ROOT / "sdks" / "python-client"),
+        str(_REPO_ROOT / "sdks" / "ui"),
+    ]
+    existing_pp = os.environ.get("PYTHONPATH", "")
+    env = {
+        **os.environ,
+        "HOME": str(tmp_home),
+        "OMNIGENT_CONFIG_HOME": str(config_home),
+        "OMNIGENT_SKIP_ONBOARD": "1",
+        "OMNIGENT_NO_UPDATE_CHECK": "1",
+        "PYTHONPATH": os.pathsep.join([*sdk_paths, existing_pp] if existing_pp else sdk_paths),
+        "TERM": "xterm-256color",
+        "LINES": str(_REPL_DIMENSIONS[0]),
+        "COLUMNS": str(_REPL_DIMENSIONS[1]),
+        "PROMPT_TOOLKIT_NO_CPR": "1",
+    }
+    return ensure_repl_test_theme_env(env)
+
+
+# The settled frame lists the seeded child (``↓ agents``) with the badge
+# asleep on the same toolbar line; the lit frame is the running badge.
+_SETTLED_TOOLBAR = re.compile(r"↓ agents.*state: sleeping")
+_RUNNING_TOOLBAR = re.compile(r"state: 1 agent running")
+
+
+def _wait_for_toolbar(repl: Any, pattern: re.Pattern[str], timeout: float) -> str:
+    """Repaint the REPL until its toolbar matches *pattern* or *timeout* elapses.
+
+    prompt-toolkit repaints only the cells that changed, so a badge flip
+    reaches the PTY as scattered fragments. Ctrl+L forces a full frame each
+    poll so the toolbar can be matched as one contiguous line.
+
+    :param repl: Live ``pexpect.spawn`` REPL sitting at its prompt.
+    :param pattern: Toolbar text to wait for, e.g. :data:`_RUNNING_TOOLBAR`.
+    :param timeout: Seconds to keep polling.
+    :returns: The last full frame, ANSI-stripped, whether or not it matched;
+        callers assert on it so a miss shows the real screen.
+    """
+    from tests.e2e.omnigent._pexpect_harness import strip_ansi
+    from tests.e2e.omnigent._repl_test_helpers import drain_for
+
+    frame = ""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        repl.sendcontrol("l")
+        frame = strip_ansi(drain_for(repl, 1.0))
+        if pattern.search(frame):
+            break
+    return frame
+
+
+@pytest.mark.posix_only
+def test_repl_toolbar_shows_child_driven_outside_parent_runner(
+    live_server: str,
+    http_client: httpx.Client,
+    coder_agent: str,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+    using_mock_llm: bool,
+    tmp_path: Path,
+) -> None:
+    """The real CLI toolbar lights up for a child the parent's runner never
+    registered.
+
+    Reproduces the shape behind a reused or directly-driven sub-agent: the
+    child exists before the REPL attaches, so the REPL seeds it idle and
+    parks its tree poll; then a turn is posted to the child directly. The
+    runner's in-process child→parent fan-out knows nothing about this child,
+    so the parent's stream only learns the child went busy if the server
+    mirrors the status edge. Without that the badge sits on
+    ``state: sleeping`` while the child works.
+
+    :param live_server: Base URL of the live server the REPL attaches to.
+    :param http_client: HTTP client pointed at the live server.
+    :param coder_agent: Uploaded agent both sessions bind to.
+    :param live_runner_id: Registered runner the parent binds to; the child
+        inherits it.
+    :param mock_llm_server_url: Mock LLM whose gate holds the child's turn
+        open while the toolbar is read.
+    :param using_mock_llm: True when no ``--llm-api-key`` was passed.
+    :param tmp_path: Per-test directory for the REPL's isolated ``HOME``.
+    """
+    pexpect = pytest.importorskip("pexpect")
+    if not using_mock_llm:
+        pytest.skip(
+            "relies on the mock LLM's gate to hold the child's turn open while "
+            "the toolbar is read."
+        )
+
+    token = f"child-turn-{uuid.uuid4().hex[:8]}"
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "child done", "block": True}],
+        match=token,
+    )
+    parent_id = create_runner_bound_session(
+        http_client, agent_name=coder_agent, runner_id=live_runner_id
+    )
+    resp = http_client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": lookup_agent_id(http_client, coder_agent),
+            "parent_session_id": parent_id,
+            "title": "probe:worker",
+        },
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    resp.raise_for_status()
+    child_id = str(resp.json()["id"])
+
+    repl = pexpect.spawn(
+        sys.executable,
+        ["-m", "omnigent", "attach", parent_id, "--server", live_server],
+        env=_attach_repl_env(tmp_path / "home"),
+        cwd=str(_REPO_ROOT),
+        encoding="utf-8",
+        codec_errors="replace",
+        timeout=120,
+        dimensions=_REPL_DIMENSIONS,
+    )
+    response_id: str | None = None
+    try:
+        repl.expect("❯", timeout=90)
+        # The REPL discovered the pre-existing child and, seeing it idle,
+        # parked its tree poll: the ↓ menu is offered but nothing is running.
+        settled = _wait_for_toolbar(repl, _SETTLED_TOOLBAR, timeout=20.0)
+        assert _SETTLED_TOOLBAR.search(settled), (
+            f"REPL never listed the seeded child with the badge asleep; saw:\n{settled}"
+        )
+
+        response_id = send_user_message_to_session(http_client, session_id=child_id, content=token)
+        lit = _wait_for_toolbar(repl, _RUNNING_TOOLBAR, timeout=25.0)
+        assert _RUNNING_TOOLBAR.search(lit), (
+            "toolbar stayed asleep while the child ran: the parent stream never "
+            f"carried the child's busy edge; saw:\n{lit}"
+        )
+    finally:
+        with contextlib.suppress(httpx.HTTPError):
+            release_mock_gate(mock_llm_server_url)
+        with contextlib.suppress(pexpect.ExceptionPexpect):
+            repl.sendcontrol("d")
+            repl.expect(pexpect.EOF, timeout=15)
+        if repl.isalive():
+            repl.terminate(force=True)
+        reset_mock_llm(mock_llm_server_url)
+    if response_id is not None:
+        poll_session_until_terminal(
+            http_client, session_id=child_id, response_id=response_id, timeout=60
+        )

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -18,6 +18,7 @@ conversation row's ``agent_id`` column.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import json
 import tarfile
@@ -659,6 +660,62 @@ async def test_child_sessions_current_task_status_reflects_relay_status_cache(
         assert row["current_task_status"] == expected_task_status
     finally:
         sessions_module._session_status_cache.pop(child.id, None)
+
+
+async def test_child_status_edge_fans_out_to_parent_stream(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """
+    A child's status transition reaches the parent's stream from the server.
+
+    The runner only fans out ``session.child_session.updated`` for children
+    it registered in-process, so a child driven outside its parent's runner
+    (or after a runner restart) used to change status with no parent-stream
+    event at all, leaving the REPL badge and the web rail on ``Idle``. The
+    server sees every transition in the status cache, so it publishes the
+    child's current summary to the parent: ``running`` → busy /
+    ``in_progress``, ``idle`` → ``completed``, and a repeated identical edge
+    stays quiet.
+
+    :param client: The test HTTP client.
+    :param db_uri: Per-test SQLite database URI.
+    """
+    from omnigent.runtime import session_stream
+    from tests.server.helpers import start_session_stream_collector
+
+    session = await _create_parent_session(client)
+    conv_store = SqlAlchemyConversationStore(db_uri)
+    child = _seed_child(
+        conv_store=conv_store,
+        parent_id=session["id"],
+        title="researcher:auth",
+        agent_id=session["agent_id"],
+    )
+    collector = await start_session_stream_collector(session["id"])
+    try:
+        sessions_module._publish_status(child.id, "running")
+        sessions_module._publish_status(child.id, "running")
+        sessions_module._publish_status(child.id, "idle")
+
+        updates: list[dict[str, Any]] = []
+        while len(updates) < 2:
+            event = await asyncio.wait_for(collector.queue.get(), timeout=5.0)
+            if event.get("type") == "session.child_session.updated":
+                updates.append(event)
+        assert [u["child_session_id"] for u in updates] == [child.id, child.id]
+        assert [u["conversation_id"] for u in updates] == [session["id"]] * 2
+        assert updates[0]["child"]["busy"] is True
+        assert updates[0]["child"]["current_task_status"] == "in_progress"
+        assert updates[1]["child"]["busy"] is False
+        assert updates[1]["child"]["current_task_status"] == "completed"
+        assert updates[1]["child"]["title"] == "researcher:auth"
+        await asyncio.sleep(0.2)
+        assert collector.queue.empty(), "a repeated identical edge must not fan out"
+    finally:
+        await collector.stop()
+        sessions_module._session_status_cache.pop(child.id, None)
+        session_stream.close(session["id"])
 
 
 async def test_child_sessions_truncates_long_message_preview(


### PR DESCRIPTION
## Related issue

Closes #6162

## Summary

- A sub-agent's `busy` / `current_task_status` on the parent's Agents rail (the REPL `state: N agents running` badge and the web rail) was only ever pushed by the runner's in-memory child→parent fan-out, which covers just the children that runner registered itself. A child reused after a runner restart, or driven directly rather than through its parent, changed status with no `session.child_session.updated` on the parent stream, so the REPL sat on `state: sleeping` while the child worked.
- The server already sees every transition in `_session_status_cache`. `_publish_status` now republishes the child's summary (the same `ChildSessionSummary` the REST route and the connect snapshot build) onto the parent's stream whenever a session that has a parent changes status. The runner fan-out stays as the fast path; the duplicate is idempotent for the REPL and the web.
- The store reads run on the ordered live-state worker (`session_live_state.submit`), so a `running` → `idle` pair can never fan out reversed and the event loop only pays a queue put. Each edge carries its own status (`cached_status`) instead of the latest one repeated.

ELI5: the runner used to be the only one telling the parent "your child is busy", and it only knew about children it had spawned itself. Now the server, which watches every session's status anyway, tells the parent too.

```text
child session.status ──relay──> _publish_status(child)
                                    │ cache value changed?
                                    └──> parent stream: session.child_session.updated
                                           {busy, current_task_status, …}
                                           └──> REPL badge / web Agents rail
```

Alternative to #6165, which bounds the staleness with a 30 s client-side poll in the REPL; this fixes the missing push at the source, so the web rail and the SDK `subtree_busy` rollup get it too.

## Test Plan

- `tests/server/integration/test_sessions_child_sessions.py::test_child_status_edge_fans_out_to_parent_stream` — `running` → `busy` / `in_progress`, `idle` → `completed` on the parent stream; a repeated identical edge stays quiet.
- `tests/e2e/test_repl_subagent_panel_events_e2e.py::test_repl_toolbar_shows_child_driven_outside_parent_runner` — boots the real server + runner + mock LLM, creates a parent and a REST-created child (so the runner never registers it), runs the real `omnigent attach` CLI under a pexpect PTY, waits for the toolbar to settle with `↓ agents` and `state: sleeping`, posts a turn to the child directly, and asserts `state: 1 agent running`. Fails on main (the toolbar stays `state: sleeping`), passes with this change.
- `uv run pytest tests/server/integration/test_sessions_child_sessions.py tests/server/routes/test_child_session_summary_labels.py tests/server/test_session_live_state.py tests/server/routes/test_sessions_runner_relay.py tests/server/routes/test_sessions_snapshot.py tests/server/routes/test_session_updates_ws.py tests/server/routes/test_sessions_crud.py tests/server/routes/test_sessions_background_task_status.py` — 244 passed.
- `pre-commit run --files <changed files>` — ruff and the repo lint hooks pass.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Toolbar frames captured from the real `omnigent attach` PTY by the new e2e (ANSI-stripped, 200 columns), before and after a turn is posted directly to the REST-created child:

**Before** — child listed, badge asleep:

```text
── coder · ready  /help help · ↓ agents · Ctrl+O debug · Ctrl+T show tools · Esc cancel · Ctrl+C exit  ○ 0% ──────────────── state: sleeping
```

**After, with this change** — the parent stream carried the child's busy edge:

```text
── coder · ready  /help help · ↓ agents · Ctrl+O debug · Ctrl+T show tools · Esc cancel · Ctrl+C exit  ○ 0% ──────── state: 1 agent running ⠋
```

**After, on main** (the two server files stashed) — the badge never moves and the e2e fails:

```text
AssertionError: toolbar stayed asleep while the child ran: the parent stream never carried the child's busy edge; saw:
── coder · ready  /help help · ↓ agents · Ctrl+O debug · Ctrl+T show tools · Esc cancel · Ctrl+C exit  ○ 0% ──────────────── state: sleeping
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The PTY e2e runs the terminal at 200 columns and polls the toolbar through Ctrl+L full repaints: at the harness default of 120 columns the right-aligned `state:` badge falls off the edge, and prompt-toolkit's diff repaint emits nothing when it flips.

## Changelog

The CLI and web Agents rail now show a sub-agent as running when it is reused or driven directly, instead of staying `Idle` until the parent's next turn.

https://claude.ai/code/session_01FjSGYW4mz69MNys4mVpegw
