### PR TITLE
fix(codex-native): bridge provider config into the model-probe home

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -862,10 +862,15 @@ def _probe_codex_home(config_overrides: Sequence[str]) -> Path:
     Persistent (unlike the hermetic discovery's temp dir) so Codex's own
     ``models_cache.json`` ETag handling makes repeat probes cheap; keyed by
     the override set so a provider change never replays another provider's
-    cache. The account's real ``auth.json`` is symlinked in, the same way
-    a session launch links it: the credential decides which models the
-    account's catalog lists (login-gated entries, the account default), so
-    a credential-less probe answers for a catalog no session will see.
+    cache.
+
+    Materialized by the same bridge a session launch uses, in its minimal
+    shape. Both halves matter: the credential decides which models the
+    account's catalog lists (login-gated entries, the account default), and
+    the provider tables decide whether Codex loads its config at all, since
+    an override naming a ``model_provider`` the home does not define fails
+    config load outright. Minimal keeps the probe from starting the user's
+    MCPs, hooks and plugins.
 
     :param config_overrides: The probe's ``-c`` overrides.
     :returns: The created ``CODEX_HOME`` directory.
@@ -873,13 +878,11 @@ def _probe_codex_home(config_overrides: Sequence[str]) -> Path:
     key = hashlib.sha256("\n".join(config_overrides).encode("utf-8")).hexdigest()[:12]
     home = Path.home() / ".omnigent" / "cache" / "codex-model-probe" / key
     home.mkdir(mode=0o700, parents=True, exist_ok=True)
-    real_auth = _codex_home_config_source_from_env() / "auth.json"
-    probe_auth = home / "auth.json"
-    if real_auth.exists():
-        with contextlib.suppress(OSError):
-            if probe_auth.is_symlink() or probe_auth.exists():
-                probe_auth.unlink()
-            probe_auth.symlink_to(real_auth)
+    # The bridge skips files that already exist, and config.toml is copied
+    # (not symlinked), so drop the copy to re-read an edited source config.
+    with contextlib.suppress(OSError):
+        (home / "config.toml").unlink(missing_ok=True)
+    _populate_codex_home_config(home, _codex_home_config_source_from_env(), minimal_config=True)
     return home
 
 

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -2395,3 +2395,53 @@ def test_resolve_databricks_codex_model_matches_servable_ids() -> None:
             _resolve_databricks_codex_model("https://h.example.com", "prof", "databricks-gpt-9-9")
             == "databricks-gpt-9-9"
         )
