### PR TITLE
fix(claude-sdk): pin family aliases to served ids for refusal-fallback

### DIFF
--- a/omnigent/claude_model_vocabulary.py
+++ b/omnigent/claude_model_vocabulary.py
@@ -236,3 +236,37 @@ def claude_model_command_arg(
         # Opus 5).
         return candidate
     return claude_model_alias(model, env)
+
+
+def _model_version_key(model: str) -> tuple[tuple[int, str | int], ...]:
+    """Order model ids naturally by their numeric segments (``4-8`` < ``5``)."""
+    return tuple(
+        (1, int(part)) if part.isdigit() else (0, part)
+        for part in re.split(r"(\d+)", normalized_model_id(model))
+        if part
+    )
+
+
+def served_alias_pins(model_ids: Iterable[str]) -> dict[str, str]:
+    """Map each family alias to the newest served id of that family.
+
+    A gateway that serves Claude under its own ids (``databricks-claude-opus-4-8``,
+    ``anthropic/claude-opus-4-8``) leaves Claude Code's alias vocabulary
+    unpinned, and an unpinned alias resolves to a canonical vendor id the
+    gateway rejects. Every alias surface — the refusal-fallback, ``/model``,
+    ``Agent``-tool spawns — then fails ``model_not_found``. This picks, per
+    family, the id the gateway actually serves so the launch env can pin it.
+
+    :param model_ids: The ids a gateway's model listing reports.
+    :returns: Alias → served id, e.g. ``{"opus": "databricks-claude-opus-4-8"}``,
+        for the families the listing serves. Ids of no Claude family are
+        ignored.
+    """
+    pins: dict[str, str] = {}
+    for model_id in model_ids:
+        alias = claude_model_alias(model_id, env={})
+        if alias not in ALIAS_MODEL_ENV_VARS:
+            continue
+        if alias not in pins or _model_version_key(model_id) > _model_version_key(pins[alias]):
+            pins[alias] = model_id
+    return pins

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import pathlib
+import subprocess
 import sys
 import tempfile
 import time
@@ -41,6 +42,7 @@ from contextlib import ExitStack, contextmanager, suppress
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Protocol, TypeAlias, cast
+from urllib.parse import urlparse
 
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary, stable_user_id
@@ -1017,6 +1019,97 @@ def _resolve_databricks_claude_model(profile: str | None) -> str:
     return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
 
 
+# Seconds to wait for the gateway auth command to print a bearer token when
+# minting one for served-model discovery. The command is either a trivial
+# ``printf`` (CI) or a ``databricks auth token`` call; 30s covers a cold CLI.
+_GATEWAY_TOKEN_TIMEOUT_S = 30.0
+
+# The Databricks AI Gateway's Anthropic Messages surface. A base URL carrying
+# this path routes to a gateway whose Claude endpoints are ``databricks-``
+# spelled, so its family aliases need the served-id pins below even when the
+# host is not under a trusted Databricks domain (e.g. a local test gateway).
+_ANTHROPIC_GATEWAY_PATH_MARKER = "/ai-gateway/anthropic"
+
+
+def _wants_alias_model_pins(base_url: str, model: str | None) -> bool:
+    """Return ``True`` when this gateway needs ``ANTHROPIC_DEFAULT_*_MODEL`` pins.
+
+    Claude Code resolves a family alias — ``opus`` / ``sonnet`` / ``haiku`` /
+    ``fable`` — to a concrete id through ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL``.
+    The refusal-fallback, ``/model``, and ``Agent``-tool spawns all speak
+    aliases. Unpinned, an alias resolves to a bare canonical id (e.g.
+    ``claude-opus-4-8``) that the Databricks gateway does not serve — it serves
+    only ``databricks-`` spelled ids — so a cyber/bio refusal that swaps to
+    Opus fails ``model_not_found``. Pin only when the gateway is a Databricks
+    Anthropic gateway (by trusted host, by path shape, or by a ``databricks-``
+    launch model), never a neutral endpoint whose served ids we do not know.
+    """
+    if is_databricks_ai_gateway_url(base_url):
+        return True
+    if urlparse(base_url).path.rstrip("/").endswith(_ANTHROPIC_GATEWAY_PATH_MARKER):
+        return True
+    return isinstance(model, str) and model.startswith(("databricks-", "databricks/"))
+
+
+def _mint_gateway_bearer(auth_command: str | None) -> str | None:
+    """Run the gateway ``apiKeyHelper`` command and return its bearer token.
+
+    The same command Claude Code invokes for the gateway (a ``printf`` of a
+    forwarded token, or ``databricks auth token``). Returns ``None`` when no
+    command is configured or it prints nothing.
+    """
+    if not auth_command:
+        return None
+    result = subprocess.run(
+        auth_command,
+        shell=True,
+        capture_output=True,
+        text=True,
+        timeout=_GATEWAY_TOKEN_TIMEOUT_S,
+    )
+    token = result.stdout.strip()
+    return token or None
+
+
+def _discover_alias_model_pins(base_url: str, auth_command: str | None) -> dict[str, str]:
+    """Map each Claude family alias to the gateway's newest served id.
+
+    Discovers the workspace's served Claude catalog and returns the
+    ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL`` env each alias needs so Claude Code's
+    refusal-fallback (and every other alias surface) routes to a servable id.
+    Returns an empty dict — leaving the gateway untouched — when discovery
+    yields no Claude models or fails for any reason.
+
+    :param base_url: The resolved ``ANTHROPIC_BASE_URL`` (may carry a path);
+        the workspace origin is its scheme + host.
+    :param auth_command: The gateway ``apiKeyHelper`` command used to mint a
+        bearer token for the discovery listing.
+    :returns: ``{env_var: served_model_id}`` for every discovered family.
+    """
+    from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS
+    from omnigent.databricks_model_discovery import discover_databricks_claude_catalog
+
+    try:
+        parsed = urlparse(base_url)
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        token = _mint_gateway_bearer(auth_command)
+        if not token:
+            return {}
+        families = discover_databricks_claude_catalog(origin, token).families
+    except Exception:  # noqa: BLE001 — discovery is best-effort; unpinned is the safe default
+        logger.warning(
+            "claude-sdk: served-model discovery for alias pins failed; "
+            "leaving ANTHROPIC_DEFAULT_*_MODEL unset",
+            exc_info=True,
+        )
+        return {}
+    return {
+        ALIAS_MODEL_ENV_VARS[family]: model_id
+        for family, model_id in families.items()
+        if family in ALIAS_MODEL_ENV_VARS
+    }
+
+
 def _resolve_gateway_env(
     profile: str | None = None,
     *,
@@ -1634,6 +1727,13 @@ class ClaudeSDKExecutor(Executor):
         # Started on the first gateway turn — __init__ has no event loop.
         self._gateway_shim: ClaudeGatewayShim | None = None
 
+        # Cached ``ANTHROPIC_DEFAULT_*_MODEL`` pins for Claude Code's family
+        # aliases, discovered from the gateway's served catalog on the first
+        # qualifying turn (see :meth:`_apply_alias_model_pins`). ``None`` until
+        # resolved; the resolved value may be empty (discovery found nothing).
+        self._alias_model_pins: dict[str, str] | None = None
+        self._alias_model_pins_resolved = False
+
         # Eagerly resolve the gateway transport env so errors surface at
         # construction time.
         self._extra_env: dict[str, str] = {}
@@ -2024,6 +2124,45 @@ class ClaudeSDKExecutor(Executor):
                 return str(metadata["session_id"])
         return "default"
 
+    async def _apply_alias_model_pins(
+        self,
+        env: dict[str, str],
+        model: str | None,
+        auth_command: str | None,
+    ) -> None:
+        """
+        Inject ``ANTHROPIC_DEFAULT_*_MODEL`` alias pins into the child env.
+
+        On a Databricks Anthropic gateway, discover the served Claude families
+        once and pin each of Claude Code's family aliases to a servable id, so
+        the CLI's refusal-fallback / ``/model`` / ``Agent``-tool spawns resolve
+        an alias to a model the gateway actually serves instead of a bare
+        canonical id it rejects. A no-op off the Databricks gateway, when every
+        alias is already pinned, or when discovery finds nothing.
+
+        :param env: The child-process env dict, mutated in place.
+        :param model: The resolved launch model (a ``databricks-`` id marks a
+            Databricks gateway even when the base URL host does not).
+        :param auth_command: The gateway ``apiKeyHelper`` command, used to mint
+            a bearer token for the served-model discovery listing.
+        """
+        base_url = env.get("ANTHROPIC_BASE_URL")
+        if not base_url or not _wants_alias_model_pins(base_url, model):
+            return
+        from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS
+
+        if all(var in env for var in ALIAS_MODEL_ENV_VARS.values()):
+            # Every alias already pinned (e.g. by a ucode launch config);
+            # respect the explicit values rather than re-deriving them.
+            return
+        if not self._alias_model_pins_resolved:
+            self._alias_model_pins = await run_sync_on_thread(
+                _discover_alias_model_pins, base_url, auth_command
+            )
+            self._alias_model_pins_resolved = True
+        for var, model_id in (self._alias_model_pins or {}).items():
+            env.setdefault(var, model_id)
+
     def _install_subagent_router_hook(
         self,
         sdk: _ClaudeSDK,
@@ -2370,6 +2509,10 @@ class ClaudeSDKExecutor(Executor):
         # ``""`` here would still leave an empty key in the child env.
         env = dict(self._extra_env)
         api_key_helper = env.pop(_CLAUDE_API_KEY_HELPER_ENV_KEY, None)
+        # Pin Claude Code's family aliases to the gateway's served ids so a
+        # refusal-fallback (or any alias surface) never routes to a canonical
+        # id the Databricks gateway rejects. No-op off the Databricks gateway.
+        await self._apply_alias_model_pins(env, model, api_key_helper)
         settings_payload = (
             json.dumps({"apiKeyHelper": api_key_helper}, separators=(",", ":"))
             if api_key_helper

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -33,7 +33,6 @@ import json
 import logging
 import os
 import pathlib
-import subprocess
 import sys
 import tempfile
 import time
@@ -42,10 +41,10 @@ from contextlib import ExitStack, contextmanager, suppress
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Protocol, TypeAlias, cast
-from urllib.parse import urlparse
 
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary, stable_user_id
+from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS, served_alias_pins
 from omnigent.cli_invocation import cli_invocation
 from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 from omnigent.inner import _proc
@@ -1019,94 +1018,47 @@ def _resolve_databricks_claude_model(profile: str | None) -> str:
     return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
 
 
-# Seconds to wait for the gateway auth command to print a bearer token when
-# minting one for served-model discovery. The command is either a trivial
-# ``printf`` (CI) or a ``databricks auth token`` call; 30s covers a cold CLI.
-_GATEWAY_TOKEN_TIMEOUT_S = 30.0
-
-# The Databricks AI Gateway's Anthropic Messages surface. A base URL carrying
-# this path routes to a gateway whose Claude endpoints are ``databricks-``
-# spelled, so its family aliases need the served-id pins below even when the
-# host is not under a trusted Databricks domain (e.g. a local test gateway).
-_ANTHROPIC_GATEWAY_PATH_MARKER = "/ai-gateway/anthropic"
-
-
-def _wants_alias_model_pins(base_url: str, model: str | None) -> bool:
-    """Return ``True`` when this gateway needs ``ANTHROPIC_DEFAULT_*_MODEL`` pins.
+def _gateway_alias_model_pins(base_url: str, auth_command: str | None) -> dict[str, str]:
+    """Pin Claude Code's family aliases to the ids a gateway serves.
 
     Claude Code resolves a family alias — ``opus`` / ``sonnet`` / ``haiku`` /
-    ``fable`` — to a concrete id through ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL``.
-    The refusal-fallback, ``/model``, and ``Agent``-tool spawns all speak
-    aliases. Unpinned, an alias resolves to a bare canonical id (e.g.
-    ``claude-opus-4-8``) that the Databricks gateway does not serve — it serves
-    only ``databricks-`` spelled ids — so a cyber/bio refusal that swaps to
-    Opus fails ``model_not_found``. Pin only when the gateway is a Databricks
-    Anthropic gateway (by trusted host, by path shape, or by a ``databricks-``
-    launch model), never a neutral endpoint whose served ids we do not know.
+    ``fable`` — through ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL``, and every alias
+    surface speaks them: the refusal-fallback (a flagged message re-issues on
+    Opus), ``/model``, ``Agent``-tool spawns. Unpinned, an alias resolves to a
+    canonical vendor id (``claude-opus-4-8``). A gateway that serves Claude under
+    its own ids (``databricks-claude-opus-4-8``) rejects that with
+    ``model_not_found``, and a refusal-fallback then kills the whole turn. List
+    what the gateway serves and pin each alias to it.
+
+    :param base_url: The gateway's ``ANTHROPIC_BASE_URL``.
+    :param auth_command: The gateway ``apiKeyHelper`` command; minted into the
+        bearer the listing is fetched with.
+    :returns: ``{env_var: served_model_id}`` per served family. Empty — leaving
+        the aliases unpinned, today's behavior — when the gateway lists no
+        Claude models or the listing cannot be fetched.
     """
-    if is_databricks_ai_gateway_url(base_url):
-        return True
-    if urlparse(base_url).path.rstrip("/").endswith(_ANTHROPIC_GATEWAY_PATH_MARKER):
-        return True
-    return isinstance(model, str) and model.startswith(("databricks-", "databricks/"))
+    from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GATEWAY_KIND
 
-
-def _mint_gateway_bearer(auth_command: str | None) -> str | None:
-    """Run the gateway ``apiKeyHelper`` command and return its bearer token.
-
-    The same command Claude Code invokes for the gateway (a ``printf`` of a
-    forwarded token, or ``databricks auth token``). Returns ``None`` when no
-    command is configured or it prints nothing.
-    """
-    if not auth_command:
-        return None
-    result = subprocess.run(
-        auth_command,
-        shell=True,
-        capture_output=True,
-        text=True,
-        timeout=_GATEWAY_TOKEN_TIMEOUT_S,
+    provider = model_catalog.ResolvedModelProvider(
+        kind=GATEWAY_KIND,
+        family=ANTHROPIC_FAMILY,
+        base_url=base_url,
+        auth_command=auth_command,
+        detail="claude-sdk gateway transport",
     )
-    token = result.stdout.strip()
-    return token or None
-
-
-def _discover_alias_model_pins(base_url: str, auth_command: str | None) -> dict[str, str]:
-    """Map each Claude family alias to the gateway's newest served id.
-
-    Discovers the workspace's served Claude catalog and returns the
-    ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL`` env each alias needs so Claude Code's
-    refusal-fallback (and every other alias surface) routes to a servable id.
-    Returns an empty dict — leaving the gateway untouched — when discovery
-    yields no Claude models or fails for any reason.
-
-    :param base_url: The resolved ``ANTHROPIC_BASE_URL`` (may carry a path);
-        the workspace origin is its scheme + host.
-    :param auth_command: The gateway ``apiKeyHelper`` command used to mint a
-        bearer token for the discovery listing.
-    :returns: ``{env_var: served_model_id}`` for every discovered family.
-    """
-    from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS
-    from omnigent.databricks_model_discovery import discover_databricks_claude_catalog
-
     try:
-        parsed = urlparse(base_url)
-        origin = f"{parsed.scheme}://{parsed.netloc}"
-        token = _mint_gateway_bearer(auth_command)
-        if not token:
-            return {}
-        families = discover_databricks_claude_catalog(origin, token).families
-    except Exception:  # noqa: BLE001 — discovery is best-effort; unpinned is the safe default
+        listing = model_catalog.listing_for_provider(provider)
+    except Exception:  # noqa: BLE001 — best-effort; unpinned aliases are the safe default
         logger.warning(
-            "claude-sdk: served-model discovery for alias pins failed; "
+            "claude-sdk: could not list the gateway's models; "
             "leaving ANTHROPIC_DEFAULT_*_MODEL unset",
             exc_info=True,
         )
         return {}
+    served = [entry.id for entry in listing.models if entry.family == "claude"]
     return {
-        ALIAS_MODEL_ENV_VARS[family]: model_id
-        for family, model_id in families.items()
-        if family in ALIAS_MODEL_ENV_VARS
+        ALIAS_MODEL_ENV_VARS[alias]: model_id
+        for alias, model_id in served_alias_pins(served).items()
     }
 
 
@@ -1728,8 +1680,8 @@ class ClaudeSDKExecutor(Executor):
         self._gateway_shim: ClaudeGatewayShim | None = None
 
         # Cached ``ANTHROPIC_DEFAULT_*_MODEL`` pins for Claude Code's family
-        # aliases, discovered from the gateway's served catalog on the first
-        # qualifying turn (see :meth:`_apply_alias_model_pins`). ``None`` until
+        # aliases, read from the gateway's model listing on the first gateway
+        # turn (see :meth:`_apply_alias_model_pins`). ``None`` until
         # resolved; the resolved value may be empty (discovery found nothing).
         self._alias_model_pins: dict[str, str] | None = None
         self._alias_model_pins_resolved = False
@@ -2124,40 +2076,31 @@ class ClaudeSDKExecutor(Executor):
                 return str(metadata["session_id"])
         return "default"
 
-    async def _apply_alias_model_pins(
-        self,
-        env: dict[str, str],
-        model: str | None,
-        auth_command: str | None,
-    ) -> None:
+    async def _apply_alias_model_pins(self, env: dict[str, str], auth_command: str | None) -> None:
         """
         Inject ``ANTHROPIC_DEFAULT_*_MODEL`` alias pins into the child env.
 
-        On a Databricks Anthropic gateway, discover the served Claude families
-        once and pin each of Claude Code's family aliases to a servable id, so
-        the CLI's refusal-fallback / ``/model`` / ``Agent``-tool spawns resolve
-        an alias to a model the gateway actually serves instead of a bare
-        canonical id it rejects. A no-op off the Databricks gateway, when every
-        alias is already pinned, or when discovery finds nothing.
+        On a gateway transport, list the gateway's models once and pin each of
+        Claude Code's family aliases to an id it serves, so the refusal-fallback
+        / ``/model`` / ``Agent``-tool spawns resolve an alias to a servable
+        model instead of a canonical vendor id the gateway may reject. A no-op
+        off the gateway (a direct Anthropic endpoint resolves aliases itself),
+        when every alias is already pinned, or when the listing yields nothing.
 
         :param env: The child-process env dict, mutated in place.
-        :param model: The resolved launch model (a ``databricks-`` id marks a
-            Databricks gateway even when the base URL host does not).
-        :param auth_command: The gateway ``apiKeyHelper`` command, used to mint
-            a bearer token for the served-model discovery listing.
+        :param auth_command: The gateway ``apiKeyHelper`` command used to mint
+            a bearer for the model listing.
         """
         base_url = env.get("ANTHROPIC_BASE_URL")
-        if not base_url or not _wants_alias_model_pins(base_url, model):
+        if not self._gateway or not base_url:
             return
-        from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS
-
         if all(var in env for var in ALIAS_MODEL_ENV_VARS.values()):
             # Every alias already pinned (e.g. by a ucode launch config);
             # respect the explicit values rather than re-deriving them.
             return
         if not self._alias_model_pins_resolved:
             self._alias_model_pins = await run_sync_on_thread(
-                _discover_alias_model_pins, base_url, auth_command
+                _gateway_alias_model_pins, base_url, auth_command
             )
             self._alias_model_pins_resolved = True
         for var, model_id in (self._alias_model_pins or {}).items():
@@ -2509,10 +2452,10 @@ class ClaudeSDKExecutor(Executor):
         # ``""`` here would still leave an empty key in the child env.
         env = dict(self._extra_env)
         api_key_helper = env.pop(_CLAUDE_API_KEY_HELPER_ENV_KEY, None)
-        # Pin Claude Code's family aliases to the gateway's served ids so a
+        # Pin Claude Code's family aliases to ids the gateway serves so a
         # refusal-fallback (or any alias surface) never routes to a canonical
-        # id the Databricks gateway rejects. No-op off the Databricks gateway.
-        await self._apply_alias_model_pins(env, model, api_key_helper)
+        # id the gateway rejects. No-op off the gateway transport.
+        await self._apply_alias_model_pins(env, api_key_helper)
         settings_payload = (
             json.dumps({"apiKeyHelper": api_key_helper}, separators=(",", ":"))
             if api_key_helper

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -968,6 +968,20 @@ def _redacted_failure_reason(exc: Exception) -> str:
     return type(exc).__name__
 
 
+def listing_for_provider(provider: ResolvedModelProvider) -> ModelListing:
+    """Enumerate one provider's model listing (cached, failures not cached).
+
+    The public face of :func:`_listing_for_provider` for callers that already
+    hold a :class:`ResolvedModelProvider` — e.g. a harness executor asking
+    what its gateway transport serves — rather than an agent spec.
+
+    :param provider: The resolved provider descriptor.
+    :returns: The provider's :class:`ModelListing`; ``verified`` is ``False``
+        with a ``note`` when the fetch failed.
+    """
+    return _listing_for_provider(provider, transport=None)
+
+
 def _listing_for_provider(
     provider: ResolvedModelProvider,
     *,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -458,6 +458,27 @@ def set_fallback_mock_llm(
     resp.raise_for_status()
 
 
+def set_mock_served_models(mock_llm_server_url: str | None, models: list[str]) -> None:
+    """
+    Set the model ids the mock gateway reports on ``GET /v1/models``.
+
+    The claude-sdk executor lists its gateway's models once per session to
+    pin Claude Code's family aliases to served ids. Cleared by
+    :func:`reset_mock_llm`, so set it after the reset.
+
+    :param mock_llm_server_url: Mock server URL or ``None``.
+    :param models: Served model ids, e.g. ``["gw-claude-opus-4-8"]``.
+    """
+    if mock_llm_server_url is None:
+        return
+    resp = httpx.post(
+        f"{mock_llm_server_url}/mock/served_models",
+        json={"models": models},
+        timeout=5.0,
+    )
+    resp.raise_for_status()
+
+
 def release_mock_gate(mock_llm_server_url: str | None) -> None:
     """
     Release the oldest pending gate on the mock LLM server.

--- a/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
+++ b/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
@@ -4,21 +4,23 @@ Claude Code's safeguards can flag a message (e.g. a security-reproduction
 prompt) and return an API *refusal*. On a refusal the CLI arms its
 refusal-fallback and re-issues the turn on a different family — Opus for the
 ``cyber`` category — resolving that family through
-``ANTHROPIC_DEFAULT_OPUS_MODEL``. On the Databricks gateway that env is only
-set if Omnigent pins it: unpinned, the alias resolves to a **bare** canonical
-id (``claude-opus-4-8``) the gateway does not serve (it serves only
-``databricks-`` spelled ids), so the fallback request fails
-``model_not_found`` and the whole turn dies with
+``ANTHROPIC_DEFAULT_OPUS_MODEL``. On a gateway that serves Claude under its own
+ids, that env is only set if Omnigent pins it: unpinned, the alias resolves to
+a **canonical** vendor id (``claude-opus-4-8``) the gateway does not serve, so
+the fallback request fails ``model_not_found`` and the whole turn dies with
 ``inner executor error: There's an issue with the selected model
-(claude-opus-4-8)`` while the UI shows ``<synthetic>`` for the model.
+(claude-opus-4-8)`` while the UI shows ``<synthetic>`` for the model. (Reported
+on the Databricks gateway, whose ids are ``databricks-claude-*``; any gateway
+with its own spellings has the same failure.)
 
-The fix pins each family alias to the workspace's served id, so the fallback
-re-issues on ``databricks-claude-opus-4-8`` (servable) and the turn completes.
+The fix lists the gateway's models and pins each family alias to a served id,
+so the fallback re-issues on the gateway's Opus and the turn completes.
 
-This drives the real journey — register a claude-sdk agent, create a
-runner-bound session (real ``claude`` CLI subprocess), send a turn the mock
-LLM refuses — and asserts the fallback landed on the served Opus id (visible
-on the Anthropic wire via the mock's request capture) and the turn completed.
+This drives the real journey — register a claude-sdk agent on the mock
+gateway, create a runner-bound session (real ``claude`` CLI subprocess), send
+a turn the mock refuses — and asserts the fallback landed on the served Opus
+id (visible on the Anthropic wire via the mock's request capture) and the turn
+completed.
 
 Usage::
 
@@ -43,13 +45,20 @@ from tests.e2e.conftest import (
     poll_session_until_terminal,
     reset_mock_llm,
     send_user_message_to_session,
+    set_mock_served_models,
 )
 
-# The workspace's served Claude ids the mock advertises on its gateway model
-# listing (see ``SERVED_CLAUDE_MODELS`` in the mock server). The launch model
-# and the Opus the refusal-fallback must route to.
-_LAUNCH_MODEL = "databricks-claude-fable-5"
-_SERVED_FALLBACK_MODEL = "databricks-claude-opus-4-8"
+# The Claude ids the mock gateway serves under its own spelling — the launch
+# model and the Opus the refusal-fallback must route to. Deliberately not a
+# real vendor's spelling: the fix must work for any gateway's ids.
+_LAUNCH_MODEL = "gw-claude-fable-5"
+_SERVED_FALLBACK_MODEL = "gw-claude-opus-4-8"
+_SERVED_MODELS = [
+    _LAUNCH_MODEL,
+    _SERVED_FALLBACK_MODEL,
+    "gw-claude-sonnet-5",
+    "gw-claude-haiku-4-5",
+]
 
 
 def _register_claude_sdk_agent(
@@ -61,10 +70,8 @@ def _register_claude_sdk_agent(
 ) -> str:
     """Register a minimal claude-sdk agent bound to the mock gateway.
 
-    ``executor.auth`` is an ``api_key`` with the mock base URL — the wiring a
-    Databricks AI Gateway provider produces — and the model is a
-    ``databricks-`` id, which marks the gateway as one whose family aliases
-    need served-id pins.
+    ``executor.auth`` is an ``api_key`` with the mock base URL — the wiring
+    any Anthropic-compatible gateway provider produces.
     """
     config = {
         "spec_version": 1,
@@ -108,10 +115,13 @@ def test_claude_sdk_refusal_fallback_routes_to_served_model(
 
     The mock refuses the launch-model (Fable) turn with a ``cyber`` refusal.
     With the alias pins the fix injects, Claude Code re-issues the turn on the
-    servable ``databricks-claude-opus-4-8`` and completes — instead of dying on
-    a bare ``claude-opus-4-8`` the gateway rejects.
+    gateway's own Opus id and completes — instead of dying on a canonical
+    ``claude-opus-4-8`` the gateway rejects.
     """
     reset_mock_llm(mock_llm_server_url)
+    # What the gateway serves: the executor lists this once per session and
+    # pins each family alias to it.
+    set_mock_served_models(mock_llm_server_url, _SERVED_MODELS)
     agent_name = _register_claude_sdk_agent(
         http_client,
         name=f"refusal-fb-{uuid.uuid4().hex[:6]}",

--- a/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
+++ b/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
@@ -1,0 +1,161 @@
+"""E2E regression test: claude-sdk refusal-fallback routes to a served model.
+
+Claude Code's safeguards can flag a message (e.g. a security-reproduction
+prompt) and return an API *refusal*. On a refusal the CLI arms its
+refusal-fallback and re-issues the turn on a different family — Opus for the
+``cyber`` category — resolving that family through
+``ANTHROPIC_DEFAULT_OPUS_MODEL``. On the Databricks gateway that env is only
+set if Omnigent pins it: unpinned, the alias resolves to a **bare** canonical
+id (``claude-opus-4-8``) the gateway does not serve (it serves only
+``databricks-`` spelled ids), so the fallback request fails
+``model_not_found`` and the whole turn dies with
+``inner executor error: There's an issue with the selected model
+(claude-opus-4-8)`` while the UI shows ``<synthetic>`` for the model.
+
+The fix pins each family alias to the workspace's served id, so the fallback
+re-issues on ``databricks-claude-opus-4-8`` (servable) and the turn completes.
+
+This drives the real journey — register a claude-sdk agent, create a
+runner-bound session (real ``claude`` CLI subprocess), send a turn the mock
+LLM refuses — and asserts the fallback landed on the served Opus id (visible
+on the Anthropic wire via the mock's request capture) and the turn completed.
+
+Usage::
+
+    pytest tests/e2e/test_claude_sdk_refusal_fallback_e2e.py -v --timeout=300
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import uuid
+
+import httpx
+import yaml
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    get_mock_requests,
+    poll_session_until_terminal,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+
+# The workspace's served Claude ids the mock advertises on its gateway model
+# listing (see ``SERVED_CLAUDE_MODELS`` in the mock server). The launch model
+# and the Opus the refusal-fallback must route to.
+_LAUNCH_MODEL = "databricks-claude-fable-5"
+_SERVED_FALLBACK_MODEL = "databricks-claude-opus-4-8"
+
+
+def _register_claude_sdk_agent(
+    client: httpx.Client,
+    *,
+    name: str,
+    model: str,
+    mock_llm_base_url: str,
+) -> str:
+    """Register a minimal claude-sdk agent bound to the mock gateway.
+
+    ``executor.auth`` is an ``api_key`` with the mock base URL — the wiring a
+    Databricks AI Gateway provider produces — and the model is a
+    ``databricks-`` id, which marks the gateway as one whose family aliases
+    need served-id pins.
+    """
+    config = {
+        "spec_version": 1,
+        "name": name,
+        "description": "claude-sdk refusal-fallback regression agent",
+        "instructions": "You are a helpful assistant. Answer the user directly.",
+        "executor": {
+            "type": "omnigent",
+            "model": model,
+            "config": {"harness": "claude-sdk"},
+            "auth": {
+                "type": "api_key",
+                "api_key": "mock-key",
+                "base_url": mock_llm_base_url,
+            },
+        },
+    }
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml.safe_dump(config).encode()
+        info = tarfile.TarInfo("config.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    resp = client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
+        headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+    )
+    if resp.status_code not in (200, 201, 409):
+        raise RuntimeError(f"agent register failed: {resp.status_code} {resp.text[:500]}")
+    return name
+
+
+def test_claude_sdk_refusal_fallback_routes_to_served_model(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """A safeguard refusal on claude-sdk falls back to the served Opus id.
+
+    The mock refuses the launch-model (Fable) turn with a ``cyber`` refusal.
+    With the alias pins the fix injects, Claude Code re-issues the turn on the
+    servable ``databricks-claude-opus-4-8`` and completes — instead of dying on
+    a bare ``claude-opus-4-8`` the gateway rejects.
+    """
+    reset_mock_llm(mock_llm_server_url)
+    agent_name = _register_claude_sdk_agent(
+        http_client,
+        name=f"refusal-fb-{uuid.uuid4().hex[:6]}",
+        model=_LAUNCH_MODEL,
+        mock_llm_base_url=mock_llm_server_url,
+    )
+    # The Fable turn is refused (cyber). The Opus re-issue and any preflight
+    # calls fall through to the queue default (a plain text answer), so the
+    # turn can complete once the fallback lands on a served model.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"refusal_category": "cyber"}],
+        key=_LAUNCH_MODEL,
+    )
+    session_id = create_runner_bound_session(
+        http_client, agent_name=agent_name, runner_id=live_runner_id
+    )
+    response_id = send_user_message_to_session(
+        http_client,
+        session_id=session_id,
+        content="Please greet me.",
+    )
+    body = poll_session_until_terminal(
+        http_client, session_id=session_id, response_id=response_id, timeout=180
+    )
+
+    reqs = get_mock_requests(mock_llm_server_url)
+    wire_models = [req.get("model") for req in reqs]
+
+    # The launch turn ran on Fable and was refused — the precondition.
+    assert _LAUNCH_MODEL in wire_models, (
+        f"the launch model {_LAUNCH_MODEL!r} never reached the wire; models seen: {wire_models}"
+    )
+    # The fix pinned the Opus alias to the served id, so the refusal-fallback
+    # re-issued on it. Without the fix the alias resolves to a bare
+    # ``claude-opus-4-8`` the gateway rejects, and no such request is made.
+    assert _SERVED_FALLBACK_MODEL in wire_models, (
+        f"the refusal-fallback did not re-issue on the served Opus id "
+        f"{_SERVED_FALLBACK_MODEL!r} — the ANTHROPIC_DEFAULT_OPUS_MODEL pin is "
+        f"missing, so the alias resolved to a canonical id the gateway rejects. "
+        f"Models seen on the wire: {wire_models}"
+    )
+    # And the turn completed rather than dying with the model_not_found error.
+    assert body["status"] == "completed", (
+        f"the turn did not complete after the refusal-fallback: "
+        f"status={body['status']!r} error={body.get('error')!r}"
+    )

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -798,27 +798,26 @@ class TestConstructor(unittest.TestCase):
 
         _run(_t())
 
-    def test_databricks_gateway_pins_family_aliases_to_served_ids(self):
-        """A Databricks gateway turn pins every discovered family alias.
+    def test_gateway_pins_family_aliases_to_served_ids(self):
+        """A gateway turn pins every family alias to an id the gateway serves.
 
         Claude Code's refusal-fallback resolves the ``opus`` alias through
-        ``ANTHROPIC_DEFAULT_OPUS_MODEL``; unpinned it lands on a bare canonical
-        id the Databricks gateway rejects (``model_not_found``). The executor
-        discovers the served families and pins each alias so the fallback
-        routes to a servable id. See ``_apply_alias_model_pins``.
+        ``ANTHROPIC_DEFAULT_OPUS_MODEL``; unpinned it lands on a canonical
+        vendor id a gateway serving its own ids rejects (``model_not_found``).
+        The executor lists the gateway's models and pins each alias to a
+        served id. See ``_apply_alias_model_pins``.
         """
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
-        from omnigent.inner.databricks_executor import DatabricksCredentials
+        from omnigent.model_catalog import ModelEntry, ModelListing
 
         async def _t():
-            with patch(
-                "omnigent.inner.databricks_executor._read_databrickscfg",
-                return_value=DatabricksCredentials(
-                    host="https://example.cloud.databricks.com",
-                    token="dapi_test_token",
-                ),
-            ):
-                executor = ClaudeSDKExecutor(gateway=True, model="databricks-claude-fable-5")
+            executor = ClaudeSDKExecutor(
+                gateway=True,
+                gateway_host="https://gateway.example.com",
+                base_url_override="https://gateway.example.com/anthropic",
+                gateway_auth_command="printf token",
+                model="gw-claude-fable-5",
+            )
 
             captured: dict[str, dict[str, str]] = {}
 
@@ -826,22 +825,21 @@ class TestConstructor(unittest.TestCase):
                 captured["env"] = dict(options.env or {})
                 raise RuntimeError("stop after env assembly")
 
+            listing = ModelListing(
+                source="openai-compatible",
+                verified=True,
+                models=(
+                    ModelEntry(id="gw-claude-fable-5", family="claude"),
+                    ModelEntry(id="gw-claude-opus-4-7", family="claude"),
+                    ModelEntry(id="gw-claude-opus-4-8", family="claude"),
+                    ModelEntry(id="gw-claude-sonnet-5", family="claude"),
+                    ModelEntry(id="gw-claude-haiku-4-5", family="claude"),
+                    ModelEntry(id="gw-gpt-5-6", family="openai"),
+                ),
+                note="",
+            )
             with (
-                patch(
-                    "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
-                    return_value="dapi_test_token",
-                ),
-                patch(
-                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
-                    return_value=SimpleNamespace(
-                        families={
-                            "fable": "databricks-claude-fable-5",
-                            "opus": "databricks-claude-opus-4-8",
-                            "sonnet": "databricks-claude-sonnet-5",
-                            "haiku": "databricks-claude-haiku-4-5",
-                        }
-                    ),
-                ),
+                patch("omnigent.model_catalog.listing_for_provider", return_value=listing),
                 patch.object(
                     executor,
                     "_get_or_create_client",
@@ -853,20 +851,22 @@ class TestConstructor(unittest.TestCase):
                         pass
 
             env = captured["env"]
-            self.assertEqual(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "databricks-claude-opus-4-8")
-            self.assertEqual(env["ANTHROPIC_DEFAULT_FABLE_MODEL"], "databricks-claude-fable-5")
-            self.assertEqual(env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "databricks-claude-sonnet-5")
-            self.assertEqual(env["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "databricks-claude-haiku-4-5")
+            # Newest served generation per family; the non-Claude id is ignored.
+            self.assertEqual(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "gw-claude-opus-4-8")
+            self.assertEqual(env["ANTHROPIC_DEFAULT_FABLE_MODEL"], "gw-claude-fable-5")
+            self.assertEqual(env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "gw-claude-sonnet-5")
+            self.assertEqual(env["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "gw-claude-haiku-4-5")
 
         _run(_t())
 
-    def test_neutral_gateway_does_not_pin_family_aliases(self):
-        """A neutral (non-Databricks) gateway is never given databricks pins.
+    def test_gateway_listing_without_claude_models_pins_nothing(self):
+        """A gateway that lists no Claude models leaves the aliases unpinned.
 
-        The served ids of a neutral endpoint are unknown, so the executor must
-        not inject ``databricks-`` aliases or run served-model discovery there.
+        The served ids are unknown, so the executor must not invent pins;
+        an unpinned alias is today's behavior, not a regression.
         """
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+        from omnigent.model_catalog import ModelEntry, ModelListing
 
         async def _t():
             executor = ClaudeSDKExecutor(
@@ -883,12 +883,14 @@ class TestConstructor(unittest.TestCase):
                 captured["env"] = dict(options.env or {})
                 raise RuntimeError("stop after env assembly")
 
-            discover = Mock()
+            listing = ModelListing(
+                source="openai-compatible",
+                verified=True,
+                models=(ModelEntry(id="gpt-5", family="openai"),),
+                note="",
+            )
             with (
-                patch(
-                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
-                    discover,
-                ),
+                patch("omnigent.model_catalog.listing_for_provider", return_value=listing),
                 patch.object(
                     executor,
                     "_get_or_create_client",
@@ -899,30 +901,26 @@ class TestConstructor(unittest.TestCase):
                     async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
                         pass
 
-            env = captured["env"]
-            self.assertNotIn("ANTHROPIC_DEFAULT_OPUS_MODEL", env)
-            discover.assert_not_called()
+            self.assertFalse({k for k in captured["env"] if k.startswith("ANTHROPIC_DEFAULT_")})
 
         _run(_t())
 
     def test_explicit_family_pins_are_not_overwritten(self):
-        """Pre-set ``ANTHROPIC_DEFAULT_*_MODEL`` pins win over discovery.
+        """Pre-set ``ANTHROPIC_DEFAULT_*_MODEL`` pins win over the listing.
 
-        A ucode launch config that already pins every alias must be respected
-        verbatim; the executor neither re-derives nor runs discovery.
+        A launch config that already pins every alias must be respected
+        verbatim; the executor neither re-derives them nor lists the gateway.
         """
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
-        from omnigent.inner.databricks_executor import DatabricksCredentials
 
         async def _t():
-            with patch(
-                "omnigent.inner.databricks_executor._read_databrickscfg",
-                return_value=DatabricksCredentials(
-                    host="https://example.cloud.databricks.com",
-                    token="dapi_test_token",
-                ),
-            ):
-                executor = ClaudeSDKExecutor(gateway=True, model="databricks-claude-fable-5")
+            executor = ClaudeSDKExecutor(
+                gateway=True,
+                gateway_host="https://gateway.example.com",
+                base_url_override="https://gateway.example.com/anthropic",
+                gateway_auth_command="printf token",
+                model="gw-claude-fable-5",
+            )
             executor._extra_env["ANTHROPIC_DEFAULT_FABLE_MODEL"] = "pinned-fable"
             executor._extra_env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "pinned-opus"
             executor._extra_env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "pinned-sonnet"
@@ -934,12 +932,9 @@ class TestConstructor(unittest.TestCase):
                 captured["env"] = dict(options.env or {})
                 raise RuntimeError("stop after env assembly")
 
-            discover = Mock()
+            listing = Mock()
             with (
-                patch(
-                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
-                    discover,
-                ),
+                patch("omnigent.model_catalog.listing_for_provider", listing),
                 patch.object(
                     executor,
                     "_get_or_create_client",
@@ -951,7 +946,7 @@ class TestConstructor(unittest.TestCase):
                         pass
 
             self.assertEqual(captured["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"], "pinned-opus")
-            discover.assert_not_called()
+            listing.assert_not_called()
 
         _run(_t())
 
@@ -1536,62 +1531,22 @@ class TestResolveGatewayEnv(unittest.TestCase):
 
 
 class TestAliasModelPins(unittest.TestCase):
-    def test_wants_pins_on_trusted_databricks_gateway(self):
-        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
+    def test_pins_map_served_families_to_env_vars(self):
+        from omnigent.inner.claude_sdk_executor import _gateway_alias_model_pins
+        from omnigent.model_catalog import ModelEntry, ModelListing
 
-        self.assertTrue(
-            _wants_alias_model_pins(
-                "https://wkspc.cloud.databricks.com/ai-gateway/anthropic", None
-            )
-        )
-
-    def test_wants_pins_on_anthropic_gateway_path_shape(self):
-        """A non-trusted host with the gateway path shape still qualifies.
-
-        A local test gateway is ``http://127.0.0.1:PORT/ai-gateway/anthropic`` —
-        not https, not a trusted domain — but its Claude endpoints are still
-        ``databricks-`` spelled, so its aliases need pinning.
-        """
-        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
-
-        self.assertTrue(
-            _wants_alias_model_pins("http://127.0.0.1:8123/ai-gateway/anthropic", None)
-        )
-
-    def test_wants_pins_on_databricks_launch_model(self):
-        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
-
-        self.assertTrue(
-            _wants_alias_model_pins("http://127.0.0.1:8123", "databricks-claude-fable-5")
-        )
-
-    def test_no_pins_on_neutral_gateway(self):
-        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
-
-        self.assertFalse(_wants_alias_model_pins("https://gateway.example.com/v1", "gpt-5"))
-        self.assertFalse(_wants_alias_model_pins("https://gateway.example.com/v1", None))
-
-    def test_discover_maps_families_to_env_vars(self):
-        from omnigent.inner.claude_sdk_executor import _discover_alias_model_pins
-
-        with (
-            patch(
-                "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
-                return_value="tok",
+        listing = ModelListing(
+            source="openai-compatible",
+            verified=True,
+            models=(
+                ModelEntry(id="databricks-claude-opus-4-8", family="claude"),
+                ModelEntry(id="databricks-claude-fable-5", family="claude"),
+                ModelEntry(id="databricks-gpt-5-6", family="openai"),
             ),
-            patch(
-                "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
-                return_value=SimpleNamespace(
-                    families={
-                        "opus": "databricks-claude-opus-4-8",
-                        "fable": "databricks-claude-fable-5",
-                    }
-                ),
-            ),
-        ):
-            pins = _discover_alias_model_pins(
-                "https://wkspc.cloud.databricks.com/ai-gateway/anthropic", "printf tok"
-            )
+            note="",
+        )
+        with patch("omnigent.model_catalog.listing_for_provider", return_value=listing) as lister:
+            pins = _gateway_alias_model_pins("https://gw.example.com/anthropic", "printf tok")
         self.assertEqual(
             pins,
             {
@@ -1599,38 +1554,46 @@ class TestAliasModelPins(unittest.TestCase):
                 "ANTHROPIC_DEFAULT_FABLE_MODEL": "databricks-claude-fable-5",
             },
         )
+        # The listing is fetched as a gateway transport: the base URL and the
+        # auth command the CLI itself uses, not a Databricks profile.
+        provider = lister.call_args.args[0]
+        self.assertEqual(provider.base_url, "https://gw.example.com/anthropic")
+        self.assertEqual(provider.auth_command, "printf tok")
+        self.assertIsNone(provider.profile)
 
-    def test_discover_returns_empty_without_token(self):
-        from omnigent.inner.claude_sdk_executor import _discover_alias_model_pins
+    def test_no_pins_when_the_listing_has_no_claude_models(self):
+        from omnigent.inner.claude_sdk_executor import _gateway_alias_model_pins
+        from omnigent.model_catalog import ModelListing
+
+        listing = ModelListing(source="openai-compatible", verified=True, models=(), note="")
+        with patch("omnigent.model_catalog.listing_for_provider", return_value=listing):
+            self.assertEqual(
+                _gateway_alias_model_pins("https://gw.example.com/anthropic", "printf tok"), {}
+            )
+
+    def test_no_pins_when_the_listing_fails(self):
+        """A failed listing is swallowed — unpinned aliases are the safe default."""
+        from omnigent.inner.claude_sdk_executor import _gateway_alias_model_pins
 
         with patch(
-            "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
-            return_value=None,
+            "omnigent.model_catalog.listing_for_provider",
+            side_effect=RuntimeError("listing unavailable"),
         ):
             self.assertEqual(
-                _discover_alias_model_pins("https://wkspc.cloud.databricks.com", None), {}
+                _gateway_alias_model_pins("https://gw.example.com/anthropic", "printf tok"), {}
             )
 
-    def test_discover_returns_empty_on_failure(self):
-        """Discovery failure is swallowed — an unpinned gateway is the safe default."""
-        from omnigent.inner.claude_sdk_executor import _discover_alias_model_pins
+    def test_direct_endpoint_never_lists_or_pins(self):
+        """Off the gateway transport the CLI resolves aliases itself."""
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
 
-        with (
-            patch(
-                "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
-                return_value="tok",
-            ),
-            patch(
-                "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
-                side_effect=RuntimeError("listing unavailable"),
-            ),
-        ):
-            self.assertEqual(
-                _discover_alias_model_pins(
-                    "https://wkspc.cloud.databricks.com/ai-gateway/anthropic", "printf tok"
-                ),
-                {},
-            )
+        executor = ClaudeSDKExecutor()
+        env = {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"}
+        listing = Mock()
+        with patch("omnigent.model_catalog.listing_for_provider", listing):
+            _run(executor._apply_alias_model_pins(env, None))
+        self.assertEqual(env, {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"})
+        listing.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -798,6 +798,163 @@ class TestConstructor(unittest.TestCase):
 
         _run(_t())
 
+    def test_databricks_gateway_pins_family_aliases_to_served_ids(self):
+        """A Databricks gateway turn pins every discovered family alias.
+
+        Claude Code's refusal-fallback resolves the ``opus`` alias through
+        ``ANTHROPIC_DEFAULT_OPUS_MODEL``; unpinned it lands on a bare canonical
+        id the Databricks gateway rejects (``model_not_found``). The executor
+        discovers the served families and pins each alias so the fallback
+        routes to a servable id. See ``_apply_alias_model_pins``.
+        """
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+        from omnigent.inner.databricks_executor import DatabricksCredentials
+
+        async def _t():
+            with patch(
+                "omnigent.inner.databricks_executor._read_databrickscfg",
+                return_value=DatabricksCredentials(
+                    host="https://example.cloud.databricks.com",
+                    token="dapi_test_token",
+                ),
+            ):
+                executor = ClaudeSDKExecutor(gateway=True, model="databricks-claude-fable-5")
+
+            captured: dict[str, dict[str, str]] = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["env"] = dict(options.env or {})
+                raise RuntimeError("stop after env assembly")
+
+            with (
+                patch(
+                    "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
+                    return_value="dapi_test_token",
+                ),
+                patch(
+                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+                    return_value=SimpleNamespace(
+                        families={
+                            "fable": "databricks-claude-fable-5",
+                            "opus": "databricks-claude-opus-4-8",
+                            "sonnet": "databricks-claude-sonnet-5",
+                            "haiku": "databricks-claude-haiku-4-5",
+                        }
+                    ),
+                ),
+                patch.object(
+                    executor,
+                    "_get_or_create_client",
+                    side_effect=fake_get_or_create_client,
+                ),
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            env = captured["env"]
+            self.assertEqual(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "databricks-claude-opus-4-8")
+            self.assertEqual(env["ANTHROPIC_DEFAULT_FABLE_MODEL"], "databricks-claude-fable-5")
+            self.assertEqual(env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "databricks-claude-sonnet-5")
+            self.assertEqual(env["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "databricks-claude-haiku-4-5")
+
+        _run(_t())
+
+    def test_neutral_gateway_does_not_pin_family_aliases(self):
+        """A neutral (non-Databricks) gateway is never given databricks pins.
+
+        The served ids of a neutral endpoint are unknown, so the executor must
+        not inject ``databricks-`` aliases or run served-model discovery there.
+        """
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+
+        async def _t():
+            executor = ClaudeSDKExecutor(
+                gateway=True,
+                gateway_host="https://gateway.example.com",
+                base_url_override="https://gateway.example.com/v1",
+                gateway_auth_command="printf token",
+                model="gpt-5",
+            )
+
+            captured: dict[str, dict[str, str]] = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["env"] = dict(options.env or {})
+                raise RuntimeError("stop after env assembly")
+
+            discover = Mock()
+            with (
+                patch(
+                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+                    discover,
+                ),
+                patch.object(
+                    executor,
+                    "_get_or_create_client",
+                    side_effect=fake_get_or_create_client,
+                ),
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            env = captured["env"]
+            self.assertNotIn("ANTHROPIC_DEFAULT_OPUS_MODEL", env)
+            discover.assert_not_called()
+
+        _run(_t())
+
+    def test_explicit_family_pins_are_not_overwritten(self):
+        """Pre-set ``ANTHROPIC_DEFAULT_*_MODEL`` pins win over discovery.
+
+        A ucode launch config that already pins every alias must be respected
+        verbatim; the executor neither re-derives nor runs discovery.
+        """
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+        from omnigent.inner.databricks_executor import DatabricksCredentials
+
+        async def _t():
+            with patch(
+                "omnigent.inner.databricks_executor._read_databrickscfg",
+                return_value=DatabricksCredentials(
+                    host="https://example.cloud.databricks.com",
+                    token="dapi_test_token",
+                ),
+            ):
+                executor = ClaudeSDKExecutor(gateway=True, model="databricks-claude-fable-5")
+            executor._extra_env["ANTHROPIC_DEFAULT_FABLE_MODEL"] = "pinned-fable"
+            executor._extra_env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = "pinned-opus"
+            executor._extra_env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = "pinned-sonnet"
+            executor._extra_env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = "pinned-haiku"
+
+            captured: dict[str, dict[str, str]] = {}
+
+            async def fake_get_or_create_client(sdk, *, session_key, options, model):
+                captured["env"] = dict(options.env or {})
+                raise RuntimeError("stop after env assembly")
+
+            discover = Mock()
+            with (
+                patch(
+                    "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+                    discover,
+                ),
+                patch.object(
+                    executor,
+                    "_get_or_create_client",
+                    side_effect=fake_get_or_create_client,
+                ),
+            ):
+                with self.assertRaises(RuntimeError):
+                    async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
+                        pass
+
+            self.assertEqual(captured["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"], "pinned-opus")
+            discover.assert_not_called()
+
+        _run(_t())
+
     def test_gateway_model_passes_through(self):
         """Explicit model on the gateway path passes through unchanged."""
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
@@ -1370,6 +1527,109 @@ class TestResolveGatewayEnv(unittest.TestCase):
             _resolve_gateway_env(
                 host_override="https://example.databricks.com/",
                 base_url_override="https://example.databricks.com/ai-gateway/anthropic",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Family-alias model pins (refusal-fallback routing)
+# ---------------------------------------------------------------------------
+
+
+class TestAliasModelPins(unittest.TestCase):
+    def test_wants_pins_on_trusted_databricks_gateway(self):
+        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
+
+        self.assertTrue(
+            _wants_alias_model_pins(
+                "https://wkspc.cloud.databricks.com/ai-gateway/anthropic", None
+            )
+        )
+
+    def test_wants_pins_on_anthropic_gateway_path_shape(self):
+        """A non-trusted host with the gateway path shape still qualifies.
+
+        A local test gateway is ``http://127.0.0.1:PORT/ai-gateway/anthropic`` —
+        not https, not a trusted domain — but its Claude endpoints are still
+        ``databricks-`` spelled, so its aliases need pinning.
+        """
+        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
+
+        self.assertTrue(
+            _wants_alias_model_pins("http://127.0.0.1:8123/ai-gateway/anthropic", None)
+        )
+
+    def test_wants_pins_on_databricks_launch_model(self):
+        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
+
+        self.assertTrue(
+            _wants_alias_model_pins("http://127.0.0.1:8123", "databricks-claude-fable-5")
+        )
+
+    def test_no_pins_on_neutral_gateway(self):
+        from omnigent.inner.claude_sdk_executor import _wants_alias_model_pins
+
+        self.assertFalse(_wants_alias_model_pins("https://gateway.example.com/v1", "gpt-5"))
+        self.assertFalse(_wants_alias_model_pins("https://gateway.example.com/v1", None))
+
+    def test_discover_maps_families_to_env_vars(self):
+        from omnigent.inner.claude_sdk_executor import _discover_alias_model_pins
+
+        with (
+            patch(
+                "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
+                return_value="tok",
+            ),
+            patch(
+                "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+                return_value=SimpleNamespace(
+                    families={
+                        "opus": "databricks-claude-opus-4-8",
+                        "fable": "databricks-claude-fable-5",
+                    }
+                ),
+            ),
+        ):
+            pins = _discover_alias_model_pins(
+                "https://wkspc.cloud.databricks.com/ai-gateway/anthropic", "printf tok"
+            )
+        self.assertEqual(
+            pins,
+            {
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-8",
+                "ANTHROPIC_DEFAULT_FABLE_MODEL": "databricks-claude-fable-5",
+            },
+        )
+
+    def test_discover_returns_empty_without_token(self):
+        from omnigent.inner.claude_sdk_executor import _discover_alias_model_pins
+
+        with patch(
+            "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
+            return_value=None,
+        ):
+            self.assertEqual(
+                _discover_alias_model_pins("https://wkspc.cloud.databricks.com", None), {}
+            )
+
+    def test_discover_returns_empty_on_failure(self):
+        """Discovery failure is swallowed — an unpinned gateway is the safe default."""
+        from omnigent.inner.claude_sdk_executor import _discover_alias_model_pins
+
+        with (
+            patch(
+                "omnigent.inner.claude_sdk_executor._mint_gateway_bearer",
+                return_value="tok",
+            ),
+            patch(
+                "omnigent.databricks_model_discovery.discover_databricks_claude_catalog",
+                side_effect=RuntimeError("listing unavailable"),
+            ),
+        ):
+            self.assertEqual(
+                _discover_alias_model_pins(
+                    "https://wkspc.cloud.databricks.com/ai-gateway/anthropic", "printf tok"
+                ),
+                {},
             )
 
 

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -703,6 +703,8 @@ class MockState:
         self.captured_requests: list[dict] = []
         self.request_count: int = 0
         self.pending_gates: list[QueuedResponse] = []
+        # Ids ``GET /v1/models`` reports; see ``POST /mock/served_models``.
+        self.served_models: list[str] = []
         self._lock = asyncio.Lock()
 
     def get_queue(self, key: str) -> _ResponseQueue:
@@ -846,6 +848,7 @@ class MockState:
                 del self.queues[key]
         self.captured_requests.clear()
         self.request_count = 0
+        self.served_models = []
 
 
 _state = MockState()
@@ -1102,30 +1105,28 @@ async def create_chat_completion(
 
 @app.get("/v1/models")
 async def list_models() -> dict:
-    """Return an empty model list (satisfies SDK preflight checks)."""
-    return {"object": "list", "data": []}
+    """List the models the mock gateway serves.
 
-
-# Served Claude families the mock advertises on the Databricks Anthropic-gateway
-# model listing. Lets the claude-sdk executor's served-model discovery resolve
-# family aliases to ``databricks-`` ids, so a refusal-fallback routes to a
-# servable model instead of a bare canonical id.
-SERVED_CLAUDE_MODELS: list[str] = [
-    "databricks-claude-fable-5",
-    "databricks-claude-opus-4-8",
-    "databricks-claude-sonnet-5",
-    "databricks-claude-haiku-4-5",
-]
-
-
-@app.get("/ai-gateway/anthropic/v1/models")
-async def list_gateway_models() -> dict:
-    """List the Databricks Anthropic-gateway Claude models (for discovery).
-
-    Mirrors the shape ``discover_databricks_claude_catalog`` reads so the
-    claude-sdk executor can pin ``ANTHROPIC_DEFAULT_*_MODEL`` to served ids.
+    Empty unless a test sets them via ``POST /mock/served_models`` — the
+    claude-sdk executor reads this to pin Claude Code's family aliases to the
+    ids the gateway actually serves.
     """
-    return {"object": "list", "data": [{"id": m, "object": "model"} for m in SERVED_CLAUDE_MODELS]}
+    return {"object": "list", "data": [{"id": m, "object": "model"} for m in _state.served_models]}
+
+
+@app.post("/mock/served_models")
+async def set_served_models(request: Request) -> dict[str, object]:
+    """Set the model ids ``GET /v1/models`` reports (cleared by ``/mock/reset``).
+
+    Body::
+
+        {"models": ["gw-claude-fable-5", "gw-claude-opus-4-8"]}
+    """
+    body = await request.json()
+    models = body.get("models", [])
+    async with _state._lock:
+        _state.served_models = [m for m in models if isinstance(m, str) and m]
+    return {"configured": True, "count": len(_state.served_models)}
 
 
 @app.post("/mock/configure")

--- a/tests/server/integration/mock_llm_server.py
+++ b/tests/server/integration/mock_llm_server.py
@@ -532,6 +532,69 @@ def anthropic_sse_tool_call_response(
     return "".join(events)
 
 
+def anthropic_sse_refusal_response(
+    model: str = "mock-model",
+    category: str = "cyber",
+) -> str:
+    """Build an Anthropic Messages SSE stream that ends in a safeguard refusal.
+
+    Mirrors the wire shape Claude's safeguards produce on a flagged message:
+    ``stop_reason: "refusal"`` plus ``stop_details.{type,category}`` in the
+    ``message_delta``. Claude Code reacts by arming its refusal-fallback and
+    re-issuing the turn on the family's ``ANTHROPIC_DEFAULT_*_MODEL`` pin — so
+    this is what exercises the fallback path on the claude-sdk harness.
+    """
+    msg_id = f"msg_{_uuid_mod.uuid4().hex[:12]}"
+    events: list[str] = []
+
+    def _evt(evt_type: str, data: dict) -> None:
+        events.append(f"event: {evt_type}\ndata: {json.dumps(data)}\n\n")
+
+    _evt(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": msg_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": model,
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 10, "output_tokens": 0},
+            },
+        },
+    )
+    _evt(
+        "content_block_start",
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+    )
+    _evt(
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "I can't help with that."},
+        },
+    )
+    _evt("content_block_stop", {"type": "content_block_stop", "index": 0})
+    _evt(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": "refusal",
+                "stop_sequence": None,
+                "stop_details": {"type": "refusal", "category": category},
+            },
+            "usage": {"output_tokens": 5},
+        },
+    )
+    _evt("message_stop", {"type": "message_stop"})
+    return "".join(events)
+
+
 # ── Response queue state ─────────────────────────────────
 
 
@@ -577,6 +640,10 @@ class QueuedResponse:
     # (``/v1/messages`` only), e.g. {"input_tokens": 50000} — lets a test
     # script the context size a claude harness observes mid-turn.
     usage: dict | None = None
+    # When set, ``/v1/messages`` returns a safeguard-refusal SSE stream with
+    # this category (e.g. ``"cyber"``) instead of text — used to exercise
+    # Claude Code's refusal-fallback on the claude-sdk harness.
+    refusal_category: str | None = None
     _gate: asyncio.Event = field(default_factory=asyncio.Event)
     _pending: asyncio.Event = field(default_factory=asyncio.Event)
 
@@ -902,10 +969,14 @@ async def create_message(
         _state.pending_gates.append(qr)
         await qr._gate.wait()
 
-    if qr.tool_calls:
-        sse_body = anthropic_sse_tool_call_response(qr.tool_calls)
+    req_model = parsed.get("model") if isinstance(parsed, dict) else None
+    echo_model = req_model if isinstance(req_model, str) and req_model else "mock-model"
+    if qr.refusal_category is not None:
+        sse_body = anthropic_sse_refusal_response(model=echo_model, category=qr.refusal_category)
+    elif qr.tool_calls:
+        sse_body = anthropic_sse_tool_call_response(qr.tool_calls, model=echo_model)
     else:
-        sse_body = anthropic_sse_text_response(qr.text, usage=qr.usage)
+        sse_body = anthropic_sse_text_response(qr.text, model=echo_model, usage=qr.usage)
 
     # Mid-stream fault: emit only a prefix and end, dropping message_stop.
     if qr.truncate_after is not None:
@@ -1035,6 +1106,28 @@ async def list_models() -> dict:
     return {"object": "list", "data": []}
 
 
+# Served Claude families the mock advertises on the Databricks Anthropic-gateway
+# model listing. Lets the claude-sdk executor's served-model discovery resolve
+# family aliases to ``databricks-`` ids, so a refusal-fallback routes to a
+# servable model instead of a bare canonical id.
+SERVED_CLAUDE_MODELS: list[str] = [
+    "databricks-claude-fable-5",
+    "databricks-claude-opus-4-8",
+    "databricks-claude-sonnet-5",
+    "databricks-claude-haiku-4-5",
+]
+
+
+@app.get("/ai-gateway/anthropic/v1/models")
+async def list_gateway_models() -> dict:
+    """List the Databricks Anthropic-gateway Claude models (for discovery).
+
+    Mirrors the shape ``discover_databricks_claude_catalog`` reads so the
+    claude-sdk executor can pin ``ANTHROPIC_DEFAULT_*_MODEL`` to served ids.
+    """
+    return {"object": "list", "data": [{"id": m, "object": "model"} for m in SERVED_CLAUDE_MODELS]}
+
+
 @app.post("/mock/configure")
 async def configure(request: Request) -> dict[str, object]:
     """
@@ -1078,6 +1171,7 @@ async def configure(request: Request) -> dict[str, object]:
                     delay=entry.get("delay", 0.0),
                     truncate_after=entry.get("truncate_after"),
                     usage=entry.get("usage"),
+                    refusal_category=entry.get("refusal_category"),
                 )
             )
         count = len(queue.responses)

--- a/tests/test_claude_model_vocabulary.py
+++ b/tests/test_claude_model_vocabulary.py
@@ -7,6 +7,7 @@ from omnigent.claude_model_vocabulary import (
     claude_model_command_arg,
     model_vocabulary_env,
     normalized_model_id,
+    served_alias_pins,
 )
 
 # A ucode-style launch pinning: each family alias mapped to a gateway id,
@@ -188,3 +189,25 @@ def test_bracket_marker_on_a_non_alias_is_not_an_argument() -> None:
     # A dangling bracket is not a marker; on a pinned env nothing else
     # claims it either (the bare-login segment fallback is separate).
     assert claude_model_alias("sonnet[", _PINNED_ENV) is None
+
+
+def test_served_alias_pins_pick_the_newest_served_id_per_family() -> None:
+    served = [
+        "databricks-claude-opus-4-7",
+        "databricks-claude-opus-4-8",
+        "anthropic/claude-sonnet-5",
+        "gw-claude-haiku-4-5",
+        "databricks-gpt-5-6",
+        "claude-opus-5[1m]",
+    ]
+    assert served_alias_pins(served) == {
+        # ``claude-opus-5`` outranks ``4-8``; the [1m] marker is not a
+        # different model, so the spelling the gateway listed is kept.
+        "opus": "claude-opus-5[1m]",
+        "sonnet": "anthropic/claude-sonnet-5",
+        "haiku": "gw-claude-haiku-4-5",
+    }
+
+
+def test_served_alias_pins_ignore_ids_of_no_claude_family() -> None:
+    assert served_alias_pins(["databricks-gpt-5-6", "gemini-3-pro", ""]) == {}


### PR DESCRIPTION
## Related issue

Closes #6235

## Summary

A `claude-sdk` session launched on the right model (Fable) dies on any turn whose content trips Claude Code's built-in safeguards: `inner executor error: There's an issue with the selected model (claude-opus-4-8)`, with the UI showing `<synthetic>` for the model.

- **Cause:** on a safeguard refusal, Claude Code re-issues the turn on Opus, resolving the `opus` family alias through `ANTHROPIC_DEFAULT_OPUS_MODEL`. `claude_sdk_executor` never set the `ANTHROPIC_DEFAULT_*_MODEL` pins, so the alias fell back to the **canonical** vendor id `claude-opus-4-8`. A gateway that serves Claude under its own ids (the reported case is the Databricks gateway's `databricks-claude-*`; any gateway with its own spellings behaves the same) rejects that → 404 `model_not_found`. `claude-native` already pins these; `claude-sdk` (repro-agent, Polly, Debby) did not.
- **Fix:** on any gateway transport, list the gateway's models once per session through the standard `GET /v1/models` and pin each of Claude Code's family aliases (`opus`/`sonnet`/`haiku`/`fable`) to the newest id it serves for that family. The refusal-fallback (and `/model`, `Agent`-tool spawns) then route to a model the gateway serves. No-op off the gateway, when every alias is already pinned, or when the listing has no Claude models (fail-open — unchanged behavior). No vendor-specific gating, discovery, or naming.

### How it fits

```
run_turn ──► _apply_alias_model_pins(env)          (gateway transport only, once per session)
                └─► _gateway_alias_model_pins(base_url, auth_command)
                       ├─► model_catalog.listing_for_provider(...)   GET {base_url}/v1/models, bearer from the apiKeyHelper
                       └─► claude_model_vocabulary.served_alias_pins(ids)   alias → newest served id per family
             env[ANTHROPIC_DEFAULT_<FAMILY>_MODEL] = served id   ──► claude CLI refusal-fallback re-issues on a served model
```

Reuses the catalog's existing bearer-auth lister (exposed as `model_catalog.listing_for_provider`) and the Claude alias vocabulary; `served_alias_pins` is the one new shared helper.

### ELI5

Claude has nicknames for its models (opus, sonnet, …). When a message gets flagged it retries on the "opus" nickname. On a gateway the nickname wasn't mapped to a real model there, so the retry asked for a model the gateway didn't have and the turn crashed. This asks the gateway what it serves and maps each nickname to one of those.

## Test Plan

- Unit (`tests/inner/test_claude_sdk_executor.py`): `_gateway_alias_model_pins` maps a listing's Claude ids to env pins (and passes the gateway transport, not a profile), returns nothing for a listing with no Claude models or a failed listing; a direct (non-gateway) endpoint never lists or pins. `run_turn` integration: a gateway pins all four aliases to the newest served ids, a listing without Claude models pins nothing, pre-set pins are respected without listing. Full file: 140 passed, 1 xfailed.
- Unit (`tests/test_claude_model_vocabulary.py`): `served_alias_pins` picks the newest served id per family across spellings and ignores non-Claude ids. 35 passed.
- E2E (`tests/e2e/test_claude_sdk_refusal_fallback_e2e.py`): a real `claude` CLI turn on a mock gateway that serves `gw-claude-*` ids (deliberately no vendor's spelling) and refuses the Fable turn (`cyber`); asserts the fallback re-issues on the served `gw-claude-opus-4-8` and the turn completes. Verified **red without the fix** (no served-Opus request on the wire) and **green with it**.
- Live on the real Databricks `oss` gateway: with the opus pin, the same flagged prompt swaps to `databricks-claude-opus-4-8` and completes; unpinned it 404s on the canonical id. Also confirmed that gateway serves the standard `GET {base_url}/v1/models` (12 Claude ids), which is what the fix reads.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Wire models the mock gateway observed on the e2e turn:
- **Without the fix:** `[gw-claude-fable-5, claude-haiku-4-5-…, claude-haiku-4-5-…, gw-claude-fable-5]` — the refusal never recovers on a served Opus.
- **With the fix:** `[gw-claude-haiku-4-5, gw-claude-fable-5, gw-claude-opus-4-8]` — refused on Fable, re-issued on the gateway's Opus, completed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e was checked in both directions (red without the fix, green with it), so it guards the regression rather than merely passing. The mock LLM server gained a scriptable safeguard-refusal response and a configurable `GET /v1/models` (`POST /mock/served_models`, cleared on reset) to make that hermetic.

## Changelog

claude-sdk agents on a gateway no longer fail a flagged turn with "issue with the selected model (claude-opus-4-8)"; a safeguard refusal now falls back to a model the gateway serves.

https://claude.ai/code/session_019Kpy6bg5UnR4kCkHqQGSpS
