### PR TITLE
feat(web): route pane OSC 52 copies through the clipboard consent gate

### DIFF
--- a/tests/e2e_ui/shells/test_terminal_clipboard_consent.py
+++ b/tests/e2e_ui/shells/test_terminal_clipboard_consent.py
@@ -1,9 +1,15 @@
-"""E2E: terminal clipboard frames require consent before writing locally.
+"""E2E: terminal clipboard writes require consent, whatever their source.
+
+Two sources reach the same gate:
+
+- a validated tmux ``clipboard-write`` control frame (a copy-mode selection),
+- raw pane OSC 52, which control mode forwards verbatim -- how a TUI running
+  in the pane (pi's copy action, vim's ``"+`` register) asks to copy.
 
 The terminal resource and attach WebSocket are browser-route mocks. This keeps
-this test tmux-free while exercising the built SPA's real TerminalView,
-TerminalSession, xterm input bookkeeping, WebSocket parsing, Sonner consent UI,
-and browser Clipboard API.
+these tests tmux-free while exercising the built SPA's real TerminalView,
+TerminalSession, xterm OSC parsing and input bookkeeping, WebSocket parsing,
+Sonner consent UI, and browser Clipboard API.
 """
 
 from __future__ import annotations
@@ -17,7 +23,7 @@ from collections.abc import Iterator
 
 import httpx
 import pytest
-from playwright.sync_api import Page, Route, WebSocketRoute, expect
+from playwright.sync_api import Locator, Page, Route, WebSocketRoute, expect
 
 from tests.e2e_ui.conftest import _build_hello_world_bundle, open_right_rail
 
@@ -52,6 +58,7 @@ def clipboard_ui_session(live_server: str) -> Iterator[tuple[str, str]]:
 
 
 def _clipboard_frame(text: str) -> str:
+    """Build the validated server->browser ``clipboard-write`` text frame."""
     encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
     return json.dumps(
         {
@@ -61,6 +68,12 @@ def _clipboard_frame(text: str) -> str:
         },
         separators=(",", ":"),
     )
+
+
+def _osc52_write(text: str) -> bytes:
+    """Build the raw pane bytes a TUI emits to copy: ``ESC ] 52 ; c ; <b64> BEL``."""
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    return f"\x1b]52;c;{encoded}\x07".encode("ascii")
 
 
 def _expect_clipboard(page: Page, expected: str) -> None:
@@ -75,12 +88,14 @@ def _expect_clipboard(page: Page, expected: str) -> None:
     raise AssertionError(f"clipboard was {actual!r}, expected {expected!r}")
 
 
-def test_terminal_clipboard_prompt_and_session_grant(
-    page: Page,
-    clipboard_ui_session: tuple[str, str],
-) -> None:
-    """The first copy asks; a session grant makes the next copy automatic."""
-    base_url, session_id = clipboard_ui_session
+def _mount_mock_terminal(
+    page: Page, base_url: str, session_id: str
+) -> tuple[Locator, list[WebSocketRoute]]:
+    """Mock the terminal resource and attach socket, then open the shell tab.
+
+    :returns: The connected ``terminal-view`` locator and the captured attach
+        sockets, whose last entry is the live one to inject server frames on.
+    """
     sockets: list[WebSocketRoute] = []
 
     terminal_list = re.compile(
@@ -118,7 +133,7 @@ def test_terminal_clipboard_prompt_and_session_grant(
 
     def _attach(ws: WebSocketRoute) -> None:
         sockets.append(ws)
-        # Swallow resize/input frames; the test injects server frames below.
+        # Swallow resize/input frames; the tests inject server frames below.
         ws.on_message(lambda _message: None)
 
     page.route(terminal_list, _serve_terminal)
@@ -142,6 +157,16 @@ def test_terminal_clipboard_prompt_and_session_grant(
     terminal = rail.get_by_test_id("terminal-view")
     expect(terminal).to_have_attribute("data-state", "connected", timeout=20_000)
     assert sockets, "mock terminal attach WebSocket did not connect"
+    return terminal, sockets
+
+
+def test_terminal_clipboard_prompt_and_session_grant(
+    page: Page,
+    clipboard_ui_session: tuple[str, str],
+) -> None:
+    """The first copy asks; a session grant makes the next copy automatic."""
+    base_url, session_id = clipboard_ui_session
+    terminal, sockets = _mount_mock_terminal(page, base_url, session_id)
 
     textarea = terminal.locator("textarea.xterm-helper-textarea")
     consent = page.get_by_test_id("terminal-clipboard-consent")
@@ -169,3 +194,75 @@ def test_terminal_clipboard_prompt_and_session_grant(
 
     _expect_clipboard(page, second)
     expect(consent).to_have_count(0)
+
+
+def test_pane_osc52_copy_prompts_then_reaches_clipboard(
+    page: Page,
+    clipboard_ui_session: tuple[str, str],
+) -> None:
+    """A TUI's in-pane copy reaches the clipboard, behind the same prompt.
+
+    Control mode forwards raw pane output, so a TUI's copy arrives as an OSC 52
+    sequence with no tmux buffer behind it -- the shape ``set-clipboard
+    external`` keeps out of tmux, but not off this socket. It must land on the
+    clipboard the way a tmux selection does, through the consent prompt, and
+    never by writing straight to it: pane output is agent-controlled, so an
+    unprompted write would let injected content replace what the user copies.
+    """
+    base_url, session_id = clipboard_ui_session
+    terminal, sockets = _mount_mock_terminal(page, base_url, session_id)
+
+    textarea = terminal.locator("textarea.xterm-helper-textarea")
+    consent = page.get_by_test_id("terminal-clipboard-consent")
+
+    copied = f"osc52-copy-{uuid.uuid4().hex}"
+    textarea.focus()
+    page.keyboard.type("a")  # Satisfy TerminalSession's recent-input gate.
+    sockets[-1].send(_osc52_write(copied))
+
+    expect(consent).to_be_visible()
+    expect(consent).to_contain_text("Allow this terminal to copy to your clipboard?")
+
+    consent.get_by_role("button", name="Copy once").click()
+    _expect_clipboard(page, copied)
+    expect(consent).to_have_count(0)
+
+
+def test_pane_osc52_read_request_is_never_answered(
+    page: Page,
+    clipboard_ui_session: tuple[str, str],
+) -> None:
+    """``OSC 52 ; c ; ?`` asks to read the clipboard; it must produce nothing.
+
+    Answering would hand agent-controlled pane output whatever the user last
+    copied. The sequence is consumed with no prompt and no reply.
+    """
+    base_url, session_id = clipboard_ui_session
+    terminal, sockets = _mount_mock_terminal(page, base_url, session_id)
+
+    sent: list[str | bytes] = []
+
+    def _record(message: str | bytes) -> None:
+        # A plain function, not ``sent.append``: Playwright tags handlers with
+        # an attribute, which a builtin method rejects.
+        sent.append(message)
+
+    sockets[-1].on_message(_record)
+
+    textarea = terminal.locator("textarea.xterm-helper-textarea")
+    consent = page.get_by_test_id("terminal-clipboard-consent")
+
+    secret = f"never-disclosed-{uuid.uuid4().hex}"
+    page.evaluate("(text) => navigator.clipboard.writeText(text)", secret)
+
+    textarea.focus()
+    page.keyboard.type("a")  # Satisfy the recent-input gate; still no answer.
+    sent.clear()
+    sockets[-1].send(b"\x1b]52;c;?\x07")
+
+    # No prompt, and nothing containing the clipboard goes back to the pane.
+    expect(consent).to_have_count(0)
+    page.wait_for_timeout(500)
+    for message in sent:
+        payload = message if isinstance(message, str) else message.decode("utf-8", "replace")
+        assert secret not in payload, f"clipboard leaked to the pane: {payload!r}"

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -615,16 +615,94 @@ describe("TerminalSession", () => {
     session.dispose();
   });
 
-  it("does not trust raw pane OSC 52 clipboard writes", async () => {
+  /** Write one OSC 52 sequence into the real xterm parser and settle it. */
+  async function writeOsc52(session: TerminalSession, payload: string): Promise<void> {
+    const term = (session as unknown as { term: Terminal }).term;
+    await new Promise<void>((resolve) => {
+      term.write(`\x1b]52;${payload}\x07`, resolve);
+    });
+  }
+
+  it("routes raw pane OSC 52 writes through the consent gate", async () => {
+    // WHY: control mode forwards raw pane bytes, so a TUI's copy (pi, vim's
+    // "+ register) reaches xterm as OSC 52 with no tmux buffer behind it.
+    // It must reach the clipboard the same way a tmux selection does — via
+    // onClipboardRequest, which prompts — and never by writing directly.
     vi.spyOn(performance, "now").mockReturnValue(10_000);
     const onClipboardRequest = vi.fn();
     const { session } = makeSession(undefined, undefined, true, onClipboardRequest);
     (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
-    const term = (session as unknown as { term: Terminal }).term;
 
-    await new Promise<void>((resolve) => {
-      term.write(`\x1b]52;;${btoa("pane output")}\x07`, resolve);
-    });
+    await writeOsc52(session, `c;${btoa("pane output")}`);
+
+    expect(onClipboardRequest).toHaveBeenCalledWith("pane output");
+    session.dispose();
+  });
+
+  it("never answers an OSC 52 read request", async () => {
+    // WHY: `?` asks the terminal to report the clipboard back into the pane.
+    // Serving it would give agent-controlled pane output read access to
+    // whatever the user last copied, so it must produce nothing at all --
+    // neither a consent prompt nor a reply on the wire.
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onClipboardRequest = vi.fn();
+    const { session, socket } = makeSession(undefined, undefined, true, onClipboardRequest);
+    (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
+    socket.open();
+    const sentBefore = socket.sent.length;
+
+    await writeOsc52(session, "c;?");
+
+    expect(onClipboardRequest).not.toHaveBeenCalled();
+    expect(socket.sent.length).toBe(sentBefore);
+    session.dispose();
+  });
+
+  it("ignores pane OSC 52 without recent input on this attachment", async () => {
+    // WHY: the same freshness gate as tmux copies. Without it, output the
+    // user never asked for -- arriving while they are reading, not typing --
+    // could still raise a prompt over the terminal.
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onClipboardRequest = vi.fn();
+    const { session } = makeSession(undefined, undefined, true, onClipboardRequest);
+    (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 1000;
+
+    await writeOsc52(session, `c;${btoa("stale copy")}`);
+
+    expect(onClipboardRequest).not.toHaveBeenCalled();
+    session.dispose();
+  });
+
+  it("ignores pane OSC 52 when terminal clipboard access is disabled", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onClipboardRequest = vi.fn();
+    const { session } = makeSession(undefined, undefined, false, onClipboardRequest);
+    (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
+
+    await writeOsc52(session, `c;${btoa("blocked copy")}`);
+
+    expect(onClipboardRequest).not.toHaveBeenCalled();
+    session.dispose();
+  });
+
+  it("rejects OSC 52 payloads that fail the shared clipboard checks", async () => {
+    // WHY: pane OSC 52 reuses the bounded, canonical base64 decoder applied
+    // to clipboard-write frames, so a pane cannot spend memory here that it
+    // could not spend through tmux, nor smuggle a non-canonical payload.
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onClipboardRequest = vi.fn();
+    const { session } = makeSession(undefined, undefined, true, onClipboardRequest);
+    (session as unknown as { lastUserInputAt: number }).lastUserInputAt = 9000;
+
+    await writeOsc52(session, "c;not!valid!base64");
+    // Non-canonical padding: decodeTerminalClipboardBase64 owns the bounded
+    // length check, exercised in its own tests above.
+    await writeOsc52(session, "c;QQ=");
+    // A cut-buffer target has no browser equivalent, so it is not a write
+    // this terminal can honor.
+    await writeOsc52(session, `7;${btoa("cut buffer")}`);
+    // No target separator at all.
+    await writeOsc52(session, btoa("malformed"));
 
     expect(onClipboardRequest).not.toHaveBeenCalled();
     session.dispose();

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -343,6 +343,44 @@ export function parseTerminalClipboardMessage(message: string): string | null {
   return decodeTerminalClipboardBase64((value as { data: string }).data);
 }
 
+/**
+ * Selection names an OSC 52 write may target, per ``xterm``'s ``Ps = 5 2``.
+ *
+ * ``c``/``p``/``s`` are the clipboard, primary and select selections — the
+ * only ones with a browser equivalent. Cut buffers (``0``-``7``) and the
+ * secondary selection (``q``) have none, so a write naming them is not a
+ * request this terminal can honor. An empty list means the default.
+ */
+const OSC52_WRITE_TARGETS_RE = /^[cps]*$/;
+
+/**
+ * Parse an OSC 52 payload (``<targets>;<base64>``) into clipboard text.
+ *
+ * Returns ``null`` for anything that must not reach the clipboard, leaving
+ * the caller nothing to forward:
+ *
+ * - ``?`` as the data, which asks the terminal to *report* the clipboard
+ *   back into the pane. Serving it would hand a pane program read access to
+ *   whatever the user last copied, so it is refused outright — this terminal
+ *   only ever writes.
+ * - a target this app has no equivalent for (cut buffers, secondary).
+ * - a payload failing the same bounded, canonical base64 check applied to
+ *   ``clipboard-write`` frames, so a pane cannot spend memory here that it
+ *   could not spend through tmux.
+ *
+ * :param payload: OSC 52 body, i.e. the bytes after ``ESC ] 52 ;``.
+ * :returns: The decoded text, or ``null`` when it must not be forwarded.
+ */
+export function parseTerminalOsc52(payload: string): string | null {
+  const separator = payload.indexOf(";");
+  if (separator === -1) return null;
+  const targets = payload.slice(0, separator);
+  const data = payload.slice(separator + 1);
+  if (data === "?") return null;
+  if (!OSC52_WRITE_TARGETS_RE.test(targets)) return null;
+  return decodeTerminalClipboardBase64(data);
+}
+
 /** Whether a clipboard event is attributable to recent input on this attach. */
 export function hadRecentTerminalInput(lastInputAt: number, now: number): boolean {
   return (
@@ -565,9 +603,20 @@ export class TerminalSession {
       // Opt into xterm's proposed APIs, matching openui's terminal setup.
       allowProposedApi: true,
     });
-    // Control mode forwards raw pane output. Consume pane OSC 52 so clipboard
-    // writes can only arrive through validated tmux `clipboard-write` frames.
-    this.osc52Dispose = this.term.parser.registerOscHandler(52, () => true);
+    // Control mode forwards raw pane output, so a pane program's OSC 52 lands
+    // here verbatim: tmux `set-clipboard external` keeps it out of a tmux
+    // buffer, but not off this socket. TUIs copy this way and have no other
+    // route to the clipboard (pi's copy action, vim's "+ register), so the
+    // sequence is honored — through the same consent gate as a validated
+    // `clipboard-write` frame, never straight to the clipboard. A pane runs
+    // agent-controlled output; an unprompted write would let injected content
+    // silently replace what the user copies. Always returns true so a payload
+    // we refuse is consumed here rather than handled anywhere else.
+    this.osc52Dispose = this.term.parser.registerOscHandler(52, (payload) => {
+      const text = parseTerminalOsc52(payload);
+      if (text !== null) this.requestClipboardWrite(text);
+      return true;
+    });
     this.fit = new FitAddon();
     this.term.loadAddon(this.fit);
     // Turn bare URLs in terminal output into clickable links. Without


### PR DESCRIPTION
## Related issue

Closes #6278

## Summary

- TUIs in a session terminal copy with OSC 52 (pi's copy action, vim's `"+` register) — the program has no system clipboard access, so it asks the terminal to write for it. Control mode forwards raw pane output, so the sequence reaches xterm verbatim; the browser discarded it, and since OSC 52 is fire-and-forget the program still reported success. In-TUI copy was a silent no-op.
- Decode it into the **existing consent path** instead of dropping it: `clipboardEnabled`, the recent-user-input window, and the Allow / Copy once / Block prompt from #5136 — the same gate a validated tmux `clipboard-write` frame passes through.
- Reads (`OSC 52 ; c ; ?`) stay refused, and write payloads reuse the bounded, canonical base64 decoder already applied to `clipboard-write` frames.

**Why not `@xterm/addon-clipboard`:** the addon writes `navigator.clipboard` directly, which is precisely what `registerOscHandler(52, () => true)` was added to prevent. A pane carries agent-controlled output, so an unprompted write lets injected content silently replace what the user copies — an address or a command swapped between copy and paste. This keeps that control and routes through it rather than around it.

```
TUI (pi / vim) emits  ESC ] 52 ; c ; <base64> BEL
  └─ tmux (set-clipboard external: no tmux buffer) → %output → WebSocket → xterm
       ├─ before: OSC 52 handler consumed it → dropped, copy silently lost ✗
       └─ after:  parseTerminalOsc52 → requestClipboardWrite
                    ├─ clipboardEnabled?  ─ no → ignored
                    ├─ recent user input? ─ no → ignored
                    └─ yes → consent prompt → navigator.clipboard.writeText ✓

tmux copy-mode selection → %paste-buffer-changed → clipboard-write frame
  └─ same requestClipboardWrite gate (unchanged)
```

## Test Plan

- `cd web && pnpm run lint && pnpm run type-check && pnpm run build` — all green.
- `pnpm vitest run src/components/blocks/TerminalSession.test.ts` — 44 passed, including five new cases: the write reaching the consent path, the read request refused, and the disabled / stale-input / malformed-payload arms.
- `uv run pytest tests/e2e_ui/shells/test_terminal_clipboard_consent.py` — 3 passed.
- Both new tests were confirmed to **fail** with the handler reverted to `() => true`, so they pin the behavior rather than just passing alongside it.
- Verified against a Kubernetes deployment (Chrome on macOS): pi's copy action raises the prompt, and the text lands on the system clipboard once allowed.

## Demo

<!-- recording to be attached: TUI copy → consent prompt → paste -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`TerminalSession.test.ts` covers each arm of the gate — the write routed to `onClipboardRequest`, the `?` read refused with nothing sent back to the pane, and the disabled-surface, stale-input and malformed-payload rejections. `test_terminal_clipboard_consent.py` drives real OSC 52 bytes through the mocked attach socket into the built SPA, so xterm's OSC parsing, the consent UI and the browser Clipboard API are all exercised end to end; a second e2e case asserts a read request produces no prompt and never returns the clipboard to the pane. The existing tmux `clipboard-write` test is unchanged and still passes — its mock setup is now shared with the new cases.

Manual verification is noted above because clipboard permissions in a focused real browser are what the deployment check adds over the mocked e2e.

## Changelog

Copying from a TUI in the web terminal (pi, vim via OSC 52) now reaches your system clipboard, after a one-time prompt
