### PR TITLE
fix(codex-native): refresh the probe home's credential, not just its config

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -44,6 +44,7 @@ from omnigent.codex_native_process_registry import (
 )
 from omnigent.inner import _proc
 from omnigent.inner.codex_executor import (
+    _CODEX_HOME_COPY_FILES,
     _CODEX_HOME_SYMLINK_FILES,
     _CODEX_ROUTER_HOOK_MODULE,
     _clean_codex_env,
@@ -884,7 +885,7 @@ def _probe_codex_home(config_overrides: Sequence[str]) -> Path:
     # the first probe's tables; a kept credential symlink would keep naming a
     # source home that has since moved, or dangle if it was removed (a
     # dangling link reads as present here, so it never self-heals).
-    for name in (*_CODEX_HOME_SYMLINK_FILES, "config.toml"):
+    for name in (*_CODEX_HOME_SYMLINK_FILES, *_CODEX_HOME_COPY_FILES):
         with contextlib.suppress(OSError):
             (home / name).unlink(missing_ok=True)
     _populate_codex_home_config(home, _codex_home_config_source_from_env(), minimal_config=True)

--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -44,6 +44,7 @@ from omnigent.codex_native_process_registry import (
 )
 from omnigent.inner import _proc
 from omnigent.inner.codex_executor import (
+    _CODEX_HOME_SYMLINK_FILES,
     _CODEX_ROUTER_HOOK_MODULE,
     _clean_codex_env,
     _codex_cli_version,
@@ -878,10 +879,14 @@ def _probe_codex_home(config_overrides: Sequence[str]) -> Path:
     key = hashlib.sha256("\n".join(config_overrides).encode("utf-8")).hexdigest()[:12]
     home = Path.home() / ".omnigent" / "cache" / "codex-model-probe" / key
     home.mkdir(mode=0o700, parents=True, exist_ok=True)
-    # The bridge skips files that already exist, and config.toml is copied
-    # (not symlinked), so drop the copy to re-read an edited source config.
-    with contextlib.suppress(OSError):
-        (home / "config.toml").unlink(missing_ok=True)
+    # The bridge skips entries that already exist and this home outlives one
+    # probe, so clear what it materializes. A kept config.toml copy would pin
+    # the first probe's tables; a kept credential symlink would keep naming a
+    # source home that has since moved, or dangle if it was removed (a
+    # dangling link reads as present here, so it never self-heals).
+    for name in (*_CODEX_HOME_SYMLINK_FILES, "config.toml"):
+        with contextlib.suppress(OSError):
+            (home / name).unlink(missing_ok=True)
     _populate_codex_home_config(home, _codex_home_config_source_from_env(), minimal_config=True)
     return home
 

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -2445,3 +2445,19 @@ def test_probe_codex_home_bridges_provider_tables_and_credential(
     )
     home = codex_native_app_server._probe_codex_home(['model_provider="Databricks"'])
     assert "https://two.example" in (home / "config.toml").read_text()
+
+    # The credential must track its source too. The home is keyed only by the
+    # overrides, so a source that moves under an unchanged override set leaves
+    # a symlink naming the old home; a removed source leaves it dangling, and
+    # a dangling link reads as present to the bridge, so an unrefreshed home
+    # would probe as logged out forever.
+    moved = tmp_path / "moved-codex"
+    source.rename(moved)
+    monkeypatch.setenv("CODEX_HOME", str(moved))
+
+    home = codex_native_app_server._probe_codex_home(['model_provider="Databricks"'])
+
+    credential = home / ".credentials.json"
+    assert credential.is_symlink()
+    assert credential.resolve() == (moved / ".credentials.json").resolve()
+    assert credential.exists(), "credential symlink must not dangle"

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import stat
 import sys
 from dataclasses import dataclass, field
@@ -2461,3 +2462,25 @@ def test_probe_codex_home_bridges_provider_tables_and_credential(
     assert credential.is_symlink()
     assert credential.resolve() == (moved / ".credentials.json").resolve()
     assert credential.exists(), "credential symlink must not dangle"
+
+    # The permanent case: a removed source leaves the link dangling, and a
+    # dangling link satisfies the bridge's skip test (is_symlink() is True
+    # while exists() is False), so an unrefreshed home could never recover.
+    shutil.rmtree(moved)
+    assert credential.is_symlink() and not credential.exists(), "expected a dangling link"
+
+    fresh = tmp_path / "fresh-codex"
+    fresh.mkdir()
+    (fresh / "config.toml").write_text(
+        'model_provider = "Databricks"\n\n[model_providers.Databricks]\n'
+        'base_url = "https://three.example"\n'
+    )
+    (fresh / ".credentials.json").write_text("{}")
+    monkeypatch.setenv("CODEX_HOME", str(fresh))
+
+    home = codex_native_app_server._probe_codex_home(['model_provider="Databricks"'])
+
+    credential = home / ".credentials.json"
+    assert credential.exists(), "a dangling credential link must self-heal"
+    assert credential.resolve() == (fresh / ".credentials.json").resolve()
+    assert "https://three.example" in (home / "config.toml").read_text()


### PR DESCRIPTION
## Related issue

Closes #6252

## Summary

Follow-up to #6249, addressing a review note on it. That PR consolidated the
model-probe home onto the shared `_populate_codex_home_config` bridge, which is
the right call, but the bridge skips any entry that already exists and the probe
home is a persistent cache keyed only on the `-c` overrides. `config.toml` was
unlinked before the bridge ran; the credential symlink was not.

- Clear every entry the bridge materializes, not just `config.toml`.
- Two failure modes this closes, both with byte-identical overrides so the cache
  key never changes: a source home that **moves** leaves the probe serving
  `config.toml` from the new source with the credential still naming the old one;
  a source home that is **removed** leaves the link dangling. The second is
  permanent, because a dangling symlink returns `False` from `exists()` but
  `True` from `is_symlink()`, and the bridge's skip test is
  `if link_path.exists() or link_path.is_symlink()`. So the home never
  self-heals and every later probe answers for a logged-out account (login-gated
  entries missing, wrong account default) with no error to point at.
- This restores a property the pre-#6249 hand-rolled code had: it re-created the
  `auth.json` symlink unconditionally on each call. Consolidating onto the bridge
  traded that for skip-if-present, and this puts it back for the whole bridged
  set rather than one file.

```
                        config.toml     credential symlink
before this PR          unlinked, so    kept, so a moved source is
                        always fresh    stale and a removed one dangles
                                        forever (cache never self-heals)

after                   unlinked        unlinked
                             \             /
                              both re-materialized from the
                              source home this probe resolved
```

## Test Plan

```
pytest tests/test_codex_native_app_server.py::test_probe_codex_home_bridges_provider_tables_and_credential
pytest tests/test_codex_native_app_server.py::test_probe_codex_model_options_uses_launch_config_and_marks_default
pytest tests/test_codex_native_app_server.py::test_probe_codex_model_options_probes_every_launch_shape
```

3 passed. The new assertions are confirmed to catch the regression: narrowing the
refresh back to `config.toml` alone fails with the credential still resolving into
the old source home while the config came from the moved one:

```
AssertionError: assert PosixPath('.../test_probe_codex_home_bridges_0/.codex/.credentials.json')
                    == PosixPath('.../test_probe_codex_home_bridges_0/moved-codex/.credentials.json')
```

The removed-source case is covered too, and asserted independently of the
moved-source case (isolating it against a narrowed fix fails with
`AssertionError: a dangling credential link must self-heal`). It removes the
source home, requires the link to actually dangle, then re-probes against a
fresh source and requires both the credential and the config to track it.

The dangling-symlink mechanism this all turns on was verified directly rather
than assumed:

```
$ python -c "...; l.symlink_to(d/'gone'); print(l.exists(), l.is_symlink())"
exists(): False  is_symlink(): True  -> bridge skips: True
```

Live, against a real `~/.codex/config.toml` on a Databricks gateway provider,
cache cleared first, confirming the added unlink does not break the warm-cache
path it runs on every probe:

```
probe 1: 5 models | probe 2 (warm home): 5 models
```

with the credential correctly relinked afterwards:

```
~/.omnigent/cache/codex-model-probe/<key>/.credentials.json -> ~/.codex/.credentials.json
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test extends the existing probe-home test with both failure modes. The
moved-source case renames the source home, repoints `CODEX_HOME`, re-probes under
the same overrides, and asserts the credential resolves into the new source. The
removed-source case then deletes it, asserts the link actually dangles (this is
what the bridge silently accepts), and requires a re-probe against a fresh source
to self-heal. Both assertions were checked to fail against a fix narrowed back to
`config.toml` alone, the second one in isolation so it is not merely riding on
the first.

Manual verification covers the warm-cache path against the real `codex` binary.
The added unlink runs on every probe including cache hits, so the thing worth
checking by hand is that a second probe against an unchanged source still returns
the full catalog rather than paying a re-link that breaks it.

## Changelog

The codex model picker no longer falls back to a logged-out model list after your Codex config home moves or is recreated.

## Issues

Resolves [OMNI-6010](https://linear.app/omnigent/issue/OMNI-6010/codex-model-probe-home-never-refreshes-its-credential-symlink-so-a)
