### PR TITLE
Label alternate shell options in terminal flyout

### DIFF
--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -526,6 +526,8 @@ describe('WorkspacePanel "+" new-tab menu', () => {
     const shellItem = await screen.findByRole("menuitem", { name: /shell \(zsh\)/i });
     shellItem.focus();
     fireEvent.keyDown(shellItem, { key: "ArrowRight" });
+    expect(await screen.findByText("Other shells")).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /^Other shells$/i })).toBeNull();
     expect(await screen.findByRole("menuitem", { name: /^bash$/i })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: /^fish$/i })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: /^zsh$/i })).toBeNull();

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -256,6 +256,7 @@ function NewTabMenu({
             {/* min-w-0 drops the default 96px floor so the box hugs the shell
                 name (e.g. "bash") instead of padding it out. */}
             <DropdownMenuSubContent className="min-w-0">
+              <DropdownMenuLabel>Other shells</DropdownMenuLabel>
               {otherShells.map((name) => (
                 <DropdownMenuItem
                   key={name}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Adds an inert `Other shells` label at the top of the terminal shell-type flyout so alternate shell choices are grouped more clearly.
- Updates the WorkspacePanel menu test to verify the label is present and not exposed as a clickable menu item.

## Test Plan

- `pnpm --filter web exec vitest run src/shell/WorkspacePanel.test.tsx` - passes, 40 tests.
- `pnpm --filter web run build` - passes, with existing Lightning CSS `::highlight(...)` warnings.
- `pnpm --filter web test` - fails in unrelated `src/shell/NewChatDialog.test.tsx` host-picker tests; the same file fails in isolation with the same 3 `This machine` lookup failures.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No screenshot attached; this is a small menu-label change covered by the updated WorkspacePanel test.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused WorkspacePanel unit test covers the new flyout label and verifies it is not selectable as a menu item.

## Changelog

The Shell flyout now labels alternate shell options as `Other shells`.
