### PR TITLE
Fix OpenCode native cleanup and tmux 3.0 compatibility

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -121,7 +121,7 @@ def _tmux_managed_option_commands(
     if keep_alive_after_exit:
         commands.extend(_tmux_session_persistence_commands())
     if allow_passthrough:
-        commands.append(["set-option", "-g", "allow-passthrough", "on"])
+        commands.append(["set-option", "-gq", "allow-passthrough", "on"])
     return commands
 
 

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -1079,12 +1079,18 @@ class TerminalInstance:
                     f"wait-for -S {_TMUX_START_ON_ATTACH_CHANNEL}",
                 ]
             )
-        # ``pane-died`` is a window-scope hook that fires when remain-on-exit
-        # keeps the pane alive after the inner process exits. We need to set
-        # it AFTER new-session (not before) because window scope requires an
-        # existing window, and global scope (-g) does not fire for pane-died.
+        # Each managed terminal has an isolated tmux server and one session.
+        # Session scope keeps this compatible with tmux 3.0 and later.
         pane_died_hook: list[list[str]] = (
-            [["set-hook", "-w", "pane-died", "detach-client -a"]]
+            [
+                [
+                    "set-hook",
+                    "-t",
+                    self.tmux_target,
+                    "pane-died",
+                    "detach-client -a",
+                ]
+            ]
             if self.keep_alive_after_exit
             else []
         )

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -200,8 +200,9 @@ def _tmux_lockdown_commands() -> list[list[str]]:
     Managed terminals must stay inside Omnigent' terminal registry.
     Disabling the prefix table and right-click context menus prevents an
     attached user from creating extra panes, windows, or sessions through
