### PR TITLE
fix: stream workspace file downloads past the 10 MiB read cap

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10080,7 +10080,9 @@ def create_runner_app(
                 while remaining > 0:
                     chunk = await asyncio.to_thread(fobj.read, min(64 * 1024, remaining))
                     if not chunk:
-                        break
+                        # Ending short of Content-Length would hand the client
+                        # a silently incomplete file; abort the transfer instead.
+                        raise RuntimeError(f"{resolved.name} shrank during download")
                     remaining -= len(chunk)
                     yield chunk
             finally:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -41,7 +41,7 @@ import click
 import httpcore
 import httpx
 from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
-from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.debug_logging import runner_primary_session_id
@@ -10049,13 +10049,13 @@ def create_runner_app(
         session_id: str,
         environment_id: str,
         path: str,
-    ) -> FileResponse:
+    ) -> StreamingResponse:
         """Serve a file's complete bytes as an attachment.
 
         The read path inlines content in a JSON envelope, so it caps at
-        ``_MAX_READ_BYTES``. A download streams straight from disk and
-        needs no cap; ``resolve_download`` applies the read path's
-        authorization, sandbox view included, before a byte is served.
+        ``_MAX_READ_BYTES``. A download streams from a descriptor and needs
+        no cap; ``open_download`` binds that descriptor to what the sandbox
+        can read before a byte is served.
 
         :param session_id: Session identifier.
         :param environment_id: Environment resource id.
@@ -10070,11 +10070,39 @@ def create_runner_app(
         await _ensure_session_registered(session_id)
         agent_spec = await _resolve_session_agent_spec(session_id)
         env = resource_registry.resolve_environment(session_id, environment_id, agent_spec)
-        resolved = await CallerProcessFilesystem(env).resolve_download(path)
-        return FileResponse(
-            resolved,
-            filename=resolved.name,
-            headers={"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
+        fobj, resolved, size = await CallerProcessFilesystem(env).open_download(path)
+
+        async def _chunks() -> AsyncIterator[bytes]:
+            # Stop at the size announced in Content-Length so a file growing
+            # underneath the download cannot overrun the response.
+            remaining = size
+            try:
+                while remaining > 0:
+                    chunk = await asyncio.to_thread(fobj.read, min(64 * 1024, remaining))
+                    if not chunk:
+                        break
+                    remaining -= len(chunk)
+                    yield chunk
+            finally:
+                fobj.close()
+
+        # Same header Starlette's FileResponse builds: a plain quoted filename
+        # when it is URL-safe, else the RFC 5987 encoded form.
+        quoted = urllib.parse.quote(resolved.name)
+        disposition = (
+            f'attachment; filename="{resolved.name}"'
+            if quoted == resolved.name
+            else f"attachment; filename*=utf-8''{quoted}"
+        )
+        return StreamingResponse(
+            _chunks(),
+            media_type=mimetypes.guess_type(resolved.name)[0] or "application/octet-stream",
+            headers={
+                "Content-Length": str(size),
+                "Content-Disposition": disposition,
+                "Cache-Control": "no-store",
+                "X-Content-Type-Options": "nosniff",
+            },
         )
 
     async def _fs_list_or_read(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10054,30 +10054,23 @@ def create_runner_app(
 
         The read path inlines content in a JSON envelope, so it caps at
         ``_MAX_READ_BYTES``. A download streams straight from disk and
-        needs no cap. Authorization is the same ``_resolve`` gate the read
-        path applies before reading.
+        needs no cap; ``resolve_download`` applies the read path's
+        authorization, sandbox view included, before a byte is served.
 
         :param session_id: Session identifier.
         :param environment_id: Environment resource id.
         :param path: Path within the environment, or an absolute path.
         :returns: The file streamed with ``Content-Disposition: attachment``.
         :raises InvalidPath: If the path names a directory.
-        :raises FilesystemPathNotFound: If nothing exists at the path.
+        :raises FilesystemPathNotFound: If nothing the caller may see exists
+            at the path.
         """
-        from omnigent.entities.environment_filesystem import (
-            FilesystemPathNotFound,
-            InvalidPath,
-        )
         from omnigent.runner.environment_filesystem import CallerProcessFilesystem
 
         await _ensure_session_registered(session_id)
         agent_spec = await _resolve_session_agent_spec(session_id)
         env = resource_registry.resolve_environment(session_id, environment_id, agent_spec)
-        resolved = CallerProcessFilesystem(env)._resolve(path)
-        if resolved.is_dir():
-            raise InvalidPath(f"Path {path!r} is a directory")
-        if not resolved.is_file():
-            raise FilesystemPathNotFound(f"Path {path!r} not found")
+        resolved = await CallerProcessFilesystem(env).resolve_download(path)
         return FileResponse(
             resolved,
             filename=resolved.name,

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -41,7 +41,7 @@ import click
 import httpcore
 import httpx
 from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
-from fastapi.responses import JSONResponse, Response, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 
 from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.debug_logging import runner_primary_session_id
@@ -9465,8 +9465,11 @@ def create_runner_app(
         after: str | None = Query(default=None),
         before: str | None = Query(default=None),
         order: str = Query(default="desc", pattern="^(asc|desc)$"),
-    ) -> JSONResponse:
+        download: bool = False,
+    ) -> Response:
         await _require_os_env(session_id)
