### PR TITLE
fix(github): source the GitHub tab from the PR, not a local branch diff

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2839,14 +2839,14 @@ class HostProcess:
         if op == "github_info":
             return r.github_info()
         if op == "github_changes":
-            return r.github_changes(cast("str | None", params.get("base")))
+            return r.github_changes()
         if op == "github_diff":
             return r.github_file_diff(
                 cast("str | None", params.get("base")),
                 str(params.get("path", "")),
             )
         if op == "github_pr_diff":
-            return r.github_pr_diff(cast("str | None", params.get("base")))
+            return r.github_pr_diff()
         raise ValueError(f"unknown fs op: {op!r}")
 
     async def _handle_create_worktree(

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -9753,10 +9753,12 @@ def create_runner_app(
             },
         )
 
-    # ── GitHub integration (read-only): PR metadata + branch-vs-base diff ──
-    # Backed by the ``gh`` CLI and ``git``; see omnigent.runner.github_resource.
-    # Each shells out synchronously, so it is offloaded to a thread like the
-    # changed-files / diff routes above (a blocked loop 503s the session).
+    # ── GitHub integration (read-only): PR metadata + the PR's files / diff ──
+    # The list and patch come from the ``gh`` CLI (the PR's "Files changed");
+    # only the per-file expand-context reader uses ``git show``. See
+    # omnigent.runner.github_resource. Each shells out synchronously, so it is
+    # offloaded to a thread like the changed-files / diff routes above (a blocked
+    # loop 503s the session).
 
     async def _github_workspace_root(session_id: str) -> str:
         """Resolve the workspace root for GitHub routes, or 404 when headless."""
@@ -9780,36 +9782,23 @@ def create_runner_app(
         return JSONResponse(status_code=200, content=info)
 
     @app.get("/v1/sessions/{session_id}/resources/github/changes")
-    async def read_github_changes(
-        session_id: str,
-        base: str | None = Query(default=None),
-    ) -> JSONResponse:
+    async def read_github_changes(session_id: str) -> JSONResponse:
         import asyncio as _asyncio
 
-        from omnigent.runner.github_resource import github_changed_files, resolve_base_ref
+        from omnigent.runner.github_resource import github_changed_files
 
         root = await _github_workspace_root(session_id)
-        resolved_base = await _asyncio.to_thread(resolve_base_ref, root, base)
-        if not resolved_base:
-            return JSONResponse(
-                status_code=200,
-                content={"object": "list", "data": [], "has_more": False},
-            )
-        result = await _asyncio.to_thread(github_changed_files, root, resolved_base)
+        result = await _asyncio.to_thread(github_changed_files, root)
         return JSONResponse(status_code=200, content=result)
 
     @app.get("/v1/sessions/{session_id}/resources/github/diff")
-    async def read_github_pr_diff(
-        session_id: str,
-        base: str | None = Query(default=None),
-    ) -> JSONResponse:
+    async def read_github_pr_diff(session_id: str) -> JSONResponse:
         import asyncio as _asyncio
 
-        from omnigent.runner.github_resource import github_pr_diff, resolve_base_ref
+        from omnigent.runner.github_resource import github_pr_diff
 
         root = await _github_workspace_root(session_id)
-        resolved_base = await _asyncio.to_thread(resolve_base_ref, root, base)
-        result = await _asyncio.to_thread(github_pr_diff, root, resolved_base or "")
+        result = await _asyncio.to_thread(github_pr_diff, root)
         return JSONResponse(status_code=200, content=result)
 
     @app.get("/v1/sessions/{session_id}/resources/github/diff/{relative_path:path}")

--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -1,9 +1,10 @@
 """GitHub integration for the session workspace, backed by the ``gh`` CLI.
 
-Powers the web UI's read-only "GitHub" rail tab. Everything here shells out to
-``gh`` (for PR metadata) and ``git`` (for the branch-vs-base diff) inside the
-session's workspace, mirroring the ``git`` subprocess pattern the changed-files
-/ diff endpoints already use (see :mod:`omnigent.runtime.filesystem_registry`).
+Powers the web UI's read-only "GitHub" rail tab, which is purely a PR view: the
+changed-files list and the whole-PR patch come straight from GitHub via ``gh``
+(``gh api .../pulls/<n>/files`` and ``gh pr diff``), so they match the PR's
+"Files changed" exactly. With no PR for the branch the tab shows its "no PR"
+empty state and fetches nothing.
 
 Design notes:
 
@@ -11,10 +12,11 @@ Design notes:
   sandboxed OS-env shell helper. The helper strips secrets from the environment,
   which would break ``gh`` auth; a plain subprocess inherits the runner process
   environment (the developer's ``gh`` auth in local dev).
-- The diff is computed locally with ``git`` against the PR's merge-base (the
-  three-dot / "Files changed" semantics GitHub shows), so it yields full
-  before/after file content the Monaco diff viewer can render — a unified-diff
-  blob cannot.
+- The list and patch are GitHub-computed, never a local ``git diff``, so a stale
+  local ``origin/<base>`` can't inflate them with files outside the PR.
+- Only the on-demand per-file expand-context reader (:func:`github_file_diff`)
+  still uses ``git show`` for full before/after content — a unified-diff blob
+  can't drive the viewer's context expansion.
 - ``available: false`` payloads let the tab render a message ("gh not installed",
   "not a git repo") instead of surfacing an error.
 """
@@ -162,43 +164,19 @@ def _summarize_checks(rollup: Any) -> dict[str, Any]:
     }
 
 
