### PR TITLE
fix(codex-native): trust merged hooks so resumed sessions skip the review screen

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1128,6 +1128,14 @@ class CodexNativeAppServer:
         session config before startup. Runner-owned headless sessions set
         this because nobody can answer Codex's project-trust TUI prompt.
         Interactive CLI sessions leave it disabled.
+    :param trust_all_hooks: Whether to persist trust for every merged hook
+        (user hooks included) during :meth:`start`. Runner-owned headless
+        sessions set this because codex ignores their
+        ``--dangerously-bypass-hook-trust`` flag for the startup
+        hook-review screen on a persistent ``resume`` attach; persisted
+        trust keeps that interactive screen from stranding a resumed web
+        session (see :func:`trust_all_codex_hooks`). Interactive CLI
+        sessions leave it disabled so a human reviews their own hooks.
     :param policy_notice_pending: One-shot flag: ``True`` once a degrade
         reason is recorded, until the runner's terminal-ensure handler
         surfaces it to Omnigent (which posts a single durable banner). Prevents
@@ -1157,6 +1165,7 @@ class CodexNativeAppServer:
     process_owner_lock: CodexNativeProcessOwnerLock | None = None
     codex_cli_version: tuple[int, int, int] | None = None
     trust_project: bool = False
+    trust_all_hooks: bool = False
     router_hooks_registered: bool = False
 
     async def start(self) -> None:
@@ -1390,6 +1399,31 @@ class CodexNativeAppServer:
                 except Exception:  # noqa: BLE001 - routing trust never blocks startup
                     _logger.warning(
                         "codex subagent-routing hook trust failed; routing will not be enforced",
+                        exc_info=True,
+                    )
+            # Runner-owned sessions launch the TUI with
+            # ``--dangerously-bypass-hook-trust``, but codex ignores that flag
+            # for the startup hook-review screen on a persistent ``resume``
+            # attach, stranding a resumed web session behind the interactive
+            # "Hooks need review" prompt. Persist trust for every merged hook so
+            # the review finds nothing to review. Best effort: a failure only
+            # risks the review screen reappearing, never blocks startup.
+            if self.trust_all_hooks:
+                try:
+                    still_untrusted = await trust_all_codex_hooks(
+                        client.request, cwd=str(self.cwd)
+                    )
+                    if still_untrusted:
+                        _logger.warning(
+                            "codex hook trust-all left %d hook(s) untrusted; the startup "
+                            "hook-review screen may still appear on resume: %s",
+                            len(still_untrusted),
+                            ", ".join(still_untrusted),
+                        )
+                except Exception:  # noqa: BLE001 - trust-all never blocks startup
+                    _logger.warning(
+                        "codex hook trust-all failed; the startup hook-review screen "
+                        "may appear on resume",
                         exc_info=True,
                     )
         except RuntimeError as exc:
@@ -1724,19 +1758,22 @@ def _write_codex_policy_hooks_file(
     _ = write_codex_hooks_file(codex_home, payloads, user_hooks_source=user_hooks_source)
 
 
-def _our_hooks_from_list(listed: _JsonObject, cwd: str, module: str) -> list[_JsonObject]:
+def _our_hooks_from_list(listed: _JsonObject, cwd: str, module: str | None) -> list[_JsonObject]:
     """
-    Extract the hooks for *cwd* whose command runs *module*.
+    Extract the hooks for *cwd*, optionally only those running *module*.
 
-    Filtering by module keeps the trust step from ever touching hooks the
-    user's own ``hooks.json`` contributed to the merged file.
+    Filtering by module keeps a trust step from ever touching hooks the
+    user's own ``hooks.json`` contributed to the merged file. Pass
+    ``module=None`` to return every hook for *cwd* (used by the
+    runner-owned trust-all pass, which deliberately covers user hooks —
+    see :func:`trust_all_codex_hooks`).
 
     :param listed: Parsed ``hooks/list`` response envelope, with
         ``result.data`` a list of ``{cwd, hooks: [...]}`` entries.
     :param cwd: The cwd whose hook set to read, e.g.
         ``"/home/user/repo"``.
-    :param module: Hook-script module marker, e.g.
-        ``"omnigent.codex_native_hook"``.
+    :param module: Hook-script module marker to filter on, e.g.
+        ``"omnigent.codex_native_hook"``; ``None`` returns all hooks.
     :returns: The matching hook metadata dicts (possibly empty), each
         with ``key``, ``currentHash``, ``trustStatus``.
     """
@@ -1752,7 +1789,7 @@ def _our_hooks_from_list(listed: _JsonObject, cwd: str, module: str) -> list[_Js
                 hook
                 for raw_hook in hooks
                 if (hook := _string_object_dict(raw_hook)) is not None
-                and module in str(hook.get("command", ""))
+                and (module is None or module in str(hook.get("command", "")))
             ]
     return []
 
@@ -1933,6 +1970,57 @@ async def trust_codex_router_hooks(request: CodexRequestFn, *, cwd: str) -> list
         len(ours),
         ", ".join(sorted(str(h.get("eventName")) for h in ours)),
     )
