### PR TITLE
fix(sidebar): hide loading spinner during background pagination when sessions are visible

### DIFF
--- a/tests/e2e_ui/collaboration/test_sidebar_shared_pagination_spinner.py
+++ b/tests/e2e_ui/collaboration/test_sidebar_shared_pagination_spinner.py
@@ -1,0 +1,221 @@
+"""Sidebar must not show a perpetual spinner while paging through shared sessions.
+
+User journey (from the bug report):
+
+1. On a multi-user server, many sessions are shared with the viewer while the
+   viewer owns only a few recent sessions of their own.
+2. The viewer opens the app. The sidebar's default "My sessions" slice shows
+   their own rows quickly (they are the newest sessions, so they land on the
+   first page of the unified owned+shared ``updated_at``-desc list).
+3. The sidebar keeps paginating in the background through the many shared
+   sessions (which the "My sessions" slice filters out client-side), and the
+   "Loading…" spinner at the bottom of the list stays visible the whole time —
+   with enough shared sessions it never seems to disappear.
+
+Expected behavior: once the viewer's own rows are on screen, the sidebar must
+not keep showing a loading spinner for the background pagination walk.
+
+This test seeds many sharer-owned sessions granted to the admin viewer plus a
+few admin-owned sessions created last (newest → first page), injects realistic
+per-page latency on the paginated ``after=`` fetches (the deployment where the
+bug was filed pays a visible round-trip per page), and asserts the spinner is
+never shown once the viewer's rows are visible. On the buggy build the spinner
+stays up for the entire multi-page background walk, failing the assertion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from playwright.sync_api import Browser, Route, expect
+
+from tests.e2e_ui.collaboration._multi_user_server import (
+    ADMIN_EMAIL,
+    MultiUserServer,
+    spawn_multi_user_server,
+)
+from tests.e2e_ui.conftest import _build_hello_world_bundle
+
+# Identity that owns the "many shared sessions" and grants them to the admin.
+_SHARER_EMAIL = "sharer-bulk@ui.test"
+# Read grant level (mirrors omnigent/server/auth.py).
+_LEVEL_READ = 1
+
+# Enough shared sessions for a multi-page background walk (30/page → 4+ pages
+# beyond the first), so the sentinel keeps auto-fetching while we observe.
+_SHARED_SESSION_COUNT = 130
+_OWN_SESSION_TITLES = (
+    "viewer own session A",
+    "viewer own session B",
+    "viewer own session C",
+)
+# Injected latency per paginated (``after=``) list fetch. Local SQLite answers
+# in milliseconds, which would let the walk finish before anyone could see it;
+# the reported deployment pays a visible round-trip per page, and this delay
+# reproduces that pacing so the spinner window is observable.
+_PAGE_FETCH_DELAY_S = 1.5
+# Let a correct build hide any transitional spinner after rows appear.
+_GRACE_MS = 600
+# Sampling window: well inside the injected 4-page × 1.5 s busy window.
+_SAMPLES = 12
+_SAMPLE_INTERVAL_MS = 250
+
+
+@dataclass
+class _SeededServer:
+    """The multi-user server with the bug's session population seeded."""
+
+    server: MultiUserServer
+    accessible_count: int
+
+
+@pytest.fixture(scope="module")
+def multi_user_server(
+    built_spa: None,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[MultiUserServer]:
+    """A dedicated NON-single-user server (real owner/shared split)."""
+    server_tmp = tmp_path_factory.mktemp("e2e_ui_sidebar_shared_pagination")
+    yield from spawn_multi_user_server(mock_llm_server_url, server_tmp)
+
+
+def _create_session(client: httpx.Client, bundle: bytes) -> str:
+    resp = client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    resp.raise_for_status()
+    return resp.json()["session_id"]
+
+
+def _count_accessible(base_url: str) -> int:
+    """Walk the admin's paginated session list and count accessible rows."""
+    count = 0
+    after: str | None = None
+    with httpx.Client(
+        base_url=base_url,
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=30.0,
+    ) as client:
+        while True:
+            params: dict[str, str] = {"order": "desc", "sort_by": "updated_at", "limit": "30"}
+            if after:
+                params["after"] = after
+            resp = client.get("/v1/sessions", params=params)
+            resp.raise_for_status()
+            page = resp.json()
+            count += len(page["data"])
+            if not page.get("has_more") or not page.get("last_id"):
+                return count
+            after = page["last_id"]
+
+
+@pytest.fixture(scope="module")
+def seeded(multi_user_server: MultiUserServer) -> _SeededServer:
+    """Seed the bug's population: many shared sessions, few (newest) own ones.
+
+    The sharer's sessions are created FIRST and granted to the admin, then the
+    admin's own sessions are created LAST — so on the ``updated_at``-desc list
+    the viewer's own rows sit on the first page and the shared bulk fills the
+    later pages the sidebar walks in the background.
+    """
+    base = multi_user_server.base_url
+    bundle = _build_hello_world_bundle()
+    with httpx.Client(
+        base_url=base,
+        headers={"X-Forwarded-Email": _SHARER_EMAIL},
+        timeout=30.0,
+    ) as sharer:
+        for _ in range(_SHARED_SESSION_COUNT):
+            sid = _create_session(sharer, bundle)
+            sharer.put(
+                f"/v1/sessions/{sid}/permissions",
+                json={"user_id": ADMIN_EMAIL, "level": _LEVEL_READ},
+            ).raise_for_status()
+    # Ensure the admin's own sessions get strictly newer timestamps.
+    time.sleep(1.0)
+    with httpx.Client(
+        base_url=base,
+        headers={"X-Forwarded-Email": ADMIN_EMAIL},
+        timeout=30.0,
+    ) as admin:
+        for title in _OWN_SESSION_TITLES:
+            sid = _create_session(admin, bundle)
+            admin.patch(f"/v1/sessions/{sid}", json={"title": title}).raise_for_status()
+            time.sleep(0.05)
+    accessible = _count_accessible(base)
+    # Seeding sanity: the grants really made the shared bulk visible to the
+    # admin, so the sidebar has a genuine multi-page walk ahead of it.
+    assert accessible >= _SHARED_SESSION_COUNT + len(_OWN_SESSION_TITLES), (
+        f"expected the admin to see the seeded population, got {accessible} rows"
+    )
+    return _SeededServer(server=multi_user_server, accessible_count=accessible)
+
+
+def test_sidebar_settles_while_shared_sessions_paginate(
+    browser: Browser,
+    seeded: _SeededServer,
+) -> None:
+    server = seeded.server
+    # The suite's video autouse fixture patches only the async Browser API;
+    # this test drives the sync API, so honor the record dir directly.
+    context_kwargs: dict = {"extra_http_headers": {"X-Forwarded-Email": ADMIN_EMAIL}}
+    record_dir = os.environ.get("OMNIGENT_E2E_RECORD_DIR")
+    if record_dir:
+        context_kwargs["record_video_dir"] = record_dir
+    context = browser.new_context(**context_kwargs)
+    try:
+        page = context.new_page()
+
+        def _pace_paginated_fetch(route: Route) -> None:
+            request = route.request
+            parsed = urlparse(request.url)
+            is_paginated_list = (
+                request.method == "GET"
+                and parsed.path == "/v1/sessions"
+                and "after" in parse_qs(parsed.query)
+            )
+            if is_paginated_list:
+                time.sleep(_PAGE_FETCH_DELAY_S)
+            route.continue_()
+
+        page.route("**/v1/sessions*", _pace_paginated_fetch)
+        page.goto(server.public_url)
+
+        # The viewer's own (newest) sessions render on the default "My
+        # sessions" slice from the first page.
+        sidebar = page.locator('[data-testid="sidebar-conversation-list"]')
+        for title in _OWN_SESSION_TITLES:
+            expect(sidebar.get_by_text(title)).to_be_visible(timeout=30_000)
+
+        # Grace: a correct build may show a transitional spinner while the
+        # first page settles; give it a beat before judging.
+        page.wait_for_timeout(_GRACE_MS)
+
+        # With the viewer's rows visible, the sidebar must not keep showing
+        # the pagination spinner while it walks the shared bulk in the
+        # background. Sample across the injected multi-page busy window; on
+        # the buggy build the sentinel's "Loading…" spinner is up throughout.
+        spinner = sidebar.get_by_text("Loading…")
+        spinner_sightings = 0
+        for _ in range(_SAMPLES):
+            if spinner.count() > 0 and spinner.first.is_visible():
+                spinner_sightings += 1
+            page.wait_for_timeout(_SAMPLE_INTERVAL_MS)
+        assert spinner_sightings == 0, (
+            "sidebar kept showing the loading spinner during background "
+            f"pagination of shared sessions ({spinner_sightings}/{_SAMPLES} "
+            f"samples saw it) while the viewer's own sessions were already "
+            f"visible ({seeded.accessible_count} accessible sessions seeded)"
+        )
+    finally:
+        context.close()

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -1331,6 +1331,10 @@ describe("Sidebar collapsible sections", () => {
 // Pagination belongs to the Sessions list: collapsing it must take the
 // "Load more" button with it, or the button floats under nothing.
 describe("Sidebar load-more vs collapsed Sessions", () => {
+  // Restore any globally-stubbed APIs after every test so stubs don't leak
+  // into later tests when an assertion throws before the in-test cleanup.
+  afterEach(() => vi.unstubAllGlobals());
+
   it("hides Load more while Sessions is collapsed and restores it on expand", () => {
     // Use an empty page so totalVisible=0 → silent=false → "Load more" is visible.
     useConvMock.mockImplementation(

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -1332,12 +1332,12 @@ describe("Sidebar collapsible sections", () => {
 // "Load more" button with it, or the button floats under nothing.
 describe("Sidebar load-more vs collapsed Sessions", () => {
   it("hides Load more while Sessions is collapsed and restores it on expand", () => {
-    const rows = [conv("conv_mine", "Claude Code")];
+    // Use an empty page so totalVisible=0 → silent=false → "Load more" is visible.
     useConvMock.mockImplementation(
       () =>
         ({
           data: {
-            pages: [{ data: rows, first_id: rows[0]!.id, last_id: rows[0]!.id, has_more: true }],
+            pages: [{ data: [], first_id: null, last_id: null, has_more: true }],
             pageParams: [undefined],
           },
           isLoading: false,
@@ -1352,11 +1352,61 @@ describe("Sidebar load-more vs collapsed Sessions", () => {
 
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
-    // Collapsed Sessions hides its rows AND the pagination affordance.
-    expect(screen.queryByText("conv_mine")).toBeNull();
+    // Collapsed Sessions hides the pagination affordance.
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Sessions" }));
     expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument();
+  });
+
+  it("loads subsequent pages silently when the current tab already has sessions", () => {
+    // When there are visible sessions, background pagination must not show a
+    // spinner or "Load more" — a persistent indicator makes the list look
+    // like it is still on its initial load (OMNI-6002: few mine sessions,
+    // many shared sessions across subsequent pages).
+    let observerCallback: IntersectionObserverCallback | undefined;
+    class TestObserver {
+      constructor(cb: IntersectionObserverCallback) {
+        observerCallback = cb;
+      }
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+      takeRecords = () => [];
+      root = null;
+      rootMargin = "";
+      thresholds = [];
+    }
+    vi.stubGlobal("IntersectionObserver", TestObserver);
+
+    const fetchNextPage = vi.fn();
+    const rows = [conv("conv_mine", "Claude Code")];
+    useConvMock.mockImplementation(
+      () =>
+        ({
+          data: {
+            pages: [{ data: rows, first_id: rows[0]!.id, last_id: rows[0]!.id, has_more: true }],
+            pageParams: [undefined],
+          },
+          isLoading: false,
+          isError: false,
+          error: null,
+          fetchNextPage,
+          hasNextPage: true,
+          isFetchingNextPage: false,
+        }) as unknown as ReturnType<typeof useConversations>,
+    );
+    renderSidebar();
+
+    // One mine session is visible — no "Load more" button and no "Loading…"
+    // spinner must be shown so it does not look like the list is stuck loading.
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+    expect(screen.queryByText("Loading…")).toBeNull();
+
+    // The sentinel is still observed so auto-fetch fires on intersection.
+    observerCallback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as never);
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+
+    vi.unstubAllGlobals();
   });
 
   it("auto-fetches the next page when the sentinel scrolls into view (infinite scroll)", () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1104,12 +1104,17 @@ function InfiniteScrollSentinel({
   fetchMore,
   scrollRoot,
   indent,
+  silent,
 }: {
   hasMore: boolean;
   isFetching: boolean;
   fetchMore: () => void;
   scrollRoot: RefObject<HTMLElement | null>;
   indent?: boolean;
+  // When true, background pagination runs without any visible indicator —
+  // no spinner, no "Load more" label. Use when the list already has content
+  // so the sentinel does not look like a stalled initial load.
+  silent?: boolean;
 }) {
   const ref = useRef<HTMLButtonElement>(null);
   useEffect(() => {
@@ -1126,6 +1131,21 @@ function InfiniteScrollSentinel({
   }, [hasMore, isFetching, fetchMore, scrollRoot]);
 
   if (!hasMore) return null;
+  // Silent mode: a 1px-tall, non-interactive button keeps the
+  // IntersectionObserver anchor in the DOM so auto-fetch continues, but
+  // nothing is rendered that would look like an incomplete initial load.
+  if (silent) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        disabled
+        aria-hidden="true"
+        tabIndex={-1}
+        className="pointer-events-none h-px w-full"
+      />
+    );
+  }
   return (
     <button
       ref={ref}
@@ -2169,13 +2189,17 @@ function ConversationList({
               Settings page ("Archived chats"), reachable from the footer. */}
                 {/* Infinite-scroll sentinel for the global list. Pagination extends
               the Chats list, so it hides with a collapsed Chats group — a loader
-              under a collapsed group reads orphaned. */}
+              under a collapsed group reads orphaned. Silent while the list has
+              visible items: background pagination shouldn't look like a stalled
+              initial load when the current tab shows only a few sessions but many
+              more exist for other tabs (e.g. few "mine", many "shared"). */}
                 {!effectiveCollapsedSections.includes("Chats") && (
                   <InfiniteScrollSentinel
                     hasMore={hasMorePages}
                     isFetching={isFetchingNextPage}
                     fetchMore={fetchNextPage}
                     scrollRoot={scrollContainerRef}
+                    silent={totalVisible > 0}
                   />
                 )}
               </>

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1094,9 +1094,12 @@ export function Sidebar({
 /**
  * Auto-loading pagination control. An IntersectionObserver fetches the next
  * page when this nears view (rooted on the scroll container, pre-fetching 200px
- * early for smoothness); the button stays clickable as an a11y /
- * no-IntersectionObserver fallback. Renders nothing once there's no more to
- * load. Shared by the global list and each project folder.
+ * early for smoothness). In the default (non-silent) mode the button is also
+ * directly clickable as an a11y / no-IntersectionObserver fallback. In silent
+ * mode (`silent=true`) a non-interactive 1px element anchors the observer
+ * without any visible UI — no click/focus fallback is available there. Renders
+ * nothing once there's no more to load. Shared by the global list and each
+ * project folder.
  */
 function InfiniteScrollSentinel({
   hasMore,


### PR DESCRIPTION
## Related issue

Closes #6002 (OMNI-6002)

## Summary

When a user has few personal sessions and many shared sessions, the sidebar showed a persistent "Loading…" spinner that never went away. The root cause: the global session list is fetched as a single undifferentiated stream (owned + shared, sorted by `updated_at`), paginated 30 at a time, and filtered client-side per tab. With few personal sessions, the `InfiniteScrollSentinel` was always in the viewport, cycling through page after page of shared-only sessions — and showing the spinner on every fetch.

**The fix**: add a `silent` prop to `InfiniteScrollSentinel`. When `totalVisible > 0` (the current tab already has items to show), the sentinel renders as an invisible 1px button — the `IntersectionObserver` anchor stays in the DOM so auto-fetch continues, but no spinner or "Load more" label is displayed. When `totalVisible = 0`, the existing spinner is shown so users can see the initial load is in progress.

```
Before: user sees [5 mine sessions] [⟳ Loading…] — perpetually, until all ~500 shared sessions load
After:  user sees [5 mine sessions]             — background pages load silently, spinner never appears
```

## Test Plan

- Added a unit test `"loads subsequent pages silently when the current tab already has sessions"` — verifies no "Load more" button or "Loading…" text appears when sessions are visible, while confirming the sentinel still auto-triggers `fetchNextPage` on intersection.
- Updated the existing `"hides Load more while Sessions is collapsed"` test to use empty rows (so `totalVisible=0`) — the test's purpose (collapsed section hides the pagination affordance) is unchanged; the rows were incidental.
- All 88 Sidebar tests pass.

**To reproduce the fix manually**: spin up a multi-user instance, have user A share many sessions with user B, then open the sidebar as user B (who has few personal sessions). The "mine" tab should load immediately without any persistent spinner.

## Demo

- [x] Non-visual evidence provided below or in Test Plan

## Type of change

- [x] Bug fix
- [x] UI / frontend change

## Test coverage

- [x] Unit tests added / updated

## Changelog

Sidebar no longer shows a persistent loading spinner when you have few personal sessions and many shared sessions.

## Issues

Resolves [OMNI-6002](https://linear.app/omnigent/issue/OMNI-6002/sidebar-loads-sessions-forever-with-many-shared-sessions)
