### PR TITLE
feat(web): single-row shell menu with hover flyout + new-shell hotkey

### DIFF
--- a/web/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.test.tsx
@@ -87,6 +87,7 @@ describe("KeyboardShortcutsDialog", () => {
     expect(screen.getByText("Recall previous prompt")).toBeTruthy();
     expect(screen.getByText("Previous session")).toBeTruthy();
     expect(screen.getByText("Toggle conversations sidebar")).toBeTruthy();
+    expect(screen.getByText("Open a new shell")).toBeTruthy();
     expect(screen.getByText("Navigate suggestions")).toBeTruthy();
   });
 

--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -92,6 +92,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     items: [
       { label: "Toggle conversations sidebar", keys: [MOD_KEY, ALT_KEY, "["] },
       { label: "Toggle workspace sidebar", keys: [MOD_KEY, ALT_KEY, "]"] },
+      { label: "Open a new shell", keys: [MOD_KEY, ALT_KEY, "T"] },
     ],
   },
   {

--- a/web/src/hooks/useNewShellHotkey.test.tsx
+++ b/web/src/hooks/useNewShellHotkey.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isNewShellHotkey, useNewShellHotkey } from "./useNewShellHotkey";
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+function event(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+function press(init: KeyboardEventInit, target: HTMLElement = document.body): KeyboardEvent {
+  const e = event(init);
+  target.dispatchEvent(e);
+  return e;
+}
+
+describe("isNewShellHotkey", () => {
+  it("uses Cmd+Alt on macOS and Ctrl+Alt on other platforms", () => {
+    expect(isNewShellHotkey(event({ code: "KeyT", metaKey: true, altKey: true }), true)).toBe(true);
+    expect(isNewShellHotkey(event({ code: "KeyT", ctrlKey: true, altKey: true }), true)).toBe(
+      false,
+    );
+    expect(isNewShellHotkey(event({ code: "KeyT", ctrlKey: true, altKey: true }), false)).toBe(
+      true,
+    );
+    expect(isNewShellHotkey(event({ code: "KeyT", metaKey: true, altKey: true }), false)).toBe(
+      false,
+    );
+  });
+
+  it("requires Alt and rejects Shift or a missing modifier", () => {
+    // No Alt → not the chord (that's the address-bar / other bindings).
+    expect(isNewShellHotkey(event({ code: "KeyT", metaKey: true }), true)).toBe(false);
+    // Shift added → reserved (browser reopen-tab); not ours.
+    expect(
+      isNewShellHotkey(event({ code: "KeyT", metaKey: true, altKey: true, shiftKey: true }), true),
+    ).toBe(false);
+  });
+
+  it("matches the physical key so Alt's remapped character doesn't matter", () => {
+    // ⌥T yields "†" on macOS; keying off e.code (not e.key) still matches.
+    expect(
+      isNewShellHotkey(event({ code: "KeyT", key: "†", metaKey: true, altKey: true }), true),
+    ).toBe(true);
+    expect(isNewShellHotkey(event({ code: "KeyG", metaKey: true, altKey: true }), true)).toBe(
+      false,
+    );
+  });
+});
+
+describe("useNewShellHotkey", () => {
+  it("launches the default shell and claims the chord", () => {
+    const onLaunch = vi.fn();
+    renderHook(() => useNewShellHotkey(onLaunch, true, false));
+
+    const e = press({ code: "KeyT", ctrlKey: true, altKey: true });
+
+    expect(onLaunch).toHaveBeenCalledTimes(1);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("defers to a focused terminal (xterm) — that surface owns its keystrokes", () => {
+    const onLaunch = vi.fn();
+    renderHook(() => useNewShellHotkey(onLaunch, true, false));
+    const term = document.createElement("div");
+    term.className = "xterm";
+    const inner = document.createElement("textarea");
+    term.appendChild(inner);
+    document.body.appendChild(term);
+    inner.focus();
+
+    const e = press({ code: "KeyT", ctrlKey: true, altKey: true }, inner);
+
+    expect(onLaunch).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("defers to a focused Monaco editor", () => {
+    const onLaunch = vi.fn();
+    renderHook(() => useNewShellHotkey(onLaunch, true, false));
+    const editor = document.createElement("div");
+    editor.className = "monaco-editor";
+    const inner = document.createElement("textarea");
+    editor.appendChild(inner);
+    document.body.appendChild(editor);
+    inner.focus();
+
+    press({ code: "KeyT", ctrlKey: true, altKey: true }, inner);
+
+    expect(onLaunch).not.toHaveBeenCalled();
+  });
+
+  it("still fires from a plain input (only editor/terminal surfaces defer)", () => {
+    const onLaunch = vi.fn();
+    renderHook(() => useNewShellHotkey(onLaunch, true, false));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    press({ code: "KeyT", ctrlKey: true, altKey: true }, input);
+
+    expect(onLaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores auto-repeat", () => {
+    const onLaunch = vi.fn();
+    renderHook(() => useNewShellHotkey(onLaunch, true, false));
+
+    press({ code: "KeyT", ctrlKey: true, altKey: true, repeat: true });
+
+    expect(onLaunch).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when disabled (no shell access / offline session)", () => {
+    const onLaunch = vi.fn();
+    renderHook(() => useNewShellHotkey(onLaunch, false, false));
+
+    const e = press({ code: "KeyT", ctrlKey: true, altKey: true });
+
+    expect(onLaunch).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
+  });
+});

--- a/web/src/hooks/useNewShellHotkey.test.tsx
+++ b/web/src/hooks/useNewShellHotkey.test.tsx
@@ -12,6 +12,13 @@ function event(init: KeyboardEventInit): KeyboardEvent {
   return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
 }
 
+/** An event whose getModifierState reports AltGraph active (jsdom can't set it via init). */
+function altGraphEvent(init: KeyboardEventInit): KeyboardEvent {
+  const e = event(init);
+  Object.defineProperty(e, "getModifierState", { value: (k: string) => k === "AltGraph" });
+  return e;
+}
+
 function press(init: KeyboardEventInit, target: HTMLElement = document.body): KeyboardEvent {
   const e = event(init);
   target.dispatchEvent(e);
@@ -38,6 +45,14 @@ describe("isNewShellHotkey", () => {
     // Shift added → reserved (browser reopen-tab); not ours.
     expect(
       isNewShellHotkey(event({ code: "KeyT", metaKey: true, altKey: true, shiftKey: true }), true),
+    ).toBe(false);
+  });
+
+  it("rejects AltGr+T — reported as Ctrl+Alt on intl layouts, must not be the chord", () => {
+    // A bare AltGr+T (no real Ctrl) on Windows/Linux would otherwise match the
+    // Ctrl+Alt predicate and swallow the character; the AltGraph guard bails.
+    expect(
+      isNewShellHotkey(altGraphEvent({ code: "KeyT", ctrlKey: true, altKey: true }), false),
     ).toBe(false);
   });
 
@@ -104,6 +119,20 @@ describe("useNewShellHotkey", () => {
     press({ code: "KeyT", ctrlKey: true, altKey: true }, input);
 
     expect(onLaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire or swallow an AltGr+T keystroke (intl layouts type into the composer)", () => {
+    const onLaunch = vi.fn();
+    renderHook(() => useNewShellHotkey(onLaunch, true, false));
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    const e = altGraphEvent({ code: "KeyT", ctrlKey: true, altKey: true });
+    input.dispatchEvent(e);
+
+    expect(onLaunch).not.toHaveBeenCalled();
+    expect(e.defaultPrevented).toBe(false);
   });
 
   it("ignores auto-repeat", () => {

--- a/web/src/hooks/useNewShellHotkey.ts
+++ b/web/src/hooks/useNewShellHotkey.ts
@@ -24,6 +24,11 @@ function isMacPlatform(): boolean {
 export function isNewShellHotkey(e: globalThis.KeyboardEvent, isMac = isMacPlatform()): boolean {
   const platformModifier = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
   if (!platformModifier || !e.altKey || e.shiftKey) return false;
+  // AltGr reports as Ctrl+Alt on Windows/Linux, so an ordinary AltGr+T
+  // keystroke on an international layout would otherwise match this chord (and
+  // get swallowed). Bail so intl typing never launches a shell — same guard the
+  // sibling hotkeys carry.
+  if (typeof e.getModifierState === "function" && e.getModifierState("AltGraph")) return false;
   // Match the physical key: Alt remaps the character on many layouts (e.g.
   // ⌥T is "†" on macOS), so keying off e.key would miss the chord.
   return e.code === "KeyT";

--- a/web/src/hooks/useNewShellHotkey.ts
+++ b/web/src/hooks/useNewShellHotkey.ts
@@ -1,0 +1,69 @@
+// ⌘⌥T (Ctrl+Alt+T on Win/Linux) opens a new shell in the workspace rail,
+// launching the remembered default type — the keyboard path for the tab-strip
+// "+" menu, whose row launches on click (mouse-only otherwise). Sibling to the
+// other app-shell hotkeys (⌘K palette, ⌘⌥[ / ⌘⌥] sidebars); like them it's
+// bound ONCE at the app shell, where the shell-launch wiring lives.
+//
+// Why ⌘⌥T: it joins the app's ⌘⌥ family (sidebar toggles, voice) with no
+// browser/OS clash — unlike ⌘` (macOS window cycling) or ⌘⇧T (browser reopen-
+// tab). "T" for terminal.
+
+import { useEffect, useRef } from "react";
+
+/** Editor/terminal surfaces that own their own keystrokes; the chord defers. */
+const TEXT_ENTRY_SURFACE = ".monaco-editor, .xterm";
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const uaData = (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData;
+  const platform = uaData?.platform ?? navigator.platform ?? navigator.userAgent ?? "";
+  return /Mac|iPhone|iPad|iPod/i.test(platform);
+}
+
+/** True for Cmd+Alt+T on Apple platforms or Ctrl+Alt+T elsewhere. */
+export function isNewShellHotkey(e: globalThis.KeyboardEvent, isMac = isMacPlatform()): boolean {
+  const platformModifier = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+  if (!platformModifier || !e.altKey || e.shiftKey) return false;
+  // Match the physical key: Alt remaps the character on many layouts (e.g.
+  // ⌥T is "†" on macOS), so keying off e.key would miss the chord.
+  return e.code === "KeyT";
+}
+
+/**
+ * Bind ⌘/Ctrl+Alt+T to open a new shell. Bind ONCE at the app shell.
+ *
+ * The chord defers to a focused Monaco editor or xterm terminal — those
+ * surfaces own their keystrokes, and stealing the chord mid-edit would surprise
+ * the user. It fires only when ``enabled`` (the caller gates on the session
+ * declaring shell access and being reachable).
+ *
+ * @param onLaunch Open the default shell (no-op if the caller can't right now).
+ * @param enabled  Pass ``false`` to disable (no session, no shell access, or an
+ *   offline session the browser can't reconnect). Defaults to enabled.
+ */
+export function useNewShellHotkey(
+  onLaunch: () => void,
+  enabled = true,
+  isMac = isMacPlatform(),
+): void {
+  // Held in a ref so the bound handler always calls the latest closure without
+  // re-registering on every render.
+  const latest = useRef(onLaunch);
+  latest.current = onLaunch;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const handler = (e: globalThis.KeyboardEvent): void => {
+      // Ignore auto-repeat: holding the chord would spawn a shell per tick.
+      if (e.repeat || !isNewShellHotkey(e, isMac)) return;
+      // Leave the chord to a focused editor/terminal that consumes keystrokes.
+      const el = document.activeElement;
+      if (el instanceof Element && el.closest(TEXT_ENTRY_SURFACE) !== null) return;
+      e.preventDefault();
+      e.stopPropagation();
+      latest.current();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [enabled, isMac]);
+}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1482,11 +1482,14 @@ export function AppShell() {
   // focus path the menu uses (mark-start snapshot, then focus the tab). Gated
   // on the session declaring shell access and being reachable: an offline
   // session can't be reconnected from the browser, so the chord is inert there,
-  // matching the menu item's disabled state.
+  // matching the menu item's disabled state. Also inert while a create is in
+  // flight, so two quick presses can't spawn two shells (the menu disables its
+  // item on create.isPending for the same reason).
   const createTerminal = useCreateTerminal(conversationId ?? "");
   const shellLaunchable =
     agentSupportsShells &&
     !!conversationId &&
+    !createTerminal.isPending &&
     liveness?.kind !== "host_offline" &&
     liveness?.kind !== "local_stranded";
   const launchDefaultShell = useCallback(() => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -13,6 +13,7 @@ import { useApproveHotkey } from "@/hooks/useApproveHotkey";
 import { useSidebarToggleHotkeys } from "@/hooks/useSidebarToggleHotkeys";
 import { useCommandPaletteHotkey } from "@/hooks/useCommandPaletteHotkey";
 import { useNewSessionHotkey } from "@/hooks/useNewSessionHotkey";
+import { useNewShellHotkey } from "@/hooks/useNewShellHotkey";
 import { useIsEmbedded } from "@/lib/embedded";
 import { AgentInfoContent, agentHasInfo } from "@/components/AgentInfo";
 import { useIdleNotifications } from "@/hooks/useIdleNotifications";
@@ -64,6 +65,7 @@ import {
   isAgentTerminalKey,
   PANEL_NO_TERMINAL_KEY,
   terminalTabKey,
+  useCreateTerminal,
   useDeleteTerminal,
   useTerminals,
 } from "@/hooks/useTerminals";
@@ -112,6 +114,7 @@ import { CloseShellDialog } from "./CloseShellDialog";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { ForkDialogContextProvider, type ForkDialogContextValue } from "./ForkDialogContext";
 import { InlineTerminalsSection } from "./InlineTerminalsSection";
+import { resolveDefaultShell } from "./preferredShell";
 import { WorkspacePanel } from "./WorkspacePanel";
 import { SessionRail } from "./SessionRail";
 import type { RightRailTab } from "./railTabs";
@@ -1473,6 +1476,35 @@ export function AppShell() {
     },
     [clearFileViewerUrl, conversationId],
   );
+
+  // ⌘⌥T (Ctrl+Alt+T) opens a new shell — the keyboard path for the tab-strip
+  // "+" menu, launching the remembered default type via the same create +
+  // focus path the menu uses (mark-start snapshot, then focus the tab). Gated
+  // on the session declaring shell access and being reachable: an offline
+  // session can't be reconnected from the browser, so the chord is inert there,
+  // matching the menu item's disabled state.
+  const createTerminal = useCreateTerminal(conversationId ?? "");
+  const shellLaunchable =
+    agentSupportsShells &&
+    !!conversationId &&
+    liveness?.kind !== "host_offline" &&
+    liveness?.kind !== "local_stranded";
+  const launchDefaultShell = useCallback(() => {
+    const name = resolveDefaultShell(boundAgent?.terminals ?? []);
+    if (name === null) return;
+    markShellCreateStarted();
+    createTerminal.mutate(name, {
+      onSuccess: (info) => openTerminalTab(terminalTabKey(info)),
+      onError: () => clearShellCreatePending(),
+    });
+  }, [
+    boundAgent,
+    createTerminal,
+    markShellCreateStarted,
+    clearShellCreatePending,
+    openTerminalTab,
+  ]);
+  useNewShellHotkey(launchDefaultShell, shellLaunchable);
 
   // Focus a shell the user just created ("+"→Shell) as soon as its tab appears
   // — a new non-agent terminal key that wasn't present when the create started.

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -481,40 +481,10 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     expect(screen.getByRole("button", { name: "Open new" })).not.toHaveFocus();
   });
 
-  it("launches the default from the keyboard (Enter) on the multi-shell row", async () => {
-    // The default-launch control is a real menuitem, so keyboard activation
-    // (Enter/Space) fires it — it must NOT be a submenu trigger, whose open
-    // keys would only reveal the flyout and never launch.
-    useSessionAgentMock.mockReturnValue({
-      data: { terminals: ["zsh", "bash", "fish"] },
-    } as unknown as ReturnType<typeof useSessionAgent>);
-    const created = { id: "terminal_zsh_s1", name: "zsh", session: "u-2", running: true };
-    const mutate = vi.fn((_name: string, opts?: { onSuccess?: (info: unknown) => void }) =>
-      opts?.onSuccess?.(created),
-    );
-    useCreateTerminalMock.mockReturnValue({
-      mutate,
-      isPending: false,
-      isError: false,
-    } as unknown as ReturnType<typeof useCreateTerminal>);
-
-    const { openTerminalTab } = renderWorkspace({ showBrowserTab: false });
-
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
-    // Radix menuitems select on keydown Enter — same path Enter takes when the
-    // item is focused via arrow keys.
-    shellItem.focus();
-    fireEvent.keyDown(shellItem, { key: "Enter" });
-
-    expect(mutate).toHaveBeenCalledWith("zsh", expect.any(Object));
-    expect(openTerminalTab).toHaveBeenCalledWith("terminal:terminal_zsh_s1");
-  });
-
   it("does not launch on the multi-shell row when the session is offline", async () => {
-    // The launch item is disabled on an offline session, so neither a click nor
-    // keyboard activation may fire a create — the split-out menuitem (not a
-    // sub-trigger) is what preserves this guard.
+    // The row is disabled on an offline session. Its click handler is a
+    // sub-trigger's onClick (which Radix runs before its own disabled check), so
+    // the handler guards on shellDisabled itself — a click must not fire create.
     useSessionAgentMock.mockReturnValue({
       data: { terminals: ["zsh", "bash", "fish"] },
     } as unknown as ReturnType<typeof useSessionAgent>);
@@ -532,8 +502,6 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     expect(shellItem).toHaveTextContent(/offline/i);
     expect(shellItem).toHaveAttribute("aria-disabled", "true");
     fireEvent.click(shellItem);
-    shellItem.focus();
-    fireEvent.keyDown(shellItem, { key: "Enter" });
     expect(mutate).not.toHaveBeenCalled();
   });
 
@@ -551,12 +519,13 @@ describe('WorkspacePanel "+" new-tab menu', () => {
 
     renderWorkspace({ showBrowserTab: false });
 
-    // Open the flyout via the separate "Other shells" chevron (ArrowRight). It
-    // lists only the non-default types — zsh is already named in the row.
+    // Open the flyout off the "Shell (zsh)" row (ArrowRight reveals the
+    // submenu). It lists only the non-default types — zsh is already named in
+    // the row itself.
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    const otherShells = await screen.findByRole("menuitem", { name: "Other shells" });
-    otherShells.focus();
-    fireEvent.keyDown(otherShells, { key: "ArrowRight" });
+    const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
+    shellItem.focus();
+    fireEvent.keyDown(shellItem, { key: "ArrowRight" });
     expect(await screen.findByRole("menuitem", { name: /^bash$/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /^fish$/i })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: /^zsh$/i })).toBeNull();

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -448,7 +448,7 @@ describe('WorkspacePanel "+" new-tab menu', () => {
   it("names the current default in the Shell item and launches it on click when several are declared", async () => {
     // Multiple declared terminals → the "Shell" item names the default inline
     // ("Shell (zsh)") and clicking it launches that default; the OTHER types
-    // live in its flyout.
+    // live behind a separate "Other shells" chevron.
     useSessionAgentMock.mockReturnValue({
       data: { terminals: ["zsh", "bash", "fish"] },
     } as unknown as ReturnType<typeof useSessionAgent>);
@@ -481,6 +481,62 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     expect(screen.getByRole("button", { name: "Open new" })).not.toHaveFocus();
   });
 
+  it("launches the default from the keyboard (Enter) on the multi-shell row", async () => {
+    // The default-launch control is a real menuitem, so keyboard activation
+    // (Enter/Space) fires it — it must NOT be a submenu trigger, whose open
+    // keys would only reveal the flyout and never launch.
+    useSessionAgentMock.mockReturnValue({
+      data: { terminals: ["zsh", "bash", "fish"] },
+    } as unknown as ReturnType<typeof useSessionAgent>);
+    const created = { id: "terminal_zsh_s1", name: "zsh", session: "u-2", running: true };
+    const mutate = vi.fn((_name: string, opts?: { onSuccess?: (info: unknown) => void }) =>
+      opts?.onSuccess?.(created),
+    );
+    useCreateTerminalMock.mockReturnValue({
+      mutate,
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useCreateTerminal>);
+
+    const { openTerminalTab } = renderWorkspace({ showBrowserTab: false });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
+    const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
+    // Radix menuitems select on keydown Enter — same path Enter takes when the
+    // item is focused via arrow keys.
+    shellItem.focus();
+    fireEvent.keyDown(shellItem, { key: "Enter" });
+
+    expect(mutate).toHaveBeenCalledWith("zsh", expect.any(Object));
+    expect(openTerminalTab).toHaveBeenCalledWith("terminal:terminal_zsh_s1");
+  });
+
+  it("does not launch on the multi-shell row when the session is offline", async () => {
+    // The launch item is disabled on an offline session, so neither a click nor
+    // keyboard activation may fire a create — the split-out menuitem (not a
+    // sub-trigger) is what preserves this guard.
+    useSessionAgentMock.mockReturnValue({
+      data: { terminals: ["zsh", "bash", "fish"] },
+    } as unknown as ReturnType<typeof useSessionAgent>);
+    const mutate = vi.fn();
+    useCreateTerminalMock.mockReturnValue({
+      mutate,
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useCreateTerminal>);
+
+    renderWorkspace({ liveness: { kind: "local_stranded" } });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
+    const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
+    expect(shellItem).toHaveTextContent(/offline/i);
+    expect(shellItem).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(shellItem);
+    shellItem.focus();
+    fireEvent.keyDown(shellItem, { key: "Enter" });
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
   it("lists only the OTHER types in the flyout and remembers a pick as the new default (persisted)", async () => {
     window.localStorage.removeItem("omnigent:preferred-shell");
     useSessionAgentMock.mockReturnValue({
@@ -495,12 +551,12 @@ describe('WorkspacePanel "+" new-tab menu', () => {
 
     renderWorkspace({ showBrowserTab: false });
 
-    // Open the "Shell (zsh)" flyout (ArrowRight). It lists only the non-default
-    // types — zsh is already named in the row itself.
+    // Open the flyout via the separate "Other shells" chevron (ArrowRight). It
+    // lists only the non-default types — zsh is already named in the row.
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
-    shellItem.focus();
-    fireEvent.keyDown(shellItem, { key: "ArrowRight" });
+    const otherShells = await screen.findByRole("menuitem", { name: "Other shells" });
+    otherShells.focus();
+    fireEvent.keyDown(otherShells, { key: "ArrowRight" });
     expect(await screen.findByRole("menuitem", { name: /^bash$/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /^fish$/i })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: /^zsh$/i })).toBeNull();

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -445,10 +445,10 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     await waitFor(() => expect(screen.queryByRole("menuitem", { name: /shell/i })).toBeNull());
   });
 
-  it("launches the default shell from the top 'Shell' item when several are declared", async () => {
-    // Multiple declared terminals → a top "Shell" item launches the default
-    // (declared[0] with no prior pick); the types live in the "More shells"
-    // flyout below.
+  it("names the current default in the Shell item and launches it on click when several are declared", async () => {
+    // Multiple declared terminals → the "Shell" item names the default inline
+    // ("Shell (zsh)") and clicking it launches that default; the OTHER types
+    // live in its flyout.
     useSessionAgentMock.mockReturnValue({
       data: { terminals: ["zsh", "bash", "fish"] },
     } as unknown as ReturnType<typeof useSessionAgent>);
@@ -464,9 +464,10 @@ describe('WorkspacePanel "+" new-tab menu', () => {
 
     const { openTerminalTab } = renderWorkspace({ showBrowserTab: false });
 
-    // Open the "+" menu and click the top "Shell" item (not "More shells").
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: /^shell$/i }));
+    // The default's type is shown inline in the row's label.
+    const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
+    fireEvent.click(shellItem);
 
     // Launches the default (first-declared) shell without a further pick.
     expect(mutate).toHaveBeenCalledWith("zsh", expect.any(Object));
@@ -480,7 +481,7 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     expect(screen.getByRole("button", { name: "Open new" })).not.toHaveFocus();
   });
 
-  it("remembers the flyout-picked shell type as the new default (persisted)", async () => {
+  it("lists only the OTHER types in the flyout and remembers a pick as the new default (persisted)", async () => {
     window.localStorage.removeItem("omnigent:preferred-shell");
     useSessionAgentMock.mockReturnValue({
       data: { terminals: ["zsh", "bash", "fish"] },
@@ -494,18 +495,23 @@ describe('WorkspacePanel "+" new-tab menu', () => {
 
     renderWorkspace({ showBrowserTab: false });
 
-    // Open the "More shells" flyout (ArrowRight) and pick "bash", which persists
-    // as the preferred type under the app-global key.
+    // Open the "Shell (zsh)" flyout (ArrowRight). It lists only the non-default
+    // types — zsh is already named in the row itself.
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    const moreShells = await screen.findByRole("menuitem", { name: /more shells/i });
-    moreShells.focus();
-    fireEvent.keyDown(moreShells, { key: "ArrowRight" });
-    fireEvent.click(await screen.findByRole("menuitem", { name: /^bash$/i }));
+    const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
+    shellItem.focus();
+    fireEvent.keyDown(shellItem, { key: "ArrowRight" });
+    expect(await screen.findByRole("menuitem", { name: /^bash$/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /^fish$/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /^zsh$/i })).toBeNull();
+
+    // Pick "bash": launches it and persists as the preferred type (app-global).
+    fireEvent.click(screen.getByRole("menuitem", { name: /^bash$/i }));
     expect(mutate).toHaveBeenCalledWith("bash", expect.any(Object));
     expect(window.localStorage.getItem("omnigent:preferred-shell")).toBe("bash");
 
-    // A fresh menu seeds its default from the persisted pick — the top "Shell"
-    // item now launches bash.
+    // A fresh menu seeds its default from the persisted pick — the row now reads
+    // "Shell (bash)" and launches bash on click.
     cleanup();
     mutate.mockClear();
     useSessionAgentMock.mockReturnValue({
@@ -513,7 +519,7 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     } as unknown as ReturnType<typeof useSessionAgent>);
     renderWorkspace({ showBrowserTab: false });
     fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), { button: 0 });
-    fireEvent.click(await screen.findByRole("menuitem", { name: /^shell$/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: /shell \(bash\)/i }));
     expect(mutate).toHaveBeenCalledWith("bash", expect.any(Object));
 
     window.localStorage.removeItem("omnigent:preferred-shell");

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -7,7 +7,6 @@ import {
   Loader2Icon,
   MaximizeIcon,
   MinimizeIcon,
-  MoreHorizontalIcon,
   PlusIcon,
   TerminalIcon,
   XIcon,
@@ -85,12 +84,13 @@ function readPreferredShell(): string | null {
 
 // ---------------------------------------------------------------------------
 // NewTabMenu — the "+" affordance in the tab strip. Opens a small dropdown
-// ("Open new") to spin up a Shell as a rail tab. A top "Shell" item launches
-// the remembered default (the last-picked type, else the first declared name);
-// when several types are declared, a "More shells" flyout lists them all so the
-// user can pick a specific one (remembered as the new default). The flyout
-// trigger only reveals the submenu — it never launches. Gated on the agent's
-// spec declaring terminal access — renders nothing else.
+// ("Open new") to spin up a Shell as a rail tab. A single "Shell" item both
+// launches and picks the type: clicking its label launches the remembered
+// default (the last-picked type, else the first declared name), and the item
+// names that default inline — "Shell (zsh)". When several types are declared,
+// the same row carries a flyout (chevron) listing the OTHER types; picking one
+// launches it and remembers it as the new default. Gated on the agent's spec
+// declaring terminal access — renders nothing otherwise.
 //
 // The "Shell" item also reflects the session's liveness so opening a shell on
 // a disconnected session isn't a silent 502:
@@ -163,7 +163,7 @@ function NewTabMenu({
   // per conversation, reached via its own pinned tab, so it's not offered here.)
   if (!canOpenShell) return null;
 
-  // The default launched on a plain "Shell" click: the remembered pick when it
+  // The default launched by the primary segment: the remembered pick when it
   // is still a declared type, else the first declared name.
   const defaultShell =
     preferred !== null && declaredTerminals.includes(preferred) ? preferred : declaredTerminals[0];
@@ -192,17 +192,21 @@ function NewTabMenu({
     launchShell(name);
   };
 
-  // One declared shell → just the "Shell" item. Several → a "More shells"
-  // flyout to pick a specific type.
+  // One declared shell → a plain "Shell" item. Several → the same row carries a
+  // flyout to the other types.
   const multipleShells = declaredTerminals.length > 1;
+  // The other declared types, shown in the row's flyout (the current default is
+  // already named in the row itself).
+  const otherShells = declaredTerminals.filter((name) => name !== defaultShell);
 
   // Liveness-derived affordance for the "Shell" item. A create in flight on a
   // wakeable session reads "Reconnecting…" (the server is waking the runner);
   // an offline session disables the item since the browser can't reconnect it.
   const isReconnecting = create.isPending && connectState === "wakeable";
   const shellDisabled = create.isPending || connectState === "offline";
-  // Icon + label + trailing hint for the "Shell" item, reflecting the connect
-  // state.
+  // Icon + label + trailing hint for the "Shell" item. The label names the
+  // current default inline — "Shell (zsh)" — so the type is visible without
+  // opening the flyout.
   const shellItemContent = (
     <>
       {isReconnecting ? (
@@ -210,7 +214,9 @@ function NewTabMenu({
       ) : (
         <TerminalIcon className="size-4" />
       )}
-      <span className="whitespace-nowrap">{isReconnecting ? "Reconnecting…" : "Shell"}</span>
+      <span className="whitespace-nowrap">
+        {isReconnecting ? "Reconnecting…" : `Shell (${defaultShell})`}
+      </span>
       {connectState === "offline" && (
         <span className="ml-auto pl-4 text-sm text-muted-foreground">Offline</span>
       )}
@@ -246,25 +252,22 @@ function NewTabMenu({
             paint over the dropdown (#3980). Only this rail menu needs it. */}
         <SuppressBrowserView />
         <DropdownMenuLabel>Open new</DropdownMenuLabel>
-        {/* Remembered default shell — the direct-launch item. */}
-        <DropdownMenuItem
-          onSelect={() => launchShell(defaultShell)}
-          disabled={shellDisabled}
-          className="cursor-pointer"
-        >
-          {shellItemContent}
-        </DropdownMenuItem>
-        {/* Other declared types live behind a flyout whose trigger only reveals
-            the submenu — it never launches, so the type list stays discoverable.
-            Picking one launches it and remembers it as the new default. */}
-        {multipleShells && (
+        {multipleShells ? (
+          // Several types → the "Shell (default)" row both launches the default
+          // (on click) and opens a flyout of the OTHER types (on hover / chevron).
+          // Picking one launches it and remembers it as the new default.
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger disabled={shellDisabled}>
-              <MoreHorizontalIcon className="size-4" />
-              <span className="whitespace-nowrap">More shells</span>
+            <DropdownMenuSubTrigger
+              disabled={shellDisabled}
+              onClick={() => launchShell(defaultShell)}
+              className="cursor-pointer"
+            >
+              {shellItemContent}
             </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              {declaredTerminals.map((name) => (
+            {/* min-w-0 drops the default 96px floor so the box hugs the shell
+                name (e.g. "bash") instead of padding it out. */}
+            <DropdownMenuSubContent className="min-w-0">
+              {otherShells.map((name) => (
                 <DropdownMenuItem
                   key={name}
                   onSelect={() => pickShell(name)}
@@ -276,6 +279,15 @@ function NewTabMenu({
               ))}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+        ) : (
+          // Single type → a plain launch item.
+          <DropdownMenuItem
+            onSelect={() => launchShell(defaultShell)}
+            disabled={shellDisabled}
+            className="cursor-pointer"
+          >
+            {shellItemContent}
+          </DropdownMenuItem>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -253,32 +253,43 @@ function NewTabMenu({
         <SuppressBrowserView />
         <DropdownMenuLabel>Open new</DropdownMenuLabel>
         {multipleShells ? (
-          // Several types → the "Shell (default)" row both launches the default
-          // (on click) and opens a flyout of the OTHER types (on hover / chevron).
-          // Picking one launches it and remembers it as the new default.
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger
+          // Several types → one visual row with TWO hit targets: a real
+          // launch item (keeps native keyboard/touch/disabled semantics) that
+          // launches the default, and a trailing chevron that opens a flyout of
+          // the OTHER types. Overloading a single sub-trigger with both actions
+          // would make the default launch mouse-only and skip the disabled
+          // guard (Radix fires the sub-trigger's onClick before its disabled
+          // check), so the two actions stay separate controls.
+          <div className="flex items-stretch">
+            <DropdownMenuItem
+              onSelect={() => launchShell(defaultShell)}
               disabled={shellDisabled}
-              onClick={() => launchShell(defaultShell)}
-              className="cursor-pointer"
+              className="flex-1 cursor-pointer"
             >
               {shellItemContent}
-            </DropdownMenuSubTrigger>
-            {/* min-w-0 drops the default 96px floor so the box hugs the shell
-                name (e.g. "bash") instead of padding it out. */}
-            <DropdownMenuSubContent className="min-w-0">
-              {otherShells.map((name) => (
-                <DropdownMenuItem
-                  key={name}
-                  onSelect={() => pickShell(name)}
-                  disabled={shellDisabled}
-                  className="cursor-pointer"
-                >
-                  {name}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
+            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                aria-label="Other shells"
+                disabled={shellDisabled}
+                className="cursor-pointer px-1.5"
+              />
+              {/* min-w-0 drops the default 96px floor so the box hugs the shell
+                  name (e.g. "bash") instead of padding it out. */}
+              <DropdownMenuSubContent className="min-w-0">
+                {otherShells.map((name) => (
+                  <DropdownMenuItem
+                    key={name}
+                    onSelect={() => pickShell(name)}
+                    disabled={shellDisabled}
+                    className="cursor-pointer"
+                  >
+                    {name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </div>
         ) : (
           // Single type → a plain launch item.
           <DropdownMenuItem

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -40,6 +40,7 @@ import type { SessionLiveness } from "@/hooks/useSessionLiveness";
 import { terminalTabKey, useCreateTerminal, useTerminals } from "@/hooks/useTerminals";
 import { SuppressBrowserView } from "@/hooks/useSuppressBrowserView";
 import GithubMono from "@lobehub/icons/es/Github/components/Mono";
+import { readPreferredShell, resolveDefaultShell, writePreferredShell } from "./preferredShell";
 import { FilesPanel } from "./FilesPanel";
 import { FileViewer } from "./FileViewer";
 import { GithubPanel } from "./GithubPanel";
@@ -66,20 +67,6 @@ function WorkspaceTabTooltip({
       <TooltipContent side="bottom">{label}</TooltipContent>
     </Tooltip>
   );
-}
-
-// localStorage key for the last shell type launched from the "+" menu, so the
-// choice is remembered across the menu's remounts (it renders in two spots) and
-// reloads. App-global (not per-session): the user's preferred shell rarely
-// varies by conversation.
-const PREFERRED_SHELL_KEY = "omnigent:preferred-shell";
-
-function readPreferredShell(): string | null {
-  try {
-    return window.localStorage.getItem(PREFERRED_SHELL_KEY);
-  } catch {
-    return null;
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -164,9 +151,9 @@ function NewTabMenu({
   if (!canOpenShell) return null;
 
   // The default launched by the primary segment: the remembered pick when it
-  // is still a declared type, else the first declared name.
-  const defaultShell =
-    preferred !== null && declaredTerminals.includes(preferred) ? preferred : declaredTerminals[0];
+  // is still a declared type, else the first declared name. Non-null here since
+  // the empty case returned above.
+  const defaultShell = resolveDefaultShell(declaredTerminals, preferred) as string;
 
   const launchShell = (name: string) => {
     setMenuOpen(false);
@@ -184,11 +171,7 @@ function NewTabMenu({
   // Launch a type and remember it as the new default for next time.
   const pickShell = (name: string) => {
     setPreferred(name);
-    try {
-      window.localStorage.setItem(PREFERRED_SHELL_KEY, name);
-    } catch {
-      /* storage unavailable — the in-memory pick still holds for this mount */
-    }
+    writePreferredShell(name);
     launchShell(name);
   };
 
@@ -253,43 +236,38 @@ function NewTabMenu({
         <SuppressBrowserView />
         <DropdownMenuLabel>Open new</DropdownMenuLabel>
         {multipleShells ? (
-          // Several types → one visual row with TWO hit targets: a real
-          // launch item (keeps native keyboard/touch/disabled semantics) that
-          // launches the default, and a trailing chevron that opens a flyout of
-          // the OTHER types. Overloading a single sub-trigger with both actions
-          // would make the default launch mouse-only and skip the disabled
-          // guard (Radix fires the sub-trigger's onClick before its disabled
-          // check), so the two actions stay separate controls.
-          <div className="flex items-stretch">
-            <DropdownMenuItem
-              onSelect={() => launchShell(defaultShell)}
+          // Several types → a single "Shell (default)" row that launches the
+          // default on click and reveals a flyout of the OTHER types on hover.
+          // The sub-trigger's built-in chevron is hidden ([&>svg:last-child]) to
+          // keep the row clean. The click handler guards on ``shellDisabled``
+          // itself because Radix runs a sub-trigger's onClick before its own
+          // disabled check — without the guard an offline session would still
+          // fire a create.
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger
               disabled={shellDisabled}
-              className="flex-1 cursor-pointer"
+              onClick={() => {
+                if (!shellDisabled) launchShell(defaultShell);
+              }}
+              className="cursor-pointer [&>svg:last-child]:hidden"
             >
               {shellItemContent}
-            </DropdownMenuItem>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger
-                aria-label="Other shells"
-                disabled={shellDisabled}
-                className="cursor-pointer px-1.5"
-              />
-              {/* min-w-0 drops the default 96px floor so the box hugs the shell
-                  name (e.g. "bash") instead of padding it out. */}
-              <DropdownMenuSubContent className="min-w-0">
-                {otherShells.map((name) => (
-                  <DropdownMenuItem
-                    key={name}
-                    onSelect={() => pickShell(name)}
-                    disabled={shellDisabled}
-                    className="cursor-pointer"
-                  >
-                    {name}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-          </div>
+            </DropdownMenuSubTrigger>
+            {/* min-w-0 drops the default 96px floor so the box hugs the shell
+                name (e.g. "bash") instead of padding it out. */}
+            <DropdownMenuSubContent className="min-w-0">
+              {otherShells.map((name) => (
+                <DropdownMenuItem
+                  key={name}
+                  onSelect={() => pickShell(name)}
+                  disabled={shellDisabled}
+                  className="cursor-pointer"
+                >
+                  {name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
         ) : (
           // Single type → a plain launch item.
           <DropdownMenuItem

--- a/web/src/shell/preferredShell.ts
+++ b/web/src/shell/preferredShell.ts
@@ -1,0 +1,42 @@
+// Shared "which shell to launch" logic for the workspace rail's "+" menu
+// (``NewTabMenu``) and the new-shell hotkey (``useNewShellHotkey``), so both
+// agree on the remembered default and persist picks the same way.
+
+// localStorage key for the last shell type launched. App-global (not
+// per-session): the user's preferred shell rarely varies by conversation, and
+// the "+" menu renders in two strip spots that must agree on the current pick.
+export const PREFERRED_SHELL_KEY = "omnigent:preferred-shell";
+
+/** The remembered shell type, or null if unset / storage unavailable. */
+export function readPreferredShell(): string | null {
+  try {
+    return window.localStorage.getItem(PREFERRED_SHELL_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist ``name`` as the preferred shell type; a no-op if storage is unavailable. */
+export function writePreferredShell(name: string): void {
+  try {
+    window.localStorage.setItem(PREFERRED_SHELL_KEY, name);
+  } catch {
+    /* storage unavailable — the in-memory pick still holds for this mount */
+  }
+}
+
+/**
+ * The shell type to launch by default from ``declared`` terminals: the
+ * remembered pick when it is still a declared type, else the first declared
+ * name. Returns null when nothing is declared (no shell to launch).
+ *
+ * @param declared Terminal names from the agent spec, in declaration order.
+ * @param preferred The remembered pick (defaults to reading localStorage).
+ */
+export function resolveDefaultShell(
+  declared: readonly string[],
+  preferred: string | null = readPreferredShell(),
+): string | null {
+  if (declared.length === 0) return null;
+  return preferred !== null && declared.includes(preferred) ? preferred : declared[0];
+}


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Two related changes to how users open a new shell from the workspace tab strip's "+" ("Open new") menu:

**1. Merge the shell picker into one row.** The menu offered a plain **Shell** item plus a separate **··· More shells** row whose nested flyout listed the shell types — burying the type switch two levels deep and never showing which shell a plain "Shell" click would launch. Now a single row names the current default inline — **"Shell (zsh)"** — launches it on click, and reveals a hover flyout of only the *other* declared types. Picking one launches it and remembers it as the new default (persisted, app-global). Single-shell agents get a plain "Shell (zsh)" item with no flyout.

**2. Add a ⌘⌥T / Ctrl+Alt+T "open new shell" hotkey.** The merged row is a Radix sub-trigger (launch on click, flyout on hover), which means launching the default from the keyboard isn't available in-menu. This hotkey restores the keyboard path: it opens a new shell launching the remembered default via the same create + focus path the menu uses. It's gated on the session declaring shell access and being reachable (inert offline, and while a create is in flight), defers to a focused editor/terminal, and carries the `AltGraph` guard the sibling hotkeys use so `AltGr+T` on international layouts isn't hijacked. Documented in the keyboard-shortcuts dialog (⌘/).

Shared default-shell resolution + localStorage persistence are factored into `web/src/shell/preferredShell.ts` so the menu and the hotkey agree.

## Test Plan

- `cd web && npm test` — the `WorkspacePanel` new-tab-menu tests were rewritten for the merged row (inline default label, flyout excludes default, offline-no-launch, persistence); new `useNewShellHotkey` tests cover the chord detector (platform, AltGr guard, physical-key match), launch, focus deferral to Monaco/xterm, auto-repeat, and disabled; `KeyboardShortcutsDialog` test asserts the new entry. All pass. Three failures in `NewChatDialog.test.tsx` are pre-existing on `main` (verified by stashing) and unrelated.
- `cd web && npm run build` — clean (tsc + vite).
- Manual: multi-shell session → row reads "Shell (zsh)", click launches zsh, hover shows `bash`/`fish`, pick `bash` → launches + row updates to "Shell (bash)", persists across reload. Press ⌘⌥T → new default shell opens and focuses; press it again while focused in a terminal → defers (no spawn). Open ⌘/ → "Open a new shell" listed under View.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<!-- Screenshots/recording of the merged "Shell (zsh)" row + flyout and the ⌘⌥T hotkey to be attached. -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: exercised the "+" menu on single- and multi-shell sessions (inline default label, one-click launch, flyout of non-default types, persisted pick) and the ⌘⌥T hotkey (launch, offline/pending inert, editor/terminal deferral). Note for the manual matrix: `Ctrl+Alt+T` is a common GNOME "open terminal" shortcut on Linux and may be intercepted by the desktop before the browser sees it — the chord may be unreachable on some Linux desktops.

## Changelog

The new-terminal menu shows the current shell inline ("Shell (zsh)") and picks other shells from a single flyout; a new ⌘⌥T / Ctrl+Alt+T shortcut opens a new shell
