### PR TITLE
fix(codex-native): fall back to a fresh thread when codex cannot load the rollout, with an in-chat notice

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -494,6 +494,40 @@ class CodexAppServerResponseError(RuntimeError):
         super().__init__(str(error))
 
 
+#: JSON-RPC internal-error code codex returns when its thread-store fails.
+_CODEX_INTERNAL_ERROR_CODE = -32603
+
+#: Substring in codex's ``-32603`` message when its thread-store cannot
+#: load/resume a thread's rollout — stable across the wrapper phrasings
+#: different codex versions use (``failed to read thread: …`` vs
+#: ``error resuming thread: …``).
+_CODEX_THREAD_STORE_ERROR = "thread-store internal error"
+
+
+def is_unreadable_thread_error(exc: BaseException) -> bool:
+    """
+    Whether a ``thread/resume`` failure means codex cannot load the thread.
+
+    Codex answers ``-32603`` with a ``thread-store internal error`` when it
+    cannot load or resume a thread's rollout JSONL — e.g. a large transcript
+    whose multibyte character straddles a read-buffer boundary is rejected as
+    invalid UTF-8 (``failed to read thread: …``), or a rollout record it
+    cannot resume (``error resuming thread: …``). Retrying never resumes such
+    a thread, unlike a refused resume (``-32600``, another writer holds the
+    thread) that clears once the holder exits.
+
+    :param exc: The exception raised by the resume request, e.g. a
+        :class:`CodexAppServerResponseError`.
+    :returns: ``True`` when only a fresh thread can carry the session on.
+    """
+    return (
+        isinstance(exc, CodexAppServerResponseError)
+        and exc.code == _CODEX_INTERNAL_ERROR_CODE
+        and exc.message is not None
+        and _CODEX_THREAD_STORE_ERROR in exc.message
+    )
+
+
 class CodexAppServerClient:
     """JSON-RPC client for a Codex app-server.
 

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -384,11 +384,16 @@ class ErrorData(BaseModel):
         ``"native_terminal_start_failed"``.
     :param message: Human-readable error message, e.g.
         ``"Native Codex requires the 'codex' CLI on PATH."``.
+    :param level: Rendering level. ``"info"`` renders the banner as a neutral
+        notice (e.g. codex started a fresh thread) rather than a failure;
+        ``None`` / ``"error"`` is the destructive default and is omitted from
+        the wire so existing error items are unchanged.
     """
 
     source: Literal["llm", "execution", "tool", "harness"]
     code: str
     message: str
+    level: Literal["error", "info"] | None = None
 
     @field_validator("code", "message")
     @classmethod

