### PR TITLE
fix(server): stop logging an offline runner as an internal error

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1767,7 +1767,20 @@ def create_app(
         :param exc: The application error.
         :returns: A JSON response with the error code and message.
         """
-        if exc.http_status >= 500:
+        if exc.code == ErrorCode.RUNNER_UNAVAILABLE:
+            # A session state, not a fault: the user's machine is asleep or
+            # the host disconnected, and clients render it as a reconnect
+            # affordance. Through the 5xx arm every poll of an offline
+            # session added an "Internal error" plus a stack, which is what
+            # buried the real 500s.
+            _logger.warning(
+                "Runner unavailable: %s",
+                exc.message,
+                extra=_error_audit_extra(
+                    request, phase="unavailable", code=str(exc.code), http_status="503"
+                ),
+            )
+        elif exc.http_status >= 500:
             _logger.error(
                 "Internal error: %s",
                 exc.message,

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -8,6 +8,7 @@ they live here following the source ↔ test directory mirroring rule.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from dataclasses import dataclass
 from io import BytesIO
@@ -15,7 +16,7 @@ from pathlib import Path
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from PIL import Image
 
 from omnigent.native_coding_agents import (
@@ -1926,3 +1927,58 @@ def test_session_id_from_request_parses_session_path() -> None:
     assert parse(_req("/v1/sessions/conv_abc")) == "conv_abc"  # type: ignore[arg-type]
     assert parse(_req("/health")) is None  # type: ignore[arg-type]
     assert parse(_req("/v1/sessions")) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_offline_runner_is_logged_as_state_while_real_faults_stay_errors(
+    app: FastAPI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    ``RUNNER_UNAVAILABLE`` logs a stateful WARN; other 5xx keep ERROR.
+
+    Both arms are asserted together because the point is the contrast:
+    downgrading every 5xx would hide genuine faults just as effectively
+    as an offline session's polling buried them.
+
+    :param app: The real application, for its registered handlers.
+    :param caplog: Pytest log capture fixture.
+    :returns: None.
+    """
+    from omnigent.errors import ErrorCode, OmnigentError
+
+    handler = app.exception_handlers[OmnigentError]
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
+            "raw_path": b"/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
+            "query_string": b"",
+            "headers": [],
+        }
+    )
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.server.app"):
+        offline = await handler(
+            request,
+            OmnigentError(
+                "runner 'runner_token_x' is offline",
+                code=ErrorCode.RUNNER_UNAVAILABLE,
+            ),
+        )
+        fault = await handler(request, OmnigentError("boom", code=ErrorCode.INTERNAL_ERROR))
+
+    # The wire contract is untouched: only the log level moves.
+    assert offline.status_code == 503
+    assert fault.status_code == 500
+
+    records = [r for r in caplog.records if r.name == "omnigent.server.app"]
+    assert len(records) == 2, f"expected one record per error, got {records}"
+    unavailable, internal = records
+    assert unavailable.levelno == logging.WARNING
+    # Raised deliberately from a known site, so a stack adds no information.
+    assert unavailable.exc_info is None
+    assert "Internal error" not in unavailable.getMessage()
+    assert internal.levelno == logging.ERROR
+    assert internal.exc_info is not None


### PR DESCRIPTION
## Summary

`RUNNER_UNAVAILABLE` maps to 503, so it fell into the error handler's `http_status >= 500` arm and was logged as:

```
ERROR Internal error: runner 'runner_token_…' is offline for conversation '…'
<20-line traceback>
```

An offline runner is not a fault — it is the ordinary resting state of a session whose machine is asleep, whose host disconnected, or that was never resumed. Clients already render it as a reconnect affordance, and it is raised deliberately from a known site, so the traceback adds lines without adding information. Since every poll of such a session produces one, it was the loudest line in the server's ERROR stream — which is exactly where the 500s that matter are supposed to stand out.

## Approach

Log `RUNNER_UNAVAILABLE` as the state it is: `WARN Runner unavailable: …`, with the audit extras kept (`phase="unavailable"`, code, status) and no `exc_info`. Every other 5xx keeps the ERROR arm and its stack. The wire contract is untouched — same 503, same body.

Scoped to `RUNNER_UNAVAILABLE` alone rather than all 503s: the other 503 code (`RUNNER_CAPABILITY_MISMATCH`) is a scheduling mismatch that is worth a stack, so it stays where it is.

## Test Plan

`tests/server/test_app.py::test_offline_runner_is_logged_as_state_while_real_faults_stay_errors` — drives the app's registered `OmnigentError` handler with a `RUNNER_UNAVAILABLE` and an `INTERNAL_ERROR`, asserting the contrast: WARN with no traceback vs ERROR with one, and both statuses unchanged (503 / 500). Fails on `main` (`assert 40 == 30`).

## Type of change

Bug fix (log hygiene; no behavior change on the wire)

## Test coverage

Unit test added.