+    return []
+
+
+async def trust_all_codex_hooks(request: CodexRequestFn, *, cwd: str) -> list[str]:
+    """
+    Persist trust for every hook discovered for *cwd*, user hooks included.
+
+    Runner-owned native sessions launch the TUI with
+    ``--dangerously-bypass-hook-trust``, which already runs every enabled
+    hook regardless of trust state. But codex only honors that flag for the
+    interactive startup hook-review *screen* when the session is not a
+    persistent resume: it computes ``bypass_hook_trust && !is_persistent_resume``,
+    and an Omnigent ``resume <thread_id> --remote`` attach is a persistent
+    resume. So a resumed web/headless session drops back to the interactive
+    "Hooks need review" screen that nobody can answer, stranding the queued
+    chat message. Persisting trust for the merged hooks (the same
+    ``hooks/list`` -> ``config/batchWrite`` flow the TUI's own "Trust all"
+    button uses) makes codex's startup review find nothing to review, so the
+    screen never appears — on a fresh launch or a resume alike.
+
+    This is not a new trust surface: these sessions already execute the very
+    same hooks unconditionally via the bypass flag. It only makes the
+    persisted trust state match that already-chosen behavior. Interactive
+    ``omnigent codex`` sessions never call this — a human at the terminal
+    reviews their own new or changed hooks.
+
+    Best-effort: a trust failure here only means the review screen may still
+    appear, so it returns the still-untrusted keys instead of raising.
+
+    :param request: Bound app-server JSON-RPC request coroutine, e.g.
+        ``client.request``.
+    :param cwd: The session cwd the hooks are scoped to, e.g.
+        ``"/home/user/repo"``.
+    :returns: Keys of hooks still untrusted afterwards; empty when every
+        discovered hook is trusted (or none are).
+    """
+    listed = await request("hooks/list", {"cwds": [cwd]})
+    all_hooks = _our_hooks_from_list(listed, cwd, None)
+    untrusted = [h for h in all_hooks if h.get("trustStatus") not in _TRUSTED_HOOK_STATUSES]
+    if not untrusted:
+        return []
+    await _persist_hook_trust(request, untrusted)
+    relisted = await request("hooks/list", {"cwds": [cwd]})
+    still_untrusted = [
+        h
+        for h in _our_hooks_from_list(relisted, cwd, None)
+        if h.get("trustStatus") not in _TRUSTED_HOOK_STATUSES
+    ]
+    if still_untrusted:
+        return [str(h.get("key")) for h in still_untrusted]
+    _logger.info("codex hook trust-all: trusted %d hook(s) for cwd %s", len(untrusted), cwd)
     return []
 
 
