### PR TITLE
fix(runner): name a by-id sub-agent child from its session snapshot

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -2784,6 +2784,12 @@ async def _send_to_existing_session(
     ``running`` handle immediately — the completion lands in the parent's
     ``sys_read_inbox`` queue, matching named-mode send.
 
+    The child's ``(agent, title)`` identity, carried by the handle, the
+    launching tool result, and the completion wake notice, comes from
+    the ``"<agent>:<title>"`` title when it has one, and otherwise from
+    the snapshot's ``sub_agent_name`` / ``agent_name`` with the verbatim
+    title, so a ``sys_session_create`` child is named like a named one.
+
     :param target_session_id: The existing child session id, e.g.
         ``"conv_abc123"``.
     :param message: The user message text to post.
@@ -2824,8 +2830,18 @@ async def _send_to_existing_session(
                 "message": "target sub-agent session is closed; create a new session to continue.",
             }
         )
-    parsed = _parse_session_title(snap_data.get("title"))
-    agent_label = parsed.agent or "agent"
+    display_title = title_without_closed_marker(_optional_string(snap_data.get("title")))
+    parsed = _parse_session_title(display_title)
+    # A sys_session_create child keeps its verbatim title and has no
+    # sub_agent_name, so when the title does not parse as "<agent>:<title>"
+    # the identity comes from the snapshot's agent fields instead.
+    agent_label = (
+        parsed.agent
+        or _optional_string(snap_data.get("sub_agent_name"))
+        or _optional_string(snap_data.get("agent_name"))
+        or "agent"
+    )
+    instance_title = parsed.title if parsed.title is not None else (display_title or "")
     existing_work = _runner_app.get_subagent_work(target_session_id)
     if existing_work is not None and existing_work.status in ("launching", "running", "waiting"):
         return (
@@ -2846,15 +2862,15 @@ async def _send_to_existing_session(
     _runner_app.register_child_session(
         target_session_id,
         parent_session_id=conversation_id,
-        title=snap_data.get("title") or "",
+        title=display_title or "",
         tool=agent_label,
-        session_name=parsed.title or "",
+        session_name=instance_title,
     )
     _runner_app.register_subagent_work(
         parent_session_id=conversation_id,
         child_session_id=target_session_id,
         agent=agent_label,
-        title=parsed.title or "",
+        title=instance_title,
         wrapper_label=_session_wrapper_label(snap_data),
         created_by=created_by,
         work_id=work_id,
@@ -2862,9 +2878,9 @@ async def _send_to_existing_session(
     _publish_child_launching_update(
         parent_session_id=conversation_id,
         child_session_id=target_session_id,
-        title=snap_data.get("title") or "",
+        title=display_title or "",
         tool=agent_label,
-        session_name=parsed.title or "",
+        session_name=instance_title,
         publish_event=publish_event,
     )
 
@@ -2891,9 +2907,9 @@ async def _send_to_existing_session(
             "conversation_id": target_session_id,
             "kind": "sub_agent",
             "agent": agent_label,
-            "title": parsed.title,
+            "title": instance_title,
             "status": "launching",
-            "message": _subagent_launching_message(agent_label, parsed.title, target_session_id),
+            "message": _subagent_launching_message(agent_label, instance_title, target_session_id),
         }
     )
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -4278,6 +4278,150 @@ async def test_sys_session_send_by_id_rejects_closed_child(
     assert registrations == []
 
 
+_BY_ID_CHILD_IDENTITY_SCENARIOS = [
+    # A sys_session_create child: verbatim title, no sub_agent_name, and
+    # agent_name is the child's own agent.
+    pytest.param("wake-check", "responder", None, "responder", "wake-check", id="verbatim-title"),
+    # A named child continued by id: the "<agent>:<title>" parse wins, so
+    # the parent's agent_name never leaks into the label.
+    pytest.param(
+        "researcher:auth", "orchestrator", "researcher", "researcher", "auth", id="parsed-title"
+    ),
+    # An Add-agent child continued by id: the "ui:<agent>:<label>" form
+    # parses the same way.
+    pytest.param(
+        "ui:claude-native-ui:1", "claude-native-ui", None, "claude-native-ui", "1", id="ui-title"
+    ),
+    # A renamed named child: the title no longer parses, and agent_name
+    # reports the parent when the sub-spec did not resolve, so
+    # sub_agent_name must outrank it.
+    pytest.param(
+        "wake-check", "orchestrator", "researcher", "researcher", "wake-check", id="sub-agent-name"
+    ),
+    # No title at all: the agent still comes from the snapshot and the
+    # instance title stays empty.
+    pytest.param(None, "responder", None, "responder", "", id="no-title"),
+    # Malformed agent fields: an empty sub_agent_name and a non-str
+    # agent_name both fall through to the last-resort label.
+    pytest.param("wake-check", 42, "", "agent", "wake-check", id="malformed-agent-fields"),
+]
+
+
+@pytest.mark.parametrize(
+    ("snapshot_title", "agent_name", "sub_agent_name", "expected_agent", "expected_title"),
+    _BY_ID_CHILD_IDENTITY_SCENARIOS,
+)
+@pytest.mark.asyncio
+async def test_sys_session_send_by_id_names_child_from_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    snapshot_title: str | None,
+    agent_name: object,
+    sub_agent_name: str | None,
+    expected_agent: str,
+    expected_title: str,
+) -> None:
+    """
+    By-id ``sys_session_send`` names the child from its snapshot.
+
+    A child dispatched by session id (``sys_session_create`` followed by
+    ``sys_session_send(session_id=...)``) keeps the verbatim title it was
+    created with and has no ``sub_agent_name``, so the
+    ``"<agent>:<title>"`` parse alone yields nothing. Everything that
+    identifies the child downstream (the work entry the wake notice is
+    rendered from, the child-to-parent registration, the launching event
+    on the parent stream, the returned handle, and the launching tool
+    result) must fall through to the snapshot's agent fields instead of
+    a literal ``agent`` with an empty title. A parsed title keeps winning
+    over those fields, ``sub_agent_name`` outranks ``agent_name``, and
+    malformed agent fields fall through to the last-resort label.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param snapshot_title: The child's stored title, e.g. ``"wake-check"``.
+    :param agent_name: The snapshot's bound agent name; a non-str value
+        stands in for malformed JSON.
+    :param sub_agent_name: The snapshot's ``sub_agent_name``, or ``None``.
+    :param expected_agent: The agent label the dispatch must resolve.
+    :param expected_title: The instance title the dispatch must resolve.
+    """
+    from omnigent.runner import app as runner_app
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    registrations: list[dict[str, Any]] = []
+    published: list[dict[str, Any]] = []
+    session_inbox: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    monkeypatch.setattr(
+        runner_app,
+        "register_child_session",
+        lambda child_id, **kwargs: registrations.append({"child_id": child_id, **kwargs}),
+    )
+
+    async def _server_handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/v1/sessions/conv_by_id_child":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "conv_by_id_child",
+                    "title": snapshot_title,
+                    "agent_name": agent_name,
+                    "sub_agent_name": sub_agent_name,
+                    "parent_session_id": "conv_parent_by_id",
+                    "labels": {},
+                    "busy": False,
+                },
+            )
+        if request.method == "PATCH" and request.url.path == "/v1/sessions/conv_by_id_child":
+            return httpx.Response(200, json={"ok": True})
+        if request.method == "POST" and request.url.path == "/v1/sessions/conv_by_id_child/events":
+            return httpx.Response(202, json={"queued": True})
+        return httpx.Response(404, json={"error": str(request.url)})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_server_handler),
+        base_url="http://server",
+    ) as server_client:
+        try:
+            output = await execute_tool(
+                tool_name="sys_session_send",
+                arguments=json.dumps({"session_id": "conv_by_id_child", "args": "continue"}),
+                server_client=server_client,
+                conversation_id="conv_parent_by_id",
+                session_inbox=session_inbox,
+                publish_event=_capturing_publish_event(published),
+            )
+            entry = runner_app.get_subagent_work("conv_by_id_child")
+        finally:
+            runner_app.unregister_subagent_work("conv_by_id_child")
+            runner_app._session_inboxes_ref.pop("conv_parent_by_id", None)
+
+    assert entry is not None, output
+    assert (entry.agent, entry.title) == (expected_agent, expected_title)
+    assert registrations == [
+        {
+            "child_id": "conv_by_id_child",
+            "parent_session_id": "conv_parent_by_id",
+            "title": snapshot_title or "",
+            "tool": expected_agent,
+            "session_name": expected_title,
+        }
+    ]
+    # The launching event is the Agents rail's live row for the child.
+    [launching] = published
+    assert launching["type"] == "session.child_session.updated"
+    assert launching["child"]["tool"] == expected_agent
+    assert launching["child"]["session_name"] == expected_title
+    assert launching["child"]["title"] == (snapshot_title or "")
+    handle = json.loads(output)
+    assert (handle["agent"], handle["title"]) == (expected_agent, expected_title)
+    assert f"sub-agent {expected_agent} title {expected_title!r}" in handle["message"]
+    # The wake notice is rendered from the registered entry, so this is the
+    # line the parent reads when the child finishes.
+    notice = runner_app._format_subagent_wake_notice(
+        agent=entry.agent, title=entry.title, status="completed", pending=1
+    )
+    assert f"sub-agent {expected_agent}/{expected_title} finished" in notice
+
+
 @pytest.mark.asyncio
 async def test_sys_session_send_completion_drains_from_parent_inbox(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

Closes #6262

## Summary

A child dispatched by session id (`sys_session_create` followed by `sys_session_send(session_id=...)`, the `spawn: true` path) keeps its verbatim title and has no `sub_agent_name`, so the `"<agent>:<title>"` parse in `_send_to_existing_session` yielded nothing and every downstream consumer saw the literal `agent` with an empty title: the work entry the wake notice is rendered from, the child-to-parent registration, the launching event on the parent stream, the returned handle, and the launching tool result.

- The agent label now resolves as the parsed agent, then the snapshot's `sub_agent_name`, then `agent_name`, then the old `agent` fallback (only non-empty strings count). `sub_agent_name` outranks `agent_name` because a named child's `agent_name` can report the parent when its sub-spec did not resolve.
- The instance title is the parsed title when the title has the `agent:title` form, otherwise the verbatim display title (closed marker stripped), and `""` only when the session has no title.
- The resolved pair is applied to `register_child_session`, `register_subagent_work`, `_publish_child_launching_update`, the handle JSON, and `_subagent_launching_message`, so the wake notice reads `[System: sub-agent responder/wake-check finished (completed) ...]` and the tool result reads `sub-agent responder title 'wake-check' launching as task ...`.
- `_parse_session_title` is untouched; verbatim titles containing a colon are a separate issue (#6247).

**ELI5:** when the orchestrator addressed a helper by its id instead of by name, the runner never looked up who the helper was and wrote "agent" on every note about it. Now it reads the name off the helper's own session record.

## Test Plan

- New `test_sys_session_send_by_id_names_child_from_snapshot` in `tests/runner/test_runner_dispatch.py`, parametrized over six snapshots (verbatim title, parsed `agent:title`, `ui:agent:label`, `sub_agent_name` outranking a parent `agent_name`, no title, malformed agent fields). It drives `execute_tool` against a mocked server and asserts the work entry, the child registration kwargs, the launching event, the handle, the launching message, and the rendered wake notice. On `main` the verbatim-title and no-title rows fail with `assert ('agent', '') == ('responder', 'wake-check')`.
- `uv run pytest tests/runner/test_runner_dispatch.py tests/runner/test_native_subagent_inbox_delivery.py`: 260 passed, 1 skipped (254 / 1 on `main`; the +6 are the new rows).
- `pre-commit run --files omnigent/runner/tool_dispatch.py tests/runner/test_runner_dispatch.py`: all hooks pass; `pyrefly check` unchanged at 0 errors.
- To check by hand, follow the issue's steps 1-4 with any `spawn: true` orchestrator and a second registered agent (for example a tiny `responder`). The parent's wake notice now names `responder/wake-check`, and the `sys_session_send` tool result reads `sub-agent responder title 'wake-check' launching as task ...`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before, on `main`, from the new test:

```
AssertionError: assert ('agent', '') == ('responder', 'wake-check')
```

After: the same rows pass, and the notice rendered from the registered entry is `[System: sub-agent responder/wake-check finished (completed) — 1 result waiting in inbox. Call sys_read_inbox to collect.]`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The fix is confined to `_send_to_existing_session`, and the parametrized test checks every consumer of the resolved identity, including the wake notice text. Not covered: the two runner-restart recovery paths (`_recover_subagent_results_from_server`, `_ensure_subagent_work_entry`) rebuild entries from server-side child summaries and can still label a verbatim-titled child by its raw title after a restart. That derivation lives on the server and is left for a follow-up.

## Changelog

Sub-agents dispatched by session id are now named in wake notices, launching results, and the Agents rail instead of showing `agent/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
