### PR TITLE
chore(electron): set desktop version to 0.12.0

### DIFF
--- a/scripts/update_versions.py
+++ b/scripts/update_versions.py
@@ -23,14 +23,9 @@ so unrelated version literals (host/runner wire-protocol versions,
 docstring examples, third-party dependency floors like
 ``databricks-mcp>=0.9.0``) are left untouched.
 
-The desktop app (``web/electron/package.json``) co-versions with the
-lockstep too, stamped with the *semver translation* of the version —
-npm and electron-builder reject PEP 440 spellings (``0.6.0rc1`` ->
-``0.6.0-rc.1``, ``0.7.0.dev0`` -> ``0.7.0-dev.0``; finals unchanged).
-
-``web/package.json`` (a ``0.0.0`` sentinel for the private SPA) is
-intentionally OUT of scope: it is not part of the release-validated
-lockstep.
+The desktop app (``web/electron/package.json``) and private SPA
+(``web/package.json``) are intentionally OUT of scope: neither is part
+of the Python distributions' release-validated lockstep.
 
 After editing the ``pyproject.toml`` files, regenerate the lockfile so
 the embedded sibling specifiers track the new version::
@@ -55,7 +50,6 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from dataclasses import dataclass
@@ -129,41 +123,6 @@ _VERSION_LINE = re.compile(r'^version = "[^"]*"$', re.MULTILINE)
 # ``VERSION = "..."`` on its own line — the runtime constant in
 # ``omnigent/version.py`` that mirrors the canonical [project].version.
 _VERSION_CONSTANT = re.compile(r'^VERSION = "[^"]*"$', re.MULTILINE)
-
-# ``"version": "..."`` in ``web/electron/package.json`` (the desktop app).
-_ELECTRON_VERSION_LINE = re.compile(r'^(?P<indent>\s*)"version": "[^"]*",$', re.MULTILINE)
-
-
-def _electron_package_json(root: Path) -> Path:
-    """Return the path to the desktop app's ``package.json``."""
-    return root / "web" / "electron" / "package.json"
-
-
-def semver_of(version: str) -> str:
-    """
-    Translate a PEP 440 lockstep version to its semver equivalent.
-
-    npm and electron-builder reject PEP 440 pre-release spellings, so the
-    desktop app is stamped with the translation: ``0.6.0rc1`` ->
-    ``0.6.0-rc.1``, ``0.7.0.dev0`` -> ``0.7.0-dev.0``, finals unchanged.
-    Semver orders the results the way PEP 440 does (dev < rc < final), so
-    the desktop auto-updater's comparisons stay correct. Post-releases
-    would NOT order correctly (semver sorts every prerelease below the
-    final); the release pipeline never mints them.
-
-    :param version: PEP 440 version, e.g. ``"0.7.0.dev0"``.
-    :returns: The semver string, e.g. ``"0.7.0-dev.0"``.
-    """
-    v = Version(version)
-    out = ".".join(str(n) for n in v.release)
-    ids: list[str] = []
-    if v.pre is not None:
-        ids += [v.pre[0], str(v.pre[1])]
-    if v.post is not None:
-        ids += ["post", str(v.post)]
-    if v.dev is not None:
-        ids += ["dev", str(v.dev)]
-    return out + (f"-{'.'.join(ids)}" if ids else "")
 
 
 def _version_py(root: Path) -> Path:
@@ -261,16 +220,6 @@ def set_version(root: Path, new_version: str) -> list[Path]:
     version_py.write_text(version_text)
     changed.append(version_py)
 
-    electron = _electron_package_json(root)
-    electron_text = _sub_exactly_once(
-        _ELECTRON_VERSION_LINE,
-        rf'\g<indent>"version": "{semver_of(new_version)}",',
-        electron.read_text(),
-        f"version field in {electron}",
-    )
-    electron.write_text(electron_text)
-    changed.append(electron)
-
     return changed
 
 
@@ -347,13 +296,6 @@ def check(root: Path, expect: str | None = None) -> str:
     if Version(constant) != Version(resolved):
         raise ValueError(
             f"omnigent/version.py VERSION {constant!r} != [project].version {resolved!r}"
-        )
-    electron = _electron_package_json(root)
-    desktop = json.loads(electron.read_text())["version"]
-    if desktop != semver_of(resolved):
-        raise ValueError(
-            f"{electron}: desktop version {desktop!r} != {semver_of(resolved)!r} "
-            f"(the semver translation of {resolved!r})"
         )
     if expect is not None and Version(resolved) != Version(expect):
         raise ValueError(f"resolved version {resolved} != expected {expect}")

