### PR TITLE
fix(runtime): ignore stray .git entries that are not repositories

### DIFF
--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -182,20 +182,27 @@ def _net_operation(first: str, last: str) -> str | None:
 
 
 def _find_git_root(path: Path) -> Path | None:
-    """Walk up the directory tree to find the nearest ``.git`` entry.
+    """Walk up the directory tree to find the nearest valid git repository.
 
     Handles both normal clones (``.git/`` directory) and git worktrees
-    (``.git`` file, a gitlink pointing at the real git dir).
+    (``.git`` file, a gitlink pointing at the real git dir). Directories
+    named ``.git`` that are not repositories (a stray leftover holding
+    unrelated files) are skipped, mirroring git's own discovery; a broken
+    gitlink file stops the search, as it does for git.
 
     :param path: Starting directory (will be resolved to an absolute path).
-    :returns: The directory that contains ``.git``, or ``None`` if *path*
-        is not inside a git repository.
+    :returns: The directory that contains a valid ``.git``, or ``None`` if
+        *path* is not inside a git repository.
     """
     current = path.resolve()
     while True:
         git_entry = current / ".git"
-        if git_entry.is_dir() or git_entry.is_file():
-            return current
+        if git_entry.is_dir():
+            if _is_git_repo(current):
+                return current
+        elif git_entry.is_file():
+            # A broken gitlink is fatal to git, not skipped — stop here.
+            return current if _is_git_repo(current) else None
         parent = current.parent
         if parent == current:
             return None
@@ -225,6 +232,51 @@ def _git_common_dir(git_root: Path) -> Path:
     if not common_dir.is_absolute():
         common_dir = git_dir / common_dir
     return common_dir.resolve()
+
+
+def _resolve_gitfile(git_entry: Path) -> Path | None:
+    """Resolve a ``.git`` gitlink file to the git directory it points at.
+
+    :returns: The resolved git directory, or ``None`` when the file is not
+        a readable ``gitdir:`` link or its target is not a directory.
+    """
+    try:
+        marker = git_entry.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not marker.startswith("gitdir:"):
+        return None
+    git_dir = Path(marker.removeprefix("gitdir:").strip())
+    if not git_dir.is_absolute():
+        git_dir = git_entry.parent / git_dir
+    git_dir = git_dir.resolve()
+    return git_dir if git_dir.is_dir() else None
+
+
+def _is_git_repo(git_root: Path) -> bool:
+    """Return True when *git_root*'s ``.git`` entry forms a working repository.
+
+    A directory named ``.git`` alone is not proof of a repository — it may
+    be a stray leftover holding unrelated files — so require what git's own
+    discovery checks: a HEAD plus object and ref stores. Linked worktrees
+    keep objects and refs in the common dir, so those are looked up there.
+
+    :param git_root: Directory containing the ``.git`` entry to validate.
+    """
+    git_entry = git_root / ".git"
+    if git_entry.is_dir():
+        git_dir = git_entry
+    elif git_entry.is_file():
+        resolved = _resolve_gitfile(git_entry)
+        if resolved is None:
+            return False
+        git_dir = resolved
+    else:
+        return False
+    if not (git_dir / "HEAD").exists():
+        return False
+    common_dir = _git_common_dir(git_root)
+    return (common_dir / "objects").is_dir() and (common_dir / "refs").is_dir()
 
 
 @contextlib.contextmanager

--- a/tests/e2e_ui/files/test_non_git_stray_gitdir.py
+++ b/tests/e2e_ui/files/test_non_git_stray_gitdir.py
@@ -1,0 +1,126 @@
+"""E2E: a session in a non-git folder below a stray ``.git`` dir shows no 502.
+
+A workspace that is not inside a git repository can still sit below a
+directory literally named ``.git`` that is NOT a repository — e.g. a leftover
+``~/.git`` holding only omnigent's untracked-cache lock file. ``_find_git_root``
+treated any ancestor ``.git`` entry as a repository, so such a workspace got a
+``GitFilesystemRegistry`` rooted at a non-repo: every ``git status`` exited 128,
+the runner's ``/changes`` endpoint answered 500 ``git_status_failed``, the
+server proxy wrapped that as a 502, and the Files panel rendered
+"Failed to load: 502" instead of the changed-files list.
+
+This drives the real user journey end to end — a runner-bound session whose
+stored workspace is a plain (non-git) folder below a stray non-repo ``.git``
+directory, the session page opened in the SPA, the Workspace rail's Changes
+tab selected — with no request interception: the SPA hits the live server,
+which proxies to the live runner, which builds the filesystem registry for the
+real workspace path. The assertion encodes the CORRECT behavior: a non-git
+workspace has no git status to fail, so the panel must show the normal empty
+state ("No workspace changes yet") and never an error line. On a build with
+the stray-``.git`` bug the panel shows "Failed to load: 502 …" and this test
+fails there — the regression guard for the fix.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import (
+    _build_hello_world_bundle,
+    _ensure_runner_online,
+    _server_state,
+    open_right_rail,
+)
+
+
+@pytest.fixture
+def non_git_workspace_session(
+    live_server: str,
+    tmp_path: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str]]:
+    """A runner-bound session whose workspace is non-git below a stray ``.git``.
+
+    Recreates the reporter-machine shape: a ``.git`` DIRECTORY that is not a
+    repository (it holds only omnigent's untracked-cache lock file) with a
+    plain non-git workspace nested below it. The session pins that workspace
+    via ``metadata.workspace``, which is what the runner's per-session
+    filesystem registry resolves against.
+
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path: Per-test dir for the stray-``.git`` tree (outside any repo).
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: ``(base_url, session_id)``.
+    """
+    stray_home = tmp_path / "home"
+    (stray_home / ".git").mkdir(parents=True)
+    (stray_home / ".git" / "omnigent-untracked-cache.lock").touch()
+    workspace = stray_home / "scratch" / "project"
+    workspace.mkdir(parents=True)
+    (workspace / "notes.txt").write_text("hello from a non-git folder\n")
+
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    bundle = _build_hello_world_bundle()
+    create = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({"workspace": str(workspace)})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = create.json()["session_id"]
+    patch = httpx.patch(
+        f"{live_server}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    )
+    patch.raise_for_status()
+    try:
+        yield (live_server, session_id)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)
+
+
+def test_non_git_workspace_under_stray_gitdir_shows_empty_changes(
+    page: Page,
+    non_git_workspace_session: tuple[str, str],
+) -> None:
+    """The Changes tab shows the empty state for a non-git workspace, never a 502."""
+    base_url, session_id = non_git_workspace_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    # The changed-files list — where the failure rendered — is the Changes
+    # rail tab (a peer of Files). Select it explicitly so the assertion does
+    # not depend on the remembered tab from a prior session.
+    changes_tab = rail.get_by_role("tab", name=re.compile("^Changes"))
+    changes_tab.click()
+    expect(changes_tab).to_have_attribute("aria-selected", "true")
+
+    # A non-git workspace has no git status to fail: the panel must settle to
+    # the normal empty state. A build that misroots the workspace on the
+    # stray ``.git`` shows "Failed to load: 502 ..." here instead, so this
+    # assertion is what fails on the broken path.
+    expect(rail.get_by_text("No workspace changes yet")).to_be_visible(timeout=30_000)
+
+    # And the failure line must never render for a non-git workspace.
+    expect(rail.get_by_text(re.compile(r"^Failed to load:"))).to_have_count(0)

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -1113,6 +1113,14 @@ def test_normalize_path_relative_dotdot_within_cwd_is_normalized(tmp_path: Path)
 # ── create_filesystem_registry factory ───────────────────────────────────────
 
 