--- a/omnigent/runner/launch_failure.py
+++ b/omnigent/runner/launch_failure.py
@@ -193,6 +193,9 @@ _FAILURE_CODE_DESCRIPTIONS: dict[str, str] = {
     "connection_error": "The connection to the agent dropped mid-turn.",
     "context_length_exceeded": "The conversation grew past the model's context window.",
     "executor_error": "The agent runtime hit an error while running the turn.",
+    "codex_thread_reset": (
+        "Codex hit an error reloading the earlier transcript, so it started a fresh thread."
+    ),
 }
 
 

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3741,9 +3741,11 @@ async def _auto_create_codex_terminal(
     forwarder so the chat and terminal share one thread.
 
     Fresh sessions launch without a thread id so the TUI owns thread
-    creation; resume sessions launch with the persisted Codex thread id.
-    The runner does not pre-create a thread, because ``codex resume`` of a
-    thread with no rollout yet exits the TUI (leaving a dead pane).
+    creation; resume sessions launch with the persisted Codex thread id,
+    falling back to a fresh thread when Codex cannot read that thread's
+    rollout (see :func:`is_unreadable_thread_error`). The runner does not
+    pre-create a thread, because ``codex resume`` of a thread with no
+    rollout yet exits the TUI (leaving a dead pane).
 
     :param session_id: Session/conversation identifier, e.g.
         ``"conv_abc123"``.
@@ -3779,6 +3781,7 @@ async def _auto_create_codex_terminal(
         build_codex_remote_args,
         codex_session_meta_model_provider,
         codex_terminal_env,
+        is_unreadable_thread_error,
         preload_codex_thread_for_resume,
         resolve_native_codex_launch,
     )
@@ -4171,6 +4174,49 @@ async def _auto_create_codex_terminal(
         ws_url=codex_ws_url,
         client_name="omnigent-codex-native-auto",
     )
+    if launch_config.external_session_id is not None:
+        from omnigent.codex_native_bridge import CodexNativeBridgeState, write_bridge_state
+
+        try:
+            await preload_codex_thread_for_resume(
+                codex_ws_url,
+                launch_config.external_session_id,
+                terminal_launch_args=launch_config.terminal_launch_args,
+            )
+        except Exception as exc:
+            if not is_unreadable_thread_error(exc):
+                # The app-server started above must not outlive a refused resume:
+                # without this close, every retry stacked another live codex
+                # process (and only the newest stayed tracked for teardown).
+                with contextlib.suppress(Exception):
+                    await app_server.close()
+                _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+                raise
+            # Codex cannot load this thread's rollout, so no retry can resume
+            # it. Start a fresh thread on the same app-server instead of
+            # failing every turn; the discovery path records the new id.
+            _logger.warning(
+                "Codex cannot read thread %s for session %s; starting a fresh "
+                "thread (earlier Codex-side context is not restored): %s",
+                launch_config.external_session_id,
+                session_id,
+                exc,
+                extra={"session_id": session_id},
+            )
+            launch_config = dataclasses.replace(launch_config, external_session_id=None)
+        else:
+            write_bridge_state(
+                bridge_dir,
+                CodexNativeBridgeState(
+                    session_id=session_id,
+                    socket_path=codex_ws_url,
+                    thread_id=launch_config.external_session_id,
+                    codex_home=str(codex_home),
+                    # The session workspace: without it the executor falls back
+                    # to the runner process's own cwd when starting turns.
+                    cwd=workspace,
+                ),
+            )
     if launch_config.external_session_id is None:
         try:
             # Connect the listener BEFORE launching the TUI so it observes the
@@ -4186,35 +4232,6 @@ async def _auto_create_codex_terminal(
             await app_server.close()
             _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
             raise
-    else:
-        from omnigent.codex_native_bridge import CodexNativeBridgeState, write_bridge_state
-
-        try:
-            await preload_codex_thread_for_resume(
-                codex_ws_url,
-                launch_config.external_session_id,
-                terminal_launch_args=launch_config.terminal_launch_args,
-            )
-        except Exception:
-            # The app-server started above must not outlive a refused resume:
-            # without this close, every retry stacked another live codex
-            # process (and only the newest stayed tracked for teardown).
-            with contextlib.suppress(Exception):
-                await app_server.close()
-            _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
-            raise
-        write_bridge_state(
-            bridge_dir,
-            CodexNativeBridgeState(
-                session_id=session_id,
-                socket_path=codex_ws_url,
-                thread_id=launch_config.external_session_id,
-                codex_home=str(codex_home),
-                # The session workspace: without it the executor falls back
-                # to the runner process's own cwd when starting turns.
-                cwd=workspace,
-            ),
-        )
 
     # Register the Codex TUI as a streamable terminal resource attached to
     # the app-server started above (``--remote`` over its loopback ws

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -2326,6 +2326,64 @@ async def _post_pi_native_credential_warning(
         )
 
 
+_CODEX_THREAD_RESET_NOTICE = (
+    "Codex reported an internal error while loading this session's saved transcript, "
+    "so Omnigent started a fresh Codex thread instead of failing the turn. The chat "
+    "history here is intact, but Codex's own memory of the earlier turns is not "
+    "restored."
+)
+
+
+async def _post_codex_thread_reset_notice(
+    *,
+    session_id: str,
+    server_client: httpx.AsyncClient | None,
+    codex_error: str,
+) -> None:
+    """Surface a codex fresh-thread fallback into the session as a notice.
+
+    Posts an ``error`` item with ``level: "info"`` via
+    ``external_conversation_item`` so the web UI renders a neutral notice pill
+    at the point the thread was reset, persists it across reload, and — because
+    ``error`` is a non-content item type — keeps it out of the next turn's
+    model context. The body quotes codex's own error so the cause is clearly
+    codex-side. Best-effort: a failed post only loses the notice.
+
+    :param session_id: Session/conversation identifier.
+    :param server_client: Runner Omnigent server client (``None`` in tests).
+    :param codex_error: The error text codex returned for ``thread/resume``,
+        e.g. ``"failed to read thread: thread-store internal error: …"``.
+    """
+    if server_client is None:
+        return
+    try:
+        resp = await server_client.post(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}/events",
+            json={
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "error",
+                    "item_data": {
+                        "source": "harness",
+                        "code": "codex_thread_reset",
+                        "message": (
+                            f"{_CODEX_THREAD_RESET_NOTICE}\n\nCodex reported: {codex_error}"
+                        ),
+                        "level": "info",
+                    },
+                },
+            },
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPError:
+        _logger.warning(
+            "codex-native: failed to surface the fresh-thread notice for session %s",
+            session_id,
+            exc_info=True,
+        )
+
+
 async def _auto_create_cursor_terminal(
     session_id: str,
     resource_registry: SessionResourceRegistry,
@@ -3777,6 +3835,7 @@ async def _auto_create_codex_terminal(
     from omnigent.codex_native_app_server import (
         _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION,
         CodexAppServerClient,
+        CodexAppServerResponseError,
         build_codex_native_server,
         build_codex_remote_args,
         codex_session_meta_model_provider,
@@ -4202,6 +4261,14 @@ async def _auto_create_codex_terminal(
                 session_id,
                 exc,
                 extra={"session_id": session_id},
+            )
+            codex_error = (
+                exc.message
+                if isinstance(exc, CodexAppServerResponseError) and exc.message
+                else str(exc)
+            )
+            await _post_codex_thread_reset_notice(
+                session_id=session_id, server_client=server_client, codex_error=codex_error
             )
             launch_config = dataclasses.replace(launch_config, external_session_id=None)
         else:

--- a/openapi.json
+++ b/openapi.json
@@ -1707,6 +1707,22 @@
             "title": "Code",
             "type": "string"
           },
+          "level": {
+            "anyOf": [
+              {
+                "enum": [
+                  "error",
+                  "info"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Rendering level. `\"info\"` renders the banner as a neutral notice (e.g. codex started a fresh thread) rather than a failure; `None` / `\"error\"` is the destructive default and is omitted from the wire so existing error items are unchanged.",
+            "title": "Level"
+          },
           "message": {
             "description": "Human-readable error message, e.g. `\"Native Codex requires the 'codex' CLI on PATH.\"`.",
             "title": "Message",

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -44,7 +44,9 @@ def _publish_native_status(
     response.raise_for_status()
 
 
-def _seed_error_item(session_id: str, *, code: str, message: str) -> None:
+def _seed_error_item(
+    session_id: str, *, code: str, message: str, level: str | None = None
+) -> None:
     """Append a committed ``error`` transcript item to the session's store.
 
     Mirrors ``seed_committed_turn`` but writes an error banner item, so the
@@ -54,6 +56,7 @@ def _seed_error_item(session_id: str, *, code: str, message: str) -> None:
     :param session_id: Session to append to, e.g. ``"conv_abc123"``.
     :param code: Error classifier, e.g. ``"required_terminal_exited"``.
     :param message: Raw error message stored alongside the code.
+    :param level: ``"info"`` seeds a neutral notice instead of a failure.
     :raises RuntimeError: If the server under test isn't one we spawned.
     """
     from omnigent.entities import ErrorData, NewConversationItem
@@ -73,7 +76,7 @@ def _seed_error_item(session_id: str, *, code: str, message: str) -> None:
             NewConversationItem(
                 type="error",
                 response_id="resp_seeded_error",
-                data=ErrorData(source="execution", code=code, message=message),
+                data=ErrorData(source="execution", code=code, message=message, level=level),  # type: ignore[arg-type]
             ),
         ],
     )
@@ -403,3 +406,32 @@ def test_error_row_divider_aligns_with_message_edges(
         f"dashed rule ends at {edges['dividerRight']:.0f}px but its row ends at "
         f"{edges['rowRight']:.0f}px"
     )
+
+
+def test_info_level_error_item_renders_as_notice_pill(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A persisted ``error`` item with ``level: "info"`` renders as a neutral notice.
+
+    This is the codex fresh-thread fallback's notice: same pill, no failure tone,
+    headline derived from the code, and it survives reload because it is an item.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+    _seed_error_item(
+        session_id,
+        code="codex_thread_reset",
+        message="Codex could not load this session's saved transcript.",
+        level="info",
+    )
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    pill = page.locator('[data-testid="error-pill"][data-level="info"]')
+    expect(pill).to_be_visible(timeout=15_000)
+    expect(pill).to_contain_text("Codex hit an error reloading", timeout=15_000)
+    expect(page.locator('[data-testid="error-pill"][data-level="error"]')).to_have_count(0)

--- a/tests/entities/test_conversation_extended.py
+++ b/tests/entities/test_conversation_extended.py
@@ -34,6 +34,20 @@ from omnigent.entities.conversation import (
 # ── ErrorData ─────────────────────────────────────────
 
 
+@pytest.mark.parametrize(
+    ("level", "expected"), [(None, None), ("info", "info"), ("error", "error")]
+)
+def test_error_data_level(level: str | None, expected: str | None) -> None:
+    kwargs = {} if level is None else {"level": level}
+    err = ErrorData(source="harness", code="codex_thread_reset", message="fresh thread", **kwargs)
+    assert err.level == expected
+
+
+def test_error_data_rejects_unknown_level() -> None:
+    with pytest.raises(ValidationError):
+        ErrorData(source="harness", code="x", message="y", level="warning")  # type: ignore[arg-type]
+
+
 def test_error_data_valid() -> None:
     err = ErrorData(
         source="execution",

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -1189,3 +1189,230 @@ async def test_auto_create_codex_terminal_refused_resume_closes_app_server(
         )
     finally:
         runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+
+async def test_auto_create_codex_terminal_unreadable_thread_starts_fresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    A thread codex cannot read falls back to a fresh thread on the same app-server.
+
+    The large-rollout incident shape: codex's thread-store rejects the
+    persisted rollout (``-32603 failed to read thread … invalid UTF-8``) on
+    every ``thread/resume``, so re-raising failed every turn of the session
+    for good. The fallback must keep the app-server, take the fresh-thread
+    path (discovery listener connected, TUI launched without the thread id,
+    discovery forwarder) and log the Codex-side context it drops.
+
+    :param tmp_path: Temporary directory for isolated bridge state.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param caplog: Log capture for the fallback warning.
+    """
+    import omnigent.codex_native_app_server as codex_app_mod
+
+    session_id = "c8e3d2f1bb225c63c8d3a2e4f5b6c7d8"
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936d"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    class _SnapshotServerClient:
+        """Server client whose snapshot carries a persisted resume thread."""
+
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            """
+            Return the session snapshot / items consumed by the helper.
+
+            :param url: Request path, e.g. ``"/v1/sessions/conv_..."``.
+            :param kwargs: Request keyword arguments (ignored).
+            :returns: HTTP 200 response carrying launch config or items.
+            """
+            del kwargs
+            if url == f"/v1/sessions/{session_id}/items":
+                return httpx.Response(
+                    200,
+                    json={"data": [], "has_more": False},
+                    request=httpx.Request("GET", url),
+                )
+            return httpx.Response(
+                200,
+                json={"external_session_id": thread_id},
+                request=httpx.Request("GET", url),
+            )
+
+    closed: list[str] = []
+
+    class _FakeCodexAppServer:
+        """Minimal app-server recording whether it was closed."""
+
+        codex_path = "/opt/codex/bin/codex"
+        codex_cli_version: tuple[int, int, int] | None = None
+
+        def __init__(self) -> None:
+            """:returns: None."""
+            self.env = {"OPENAI_API_KEY": "sk-test"}
+            self.codex_home = tmp_path / "unconfigured-codex-home"
+            self.listen_url: str | None = None
+            self.config_overrides: list[str] = []
+
+        async def start(self) -> None:
+            """:returns: None."""
+
+        async def close(self) -> None:
+            """Record a teardown the fallback must not perform."""
+            closed.append("closed")
+
+    def _fake_build_codex_native_server(**kwargs: Any) -> _FakeCodexAppServer:
+        """
+        Build a fake app-server bound to the requested CODEX_HOME.
+
+        :param kwargs: Keyword arguments passed by the runner helper.
+        :returns: Fresh fake app-server.
+        """
+        app_server = _FakeCodexAppServer()
+        app_server.codex_home = kwargs["codex_home"]
+        return app_server
+
+    connected: list[str] = []
+
+    class _RecordingClient:
+        """Event client recording the fresh-thread discovery connect."""
+
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            """
+            :param ws_url: App-server WebSocket URL.
+            :param client_name: JSON-RPC client name.
+            """
+            self.ws_url = ws_url
+            self.client_name = client_name
+
+        async def connect(self) -> None:
+            """Record the connect the fresh-thread path owes."""
+            connected.append(self.client_name)
+
+        async def close(self) -> None:
+            """:returns: None."""
+
+    async def _unreadable_preload(
+        transport: str,
+        loaded_thread_id: str,
+        *,
+        terminal_launch_args: list[str] | None = None,
+    ) -> None:
+        """
+        Refuse the resume the way codex's thread-store does for a bad rollout.
+
+        :param transport: App-server transport URL (ignored).
+        :param loaded_thread_id: Thread id passed to ``thread/resume``.
+        :raises CodexAppServerResponseError: Always, mirroring the app-server.
+        """
+        del transport, terminal_launch_args
+        raise codex_app_mod.CodexAppServerResponseError(
+            {
+                "code": -32603,
+                "message": (
+                    "failed to read thread: thread-store internal error: failed to "
+                    f"load thread history /codex-home/rollout-{loaded_thread_id}.jsonl: "
+                    "stream did not contain valid UTF-8"
+                ),
+            }
+        )
+
+    launched_args: list[list[str]] = []
+
+    class _FakeResourceRegistry:
+        """Captures the TUI argv instead of launching tmux."""
+
+        async def launch_auxiliary_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            """Record the launch argv and return a terminal resource view."""
+            del terminal_name, session_key, resource_role, parent_os_env
+            launched_args.append(list(spec.args))
+            return SessionResourceView(
+                id="terminal_codex_main",
+                type="terminal",
+                session_id=session_id,
+                name="Codex",
+            )
+
+    runs: list[_ForwarderRun] = []
+
+    async def _parking_discover_thread(**kwargs: Any) -> None:
+        """Park forever in place of the fresh-thread discovery forwarder."""
+        del kwargs
+        run = _ForwarderRun(task=asyncio.current_task())
+        runs.append(run)
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            run.cancelled = True
+            raise
+
+    async def _unexpected_known_thread(**kwargs: Any) -> None:
+        """Fail if the unreadable thread is still forwarded as known."""
+        del kwargs
+        raise AssertionError("an unreadable thread must not be forwarded as a known thread")
+
+    monkeypatch.setattr(
+        codex_app_mod,
+        "build_codex_native_server",
+        _fake_build_codex_native_server,
+    )
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _RecordingClient)
+    monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _unreadable_preload)
+    monkeypatch.setattr(
+        runner_app_mod, "_codex_discover_thread_and_forward", _parking_discover_thread
+    )
+    monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _unexpected_known_thread)
+
+    agent_spec = AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex-native", "model": "gpt-5-default"},
+        ),
+    )
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
+            await runner_app_mod._auto_create_codex_terminal(
+                session_id,
+                _FakeResourceRegistry(),  # type: ignore[arg-type]
+                lambda _sid, _evt: None,
+                agent_spec=agent_spec,
+                server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
+            )
+        await asyncio.sleep(0)
+
+        assert closed == [], "the fallback must keep the app-server for the fresh thread"
+        assert connected == ["omnigent-codex-native-auto"], (
+            "the fresh-thread path must connect the discovery listener"
+        )
+        assert launched_args and thread_id not in launched_args[0], (
+            f"the TUI must not resume the unreadable thread: argv={launched_args}"
+        )
+        assert len(runs) == 1 and runs[0].cancelled is False, (
+            "exactly one live discovery forwarder must mirror the fresh thread"
+        )
+        assert any(
+            thread_id in record.getMessage() and "starting a fresh thread" in record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        ), "dropping the Codex-side context must leave a warning naming the thread"
+    finally:
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+        await _drain_forwarder_runs(runs)

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -1220,6 +1220,8 @@ async def test_auto_create_codex_terminal_unreadable_thread_starts_fresh(
     monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
 
+    posted: list[dict[str, Any]] = []
+
     class _SnapshotServerClient:
         """Server client whose snapshot carries a persisted resume thread."""
 
@@ -1242,6 +1244,21 @@ async def test_auto_create_codex_terminal_unreadable_thread_starts_fresh(
                 200,
                 json={"external_session_id": thread_id},
                 request=httpx.Request("GET", url),
+            )
+
+        async def post(self, url: str, **kwargs: Any) -> httpx.Response:
+            """
+            Record the notice the fallback posts and accept it.
+
+            :param url: Request path, e.g. ``"/v1/sessions/conv_.../events"``.
+            :param kwargs: Request keyword arguments (``json`` is the event body).
+            :returns: HTTP 202 acknowledgement.
+            """
+            posted.append({"url": url, "json": kwargs.get("json")})
+            return httpx.Response(
+                202,
+                json={"queued": False, "item_id": "notice_1"},
+                request=httpx.Request("POST", url),
             )
 
     closed: list[str] = []
@@ -1398,6 +1415,17 @@ async def test_auto_create_codex_terminal_unreadable_thread_starts_fresh(
         await asyncio.sleep(0)
 
         assert closed == [], "the fallback must keep the app-server for the fresh thread"
+        assert [p["url"] for p in posted] == [f"/v1/sessions/{session_id}/events"], (
+            "the fallback must surface exactly one notice into the session"
+        )
+        notice = posted[0]["json"]
+        assert notice["type"] == "external_conversation_item"
+        assert notice["data"]["item_type"] == "error"
+        assert notice["data"]["item_data"]["code"] == "codex_thread_reset"
+        assert notice["data"]["item_data"]["level"] == "info"
+        # The body names codex as the source and quotes its own error text.
+        assert "Codex reported an internal error" in notice["data"]["item_data"]["message"]
+        assert "stream did not contain valid UTF-8" in notice["data"]["item_data"]["message"]
         assert connected == ["omnigent-codex-native-auto"], (
             "the fresh-thread path must connect the discovery listener"
         )

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -10251,3 +10251,50 @@ async def test_create_session_notifies_runner_with_init_envelope(
         "runner seeds it into the first spawn; got "
         f"{envelope.snapshot.model_override!r}"
     )
+
+
+async def test_external_info_error_item_publishes_and_persists_level(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    An external ``error`` item with ``level: "info"`` keeps its level on both
+    the live ``response.output_item.done`` frame and the persisted item.
+
+    This is the runner's fresh-thread notice: the web renders it as a neutral
+    pill live, and again after reload from the items endpoint.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "error",
+                "item_data": {
+                    "source": "harness",
+                    "code": "codex_thread_reset",
+                    "message": "Codex started a fresh thread.",
+                    "level": "info",
+                },
+            },
+        },
+    )
+    assert resp.status_code in (200, 202)
+
+    done = [ev for _sid, ev in published if ev.get("type") == "response.output_item.done"]
+    assert len(done) == 1
+    assert done[0]["item"]["type"] == "error"
+    assert done[0]["item"]["level"] == "info"
+
+    items = await client.get(f"/v1/sessions/{session['id']}/items")
+    errors = [item for item in items.json()["data"] if item["type"] == "error"]
+    assert len(errors) == 1
+    assert errors[0]["level"] == "info"

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -793,6 +793,64 @@ def test_preload_codex_thread_for_resume_resumes_and_closes(
     assert fake_client.closed is True
 
 
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (
+            codex_native_app_server.CodexAppServerResponseError(
+                {
+                    "code": -32603,
+                    "message": (
+                        "failed to read thread: thread-store internal error: failed to "
+                        "load thread history /codex-home/sessions/rollout.jsonl: stream "
+                        "did not contain valid UTF-8"
+                    ),
+                }
+            ),
+            True,
+        ),
+        (
+            codex_native_app_server.CodexAppServerResponseError(
+                {
+                    "code": -32603,
+                    "message": (
+                        "error resuming thread: Fatal error: Failed to initialize "
+                        "session: thread-store internal error: failed to resume local "
+                        "thread recorder: final paginated rollout record at "
+                        "/codex-home/sessions/rollout.jsonl is missing an ordinal"
+                    ),
+                }
+            ),
+            True,
+        ),
+        (
+            codex_native_app_server.CodexAppServerResponseError(
+                {"code": -32603, "message": "internal error: something unrelated"}
+            ),
+            False,
+        ),
+        (
+            codex_native_app_server.CodexAppServerResponseError(
+                {"code": -32600, "message": "thread 019e already has an active writer"}
+            ),
+            False,
+        ),
+        (RuntimeError("thread-store internal error: not an app-server error"), False),
+    ],
+)
+def test_is_unreadable_thread_error(exc: BaseException, expected: bool) -> None:
+    """
+    Only codex's thread-store read failure counts as an unreadable thread.
+
+    A refused resume (another writer holds the thread) and a plain runtime
+    error must keep failing loud rather than silently starting a fresh thread.
+
+    :param exc: Exception raised by the resume request.
+    :param expected: Whether it classifies as an unreadable thread.
+    """
+    assert codex_native_app_server.is_unreadable_thread_error(exc) is expected
+
+
 def test_codex_resume_permission_params_parse_legacy_flags() -> None:
     """Legacy approval and sandbox flags become preload overrides."""
     assert codex_native_app_server._codex_resume_permission_params(

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -838,6 +838,7 @@ function renderItem(
           title={item.title}
           cause={item.cause}
           remediation={item.remediation}
+          level={item.level}
           onRetry={onRetryError ? () => onRetryError(item) : undefined}
         />
       );

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -742,3 +742,32 @@ describe("routing decision — harness / scope / raw pick", () => {
     expect(screen.queryByText(/"router_source"/)).toBeNull();
   });
 });
+
+describe("ErrorBanner — info level", () => {
+  it("renders a neutral notice pill with the code's headline and an info icon", () => {
+    render(
+      <ErrorBanner
+        message="Codex could not load this session's saved transcript."
+        source="harness"
+        code="codex_thread_reset"
+        level="info"
+      />,
+    );
+    const pill = screen.getByTestId("error-pill");
+    expect(pill).toHaveAttribute("data-level", "info");
+    expect(screen.getByTestId("error-headline")).toHaveTextContent(
+      "Codex hit an error reloading the earlier transcript, so it started a fresh thread.",
+    );
+    expect(screen.getByTestId("error-headline")).not.toHaveClass("text-destructive");
+    const icon = screen.getByTestId("error-status-icon");
+    expect(icon).toHaveClass("lucide-info");
+    expect(icon).not.toHaveClass("text-destructive");
+    expect(screen.getByRole("button", { name: "Dismiss notice" })).toBeInTheDocument();
+  });
+
+  it("keeps the destructive pill as the default level", () => {
+    render(<ErrorBanner message="boom" source="execution" code="runner_error" />);
+    expect(screen.getByTestId("error-pill")).toHaveAttribute("data-level", "error");
+    expect(screen.getByTestId("error-status-icon")).toHaveClass("text-destructive");
+  });
+});

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -1,7 +1,8 @@
 // Inline status indicators for non-tool, non-text, non-reasoning blocks.
 // Each is small enough to live in one file.
 //
-// - ErrorBanner: centered destructive pill with an expandable message body.
+// - ErrorBanner: centered destructive pill with an expandable message body;
+//   `level="info"` renders it as a neutral notice instead.
 // - RetryIndicator: muted one-liner about an in-flight retry.
 // - CompactionMarker: permanent marker shown after compaction completes.
 //   The in-progress state renders as a Shimmer in ChatPage, mirroring
@@ -13,6 +14,7 @@ import {
   CheckIcon,
   ChevronRightIcon,
   CopyIcon,
+  InfoIcon,
   RotateCcwIcon,
   RotateCwIcon,
   ShieldXIcon,
@@ -47,6 +49,8 @@ interface ErrorBannerProps {
   cause?: string;
   /** Concrete next step to fix it, e.g. a command to run. */
   remediation?: string;
+  /** `"info"` renders a neutral notice (no failure tone) instead of a destructive error. */
+  level?: "error" | "info";
   /** Reconnect the existing session without replaying or duplicating user input. */
   onRetry?: () => Promise<void>;
 }
@@ -68,6 +72,8 @@ const FAILURE_CODE_DESCRIPTIONS: Record<string, string> = {
   context_length_exceeded: "The conversation grew past the model's context window.",
   executor_error: "The agent runtime hit an error while running the turn.",
   workspace_missing: "The session workspace no longer exists on the host.",
+  codex_thread_reset:
+    "Codex hit an error reloading the earlier transcript, so it started a fresh thread.",
 };
 
 const RETRYABLE_ERROR_CODES = new Set([
@@ -144,9 +150,14 @@ export function ErrorBanner({
   title,
   cause,
   remediation,
+  level,
   onRetry,
 }: ErrorBannerProps) {
-  const headline = title || FAILURE_CODE_DESCRIPTIONS[code] || "Something went wrong";
+  const notice = level === "info";
+  const tone = notice ? "var(--muted-foreground)" : "var(--destructive)";
+  const StatusIcon = notice ? InfoIcon : AlertCircleIcon;
+  const headline =
+    title || FAILURE_CODE_DESCRIPTIONS[code] || (notice ? "Notice" : "Something went wrong");
   const parsed = useMemo(() => parseErrorMessage(message), [message]);
   const messageText = useMemo(() => {
     const parts: string[] = [];
@@ -250,12 +261,12 @@ export function ErrorBanner({
         aria-hidden="true"
         className="pointer-events-none absolute top-[20px] right-0 left-0 h-px"
         style={{
-          background:
-            "repeating-linear-gradient(to right, color-mix(in srgb, var(--destructive) 32%, transparent) 0 2px, transparent 2px 6px)",
+          background: `repeating-linear-gradient(to right, color-mix(in srgb, ${tone} 32%, transparent) 0 2px, transparent 2px 6px)`,
         }}
       />
       <div
         data-testid="error-pill"
+        data-level={notice ? "info" : "error"}
         onClick={() => setExpanded((value) => !value)}
         onMouseEnter={() => setHeaderHovered(true)}
         onMouseLeave={() => setHeaderHovered(false)}
@@ -271,9 +282,8 @@ export function ErrorBanner({
         }}
         className="group/error relative z-10 w-[560px] max-w-full cursor-pointer rounded-[12px] p-[8px] text-foreground"
         style={{
-          background:
-            "color-mix(in srgb, var(--destructive) 4%, var(--app-shell-bg, var(--background)))",
-          border: "1px solid color-mix(in srgb, var(--destructive) 32%, transparent)",
+          background: `color-mix(in srgb, ${tone} 4%, var(--app-shell-bg, var(--background)))`,
+          border: `1px solid color-mix(in srgb, ${tone} 32%, transparent)`,
         }}
       >
         <div className="flex w-full min-w-0 items-start gap-[4px]">
@@ -313,9 +323,12 @@ export function ErrorBanner({
                   aria-hidden="true"
                 />
               ) : (
-                <AlertCircleIcon
+                <StatusIcon
                   data-testid="error-status-icon"
-                  className="size-[18px] text-destructive duration-150 animate-in fade-in"
+                  className={cn(
+                    "size-[18px] duration-150 animate-in fade-in",
+                    notice ? "text-muted-foreground" : "text-destructive",
+                  )}
                   aria-hidden="true"
                 />
               )}
@@ -323,7 +336,10 @@ export function ErrorBanner({
             <span
               data-testid="error-headline"
               title={headline}
-              className="mr-[4px] min-w-0 flex-1 truncate whitespace-nowrap leading-6 text-destructive"
+              className={cn(
+                "mr-[4px] min-w-0 flex-1 truncate whitespace-nowrap leading-6",
+                notice ? "text-foreground" : "text-destructive",
+              )}
             >
               {headline}
             </span>
@@ -349,7 +365,7 @@ export function ErrorBanner({
             type="button"
             variant="ghost"
             size="icon-xs"
-            aria-label="Dismiss error message"
+            aria-label={notice ? "Dismiss notice" : "Dismiss error message"}
             onClick={(event) => {
               event.stopPropagation();
               setDismissed(true);

--- a/web/src/lib/blockStream.ts
+++ b/web/src/lib/blockStream.ts
@@ -783,6 +783,7 @@ function* processEvent(state: ReducerState, event: StreamEvent): Generator<AnyBl
         message: event.error.message,
         source: event.source,
         code: event.error.code,
+        ...(event.error.level ? { level: event.error.level } : {}),
         ...structuredErrorFields(event.error),
       } satisfies ErrorBlock;
       return;

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -311,6 +311,8 @@ export interface ErrorBlock {
   type: "error";
   ctx: BlockContext;
   message: string;
+  /** `"info"` renders as a neutral notice pill instead of a destructive error. */
+  level?: "error" | "info";
   /** Where the error originated, e.g. "llm". */
   source: string;
   /** Machine-readable error code, e.g. "llm_auth_failed". Empty when omitted. */

--- a/web/src/lib/conversationItems.ts
+++ b/web/src/lib/conversationItems.ts
@@ -62,6 +62,8 @@ export interface ErrorItem extends BaseItem {
   source: string;
   code: string;
   message: string;
+  /** `"info"` renders as a neutral notice pill instead of a destructive error. */
+  level?: "error" | "info";
   /** Friendly headline for a classified failure. Present when the runner classified it. */
   title?: string;
   /** One/two-sentence explanation of why it failed. Paired with `title`. */

--- a/web/src/lib/itemsToBlocks.test.ts
+++ b/web/src/lib/itemsToBlocks.test.ts
@@ -222,6 +222,24 @@ describe("itemsToBlocks — flat shape", () => {
     expect(td?.interrupted).toBe(true);
   });
 
+  it("error items carry an info level through to the block only when set", () => {
+    const base = {
+      response_id: "resp_notice",
+      type: "error" as const,
+      status: "completed" as const,
+      source: "harness",
+      code: "codex_thread_reset",
+      message: "Codex started a fresh thread.",
+    };
+    const items: ConversationItem[] = [
+      { ...base, id: "err_info", level: "info" },
+      { ...base, id: "err_plain" },
+    ];
+    const [info, plain] = itemsToBlocks(items) as ErrorBlock[];
+    expect(info?.level).toBe("info");
+    expect(plain).not.toHaveProperty("level");
+  });
+
   it("error items produce ErrorBlock banners on reload", () => {
     const items: ConversationItem[] = [
       {

--- a/web/src/lib/itemsToBlocks.ts
+++ b/web/src/lib/itemsToBlocks.ts
@@ -372,6 +372,7 @@ function errorToBlock(item: ErrorItem): ErrorBlock {
     source: item.source,
     code: item.code,
     message: item.message,
+    ...(item.level ? { level: item.level } : {}),
     ...structuredErrorFields(item),
   };
 }

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -377,6 +377,27 @@ describe("buildBubbles — bubble grouping", () => {
     ]);
   });
 
+  it("error block level reaches the render item", () => {
+    const blocks: AnyBlock[] = [
+      {
+        type: "user_message",
+        ctx: ctx({ itemId: "u1", responseId: "resp_1" }),
+        content: [{ type: "input_text", text: "First" }],
+      },
+      {
+        type: "error",
+        ctx: ctx({ itemId: "err_info", responseId: "resp_1" }),
+        source: "harness",
+        code: "codex_thread_reset",
+        message: "Codex started a fresh thread.",
+        level: "info",
+      },
+    ];
+    const bubbles = buildBubbles(blocks, null);
+    const asst = bubbles[1] as Extract<Bubble, { kind: "assistant" }>;
+    expect(asst.items[0]).toMatchObject({ kind: "error", level: "info" });
+  });
+
   it("compaction block becomes a standalone compaction bubble", () => {
     const blocks: AnyBlock[] = [
       {

--- a/web/src/lib/renderItems.ts
+++ b/web/src/lib/renderItems.ts
@@ -99,6 +99,7 @@ export type RenderItem =
       message: string;
       source: string;
       code: string;
+      level?: "error" | "info";
       title?: string;
       cause?: string;
       remediation?: string;
@@ -1485,6 +1486,7 @@ function buildAssistantItems(
         message: b.message,
         source: b.source,
         code: b.code,
+        ...(b.level ? { level: b.level } : {}),
         ...(b.title ? { title: b.title } : {}),
         ...(b.cause ? { cause: b.cause } : {}),
         ...(b.remediation ? { remediation: b.remediation } : {}),

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -300,3 +300,25 @@ describe("parseEvent — session.mcp_startup", () => {
     ).toBeNull();
   });
 });
+
+describe("parseEvent — response.output_item.done error level", () => {
+  it("lifts level: info onto the error event and omits it otherwise", () => {
+    const item = {
+      id: "err_1",
+      response_id: "resp_1",
+      type: "error",
+      source: "harness",
+      code: "codex_thread_reset",
+      message: "Codex started a fresh thread.",
+    };
+    const info = parseEvent("response.output_item.done", { item: { ...item, level: "info" } });
+    expect(info).toMatchObject({
+      type: "error",
+      error: { code: "codex_thread_reset", level: "info" },
+    });
+    const plain = parseEvent("response.output_item.done", { item });
+    const plainError = plain?.type === "error" ? plain.error : null;
+    expect(plainError).not.toBeNull();
+    expect(plainError).not.toHaveProperty("level");
+  });
+});

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -1184,6 +1184,7 @@ function parseOutputItem(data: Record<string, unknown>): StreamEvent | null {
       error: {
         code: String(rec.code ?? ""),
         message: String(rec.message ?? ""),
+        ...(rec.level === "info" ? { level: "info" as const } : {}),
       },
       itemId,
       responseId,
@@ -1324,6 +1325,7 @@ function parseErrorInfo(raw: unknown): ErrorInfo {
     if (typeof r.title === "string" && r.title) info.title = r.title;
     if (typeof r.cause === "string" && r.cause) info.cause = r.cause;
     if (typeof r.remediation === "string" && r.remediation) info.remediation = r.remediation;
+    if (r.level === "info") info.level = "info";
     return info;
   }
   return { code: "", message: String(raw ?? "") };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -72,6 +72,8 @@ export interface Usage {
 export interface ErrorInfo {
   code: string;
   message: string;
+  /** `"info"` renders as a neutral notice pill instead of a destructive error. */
+  level?: "error" | "info";
   /** Friendly headline for a classified failure, e.g. "Claude Code can't run as root". */
   title?: string;
   /** One/two-sentence explanation of why it failed. Paired with `title`. */


### PR DESCRIPTION
## Related issue

Closes #6269

## Summary

- A codex-native session whose rollout codex's thread-store cannot load failed **every** turn with `native_terminal_start_failed`: the resume preload re-raised on each launch, and no retry can ever load that rollout. Seen on a 38 MB transcript that was entirely valid UTF-8 (a 1.75 MB inline image pushed multibyte characters onto codex's read-buffer boundaries); newer codex phrases the same class as `error resuming thread: … thread-store internal error: …`.
- The runner now classifies that error (`-32603` + `thread-store internal error`) and falls back to the existing fresh-thread launch on the same app-server, so the session keeps working. A refused resume (`-32600`, another writer holds the thread) keeps its close-and-raise handling.
- The user sees why: the runner posts a persisted `error` item with a new `level: "info"`, which the web renders as a neutral notice pill at the point of the reset ("Codex hit an error reloading the earlier transcript, so it started a fresh thread"), with codex's own error text in the expandable body. No new SSE type: the item rides the existing `external_conversation_item` path, shows live via `response.output_item.done`, survives reload, and stays out of the model context like other error items.

**ELI5:** Codex keeps its own diary of the conversation on disk. Sometimes Codex chokes on reading its diary back. Before, Omnigent then refused to do anything at all, forever. Now Omnigent hands Codex a blank diary, tells you it did so, and carries on. The chat history you see is untouched; only Codex's private memory of earlier turns is lost.

```mermaid
flowchart LR
  A[turn on resumed codex session] --> B[preload thread/resume]
  B -- ok --> C[attach TUI to thread]
  B -- "-32603 thread-store internal error" --> D[log + post info notice item]
  D --> E[fresh-thread launch on same app-server]
  E --> F[discovery forwarder records new thread]
  B -- "any other error (e.g. -32600 writer lock)" --> G[close app-server, raise]
```

## Test Plan

- Unit: `is_unreadable_thread_error` parametrized over both real codex phrasings plus `-32603` without the substring, `-32600`, and a plain `RuntimeError` (all negatives); `ErrorData.level` accepts `info`/`error`/unset and rejects others.
- Runner: `test_auto_create_codex_terminal_unreadable_thread_starts_fresh` asserts the app-server is kept, the discovery listener connects, the TUI argv has no thread id, exactly one notice is posted (`item_type=error`, `level=info`, `code=codex_thread_reset`, body quotes codex's error), and the fallback warning is logged; the sibling `-32600` test still raises.
- Server: `test_external_info_error_item_publishes_and_persists_level` checks the level on both the live `response.output_item.done` frame and the persisted item.
- Web (vitest): `ErrorBanner` info variant (headline from the code table, info icon, no destructive classes, `data-level=info`, "Dismiss notice"); level passthrough in `itemsToBlocks`, `renderItems`, and `parseEvent`.
- E2E UI: `test_info_level_error_item_renders_as_notice_pill` seeds an info-level item and asserts the neutral pill in a real browser.
- Live, end to end, against real codex 0.152.1 on a local server + host: drove a codex-native turn, stopped the session, inflated its rollout with multi-MB multibyte lines (valid UTF-8, unloadable by codex), and sent again. Before this change: `status=failed`, `native_terminal_start_failed`, every time. After: a new thread and rollout are created, the queued message is delivered, codex replies, the turn completes idle with no error, and the notice pill appears in the transcript and persists across reload. The unloadable rollout is left untouched.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Transcript after the fallback, as rendered by the web UI (info pill is the muted, non-red variant of the error pill):

```
  Reply with exactly the word pong and nothing else.
pong
  ┌─ ⓘ Codex hit an error reloading the earlier transcript, so it started a fresh thread. ─┐
  │ Codex reported an internal error while loading this session's saved transcript, so     │
  │ Omnigent started a fresh Codex thread instead of failing the turn. …                   │
  │ Codex reported: failed to read thread: thread-store internal error: …                  │
  └────────────────────────────────────────────────────────────────────────────────────────┘
  Reply with exactly the word pong2 and nothing else.
pong2
```

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was the live run described in Test Plan (real codex binary, real server/host/runner, real rollout on disk). Known limitation, unchanged here: the session row's `external_session_id` is immutable once set, so it keeps pointing at the unloadable thread and each cold resume re-runs the fallback (and posts another notice) rather than sticking the healthy thread; chat works either way.

## Changelog

Codex sessions whose saved transcript Codex can't reload now continue on a fresh Codex thread with an in-chat notice, instead of failing every turn.

https://claude.ai/code/session_01R3Rs6FRegGU7SEHGsHXUC1
