### PR TITLE
fix: preserve live terminals with foreign or unknown ownership

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -59,12 +59,22 @@ _TMUX_CONVERSATION_LINK_OPTION = "@omnigent-conversation-link"
 
 _TMUX_START_ON_ATTACH_CHANNEL = "omnigent-start-on-attach"
 # Each terminal instance lives in a private tmpdir with this prefix
-# (see ``create_terminal_instance``). The owner-pid marker inside it
-# records the process that launched the instance so a later startup
-# can reap tmux servers whose owner died without graceful shutdown
+# (see ``create_terminal_instance``). The owner marker inside it records
+# the process that launched the instance so a later startup can reap
+# tmux servers whose owner died without graceful shutdown
 # (``reap_orphaned_terminals``).
 _TERMINAL_DIR_PREFIX = "omnigent-terminal-"
 _OWNER_PID_FILENAME = "owner.pid"
+# Marker keys written after the pid line (see ``_write_owner_claim``).
+# They record WHICH pid domain the pid belongs to: a pid only names a
+# process within one pid namespace and one boot, while the instance
+# dirs live in a shared temp root that outlives both.
+_OWNER_CLAIM_PID_NS_KEY = "pid_ns"
+_OWNER_CLAIM_BOOT_KEY = "boot"
+# Recorded as the pid namespace on platforms that have none (macOS,
+# Windows): every process there shares one pid domain, so the claim is
+# still placeable and the pid still decides.
+_OWNER_CLAIM_NO_PID_NS = "none"
 # Bound for each ``tmux kill-server`` in the orphan sweep; a wedged
 # tmux must not stall runner startup.
 _REAP_KILL_TIMEOUT_S = 10.0
@@ -674,6 +684,146 @@ def _terminals_tmp_root() -> Path:
     return Path(tempfile.gettempdir())
 
 
+@dataclass(frozen=True)
+class _OwnerClaim:
+    """
+    An instance dir's recorded owner, and the pid domain it belongs to.
+
+    :ivar pid: The pid recorded at instance creation, e.g. ``48213``.
+    :ivar pid_ns: Identity of the pid namespace that minted *pid*
+        (``/proc/self/ns/pid``, e.g. ``"pid:[4026531836]"``), or
+        :data:`_OWNER_CLAIM_NO_PID_NS` on platforms without them.
+    :ivar boot_id: Identity of the boot that minted *pid*
+        (``/proc/sys/kernel/random/boot_id``), or ``None`` where the
+        kernel does not publish one.
+    """
+
+    pid: int
+    pid_ns: str
+    boot_id: str | None
+
+
+def _read_text_or_none(path: str) -> str | None:
+    """
+    Read a small kernel file, returning ``None`` when unavailable.
+
+    :param path: Absolute path, e.g.
+        ``"/proc/sys/kernel/random/boot_id"``.
+    :returns: The stripped contents, or ``None`` off Linux / when
+        the path is masked.
+    """
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read().strip() or None
+    except OSError:
+        return None
+
+
+def _current_pid_ns() -> str:
+    """
+    Return this process's pid-namespace identity.
+
+    :returns: The ``/proc/self/ns/pid`` link target, e.g.
+        ``"pid:[4026531836]"``, or :data:`_OWNER_CLAIM_NO_PID_NS`
+        where the kernel exposes no namespace to read.
+    """
+    try:
+        return os.readlink("/proc/self/ns/pid")
+    except OSError:
+        return _OWNER_CLAIM_NO_PID_NS
+
+
+def _current_boot_id() -> str | None:
+    """
+    Return this boot's identity.
+
+    :returns: The kernel's boot id, or ``None`` where unpublished.
+    """
+    return _read_text_or_none("/proc/sys/kernel/random/boot_id")
+
+
+def _write_owner_claim(instance_dir: Path) -> None:
+    """
+    Record this process as the instance dir's owner.
+
+    The pid goes on the first line, followed by ``key=value`` lines
+    naming the pid domain (namespace, boot) so a later sweep can tell
+    whether that pid is even resolvable from where it runs — see
+    :func:`_read_owner_claim`.
+
+    Also the compatibility boundary: an older build reads the whole
+    file as one integer, so the extra lines make its sweep treat the
+    marker as unreadable and skip the dir. Skipping is the safe
+    direction (a leaked tmux server, not a destroyed live one).
+
+    :param instance_dir: The instance's private dir.
+    :returns: None.
+    """
+    lines = [str(os.getpid()), f"{_OWNER_CLAIM_PID_NS_KEY}={_current_pid_ns()}"]
+    boot_id = _current_boot_id()
+    if boot_id is not None:
+        lines.append(f"{_OWNER_CLAIM_BOOT_KEY}={boot_id}")
+    (instance_dir / _OWNER_PID_FILENAME).write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _read_owner_claim(instance_dir: Path) -> _OwnerClaim | None:
+    """
+    Parse an instance dir's owner marker.
+
+    :param instance_dir: Candidate instance dir under the sweep root.
+    :returns: The claim, or ``None`` when there is no marker, it is
+        unreadable, or it predates the pid-domain fields (a bare pid
+        this process cannot place in a namespace, so it cannot judge
+        whether the owner is alive).
+    """
+    try:
+        raw = (instance_dir / _OWNER_PID_FILENAME).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    lines = [line.strip() for line in raw.splitlines() if line.strip()]
+    if not lines:
+        return None
+    try:
+        pid = int(lines[0])
+    except ValueError:
+        return None
+    fields = dict(line.split("=", 1) for line in lines[1:] if "=" in line)
+    pid_ns = fields.get(_OWNER_CLAIM_PID_NS_KEY)
+    if pid_ns is None:
+        # Bare-pid marker from a build before this sweep learned that a
+        # pid is domain-relative. Unplaceable, so not judgeable.
+        return None
+    return _OwnerClaim(pid=pid, pid_ns=pid_ns, boot_id=fields.get(_OWNER_CLAIM_BOOT_KEY))
+
+
+def _owner_is_gone(claim: _OwnerClaim) -> bool:
+    """
+    Decide whether an instance dir's owner definitively no longer exists.
+
+    A recorded pid is only a name for a process inside the pid namespace
+    and boot that minted it, while the instance dirs sit in a temp root
+    shared across both. Reading a foreign pid as a local one is what let
+    a fresh runner mistake other processes' live terminals for leaks and
+    kill the tmux servers under them, so a pid decides the question only
+    when this process shares its domain.
+
+    :param claim: The dir's recorded owner (see :func:`_read_owner_claim`).
+    :returns: ``True`` only on positive evidence of abandonment: the
+        marker is from an earlier boot (nothing it named can still be
+        running), or the pid is resolvable here and gone.
+    """
+    boot_id = _current_boot_id()
+    if claim.boot_id is not None and boot_id is not None and claim.boot_id != boot_id:
+        # Written before this boot, so neither the owner nor the tmux
+        # server it launched survived; the dir is pure garbage.
+        return True
+    if claim.pid_ns != _current_pid_ns():
+        # A pid from another namespace names an unrelated process here
+        # (or nothing at all) — no conclusion is available.
+        return False
+    return not _process_alive(claim.pid)
+
+
 def reap_orphaned_terminals() -> int:
     """
     Kill terminal tmux servers whose owning process is gone.
@@ -684,10 +834,16 @@ def reap_orphaned_terminals() -> int:
     whose whole process group is torn down by a test harness — leaks
     them forever, one per session now that runner-bound SDK sessions
     auto-create the embedded REPL terminal. Each instance dir records
-    its owner pid at creation; this sweep (run at runner startup) kills
-    the tmux server of every instance whose owner no longer exists and
-    removes the instance dir. Dirs without an owner-pid marker are left
-    untouched — they are either from an older version or not ours.
+    its owner at creation; this sweep (run at runner startup) kills the
+    tmux server of every instance whose owner definitively no longer
+    exists (see :func:`_owner_is_gone`) and removes the instance dir.
+
+    Everything else is left untouched — an unreadable or unplaceable
+    marker, and a marker whose owner cannot be resolved from here.
+    The sweep is a best-effort GC of leaked servers, so the two
+    outcomes are not symmetric: skipping costs one idle tmux server
+    until the next sweep, while a wrong reap kills a live terminal
+    under a running agent, taking its in-flight turn with it.
 
     :returns: The number of orphaned instance dirs reaped.
     """
