### PR TITLE
Fix multi-host credential placeholders

### DIFF
--- a/omnigent/inner/credential_proxy.py
+++ b/omnigent/inner/credential_proxy.py
@@ -194,6 +194,7 @@ def prepare_credential_proxy_runtime(
     if spec.databricks is not None:
         _prepare_databricks_runtime(spec.databricks, runtime)
 
+    synthetic_by_env: dict[str, str] = {}
     for entry in spec.entries:
         real_secret = _resolve_secret(entry.source, parent_env=parent_env)
         # Mint a placeholder only when the entry injects an env var. The
@@ -202,10 +203,20 @@ def prepare_credential_proxy_runtime(
         # no placeholder to mint or guard.
         synthetic: str | None = None
         if entry.inject_env:
-            # 24 bytes -> 192 bits of entropy, well past any brute-force or
-            # collision concern for a short-lived per-session placeholder.
-            synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}{secrets.token_urlsafe(24)}"
+            existing = {
+                synthetic_by_env[env_name]
+                for env_name in entry.inject_env
+                if env_name in synthetic_by_env
+            }
+            if len(existing) > 1:
+                raise ValueError(
+                    "credential_proxy inject_env names resolve to conflicting placeholders"
+                )
+            synthetic = existing.pop() if existing else None
+            if synthetic is None:
+                synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}{secrets.token_urlsafe(24)}"
             for env_name in entry.inject_env:
