### PR TITLE
fix(claude-native): stop a bridge-write failure from muting the session

### DIFF
--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -94,6 +94,11 @@ _PERMISSION_MODE_POLL_INTERVAL_S = 2.0
 # the loop resumes. Generous vs the 0.25s poll so a legitimately slow batch
 # (large backlog, slow posts) never trips it.
 _FORWARD_LOOP_STALL_DEADLINE_S = 300.0
+# Ceiling on the poll backoff after a failing iteration. A fault that does not
+# clear on its own (a full bridge dir, a wedged mount) otherwise retries — and
+# logs a traceback — four times a second for as long as the session lives;
+# recovery still lands within this window once the fault clears.
+_FORWARD_LOOP_FAILURE_BACKOFF_MAX_S = 30.0
 _POST_TIMEOUT_S = 10.0
 _MAX_SEEN_SOURCE_IDS = 2000
 _CURSOR_FINGERPRINT_BYTES = 256
@@ -758,6 +763,25 @@ class _PostRetryTracker:
         )
 
 
+def _forward_loop_delay(poll_interval_s: float, failure_streak: int) -> float:
+    """
+    Seconds to wait before the forward loop's next iteration.
+
+    A clean iteration keeps the normal poll cadence. A failing one backs off
+    exponentially so a fault that does not clear on its own stops spinning at
+    the poll rate, capped so recovery is still prompt once it clears.
+
+    :param poll_interval_s: Normal spacing between transcript polls.
+    :param failure_streak: Consecutive failed iterations; ``0`` when the last
+        iteration completed.
+    :returns: Delay in seconds.
+    """
+    if failure_streak <= 0:
+        return poll_interval_s
+    backoff = poll_interval_s * 2 ** (failure_streak - 1)
+    return min(backoff, _FORWARD_LOOP_FAILURE_BACKOFF_MAX_S)
+
+
 async def forward_claude_transcript_to_session(
     *,
     base_url: str,
@@ -847,6 +871,7 @@ async def forward_claude_transcript_to_session(
     from omnigent.cli_auth import open_server_client
 
     async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
+        failure_streak = 0
         while True:
             try:
                 async with asyncio.timeout(_FORWARD_LOOP_STALL_DEADLINE_S):
@@ -1089,13 +1114,23 @@ async def forward_claude_transcript_to_session(
                     extra={"session_id": session_id},
                 )
             except Exception:
-                _logger.exception(
-                    "Claude transcript forwarder loop failed; session=%s bridge_dir=%s",
-                    session_id,
-                    bridge_dir,
-                    extra={"session_id": session_id},
-                )
-            await asyncio.sleep(poll_interval_s)
+                failure_streak += 1
+                # A fault that repeats every poll would post one traceback per
+                # 0.25s tick. Report the first, then only as the streak
+                # doubles (1, 2, 4, 8, …), so a persistent fault stays visible
+                # without burying every other error in the fleet's logs.
+                if failure_streak & (failure_streak - 1) == 0:
+                    _logger.exception(
+                        "Claude transcript forwarder loop failed "
+                        "(%d consecutive); session=%s bridge_dir=%s",
+                        failure_streak,
+                        session_id,
+                        bridge_dir,
+                        extra={"session_id": session_id},
+                    )
+            else:
+                failure_streak = 0
+            await asyncio.sleep(_forward_loop_delay(poll_interval_s, failure_streak))
 
 
 def _subagents_dir_for_transcript(transcript_path: Path) -> Path:

--- a/omnigent/claude_native_status.py
+++ b/omnigent/claude_native_status.py
@@ -86,8 +86,8 @@ def sync_raw_status_context(
 
     :param bridge_dir: Bridge directory shared with the statusLine shim.
     :param last_sig: Signature returned by the previous call, or ``None``.
-    :returns: The new signature to carry forward (unchanged on a miss or
-        an unparseable file, so the next poll retries).
+    :returns: The new signature to carry forward (unchanged on a miss, an
+        unparseable file or a failed write, so the next poll retries).
     """
     raw_path = bridge_dir / CONTEXT_RAW_FILE
     try:
@@ -105,7 +105,14 @@ def sync_raw_status_context(
         return sig
     record = normalize_status_payload(payload)
     if record is not None:
-        _write_record_atomic(bridge_dir, record)
+        try:
+            _write_record_atomic(bridge_dir, record)
+        except OSError:
+            # A full or read-only bridge dir must not fail the caller's whole
+            # poll: only the context pill is at stake here, while the same
+            # iteration also forwards transcript items, hooks and cost.
+            # Keeping the old signature retries the write on the next poll.
+            return last_sig
     return sig
 
 

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -8666,3 +8666,95 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings, "the deadline trip must be loudly logged, never silent"
     # The warning's traceback names the stalled await for next-time forensics.
     assert stall_warnings[0].exc_info is not None
+
+
+def test_forward_loop_delay_backs_off_then_caps() -> None:
+    """A failing iteration waits longer each time, up to the ceiling.
+
+    :returns: None.
+    """
+    assert forwarder._forward_loop_delay(0.25, 0) == 0.25
+    assert forwarder._forward_loop_delay(0.25, 1) == 0.25
+    assert forwarder._forward_loop_delay(0.25, 2) == 0.5
+    assert forwarder._forward_loop_delay(0.25, 3) == 1.0
+    assert forwarder._forward_loop_delay(0.25, 4) == 2.0
+    assert forwarder._forward_loop_delay(0.25, 99) == forwarder._FORWARD_LOOP_FAILURE_BACKOFF_MAX_S
+
+
+async def test_forwarder_backs_off_and_throttles_a_repeating_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A fault that repeats every poll stops spinning and stops flooding.
+
+    A bridge dir that cannot be written failed the same step on every
+    0.25s tick, so one wedged session posted hundreds of identical
+    tracebacks — enough to crowd every other error out of a fleet-wide
+    error view.
+
+    :param tmp_path: Per-test temp directory.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param caplog: Captured log records.
+    :returns: None.
+    """
+    monkeypatch.setattr("omnigent.claude_native_bridge._BRIDGE_ROOT", tmp_path / "root")
+    bridge_dir = prepare_bridge_dir(
+        "conv_abc",
+        bridge_id="bridge_stuck",
+        workspace=tmp_path,
+    )
+
+    def _wedged(_bridge_dir: Path) -> str | None:
+        raise OSError("bridge dir is unreadable")
+
+    monkeypatch.setattr(forwarder, "read_active_session_id", _wedged)
+
+    streaks: list[int] = []
+    stop = asyncio.Event()
+
+    def _record_delay(poll_interval_s: float, failure_streak: int) -> float:
+        streaks.append(failure_streak)
+        if len(streaks) < 6:
+            # Keep the test fast; the delay itself is covered by the unit test
+            # above, so this only asserts which streak the loop hands it.
+            return 0.0
+        # Park the loop so the assertions below see a fixed iteration count.
+        stop.set()
+        return 60.0
+
+    monkeypatch.setattr(forwarder, "_forward_loop_delay", _record_delay)
+
+    caplog.set_level(logging.ERROR, logger="omnigent.claude_native_forwarder")
+    task = asyncio.create_task(
+        forward_claude_transcript_to_session(
+            base_url="http://127.0.0.1:1",
+            headers={},
+            session_id="conv_abc",
+            bridge_dir=bridge_dir,
+            agent_name="claude-native-ui",
+            start_at_end=False,
+            poll_interval_s=0.01,
+        )
+    )
+    try:
+        await asyncio.wait_for(stop.wait(), timeout=10.0)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    # The streak advances every iteration, so the backoff grows instead of
+    # retrying at the poll cadence forever.
+    assert streaks[:6] == [1, 2, 3, 4, 5, 6]
+
+    # Only the doubling iterations report, so a persistent fault leaves a
+    # handful of tracebacks rather than one per tick.
+    failures = [
+        record
+        for record in caplog.records
+        if "Claude transcript forwarder loop failed" in record.getMessage()
+    ]
+    reported = [record.args[0] for record in failures if record.args]
+    assert reported[:3] == [1, 2, 4]
+    assert all(streak & (streak - 1) == 0 for streak in reported)

--- a/tests/test_claude_native_status.py
+++ b/tests/test_claude_native_status.py
@@ -254,3 +254,44 @@ def test_sync_raw_status_context_normalizes_and_retries(tmp_path: Path) -> None:
     assert new_sig != sig
     written = _json.loads((tmp_path / "context.json").read_text("utf-8"))
     assert written["model"] == "claude-sonnet-4-6"
+
+
+def test_sync_raw_status_context_survives_a_failed_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unwritable bridge dir leaves the signature alone instead of raising.
+
+    The forwarder calls this at the top of a poll that also mirrors
+    transcript items, hooks and cost, so letting an ENOSPC out of the
+    context-pill write stopped all of that for the rest of the session.
+    """
+    import errno
+
+    from omnigent.claude_native_status import CONTEXT_RAW_FILE, sync_raw_status_context
+
+    raw_path = tmp_path / CONTEXT_RAW_FILE
+    raw_path.write_text(
+        json.dumps({"context_window": {"context_window_size": 1000}}),
+        encoding="utf-8",
+    )
+    real_write = claude_native_status._write_record_atomic
+    full_disk = True
+
+    def _write(bridge_dir: Path, record: dict[str, object]) -> None:
+        if full_disk:
+            raise OSError(errno.ENOSPC, "No space left on device")
+        real_write(bridge_dir, record)
+
+    monkeypatch.setattr(claude_native_status, "_write_record_atomic", _write)
+
+    prior = (12345, 67)
+    assert sync_raw_status_context(tmp_path, prior) == prior
+    assert not (tmp_path / "context.json").exists()
+
+    # The retained signature means the next poll retries rather than
+    # treating the raw capture as already mirrored.
+    full_disk = False
+    assert sync_raw_status_context(tmp_path, prior) != prior
+    assert json.loads((tmp_path / "context.json").read_text("utf-8")) == {
+        "context_window_size": 1000
+    }


### PR DESCRIPTION
## Related issue

Closes # <!-- none: found by a sweep of `ai_devtools_prod.default.omnigent_debug_logs`, evidence inline below. Happy to file one if the queue wants a ticket. -->

## Summary

A host whose `TMPDIR` filled up produced **641 identical tracebacks in eight minutes** from one claude-native session, and forwarding to the chat view stopped for the rest of that session. The full disk is the user's problem; two things in the poll loop are ours.

- **A cosmetic write took the whole poll down.** `sync_raw_status_context` runs near the top of the iteration, *before* the loop forwards deltas, transcript items, hook events, sub-agents, cost, the live model and the permission mode. Its `context.json` write was the one uncaught `OSError` in that function, so an ENOSPC there aborted every later step — the chat view went silent when only the context-window pill was at stake. The statusLine shim's own writer (`_write_context_atomic`) already soft-fails the same write; this contains it on the forwarder path too and keeps the old signature so the next poll retries.
- **No backoff, no throttle.** The `except Exception` logged a full traceback and slept the plain `poll_interval_s` (0.25s), so a fault that does not clear on its own retried *and* reported four times a second for the life of the session. Now the poll backs off exponentially to a 30s ceiling, and reports only as the failure streak doubles (1, 2, 4, 8, …).

`supervise_forwarder` does not help here — its docstring scopes it to errors raised *outside* this per-iteration catch.

### Production evidence

```
runner  omnigent.claude_native_forwarder.forward_claude_transcript_to_session
Claude transcript forwarder loop failed; session=<id> bridge_dir=<TMPDIR>/claude-native/<id>

  File ".../claude_native_forwarder.py", line 933, in forward_claude_transcript_to_session
    status_raw_sig = sync_raw_status_context(bridge_dir, status_raw_sig)
  File ".../claude_native_status.py", line 108, in sync_raw_status_context
    _write_record_atomic(bridge_dir, record)
OSError: [Errno 28] No space left on device: '.../.context-1mn9o4p2'
```

641 rows, 3 sessions, one host, 2026-09-03 03:34–03:42, `0.12.0.dev0`. Those rows also crowded **197 of the 200** slots out of the fleet error view for that window.

### Effect on the reported volume

| | before | after |
|---|---|---|
| polls in the first 8s of a persistent fault | 32 | 6 |
| steady-state retry cadence | 4 / second | 1 / 30s |
| tracebacks in 8 minutes | 641 | ~5 |

## Test Plan

Both new tests were confirmed to fail on `origin/main` before the fix and pass after (source reverted with `git checkout --`, tests re-run, source restored):

```
# fails without the fix: OSError propagates out of the status sync
tests/test_claude_native_status.py::test_sync_raw_status_context_survives_a_failed_write

# fails without the fix: AttributeError, no backoff helper exists
tests/test_claude_native_forwarder.py::test_forward_loop_delay_backs_off_then_caps
tests/test_claude_native_forwarder.py::test_forwarder_backs_off_and_throttles_a_repeating_failure
```

Full suites for both touched modules:

```
$ python -m pytest tests/test_claude_native_status.py tests/test_claude_native_forwarder.py -q
163 passed in 43.10s
```

`ruff check`, `ruff format` and `pyrefly check` clean for both files (`pyrefly` reports zero errors in either).

Manual reproduction, no full disk needed: start a claude-native session, let the statusLine shim write `context_raw.json` once, then `chmod 500` the bridge dir. Before this change the chat view stops receiving assistant output entirely and the runner log takes a traceback every 0.25s; after it, the context pill freezes and everything else keeps streaming.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new loop test drives the real `forward_claude_transcript_to_session` with a wedged bridge read, asserting both that the failure streak advances the backoff (1, 2, 3, 4, 5, 6) and that only the doubling iterations report (1, 2, 4). The manual `chmod 500` reproduction above covers the user-visible half — that transcript forwarding survives a failed context write — which no automated test exercises end to end.

## Changelog

A claude-native session keeps streaming when its bridge directory cannot be written, instead of going silent until it is restarted.