@@ -2160,6 +2248,7 @@ def build_codex_native_server(
     developer_instructions: str | None = None,
     bypass_sandbox: bool = False,
     trust_project: bool = False,
+    trust_all_hooks: bool = False,
 ) -> CodexNativeAppServer:
     """
     Build a configured native Codex app-server process wrapper.
@@ -2198,6 +2287,12 @@ def build_codex_native_server(
     :param trust_project: Whether to trust ``cwd`` in the private session
         config before app-server startup. Intended for runner-owned headless
         sessions whose hidden TUI cannot answer Codex's project-trust prompt.
+    :param trust_all_hooks: Whether to persist trust for every merged hook
+        during startup. Intended for runner-owned headless sessions whose
+        ``--dangerously-bypass-hook-trust`` flag codex ignores for the
+        startup hook-review screen on a persistent ``resume`` attach (see
+        :func:`trust_all_codex_hooks`). Interactive CLI sessions leave it
+        disabled so a human reviews their own new or changed hooks.
     :returns: Configured app-server process wrapper.
     :raises ImportError: If no Codex CLI is available.
     :raises OSError: If Databricks routing was requested but no
@@ -2260,6 +2355,7 @@ def build_codex_native_server(
         python_executable=python_executable,
         pinned_model=pinned_model,
         trust_project=trust_project,
+        trust_all_hooks=trust_all_hooks,
     )
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4122,6 +4122,12 @@ async def _auto_create_codex_terminal(
         # creating a thread. This TUI runs detached for the web UI, so persist
         # the runner-owned acknowledgements in the private session config.
         trust_project=True,
+        # Codex ignores --dangerously-bypass-hook-trust for the startup
+        # hook-review screen on a persistent ``resume`` attach, which strands a
+        # resumed web session behind the interactive "Hooks need review" prompt.
+        # Persist trust for every merged hook so the review finds nothing to
+        # review. See trust_all_codex_hooks.
+        trust_all_hooks=True,
     )
     # Generate routing hooks.json (and bypass codex's hook-trust prompt): the
     # app-server reads the endpoint out of its own process env at start, and

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -29,6 +29,7 @@ from omnigent.codex_native_app_server import (
     build_codex_native_server,
     discover_codex_model_options,
     framework_approved_tools,
+    trust_all_codex_hooks,
     trust_codex_router_hooks,
     trust_native_policy_hooks,
 )
@@ -1936,6 +1937,94 @@ async def test_trust_step_covers_router_hooks_when_routing_armed(
     for write in _batchwrite_calls(client):
         trusted.update(write.params["edits"][0]["value"])
     assert set(trusted) == {"policy", "gate"}
+
+
+async def test_trust_all_codex_hooks_trusts_user_hooks() -> None:
+    """
+    The runner-owned trust-all pass covers user hooks, not just Omnigent's.
+
+    Codex ignores ``--dangerously-bypass-hook-trust`` for the startup
+    review screen on a persistent ``resume``; persisting trust for the
+    merged user hooks is what keeps that screen from stranding a resumed
+    web session, so this pass must reach hooks the policy trust never does.
+    """
+    client = _FakeCodexClient(
+        hooks=[
+            _hook("ours", _OUR_COMMAND, "untrusted", "sha256:ours"),
+            _hook("theirs", _USER_COMMAND, "untrusted", "sha256:theirs"),
+        ]
+    )
+
+    assert await trust_all_codex_hooks(client.request, cwd=_CWD) == []
+
+    writes = _batchwrite_calls(client)
+    assert len(writes) == 1
+    written = writes[0].params["edits"][0]["value"]
+    assert written == {
+        "ours": {"trusted_hash": "sha256:ours"},
+        "theirs": {"trusted_hash": "sha256:theirs"},
+    }
+
+
+async def test_trust_all_codex_hooks_reports_still_untrusted_without_raising() -> None:
+    """
+    A hash that never flips is returned, not raised.
+
+    The trust-all pass is a UX fix (suppress the review screen), not a
+    security gate, so a persistent failure only risks the screen
+    reappearing and must never block startup.
+    """
+    client = _FakeCodexClient(
+        hooks=[_hook("theirs", _USER_COMMAND, "untrusted", "sha256:theirs")],
+        flip_on_trust=False,
+    )
+
+    assert await trust_all_codex_hooks(client.request, cwd=_CWD) == ["theirs"]
+
+
+async def test_trust_step_trusts_user_hooks_only_when_trust_all_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    ``trust_all_hooks`` gates whether the startup step trusts user hooks.
+
+    Runner-owned sessions enable it so a resumed web session never faces
+    the interactive review screen; interactive CLI sessions leave it off so
+    a human at the terminal reviews their own new or changed hooks.
+    """
+
+    async def _fake_connect(self: Any) -> None:
+        return None
+
+    async def _fake_close(self: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "omnigent.codex_native_app_server.CodexAppServerClient.connect", _fake_connect
+    )
+    monkeypatch.setattr("omnigent.codex_native_app_server.CodexAppServerClient.close", _fake_close)
+
+    for trust_all, expected in ((True, {"policy", "theirs"}), (False, {"policy"})):
+        client = _FakeCodexClient(
+            hooks=[
+                _hook("policy", _OUR_COMMAND, "untrusted", "sha256:policy"),
+                _hook("theirs", _USER_COMMAND, "untrusted", "sha256:theirs"),
+            ]
+        )
+        monkeypatch.setattr(
+            "omnigent.codex_native_app_server.CodexAppServerClient.request",
+            lambda self, method, params, _c=client: _c.request(method, params),
+        )
+        server = _test_app_server(
+            tmp_path, tmp_path / "codex-home", tmp_path / "bridge", Path(_CWD)
+        )
+        server.trust_all_hooks = trust_all
+        await server._trust_policy_hooks()
+
+        trusted: dict[str, Any] = {}
+        for write in _batchwrite_calls(client):
+            trusted.update(write.params["edits"][0]["value"])
+        assert set(trusted) == expected
 
 
 async def test_policy_hook_command_runs_python_isolated() -> None:


### PR DESCRIPTION
## Related issue

No dedicated issue. Related (deliberately **not** closed, see the product note in Summary): #4936, #4937, #5820, #4813.