+                synthetic_by_env[env_name] = synthetic
                 runtime.helper_env_updates[env_name] = synthetic
         runtime.rewrites.append(
             CredentialRewriteRule(

--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -246,16 +246,15 @@ class EgressProxy:
         #   injects the real credential. Exactly one rule per host — the
         #   parser rejects duplicate-host bindings, so this map never
         #   silently drops a rule.
-        # - ``_cred_by_synthetic``: the opt-in placeholder path. Only
-        #   entries that injected an ``oa_cred_*`` env var register here;
-        #   the synthetic is globally unique so it alone identifies the
-        #   rule (and thus the bound host) for the swap + leak guard.
+        # - ``_cred_by_synthetic``: the opt-in placeholder path. One
+        #   placeholder may intentionally serve several configured hosts.
         self._cred_by_host: dict[str, CredentialRewriteRule] = {}
-        self._cred_by_synthetic: dict[str, CredentialRewriteRule] = {}
+        self._cred_by_synthetic: dict[str, dict[str, CredentialRewriteRule]] = {}
         for rule in credential_rewrites or []:
-            self._cred_by_host[rule.host.lower()] = rule
+            host = rule.host.lower()
+            self._cred_by_host[host] = rule
             if rule.synthetic is not None:
-                self._cred_by_synthetic[rule.synthetic] = rule
+                self._cred_by_synthetic.setdefault(rule.synthetic, {})[host] = rule
         # Precompute the expected header bytes ONCE so the per-request
         # comparison is a constant-time memcmp instead of repeating
         # the base64 round-trip on every connection. Stored as bytes
@@ -1225,8 +1224,9 @@ class EgressProxy:
                     # leave it alone (and don't also inject over it).
                     rewritten.append(value)
                     continue
-                rule = self._cred_by_synthetic.get(synthetic)
-                if rule is None or rule.host != host_key:
+                rules = self._cred_by_synthetic.get(synthetic)
+                rule = rules.get(host_key) if rules is not None else None
+                if rule is None:
                     # A value carrying our placeholder prefix that we don't
                     # recognise for this host. Refuse rather than forward —
                     # this is the leak guard for a compromised sandbox that

--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -1756,6 +1756,39 @@ async def test_credential_rewrite_swaps_via_refreshing_provider(
     assert synthetic not in (captured[0].authorization or "")
 
 
+@pytest.mark.parametrize("host", ["api.cursor.com", "api2.cursor.sh", "agent.cursor.sh"])
+def test_credential_rewrite_accepts_shared_synthetic_on_configured_hosts(
+    ca_paths: tuple[Path, Path, Path], host: str
+) -> None:
+    cert_path, key_path, _ = ca_paths
+    synthetic = f"{SYNTHETIC_CREDENTIAL_PREFIX}cursor"
+    rules = [
+        CredentialRewriteRule(
+            host=allowed_host,
+            scheme="bearer",
+            synthetic=synthetic,
+            real_secret="real-cursor-secret",
+        )
+        for allowed_host in ("api.cursor.com", "api2.cursor.sh", "agent.cursor.sh")
+    ]
+    proxy = EgressProxy(
+        parse_rules(["* api.cursor.com/**", "* api2.cursor.sh/**", "* agent.cursor.sh/**"]),
+        cert_path,
+        key_path,
+        credential_rewrites=rules,
+    )
+
+    result = proxy._rewrite_authorization(
+        method="POST",
+        host=host,
+        headers_raw=f"Authorization: Bearer {synthetic}\r\n\r\n".encode(),
+    )
+
+    assert result.error is None
+    assert b"Authorization: Bearer real-cursor-secret" in result.headers
+    assert synthetic.encode() not in result.headers
+
+
 @pytest.mark.asyncio
 async def test_credential_rewrite_swaps_basic_password(
     ca_paths: tuple[Path, Path, Path],

--- a/tests/inner/test_credential_proxy.py
+++ b/tests/inner/test_credential_proxy.py
@@ -123,6 +123,26 @@ def test_env_source_resolves_and_mints_synthetic() -> None:
     assert rule.scheme == "bearer"
 
 
+def test_shared_env_reuses_placeholder_across_hosts() -> None:
+    source = CredentialSourceSpec(kind="env", env="CURSOR_SECRET")
+    spec = CredentialProxySpec(
+        entries=[
+            _bearer_entry("api.cursor.com", env_var="CURSOR_API_KEY", source=source),
+            _bearer_entry("api2.cursor.sh", env_var="CURSOR_API_KEY", source=source),
+            _bearer_entry("agent.cursor.sh", env_var="CURSOR_API_KEY", source=source),
+        ]
+    )
+
+    runtime = prepare_credential_proxy_runtime(
+        spec, parent_env={"CURSOR_SECRET": "real-cursor-secret"}
+    )
+
+    synthetic = runtime.helper_env_updates["CURSOR_API_KEY"]
+    assert synthetic.startswith(SYNTHETIC_CREDENTIAL_PREFIX)
+    assert {rule.synthetic for rule in runtime.rewrites} == {synthetic}
+    assert {rule.real_secret for rule in runtime.rewrites} == {"real-cursor-secret"}
+
+
 def test_file_source_resolves_secret(tmp_path: Path) -> None:
     """A ``file`` source reads the secret from disk, stripped of whitespace.
 


### PR DESCRIPTION
## Related issue

Closes #6232

## Summary

- Reuse one synthetic credential placeholder when several intended hosts share the same injected environment variable.
- Preserve host-scoped real-secret rewriting and the cross-host leak guard.
- Add a regression test matching Cursor's three-host `CURSOR_API_KEY` configuration.

ELI5: Cursor uses one key to contact several Cursor servers. Omnigent previously handed it a token that only one of those servers recognized; now every explicitly allowed Cursor server recognizes the same temporary token.

```text
CURSOR_API_KEY=oa_cred_X
        |-- api.cursor.com   -> real key
        |-- api2.cursor.sh   -> real key
        `-- agent.cursor.sh  -> real key
```

## Test Plan

- `uv run --group test pytest -q tests/inner/test_credential_proxy.py` — 14 passed.
- `ruff format` and `ruff check` passed through pre-commit.
- Full `pyrefly` was attempted but the local environment lacks existing optional OpenTelemetry modules unrelated to this change.
- OMNI-5700 run `33676159176` reproduced the pre-fix failure: the final configured Cursor host accepted the placeholder while another intended Cursor host rejected it.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified that expanded multi-host rules now share the exact placeholder injected into `CURSOR_API_KEY`; each rule retains its own host-scoped rewrite to the real secret.

## Changelog

Credential-proxied clients can use one injected token across all explicitly configured service hosts.
