### PR TITLE
Lazy load xterm

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2049,14 +2049,13 @@ function MainAgentSurface({
     if (!mountTerminal || !conversationId) return;
     setWarmTerminals((prev) => updateWarmTerminalSurfaces(prev, conversationId, terminalReadOnly));
   }, [mountTerminal, conversationId, terminalReadOnly]);
-  // Render from a derived list that already includes the active session,
-  // so a fresh session's surface mounts in the same commit (the effect
-  // above persists it one commit later) and its readOnly snapshot tracks
-  // a late permission hydrate while it is the active session.
-  const renderedTerminals =
-    mountTerminal && conversationId
-      ? updateWarmTerminalSurfaces(warmTerminals, conversationId, terminalReadOnly)
-      : warmTerminals;
+  // Derive from warmTerminals only — the effect above adds the active session
+  // after the first paint, so xterm (a lazy chunk) never loads on the initial
+  // render. Previously the active session was included here same-commit to
+  // avoid the one-frame delay; that optimization is removed so the terminal
+  // chunk defers until after first paint. Returning to an already-warm
+  // background session is still same-commit (it's already in warmTerminals).
+  const renderedTerminals = warmTerminals;
   const handleTerminalResume = useCallback(async () => {
     if (!conversationId) throw new Error("Session is not available");
     if (liveness.kind === "host_offline" || liveness.kind === "local_stranded") {

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -1074,7 +1074,7 @@ describe("TerminalFirstContext", () => {
     expect(regularProbe).toHaveAttribute("data-is-claude-native", "false");
   });
 
-  it("targets the agent terminal while a user shell remains open in the workspace rail", () => {
+  it("targets the agent terminal while a user shell remains open in the workspace rail", async () => {
     writeSessionWorkspaceState("conv_native", {
       open: true,
       selectedTerminalKey: "terminal:terminal_bash_s1",
@@ -1104,7 +1104,8 @@ describe("TerminalFirstContext", () => {
 
     renderShell("/c/conv_native");
 
-    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
+    // findByTestId waits for the lazy TerminalView chunk to resolve through its Suspense boundary.
+    expect(await screen.findByTestId("terminal-view-stub")).toHaveTextContent("terminal_bash_s1");
     fireEvent.click(screen.getByTestId("view-mode-terminal"));
     expect(screen.getByTestId("view-probe")).toHaveAttribute(
       "data-terminal-view-key",

--- a/web/src/shell/MainTerminalView.test.tsx
+++ b/web/src/shell/MainTerminalView.test.tsx
@@ -152,11 +152,12 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("MainTerminalView — terminal-first SDK sessions", () => {
-  it("renders the REPL chrome-free: shells and the + stay out of the pill view", () => {
+  it("renders the REPL chrome-free: shells and the + stay out of the pill view", async () => {
     renderView({ terminals: [REPL_TERMINAL, BASH_SHELL] });
 
-    // The agent's terminal fills the pane.
-    expect(screen.getByTestId("terminal-view")).toHaveAttribute(
+    // The agent's terminal fills the pane. findByTestId waits for the lazy
+    // TerminalView chunk to resolve through its Suspense boundary.
+    expect(await screen.findByTestId("terminal-view")).toHaveAttribute(
       "data-terminal-id",
       "terminal_tui_main",
     );

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -15,9 +15,6 @@
 
 import { Loader2Icon, TerminalIcon, XIcon } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
-const TerminalView = lazy(() =>
-  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
-);
 import { Button } from "@/components/ui/button";
 import {
   AGENT_TERMINAL_IDS,
@@ -28,6 +25,10 @@ import {
 import { useTerminalFirst } from "./TerminalFirstContext";
 import { TerminalStatusBadge } from "./terminalStatus";
 import { useTerminalStatuses } from "./useTerminalStatuses";
+
+const TerminalView = lazy(() =>
+  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
+);
 
 interface MainTerminalViewProps {
   conversationId: string;

--- a/web/src/shell/MainTerminalView.tsx
+++ b/web/src/shell/MainTerminalView.tsx
@@ -14,8 +14,10 @@
 // shells are opened and created from the rail's tab strip ("+" menu).
 
 import { Loader2Icon, TerminalIcon, XIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { TerminalView } from "@/components/blocks/TerminalView";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+const TerminalView = lazy(() =>
+  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
+);
 import { Button } from "@/components/ui/button";
 import {
   AGENT_TERMINAL_IDS,
@@ -270,19 +272,21 @@ export function MainTerminalView({
                   key={`${conversationId}:${activeTerminal.id}`}
                   className="flex h-full flex-col"
                 >
-                  <TerminalView
-                    sessionId={conversationId}
-                    terminalId={activeTerminal.id}
-                    readOnly={readOnly}
-                    active={visible}
-                    directAttachUrl={activeTerminal.directAttachUrl}
-                    onResume={runnerOffline && onResume ? handleResume : undefined}
-                    resumePending={resumePending}
-                    onStateChange={(state) => {
-                      setTerminalConnectionState(activeTerminal.id, state);
-                    }}
-                    onActivity={() => markTerminalActive(activeTerminal.id)}
-                  />
+                  <Suspense fallback={null}>
+                    <TerminalView
+                      sessionId={conversationId}
+                      terminalId={activeTerminal.id}
+                      readOnly={readOnly}
+                      active={visible}
+                      directAttachUrl={activeTerminal.directAttachUrl}
+                      onResume={runnerOffline && onResume ? handleResume : undefined}
+                      resumePending={resumePending}
+                      onStateChange={(state) => {
+                        setTerminalConnectionState(activeTerminal.id, state);
+                      }}
+                      onActivity={() => markTerminalActive(activeTerminal.id)}
+                    />
+                  </Suspense>
                 </div>
               )}
             </div>

--- a/web/src/shell/TerminalsPanel.test.tsx
+++ b/web/src/shell/TerminalsPanel.test.tsx
@@ -117,7 +117,7 @@ describe("TerminalsPanel navigation", () => {
     expect(screen.queryByTestId("terminal-view")).toBeNull();
   });
 
-  it("shows terminal view after clicking a row, deferred until expanded", () => {
+  it("shows terminal view after clicking a row, deferred until expanded", async () => {
     renderPanel();
 
     fireEvent.click(screen.getByRole("button", { name: /worker/i }));
@@ -128,7 +128,9 @@ describe("TerminalsPanel navigation", () => {
     // TerminalView deferred until 180 ms settle.
     expect(screen.queryByTestId("terminal-view")).toBeNull();
 
-    act(() => {
+    // async act flushes both the fake-timer tick and any Suspense microtasks
+    // from the lazy TerminalView chunk resolving through its boundary.
+    await act(async () => {
       vi.advanceTimersByTime(180);
     });
 

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -25,8 +25,10 @@
 
 import { TerminalIcon, XIcon } from "lucide-react";
 import type { CSSProperties } from "react";
-import { useEffect, useRef, useState } from "react";
-import { TerminalView } from "@/components/blocks/TerminalView";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
+const TerminalView = lazy(() =>
+  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
+);
 import { Button } from "@/components/ui/button";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
 import { useIOSNativeKeyboardInset } from "@/hooks/useIOSNativeKeyboardInset";
@@ -239,16 +241,18 @@ export function TerminalsPanel({
             // across same-shape sessions (e.g. `terminal_claude_main`), so id
             // alone reuses the xterm mount and shows stale scrollback.
             <div key={`${conversationId}:${activeTerminal.id}`} className="flex h-full flex-col">
-              <TerminalView
-                sessionId={conversationId}
-                terminalId={activeTerminal.id}
-                readOnly={readOnly}
-                directAttachUrl={activeTerminal.directAttachUrl}
-                onStateChange={(state) => {
-                  setTerminalConnectionState(activeTerminal.id, state);
-                }}
-                onActivity={() => markTerminalActive(activeTerminal.id)}
-              />
+              <Suspense fallback={null}>
+                <TerminalView
+                  sessionId={conversationId}
+                  terminalId={activeTerminal.id}
+                  readOnly={readOnly}
+                  directAttachUrl={activeTerminal.directAttachUrl}
+                  onStateChange={(state) => {
+                    setTerminalConnectionState(activeTerminal.id, state);
+                  }}
+                  onActivity={() => markTerminalActive(activeTerminal.id)}
+                />
+              </Suspense>
             </div>
           ) : (
             <div className="flex-1" />

--- a/web/src/shell/TerminalsPanel.tsx
+++ b/web/src/shell/TerminalsPanel.tsx
@@ -26,9 +26,6 @@
 import { TerminalIcon, XIcon } from "lucide-react";
 import type { CSSProperties } from "react";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
-const TerminalView = lazy(() =>
-  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
-);
 import { Button } from "@/components/ui/button";
 import { useResizablePanel } from "@/hooks/useResizablePanel";
 import { useIOSNativeKeyboardInset } from "@/hooks/useIOSNativeKeyboardInset";
@@ -37,6 +34,10 @@ import { cn } from "@/lib/utils";
 import { NewTerminalButton } from "./NewTerminalButton";
 import { TerminalStatusBadge } from "./terminalStatus";
 import { useTerminalSplit } from "./useTerminalSplit";
+
+const TerminalView = lazy(() =>
+  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
+);
 
 interface TerminalsPanelProps {
   open: boolean;

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -331,7 +331,7 @@ describe("WorkspacePanel shell tabs", () => {
     expect(shellTab).not.toHaveClass("h-[32px]");
   });
 
-  it("surfaces the active shell's xterm in the content slot", () => {
+  it("surfaces the active shell's xterm in the content slot", async () => {
     useTerminalsMock.mockReturnValue({ terminals: [term], isLoading: false, error: null });
     renderWorkspace({
       openTerminals: [termKey],
@@ -340,7 +340,9 @@ describe("WorkspacePanel shell tabs", () => {
 
     // The selected shell tab owns the single content slot — its terminal id is
     // attached, and neither the files scope view nor a file viewer mounts.
-    expect(screen.getByTestId("terminal-view-stub")).toHaveTextContent("terminal_zsh_s1");
+    // findByTestId waits for the lazy TerminalView chunk to resolve through
+    // its Suspense boundary.
+    expect(await screen.findByTestId("terminal-view-stub")).toHaveTextContent("terminal_zsh_s1");
     expect(screen.queryByTestId("files-panel-stub")).toBeNull();
     expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
   });

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -15,6 +15,8 @@ import {
 import {
   type CSSProperties,
   type ReactElement,
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useRef,
@@ -34,10 +36,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { lazy, Suspense } from "react";
-const TerminalView = lazy(() =>
-  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
-);
 import { BrowserPane } from "@/components/BrowserPane/BrowserPane";
 import { useSessionAgent } from "@/hooks/useAgents";
 import type { SessionLiveness } from "@/hooks/useSessionLiveness";
@@ -52,6 +50,10 @@ import { SubagentsPanel } from "./SubagentsPanel";
 import { useTerminalStatuses } from "./useTerminalStatuses";
 import { type RightRailTab, TAB_BADGE_BASE } from "./railTabs";
 import { Button } from "../components/ui/button";
+
+const TerminalView = lazy(() =>
+  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
+);
 
 function WorkspaceTabTooltip({
   label,

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -34,7 +34,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TerminalView } from "@/components/blocks/TerminalView";
+import { lazy, Suspense } from "react";
+const TerminalView = lazy(() =>
+  import("@/components/blocks/TerminalView").then((m) => ({ default: m.TerminalView })),
+);
 import { BrowserPane } from "@/components/BrowserPane/BrowserPane";
 import { useSessionAgent } from "@/hooks/useAgents";
 import type { SessionLiveness } from "@/hooks/useSessionLiveness";
@@ -524,15 +527,17 @@ function RailTerminalView({
   }
   return (
     <div key={terminal.id} className="flex h-full min-h-0 flex-col">
-      <TerminalView
-        sessionId={conversationId}
-        terminalId={terminal.id}
-        readOnly={readOnly}
-        focusOnConnect={autoFocus}
-        directAttachUrl={terminal.directAttachUrl}
-        onStateChange={(state) => setTerminalConnectionState(terminal.id, state)}
-        onActivity={() => markTerminalActive(terminal.id)}
-      />
+      <Suspense fallback={null}>
+        <TerminalView
+          sessionId={conversationId}
+          terminalId={terminal.id}
+          readOnly={readOnly}
+          focusOnConnect={autoFocus}
+          directAttachUrl={terminal.directAttachUrl}
+          onStateChange={(state) => setTerminalConnectionState(terminal.id, state)}
+          onActivity={() => markTerminalActive(terminal.id)}
+        />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## Related issue

Closes #6095 <!-- OMNI-6095: https://linear.app/omnigent/issue/OMNI-6095/lazy-load-monaco-xterm-threejs-and-pdfjs -->

## Summary

- **xterm (`@xterm/xterm` + WebGL/fit/web-links addons, ~479 KB) was loading on every page load** — even when the terminal is never opened. It's now a lazy chunk that loads off the critical render path.
- **Monaco, PDF.js, and Three.js were already lazy** (split in `CodeViewer.tsx`) — no changes needed there.
- The lazy boundary sits at the `<TerminalView>` render sites in `WorkspacePanel`, `TerminalsPanel`, and `MainTerminalView`, each wrapped with `<Suspense fallback={null}>`.
- The pre-warmed hidden terminal overlay (mounted in the background for terminal-first sessions so Chat↔Terminal switching is instant) was loading xterm synchronously on first render. Fixed by removing the same-commit mount optimisation in `renderedTerminals` — the `useEffect` now handles the mount one tick after first paint, keeping the pre-warm intact while pushing xterm off the critical path.

**ELI5:** The browser used to download and parse a 479 KB terminal emulator before showing anything. Now it paints the page first, then loads xterm quietly in the background.

**Bundle impact (measured, prod build):**

| | Before | After |
|---|---|---|
| Main bundle (`index-*.js`) | 3,897 KB | 3,364 KB |
| `TerminalView-*.js` (new lazy chunk) | — | 479 KB |
| **Main bundle reduction** | | **−534 KB (−14%)** |

## Test Plan

1. `cd web && npm run type-check` — no new errors
2. `cd web && npx vitest run src/shell/TerminalsPanel.test.tsx src/shell/MainTerminalView.test.tsx src/shell/WorkspacePanel.test.tsx src/pages/ChatPage.test.ts src/pages/ChatPage.composer.test.tsx` — all pass
3. Manual — `npm run build && npm run preview`, open DevTools → Network → JS filter:
   - Cold page load: no `TerminalView-*.js` request
   - Open a Claude Code session: `TerminalView-*.js` loads **after** all other scripts settle — verified as `pending` while 57 other chunks are `200`
   - Switch to Terminal view: terminal connects and works normally

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Network waterfall before: xterm bundled in `index-*.js`, loaded synchronously with the page.

Network waterfall after:
```
index-*.js            200  ← 534 KB lighter
[57 other chunks]     200
TerminalView-*.js  pending  ← loads after first paint
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Three test files updated (`TerminalsPanel.test.tsx`, `MainTerminalView.test.tsx`, `WorkspacePanel.test.tsx`) to use `async`/`findByTestId` or `await act(async () => {...})` where previously synchronous `getByTestId` was used after the new `Suspense` boundary. Manual verification confirmed xterm defers past first paint in `npm run preview`.

## Changelog

Initial page load is 534 KB lighter: xterm now loads as a separate chunk after first paint instead of blocking the main bundle.