### PR TITLE
feat(web): distinct GitHub panel empty states with old-host prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,7 +231,7 @@ website under `/releases`.
 - [Feature] Scheduled tasks can now set a per-firing cost budget (`max_cost_usd`) that caps LLM spend on each run (#4791)
 - [Bug fix] Sub-agent inbox wake notices no longer repeat the same "results waiting in inbox" line while a parent's results sit undrained. (#4803)
 - [Chore] Cache session access checks briefly to cut per-event database load on active sessions (#4820)
-- [Chore] `omnigent host` conflict error now shows the exact `omnigent host stop --server (#4821)
+- [Chore] `omnigent host` conflict error now shows the exact `omnigent host stop` command to run (#4821)
 - [Bug fix] Resuming a conversation no longer fails with `string indices must be integers` when the history contains a plain-text assistant message (#4824)
 - [UI / Bug fix / Feature] Cmd/Ctrl+N now starts a new session, including in the macOS desktop app without opening another app window. (#4840)
 - [Bug fix] Agent and session discovery tools now page large catalogs through an opaque cursor, or return a bounded diagnostic when the smallest page cannot fit. (#4892)

--- a/tests/e2e_ui/github/test_github_tab.py
+++ b/tests/e2e_ui/github/test_github_tab.py
@@ -7,18 +7,22 @@ with ``page.route`` and answered with canned JSON, so the test exercises the
 *frontend* — the PR header, the CI-check pills, and the folder-tree sidebar —
 without a real ``gh``/``git`` (which a CI workspace has no PR for anyway).
 
-Two behaviours are pinned:
+Three behaviours are pinned:
 
 1. Opening the GitHub rail tab renders the associated PR (title + number), its
    CI checks as labeled pills, and the branch-vs-base file tree — with a
    single-child directory chain (``src`` → ``app``) compacted into one row.
 2. The composer status line's ``#<pr>`` link opens that tab.
+3. A host predating the ``/resources/github`` route 404s "Resource 'github'
+   not found", which the panel renders as an actionable "update your host"
+   empty state rather than the generic "unavailable" one.
 
-Neither sends a message, so both stay fast and LLM-free.
+None sends a message, so all stay fast and LLM-free.
 """
 
 from __future__ import annotations
 
+import json
 import re
 
 from playwright.sync_api import Page, expect
@@ -172,3 +176,46 @@ def test_composer_pr_link_opens_github_tab(
     pr_link.click()
     rail = page.get_by_role("complementary", name="Workspace")
     expect(rail.get_by_text("Add the GitHub tab")).to_be_visible(timeout=30_000)
+
+
+def _stub_github_outdated_host(page: Page) -> None:
+    """404 the info endpoint with the message an outdated host returns.
+
+    A host predating the ``/resources/github`` route has no such resource, so
+    its generic lookup 404s "Resource 'github' not found". The status MUST be
+    set explicitly (``fulfill`` defaults to 200), and the body carries the exact
+    message the client keys on (``githubNotFoundReason``). Only ``/resources/
+    github`` needs stubbing: an unavailable payload resolves no base ref, so the
+    changes/diff queries stay disabled and never fire.
+    """
+    page.route(
+        re.compile(r"/resources/github(?:\?|$)"),
+        lambda r: r.fulfill(
+            status=404,
+            headers={"content-type": "application/json"},
+            body=json.dumps({"error": {"message": "Resource 'github' not found"}}),
+        ),
+    )
+
+
+def test_github_tab_prompts_to_update_outdated_host(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """An outdated host's 404 renders the "update your host" empty state.
+
+    Pins the full old-host chain end to end: the 404 body → ``githubNotFoundReason``
+    → the ``host_outdated`` state → the actionable empty state, rather than the
+    generic "GitHub isn't available" one.
+    """
+    base_url, session_id = seeded_session
+    _stub_github_outdated_host(page)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name="GitHub").click()
+
+    expect(rail.get_by_text("Update your host to use GitHub")).to_be_visible(timeout=30_000)
+    # The hint names the version floor so the user knows what to update to.
+    expect(rail.get_by_text(re.compile(r"0\.13\.0 or later"))).to_be_visible()

--- a/web/src/hooks/useGithub.test.ts
+++ b/web/src/hooks/useGithub.test.ts
@@ -1,0 +1,21 @@
+// Tests for the pure helpers in useGithub — the 404 → reason classifier that
+// steers an outdated host to the "update your host" panel state.
+
+import { describe, expect, it } from "vitest";
+import { githubNotFoundReason } from "@/hooks/useGithub";
+
+describe("githubNotFoundReason", () => {
+  it("flags an outdated host from its 'resource not found' message", () => {
+    // The exact shape an old runner's generic resource lookup returns.
+    expect(githubNotFoundReason("Resource 'github' not found")).toBe("host_outdated");
+    // Case-insensitive, tolerant of quoting.
+    expect(githubNotFoundReason("resource github not found")).toBe("host_outdated");
+  });
+
+  it("treats every other 404 as a generic no-workspace reason", () => {
+    expect(githubNotFoundReason("workspace directory does not exist on host")).toBe("no_os_env");
+    expect(githubNotFoundReason("Resource 'terminal' not found")).toBe("no_os_env");
+    expect(githubNotFoundReason(undefined)).toBe("no_os_env");
+    expect(githubNotFoundReason("")).toBe("no_os_env");
+  });
+});

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -58,16 +58,24 @@ export interface GithubRepo {
   name_with_owner: string | null;
 }
 
+/** Why the panel can't show GitHub content.
+ *  - `not_a_git_repo` — the workspace exists but isn't a git checkout.
+ *  - `no_os_env` — no workspace/filesystem to read (404 from a current host).
+ *  - `host_outdated` — the host predates the `/resources/github` route and
+ *    404s "Resource 'github' not found"; synthesized in {@link fetchGithubInfo}. */
+export type GithubUnavailableReason = "not_a_git_repo" | "no_os_env" | "host_outdated";
+
 export interface GithubInfo {
   object: "session.github.info";
   /** False only when this isn't a git repo (see reason); the diff needs one. */
   available: boolean;
-  /** Why unavailable: "not_a_git_repo" | "no_os_env". */
-  reason?: string;
-  /** Whether the `gh` CLI is present. When false, PR/repo are null but the
-   *  branch-vs-base diff still renders from git. */
+  /** Why unavailable — see {@link GithubUnavailableReason}. */
+  reason?: GithubUnavailableReason;
+  /** Whether the `gh` CLI is present on the host. When false, PR/repo are null
+   *  (the panel prompts to install `gh`). */
   gh_available?: boolean;
-  /** Whether gh has an authenticated host (false → prompt `gh auth login`). */
+  /** Whether gh has an authenticated host (false → the panel points at
+   *  `gh auth status`). */
   authenticated?: boolean;
   branch?: string;
   repo?: GithubRepo | null;
@@ -109,12 +117,44 @@ async function errorFromResponse(res: Response): Promise<Error> {
   return new Error(message);
 }
 
+/** Classify a 404 body from the GitHub resource endpoint.
+ *
+ * A host/runner predating the `/resources/github` route has no such resource,
+ * so its generic resource lookup 404s "Resource 'github' not found". That
+ * distinct message is the only signal that the host is too old (an old host
+ * can't advertise a version field the new UI would know to read), so we match
+ * it to steer the panel to its "update your host" state rather than the
+ * generic "unavailable" one. Every other 404 (no workspace, missing dir) is a
+ * genuine `no_os_env`.
+ *
+ * Temporary: the route ships in 0.13.0, so this shim is only for hosts below
+ * it. @deprecated — expected removal ~0.16.0, once <0.13.0 hosts have aged out.
+ */
+export function githubNotFoundReason(message: string | undefined): GithubUnavailableReason {
+  return message && /resource\b.*\bgithub\b.*not found/i.test(message)
+    ? "host_outdated"
+    : "no_os_env";
+}
+
 async function fetchGithubInfo(conversationId: string): Promise<GithubInfo> {
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(conversationId)}/resources/github`,
   );
   if (res.status === 404) {
-    return { object: "session.github.info", available: false, reason: "no_os_env" };
+    // Preserve the server's message so an outdated host (no github route) is
+    // told to update, rather than collapsing every 404 to "unavailable".
+    let message: string | undefined;
+    try {
+      const body = (await res.json()) as { error?: { message?: string } };
+      message = body?.error?.message;
+    } catch {
+      // Non-JSON body — fall back to the generic reason.
+    }
+    return {
+      object: "session.github.info",
+      available: false,
+      reason: githubNotFoundReason(message),
+    };
   }
   if (res.status === 503 && (await isRunnerUnavailable503(res))) {
     throw new RunnerOfflineError();

--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -55,7 +55,8 @@ vi.mock("@/components/theme/useResolvedThemeMode", () => ({
   useResolvedThemeMode: () => "light",
 }));
 
-import { GithubPanel } from "./GithubPanel";
+import { GithubPanel, deriveGithubPanelState } from "./GithubPanel";
+import { RunnerOfflineError } from "@/hooks/useWorkspaceChangedFiles";
 
 function file(
   path: string,
@@ -303,6 +304,116 @@ describe("GithubPanel", () => {
       isFetching: false,
     };
     renderPanel();
-    expect(screen.getByText(/isn.t a git repository/)).toBeInTheDocument();
+    expect(screen.getByText("Not a git repository")).toBeInTheDocument();
+    expect(screen.queryByTestId("diff")).toBeNull();
+  });
+
+  it("prompts to update the host when it predates the GitHub route", () => {
+    state.info = {
+      data: { object: "session.github.info", available: false, reason: "host_outdated" },
+      isLoading: false,
+      error: null,
+      isFetching: false,
+    };
+    renderPanel();
+    expect(screen.getByText("Update your host to use GitHub")).toBeInTheDocument();
+    expect(screen.getByText(/0\.13\.0 or later/)).toBeInTheDocument();
+    expect(screen.queryByTestId("diff")).toBeNull();
+  });
+
+  it("prompts to install the GitHub CLI when gh is missing", () => {
+    state.info!.data!.gh_available = false;
+    renderPanel();
+    expect(screen.getByText("GitHub CLI not found")).toBeInTheDocument();
+    expect(screen.queryByTestId("diff")).toBeNull();
+  });
+
+  it("prompts to check gh auth when the upstream repo can't be resolved", () => {
+    // Signed in, but `gh repo view` failed → no repo resolved.
+    state.info!.data!.authenticated = true;
+    state.info!.data!.repo = null;
+    renderPanel();
+    expect(screen.getByText("Can’t reach the upstream repo")).toBeInTheDocument();
+    expect(screen.getByText(/gh auth status/)).toBeInTheDocument();
+    expect(screen.queryByTestId("diff")).toBeNull();
+  });
+
+  it("shows a no-open-PR empty state (naming the branch) and hides the diff", () => {
+    state.info!.data!.pr = null;
+    renderPanel();
+    expect(screen.getByText(/No open PR for/)).toBeInTheDocument();
+    expect(screen.getByText("test/pr-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("diff")).toBeNull();
+  });
+});
+
+describe("deriveGithubPanelState", () => {
+  const ready: GithubInfo = {
+    object: "session.github.info",
+    available: true,
+    gh_available: true,
+    authenticated: true,
+    branch: "feat/x",
+    base_ref: "main",
+    repo: { name_with_owner: "acme/app" },
+    pr: {
+      number: 1,
+      title: "t",
+      state: "OPEN",
+      url: "u",
+      is_draft: false,
+      author: "a",
+      base_ref: "main",
+      head_ref: "feat/x",
+      checks: { passing: 0, failing: 0, pending: 0, total: 0, runs: [] },
+    },
+  };
+  const q = (over: Partial<{ isLoading: boolean; error: unknown; data: GithubInfo }>) => ({
+    isLoading: false,
+    error: null as unknown,
+    data: undefined as GithubInfo | undefined,
+    ...over,
+  });
+
+  it("orders transient states ahead of data", () => {
+    expect(deriveGithubPanelState(q({ isLoading: true })).kind).toBe("loading");
+    expect(deriveGithubPanelState(q({ error: new RunnerOfflineError() })).kind).toBe(
+      "runner-offline",
+    );
+    expect(deriveGithubPanelState(q({ error: new Error("boom") })).kind).toBe("error");
+  });
+
+  it("maps each unavailable reason to its own state", () => {
+    expect(deriveGithubPanelState(q({ data: undefined })).kind).toBe("unavailable");
+    expect(
+      deriveGithubPanelState(
+        q({ data: { object: "session.github.info", available: false, reason: "no_os_env" } }),
+      ).kind,
+    ).toBe("unavailable");
+    expect(
+      deriveGithubPanelState(
+        q({ data: { object: "session.github.info", available: false, reason: "not_a_git_repo" } }),
+      ).kind,
+    ).toBe("not-a-git-repo");
+    expect(
+      deriveGithubPanelState(
+        q({ data: { object: "session.github.info", available: false, reason: "host_outdated" } }),
+      ).kind,
+    ).toBe("host-outdated");
+  });
+
+  it("walks the gh layer: cli → auth → repo → pr → ready", () => {
+    expect(deriveGithubPanelState(q({ data: { ...ready, gh_available: false } })).kind).toBe(
+      "no-gh-cli",
+    );
+    expect(deriveGithubPanelState(q({ data: { ...ready, authenticated: false } })).kind).toBe(
+      "repo-unresolved",
+    );
+    expect(deriveGithubPanelState(q({ data: { ...ready, repo: null } })).kind).toBe(
+      "repo-unresolved",
+    );
+    const noPr = deriveGithubPanelState(q({ data: { ...ready, pr: null } }));
+    expect(noPr).toEqual({ kind: "no-pr", branch: "feat/x" });
+    expect(deriveGithubPanelState(q({ data: ready }))).toEqual({ kind: "ready" });
   });
 });

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -11,9 +11,11 @@
 // reader expands unchanged context.
 //
 // Data comes from the runner's read-only GitHub resource API (see
-// hooks/useGithub.ts), which shells out to `gh` + `git`. When gh is missing /
-// unauthenticated / the workspace isn't a repo, the panel renders a message
-// rather than an error.
+// hooks/useGithub.ts), which shells out to `gh` + `git`. `deriveGithubPanelState`
+// is the single switch that turns the info query into what the panel shows: an
+// outdated host, a non-git workspace, a missing `gh` CLI, an unresolved
+// upstream repo, or no open PR each render their own empty state, and only an
+// open PR falls through to the header + stacked diff.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -21,22 +23,28 @@ import {
   ChevronRightIcon,
   ChevronsDownUpIcon,
   ChevronsUpDownIcon,
+  AlertCircleIcon,
   CircleCheckIcon,
   CircleDotIcon,
   CircleXIcon,
   Columns2Icon,
+  DownloadIcon,
   ExternalLinkIcon,
   FileDiffIcon,
   FileMinusIcon,
   FilePlusIcon,
   FileSymlinkIcon,
   FolderIcon,
+  GitBranchIcon,
+  GitPullRequestIcon,
+  KeyRoundIcon,
   Loader2Icon,
   type LucideIcon,
   PanelLeftCloseIcon,
   PanelLeftOpenIcon,
   RefreshCwIcon,
   Rows2Icon,
+  TerminalIcon,
 } from "lucide-react";
 import { FileDiff } from "@pierre/diffs/react";
 import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
@@ -56,19 +64,85 @@ import {
   useGithubPrDiff,
   type GithubChangedFile,
   type GithubCheckRun,
+  type GithubInfo,
 } from "@/hooks/useGithub";
 
 // Shiki bundled themes matching the app's editor look; the concrete side is
 // chosen by `themeType` from the app's resolved light/dark mode.
 const DIFF_THEME = { dark: "github-dark", light: "github-light" } as const;
 
-/** Centered muted message filling the panel — the shared empty/error/loading shell. */
+/** Centered muted message filling the panel — the shared loading/transient shell. */
 function PanelMessage({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-ui text-muted-foreground">
       {children}
     </div>
   );
+}
+
+/** Full-panel empty state: an icon, a title, and an optional hint line. Used
+ *  for every "no GitHub content to show" reason so they read as one family. */
+function GithubEmptyState({
+  icon: Icon,
+  title,
+  hint,
+}: {
+  icon: LucideIcon;
+  title: React.ReactNode;
+  hint?: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+      <Icon className="size-8 text-muted-foreground/50" />
+      <p className="text-ui font-medium text-foreground">{title}</p>
+      {hint && <p className="max-w-xs text-ui text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}
+
+/** The one thing the panel should show, derived from the info query. Every
+ *  non-`ready` kind is a whole-panel state; `ready` renders the PR + diff. */
+export type GithubPanelState =
+  | { kind: "loading" }
+  | { kind: "runner-offline" }
+  | { kind: "error"; message: string }
+  | { kind: "host-outdated" }
+  | { kind: "unavailable" }
+  | { kind: "not-a-git-repo" }
+  | { kind: "no-gh-cli" }
+  | { kind: "repo-unresolved" }
+  | { kind: "no-pr"; branch: string | undefined }
+  | { kind: "ready" };
+
+/** Central switch turning the GitHub info query into the panel's state.
+ *
+ * Order matters: transient states (loading/offline/error) first, then the
+ * git-first availability reasons, then the `gh` enhancement layer (CLI → auth
+ * → repo → PR). `ready` is reached only with an open PR to render. */
+export function deriveGithubPanelState(info: {
+  isLoading: boolean;
+  error: unknown;
+  data: GithubInfo | undefined;
+}): GithubPanelState {
+  if (info.isLoading) return { kind: "loading" };
+  if (info.error) {
+    if (info.error instanceof RunnerOfflineError) return { kind: "runner-offline" };
+    return { kind: "error", message: (info.error as Error).message };
+  }
+  const data = info.data;
+  if (!data || !data.available) {
+    if (data?.reason === "not_a_git_repo") return { kind: "not-a-git-repo" };
+    if (data?.reason === "host_outdated") return { kind: "host-outdated" };
+    return { kind: "unavailable" };
+  }
+  // Git repo present; `gh` layers PR/repo metadata on top of it.
+  if (data.gh_available === false) return { kind: "no-gh-cli" };
+  // Not signed in, or signed in but the upstream repo can't be resolved —
+  // both point the user at `gh auth status`.
+  if (data.authenticated === false) return { kind: "repo-unresolved" };
+  if (!data.repo?.name_with_owner) return { kind: "repo-unresolved" };
+  if (!data.pr) return { kind: "no-pr", branch: data.branch };
+  return { kind: "ready" };
 }
 
 /** A ghost icon button with a tooltip; the toolbar's shared control element.
@@ -627,38 +701,96 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
   };
 
   // ── Whole-panel states (before the header + stacked diff) ───────────────
-  if (info.isLoading) {
-    return (
-      <PanelMessage>
-        <Loader2Icon className="size-5 animate-spin" />
-        Loading GitHub…
-      </PanelMessage>
-    );
-  }
-  if (info.error) {
-    if (info.error instanceof RunnerOfflineError) {
+  // One central switch: every non-`ready` kind returns its own whole-panel
+  // state, so the diff below renders only when there's an open PR.
+  const panelState = deriveGithubPanelState({
+    isLoading: info.isLoading,
+    error: info.error,
+    data: info.data,
+  });
+  switch (panelState.kind) {
+    case "loading":
+      return (
+        <PanelMessage>
+          <Loader2Icon className="size-5 animate-spin" />
+          Loading GitHub…
+        </PanelMessage>
+      );
+    case "runner-offline":
       return (
         <PanelMessage>The agent is asleep. Send a message to reconnect its runner.</PanelMessage>
       );
-    }
-    return <PanelMessage>Couldn’t load GitHub info: {(info.error as Error).message}</PanelMessage>;
-  }
-  const data = info.data;
-  if (!data || !data.available) {
-    if (data?.reason === "not_a_git_repo") {
-      return <PanelMessage>This workspace isn’t a git repository.</PanelMessage>;
-    }
-    return <PanelMessage>GitHub isn’t available for this session.</PanelMessage>;
+    case "error":
+      return <PanelMessage>Couldn’t load GitHub info: {panelState.message}</PanelMessage>;
+    case "host-outdated":
+      return (
+        <GithubEmptyState
+          icon={DownloadIcon}
+          title="Update your host to use GitHub"
+          hint="The GitHub panel needs the host running Omnigent 0.13.0 or later. Update the host, then reconnect the session."
+        />
+      );
+    case "not-a-git-repo":
+      return (
+        <GithubEmptyState
+          icon={GitBranchIcon}
+          title="Not a git repository"
+          hint="This workspace isn’t a git checkout, so there’s no branch or PR to show."
+        />
+      );
+    case "no-gh-cli":
+      return (
+        <GithubEmptyState
+          icon={TerminalIcon}
+          title="GitHub CLI not found"
+          hint={
+            <>
+              Install the GitHub CLI (<span className="font-mono">gh</span>) on the host to see this
+              branch’s pull request and CI status.
+            </>
+          }
+        />
+      );
+    case "repo-unresolved":
+      return (
+        <GithubEmptyState
+          icon={KeyRoundIcon}
+          title="Can’t reach the upstream repo"
+          hint={
+            <>
+              Run <span className="font-mono">gh auth status</span> on the host to confirm the
+              GitHub CLI is signed in to the right account.
+            </>
+          }
+        />
+      );
+    case "no-pr":
+      // TODO: offer a "Create PR" action here once the panel can open PRs.
+      return (
+        <GithubEmptyState
+          icon={GitPullRequestIcon}
+          title={
+            <>
+              No open PR for <span className="font-mono">{panelState.branch ?? "this branch"}</span>
+            </>
+          }
+          hint="When you open a pull request for this branch, it’ll show up here."
+        />
+      );
+    case "unavailable":
+      return (
+        <GithubEmptyState
+          icon={AlertCircleIcon}
+          title="GitHub isn’t available"
+          hint="There’s no GitHub information to show for this session."
+        />
+      );
   }
 
-  const pr = data.pr ?? null;
-  const checks = pr?.checks;
-  const ghNote =
-    data.gh_available === false
-      ? "GitHub CLI (gh) not installed — showing local branch diff."
-      : data.authenticated === false
-        ? "Not signed in — run `gh auth login` for PR info."
-        : null;
+  // ── Ready: an open PR to render as its header + the stacked diff ─────────
+  const data = info.data!;
+  const pr = data.pr!;
+  const checks = pr.checks;
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -685,66 +817,45 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
               />
             </IconButton>
           </div>
-          {pr ? (
-            <>
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                <a
-                  href={pr.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="group inline-flex min-w-0 items-center gap-1 text-ui font-medium hover:underline"
-                >
-                  <span className="truncate">{pr.title}</span>
-                  <span className="shrink-0 text-muted-foreground">#{pr.number}</span>
-                  <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
-                </a>
-              </div>
-              {/* CI status checks (from the PR's statusCheckRollup), on their own
-                line as pills; hover a pill to see the job names in that bucket. */}
-              {checks && checks.total > 0 && (
-                <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-muted-foreground">
-                  <span className="text-ui font-medium">Checks</span>
-                  <CheckPill
-                    label="passed"
-                    count={checks.passing}
-                    runs={checks.runs.filter((r) => r.bucket === "passing")}
-                    icon={
-                      <CircleCheckIcon className="size-2.5 text-green-600 dark:text-green-400" />
-                    }
-                    className="border-green-500/25 bg-green-500/10 text-green-700 dark:text-green-400"
-                  />
-                  <CheckPill
-                    label="pending"
-                    count={checks.pending}
-                    runs={checks.runs.filter((r) => r.bucket === "pending")}
-                    icon={<CircleDotIcon className="size-2.5 text-amber-600 dark:text-amber-400" />}
-                    className="border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-400"
-                  />
-                  <CheckPill
-                    label="failed"
-                    count={checks.failing}
-                    runs={checks.runs.filter((r) => r.bucket === "failing")}
-                    icon={<CircleXIcon className="size-2.5 text-red-600 dark:text-red-400" />}
-                    className="border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-400"
-                  />
-                </div>
-              )}
-            </>
-          ) : (
-            <p className="mt-1 text-ui text-muted-foreground">
-              {ghNote ?? (
-                <>
-                  No open PR for <span className="font-mono">{data.branch}</span>
-                  {baseRef && (
-                    <>
-                      {" "}
-                      — showing changes vs <span className="font-mono">{baseRef}</span>
-                    </>
-                  )}
-                  .
-                </>
-              )}
-            </p>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <a
+              href={pr.url}
+              target="_blank"
+              rel="noreferrer"
+              className="group inline-flex min-w-0 items-center gap-1 text-ui font-medium hover:underline"
+            >
+              <span className="truncate">{pr.title}</span>
+              <span className="shrink-0 text-muted-foreground">#{pr.number}</span>
+              <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
+            </a>
+          </div>
+          {/* CI status checks (from the PR's statusCheckRollup), on their own
+            line as pills; hover a pill to see the job names in that bucket. */}
+          {checks.total > 0 && (
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-muted-foreground">
+              <span className="text-ui font-medium">Checks</span>
+              <CheckPill
+                label="passed"
+                count={checks.passing}
+                runs={checks.runs.filter((r) => r.bucket === "passing")}
+                icon={<CircleCheckIcon className="size-2.5 text-green-600 dark:text-green-400" />}
+                className="border-green-500/25 bg-green-500/10 text-green-700 dark:text-green-400"
+              />
+              <CheckPill
+                label="pending"
+                count={checks.pending}
+                runs={checks.runs.filter((r) => r.bucket === "pending")}
+                icon={<CircleDotIcon className="size-2.5 text-amber-600 dark:text-amber-400" />}
+                className="border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+              />
+              <CheckPill
+                label="failed"
+                count={checks.failing}
+                runs={checks.runs.filter((r) => r.bucket === "failing")}
+                icon={<CircleXIcon className="size-2.5 text-red-600 dark:text-red-400" />}
+                className="border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-400"
+              />
+            </div>
           )}
           {/* Controls bar: hide the file list (left); toggle layout + expand/
             collapse every diff (right). */}


### PR DESCRIPTION
## Related issue

No tracked issue — this fixes a bug found while debugging the GitHub side panel:
an outdated host showed a misleading "GitHub isn't available for this session."
message with no hint to update. Happy to file one if the team wants it linked.

Closes #

## Summary

- The GitHub side panel funneled several unrelated conditions into one generic
  **"GitHub isn't available for this session."** message. The worst case: a host
  predating the `/resources/github` route 404s `Resource 'github' not found`,
  which rendered as that same generic string — the user had no way to know their
  host was simply out of date.
- Route the info query through a single **`deriveGithubPanelState()`** switch and
  give each reason its own full-panel empty state (icon + title + hint): outdated
  host (update to 0.13.0+), not a git repo, missing `gh` CLI, unresolved upstream
  repo (check `gh auth status`), and no open PR (names the branch; a Create-PR
  action is left as a `TODO`). Only an open PR falls through to the PR header +
  stacked diff.
- Detect the outdated host by preserving the 404 body and matching its
  `Resource 'github' not found` message (`githubNotFoundReason`), since a
  *current* runner 404s the same path with different messages (headless session,
  missing workspace dir). Marked `@deprecated` for removal ~0.16.0 once
  sub-0.13.0 hosts age out.

**ELI5:** the panel used to say "GitHub isn't available" for five different
reasons. Now it tells you *which* reason and what to do about it.

**Behavior change:** the branch-vs-base diff now renders only when there's an
open PR (the panel is PR-scoped). Working-tree changes still live in the
**Changes** tab.

### State mapping

```mermaid
flowchart TD
    Q[github info query] --> L{loading?}
    L -- yes --> Loading
    L -- no --> E{error?}
    E -- RunnerOffline --> RO[runner-offline]
    E -- other --> Err[error]
    E -- none --> A{available?}
    A -- "reason: host_outdated" --> HO[host-outdated: update host]
    A -- "reason: not_a_git_repo" --> NG[not-a-git-repo]
    A -- other / no data --> UN[unavailable]
    A -- yes --> G{gh present?}
    G -- no --> NC[no-gh-cli: install gh]
    G -- yes --> AU{authed & repo?}
    AU -- no --> RU[repo-unresolved: check gh auth]
    AU -- yes --> P{open PR?}
    P -- no --> NP[no-pr: names branch]
    P -- yes --> RD[ready: header + diff]
```

## Test Plan

- **Added unit tests:**
  - `deriveGithubPanelState` — transient ordering (loading / runner-offline /
    error), each unavailable reason (`not_a_git_repo` / `host_outdated` /
    generic), and the gh layer walk (cli → auth → repo → pr → ready).
  - `githubNotFoundReason` — the 404 classifier (old-host message →
    `host_outdated`; every other 404 → `no_os_env`).
  - Updated `GithubPanel.test.tsx` for the new empty states and asserted the
    diff is hidden in each.
- **Not run locally:** `pnpm type-check` / `vitest` / `pnpm lint` — this
  environment has no network to `pnpm install` the web deps. Please run before
  merge:
  ```bash
  cd web && pnpm install
  pnpm type-check
  pnpm test src/shell/GithubPanel.test.tsx src/hooks/useGithub.test.ts
  pnpm lint
  ```
- **Manual (recommended):** open a session's **GitHub** tab and reproduce each
  state — old host (< 0.13.0), `gh` off `PATH`, `gh auth logout`, non-git
  workspace, a branch with no open PR, and a branch with an open PR (unchanged).

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

> ⚠️ This is a UI change, but I couldn't run the frontend in this environment to
> capture screenshots. **Screenshots of the new empty states should be attached
> before merge:** outdated host, missing `gh` CLI, `gh auth`, not-a-git-repo, and
> no-open-PR.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the new `deriveGithubPanelState` state machine and the
`githubNotFoundReason` 404 classifier. `type-check` / `vitest` / `lint` were
**not** executed locally (no network to install web deps) — exact commands are
in the Test Plan. Manual visual verification of each empty state is still
pending (see Demo).

## Changelog

The GitHub panel now names each reason it has nothing to show — an outdated
host, a missing `gh` CLI, a wrong `gh` auth, a non-git workspace, or no open PR
— instead of a single generic "unavailable" message.

---

This pull request and its description were written by Isaac.
