### PR TITLE
fix(web): hide the GitHub rail tab when the workspace is not a git repo

### DIFF
--- a/tests/e2e_ui/github/test_github_tab.py
+++ b/tests/e2e_ui/github/test_github_tab.py
@@ -7,14 +7,16 @@ with ``page.route`` and answered with canned JSON, so the test exercises the
 *frontend* — the PR header, the CI-check pills, and the folder-tree sidebar —
 without a real ``gh``/``git`` (which a CI workspace has no PR for anyway).
 
-Two behaviours are pinned:
+Three behaviours are pinned:
 
 1. Opening the GitHub rail tab renders the associated PR (title + number), its
    CI checks as labeled pills, and the branch-vs-base file tree — with a
    single-child directory chain (``src`` → ``app``) compacted into one row.
 2. The composer status line's ``#<pr>`` link opens that tab.
+3. A workspace with no git checkout gets no GitHub tab at all (the rail keeps
+   Files), rather than a panel that can only say "not a git repo".
 
-Neither sends a message, so both stay fast and LLM-free.
+None sends a message, so all three stay fast and LLM-free.
 """
 
 from __future__ import annotations
@@ -58,6 +60,15 @@ _INFO = {
             ],
         },
     },
+}
+
+# GET /resources/github for a workspace with no git checkout. The rail hides
+# its GitHub tab on this answer instead of mounting a panel that can only say
+# "not a git repo".
+_INFO_NOT_A_GIT_REPO = {
+    "object": "session.github.info",
+    "available": False,
+    "reason": "not_a_git_repo",
 }
 
 # GET /resources/github/changes — files changed vs the base. ``src`` → ``app``
@@ -172,3 +183,26 @@ def test_composer_pr_link_opens_github_tab(
     pr_link.click()
     rail = page.get_by_role("complementary", name="Workspace")
     expect(rail.get_by_text("Add the GitHub tab")).to_be_visible(timeout=30_000)
+
+
+def test_github_tab_hidden_for_non_git_workspace(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A workspace that isn't a git repo gets no GitHub tab; Files stays."""
+    base_url, session_id = seeded_session
+    # Only the info endpoint is reachable here: with the tab gone, nothing
+    # requests the changes or the diff.
+    page.route(
+        re.compile(r"/resources/github(?:\?|$)"),
+        lambda r: r.fulfill(json=_INFO_NOT_A_GIT_REPO),
+    )
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    # Files and Agents prove the tab strip has rendered, so the GitHub check
+    # below can't pass vacuously on an empty rail.
+    expect(rail.get_by_role("tab", name="Files")).to_be_visible(timeout=30_000)
+    expect(rail.get_by_role("tab", name="Agents")).to_be_visible()
+    expect(rail.get_by_role("tab", name="GitHub")).to_have_count(0)

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -62,8 +62,8 @@ export interface GithubInfo {
   object: "session.github.info";
   /** False only when this isn't a git repo (see reason); the diff needs one. */
   available: boolean;
-  /** Why unavailable: "not_a_git_repo" | "no_os_env". */
-  reason?: string;
+  /** Why unavailable: no git checkout on disk, or no os_env at all. */
+  reason?: "not_a_git_repo" | "no_os_env";
   /** Whether the `gh` CLI is present. When false, PR/repo are null but the
    *  branch-vs-base diff still renders from git. */
   gh_available?: boolean;
@@ -128,7 +128,9 @@ async function fetchGithubInfo(conversationId: string): Promise<GithubInfo> {
  *
  * Disabled when the runner is known offline. Retries the runner-offline case
  * with capped backoff so a cold-booting runner resolves before any error UI.
- * No polling — the panel refetches on a manual Refresh.
+ * No polling — the panel refetches on a manual Refresh, and the chat store
+ * re-probes an unavailable answer when the workspace changes, so a hidden
+ * GitHub tab can come back (see ``scheduleWorkspaceFilesystemInvalidation``).
  */
 export function useGithubInfo(conversationId: string | undefined) {
   const serveable = useWorkspaceServeable(conversationId);

--- a/web/src/shell/AppShell.subagent-nav.test.tsx
+++ b/web/src/shell/AppShell.subagent-nav.test.tsx
@@ -55,6 +55,14 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
     isLoading: false,
   })),
 }));
