### PR TITLE
fix(egress): relay unrestricted HTTP/2 tunnels

### DIFF
--- a/omnigent/inner/egress/proxy.py
+++ b/omnigent/inner/egress/proxy.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import contextlib
 import email.policy
 import functools
 import hmac
@@ -55,6 +56,7 @@ from omnigent.inner.egress.rules import (
 logger = logging.getLogger(__name__)
 
 _CONNECT_RESPONSE = b"HTTP/1.1 200 Connection Established\r\n\r\n"
+_HTTP2_PREFACE_FIRST_LINE = b"PRI * HTTP/2.0\r\n"
 _BUF_SIZE = 65536
 _HEADER_MAX = 65536
 # S6 (security): the smallest printable ASCII byte (SP). Any byte below
@@ -235,8 +237,11 @@ class EgressProxy:
         # agent-controlled trust store entirely.
         if upstream_ca_bundle is not None:
             self._upstream_ssl_ctx = ssl.create_default_context(cafile=str(upstream_ca_bundle))
+            self._upstream_h2_ssl_ctx = ssl.create_default_context(cafile=str(upstream_ca_bundle))
         else:
             self._upstream_ssl_ctx = ssl.create_default_context()
+            self._upstream_h2_ssl_ctx = ssl.create_default_context()
+        self._upstream_h2_ssl_ctx.set_alpn_protocols(["h2"])
         self._block_private_destinations = block_private_destinations
         self._auth_token = auth_token
         # Two indexes over the rewrite rules:
@@ -508,6 +513,10 @@ class EgressProxy:
         await writer.drain()
 
         ssl_ctx = self._cert_cache.get_ssl_context(host)
+        if self._allows_http2_passthrough(host):
+            ssl_ctx.set_alpn_protocols(["h2", "http/1.1"])
+        else:
+            ssl_ctx.set_alpn_protocols(["http/1.1"])
 
         # Wire the post-handshake reader / protocol *before* calling
         # ``start_tls`` and pass them in directly, rather than calling
@@ -567,6 +576,30 @@ class EgressProxy:
         try:
             inner_first = await asyncio.wait_for(tls_reader.readline(), timeout=30)
             if not inner_first:
+                return
+
+            if inner_first == _HTTP2_PREFACE_FIRST_LINE:
+                if not self._allows_unrestricted_host(host):
+                    logger.warning(
+                        "BLOCKED-H2 https://%s — HTTP/2 requires an unrestricted host rule",
+                        host,
+                    )
+                    await self._send_forbidden(
+                        tls_writer, "HTTP/2 requires an unrestricted host rule"
+                    )
+                    return
+                if host.lower() in self._cred_by_host:
+                    logger.warning(
+                        "BLOCKED-H2-CREDENTIAL https://%s — opaque HTTP/2 "
+                        "cannot rewrite credentials",
+                        host,
+                    )
+                    await self._send_forbidden(
+                        tls_writer, "HTTP/2 cannot use a credential rewrite rule"
+                    )
+                    return
+                logger.info("ALLOW-H2 https://%s/**", host)
+                await self._forward_http2(tls_reader, tls_writer, host, port, inner_first)
                 return
 
             inner_line = inner_first.decode("latin-1", errors="replace").strip()
@@ -678,6 +711,65 @@ class EgressProxy:
                 await asyncio.wait_for(tls_writer.wait_closed(), timeout=2)
             except Exception:  # noqa: BLE001 — TLS close is best-effort
                 pass
+
+    def _allows_unrestricted_host(self, host: str) -> bool:
+        """Return whether one rule allows every method and path for *host*."""
+        return any(rule.allows_all_requests_to(host) for rule in self._rules)
+
+    def _allows_http2_passthrough(self, host: str) -> bool:
+        """Return whether opaque HTTP/2 relay is safe for *host*."""
+        return self._allows_unrestricted_host(host) and host.lower() not in self._cred_by_host
+
+    async def _forward_http2(
+        self,
+        client_reader: asyncio.StreamReader,
+        client_writer: asyncio.StreamWriter,
+        host: str,
+        port: int,
+        initial_data: bytes,
+    ) -> None:
+        """Relay an opaque HTTP/2 connection for an unrestricted host."""
+        try:
+            pinned_ip = await self._assert_destination_allowed(host, port)
+        except PermissionError as exc:
+            logger.warning("BLOCKED-DEST h2://%s:%d - %s", host, port, exc)
+            return
+
+        connect_host = pinned_ip or host
+        try:
+            upstream_reader, upstream_writer = await asyncio.wait_for(
+                asyncio.open_connection(
+                    connect_host,
+                    port,
+                    ssl=self._upstream_h2_ssl_ctx,
+                    server_hostname=host,
+                ),
+                timeout=30,
+            )
+        except Exception as exc:  # noqa: BLE001 — closing the h2 stream signals failure
+            logger.warning("Cannot connect HTTP/2 upstream %s:%d - %s", host, port, exc)
+            return
+
+        async def relay(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            while data := await reader.read(_BUF_SIZE):
+                writer.write(data)
+                await writer.drain()
+
+        try:
+            upstream_writer.write(initial_data)
+            await upstream_writer.drain()
+            tasks = {
+                asyncio.create_task(relay(client_reader, upstream_writer)),
+                asyncio.create_task(relay(upstream_reader, client_writer)),
+            }
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*done, *pending, return_exceptions=True)
+        finally:
+            upstream_writer.close()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(upstream_writer.wait_closed(), timeout=2)
 
     async def _forward_https(
         self,

--- a/omnigent/inner/egress/rules.py
+++ b/omnigent/inner/egress/rules.py
@@ -94,6 +94,10 @@ class EgressRule:
             return False
         return self._path_matches(path)
 
+    def allows_all_requests_to(self, host: str) -> bool:
+        """Return whether this rule allows every method and path for *host*."""
+        return "*" in self.methods and self.path_pattern == "/**" and self._host_matches(host)
+
     def _method_matches(self, method: str) -> bool:
         if "*" in self.methods:
             return True

--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -1155,6 +1155,212 @@ def _mitm_client_send_inner(
             raw.close()
 
 
+def _mitm_client_selected_alpn(
+    proxy_port: int,
+    connect_target: str,
+    server_hostname: str,
+    ca_bundle: Path,
+) -> str | None:
+    raw = socket.create_connection(("127.0.0.1", proxy_port), timeout=10)
+    try:
+        connect = f"CONNECT {connect_target} HTTP/1.1\r\nHost: {server_hostname}\r\n\r\n"
+        raw.sendall(connect.encode("latin-1"))
+        established = b""
+        while b"\r\n\r\n" not in established:
+            chunk = raw.recv(4096)
+            if not chunk:
+                break
+            established += chunk
+
+        ctx = ssl.create_default_context(cafile=str(ca_bundle))
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+        ctx.set_alpn_protocols(["h2", "http/1.1"])
+        tls = ctx.wrap_socket(raw, server_hostname=server_hostname)
+        try:
+            return tls.selected_alpn_protocol()
+        finally:
+            with contextlib.suppress(Exception):
+                tls.close()
+    finally:
+        with contextlib.suppress(Exception):
+            raw.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_relays_http2_for_unrestricted_host(
+    ca_paths: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cert_path, key_path, bundle_path = ca_paths
+    host = "agent.example.com"
+    request = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nopaque-client-frames"
+    response = b"opaque-server-frames"
+    received: list[bytes] = []
+
+    async def _upstream(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        received.append(await reader.readexactly(len(request)))
+        writer.write(response)
+        await writer.drain()
+        writer.close()
+
+    upstream_ctx = HostCertCache(cert_path, key_path).get_ssl_context(host)
+    upstream_ctx.set_alpn_protocols(["h2"])
+    upstream = await asyncio.start_server(_upstream, "127.0.0.1", 0, ssl=upstream_ctx)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+    proxy = EgressProxy(
+        parse_rules([f"* {host}/**"]),
+        cert_path,
+        key_path,
+        upstream_ca_bundle=bundle_path,
+        block_private_destinations=False,
+    )
+    proxy_port = await proxy.start_tcp()
+    monkeypatch.setattr(asyncio.get_event_loop(), "getaddrinfo", _resolve_to_loopback())
+
+    try:
+        observed = await asyncio.wait_for(
+            asyncio.to_thread(
+                _mitm_client_send_inner,
+                proxy_port,
+                f"{host}:{upstream_port}",
+                host,
+                bundle_path,
+                request,
+            ),
+            timeout=15,
+        )
+        assert received == [request]
+        assert observed == response
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_connect_advertises_http2_only_for_safe_passthrough(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    cert_path, key_path, bundle_path = ca_paths
+    unrestricted_host = "unrestricted.example.com"
+    restricted_host = "restricted.example.com"
+    credential_host = "credential.example.com"
+    proxy = EgressProxy(
+        parse_rules(
+            [
+                f"* {unrestricted_host}/**",
+                f"POST {restricted_host}/allowed/**",
+                f"* {credential_host}/**",
+            ]
+        ),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[
+            CredentialRewriteRule(
+                host=credential_host,
+                scheme="bearer",
+                synthetic=f"{SYNTHETIC_CREDENTIAL_PREFIX}test",
+                real_secret="real-secret",
+            )
+        ],
+    )
+    proxy_port = await proxy.start_tcp()
+
+    try:
+        for host, expected in (
+            (unrestricted_host, "h2"),
+            (restricted_host, "http/1.1"),
+            (credential_host, "http/1.1"),
+        ):
+            selected = await asyncio.wait_for(
+                asyncio.to_thread(
+                    _mitm_client_selected_alpn,
+                    proxy_port,
+                    f"{host}:443",
+                    host,
+                    bundle_path,
+                ),
+                timeout=15,
+            )
+            assert selected == expected
+    finally:
+        await proxy.stop()
+
+
+@pytest.mark.asyncio
+async def test_connect_blocks_http2_for_path_restricted_host(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    cert_path, key_path, bundle_path = ca_paths
+    host = "restricted.example.com"
+    proxy = EgressProxy(
+        parse_rules([f"POST {host}/allowed/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+    )
+    proxy_port = await proxy.start_tcp()
+
+    try:
+        observed = await asyncio.wait_for(
+            asyncio.to_thread(
+                _mitm_client_send_inner,
+                proxy_port,
+                f"{host}:443",
+                host,
+                bundle_path,
+                b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+            ),
+            timeout=15,
+        )
+        assert b"403 Forbidden" in observed
+        assert b"unrestricted host rule" in observed
+    finally:
+        await proxy.stop()
+
+
+@pytest.mark.asyncio
+async def test_connect_blocks_http2_when_host_has_credential_rewrite(
+    ca_paths: tuple[Path, Path, Path],
+) -> None:
+    cert_path, key_path, bundle_path = ca_paths
+    host = "credential.example.com"
+    connect_host = "Credential.Example.Com"
+    proxy = EgressProxy(
+        parse_rules([f"* {host}/**"]),
+        cert_path,
+        key_path,
+        block_private_destinations=False,
+        credential_rewrites=[
+            CredentialRewriteRule(
+                host=host,
+                scheme="bearer",
+                synthetic=f"{SYNTHETIC_CREDENTIAL_PREFIX}test",
+                real_secret="real-secret",
+            )
+        ],
+    )
+    proxy_port = await proxy.start_tcp()
+
+    try:
+        observed = await asyncio.wait_for(
+            asyncio.to_thread(
+                _mitm_client_send_inner,
+                proxy_port,
+                f"{connect_host}:443",
+                host,
+                bundle_path,
+                b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+            ),
+            timeout=15,
+        )
+        assert b"403 Forbidden" in observed
+        assert b"credential rewrite rule" in observed
+    finally:
+        await proxy.stop()
+
+
 @pytest.mark.asyncio
 async def test_s6_connect_rejects_control_byte_in_inner_request_line(
     ca_paths: tuple[Path, Path, Path],


### PR DESCRIPTION
## Related issue

Closes #6283

## Summary

- Preserve opaque HTTP/2 streams inside CONNECT tunnels when the destination has an unrestricted `* host/**` rule.
- Refuse HTTP/2 passthrough for path-restricted hosts or hosts with credential rewrites, where opaque relay would bypass enforcement.
- Advertise and use the `h2` ALPN protocol for MITM client and upstream TLS connections.

ELI5: the proxy previously translated Cursor's HTTP/2 greeting into a fake HTTP/1.1 request. It now recognizes that greeting and safely pipes the HTTP/2 connection through when no per-request inspection is required.

```text
Cursor --CONNECT--> egress proxy --TLS/h2--> Cursor backend
                       |                          |
                       +-- exact host policy ----+
```

## Test Plan

- `PYTHONPATH=. /home/sandbox-agent/workspace/omnigent/.venv/bin/python -m pytest -q tests/inner/egress/test_proxy.py` (`76 passed`)
- `/home/sandbox-agent/workspace/omnigent/.venv/bin/ruff format --check omnigent/inner/egress/proxy.py tests/inner/egress/test_proxy.py`
- `/home/sandbox-agent/workspace/omnigent/.venv/bin/ruff check omnigent/inner/egress/proxy.py tests/inner/egress/test_proxy.py`
- Added round-trip coverage plus restricted-rule and credential-rewrite rejection cases.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The new round-trip test sends an HTTP/2 connection preface and opaque frame bytes through the MITM proxy and verifies the TLS upstream receives them byte-for-byte and returns its response.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused proxy suite covers HTTP/1 regressions, HTTP/2 relay, restricted host rules, and credential rewrite rejection.

## Changelog

HTTP/2 clients can connect through unrestricted egress proxy routes without their streams being rewritten as HTTP/1.1.
