### PR TITLE
feat(cli): print a "new session here" link that opens the composer on the launch directory

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -106,7 +106,11 @@ from omnigent.claude_native_state import (
     write_launch_state,
 )
 from omnigent.cli_invocation import cli_invocation
-from omnigent.conversation_browser import conversation_url, open_conversation_link_if_enabled
+from omnigent.conversation_browser import (
+    conversation_url,
+    new_session_url,
+    open_conversation_link_if_enabled,
+)
 from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.host.daemon_launch import (
     daemon_poll_intervals,
@@ -4296,6 +4300,9 @@ def _run_with_remote_server(
                 )
 
             host_id = load_or_create_host_identity().host_id
+            # Sampled once: the runner's cwd and the "new session here" link
+            # below must name the same directory, and a resume can move cwd.
+            launch_workspace = str(Path.cwd().resolve())
             _mark_startup_step(
                 startup_profiler,
                 "host identity loaded",
@@ -4328,7 +4335,7 @@ def _run_with_remote_server(
                         session_bundle=bundle,
                         claude_args=claude_args,
                         host_id=host_id,
-                        workspace=str(Path.cwd().resolve()),
+                        workspace=launch_workspace,
                         startup_profiler=startup_profiler,
                         startup_progress=progress,
                     )
@@ -4352,6 +4359,14 @@ def _run_with_remote_server(
             _record_launch_for_fresh_session(prepared.session_id)
             startup_profiler.mark("fresh remote launch state recorded")
         click.echo(f"Web UI: {conversation_url(base_url, prepared.session_id)}", err=True)
+        # The line above mirrors THIS session. Starting a fresh session from
+        # the web had no way to inherit the launch directory, so offer a link
+        # whose composer opens on it already.
+        click.echo(
+            "New session here: "
+            f"{new_session_url(base_url, workspace=launch_workspace, host_id=host_id)}",
+            err=True,
+        )
         startup_profiler.mark("remote web ui url printed")
         open_conversation_link_if_enabled(
             base_url=base_url,

--- a/omnigent/conversation_browser.py
+++ b/omnigent/conversation_browser.py
@@ -78,6 +78,42 @@ def conversation_url(base_url: str, conversation_id: str) -> str:
     return f"{base_url.rstrip('/')}/c/{encoded_id}"
 
 
+def new_session_url(base_url: str, *, workspace: str, host_id: str) -> str:
+    """
+    Build the browser URL for a NEW session prefilled with a directory.
+
+    :func:`conversation_url` links the session that already exists, so a
+    terminal launch has no way to carry its cwd into a *fresh* web session.
+    This lands on the new-session composer with the working directory and
+    host preselected (``?host=`` + ``?workspace=``), so starting one from a
+    CLI launch keeps the directory the CLI was run in.
+
+    The host rides along because a path only means something on one machine —
+    the composer will not bind ``workspace`` to a different host.
+
+    :param base_url: Omnigent server base URL, e.g. ``"http://127.0.0.1:6767"``.
+    :param workspace: Absolute directory on *host_id*, e.g. ``"/Users/me/proj"``.
+    :param host_id: Host the directory lives on, e.g. ``"host_abc123"``.
+    :returns: Browser URL, e.g.
+        ``"http://127.0.0.1:6767/?host=host_abc123&workspace=%2FUsers%2Fme%2Fproj"``.
+    """
+    server = ServerUrl.from_api_base(base_url)
+    params = {"host": host_id, "workspace": workspace}
+    parsed = urllib.parse.urlsplit(server.api_base)
+    if server.is_workspace_hosted:
+        if server.org_id:
+            params["o"] = server.org_id
+        path = WORKSPACE_UI_PATH
+    else:
+        # The composer is the SPA's index route, and urlsplit leaves an
+        # origin-only base with an empty path — without the explicit "/" the
+        # query would fuse onto the host (``http://h:6767?host=``).
+        path = parsed.path or "/"
+    return urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, path, urllib.parse.urlencode(params), "")
+    )
+
+
 def open_conversation_url(url: str) -> bool:
     """
     Open a conversation URL in the user's default browser.

--- a/tests/test_conversation_browser.py
+++ b/tests/test_conversation_browser.py
@@ -217,6 +217,71 @@ def test_conversation_url_workspace_hosted_without_org_record(tmp_path, monkeypa
     assert url == "https://example.databricks.com/omnigent/c/conv_abc123"
 
 
+def test_new_session_url_workspace_hosted_carries_host_and_dir(tmp_path, monkeypatch) -> None:
+    """The SPA-mount deep link carries host, workspace and the ?o selector.
+
+    A terminal launch's own link only mirrors that session, so this is the
+    link that lets a NEW web session start in the directory the CLI ran in.
+    """
+    from omnigent.cli_auth import store_databricks_auth
+    from omnigent.conversation_browser import new_session_url
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    store_databricks_auth(
+        server,
+        "https://example.databricks.com",
+        org_id="2850744067564480",
+    )
+
+    url = new_session_url(server, workspace="/home/me/proj", host_id="host_abc123")
+
+    assert url == (
+        "https://example.databricks.com/omnigent"
+        "?host=host_abc123&workspace=%2Fhome%2Fme%2Fproj&o=2850744067564480"
+    )
+
+
+def test_new_session_url_plain_server_uses_index_route(tmp_path, monkeypatch) -> None:
+    """A bare server base gets the explicit "/" so the query can't fuse to the host.
+
+    ``urlsplit("http://127.0.0.1:6767").path`` is empty, and urlunsplit would
+    otherwise emit ``http://127.0.0.1:6767?host=...`` — a URL the SPA router
+    does not resolve to the composer.
+    """
+    from omnigent.conversation_browser import new_session_url
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
+
+    url = new_session_url("http://127.0.0.1:6767", workspace="/srv/repo", host_id="host_1")
+
+    assert url == "http://127.0.0.1:6767/?host=host_1&workspace=%2Fsrv%2Frepo"
+
+
+def test_new_session_url_quotes_directories_with_spaces(tmp_path, monkeypatch) -> None:
+    """Paths with spaces or ``&`` survive the round trip percent-encoded.
+
+    An unencoded ``&`` in a directory name would split into a bogus extra
+    query param and truncate the seeded path.
+    """
+    from omnigent.conversation_browser import new_session_url
+
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
+
+    url = new_session_url("http://127.0.0.1:6767", workspace="/srv/a b&c", host_id="host_1")
+
+    assert url == "http://127.0.0.1:6767/?host=host_1&workspace=%2Fsrv%2Fa+b%26c"
+
+
 def test_conversation_url_plain_server_unchanged(tmp_path, monkeypatch) -> None:
     """Non-workspace servers keep the plain /c/<id> link shape."""
     from omnigent.conversation_browser import conversation_url

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1677,6 +1677,57 @@ describe("NewChatLandingScreen", () => {
     );
   });
 
+  it("seeds the working directory from the host's most recent session", async () => {
+    // A session started from a terminal (`omnigent claude` in a directory)
+    // records that cwd as its workspace but never touches this browser's
+    // recents, so the server-side session must win over the stale recent.
+    useDirectorySessionsMock.mockReturnValue({
+      data: [conv({ id: "s1", host_id: "host_1", workspace: "/Users/corey/universe" })],
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "universe",
+      ),
+    );
+  });
+
+  it("ignores another host's session when seeding the working directory", async () => {
+    // Paths are host-specific: host_2's workspace must not seed host_1, which
+    // falls back to its own recent ("/Users/corey/repo").
+    useDirectorySessionsMock.mockReturnValue({
+      data: [conv({ id: "s1", host_id: "host_2", workspace: "/Users/corey/universe" })],
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+  });
+
+  it("holds the working-directory seed until the session list resolves", async () => {
+    // Seeding the recent while the scan is in flight would lock the
+    // once-per-host guard and lose to a newer terminal-launched workspace.
+    useDirectorySessionsMock.mockReturnValue({
+      data: undefined,
+      isError: false,
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() => expect(screen.getByTestId("new-chat-landing-host-chip")).toBeTruthy());
+    expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).not.toContain("repo");
+  });
+
+  it("falls back to the recent when the session scan fails", async () => {
+    // A failed scan must not stall the seed forever — the field still fills.
+    useDirectorySessionsMock.mockReturnValue({
+      data: undefined,
+      isError: true,
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding();
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+  });
+
   it("quotes server URLs in host and Lakebox connect commands", () => {
     setOmnigentHostConfig({ cliServerUrlSuffix: "/api?profile=dev&glob=*" });
     renderLanding({ databricks_features: true });

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1716,6 +1716,60 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).not.toContain("repo");
   });
 
+  it("seeds the working directory and host from a CLI deep link", async () => {
+    // `?host=` + `?workspace=` is what `omnigent <harness>` prints so a fresh
+    // web session starts where the CLI ran. It must beat the localStorage
+    // recent ("/Users/corey/repo") that would otherwise seed the field.
+    renderLanding({}, "/?host=host_1&workspace=/Users/corey/from-cli");
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "from-cli",
+      ),
+    );
+    const { body } = await submitAndReadBody();
+    expect(body.host_id).toBe("host_1");
+    expect(body.workspace).toBe("/Users/corey/from-cli");
+  });
+
+  it("beats the host's most recent session workspace with a CLI deep link", async () => {
+    // The deep link is an explicit request for THIS directory; the
+    // last-session seed is only a guess, so the link outranks it.
+    useDirectorySessionsMock.mockReturnValue({
+      data: [conv({ id: "s1", host_id: "host_1", workspace: "/Users/corey/universe" })],
+    } as unknown as ReturnType<typeof useDirectorySessions>);
+    renderLanding({}, "/?host=host_1&workspace=/Users/corey/from-cli");
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "from-cli",
+      ),
+    );
+  });
+
+  it("ignores a non-absolute workspace in the URL", async () => {
+    // The create body requires an absolute path, so a relative one is dropped
+    // rather than seeded — the normal seed order takes over.
+    renderLanding({}, "/?host=host_1&workspace=relative/dir");
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain("repo"),
+    );
+  });
+
+  it("leaves the host unselected when a deep link names an offline host", async () => {
+    // Binding another machine's path is worse than an empty slot, so an
+    // unresolvable `?host=` must not fall through to the first online host.
+    useHostsMock.mockReturnValue({
+      data: [host("online"), { ...host("online"), host_id: "host_2" } as Host],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useHosts>);
+    renderLanding({}, "/?host=host_gone&workspace=/Users/corey/from-cli");
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-workspace-chip").textContent).toContain(
+        "from-cli",
+      ),
+    );
+    expect(screen.getByTestId("new-chat-landing-submit")).toBeDisabled();
+  });
+
   it("falls back to the recent when the session scan fails", async () => {
     // A failed scan must not stall the seed forever — the field still fills.
     useDirectorySessionsMock.mockReturnValue({

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2038,6 +2038,15 @@ export function NewChatLandingScreen() {
   // Project driving this visit, when the sidebar's per-project "new session"
   // pencil landed here with a `?project=` query param. Empty otherwise.
   const projectParam = searchParams.get("project") ?? "";
+  // Directory + host a CLI launch deep-linked in (`new_session_url` in
+  // omnigent/conversation_browser.py): a terminal session's own link only ever
+  // mirrors that session, so this is how a `omnigent <harness>` launch carries
+  // its cwd into a NEW web session. A path means nothing without the machine it
+  // is on, so the two are honored together. A non-absolute `workspace` is
+  // dropped rather than sent — the create body requires an absolute path.
+  const workspaceParam = searchParams.get("workspace") ?? "";
+  const workspaceFromUrl = isValidWorkspace(workspaceParam) ? workspaceParam.trim() : "";
+  const hostParam = searchParams.get("host");
   // Project prefill source: a project-driven visit seeds the composer from the
   // project's stored defaults (host / working directory / agent / worktree).
   // `?project=` carries the project NAME, so resolve it to the first-class id
@@ -2394,7 +2403,12 @@ export function NewChatLandingScreen() {
   const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
     () => restoredDraft?.sandboxRepoBranch ?? "",
   );
-  const [workspace, setWorkspace] = useState<string>(() => restoredDraft?.workspace ?? "");
+  // The URL seed is the mount-time value, so no effect can race it and the
+  // once-per-host auto-seed (which only fills an EMPTY field) leaves it alone.
+  // A restored draft still wins: that is the user's own edit from this visit.
+  const [workspace, setWorkspace] = useState<string>(
+    () => restoredDraft?.workspace || workspaceFromUrl,
+  );
   // Source tracking for the create's field-omission contract: true while the
   // slot's value is the untouched seed the project-prefill effect wrote from
   // the config. ANY other write — a picker selection, browsing, a host
@@ -2702,6 +2716,18 @@ export function NewChatLandingScreen() {
     if (sandboxSelected) return;
     if (selectedHostId !== null) return;
 
+    // A CLI deep link (`?host=` + `?workspace=`) outranks the persisted pick:
+    // it names the machine the linked directory is on. Honored under the same
+    // rules as a persisted pick — wait for the list, and bind only an online
+    // host — and it deliberately does NOT fall through to the defaults, since
+    // seeding one machine's path onto another is worse than an empty slot.
+    if (hostParam !== null) {
+      if (hostsLoading) return;
+      const requested = (hosts ?? []).find((h) => h.host_id === hostParam && h.status === "online");
+      if (requested) setSelectedHostId(requested.host_id);
+      return;
+    }
+
     // Read the persisted pick once, as a mount-time seed — deliberately NOT a
     // dependency: it only matters until the slot is filled, and re-running on
     // its value would fight an explicit in-session selection.
@@ -2744,6 +2770,7 @@ export function NewChatLandingScreen() {
   }, [
     hosts,
     hostsLoading,
+    hostParam,
     selectedHostId,
     sandboxSelected,
     managedSandboxesEnabled,

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2305,7 +2305,9 @@ export function NewChatLandingScreen() {
   );
   // Sessions on the selected host — fetched only when a host is selected,
   // to avoid registering hundreds of sessions into the health poll at idle.
-  const { data: directorySessions } = useDirectorySessions(selectedHostId !== null);
+  const { data: directorySessions, isError: directorySessionsErrored } = useDirectorySessions(
+    selectedHostId !== null,
+  );
   // True when the user picked the sandbox option instead of a connected
   // host — the server provisions a sandbox host at create time
   // (host_type: "managed"), so no host_id or workspace is sent.
@@ -2784,10 +2786,35 @@ export function NewChatLandingScreen() {
   // falls through to the global one, then to blank (fork from current branch).
   const projectBaseBranch = storedProjectConfig?.base_branch?.trim() || null;
 
-  // The path the once-per-host auto-seed WOULD land on: the most-recent path,
-  // else the derived home. Exposed as a memo so we can probe its repo for
-  // worktrees before committing to it (see the fork-fresh redirect below).
-  const autoSeedCandidate = useMemo(() => recent[0] ?? derivedHome ?? null, [recent, derivedHome]);
+  // Working directory of the host's most recently active session — the only
+  // signal that sees a session started from a terminal (`omnigent claude` in a
+  // directory records that cwd as its workspace). `recent` is localStorage, so
+  // it only ever holds directories picked in THIS browser; every web pick also
+  // creates a session, making this the same set plus terminal launches, ordered
+  // by real `updated_at`. `undefined` = the list is still resolving, so the
+  // seed can wait rather than locking in a stale browser-local recent.
+  const latestHostWorkspace = useMemo<string | null | undefined>(() => {
+    if (selectedHostId === null || sandboxSelected) return null;
+    // A failed scan must not stall the seed forever — fall through to `recent`.
+    if (directorySessionsErrored) return null;
+    if (directorySessions === undefined) return undefined;
+    const match = directorySessions.find(
+      (s) => s.host_id === selectedHostId && s.workspace != null && isValidWorkspace(s.workspace),
+    );
+    return match?.workspace?.trim() ?? null;
+  }, [directorySessions, directorySessionsErrored, selectedHostId, sandboxSelected]);
+  // Hold the seed while the session list resolves, so a browser-local recent
+  // can't win the race and lock the once-per-host guard below.
+  const autoSeedPending = latestHostWorkspace === undefined;
+
+  // The path the once-per-host auto-seed WOULD land on: the host's last session
+  // workspace, else the most-recent path, else the derived home. Exposed as a
+  // memo so we can probe its repo for worktrees before committing to it (see
+  // the fork-fresh redirect below).
+  const autoSeedCandidate = useMemo(
+    () => latestHostWorkspace ?? recent[0] ?? derivedHome ?? null,
+    [latestHostWorkspace, recent, derivedHome],
+  );
   // "Fork fresh from default": when the project defines a default base branch,
   // a fresh new-chat must NOT silently continue in the last-used worktree — it
   // should fork a new branch off that default. The auto-seed can land on a
@@ -2802,6 +2829,7 @@ export function NewChatLandingScreen() {
     !sandboxSelected &&
     projectBaseBranch !== null &&
     seededHostRef.current !== selectedHostId &&
+    !autoSeedPending &&
     autoSeedCandidate !== null;
   const {
     data: seedWorktrees,
@@ -2840,13 +2868,15 @@ export function NewChatLandingScreen() {
   ]);
 
   // Seed the working directory once per host, into an empty field only, so an
-  // explicit pick isn't clobbered. Prefer the most-recent path; else the
-  // derived home (which can arrive a render later, hence the dep). Holds
-  // off while a project prefill is deciding on a workspace of its own.
+  // explicit pick isn't clobbered. Prefer the host's last session workspace;
+  // else the most-recent path; else the derived home (which can arrive a render
+  // later, hence the dep). Holds off while a project prefill is deciding on a
+  // workspace of its own.
   useEffect(() => {
     if (!prefillSettled) return;
     if (selectedHostId === null) return;
     if (seededHostRef.current === selectedHostId) return;
+    if (autoSeedPending) return;
     if (autoSeedCandidate === null) return;
     // Fork-fresh redirect pending: wait for the probe rather than seeding the
     // wrong path (and locking the once-per-host guard).
@@ -2879,6 +2909,7 @@ export function NewChatLandingScreen() {
   }, [
     selectedHostId,
     autoSeedCandidate,
+    autoSeedPending,
     prefillSettled,
     forkFreshMainPath,
     workspace,


### PR DESCRIPTION
## Related issue

Closes #

<!-- No issue filed. Happy to open one if a maintainer wants tracking. -->

> **Stacked on #6239.** Its commit is the first of the two here; review this PR's
> own commit (`feat(cli): print a "new session here" link…`) for the new work, and
> merge after #6239.

## Summary

`Web UI: <url>` links the session the CLI just created — a *mirror* of the terminal
session. There was no link that starts a **fresh** web session in the directory the
CLI was run in: the composer's working-directory field seeds from browser-local
recents and the host's home directory, neither of which a terminal launch
influences. So starting a new session from the web always began by re-navigating to
the directory you were already sitting in.

This adds a second link:

```
Web UI:           https://<ws>/omnigent/c/conv_abc
New session here: https://<ws>/omnigent?host=host_1&workspace=%2Fsrv%2Frepo
```

- New `new_session_url()` in `conversation_browser.py`, built on `ServerUrl` like
  `conversation_url` (workspace SPA mount + `?o=` selector for Databricks-hosted
  servers, the SPA index route otherwise).
- The web composer honors `?workspace=` and `?host=`. The **host rides along
  because a path only means something on one machine** — an unresolvable or
  offline `?host=` leaves the host slot empty rather than binding another
  machine's path to it.
- The URL seed is the **mount-time state value**, so it outranks every other seed
  (recents, the host's last session workspace, derived home) with no effect
  ordering to race, and the once-per-host auto-seed (which only fills an *empty*
  field) leaves it alone. A restored in-session draft still wins — that's the
  user's own edit.
- The launch cwd is now sampled once into `launch_workspace` and shared with the
  runner launch, so the printed link provably names the directory the runner got
  (a resume can move cwd between the two reads).

**Deliberately not changed:** the existing `Web UI:` line and the
`auto_open_conversation` target still point at the launched session. Auto-opening
a *new-chat* page instead of the session you just started would be surprising, and
repointing that line would regress every other consumer.

**Scope:** wired into the claude-native remote/daemon launch (the host-backed path,
which is the one with a `host_id` to put in the link). The helper is
harness-agnostic; the other `*_native` harnesses print the same `Web UI:` line and
can adopt it in a follow-up.

## Test Plan

Python — `pytest tests/test_conversation_browser.py tests/test_claude_native_hook.py` → 76 passed.
Three new cases pin `new_session_url`: the Databricks SPA mount (host + workspace +
`?o=`), the bare-server index route (the explicit `/` that keeps the query off the
netloc), and percent-encoding of a directory containing a space and `&`.

Web — `vitest run` over the 7 dialog-related suites → 428 passed.
`tsc -b`, `oxlint --deny-warnings --report-unused-disable-directives .`, and
`ruff check` / `ruff format --check` are clean. `pyrefly check` reports no errors in
the touched files (78 pre-existing elsewhere).

The two behavioural web tests were confirmed to **fail** without the
`NewChatDialog.tsx` change (the chip reads the localStorage recent `repo` instead of
the deep-linked `from-cli`), so they guard the actual change.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The CLI change is the literal stderr line quoted in the Summary. The web change is
the value prefilled into the working-directory field / footer chip, with no layout
or styling change; the added tests assert that rendered chip text plus the resulting
`POST /v1/sessions` body (`host_id` + `workspace`), which is more than a screenshot
would show.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Seven new tests: three on `new_session_url` (URL shapes + encoding) and four on the
composer (seeds dir + host from the link and sends both in the create body; the link
outranks the host's last-session seed; a non-absolute `workspace` is dropped; an
offline `?host=` leaves the host unselected). Not verified against a live server in a
browser.

## Changelog

A terminal launch now also prints a "New session here" link that opens the web
composer already pointed at the directory you ran the CLI in, so starting a fresh web
session no longer means re-navigating to it.