-def _git_default_base(root: str) -> str | None:
-    """Detect the repo's default branch name from git alone (no ``gh``).
-
-    Lets the branch-vs-base diff resolve a base even when ``gh`` is missing or
-    unauthenticated (e.g. served over the host fallback). Prefers the remote's
-    published HEAD, then a conventional ``main``/``master``.
-
-    :param root: Absolute workspace path.
-    :returns: A branch name, e.g. ``"main"``, or ``None``.
-    """
-    rc, out, _ = _git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], cwd=root)
-    if rc == 0 and out.strip():
-        # "refs/remotes/origin/main" → "main"
-        return out.strip().rsplit("/", 1)[-1]
-    # No published remote HEAD: fall back to a conventional default, preferring
-    # the remote-tracking ref, then a local branch (a local-only workspace).
-    for candidate in ("origin/main", "origin/master", "main", "master"):
-        rc, _, _ = _git(["rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"], cwd=root)
-        if rc == 0:
-            return candidate.rsplit("/", 1)[-1]
-    return None
-
-
 def github_info(root: str) -> dict[str, Any]:
     """Resolve GitHub context for the workspace: repo, branch, base, and PR.
 
-    Git-first: a git checkout is the fundamental requirement (the branch-vs-base
-    diff is viewable from git alone), and ``gh`` layers PR/repo metadata on top.
-    So ``available`` reflects "is a git repo", and ``base_ref`` is populated from
-    git even when ``gh`` is absent — this is what lets the host fallback serve
-    the diff when the runner is offline and its machine has no ``gh``.
+    Git-first: a git checkout is the fundamental requirement, so ``available``
+    reflects "is a git repo". ``gh`` layers the repo / PR metadata on top;
+    ``base_ref`` is the PR's base branch (``None`` when there's no PR, since the
+    tab is a pure PR view).
 
     :param root: Absolute path to the session workspace.
     :returns: A ``session.github.info`` object. ``available`` is false only when
         this isn't a git repo (``reason: not_a_git_repo``). ``gh_available`` /
         ``authenticated`` report whether the ``gh`` CLI is present and signed in;
-        ``repo`` / ``pr`` are null without it, and the diff still renders.
+        ``repo`` / ``pr`` / ``base_ref`` are null without it.
     """
     payload: dict[str, Any] = {"object": "session.github.info"}
 
@@ -207,11 +185,10 @@ def github_info(root: str) -> dict[str, Any]:
         payload.update(available=False, reason="not_a_git_repo")
         return payload
     branch = out.strip()
-    git_base = _git_default_base(root)
     payload.update(
         available=True,
         branch=branch,
-        base_ref=git_base,
+        base_ref=None,
         repo=None,
         pr=None,
     )
@@ -229,15 +206,11 @@ def github_info(root: str) -> dict[str, Any]:
     if not authenticated:
         return payload
 
-    default_branch: str | None = None
-    rc, out, _ = _gh(["repo", "view", "--json", "nameWithOwner,defaultBranchRef"], cwd=root)
+    rc, out, _ = _gh(["repo", "view", "--json", "nameWithOwner"], cwd=root)
     if rc == 0:
         try:
             data = json.loads(out)
             payload["repo"] = {"name_with_owner": data.get("nameWithOwner")}
-            ref = data.get("defaultBranchRef")
-            if isinstance(ref, dict):
-                default_branch = ref.get("name")
         except (ValueError, AttributeError):
             pass
 
@@ -262,9 +235,8 @@ def github_info(root: str) -> dict[str, Any]:
             pr = None
     payload["pr"] = pr
 
-    # Diff base precedence: the PR's base, else gh's default branch, else the
-    # git-derived default already set above.
-    payload["base_ref"] = (pr.get("base_ref") if pr else None) or default_branch or git_base
+    # A pure PR view: the base is the PR's base branch, else null (no PR).
+    payload["base_ref"] = pr.get("base_ref") if pr else None
     return payload
 
 
@@ -309,67 +281,84 @@ def _resolve_diff_base(root: str, base: str) -> str | None:
     return resolved
 
 
