### PR TITLE
Preserve approval across trusted fork pushes

### DIFF
--- a/.github/scripts/maintainer_approval.py
+++ b/.github/scripts/maintainer_approval.py
@@ -47,7 +47,7 @@ def approval_decision(
     commits: list[dict[str, Any]],
     timeline: list[dict[str, Any]] | None = None,
 ) -> ApprovalDecision:
-    """Accept current approval or trusted same-repository successor commits."""
+    """Accept current approval or trusted successor commits."""
     maintainers = {login.casefold() for login in maintainers}
     trusted_successors = {login.casefold() for login in trusted_successors}
     if author.casefold() in maintainers:
@@ -56,7 +56,9 @@ def approval_decision(
     commit_positions = {
         str(commit.get("sha") or ""): index for index, commit in enumerate(commits)
     }
-    same_repository = head_repository.casefold() == repository.casefold()
+    head_scope = (
+        "same-repository" if head_repository.casefold() == repository.casefold() else "fork"
+    )
     failures: list[str] = []
     for login, review in latest_decisive_reviews(reviews).items():
         if login.casefold() not in maintainers:
@@ -67,9 +69,6 @@ def approval_decision(
         approved_sha = str(review.get("commit_id") or "")
         if review_state == "APPROVED" and approved_sha == head_sha:
             return ApprovalDecision(True, f"Current head approved by maintainer @{login}.")
-        if not same_repository:
-            failures.append(f"@{login}'s approval predates a fork-head update")
-            continue
         position = commit_positions.get(approved_sha)
         if position is None:
             failures.append(f"@{login}'s approved commit is no longer in PR history")
@@ -87,7 +86,7 @@ def approval_decision(
         if not untrusted:
             if review_state == "DISMISSED" and not trusted_automatic_dismissal(
                 review=review,
-                successor_shas={str(commit.get("sha") or "") for commit in successors},
+                successor_commits={str(commit.get("sha") or ""): commit for commit in successors},
                 trusted_successors=trusted_successors,
                 timeline=timeline or [],
             ):
@@ -98,7 +97,8 @@ def approval_decision(
             return ApprovalDecision(
                 True,
                 f"Maintainer @{login} approved {approved_sha[:9]}; only trusted "
-                f"automation committed through {head_sha[:9]}.",
+                f"automation committed on the {head_scope} head through "
+                f"{head_sha[:9]}.",
             )
         failures.append(
             f"@{login}'s approval predates untrusted commit(s): {', '.join(untrusted)}"
@@ -111,25 +111,30 @@ def approval_decision(
 def trusted_automatic_dismissal(
     *,
     review: dict[str, Any],
-    successor_shas: set[str],
+    successor_commits: dict[str, dict[str, Any]],
     trusted_successors: set[str],
     timeline: list[dict[str, Any]],
 ) -> bool:
     review_id = str(review.get("id") or "")
     for event in timeline:
         dismissed = event.get("dismissed_review") or {}
-        actor = event.get("actor") or {}
         if str(event.get("event") or "") != "review_dismissed":
             continue
         if str(dismissed.get("review_id") or "") != review_id:
             continue
         if str(dismissed.get("state") or "").upper() != "APPROVED":
             continue
-        if str(actor.get("login") or "").casefold() not in trusted_successors:
+        if dismissed.get("dismissal_message") not in {None, ""}:
             continue
-        if str(dismissed.get("dismissal_commit_id") or "") not in successor_shas:
+        dismissal_commit = successor_commits.get(str(dismissed.get("dismissal_commit_id") or ""))
+        if dismissal_commit is None:
             continue
-        return True
+        author_login = str((dismissal_commit.get("author") or {}).get("login") or "").casefold()
+        committer_login = str(
+            (dismissal_commit.get("committer") or {}).get("login") or ""
+        ).casefold()
+        if author_login in trusted_successors and committer_login in trusted_successors:
+            return True
     return False
 
 

--- a/.github/scripts/maintainer_approval_test.py
+++ b/.github/scripts/maintainer_approval_test.py
@@ -23,7 +23,13 @@ def commit(sha: str, login: str = "omni-resolve-agent[bot]"):
     }
 
 
-def dismissal_event(*, review_id=1, actor="omni-resolve-agent[bot]", commit_id="new"):
+def dismissal_event(
+    *,
+    review_id=1,
+    actor="omni-resolve-agent[bot]",
+    commit_id="new",
+    dismissal_message=None,
+):
     return {
         "event": "review_dismissed",
         "actor": {"login": actor},
@@ -31,6 +37,7 @@ def dismissal_event(*, review_id=1, actor="omni-resolve-agent[bot]", commit_id="
             "review_id": review_id,
             "state": "approved",
             "dismissal_commit_id": commit_id,
+            "dismissal_message": dismissal_message,
         },
     }
 
@@ -74,11 +81,32 @@ def test_auto_dismissed_approval_survives_the_trusted_push_that_dismissed_it():
     assert "only trusted automation committed" in decision.reason
 
 
+def test_trusted_fork_push_preserves_approval():
+    decision = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("new")],
+        head_repository="contributor/omnigent",
+    )
+    assert decision.approved
+    assert "only trusted automation committed" in decision.reason
+    assert "fork head" in decision.reason
+
+
+def test_auto_dismissed_fork_approval_accepts_human_push_token_actor():
+    decision = decide(
+        reviews=[review("DISMISSED", "old")],
+        commits=[commit("old"), commit("new")],
+        timeline=[dismissal_event(actor="fork-push-token-owner")],
+        head_repository="contributor/omnigent",
+    )
+    assert decision.approved
+
+
 def test_dismissed_approval_requires_a_trusted_matching_dismissal_event():
     manual = decide(
         reviews=[review("DISMISSED", "old")],
         commits=[commit("old"), commit("new")],
-        timeline=[dismissal_event(actor="maintainer")],
+        timeline=[dismissal_event(actor="maintainer", dismissal_message="withdrawn")],
     )
     wrong_commit = decide(
         reviews=[review("DISMISSED", "old")],
@@ -89,7 +117,7 @@ def test_dismissed_approval_requires_a_trusted_matching_dismissal_event():
     assert not wrong_commit.approved
 
 
-def test_approval_does_not_survive_untrusted_or_fork_updates():
+def test_approval_does_not_survive_untrusted_updates():
     untrusted = decide(
         reviews=[review("APPROVED", "old")],
         commits=[commit("old"), commit("new", "contributor")],
@@ -97,13 +125,13 @@ def test_approval_does_not_survive_untrusted_or_fork_updates():
     assert not untrusted.approved
     assert "untrusted commit" in untrusted.reason
 
-    fork = decide(
+    untrusted_fork = decide(
         reviews=[review("APPROVED", "old")],
-        commits=[commit("old"), commit("new")],
+        commits=[commit("old"), commit("new", "contributor")],
         head_repository="contributor/omnigent",
     )
-    assert not fork.approved
-    assert "fork-head update" in fork.reason
+    assert not untrusted_fork.approved
+    assert "untrusted commit" in untrusted_fork.reason
 
 
 def test_approval_does_not_survive_rewritten_history():


### PR DESCRIPTION
## Related issue

N/A — Test / CI change.

## Summary

- Preserve a maintainer approval when every successor commit is authored and committed by trusted automation, including contributor-fork heads.
- Recognize legacy auto-dismissals triggered by a trusted bot commit even when a human fork-push token appears as the timeline actor.
- Continue rejecting rewritten history, contributor-authored successors, requested changes, and explicit human dismissals.

**ELI5:** moving the PR branch between repositories does not make an Otto-authored commit less trustworthy. The evaluator now checks who authored every new commit instead of rejecting all fork updates.

```text
maintainer approval -> trusted bot commit(s) -> approval remains valid
                    -> any other commit       -> new approval required
```

## Test Plan

- `uv run --with pytest pytest -q .github/scripts/maintainer_approval_test.py`
- `uv run --with pre-commit pre-commit run --files .github/scripts/maintainer_approval.py .github/scripts/maintainer_approval_test.py`
- Covered same-repository successors, fork successors, legacy auto-dismissals, explicit dismissals, untrusted commits, rewritten history, and later requested changes.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The focused evaluator suite passes all 10 cases.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The evaluator is a pure decision function; unit cases exercise each trust and invalidation path without mutating repository settings.