+vi.mock("@/hooks/useGithub", () => ({
+  // A git workspace, so the rail's GitHub tab stays put alongside Files.
+  useGithubInfo: vi.fn(() => ({
+    data: { object: "session.github.info", available: true },
+    isLoading: false,
+    error: null,
+  })),
+}));
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
   // Keep the real module — childSessionsQueryKey, MAX_TREE_DEPTH, and
   // cachedTreeContains (which reads the query cache seeded below) stay

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -56,6 +56,13 @@ vi.mock("@/hooks/useWorkspaceChangedFiles", () => ({
   useWorkspaceChangedFiles: vi.fn(() => ({ data: undefined, isLoading: true })),
 }));
 
+vi.mock("@/hooks/useGithub", () => ({
+  // The shell reads the git info only to gate the GitHub rail tab. The panel
+  // (the module's other consumer under the shell) is stubbed below, so the
+  // remaining data hooks are never reached.
+  useGithubInfo: vi.fn(() => ({ data: undefined, isLoading: true })),
+}));
+
 vi.mock("@/hooks/useChildSessions", async (importOriginal) => ({
   // Keep the real module (childSessionsQueryKey, MAX_TREE_DEPTH,
   // cachedTreeContains) — only the hook is replaced.
@@ -178,6 +185,13 @@ vi.mock("./SubagentsPanel", () => ({
     <div data-testid="subagents-panel" data-conversation-id={conversationId} />
   ),
 }));
+vi.mock("./GithubPanel", () => ({
+  // Marker only — the panel's own states are covered by GithubPanel.test.tsx;
+  // here it just proves which tab the rail mounted.
+  GithubPanel: ({ conversationId }: { conversationId: string }) => (
+    <div data-testid="github-panel" data-conversation-id={conversationId} />
+  ),
+}));
 // The real WorkspacePanel mounts a rail xterm for an open shell tab; stub the
 // low-level view to a marker echoing the attached terminal id.
 vi.mock("@/components/blocks/TerminalView", () => ({
@@ -229,6 +243,10 @@ import {
 
 const useEnvironmentMock = vi.mocked(useWorkspaceEnvironment);
 const useChangedFilesMock = vi.mocked(useWorkspaceChangedFiles);
+
+import { useGithubInfo } from "@/hooks/useGithub";
+
+const useGithubInfoMock = vi.mocked(useGithubInfo);
 
 import { useChildSessions } from "@/hooks/useChildSessions";
 
@@ -534,6 +552,12 @@ beforeEach(() => {
   useChangedFilesMock.mockReset();
   useChangedFilesMock.mockReturnValue({ data: undefined, isLoading: true } as unknown as ReturnType<
     typeof useWorkspaceChangedFiles
+  >);
+  // Default: git info still loading (data undefined) → the GitHub tab stays
+  // visible, mirroring the environment default above.
+  useGithubInfoMock.mockReset();
+  useGithubInfoMock.mockReturnValue({ data: undefined, isLoading: true } as unknown as ReturnType<
+    typeof useGithubInfo
   >);
   // The Chat/TUI toggle persists its position to sessionStorage so leaving
   // and re-entering a conversation restores the last view. Clear
@@ -2491,6 +2515,115 @@ describe("FilesPanel visibility", () => {
   });
 });
 
+describe("GitHub tab visibility", () => {
+  // The GitHub rail tab needs a git checkout on disk. The runner reports that
+  // through the same info query the panel reads; the shell drops the tab only
+  // on a definitive "not a git repo" answer, never on an unknown one.
+  function mockWorkspaceWithFiles() {
+    useEnvironmentMock.mockReturnValue({
+      data: { available: true, root: null },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useWorkspaceEnvironment>);
+    mockConversations([{ id: "conv_git", permission_level: null }]);
+  }
+
+  it("hides the GitHub tab, but keeps Files, when the workspace isn't a git repo", () => {
+    mockWorkspaceWithFiles();
+    useGithubInfoMock.mockReturnValue({
+      data: { object: "session.github.info", available: false, reason: "not_a_git_repo" },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useGithubInfo>);
+
+    renderShell("/c/conv_git");
+
+    expect(screen.queryByRole("tab", { name: "GitHub" })).toBeNull();
+    expect(screen.getByRole("tab", { name: "Files" })).toBeInTheDocument();
+  });
+
+  it("keeps the GitHub tab while the git info is still loading", () => {
+    // Unknown is not "not a repo": a cold-booting runner must not make the
+    // tab flash away before it has answered.
+    mockWorkspaceWithFiles();
+    useGithubInfoMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    } as unknown as ReturnType<typeof useGithubInfo>);
+
+    renderShell("/c/conv_git");
+
+    expect(screen.getByRole("tab", { name: "GitHub" })).toBeInTheDocument();
+  });
+
+  it("keeps the GitHub tab when the git info query fails", () => {
+    mockWorkspaceWithFiles();
+    useGithubInfoMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("runner unavailable"),
+    } as unknown as ReturnType<typeof useGithubInfo>);
+
+    renderShell("/c/conv_git");
+
+    expect(screen.getByRole("tab", { name: "GitHub" })).toBeInTheDocument();
+  });
+
+  it("shows the GitHub tab for a git workspace", () => {
+    mockWorkspaceWithFiles();
+    useGithubInfoMock.mockReturnValue({
+      data: { object: "session.github.info", available: true, branch: "main" },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useGithubInfo>);
+
+    renderShell("/c/conv_git");
+
+    expect(screen.getByRole("tab", { name: "GitHub" })).toBeInTheDocument();
+    // Keyed by the route's own conversation, so the shell shares the panel's
+    // and composer's cache entry instead of issuing a second request.
+    expect(useGithubInfoMock).toHaveBeenCalledWith("conv_git");
+  });
+
+  it("falls back to Files when the selected GitHub tab turns out to be unavailable", () => {
+    // The user opens GitHub while the info is still loading, then the runner
+    // answers "not a git repo": the tab goes away and the selection must land
+    // on Files rather than strand the rail on a hidden tab.
+    mockWorkspaceWithFiles();
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const makeTree = () => (
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter initialEntries={["/c/conv_git"]}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route path="c/:conversationId" element={<div>chat</div>} />
+              </Route>
+            </Routes>
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+    const { rerender } = render(makeTree());
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "GitHub" }));
+    expect(screen.getByRole("tab", { name: "GitHub" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("github-panel")).toHaveAttribute("data-conversation-id", "conv_git");
+
+    useGithubInfoMock.mockReturnValue({
+      data: { object: "session.github.info", available: false, reason: "not_a_git_repo" },
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useGithubInfo>);
+    rerender(makeTree());
+
+    expect(screen.queryByRole("tab", { name: "GitHub" })).toBeNull();
+    expect(screen.queryByTestId("github-panel")).toBeNull();
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("files-panel")).toBeInTheDocument();
+  });
+});
+
 describe("Right workspace card visibility", () => {
   it("reserves the visible pane width plus its two desktop margins from the header", () => {
     useEnvironmentMock.mockReturnValue({
@@ -2515,7 +2648,7 @@ describe("Right workspace card visibility", () => {
     // A no-os_env agent (available: false) with no shells
     // still has the unconditional Agents tab (the panel lists at least
     // the main agent), so the card mounts, the Agents tab is selected
-    // by the fallback, and Files/Shells are absent. An unmounted
+    // by the fallback, and Files/GitHub/Shells are absent. An unmounted
     // card here means the always-visible Agents rule regressed.
     useEnvironmentMock.mockReturnValue({
       data: { available: false, root: null, home: null },
@@ -2527,6 +2660,7 @@ describe("Right workspace card visibility", () => {
 
     expect(screen.getByRole("complementary", { name: "Workspace" })).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: /Files/i })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "GitHub" })).toBeNull();
     expect(screen.queryByRole("tab", { name: /Shells/i })).toBeNull();
     // The tab-fallback effect lands on Agents (the only available tab).
     expect(screen.getByRole("tab", { name: /Agents/i })).toHaveAttribute("aria-selected", "true");

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -67,6 +67,7 @@ import {
   useDeleteTerminal,
   useTerminals,
 } from "@/hooks/useTerminals";
+import { useGithubInfo } from "@/hooks/useGithub";
 import {
   useWorkspaceChangedFiles,
   useWorkspaceEnvironment,
@@ -729,6 +730,10 @@ export function AppShell() {
   // it is enough to prove availability without paying for directory contents.
   const environmentQuery = useWorkspaceEnvironment(conversationId);
   const showFilesPanel = environmentQuery.data?.available !== false;
+  // The GitHub tab also needs a git checkout on disk. This shares the GitHub
+  // panel's info query, so it costs no extra request.
+  const githubInfoQuery = useGithubInfo(conversationId);
+  const workspaceNotGitRepo = githubInfoQuery.data?.reason === "not_a_git_repo";
   // Per-tab availability for the right workspace rail — the single source
   // of truth shared by the tab-fallback effect below, the rail's mount
   // gate, and the header's collapse toggle, so they can never disagree.
@@ -739,11 +744,10 @@ export function AppShell() {
         // Changes tab shares the Files gate — same on-disk workspace, just the
         // changed-files scope.
         changes: showFilesPanel,
-        // GitHub tab shares the Files gate too — it needs a git checkout on
-        // disk. The panel itself renders the "gh not installed" / "not a git
-        // repo" / "no PR" states, so the tab is present whenever there's a
-        // workspace.
-        github: showFilesPanel,
+        // GitHub tab: hidden once the runner reports the workspace isn't a
+        // git repo. An unknown answer (loading, errored, runner offline) keeps
+        // the tab, so a cold-booting runner never makes it flash away.
+        github: showFilesPanel && !workspaceNotGitRepo,
         // Browser tab: shown only when the desktop shell hosts the embedded
         // WebContentsView. A plain web build has no embedded browser, and an
         // older desktop build predates the `browser*` bridge — both hide the
@@ -757,18 +761,16 @@ export function AppShell() {
         // rail's tab strip (see WorkspacePanel's TerminalTabsStrip / "+"
         // menu). Mobile keeps a shells drawer (see ``showShellsTab`` below).
       }) as const,
-    [showFilesPanel],
+    [showFilesPanel, workspaceNotGitRepo],
   );
   // Whether the rail has anything at all to show. When false the workspace
   // card doesn't mount and the header hides its collapse toggle — a
   // no-filesystem agent with no terminals/sub-agents would otherwise
   // render an empty white card with no way to dismiss it.
   const hasRailContent = Object.values(railTabsAvailable).some(Boolean);
-  // Keep the selected tab valid. When the current tab disappears — e.g. the
-  // files panel turns off — fall back to the first still-visible tab in
-  // display order (Files · Changes · Agents · Browser). Picking
-  // the first available (rather than ping-ponging between two effects) keeps
-  // this convergent even when several tabs vanish at once.
+  // Keep the selected tab valid: when the current tab disappears (files panel
+  // off, runner reports no git repo), fall back to the first still-visible tab
+  // in display order. First-available keeps this convergent when several vanish.
   useEffect(() => {
     if (railTabsAvailable[rightRailTab]) return;
     const next = (["files", "changes", "github", "subagents", "browser"] as const).find(

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -563,7 +563,7 @@ interface WorkspacePanelProps {
   onRightRailTabChange: (next: RightRailTab) => void;
   /** Whether the Files/Changes tabs are available (agent spec exposes an os_env). */
   showFilesPanel: boolean;
-  /** Whether the GitHub tab is available (same on-disk-workspace gate as Files). */
+  /** Whether the GitHub tab is available (the Files gate plus a git checkout on disk). */
   showGithubTab: boolean;
   /** Whether the Browser tab is available — Electron shell only (hidden in a
    *  plain web build, which has no embedded WebContentsView). */

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -54,6 +54,7 @@ import type {
 import type { TerminalInfo } from "@/hooks/useTerminals";
 import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
+import type { GithubInfo } from "@/hooks/useGithub";
 import {
   consumePendingInitialPrompt,
   handleSessionEvent,
@@ -4368,6 +4369,28 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       });
       spy.mockRestore();
     });
+
+    it("marks the GitHub info stale without refetching (its tab follows the same workspace)", async () => {
+      seedSession("conv_sw", []);
+      await useChatStore.getState().switchTo("conv_sw");
+      const spy = vi.spyOn(client, "invalidateQueries");
+
+      handleSessionEvent({
+        type: "session_agent_changed",
+        conversationId: "conv_sw",
+        agentId: "ag_clone",
+        agentName: "Claude Code (switch ag_clone)",
+      });
+
+      // Same reasoning as the environment above: the new agent's workspace
+      // may or may not be a git checkout, but a refetch now would re-serve
+      // the OLD agent's answer, so only stale-mark it (refetchType "none").
+      expect(spy).toHaveBeenCalledWith({
+        queryKey: ["github-info", "conv_sw"],
+        refetchType: "none",
+      });
+      spy.mockRestore();
+    });
   });
 
   describe("session.terminal_pending", () => {
@@ -6157,6 +6180,87 @@ describe("chatStore — handleSessionEvent (resource events)", () => {
       // ONE debounced flush (the two events above coalesced). 10 would mean
       // the debounce broke and each event flushed separately.
       expect(spy).toHaveBeenCalledTimes(5);
+      spy.mockRestore();
+    });
+
+    it("re-probes an unavailable GitHub answer so a hidden GitHub tab can come back", async () => {
+      // A workspace that isn't a git repo hides the GitHub rail tab, and with
+      // it the panel's own Refresh — so a git init / clone by the agent must
+      // re-run the probe from here.
+      vi.useFakeTimers();
+      client.setQueryData<GithubInfo>(["github-info", "conv_abc"], {
+        object: "session.github.info",
+        available: false,
+        reason: "not_a_git_repo",
+      });
+      const spy = vi.spyOn(client, "invalidateQueries");
+      handleSessionEvent({
+        type: "session_changed_files_invalidated",
+        sessionId: "conv_abc",
+        environmentId: "default",
+      });
+
+      await vi.advanceTimersByTimeAsync(750);
+
+      expect(spy).toHaveBeenCalledWith({ queryKey: ["github-info", "conv_abc"] });
+      spy.mockRestore();
+    });
+
+    it("leaves an available GitHub answer to the panel's own Refresh", async () => {
+      // A git workspace's probe runs gh round-trips; charging that per edit
+      // burst isn't worth it when the visible tab's panel can refresh itself.
+      vi.useFakeTimers();
+      client.setQueryData<GithubInfo>(["github-info", "conv_abc"], {
+        object: "session.github.info",
+        available: true,
+        branch: "main",
+      });
+      const spy = vi.spyOn(client, "invalidateQueries");
+      handleSessionEvent({
+        type: "session_changed_files_invalidated",
+        sessionId: "conv_abc",
+        environmentId: "default",
+      });
+
+      await vi.advanceTimersByTimeAsync(750);
+
+      expect(spy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["github-info", "conv_abc"] }),
+      );
+      expect(spy).toHaveBeenCalledTimes(5);
+      spy.mockRestore();
+    });
+
+    it("re-probes a GitHub answer an agent switch marked stale", async () => {
+      // The switch handler only stale-marks the info (the runner reset hasn't
+      // run yet); the reset's changed-files event is the refetch, in both
+      // directions across a git-repo boundary.
+      seedSession("conv_sw", []);
+      await useChatStore.getState().switchTo("conv_sw");
+      client.setQueryData<GithubInfo>(["github-info", "conv_sw"], {
+        object: "session.github.info",
+        available: true,
+        branch: "main",
+      });
+      handleSessionEvent({
+        type: "session_agent_changed",
+        conversationId: "conv_sw",
+        agentId: "ag_clone",
+        agentName: "Claude Code (switch ag_clone)",
+      });
+      expect(client.getQueryState(["github-info", "conv_sw"])?.isInvalidated).toBe(true);
+
+      vi.useFakeTimers();
+      const spy = vi.spyOn(client, "invalidateQueries");
+      handleSessionEvent({
+        type: "session_changed_files_invalidated",
+        sessionId: "conv_sw",
+        environmentId: "default",
+      });
+
+      await vi.advanceTimersByTimeAsync(750);
+
+      expect(spy).toHaveBeenCalledWith({ queryKey: ["github-info", "conv_sw"] });
       spy.mockRestore();
     });
   });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -93,6 +93,7 @@ import { clearSseLog, pushSseEvent } from "@/lib/sseEventLog";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { sessionItemsQueryKey } from "@/hooks/useSessionItems";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
+import type { GithubInfo } from "@/hooks/useGithub";
 import { overlayTitleIntoCaches, type ConversationsInfiniteData } from "@/lib/sessionListCache";
 import { useTerminalActivityStore } from "./terminalActivity";
 import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
@@ -1219,6 +1220,13 @@ function scheduleWorkspaceFilesystemInvalidation(sessionId: string): void {
     queryClient?.invalidateQueries({
       queryKey: ["workspace-environment", sessionId],
     });
+    // Re-probe the GitHub info when its cached answer is unavailable (a hidden
+    // GitHub tab has no Refresh of its own) or already marked stale, e.g. by an
+    // agent switch. A git workspace's probe costs gh round-trips, so edits skip it.
+    const github = queryClient?.getQueryState<GithubInfo>(["github-info", sessionId]);
+    if (github?.data?.available === false || github?.isInvalidated) {
+      queryClient?.invalidateQueries({ queryKey: ["github-info", sessionId] });
+    }
   }, WORKSPACE_INVALIDATION_DEBOUNCE_MS);
   workspaceInvalidationTimers.set(sessionId, timer);
 }
@@ -5373,6 +5381,12 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
       // lost reset — the next focus/remount refetch corrects the tab.
       queryClient?.invalidateQueries({
         queryKey: ["workspace-environment", event.conversationId],
+        refetchType: "none",
+      });
+      // The GitHub tab's git-repo probe reads the same workspace, so it gets
+      // the same stale-mark; the reset's changed-files event then refetches it.
+      queryClient?.invalidateQueries({
+        queryKey: ["github-info", event.conversationId],
         refetchType: "none",
       });
       // The switch closes the old agent's terminals on the runner


### PR DESCRIPTION
## Related issue

Closes #6260

## Summary

The GitHub rail tab was shown for every workspace with an `os_env`, so a workspace that is not a git checkout offered a tab whose panel could only say "This workspace isn't a git repository."

- `AppShell` now gates `railTabsAvailable.github` on the GitHub info query the panel and composer already share (`useGithubInfo`, same query key, so no extra request): the tab disappears on a definitive `not_a_git_repo` answer and stays while the answer is unknown (loading, errored, runner offline), so a cold-booting runner never makes it flash away. The existing tab-fallback effect moves a selected GitHub tab to Files when it goes.
- A hidden tab has no Refresh of its own, so `chatStore` re-probes an unavailable `github-info` answer when the workspace's changed-files event fires, and stale-marks it on an agent switch alongside the environment query. A git workspace's probe shells out to `gh`, so an available answer is left to the panel's own Refresh as before.
- `GithubInfo.reason` is narrowed to its two runtime values.

**ELI5:** the toolbar used to show a GitHub button in every folder and only tell you "there's no git here" after you clicked it. Now it checks first and leaves the button out; if the agent later runs `git init`, the button comes back.

## Test Plan

- `web/src/shell/AppShell.test.tsx`: new "GitHub tab visibility" block: hidden on `not_a_git_repo` while Files stays; kept while loading, on error, and for a git workspace; the query is keyed by the route's conversation; a selected GitHub tab falls back to Files when the answer arrives. The existing no-os_env test also asserts the tab is absent. These fail on `main` (the tab renders).
- `web/src/store/chatStore.test.ts`: the changed-files event re-probes an unavailable or stale-marked answer and leaves an available one alone; the agent-switch handler stale-marks it.
- `tests/e2e_ui/github/test_github_tab.py`: new `test_github_tab_hidden_for_non_git_workspace` (stubbed `/resources/github` answering `not_a_git_repo`; Files and Agents render, GitHub has count 0). Ran locally with the harness: 3 passed.
- `cd web && pnpm test src/shell/AppShell.test.tsx src/shell/AppShell.subagent-nav.test.tsx src/shell/WorkspacePanel.test.tsx src/shell/GithubPanel.test.tsx src/store/chatStore.test.ts`: 554 passed. `tsc -b`, `oxlint`, and `prettier --check` clean.
- By hand: open a session whose workspace is not a git repository and expand the right rail. The toolbar shows Files, Changes, and Agents with no GitHub icon. Ask the agent to run `git init` there; the tab returns once the agent's next tool call changes files (the re-probe rides the changed-files event).

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before and after on a session whose workspace is not a git repository (captured with the e2e harness, `/resources/github` stubbed to `not_a_git_repo`):

![GitHub tab before and after](https://raw.githubusercontent.com/josuediazflores/omnigent/assets/pr-demos/6260/github-tab-before-after.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

One residual the re-probe does not cover: a hidden tab in a workspace that becomes a git repository without any changed-files event (for example a clone done outside the agent) stays hidden until the session is reopened. Also noted for a follow-up outside the web scope: `omnigent/runner/github_resource.py` reports `not_a_git_repo` when the `git` probe fails to spawn or times out, so that answer is not strictly definitive on the runner side.

## Changelog

The GitHub tab is hidden for workspaces that aren't git repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