## Summary

Resumed native-Codex web/headless sessions dead-end on Codex's interactive **"Hooks need review" / "Trust all and continue"** screen that nobody at the terminal can answer, stranding the queued chat message. #5108 was meant to suppress this but could not.

**Root cause (codex source + live process argv).** Codex only honors `--dangerously-bypass-hook-trust` for the startup review *screen* when the launch is not a persistent resume:

```rust
// codex-rs/tui/src/lib.rs
let is_persistent_resume = !matches!(&app_server_target, AppServerTarget::Embedded)
    && matches!(&session_selection, SessionSelection::Resume(_));
let bypass_hook_trust_for_startup_review = config.bypass_hook_trust && !is_persistent_resume;
```

An Omnigent runner-owned terminal attaches with `resume <thread_id> --remote`, which is a persistent (non-Embedded) resume, so the bypass is forced to `false` even though the flag is on the argv (confirmed on a live TUI process carrying both `--dangerously-bypass-hook-trust` and `resume --remote`). This guard exists in every codex Omnigent ships (0.139 / 0.140 / 0.146+). Fresh sessions never hit it (no `resume` subcommand), which is why the bug only recurs when a session is reopened. At runtime the hooks still execute (the engine honors `source.bypass_hook_trust`); only the interactive screen blocks.

**Why #5108 didn't fix it.** #5108 only changed *whether* the flag is emitted (a failed `codex --version` probe still emits it). The flag was already emitted; codex silently drops its review effect on resume regardless.

**Fix.** Persist trust for every merged hook (user hooks included) during runner-owned app-server start, via a new `trust_all_codex_hooks()` pass using the same `hooks/list` -> `config/batchWrite` flow codex's own "Trust all" button uses. Gated by a new `trust_all_hooks` field on `CodexNativeAppServer` / `build_codex_native_server`, set only from the runner path (next to `trust_project=True`). Codex's startup review then finds nothing to review on a fresh launch or a resume alike. Interactive `omnigent codex` leaves it off, so a human at the terminal still reviews their own hooks. Best-effort: a trust failure is logged, never blocks startup.

**Product note.** This is the opposite direction from #4936 / #5820 (keep the review interactive and make chat wait) and #4937 / #4813 (persist trust + a manual "Review hooks" UI). Maintainer decision: runner-owned sessions are headless, so an interactive hook-approval ceremony is not a valid gate there; Omnigent provisions and vets the private `CODEX_HOME` itself. This change is not a new trust surface: these sessions already execute the very same hooks unconditionally under the bypass flag. It only makes the persisted trust state match that already-chosen behavior.

```text
runner start -> app-server up -> trust policy hooks (loud) -> trust router hooks
            -> trust ALL merged hooks (new, best-effort)
            -> TUI `resume --remote` -> hooks/list: nothing untrusted -> no review screen
```

## Test Plan

- New unit tests in `tests/test_codex_native_app_server.py`:
  - `test_trust_all_codex_hooks_trusts_user_hooks` (covers hooks the policy trust never touches)
  - `test_trust_all_codex_hooks_reports_still_untrusted_without_raising` (best-effort, no raise)
  - `test_trust_step_trusts_user_hooks_only_when_trust_all_enabled` (gate on/off; interactive CLI unchanged)
- Existing `test_user_hooks_are_never_trusted` (policy-only path) untouched and still passing.
- `pytest tests/test_codex_native_app_server.py` — 75 passed.
- `ruff check` / `ruff format --check` clean; `pyrefly check` 0 errors on both touched modules.
- Root cause verified against a live session: TUI argv carries `--dangerously-bypass-hook-trust` + `resume --remote`; private `config.toml` `[hooks.state]` shows the merged user hooks at group index >= 1 were the untrusted ones.

Pre-existing, unrelated: 3 Pi-cwd tests in `tests/runner/test_app_sessions_native_terminals_runtime.py` fail identically on a clean tree (HTTP 400).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Manual check: on a host with a `~/.codex/hooks.json`, start a native Codex session from the web UI, force a resume (reopen after the terminal is recreated, e.g. runner reconnect / redeploy), send a message. Before: lands on "Hooks need review". After: the message goes straight through.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the root-cause proof on a live runner-owned session (argv + `[hooks.state]` inspection); the behavioral fix is pinned by the three new unit tests, which exercise the trust-all pass directly and through `CodexNativeAppServer._trust_policy_hooks` with the gate both on and off.

## Changelog

Resumed native Codex sessions launched from the web no longer get stuck behind the terminal-only "Hooks need review" prompt.

https://claude.ai/code/session_013aKKexTvto9W8NTu5eA8Kn
