### PR TITLE
fix(claude-sdk): pin opus to the served Opus 4.8 so the refusal-fallback arms

### DIFF
--- a/omnigent/claude_model_vocabulary.py
+++ b/omnigent/claude_model_vocabulary.py
@@ -82,6 +82,10 @@ MODEL_VOCABULARY_ENV_VARS: tuple[str, ...] = (
 #: this module stays stdlib-only for hook subprocesses, which also means it
 #: cannot honour a deployment's ``routing.model_prefix`` override.
 _CATALOG_PREFIXES: tuple[str, ...] = ("databricks-", "system.ai.")
+# Claude Code re-issues a safeguard-flagged turn on this canonical model, and
+# only when the ``opus`` alias resolves to it; any other Opus, newer included,
+# makes it decline the fallback (``model_refusal_no_fallback``).
+REFUSAL_FALLBACK_MODEL = "claude-opus-4-8"
 _SEGMENT_RE = re.compile(r"[^a-z0-9]+")
 
 
@@ -247,26 +251,52 @@ def _model_version_key(model: str) -> tuple[tuple[int, str | int], ...]:
     )
 
 
+def _spells_canonical_model(model_id: str, canonical: str) -> bool:
+    """Whether *model_id* is a gateway's spelling of the *canonical* vendor id.
+
+    :param model_id: A served id, e.g. ``"gw-claude-opus-4-8"``.
+    :param canonical: A canonical id, e.g. ``"claude-opus-4-8"``.
+    :returns: ``True`` for ``databricks-claude-opus-4-8``,
+        ``anthropic/claude-opus-4-8`` or ``claude-opus-4-8[1m]``; ``False`` for
+        another generation such as ``claude-opus-4-8-fast`` or ``claude-opus-5``.
+    """
+    return (
+        re.fullmatch(rf"(?:.*[^a-z0-9])?{re.escape(canonical)}", normalized_model_id(model_id))
+        is not None
+    )
+
+
 def served_alias_pins(model_ids: Iterable[str]) -> dict[str, str]:
-    """Map each family alias to the newest served id of that family.
+    """Map each family alias to a served id of that family.
 
     A gateway that serves Claude under its own ids (``databricks-claude-opus-4-8``,
     ``anthropic/claude-opus-4-8``) leaves Claude Code's alias vocabulary
     unpinned, and an unpinned alias resolves to a canonical vendor id the
     gateway rejects. Every alias surface — the refusal-fallback, ``/model``,
     ``Agent``-tool spawns — then fails ``model_not_found``. This picks, per
