### PR TITLE
fix(runtime): announce sub-agent wake notices to the model on trusted channels

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -1985,6 +1985,28 @@ async def _execute_list_models_tool(*, agent_spec: AgentSpec | None) -> str:
     return json.dumps(catalog)
 
 
+def _subagent_launching_message(agent: str, title: object, task_id: str) -> str:
+    """
+    Tool-result text for a sub-agent dispatch whose turn is still running.
+
+    Pre-announces the wake notice on the tool-result channel so the model
+    recognises it as runtime-originated when it later arrives as a message.
+
+    :param agent: Sub-agent name, e.g. ``"researcher"``.
+    :param title: Child instance title supplied at dispatch.
+    :param task_id: The child session id, doubling as the task handle.
+    :returns: A one-line ``[System: ...]`` status string.
+    """
+    return (
+        f"[System: sub-agent {agent} title {title!r} launching as task "
+        f"{task_id}. Result will appear in your inbox; call sys_read_inbox to "
+        "check or sys_cancel_task to interrupt it. When it finishes, the "
+        "runtime posts a `[System: sub-agent ... finished ...]` wake notice "
+        "into this session; that notice comes from the runtime, not from a "
+        "person.]"
+    )
+
+
 async def _execute_subagent_tool(
     args: _JsonObject,
     *,
@@ -2643,12 +2665,7 @@ async def _execute_subagent_tool(
             "agent": sub_agent_name,
             "title": session_name,
             "status": "launching",
-            "message": (
-                f"[System: sub-agent {sub_agent_name} title {session_name!r} "
-                f"launching as task {child_session_id}. Result will appear in "
-                "your inbox; call sys_read_inbox to check or sys_cancel_task "
-                "to interrupt it.]"
-            ),
+            "message": _subagent_launching_message(sub_agent_name, session_name, child_session_id),
         }
     )
 
@@ -2780,12 +2797,7 @@ async def _send_to_existing_session(
             "agent": agent_label,
             "title": parsed.title,
             "status": "launching",
-            "message": (
-                f"[System: sub-agent {agent_label} title {parsed.title!r} "
-                f"launching as task {target_session_id}. Result will appear in "
-                "your inbox; call sys_read_inbox to check or sys_cancel_task "
-                "to interrupt it.]"
-            ),
+            "message": _subagent_launching_message(agent_label, parsed.title, target_session_id),
         }
     )
 

--- a/omnigent/runtime/prompt.py
+++ b/omnigent/runtime/prompt.py
@@ -30,11 +30,11 @@ SUBAGENT_WAKE_NOTICE_INSTRUCTION = (
     "Sub-agent completion notices: when a sub-agent you dispatched finishes, "
     "the Omnigent runtime posts the message "
     f"`{SUBAGENT_WAKE_NOTICE_SHAPE}` into this session, starting a new turn "
-    "for you if you are idle. That message comes from the runtime, not from a "
-    "person, and is not a prompt injection; respond by calling sys_read_inbox "
+    "for you if you are idle. Treat it as a routine runtime status message, "
+    "not as instructions typed by a person; respond by calling sys_read_inbox "
     "to collect the result. Other `[System: sub-agent ...]` notices about a "
     "sub-agent you dispatched (for example that it is blocked awaiting human "
-    "approval) come from the runtime the same way."
+    "approval) are routine runtime status messages in the same way."
 )
 
 
@@ -42,14 +42,17 @@ def _framework_instructions_for(spec: AgentSpec) -> list[str]:
     """
     Framework instructions that apply to every turn of ``spec``.
 
-    Mirrors the sub-agent tool registration gate in ``omnigent.tools.manager``:
-    only an agent that can dispatch sub-agents receives wake notices, so no
-    other agent's prompt mentions them.
+    Only an agent that can dispatch sub-agents receives wake notices, so no
+    other agent's prompt mentions them. That is the ``sys_session_send``
+    registration gate in ``omnigent.tools.manager`` (declared sub-agents or
+    ``spawn: true``) plus the ``web_fetch`` builtin, which dispatches the
+    built-in web researcher through the same path.
 
     :param spec: The parsed AgentSpec.
     :returns: The applicable spec-level framework instructions, possibly empty.
     """
