### PR TITLE
Recover sub-agent results after runner restart via delivery receipts

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1795,8 +1795,9 @@ async def _fetch_latest_assistant_text(
 
     :param server_client: HTTP client connected to the Omnigent server.
     :param session_id: Session to read, e.g. ``"conv_child456"``.
-    :returns: Joined text blocks of the newest assistant message, or
-        ``None`` when the transcript holds no assistant text.
+    :returns: Joined text blocks of the newest assistant message (empty when
+        that message carries no text, matching live delivery), or ``None``
+        when the transcript holds no assistant message.
     :raises _SubagentRecoveryReadError: When a page read fails.
     """
     params: dict[str, str] = {"limit": "100", "order": "desc"}
@@ -1805,13 +1806,11 @@ async def _fetch_latest_assistant_text(
         for item in page.get("data", []):
             if item.get("type") != "message" or item.get("role") != "assistant":
                 continue
-            parts = [
+            return "\n".join(
                 block["text"]
                 for block in item.get("content", [])
                 if block.get("type") in {"output_text", "text"} and block.get("text")
-            ]
-            if parts:
-                return "\n".join(parts)
+            )
         if not page.get("has_more") or not page.get("last_id"):
             return None
         params["after"] = page["last_id"]

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -404,6 +404,12 @@ _SUBAGENT_DELIVERY_ALREADY_DELIVERED = "already_delivered"
 _SUBAGENT_DELIVERY_UNTRACKED = "untracked"
 _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY = "missing_work_entry"
 _SUBAGENT_DELIVERY_MISSING_PARENT_INBOX = "missing_parent_inbox"
+# Runner-owned labels on a child session that make sub-agent result delivery
+# durable across a runner restart. The dispatch id is stamped when a turn is
+# sent to the child; the delivered id is the receipt the parent's
+# ``sys_read_inbox`` drain writes once it has consumed that turn's result.
+SUBAGENT_DISPATCH_ID_LABEL_KEY = "omnigent.subagent.dispatch_id"
+SUBAGENT_DELIVERED_ID_LABEL_KEY = "omnigent.subagent.delivered_id"
 # Read budget for runner→server POSTs that can PARK behind a human-approval
 # ASK gate: policy evaluation (``_evaluate_policy_via_omnigent``) and sub-agent
 # wake-notice delivery (``_deliver_subagent_wake_post``). Both are gated at the
@@ -1512,6 +1518,11 @@ class _SubagentDeliveryAck:
 _subagent_work_by_child: dict[str, _SubagentWorkEntry] = {}
 _subagent_work_by_parent: dict[str, set[str]] = {}
 _drained_delivered_subagent_children: set[str] = set()
+# Parents whose restart-recovery scan completed in this process, plus a
+# per-parent lock so an init racing a sys_read_inbox drain cannot run two
+# scans that both pass the registry check and queue one result twice.
+_subagent_recovery_done: set[str] = set()
+_subagent_recovery_locks: dict[str, asyncio.Lock] = {}
 
 # Per-(parent, agent_type) monotonic ordinal counter for structured
 # sub-agent names (e.g. "researcher-1", "researcher-2").
@@ -1548,6 +1559,15 @@ def recover_subagent_ordinals(
     _subagent_ordinal_counters[key] = max_ordinal
 
 
+def new_subagent_work_id() -> str:
+    """
+    Mint the id of one sub-agent dispatch, e.g. ``"subagent_a1b2c3d4e5f6"``.
+
+    :returns: A fresh dispatch id.
+    """
+    return f"subagent_{uuid.uuid4().hex[:12]}"
+
+
 def register_subagent_work(
     *,
     parent_session_id: str,
@@ -1556,6 +1576,7 @@ def register_subagent_work(
     title: str,
     wrapper_label: str | None = None,
     created_by: str | None = None,
+    work_id: str | None = None,
 ) -> _SubagentWorkEntry:
     """
     Register one running sub-agent dispatch.
@@ -1573,6 +1594,8 @@ def register_subagent_work(
         label, e.g. ``"claude-code-native-ui"``.
     :param created_by: Human actor that dispatched this child turn, if
         known from the parent turn context.
+    :param work_id: Dispatch id already stamped on the child session,
+        e.g. ``"subagent_a1b2c3d4e5f6"``; ``None`` mints a new one.
     :returns: The registered work entry.
     """
     prior = _subagent_work_by_child.get(child_session_id)
@@ -1586,7 +1609,7 @@ def register_subagent_work(
     entry = _SubagentWorkEntry(
         parent_session_id=parent_session_id,
         child_session_id=child_session_id,
-        work_id=f"subagent_{uuid.uuid4().hex[:12]}",
+        work_id=work_id or new_subagent_work_id(),
         agent=agent,
         title=title,
         wrapper_label=wrapper_label,
@@ -1699,6 +1722,139 @@ def list_subagent_work(parent_session_id: str) -> list[_SubagentWorkEntry]:
         if (entry := _subagent_work_by_child.get(child_id)) is not None
     ]
     return sorted(entries, key=lambda entry: entry.created_at)
+
+
+def undelivered_subagent_dispatch_id(labels: Mapping[str, object]) -> str | None:
+    """
+    Return the dispatch id of a child turn whose result the parent never drained.
+
+    :param labels: Child session labels, e.g.
+        ``{"omnigent.subagent.dispatch_id": "subagent_a1b2c3d4e5f6"}``.
+    :returns: The dispatch id when the delivered-id receipt is missing or
+        names an earlier turn; ``None`` for a drained turn, or for a child
+        created before dispatch ids were stamped.
+    """
+    dispatch_id = labels.get(SUBAGENT_DISPATCH_ID_LABEL_KEY)
+    if not isinstance(dispatch_id, str) or not dispatch_id:
+        return None
+    if labels.get(SUBAGENT_DELIVERED_ID_LABEL_KEY) == dispatch_id:
+        return None
+    return dispatch_id
+
+
+async def _list_child_sessions(
+    server_client: httpx.AsyncClient, parent_id: str
+) -> list[_JsonObject]:
+    """
+    Return every child-session summary of a parent, following pagination.
+
+    :param server_client: HTTP client connected to the Omnigent server.
+    :param parent_id: Parent session id, e.g. ``"conv_parent123"``.
+    :returns: Child summaries as returned by the sessions API.
+    :raises httpx.HTTPError: When a page read fails.
+    """
+    children: list[_JsonObject] = []
+    params: dict[str, str] = {"limit": "1000"}
+    while True:
+        response = await server_client.get(
+            f"/v1/sessions/{parent_id}/child_sessions", params=params, timeout=10.0
+        )
+        response.raise_for_status()
+        page = response.json()
+        children.extend(page.get("data", []))
+        if not page.get("has_more") or not page.get("last_id"):
+            return children
+        params["after"] = page["last_id"]
+
+
+async def _fetch_latest_assistant_text(
+    server_client: httpx.AsyncClient, session_id: str
+) -> str | None:
+    """
+    Return the newest assistant message text of a session, reading newest first.
+
+    :param server_client: HTTP client connected to the Omnigent server.
+    :param session_id: Session to read, e.g. ``"conv_child456"``.
+    :returns: Joined text blocks of the newest assistant message, or
+        ``None`` when the transcript holds no assistant text.
+    :raises httpx.HTTPError: When a page read fails.
+    """
+    params: dict[str, str] = {"limit": "100", "order": "desc"}
+    while True:
+        response = await server_client.get(
+            f"/v1/sessions/{session_id}/items", params=params, timeout=10.0
+        )
+        response.raise_for_status()
+        page = response.json()
+        for item in page.get("data", []):
+            if item.get("type") != "message" or item.get("role") != "assistant":
+                continue
+            parts = [
+                block["text"]
+                for block in item.get("content", [])
+                if block.get("type") in {"output_text", "text"} and block.get("text")
+            ]
+            if parts:
+                return "\n".join(parts)
+        if not page.get("has_more") or not page.get("last_id"):
+            return None
+        params["after"] = page["last_id"]
+
+
+async def _recover_subagent_results_from_server(
+    *,
+    server_client: httpx.AsyncClient,
+    parent_id: str,
+    schedule_wake: Callable[[_SubagentWorkEntry], None],
+) -> None:
+    """
+    Re-queue terminal child results whose delivery receipt is missing.
+
+    A child turn is stamped with a dispatch id when it is sent, and the
+    parent's ``sys_read_inbox`` drain writes that id back as the delivered
+    id. A terminal child whose two ids differ was never drained, so its
+    result is rebuilt from the child transcript and queued again under the
+    same dispatch id, letting the eventual drain close the loop.
+
+    :param server_client: HTTP client connected to the Omnigent server.
+    :param parent_id: Parent session whose inbox was recreated, e.g.
+        ``"conv_parent123"``.
+    :param schedule_wake: Callback that posts the parent wake notice.
+    :raises httpx.HTTPError: When a server read fails; the caller retries.
+    """
+    for child in await _list_child_sessions(server_client, parent_id):
+        child_id = child.get("id")
+        status = child.get("current_task_status")
+        if not isinstance(child_id, str) or not isinstance(status, str):
+            continue
+        if status not in _SUBAGENT_TERMINAL_STATUSES:
+            continue
+        if (
+            get_subagent_work(child_id) is not None
+            or child_id in _drained_delivered_subagent_children
+        ):
+            continue
+        labels = child.get("labels")
+        dispatch_id = undelivered_subagent_dispatch_id(labels if isinstance(labels, dict) else {})
+        if dispatch_id is None:
+            continue
+        output: str | None = None
+        if status == "failed":
+            error = child.get("last_task_error")
+            message = error.get("message") if isinstance(error, dict) else None
+            output = message if isinstance(message, str) else None
+        else:
+            output = await _fetch_latest_assistant_text(server_client, child_id)
+        entry = register_subagent_work(
+            parent_session_id=parent_id,
+            child_session_id=child_id,
+            agent=str(child.get("tool") or child.get("agent_name") or "sub-agent"),
+            title=str(child.get("session_name") or ""),
+            work_id=dispatch_id,
+        )
+        ack = mark_subagent_work_terminal(child_id, status=status, output=output)
+        if ack.delivered_now:
+            schedule_wake(entry)
 
 
 def mark_subagent_work_terminal(
@@ -3420,6 +3576,9 @@ def create_runner_app(
             _session_event_queues[session_id] = asyncio.Queue()
         if session_id not in _session_inboxes:
             _session_inboxes[session_id] = asyncio.Queue()
+        # A fresh queue can mean a fresh runner process rather than a fresh
+        # session: re-queue results the previous process never drained.
+        await _recover_undrained_subagent_results(session_id)
         if session_id not in _session_async_tasks:
             _session_async_tasks[session_id] = {}
         raw_sub_agent_name = body.get("sub_agent_name")
@@ -4017,6 +4176,8 @@ def create_runner_app(
         _last_server_item_id.pop(session_id, None)
         _session_event_queues.pop(session_id, None)
         _session_inboxes.pop(session_id, None)
+        _subagent_recovery_done.discard(session_id)
+        _subagent_recovery_locks.pop(session_id, None)
         _subagent_wake_pending.discard(session_id)
         _stranded_wake_parents.discard(session_id)
         _last_rewake_notice.pop(session_id, None)
@@ -4487,6 +4648,43 @@ def create_runner_app(
             agent=agent,
             title=snapshot.sub_agent_name or "",
         )
+
+    async def _recover_undrained_subagent_results(parent_id: str) -> None:
+        """
+        Re-queue terminal child results lost with a runner process restart.
+
+        The parent inbox is a process-local queue, so a result queued before
+        a restart but not yet drained would otherwise vanish. Runs once per
+        parent per process; a scan that fails on a server read is retried
+        before the next ``sys_read_inbox`` drain.
+
+        :param parent_id: Parent session whose inbox was recreated, e.g.
+            ``"conv_parent123"``.
+        :returns: None.
+        """
+        if parent_id in _subagent_recovery_done or parent_id not in _session_inboxes:
+            return
+        lock = _subagent_recovery_locks.setdefault(parent_id, asyncio.Lock())
+        async with lock:
+            if parent_id in _subagent_recovery_done:
+                return
+            try:
+                await _recover_subagent_results_from_server(
+                    server_client=server_client,
+                    parent_id=parent_id,
+                    schedule_wake=_schedule_subagent_wake,
+                )
+            except (httpx.HTTPError, ValueError):
+                _logger.warning(
+                    "Failed to recover undrained sub-agent results for %s",
+                    parent_id,
+                    exc_info=True,
+                    extra={"session_id": parent_id},
+                )
+                return
+            _subagent_recovery_done.add(parent_id)
+
+    app.state.recover_undrained_subagent_results = _recover_undrained_subagent_results
 
     def _note_session_harness_override(conv_id: str, harness_override: str | None) -> None:
         """Record the harness a session was forwarded, so reads match the run.
@@ -10382,6 +10580,11 @@ def create_runner_app(
                     status_code=200,
                     content={"error": {"code": -32000, "message": "Missing tool name"}},
                 )
+
+            if tool_name == "sys_read_inbox":
+                # A scan that failed at initialization must not leave the
+                # drain reporting an empty inbox; this is a no-op once done.
+                await _recover_undrained_subagent_results(session_id)
 
             if "__" in tool_name:
                 if mcp_manager is None:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -4672,14 +4672,18 @@ def create_runner_app(
         The parent inbox is a process-local queue, so a result queued before
         a restart but not yet drained would otherwise vanish. Runs once per
         parent per process; a scan that fails on a server read is retried
-        before the next ``sys_read_inbox`` drain.
+        before the next ``sys_read_inbox`` drain. The inbox is created here
+        when missing: after a reconnect the server can dispatch a pending
+        message before it re-initializes the session, and that turn's drain
+        must still see the recovered results.
 
         :param parent_id: Parent session whose inbox was recreated, e.g.
             ``"conv_parent123"``.
         :returns: None.
         """
-        if parent_id in _subagent_recovery_done or parent_id not in _session_inboxes:
+        if parent_id in _subagent_recovery_done:
             return
+        _session_inboxes.setdefault(parent_id, asyncio.Queue())
         lock = _subagent_recovery_locks.setdefault(parent_id, asyncio.Lock())
         async with lock:
             if parent_id in _subagent_recovery_done:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -1742,6 +1742,28 @@ def undelivered_subagent_dispatch_id(labels: Mapping[str, object]) -> str | None
     return dispatch_id
 
 
+class _SubagentRecoveryReadError(Exception):
+    """A sessions API read needed by restart recovery returned a non-200."""
+
+
+async def _get_recovery_page(
+    server_client: httpx.AsyncClient, path: str, params: dict[str, str]
+) -> Any:
+    """
+    Read one page of a sessions API listing for restart recovery.
+
+    :param server_client: HTTP client connected to the Omnigent server.
+    :param path: Sessions API path, e.g. ``"/v1/sessions/conv_p/child_sessions"``.
+    :param params: Query parameters, e.g. ``{"limit": "1000"}``.
+    :returns: The decoded JSON page.
+    :raises _SubagentRecoveryReadError: When the server returns a non-200.
+    """
+    response = await server_client.get(path, params=params, timeout=10.0)
+    if response.status_code != 200:
+        raise _SubagentRecoveryReadError(f"{path} returned {response.status_code}")
+    return response.json()
+
+
 async def _list_child_sessions(
     server_client: httpx.AsyncClient, parent_id: str
 ) -> list[_JsonObject]:
@@ -1751,16 +1773,14 @@ async def _list_child_sessions(
     :param server_client: HTTP client connected to the Omnigent server.
     :param parent_id: Parent session id, e.g. ``"conv_parent123"``.
     :returns: Child summaries as returned by the sessions API.
-    :raises httpx.HTTPError: When a page read fails.
+    :raises _SubagentRecoveryReadError: When a page read fails.
     """
     children: list[_JsonObject] = []
     params: dict[str, str] = {"limit": "1000"}
     while True:
-        response = await server_client.get(
-            f"/v1/sessions/{parent_id}/child_sessions", params=params, timeout=10.0
+        page = await _get_recovery_page(
+            server_client, f"/v1/sessions/{parent_id}/child_sessions", params
         )
-        response.raise_for_status()
-        page = response.json()
         children.extend(page.get("data", []))
         if not page.get("has_more") or not page.get("last_id"):
             return children
@@ -1777,15 +1797,11 @@ async def _fetch_latest_assistant_text(
     :param session_id: Session to read, e.g. ``"conv_child456"``.
     :returns: Joined text blocks of the newest assistant message, or
         ``None`` when the transcript holds no assistant text.
-    :raises httpx.HTTPError: When a page read fails.
+    :raises _SubagentRecoveryReadError: When a page read fails.
     """
     params: dict[str, str] = {"limit": "100", "order": "desc"}
     while True:
-        response = await server_client.get(
-            f"/v1/sessions/{session_id}/items", params=params, timeout=10.0
-        )
-        response.raise_for_status()
-        page = response.json()
+        page = await _get_recovery_page(server_client, f"/v1/sessions/{session_id}/items", params)
         for item in page.get("data", []):
             if item.get("type") != "message" or item.get("role") != "assistant":
                 continue
@@ -1820,7 +1836,8 @@ async def _recover_subagent_results_from_server(
     :param parent_id: Parent session whose inbox was recreated, e.g.
         ``"conv_parent123"``.
     :param schedule_wake: Callback that posts the parent wake notice.
-    :raises httpx.HTTPError: When a server read fails; the caller retries.
+    :raises _SubagentRecoveryReadError: When a server read returns a
+        non-200; the caller retries on the next drain.
     """
     for child in await _list_child_sessions(server_client, parent_id):
         child_id = child.get("id")
@@ -4674,7 +4691,7 @@ def create_runner_app(
                     parent_id=parent_id,
                     schedule_wake=_schedule_subagent_wake,
                 )
-            except (httpx.HTTPError, ValueError):
+            except (httpx.HTTPError, _SubagentRecoveryReadError, ValueError):
                 _logger.warning(
                     "Failed to recover undrained sub-agent results for %s",
                     parent_id,

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1360,6 +1360,39 @@ async def _session_turn_actor(
     return actor if isinstance(actor, str) and actor else None
 
 
+async def _stamp_subagent_dispatch(
+    server_client: httpx.AsyncClient, child_session_id: str, work_id: str
+) -> str | None:
+    """
+    Record a continued child turn's dispatch id on the child session.
+
+    A new child carries the id in its create body; a continued child keeps
+    its session, so the new turn's id is written before the message is
+    posted. The parent's ``sys_read_inbox`` drain writes the matching
+    delivered-id receipt, which is how a runner restart tells a drained
+    turn from a lost one. Failing here aborts the send: a missing stamp
+    would let the previous turn's receipt mask this turn's result.
+
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :param child_session_id: Child session id, e.g. ``"conv_abc123"``.
+    :param work_id: Dispatch id, e.g. ``"subagent_a1b2c3d4e5f6"``.
+    :returns: A parent-visible error string, or ``None`` on success.
+    """
+    from omnigent.runner import app as _runner_app
+
+    try:
+        resp = await server_client.patch(
+            f"/v1/sessions/{child_session_id}",
+            json={"labels": {_runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY: work_id}},
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:
+        return f"Error: failed to record sub-agent dispatch: {type(exc).__name__}: {exc}"
+    if resp.status_code >= 400:
+        return f"Error: failed to record sub-agent dispatch: {resp.status_code} {resp.text[:200]}"
+    return None
+
+
 async def _post_child_message_event(
     server_client: httpx.AsyncClient,
     session_id: str,
@@ -2174,6 +2207,7 @@ async def _execute_subagent_tool(
     assert not isinstance(existing, str)
     created_child = False
     child_wrapper_label: str | None = None
+    work_id = _runner_app.new_subagent_work_id()
     if existing is not None:
         child_session_id = existing.get("id")
         if not isinstance(child_session_id, str) or not child_session_id:
@@ -2337,6 +2371,7 @@ async def _execute_subagent_tool(
             "parent_session_id": conversation_id,
             "title": f"{sub_agent_name}:{session_name}",
             "sub_agent_name": sub_agent_name,
+            "labels": {_runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY: work_id},
         }
         if harness_override_canonical is not None:
             create_body["harness_override"] = harness_override_canonical
@@ -2565,7 +2600,13 @@ async def _execute_subagent_tool(
         title=session_name,
         wrapper_label=child_wrapper_label,
         created_by=dispatch_created_by,
+        work_id=work_id,
     )
+    if not created_child:
+        stamp_error = await _stamp_subagent_dispatch(server_client, child_session_id, work_id)
+        if stamp_error is not None:
+            await _teardown_failed_child(server_client, child_session_id, created_child=False)
+            return stamp_error
     _publish_child_launching_update(
         parent_session_id=conversation_id,
         child_session_id=child_session_id,
@@ -2736,7 +2777,7 @@ async def _send_to_existing_session(
         tool=agent_label,
         session_name=parsed.title or "",
     )
-    _runner_app.register_subagent_work(
+    entry = _runner_app.register_subagent_work(
         parent_session_id=conversation_id,
         child_session_id=target_session_id,
         agent=agent_label,
@@ -2744,6 +2785,11 @@ async def _send_to_existing_session(
         wrapper_label=_session_wrapper_label(snap_data),
         created_by=created_by,
     )
+    stamp_error = await _stamp_subagent_dispatch(server_client, target_session_id, entry.work_id)
+    if stamp_error is not None:
+        _runner_app.unregister_child_session(target_session_id)
+        _runner_app.unregister_subagent_work(target_session_id)
+        return stamp_error
     _publish_child_launching_update(
         parent_session_id=conversation_id,
         child_session_id=target_session_id,
@@ -7389,11 +7435,20 @@ async def _evaluate_subagent_inbox_output(
     return _apply_subagent_policy_verdict(payload, verdict)
 
 
-def _cleanup_drained_subagent_work(payload: _JsonObject) -> None:
+async def _cleanup_drained_subagent_work(
+    payload: _JsonObject, *, server_client: httpx.AsyncClient | None
+) -> None:
     """
     Remove terminal sub-agent work after its inbox item is drained.
 
+    Also writes the delivered-id receipt on the child session so a runner
+    restart does not re-queue this turn's result. The write is best effort:
+    a lost receipt costs one duplicate delivery after a restart, whereas a
+    lost result would never reach the parent.
+
     :param payload: Drained inbox payload.
+    :param server_client: HTTP client pointed at the Omnigent server, or
+        ``None`` when the drain runs without server access.
     :returns: None.
     """
     if payload.get("type") != "sub_agent":
@@ -7413,6 +7468,27 @@ def _cleanup_drained_subagent_work(payload: _JsonObject) -> None:
         work_id=work_id,
         remember_drained_delivery=True,
     )
+    if server_client is None:
+        return
+    try:
+        resp = await server_client.patch(
+            f"/v1/sessions/{child_id}",
+            json={"labels": {_runner_app.SUBAGENT_DELIVERED_ID_LABEL_KEY: work_id}},
+            timeout=30.0,
+        )
+    except httpx.HTTPError:
+        _logger.warning(
+            "Failed to record sub-agent delivery receipt for child=%s",
+            child_id,
+            exc_info=True,
+        )
+        return
+    if resp.status_code >= 400:
+        _logger.warning(
+            "Sub-agent delivery receipt for child=%s returned %d",
+            child_id,
+            resp.status_code,
+        )
 
 
 async def _drain_inbox(
@@ -7463,7 +7539,7 @@ async def _drain_inbox(
         if evaluation.retry_original:
             retry_payloads.append(payload)
         else:
-            _cleanup_drained_subagent_work(evaluation.payload)
+            await _cleanup_drained_subagent_work(evaluation.payload, server_client=server_client)
     for payload in retry_payloads:
         inbox.put_nowait(payload)
     return "\n\n".join(items) if items else "Inbox is empty — no completed tasks."

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1360,37 +1360,58 @@ async def _session_turn_actor(
     return actor if isinstance(actor, str) and actor else None
 
 
-async def _stamp_subagent_dispatch(
-    server_client: httpx.AsyncClient, child_session_id: str, work_id: str
+async def _patch_subagent_label(
+    server_client: httpx.AsyncClient, child_session_id: str, key: str, value: str
 ) -> str | None:
     """
-    Record a continued child turn's dispatch id on the child session.
+    Write one runner-owned sub-agent label on a child session.
 
-    A new child carries the id in its create body; a continued child keeps
-    its session, so the new turn's id is written before the message is
-    posted. The parent's ``sys_read_inbox`` drain writes the matching
-    delivered-id receipt, which is how a runner restart tells a drained
-    turn from a lost one. Failing here aborts the send: a missing stamp
-    would let the previous turn's receipt mask this turn's result.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :param child_session_id: Child session id, e.g. ``"conv_abc123"``.
+    :param key: Label key, e.g. ``"omnigent.subagent.dispatch_id"``.
+    :param value: Label value, e.g. ``"subagent_a1b2c3d4e5f6"``.
+    :returns: A short failure description, or ``None`` on success.
+    """
+    try:
+        resp = await server_client.patch(
+            f"/v1/sessions/{child_session_id}",
+            json={"labels": {key: value}},
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:
+        return f"{type(exc).__name__}: {exc}"
+    if resp.status_code >= 400:
+        return f"{resp.status_code} {resp.text[:200]}"
+    return None
+
+
+async def _record_subagent_receipt(
+    server_client: httpx.AsyncClient, child_session_id: str, work_id: str
+) -> None:
+    """
+    Mark a dispatch id as one that will never be delivered as a new result.
+
+    Written when the parent drains the turn's result, and when a continued
+    turn was stamped but its send failed. Best effort: a lost receipt costs
+    one duplicate delivery after a runner restart, whereas a lost result
+    would never reach the parent.
 
     :param server_client: HTTP client pointed at the Omnigent server.
     :param child_session_id: Child session id, e.g. ``"conv_abc123"``.
     :param work_id: Dispatch id, e.g. ``"subagent_a1b2c3d4e5f6"``.
-    :returns: A parent-visible error string, or ``None`` on success.
+    :returns: None.
     """
     from omnigent.runner import app as _runner_app
 
-    try:
-        resp = await server_client.patch(
-            f"/v1/sessions/{child_session_id}",
-            json={"labels": {_runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY: work_id}},
-            timeout=30.0,
+    error = await _patch_subagent_label(
+        server_client, child_session_id, _runner_app.SUBAGENT_DELIVERED_ID_LABEL_KEY, work_id
+    )
+    if error is not None:
+        _logger.warning(
+            "Failed to record sub-agent delivery receipt for child=%s: %s",
+            child_session_id,
+            error,
         )
-    except httpx.HTTPError as exc:
-        return f"Error: failed to record sub-agent dispatch: {type(exc).__name__}: {exc}"
-    if resp.status_code >= 400:
-        return f"Error: failed to record sub-agent dispatch: {resp.status_code} {resp.text[:200]}"
-    return None
 
 
 async def _post_child_message_event(
@@ -1627,17 +1648,23 @@ async def _teardown_failed_child(
     also reclaims any files copied into it before the failure — leaving an
     empty child behind would poison a retry with the same ``(agent, title)``
     (the next send would attach to the phantom instead of spawning clean)
-    and orphan the copied file rows. Used on both the copy/content failure
-    and the message-post failure paths so they tear down identically.
+    and orphan the copied file rows. A continued child keeps its session,
+    so its already-stamped dispatch id gets a delivery receipt instead;
+    otherwise a runner restart would replay the previous turn's result as
+    this turn's. Used on both the copy/content failure and the
+    message-post failure paths so they tear down identically.
 
     :returns: ``None`` when no server cleanup was needed or cleanup
         succeeded, otherwise a parent-visible warning string.
     """
     from omnigent.runner import app as _runner_app
 
+    entry = _runner_app.get_subagent_work(child_session_id)
     _runner_app.unregister_child_session(child_session_id)
     _runner_app.unregister_subagent_work(child_session_id)
     if not created_child:
+        if entry is not None:
+            await _record_subagent_receipt(server_client, child_session_id, entry.work_id)
         return None
 
     last_error = ""
@@ -2586,6 +2613,15 @@ async def _execute_subagent_tool(
     # title/tool/session_name are known here (we set the title above), so
     # even a cold status update carries a display name. Cleaned up when
     # the child session ends.
+    if not created_child:
+        # A new child carries this turn's id in its create body; a continued
+        # child keeps its session, so the id is written first. A missing
+        # stamp would let the previous turn's receipt mask this turn's result.
+        stamp_error = await _patch_subagent_label(
+            server_client, child_session_id, _runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY, work_id
+        )
+        if stamp_error is not None:
+            return f"Error: failed to record sub-agent dispatch: {stamp_error}"
     _runner_app.register_child_session(
         child_session_id,
         parent_session_id=conversation_id,
@@ -2602,11 +2638,6 @@ async def _execute_subagent_tool(
         created_by=dispatch_created_by,
         work_id=work_id,
     )
-    if not created_child:
-        stamp_error = await _stamp_subagent_dispatch(server_client, child_session_id, work_id)
-        if stamp_error is not None:
-            await _teardown_failed_child(server_client, child_session_id, created_child=False)
-            return stamp_error
     _publish_child_launching_update(
         parent_session_id=conversation_id,
         child_session_id=child_session_id,
@@ -2770,6 +2801,12 @@ async def _send_to_existing_session(
             f"Error: session {target_session_id!r} is already running; "
             "wait for completion before sending again"
         )
+    work_id = _runner_app.new_subagent_work_id()
+    stamp_error = await _patch_subagent_label(
+        server_client, target_session_id, _runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY, work_id
+    )
+    if stamp_error is not None:
+        return f"Error: failed to record sub-agent dispatch: {stamp_error}"
     _runner_app.register_child_session(
         target_session_id,
         parent_session_id=conversation_id,
@@ -2777,19 +2814,15 @@ async def _send_to_existing_session(
         tool=agent_label,
         session_name=parsed.title or "",
     )
-    entry = _runner_app.register_subagent_work(
+    _runner_app.register_subagent_work(
         parent_session_id=conversation_id,
         child_session_id=target_session_id,
         agent=agent_label,
         title=parsed.title or "",
         wrapper_label=_session_wrapper_label(snap_data),
         created_by=created_by,
+        work_id=work_id,
     )
-    stamp_error = await _stamp_subagent_dispatch(server_client, target_session_id, entry.work_id)
-    if stamp_error is not None:
-        _runner_app.unregister_child_session(target_session_id)
-        _runner_app.unregister_subagent_work(target_session_id)
-        return stamp_error
     _publish_child_launching_update(
         parent_session_id=conversation_id,
         child_session_id=target_session_id,
@@ -2807,12 +2840,10 @@ async def _send_to_existing_session(
             created_by=created_by,
         )
     except httpx.HTTPError as exc:
-        _runner_app.unregister_child_session(target_session_id)
-        _runner_app.unregister_subagent_work(target_session_id)
+        await _teardown_failed_child(server_client, target_session_id, created_child=False)
         return f"Error: failed to send message to child: {type(exc).__name__}: {exc}"
     if msg_resp.status_code >= 400:
-        _runner_app.unregister_child_session(target_session_id)
-        _runner_app.unregister_subagent_work(target_session_id)
+        await _teardown_failed_child(server_client, target_session_id, created_child=False)
         return (
             f"Error: failed to send message to child: {msg_resp.status_code} {msg_resp.text[:200]}"
         )
@@ -7468,27 +7499,8 @@ async def _cleanup_drained_subagent_work(
         work_id=work_id,
         remember_drained_delivery=True,
     )
-    if server_client is None:
-        return
-    try:
-        resp = await server_client.patch(
-            f"/v1/sessions/{child_id}",
-            json={"labels": {_runner_app.SUBAGENT_DELIVERED_ID_LABEL_KEY: work_id}},
-            timeout=30.0,
-        )
-    except httpx.HTTPError:
-        _logger.warning(
-            "Failed to record sub-agent delivery receipt for child=%s",
-            child_id,
-            exc_info=True,
-        )
-        return
-    if resp.status_code >= 400:
-        _logger.warning(
-            "Sub-agent delivery receipt for child=%s returned %d",
-            child_id,
-            resp.status_code,
-        )
+    if server_client is not None:
+        await _record_subagent_receipt(server_client, child_id, work_id)
 
 
 async def _drain_inbox(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -33,9 +33,9 @@ import subprocess
 import sys
 import tarfile
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import Any
+from typing import IO, Any, cast
 
 import httpx
 import pytest
@@ -541,7 +541,7 @@ def openai_judge_api_key(
     )
 
 
-_live_runner_state: dict[str, str] = {}
+_live_runner_state: dict[str, Any] = {}
 
 
 @pytest.fixture(scope="session")
@@ -762,6 +762,13 @@ def live_server(
         stdout=runner_log_handle,
         stderr=subprocess.STDOUT,
     )
+    # Keep the mutable process handle visible to restart E2E tests. The server
+    # fixture still owns final cleanup, including whichever generation is live.
+    _live_runner_state["process"] = runner_proc
+    _live_runner_state["args"] = [runner_executable(), "-m", "omnigent.runner._entry"]
+    _live_runner_state["env"] = runner_env
+    _live_runner_state["cwd"] = compat_runner_cwd()
+    _live_runner_state["log_handle"] = runner_log_handle
 
     health_iters = int(HEALTH_TIMEOUT_S / POLL_INTERVAL_S)
     for _ in range(health_iters):
@@ -809,6 +816,7 @@ def live_server(
     try:
         yield base_url
     finally:
+        runner_proc = _live_runner_state.get("process", runner_proc)
         if runner_proc.poll() is None:
             runner_proc.send_signal(signal.SIGTERM)
             try:
@@ -824,6 +832,71 @@ def live_server(
             proc.kill()
             proc.wait(timeout=5)
         log_handle.close()
+
+
+@pytest.fixture
+def restart_live_runner(live_server: str, live_runner_id: str) -> Callable[[], None]:
+    """
+    Return a callback that kills and replaces the live runner subprocess.
+
+    The replacement uses the same runner id, tunnel binding, environment, and
+    server. This models a process crash/restart without resetting durable server
+    state, which is the lifecycle boundary restart recovery must survive.
+
+    :param live_server: Base URL of the live server kept across the restart.
+    :param live_runner_id: Stable runner identity reused by the replacement.
+    :returns: Callback that completes after the replacement tunnel is online.
+    """
+
+    def restart() -> None:
+        old_proc = cast(subprocess.Popen[bytes], _live_runner_state["process"])
+        old_proc.kill()
+        old_proc.wait(timeout=10)
+
+        # Do not mistake the dead tunnel's briefly stale registry entry for the
+        # replacement connection; observe the disconnect before starting it.
+        disconnect_deadline = time.monotonic() + HEALTH_TIMEOUT_S
+        while time.monotonic() < disconnect_deadline:
+            response = httpx.get(
+                f"{live_server}/v1/runners/{live_runner_id}/status",
+                timeout=2,
+            )
+            if response.status_code == 200 and response.json().get("online") is False:
+                break
+            time.sleep(POLL_INTERVAL_S)
+        else:
+            raise AssertionError("killed runner tunnel remained online before restart")
+
+        replacement = subprocess.Popen(
+            cast(list[str], _live_runner_state["args"]),
+            env=cast(dict[str, str], _live_runner_state["env"]),
+            cwd=cast(str | None, _live_runner_state["cwd"]),
+            stdout=cast(IO[bytes], _live_runner_state["log_handle"]),
+            stderr=subprocess.STDOUT,
+        )
+        _live_runner_state["process"] = replacement
+
+        deadline = time.monotonic() + HEALTH_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if replacement.poll() is not None:
+                raise AssertionError(
+                    f"replacement runner exited early with code {replacement.returncode}"
+                )
+            try:
+                response = httpx.get(
+                    f"{live_server}/v1/runners/{live_runner_id}/status",
+                    timeout=2,
+                )
+                if response.status_code == 200 and response.json().get("online") is True:
+                    return
+            except httpx.HTTPError:
+                # The server may briefly refuse connections while the tunnel
+                # re-registers; keep polling until the deadline.
+                pass
+            time.sleep(POLL_INTERVAL_S)
+        raise AssertionError("replacement runner did not reconnect before timeout")
+
+    return restart
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_subagent_restart_recovery_e2e.py
+++ b/tests/e2e/test_subagent_restart_recovery_e2e.py
@@ -1,0 +1,200 @@
+"""End-to-end coverage for sub-agent inbox recovery after runner restart.
+
+This test uses the real server and runner subprocesses with the mock LLM. It
+kills the runner after a child result reaches the process-local inbox, starts a
+fresh runner against the unchanged server database, and drains the result from
+the parent through ``sys_read_inbox``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import POLL_INTERVAL_S
+
+_CHILD_RESULT = "DURABLE_RESTART_RESULT"
+_WAKE_WITHOUT_DRAIN = "WAKE_COMPLETED_WITHOUT_INBOX_DRAIN"
+
+pytestmark = [
+    pytest.mark.timeout(600, method="signal"),
+    pytest.mark.min_server_version("0.3.0"),
+]
+
+
+def _tool_call(name: str, arguments: dict[str, str], call_id: str) -> dict[str, object]:
+    """Build one mock Responses API tool-call entry.
+
+    :param name: Tool name, e.g. ``"sys_read_inbox"``.
+    :param arguments: JSON-serializable tool arguments.
+    :param call_id: Stable mock call id.
+    :returns: Mock LLM tool-call response entry.
+    """
+    return {"call_id": call_id, "name": name, "arguments": json.dumps(arguments)}
+
+
+def _session_items(client: httpx.Client, session_id: str) -> list[dict[str, object]]:
+    """Return all durable items for a session in chronological order.
+
+    :param client: HTTP client connected to the live server.
+    :param session_id: Session id to query.
+    :returns: Durable session item dictionaries.
+    """
+    response = client.get(
+        f"/v1/sessions/{session_id}/items",
+        params={"limit": 1000, "order": "asc"},
+    )
+    response.raise_for_status()
+    return response.json()["data"]
+
+
+def _wait_for_text(client: httpx.Client, session_id: str, text: str, timeout: float) -> None:
+    """Wait until text is durably visible in a session transcript.
+
+    :param client: HTTP client connected to the live server.
+    :param session_id: Session id to query.
+    :param text: Exact marker expected anywhere in the serialized items.
+    :param timeout: Maximum seconds to wait.
+    :raises AssertionError: If the marker does not appear before timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if text in json.dumps(_session_items(client, session_id)):
+            return
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"{text!r} did not appear in session {session_id}")
+
+
+def test_subagent_inbox_survives_real_runner_process_restart(
+    http_client: httpx.Client,
+    live_runner_id: str,
+    mock_llm_server_url: str,
+    restart_live_runner: Callable[[], None],
+) -> None:
+    """A fresh runner reconstructs an undrained terminal child result.
+
+    The first runner dispatches a child and receives its completion wake, but
+    the parent deliberately does not call ``sys_read_inbox``. The test then
+    kills that process. On the next user turn, the replacement runner must boot
+    the parent session, recover the child output from server state, and return
+    it through the real inbox tool.
+
+    :param http_client: Client connected to the real server subprocess.
+    :param live_runner_id: Stable id shared by both runner generations.
+    :param mock_llm_server_url: Mock Responses API base URL.
+    :param restart_live_runner: Callback that kills and replaces the runner.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    parent_model = f"restart-parent-{suffix}"
+    child_model = f"restart-child-{suffix}"
+    mock_base_url = f"{mock_llm_server_url}/v1"
+    parent_name = register_inline_agent(
+        http_client,
+        name=f"restart-parent-{suffix}",
+        harness="openai-agents",
+        model=parent_model,
+        profile="",
+        prompt="Dispatch the researcher and use sys_read_inbox when explicitly asked.",
+        mock_llm_base_url=mock_base_url,
+        extra_config={
+            "tools": {
+                "researcher": {
+                    "type": "agent",
+                    "description": "Returns a fixed restart recovery marker.",
+                    "executor": {
+                        "harness": "openai-agents",
+                        "model": child_model,
+                        "auth": {
+                            "type": "api_key",
+                            "api_key": "mock-key",
+                            "base_url": mock_base_url,
+                        },
+                    },
+                    "prompt": f"Return {_CHILD_RESULT} verbatim.",
+                }
+            }
+        },
+    )
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "sys_session_send",
+                        {"agent": "researcher", "title": "restart", "args": "run"},
+                        "dispatch-call",
+                    )
+                ]
+            },
+            {"text": "Child dispatched."},
+            # Auto-wake proves runner one received completion, but deliberately
+            # leaves its process-local inbox undrained before the crash.
+            {"text": _WAKE_WITHOUT_DRAIN},
+            {"tool_calls": [_tool_call("sys_read_inbox", {}, "inbox-call")]},
+            {"text": "Recovered the child result after restart."},
+        ],
+        key=parent_model,
+    )
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": _CHILD_RESULT}],
+        key=child_model,
+    )
+
+    parent_id = create_runner_bound_session(
+        http_client,
+        agent_name=parent_name,
+        runner_id=live_runner_id,
+    )
+    dispatch_id = send_user_message_to_session(
+        http_client,
+        session_id=parent_id,
+        content="Dispatch the researcher.",
+    )
+    poll_session_until_terminal(
+        http_client,
+        session_id=parent_id,
+        response_id=dispatch_id,
+        timeout=180,
+    )
+    _wait_for_text(http_client, parent_id, _WAKE_WITHOUT_DRAIN, timeout=240)
+
+    restart_live_runner()
+
+    send_user_message_to_session(
+        http_client,
+        session_id=parent_id,
+        content="Read the inbox now.",
+    )
+    # Session status can still reflect the preceding idle turn briefly after
+    # enqueue, so wait for the durable recovered payload rather than sampling it.
+    _wait_for_text(http_client, parent_id, _CHILD_RESULT, timeout=180)
+
+    items = _session_items(http_client, parent_id)
+    calls = {
+        item.get("call_id")
+        for item in items
+        if item.get("type") == "function_call" and item.get("name") == "sys_read_inbox"
+    }
+    inbox_outputs = [
+        item.get("output")
+        for item in items
+        if item.get("type") == "function_call_output" and item.get("call_id") in calls
+    ]
+    assert _CHILD_RESULT in json.dumps(inbox_outputs), json.dumps(items, indent=2)

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -2071,7 +2071,23 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
                 return type(
                     "Response",
                     (),
-                    {"status_code": 200, "json": lambda self: {"data": []}},
+                    {
+                        "status_code": 200,
+                        "json": lambda self: {"data": []},
+                        "raise_for_status": lambda self: None,
+                    },
+                )()
+            if path.endswith("/child_sessions"):
+                # Restart recovery lists the session's children; an empty
+                # list ends the scan after this single read.
+                return type(
+                    "Response",
+                    (),
+                    {
+                        "status_code": 200,
+                        "json": lambda self: {"data": [], "has_more": False},
+                        "raise_for_status": lambda self: None,
+                    },
                 )()
             raise AssertionError(f"unexpected metadata callback: {path}")
 
@@ -2130,7 +2146,13 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
     assert first_response.json()["session_init_protocol_version"] == 2
     assert resolver_calls == 1
     assert len(pm.get_client_calls) == 1
-    assert server_client.get_paths == [f"/v1/sessions/{session_id}/items"]
+    # The envelope supplies session metadata, so the only snapshot-style
+    # callback is the history read; restart recovery adds one read of the
+    # durable child-session list, which is empty here.
+    assert server_client.get_paths == [
+        f"/v1/sessions/{session_id}/child_sessions",
+        f"/v1/sessions/{session_id}/items",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_workflow_init.py
+++ b/tests/runner/test_app_sessions_native_workflow_init.py
@@ -2071,11 +2071,7 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
                 return type(
                     "Response",
                     (),
-                    {
-                        "status_code": 200,
-                        "json": lambda self: {"data": []},
-                        "raise_for_status": lambda self: None,
-                    },
+                    {"status_code": 200, "json": lambda self: {"data": []}},
                 )()
             if path.endswith("/child_sessions"):
                 # Restart recovery lists the session's children; an empty
@@ -2086,7 +2082,6 @@ async def test_create_session_envelope_is_single_flight_and_skips_metadata_callb
                     {
                         "status_code": 200,
                         "json": lambda self: {"data": [], "has_more": False},
-                        "raise_for_status": lambda self: None,
                     },
                 )()
             raise AssertionError(f"unexpected metadata callback: {path}")

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -552,6 +552,31 @@ async def test_runner_restart_replays_continued_turn_with_stale_receipt(
 
 
 @pytest.mark.asyncio
+async def test_runner_restart_recovers_text_less_final_turn_as_no_output(
+    _clean_subagent_registry: None,
+) -> None:
+    """The newest assistant message wins even without text, as in live delivery.
+
+    Walking past it to an older message would surface a previous turn's text
+    as this turn's result.
+    """
+    runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    child_items = [
+        {"type": "message", "role": "assistant", "content": []},
+        _CHILD_RESULT_ITEM,
+    ]
+    app = create_runner_app(
+        server_client=_RecoveryServerClient([_child_summary()], child_items=child_items),  # type: ignore[arg-type]
+    )
+
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+
+    payload = runner_app._session_inboxes_ref[PARENT_SESSION_ID].get_nowait()
+    assert payload["status"] == "completed"
+    assert payload["output"] == ""
+
+
+@pytest.mark.asyncio
 async def test_runner_restart_recovers_failed_child_error(
     _clean_subagent_registry: None,
 ) -> None:

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -20,7 +20,6 @@ import asyncio
 from collections.abc import Iterator
 from typing import Any
 
-import httpx
 import pytest
 
 from omnigent.runner import app as runner_app
@@ -178,16 +177,6 @@ class _RecoveryServerClient(NullServerClient):
         def json(self) -> dict[str, Any]:
             """Return the configured JSON payload."""
             return self._payload
-
-        def raise_for_status(self) -> None:
-            """Raise the httpx status error production code catches."""
-            if self.status_code >= 400:
-                request = httpx.Request("GET", "http://server/")
-                raise httpx.HTTPStatusError(
-                    str(self.status_code),
-                    request=request,
-                    response=httpx.Response(self.status_code, request=request),
-                )
 
     async def get(self, url: str, **kwargs: Any) -> Any:
         """

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -552,6 +552,29 @@ async def test_runner_restart_replays_continued_turn_with_stale_receipt(
 
 
 @pytest.mark.asyncio
+async def test_drain_before_session_init_still_recovers(
+    _clean_subagent_registry: None,
+) -> None:
+    """A drain that runs before the session is initialized still recovers.
+
+    After a reconnect the server can dispatch a pending message before it
+    re-initializes the session on the replacement runner, so the parent has no
+    inbox yet when ``sys_read_inbox`` runs. Recovery must create the inbox and
+    queue the result rather than treat the missing inbox as nothing to do.
+    """
+    app = create_runner_app(
+        server_client=_RecoveryServerClient([_child_summary()]),  # type: ignore[arg-type]
+    )
+    assert PARENT_SESSION_ID not in runner_app._session_inboxes_ref
+
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+
+    payload = runner_app._session_inboxes_ref[PARENT_SESSION_ID].get_nowait()
+    assert payload["conversation_id"] == CHILD_SESSION_ID
+    assert payload["output"] == "review complete: LGTM"
+
+
+@pytest.mark.asyncio
 async def test_runner_restart_recovers_text_less_final_turn_as_no_output(
     _clean_subagent_registry: None,
 ) -> None:

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -20,6 +20,7 @@ import asyncio
 from collections.abc import Iterator
 from typing import Any
 
+import httpx
 import pytest
 
 from omnigent.runner import app as runner_app
@@ -52,11 +53,15 @@ def _clean_subagent_registry() -> Iterator[None]:
         {k: set(v) for k, v in runner_app._subagent_work_by_parent.items()},
         dict(runner_app._session_inboxes_ref),
         set(runner_app._drained_delivered_subagent_children),
+        set(runner_app._subagent_recovery_done),
+        dict(runner_app._subagent_recovery_locks),
     )
     runner_app._subagent_work_by_child.clear()
     runner_app._subagent_work_by_parent.clear()
     runner_app._session_inboxes_ref.clear()
     runner_app._drained_delivered_subagent_children.clear()
+    runner_app._subagent_recovery_done.clear()
+    runner_app._subagent_recovery_locks.clear()
     try:
         yield
     finally:
@@ -68,6 +73,10 @@ def _clean_subagent_registry() -> Iterator[None]:
         runner_app._session_inboxes_ref.update(saved[2])
         runner_app._drained_delivered_subagent_children.clear()
         runner_app._drained_delivered_subagent_children.update(saved[3])
+        runner_app._subagent_recovery_done.clear()
+        runner_app._subagent_recovery_done.update(saved[4])
+        runner_app._subagent_recovery_locks.clear()
+        runner_app._subagent_recovery_locks.update(saved[5])
 
 
 class _SnapshotServerClient(NullServerClient):
@@ -103,6 +112,101 @@ class _SnapshotServerClient(NullServerClient):
         if url.rstrip("/").endswith("/items"):
             return self._Resp({"data": [], "has_more": False})
         return self._Response()
+
+
+DISPATCH_ID = "subagent_dispatch0001"
+_CHILD_RESULT_ITEM: dict[str, Any] = {
+    "type": "message",
+    "role": "assistant",
+    "content": [{"type": "output_text", "text": "review complete: LGTM"}],
+}
+
+
+def _child_summary(**overrides: Any) -> dict[str, Any]:
+    """
+    Build a terminal child-session summary as the sessions API returns it.
+
+    :param overrides: Field overrides, e.g. ``current_task_status="failed"``.
+    :returns: Child summary carrying an undrained dispatch id by default.
+    """
+    summary: dict[str, Any] = {
+        "id": CHILD_SESSION_ID,
+        "tool": "reviewer",
+        "session_name": "review",
+        "current_task_status": "completed",
+        "labels": {runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY: DISPATCH_ID},
+    }
+    summary.update(overrides)
+    return summary
+
+
+class _RecoveryServerClient(NullServerClient):
+    """Serve the durable child records that restart recovery reads."""
+
+    def __init__(
+        self,
+        children: list[dict[str, Any]],
+        *,
+        child_items: list[dict[str, Any]] | None = None,
+        failed_item_sessions: set[str] | None = None,
+    ) -> None:
+        """
+        Configure the child list and transcript returned by the fake server.
+
+        :param children: Parent's child-session summaries.
+        :param child_items: Child transcript, newest first.
+        :param failed_item_sessions: Session ids whose item read returns 503.
+        """
+        self.children = children
+        self.child_items = [_CHILD_RESULT_ITEM] if child_items is None else child_items
+        self.failed_item_sessions = failed_item_sessions or set()
+        self.requests: list[tuple[str, dict[str, Any]]] = []
+
+    class _Resp:
+        """Minimal HTTP response carrying a JSON payload."""
+
+        def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+            """
+            Store one JSON response payload.
+
+            :param payload: JSON object returned by :meth:`json`.
+            :param status_code: HTTP status exposed to production code.
+            """
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self) -> dict[str, Any]:
+            """Return the configured JSON payload."""
+            return self._payload
+
+        def raise_for_status(self) -> None:
+            """Raise the httpx status error production code catches."""
+            if self.status_code >= 400:
+                request = httpx.Request("GET", "http://server/")
+                raise httpx.HTTPStatusError(
+                    str(self.status_code),
+                    request=request,
+                    response=httpx.Response(self.status_code, request=request),
+                )
+
+    async def get(self, url: str, **kwargs: Any) -> Any:
+        """
+        Return child summaries and transcripts for recovery reads.
+
+        :param url: Requested sessions API path.
+        :param kwargs: HTTP request options; ``params`` are recorded.
+        :returns: Minimal response for the requested resource.
+        """
+        params = dict(kwargs.get("params") or {})
+        self.requests.append((url, params))
+        if url.endswith(f"/{PARENT_SESSION_ID}/child_sessions"):
+            return self._Resp({"data": self.children, "has_more": False})
+        if url.endswith("/items"):
+            session_id = url.rstrip("/").split("/")[-2]
+            if session_id in self.failed_item_sessions:
+                return self._Resp({}, status_code=503)
+            return self._Resp({"data": self.child_items, "has_more": False})
+        return self._Resp({"data": [], "has_more": False})
 
 
 def _child_snapshot(
@@ -349,6 +453,186 @@ async def test_top_level_session_idle_is_noop(
 
     assert http == 204
     assert items == []
+
+
+@pytest.mark.asyncio
+async def test_runner_restart_recovers_undrained_terminal_child(
+    _clean_subagent_registry: None,
+) -> None:
+    """A fresh runner rebuilds an undrained child result from the receipt gap.
+
+    Nothing survives the process: no work entry, inbox item, or drained
+    tombstone. The child carries a dispatch id but no delivered-id receipt,
+    so initializing the parent must re-queue its result under that same id.
+    """
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """
+        Return the parent spec needed by the public initialization route.
+
+        :param agent_id: Bound agent id supplied by initialization.
+        :param session_id: Parent session id being initialized.
+        :returns: Minimal parent agent specification.
+        """
+        del agent_id, session_id
+        return AgentSpec(spec_version=1, name="orchestrator")
+
+    server_client = _RecoveryServerClient([_child_summary()])
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=server_client,  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        response = await client.post(
+            "/v1/sessions",
+            json={"session_id": PARENT_SESSION_ID, "agent_id": "ag_orchestrator"},
+        )
+
+    assert response.status_code == 201
+    inbox = runner_app._session_inboxes_ref[PARENT_SESSION_ID]
+    assert inbox.qsize() == 1
+    payload = inbox.get_nowait()
+    assert payload["conversation_id"] == CHILD_SESSION_ID
+    assert payload["status"] == "completed"
+    assert payload["output"] == "review complete: LGTM"
+    assert payload["work_id"] == DISPATCH_ID
+    child_reads = [
+        params
+        for url, params in server_client.requests
+        if url.endswith(f"/{CHILD_SESSION_ID}/items")
+    ]
+    assert child_reads == [{"limit": "100", "order": "desc"}]
+    request_count = len(server_client.requests)
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+    assert len(server_client.requests) == request_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "labels",
+    [
+        {
+            runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY: DISPATCH_ID,
+            runner_app.SUBAGENT_DELIVERED_ID_LABEL_KEY: DISPATCH_ID,
+        },
+        {},
+    ],
+)
+async def test_runner_restart_skips_drained_and_unstamped_children(
+    _clean_subagent_registry: None,
+    labels: dict[str, str],
+) -> None:
+    """A matching receipt, or a child created before receipts, is not replayed.
+
+    :param _clean_subagent_registry: Isolates module-level runner state.
+    :param labels: Either a drained turn's labels or a legacy child's none.
+    """
+    runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    server_client = _RecoveryServerClient([_child_summary(labels=labels)])
+    app = create_runner_app(server_client=server_client)  # type: ignore[arg-type]
+
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+
+    assert runner_app._session_inboxes_ref[PARENT_SESSION_ID].empty()
+    assert runner_app.get_subagent_work(CHILD_SESSION_ID) is None
+    assert not any(url.endswith("/items") for url, _ in server_client.requests)
+
+
+@pytest.mark.asyncio
+async def test_runner_restart_replays_continued_turn_with_stale_receipt(
+    _clean_subagent_registry: None,
+) -> None:
+    """A receipt for an earlier turn cannot mask a continued child's new turn."""
+    runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    labels = {
+        runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY: "subagent_turn2",
+        runner_app.SUBAGENT_DELIVERED_ID_LABEL_KEY: "subagent_turn1",
+    }
+    app = create_runner_app(
+        server_client=_RecoveryServerClient([_child_summary(labels=labels)]),  # type: ignore[arg-type]
+    )
+
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+
+    payload = runner_app._session_inboxes_ref[PARENT_SESSION_ID].get_nowait()
+    assert payload["work_id"] == "subagent_turn2"
+    assert payload["output"] == "review complete: LGTM"
+
+
+@pytest.mark.asyncio
+async def test_runner_restart_recovers_failed_child_error(
+    _clean_subagent_registry: None,
+) -> None:
+    """A failed child replays its durable error without reading its transcript."""
+    runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    server_client = _RecoveryServerClient(
+        [
+            _child_summary(
+                current_task_status="failed",
+                last_task_error={"code": "required_terminal_exited", "message": "pane died"},
+            )
+        ]
+    )
+    app = create_runner_app(server_client=server_client)  # type: ignore[arg-type]
+
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+
+    payload = runner_app._session_inboxes_ref[PARENT_SESSION_ID].get_nowait()
+    assert payload["status"] == "failed"
+    assert payload["output"] == "pane died"
+    assert not any(url.endswith("/items") for url, _ in server_client.requests)
+
+
+@pytest.mark.asyncio
+async def test_runner_restart_retries_after_child_history_read_failure(
+    _clean_subagent_registry: None,
+) -> None:
+    """A failed transcript read leaves the scan unfinished so the drain retries it."""
+    runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    server_client = _RecoveryServerClient(
+        [_child_summary()], failed_item_sessions={CHILD_SESSION_ID}
+    )
+    app = create_runner_app(server_client=server_client)  # type: ignore[arg-type]
+
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+    assert runner_app._session_inboxes_ref[PARENT_SESSION_ID].empty()
+    assert PARENT_SESSION_ID not in runner_app._subagent_recovery_done
+
+    server_client.failed_item_sessions.clear()
+    await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+
+    payload = runner_app._session_inboxes_ref[PARENT_SESSION_ID].get_nowait()
+    assert payload["conversation_id"] == CHILD_SESSION_ID
+    assert PARENT_SESSION_ID in runner_app._subagent_recovery_done
+
+
+@pytest.mark.asyncio
+async def test_concurrent_recovery_scans_deliver_exactly_once(
+    _clean_subagent_registry: None,
+) -> None:
+    """Session initialization racing a ``sys_read_inbox`` drain queues one result."""
+
+    class _YieldingRecoveryServerClient(_RecoveryServerClient):
+        """Yield to the event loop on every read, exposing the interleaving."""
+
+        async def get(self, url: str, **kwargs: Any) -> Any:
+            await asyncio.sleep(0)
+            return await super().get(url, **kwargs)
+
+    runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
+    app = create_runner_app(
+        server_client=_YieldingRecoveryServerClient([_child_summary()]),  # type: ignore[arg-type]
+    )
+
+    await asyncio.gather(
+        app.state.recover_undrained_subagent_results(PARENT_SESSION_ID),
+        app.state.recover_undrained_subagent_results(PARENT_SESSION_ID),
+    )
+
+    assert runner_app._session_inboxes_ref[PARENT_SESSION_ID].qsize() == 1
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -3106,6 +3106,7 @@ async def test_sys_session_send_reuses_existing_child_session(
 
     create_posts = 0
     event_posts: list[dict[str, Any]] = []
+    dispatch_stamps: list[dict[str, Any]] = []
     published: list[dict[str, Any]] = []
 
     monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
@@ -3139,6 +3140,11 @@ async def test_sys_session_send_reuses_existing_child_session(
         if request.method == "POST" and request.url.path == "/v1/sessions":
             create_posts += 1
             return httpx.Response(500, json={"error": "duplicate"})
+        if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_existing":
+            dispatch_stamps.append(
+                {"events_before": len(event_posts), **json.loads(request.content)["labels"]}
+            )
+            return httpx.Response(200, json={"ok": True})
         if request.method == "POST" and request.url.path == "/v1/sessions/conv_existing/events":
             event_posts.append(json.loads(request.content))
             return httpx.Response(200, json={"ok": True})
@@ -3175,6 +3181,11 @@ async def test_sys_session_send_reuses_existing_child_session(
     assert "continued ok" not in payload["message"]
     assert event_posts[0]["created_by"] == "bob@example.com"
     assert event_posts[0]["data"]["content"][0]["text"] == "continue"
+    # The new turn's dispatch id is stamped on the child before its message
+    # is posted, so a restart can tell this turn from the drained one.
+    [stamp] = dispatch_stamps
+    assert stamp["events_before"] == 0
+    assert stamp[runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY].startswith("subagent_")
     assert published[-1]["type"] == "session.child_session.updated"
     assert published[-1]["child"]["current_task_status"] == "launching"
     assert published[-1]["child"]["busy"] is False
@@ -3273,6 +3284,8 @@ async def test_sys_session_send_existing_child_retries_without_rejected_actor(
                     "title": "worker:retry",
                 },
             )
+        if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_existing_retry":
+            return httpx.Response(200, json={"ok": True})
         if (
             request.method == "POST"
             and request.url.path == "/v1/sessions/conv_existing_retry/events"
@@ -4282,6 +4295,8 @@ async def test_sys_session_send_completion_drains_from_parent_inbox(
     monkeypatch.setattr(runner_app, "get_session_agent_id", lambda _sid: "ag_parent")
     monkeypatch.setattr(runner_app, "register_child_session", lambda *a, **k: None)
     session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    create_bodies: list[dict[str, Any]] = []
+    label_patches: list[dict[str, Any]] = []
 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         """Serve child-session create, lookup, and message POST requests."""
@@ -4291,7 +4306,11 @@ async def test_sys_session_send_completion_drains_from_parent_inbox(
         ):
             return httpx.Response(200, json={"data": []})
         if request.method == "POST" and request.url.path == "/v1/sessions":
+            create_bodies.append(json.loads(request.content))
             return httpx.Response(201, json={"id": "conv_child_inbox"})
+        if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_child_inbox":
+            label_patches.append(json.loads(request.content)["labels"])
+            return httpx.Response(200, json={"ok": True})
         if request.method == "POST" and request.url.path == "/v1/sessions/conv_child_inbox/events":
             return httpx.Response(202, json={"queued": True})
         if (
@@ -4342,6 +4361,11 @@ async def test_sys_session_send_completion_drains_from_parent_inbox(
 
     assert "sub-agent task conv_child_inbox completed" in inbox_output
     assert "worker:phase-a returned: CHILD_MARKER" in inbox_output
+    # The dispatch id rides along with child creation, and the drain writes
+    # it back as the delivered-id receipt a runner restart checks.
+    dispatch_id = create_bodies[0]["labels"][runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY]
+    assert dispatch_id.startswith("subagent_")
+    assert label_patches == [{runner_app.SUBAGENT_DELIVERED_ID_LABEL_KEY: dispatch_id}]
 
 
 @pytest.mark.asyncio
@@ -4391,6 +4415,8 @@ async def test_subagent_inbox_cleanup_does_not_unregister_next_turn(
             )
         if request.method == "POST" and request.url.path == "/v1/sessions":
             return httpx.Response(201, json={"id": child_id})
+        if request.method == "PATCH" and request.url.path == f"/v1/sessions/{child_id}":
+            return httpx.Response(200, json={"ok": True})
         if request.method == "POST" and request.url.path == f"/v1/sessions/{child_id}/events":
             return httpx.Response(202, json={"queued": True})
         if (
@@ -8003,6 +8029,8 @@ async def test_sys_session_send_session_id_posts_to_direct_child(
                     "title": "researcher:auth",
                 },
             )
+        if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_child":
+            return httpx.Response(200, json={"ok": True})
         if request.method == "POST" and request.url.path == "/v1/sessions/conv_child/events":
             event_posts.append(json.loads(request.content))
             return httpx.Response(200, json={"ok": True})

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7997,6 +7997,68 @@ async def test_sys_session_get_info_hides_native_ui_wrapper_agent_name() -> None
 
 
 @pytest.mark.asyncio
+async def test_sys_session_send_failed_continuation_receipts_its_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A continued turn stamped on the child but never sent gets a receipt.
+
+    The dispatch id is written before the message post so a runner restart can
+    find the turn. When the post then fails, the child keeps that stamp with no
+    turn behind it; without the receipt, recovery would replay the previous
+    turn's result as this one after a restart.
+
+    :param monkeypatch: Stubs the runner-local child registration so the
+        dispatch runs without a live runner.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    monkeypatch.setattr(runner_app, "register_child_session", lambda *a, **k: None)
+    label_patches: list[dict[str, str]] = []
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_child":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "conv_child",
+                    "parent_session_id": "conv_caller",
+                    "title": "researcher:auth",
+                },
+            )
+        if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_child":
+            label_patches.append(json.loads(request.content)["labels"])
+            return httpx.Response(200, json={"ok": True})
+        if request.method == "POST" and request.url.path == "/v1/sessions/conv_child/events":
+            return httpx.Response(503, json={"error": "child unavailable"})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps({"session_id": "conv_child", "args": "continue please"}),
+                server_client=server_client,
+                conversation_id="conv_caller",
+                agent_spec=SimpleNamespace(sub_agents=[SimpleNamespace(name="researcher")]),
+                session_inbox=asyncio.Queue(),
+            )
+        finally:
+            runner_app.unregister_subagent_work("conv_child")
+            runner_app._session_inboxes_ref.pop("conv_caller", None)
+
+    assert output.startswith("Error: failed to send message to child: 503")
+    assert runner_app.get_subagent_work("conv_child") is None
+    stamp, receipt = label_patches
+    dispatch_id = stamp[runner_app.SUBAGENT_DISPATCH_ID_LABEL_KEY]
+    assert dispatch_id.startswith("subagent_")
+    assert receipt == {runner_app.SUBAGENT_DELIVERED_ID_LABEL_KEY: dispatch_id}
+
+
+@pytest.mark.asyncio
 async def test_sys_session_send_session_id_posts_to_direct_child(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #5172

Supersedes #5373. Resolves [OMNI-4482](https://linear.app/omnigent/issue/OMNI-4482/bug-a-runner-restart-permanently-loses-undelivered-sub-agent-results).

## Summary

A runner restart loses every sub-agent result that was queued in the parent's process-local inbox but not yet drained. This PR makes delivery durable with a receipt on the child session instead of reconstructing delivery state from transcripts:

- **Dispatch id on send.** Each child turn is stamped with an `omnigent.subagent.dispatch_id` label holding its work id: in the create body for a new child, and via a PATCH before the message post for a continued one. A failed stamp aborts the send, so a stale receipt can never mask a newer turn.
- **Delivered id on drain.** After `sys_read_inbox` consumes a result, the runner writes `omnigent.subagent.delivered_id` with the same work id. This is best effort: a lost receipt costs one duplicate after a restart, whereas a lost result would never arrive.
- **Recovery on init.** When a parent session initializes, the runner lists its child sessions and re-queues any terminal child whose two ids differ, using the newest assistant message (or the durable `last_task_error`) as the output. The recovered entry keeps the durable work id, so its eventual drain closes the loop. The scan runs once per parent per process; one that fails on a server read is retried before the next `sys_read_inbox`.

ELI5: every job handed to a sub-agent gets a ticket number, and the parent hands the ticket back when it reads the result. After a restart, the runner re-delivers any finished job whose ticket was never handed back.

```
dispatch ──▶ child.labels[dispatch_id] = W        (create body / PATCH)
child finishes ──▶ parent inbox (in-memory) ──▶ sys_read_inbox drains
                                             └──▶ child.labels[delivered_id] = W
runner restarts ──▶ parent init ──▶ for each terminal child:
                                     dispatch_id != delivered_id ? re-queue : skip
```

Compared with #5373 there is no server API change, no transcript parsing, no coupling to the `sys_read_inbox` render format, no compaction handling, no timestamp comparison, and no TTL memo.

Known limit shared with #5373: a child's terminal status comes from the server's in-memory status cache, so recovery covers a runner restart, not a server restart.

## Test Plan

The e2e test from #5373 (`tests/e2e/test_subagent_restart_recovery_e2e.py`, unchanged apart from a CodeQL nit in the fixture) starts the real server and runner, dispatches a child through the mock LLM, lets the parent receive the completion wake without draining, `SIGKILL`s the runner, starts a replacement with the same identity, and asserts the child marker appears in persisted `sys_read_inbox` output.

- Same test with `main`'s runner code: `1 failed in 193.59s` at `'DURABLE_RESTART_RESULT' did not appear in session …` (the inbox wait times out; the replacement runner reports an empty inbox).
- This branch: `1 passed in 20.70s` (the replacement runner re-queues the result at parent init and `sys_read_inbox` returns it).

Unit coverage in `tests/runner/`:

- `test_native_subagent_inbox_delivery.py`: recovery re-queues an undrained terminal child under its dispatch id via the public init route; a matching receipt or an unstamped legacy child is skipped; a stale receipt on a continued child replays the new turn; a failed child replays its durable error; a failed transcript read is retried on the next call; two racing scans deliver exactly once; a text-less final assistant message recovers as "no output", matching live delivery; a `sys_read_inbox` drain that runs before the session is re-initialized (the server can dispatch a pending message ahead of its reconnect catch-up) still recovers, because recovery creates the inbox on demand.
- `test_runner_dispatch.py`: child creation carries the dispatch id and the drain writes it back as the delivered id; a continued child is stamped before its message is posted; a continued send that fails after the stamp writes a receipt so a restart cannot replay the previous turn.
- `test_app_sessions_native_workflow_init.py`: the init-path exact-calls contract now includes the child-session read.

Local runs (worktree venv, `-p no:cacheprovider`):

- `pytest tests/runner/test_native_subagent_inbox_delivery.py tests/runner/test_app_sessions_native_workflow_init.py tests/runner/test_runner_dispatch.py`: 314 passed, 1 skipped.
- Rest of `tests/runner` (`-n 6`): 13 failures, every one of which fails identically with `main`'s runner code checked out in the same worktree (codex-native settings/bridge, pi cwd threading, `reset_state` rematerialization), so they are pre-existing in this environment.
- `pre-commit run --files <changed files>`: all 12 hooks pass (ruff, pyrefly, …).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e test is the regression gate: it fails on `main` and passes here. Unit tests cover each receipt state the recovery scan can encounter.

## Changelog

Sub-agent results that were waiting in a parent's inbox now survive a runner restart instead of being lost.

https://claude.ai/code/session_01RgBvSQZZuv5NJsyo5etRM2
