### PR TITLE
ci(polly-review): ask Polly whether the PR's approach is the simplest one

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -398,13 +398,14 @@ jobs:
           """ if is_external else ""
 
           # The "Missing visual demonstration" report item + rule are only included
-          # for external contributors; otherwise the review has just the 4 standard
+          # for external contributors; otherwise the review has just the 5 standard
           # sections. Build the numbered list so the numbering stays contiguous
           # regardless of whether the visual item is present.
           standard_items = [
               "**Blocking issues** — correctness bugs, broken contracts, missing error handling on failure paths, data loss risks.",
               "**Security vulnerabilities** — injection (SQL, command, template), authentication/authorization bypasses, secret exposure, unsafe deserialization, path traversal, SSRF, and any change that weakens an existing security boundary. Flag even subtle issues.",
               "**Non-blocking notes** — design concerns or edge cases worth flagging (brief).",
+              "**Approach** — is there a materially simpler or more consistent way to reach the PR's stated goal, given existing patterns in the repo (config surfaces, variables, helpers, conventions)? Name the concrete alternative briefly, or say the approach is sound. Never blocking.",
               "**Summary** — one-paragraph overall assessment.",
           ]
           visual_item = [


### PR DESCRIPTION
## Related issue

No issue — `Test / CI` change.

## Summary

- Polly AI Review only ever judged what is in the diff: blocking bugs, security, brief non-blocking notes, summary. Nothing asked it whether the PR's approach is the right one, so it never says "there is a simpler / more consistent way to do this" even when the repo already has a pattern for it.
- This adds an **Approach** item to the review prompt, between Non-blocking notes and Summary: is there a materially simpler or more consistent way to reach the PR's stated goal given existing repo patterns? Name the concrete alternative briefly, or say the approach is sound. It is explicitly never blocking, so taste does not become a merge gate.
- The numbered section list is built from the same `standard_items` list, so numbering stays contiguous with or without the external-contributor visual-demo item.

## Test Plan

- `pre-commit run --files .github/workflows/polly-review.yml`: green (YAML syntax, hardcoded-model lint, whitespace).
- Extracted the embedded prompt-builder Python heredoc from the workflow and `ast.parse`d it: parses.
- Live: the Polly AI Review run on this PR uses the new prompt (pull_request runs take the workflow from the PR's merge ref), so its comment should carry an **Approach** section.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Prompt-text-only change inside a workflow; no code path to unit test. Verified by pre-commit, a parse of the embedded Python, and Polly's own review on this PR.

https://claude.ai/code/session_014fTbSd7oQUqgoctyvH6tDN