-# git diff status letters → the status vocabulary the web changed-files list uses.
-_STATUS_MAP = {
-    "A": "created",
-    "M": "modified",
-    "D": "deleted",
-    "R": "renamed",
-    "C": "created",
-    "T": "modified",
+# GitHub pulls/files ``status`` → the status vocabulary the web list uses.
+_GH_STATUS_MAP = {
+    "added": "created",
+    "removed": "deleted",
+    "modified": "modified",
+    "renamed": "renamed",
+    "copied": "created",
+    "changed": "modified",
+    "unchanged": "modified",
 }
 
 
-def github_changed_files(root: str, base: str) -> dict[str, Any]:
-    """List files changed on HEAD relative to the base branch's merge-base.
+def _pr_number(root: str) -> int | None:
+    """Return the PR number for the workspace's branch, or ``None``.
 
     :param root: Absolute workspace path.
-    :param base: Base branch name, e.g. ``"main"``.
+    :returns: The associated PR's number, or ``None`` when ``gh`` finds no PR
+        (none for the branch, ``gh`` missing, or not authenticated).
+    """
+    rc, out, _ = _gh(["pr", "view", "--json", "number"], cwd=root)
+    if rc != 0:
+        return None
+    try:
+        number = json.loads(out).get("number")
+    except (ValueError, AttributeError):
+        return None
+    return number if isinstance(number, int) else None
+
+
+def github_changed_files(root: str) -> dict[str, Any]:
+    """List the PR's changed files, straight from GitHub.
+
+    Sourced from ``gh api .../pulls/<n>/files`` so the set (and each file's
+    status / line counts) matches the PR's "Files changed" exactly — never a
+    local ``git diff``. Empty when the branch has no PR.
+
+    :param root: Absolute workspace path.
     :returns: A ``list`` object whose ``data`` entries carry ``path`` / ``name``
         / ``status`` / ``lines_added`` / ``lines_removed``.
     """
-    diff_base = _resolve_diff_base(root, base)
-    if diff_base is None:
-        return {"object": "list", "data": [], "has_more": False}
-
-    # numstat first (adds/dels + final path), keyed by path for the status merge.
-    # ``-M`` detects renames so a moved file shows once (matching the whole-PR
-    # patch the diff view parses), not as a delete + add pair.
-    counts: dict[str, tuple[int | None, int | None]] = {}
-    rc, out, _ = _git(["diff", "-M", "--numstat", diff_base, "HEAD"], cwd=root)
-    if rc == 0:
-        for line in out.splitlines():
-            parts = line.split("\t")
-            if len(parts) < 3:
-                continue
-            added, removed, path = parts[0], parts[1], parts[-1]
-            counts[path] = (
-                None if added == "-" else int(added),
-                None if removed == "-" else int(removed),
-            )
+    empty: dict[str, Any] = {"object": "list", "data": [], "has_more": False}
+    number = _pr_number(root)
+    if number is None:
+        return empty
+    # ``{owner}`` / ``{repo}`` are filled by ``gh`` from the repo; ``--paginate``
+    # concatenates the pages of the (array) response into one JSON array.
+    rc, out, _ = _gh(
+        ["api", "--paginate", f"repos/{{owner}}/{{repo}}/pulls/{number}/files?per_page=100"],
+        cwd=root,
+    )
+    if rc != 0:
+        return empty
+    try:
+        entries = json.loads(out)
+    except ValueError:
+        return empty
+    if not isinstance(entries, list):
+        return empty
 
     data: list[dict[str, Any]] = []
-    rc, out, _ = _git(["diff", "-M", "--name-status", diff_base, "HEAD"], cwd=root)
-    if rc == 0:
-        for line in out.splitlines():
-            parts = line.split("\t")
-            if len(parts) < 2:
-                continue
-            code = parts[0][:1]
-            # For renames/copies (``R100\told\tnew``) the last field is the
-            # current path — the one the diff endpoint reads at HEAD.
-            path = parts[-1]
-            added, removed = counts.get(path, (None, None))
-            data.append(
-                {
-                    "object": "session.github.changed_file",
-                    "path": path,
-                    "name": path.split("/")[-1],
-                    "status": _STATUS_MAP.get(code, "modified"),
-                    "lines_added": added,
-                    "lines_removed": removed,
-                }
-            )
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        # ``filename`` is the current path (the new name for a rename) — the one
+        # the diff endpoint reads at HEAD, matching the whole-PR patch.
+        path = entry.get("filename")
+        if not path:
+            continue
+        data.append(
+            {
+                "object": "session.github.changed_file",
+                "path": path,
+                "name": str(path).split("/")[-1],
+                "status": _GH_STATUS_MAP.get(str(entry.get("status")), "modified"),
+                "lines_added": entry.get("additions"),
+                "lines_removed": entry.get("deletions"),
+            }
+        )
     return {"object": "list", "data": data, "has_more": False}
 
 
@@ -405,21 +394,16 @@ def github_file_diff(root: str, base: str, path: str) -> dict[str, Any]:
     }
 
 
-def github_pr_diff(root: str, base: str) -> dict[str, Any]:
-    """Return the whole PR as one unified diff patch (HEAD vs the base merge-base).
+def github_pr_diff(root: str) -> dict[str, Any]:
+    """Return the whole PR as one unified diff patch, straight from GitHub.
 
-    One ``git diff`` for every changed file, so the web view can render the
-    entire PR from a single call (parsed client-side into per-file diffs).
-    ``-M`` detects renames so a move renders as one file rather than a
-    delete + add.
+    ``gh pr diff`` yields the PR's "Files changed" patch (server-computed against
+    the base's merge-base), which the web view parses client-side into per-file
+    diffs. Empty when the branch has no PR.
 
     :param root: Absolute workspace path.
-    :param base: Base branch name, e.g. ``"main"``.
     :returns: A ``session.github.pr_diff`` object with the ``patch`` text
-        (empty when the base can't be resolved / there are no changes).
+        (empty when there's no PR / no changes).
     """
-    diff_base = _resolve_diff_base(root, base)
-    if diff_base is None:
-        return {"object": "session.github.pr_diff", "patch": ""}
-    rc, out, _ = _git(["diff", "-M", diff_base, "HEAD"], cwd=root)
+    rc, out, _ = _gh(["pr", "diff"], cwd=root)
     return {"object": "session.github.pr_diff", "patch": out if rc == 0 else ""}

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -2155,18 +2155,16 @@ def register_resources_routes(
     async def read_github_pr_diff(
         request: Request,
         session_id: str,
-        base: str | None = Query(default=None),
     ) -> Any:
         """
         Return the whole PR as one unified diff patch.
 
-        One ``git diff`` covering every changed file, gzipped on the way out
+        ``gh pr diff`` covering every changed file, gzipped on the way out
         (patches are large). The web view parses it client-side into per-file
         diffs. Falls back to the host tunnel when the runner is offline.
 
         :param request: The incoming FastAPI request (for auth).
         :param session_id: Session/conversation identifier.
-        :param base: Base branch name; the default is derived when omitted.
         :returns: JSON with the ``patch`` text.
         """
         conv = await _validate_session(session_id, request, LEVEL_READ)
@@ -2174,9 +2172,8 @@ def register_resources_routes(
             session_id,
             conv,
             op="github_pr_diff",
-            host_params={"base": base},
+            host_params={},
             runner_path=f"/v1/sessions/{session_id}/resources/github/diff",
-            runner_params={"base": base} if base else None,
         )
 
     @file_read_router.get(
@@ -2493,15 +2490,12 @@ def register_resources_routes(
     async def list_session_github_changes(
         request: Request,
         session_id: str,
-        base: str | None = Query(default=None),
     ) -> dict[str, Any]:
         """
-        List files changed on the branch relative to its base (PR diff).
+        List the PR's changed files (empty when the branch has no PR).
 
         :param request: The incoming FastAPI request (for auth).
         :param session_id: Session/conversation identifier.
-        :param base: Base branch name; the runner derives the default when
-            omitted.
         :returns: Flat list of changed files with ``status`` and line counts.
         """
         conv = await _validate_session(session_id, request, LEVEL_READ)
@@ -2509,9 +2503,8 @@ def register_resources_routes(
             session_id,
             conv,
             op="github_changes",
-            host_params={"base": base},
+            host_params={},
             runner_path=f"/v1/sessions/{session_id}/resources/github/changes",
-            runner_params={"base": base} if base else None,
         )
 
     # Generic single-resource lookup — registered AFTER typed

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -470,24 +470,20 @@ class WorkspaceReader:
         }
 
     # ── GitHub integration (read-only) ────────────────────────────
-    # Serve the same read-only PR-metadata + branch-vs-base diff the runner's
+    # Serve the same read-only PR metadata + the PR's files / diff the runner's
     # GitHub endpoints do, so the tab keeps working when the runner is offline
     # but the host still holds the workspace. Delegates to the shared
-    # ``github_resource`` helpers against this reader's confined root; the git
-    # ops are read-only and ``gh`` is the developer's own authenticated CLI.
+    # ``github_resource`` helpers against this reader's confined root; the list
+    # and patch come from ``gh`` (the developer's authenticated CLI) and only the
+    # per-file reader shells out to a read-only ``git show``.
 
     def github_info(self) -> _WorkspacePayload:
         """GitHub context (repo, branch, base ref, PR) for the workspace."""
         return cast("_WorkspacePayload", github_resource.github_info(str(self._root)))
 
-    def github_changes(self, base: str | None) -> _WorkspacePayload:
-        """Files changed on HEAD vs the base branch (``base`` derived if None)."""
-        resolved = github_resource.resolve_base_ref(str(self._root), base)
-        if not resolved:
-            return {"object": "list", "data": [], "has_more": False}
-        return cast(
-            "_WorkspacePayload", github_resource.github_changed_files(str(self._root), resolved)
-        )
+    def github_changes(self) -> _WorkspacePayload:
+        """The PR's changed files (empty when the branch has no PR)."""
+        return cast("_WorkspacePayload", github_resource.github_changed_files(str(self._root)))
 
     def github_file_diff(self, base: str | None, relative_path: str) -> _WorkspacePayload:
         """Before/after content for one file, HEAD vs the base merge-base."""
@@ -497,10 +493,6 @@ class WorkspaceReader:
             github_resource.github_file_diff(str(self._root), resolved or "", relative_path),
         )
 
-    def github_pr_diff(self, base: str | None) -> _WorkspacePayload:
-        """The whole PR as one unified diff patch (base derived if None)."""
-        resolved = github_resource.resolve_base_ref(str(self._root), base)
-        return cast(
-            "_WorkspacePayload",
-            github_resource.github_pr_diff(str(self._root), resolved or ""),
-        )
+    def github_pr_diff(self) -> _WorkspacePayload:
+        """The whole PR as one unified diff patch (empty when there's no PR)."""
+        return cast("_WorkspacePayload", github_resource.github_pr_diff(str(self._root)))

--- a/openapi.json
+++ b/openapi.json
@@ -13303,7 +13303,7 @@
     },
     "/v1/sessions/{session_id}/resources/github/changes": {
       "get": {
-        "description": "List files changed on the branch relative to its base (PR diff).\n\n**Returns:** Flat list of changed files with `status` and line counts.",
+        "description": "List the PR's changed files (empty when the branch has no PR).\n\n**Returns:** Flat list of changed files with `status` and line counts.",
         "operationId": "list_session_github_changes_v1_sessions__session_id__resources_github_changes_get",
         "parameters": [
           {
@@ -13314,23 +13314,6 @@
             "schema": {
               "title": "Session Id",
               "type": "string"
-            }
-          },
-          {
-            "description": "Base branch name; the runner derives the default when omitted.",
-            "in": "query",
-            "name": "base",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Base"
             }
           }
         ],

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -1,16 +1,18 @@
 """Tests for :mod:`omnigent.runner.github_resource`.
 
-The ``git``-backed functions (:func:`github_changed_files`,
-:func:`github_file_diff`) run against a real temp repo so the subprocess path is
-fully exercised. The ``gh``-backed :func:`github_info` is covered for its
-availability fallbacks (``gh`` missing, not a git repo) and its check-summary
-reducer, which don't require ``gh`` or the network.
+:func:`github_file_diff` (the on-demand expand-context reader) runs ``git show``
+against a real temp repo. The PR-backed :func:`github_changed_files` /
+:func:`github_pr_diff` shell out to ``gh``, stubbed here via :func:`_stub_gh`.
+:func:`github_info`'s availability fallbacks and its check-summary reducer need
+neither ``gh`` nor the network.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
@@ -23,6 +25,25 @@ from omnigent.runner.github_resource import (
     github_info,
     github_pr_diff,
 )
+
+
+def _stub_gh(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: dict[tuple[str, ...], tuple[int, str, str]],
+) -> None:
+    """Stub ``github_resource._gh`` to answer by the argv's leading tokens.
+
+    :param responses: Maps a leading-argv prefix (e.g. ``("pr", "view")``) to
+        the ``(returncode, stdout, stderr)`` it should return.
+    """
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        for prefix, value in responses.items():
+            if tuple(argv[: len(prefix)]) == prefix:
+                return value
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
 
 
 def _git_env() -> dict[str, str]:
@@ -64,13 +85,11 @@ def repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_github_info_gh_not_installed_still_serves_git(
-    repo: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Without ``gh``, a git repo still reports branch + base so the diff renders.
+def test_github_info_gh_not_installed(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without ``gh`` there's no PR knowable, so base/pr/repo are null.
 
-    This is what lets the host fallback serve the branch-vs-base diff when the
-    runner is offline and its machine has no ``gh``.
+    ``available`` still reflects "is a git repo" and reports the branch; the tab
+    is a pure PR view, so ``base_ref`` is null until a PR resolves it.
     """
     monkeypatch.setattr(github_resource.shutil, "which", lambda _name: None)
     info = github_info(str(repo))
@@ -78,7 +97,7 @@ def test_github_info_gh_not_installed_still_serves_git(
     assert info["gh_available"] is False
     assert info["authenticated"] is False
     assert info["branch"] == "feature"
-    assert info["base_ref"] == "main"
+    assert info["base_ref"] is None
     assert info["pr"] is None
     assert info["repo"] is None
 
@@ -91,17 +110,36 @@ def test_github_info_not_a_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert info["reason"] == "not_a_git_repo"
 
 
-def test_github_changed_files_statuses(repo: Path) -> None:
-    """Changed-files list reports add/modify/delete against the base branch."""
-    result = github_changed_files(str(repo), "main")
+def test_github_changed_files_maps_pr_file_statuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The list comes from ``gh api pulls/<n>/files``, mapping GitHub statuses."""
+    files = [
+        {"filename": "newfile.py", "status": "added", "additions": 1, "deletions": 0},
+        {"filename": "src/fileA.py", "status": "modified", "additions": 2, "deletions": 1},
+        {"filename": "fileB.py", "status": "removed", "additions": 0, "deletions": 3},
+        {
+            "filename": "new/name.py",
+            "status": "renamed",
+            "additions": 0,
+            "deletions": 0,
+            "previous_filename": "old/name.py",
+        },
+    ]
+    _stub_gh(
+        monkeypatch,
+        {
+            ("pr", "view"): (0, json.dumps({"number": 7}), ""),
+            ("api",): (0, json.dumps(files), ""),
+        },
+    )
+    result = github_changed_files("/root")
     by_path = {entry["path"]: entry for entry in result["data"]}
     assert by_path["newfile.py"]["status"] == "created"
-    assert by_path["fileA.py"]["status"] == "modified"
+    assert by_path["src/fileA.py"]["status"] == "modified"
     assert by_path["fileB.py"]["status"] == "deleted"
-    assert "fileC.py" not in by_path
-    # Line counts come from numstat: the added file gains a line.
+    assert by_path["new/name.py"]["status"] == "renamed"
+    # Line counts and the display name come straight from the PR file entry.
     assert by_path["newfile.py"]["lines_added"] == 1
-    assert by_path["newfile.py"]["name"] == "newfile.py"
+    assert by_path["src/fileA.py"]["name"] == "fileA.py"
 
 
 def test_github_file_diff_added(repo: Path) -> None:
@@ -125,30 +163,23 @@ def test_github_file_diff_deleted(repo: Path) -> None:
     assert diff["after"] is None
 
 
-def test_github_changed_files_unresolvable_base(repo: Path) -> None:
-    """An unknown base ref yields an empty list rather than an error."""
-    result = github_changed_files(str(repo), "does-not-exist")
-    assert result == {"object": "list", "data": [], "has_more": False}
+def test_github_changed_files_no_pr(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no PR for the branch, the list is empty (no local git fallback)."""
+    _stub_gh(monkeypatch, {("pr", "view"): (1, "", "no pull requests found")})
+    assert github_changed_files("/root") == {"object": "list", "data": [], "has_more": False}
 
 
-def test_github_pr_diff_covers_all_files(repo: Path) -> None:
-    """The whole-PR patch is one unified diff spanning every changed file."""
-    result = github_pr_diff(str(repo), "main")
-    patch = result["patch"]
-    # One diff header per changed file, plus the actual change content.
-    assert "diff --git a/fileA.py b/fileA.py" in patch
-    assert "diff --git a/newfile.py b/newfile.py" in patch
-    assert "diff --git a/fileB.py b/fileB.py" in patch
-    assert "+A changed" in patch
-    assert "fileC.py" not in patch  # unchanged file absent
+def test_github_pr_diff_returns_gh_patch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole-PR patch is ``gh pr diff`` verbatim (GitHub-computed)."""
+    patch = "diff --git a/fileA.py b/fileA.py\n@@ -1 +1 @@\n-A base\n+A changed\n"
+    _stub_gh(monkeypatch, {("pr", "diff"): (0, patch, "")})
+    assert github_pr_diff("/root") == {"object": "session.github.pr_diff", "patch": patch}
 
 
-def test_github_pr_diff_unresolvable_base(repo: Path) -> None:
-    """An unknown base ref yields an empty patch rather than an error."""
-    assert github_pr_diff(str(repo), "does-not-exist") == {
-        "object": "session.github.pr_diff",
-        "patch": "",
-    }
+def test_github_pr_diff_no_pr(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no PR for the branch, the patch is empty rather than an error."""
+    _stub_gh(monkeypatch, {("pr", "diff"): (1, "", "no pull requests found")})
+    assert github_pr_diff("/root") == {"object": "session.github.pr_diff", "patch": ""}
 
 
 def test_summarize_checks_mixed() -> None:

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -2585,13 +2585,13 @@ async def test_github_info_proxies_to_runner(client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_github_changes_forwards_base_param(client: httpx.AsyncClient) -> None:
-    """GET /resources/github/changes forwards ``?base=`` to the runner."""
+async def test_github_changes_proxies_to_runner(client: httpx.AsyncClient) -> None:
+    """GET /resources/github/changes proxies the PR file list to the runner."""
     fake_runner = _FakeRunnerClient(payload={"object": "list", "data": [], "has_more": False})
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
     resp = await client.get(
-        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/github/changes?base=main"
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/github/changes"
     )
 
     assert resp.status_code == 200
@@ -2599,19 +2599,16 @@ async def test_github_changes_forwards_base_param(client: httpx.AsyncClient) -> 
         "GET",
         "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/github/changes",
     ) in fake_runner.calls
-    assert {"base": "main"} in fake_runner.get_params
 
 
 @pytest.mark.asyncio
 async def test_github_pr_diff_proxies_whole_patch(client: httpx.AsyncClient) -> None:
-    """GET /resources/github/diff (no path) proxies the whole-PR patch + base."""
+    """GET /resources/github/diff (no path) proxies the whole-PR patch."""
     payload = {"object": "session.github.pr_diff", "patch": "diff --git a/x b/x\n"}
     fake_runner = _FakeRunnerClient(payload=payload)
     set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
 
-    resp = await client.get(
-        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/github/diff?base=main"
-    )
+    resp = await client.get("/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/github/diff")
 
     assert resp.status_code == 200
     assert resp.json() == payload
@@ -2619,7 +2616,6 @@ async def test_github_pr_diff_proxies_whole_patch(client: httpx.AsyncClient) -> 
         "GET",
         "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/github/diff",
     ) in fake_runner.calls
-    assert {"base": "main"} in fake_runner.get_params
 
 
 @pytest.mark.asyncio

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -372,11 +372,10 @@ def _git_branch_repo(path: Path) -> None:
     )
 
 
-def test_github_info_without_gh_reports_git_state(tmp_path: Path, monkeypatch) -> None:
-    """The host serves branch + base from git even when ``gh`` is absent.
+def test_github_info_without_gh_reports_no_pr(tmp_path: Path, monkeypatch) -> None:
+    """Without ``gh`` the host reports the git repo/branch but no PR or base.
 
-    This is what keeps the branch-vs-base diff viewable when the runner is
-    offline and the host machine has no ``gh``.
+    The tab is a pure PR view, so ``base_ref`` stays null until a PR resolves it.
     """
     from omnigent import workspace_fs
 
@@ -389,22 +388,37 @@ def test_github_info_without_gh_reports_git_state(tmp_path: Path, monkeypatch) -
     assert info["available"] is True
     assert info["gh_available"] is False
     assert info["branch"] == "feature"
-    assert info["base_ref"] == "main"
+    assert info["base_ref"] is None
 
 
-def test_github_changes_lists_branch_diff(tmp_path: Path) -> None:
-    """``github_changes`` derives the base and lists the branch's changes."""
+def test_github_changes_lists_pr_files(tmp_path: Path, monkeypatch) -> None:
+    """``github_changes`` delegates to the gh-backed PR file list."""
+    from omnigent import workspace_fs
+
     _git_branch_repo(tmp_path)
+
+    def fake_gh(argv, *, cwd):
+        if tuple(argv[:2]) == ("pr", "view"):
+            return (0, '{"number": 3}', "")
+        if tuple(argv[:1]) == ("api",):
+            return (
+                0,
+                '[{"filename": "app.txt", "status": "modified", "additions": 1, "deletions": 1}]',
+                "",
+            )
+        return (1, "", "")
+
+    monkeypatch.setattr(workspace_fs.github_resource, "_gh", fake_gh)
     reader = WorkspaceReader(tmp_path)
 
-    result = reader.github_changes(None)
+    result = reader.github_changes()
 
     paths = {entry["path"]: entry["status"] for entry in result["data"]}
     assert paths.get("app.txt") == "modified"
 
 
 def test_github_file_diff_returns_before_after(tmp_path: Path) -> None:
-    """``github_file_diff`` returns base vs HEAD content for a file."""
+    """``github_file_diff`` returns base vs HEAD content for a file (git show)."""
     _git_branch_repo(tmp_path)
     reader = WorkspaceReader(tmp_path)
 
@@ -414,12 +428,21 @@ def test_github_file_diff_returns_before_after(tmp_path: Path) -> None:
     assert diff["after"] == "changed\n"
 
 
-def test_github_pr_diff_returns_whole_patch(tmp_path: Path) -> None:
-    """``github_pr_diff`` returns the whole branch-vs-base patch (base derived)."""
+def test_github_pr_diff_returns_whole_patch(tmp_path: Path, monkeypatch) -> None:
+    """``github_pr_diff`` delegates to ``gh pr diff``."""
+    from omnigent import workspace_fs
+
     _git_branch_repo(tmp_path)
+
+    def fake_gh(argv, *, cwd):
+        if tuple(argv[:2]) == ("pr", "diff"):
+            return (0, "diff --git a/app.txt b/app.txt\n+changed\n", "")
+        return (1, "", "")
+
+    monkeypatch.setattr(workspace_fs.github_resource, "_gh", fake_gh)
     reader = WorkspaceReader(tmp_path)
 
-    result = reader.github_pr_diff(None)
+    result = reader.github_pr_diff()
 
     assert "diff --git a/app.txt b/app.txt" in result["patch"]
     assert "+changed" in result["patch"]

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -2,9 +2,9 @@
 //
 //   useGithubInfo        — GET /resources/github
 //                          repo / branch / base ref / associated PR + CI summary.
-//   useGithubChangedFiles — GET /resources/github/changes?base=<ref>
-//                          files changed on the branch vs its base (sidebar list).
-//   useGithubPrDiff      — GET /resources/github/diff?base=<ref>
+//   useGithubChangedFiles — GET /resources/github/changes
+//                          the PR's changed files (sidebar list).
+//   useGithubPrDiff      — GET /resources/github/diff
 //                          the whole PR as one unified-diff patch.
 //   fetchGithubFileContents — GET /resources/github/diff/{path}?base=<ref>
 //                          before/after full content for one file, fetched on
@@ -79,7 +79,7 @@ export interface GithubInfo {
   authenticated?: boolean;
   branch?: string;
   repo?: GithubRepo | null;
-  /** Branch the diff is computed against (PR base, gh default, else git default). */
+  /** The PR's base branch; null when there's no PR (the tab is a PR view). */
   base_ref?: string | null;
   pr?: GithubPr | null;
 }
@@ -182,13 +182,9 @@ export function useGithubInfo(conversationId: string | undefined) {
   });
 }
 