+
+
+def test_probe_codex_home_bridges_provider_tables_and_credential(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The probe home carries the provider tables its overrides name.
+
+    A launch shape resolved off the user's ``config.toml`` pins only a
+    provider *name* (``-c model_provider="Databricks"``). Codex refuses to
+    load a config that names an undefined provider, exiting before it binds
+    the listener, so a probe home holding only a credential yields no
+    catalog at all. Minimal keeps the user's MCP/hook/plugin config out.
+    """
+    from omnigent import codex_native_app_server
+
+    source = tmp_path / ".codex"
+    source.mkdir()
+    (source / "config.toml").write_text(
+        'model_provider = "Databricks"\n'
+        "\n"
+        "[model_providers.Databricks]\n"
+        'base_url = "https://ws.example/serving-endpoints"\n'
+        "\n"
+        "[mcp_servers.slow]\n"
+        'command = "sleep"\n'
+    )
+    (source / ".credentials.json").write_text("{}")
+    (source / "hooks.json").write_text("{}")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+
+    home = codex_native_app_server._probe_codex_home(['model_provider="Databricks"'])
+
+    config = (home / "config.toml").read_text()
+    assert "[model_providers.Databricks]" in config
+    assert "https://ws.example/serving-endpoints" in config
+    # The credential the account's catalog is gated on, in either spelling.
+    assert (home / ".credentials.json").is_symlink()
+    # Minimal: no MCPs to boot and no hooks to fire during a probe.
+    assert "mcp_servers" not in config
+    assert not (home / "hooks.json").exists()
+
+    # A persistent home must re-read an edited source config, not pin the
+    # tables copied on first use.
+    (source / "config.toml").write_text(
+        'model_provider = "Other"\n\n[model_providers.Other]\nbase_url = "https://two.example"\n'
+    )
+    home = codex_native_app_server._probe_codex_home(['model_provider="Databricks"'])
+    assert "https://two.example" in (home / "config.toml").read_text()


### PR DESCRIPTION
## Related issue

Closes #6248

## Summary

The codex-native model catalog probe built its `CODEX_HOME` by hand and
materialized only `auth.json`, never `config.toml`. When a host's codex routing
comes from the user's own `~/.codex/config.toml`, ambient detection pins just the
provider *name* (`-c model_provider="Databricks"`) while the
`[model_providers.Databricks]` tables live in that config file, which the probe
home never received. Codex refuses to load a config naming a provider it cannot
see and exits 1 before binding its listener, so every probe raised
`Codex model discovery exited early (1)` and the pre-launch picker offered zero
models (`host/connect.py` deliberately keeps no curated fallback).

- `_probe_codex_home` now calls the same bridge a session launch uses
  (`_populate_codex_home_config(..., minimal_config=True)`) instead of
  re-implementing a subset of it. `minimal_config` already exists for this shape:
  it copies only `model_provider` / `model_providers` / `profiles` and skips
  hooks, `AGENTS.md` and plugin dirs, so a probe still starts no MCPs. It is
  already used by `runner/background_titles/codex_native.py` for the same reason.
- Fixes the credential as a side effect: the hand-rolled version linked only
  `auth.json`, while `_CODEX_HOME_SYMLINK_FILES` also covers
  `.credentials.json`. A home storing the credential under that spelling was
  probing as logged out, so login-gated entries and the account default were
  wrong even when the probe did boot.
- Every entry the bridge materializes is unlinked first, because the bridge skips
  files that already exist and the probe home is deliberately persistent (codex's
  `models_cache.json` ETag reuse). Without that, the tables copied on first use
  would be pinned forever and later edits to `~/.codex/config.toml` ignored. The
  same applies to the credential: the home is keyed only by the overrides, so a
  source home that moves under an unchanged override set would leave the symlink
  naming the old path, and a removed source would leave it dangling. A dangling
  link reads as present to the bridge's skip check, so such a home could never
  self-heal and every later probe would answer for a logged-out account.

ELI5: the probe was handed the *name* of a door but not the door. Now it gets the
same keyring the real session launch gets, minus the noisy extras.

```
before                                  after
------                                  -----
probe home:  auth.json only             probe home:  config.toml (provider
  (absent on homes using                  tables only) + credential symlink
   .credentials.json)                      (.credentials.json / auth.json)
     |                                        |
  -c model_provider="Databricks"          -c model_provider="Databricks"
     |                                        |
  codex: "Model provider                  codex: binds listener,
   `Databricks` not found" -> exit 1       model/list -> 5 models
     |                                        |
  RuntimeError: exited early (1)          catalog populated
  picker: 0 models                        picker: real models
```

## Test Plan

Unit, on the failing path:

```
pytest tests/test_codex_native_app_server.py::test_probe_codex_home_bridges_provider_tables_and_credential
pytest tests/test_codex_native_app_server.py::test_probe_codex_model_options_uses_launch_config_and_marks_default
pytest tests/test_codex_native_app_server.py::test_probe_codex_model_options_probes_every_launch_shape
```

3 passed. Both halves of the new test are confirmed to catch their regression by
reverting only `codex_native_app_server.py`:

- dropping the bridge call fails with
  `FileNotFoundError: .../codex-model-probe/<key>/config.toml`;
- narrowing the refresh back to `config.toml` alone fails the credential
  assertion, with the symlink still resolving into the old `.codex` while the
  config came from `moved-codex`.

Live, against a real `~/.codex/config.toml` using a Databricks gateway provider
(the configuration that reproduced the bug), with the probe cache cleared first:

```
$ rm -rf ~/.omnigent/cache/codex-model-probe
$ python -c 'import asyncio; from omnigent.codex_native_app_server import \
    probe_codex_model_options; print(asyncio.run(probe_codex_model_options()))'
PROBE OK: 5 models
   gpt-5.6-sol   | default: True
   gpt-5.6-terra | default: False
   gpt-5.6-luna  | default: False
   gpt-5.5       | default: False
   gpt-5.2       | default: False
```

A second, warm-home probe returns the same 5 models, with the credential
correctly relinked. The same command before the fix raised `RuntimeError: Codex
model discovery exited early (1)`. Inspected the materialized home to confirm the
minimal shape held:
`model_providers` present (3 hits), `mcp_servers` absent (0 hits), no
`hooks.json`, credential symlinked to the real `~/.codex/.credentials.json`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test drives `_probe_codex_home` against a fake source home and asserts
the three properties the bug turned on: the provider tables are present, the
credential is symlinked, and a persistent home re-reads an edited source config
rather than pinning the first copy. It also asserts the minimal shape (no
`mcp_servers`, no `hooks.json`) so a future widening to a full config copy does
not silently make probes start the user's MCP servers.

Manual verification covers what a unit test cannot: that the real `codex`
binary actually boots and returns a catalog under this materialization. The
failure mode was a subprocess exiting on its own config validation, so the fix
is only meaningful against a real CLI and a real provider config.

## Changelog

The codex model picker now lists models when your codex routing comes from a custom provider in `~/.codex/config.toml`, instead of coming up empty.
