### PR TITLE
fix(web): float the background-task pill as an overlay so it stops clipping the transcript

### DIFF
--- a/web/src/pages/BackgroundTaskPill.test.tsx
+++ b/web/src/pages/BackgroundTaskPill.test.tsx
@@ -1,0 +1,104 @@
+// Tests for BackgroundTaskPill — the "N background task(s)" pill shown above
+// the composer while background shells outlive a turn. We mock the store so
+// the count/self-hide logic and the overlay layout are exercised in isolation.
+//
+// The overlay layout matters: the pill floats over the transcript's bottom
+// (absolute + bottom-full) rather than taking a flow row. A flow row butts
+// against the transcript's overflow edge and clips its last line — the bug this
+// covers — so these tests pin the classes that keep it an overlay.
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BackgroundTaskInfo } from "@/lib/types";
+
+interface StoreShape {
+  backgroundTaskCount: number;
+  backgroundTasks: BackgroundTaskInfo[];
+}
+
+const h = vi.hoisted(() => ({
+  count: 0,
+  tasks: [] as BackgroundTaskInfo[],
+}));
+
+vi.mock("@/store/chatStore", () => ({
+  useChatStore: (selector: (s: StoreShape) => unknown) =>
+    selector({ backgroundTaskCount: h.count, backgroundTasks: h.tasks }),
+}));
+
+import { BackgroundTaskPill } from "./ChatPage";
+
+afterEach(() => {
+  cleanup();
+  h.count = 0;
+  h.tasks = [];
+});
+
+describe("BackgroundTaskPill", () => {
+  it("renders nothing when no background tasks are running", () => {
+    // WHY: the pill must occupy no space (and cast no overlay) when idle, so it
+    // self-gates to null rather than rendering an empty container.
+    h.count = 0;
+    const { container } = render(<BackgroundTaskPill />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the singular count", () => {
+    // Scope to the visible pill: an invisible spacer mirrors the same label to
+    // reserve the collapsed footprint, so the text appears twice in the DOM.
+    h.count = 1;
+    render(<BackgroundTaskPill />);
+    const pill = screen.getByTestId("background-task-pill");
+    expect(within(pill).getByText("1 background task")).toBeInTheDocument();
+  });
+
+  it("pluralizes the count", () => {
+    h.count = 3;
+    render(<BackgroundTaskPill />);
+    const pill = screen.getByTestId("background-task-pill");
+    expect(within(pill).getByText("3 background tasks")).toBeInTheDocument();
+  });
+
+  it("floats as an overlay pinned above the composer, not a flow row", () => {
+    // WHY: the pill must NOT reserve a flow row. A reserved row sits against the
+    // transcript's bottom overflow edge and clips its last line (the reported
+    // bug). The fix pins it as an overlay (absolute + bottom-full) that is
+    // pointer-transparent except for the pill itself, so the transcript beneath
+    // stays visible and scrollable.
+    h.count = 2;
+    const { container } = render(<BackgroundTaskPill />);
+    const overlay = container.firstElementChild as HTMLElement;
+    expect(overlay).toHaveClass("absolute");
+    expect(overlay).toHaveClass("bottom-full");
+    expect(overlay).toHaveClass("pointer-events-none");
+  });
+
+  it("re-enables pointer events on the pill itself so it stays interactive", () => {
+    // WHY: the overlay is pointer-transparent (so the transcript beneath stays
+    // clickable), but the pill must still take hover/tap to expand — it opts
+    // back in with pointer-events-auto.
+    h.count = 1;
+    const pill = render(<BackgroundTaskPill />).getByTestId("background-task-pill");
+    // The pill's positioned wrapper re-enables pointer events.
+    expect(pill.parentElement).toHaveClass("pointer-events-auto");
+  });
+
+  it("keeps a plain tally (not expandable) when no per-shell detail is present", () => {
+    // WHY: an older runner reports only the count with no `backgroundTasks`
+    // detail; the pill must stay a non-focusable tally rather than advertising
+    // an empty expandable card.
+    h.count = 2;
+    h.tasks = [];
+    const pill = render(<BackgroundTaskPill />).getByTestId("background-task-pill");
+    expect(pill).not.toHaveAttribute("tabindex");
+  });
+
+  it("becomes focusable/expandable when per-shell detail is present", () => {
+    // WHY: with per-shell detail the pill expands into a card listing each
+    // shell, so it must be reachable by keyboard (tabIndex 0) and focus-open.
+    h.count = 1;
+    h.tasks = [{ id: "s1", description: "Wait for CI" }];
+    const pill = render(<BackgroundTaskPill />).getByTestId("background-task-pill");
+    expect(pill).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -4224,8 +4224,14 @@ function SubagentComposerTray({ label }: { label: string }) {
  * corner radius (CSS can't animate to an `auto` size), growing upward out of an
  * absolute layer over a hidden spacer so the composer below never shifts. A
  * count-only edge (older runner, no per-shell detail) stays a plain tally.
+ *
+ * The whole pill floats as an overlay pinned just above the composer (its form
+ * is `relative`, this is `bottom-full`) rather than taking a flow row — a
+ * reserved row would butt against the transcript's bottom overflow edge and
+ * clip the last line. Only the pill itself takes pointer events so the
+ * transcript underneath stays interactive.
  */
-function BackgroundTaskPill() {
+export function BackgroundTaskPill() {
   const bgCount = useChatStore((s) => s.backgroundTaskCount);
   const bgTasks = useChatStore((s) => s.backgroundTasks);
   const [open, setOpen] = useState(false);
@@ -4249,96 +4255,104 @@ function BackgroundTaskPill() {
   const showCard = open && canExpand;
 
   return (
-    <div className={cn("mx-auto flex w-full px-1 pb-1.5", CHAT_COLUMN_WIDTH)}>
-      <div className="relative">
-        {/* Reserves the collapsed footprint so the absolute, upward-growing
+    // Floats above the composer instead of taking a flow row: a reserved row
+    // would butt against the transcript's bottom overflow edge and clip its
+    // last line. Pinned to the composer's top (bottom-full) and re-applying the
+    // form's px-4/md:px-6 inset so the pill lines up with the composer card.
+    // pointer-events-none lets the transcript underneath stay scrollable /
+    // selectable — only the pill itself re-enables them.
+    <div className="pointer-events-none absolute inset-x-0 bottom-full px-4 md:px-6">
+      <div className={cn("mx-auto flex w-full px-1 pb-1.5", CHAT_COLUMN_WIDTH)}>
+        <div className="pointer-events-auto relative">
+          {/* Reserves the collapsed footprint so the absolute, upward-growing
             card never shoves the composer. */}
-        <div aria-hidden className="invisible px-3 py-1.5 text-sm">
-          <div className="flex items-center gap-1.5 whitespace-nowrap">
-            <SquareTerminalIcon className="size-3.5 shrink-0" aria-hidden="true" />
-            <span>
-              {bgCount} background task{bgCount === 1 ? "" : "s"}
-            </span>
+          <div aria-hidden className="invisible px-3 py-1.5 text-sm">
+            <div className="flex items-center gap-1.5 whitespace-nowrap">
+              <SquareTerminalIcon className="size-3.5 shrink-0" aria-hidden="true" />
+              <span>
+                {bgCount} background task{bgCount === 1 ? "" : "s"}
+              </span>
+            </div>
           </div>
-        </div>
-        <div
-          role="status"
-          data-testid="background-task-pill"
-          aria-label={`${bgCount} background task${bgCount === 1 ? "" : "s"} still running`}
-          tabIndex={canExpand ? 0 : undefined}
-          // Hover opens ONLY for a real mouse. On touch, opening on emulated
-          // hover triggers iOS's "first tap reveals hover, second tap clicks"
-          // heuristic — which swallows the first tap inconsistently. Touch opens
-          // via onClick instead, so the first tap always lands.
-          onPointerEnter={(e) => {
-            if (e.pointerType === "mouse" && canExpand) setOpen(true);
-          }}
-          onPointerLeave={(e) => {
-            if (e.pointerType === "mouse") setOpen(false);
-          }}
-          // Tap/click: open and focus the pill so onBlur can close it on
-          // tap-out (a gesture-driven focus() works even on iOS, where tapping a
-          // non-button element otherwise won't focus it).
-          onClick={(e) => {
-            if (!canExpand) return;
-            setOpen(true);
-            e.currentTarget.focus({ preventScroll: true });
-          }}
-          onFocus={() => canExpand && setOpen(true)}
-          onBlur={(e) => {
-            // Close when focus leaves the pill entirely (tap/click outside,
-            // Tab away); staying open if it moves to a child.
-            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false);
-          }}
-          style={box ? { width: box.width, height: box.height } : undefined}
-          className={cn(
-            "absolute bottom-0 left-0 overflow-hidden rounded-2xl bg-card text-sm shadow-sm ring-1 ring-border transition-[width,height,box-shadow] duration-200 ease-out",
-            showCard && "z-10 shadow-menu",
-          )}
-        >
           <div
-            ref={contentRef}
-            // Cap at Tailwind's `md` container (28rem/448px), but never wider
-            // than the viewport minus a margin so it can't overflow on a narrow
-            // screen. The margin exceeds the composer's own px-4/px-6 inset (this
-            // pill sits at px-1) so the card's right edge, ring included, stays
-            // inside the composer rather than overhanging it.
-            style={
-              showCard ? { maxWidth: "min(var(--container-md, 28rem), 100vw - 3rem)" } : undefined
-            }
-            className={cn("w-max text-left", showCard ? "px-3 py-2" : "px-3 py-1.5")}
-          >
-            {showCard ? (
-              <ul className="flex animate-in flex-col gap-1.5 fade-in-0 duration-200">
-                {bgTasks.map((task, i) => {
-                  const label = task.description || task.command || "Background shell";
-                  const cmd = task.command && task.command !== label ? task.command : null;
-                  return (
-                    <li key={task.id ?? i} className="flex items-start gap-2">
-                      <SquareTerminalIcon
-                        className="mt-0.5 size-3.5 shrink-0 text-muted-foreground"
-                        aria-hidden="true"
-                      />
-                      <div className="min-w-0">
-                        <div className="truncate text-foreground">{label}</div>
-                        {cmd ? (
-                          <div className="truncate font-mono text-xs text-muted-foreground">
-                            {cmd}
-                          </div>
-                        ) : null}
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            ) : (
-              <div className="flex items-center gap-1.5 whitespace-nowrap text-muted-foreground">
-                <SquareTerminalIcon className="size-3.5 shrink-0" aria-hidden="true" />
-                <span>
-                  {bgCount} background task{bgCount === 1 ? "" : "s"}
-                </span>
-              </div>
+            role="status"
+            data-testid="background-task-pill"
+            aria-label={`${bgCount} background task${bgCount === 1 ? "" : "s"} still running`}
+            tabIndex={canExpand ? 0 : undefined}
+            // Hover opens ONLY for a real mouse. On touch, opening on emulated
+            // hover triggers iOS's "first tap reveals hover, second tap clicks"
+            // heuristic — which swallows the first tap inconsistently. Touch opens
+            // via onClick instead, so the first tap always lands.
+            onPointerEnter={(e) => {
+              if (e.pointerType === "mouse" && canExpand) setOpen(true);
+            }}
+            onPointerLeave={(e) => {
+              if (e.pointerType === "mouse") setOpen(false);
+            }}
+            // Tap/click: open and focus the pill so onBlur can close it on
+            // tap-out (a gesture-driven focus() works even on iOS, where tapping a
+            // non-button element otherwise won't focus it).
+            onClick={(e) => {
+              if (!canExpand) return;
+              setOpen(true);
+              e.currentTarget.focus({ preventScroll: true });
+            }}
+            onFocus={() => canExpand && setOpen(true)}
+            onBlur={(e) => {
+              // Close when focus leaves the pill entirely (tap/click outside,
+              // Tab away); staying open if it moves to a child.
+              if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setOpen(false);
+            }}
+            style={box ? { width: box.width, height: box.height } : undefined}
+            className={cn(
+              "absolute bottom-0 left-0 overflow-hidden rounded-2xl bg-card text-sm shadow-sm ring-1 ring-border transition-[width,height,box-shadow] duration-200 ease-out",
+              showCard && "z-10 shadow-menu",
             )}
+          >
+            <div
+              ref={contentRef}
+              // Cap at Tailwind's `md` container (28rem/448px), but never wider
+              // than the viewport minus a margin so it can't overflow on a narrow
+              // screen. The margin exceeds the composer's own px-4/px-6 inset (this
+              // pill sits at px-1) so the card's right edge, ring included, stays
+              // inside the composer rather than overhanging it.
+              style={
+                showCard ? { maxWidth: "min(var(--container-md, 28rem), 100vw - 3rem)" } : undefined
+              }
+              className={cn("w-max text-left", showCard ? "px-3 py-2" : "px-3 py-1.5")}
+            >
+              {showCard ? (
+                <ul className="flex animate-in flex-col gap-1.5 fade-in-0 duration-200">
+                  {bgTasks.map((task, i) => {
+                    const label = task.description || task.command || "Background shell";
+                    const cmd = task.command && task.command !== label ? task.command : null;
+                    return (
+                      <li key={task.id ?? i} className="flex items-start gap-2">
+                        <SquareTerminalIcon
+                          className="mt-0.5 size-3.5 shrink-0 text-muted-foreground"
+                          aria-hidden="true"
+                        />
+                        <div className="min-w-0">
+                          <div className="truncate text-foreground">{label}</div>
+                          {cmd ? (
+                            <div className="truncate font-mono text-xs text-muted-foreground">
+                              {cmd}
+                            </div>
+                          ) : null}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <div className="flex items-center gap-1.5 whitespace-nowrap text-muted-foreground">
+                  <SquareTerminalIcon className="size-3.5 shrink-0" aria-hidden="true" />
+                  <span>
+                    {bgCount} background task{bgCount === 1 ? "" : "s"}
+                  </span>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -5240,7 +5254,10 @@ export function Composer({
   return (
     <form
       onSubmit={handleSubmit}
-      className={cn("chat-composer-form px-4 md:px-6", isTerminalFirst ? "pb-1.5" : "pb-3")}
+      className={cn(
+        "chat-composer-form relative px-4 md:px-6",
+        isTerminalFirst ? "pb-1.5" : "pb-3",
+      )}
     >
       {/* Hidden file input for the attach button */}
       <input
@@ -5258,9 +5275,9 @@ export function Composer({
         }}
       />
       {/* Background tasks that outlive the turn show as a pill, not the
-          "Working…" shimmer. Sits above the queued/sub-agent trays: those dock
-          onto the composer card with a negative margin, so nothing may come
-          between them and the card. Self-gates to null otherwise. */}
+          "Working…" shimmer. Floats as an overlay above the composer (the form
+          is `relative`) rather than a flow row, so it never clips the
+          transcript's last line. Self-gates to null otherwise. */}
       <BackgroundTaskPill />
       {/* Queued messages — peeks above the card like the sub-agent tray.
           Lists follow-ups held while the agent is busy; drains FIFO on idle.


### PR DESCRIPTION
## Related issue

Closes #

## Summary

The "N background task(s)" pill above the composer was rendering as an in-flow row inside the composer form, reserving a full row above the composer card. That row sat directly against the transcript's bottom overflow edge, hard-clipping the last line of the transcript.

This floats the pill as an overlay instead: the composer form is now `relative`, and the pill is an `absolute bottom-full` layer that re-applies the form's horizontal inset so it still lines up with the composer card. The overlay is `pointer-events-none` (the transcript beneath stays scrollable/selectable) and only the pill itself opts back in with `pointer-events-auto`. So the pill now sits *on top of* the transcript text rather than pushing it up and clipping it.

## Test Plan

- `cd web && npm test` — full suite green except 3 pre-existing `NewChatDialog.test.tsx` failures (confirmed failing on the clean tree, unrelated to this change).
- `cd web && npm run build` — passes (`tsc -b && vite build`).
- Added `web/src/pages/BackgroundTaskPill.test.tsx` (7 tests): count/pluralization, self-hide when idle, overlay layout classes (`absolute` / `bottom-full` / `pointer-events-none`), the pill's `pointer-events-auto` opt-in, and the count-only vs. expandable (`tabIndex`) states.
- Manual: open a session with a running background task, scroll the transcript to the bottom, and confirm the last line is no longer clipped and the pill floats over the text just above the composer, still expanding on hover/tap.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

<!-- UI layout fix; before/after is the transcript's last line no longer being clipped. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added render tests for `BackgroundTaskPill` pinning both the display logic and the overlay layout classes that keep it from reserving a flow row. Manually verified the transcript's last line is no longer clipped by scrolling a session with a live background task to the bottom.

## Changelog

Background-task pill no longer clips the last line of the chat transcript

This pull request and its description were written by Isaac.