+        if download:
+            return await _fs_download(session_id, environment_id, relative_path)
         return await _fs_list_or_read(
             session_id,
             environment_id,
@@ -10040,6 +10043,45 @@ def create_runner_app(
         return JSONResponse(
             status_code=200,
             content={"meta_text": format_skill_meta_text(skill, arguments)},
+        )
+
+    async def _fs_download(
+        session_id: str,
+        environment_id: str,
+        path: str,
+    ) -> FileResponse:
+        """Serve a file's complete bytes as an attachment.
+
+        The read path inlines content in a JSON envelope, so it caps at
+        ``_MAX_READ_BYTES``. A download streams straight from disk and
+        needs no cap. Authorization is the same ``_resolve`` gate the read
+        path applies before reading.
+
+        :param session_id: Session identifier.
+        :param environment_id: Environment resource id.
+        :param path: Path within the environment, or an absolute path.
+        :returns: The file streamed with ``Content-Disposition: attachment``.
+        :raises InvalidPath: If the path names a directory.
+        :raises FilesystemPathNotFound: If nothing exists at the path.
+        """
+        from omnigent.entities.environment_filesystem import (
+            FilesystemPathNotFound,
+            InvalidPath,
+        )
+        from omnigent.runner.environment_filesystem import CallerProcessFilesystem
+
+        await _ensure_session_registered(session_id)
+        agent_spec = await _resolve_session_agent_spec(session_id)
+        env = resource_registry.resolve_environment(session_id, environment_id, agent_spec)
+        resolved = CallerProcessFilesystem(env)._resolve(path)
+        if resolved.is_dir():
+            raise InvalidPath(f"Path {path!r} is a directory")
+        if not resolved.is_file():
+            raise FilesystemPathNotFound(f"Path {path!r} not found")
+        return FileResponse(
+            resolved,
+            filename=resolved.name,
+            headers={"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
         )
 
     async def _fs_list_or_read(

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -17,7 +17,7 @@ import re
 import stat
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, ParamSpec
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec
 
 from omnigent.entities.environment_filesystem import (
     DeleteFilesystemResult,
@@ -913,17 +913,20 @@ class CallerProcessFilesystem:
             entry=entry,
         )
 
-    async def stat(self, path: str) -> FilesystemEntry:
-        """Return metadata for a single path via the sandboxed helper.
+    async def _helper_stat(self, target: str) -> dict[str, Any] | None:
+        """Stat *target* through the sandboxed helper.
 
-        :param path: Relative path within the environment.
-        :returns: The filesystem entry.
-        :raises FilesystemPathNotFound: If the path does not exist.
+        The helper sees the workspace as the sandbox presents it, so a path
+        the sandbox masks (a dotfile, an escaping symlink) reads as absent
+        here, exactly as it does to the environment's file tools.
+
+        :param target: Path as the helper should see it: workspace-relative,
+            or absolute for a path under a declared grant.
+        :returns: ``{"s": size, "m": mtime, "d": is_dir, "l": is_symlink}``,
+            or ``None`` when the helper cannot see the path.
         """
         import json as _json
 
-        validated = _validate_path(path) if path else ""
-        target = validated or "."
         # Embed the path as a Python literal via json.dumps and shell-quote
         # the entire script (matching list_dir/search_files). This keeps the
         # caller-controlled path out of any shell-interpreted context: it never
@@ -943,11 +946,23 @@ class CallerProcessFilesystem:
             f"python3 -c {_shell_quote(_script)}",
         )
         if "error" in result or result.get("exit_code", 1) != 0:
-            raise FilesystemPathNotFound(f"Path {path!r} not found")
+            return None
         try:
-            info = _json.loads(result.get("stdout", "{}"))
-        except _json.JSONDecodeError as exc:
-            raise FilesystemPathNotFound(f"Path {path!r} not found") from exc
+            return _json.loads(result.get("stdout", "{}"))
+        except _json.JSONDecodeError:
+            return None
+
+    async def stat(self, path: str) -> FilesystemEntry:
+        """Return metadata for a single path via the sandboxed helper.
+
+        :param path: Relative path within the environment.
+        :returns: The filesystem entry.
+        :raises FilesystemPathNotFound: If the path does not exist.
+        """
+        validated = _validate_path(path) if path else ""
+        info = await self._helper_stat(validated or ".")
+        if info is None:
+            raise FilesystemPathNotFound(f"Path {path!r} not found")
         name = os.path.basename(validated) if validated else ""
         entry_type: Literal["file", "directory", "symlink"] = "file"
         if info.get("d"):
@@ -962,6 +977,40 @@ class CallerProcessFilesystem:
             bytes=info["s"] if entry_type == "file" else None,
             modified_at=info["m"],
         )
+
+    async def resolve_download(self, path: str) -> Path:
+        """Resolve *path* to a regular file whose bytes may be served directly.
+
+        Applies the read path's authorization without its transport:
+        ``_resolve`` for containment and grants, then the sandboxed helper's
+        own view for any path the helper can reach, so a file the sandbox
+        masks (a dotfile, an escaping symlink) is refused here exactly as
+        ``read`` refuses it. A path admitted only because the environment is
+        unconfined has no sandbox to consult. The caller streams the file
+        itself, which the helper's single-message protocol cannot do.
+
+        :param path: Relative path within the environment, or an absolute
+            path elsewhere on the filesystem.
+        :returns: The resolved regular file.
+        :raises InvalidPath: If the path names a directory.
+        :raises FilesystemPathNotFound: If the path is missing or hidden
+            from the helper.
+        :raises PathUnreachable: If an absolute path is out of reach.
+        """
+        resolved = self._resolve(path)
+        if not self._absolute(path):
+            visible = await self._helper_stat(_validate_path(path) or ".") is not None
+        elif self._within_grants(resolved):
+            visible = await self._helper_stat(str(resolved)) is not None
+        else:
+            visible = resolved.exists()
+        if not visible:
+            raise FilesystemPathNotFound(f"Path {path!r} not found")
+        if resolved.is_dir():
+            raise InvalidPath(f"Path {path!r} is a directory")
+        if not resolved.is_file():
+            raise FilesystemPathNotFound(f"Path {path!r} not found")
+        return resolved
 
     async def edit_text(
         self,

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -17,7 +17,7 @@ import re
 import stat
 from collections.abc import Awaitable, Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, ParamSpec
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, ParamSpec
 
 from omnigent.entities.environment_filesystem import (
     DeleteFilesystemResult,
@@ -913,17 +913,24 @@ class CallerProcessFilesystem:
             entry=entry,
         )
 
-    async def _helper_stat(self, target: str) -> dict[str, Any] | None:
+    async def _helper_stat(
+        self, target: str, *, probe_read: bool = False
+    ) -> dict[str, Any] | None:
         """Stat *target* through the sandboxed helper.
 
-        The helper sees the workspace as the sandbox presents it, so a path
-        the sandbox masks (a dotfile, an escaping symlink) reads as absent
-        here, exactly as it does to the environment's file tools.
+        The helper sees the workspace as the sandbox presents it. Each
+        backend masks differently: bwrap binds ``/dev/null`` over a masked
+        file, so it stats as a character device on another inode, while
+        Seatbelt leaves ``stat`` working and fails the read. ``probe_read``
+        opens the file and reads a byte inside the helper so ``"r"`` means
+        "a regular file the helper can actually read" under either.
 
         :param target: Path as the helper should see it: workspace-relative,
             or absolute for a path under a declared grant.
-        :returns: ``{"s": size, "m": mtime, "d": is_dir, "l": is_symlink}``,
-            or ``None`` when the helper cannot see the path.
+        :param probe_read: Also attempt a one-byte read of a regular file.
+        :returns: ``{"s": size, "m": mtime, "d": is_dir, "l": is_symlink,
+            "r": readable_regular_file, "dev": st_dev, "ino": st_ino}``, or
+            ``None`` when the helper cannot stat the path.
         """
         import json as _json
 
@@ -937,8 +944,16 @@ class CallerProcessFilesystem:
                 "import os, json, stat as S",
                 f"p = {_json.dumps(target)}",
                 "s = os.stat(p)",
+                "r = S.S_ISREG(s.st_mode)",
+                f"if r and {probe_read!r}:",
+                "    try:",
+                "        with open(p, 'rb') as f:",
+                "            f.read(1)",
+                "    except OSError:",
+                "        r = False",
                 "print(json.dumps({'s': s.st_size, 'm': int(s.st_mtime),",
-                "    'd': S.S_ISDIR(s.st_mode), 'l': S.S_ISLNK(s.st_mode)}))",
+                "    'd': S.S_ISDIR(s.st_mode), 'l': S.S_ISLNK(s.st_mode),",
+                "    'r': r, 'dev': s.st_dev, 'ino': s.st_ino}))",
             ]
         )
         result = await _run_os_env_async(
@@ -978,39 +993,57 @@ class CallerProcessFilesystem:
             modified_at=info["m"],
         )
 
-    async def resolve_download(self, path: str) -> Path:
-        """Resolve *path* to a regular file whose bytes may be served directly.
+    async def open_download(self, path: str) -> tuple[BinaryIO, Path, int]:
+        """Open *path* for a raw download, bound to what the sandbox can read.
 
-        Applies the read path's authorization without its transport:
-        ``_resolve`` for containment and grants, then the sandboxed helper's
-        own view for any path the helper can reach, so a file the sandbox
-        masks (a dotfile, an escaping symlink) is refused here exactly as
-        ``read`` refuses it. A path admitted only because the environment is
-        unconfined has no sandbox to consult. The caller streams the file
-        itself, which the helper's single-message protocol cannot do.
+        The bytes are served from this process, since the helper's
+        single-message protocol cannot stream, so the file is opened here
+        first and the sandboxed helper is then asked to stat and read the
+        same path. The helper must report a readable regular file on the
+        very inode this process opened: a bwrap ``/dev/null`` mask is a
+        character device on another inode, a Seatbelt mask stats fine but
+        fails the read, and a path swapped between the two steps no longer
+        matches. A path admitted only because the environment is unconfined
+        has no sandbox to consult.
 
         :param path: Relative path within the environment, or an absolute
             path elsewhere on the filesystem.
-        :returns: The resolved regular file.
+        :returns: The open file at byte 0, its resolved path, and its size.
         :raises InvalidPath: If the path names a directory.
-        :raises FilesystemPathNotFound: If the path is missing or hidden
-            from the helper.
+        :raises FilesystemPathNotFound: If the path is missing, not a
+            regular file, or hidden from the helper.
         :raises PathUnreachable: If an absolute path is out of reach.
         """
         resolved = self._resolve(path)
-        if not self._absolute(path):
-            visible = await self._helper_stat(_validate_path(path) or ".") is not None
-        elif self._within_grants(resolved):
-            visible = await self._helper_stat(str(resolved)) is not None
-        else:
-            visible = resolved.exists()
-        if not visible:
-            raise FilesystemPathNotFound(f"Path {path!r} not found")
         if resolved.is_dir():
             raise InvalidPath(f"Path {path!r} is a directory")
-        if not resolved.is_file():
-            raise FilesystemPathNotFound(f"Path {path!r} not found")
-        return resolved
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+        try:
+            fd = os.open(resolved, flags)
+        except OSError as exc:
+            raise FilesystemPathNotFound(f"Path {path!r} not found") from exc
+        try:
+            st = os.fstat(fd)
+            if not stat.S_ISREG(st.st_mode):
+                raise FilesystemPathNotFound(f"Path {path!r} not found")
+            if not self._absolute(path):
+                target: str | None = _validate_path(path) or "."
+            elif self._within_grants(resolved):
+                target = str(resolved)
+            else:
+                target = None
+            if target is not None:
+                info = await self._helper_stat(target, probe_read=True)
+                if (
+                    info is None
+                    or not info.get("r")
+                    or (info.get("dev"), info.get("ino")) != (st.st_dev, st.st_ino)
+                ):
+                    raise FilesystemPathNotFound(f"Path {path!r} not found")
+        except BaseException:
+            os.close(fd)
+            raise
+        return os.fdopen(fd, "rb"), resolved, st.st_size
 
     async def edit_text(
         self,

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -922,12 +922,14 @@ class CallerProcessFilesystem:
         backend masks differently: bwrap binds ``/dev/null`` over a masked
         file, so it stats as a character device on another inode, while
         Seatbelt leaves ``stat`` working and fails the read. ``probe_read``
-        opens the file and reads a byte inside the helper so ``"r"`` means
-        "a regular file the helper can actually read" under either.
+        opens the file inside the helper, takes the identity from that
+        descriptor, and reads a byte from it, so ``"r"`` means "a regular
+        file the helper can actually read" under either, and the reported
+        inode is the one that was read rather than one stat'ed separately.
 
         :param target: Path as the helper should see it: workspace-relative,
             or absolute for a path under a declared grant.
-        :param probe_read: Also attempt a one-byte read of a regular file.
+        :param probe_read: Also open and read one byte of a regular file.
         :returns: ``{"s": size, "m": mtime, "d": is_dir, "l": is_symlink,
             "r": readable_regular_file, "dev": st_dev, "ino": st_ino}``, or
             ``None`` when the helper cannot stat the path.
@@ -948,6 +950,8 @@ class CallerProcessFilesystem:
                 f"if r and {probe_read!r}:",
                 "    try:",
                 "        with open(p, 'rb') as f:",
+                "            s = os.fstat(f.fileno())",
+                "            r = S.S_ISREG(s.st_mode)",
                 "            f.read(1)",
                 "    except OSError:",
                 "        r = False",

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -21,7 +21,8 @@ from fastapi import (
     Request,
     UploadFile,
 )
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
 
 from omnigent.entities import (
     Conversation,
@@ -245,6 +246,95 @@ def register_resources_routes(
         if conv is None:
             raise _session_not_found()
         return conv
+
+    # Per-chunk read budget for a streamed download, mirroring the event
+    # relay: a stall this long means the tunnel is dead, while a large file
+    # legitimately outlives any total timeout.
+    _download_timeout = httpx.Timeout(connect=5.0, read=45.0, write=None, pool=None)
+
+    async def _stream_download_from_runner(
+        request: Request,
+        session_id: str,
+        conversation: Conversation,
+        runner_path: str,
+    ) -> Response:
+        """Stream a file download from the runner without buffering it.
+
+        The runner serves the bytes straight from disk; forwarding them
+        chunk by chunk keeps the server's memory flat however large the
+        file is. There is no host fallback: the host tunnel's filesystem
+        op answers in a single message, so it cannot stream a file.
+
+        :param request: The incoming request, for the gzip opt-out.
+        :param session_id: Session/conversation identifier.
+        :param conversation: Conversation loaded during authorization.
+        :param runner_path: Runner-relative URL carrying ``download=true``.
+        :returns: The attachment, streamed as the runner sends it, or the
+            runner's own error body for a directory or out-of-grant path.
+        :raises OmnigentError: ``not_found`` when the file is missing;
+            ``runner_unavailable`` when the runner predates downloads.
+        :raises HTTPException: 502 when no runner can be reached.
+        """
+        runner_client = await _get_runner_client_for_resource_access(
+            session_id,
+            conversation=conversation,
+        )
+        if runner_client is None:
+            raise HTTPException(
+                status_code=502,
+                detail="no runner available for resource access",
+            )
+        try:
+            resp = await runner_client.send(
+                runner_client.build_request("GET", runner_path, timeout=_download_timeout),
+                stream=True,
+            )
+        except (httpx.HTTPError, ConnectionError) as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="runner download endpoint unavailable",
+            ) from exc
+        if resp.status_code == 200 and "content-disposition" in resp.headers:
+            skip_gzip(request)
+            forwarded = {
+                name: resp.headers[name]
+                for name in (
+                    "content-type",
+                    "content-length",
+                    "content-encoding",
+                    "content-disposition",
+                    "cache-control",
+                    "x-content-type-options",
+                )
+                if name in resp.headers
+            }
+            return StreamingResponse(
+                resp.aiter_raw(),
+                headers=forwarded,
+                background=BackgroundTask(resp.aclose),
+            )
+        await resp.aread()
+        await resp.aclose()
+        if resp.status_code == 200:
+            # A runner that predates ``download=true`` ignores it and answers
+            # the capped JSON envelope; serving that would truncate silently.
+            raise OmnigentError(
+                "Session runner does not support file downloads; restart the session",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        error = payload.get("error") if isinstance(payload, dict) else None
+        if not isinstance(error, dict):
+            raise HTTPException(status_code=502, detail="runner download failed")
+        if resp.status_code == 404:
+            raise OmnigentError(
+                str(error.get("message") or "File not found"),
+                code=ErrorCode.NOT_FOUND,
+            )
+        return JSONResponse(status_code=resp.status_code, content=payload)
 
     async def _proxy_get_to_runner(
         session_id: str,
@@ -2090,6 +2180,19 @@ def register_resources_routes(
         "/sessions/{session_id}/resources/environments"
         "/{environment_id}/filesystem/{relative_path:path}",
         response_model=None,
+        responses={
+            200: {
+                "description": (
+                    "File content or directory listing as JSON; the raw file "
+                    "as an attachment when `download=true`."
+                ),
+                "content": {
+                    "application/octet-stream": {
+                        "schema": {"type": "string", "format": "binary"},
+                    },
+                },
+            },
+        },
     )
     async def read_or_list_environment_path(
         request: Request,
@@ -2100,6 +2203,9 @@ def register_resources_routes(
         after: str | None = Query(default=None),
         before: str | None = Query(default=None),
         order: str = Query(default="desc", pattern="^(asc|desc)$"),
+        # A plain default, not ``Query(...)``: the root listing calls this
+        # function directly, and a ``Query`` object is truthy.
+        download: bool = False,
     ) -> Any:
         """
         Read a file or list a directory in an environment.
@@ -2113,7 +2219,10 @@ def register_resources_routes(
         :param after: Cursor entry id for forward pagination.
         :param before: Cursor entry id for backward pagination.
         :param order: Sort order, ``"asc"`` or ``"desc"``.
-        :returns: File content or directory listing.
+        :param download: When ``True``, stream the complete file as an
+            attachment with no size cap instead of the capped JSON
+            envelope. A directory rejects it with 400.
+        :returns: File content or directory listing, or the raw file.
         """
         params: dict[str, str] = {"limit": str(limit), "order": order}
         if after is not None:
@@ -2137,6 +2246,14 @@ def register_resources_routes(
         runner_rel = (
             "%2F" + urllib.parse.quote(relative_path.lstrip("/")) if absolute else relative_path
         )
+        if download:
+            return await _stream_download_from_runner(
+                request,
+                session_id,
+                conv,
+                f"/v1/sessions/{session_id}/resources/environments"
+                f"/{environment_id}/filesystem/{runner_rel}?download=true",
+            )
         path = (
             f"/v1/sessions/{session_id}/resources/environments"
             f"/{environment_id}/filesystem/{runner_rel}?{qs}"

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -7,7 +7,7 @@ import functools
 import mimetypes
 import ntpath
 import urllib.parse
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from pathlib import Path
 from typing import Annotated, Any, cast
 
@@ -22,7 +22,6 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.responses import JSONResponse, Response, StreamingResponse
-from starlette.background import BackgroundTask
 
 from omnigent.entities import (
     Conversation,
@@ -310,11 +309,18 @@ def register_resources_routes(
                 )
                 if name in resp.headers
             }
-            return StreamingResponse(
-                resp.aiter_raw(),
-                headers=forwarded,
-                background=BackgroundTask(resp.aclose),
-            )
+
+            async def _relay() -> AsyncIterator[bytes]:
+                # Close the runner response on every exit, a client
+                # disconnect included: Starlette skips the background task
+                # on disconnect, which would leak the tunnel request.
+                try:
+                    async for chunk in resp.aiter_raw():
+                        yield chunk
+                finally:
+                    await resp.aclose()
+
+            return StreamingResponse(_relay(), headers=forwarded)
         await resp.aread()
         await resp.aclose()
         if resp.status_code == 200:

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -334,8 +334,10 @@ def register_resources_routes(
                 if name in resp.headers
             }
             return _RunnerStreamResponse(resp, headers=forwarded)
-        await resp.aread()
-        await resp.aclose()
+        try:
+            await resp.aread()
+        finally:
+            await resp.aclose()
         if resp.status_code == 200:
             # A runner that predates ``download=true`` ignores it and answers
             # the capped JSON envelope; serving that would truncate silently.
@@ -517,6 +519,21 @@ def register_resources_routes(
             conversation.workspace,
         )
 
+    def _runner_path_segment(relative_path: str, *, absolute: bool) -> str:
+        """Encode a browse path for the runner's ``{relative_path:path}`` segment.
+
+        Only the leading slash is encoded, since a literal "//" is what proxies
+        collapse; interior slashes travel fine and keep logs readable. Every
+        other character is quoted, so a literal "%" in a name is not decoded a
+        second time by the runner into a path the gate here never saw.
+
+        :param relative_path: Decoded path, with a leading slash iff *absolute*.
+        :param absolute: Whether the path is host-absolute.
+        :returns: The encoded segment.
+        """
+        quoted = urllib.parse.quote(relative_path.lstrip("/"))
+        return "%2F" + quoted if absolute else quoted
+
     def _mutating_runner_path(
         session_id: str,
         environment_id: str,
@@ -535,12 +552,7 @@ def register_resources_routes(
         :param relative_path: Client-supplied path.
         :returns: The runner-relative URL.
         """
-        absolute = relative_path.startswith("/")
-        # Encode only the leading slash: a literal "//" is what proxies
-        # collapse, while interior slashes travel fine.
-        encoded = (
-            "%2F" + urllib.parse.quote(relative_path.lstrip("/")) if absolute else relative_path
-        )
+        encoded = _runner_path_segment(relative_path, absolute=relative_path.startswith("/"))
         return (
             f"/v1/sessions/{session_id}/resources/environments"
             f"/{environment_id}/filesystem/{encoded}"
@@ -2256,11 +2268,7 @@ def register_resources_routes(
         )
 
         qs = urllib.parse.urlencode(params)
-        # Encode only the leading slash: a literal "//" is what proxies
-        # collapse, while interior slashes travel fine and keep logs readable.
-        runner_rel = (
-            "%2F" + urllib.parse.quote(relative_path.lstrip("/")) if absolute else relative_path
-        )
+        runner_rel = _runner_path_segment(relative_path, absolute=absolute)
         if download:
             return await _stream_download_from_runner(
                 request,

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -270,9 +270,10 @@ def register_resources_routes(
         :param conversation: Conversation loaded during authorization.
         :param runner_path: Runner-relative URL carrying ``download=true``.
         :returns: The attachment, streamed as the runner sends it, or the
-            runner's own error body for a directory or out-of-grant path.
-        :raises OmnigentError: ``not_found`` when the file is missing;
-            ``runner_unavailable`` when the runner predates downloads.
+            runner's own error body and status for a missing file, a
+            directory, or an out-of-grant path.
+        :raises OmnigentError: ``runner_unavailable`` when the runner
+            predates downloads.
         :raises HTTPException: 502 when no runner can be reached.
         """
         runner_client = await _get_runner_client_for_resource_access(
@@ -326,14 +327,8 @@ def register_resources_routes(
             payload = resp.json()
         except ValueError:
             payload = None
-        error = payload.get("error") if isinstance(payload, dict) else None
-        if not isinstance(error, dict):
+        if not isinstance(payload, dict) or not isinstance(payload.get("error"), dict):
             raise HTTPException(status_code=502, detail="runner download failed")
-        if resp.status_code == 404:
-            raise OmnigentError(
-                str(error.get("message") or "File not found"),
-                code=ErrorCode.NOT_FOUND,
-            )
         return JSONResponse(status_code=resp.status_code, content=payload)
 
     async def _proxy_get_to_runner(

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -7,7 +7,7 @@ import functools
 import mimetypes
 import ntpath
 import urllib.parse
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import Annotated, Any, cast
 
@@ -22,6 +22,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from starlette.types import Receive, Scope, Send
 
 from omnigent.entities import (
     Conversation,
@@ -94,6 +95,29 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.file_store import FileStore
 from omnigent.stores.permission_store import PermissionStore
+
+
+class _RunnerStreamResponse(StreamingResponse):
+    """Stream a runner response body and close it however the send ends.
+
+    A generator ``finally`` only runs once the body is first pulled, so a
+    send that fails before that, or a client that disconnects (where
+    Starlette skips background tasks), would leak the tunnel request.
+    Closing in ``__call__`` covers every exit.
+
+    :param upstream: The runner's streamed response.
+    :param headers: Response headers to forward.
+    """
+
+    def __init__(self, upstream: httpx.Response, *, headers: Mapping[str, str]) -> None:
+        super().__init__(upstream.aiter_raw(), headers=headers)
+        self._upstream = upstream
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            await self._upstream.aclose()
 
 
 def register_resources_routes(
@@ -309,18 +333,7 @@ def register_resources_routes(
                 )
                 if name in resp.headers
             }
-
-            async def _relay() -> AsyncIterator[bytes]:
-                # Close the runner response on every exit, a client
-                # disconnect included: Starlette skips the background task
-                # on disconnect, which would leak the tunnel request.
-                try:
-                    async for chunk in resp.aiter_raw():
-                        yield chunk
-                finally:
-                    await resp.aclose()
-
-            return StreamingResponse(_relay(), headers=forwarded)
+            return _RunnerStreamResponse(resp, headers=forwarded)
         await resp.aread()
         await resp.aclose()
         if resp.status_code == 200:

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -247,9 +247,10 @@ def register_resources_routes(
             raise _session_not_found()
         return conv
 
-    # Per-chunk read budget for a streamed download, mirroring the event
-    # relay: a stall this long means the tunnel is dead, while a large file
-    # legitimately outlives any total timeout.
+    # Per-chunk read budget for a direct HTTP runner client; no total timeout,
+    # since a large file legitimately outlives any. The WebSocket tunnel
+    # transport ignores httpx timeouts: there, a runner that drops aborts the
+    # body iterator once the tunnel closes.
     _download_timeout = httpx.Timeout(connect=5.0, read=45.0, write=None, pool=None)
 
     async def _stream_download_from_runner(

--- a/openapi.json
+++ b/openapi.json
@@ -12305,7 +12305,7 @@
         ]
       },
       "get": {
-        "description": "Read a file or list a directory in an environment.\n\n**Returns:** File content or directory listing.",
+        "description": "Read a file or list a directory in an environment.\n\n**Returns:** File content or directory listing, or the raw file.",
         "operationId": "read_or_list_environment_path_v1_sessions__session_id__resources_environments__environment_id__filesystem__relative_path__get",
         "parameters": [
           {
@@ -12396,6 +12396,17 @@
               "title": "Order",
               "type": "string"
             }
+          },
+          {
+            "description": "When `True`, stream the complete file as an attachment with no size cap instead of the capped JSON envelope. A directory rejects it with 400.",
+            "in": "query",
+            "name": "download",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Download",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -12403,9 +12414,15 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "File content or directory listing as JSON; the raw file as an attachment when `download=true`."
           },
           "422": {
             "content": {

--- a/tests/e2e/test_filesystem_changed_files_e2e.py
+++ b/tests/e2e/test_filesystem_changed_files_e2e.py
@@ -482,6 +482,48 @@ def test_filesystem_listing_shape(
         )
 
 
+@pytest.mark.min_server_version("0.13.0")
+@pytest.mark.min_runner_version("0.13.0")
+def test_filesystem_download_returns_complete_file_past_read_cap(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    databricks_workspace_host: str | None,
+) -> None:
+    """``?download=true`` streams a file larger than the read cap intact.
+
+    The runner runs on this machine, so the workspace root the listing
+    reports is writable here: drop a file one byte over the cap into it,
+    confirm the viewer read truncates it, then download it through the
+    server (and the runner tunnel) and compare every byte.
+
+    :param http_client: HTTP client pointed at the live server.
+    :param live_runner_id: Runner id registered by the live server.
+    :param databricks_workspace_host: Workspace host URL when the
+        test suite routes LLM calls through Databricks model serving.
+    """
+    from omnigent.runner.environment_filesystem import _MAX_READ_BYTES
+
+    session_id = _create_bound_session(
+        http_client,
+        live_runner_id=live_runner_id,
+        databricks_workspace_host=databricks_workspace_host,
+    )
+    listing = http_client.get(_fs_root_url(session_id))
+    listing.raise_for_status()
+    payload = os.urandom(_MAX_READ_BYTES + 1)
+    (Path(listing.json()["base"]) / "big.bin").write_bytes(payload)
+
+    read = http_client.get(_fs_file_url(session_id, "big.bin"))
+    read.raise_for_status()
+    assert read.json()["truncated"] is True
+
+    resp = http_client.get(_fs_file_url(session_id, "big.bin"), params={"download": "true"})
+    resp.raise_for_status()
+    assert resp.headers["content-disposition"] == 'attachment; filename="big.bin"'
+    assert resp.headers["content-length"] == str(len(payload))
+    assert resp.content == payload
+
+
 def test_filesystem_user_write_put_round_trip(
     http_client: httpx.Client,
     live_runner_id: str,

--- a/tests/e2e_ui/files/test_right_panel.py
+++ b/tests/e2e_ui/files/test_right_panel.py
@@ -8,6 +8,7 @@ unreachable on the desktop viewport these tests run at.
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -164,3 +165,45 @@ def test_right_panel_terminals_and_file_viewer(
     finally:
         if test_file.exists():
             test_file.unlink()
+
+
+def test_changes_row_download_saves_the_complete_file(
+    page: Page,
+    seeded_session: tuple[str, str],
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> None:
+    """The row download button saves the whole file, past the viewer's read cap.
+
+    The viewer's JSON read truncates at the server's cap, and the download
+    button used to reuse it, so anything larger came back cut off with no
+    warning. Drop a file one byte over the cap into the workspace, download
+    it through the real server and runner, and compare every byte.
+    """
+    from omnigent.runner.environment_filesystem import _MAX_READ_BYTES
+
+    base_url, session_id = seeded_session
+    env = page.request.get(f"{base_url}/v1/sessions/{session_id}/resources/environments/default")
+    assert env.status == 200, env.text()
+    target = Path(env.json()["metadata"]["root"]) / "big-download.bin"
+    payload = os.urandom(_MAX_READ_BYTES + 1)
+    target.write_bytes(payload)
+    # The workspace is a real checkout shared with every other test in the
+    # shard, so the file must not outlive the test.
+    request.addfinalizer(lambda: target.unlink(missing_ok=True))
+
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Changes")).click()
+    row = rail.get_by_role("button", name=re.compile(r"^big-download\.bin"))
+    expect(row).to_be_visible(timeout=30_000)
+    # The download icon is hover-revealed on its row.
+    row.hover()
+    with page.expect_download() as download_info:
+        rail.get_by_role("button", name="Download big-download.bin").click()
+    download = download_info.value
+    assert download.suggested_filename == "big-download.bin"
+    saved = tmp_path / "big-download.bin"
+    download.save_as(saved)
+    assert saved.read_bytes() == payload

--- a/tests/e2e_ui/files/test_right_panel.py
+++ b/tests/e2e_ui/files/test_right_panel.py
@@ -8,7 +8,6 @@ unreachable on the desktop viewport these tests run at.
 
 from __future__ import annotations
 
-import os
 import re
 from pathlib import Path
 
@@ -167,45 +166,52 @@ def test_right_panel_terminals_and_file_viewer(
             test_file.unlink()
 
 
-def test_changes_row_download_saves_the_complete_file(
+def test_file_viewer_download_saves_the_complete_file(
     page: Page,
     seeded_session: tuple[str, str],
     request: pytest.FixtureRequest,
     tmp_path: Path,
 ) -> None:
-    """The row download button saves the whole file, past the viewer's read cap.
+    """The viewer's "Download file" saves the whole file, past the read cap.
 
     The viewer's JSON read truncates at the server's cap, and the download
-    button used to reuse it, so anything larger came back cut off with no
-    warning. Drop a file one byte over the cap into the workspace, download
-    it through the real server and runner, and compare every byte.
+    used to reuse it, so anything larger came back cut off with no
+    warning. Drop a text file one byte over the cap into the workspace,
+    open it from the Files tree, download it through the real server and
+    runner, and compare every byte.
     """
     from omnigent.runner.environment_filesystem import _MAX_READ_BYTES
 
     base_url, session_id = seeded_session
-    env = page.request.get(f"{base_url}/v1/sessions/{session_id}/resources/environments/default")
-    assert env.status == 200, env.text()
-    target = Path(env.json()["metadata"]["root"]) / "big-download.bin"
-    payload = os.urandom(_MAX_READ_BYTES + 1)
-    # A fresh session's workspace may not exist on disk yet.
-    target.parent.mkdir(parents=True, exist_ok=True)
+    # Listing the root materializes a fresh session's workspace on the
+    # runner; on CI it does not exist on disk before that.
+    listing = page.request.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/environments/default/filesystem"
+    )
+    assert listing.status == 200, listing.text()
+    target = Path(listing.json()["base"]) / "big-download.txt"
+    line = b"0123456789abcdef" * 4 + b"\n"
+    payload = (line * (_MAX_READ_BYTES // len(line) + 1))[: _MAX_READ_BYTES + 1]
     target.write_bytes(payload)
-    # The workspace is a real checkout shared with every other test in the
-    # shard, so the file must not outlive the test.
     request.addfinalizer(lambda: target.unlink(missing_ok=True))
 
     page.goto(f"{base_url}/c/{session_id}")
     open_right_rail(page)
     rail = page.get_by_role("complementary", name="Workspace")
-    rail.get_by_role("tab", name=re.compile("^Changes")).click()
-    row = rail.get_by_role("button", name=re.compile(r"^big-download\.bin"))
+    rail.get_by_role("tab", name=re.compile("^Files")).click()
+    # The row's open button carries the name as visible text; the icon-only
+    # copy-path button next to it carries it only in its label.
+    row = rail.get_by_role("button", name=re.compile(r"big-download\.txt")).filter(
+        has_text="big-download.txt"
+    )
     expect(row).to_be_visible(timeout=30_000)
-    # The download icon is hover-revealed on its row.
-    row.hover()
+    row.click()
+    expect(rail.get_by_test_id("file-viewer")).to_be_visible()
+    rail.get_by_role("button", name="View settings").click()
     with page.expect_download() as download_info:
-        rail.get_by_role("button", name="Download big-download.bin").click()
+        page.get_by_role("menuitem", name="Download file").click()
     download = download_info.value
-    assert download.suggested_filename == "big-download.bin"
-    saved = tmp_path / "big-download.bin"
+    assert download.suggested_filename == "big-download.txt"
+    saved = tmp_path / "big-download.txt"
     download.save_as(saved)
     assert saved.read_bytes() == payload

--- a/tests/e2e_ui/files/test_right_panel.py
+++ b/tests/e2e_ui/files/test_right_panel.py
@@ -187,6 +187,8 @@ def test_changes_row_download_saves_the_complete_file(
     assert env.status == 200, env.text()
     target = Path(env.json()["metadata"]["root"]) / "big-download.bin"
     payload = os.urandom(_MAX_READ_BYTES + 1)
+    # A fresh session's workspace may not exist on disk yet.
+    target.parent.mkdir(parents=True, exist_ok=True)
     target.write_bytes(payload)
     # The workspace is a real checkout shared with every other test in the
     # shard, so the file must not outlive the test.

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -545,6 +545,34 @@ async def test_download_rejects_directory_and_missing_path(
 
 
 @pytest.mark.asyncio
+async def test_download_refuses_path_hidden_from_sandbox(
+    client: httpx.AsyncClient,
+    workspace: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file the sandbox hides from the helper is refused, as the read path refuses it.
+
+    The fixture's ``none`` sandbox hides nothing, so the helper's view is
+    stood in for: the download must consult it and stop on a masked path
+    even though the file is on disk.
+    """
+    (workspace / ".env").write_text("SECRET=1")
+    consulted: list[str] = []
+
+    async def _hidden(self: CallerProcessFilesystem, target: str) -> None:
+        del self
+        consulted.append(target)
+
+    monkeypatch.setattr(CallerProcessFilesystem, "_helper_stat", _hidden)
+    resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/filesystem/.env",
+        params={"download": "true"},
+    )
+    assert resp.status_code == 404
+    assert consulted == [".env"]
+
+
+@pytest.mark.asyncio
 async def test_filesystem_session_without_agent_id_returns_typed_404(
     registry: SessionResourceRegistry,
 ) -> None:

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
+import sys
 from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -544,31 +546,121 @@ async def test_download_rejects_directory_and_missing_path(
     assert resp.json()["error"]["code"] == code
 
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SANDBOX_BACKENDS = [
+    pytest.param(
+        "linux_bwrap",
+        marks=pytest.mark.skipif(
+            not (sys.platform.startswith("linux") and shutil.which("bwrap")),
+            reason="linux_bwrap requires Linux + bwrap on PATH",
+        ),
+    ),
+    pytest.param(
+        "darwin_seatbelt",
+        marks=pytest.mark.skipif(
+            not (sys.platform == "darwin" and shutil.which("sandbox-exec")),
+            reason="darwin_seatbelt requires macOS + sandbox-exec on PATH",
+        ),
+    ),
+]
+
+
 @pytest.mark.asyncio
-async def test_download_refuses_path_hidden_from_sandbox(
+@pytest.mark.parametrize("sandbox_type", _SANDBOX_BACKENDS)
+async def test_download_under_real_sandbox_refuses_masked_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    sandbox_type: str,
+) -> None:
+    """A confined helper's view gates the download.
+
+    A masked dotfile is refused and its bytes never leave, while a plain
+    file streams intact. bwrap masks by binding ``/dev/null`` over the file
+    (stat succeeds on another inode) and Seatbelt by denying the read (stat
+    succeeds, the read fails); both must be caught.
+    """
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    (ws / ".env").write_text("OMNI_TEST_SECRET=super-secret-value-12345")
+    payload = os.urandom(256 * 1024)
+    (ws / "plain.bin").write_bytes(payload)
+    # The helper imports omnigent from this checkout, which the sandbox
+    # must be allowed to read.
+    monkeypatch.setenv("PYTHONPATH", f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}")
+    os_env = create_os_environment(
+        OSEnvSpec(
+            type="caller_process",
+            cwd=str(ws),
+            sandbox=OSEnvSandboxSpec(type=sandbox_type, read_paths=[str(_REPO_ROOT)]),
+        )
+    )
+    assert os_env is not None
+    reg = SessionResourceRegistry()
+    reg._primary_envs["conv_test"] = os_env
+    app = create_runner_app(
+        resource_registry=reg,
+        runner_workspace=ws,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    base = f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/filesystem"
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://runner"
+        ) as client:
+            masked = await client.get(f"{base}/.env", params={"download": "true"})
+            assert masked.status_code == 404
+            assert b"super-secret-value-12345" not in masked.content
+
+            plain = await client.get(f"{base}/plain.bin", params={"download": "true"})
+            assert plain.status_code == 200
+            assert plain.content == payload
+    finally:
+        os_env.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "helper_view",
+    [
+        pytest.param(
+            lambda st: {"r": False, "dev": st.st_dev, "ino": st.st_ino}, id="read-denied"
+        ),
+        pytest.param(lambda st: {"r": False, "dev": 0, "ino": 0}, id="dev-null-bind"),
+        pytest.param(
+            lambda st: {"r": True, "dev": st.st_dev, "ino": st.st_ino + 1}, id="other-inode"
+        ),
+        pytest.param(lambda st: None, id="stat-denied"),
+    ],
+)
+async def test_download_refuses_what_the_helper_cannot_read(
     client: httpx.AsyncClient,
     workspace: Path,
     monkeypatch: pytest.MonkeyPatch,
+    helper_view: object,
 ) -> None:
-    """A file the sandbox hides from the helper is refused, as the read path refuses it.
+    """Each way a sandbox can hide a file from the helper refuses the download.
 
-    The fixture's ``none`` sandbox hides nothing, so the helper's view is
-    stood in for: the download must consult it and stop on a masked path
-    even though the file is on disk.
+    The fixture's ``none`` sandbox hides nothing, so the helper's answer is
+    stood in for with the signatures the real backends produce, plus a
+    file replaced under the check.
     """
-    (workspace / ".env").write_text("SECRET=1")
+    secret = workspace / ".env"
+    secret.write_text("SECRET=1")
+    view = helper_view(secret.stat())  # type: ignore[operator]
     consulted: list[str] = []
 
-    async def _hidden(self: CallerProcessFilesystem, target: str) -> None:
-        del self
+    async def _stat(self: CallerProcessFilesystem, target: str, *, probe_read: bool = False):
+        del self, probe_read
         consulted.append(target)
+        return view
 
-    monkeypatch.setattr(CallerProcessFilesystem, "_helper_stat", _hidden)
+    monkeypatch.setattr(CallerProcessFilesystem, "_helper_stat", _stat)
     resp = await client.get(
         f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/filesystem/.env",
         params={"download": "true"},
     )
     assert resp.status_code == 404
+    assert b"SECRET" not in resp.content
     assert consulted == [".env"]
 
 

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -496,6 +496,55 @@ async def test_read_nonexistent_file_returns_404(
 
 
 @pytest.mark.asyncio
+async def test_download_returns_complete_file_past_read_cap(
+    client: httpx.AsyncClient,
+    workspace: Path,
+) -> None:
+    """``?download=true`` streams the whole file where the read path truncates."""
+    from omnigent.runner.environment_filesystem import _MAX_READ_BYTES
+
+    payload = os.urandom(_MAX_READ_BYTES + 1)
+    (workspace / "big.bin").write_bytes(payload)
+    url = (
+        f"/v1/sessions/conv_test/resources/environments"
+        f"/{DEFAULT_ENVIRONMENT_ID}/filesystem/big.bin"
+    )
+
+    read = await client.get(url)
+    assert read.status_code == 200
+    assert read.json()["truncated"] is True
+
+    resp = await client.get(url, params={"download": "true"})
+    assert resp.status_code == 200
+    assert resp.content == payload
+    assert resp.headers["content-length"] == str(len(payload))
+    assert resp.headers["content-type"] == "application/octet-stream"
+    assert resp.headers["content-disposition"] == 'attachment; filename="big.bin"'
+    assert resp.headers["x-content-type-options"] == "nosniff"
+    assert resp.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "status", "code"),
+    [("src", 400, "invalid_path"), ("nope.bin", 404, "path_not_found")],
+)
+async def test_download_rejects_directory_and_missing_path(
+    client: httpx.AsyncClient,
+    path: str,
+    status: int,
+    code: str,
+) -> None:
+    """A directory has no raw bytes to serve, and a missing path stays a 404."""
+    resp = await client.get(
+        f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/filesystem/{path}",
+        params={"download": "true"},
+    )
+    assert resp.status_code == status
+    assert resp.json()["error"]["code"] == code
+
+
+@pytest.mark.asyncio
 async def test_filesystem_session_without_agent_id_returns_typed_404(
     registry: SessionResourceRegistry,
 ) -> None:

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -6,12 +6,13 @@ import asyncio
 import contextlib
 import logging
 from collections.abc import AsyncIterator, Callable, Iterator
+from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 
 from omnigent.entities import DEFAULT_ENVIRONMENT_ID, Conversation, ConversationItem, PagedList
 from omnigent.errors import ErrorCode, OmnigentError
@@ -3012,6 +3013,131 @@ async def test_filesystem_read_proxies_to_runner(
     )
     assert resp.status_code == 200
     assert resp.json()["content"] == "hello world"
+
+
+@contextlib.asynccontextmanager
+async def _runner_app_client(runner: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    """Route session resources to a stub runner app over a real httpx client.
+
+    The download proxy streams through ``build_request``/``send`` rather
+    than the canned ``get`` the fake client answers, so it needs a client
+    with real transport semantics.
+
+    :param runner: Stub runner app serving the filesystem route.
+    :returns: The client bound to the stub, installed as the runner router.
+    """
+    transport = httpx.ASGITransport(app=runner)
+    async with httpx.AsyncClient(transport=transport, base_url="http://runner") as runner_http:
+        set_runner_router(_FakeRunnerRouter(runner_http))  # type: ignore[arg-type]
+        yield runner_http
+
+
+_FS_ROUTE = (
+    "/v1/sessions/{session_id}/resources/environments/{environment_id}"
+    "/filesystem/{relative_path:path}"
+)
+_DOWNLOAD_URL = (
+    "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default"
+    "/filesystem/data/big.bin?download=true"
+)
+
+
+@pytest.mark.asyncio
+async def test_filesystem_download_streams_runner_attachment(
+    client: httpx.AsyncClient,
+    tmp_path: Path,
+) -> None:
+    """``?download=true`` forwards the runner's attachment and headers verbatim."""
+    payload = bytes(range(256)) * 64
+    (tmp_path / "big.bin").write_bytes(payload)
+    runner = FastAPI()
+    seen: list[tuple[str, bool]] = []
+
+    @runner.get(_FS_ROUTE)
+    async def _serve(
+        session_id: str,
+        environment_id: str,
+        relative_path: str,
+        download: bool = False,
+    ) -> FileResponse:
+        del session_id, environment_id
+        seen.append((relative_path, download))
+        return FileResponse(
+            tmp_path / "big.bin",
+            filename="big.bin",
+            headers={"Cache-Control": "no-store"},
+        )
+
+    async with _runner_app_client(runner):
+        resp = await client.get(_DOWNLOAD_URL)
+
+    assert resp.status_code == 200
+    assert resp.content == payload
+    assert resp.headers["content-disposition"] == 'attachment; filename="big.bin"'
+    assert resp.headers["content-length"] == str(len(payload))
+    assert resp.headers["cache-control"] == "no-store"
+    assert seen == [("data/big.bin", True)]
+
+
+@pytest.mark.asyncio
+async def test_filesystem_download_rejects_runner_without_download_support(
+    client: httpx.AsyncClient,
+) -> None:
+    """A runner that ignores ``download`` answers the capped JSON envelope.
+
+    Serving that would truncate silently, so the proxy fails loudly instead.
+    """
+    runner = FastAPI()
+
+    @runner.get(_FS_ROUTE)
+    async def _serve(session_id: str, environment_id: str, relative_path: str) -> JSONResponse:
+        del session_id, environment_id, relative_path
+        return JSONResponse(
+            {
+                "object": "session.environment.filesystem.file_content",
+                "content": "partial",
+                "truncated": True,
+            }
+        )
+
+    async with _runner_app_client(runner):
+        resp = await client.get(_DOWNLOAD_URL)
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "runner_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("runner_status", "runner_code", "expected_code"),
+    [
+        (404, "path_not_found", "not_found"),
+        (400, "invalid_path", "invalid_path"),
+        (403, "path_unreachable", "path_unreachable"),
+    ],
+)
+async def test_filesystem_download_forwards_runner_errors(
+    client: httpx.AsyncClient,
+    runner_status: int,
+    runner_code: str,
+    expected_code: str,
+) -> None:
+    """A missing, directory, or out-of-grant path keeps the runner's status."""
+    runner = FastAPI()
+
+    @runner.get(_FS_ROUTE)
+    async def _serve(session_id: str, environment_id: str, relative_path: str) -> JSONResponse:
+        del session_id, environment_id, relative_path
+        return JSONResponse(
+            status_code=runner_status,
+            content={"error": {"code": runner_code, "message": "nope"}},
+        )
+
+    async with _runner_app_client(runner):
+        resp = await client.get(_DOWNLOAD_URL)
+
+    assert resp.status_code == runner_status
+    assert resp.json()["error"] == {"code": expected_code, "message": "nope"}
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -3136,6 +3136,43 @@ async def test_filesystem_download_forwards_runner_errors(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["read", "download", "write"])
+async def test_filesystem_forwards_a_literal_percent_still_encoded(
+    client: httpx.AsyncClient,
+    operation: str,
+) -> None:
+    """A name the server decoded to a literal ``%2F`` reaches the runner as that name.
+
+    Forwarded verbatim it would decode once more into an absolute path,
+    past the owner-only gate the server applied at workspace level.
+    """
+    runner = FastAPI()
+    seen: list[str] = []
+
+    @runner.get(_FS_ROUTE)
+    @runner.put(_FS_ROUTE)
+    async def _serve(session_id: str, environment_id: str, relative_path: str) -> JSONResponse:
+        del session_id, environment_id
+        seen.append(relative_path)
+        return JSONResponse(
+            status_code=404,
+            content={"error": {"code": "path_not_found", "message": "nope"}},
+        )
+
+    url = (
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/environments/default"
+        "/filesystem/%252Fetc/passwd"
+    )
+    async with _runner_app_client(runner):
+        if operation == "write":
+            await client.put(url, json={"content": "x", "encoding": "utf-8"})
+        else:
+            await client.get(url, params={"download": "true"} if operation == "download" else None)
+
+    assert seen == ["%2Fetc/passwd"]
+
+
+@pytest.mark.asyncio
 async def test_filesystem_write_proxies_to_runner(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -3109,20 +3109,15 @@ async def test_filesystem_download_rejects_runner_without_download_support(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("runner_status", "runner_code", "expected_code"),
-    [
-        (404, "path_not_found", "not_found"),
-        (400, "invalid_path", "invalid_path"),
-        (403, "path_unreachable", "path_unreachable"),
-    ],
+    ("runner_status", "code"),
+    [(404, "path_not_found"), (400, "invalid_path"), (403, "path_unreachable")],
 )
 async def test_filesystem_download_forwards_runner_errors(
     client: httpx.AsyncClient,
     runner_status: int,
-    runner_code: str,
-    expected_code: str,
+    code: str,
 ) -> None:
-    """A missing, directory, or out-of-grant path keeps the runner's status."""
+    """A missing, directory, or out-of-grant path keeps the runner's status and code."""
     runner = FastAPI()
 
     @runner.get(_FS_ROUTE)
@@ -3130,14 +3125,14 @@ async def test_filesystem_download_forwards_runner_errors(
         del session_id, environment_id, relative_path
         return JSONResponse(
             status_code=runner_status,
-            content={"error": {"code": runner_code, "message": "nope"}},
+            content={"error": {"code": code, "message": "nope"}},
         )
 
     async with _runner_app_client(runner):
         resp = await client.get(_DOWNLOAD_URL)
 
     assert resp.status_code == runner_status
-    assert resp.json()["error"] == {"code": expected_code, "message": "nope"}
+    assert resp.json()["error"] == {"code": code, "message": "nope"}
 
 
 @pytest.mark.asyncio

--- a/web/src/hooks/useFileContent.test.tsx
+++ b/web/src/hooks/useFileContent.test.tsx
@@ -2,6 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
+import type * as HostModule from "@/lib/host";
+import type * as NativeBridgeModule from "@/lib/nativeBridge";
 
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useSessionRunnerOnline: vi.fn(),
@@ -10,8 +12,19 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({
 vi.mock("@/store/chatStore", () => ({
   useChatStore: vi.fn(),
 }));
+vi.mock("@/lib/host", async (importOriginal) => ({
+  ...(await importOriginal<typeof HostModule>()),
+  isDatabricksWorkspace: vi.fn(() => false),
+}));
+vi.mock("@/lib/nativeBridge", async (importOriginal) => ({
+  ...(await importOriginal<typeof NativeBridgeModule>()),
+  isAndroidShell: vi.fn(() => false),
+  isIOSShell: vi.fn(() => false),
+}));
 
 import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { isDatabricksWorkspace } from "@/lib/host";
+import { isAndroidShell, isIOSShell } from "@/lib/nativeBridge";
 import { useChatStore } from "@/store/chatStore";
 import {
   downloadWorkspaceFile,
@@ -209,64 +222,85 @@ function blobResponse(blob: Blob): Response {
   } as unknown as Response;
 }
 
+/** Capture every synthetic download link the code clicks, as `[href, download]`. */
+function captureDownloadClicks(): [string, string][] {
+  const clicked: [string, string][] = [];
+  const origCreateElement = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+    const el = origCreateElement(tag);
+    if (tag === "a")
+      vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(() => {
+        const a = el as HTMLAnchorElement;
+        clicked.push([a.getAttribute("href") ?? "", a.download]);
+      });
+    return el;
+  });
+  return clicked;
+}
+
+const DOWNLOAD_URL =
+  "/v1/sessions/sess_123/resources/environments/default/filesystem/src/main.py?download=true";
+
 describe("downloadWorkspaceFile", () => {
-  it("fetches the raw file with download=true and downloads it under the path's filename", async () => {
-    // The raw-download response is the file itself, not the JSON envelope, so
-    // the bytes reach the browser untouched however large the file is.
+  it("clicks a link to the raw download URL so the browser streams it to disk", async () => {
+    // A same-origin navigation shows in the browser's download UI at once and
+    // never buffers the file in the page, unlike a fetch-then-Blob.
+    const clicked = captureDownloadClicks();
+
+    await downloadWorkspaceFile("sess_123", "src/main.py");
+
+    expect(clicked).toEqual([[DOWNLOAD_URL, "main.py"]]);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["the managed embed", isDatabricksWorkspace],
+    ["the iOS shell", isIOSShell],
+    ["the Android shell", isAndroidShell],
+  ])("fetches the bytes through the app's transport in %s", async (_label, predicate) => {
+    // The embed host supplies auth headers and replica routing that a bare
+    // navigation lacks, and the mobile shells save http(s) downloads outside
+    // the WebView's session, so the bytes come through authenticatedFetch.
+    vi.mocked(predicate).mockReturnValueOnce(true);
     const file = new Blob(["print('hi')"], { type: "text/x-python" });
     fetchMock.mockResolvedValueOnce(blobResponse(file));
-    const clickedLinks: string[] = [];
-    const origCreateElement = document.createElement.bind(document);
-    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
-      const el = origCreateElement(tag);
-      if (tag === "a")
-        vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(() => {
-          clickedLinks.push((el as HTMLAnchorElement).download);
-        });
-      return el;
-    });
+    const clicked = captureDownloadClicks();
     const createObjectURL = vi.fn(() => "blob:x");
     vi.stubGlobal("URL", { createObjectURL, revokeObjectURL: vi.fn() });
 
     await downloadWorkspaceFile("sess_123", "src/main.py");
 
-    // The request goes through authenticatedFetch, which adds auth headers
-    // and `cache: "no-store"` (see lib/identity.ts) — assert the URL plus that
-    // cache-bypass init rather than a bare single-arg call.
+    // authenticatedFetch adds auth headers and `cache: "no-store"` (see
+    // lib/identity.ts) — assert the URL plus that cache-bypass init.
     expect(fetchMock).toHaveBeenCalledWith(
-      "/v1/sessions/sess_123/resources/environments/default/filesystem/src/main.py?download=true",
+      DOWNLOAD_URL,
       expect.objectContaining({ cache: "no-store" }),
     );
     expect(createObjectURL).toHaveBeenCalledWith(file);
-    // The download filename is derived from the last path segment.
-    expect(clickedLinks).toEqual(["main.py"]);
+    expect(clicked).toEqual([["blob:x", "main.py"]]);
 
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
   it("names the host base for an absolute path alongside download=true", async () => {
-    fetchMock.mockResolvedValueOnce(blobResponse(new Blob(["x"])));
-    const origCreateElement = document.createElement.bind(document);
-    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
-      const el = origCreateElement(tag);
-      if (tag === "a") vi.spyOn(el as HTMLAnchorElement, "click").mockImplementation(() => {});
-      return el;
-    });
-    vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+    const clicked = captureDownloadClicks();
 
     await downloadWorkspaceFile("sess_abc", "/Users/me/reports/q3.pdf");
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/v1/sessions/sess_abc/resources/environments/default/filesystem/Users/me/reports/q3.pdf?download=true&base=host",
-      expect.objectContaining({ cache: "no-store" }),
-    );
+    expect(clicked).toEqual([
+      [
+        "/v1/sessions/sess_abc/resources/environments/default/filesystem/Users/me/reports/q3.pdf?download=true&base=host",
+        "q3.pdf",
+      ],
+    ]);
 
     vi.restoreAllMocks();
-    vi.unstubAllGlobals();
   });
-
   it("propagates fetch errors to the caller", async () => {
+    vi.mocked(isDatabricksWorkspace).mockReturnValueOnce(true);
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 404,

--- a/web/src/hooks/useFileContent.test.tsx
+++ b/web/src/hooks/useFileContent.test.tsx
@@ -200,18 +200,21 @@ describe("triggerBrowserDownload", () => {
 // downloadWorkspaceFile
 // ---------------------------------------------------------------------------
 
+function blobResponse(blob: Blob): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    blob: async () => blob,
+  } as unknown as Response;
+}
+
 describe("downloadWorkspaceFile", () => {
-  it("fetches the correct URL and triggers a download with the filename from the path", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        object: "session.environment.filesystem.file_content",
-        path: "src/main.py",
-        content_type: "text/x-python",
-        encoding: "utf-8",
-        content: "print('hi')",
-        bytes: 11,
-      }),
-    );
+  it("fetches the raw file with download=true and downloads it under the path's filename", async () => {
+    // The raw-download response is the file itself, not the JSON envelope, so
+    // the bytes reach the browser untouched however large the file is.
+    const file = new Blob(["print('hi')"], { type: "text/x-python" });
+    fetchMock.mockResolvedValueOnce(blobResponse(file));
     const clickedLinks: string[] = [];
     const origCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
@@ -222,17 +225,19 @@ describe("downloadWorkspaceFile", () => {
         });
       return el;
     });
-    vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
+    const createObjectURL = vi.fn(() => "blob:x");
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL: vi.fn() });
 
     await downloadWorkspaceFile("sess_123", "src/main.py");
 
-    // fetchFileContent goes through authenticatedFetch, which adds auth headers
+    // The request goes through authenticatedFetch, which adds auth headers
     // and `cache: "no-store"` (see lib/identity.ts) — assert the URL plus that
     // cache-bypass init rather than a bare single-arg call.
     expect(fetchMock).toHaveBeenCalledWith(
-      "/v1/sessions/sess_123/resources/environments/default/filesystem/src/main.py",
+      "/v1/sessions/sess_123/resources/environments/default/filesystem/src/main.py?download=true",
       expect.objectContaining({ cache: "no-store" }),
     );
+    expect(createObjectURL).toHaveBeenCalledWith(file);
     // The download filename is derived from the last path segment.
     expect(clickedLinks).toEqual(["main.py"]);
 
@@ -240,19 +245,8 @@ describe("downloadWorkspaceFile", () => {
     vi.unstubAllGlobals();
   });
 
-  it("logs a console warning when the server returns truncated: true", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        object: "session.environment.filesystem.file_content",
-        path: "big.txt",
-        content_type: "text/plain",
-        encoding: "utf-8",
-        content: "partial content",
-        bytes: 15,
-        truncated: true,
-      }),
-    );
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("names the host base for an absolute path alongside download=true", async () => {
+    fetchMock.mockResolvedValueOnce(blobResponse(new Blob(["x"])));
     const origCreateElement = document.createElement.bind(document);
     vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
       const el = origCreateElement(tag);
@@ -261,10 +255,12 @@ describe("downloadWorkspaceFile", () => {
     });
     vi.stubGlobal("URL", { createObjectURL: vi.fn(() => "blob:x"), revokeObjectURL: vi.fn() });
 
-    await downloadWorkspaceFile("sess_abc", "big.txt");
+    await downloadWorkspaceFile("sess_abc", "/Users/me/reports/q3.pdf");
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("big.txt"));
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("truncated"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/sessions/sess_abc/resources/environments/default/filesystem/Users/me/reports/q3.pdf?download=true&base=host",
+      expect.objectContaining({ cache: "no-store" }),
+    );
 
     vi.restoreAllMocks();
     vi.unstubAllGlobals();

--- a/web/src/hooks/useFileContent.ts
+++ b/web/src/hooks/useFileContent.ts
@@ -7,7 +7,9 @@
 
 import { useEffect, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { isDatabricksWorkspace } from "@/lib/host";
 import { authenticatedFetch } from "@/lib/identity";
+import { isAndroidShell, isIOSShell } from "@/lib/nativeBridge";
 import {
   browseLocationBase,
   browseLocationSegment,
@@ -98,31 +100,47 @@ export function fileContentToBlob(data: FileContentResponse): Blob {
  */
 export function triggerBrowserDownload(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
+  clickDownloadLink(url, filename);
+  URL.revokeObjectURL(url);
+}
+
+function clickDownloadLink(href: string, filename: string): void {
   const link = document.createElement("a");
-  link.href = url;
+  link.href = href;
   link.download = filename;
   document.body.append(link);
   link.click();
   link.remove();
-  URL.revokeObjectURL(url);
 }
 
 /**
- * Fetch a workspace file's complete bytes and trigger a browser download.
+ * Download a workspace file's complete bytes.
  *
  * Asks the filesystem endpoint for the raw file (`download=true`), which the
  * server streams with no size cap, rather than the viewer's JSON envelope,
  * which is truncated past the server's read cap.
  *
+ * In a browser this is a plain same-origin link click: the browser streams the
+ * attachment straight to disk and shows it in its download UI at once, and the
+ * session cookie or proxy identity header rides along as on any request. The
+ * managed embed owns the transport (auth headers, replica routing) and the
+ * mobile shells save http(s) downloads outside the WebView's session, so those
+ * fetch the bytes through `authenticatedFetch` and hand them over as a Blob,
+ * which only surfaces once the whole file has arrived.
+ *
  * :param conversationId: The session/conversation ID, e.g. ``"sess_abc123"``.
  * :param path: Workspace-relative file path, e.g. ``"src/main.py"``.
  */
 export async function downloadWorkspaceFile(conversationId: string, path: string): Promise<void> {
-  const res = await authenticatedFetch(
-    workspaceFileUrl(conversationId, path, { download: "true" }),
-  );
+  const url = workspaceFileUrl(conversationId, path, { download: "true" });
+  const filename = path.split("/").pop() ?? path;
+  if (!isDatabricksWorkspace() && !isIOSShell() && !isAndroidShell()) {
+    clickDownloadLink(url, filename);
+    return;
+  }
+  const res = await authenticatedFetch(url);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  triggerBrowserDownload(await res.blob(), path.split("/").pop() ?? path);
+  triggerBrowserDownload(await res.blob(), filename);
 }
 
 /**

--- a/web/src/hooks/useFileContent.ts
+++ b/web/src/hooks/useFileContent.ts
@@ -29,22 +29,38 @@ export interface FileContentResponse {
   truncated?: boolean;
 }
 
+/**
+ * Build the filesystem URL for a workspace file.
+ *
+ * Reuses the shared browse-location wire form: a per-segment-encoded path with
+ * literal slashes and, for an absolute path (a file opened while browsing
+ * outside the workspace), the base named by `?base=host`. Keeping this on the
+ * shared helpers means the slash-merge-safe contract lives in one place (see
+ * `browseLocationSegment`).
+ *
+ * :param conversationId: The session/conversation ID, e.g. ``"sess_abc123"``.
+ * :param path: Workspace-relative or host-absolute file path.
+ * :param query: Extra query parameters, e.g. ``{ download: "true" }``.
+ */
+function workspaceFileUrl(
+  conversationId: string,
+  path: string,
+  query: Record<string, string> = {},
+): string {
+  const base = browseLocationBase(path);
+  const params = new URLSearchParams(base ? { ...query, base } : query).toString();
+  return (
+    `/v1/sessions/${encodeURIComponent(conversationId)}` +
+    `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${browseLocationSegment(path)}` +
+    (params ? `?${params}` : "")
+  );
+}
+
 export async function fetchFileContent(
   conversationId: string,
   path: string,
 ): Promise<FileContentResponse> {
-  // Reuse the shared browse-location wire form: a per-segment-encoded path with
-  // literal slashes and, for an absolute path (a file opened while browsing
-  // outside the workspace), the base named by `?base=host`. Keeping this on the
-  // shared helpers means the slash-merge-safe contract lives in one place (see
-  // `browseLocationSegment`).
-  const encodedPath = browseLocationSegment(path);
-  const base = browseLocationBase(path);
-  const url =
-    `/v1/sessions/${encodeURIComponent(conversationId)}` +
-    `/resources/environments/${DEFAULT_ENVIRONMENT_ID}/filesystem/${encodedPath}` +
-    (base ? `?base=${base}` : "");
-  const res = await authenticatedFetch(url);
+  const res = await authenticatedFetch(workspaceFileUrl(conversationId, path));
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
   return (await res.json()) as FileContentResponse;
 }
@@ -92,23 +108,21 @@ export function triggerBrowserDownload(blob: Blob, filename: string): void {
 }
 
 /**
- * Fetch a workspace file and trigger a browser download of its contents.
+ * Fetch a workspace file's complete bytes and trigger a browser download.
  *
- * Logs a console warning when the server indicates the file was truncated
- * (``truncated: true``) so callers know the downloaded content may be
- * incomplete.
+ * Asks the filesystem endpoint for the raw file (`download=true`), which the
+ * server streams with no size cap, rather than the viewer's JSON envelope,
+ * which is truncated past the server's read cap.
  *
  * :param conversationId: The session/conversation ID, e.g. ``"sess_abc123"``.
  * :param path: Workspace-relative file path, e.g. ``"src/main.py"``.
  */
 export async function downloadWorkspaceFile(conversationId: string, path: string): Promise<void> {
-  const data = await fetchFileContent(conversationId, path);
-  if (data.truncated) {
-    console.warn(
-      `[web] File "${path}" was truncated by the server — downloaded content may be incomplete.`,
-    );
-  }
-  triggerBrowserDownload(fileContentToBlob(data), path.split("/").pop() ?? path);
+  const res = await authenticatedFetch(
+    workspaceFileUrl(conversationId, path, { download: "true" }),
+  );
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  triggerBrowserDownload(await res.blob(), path.split("/").pop() ?? path);
 }
 
 /**

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -67,7 +67,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { fileContentToBlob, triggerBrowserDownload, useFileContent } from "@/hooks/useFileContent";
+import { downloadWorkspaceFile, useFileContent } from "@/hooks/useFileContent";
 import { useFileDiff } from "@/hooks/useFileDiff";
 import {
   type Comment,
@@ -498,10 +498,10 @@ function FileViewerBody({
   );
 
   const downloadFile = useCallback(() => {
-    const data = fileQuery.data;
-    if (!data) return;
-    triggerBrowserDownload(fileContentToBlob(data), path.split("/").pop() ?? path);
-  }, [fileQuery.data, path]);
+    downloadWorkspaceFile(conversationId, path).catch((err) =>
+      console.warn("Failed to download file", err),
+    );
+  }, [conversationId, path]);
 
   // Pop the HTML artifact into its own browser tab. The artifact is rendered in
   // a sandboxed, opaque-origin iframe (see `openHtmlArtifactInNewTab`), so it
@@ -1076,9 +1076,7 @@ function FileViewerBody({
     settingsMenu.push({
       key: "download",
       label: "Download file",
-      tooltip: fileQuery.data.truncated
-        ? "Download (file was truncated — content may be incomplete)"
-        : "Download",
+      tooltip: "Download",
       icon: <DownloadIcon className="size-4" />,
       active: false,
       onSelect: downloadFile,

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -9,6 +9,7 @@
 //   │  - gutter icon → add comment    │                  │
 //   └──────────────────────────────────┴──────────────────┘
 
+import { toast } from "sonner";
 import {
   lazy,
   Suspense,
@@ -498,9 +499,7 @@ function FileViewerBody({
   );
 
   const downloadFile = useCallback(() => {
-    downloadWorkspaceFile(conversationId, path).catch((err) =>
-      console.warn("Failed to download file", err),
-    );
+    downloadWorkspaceFile(conversationId, path).catch(() => toast.error("Download failed"));
   }, [conversationId, path]);
 
   // Pop the HTML artifact into its own browser tab. The artifact is rendered in


### PR DESCRIPTION
## Related issue

Closes #5793

## Summary

- The workspace "Download file" button reused the viewer's capped JSON read, so any file over 10 MiB (or 2,000 text lines) was saved incomplete, with only a console warning.
- `GET .../filesystem/{path}?download=true` now returns the raw file as an attachment, streamed on both legs: the runner streams it in 64 KiB chunks from a descriptor it opened, and the server forwards the runner's byte stream without buffering it, so a multi-GB download never lands in server memory. No size cap applies.
- Both download entry points in the web UI (the Changes-row icon and the viewer's "Download file" menu item) use it as a plain same-origin link click, so the browser shows the download at once and streams it to disk instead of buffering the whole file in the tab. The managed Databricks embed and the iOS/Android shells keep fetching through the app's transport and handing over a Blob, since a bare navigation lacks the embed's auth headers and Android's `DownloadManager` runs outside the WebView's session. The "content may be incomplete" tooltip is gone, and a failed fetch-path download shows a toast.
- The runner serves the bytes from a descriptor it opens itself, but only after the sandboxed helper confirms it can stat and read a regular file on that same inode, so a file the sandbox masks (bwrap binds `/dev/null` over it, Seatbelt denies the read) is refused exactly as the viewer refuses it, and a path swapped between check and open no longer matches.
- A runner that predates the flag ignores it and answers the JSON envelope; the server detects that (no `Content-Disposition`) and returns a 503 asking to restart the session rather than a silently truncated file. Runner 400/403/404 bodies pass through with their status.
- The path segment forwarded to the runner is percent-encoded on every filesystem route, so a name the server decoded to a literal `%2F` can no longer be decoded a second time by the runner into an absolute path that skipped the owner-only gate. That asymmetry predates this PR on the capped read and write routes, and the uncapped download made it worth closing here.
- No host fallback: the host tunnel's filesystem op answers in one message and cannot stream, so a download needs the runner online (503 otherwise, like other runner-only actions).

ELI5: the viewer asks for a *preview* of a file (capped, wrapped in JSON). The download button now asks for the *file itself*, and every hop hands the bytes along as they arrive instead of holding the whole thing.

```mermaid
sequenceDiagram
  participant B as Browser
  participant S as Server
  participant R as Runner
  B->>S: GET .../filesystem/big.bin?download=true
  S->>R: GET .../filesystem/big.bin?download=true (over the runner tunnel)
  R-->>S: 200 attachment, 64 KiB chunks from an open descriptor
  S-->>B: StreamingResponse, chunks forwarded as they arrive
```

Supersedes the approach in #5937, which buffered the whole file in the server proxy and read the host fallback from the server's own disk.

## Test Plan

- `tests/runner/test_environment_filesystem.py`: a 10 MiB + 1 byte file is truncated by the read path and returned byte-exact by `?download=true` with the attachment headers; a directory gives 400 and a missing path 404.
- `tests/server/routes/test_session_resources.py`: the proxy forwards a stub runner's attachment and headers; a runner answering JSON to `download=true` yields a 503 `runner_unavailable`; runner 404/400/403 keep their status and body.
- `tests/e2e/test_filesystem_changed_files_e2e.py`: real server and runner over the tunnel, 10 MiB + 1 bytes compared byte-for-byte (gated `min_server_version` / `min_runner_version` 0.13.0 for the compat smoke jobs).
- `tests/e2e_ui/files/test_right_panel.py`: Playwright opens a 10 MiB + 1 text file from the Files tree, downloads it through the viewer's "Download file" menu, and compares the saved bytes.
- `tests/runner/test_environment_filesystem.py` (sandbox parity): a real sandboxed helper (`darwin_seatbelt` locally, `linux_bwrap` in CI) refuses a masked `.env` and streams a plain file intact; a second test covers each backend's mask signature (read denied, `/dev/null` bind, another inode, stat denied).
- `web/src/hooks/useFileContent.test.tsx`: a browser download clicks a link to the `download=true` URL (plus `base=host` for absolute paths) without fetching; the managed embed and each mobile shell fetch through `authenticatedFetch` and save the blob.
- Full runner, server-route, and workspace_fs suites (230 tests), web vitest for every `fileContentToBlob` consumer, ruff, pyrefly, oxlint, tsc, prettier, and `scripts/dump_openapi.py --check`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Nothing visual changes: the same button and menu item now fetch `?download=true` and save the response. Evidence is the e2e and Playwright tests above, which download a file one byte over the cap and compare bytes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The server-side tunnel body queue is unbounded, so a slow browser can still make the server hold part of a large file in flight. That is pre-existing tunnel behavior and out of scope here.

## Changelog

Downloading a workspace file larger than 10 MiB now saves the complete file instead of a silently truncated one

https://claude.ai/code/session_01P9GM8aqjVSigfcAjEWEEVM
