### PR TITLE
feat(web): defer non-streaming sidebar/rail updates with useDeferredValue (OMNI-6093)

### DIFF
--- a/web/src/shell/SessionRail.tsx
+++ b/web/src/shell/SessionRail.tsx
@@ -7,7 +7,7 @@
 // parity with the TUI Ctrl+O overlay.
 
 import { BotIcon, ChevronDownIcon, MessageSquareIcon, type LucideIcon } from "lucide-react";
-import { useState } from "react";
+import { useDeferredValue, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -37,7 +37,10 @@ export function SessionRail({
   onExpandExecutionLogs,
   suppressed,
 }: SessionRailProps) {
-  const { children } = useChildSessions(conversationId);
+  const { children: liveChildren } = useChildSessions(conversationId);
+  // Defer child-session list updates so rail re-renders don't compete with
+  // the active streaming bubble.
+  const children = useDeferredValue(liveChildren);
   if (suppressed) return null;
   return <ExecutionLogsCard childSessions={children} onExpand={onExpandExecutionLogs} />;
 }

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useDeferredValue,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -1455,11 +1456,14 @@ function ConversationList({
     () => new Map(hosts.map((host) => [host.host_id, host] as const)),
     [hosts],
   );
+  // Defer the paginated data so WS-push cache updates re-render the list at
+  // low priority, keeping streaming-bubble frames uncontested.
+  const deferredData = useDeferredValue(conversationsQuery.data);
   // All loaded conversations from the single paginated list (for the flat
   // session list; pinned rows are merged in from the server pinned query).
   const allConversations = useMemo(
-    () => conversationsQuery.data?.pages.flatMap((page) => page.data) ?? [],
-    [conversationsQuery.data],
+    () => deferredData?.pages.flatMap((page) => page.data) ?? [],
+    [deferredData],
   );
 
   // Project folders ({ id, name }) for grouping sessions — first-class id

--- a/web/src/shell/SubagentsGraphView.tsx
+++ b/web/src/shell/SubagentsGraphView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type { NodeTypes, NodeProps, Node } from "@xyflow/react";
 import { ReactFlow, Background, Position, Handle, useReactFlow } from "@xyflow/react";
 import { useLocation, useNavigate } from "@/lib/routing";
@@ -163,7 +163,9 @@ interface SubagentsGraphViewProps {
 
 export function SubagentsGraphView({ conversationId, rootSessionId }: SubagentsGraphViewProps) {
   const { session } = useSession(rootSessionId);
-  const { children: rootChildren } = useChildSessions(rootSessionId);
+  const { children: liveRootChildren } = useChildSessions(rootSessionId);
+  // Defer child-session updates so graph re-layouts render at low priority.
+  const rootChildren = useDeferredValue(liveRootChildren);
 
   const [childrenMap, setChildrenMap] = useState<Map<string, ChildSessionInfo[]>>(() => new Map());
 

--- a/web/src/shell/SubagentsPanel.tsx
+++ b/web/src/shell/SubagentsPanel.tsx
@@ -14,7 +14,7 @@
 // Each row is a Link to the target conversation page so cmd/middle-
 // click opens it in a new tab, matching the sidebar's behavior.
 
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense, useDeferredValue, useState } from "react";
 import type { ComponentType, SVGProps } from "react";
 import {
   BookOpenIcon,
@@ -111,7 +111,10 @@ interface SubagentsPanelProps {
 type ViewMode = "list" | "graph";
 
 export function SubagentsPanel({ conversationId, rootSessionId }: SubagentsPanelProps) {
-  const { children, isLoading, error } = useChildSessions(rootSessionId);
+  const { children: liveChildren, isLoading, error } = useChildSessions(rootSessionId);
+  // Defer child-session list updates so sub-agent status changes render at
+  // low priority and don't interrupt the active streaming bubble.
+  const children = useDeferredValue(liveChildren);
   const [addOpen, setAddOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [collapsedRows, setCollapsedRows] = useState<Record<string, boolean>>({});
@@ -605,7 +608,10 @@ function SubagentRow({
   // This child's own sub-agents, rendered as the next tree level.
   // Disabled (null id) at the depth cap so the fan-out of fetches is
   // bounded; ``useChildSessions`` skips the query entirely for null.
-  const { children: grandchildren } = useChildSessions(depth < MAX_TREE_DEPTH ? child.id : null);
+  const { children: liveGrandchildren } = useChildSessions(
+    depth < MAX_TREE_DEPTH ? child.id : null,
+  );
+  const grandchildren = useDeferredValue(liveGrandchildren);
   const hasGrandchildren = grandchildren.length > 0;
   const ToggleIcon = collapsed ? ChevronRightIcon : ChevronDownIcon;
   return (


### PR DESCRIPTION
## Summary

- Wraps conversation-list and child-session-list data in `useDeferredValue` at the consumer render boundary so React can deprioritise those re-renders when the streaming bubble is pending
- This is the correct lever: `useDeferredValue` works at the React component level, whereas the previously attempted `startTransition` approach (reviewed by Polly) was inert because React Query v5 delivers cache updates via `useSyncExternalStore`, which React keeps synchronous regardless of transition scope

**Sites changed:**
- `Sidebar` (`ConversationList`): defers paginated conversation data before building `allConversations`
- `SubagentsPanel`: defers root child-session list
- `SubagentRow`: defers grandchild list
- `SubagentsGraphView`: defers root children that drive graph layout
- `SessionRail`: defers child-session list for the execution-logs card

**Not deferred (stay urgent):** streaming block state, composer input, navigation.

## Test Plan

- [x] `npx vitest run src/hooks/SessionUpdatesProvider.test.tsx src/store/chatStore.test.ts` — 389 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --write` + `npx oxlint` — clean
- Manual: during active streaming, sidebar row refreshes and agent-rail updates should yield to the streaming bubble under CPU pressure (verify with React Profiler / Chrome performance trace)

## Demo

N/A — scheduling change; no visible behaviour difference under normal load. Observable improvement under CPU pressure during streaming.

## Type of change

- [x] Performance improvement

## Test coverage

- [x] Existing tests cover the changed paths

## Coverage notes

`useDeferredValue` produces a lagging copy of the value — React renders with the previous copy first, then re-renders with the fresh value when the main thread is idle. No data is lost, only deferred. Existing tests are unaffected because they run synchronously and the deferred value resolves immediately in test environments.

Closes OMNI-6093

This pull request and its description were written by Isaac.