### PR TITLE
feat(web): show model connection source on composer hover

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -870,6 +870,29 @@ class ModelOptionsResult:
     routable_models: list[str]
 
 
+def _model_configuration_source_for_harness(harness: str) -> dict[str, str] | None:
+    """Resolve the host's ambient model provider without exposing credentials."""
+    from omnigent.model_catalog import model_configuration_source, resolve_model_provider
+    from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+    spec = AgentSpec(
+        spec_version=1,
+        name="host-model-preview",
+        executor=ExecutorSpec(type="omnigent", config={"harness": harness}),
+    )
+    provider = resolve_model_provider(spec, harness)
+    return model_configuration_source(provider, harness=harness)
+
+
+def _with_model_configuration_source(
+    models: list[dict[str, object]], harness: str
+) -> list[dict[str, object]]:
+    source = _model_configuration_source_for_harness(harness)
+    if source is None:
+        return models
+    return [{**model, "source": source} for model in models]
+
+
 @dataclass
 class _RunnerHandle:
     """A spawned runner subprocess and where its output lands.
@@ -2695,6 +2718,7 @@ class HostProcess:
         re-reads that authoritative snapshot after bind.
         """
         harness = canonicalize_harness(frame.harness) or frame.harness
+        with_source = functools.partial(_with_model_configuration_source, harness=harness)
         if harness == "codex-native":
             # Harness-truth lane: every launch shape is answered from the
             # shared catalog, probed from the configured Codex binary itself.
@@ -2705,7 +2729,7 @@ class HostProcess:
                 return HostModelOptionsResultFrame(
                     request_id=frame.request_id,
                     status="ok",
-                    models=probed.models,
+                    models=with_source(probed.models),
                     routable_models=probed.routable_models,
                 )
             return HostModelOptionsResultFrame(
@@ -2730,7 +2754,7 @@ class HostProcess:
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,
                 status="ok",
-                models=pi_models,
+                models=with_source(pi_models),
             )
 
         if is_claude_sdk_harness_name(harness):
@@ -2766,13 +2790,15 @@ class HostProcess:
                     return HostModelOptionsResultFrame(
                         request_id=frame.request_id,
                         status="ok",
-                        models=probed.models,
+                        models=with_source(probed.models),
                         routable_models=probed.routable_models,
                     )
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,
                 status="ok",
-                models=[{"id": model.id, "displayName": model.id} for model in listing.models],
+                models=with_source(
+                    [{"id": model.id, "displayName": model.id} for model in listing.models]
+                ),
                 routable_models=[model.id for model in listing.models],
             )
         if harness != "claude-native":