-    family, the id the gateway actually serves so the launch env can pin it.
+    family, an id the gateway actually serves so the launch env can pin it.
+
+    The newest served id of a family wins, except that ``opus`` pins the
+    served spelling of :data:`REFUSAL_FALLBACK_MODEL` whenever the gateway
+    serves it: the refusal-fallback arms only for that exact model, so a
+    newer Opus pin would leave a flagged turn with no fallback at all.
 
     :param model_ids: The ids a gateway's model listing reports.
     :returns: Alias → served id, e.g. ``{"opus": "databricks-claude-opus-4-8"}``,
         for the families the listing serves. Ids of no Claude family are
         ignored.
     """
+    served = list(model_ids)
     pins: dict[str, str] = {}
-    for model_id in model_ids:
+    for model_id in served:
         alias = claude_model_alias(model_id, env={})
         if alias not in ALIAS_MODEL_ENV_VARS:
             continue
         if alias not in pins or _model_version_key(model_id) > _model_version_key(pins[alias]):
             pins[alias] = model_id
+    fallback_alias = claude_model_alias(REFUSAL_FALLBACK_MODEL, env={})
+    for model_id in served:
+        if _spells_canonical_model(model_id, REFUSAL_FALLBACK_MODEL):
+            pins[fallback_alias] = model_id
+            break
     return pins

--- a/omnigent/claude_model_vocabulary.py
+++ b/omnigent/claude_model_vocabulary.py
@@ -82,10 +82,6 @@ MODEL_VOCABULARY_ENV_VARS: tuple[str, ...] = (
 #: this module stays stdlib-only for hook subprocesses, which also means it
 #: cannot honour a deployment's ``routing.model_prefix`` override.
 _CATALOG_PREFIXES: tuple[str, ...] = ("databricks-", "system.ai.")
-# Claude Code re-issues a safeguard-flagged turn on this canonical model, and
-# only when the ``opus`` alias resolves to it; any other Opus, newer included,
-# makes it decline the fallback (``model_refusal_no_fallback``).
-REFUSAL_FALLBACK_MODEL = "claude-opus-4-8"
 _SEGMENT_RE = re.compile(r"[^a-z0-9]+")
 
 
@@ -277,15 +273,20 @@ def served_alias_pins(model_ids: Iterable[str]) -> dict[str, str]:
     family, an id the gateway actually serves so the launch env can pin it.
 
     The newest served id of a family wins, except that ``opus`` pins the
-    served spelling of :data:`REFUSAL_FALLBACK_MODEL` whenever the gateway
-    serves it: the refusal-fallback arms only for that exact model, so a
-    newer Opus pin would leave a flagged turn with no fallback at all.
+    served spelling of Claude Code's refusal-fallback target
+    (:data:`~omnigent.model_fallbacks.CLAUDE_REFUSAL_FALLBACK_MODEL`) whenever
+    the gateway serves it: the refusal-fallback arms only for that exact
+    model, so a newer Opus pin would leave a flagged turn with no fallback.
 
     :param model_ids: The ids a gateway's model listing reports.
     :returns: Alias → served id, e.g. ``{"opus": "databricks-claude-opus-4-8"}``,
         for the families the listing serves. Ids of no Claude family are
         ignored.
     """
+    # Lazy: model_fallbacks pulls in onboarding config, and this module stays
+    # stdlib-only at import time for Claude Code's hook subprocesses.
+    from omnigent.model_fallbacks import CLAUDE_REFUSAL_FALLBACK_MODEL
+
     served = list(model_ids)
     pins: dict[str, str] = {}
     for model_id in served:
@@ -294,9 +295,10 @@ def served_alias_pins(model_ids: Iterable[str]) -> dict[str, str]:
             continue
         if alias not in pins or _model_version_key(model_id) > _model_version_key(pins[alias]):
             pins[alias] = model_id
-    fallback_alias = claude_model_alias(REFUSAL_FALLBACK_MODEL, env={})
-    for model_id in served:
-        if _spells_canonical_model(model_id, REFUSAL_FALLBACK_MODEL):
-            pins[fallback_alias] = model_id
-            break
+    fallback_alias = claude_model_alias(CLAUDE_REFUSAL_FALLBACK_MODEL, env={})
+    if fallback_alias is not None:
+        for model_id in served:
+            if _spells_canonical_model(model_id, CLAUDE_REFUSAL_FALLBACK_MODEL):
+                pins[fallback_alias] = model_id
+                break
     return pins

