### PR TITLE
docs: clarify rerun approval behavior

### DIFF
--- a/.github/workflows/rerun-ci.yml
+++ b/.github/workflows/rerun-ci.yml
@@ -1,8 +1,8 @@
 # A contributor comments `/rerun` on a PR to re-run its failed CI **on the
 # existing head commit** -- no empty commit, no rebase, so no push event and
-# thus no dismissed approvals (branch protection keeps dismiss-stale-reviews
-# on to block approve-then-swap). Use for flaky-test recovery instead of
-# pushing a throwaway commit to re-trigger checks.
+# no new head for the custom approval evaluator to validate. Use for flaky-test
+# recovery instead of pushing a throwaway commit that resets checks and requires
+# approval validation for the successor commit.
 #
 # CI here runs entirely against the in-process mock LLM (no gateway spend), so
 # a re-run costs only Actions minutes; `cancel-in-progress` on each suite caps


### PR DESCRIPTION
## Related issue

N/A — docs-only follow-up to the approval-preservation change.

## Summary

- Update the `/rerun` workflow header to reflect that native stale-review dismissal is disabled.
- Explain that re-running the existing head avoids successor-commit validation and check resets.

## Test Plan

- `uv run --no-sync pre-commit run --files .github/workflows/rerun-ci.yml`
- Confirmed the repository ruleset has `dismiss_stale_reviews_on_push: false`.
- Confirmed classic branch protection has `dismiss_stale_reviews: false` and still requires `Maintainer Approval` and `Merge Ready`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The focused pre-commit hooks, including YAML syntax validation, pass.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the live ruleset and branch-protection API responses and ran all pre-commit hooks applicable to the edited workflow file.