-async function fetchGithubChangedFiles(
-  conversationId: string,
-  base: string | undefined,
-): Promise<GithubChangedFilesResult> {
-  const params = base ? `?base=${encodeURIComponent(base)}` : "";
+async function fetchGithubChangedFiles(conversationId: string): Promise<GithubChangedFilesResult> {
   const res = await authenticatedFetch(
-    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/github/changes${params}`,
+    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/github/changes`,
   );
   if (res.status === 404) return { available: false, data: [] };
   if (res.status === 503 && (await isRunnerUnavailable503(res))) {
@@ -200,22 +196,18 @@ async function fetchGithubChangedFiles(
 }
 
 /**
- * Fetch files changed on the branch relative to `base` (the PR "Files
- * changed"). Pass the `base_ref` from {@link useGithubInfo}; when omitted the
- * runner derives the default branch (an extra gh call).
+ * Fetch the PR's changed files (the "Files changed" list). Enabled only when a
+ * PR exists (pass `hasPr` from {@link useGithubInfo}); the runner returns an
+ * empty list otherwise.
  */
-export function useGithubChangedFiles(
-  conversationId: string | undefined,
-  base: string | undefined,
-) {
+export function useGithubChangedFiles(conversationId: string | undefined, hasPr: boolean) {
   const serveable = useWorkspaceServeable(conversationId);
   return useQuery({
-    queryKey: ["github-changed-files", conversationId, base ?? null],
-    queryFn: () => fetchGithubChangedFiles(conversationId!, base),
-    // Wait for a base ref (from useGithubInfo) — without one there's nothing to
-    // diff against, and it also skips the query when GitHub is
-    // unavailable/unauthenticated (no base ref is resolved in those states).
-    enabled: !!conversationId && !!base && serveable !== false,
+    queryKey: ["github-changed-files", conversationId],
+    queryFn: () => fetchGithubChangedFiles(conversationId!),
+    // Only a PR has files to show — skip the call in every no-PR / unavailable
+    // / unauthenticated state (the panel shows an empty state instead).
+    enabled: !!conversationId && hasPr && serveable !== false,
     retry: shouldRetryRunnerOffline,
     retryDelay: runnerOfflineRetryDelay,
     staleTime: 30_000,
@@ -252,13 +244,9 @@ export interface GithubPrDiffResponse {
   patch: string;
 }
 
-async function fetchGithubPrDiff(
-  conversationId: string,
-  base: string | undefined,
-): Promise<GithubPrDiffResponse> {
-  const params = base ? `?base=${encodeURIComponent(base)}` : "";
+async function fetchGithubPrDiff(conversationId: string): Promise<GithubPrDiffResponse> {
   const res = await authenticatedFetch(
-    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/github/diff${params}`,
+    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/github/diff`,
   );
   if (res.status === 503 && (await isRunnerUnavailable503(res))) {
     throw new RunnerOfflineError();
@@ -270,15 +258,15 @@ async function fetchGithubPrDiff(
 /**
  * Fetch the whole PR as one unified diff patch. The panel parses it
  * client-side into per-file diffs, so the entire PR renders from a single
- * call. Waits for a base ref (from {@link useGithubInfo}); disabled when the
- * runner is known offline.
+ * call. Enabled only when a PR exists (pass `hasPr` from {@link useGithubInfo});
+ * disabled when the runner is known offline.
  */
-export function useGithubPrDiff(conversationId: string | undefined, base: string | undefined) {
+export function useGithubPrDiff(conversationId: string | undefined, hasPr: boolean) {
   const serveable = useWorkspaceServeable(conversationId);
   return useQuery({
-    queryKey: ["github-pr-diff", conversationId, base ?? null],
-    queryFn: () => fetchGithubPrDiff(conversationId!, base),
-    enabled: !!conversationId && !!base && serveable !== false,
+    queryKey: ["github-pr-diff", conversationId],
+    queryFn: () => fetchGithubPrDiff(conversationId!),
+    enabled: !!conversationId && hasPr && serveable !== false,
     retry: shouldRetryRunnerOffline,
     retryDelay: runnerOfflineRetryDelay,
     staleTime: 30_000,

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -544,9 +544,13 @@ function SidebarNode({
 export function GithubPanel({ conversationId }: { conversationId: string }) {
   const queryClient = useQueryClient();
   const info = useGithubInfo(conversationId);
+  // The tab is a pure PR view: the list + patch are the PR's, fetched only when
+  // one exists. `baseRef` is kept for the on-demand expand-context loader
+  // (git show <base>:<path>) and the "branch → base" label.
   const baseRef = info.data?.base_ref ?? undefined;
-  const changes = useGithubChangedFiles(conversationId, baseRef);
-  const prDiff = useGithubPrDiff(conversationId, baseRef);
+  const hasPr = !!info.data?.pr;
+  const changes = useGithubChangedFiles(conversationId, hasPr);
+  const prDiff = useGithubPrDiff(conversationId, hasPr);
 
   const themeType = useResolvedThemeMode();
   // Diff layout is the app-global FileViewer preference (unified/split); seed


### PR DESCRIPTION
## Related issue

No tracking issue — the bug surfaced while reviewing why the GitHub tab showed far more files than the PR.

## Summary

- The read-only GitHub rail tab rebuilt the PR **locally** with `git diff` against the merge-base of the workspace's `origin/<base>` and `HEAD`. When that remote-tracking ref is stale (never re-fetched after worktree creation), the merge-base collapses onto it and the tab renders the **entire branch-vs-`main` diff** — far more files than the PR contains (131 vs 6 on the repro worktree).
- Made it a **pure PR view sourced from `gh`**: the changed-files list now comes from `gh api .../pulls/<n>/files` and the patch from `gh pr diff`, so both match the PR's "Files changed" exactly and can't drift with a stale local ref. `github_info.base_ref` is now the PR's base (or null).
- With no PR for the branch, the tab shows its existing **"no PR" empty state** and fetches nothing. The now-vestigial `base` plumbing is removed from the list/patch paths (runner routes, server proxies, host fallback, `WorkspaceReader`); only the on-demand per-file **expand-context** reader still uses `git show` (unchanged, by design).

## Test Plan

- `uv run --no-sync python -m pytest tests/runner/test_github_resource.py tests/test_workspace_fs.py tests/server/routes/test_session_resources.py -q -k github` → **31 pass**.
- `pnpm --dir web exec vitest run src/shell/GithubPanel.test.tsx src/hooks/useGithub.test.ts` → **20 pass**.
- `ruff check` / `ruff format` / `oxlint` / `tsc` / `pyrefly` clean; `openapi.json` regenerated via `scripts/dump_openapi.py`.
- **End-to-end** against the repro worktree (PR #6275): `github_changed_files` / `github_pr_diff` return the **6** PR files and a 6-file-header patch — matching `gh pr view --json files` — where the old local-`git diff` path produced **131** files.
- Manual: open the GitHub tab on a session whose branch is behind `main` → shows only the PR's files (previously inflated). No-PR branch → "no PR" empty state, no `/changes` or `/diff` requests. Expand-unchanged-context on a modified file still works.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No visual/layout change — the tab renders the same components; the fix is the data they're fed. Evidence: 6 (correct) vs 131 (buggy) files for PR #6275, per Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the `gh`-backed functions against the repro worktree (PR #6275) and confirmed 6 files matching `gh pr view --json files`, versus the 131-file whole-branch diff the stale-`origin/main` local diff produced. Unit tests updated across the runner, host-fallback, and server-proxy layers; the `git show` expand-context path keeps its real-temp-repo tests.

## Changelog

The GitHub tab now shows exactly the PR's files and diff (sourced from `gh`) instead of the whole branch-vs-`main` diff that appeared when the workspace's local base ref was stale.