-    tmux UI controls. The root-table unbinds are quiet so missing default
-    mouse bindings on a tmux version do not fail terminal launch.
+    tmux UI controls. The private server uses ``-f /dev/null``, so these
+    default root-table bindings are stable. Avoid ``unbind-key -q`` because
+    tmux 3.0 lacks it.
 
     :returns: Tmux commands that disable prefix and creation menus.
     """
@@ -209,12 +210,12 @@ def _tmux_lockdown_commands() -> list[list[str]]:
         ["set-option", "-g", "prefix", "None"],
         ["set-option", "-g", "prefix2", "None"],
         ["unbind-key", "-a", "-T", "prefix"],
-        ["unbind-key", "-q", "-T", "root", "MouseDown3Pane"],
-        ["unbind-key", "-q", "-T", "root", "M-MouseDown3Pane"],
-        ["unbind-key", "-q", "-T", "root", "MouseDown3Status"],
-        ["unbind-key", "-q", "-T", "root", "M-MouseDown3Status"],
-        ["unbind-key", "-q", "-T", "root", "MouseDown3StatusLeft"],
-        ["unbind-key", "-q", "-T", "root", "M-MouseDown3StatusLeft"],
+        ["unbind-key", "-T", "root", "MouseDown3Pane"],
+        ["unbind-key", "-T", "root", "M-MouseDown3Pane"],
+        ["unbind-key", "-T", "root", "MouseDown3Status"],
+        ["unbind-key", "-T", "root", "M-MouseDown3Status"],
+        ["unbind-key", "-T", "root", "MouseDown3StatusLeft"],
+        ["unbind-key", "-T", "root", "M-MouseDown3StatusLeft"],
     ]
 
 

--- a/omnigent/opencode_native_app_server.py
+++ b/omnigent/opencode_native_app_server.py
@@ -491,7 +491,11 @@ class OpenCodeNativeServer:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        await self._wait_until_ready()
+        try:
+            await self._wait_until_ready()
+        except BaseException:
+            await self.close()
+            raise
 
     async def _wait_until_ready(self, *, attempts: int = 60, delay: float = 0.5) -> None:
         """

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1400,14 +1400,16 @@ def create_app(
         _pane_reaper = getattr(app.state, "native_pane_reaper", None)
         if _pane_reaper is not None:
             await _pane_reaper.shutdown()
-        # Close host-spawned codex-native app-servers before the process exits.
-        # Each is spawned in its own session (survives the runner's death), and a
-        # host-initiated stop tears the runner down without a per-session DELETE,
-        # so without this they orphan as lingering ``codex`` processes.
-        from omnigent.runner.native import teardown_all_codex_native_app_servers
+        # Close native app servers before their owning runner exits.
+        from omnigent.runner.native import (
+            teardown_all_codex_native_app_servers,
+            teardown_all_opencode_native_servers,
+        )
 
         with contextlib.suppress(Exception):
             await teardown_all_codex_native_app_servers()
+        with contextlib.suppress(Exception):
+            await teardown_all_opencode_native_servers()
         await pm.shutdown()
         await _terminal_registry.shutdown()
         if mcp_manager is not None:

--- a/omnigent/runner/native/__init__.py
+++ b/omnigent/runner/native/__init__.py
@@ -126,7 +126,9 @@ from omnigent.runner.native.orchestration import (
     _terminal_tmux_pane,
     _unwrap_resolved_spec,
     teardown_all_codex_native_app_servers,
+    teardown_all_opencode_native_servers,
     teardown_codex_native_app_server,
+    teardown_opencode_native_server,
 )
 
 __all__ = [
@@ -255,5 +257,7 @@ __all__ = [
     "_terminal_tmux_pane",
     "_unwrap_resolved_spec",
     "teardown_all_codex_native_app_servers",
+    "teardown_all_opencode_native_servers",
     "teardown_codex_native_app_server",
+    "teardown_opencode_native_server",
 ]

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -250,6 +250,24 @@ async def teardown_all_codex_native_app_servers() -> None:
             await teardown_codex_native_app_server(session_id)
 
 
+async def teardown_opencode_native_server(session_id: str) -> None:
+    """Tear down one host-spawned OpenCode server and its forwarder."""
+    if session_id not in _AUTO_OPENCODE_SERVERS:
+        return
+    await _cancel_auto_forwarder_task(session_id)
+    leftover = _AUTO_OPENCODE_SERVERS.pop(session_id, None)
+    if leftover is not None:
+        with contextlib.suppress(Exception):
+            await leftover.close()
+
+
+async def teardown_all_opencode_native_servers() -> None:
+    """Tear down every host-spawned OpenCode server on this runner."""
+    for session_id in list(_AUTO_OPENCODE_SERVERS):
+        with contextlib.suppress(Exception):
+            await teardown_opencode_native_server(session_id)
+
+
 def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -> None:
     """
     Register a session's transcript-forwarder task in the keyed registry.
@@ -1414,7 +1432,7 @@ async def _auto_create_opencode_terminal(
                 workspace=workspace,
             ),
         )
-    except Exception:
+    except BaseException:
         await server.close()
         _AUTO_OPENCODE_SERVERS.pop(session_id, None)
         raise
@@ -1483,7 +1501,7 @@ async def _auto_create_opencode_terminal(
                 "resource": session_resource_view_to_dict(terminal_view),
             },
         )
-    except Exception:
+    except BaseException:
         await _cancel_auto_forwarder_task(session_id)
         await server.close()
         _AUTO_OPENCODE_SERVERS.pop(session_id, None)

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -612,6 +612,11 @@ async def test_launch_keeps_server_alive_when_opted_in(
     cmd = await _capture_launch_argv(tmp_path, monkeypatch, keep_alive_after_exit=True)
     assert contains_subsequence(cmd, ["set-option", "-gq", "remain-on-exit", "on"])
     assert contains_subsequence(cmd, ["set-option", "-sq", "exit-empty", "off"])
+    assert contains_subsequence(
+        cmd,
+        ["set-hook", "-t", "main", "pane-died", "detach-client -a"],
+    )
+    assert not contains_subsequence(cmd, ["set-hook", "-w", "pane-died"])
 
 
 @pytest.mark.asyncio

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -62,6 +62,16 @@ def contains_subsequence(values: list[str], expected: list[str]) -> bool:
     )
 
 
+def test_allow_passthrough_option_is_quiet_for_older_tmux() -> None:
+    """An unsupported allow-passthrough option must not abort terminal launch."""
+    commands = terminal_mod._tmux_managed_option_commands(
+        10_000,
+        allow_passthrough=True,
+    )
+
+    assert ["set-option", "-gq", "allow-passthrough", "on"] in commands
+
+
 def test_threaded_idle_watcher_reports_terminal_exit(tmp_path: Path) -> None:
     """
     The threaded watcher reports tmux disappearance instead of exiting silently.

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -834,18 +834,21 @@ async def test_launch_disables_tmux_pane_and_window_creation_controls(
     assert contains_subsequence(cmd, ["set-option", "-g", "prefix", "None"])
     assert contains_subsequence(cmd, ["set-option", "-g", "prefix2", "None"])
     assert contains_subsequence(cmd, ["unbind-key", "-a", "-T", "prefix"])
-    assert contains_subsequence(cmd, ["unbind-key", "-q", "-T", "root", "MouseDown3Pane"])
-    assert contains_subsequence(cmd, ["unbind-key", "-q", "-T", "root", "M-MouseDown3Pane"])
-    assert contains_subsequence(cmd, ["unbind-key", "-q", "-T", "root", "MouseDown3Status"])
-    assert contains_subsequence(cmd, ["unbind-key", "-q", "-T", "root", "M-MouseDown3Status"])
+    # tmux 3.0a has all six default bindings but no ``unbind-key -q`` flag.
+    # Keep the lockdown usable on supported older Linux distributions.
+    assert contains_subsequence(cmd, ["unbind-key", "-T", "root", "MouseDown3Pane"])
+    assert contains_subsequence(cmd, ["unbind-key", "-T", "root", "M-MouseDown3Pane"])
+    assert contains_subsequence(cmd, ["unbind-key", "-T", "root", "MouseDown3Status"])
+    assert contains_subsequence(cmd, ["unbind-key", "-T", "root", "M-MouseDown3Status"])
     assert contains_subsequence(
         cmd,
-        ["unbind-key", "-q", "-T", "root", "MouseDown3StatusLeft"],
+        ["unbind-key", "-T", "root", "MouseDown3StatusLeft"],
     )
     assert contains_subsequence(
         cmd,
-        ["unbind-key", "-q", "-T", "root", "M-MouseDown3StatusLeft"],
+        ["unbind-key", "-T", "root", "M-MouseDown3StatusLeft"],
     )
+    assert not contains_subsequence(cmd, ["unbind-key", "-q"])
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -518,6 +518,59 @@ async def test_teardown_all_codex_native_app_servers_closes_every_session() -> N
 
 
 @pytest.mark.asyncio
+async def test_teardown_all_opencode_native_servers_closes_every_session() -> None:
+    """Runner shutdown closes every registered ``opencode serve`` child."""
+    session_ids = [
+        "dddd3333dddd3333dddd3333dddd3333",
+        "eeee4444eeee4444eeee4444eeee4444",
+    ]
+    runs = [_ForwarderRun() for _ in session_ids]
+    closed: list[str] = []
+
+    def _make_parked(run: _ForwarderRun) -> Any:
+        async def _parked() -> None:
+            run.task = asyncio.current_task()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                run.cancelled = True
+                raise
+
+        return _parked
+
+    class _FakeServer:
+        def __init__(self, session_id: str) -> None:
+            self._session_id = session_id
+
+        async def close(self) -> None:
+            closed.append(self._session_id)
+
+    try:
+        for session_id, run in zip(session_ids, runs, strict=True):
+            task = asyncio.create_task(_make_parked(run)())
+            runner_app_mod._register_auto_forwarder_task(session_id, task)
+            runner_app_mod._AUTO_OPENCODE_SERVERS[session_id] = _FakeServer(session_id)
+        await asyncio.sleep(0)
+
+        await runner_app_mod.teardown_all_opencode_native_servers()
+
+        assert sorted(closed) == sorted(session_ids)
+        assert all(
+            session_id not in runner_app_mod._AUTO_OPENCODE_SERVERS for session_id in session_ids
+        )
+        assert all(
+            session_id not in runner_app_mod._AUTO_FORWARDER_TASKS for session_id in session_ids
+        )
+        assert all(run.cancelled for run in runs)
+        await runner_app_mod.teardown_all_opencode_native_servers()
+    finally:
+        for session_id in session_ids:
+            runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+            runner_app_mod._AUTO_OPENCODE_SERVERS.pop(session_id, None)
+        await _drain_forwarder_runs(runs)
+
+
+@pytest.mark.asyncio
 async def test_register_auto_forwarder_task_replaces_incumbent_and_survives_stale_evict() -> None:
     """
     Re-registration cancels the incumbent; its done-callback can't evict the successor.

--- a/tests/test_opencode_native_app_server.py
+++ b/tests/test_opencode_native_app_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -182,6 +183,54 @@ async def test_start_polls_until_ready(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert started["argv"][1] == "serve"
     assert server.process is not None
     assert server.process.pid == 4242
+
+
+async def test_start_closes_process_when_readiness_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cancellation during readiness cannot orphan ``opencode serve``."""
+    server = _server(monkeypatch, tmp_path)
+
+    class _FakeProc:
+        returncode: int | None = None
+        terminated = False
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def terminate(self) -> None:
+            self.terminated = True
+            self.returncode = -15
+
+        def wait(self, _timeout: float | None = None) -> int:
+            assert self.returncode is not None
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    process = _FakeProc()
+    readiness_started = asyncio.Event()
+
+    async def cancelled_wait(self: OpenCodeNativeServer) -> None:
+        readiness_started.set()
+        await asyncio.Event().wait()
+
+    async def direct_to_thread(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(appsrv.subprocess, "Popen", lambda argv, **kwargs: process)
+    monkeypatch.setattr(OpenCodeNativeServer, "_wait_until_ready", cancelled_wait)
+    monkeypatch.setattr(appsrv.asyncio, "to_thread", direct_to_thread)
+
+    start_task = asyncio.create_task(server.start())
+    await readiness_started.wait()
+    start_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    assert process.terminated is True
+    assert server.process is None
 
 
 async def test_start_raises_on_unsupported_version_without_env(


### PR DESCRIPTION
## Related issue

Closes #6267

## Summary

- Reap `opencode serve` when readiness is cancelled and sweep every registered OpenCode server during runner shutdown.
- Keep the private tmux terminal lockdown compatible with tmux 3.0a by avoiding unsupported `unbind-key -q` and quietly probing the optional `allow-passthrough` setting.
- Add cancellation, shutdown-sweep, and older-tmux regression coverage.

ELI5: a session that fails halfway through startup now cleans up the helper it already started, and older tmux versions no longer reject newer-only command syntax.

```text
OpenCode session -> spawn server -> readiness -> terminal
                         |              |
                  runner shutdown   cancellation
                         +------> close server

private tmux -> remove known root bindings -> quiet optional passthrough setting
```

## Test Plan

- Synced the locked lint environment used by CI: `uv sync --locked --group lint --extra hindsight --extra nimble --extra s3 --extra tracing`.
- Ran pre-commit on all eight changed files; Ruff, Pyrefly, policy checks, and file-hygiene checks passed.
- Ran `pytest` across the three affected test modules while excluding the separate real-tmux survival fixture: **94 passed, 1 deselected**.
- On Ubuntu Linux with tmux 3.0a and OpenCode 1.17.13, launched a real disposable `opencode-native` session through a remote runner, waited for the terminal to become ready, deleted the exact session, and verified that neither the runner nor `opencode serve` remained.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The live launch reached an idle/healthy terminal and the exact-session teardown left no OpenCode child or runner process.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The automated tests cover startup cancellation, idempotent all-session shutdown, and the exact tmux argument forms. Manual verification exercised the complete real OpenCode/tmux runner lifecycle on tmux 3.0a.

## Changelog

OpenCode native sessions now start on older tmux hosts and clean up their server processes when cancelled or shut down.