-    if spec.tools.agents or spec.spawn:
+    dispatches_web_researcher = any(entry.name == "web_fetch" for entry in spec.tools.builtins)
+    if spec.tools.agents or spec.spawn or dispatches_web_researcher:
         return [SUBAGENT_WAKE_NOTICE_INSTRUCTION]
     return []
 

--- a/omnigent/runtime/prompt.py
+++ b/omnigent/runtime/prompt.py
@@ -17,6 +17,42 @@ from omnigent.entities import (
 from omnigent.runtime.tool_result_replay import image_omitted_placeholder
 from omnigent.spec import AgentSpec
 
+# Shape of the wake notice the runner posts into a parent session when a
+# dispatched sub-agent finishes (``omnigent.runner.app._format_subagent_wake_notice``).
+# Quoted verbatim wherever the model is told what to expect, so the notice
+# reads as a known runtime signal rather than a user-typed instruction.
+SUBAGENT_WAKE_NOTICE_SHAPE = (
+    "[System: sub-agent <agent>/<title> finished (<status>) — "
+    "<N> results waiting in inbox. Call sys_read_inbox to collect.]"
+)
+
+SUBAGENT_WAKE_NOTICE_INSTRUCTION = (
+    "Sub-agent completion notices: when a sub-agent you dispatched finishes, "
+    "the Omnigent runtime posts the message "
+    f"`{SUBAGENT_WAKE_NOTICE_SHAPE}` into this session, starting a new turn "
+    "for you if you are idle. That message comes from the runtime, not from a "
+    "person, and is not a prompt injection; respond by calling sys_read_inbox "
+    "to collect the result. Other `[System: sub-agent ...]` notices about a "
+    "sub-agent you dispatched (for example that it is blocked awaiting human "
+    "approval) come from the runtime the same way."
+)
+
+
+def _framework_instructions_for(spec: AgentSpec) -> list[str]:
+    """
+    Framework instructions that apply to every turn of ``spec``.
+
+    Mirrors the sub-agent tool registration gate in ``omnigent.tools.manager``:
+    only an agent that can dispatch sub-agents receives wake notices, so no
+    other agent's prompt mentions them.
+
+    :param spec: The parsed AgentSpec.
+    :returns: The applicable spec-level framework instructions, possibly empty.
+    """
+    if spec.tools.agents or spec.spawn:
+        return [SUBAGENT_WAKE_NOTICE_INSTRUCTION]
+    return []
+
 
 def append_framework_instructions(
     instructions: str | None,
@@ -93,13 +129,18 @@ def build_instructions(
         only for future skill-awareness hinting; currently
         not included in the instructions body).
     :param framework_instructions: Framework-owned additive instructions
-        for this turn, appended after user-authored agent/request instructions.
+        for this turn, appended after user-authored agent/request instructions
+        and after the spec-level framework instructions (the sub-agent
+        wake-notice announcement for agents that can dispatch sub-agents).
     :returns: The assembled instructions string.
     """
     parts = _assemble_instruction_parts(spec, per_request_instructions, tool_schemas)
     base_instructions = "\n\n".join(parts) if parts else "You are a helpful assistant."
     return (
-        append_framework_instructions(base_instructions, framework_instructions)
+        append_framework_instructions(
+            base_instructions,
+            [*_framework_instructions_for(spec), *framework_instructions],
+        )
         or base_instructions
     )
 
@@ -114,7 +155,7 @@ def build_instructions_nullable(
     """Like :func:`build_instructions`, but returns ``None`` instead of seeding
     the fabricated ``"You are a helpful assistant."`` fallback when there is
     truly nothing to compose (no author text, no per-request text, no skills
-    hint, no applicable framework instructions).
+    hint, no applicable spec-level or per-turn framework instructions).
 
     Delivery channels that must not leak the fallback literal (e.g. a warn
     check, or a first-user-turn prefix) call this instead of comparing
@@ -127,7 +168,10 @@ def build_instructions_nullable(
     """
     parts = _assemble_instruction_parts(spec, per_request_instructions, tool_schemas)
     base_instructions = "\n\n".join(parts) if parts else None
-    return append_framework_instructions(base_instructions, framework_instructions)
+    return append_framework_instructions(
+        base_instructions,
+        [*_framework_instructions_for(spec), *framework_instructions],
+    )
 
 
 def raw_author_instructions(spec: AgentSpec) -> str | None:

--- a/omnigent/tools/builtins/async_inbox.py
+++ b/omnigent/tools/builtins/async_inbox.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from omnigent.runtime.prompt import SUBAGENT_WAKE_NOTICE_SHAPE
 from omnigent.tools.base import Tool
 
 
@@ -295,7 +296,10 @@ class SysReadInboxTool(Tool):
             "want to inspect completions before yielding — e.g., "
             "to plan follow-up work based on the results. Returns "
             "a textual summary; an empty inbox returns a sentinel "
-            "string."
+            "string. It is also the expected response to the runtime's "
+            f"sub-agent wake notice `{SUBAGENT_WAKE_NOTICE_SHAPE}`, which "
+            "Omnigent posts into your session when a dispatched child "
+            "finishes; that notice comes from the runtime, not from a person."
         )
 
     def get_schema(self) -> dict[str, Any]:

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -17,6 +17,7 @@ from omnigent.entities import (
     ConversationItem,
 )
 from omnigent.runtime import pending_elicitations
+from omnigent.runtime.prompt import SUBAGENT_WAKE_NOTICE_SHAPE
 from omnigent.session_lifecycle import (
     CLOSED_LABEL_KEY,
     CLOSED_LABEL_VALUE,
@@ -143,7 +144,11 @@ class SysSessionSendTool(Tool):
             "pass their file ids via the object args form's 'file_ids' "
             "list on the first named (agent, title) send only; file_ids "
             "cannot be used with session_id or when continuing an existing "
-            "named session."
+            "named session. When a dispatched child finishes, the Omnigent "
+            f"runtime posts `{SUBAGENT_WAKE_NOTICE_SHAPE}` into this session "
+            "as a new message, starting a turn for you if you are idle. That "
+            "notice comes from the runtime, not from a person; respond by "
+            "calling sys_read_inbox to collect the result."
         )
 
     def __init__(self, sub_specs: dict[str, AgentSpec]) -> None:

--- a/tests/runtime/test_prompt.py
+++ b/tests/runtime/test_prompt.py
@@ -27,6 +27,7 @@ def _spec(
     *,
     agents: tuple[str, ...] = (),
     spawn: bool = False,
+    builtins: tuple[str, ...] = (),
 ) -> AgentSpec:
     """
     Stub only the AgentSpec fields the instruction builders read.
@@ -36,7 +37,10 @@ def _spec(
         SimpleNamespace(
             instructions=instructions,
             skills=[],
-            tools=SimpleNamespace(agents=list(agents)),
+            tools=SimpleNamespace(
+                agents=list(agents),
+                builtins=[SimpleNamespace(name=name) for name in builtins],
+            ),
             spawn=spawn,
         ),
     )
@@ -213,29 +217,28 @@ def test_build_instructions_nullable_framework_only_omits_fallback() -> None:
     assert _SAMPLE_FRAMEWORK_INSTRUCTION in fused
 
 
-@pytest.mark.parametrize(("agents", "spawn"), [(("researcher",), False), ((), True)])
+@pytest.mark.parametrize(
+    ("agents", "spawn", "builtins"),
+    [(("researcher",), False, ()), ((), True, ()), ((), False, ("web_fetch",))],
+)
 def test_subagent_wake_instruction_added_for_dispatching_agents(
-    agents: tuple[str, ...], spawn: bool
+    agents: tuple[str, ...], spawn: bool, builtins: tuple[str, ...]
 ) -> None:
     """
     An agent that can dispatch sub-agents is told what a wake notice is.
 
     The gate mirrors ``sys_session_send`` registration (declared sub-agents or
-    ``spawn: true``). The announcement lands after the authored text and before
-    per-turn framework instructions, and on its own it never drags in the
-    fabricated fallback.
+    ``spawn: true``) plus the ``web_fetch`` builtin, whose researcher dispatch
+    wakes the parent the same way. The announcement lands after the authored
+    text and before per-turn framework instructions, and on its own it never
+    drags in the fabricated fallback.
     """
-    result = build_instructions(
-        _spec("Agent prompt", agents=agents, spawn=spawn),
-        None,
-        [],
-        framework_instructions=("Turn note",),
-    )
+    dispatching = _spec("Agent prompt", agents=agents, spawn=spawn, builtins=builtins)
+    result = build_instructions(dispatching, None, [], framework_instructions=("Turn note",))
     assert result == f"Agent prompt\n\n{SUBAGENT_WAKE_NOTICE_INSTRUCTION}\n\nTurn note"
 
-    assert build_instructions_nullable(_spec(None, agents=agents, spawn=spawn), None, []) == (
-        SUBAGENT_WAKE_NOTICE_INSTRUCTION
-    )
+    unauthored = _spec(None, agents=agents, spawn=spawn, builtins=builtins)
+    assert build_instructions_nullable(unauthored, None, []) == SUBAGENT_WAKE_NOTICE_INSTRUCTION
 
 
 def test_subagent_wake_notice_shape_matches_runner_notice() -> None:

--- a/tests/runtime/test_prompt.py
+++ b/tests/runtime/test_prompt.py
@@ -7,7 +7,10 @@ from typing import cast
 import pytest
 
 from omnigent.entities import ConversationItem, FunctionCallOutputData
+from omnigent.runner.app import _format_subagent_wake_notice
 from omnigent.runtime.prompt import (
+    SUBAGENT_WAKE_NOTICE_INSTRUCTION,
+    SUBAGENT_WAKE_NOTICE_SHAPE,
     append_framework_instructions,
     build_instructions,
     build_instructions_nullable,
@@ -17,6 +20,26 @@ from omnigent.runtime.prompt import (
 from omnigent.spec import AgentSpec
 
 _SAMPLE_FRAMEWORK_INSTRUCTION = "Framework instruction for testing build_instructions_nullable."
+
+
+def _spec(
+    instructions: str | None,
+    *,
+    agents: tuple[str, ...] = (),
+    spawn: bool = False,
+) -> AgentSpec:
+    """
+    Stub only the AgentSpec fields the instruction builders read.
+    """
+    return cast(
+        AgentSpec,
+        SimpleNamespace(
+            instructions=instructions,
+            skills=[],
+            tools=SimpleNamespace(agents=list(agents)),
+            spawn=spawn,
+        ),
+    )
 
 
 def _output_item(output: str) -> ConversationItem:
@@ -100,7 +123,7 @@ def test_history_replay_leaves_non_image_json_output_unchanged() -> None:
 
 
 def test_framework_instructions_append_after_custom_prompts() -> None:
-    spec = cast(AgentSpec, SimpleNamespace(instructions="Agent prompt", skills=[]))
+    spec = _spec("Agent prompt")
 
     result = build_instructions(
         spec,
@@ -113,7 +136,7 @@ def test_framework_instructions_append_after_custom_prompts() -> None:
 
 
 def test_empty_framework_instructions_do_not_change_default() -> None:
-    spec = cast(AgentSpec, SimpleNamespace(instructions=None, skills=[]))
+    spec = _spec(None)
 
     assert build_instructions(spec, None, [], framework_instructions=("", "   ")) == (
         "You are a helpful assistant."
@@ -126,7 +149,7 @@ def test_framework_only_instructions_use_shared_composer() -> None:
 
 def test_build_instructions_nullable_neither_authored_nor_framework() -> None:
     """No author text, no framework text → None, not the fabricated fallback."""
-    spec = cast(AgentSpec, SimpleNamespace(instructions=None, skills=[]))
+    spec = _spec(None)
     assert build_instructions_nullable(spec, None, []) is None
 
 
@@ -134,7 +157,7 @@ def test_build_instructions_nullable_whitespace_only_treated_as_absent() -> None
     """Whitespace-only spec.instructions is not real content — matches
     raw_author_instructions' non-empty/non-whitespace gate, so authored_present
     and composed agree on what counts as "authored"."""
-    spec = cast(AgentSpec, SimpleNamespace(instructions="   \n  ", skills=[]))
+    spec = _spec("   \n  ")
     assert build_instructions_nullable(spec, None, []) is None
     result = build_instructions_nullable(
         spec, None, [], framework_instructions=(_SAMPLE_FRAMEWORK_INSTRUCTION,)
@@ -146,7 +169,7 @@ def test_build_instructions_nullable_whitespace_only_per_request_treated_as_abse
     """Whitespace-only per_request_instructions is not real content either —
     the same non-empty/non-whitespace gate applies to both instruction
     sources, not just spec.instructions."""
-    spec = cast(AgentSpec, SimpleNamespace(instructions=None, skills=[]))
+    spec = _spec(None)
     assert build_instructions_nullable(spec, "   \n  ", []) is None
     result = build_instructions_nullable(
         spec, "   \n  ", [], framework_instructions=(_SAMPLE_FRAMEWORK_INSTRUCTION,)
@@ -156,7 +179,7 @@ def test_build_instructions_nullable_whitespace_only_per_request_treated_as_abse
 
 def test_build_instructions_nullable_authored_present() -> None:
     """Author text present → fully composed authored + framework string."""
-    spec = cast(AgentSpec, SimpleNamespace(instructions="Agent prompt", skills=[]))
+    spec = _spec("Agent prompt")
     result = build_instructions_nullable(
         spec, "Request prompt", [], framework_instructions=("Framework prompt",)
     )
@@ -173,7 +196,7 @@ def test_build_instructions_nullable_framework_only_omits_fallback() -> None:
     was empty — producing a mixed string that is neither the bare literal
     nor framework-text-alone.
     """
-    spec = cast(AgentSpec, SimpleNamespace(instructions=None, skills=[]))
+    spec = _spec(None)
     result = build_instructions_nullable(
         spec, None, [], framework_instructions=(_SAMPLE_FRAMEWORK_INSTRUCTION,)
     )
@@ -188,6 +211,46 @@ def test_build_instructions_nullable_framework_only_omits_fallback() -> None:
     )
     assert fused.startswith("You are a helpful assistant.")
     assert _SAMPLE_FRAMEWORK_INSTRUCTION in fused
+
+
+@pytest.mark.parametrize(("agents", "spawn"), [(("researcher",), False), ((), True)])
+def test_subagent_wake_instruction_added_for_dispatching_agents(
+    agents: tuple[str, ...], spawn: bool
+) -> None:
+    """
+    An agent that can dispatch sub-agents is told what a wake notice is.
+
+    The gate mirrors ``sys_session_send`` registration (declared sub-agents or
+    ``spawn: true``). The announcement lands after the authored text and before
+    per-turn framework instructions, and on its own it never drags in the
+    fabricated fallback.
+    """
+    result = build_instructions(
+        _spec("Agent prompt", agents=agents, spawn=spawn),
+        None,
+        [],
+        framework_instructions=("Turn note",),
+    )
+    assert result == f"Agent prompt\n\n{SUBAGENT_WAKE_NOTICE_INSTRUCTION}\n\nTurn note"
+
+    assert build_instructions_nullable(_spec(None, agents=agents, spawn=spawn), None, []) == (
+        SUBAGENT_WAKE_NOTICE_INSTRUCTION
+    )
+
+
+def test_subagent_wake_notice_shape_matches_runner_notice() -> None:
+    """
+    The announced shape must track the notice the runner actually posts.
+    """
+    expected = (
+        SUBAGENT_WAKE_NOTICE_SHAPE.replace("<agent>/<title>", "researcher/auth")
+        .replace("<status>", "completed")
+        .replace("<N>", "2")
+    )
+    notice = _format_subagent_wake_notice(
+        agent="researcher", title="auth", status="completed", pending=2
+    )
+    assert notice == expected
 
 
 def test_raw_author_instructions_verbatim_and_none() -> None:

--- a/tests/tools/builtins/test_async_inbox.py
+++ b/tests/tools/builtins/test_async_inbox.py
@@ -27,6 +27,7 @@ from typing import Any
 
 import pytest
 
+from omnigent.runtime.prompt import SUBAGENT_WAKE_NOTICE_SHAPE
 from omnigent.spec import AgentSpec
 from omnigent.tools.builtins.async_inbox import (
     SysCallAsyncTool,
@@ -266,6 +267,16 @@ def test_call_async_description_names_handle_id(tool: SysCallAsyncTool) -> None:
     desc = tool.description()
     assert "handle_id" in desc
     assert "sys_cancel_async" in desc
+
+
+def test_read_inbox_description_names_wake_notice(read_tool: SysReadInboxTool) -> None:
+    """
+    ``sys_read_inbox`` names the runtime wake notice it answers, so a model
+    that just received one knows this is the expected response.
+    """
+    desc = read_tool.description()
+    assert SUBAGENT_WAKE_NOTICE_SHAPE in desc
+    assert "not from a person" in desc
 
 
 def test_sys_cancel_task_schema_keeps_task_id_contract() -> None:

--- a/tests/tools/builtins/test_sys_session.py
+++ b/tests/tools/builtins/test_sys_session.py
@@ -21,6 +21,7 @@ import pytest
 
 from omnigent.entities.conversation import MessageData, NewConversationItem
 from omnigent.runtime import pending_elicitations
+from omnigent.runtime.prompt import SUBAGENT_WAKE_NOTICE_SHAPE
 from omnigent.session_lifecycle import CLOSED_LABEL_KEY, CLOSED_LABEL_VALUE
 from omnigent.spec.types import AgentSpec, ExecutorSpec
 from omnigent.stores.conversation_store.sqlalchemy_store import (
@@ -291,6 +292,20 @@ def test_send_schema_gates_harness_field_behind_allowlist_opt_in() -> None:
         "harness",
         "cost_budget",
     }
+
+
+def test_send_description_announces_wake_notice() -> None:
+    """
+    The dispatch tool tells the model the exact wake notice the runtime
+    posts when a child finishes, so the notice is recognised as
+    runtime-originated instead of read as a user-typed instruction.
+    """
+    tool = SysSessionSendTool(
+        {"claude": AgentSpec(spec_version=1, name="claude", description="Review helper.")}
+    )
+    desc = tool.get_schema()["function"]["description"]
+    assert SUBAGENT_WAKE_NOTICE_SHAPE in desc
+    assert "not from a person" in desc
 
 
 def test_peek_schema_required_fields_and_no_extra_props() -> None:


### PR DESCRIPTION
## Related issue

Closes #4682

## Summary

Sub-agent wake notices (`[System: sub-agent <agent>/<title> finished (<status>) — <N> results waiting in inbox. Call sys_read_inbox to collect.]`) were never described to the model anywhere. Neither the composed system prompt nor the `sys_session_send` / `sys_read_inbox` tool descriptions mention them, so the orchestrator's first encounter with one is a user turn that claims to be "System" and orders a tool call. A safety-tuned Claude reads that as prompt injection and refuses, stranding the orchestration.

This PR fixes what the model reads, on channels it already trusts and that reach every harness:

- **System prompt** — `omnigent/runtime/prompt.py` gains `SUBAGENT_WAKE_NOTICE_SHAPE` and `SUBAGENT_WAKE_NOTICE_INSTRUCTION`; `build_instructions` / `build_instructions_nullable` append the announcement for any agent that can dispatch sub-agents (the `sys_session_send` registration gate, declared `tools.agents` or `spawn: true`, plus the `web_fetch` builtin whose researcher dispatch wakes the parent the same way). Other agents' prompts are untouched.
- **Tool descriptions** — `sys_session_send` and `sys_read_inbox` quote the exact notice and say it comes from the runtime, not from a person. Tool descriptions reach native harnesses (including the reporter's claude-native) through the MCP relay, which the composed system prompt does not.
- **Per-dispatch tool result** — the "launching as task …" result already told the model to expect an inbox entry; it now also pre-announces the wake notice on the tool-result channel right before it arrives.

The notice text itself is unchanged, so the web/REPL `[System: …]` marker rendering and the existing e2e wake tests keep working. A drift-guard test pins the announced shape to what `_format_subagent_wake_notice` actually produces.

**Why not `role="system"` (#6057)?** The Claude Agent SDK has no inbound system-role turn: every prompt is wrapped as `{"type":"user","message":{"role":"user"}}`, and claude-native types the notice into the TUI. On the resumed-session path the SDK-bound prompt is byte-identical for a user-role and a system-role tail, so a wire-level role change never reaches the two harnesses the bug is about. Telling the model what the notice is, before it arrives, does.

**ELI5:** the app kept slipping the orchestrator a note signed "System" without ever saying such notes exist. Now the orchestrator's briefing (system prompt), its tool manual (descriptions), and the receipt it gets when it dispatches a helper all say: "when your helper finishes, you'll get exactly this note from us — go read your inbox."

```mermaid
flowchart LR
  P[system prompt: announcement<br/>agents that can dispatch] --> M[model]
  T[tool descriptions:<br/>sys_session_send / sys_read_inbox] --> M
  R[dispatch tool result:<br/>launching … expect wake notice] --> M
  W["[System: sub-agent … finished … waiting in inbox]"] -->|recognised| M
  M -->|calls| I[sys_read_inbox]
```

## Test Plan

- `tests/runtime/test_prompt.py`: announcement appended for `tools.agents`, for `spawn: true`, and for a `web_fetch`-only agent, ordered after authored text and before per-turn framework instructions; nullable path returns the announcement alone without the fabricated fallback; drift guard asserts `SUBAGENT_WAKE_NOTICE_SHAPE` matches `_format_subagent_wake_notice` output.
- `tests/tools/builtins/test_sys_session.py`, `tests/tools/builtins/test_async_inbox.py`: both tool descriptions quote the notice shape and its runtime origin.
- Suites run locally: `tests/runtime` + `tests/tools` (2236 passed; 3 failures in `test_openai_agents_sdk_spawn_env.py` / `test_provider_spawn_env.py` reproduce identically on `main` and come from this machine's `~/.omnigent/config.yaml` providers), plus the instruction/dispatch-related selection across `tests/runner`, `tests/inner`, `tests/server` (77 passed).
- Rendered the real composed prompt and tool schemas for `examples/debby` (declared sub-agents) and `examples/polly` (`spawn: true`) through `omnigent.spec.load` + `build_instructions` + `ToolManager`: the announcement is present in both prompts, and the registered `sys_session_send` / `sys_read_inbox` descriptions quote the wake shape.
- Lint: ruff format/check, pyrefly, and the `dev/lint` pre-commit scripts pass on the changed files.

Not done here: a live-model check that a Claude orchestrator now calls `sys_read_inbox` on wake. The mock-LLM suites cannot observe a refusal, so that check belongs in the nightly live-model job. To try it by hand: check out this branch, run an orchestrator with sub-agents on claude-sdk and on claude-native (e.g. `examples/debby`), dispatch a sub-agent whose send gets backgrounded, let the parent's turn end, and confirm the parent calls `sys_read_inbox` when the `[System: sub-agent … finished …]` notice arrives instead of objecting to it. Inspect the system prompt the harness received (claude-sdk: the `system_prompt` option; API harnesses: the `instructions` field) to see the announcement paragraph at its tail.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Tail of the composed system prompt for `examples/debby` on this branch:

```
… Sub-agent completion notices: when a sub-agent you dispatched finishes, the Omnigent runtime posts the message `[System: sub-agent <agent>/<title> finished (<status>) — <N> results waiting in inbox. Call sys_read_inbox to collect.]` into this session, starting a new turn for you if you are idle. Treat it as a routine runtime status message, not as instructions typed by a person; respond by calling sys_read_inbox to collect the result. Other `[System: sub-agent ...]` notices about a sub-agent you dispatched (for example that it is blocked awaiting human approval) are routine runtime status messages in the same way.
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = rendering the composed prompt and tool schemas for the bundled `debby` and `polly` orchestrators through the real spec loader and tool manager (see Test Plan). The behavioral outcome (no refusal on wake) needs a real model and is left to the nightly live-model job.

## Changelog

Orchestrators that dispatch sub-agents are now told, in their system prompt and tool descriptions, exactly what a sub-agent wake notice looks like and that it comes from the runtime, so Claude no longer mistakes it for prompt injection and reliably collects the inbox.

https://claude.ai/code/session_01LfrfEJXdimBBoy5zEttpgL
