### PR TITLE
fix(server): report a terminal-transfer collision as a conflict, not bad input

### DIFF
--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -1242,9 +1242,12 @@ def register_resources_routes(
             )
         if status == 409:
             error = payload.get("error", {})
+            # The target session already owns a terminal under this name, which
+            # is a state conflict and not a malformed request: INVALID_INPUT
+            # would surface it as a 400 and tell the caller to fix its input.
             raise OmnigentError(
                 error.get("message", "Terminal transfer conflict"),
-                code=ErrorCode.INVALID_INPUT,
+                code=ErrorCode.CONFLICT,
             )
         if status >= 400:
             error = payload.get("error", {})

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -1709,6 +1709,53 @@ async def test_transfer_terminal_surfaces_runner_error_without_crashing(
 
 
 @pytest.mark.asyncio
+async def test_transfer_terminal_surfaces_a_runner_conflict_as_409(
+    client: httpx.AsyncClient,
+) -> None:
+    """A terminal-name collision on the target reaches the caller as a 409.
+
+    The runner returns 409 ``resource_conflict`` when the target session
+    already owns a terminal under the same name — a state conflict the
+    caller cannot fix by changing its request. Mapping it to
+    ``INVALID_INPUT`` surfaced it as a 400, so a real collision was
+    indistinguishable from a malformed transfer, and the 409 a client did
+    see had to have come from somewhere else entirely.
+
+    :param client: Server test client.
+    :returns: None.
+    """
+    session_id = "79b22ebd2309e48fdeb450c65611d51b"
+    path = f"/v1/sessions/{session_id}/resources/terminals/terminal_bash_s1/transfer"
+    fake_runner = _FakeRunnerClient(
+        responses={
+            path: (
+                409,
+                {
+                    "error": {
+                        "code": "resource_conflict",
+                        "message": (
+                            "target session already has terminal 'bash' for session key 's1'"
+                        ),
+                    }
+                },
+            ),
+        },
+    )
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.post(path, json={"target_session_id": "5d29bee4350489d66feafecfebd94a97"})
+
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["error"]["code"] == ErrorCode.CONFLICT
+    assert body["error"]["message"] == (
+        "target session already has terminal 'bash' for session key 's1'"
+    )
+    assert "id" not in body
+    assert fake_runner.calls == [("POST", path)]
+
+
+@pytest.mark.asyncio
 async def test_delete_terminal_surfaces_runner_404(
     client: httpx.AsyncClient,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes # <!-- none: found by a sweep of `ai_devtools_prod.default.omnigent_debug_logs`, evidence inline below. Happy to file one if the queue wants a ticket. -->

## Summary

The runner returns `409 resource_conflict` when a terminal transfer's target session already owns a terminal under the same name and session key — the target holds state that blocks the move, which no change to the request can fix. The route mapped it to `ErrorCode.INVALID_INPUT`, so it reached the caller as a **400** telling them their input was wrong, and a genuine collision was indistinguishable from a malformed transfer.

This matters for diagnosis, not just tidiness. Native `/clear` rotation transfers the live pane onto a fresh session, and a rotation that failed in the fleet logged a **409** from this endpoint:

```
runner  omnigent.claude_native_forwarder._maybe_rotate_session_on_clear
Claude /clear rotation failed; consuming the clear hook to avoid a re-rotation loop.

httpx.HTTPStatusError: Client error '409 Conflict' for url
  '.../v1/sessions/<id>/resources/terminals/terminal_claude_main/transfer'
```

Because a real terminal collision would have arrived as a 400, that 409 must have come from a *different* conflict on the path (most likely `runner/routing.py`'s "not bound to a runner"), which points at the rotation racing its own runner rebind. With the mapping corrected the two are distinguishable in the logs, so the next occurrence is diagnosable.

### Scope

Error-code mapping only. It does **not** change the rotation's own behaviour — `/clear` still consumes the hook when the transfer fails, so the underlying rotation race is untouched and needs its own change once the logs identify it.

Every caller of the route only calls `raise_for_status()`, so none branches on 400 vs 409 and the surfaced message is unchanged:

- `claude_native_forwarder.py:2269, 2418`
- `claude_native_hook.py:523, 605`
- `codex_native_forwarder.py:2126`
- `antigravity_native_reader.py:3148`

## Test Plan

New test, confirmed to fail on `origin/main` before the fix (`assert 400 == 409`) and pass after:

```
tests/server/routes/test_session_resources.py::test_transfer_terminal_surfaces_a_runner_conflict_as_409
```

It drives the real route with a fake runner returning `409 resource_conflict`, and asserts the client sees status 409, code `conflict`, the runner's message verbatim, no resource body, and exactly one proxied POST.

Affected suites:

```
$ python -m pytest tests/server/routes/test_session_resources.py -q
163 passed in 69.49s

$ python -m pytest tests/runner/test_session_resources.py tests/terminals/test_registry.py -q
87 passed in 64.53s
```

`ruff check`, `ruff format` and `pyrefly check` clean.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing parametrised `test_transfer_terminal_surfaces_runner_error_without_crashing` deliberately covers only the non-404/409 branch; this adds the 409 case it excludes. The 404 branch and the happy path already have their own tests in the same file.

## Changelog

A terminal transfer that collides with an existing terminal on the target session now reports a 409 conflict instead of a 400 invalid-input error.