@@ -2786,7 +2812,7 @@ class HostProcess:
             return HostModelOptionsResultFrame(
                 request_id=frame.request_id,
                 status="ok",
-                models=probed.models,
+                models=with_source(probed.models),
                 routable_models=probed.routable_models,
             )
         return HostModelOptionsResultFrame(

--- a/omnigent/model_catalog.py
+++ b/omnigent/model_catalog.py
@@ -39,6 +39,7 @@ import subprocess
 import threading
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Literal, TypeAlias, cast
+from urllib.parse import urlsplit
 
 import click
 import httpx
@@ -63,6 +64,7 @@ from omnigent.model_resolver import (
 )
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
+    BEDROCK_KIND,
     CLI_CONFIG_KIND,
     DATABRICKS_KIND,
     KEY_KIND,
@@ -248,6 +250,62 @@ class ResolvedModelProvider:
     auth_command: str | None = None
     cli: str | None = None
     detail: str = ""
+
+
+def _model_configuration_host(base_url: str) -> str | None:
+    """Extract a host without carrying URL userinfo into browser metadata."""
+    try:
+        parsed = urlsplit(base_url if "://" in base_url else f"//{base_url}")
+        if not parsed.hostname:
+            return None
+        hostname = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return None
+    return f"{hostname}:{port}" if port is not None else hostname
+
+
+def model_configuration_source(
+    provider: ResolvedModelProvider, *, harness: str | None = None
+) -> dict[str, str] | None:
+    """Return non-secret coordinates describing how a model is reached."""
+    if provider.kind == NONE_KIND:
+        return None
+
+    # Native Claude deliberately ignores legacy api_key auth and uses its own
+    # CLI login. Named key providers still route through the configured key.
+    if (
+        harness in {"claude-native", "native-claude"}
+        and provider.kind == KEY_KIND
+        and provider.detail == "api_key auth"
+    ):
+        return {"kind": SUBSCRIPTION_KIND, "label": "Subscription", "name": "claude"}
+
+    source: dict[str, str] = {"kind": provider.kind}
+    if provider.kind == SUBSCRIPTION_KIND:
+        source.update(label="Subscription", name=provider.cli or "CLI login")
+    elif provider.kind == DATABRICKS_KIND:
+        source.update(label="Workspace", name=provider.profile or "DEFAULT")
+    elif provider.kind in {"gateway", "local"}:
+        source["label"] = "AI Gateway" if provider.kind == "gateway" else "Local"
+        name = provider.detail.removeprefix("provider '").removesuffix("'")
+        if name:
+            source["name"] = name
+    elif provider.kind == CLI_CONFIG_KIND:
+        source.update(label="CLI config", name=provider.detail or provider.cli or "Codex")
+    elif provider.kind == BEDROCK_KIND:
+        source["label"] = "Bedrock"
+        name = provider.detail.removeprefix("provider '").removesuffix("'")
+        if name:
+            source["name"] = name
+    else:
+        source["label"] = "API key"
+        name = provider.family or provider.detail.removeprefix("provider '").removesuffix("'")
+        if name:
+            source["name"] = name
+    if provider.base_url and (host := _model_configuration_host(provider.base_url)):
+        source["host"] = host
+    return source
 
 
 def is_direct_openai_provider(provider: ResolvedModelProvider) -> bool:

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -22,7 +22,7 @@ import tempfile
 import time
 import urllib.parse
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, cast, overload
 
@@ -10025,7 +10025,10 @@ def create_runner_app(
         if harness == "opencode-native":
             try:
                 models = await _opencode_native_model_options(session_id)
-                return JSONResponse(status_code=200, content={"models": models})
+                return JSONResponse(
+                    status_code=200,
+                    content={"models": _with_model_configuration_source(session_id, models)},
+                )
             except _CodexNativeModelOptionsNotReady:
                 return JSONResponse(
                     status_code=503,
@@ -10051,9 +10054,10 @@ def create_runner_app(
                     },
                 )
         try:
+            models = await _codex_native_model_options(session_id)
             return JSONResponse(
                 status_code=200,
-                content={"models": await _codex_native_model_options(session_id)},
+                content={"models": _with_model_configuration_source(session_id, models)},
             )
         except _CodexNativeModelOptionsNotReady:
             return JSONResponse(
@@ -10100,7 +10104,10 @@ def create_runner_app(
                     "detail": _client_safe_error_detail(exc, context="kiro-native model options"),
                 },
             )
-        return JSONResponse(status_code=200, content={"models": models})
+        return JSONResponse(
+            status_code=200,
+            content={"models": _with_model_configuration_source(session_id, models)},
+        )
 
     @app.get("/v1/sessions/{session_id}/cursor-model-options")
     async def get_session_cursor_model_options(session_id: str) -> JSONResponse:
@@ -10131,7 +10138,10 @@ def create_runner_app(
             for option in models
             if option.get("id") and option.get("displayName")
         }
-        return JSONResponse(status_code=200, content={"models": models})
+        return JSONResponse(
+            status_code=200,
+            content={"models": _with_model_configuration_source(session_id, models)},
+        )
 
     # Claude's session listing IS the shared launch catalog: the same
     # fingerprint-keyed store file the launch resolved against and the
@@ -10142,6 +10152,26 @@ def create_runner_app(
     # (the server's fetch retries those) while the store's single-flight
     # probe completes in the background.
     _claude_model_options_rows: dict[str, list[dict[str, object]]] = {}
+
+    def _model_configuration_source(session_id: str) -> dict[str, str] | None:
+        """Return the session's non-secret model-provider coordinates."""
+        from omnigent.model_catalog import model_configuration_source, resolve_model_provider
+
+        spec_entry = _session_spec_cache.get(session_id)
+        if spec_entry is None:
+            return None
+        spec = spec_entry.spec if hasattr(spec_entry, "spec") else spec_entry
+        harness = _session_harness_name(session_id)
+        provider = resolve_model_provider(spec, harness)
+        return model_configuration_source(provider, harness=harness)
+
+    def _with_model_configuration_source(
+        session_id: str, rows: Sequence[Mapping[str, object]]
+    ) -> list[dict[str, object]]:
+        source = _model_configuration_source(session_id)
+        if source is None:
+            return [dict(row) for row in rows]
+        return [{**row, "source": source} for row in rows]
 
     @app.get("/v1/sessions/{session_id}/claude-model-options")
     async def get_session_claude_model_options(session_id: str) -> JSONResponse:
@@ -10208,6 +10238,7 @@ def create_runner_app(
                     "detail": "the harness model probe failed; retrying",
                 },
             )
+        rows = _with_model_configuration_source(session_id, rows)
         _claude_model_options_rows[session_id] = rows
         return JSONResponse(status_code=200, content={"models": rows})
 

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -625,7 +625,18 @@ async def test_cursor_native_model_options_use_cli_catalog(
         )
 
     assert response.status_code == 200
-    assert response.json() == {"models": expected}
+    assert response.json() == {
+        "models": [
+            {
+                **expected[0],
+                "source": {
+                    "kind": "subscription",
+                    "label": "Subscription",
+                    "name": "cursor-agent",
+                },
+            }
+        ]
+    }
     assert event_response.status_code == 204
     assert injected == [("provider-latest", "Provider Latest")]
 

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -26,9 +26,11 @@ from omnigent.codex_model_vocabulary import codex_spawn_model
 from omnigent.model_catalog import (
     ModelEntry,
     ModelListing,
+    ResolvedModelProvider,
     catalog_for_spec,
     catalog_model_entries,
     list_models_for_worker,
+    model_configuration_source,
     model_family_token,
     resolve_catalog_model,
     resolve_model_provider,
@@ -100,6 +102,125 @@ def _worker_spec(harness: str, **executor_kwargs: object) -> AgentSpec:
         name="worker",
         executor=ExecutorSpec(type="omnigent", config={"harness": harness}, **executor_kwargs),  # type: ignore[arg-type]
     )
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected"),
+    [
+        pytest.param(ResolvedModelProvider(kind="none"), None, id="none"),
+        pytest.param(
+            ResolvedModelProvider(kind="subscription", cli="claude"),
+            {"kind": "subscription", "label": "Subscription", "name": "claude"},
+            id="subscription",
+        ),
+        pytest.param(
+            ResolvedModelProvider(kind="databricks", profile="production-west"),
+            {"kind": "databricks", "label": "Workspace", "name": "production-west"},
+            id="databricks",
+        ),
+        pytest.param(
+            ResolvedModelProvider(
+                kind="gateway",
+                detail="provider 'production'",
+                base_url="https://gateway.example.com/v1",
+            ),
+            {
+                "kind": "gateway",
+                "label": "AI Gateway",
+                "name": "production",
+                "host": "gateway.example.com",
+            },
+            id="gateway",
+        ),
+        pytest.param(
+            ResolvedModelProvider(
+                kind="local",
+                detail="provider 'ollama'",
+                base_url="http://localhost:11434/v1",
+            ),
+            {
+                "kind": "local",
+                "label": "Local",
+                "name": "ollama",
+                "host": "localhost:11434",
+            },
+            id="local",
+        ),
+        pytest.param(
+            ResolvedModelProvider(
+                kind="bedrock",
+                family="anthropic",
+                detail="provider 'production-bedrock'",
+                base_url="https://bedrock-runtime.us-west-2.amazonaws.com",
+            ),
+            {
+                "kind": "bedrock",
+                "label": "Bedrock",
+                "name": "production-bedrock",
+                "host": "bedrock-runtime.us-west-2.amazonaws.com",
+            },
+            id="bedrock",
+        ),
+        pytest.param(
+            ResolvedModelProvider(kind="cli-config", cli="codex", detail="config.toml"),
+            {"kind": "cli-config", "label": "CLI config", "name": "config.toml"},
+            id="cli-config",
+        ),
+        pytest.param(
+            ResolvedModelProvider(
+                kind="key",
+                family="anthropic",
+                base_url="https://must-not-leak:secret@api.anthropic.com:8443/v1",
+                api_key="must-not-leak",
+            ),
+            {
+                "kind": "key",
+                "label": "API key",
+                "name": "anthropic",
+                "host": "api.anthropic.com:8443",
+            },
+            id="api-key",
+        ),
+        pytest.param(
+            ResolvedModelProvider(
+                kind="gateway",
+                detail="provider 'production'",
+                base_url="https://[malformed/v1",
+            ),
+            {"kind": "gateway", "label": "AI Gateway", "name": "production"},
+            id="malformed-url",
+        ),
+    ],
+)
+def test_model_configuration_source_exposes_only_safe_coordinates(
+    provider: ResolvedModelProvider, expected: dict[str, str] | None
+) -> None:
+    """Composer metadata identifies the connection without serializing credentials."""
+    source = model_configuration_source(provider)
+    assert source == expected
+    assert "must-not-leak" not in repr(source)
+    assert "secret" not in repr(source)
+
+
+def test_native_claude_legacy_api_key_source_is_its_cli_subscription() -> None:
+    """Native Claude ignores legacy API-key auth while SDK Claude consumes it."""
+    provider = ResolvedModelProvider(
+        kind="key",
+        family="anthropic",
+        api_key="must-not-leak",
+        detail="api_key auth",
+    )
+
+    assert model_configuration_source(provider, harness="claude-native") == {
+        "kind": "subscription",
+        "label": "Subscription",
+        "name": "claude",
+    }
+    assert model_configuration_source(provider, harness="claude-sdk") == {
+        "kind": "key",
+        "label": "API key",
+        "name": "anthropic",
+    }
 
 
 _DATABRICKS_DEFAULT_CONFIG = (

--- a/web/src/lib/modelConfigurationSource.test.ts
+++ b/web/src/lib/modelConfigurationSource.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { modelConfigurationSourceRows } from "@/lib/modelConfigurationSource";
+
+describe("modelConfigurationSourceRows", () => {
+  it.each([
+    [
+      { kind: "databricks", label: "Workspace", name: "production-west", host: "ws.example.com" },
+      "Databricks · production-west",
+    ],
+    [
+      { kind: "gateway", label: "AI Gateway", name: "production", host: "gw.example.com" },
+      "AI Gateway · production",
+    ],
+    [
+      { kind: "key", label: "API key", name: "anthropic", host: "api.anthropic.com" },
+      "API key · anthropic",
+    ],
+    [
+      {
+        kind: "bedrock",
+        label: "Bedrock",
+        name: "production-bedrock",
+        host: "bedrock-runtime.us-west-2.amazonaws.com",
+      },
+      "Bedrock · production-bedrock",
+    ],
+  ])("uses one identifying detail for %#", (source, value) => {
+    expect(modelConfigurationSourceRows(source)).toEqual([{ label: "Connection", value }]);
+  });
+});

--- a/web/src/lib/modelConfigurationSource.ts
+++ b/web/src/lib/modelConfigurationSource.ts
@@ -1,0 +1,37 @@
+import type { ModelConfigurationSource } from "@/lib/types";
+
+export interface ModelConfigurationSourceRow {
+  label: string;
+  value: string;
+}
+
+function titleCaseProvider(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/** Turn non-secret provider coordinates into concise, labeled UI rows. */
+export function modelConfigurationSourceRows(
+  source: ModelConfigurationSource | null | undefined,
+): ModelConfigurationSourceRow[] {
+  if (!source) return [];
+
+  const name = source.name ? titleCaseProvider(source.name) : null;
+  const connection =
+    source.kind === "subscription" && name
+      ? `${name} subscription`
+      : source.kind === "databricks"
+        ? ["Databricks", source.name ?? source.host].filter(Boolean).join(" · ")
+        : source.kind === "gateway"
+          ? ["AI Gateway", source.name ?? source.host].filter(Boolean).join(" · ")
+          : source.kind === "bedrock"
+            ? ["Bedrock", source.name ?? source.host].filter(Boolean).join(" · ")
+            : source.kind === "key"
+              ? ["API key", source.name ?? source.host].filter(Boolean).join(" · ")
+              : [source.label, source.name, source.host].filter(Boolean).join(" · ");
+  return [
+    {
+      label: "Connection",
+      value: connection,
+    },
+  ];
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -555,6 +555,18 @@ export interface NativeReasoningEffortOption {
   description?: string;
 }
 
+/** Non-secret provenance for the configuration serving a model. */
+export interface ModelConfigurationSource {
+  /** Stable provider category, e.g. `subscription`, `databricks`, or `gateway`. */
+  kind: string;
+  /** Compact composer label, e.g. `Subscription` or `Workspace`. */
+  label: string;
+  /** Specific configured source, e.g. a provider name or Databricks profile. */
+  name?: string;
+  /** Non-secret endpoint host, when the provider has one. */
+  host?: string;
+}
+
 /** One runner-owned native model-picker row. */
 export interface NativeModelOption {
   /** Native picker id (a Claude alias or Codex model id). */
@@ -569,4 +581,6 @@ export interface NativeModelOption {
   supportedReasoningEfforts?: NativeReasoningEffortOption[];
   /** Whether the native catalog marks this as the default model. */
   isDefault?: boolean;
+  /** Configuration that supplies this model; never includes credentials. */
+  source?: ModelConfigurationSource;
 }

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -710,6 +710,68 @@ describe("Composer slash-command submit routing", () => {
     expect(screen.getByTestId("composer-config-model")).toBeTruthy();
   });
 
+  it("shows the model connection from both the model label and session gear", async () => {
+    useChatStore.setState({ llmModel: "sonnet" });
+    const options = CLAUDE_MODEL_OPTIONS.map((option) => ({
+      ...option,
+      source: {
+        kind: "databricks",
+        label: "Workspace",
+        name: "production-west",
+        host: "acme.cloud.databricks.com",
+      },
+    }));
+    render(
+      <Composer
+        {...composerProps({
+          showModels: true,
+          modelPickerKind: "claude",
+          codexModelOptions: options,
+        })}
+      />,
+    );
+
+    const source = screen.getByTestId("composer-model-source");
+    expect(source).toHaveTextContent("Sonnet 4.6");
+    expect(source).not.toHaveTextContent("Workspace");
+    fireEvent.focus(source);
+    const tooltip = await screen.findByTestId("composer-model-source-tooltip");
+    expect(tooltip).toHaveTextContent("Connection: Databricks · production-west");
+    expect(tooltip).not.toHaveTextContent("acme.cloud.databricks.com");
+    expect(tooltip).not.toHaveTextContent("Profile:");
+    expect(tooltip).not.toHaveTextContent("Host:");
+
+    fireEvent.blur(source);
+    fireEvent.focus(screen.getByTestId("composer-config-gear"));
+    const gearTooltip = await screen.findByTestId("composer-config-gear-tooltip");
+    expect(gearTooltip).toHaveTextContent("Connection: Databricks · production-west");
+    expect(gearTooltip.textContent?.indexOf("Connection:")).toBeGreaterThan(
+      gearTooltip.textContent?.indexOf("Effort:") ?? -1,
+    );
+  });
+
+  it("labels subscription provenance instead of showing an unexplained CLI name", async () => {
+    useChatStore.setState({ llmModel: "sonnet" });
+    const options = CLAUDE_MODEL_OPTIONS.map((option) => ({
+      ...option,
+      source: { kind: "subscription", label: "Subscription", name: "claude" },
+    }));
+    render(
+      <Composer
+        {...composerProps({
+          showModels: true,
+          modelPickerKind: "claude",
+          codexModelOptions: options,
+        })}
+      />,
+    );
+
+    fireEvent.focus(screen.getByTestId("composer-model-source"));
+    const tooltip = await screen.findByTestId("composer-model-source-tooltip");
+    expect(tooltip).toHaveTextContent("Connection: Claude subscription");
+    expect(tooltip).not.toHaveTextContent("Authentication");
+  });
+
   it("does not open an empty Claude config modal while the live catalog loads", () => {
     const onSend = vi.fn();
     render(
@@ -910,6 +972,10 @@ describe("Composer model/effort label", () => {
       selectedEffort: "high",
       costControlModeOverride: "on",
     });
+    const options = CLAUDE_MODEL_OPTIONS.map((option) => ({
+      ...option,
+      source: { kind: "subscription", label: "Subscription", name: "claude" },
+    }));
     renderWithTooltips(
       <Composer
         {...composerProps({
@@ -918,12 +984,14 @@ describe("Composer model/effort label", () => {
           modelPickerKind: "claude",
           showModels: true,
           costRoutingEligible: true,
+          codexModelOptions: options,
         })}
       />,
     );
     expect(label()).toHaveTextContent("Smart Routing");
     expect(label()).not.toHaveTextContent("Opus");
     expect(label()).not.toHaveTextContent("High");
+    expect(screen.queryByTestId("composer-model-source")).toBeNull();
   });
 
   it("renders the reported model, never the request or the sticky", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -11,6 +11,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import {
   ArrowUpIcon,
@@ -112,6 +113,7 @@ import {
 import { getCurrentAuthorId } from "@/lib/identity";
 import { retrySession } from "@/lib/sessionsApi";
 import { codexEffortLevelsForModel, findNativeModelOption } from "@/lib/codexNativeModels";
+import { modelConfigurationSourceRows } from "@/lib/modelConfigurationSource";
 import {
   composerAttachmentKey,
   consumePendingInitialPrompt,
@@ -5651,14 +5653,20 @@ export function Composer({
               />
             )}
             <div className="flex min-h-9 min-w-0 items-center rounded-lg transition-colors empty:hidden md:min-h-8 has-[button:not([aria-disabled=true])]:hover:bg-muted dark:has-[button:not([aria-disabled=true])]:hover:bg-muted/50 [&>button]:bg-transparent!">
-              <ComposerModelEffortLabel
-                showModels={showModels}
-                showEffort={showEffort}
+              <ComposerModelSource
                 modelPickerKind={modelPickerKind}
                 codexModelOptions={codexModelOptions}
                 costRoutingEligible={costRoutingEligible}
-                harnessLabel={harnessLabel}
-              />
+              >
+                <ComposerModelEffortLabel
+                  showModels={showModels}
+                  showEffort={showEffort}
+                  modelPickerKind={modelPickerKind}
+                  codexModelOptions={codexModelOptions}
+                  costRoutingEligible={costRoutingEligible}
+                  harnessLabel={harnessLabel}
+                />
+              </ComposerModelSource>
               <ComposerConfigGear
                 harnessLabel={harnessLabel}
                 showModels={showModels}
@@ -6648,11 +6656,11 @@ function ComposerConfigGear({
           {summary.length > 0 && (
             <TooltipContent
               side="top"
-              className="flex-col items-start gap-0.5 px-3 py-2"
+              className="max-w-80 flex-col items-start gap-0.5 px-3 py-2"
               data-testid="composer-config-gear-tooltip"
             >
               {summary.map((row) => (
-                <span key={row.label} className="text-muted-foreground">
+                <span key={row.label} className="max-w-72 truncate text-muted-foreground">
                   {row.label}:{" "}
                   <span className="text-background dark:text-popover-foreground">{row.value}</span>
                 </span>
@@ -6700,7 +6708,10 @@ function useSessionConfigSummary({
 }): { label: string; value: string }[] {
   const selectedEffort = useSessionEffort();
   const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
-  const { modelLabel } = useResolvedComposerModel(modelPickerKind, codexModelOptions);
+  const { effectiveModel, modelLabel } = useResolvedComposerModel(
+    modelPickerKind,
+    codexModelOptions,
+  );
   const routingOn = costRoutingEligible && costControlModeOverride === "on";
 
   const rows: { label: string; value: string }[] = [];
@@ -6716,6 +6727,12 @@ function useSessionConfigSummary({
   if (showEffort && !routingOn) {
     const effortValue = formatStatusEffortLabel(selectedEffort, modelPickerKind === "codex");
     rows.push({ label: "Effort", value: effortValue ?? "Default" });
+  }
+  if (!routingOn) {
+    const source =
+      findNativeModelOption(codexModelOptions, effectiveModel)?.source ??
+      codexModelOptions.find((option) => option.source)?.source;
+    rows.push(...modelConfigurationSourceRows(source));
   }
   return rows;
 }
@@ -6824,6 +6841,59 @@ function useResolvedComposerModel(
     effectiveModel,
     modelLabel,
   };
+}
+
+/** Compact, inspectable provenance beside the composer's model label. */
+function ComposerModelSource({
+  modelPickerKind,
+  codexModelOptions,
+  costRoutingEligible,
+  children,
+}: {
+  modelPickerKind: NativeModelPickerKind | null;
+  codexModelOptions: readonly NativeModelOption[];
+  costRoutingEligible: boolean;
+  children: ReactNode;
+}) {
+  const costControlModeOverride = useChatStore((s) => s.costControlModeOverride);
+  const { effectiveModel } = useResolvedComposerModel(modelPickerKind, codexModelOptions);
+  const source =
+    findNativeModelOption(codexModelOptions, effectiveModel)?.source ??
+    codexModelOptions.find((option) => option.source)?.source;
+  const routingOn = costRoutingEligible && costControlModeOverride === "on";
+  if (routingOn || !source) return children;
+
+  const rows = modelConfigurationSourceRows(source);
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            tabIndex={0}
+            data-testid="composer-model-source"
+            className="min-w-0 shrink outline-none rounded-md focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {children}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          className="flex max-w-80 flex-col items-start gap-1 px-3 py-2"
+          data-testid="composer-model-source-tooltip"
+        >
+          <span className="font-medium text-background dark:text-popover-foreground">
+            Model configuration
+          </span>
+          {rows.map((row) => (
+            <span key={row.label} className="max-w-72 truncate text-muted-foreground">
+              {row.label}:{" "}
+              <span className="text-background dark:text-popover-foreground">{row.value}</span>
+            </span>
+          ))}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
 }
 
 /**

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3535,6 +3535,34 @@ describe("NewChatLandingScreen agent picker + config gear", () => {
     expect(tooltip.textContent).not.toContain("—");
   });
 
+  it("shows the selected host's model provider in the gear tooltip", async () => {
+    useHostModelOptionsMock.mockImplementation(
+      (_hostId, harness) =>
+        (harness === "claude-native"
+          ? {
+              ...CLAUDE_MODEL_OPTIONS_RESULT,
+              data: CLAUDE_MODEL_OPTIONS_RESULT.data.map((model) => ({
+                ...model,
+                source: { kind: "subscription", label: "Subscription", name: "claude" },
+              })),
+            }
+          : CODEX_MODEL_OPTIONS_RESULT) as unknown as ReturnType<typeof useHostModelOptions>,
+    );
+    renderLanding();
+
+    fireEvent.focus(screen.getByTestId("new-chat-landing-config-gear"));
+    await waitFor(() =>
+      expect(screen.getAllByTestId("new-chat-landing-config-gear-tooltip").length).toBeGreaterThan(
+        0,
+      ),
+    );
+    const tooltip = screen.getAllByTestId("new-chat-landing-config-gear-tooltip")[0];
+    expect(tooltip).toHaveTextContent("Connection: Claude subscription");
+    expect(tooltip.textContent?.indexOf("Connection:")).toBeGreaterThan(
+      tooltip.textContent?.indexOf("Permissions:") ?? -1,
+    );
+  });
+
   it("reflects an armed Codex bypass as the Approval value in the gear tooltip", async () => {
     renderLanding();
     // Arm bypass on Codex (a2) via the Approval dropdown, Save.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -212,6 +212,7 @@ import { useNativeServerSwitcherForMainSurface } from "@/hooks/useNativeServerSw
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import type { Conversation } from "@/hooks/useConversations";
 import type { NativeModelOption } from "@/lib/types";
+import { modelConfigurationSourceRows } from "@/lib/modelConfigurationSource";
 import {
   useConversations,
   useProjectConfig,
@@ -2328,6 +2329,7 @@ export function NewChatLandingScreen() {
             // Keep the catalog's default marker: the Default row names the
             // model a bare launch truly runs, for claude exactly as codex.
             isDefault: option.isDefault,
+            source: option.source,
           })),
     [hostClaudeModelOptions, sandboxSelected],
   );
@@ -2342,6 +2344,7 @@ export function NewChatLandingScreen() {
         : (hostPiModelOptions ?? []).map((option) => ({
             id: option.id,
             displayName: option.displayName ?? option.id,
+            source: option.source,
           })),
     [hostPiModelOptions, sandboxSelected],
   );
@@ -2978,6 +2981,13 @@ export function NewChatLandingScreen() {
       selectedAgent?.harness != null &&
       selectedAgent.harness in brainHarnessLabelsAll);
   const configSummary = useMemo((): { label: string; value: string }[] => {
+    const sourceRows = (options: readonly NativeModelOption[]) => {
+      if (routingOn) return [];
+      const source =
+        options.find((option) => option.id === pickedModel)?.source ??
+        options.find((option) => option.source)?.source;
+      return modelConfigurationSourceRows(source);
+    };
     if (smartRoutingHarnessSelected) {
       // Top-level Smart Routing's modal is the locked Permissions row alone, so
       // mirror it. Report the constant — never a mode left over in state from a
@@ -2987,7 +2997,7 @@ export function NewChatLandingScreen() {
     if (supportsModelPicker && !supportsPermissionMode) {
       const modelValue =
         piModelOptions.find((model) => model.id === pickedModel)?.displayName ?? "Default";
-      return [{ label: "Model", value: modelValue }];
+      return [{ label: "Model", value: modelValue }, ...sourceRows(piModelOptions)];
     }
     if (supportsPermissionMode) {
       const modelValue = routingOn
@@ -3008,6 +3018,7 @@ export function NewChatLandingScreen() {
         { label: "Model", value: modelValue },
         { label: "Effort", value: effortValue },
         { label: "Permissions", value: permissionValue },
+        ...sourceRows(claudeModelOptions),
       ];
     }
     // Codex folds routing into its Model row, so report it the same way Claude
@@ -3038,7 +3049,11 @@ export function NewChatLandingScreen() {
                   : defaultModelLabel(codexModelOptions),
               },
             ];
-      return [...modelRows, { label: "Approval", value: approvalValue }];
+      return [
+        ...modelRows,
+        { label: "Approval", value: approvalValue },
+        ...(isCodex ? sourceRows(codexModelOptions) : []),
+      ];
     }
     if (supportsCursorMode) {
       const modeValue =
@@ -4916,11 +4931,14 @@ export function NewChatLandingScreen() {
                           </TooltipTrigger>
                           <TooltipContent
                             side="top"
-                            className="flex-col items-start gap-0.5 px-3 py-2"
+                            className="max-w-80 flex-col items-start gap-0.5 px-3 py-2"
                             data-testid="new-chat-landing-config-gear-tooltip"
                           >
                             {configSummary.map((row) => (
-                              <span key={row.label} className="text-muted-foreground">
+                              <span
+                                key={row.label}
+                                className="max-w-72 truncate text-muted-foreground"
+                              >
                                 {row.label}:{" "}
                                 <span className="text-background dark:text-popover-foreground">
                                   {row.value}


### PR DESCRIPTION
## Related issue

N/A — requested directly.

## Summary

- Surface the non-secret connection behind each native model option so people can distinguish a Claude subscription, Databricks workspace, AI Gateway, API key, local provider, or CLI config.
- Show one compact `Connection` row at the bottom of the configuration tooltip on both the new-session and active-session composer gears. The model label also exposes the same hover detail, and long values truncate.
- Keep credentials out of the response, centralize source serialization, and omit connection provenance while Smart Routing may choose a provider per turn.

ELI5: the model picker already knows which configured connection will serve a model. This change passes a safe label to the browser and reveals it only when someone hovers the relevant composer control.

```mermaid
flowchart LR
  A[Resolved model provider] --> B[Safe source metadata]
  B --> C[Native model options API]
  C --> D[New-session gear hover]
  C --> E[Session gear hover]
  C --> F[Model-label hover]
```

## Test Plan

- `UV_INDEX_URL=https://pypi.org/simple .venv/bin/pre-commit run --all-files --show-diff-on-failure`
- `.venv/bin/pytest -q tests/test_model_catalog.py` (94 passed)
- `pnpm --filter web exec vitest run src/lib/modelConfigurationSource.test.ts src/pages/ChatPage.composer.test.tsx src/shell/NewChatDialog.test.tsx -t "model connection|subscription provenance|model provider"` (3 passed)
- Started a local server and host, then manually verified the gear tooltip on both a new-session composer and an existing session composer.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The recording first hovers the new-session gear, then the gear inside an existing session:

![Model connection source hover demo](https://raw.githubusercontent.com/dbczumar/omnigent/refs/heads/pr-assets/model-connection-source/.github/pr-assets/model-connection-source-demo.gif)

[Open the MP4 recording](https://raw.githubusercontent.com/dbczumar/omnigent/refs/heads/pr-assets/model-connection-source/.github/pr-assets/model-connection-source-demo.mp4) · [Full-size connection variants](https://raw.githubusercontent.com/dbczumar/omnigent/refs/heads/pr-assets/model-connection-source/.github/pr-assets/model-connection-source-variants.png) · [Full-size in-session screenshot](https://raw.githubusercontent.com/dbczumar/omnigent/refs/heads/pr-assets/model-connection-source/.github/pr-assets/model-connection-source-session.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the running new-session and active-session composers. Unit coverage checks every source format, both gear surfaces, model-label hover, selected-host propagation, truncation-ready one-line formatting, and that API key material is never serialized.

## Changelog

See which connection supplies your selected model by hovering the composer configuration gear.