+def _init_fake_git_repo(repo: Path) -> None:
+    """Give *repo* the minimal .git layout repo validation requires."""
+    git_dir = repo / ".git"
+    (git_dir / "objects").mkdir(parents=True)
+    (git_dir / "refs").mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+
 def test_create_filesystem_registry_git_workspace(tmp_path: Path) -> None:
     """A directory with a .git subdirectory yields :class:`GitFilesystemRegistry`.
 
@@ -1120,7 +1128,7 @@ def test_create_filesystem_registry_git_workspace(tmp_path: Path) -> None:
     workspaces would fall back to the plain agent-edit registry, losing
     git-backed baseline support.
     """
-    (tmp_path / ".git").mkdir()
+    _init_fake_git_repo(tmp_path)
     registry = create_filesystem_registry(tmp_path)
     assert isinstance(registry, GitFilesystemRegistry), (
         f"Expected GitFilesystemRegistry for a git workspace, got {type(registry).__name__}. "
@@ -1147,7 +1155,7 @@ def test_create_filesystem_registry_nested_git_workspace(tmp_path: Path) -> None
     workspaces (agent sandboxes inside a repo) would incorrectly use the
     plain agent-edit registry and lose git-backed baseline support.
     """
-    (tmp_path / ".git").mkdir()
+    _init_fake_git_repo(tmp_path)
     nested = tmp_path / "subdir" / "workspace"
     nested.mkdir(parents=True)
     registry = create_filesystem_registry(nested)
@@ -1155,6 +1163,94 @@ def test_create_filesystem_registry_nested_git_workspace(tmp_path: Path) -> None
         f"Expected GitFilesystemRegistry for a nested git workspace, "
         f"got {type(registry).__name__}. "
         "_find_git_root may not be walking parent directories."
+    )
+
+
+def test_create_filesystem_registry_bogus_git_dir(tmp_path: Path) -> None:
+    """A stray .git directory that is not a repository must not count as one.
+
+    Regression test: a workspace under an ancestor with a leftover ``.git``
+    dir (e.g. one holding only an untracked-cache lock file) was given a
+    :class:`GitFilesystemRegistry` rooted at that ancestor; every git command
+    then failed, and the working-folder changed-files view returned 502.
+
+    Failure means _find_git_root is accepting directories that lack the
+    HEAD/objects/refs layout git itself requires.
+    """
+    bogus_home = tmp_path / "home"
+    (bogus_home / ".git").mkdir(parents=True)
+    (bogus_home / ".git" / "omnigent-untracked-cache.lock").write_text("", encoding="utf-8")
+    workspace = bogus_home / "project"
+    workspace.mkdir()
+    registry = create_filesystem_registry(workspace)
+    assert isinstance(registry, AgentEditFilesystemRegistry), (
+        f"Expected AgentEditFilesystemRegistry under a bogus .git ancestor, "
+        f"got {type(registry).__name__}. "
+        "_find_git_root may be treating any .git directory as a repository."
+    )
+
+
+def test_create_filesystem_registry_bogus_git_dir_below_real_repo(tmp_path: Path) -> None:
+    """An invalid .git dir between the workspace and a real repo is skipped.
+
+    Mirrors git's own discovery: a ``.git`` directory that fails validation
+    is treated as absent and the walk continues upward.
+
+    Failure means a stray .git dir shadows the real repository above it.
+    """
+    _init_fake_git_repo(tmp_path)
+    nested = tmp_path / "subdir" / "workspace"
+    nested.mkdir(parents=True)
+    (nested / ".git").mkdir()
+    registry = create_filesystem_registry(nested)
+    assert isinstance(registry, GitFilesystemRegistry), (
+        f"Expected GitFilesystemRegistry rooted at the real repo above a bogus "
+        f".git dir, got {type(registry).__name__}. "
+        "_find_git_root may be stopping at invalid .git directories."
+    )
+
+
+def test_create_filesystem_registry_broken_gitlink(tmp_path: Path) -> None:
+    """A .git file pointing at a nonexistent git dir yields the plain registry.
+
+    Git itself treats a broken gitlink as fatal rather than walking past it,
+    so the workspace must be handled as non-git.
+
+    Failure means _find_git_root accepts gitlinks whose target is missing.
+    """
+    (tmp_path / ".git").write_text("gitdir: /nonexistent/gitdir\n", encoding="utf-8")
+    registry = create_filesystem_registry(tmp_path)
+    assert isinstance(registry, AgentEditFilesystemRegistry), (
+        f"Expected AgentEditFilesystemRegistry for a broken gitlink, "
+        f"got {type(registry).__name__}. "
+        "_find_git_root may be accepting gitlinks without validating the target."
+    )
+
+
+def test_create_filesystem_registry_linked_worktree(tmp_path: Path) -> None:
+    """A valid worktree gitlink still yields :class:`GitFilesystemRegistry`.
+
+    Worktree git dirs carry HEAD but keep objects/refs in the common dir, so
+    validation must follow ``commondir`` rather than demanding them inline.
+
+    Failure means worktree workspaces lose git-backed baseline support.
+    """
+    common_dir = tmp_path / "repo" / ".git"
+    (common_dir / "objects").mkdir(parents=True)
+    (common_dir / "refs").mkdir()
+    (common_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    worktree_git_dir = common_dir / "worktrees" / "feature"
+    worktree_git_dir.mkdir(parents=True)
+    (worktree_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    (worktree_git_dir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+    workspace = tmp_path / "feature"
+    workspace.mkdir()
+    (workspace / ".git").write_text(f"gitdir: {worktree_git_dir}\n", encoding="utf-8")
+    registry = create_filesystem_registry(workspace)
+    assert isinstance(registry, GitFilesystemRegistry), (
+        f"Expected GitFilesystemRegistry for a linked worktree, "
+        f"got {type(registry).__name__}. "
+        "_is_git_repo may not be resolving commondir for worktree git dirs."
     )
 
 


### PR DESCRIPTION
## Related issue

Resolves OMNI-3189 (Linear)

## Summary

- `_find_git_root` treated *any* ancestor `.git` entry as a repository. A workspace below a leftover `.git` directory (e.g. `~/.git` holding only omnigent's untracked-cache lock file) got a `GitFilesystemRegistry` rooted at the non-repo; every `git status` exited 128, the runner's `/changes` endpoint answered 500 `git_status_failed`, the server proxy wrapped that as HTTP 502, and the Workspace rail's Changes tab rendered **"Failed to load: 502 Bad Gateway"** instead of the empty-changes state.
- Validate `.git` candidates the way git's own discovery does — HEAD plus object and ref stores (the latter via `commondir` for linked worktrees) — skip invalid `.git` directories, and stop at broken gitlink files so non-git workspaces fall back to `AgentEditFilesystemRegistry`.

Credit: fix authored by @yaoharry on branch `harry-yao/fix-stray-git-dir-502`; cherry-picked here with original authorship preserved.

## Test Plan

- `uv run pytest tests/runtime/test_filesystem_registry.py` — 78 passed (includes 4 new cases: `bogus_git_dir`, `bogus_git_dir_below_real_repo`, `broken_gitlink`, `linked_worktree`).
- `uv run pytest tests/e2e_ui/files/test_non_git_stray_gitdir.py` — end-to-end regression: drives the real SPA/server/runner with a stray non-repo `.git` ancestor; asserts Changes tab shows "No workspace changes yet", not a 502 error.

**Manual validation steps:**

```bash
# Create the stray-.git shape the reporter described
mkdir -p /tmp/strayhome/.git
touch /tmp/strayhome/.git/omnigent-untracked-cache.lock
mkdir -p /tmp/strayhome/scratch/project
echo hello > /tmp/strayhome/scratch/project/notes.txt

# Start a session whose workspace is the non-git folder
omnigent claude --server '' --workspace /tmp/strayhome/scratch/project
```

Open the session page → Workspace rail → Changes tab.
**Before fix:** "Failed to load: 502 Bad Gateway".
**After fix:** "No workspace changes yet" (normal empty state).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

78 unit tests pass; e2e regression test passes on the fixed tree and fails on the unfixed tree (the assertion `"Failed to load: 502 Bad Gateway"` paragraph rendered where `"No workspace changes yet"` was asserted).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable