### PR TITLE
fix(web): seed the new-session working directory from the host's last session

### DIFF
--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1677,6 +1677,57 @@ describe("NewChatLandingScreen", () => {
     );
   });
 
+  it("seeds the working directory from the host's most recent session", async () => {
+    // A session started from a terminal (`omnigent claude` in a directory)
+    // records that cwd as its workspace but never touches this browser's
+    // recents, so the server-side session must win over the stale recent.
+    useDirectorySessionsMock.mockReturnValue({
+      data: [conv({ id: "s1", host_id: "host_1", workspace: "/Users/corey/universe" })],
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "universe",
+      ),
+    );
+  });
+
+  it("ignores another host's session when seeding the working directory", async () => {
+    // Paths are host-specific: host_2's workspace must not seed host_1, which
+    // falls back to its own recent ("/Users/corey/repo").
+    useDirectorySessionsMock.mockReturnValue({
+      data: [conv({ id: "s1", host_id: "host_2", workspace: "/Users/corey/universe" })],
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+  });
+
+  it("holds the working-directory seed until the session list resolves", async () => {
+    // Seeding the recent while the scan is in flight would lock the
+    // once-per-host guard and lose to a newer terminal-launched workspace.
+    useDirectorySessionsMock.mockReturnValue({
+      data: undefined,
+      isError: false,
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() => expect(screen.getByTestId("new-chat-landing-host-chip")).toBeTruthy());
+    expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).not.toContain("repo");
+  });
+
+  it("falls back to the recent when the session scan fails", async () => {
+    // A failed scan must not stall the seed forever — the field still fills.
+    useDirectorySessionsMock.mockReturnValue({
+      data: undefined,
+      isError: true,
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+  });
+
   it("quotes server URLs in host and Lakebox connect commands", () => {
     setOmnigentHostConfig({ cliServerUrlSuffix: "/api?profile=dev&glob=*" });
     renderLanding({ databricks_features: true });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2305,7 +2305,9 @@ export function NewChatLandingScreen() {
   );
   // Sessions on the selected host — fetched only when a host is selected,
   // to avoid registering hundreds of sessions into the health poll at idle.
-  const { data: directorySessions } = useDirectorySessions(selectedHostId !== null);
+  const { data: directorySessions, isError: directorySessionsErrored } = useDirectorySessions(
+    selectedHostId !== null,
+  );
   // True when the user picked the sandbox option instead of a connected
   // host — the server provisions a sandbox host at create time
   // (host_type: "managed"), so no host_id or workspace is sent.
@@ -2784,10 +2786,35 @@ export function NewChatLandingScreen() {
   // falls through to the global one, then to blank (fork from current branch).
   const projectBaseBranch = storedProjectConfig?.base_branch?.trim() || null;
 
-  // The path the once-per-host auto-seed WOULD land on: the most-recent path,
-  // else the derived home. Exposed as a memo so we can probe its repo for
-  // worktrees before committing to it (see the fork-fresh redirect below).
-  const autoSeedCandidate = useMemo(() => recent[0] ?? derivedHome ?? null, [recent, derivedHome]);
+  // Working directory of the host's most recently active session — the only
+  // signal that sees a session started from a terminal (`omnigent claude` in a
+  // directory records that cwd as its workspace). `recent` is localStorage, so
+  // it only ever holds directories picked in THIS browser; every web pick also
+  // creates a session, making this the same set plus terminal launches, ordered
+  // by real `updated_at`. `undefined` = the list is still resolving, so the
+  // seed can wait rather than locking in a stale browser-local recent.
+  const latestHostWorkspace = useMemo<string | null | undefined>(() => {
+    if (selectedHostId === null || sandboxSelected) return null;
+    // A failed scan must not stall the seed forever — fall through to `recent`.
+    if (directorySessionsErrored) return null;
+    if (directorySessions === undefined) return undefined;
+    const match = directorySessions.find(
+      (s) => s.host_id === selectedHostId && s.workspace != null && isValidWorkspace(s.workspace),
+    );
+    return match?.workspace?.trim() ?? null;
+  }, [directorySessions, directorySessionsErrored, selectedHostId, sandboxSelected]);
+  // Hold the seed while the session list resolves, so a browser-local recent
+  // can't win the race and lock the once-per-host guard below.
+  const autoSeedPending = latestHostWorkspace === undefined;
+
+  // The path the once-per-host auto-seed WOULD land on: the host's last session
+  // workspace, else the most-recent path, else the derived home. Exposed as a
+  // memo so we can probe its repo for worktrees before committing to it (see
+  // the fork-fresh redirect below).
+  const autoSeedCandidate = useMemo(
+    () => latestHostWorkspace ?? recent[0] ?? derivedHome ?? null,
+    [latestHostWorkspace, recent, derivedHome],
+  );
   // "Fork fresh from default": when the project defines a default base branch,
   // a fresh new-chat must NOT silently continue in the last-used worktree — it
   // should fork a new branch off that default. The auto-seed can land on a
@@ -2802,6 +2829,7 @@ export function NewChatLandingScreen() {
     !sandboxSelected &&
     projectBaseBranch !== null &&
     seededHostRef.current !== selectedHostId &&
+    !autoSeedPending &&
     autoSeedCandidate !== null;
   const {
     data: seedWorktrees,
@@ -2840,13 +2868,15 @@ export function NewChatLandingScreen() {
   ]);
 
   // Seed the working directory once per host, into an empty field only, so an
-  // explicit pick isn't clobbered. Prefer the most-recent path; else the
-  // derived home (which can arrive a render later, hence the dep). Holds
-  // off while a project prefill is deciding on a workspace of its own.
+  // explicit pick isn't clobbered. Prefer the host's last session workspace;
+  // else the most-recent path; else the derived home (which can arrive a render
+  // later, hence the dep). Holds off while a project prefill is deciding on a
+  // workspace of its own.
   useEffect(() => {
     if (!prefillSettled) return;
     if (selectedHostId === null) return;
     if (seededHostRef.current === selectedHostId) return;
+    if (autoSeedPending) return;
     if (autoSeedCandidate === null) return;
     // Fork-fresh redirect pending: wait for the probe rather than seeding the
     // wrong path (and locking the once-per-host guard).
@@ -2879,6 +2909,7 @@ export function NewChatLandingScreen() {
   }, [
     selectedHostId,
     autoSeedCandidate,
+    autoSeedPending,
     prefillSettled,
     forkFreshMainPath,
     workspace,


### PR DESCRIPTION
## Related issue

Closes #

<!-- No existing issue covers this; #509 is the adjacent case (defaulting the
workspace from the *agent's* `os_env.cwd`), which this PR does not address. Happy
to file one if a maintainer wants the tracking issue. -->

## Summary

Launching a harness from a terminal — `omnigent claude` from `~/src/myrepo` — records
that cwd as the session's `workspace`. But starting a **new** session from the web UI
against the same host ignored that directory: the working-directory seed read only
`omnigent:recent-workspaces` in `localStorage`, which is written on web submit and
never by a CLI launch. So the field fell back to the last pick made *in that browser*,
or to the host's home directory on a first visit, and you had to re-navigate to the
directory you were just working in.

- Seed the new-chat working directory from the workspace of the host's **most recently
  updated session**, falling back to the browser-local recent and then the derived home.
- The session list is already fetched by the dialog for the directory-conflict hint and
  carries `host_id` + `workspace`, so this adds no request. It is also a superset of the
  recents — every web pick creates a session too — with real `updated_at` ordering
  instead of an untimestamped browser list, and it carries across browsers and devices.
- The seed now waits for that list to resolve, so a stale recent can't win the race and
  lock the once-per-host seed guard. A failed scan falls through to the old behaviour
  rather than leaving the field blank.

ELI5: the field used to remember only what *this browser* last picked. Now it asks the
server "where was this machine last working?", which is the directory you ran the CLI in.

```
                    old                         new
  recent[0] (localStorage, this browser only)
      ↓                                   latest session workspace on host  ← CLI launch lands here
  derivedHome                                   ↓
                                          recent[0]
                                                ↓
                                          derivedHome
```

## Test Plan

`web/`: `pnpm vitest run src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx
src/shell/NewChatDialog.projectPrefill.test.tsx src/shell/NewChatDialog.projectCreate.test.tsx
src/shell/NewChatLandingScreen.mobileChrome.test.tsx src/hooks/useRecentWorkspaces.test.ts
src/shell/ResumeWithDirectoryDialog.test.tsx` → 424 passed.
`pnpm tsc -b`, `pnpm oxlint --deny-warnings --report-unused-disable-directives .` and
`pnpm prettier --check` are all clean.

The new "seeds the working directory from the host's most recent session" test was
confirmed to fail on the parent commit (chip reads the localStorage recent `repo`
instead of the session's `universe`), so it guards the actual behaviour change.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The only visible difference is the value prefilled into the working-directory field /
footer chip, with no layout or styling change. The added tests assert exactly that
rendered chip text for each seed source, which is the same thing a screenshot would show.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Four new unit tests cover the seed order (host session beats the localStorage recent),
host scoping (another host's workspace never seeds this one), the hold while the session
list resolves, and the fall-through when the scan errors. Not verified against a live
server in a browser.

## Changelog

Starting a new session from the web UI now defaults the working directory to where that
machine was last working — including the directory a terminal `omnigent <harness>` launch
was started from — instead of only the last directory picked in that browser.
