### PR TITLE
fix(claude-native): require delivery acknowledgement

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2824,7 +2824,7 @@ def _wait_for_user_prompt_submit_ack(
         timeout_s = _DELIVERY_ACK_TIMEOUT_S
     deadline = time.monotonic() + timeout_s
     current_session_id = expected_claude_session_id
-    if current_session_id is None and byte_offset:
+    if byte_offset:
         prior = read_hook_events_from_offset(bridge_dir, 0, start_event_count=0)
         for record in prior.records:
             if record.byte_offset > byte_offset:
@@ -3315,10 +3315,12 @@ def inject_user_message(
     # ``paste-buffer -p`` wraps it in the same bracketed-paste markers so
     # interior newlines (mapped to CR below) stay data instead of becoming
     # per-line submits. See anthropics/claude-code#52126.
+    paste_payload = _paste_payload_bytes(injected_text + "\n")
+    expected_delivery_prompt = _normalized_delivery_prompt(paste_payload.decode("utf-8"))
     with tempfile.NamedTemporaryFile(
         dir=bridge_dir, prefix="paste_", suffix=".bin", delete=False
     ) as paste_file:
-        paste_file.write(_paste_payload_bytes(injected_text + "\n"))
+        paste_file.write(paste_payload)
         paste_path = paste_file.name
     try:
         _run_tmux(info["socket_path"], "load-buffer", "-b", "omnigent-paste", paste_path)
@@ -3361,13 +3363,6 @@ def inject_user_message(
             # best-effort blind submit rather than hard-failing.
             time.sleep(_PASTE_SETTLE_S)
             _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-            if require_delivery_ack:
-                _wait_for_user_prompt_submit_ack(
-                    bridge_dir,
-                    byte_offset=hook_offset,
-                    expected_prompt=injected_text,
-                    expected_claude_session_id=expected_claude_session_id,
-                )
             return
         raise RuntimeError(
             f"The pasted draft was never visible in Claude Code's input box after "
@@ -3401,7 +3396,7 @@ def inject_user_message(
         _wait_for_user_prompt_submit_ack(
             bridge_dir,
             byte_offset=hook_offset,
-            expected_prompt=injected_text,
+            expected_prompt=expected_delivery_prompt,
             expected_claude_session_id=expected_claude_session_id,
         )
 

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -175,6 +175,9 @@ _PASTE_COMMIT_TIMEOUT_S = 5.0
 # actually left the input box (re-sending Enter while it hasn't)
 # before failing loud.
 _SUBMIT_VERIFY_TIMEOUT_S = 10.0
+# UserPromptSubmit is the terminal's delivery acknowledgement. Composer
+# state alone is ambiguous because an in-pane restart also clears it.
+_DELIVERY_ACK_TIMEOUT_S = 10.0
 # Minimum spacing between repeated submit Enters during verification.
 # Long enough for the TUI to clear the box after a successful submit
 # (so a slow-but-successful first Enter isn't double-tapped), short
@@ -516,6 +519,8 @@ class ClaudeHookRecord:
         advance past it.
     :param source: Claude ``SessionStart`` source, e.g. ``"clear"``,
         or ``None`` for hook records without a source field.
+    :param prompt: User text from a ``UserPromptSubmit`` hook, or
+        ``None`` for other hook events.
     :param claude_session_id: Claude-native session uuid from the hook
         payload, e.g. ``"a1b2c3d4-1234-5678-9abc-def012345678"``,
         or ``None`` when absent.
@@ -572,6 +577,7 @@ class ClaudeHookRecord:
     event_name: str | None
     recorded_at: float | None = None
     source: str | None = None
+    prompt: str | None = None
     claude_session_id: str | None = None
     transcript_path: Path | None = None
     previous_claude_session_id: str | None = None
@@ -2786,6 +2792,74 @@ def read_hook_events_from_offset(
     )
 
 
+def _hook_file_size(bridge_dir: Path) -> int:
+    """Return the hook log size used to snapshot future events."""
+    path = bridge_dir / _HOOKS_FILE
+    try:
+        return path.stat().st_size
+    except FileNotFoundError:
+        return 0
+
+
+def _is_subagent_hook_record(record: ClaudeHookRecord) -> bool:
+    """Return whether a hook record belongs to a Claude subagent."""
+    return record.transcript_path is not None and "subagents" in record.transcript_path.parts
+
+
+def _normalized_delivery_prompt(prompt: str) -> str:
+    """Normalize hook and injected prompt text for acknowledgement matching."""
+    return prompt.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
+
+
+def _wait_for_user_prompt_submit_ack(
+    bridge_dir: Path,
+    *,
+    byte_offset: int,
+    expected_prompt: str,
+    expected_claude_session_id: str | None,
+    timeout_s: float | None = None,
+) -> None:
+    """Wait for Claude to acknowledge the exact prompt submitted after an offset."""
+    if timeout_s is None:
+        timeout_s = _DELIVERY_ACK_TIMEOUT_S
+    deadline = time.monotonic() + timeout_s
+    current_session_id = expected_claude_session_id
+    initial_session_id = expected_claude_session_id
+    expected = _normalized_delivery_prompt(expected_prompt)
+    offset = byte_offset
+    while time.monotonic() < deadline:
+        result = read_hook_events_from_offset(
+            bridge_dir,
+            offset,
+            start_event_count=0,
+        )
+        offset = result.byte_offset
+        for record in result.records:
+            if _is_subagent_hook_record(record):
+                continue
+            if record.event_name == "SessionStart" and record.claude_session_id:
+                current_session_id = record.claude_session_id
+                continue
+            if record.event_name != "UserPromptSubmit" or record.prompt is None:
+                continue
+            if _normalized_delivery_prompt(record.prompt) != expected:
+                continue
+            if current_session_id and record.claude_session_id != current_session_id:
+                continue
+            return
+        time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
+
+    if current_session_id and current_session_id != initial_session_id:
+        raise RuntimeError(
+            "Claude Code restarted while the message was being submitted and the new "
+            "session did not acknowledge it. The message was not delivered."
+        )
+    raise RuntimeError(
+        f"Claude Code did not acknowledge the submitted message within {timeout_s}s. "
+        "The message may not have been delivered."
+    )
+
+
 def stop_hook_seen_since(bridge_dir: Path, start_event_count: int) -> bool:
     """
     Return whether Claude reported a stop event after a hook cursor.
@@ -2888,6 +2962,7 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
     if isinstance(raw_event_name, str) and raw_event_name:
         event_name = raw_event_name
     raw_source = payload.get("source") if isinstance(payload, dict) else None
+    raw_prompt = payload.get("prompt") if isinstance(payload, dict) else None
     raw_recorded_at = envelope.get("recorded_at") if isinstance(envelope, dict) else None
     raw_claude_session_id = payload.get("session_id") if isinstance(payload, dict) else None
     raw_transcript_path = payload.get("transcript_path") if isinstance(payload, dict) else None
@@ -2978,6 +3053,7 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
         if isinstance(raw_recorded_at, (int, float)) and not isinstance(raw_recorded_at, bool)
         else None,
         source=raw_source if isinstance(raw_source, str) and raw_source else None,
+        prompt=raw_prompt if isinstance(raw_prompt, str) else None,
         claude_session_id=(
             raw_claude_session_id
             if isinstance(raw_claude_session_id, str) and raw_claude_session_id
@@ -3158,14 +3234,16 @@ def inject_user_message(
     client→server command at ~16KB, so a large message — e.g. a PR diff
     in a sub-agent dispatch — failed with "command too long".
 
-    The submit is **verified, not fire-and-forget**: Claude Code
+    The submit is **acknowledged, not fire-and-forget**: Claude Code
     coalesces rapid stdin bursts into a paste, so an Enter that lands
     while the TUI is still consuming the paste is folded in as a
     newline and the draft sits unsent. This helper first polls
     ``capture-pane`` until the draft is visible in the input box (the
     paste was committed), sends Enter, then polls that the draft left
     the box — re-sending Enter while it hasn't — and raises if the
-    message never submits.
+    message never submits. An empty composer is not sufficient evidence:
+    after it clears, this helper also waits for the matching
+    ``UserPromptSubmit`` hook from the active Claude session.
 
     :param bridge_dir: Bridge directory path.
     :param content: User text from the Omnigent web UI. Must be non-empty.
@@ -3177,7 +3255,8 @@ def inject_user_message(
         invocation fails, if the paste draft was never confirmed in the
         input box after ``_PASTE_COMMIT_TIMEOUT_S`` (the TUI was still
         consuming the paste — message not submitted), or if the draft
-        never leaves the input box after repeated submit Enters.
+        never leaves the input box after repeated submit Enters, or Claude
+        never acknowledges the submitted prompt.
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
     # A surface left occupying the composer swallows everything typed
@@ -3206,6 +3285,12 @@ def inject_user_message(
     # that Omnigent cannot drive. Allowed commands (``/clear``,
     # ``/model``, ``/fork``, skills, etc.) pass through unchanged.
     injected_text = _escape_unsupported_slash_command(content)
+    command_name = _first_slash_command_name(content)
+    # Built-in lifecycle commands do not consistently emit UserPromptSubmit;
+    # ordinary prompts, escaped commands, and skills do.
+    require_delivery_ack = command_name not in _CLAUDE_NATIVE_ALLOWED_USER_SLASH_COMMANDS
+    hook_offset = _hook_file_size(bridge_dir) if require_delivery_ack else 0
+    expected_claude_session_id = read_claude_session_id(bridge_dir)
     # Trailing newline absorbs a trailing "\" so it can't escape the submit Enter.
     # Delivered through a tmux buffer, NOT ``send-keys`` argv: tmux caps one
     # client→server command at ~16KB, so per-byte hex argv blew up with
@@ -3261,6 +3346,13 @@ def inject_user_message(
             # best-effort blind submit rather than hard-failing.
             time.sleep(_PASTE_SETTLE_S)
             _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
+            if require_delivery_ack:
+                _wait_for_user_prompt_submit_ack(
+                    bridge_dir,
+                    byte_offset=hook_offset,
+                    expected_prompt=injected_text,
+                    expected_claude_session_id=expected_claude_session_id,
+                )
             return
         raise RuntimeError(
             f"The pasted draft was never visible in Claude Code's input box after "
@@ -3281,14 +3373,22 @@ def inject_user_message(
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
         pane = _capture_pane(info["socket_path"], info["tmux_target"])
         if not _draft_in_input_box(pane, needle):
-            return
+            break
         if time.monotonic() - last_enter >= _SUBMIT_RETRY_INTERVAL_S:
             _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
             last_enter = time.monotonic()
-    raise RuntimeError(
-        f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
-        "(the draft is still in the input box). The message was not delivered."
-    )
+    else:
+        raise RuntimeError(
+            f"Claude Code did not accept the submitted message within {_SUBMIT_VERIFY_TIMEOUT_S}s "
+            "(the draft is still in the input box). The message was not delivered."
+        )
+    if require_delivery_ack:
+        _wait_for_user_prompt_submit_ack(
+            bridge_dir,
+            byte_offset=hook_offset,
+            expected_prompt=injected_text,
+            expected_claude_session_id=expected_claude_session_id,
+        )
 
 
 def inject_interrupt(

--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -2808,7 +2808,7 @@ def _is_subagent_hook_record(record: ClaudeHookRecord) -> bool:
 
 def _normalized_delivery_prompt(prompt: str) -> str:
     """Normalize hook and injected prompt text for acknowledgement matching."""
-    return prompt.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
+    return prompt.replace("\r\n", "\n").replace("\r", "\n").rstrip()
 
 
 def _wait_for_user_prompt_submit_ack(
@@ -2824,7 +2824,18 @@ def _wait_for_user_prompt_submit_ack(
         timeout_s = _DELIVERY_ACK_TIMEOUT_S
     deadline = time.monotonic() + timeout_s
     current_session_id = expected_claude_session_id
-    initial_session_id = expected_claude_session_id
+    if current_session_id is None and byte_offset:
+        prior = read_hook_events_from_offset(bridge_dir, 0, start_event_count=0)
+        for record in prior.records:
+            if record.byte_offset > byte_offset:
+                break
+            if (
+                record.event_name == "SessionStart"
+                and record.claude_session_id
+                and not _is_subagent_hook_record(record)
+            ):
+                current_session_id = record.claude_session_id
+    restart_seen = False
     expected = _normalized_delivery_prompt(expected_prompt)
     offset = byte_offset
     while time.monotonic() < deadline:
@@ -2838,6 +2849,8 @@ def _wait_for_user_prompt_submit_ack(
             if _is_subagent_hook_record(record):
                 continue
             if record.event_name == "SessionStart" and record.claude_session_id:
+                if current_session_id and record.claude_session_id != current_session_id:
+                    restart_seen = True
                 current_session_id = record.claude_session_id
                 continue
             if record.event_name != "UserPromptSubmit" or record.prompt is None:
@@ -2849,7 +2862,7 @@ def _wait_for_user_prompt_submit_ack(
             return
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
 
-    if current_session_id and current_session_id != initial_session_id:
+    if restart_seen:
         raise RuntimeError(
             "Claude Code restarted while the message was being submitted and the new "
             "session did not acknowledge it. The message was not delivered."
@@ -3286,9 +3299,12 @@ def inject_user_message(
     # ``/model``, ``/fork``, skills, etc.) pass through unchanged.
     injected_text = _escape_unsupported_slash_command(content)
     command_name = _first_slash_command_name(content)
+    needle = _submit_needle(content)
     # Built-in lifecycle commands do not consistently emit UserPromptSubmit;
-    # ordinary prompts, escaped commands, and skills do.
-    require_delivery_ack = command_name not in _CLAUDE_NATIVE_ALLOWED_USER_SLASH_COMMANDS
+    # whitespace-only submissions do not emit it at all.
+    require_delivery_ack = bool(needle) and (
+        command_name not in _CLAUDE_NATIVE_ALLOWED_USER_SLASH_COMMANDS
+    )
     hook_offset = _hook_file_size(bridge_dir) if require_delivery_ack else 0
     expected_claude_session_id = read_claude_session_id(bridge_dir)
     # Trailing newline absorbs a trailing "\" so it can't escape the submit Enter.
@@ -3331,7 +3347,6 @@ def inject_user_message(
     # the message (the caller gets no error but the turn never runs).
     # When the needle is empty (whitespace-only content) the draft cannot
     # be confirmed either way; fall through to best-effort blind submit.
-    needle = _submit_needle(content)
     draft_seen = False
     deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
     while time.monotonic() < deadline:

--- a/tests/e2e/test_claude_native_inpane_restart_e2e.py
+++ b/tests/e2e/test_claude_native_inpane_restart_e2e.py
@@ -1,15 +1,10 @@
 """End-to-end regression for the claude-native in-pane-restart first-message drop.
 
-The bug: ``inject_user_message`` gates the
-first web-UI message on ``_wait_for_claude_prompt_ready``, which only
-proves *a* prompt glyph is rendered — it carries no process identity.
-When the wrapped Claude Code process restarts inside the same tmux pane
-between prompt-render and injection (observed: claude-code 2.1.170's
-fullscreen-switch re-exec ~12s into boot; the class also covers
-auto-update restarts and crash-restarts), the paste + Enter land in the
-dying process and are discarded by the restarted process's boot-time
-input flush. Nothing notices: the turn is marked injected, no error
-surfaces in the web UI, and the message never reaches Claude.
+The bug: ``inject_user_message`` used composer state as delivery proof.
+When Claude Code restarted inside the same tmux pane, either before the
+draft appeared or after the draft was observed but before Enter landed,
+the new process rendered an empty composer. The bridge mistook that for
+a successful submit even though no process accepted the message.
 
 Making the race deterministic
 -----------------------------
@@ -21,29 +16,14 @@ this test drives the *real* delivery path (``inject_user_message`` — the
 exact function the claude-native executor's web turn calls) against a
 real tmux pane running a scripted Claude-Code-shaped TUI that:
 
-1. renders a genuine composer (box rule + ``❯`` row) so the readiness
-   gate passes, then
-2. restarts in-pane after a delay without ever reading its input
-   (modeling the dying pre-restart process), and
-3. the restarted process flushes pending terminal input
-   (``termios.tcflush``) — faithfully modeling Claude Code's boot-time
-   input flush, which is what discards the early keystrokes — and then
-   runs a working composer that records every submitted message.
+1. renders a genuine composer (box rule + ``❯`` row),
+2. restarts either before consuming the paste or after rendering it,
+3. flushes pending input while starting the replacement process, and
+4. records ``SessionStart`` and ``UserPromptSubmit`` hooks.
 
-With the model, an injection gated only on the prompt glyph reliably
-loses the message: the paste lands in the pre-restart process's pty
-buffer and the restart flushes it, while ``inject_user_message`` returns
-success (its draft-visibility check fails open and submits blind).
-
-The control test (no restart) proves the fake TUI faithfully accepts the
-same delivery: the readiness gate, paste, and submit all work, and the
-message is recorded. Only the in-pane restart makes it vanish.
-
-The regression contract: after ``inject_user_message`` reports success,
-the message must actually have been delivered to the (post-restart)
-Claude process. A loud ``RuntimeError`` also passes — an error surfacing
-in the web UI is not a *silent* drop. Today the restart test FAILS: the
-inject succeeds and the message vanishes.
+The control proves the same fake TUI accepts and acknowledges an ordinary
+message without a restart. Both restart cases must raise rather than
+returning silent success without a matching acknowledgement.
 """
 
 from __future__ import annotations
@@ -57,6 +37,7 @@ from pathlib import Path
 
 import pytest
 
+from omnigent import claude_native_bridge
 from omnigent.claude_native_bridge import (
     bridge_dir_for_bridge_id,
     inject_user_message,
@@ -72,15 +53,17 @@ _MARKER = "the first message must survive an in-pane restart"
 # gate needs to pass and paste (< 2s here), so the injection reliably
 # lands in the dying process — modeling 2.1.170's ~12s fullscreen re-exec.
 _RESTART_AFTER_S = 4.0
+_DRAFT_RESTART_AFTER_S = 0.3
 
 # A Claude-Code-shaped TUI: composer box framed by rules with a leading
 # "❯" glyph (what _wait_for_claude_prompt_ready / _draft_in_input_box
 # key on), bracketed paste enabled, drafts rendered in the box, and
 # every submitted (Enter outside a paste) non-empty draft appended to
-# $FAKE_CLAUDE_DELIVERED — the analog of a UserPromptSubmit hook event.
+# $FAKE_CLAUDE_DELIVERED and recorded as a UserPromptSubmit hook event.
 # Enter may arrive as "\r" or "\n" (cbreak leaves ICRNL on); either
 # submits outside a paste and is a plain line break inside one.
 _FAKE_CLAUDE_TUI = r"""
+import json
 import os
 import sys
 import termios
@@ -89,6 +72,8 @@ import tty
 
 PHASE = os.environ.get("FAKE_CLAUDE_PHASE", "boot")
 DELIVERED = os.environ["FAKE_CLAUDE_DELIVERED"]
+HOOKS = os.environ["FAKE_CLAUDE_HOOKS"]
+SESSION_ID = os.environ["FAKE_CLAUDE_SESSION_ID"]
 RESTART_AFTER = float(os.environ.get("FAKE_CLAUDE_RESTART_AFTER", "4"))
 
 RULE = "─" * 40
@@ -106,7 +91,16 @@ def draw(draft: str = "") -> None:
     sys.stdout.flush()
 
 
+def record_hook(event: str, *, prompt: str | None = None) -> None:
+    payload = {"hook_event_name": event, "session_id": SESSION_ID}
+    if prompt is not None:
+        payload["prompt"] = prompt
+    with open(HOOKS, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"recorded_at": time.time(), "payload": payload}) + "\n")
+
+
 tty.setcbreak(FD)
+record_hook("SessionStart")
 
 if PHASE == "boot":
     # The dying pre-restart process: renders a real prompt, never reads
@@ -116,6 +110,7 @@ if PHASE == "boot":
     draw()
     time.sleep(RESTART_AFTER)
     os.environ["FAKE_CLAUDE_PHASE"] = "ready"
+    os.environ["FAKE_CLAUDE_SESSION_ID"] = "ready-session"
     os.execv(sys.executable, [sys.executable] + sys.argv)
 
 # The restarted process: boot-time input flush (exactly what Claude Code
@@ -141,6 +136,12 @@ while True:
         if pending.startswith("\x1b[201~"):
             in_paste = False
             pending = pending[6:]
+            if PHASE == "restart_after_draft":
+                draw(draft)
+                time.sleep(RESTART_AFTER)
+                os.environ["FAKE_CLAUDE_PHASE"] = "ready"
+                os.environ["FAKE_CLAUDE_SESSION_ID"] = "ready-session"
+                os.execv(sys.executable, [sys.executable] + sys.argv)
             continue
         if pending.startswith("\x1b"):
             if len(pending) < 6:
@@ -151,8 +152,10 @@ while True:
         pending = pending[1:]
         if ch in ("\r", "\n") and not in_paste:
             if draft.strip():
+                submitted = draft.rstrip()
                 with open(DELIVERED, "a", encoding="utf-8") as fh:
-                    fh.write(draft + "\n")
+                    fh.write(submitted + "\n")
+                record_hook("UserPromptSubmit", prompt=submitted)
             draft = ""
         elif ch in ("\r", "\n", "\t"):
             draft += " "
@@ -179,15 +182,16 @@ def _launch_fake_claude(
     """Start the fake Claude TUI in a fresh tmux pane and advertise it.
 
     :param tmp_path: Test temp dir for the socket / script / record file.
-    :param phase: ``"boot"`` (renders a prompt, then restarts in-pane) or
-        ``"ready"`` (control: a working composer from the start).
+    :param phase: ``"boot"`` (restart before paste consumption),
+        ``"restart_after_draft"``, or ``"ready"`` (control).
     :returns: ``(bridge_dir, delivered_file, socket_path)``.
     """
     bridge_dir = bridge_dir_for_bridge_id(f"bridge_e2e_{uuid.uuid4().hex}")
     delivered = tmp_path / "delivered.txt"
     script = tmp_path / "fake_claude.py"
     script.write_text(_FAKE_CLAUDE_TUI, encoding="utf-8")
-    socket = tmp_path / "tmux.sock"
+    socket = Path("/tmp") / f"og-claude-{uuid.uuid4().hex[:12]}.sock"
+    restart_after = _DRAFT_RESTART_AFTER_S if phase == "restart_after_draft" else _RESTART_AFTER_S
     _tmux(
         socket,
         "new-session",
@@ -201,9 +205,13 @@ def _launch_fake_claude(
         "-e",
         f"FAKE_CLAUDE_DELIVERED={delivered}",
         "-e",
-        f"FAKE_CLAUDE_RESTART_AFTER={_RESTART_AFTER_S}",
+        f"FAKE_CLAUDE_HOOKS={bridge_dir / 'hooks.jsonl'}",
+        "-e",
+        f"FAKE_CLAUDE_RESTART_AFTER={restart_after}",
         "-e",
         f"FAKE_CLAUDE_PHASE={phase}",
+        "-e",
+        f"FAKE_CLAUDE_SESSION_ID={'ready-session' if phase == 'ready' else 'boot-session'}",
         f"{sys.executable} {script}",
     )
     # What the runner does when it launches the terminal.
@@ -217,6 +225,7 @@ def _cleanup(socket: Path, bridge_dir: Path) -> None:
         check=False,
         capture_output=True,
     )
+    socket.unlink(missing_ok=True)
     shutil.rmtree(bridge_dir, ignore_errors=True)
 
 
@@ -248,21 +257,27 @@ def test_first_web_message_survives_inpane_claude_restart(tmp_path: Path) -> Non
     try:
         # What the web UI's first turn does (the claude-native executor's
         # run_turn delegates straight to this function).
-        try:
+        with pytest.raises(RuntimeError):
             inject_user_message(bridge_dir, content=_MARKER, timeout_s=20.0)
-        except RuntimeError:
-            # A loud failure surfaces in the web UI as an error — that is
-            # an acceptable non-silent outcome, not the reported bug.
-            return
+        assert not _message_recorded(delivered, timeout_s=0.5)
+    finally:
+        _cleanup(socket, bridge_dir)
 
-        # inject_user_message reported success, so the message must have
-        # actually reached the (post-restart) Claude process.
-        assert _message_recorded(delivered), (
-            "inject_user_message returned success, but the first message never "
-            "reached the Claude process that survived the in-pane restart — it "
-            "was silently dropped (no delivery record, no error surfaced). "
-            "The readiness gate passed against the dying pre-restart process's "
-            "prompt and the restart's boot-time input flush discarded the paste."
-        )
+
+def test_restart_after_draft_visibility_does_not_report_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A restart after draft detection still requires a submit acknowledgement."""
+    monkeypatch.setattr(claude_native_bridge, "_PASTE_SETTLE_S", 1.0)
+    monkeypatch.setattr(claude_native_bridge, "_DELIVERY_ACK_TIMEOUT_S", 1.0)
+    bridge_dir, delivered, socket = _launch_fake_claude(
+        tmp_path,
+        phase="restart_after_draft",
+    )
+    try:
+        with pytest.raises(RuntimeError, match="restarted"):
+            inject_user_message(bridge_dir, content=_MARKER, timeout_s=20.0)
+        assert not _message_recorded(delivered, timeout_s=0.5)
     finally:
         _cleanup(socket, bridge_dir)

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -1926,14 +1926,14 @@ def test_wait_for_prompt_submit_ack_accepts_matching_prompt(tmp_path: Path) -> N
         {
             "hook_event_name": "UserPromptSubmit",
             "session_id": "active-session",
-            "prompt": "line one\r\nline two\n",
+            "prompt": "line one\r\nline two",
         },
     )
 
     claude_native_bridge._wait_for_user_prompt_submit_ack(
         bridge_dir,
         byte_offset=0,
-        expected_prompt="line one\nline two",
+        expected_prompt="line one\nline two \t\n",
         expected_claude_session_id="active-session",
         timeout_s=0.1,
     )
@@ -2017,6 +2017,58 @@ def test_wait_for_prompt_submit_ack_ignores_subagent_session_start(tmp_path: Pat
         expected_claude_session_id="parent-session",
         timeout_s=0.1,
     )
+
+
+def test_wait_for_prompt_submit_ack_cold_start_timeout_is_not_restart(tmp_path: Path) -> None:
+    """The first observed session is startup, not evidence of a restart."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "initial-session",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="did not acknowledge"):
+        claude_native_bridge._wait_for_user_prompt_submit_ack(
+            bridge_dir,
+            byte_offset=0,
+            expected_prompt="expected prompt",
+            expected_claude_session_id=None,
+            timeout_s=0.01,
+        )
+
+
+def test_wait_for_prompt_submit_ack_detects_restart_after_unpinned_startup(
+    tmp_path: Path,
+) -> None:
+    """A startup hook before the injection offset establishes the prior session."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "initial-session",
+        },
+    )
+    hook_offset = claude_native_bridge._hook_file_size(bridge_dir)
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "replacement-session",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="restarted"):
+        claude_native_bridge._wait_for_user_prompt_submit_ack(
+            bridge_dir,
+            byte_offset=hook_offset,
+            expected_prompt="expected prompt",
+            expected_claude_session_id=None,
+            timeout_s=0.01,
+        )
 
 
 def test_read_transcript_items_since_surfaces_skill_as_slash_command(
@@ -9354,7 +9406,11 @@ def test_inject_user_message_whitespace_only_content_submits_blind(
     behavior.  This must not raise: the best-effort path is retained for content
     whose draft position cannot be determined.
     """
-    _bypass_delivery_ack(monkeypatch)
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_wait_for_user_prompt_submit_ack",
+        lambda *_args, **_kwargs: pytest.fail("whitespace-only input must not wait for an ack"),
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_COMMIT_TIMEOUT_S", 0.1)

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -2071,6 +2071,44 @@ def test_wait_for_prompt_submit_ack_detects_restart_after_unpinned_startup(
         )
 
 
+def test_wait_for_prompt_submit_ack_prefers_pre_offset_session_over_stale_state(
+    tmp_path: Path,
+) -> None:
+    """The hook log closes the append-before-state-update identity race."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "initial-session",
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "replacement-session",
+        },
+    )
+    hook_offset = claude_native_bridge._hook_file_size(bridge_dir)
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "replacement-session",
+            "prompt": "expected prompt",
+        },
+    )
+
+    claude_native_bridge._wait_for_user_prompt_submit_ack(
+        bridge_dir,
+        byte_offset=hook_offset,
+        expected_prompt="expected prompt",
+        expected_claude_session_id="initial-session",
+        timeout_s=0.1,
+    )
+
+
 def test_read_transcript_items_since_surfaces_skill_as_slash_command(
     tmp_path: Path,
 ) -> None:
@@ -3654,7 +3692,9 @@ def test_inject_user_message_escapes_unsupported_slash_command_payload(
 ) -> None:
     """
     Unsupported slash commands land in the tmux buffer with a leading
-    zero-width escape so Claude Code treats them as user text.
+    zero-width escape so Claude Code treats them as user text. Delivery
+    acknowledgement uses the transported text after unsafe control bytes
+    have been removed.
     """
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(
@@ -3697,9 +3737,17 @@ def test_inject_user_message_escapes_unsupported_slash_command_payload(
     assert loaded_payloads[0].startswith("\ufeff/help".encode("utf-8"))
     assert acknowledged_prompts == ["\ufeff/help"]
 
+    inject_user_message(bridge_dir, content="  /help")
+    assert loaded_payloads[1].startswith("  \ufeff/help".encode("utf-8"))
+    assert acknowledged_prompts == ["\ufeff/help", "  \ufeff/help"]
+
+    inject_user_message(bridge_dir, content="hello\x0cworld\x07")
+    assert loaded_payloads[2] == b"helloworld\r"
+    assert acknowledged_prompts == ["\ufeff/help", "  \ufeff/help", "helloworld"]
+
     inject_user_message(bridge_dir, content="/clear")
-    assert not loaded_payloads[1].startswith("\ufeff".encode("utf-8"))
-    assert acknowledged_prompts == ["\ufeff/help"]
+    assert not loaded_payloads[3].startswith("\ufeff".encode("utf-8"))
+    assert acknowledged_prompts == ["\ufeff/help", "  \ufeff/help", "helloworld"]
 
 
 def test_inject_user_message_raises_when_tmux_target_never_published(

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -96,6 +96,15 @@ def _composer_pane(draft: str = "") -> str:
 """
 
 
+def _bypass_delivery_ack(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep composer-focused injection tests independent of hook acknowledgement."""
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_wait_for_user_prompt_submit_ack",
+        lambda *_args, **_kwargs: None,
+    )
+
+
 def _load_invocation_settings(args: list[str]) -> dict[str, Any]:
     settings_path = Path(args[args.index("--settings") + 1])
     return json.loads(settings_path.read_text(encoding="utf-8"))
@@ -1885,6 +1894,131 @@ def test_read_hook_events_from_offset_preserves_partial_trailing_line(tmp_path: 
     assert [record.event_name for record in second.records] == ["Stop"]
 
 
+def test_hook_file_size_excludes_partial_record_present_before_injection(tmp_path: Path) -> None:
+    """A pre-existing partial hook cannot acknowledge the new injection."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    hooks_path = bridge_dir / "hooks.jsonl"
+    hooks_path.write_text(
+        '{"payload":{"hook_event_name":"UserPromptSubmit","prompt":"old',
+        encoding="utf-8",
+    )
+
+    hook_offset = claude_native_bridge._hook_file_size(bridge_dir)
+    with hooks_path.open("a", encoding="utf-8") as handle:
+        handle.write(' prompt"}}\n')
+
+    with pytest.raises(RuntimeError, match="did not acknowledge"):
+        claude_native_bridge._wait_for_user_prompt_submit_ack(
+            bridge_dir,
+            byte_offset=hook_offset,
+            expected_prompt="old prompt",
+            expected_claude_session_id=None,
+            timeout_s=0.01,
+        )
+
+
+def test_wait_for_prompt_submit_ack_accepts_matching_prompt(tmp_path: Path) -> None:
+    """A matching parent-session hook is an authoritative delivery acknowledgement."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "active-session",
+            "prompt": "line one\r\nline two\n",
+        },
+    )
+
+    claude_native_bridge._wait_for_user_prompt_submit_ack(
+        bridge_dir,
+        byte_offset=0,
+        expected_prompt="line one\nline two",
+        expected_claude_session_id="active-session",
+        timeout_s=0.1,
+    )
+
+
+def test_wait_for_prompt_submit_ack_ignores_mismatched_prompt(tmp_path: Path) -> None:
+    """An unrelated prompt hook cannot acknowledge the injected message."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "active-session",
+            "prompt": "some other prompt",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="did not acknowledge"):
+        claude_native_bridge._wait_for_user_prompt_submit_ack(
+            bridge_dir,
+            byte_offset=0,
+            expected_prompt="expected prompt",
+            expected_claude_session_id="active-session",
+            timeout_s=0.01,
+        )
+
+
+def test_wait_for_prompt_submit_ack_rejects_old_session_after_restart(tmp_path: Path) -> None:
+    """A matching acknowledgement from the replaced session is not delivery."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "new-session",
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "old-session",
+            "prompt": "expected prompt",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="restarted"):
+        claude_native_bridge._wait_for_user_prompt_submit_ack(
+            bridge_dir,
+            byte_offset=0,
+            expected_prompt="expected prompt",
+            expected_claude_session_id="old-session",
+            timeout_s=0.01,
+        )
+
+
+def test_wait_for_prompt_submit_ack_ignores_subagent_session_start(tmp_path: Path) -> None:
+    """Subagent lifecycle hooks do not replace the expected parent session."""
+    bridge_dir = tmp_path / "bridge"
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "subagent-session",
+            "transcript_path": str(tmp_path / "session" / "subagents" / "agent.jsonl"),
+        },
+    )
+    record_hook_event(
+        bridge_dir,
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "session_id": "parent-session",
+            "prompt": "expected prompt",
+        },
+    )
+
+    claude_native_bridge._wait_for_user_prompt_submit_ack(
+        bridge_dir,
+        byte_offset=0,
+        expected_prompt="expected prompt",
+        expected_claude_session_id="parent-session",
+        timeout_s=0.1,
+    )
+
+
 def test_read_transcript_items_since_surfaces_skill_as_slash_command(
     tmp_path: Path,
 ) -> None:
@@ -3341,6 +3475,7 @@ def test_inject_user_message_pastes_content_then_submits(
     regresses to send-keys argv delivery, drops the trailing Enter, or
     stops clearing the stale buffer.
     """
+    _bypass_delivery_ack(monkeypatch)
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(
@@ -3477,6 +3612,7 @@ def test_inject_user_message_escapes_unsupported_slash_command_payload(
     )
 
     loaded_payloads: list[bytes] = []
+    acknowledged_prompts: list[str] = []
     tui = {"pane": _composer_pane()}
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
@@ -3499,12 +3635,19 @@ def test_inject_user_message_escapes_unsupported_slash_command_payload(
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_wait_for_user_prompt_submit_ack",
+        lambda *_args, **kwargs: acknowledged_prompts.append(str(kwargs["expected_prompt"])),
+    )
 
     inject_user_message(bridge_dir, content="/help")
     assert loaded_payloads[0].startswith("\ufeff/help".encode("utf-8"))
+    assert acknowledged_prompts == ["\ufeff/help"]
 
     inject_user_message(bridge_dir, content="/clear")
     assert not loaded_payloads[1].startswith("\ufeff".encode("utf-8"))
+    assert acknowledged_prompts == ["\ufeff/help"]
 
 
 def test_inject_user_message_raises_when_tmux_target_never_published(
@@ -3581,6 +3724,7 @@ def test_inject_user_message_waits_for_claude_prompt_before_typing(
     no send-keys is issued until ``capture-pane`` shows the prompt
     glyph, and that injection proceeds once it does.
     """
+    _bypass_delivery_ack(monkeypatch)
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     bridge_dir = tmp_path / "bridge"
     write_tmux_target(
@@ -3758,6 +3902,7 @@ def test_inject_user_message_resends_enter_when_first_submit_swallowed(
     fire-and-forget Enter would send exactly one and return "success"
     with the message undelivered.
     """
+    _bypass_delivery_ack(monkeypatch)
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     # Shrink the polling cadence so the retry happens in milliseconds —
     # the production defaults (1s retry spacing) would make this test slow.
@@ -6221,6 +6366,23 @@ def test_hook_record_parses_todo_write_todos() -> None:
     assert record.task_status is None
 
 
+def test_hook_record_parses_user_prompt_submit_prompt() -> None:
+    """``UserPromptSubmit`` exposes the prompt used for delivery matching."""
+    record = _hook_record_from_jsonl_record(
+        _make_jsonl_record(
+            {
+                "hook_event_name": "UserPromptSubmit",
+                "session_id": "claude-session",
+                "prompt": "deliver me",
+            }
+        )
+    )
+
+    assert record.event_name == "UserPromptSubmit"
+    assert record.claude_session_id == "claude-session"
+    assert record.prompt == "deliver me"
+
+
 def test_hook_record_parses_task_update() -> None:
     """
     ``PostToolUse/TaskUpdate`` → ``record.task_id`` and ``record.task_status``.
@@ -8418,6 +8580,7 @@ def test_inject_user_message_restores_an_occupied_input_box_first(
     (its own documented dismissal), restoring the empty input box, then
     deliver the message normally.
     """
+    _bypass_delivery_ack(monkeypatch)
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     bridge_dir = tmp_path / "bridge"
@@ -8601,6 +8764,7 @@ def test_inject_user_message_retries_a_swallowed_occupied_input_escape(
     Retries fire only while the surface is verifiably on screen, so none
     can reach the restored composer (where Escape interrupts a turn).
     """
+    _bypass_delivery_ack(monkeypatch)
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     monkeypatch.setattr(
@@ -9190,6 +9354,7 @@ def test_inject_user_message_whitespace_only_content_submits_blind(
     behavior.  This must not raise: the best-effort path is retained for content
     whose draft position cannot be determined.
     """
+    _bypass_delivery_ack(monkeypatch)
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_COMMIT_TIMEOUT_S", 0.1)


### PR DESCRIPTION
## Related issue

Follow-up to #5494 for the remaining in-pane restart race from #2060.

## Summary

- Require a matching parent-session `UserPromptSubmit` hook before ordinary claude-native messages are reported as delivered. An empty composer alone is ambiguous because an in-pane restart also clears it.
- Snapshot the hook log before injection, follow `SessionStart` identity changes, ignore subagent hooks, and raise explicitly when no matching acknowledgement arrives. Built-in lifecycle commands keep their existing behavior because they do not consistently emit `UserPromptSubmit`.
- Extend the real-tmux regression harness to cover a restart after the draft becomes visible but before Enter lands.

**ELI5:** Seeing the text box become empty is like seeing a package leave the loading dock—it does not prove anyone received it. The matching hook is the delivery receipt.

```text
paste -> draft visible -> Enter -> matching UserPromptSubmit -> success
                              \
                               restart -> no receipt -> RuntimeError
```

## Test Plan

```bash
PYTHONPATH=. .venv/bin/python -m pytest tests/test_claude_native_bridge.py -q
TMPDIR=/tmp PYTHONPATH=. .venv/bin/python -m pytest tests/e2e/test_claude_native_inpane_restart_e2e.py -q
.venv/bin/pre-commit run --all-files
```

Results: 304 bridge tests passed, 3 tmux e2e tests passed, and all pre-commit hooks passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The e2e harness exercises the production injection function against a real tmux pane. Its control receives a matching acknowledgement; both pre-draft and post-draft restart cases raise instead of returning silent success.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage checks prompt parsing and normalization, exact matching, hook-log snapshots, parent-session changes, stale-session rejection, and subagent isolation. The tmux e2e reproduces the process restart at both vulnerable points.

## Changelog

Messages sent to claude-native are no longer silently reported as delivered when Claude Code restarts during submission.