--- a/omnigent/model_fallbacks.py
+++ b/omnigent/model_fallbacks.py
@@ -64,6 +64,22 @@ _CODEX_LAUNCH_DEFAULT = StaticModelFallback(
 CODEX_DEFAULT_MODEL = _CODEX_LAUNCH_DEFAULT.model_ids[0]
 
 
+#: The model Claude Code re-issues a safeguard-flagged turn on. Its refusal
+#: route table sends both the cyber and bio categories here, and the swap arms
+#: only when the ``opus`` alias resolves to this exact model, so a launch env
+#: pins ``opus`` to the gateway's spelling of it (``served_alias_pins``).
+_CLAUDE_REFUSAL_FALLBACK = StaticModelFallback(
+    model_ids=("claude-opus-4-8",),
+    owner="Claude SDK alias pins (omnigent.claude_model_vocabulary)",
+    provenance="Claude Code's built-in refusal-fallback route table",
+    discovery_gap=(
+        "no API reports the model the CLI's refusal-fallback targets; it is hardcoded in the CLI"
+    ),
+)
+
+CLAUDE_REFUSAL_FALLBACK_MODEL = _CLAUDE_REFUSAL_FALLBACK.model_ids[0]
+
+
 # ── Smart Routing ───────────────────────────────────────────────────────────
 #
 # The router's static tables. A live per-session catalog wins wherever one is

--- a/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
+++ b/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
@@ -56,6 +56,10 @@ _SERVED_FALLBACK_MODEL = "gw-claude-opus-4-8"
 _SERVED_MODELS = [
     _LAUNCH_MODEL,
     _SERVED_FALLBACK_MODEL,
+    # A newer Opus the gateway also serves. The fallback must still land on
+    # Opus 4.8: Claude Code declines the swap when ``opus`` pins to anything
+    # else, and a workspace that serves Opus 5 is exactly where this broke.
+    "gw-claude-opus-5",
     "gw-claude-sonnet-5",
     "gw-claude-haiku-4-5",
 ]

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -832,6 +832,7 @@ class TestConstructor(unittest.TestCase):
                     ModelEntry(id="gw-claude-fable-5", family="claude"),
                     ModelEntry(id="gw-claude-opus-4-7", family="claude"),
                     ModelEntry(id="gw-claude-opus-4-8", family="claude"),
+                    ModelEntry(id="gw-claude-opus-5", family="claude"),
                     ModelEntry(id="gw-claude-sonnet-5", family="claude"),
                     ModelEntry(id="gw-claude-haiku-4-5", family="claude"),
                     ModelEntry(id="gw-gpt-5-6", family="openai"),
@@ -851,7 +852,9 @@ class TestConstructor(unittest.TestCase):
                         pass
 
             env = captured["env"]
-            # Newest served generation per family; the non-Claude id is ignored.
+            # Newest served generation per family, except ``opus``: the
+            # refusal-fallback arms only for Opus 4.8, so its served spelling
+            # wins over the newer Opus 5. The non-Claude id is ignored.
             self.assertEqual(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "gw-claude-opus-4-8")
             self.assertEqual(env["ANTHROPIC_DEFAULT_FABLE_MODEL"], "gw-claude-fable-5")
             self.assertEqual(env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "gw-claude-sonnet-5")

--- a/tests/test_claude_model_vocabulary.py
+++ b/tests/test_claude_model_vocabulary.py
@@ -191,21 +191,40 @@ def test_bracket_marker_on_a_non_alias_is_not_an_argument() -> None:
     assert claude_model_alias("sonnet[", _PINNED_ENV) is None
 
 
-def test_served_alias_pins_pick_the_newest_served_id_per_family() -> None:
+@pytest.mark.parametrize(
+    "served_fallback",
+    [
+        "databricks-claude-opus-4-8",
+        "anthropic/claude-opus-4-8",
+        "gw-claude-opus-4-8",
+        "claude-opus-4-8[1m]",
+    ],
+)
+def test_served_alias_pins_pin_opus_to_the_served_refusal_fallback_model(
+    served_fallback: str,
+) -> None:
     served = [
         "databricks-claude-opus-4-7",
-        "databricks-claude-opus-4-8",
+        served_fallback,
+        "anthropic/claude-sonnet-4-6",
         "anthropic/claude-sonnet-5",
         "gw-claude-haiku-4-5",
         "databricks-gpt-5-6",
-        "claude-opus-5[1m]",
+        "claude-opus-5",
     ]
     assert served_alias_pins(served) == {
-        # ``claude-opus-5`` outranks ``4-8``; the [1m] marker is not a
-        # different model, so the spelling the gateway listed is kept.
-        "opus": "claude-opus-5[1m]",
+        # Newest per family, except ``opus``: the refusal-fallback arms only
+        # for Opus 4.8, so its served spelling outranks the newer Opus 5.
+        "opus": served_fallback,
         "sonnet": "anthropic/claude-sonnet-5",
         "haiku": "gw-claude-haiku-4-5",
+    }
+
+
+def test_served_alias_pins_pick_the_newest_opus_when_the_fallback_model_is_not_served() -> None:
+    assert served_alias_pins(["databricks-claude-opus-4-7", "claude-opus-5[1m]"]) == {
+        # The [1m] marker is not a different model, so the listed spelling is kept.
+        "opus": "claude-opus-5[1m]",
     }
 
 


### PR DESCRIPTION
## Related issue

Closes #6265

## Summary

- #6236 pins Claude Code's family aliases from the gateway's model listing, taking the newest served id per family. On a workspace that serves Opus 5 next to Opus 4.8 (the Databricks `oss` workspace today) that pinned `opus` to Opus 5.
- Claude Code's refusal-fallback re-issues a safeguard-flagged turn on canonical `claude-opus-4-8` and arms only when the `opus` alias resolves to that exact model, so the Opus 5 pin made the CLI emit `model_refusal_no_fallback` and the turn died with `API Error: Fable 5 has safety measures that flagged this message ...` (omnigent-internal repro run 33714311211, OMNI-2283).
- `served_alias_pins` now pins `opus` to the served spelling of Opus 4.8 whenever the listing has one (`databricks-claude-opus-4-8`, `anthropic/claude-opus-4-8`, `gw-claude-opus-4-8`, `claude-opus-4-8[1m]`); the other families keep the newest served id. The target lives in `omnigent/model_fallbacks.py` as a `StaticModelFallback` record (`CLAUDE_REFUSAL_FALLBACK_MODEL`) with owner, provenance, and discovery gap, so the coupling to the CLI's route table is explicit and the hardcoded-model lint is satisfied.

ELI5: Claude Code will only hand a flagged message to Opus 4.8 specifically. We were telling it "Opus means Opus 5", so it refused to hand it over at all. Now "Opus" means the gateway's Opus 4.8 whenever the gateway has one.

## Test Plan

- Live A/B on the Databricks gateway with the CI-pinned Claude Code 2.1.212, identical env except the pin: `ANTHROPIC_DEFAULT_OPUS_MODEL=databricks-claude-opus-5` gives `model_refusal_no_fallback` and the turn fails; `=databricks-claude-opus-4-8` gives `model_refusal_fallback`, the turn re-issues on `databricks-claude-opus-4-8` and completes with a real answer.
- `tests/test_claude_model_vocabulary.py`: the pin test now serves a newer Opus and is parametrized over four gateway spellings of Opus 4.8; a second test covers the newest-Opus fallback when 4.8 is not served.
- `tests/inner/test_claude_sdk_executor.py::test_gateway_pins_family_aliases_to_served_ids`: the listing now includes `gw-claude-opus-5`; the pin must stay on `gw-claude-opus-4-8`.
- `tests/e2e/test_claude_sdk_refusal_fallback_e2e.py`: the mock gateway now serves `gw-claude-opus-5` too. Red without this change (the fallback left the served id), green with it (36s).
- Full `tests/test_claude_model_vocabulary.py` + `tests/inner/test_claude_sdk_executor.py`: 179 passed, 1 xfailed. `pre-commit` clean on the changed files.
- End-to-end in CI, PASSED: omnigent-internal repro run on OMNI-2283 with `ref=fix/claude-sdk-refusal-fallback-target-pin` (https://github.com/omnigent-ai/omnigent-internal/actions/runs/33716949773), on top of omnigent-internal#276 which repoints CI's Claude base URL at `/ai-gateway/anthropic` so the listing is reachable. Runner log: listing `200 OK` at both turn starts, the cyber safeguard tripped again mid-session and the CLI emitted `model_refusal_fallback` with `fallback_model: databricks-claude-opus-4-8`, no `is_error` turns, and the ticket reached verdict `reproduced` for the first time (the two earlier runs ended in `needs_more_info` after the failed turn).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the live A/B above against the real Databricks gateway and the real Claude Code 2.1.212 binary CI pins, which is the only place the CLI's refusal route table is exercised for real; the e2e covers the same decision against the mock gateway with the locally installed CLI.

## Changelog

claude-sdk agents on a gateway that serves a newer Opus recover from a safeguard refusal on Opus 4.8 instead of failing the turn

https://claude.ai/code/session_01WTmWmeC4VXaXhQxR3oibT6