@@ -695,11 +851,8 @@ def reap_orphaned_terminals() -> int:
         return 0
     reaped = 0
     for entry in _terminals_tmp_root().glob(f"{_TERMINAL_DIR_PREFIX}*"):
-        try:
-            pid = int((entry / _OWNER_PID_FILENAME).read_text(encoding="utf-8").strip())
-        except (OSError, ValueError):
-            continue
-        if _process_alive(pid):
+        claim = _read_owner_claim(entry)
+        if claim is None or not _owner_is_gone(claim):
             continue
         socket_path = entry / "tmux.sock"
         if socket_path.exists():
@@ -2010,7 +2163,7 @@ def create_terminal_instance(
     # Record the owning process so a later startup can reap this tmux
     # server if we die without graceful shutdown (SIGKILL, harness
     # teardown) — see ``reap_orphaned_terminals``.
-    (private_dir / _OWNER_PID_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
+    _write_owner_claim(private_dir)
 
     # Resolve os_env spec.  If none specified, inherit from parent.
     effective_os_env_spec = build_terminal_os_env_spec(

--- a/tests/e2e/test_codex_main_terminal_tmux_disappears_e2e.py
+++ b/tests/e2e/test_codex_main_terminal_tmux_disappears_e2e.py
@@ -1,0 +1,218 @@
+r"""E2E regression: the Codex ``codex:main`` terminal disappears from tmux
+and the session is torn down.
+
+The observable signature: ``omnigent.inner.terminal._idle_watch_loop_threaded``
+logs at ERROR
+
+    tmux unavailable after 3 consecutive probes for terminal codex:main
+
+The user journey: a user is running a Codex (``codex-native``)
+session, whose Codex TUI the runner auto-launches into the session-scoped
+``codex:main`` managed tmux terminal. Mid-session the tmux server backing that
+terminal goes away. The runner's threaded idle watcher — armed on exactly this
+terminal in ``omnigent/runner/resource_registry.py`` — probes the pane every
+``_IDLE_POLL_INTERVAL_SECONDS`` with ``capture-pane``; when that fails it
+confirms with ``has-session``. Once both fail for
+``_IDLE_EXIT_FAILURE_THRESHOLD`` (3) consecutive probes the watcher declares
+the terminal gone: it logs the signature above, flips ``instance.running`` to
+``False`` and fires ``on_exit``. In production ``on_exit`` routes through
+``_handle_terminal_exit`` → ``_publish_terminal_exit`` (``omnigent/runner/app.py``),
+which publishes ``session.resource.deleted`` for the terminal (the pane
+disappears from the web UI) and, because ``codex:main`` is a REQUIRED terminal,
+marks the session ``failed`` with ``Required terminal exited unexpectedly``.
+
+This test drives the real product path end to end with a real tmux server and
+the production launch + watcher wiring (no LLM, no codex binary needed — the
+inner pane process is a stand-in that fills the pane the way a booted Codex TUI
+does; the managed-terminal launch, the ``codex:main`` naming and the threaded
+idle watcher are the production ones):
+
+1. Launch the ``codex:main`` managed terminal through the production
+   ``TerminalRegistry`` (the same call ``launch_required_terminal`` makes).
+2. Arm the real threaded idle watcher with an ``on_exit`` callback, exactly as
+   the runner arms it for a native terminal.
+3. Inject the reported fault: the tmux server backing ``codex:main`` disappears
+   (``kill-server`` — the deterministic stand-in for the reported "disappears
+   from tmux" condition, whatever removes it in production: an ungraceful
+   runner teardown + startup orphan sweep, OOM, a /tmp reaper, a crash).
+4. Observe the reported outcome: within the watcher's probe budget it logs the
+   exact ``tmux unavailable after 3 consecutive probes for terminal codex:main``
+   signature, fires ``on_exit`` (the teardown that removes the pane and fails
+   the session), and marks the instance not running.
+
+The sibling test guards the opposite direction — a healthy ``codex:main`` pane
+must **not** trip the watcher, so a live user's Codex terminal never vanishes
+while its tmux server is fine.
+
+Runs with only ``tmux``::
+
+    pytest tests/e2e/test_codex_main_terminal_tmux_disappears_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
+from omnigent.inner.terminal import (
+    _IDLE_EXIT_FAILURE_THRESHOLD,
+    _IDLE_POLL_INTERVAL_SECONDS,
+)
+from omnigent.terminals import TerminalRegistry
+
+pytestmark = pytest.mark.skipif(shutil.which("tmux") is None, reason="requires tmux on PATH")
+
+# The runner arms the codex-native idle watcher on a terminal named ``codex``
+# with session key ``main`` — so the emitted signature reads exactly
+# "... for terminal codex:main", the string the KPI groups on.
+_TERMINAL_NAME = "codex"
+_SESSION_KEY = "main"
+
+# The watcher needs _IDLE_EXIT_FAILURE_THRESHOLD consecutive failed probes,
+# one per poll interval, to declare the terminal gone. Give it generous
+# headroom past that so a slow CI box never flakes the detection.
+_EXIT_BUDGET_S = max(30.0, _IDLE_EXIT_FAILURE_THRESHOLD * _IDLE_POLL_INTERVAL_SECONDS * 6)
+
+# How long a healthy pane is watched in the negative test — several poll
+# intervals, long enough that a spurious teardown would have fired.
+_HEALTHY_OBSERVE_S = max(6.0, _IDLE_POLL_INTERVAL_SECONDS * 5)
+
+
+def _codex_like_pane_spec(cwd: Path) -> TerminalEnvSpec:
+    """A pane that fills like a booted Codex TUI, then idles waiting for input.
+
+    :param cwd: Working directory for the pane process.
+    :returns: A managed-terminal spec whose inner process stays alive (so the
+        pane is live and healthy until the tmux server itself is removed).
+    """
+    return TerminalEnvSpec(
+        command="bash",
+        args=["-c", "echo 'CODEX TUI READY'; exec sleep 600"],
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=str(cwd),
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+
+
+async def test_codex_main_terminal_torn_down_when_tmux_server_disappears(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When ``codex:main``'s tmux server disappears the watcher tears the
+    terminal down and logs the teardown signature.
+
+    Reproduces the reported failure: the threaded idle watcher detects the
+    vanished server after ``_IDLE_EXIT_FAILURE_THRESHOLD`` probes, logs
+    ``tmux unavailable after 3 consecutive probes for terminal codex:main``,
+    fires ``on_exit`` (which in production removes the pane from the UI and
+    fails the required-terminal session), and marks the instance not running.
+
+    :param tmp_path: Working directory for the managed terminal.
+    :param caplog: Captures the watcher's ERROR-level signature line.
+    """
+    reg = TerminalRegistry()
+    exited = threading.Event()
+    try:
+        instance = await reg.launch(
+            "conv_codex_main_vanish",
+            _TERMINAL_NAME,
+            _SESSION_KEY,
+            _codex_like_pane_spec(tmp_path),
+        )
+        assert instance.running, "codex:main terminal failed to launch"
+        assert instance.tmux_target == _SESSION_KEY
+        socket_path = str(instance.socket_path)
+
+        def _on_exit() -> None:
+            # Production ``on_exit`` -> _handle_terminal_exit ->
+            # _publish_terminal_exit: session.resource.deleted (pane vanishes)
+            # + session.status failed ("Required terminal exited unexpectedly").
+            exited.set()
+
+        instance.start_idle_watcher_thread(on_exit=_on_exit)
+
+        # The watcher must stay quiet while the pane is healthy — a teardown
+        # here would mean the exit was spurious, not caused by the fault.
+        assert not exited.wait(2.0), "watcher declared exit on a healthy codex:main pane"
+        assert instance.running
+
+        with caplog.at_level(logging.ERROR, logger="omnigent.inner.terminal"):
+            # THE REPORTED FAULT: the tmux server backing codex:main disappears.
+            subprocess.run(
+                ["tmux", "-S", socket_path, "kill-server"],
+                check=False,
+                capture_output=True,
+                timeout=15.0,
+            )
+
+            fired = exited.wait(_EXIT_BUDGET_S)
+
+        assert fired, (
+            "the idle watcher never fired on_exit after the codex:main tmux "
+            f"server disappeared (waited {_EXIT_BUDGET_S:.0f}s); the session "
+            "would hang instead of tearing down"
+        )
+        assert not instance.running, (
+            "instance.running stayed True after the tmux server vanished; the "
+            "watcher must mark the terminal gone"
+        )
+        signature = (
+            f"tmux unavailable after {_IDLE_EXIT_FAILURE_THRESHOLD} consecutive "
+            f"probes for terminal {_TERMINAL_NAME}:{_SESSION_KEY}"
+        )
+        assert signature in caplog.text, (
+            "expected the teardown signature "
+            f"{signature!r} in the watcher's logs, got:\n{caplog.text}"
+        )
+    finally:
+        await reg.shutdown()
+
+
+async def test_codex_main_terminal_watcher_stays_quiet_while_tmux_is_healthy(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A healthy ``codex:main`` pane must never trip the watcher.
+
+    Guards the opposite direction of the bug: a live user's Codex terminal
+    must not disappear (no ``on_exit``, no teardown signature) while its tmux
+    server is perfectly healthy. If a future change made the watcher declare
+    exit on transient/slow probes, this catches it.
+
+    :param tmp_path: Working directory for the managed terminal.
+    :param caplog: Asserts the teardown signature is absent for a healthy pane.
+    """
+    reg = TerminalRegistry()
+    exited = threading.Event()
+    try:
+        instance = await reg.launch(
+            "conv_codex_main_healthy",
+            _TERMINAL_NAME,
+            _SESSION_KEY,
+            _codex_like_pane_spec(tmp_path),
+        )
+        assert instance.running, "codex:main terminal failed to launch"
+
+        instance.start_idle_watcher_thread(on_exit=exited.set)
+
+        with caplog.at_level(logging.ERROR, logger="omnigent.inner.terminal"):
+            spurious = exited.wait(_HEALTHY_OBSERVE_S)
+
+        assert not spurious, (
+            "the idle watcher declared codex:main exited while its tmux server "
+            "was healthy — a live user's Codex terminal would vanish for no reason"
+        )
+        assert instance.running, "healthy codex:main terminal was marked not running"
+        assert "tmux unavailable after" not in caplog.text, (
+            f"the teardown signature was logged for a healthy pane:\n{caplog.text}"
+        )
+    finally:
+        await reg.shutdown()

--- a/tests/e2e/test_opencode_terminal_survives_orphan_sweep_e2e.py
+++ b/tests/e2e/test_opencode_terminal_survives_orphan_sweep_e2e.py
@@ -1,0 +1,186 @@
+"""The startup orphan sweep must not take down a live ``opencode:main`` terminal.
+
+An ``opencode-native`` session's runner launches the OpenCode TUI into a managed
+tmux terminal named ``opencode:main`` and arms the threaded idle watcher on it.
+Terminal instance dirs live in a temp root shared by every process on the box,
+and any *other* runner starting up sweeps that root for leaked tmux servers
+(:func:`omnigent.inner.terminal.reap_orphaned_terminals`). A sweep that reads an
+owner pid it cannot place locally — a marker written in a different pid
+namespace or boot reads as a bare pid naming no live process here — must NOT
+treat the live terminal as an orphan. When it does, ``tmux kill-server`` lands
+on a socket a running session is using; the idle watcher then fails three
+consecutive probes, logs at ERROR::
+
+    tmux unavailable after 3 consecutive probes for terminal opencode:main
+
+flips the instance to not running, and fires ``on_exit`` — the runner deletes
+``terminal_opencode_main`` and the user's OpenCode terminal disappears from the
+session mid-flight.
+
+This test drives that chain against a real tmux server and the real threaded
+watcher: launch a live ``opencode:main`` terminal, arm the watcher, stamp the
+owner marker with a pid that does not resolve in this namespace, run the
+startup sweep, and require the terminal to survive — no reap, no watchdog
+teardown, no ``tmux unavailable`` ERROR. On the namespace-blind sweep the live
+server is killed and the watcher tears the terminal down, so this fails; the
+pid-domain-aware sweep leaves it alone and it passes.
+
+The opposite direction — a *genuinely* vanished tmux server must still tear the
+terminal down, and a healthy pane must never trip the watcher — is covered by
+``tests/e2e/test_codex_main_terminal_tmux_disappears_e2e.py`` (the watcher is
+terminal-name-agnostic).
+
+Runs with only ``tmux``::
+
+    pytest tests/e2e/test_opencode_terminal_survives_orphan_sweep_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import shutil
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+import omnigent.inner.terminal as terminal_mod
+from omnigent.inner.terminal import (
+    _IDLE_EXIT_FAILURE_THRESHOLD,
+    _IDLE_POLL_INTERVAL_SECONDS,
+    TerminalInstance,
+    reap_orphaned_terminals,
+)
+
+pytestmark = pytest.mark.skipif(shutil.which("tmux") is None, reason="requires tmux on PATH")
+
+# The runner arms the opencode-native idle watcher on a terminal named
+# ``opencode`` with session key ``main`` — the watchdog signature the KPI
+# groups on reads exactly "... for terminal opencode:main".
+_TERMINAL_NAME = "opencode"
+_SESSION_KEY = "main"
+
+# After the sweep runs, watch the pane past the watcher's full probe budget
+# (3 failed probes, one per poll interval) with headroom for a slow CI box: a
+# wrongly killed tmux server MUST have tripped the watcher within this window,
+# so a quiet watcher here means the terminal really survived.
+_QUIET_OBSERVE_S = max(8.0, _IDLE_EXIT_FAILURE_THRESHOLD * _IDLE_POLL_INTERVAL_SECONDS * 3)
+
+
+def _tmux_server_reachable(socket_path: Path, target: str) -> bool:
+    """Return whether the private tmux server/session is still reachable.
+
+    :param socket_path: The instance's private tmux control socket.
+    :param target: The tmux session target, e.g. ``"main"``.
+    :returns: ``True`` when ``has-session`` succeeds (server alive).
+    """
+    probe = subprocess.run(
+        ["tmux", "-S", str(socket_path), "has-session", "-t", target],
+        capture_output=True,
+        timeout=5,
+    )
+    return probe.returncode == 0
+
+
+async def test_opencode_main_terminal_survives_foreign_runner_startup_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A foreign runner's startup sweep must leave the live ``opencode:main`` alone.
+
+    :param monkeypatch: Retargets the sweep's temp root at a private scratch dir.
+    :param caplog: Asserts the watchdog's teardown signature is never logged.
+    """
+    # A SHORT scratch root — the tmux control socket path must stay under the
+    # ~108-char AF_UNIX limit, so pytest's deeply nested ``tmp_path`` can't be
+    # used. Retargeting the sweep's scan root here also keeps it off other
+    # tests' live instance dirs.
+    scratch = Path(tempfile.mkdtemp(prefix="og-oc-sweep-"))
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: scratch)
+
+    # The dir name must carry the sweep's prefix so its glob matches it.
+    instance_dir = scratch / f"{terminal_mod._TERMINAL_DIR_PREFIX}1"
+    instance_dir.mkdir()
+    socket_path = instance_dir / "tmux.sock"
+
+    # A real, long-lived pane standing in for the booted OpenCode TUI: fills
+    # the pane, then idles waiting for input, alive until tmux itself dies.
+    instance = TerminalInstance(
+        name=_TERMINAL_NAME,
+        session_key=_SESSION_KEY,
+        socket_path=socket_path,
+        private_dir=instance_dir,
+        command="bash",
+        args=["-c", "echo 'OPENCODE TUI READY'; exec sleep 600"],
+        keep_alive_after_exit=True,
+    )
+    exited = threading.Event()
+    await instance.launch(cwd=instance_dir)
+    try:
+        for _ in range(250):
+            if _tmux_server_reachable(socket_path, instance.tmux_target):
+                break
+            await asyncio.sleep(0.02)
+        else:  # pragma: no cover - only on a launch hang/regression
+            raise AssertionError("tmux server never became reachable after launch")
+
+        # Arm the real threaded idle watcher exactly as the runner arms it for
+        # the native terminal; its on_exit is what deletes the resource in
+        # production.
+        instance.start_idle_watcher_thread(on_exit=exited.set)
+        assert not exited.wait(2.0), "watcher declared exit on a healthy opencode:main pane"
+
+        # Owner marker the sweep cannot place: a pid that is dead in this
+        # namespace — byte-identical to what a namespace-blind reader sees for
+        # a marker written by a runner in a different pid namespace or boot,
+        # while the tmux server (and its true owner) is alive.
+        dead = subprocess.Popen(["sh", "-c", "exit 0"])
+        dead.wait()
+        assert not terminal_mod._process_alive(dead.pid), (
+            f"precondition: pid {dead.pid} must be dead in this namespace "
+            "(a reused pid would invalidate the scenario; extremely rare, rerun)"
+        )
+        (instance_dir / terminal_mod._OWNER_PID_FILENAME).write_text(
+            str(dead.pid), encoding="utf-8"
+        )
+
+        with caplog.at_level(logging.ERROR, logger="omnigent.inner.terminal"):
+            # A foreign runner starts up and sweeps for leaked terminals.
+            reaped = reap_orphaned_terminals()
+            # Watch past the watcher's whole probe budget: if the sweep killed
+            # the live server, on_exit fires in here with the reported
+            # signature in the log.
+            fired = exited.wait(_QUIET_OBSERVE_S)
+
+        signature = (
+            f"tmux unavailable after {_IDLE_EXIT_FAILURE_THRESHOLD} consecutive "
+            f"probes for terminal {_TERMINAL_NAME}:{_SESSION_KEY}"
+        )
+        assert not fired, (
+            "the startup orphan sweep took down a LIVE opencode:main terminal: "
+            "the idle watcher fired on_exit (in production the runner deletes "
+            "terminal_opencode_main and the user's OpenCode terminal disappears "
+            f"from the session). watcher log:\n{caplog.text}"
+        )
+        assert reaped == 0, (
+            "orphan sweep reaped a LIVE opencode:main terminal whose owner pid "
+            f"is merely unresolvable in this namespace (reaped={reaped})"
+        )
+        assert signature not in caplog.text, (
+            f"the watchdog logged the teardown signature {signature!r} for a "
+            f"terminal that was alive before the sweep:\n{caplog.text}"
+        )
+        assert instance.running, "live opencode:main terminal was marked not running"
+        assert _tmux_server_reachable(socket_path, instance.tmux_target), (
+            "orphan sweep killed the live tmux server backing opencode:main"
+        )
+        assert instance_dir.exists(), "orphan sweep removed a live terminal's instance dir"
+    finally:
+        # Under the bug the server is already gone; swallow teardown errors.
+        with contextlib.suppress(Exception):
+            await instance.close()
+        shutil.rmtree(scratch, ignore_errors=True)

--- a/tests/e2e/test_orphan_sweep_keeps_live_terminal.py
+++ b/tests/e2e/test_orphan_sweep_keeps_live_terminal.py
@@ -1,0 +1,137 @@
+"""The startup orphan sweep must not reap live terminals it cannot place an owner for.
+
+The runner's startup orphan sweep (:func:`reap_orphaned_terminals`) decides a
+terminal tmux server is a leak by reading the owner pid recorded in its instance
+dir and asking whether that pid is alive *here*. But a bare pid names a process
+only inside the pid namespace + boot that minted it, while the instance dirs sit
+in a temp root shared by every process on the box. When a starting runner reads
+a marker written by another runner in a *different* pid namespace (or a previous
+boot), that pid resolves to nothing locally, the sweep calls the terminal an
+orphan, and it runs ``tmux kill-server`` on the socket a running agent is still
+using.
+
+The user then sees a session failed with "Required terminal exited
+unexpectedly; the session runtime is no longer available." while the terminal
+never actually exited (the runner logs the exit with *no* ``(exited with status
+N)`` -- the pane was alive when the sweep decided it was gone).
+
+This exercises the real sweep against a real, live tmux server whose owner-pid
+marker names a pid that is not alive in this namespace -- the exact byte-level
+state a foreign-namespace / legacy-bare-pid marker produces for the
+namespace-blind sweep. The sweep must LEAVE the live server alone (absence of a
+resolvable owner is not evidence of death). On the buggy build the sweep kills
+the live server and removes the instance dir, so this fails; the fix makes it
+pass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import omnigent.inner.terminal as terminal_mod
+from omnigent.inner.terminal import TerminalInstance, reap_orphaned_terminals
+
+
+def _tmux_server_reachable(socket_path: Path, target: str) -> bool:
+    """Return whether the private tmux server/session is still reachable.
+
+    :param socket_path: The instance's private tmux control socket.
+    :param target: The tmux session target, e.g. ``"s1:main"``.
+    :returns: ``True`` when ``has-session`` succeeds (server alive).
+    """
+    probe = subprocess.run(
+        ["tmux", "-S", str(socket_path), "has-session", "-t", target],
+        capture_output=True,
+        timeout=5,
+    )
+    return probe.returncode == 0
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="requires a real tmux binary")
+@pytest.mark.asyncio
+async def test_orphan_sweep_keeps_live_terminal_with_unresolvable_owner_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The startup sweep must not reap a live terminal it cannot place an owner for.
+
+    :param monkeypatch: Retargets the sweep's temp root at the scratch dir.
+    """
+    # A SHORT scratch root -- the tmux control socket path must stay under the
+    # ~108-char AF_UNIX limit, so pytest's deeply-nested ``tmp_path`` can't be
+    # used. Retarget the sweep's scan root here so it only ever considers our
+    # own instance dir (the module exposes this indirection for exactly this
+    # reason).
+    scratch = Path(tempfile.mkdtemp(prefix="og-sweep-"))
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: scratch)
+
+    # The dir name must carry the sweep's prefix so its glob matches it.
+    instance_dir = scratch / f"{terminal_mod._TERMINAL_DIR_PREFIX}1"
+    instance_dir.mkdir()
+    socket_path = instance_dir / "tmux.sock"
+
+    # A real, long-lived tmux terminal: stands in for a user's live agent CLI
+    # (a running ``claude:main`` pane). Its true owner -- this test process --
+    # is alive throughout.
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=socket_path,
+        private_dir=instance_dir,
+        command="sh",
+        args=["-c", "sleep 600"],
+        keep_alive_after_exit=True,
+    )
+    await instance.launch(cwd=instance_dir)
+    try:
+        # Wait for the private tmux server to come up.
+        for _ in range(250):
+            if _tmux_server_reachable(socket_path, instance.tmux_target):
+                break
+            await asyncio.sleep(0.02)
+        else:  # pragma: no cover - only on a launch hang/regression
+            raise AssertionError("tmux server never became reachable after launch")
+
+        # Owner-pid marker that is NOT alive in this namespace: spawn a child,
+        # let it exit, and reap it, then stamp its now-dead pid. This is
+        # byte-identical to what the namespace-blind sweep reads for a marker
+        # written by a runner in a *different* pid namespace / previous boot --
+        # a bare integer that names no live process here, even though the tmux
+        # server (and its real owner) is alive.
+        dead = subprocess.Popen(["sh", "-c", "exit 0"])
+        dead.wait()
+        dead_pid = dead.pid
+        assert not terminal_mod._process_alive(dead_pid), (
+            f"precondition: pid {dead_pid} must be dead in this namespace "
+            "(a reused pid would invalidate the repro; extremely rare, rerun)"
+        )
+        (instance_dir / terminal_mod._OWNER_PID_FILENAME).write_text(
+            str(dead_pid), encoding="utf-8"
+        )
+
+        reaped = reap_orphaned_terminals()
+
+        # The live tmux server must survive: an owner pid that cannot be placed
+        # in this namespace is not evidence the terminal died. On the buggy
+        # build the sweep reaps it (kill-server on the live socket + rmtree),
+        # so all three assertions fail.
+        assert reaped == 0, (
+            "orphan sweep reaped a LIVE terminal whose owner pid is merely "
+            f"unresolvable in this namespace (reaped={reaped})"
+        )
+        assert _tmux_server_reachable(socket_path, instance.tmux_target), (
+            "orphan sweep killed the live tmux server -- a running agent's turn "
+            "would fail with 'Required terminal exited unexpectedly'"
+        )
+        assert instance_dir.exists(), "orphan sweep removed a live terminal's instance dir"
+    finally:
+        # Under the bug the server is already gone; swallow teardown errors.
+        with contextlib.suppress(Exception):
+            await instance.close()
+        shutil.rmtree(scratch, ignore_errors=True)

--- a/tests/e2e_ui/chat/test_opencode_terminal_survives_sweep_ui.py
+++ b/tests/e2e_ui/chat/test_opencode_terminal_survives_sweep_ui.py
@@ -1,0 +1,242 @@
+"""Web-lane recording driver — the ``opencode:main`` terminal survives a sweep.
+
+Recording driver (an ``after`` clip on the ``terminal`` surface) for the fix
+whose durable regression guard is
+``tests/e2e/test_opencode_terminal_survives_orphan_sweep_e2e.py``. It stands up
+a real runner-direct ``opencode-native-ui`` session so the runner auto-creates
+the live ``opencode:main`` terminal, shows that terminal in the SPA's Terminal
+view, then drives the condition that used to take it down: a *foreign* runner's
+startup orphan sweep reads the terminal's owner marker as a pid it cannot place
+(the dir is stamped with a pid that is dead in this namespace — what a marker
+written in another pid namespace or boot reads as locally) and runs
+``reap_orphaned_terminals``. The namespace-blind sweep killed the live tmux
+server here, the idle watcher logged ``tmux unavailable after 3 consecutive
+probes for terminal opencode:main`` and the pane vanished from the session; the
+pid-domain-aware sweep leaves it alone. The Playwright video captures the
+OpenCode terminal pane present, the sweep running, and the pane still alive
+afterwards.
+
+Run under the e2e_ui recorder (spawns its own local server + runner; this test
+uses the pytest-playwright ``page`` fixture, so ``--video on`` records it)::
+
+    OMNIGENT_E2E_OPENCODE_NATIVE=1 \\
+    pytest tests/e2e_ui/chat/test_opencode_terminal_survives_sweep_ui.py \\
+        --ui-skip-build -p no:randomly --video on --output recordings/opencode-sweep
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.inner.terminal import (
+    _IDLE_EXIT_FAILURE_THRESHOLD,
+    _IDLE_POLL_INTERVAL_SECONDS,
+    _OWNER_PID_FILENAME,
+)
+from tests.e2e_ui.conftest import _ensure_runner_online, _server_state
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("OMNIGENT_E2E_OPENCODE_NATIVE") != "1" or shutil.which("opencode") is None,
+    reason=(
+        "opencode-native sweep-survival recording needs a pinned `opencode` binary; "
+        "set OMNIGENT_E2E_OPENCODE_NATIVE=1 to run"
+    ),
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TERMINAL_APPEAR_TIMEOUT_S = 90.0
+# Past the idle watcher's whole probe budget (3 failed probes, one per poll
+# interval) plus margin: a killed tmux server MUST have tripped it in here.
+_SURVIVE_OBSERVE_MS = int(
+    max(8.0, _IDLE_EXIT_FAILURE_THRESHOLD * _IDLE_POLL_INTERVAL_SECONDS * 3) * 1000
+)
+
+
+def _create_native_opencode_session(base_url: str, runner_id: str) -> str:
+    """Register the ``opencode-native`` wrapper agent and bind its session.
+
+    Mirrors :func:`tests.e2e_ui.conftest._create_native_goose_session` for
+    opencode: reuses the terminal-first spec ``omnigent opencode`` ships and
+    stamps the wrapper / terminal-first labels. Binding triggers the runner's
+    opencode-native auto-bootstrap (``_auto_create_opencode_terminal``), which
+    launches ``opencode serve`` + ``opencode attach`` in the session terminal.
+    """
+    from omnigent._wrapper_labels import (
+        OPENCODE_NATIVE_WRAPPER_VALUE,
+        UI_MODE_LABEL_KEY,
+        UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY,
+    )
+
+    try:  # current layout
+        from omnigent.harnesses.opencode_native.main import _materialize_opencode_agent_spec
+    except ImportError:  # pre-harnesses-package layout
+        from omnigent.opencode_native import _materialize_opencode_agent_spec
+
+    with tempfile.TemporaryDirectory() as _tmp:
+        spec_path = _materialize_opencode_agent_spec(Path(_tmp))
+        yaml_text = spec_path.read_text()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml_text.encode()
+        info = tarfile.TarInfo("opencode-native-ui.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    labels = {
+        UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY: OPENCODE_NATIVE_WRAPPER_VALUE,
+    }
+    metadata = {"labels": labels, "workspace": str(_REPO_ROOT)}
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": json.dumps(metadata)},
+        files={"bundle": ("opencode-native-ui.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    # Bind with a generous timeout: unlike goose/codex, opencode-native's bind
+    # boots ``opencode serve`` synchronously, which can exceed the shared
+    # helper's 10s budget.
+    patch = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=90.0,
+    )
+    patch.raise_for_status()
+    return session_id
+
+
+def _terminal_ids(base_url: str, session_id: str) -> list[str]:
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}/resources", timeout=10.0)
+    if resp.status_code != 200:
+        return []
+    return [r.get("id") for r in resp.json().get("data", []) if r.get("type") == "terminal"]
+
+
+def _wait_for_terminal_socket(base_url: str, session_id: str, resource_id: str) -> str:
+    deadline = time.monotonic() + _TERMINAL_APPEAR_TIMEOUT_S
+    last: list[str] = []
+    while time.monotonic() < deadline:
+        last = _terminal_ids(base_url, session_id)
+        if resource_id in last:
+            detail = httpx.get(
+                f"{base_url}/v1/sessions/{session_id}/resources/terminals/{resource_id}",
+                timeout=10.0,
+            )
+            detail.raise_for_status()
+            socket = detail.json().get("metadata", {}).get("tmux_socket")
+            if socket:
+                return str(socket)
+        time.sleep(1.0)
+    raise AssertionError(
+        f"opencode terminal {resource_id!r} never registered a tmux socket within "
+        f"{_TERMINAL_APPEAR_TIMEOUT_S}s; saw {last!r}"
+    )
+
+
+def _run_foreign_startup_sweep(instance_dir: Path) -> str:
+    """Run ``reap_orphaned_terminals`` the way a starting runner would.
+
+    A separate interpreter (the "foreign runner") sweeps the temp root the
+    instance dir lives in. Returns the subprocess's combined output for
+    diagnostics.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join([str(_REPO_ROOT), env.get("PYTHONPATH", "")]).rstrip(
+        os.pathsep
+    )
+    # The sweep scans tempfile.gettempdir(); point the foreign runner's temp
+    # root at the dir the live instance actually lives in.
+    env["TMPDIR"] = str(instance_dir.parent)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from omnigent.inner.terminal import reap_orphaned_terminals; "
+            "print('reaped', reap_orphaned_terminals())",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return f"rc={proc.returncode} stdout={proc.stdout!r} stderr={proc.stderr!r}"
+
+
+def test_opencode_terminal_persists_in_ui_through_foreign_runner_sweep(
+    page: Page,
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Film the OpenCode terminal pane staying alive through a startup sweep."""
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    session_id: str | None = None
+    try:
+        runner_id = str(_server_state["runner_id"])
+        session_id = _create_native_opencode_session(live_server, runner_id)
+        terminal_id = terminal_resource_id("opencode", "main")
+        tmux_socket = _wait_for_terminal_socket(live_server, session_id, terminal_id)
+        instance_dir = Path(tmux_socket).parent
+
+        # Show the live OpenCode terminal in the SPA's Terminal view.
+        page.goto(f"{live_server}/c/{session_id}")
+        expect(page.get_by_label("Message the agent")).to_be_visible(timeout=30_000)
+        # Switch Chat -> Terminal view via the header toggle.
+        page.get_by_role("button", name="Terminal view").click()
+        term = page.get_by_test_id("main-terminal-view")
+        expect(term).to_have_attribute("data-visible", "true", timeout=15_000)
+        # Let the OpenCode TUI paint into the pane, on camera.
+        page.wait_for_timeout(4_000)
+
+        # Stamp the owner marker with a pid that is dead in this namespace —
+        # what a namespace-blind sweep reads for a marker written by a runner
+        # in another pid namespace or boot, while the terminal is fully alive.
+        dead = subprocess.Popen(["sh", "-c", "exit 0"])
+        dead.wait()
+        (instance_dir / _OWNER_PID_FILENAME).write_text(str(dead.pid), encoding="utf-8")
+
+        # A foreign runner starts up and sweeps for leaked terminals. This is
+        # the condition that used to kill the live tmux server, after which
+        # the watcher logged 'tmux unavailable after 3 consecutive probes for
+        # terminal opencode:main' and the pane vanished from the session.
+        sweep_diag = _run_foreign_startup_sweep(instance_dir)
+
+        # Keep filming past the watcher's whole probe budget: were the server
+        # gone, the pane would be torn down in this window.
+        page.wait_for_timeout(_SURVIVE_OBSERVE_MS)
+
+        assert terminal_id in _terminal_ids(live_server, session_id), (
+            "opencode terminal was deleted after the foreign runner's startup "
+            f"sweep — the live pane did not survive. sweep: {sweep_diag}"
+        )
+        expect(term).to_have_attribute("data-visible", "true")
+        # Hold the surviving pane on camera for a beat.
+        page.wait_for_timeout(3_000)
+    finally:
+        with __import__("contextlib").suppress(Exception):
+            if session_id is not None:
+                httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -1323,20 +1323,46 @@ def test_idle_detector_suppress_activity_discounts_client_driven_repaint() -> No
     )
 
 
-def _write_instance_dir(root: Path, name: str, owner_pid: int | None) -> Path:
+def _write_instance_dir(
+    root: Path,
+    name: str,
+    owner_pid: int | None,
+    *,
+    pid_ns: str | None = None,
+    boot_id: str | None = None,
+    legacy: bool = False,
+) -> Path:
     """
     Create a fake terminal instance dir under the sweep root.
+
+    Writes the same marker shape ``create_terminal_instance`` does: the
+    pid, plus the pid domain that makes it resolvable.
 
     :param root: Fake temp root the sweep scans.
     :param name: Directory name, e.g. ``"omnigent-terminal-dead1"``.
     :param owner_pid: Owner pid to record, or ``None`` for no marker
         (an unrelated / pre-marker dir the sweep must not touch).
+    :param pid_ns: Pid namespace to record; defaults to this process's.
+    :param boot_id: Boot id to record; defaults to this boot's.
+    :param legacy: Write a bare pid with no domain fields, as builds
+        before the sweep learned that a pid is domain-relative did.
     :returns: The created directory path.
     """
     instance_dir = root / name
     instance_dir.mkdir()
-    if owner_pid is not None:
+    if owner_pid is None:
+        return instance_dir
+    if legacy:
         (instance_dir / "owner.pid").write_text(str(owner_pid), encoding="utf-8")
+        return instance_dir
+    lines = [str(owner_pid)]
+    effective_ns = pid_ns if pid_ns is not None else terminal_mod._current_pid_ns()
+    if effective_ns is not None:
+        lines.append(f"pid_ns={effective_ns}")
+    effective_boot = boot_id if boot_id is not None else terminal_mod._current_boot_id()
+    if effective_boot is not None:
+        lines.append(f"boot={effective_boot}")
+    (instance_dir / "owner.pid").write_text("\n".join(lines) + "\n", encoding="utf-8")
     return instance_dir
 
 
@@ -1445,6 +1471,157 @@ def test_reap_orphaned_terminals_kills_server_for_dead_owner_socket(
     # kill-server targeted exactly this instance's socket; a missing
     # call means the tmux server (the real leak) survives dir removal.
     assert kill_calls == [["tmux", "-S", str(socket_path), "kill-server"]]
+
+
+def test_reap_orphaned_terminals_keeps_dirs_claimed_in_another_pid_namespace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A pid from a foreign pid namespace never condemns a terminal.
+
+    Instance dirs live in a temp root shared by every process on the
+    box, but a pid only names a process inside the namespace that
+    minted it. Read as a local pid, another namespace's live runner
+    looks dead — and the sweep then kills the tmux server under a
+    running agent, ending its in-flight turn. So a claim stamped with
+    a namespace this process is not in yields no conclusion, even
+    though the pid resolves to nothing here.
+
+    :param tmp_path: Fake temp root the sweep scans.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+
+    def _raise_if_called(*args: object, **kwargs: object) -> None:
+        """Fail the test if the sweep tries to kill a foreign server."""
+        raise AssertionError(f"kill-server must not run: {args} {kwargs}")
+
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: tmp_path)
+    monkeypatch.setattr(terminal_mod, "_tmux_available", lambda: True)
+    monkeypatch.setattr(
+        terminal_mod,
+        "subprocess",
+        SimpleNamespace(run=_raise_if_called, TimeoutExpired=TimeoutError),
+    )
+    foreign_dir = _write_instance_dir(
+        tmp_path,
+        "omnigent-terminal-foreignns",
+        _dead_pid(),
+        pid_ns="pid:[4026599999]",
+    )
+    (foreign_dir / "tmux.sock").touch()
+
+    reaped = terminal_mod.reap_orphaned_terminals()
+
+    assert reaped == 0
+    assert foreign_dir.exists()
+
+
+def test_reap_orphaned_terminals_keeps_legacy_bare_pid_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A marker with no pid domain is unplaceable, so it is left alone.
+
+    Builds predating the domain fields wrote a bare pid, and hosts run
+    several builds at once (a released runner beside a dev checkout).
+    Such a pid cannot be placed in a namespace, so the sweep has no
+    basis to call its owner dead and must not act on it.
+
+    :param tmp_path: Fake temp root the sweep scans.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: tmp_path)
+    monkeypatch.setattr(terminal_mod, "_tmux_available", lambda: True)
+    legacy_dir = _write_instance_dir(
+        tmp_path, "omnigent-terminal-legacy1", _dead_pid(), legacy=True
+    )
+
+    reaped = terminal_mod.reap_orphaned_terminals()
+
+    assert reaped == 0
+    assert legacy_dir.exists()
+
+
+def test_reap_orphaned_terminals_reaps_dirs_from_a_previous_boot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A dir stamped with an earlier boot is garbage regardless of its pid.
+
+    Nothing the marker named survived the reboot — the tmux server
+    included — so the dir is collectable even though the recorded pid
+    is live in this boot (pids are reused across boots, which would
+    otherwise pin the leak forever).
+
+    :param tmp_path: Fake temp root the sweep scans.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import os
+
+    monkeypatch.setattr(terminal_mod, "_terminals_tmp_root", lambda: tmp_path)
+    monkeypatch.setattr(terminal_mod, "_tmux_available", lambda: True)
+    monkeypatch.setattr(
+        terminal_mod,
+        "subprocess",
+        SimpleNamespace(
+            run=lambda *a, **k: SimpleNamespace(returncode=0), TimeoutExpired=TimeoutError
+        ),
+    )
+    # A boot id is only published on Linux; elsewhere the marker carries
+    # none and the pid stays the only signal (see _owner_is_gone).
+    monkeypatch.setattr(terminal_mod, "_current_boot_id", lambda: "boot-now")
+    stale_dir = _write_instance_dir(
+        tmp_path, "omnigent-terminal-prevboot", os.getpid(), boot_id="boot-before"
+    )
+
+    reaped = terminal_mod.reap_orphaned_terminals()
+
+    assert reaped == 1
+    assert not stale_dir.exists()
+
+
+def test_create_terminal_instance_records_a_placeable_owner_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The marker a real instance writes is one the sweep can act on.
+
+    Guards the seam between the writer and the sweep: if the two ever
+    disagree on the marker shape, every dir reads as unplaceable and
+    the leak the sweep exists for comes back silently.
+
+    :param tmp_path: Working directory for the terminal spec.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    import os
+
+    # create_terminal_instance only guards on tmux availability, so
+    # faking the predicate keeps this runnable without tmux installed.
+    monkeypatch.setattr(terminal_mod, "_tmux_available", lambda: True)
+
+    result = create_terminal_instance(
+        name="bash",
+        session_key="s1",
+        spec=TerminalEnvSpec(
+            command="bash", os_env=OSEnvSpec(type="caller_process", cwd=str(tmp_path))
+        ),
+    )
+    claim = terminal_mod._read_owner_claim(result.instance.private_dir)
+
+    assert claim is not None, "the writer must produce a marker the sweep can parse"
+    assert claim.pid == os.getpid()
+    assert claim.pid_ns == terminal_mod._current_pid_ns()
+    assert claim.boot_id == terminal_mod._current_boot_id()
+    # This process owns it and is alive, so it is not collectable.
+    assert terminal_mod._owner_is_gone(claim) is False
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Related issue

Closes #7340

## Summary

Starting a runner can kill another runner's live tmux terminal when a shared scratch directory contains owner PIDs from a different namespace. Record the namespace and boot alongside the PID, and reap only a proven dead owner in the matching domain. Skip legacy, malformed, foreign, or unreadable ownership records. A different boot ID can belong to another live kernel, so it also requires preservation.

Terminal and native bridge cleanup (#7356) share one ownership helper. Both branches contain the shared foundation commit and can merge in either order.

ELI5: a process number is meaningful only in the environment that assigned it.

```text
owner record → matching boot and namespace + dead PID? → clean up
             → otherwise → preserve terminal
```

## Test Plan

- `PYTHONPATH="$PWD/sdks/python-client:$PWD/sdks/ui:$PWD" .venv/bin/python -m pytest tests/inner/test_terminal.py tests/native/test_owner_claim.py tests/e2e/test_orphan_sweep_keeps_live_terminal.py -q` — 99 passed.
- Four real-tmux cases use an isolated scratch root: legacy, foreign and unreadable ownership preserve a live server; a dead local owner is reaped.
- Negative control against the earlier namespace implementation: four new ownership-validation cases failed before the additional fixes.
- Every applicable pre-commit hook, including Python type checking, passed.
- Human check: keep two native sessions running, start another runner, and confirm both existing terminals remain reachable and accept input.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A for visual media; the isolated real-tmux regression exercises the cleanup boundary directly.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Real-tmux coverage is local and isolated; no provider credentials are needed. Legacy, unknown and different-boot ownership may leave an orphan for later inspection. Linux requires readable matching boot and namespace identities; non-Linux retains local PID support. Terminal-loss telemetry does not identify how many observed failures came from this specific sweep.

## Changelog

Starting another runner preserves live terminals whose owner belongs to a different or unknown process namespace.