--- a/tests/scripts/test_update_versions.py
+++ b/tests/scripts/test_update_versions.py
@@ -40,15 +40,13 @@ _PYPROJECTS = [
 ]
 # The runtime version constant is stamped/verified alongside the pyprojects.
 _VERSION_PY = "omnigent/version.py"
-# The desktop app co-versions via the semver translation of the lockstep version.
-_ELECTRON_PKG = "web/electron/package.json"
 
 
 @pytest.fixture
 def repo_copy(tmp_path: Path) -> Path:
     """Copy the real version-carrying files into a temp repo root."""
     root = tmp_path / "repo"
-    for rel in (*_PYPROJECTS, _VERSION_PY, _ELECTRON_PKG):
+    for rel in (*_PYPROJECTS, _VERSION_PY):
         dst = root / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
         dst.write_text((_REPO_ROOT / rel).read_text())
@@ -57,8 +55,8 @@ def repo_copy(tmp_path: Path) -> Path:
 
 def test_set_version_rewrites_every_location(repo_copy: Path) -> None:
     changed = update_versions.set_version(repo_copy, "9.9.9")
-    # Four pyprojects, omnigent/version.py, and the desktop package.json.
-    assert len(changed) == 6
+    # Four pyprojects and omnigent/version.py.
+    assert len(changed) == 5
     # root: version line + three sibling pins (client, ui-sdk, slack);
     # client/ui SDKs: version line + one pin; slack: version line only.
     assert (repo_copy / "pyproject.toml").read_text().count("9.9.9") == 4
@@ -161,33 +159,3 @@ def test_next_dev_version(released: str, expected: str) -> None:
 def test_validate_pep440_rejects_junk() -> None:
     with pytest.raises(SystemExit, match="invalid version"):
         update_versions._validate_pep440("not-a-version")
-
-
-@pytest.mark.parametrize(
-    ("pep440", "semver"),
-    [
-        ("0.8.0", "0.8.0"),
-        ("0.6.0rc1", "0.6.0-rc.1"),
-        ("0.9.0.dev0", "0.9.0-dev.0"),
-        ("0.9.0.dev20260804", "0.9.0-dev.20260804"),
-    ],
-)
-def test_semver_of(pep440: str, semver: str) -> None:
-    assert update_versions.semver_of(pep440) == semver
-
-
-def test_set_version_stamps_desktop_semver(repo_copy: Path) -> None:
-    """The desktop package.json gets the semver translation, not raw PEP 440."""
-    update_versions.set_version(repo_copy, "9.9.9rc1")
-    electron = repo_copy / _ELECTRON_PKG
-    assert '"version": "9.9.9-rc.1",' in electron.read_text()
-    assert update_versions.check(repo_copy, expect="9.9.9rc1") == "9.9.9rc1"
-
-
-def test_check_detects_desktop_drift(repo_copy: Path) -> None:
-    """A hand-edited (or forgotten) desktop version fails check()."""
-    update_versions.set_version(repo_copy, "9.9.9")
-    electron = repo_copy / _ELECTRON_PKG
-    electron.write_text(electron.read_text().replace('"version": "9.9.9",', '"version": "9.9.8",'))
-    with pytest.raises(ValueError, match="desktop version"):
-        update_versions.check(repo_copy)

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnigent-desktop-electron",
   "productName": "Omnigent",
-  "version": "0.13.0-dev.0",
+  "version": "0.12.0",
   "description": "Omnigent desktop shell (Electron edition) \u2014 a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Stamp the Electron desktop package as version `0.12.0` for the desktop release.
- Leave the Python packages and general Omnigent release metadata unchanged.

## Test Plan

- `node -e "const p=require('./web/electron/package.json'); if (p.version !== '0.12.0') throw new Error(p.version); console.log(p.name + '@' + p.version)"`
- `git diff --check`
- `pre-commit` passed during commit.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This is a package metadata-only version stamp; the package manifest was loaded directly to verify the resulting version.
