### PR TITLE
fix(web): prevent composer and transcript jump during auto-grow in Gecko

### DIFF
--- a/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
+++ b/tests/e2e_ui/chat/test_composer_growth_transcript_stability.py
@@ -658,3 +658,85 @@ def test_composer_growth_reflows_transcript_without_covering_output(
     assert send_relocked_grown["distanceFromBottom"] <= 1, send_relocked_grown
     assert abs(send_relocked_grown["overlap"]) <= 1, send_relocked_grown
     expect(composer).to_be_focused()
+
+
+def test_composer_growth_keeps_bottom_locked_transcript_pinned_every_frame(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A bottom-locked transcript must pin in the same frame the composer grows.
+
+    The library's ``scrollToBottom`` defers through a ``requestAnimationFrame``
+    promise, so without a synchronous re-pin the frame after a viewport shrink
+    paints with the transcript shoved up by one line height (the "jumping text"
+    of the auto-grow bounce) and snaps back a frame later. Settlement-only
+    probes can't see that intermediate frame, so this test samples the
+    scroll container's distance-from-bottom on every animation frame while
+    three newlines grow the composer: no sampled frame may fall off the bottom.
+    """
+    base_url, session_id = seeded_session
+    for i in range(6):
+        seed_committed_turn(
+            session_id,
+            prompt=f"Question {i}?",
+            reply=f"Paragraph {i}. " + ("filler sentence for height. " * 12),
+            response_id=f"frame_pin_{i}",
+        )
+    page.goto(f"{base_url}/c/{session_id}")
+
+    expect(page.locator(_TEXT_SECTION)).to_have_count(6, timeout=30_000)
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.click()
+    baseline = _settled_geometry(page)
+    assert baseline["distanceFromBottom"] <= 1, baseline
+
+    # The page-load layout may still be settling through one last async pin
+    # (the library's `scrollToBottom` fires on mount). Wait until two
+    # consecutive rAF frames agree on distance ≤ 0 so we only sample growth
+    # frames, not the initial mount settle.
+    page.wait_for_timeout(200)
+    assert _settled_geometry(page)["distanceFromBottom"] <= 1
+
+    distances = page.evaluate(
+        """async () => {
+            const textarea = document.querySelector(
+                'textarea[aria-label="Message the agent"]'
+            );
+            const scroller = textarea.closest('form')
+                .parentElement.querySelector('[role="log"] > div');
+            const samples = [];
+            let sampling = true;
+            const sample = () => {
+                samples.push(
+                    scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
+                );
+                if (sampling) requestAnimationFrame(sample);
+            };
+            requestAnimationFrame(sample);
+            const setter = Object.getOwnPropertyDescriptor(
+                HTMLTextAreaElement.prototype, 'value'
+            ).set;
+            for (let i = 0; i < 3; i += 1) {
+                setter.call(textarea, textarea.value + '\\n');
+                textarea.dispatchEvent(new InputEvent('input', { bubbles: true }));
+                await new Promise((resolve) => setTimeout(resolve, 60));
+            }
+            sampling = false;
+            // One settle window, then a final reading after the last frame.
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            samples.push(
+                scroller.scrollHeight - scroller.clientHeight - scroller.scrollTop
+            );
+            return samples;
+        }"""
+    )
+    # Every observed frame stays pinned: the deferred library pin may park one
+    # pixel short of the maximum, but never a full wrapped line behind it.
+    assert max(distances, default=0) <= 1, distances
+
+    grown = _settled_geometry(page)
+    assert grown["composerHeight"] > baseline["composerHeight"], grown
+    assert grown["distanceFromBottom"] <= 1, grown
+    assert abs(grown["overlap"]) <= 1, grown
+    expect(composer).to_be_focused()

--- a/web/src/components/chat/Transcript.tsx
+++ b/web/src/components/chat/Transcript.tsx
@@ -70,6 +70,8 @@ export interface TranscriptProps {
   sandboxLaunching: boolean;
   /** Terminal-first spin-up bits for the cold-launch empty state. */
   terminalFirst: { isTerminalFirst: boolean; terminalStartingUp?: boolean } | null | undefined;
+  /** Pub/sub ref for the LatestTurnSpacer's synchronous re-measure handle. */
+  spacerMeasureRef: React.RefObject<(() => void) | null>;
 }
 
 /**
@@ -93,6 +95,7 @@ function TranscriptImpl({
   agentsError,
   sandboxLaunching,
   terminalFirst,
+  spacerMeasureRef,
 }: TranscriptProps) {
   const blocks = useChatStore((s) => s.blocks);
   const pendingUserMessages = useChatStore((s) => s.pendingUserMessages);
@@ -298,6 +301,7 @@ function TranscriptImpl({
             <LatestTurnSpacer
               scrollElement={scroller?.el ?? null}
               topGapPx={hasTasks ? 16 : undefined}
+              measureRef={spacerMeasureRef}
             />
           </ConversationContent>
           <ConversationScrollButton />

--- a/web/src/components/chat/chatBubbleParts.tsx
+++ b/web/src/components/chat/chatBubbleParts.tsx
@@ -945,10 +945,21 @@ export function KeepBottomOnViewportResize() {
       if (nextHeight === clientHeight) return;
       clientHeight = nextHeight;
       if (!wasBottomLocked) return;
+      // Gecko delivers this callback before the frame paints, but the
+      // library's scrollToBottom always lands a frame later (it defers
+      // through a rAF promise), so the shrink paints with the transcript
+      // shoved up before the follow-up pin snaps it back — a visible
+      // bounce on every wrapped composer line. Pin synchronously here
+      // first; the async pins below stay as a safety net for engines that
+      // deliver the callback after paint. Target the library's park
+      // position (one pixel short) so the settle is identical whether our
+      // write or the library's lands last.
+      el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - 1);
       scrollToBottom("instant");
       if (frame !== null) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
         frame = null;
+        el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - 1);
         scrollToBottom("instant");
       });
     });
@@ -1159,17 +1170,27 @@ const MAX_RESERVED_VIEWPORT_FRACTION = 1 / 3;
  */
 export function LatestTurnSpacer({
   scrollElement,
-  // Gap left above the pinned anchor. Defaults to clearing the top fade band.
+  // Gap left above the pinned anchor. Defaults to clearing the top fade band;
+  // with the Plan accordion pinned above (fade dropped, container already below
+  // the header), the caller passes the small content inset so a framed turn
+  // rests just below the accordion instead of 80px lower.
   topGapPx = PINNED_ANCHOR_TOP_GAP_PX,
+  // Set to the spacer's latest measure() so a sibling (the composer's
+  // same-task growth pin) can re-measure before reading scroll geometry —
+  // the spacer's own ResizeObserver delivery runs a frame later, and the
+  // intervening paint is the visible transcript jump.
+  measureRef,
 }: {
   scrollElement?: HTMLElement | null;
   topGapPx?: number;
+  measureRef?: React.RefObject<(() => void) | null>;
 } = {}) {
   const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
     scrollRef: React.RefObject<HTMLElement>;
   };
   // Block changes remeasure the frozen anchor; streaming growth is covered by
-  // the ResizeObserver. The hydration gate remounts this component on a switch.
+  // the ResizeObserver. The hydration gate remounts this component on a
+  // conversation switch, which captures that conversation's initial anchor.
   const blockCount = useChatStore((s) => s.blocks.length);
   const spacerRef = useRef<HTMLDivElement>(null);
   // `undefined` means capture has not run; `null` is a completed capture with
@@ -1245,6 +1266,14 @@ export function LatestTurnSpacer({
   useLayoutEffect(() => {
     measure();
   }, [measure, blockCount]);
+
+  useLayoutEffect(() => {
+    if (!measureRef) return;
+    measureRef.current = measure;
+    return () => {
+      if (measureRef.current === measure) measureRef.current = null;
+    };
+  }, [measure, measureRef]);
 
   useLayoutEffect(() => {
     const scrollEl = scrollElement ?? ctx.scrollRef?.current;

--- a/web/src/hooks/useAutoGrowTextarea.test.tsx
+++ b/web/src/hooks/useAutoGrowTextarea.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoGrowTextarea } from "./useAutoGrowTextarea";
 
@@ -161,5 +161,213 @@ describe("useAutoGrowTextarea", () => {
     stubScrollHeight(ta, 800);
     roCallback?.([], {} as ResizeObserver);
     expect(growth.at(-1)).toBe(180);
+  });
+
+  it("pins the textarea's overflow while collapsed and restores it after", () => {
+    // Gecko paints the collapsed one-row box's overflow of its draft as a
+    // caret jump for the layout the measure lasts. Assert the invariant that
+    // prevents it: the textarea clips its own overflow for exactly as long
+    // as it is collapsed. Blink suppresses the intermediate paint, which is
+    // why only Firefox-based browsers show the bounce.
+    const { getByTestId } = render(<Harness value="two\nlines" />);
+    const ta = getByTestId("ta") as HTMLTextAreaElement;
+    const wrapper = getByTestId("wrapper") as HTMLDivElement;
+    wrapper.getBoundingClientRect = () => ({ height: 100 }) as DOMRect;
+
+    let overflowWhileCollapsed: string | null = null;
+    Object.defineProperty(ta, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        overflowWhileCollapsed = ta.style.overflowY;
+        return 40;
+      },
+    });
+    roCallback?.([], {} as ResizeObserver);
+
+    expect(overflowWhileCollapsed).toBe("hidden");
+    // Released once the real height is on, so a capped draft still scrolls
+    // (the CSS class governs overflow between measures).
+    expect(ta.style.overflowY).toBe("");
+    expect(ta.style.height).toBe("40px");
+  });
+
+  it("restores the scroll offset the collapse clamped away", () => {
+    // Setting ``height:auto`` collapses the box and Gecko drops its scroll
+    // offset along the way, leaving a capped draft mid-scroll read as
+    // scrolled-to-top on every re-measure. jsdom has no layout, so model the
+    // loss: the backing offset resets while the box is collapsed. The hook
+    // must put the pre-collapse offset back once the height lands, bounded
+    // by the new box exactly as the browser would clamp it.
+    const { getByTestId } = render(<Harness value="long draft" />);
+    const ta = getByTestId("ta") as HTMLTextAreaElement;
+    const wrapper = getByTestId("wrapper") as HTMLDivElement;
+    wrapper.getBoundingClientRect = () => ({ height: 100 }) as DOMRect;
+
+    // Back the element's scroll offset so the hook's save and restore go
+    // through the property the browser would.
+    let scrollTop = 300;
+    Object.defineProperty(ta, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (v: number) => {
+        scrollTop = v;
+      },
+    });
+    stubScrollHeight(ta, 800);
+    // The capped box: 800px of draft in a 10-row (200px) tall viewport.
+    Object.defineProperty(ta, "clientHeight", {
+      configurable: true,
+      get: () => 200,
+    });
+    Object.defineProperty(ta, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        // Gecko drops the offset when the box collapses.
+        if (ta.style.height === "auto") scrollTop = 0;
+        return 800;
+      },
+    });
+    roCallback?.([], {} as ResizeObserver);
+
+    expect(ta.style.height).toBe("200px");
+    expect(scrollTop).toBe(300);
+  });
+
+  it("reports growth only after the measurement guards are released", () => {
+    // A caller reacts to growth by re-pinning a sibling viewport (the
+    // transcript under a growing composer) in the same task as the height
+    // change. That pin must read the released geometry: while the wrapper is
+    // still pinned at its old height the sibling hasn't shrunk yet, so a pin
+    // written then is a silent no-op and the next paint bounces anyway.
+    let observed: { ta: HTMLTextAreaElement; wrapper: HTMLDivElement } | null = null;
+    const guardStates: { px: number; released: boolean }[] = [];
+    const probe = (px: number) => {
+      // The mount-time measure reports 0 before `observed` is set; only the
+      // post-observer reports (the ones this test is about) are recorded.
+      if (!observed) return;
+      const { ta, wrapper } = observed;
+      guardStates.push({
+        px,
+        released:
+          wrapper.style.height === "" && wrapper.style.overflow === "" && ta.style.overflowY === "",
+      });
+    };
+    const { getByTestId } = render(<Harness value="two\nlines" onGrowth={probe} />);
+    const ta = getByTestId("ta") as HTMLTextAreaElement;
+    const wrapper = getByTestId("wrapper") as HTMLDivElement;
+    observed = { ta, wrapper };
+
+    wrapper.getBoundingClientRect = () => ({ height: 100 }) as DOMRect;
+    stubScrollHeight(ta, 40);
+    roCallback?.([], {} as ResizeObserver);
+
+    // The reported growth: 40px box minus the 20px resting row.
+    expect(guardStates.at(-1)?.px).toBe(20);
+    expect(guardStates.at(-1)?.released).toBe(true);
+  });
+
+  it("restores ancestor scrollTop if style.height = auto triggers parent scroll offset drop", () => {
+    let parentScrollTop = 150;
+    function ScrollParentHarness({ value }: { value: string }) {
+      const parentRef = useRef<HTMLDivElement>(null);
+      const ref = useRef<HTMLTextAreaElement>(null);
+      useAutoGrowTextarea(ref, value, 10);
+
+      useLayoutEffect(() => {
+        if (parentRef.current) {
+          Object.defineProperty(parentRef.current, "scrollTop", {
+            configurable: true,
+            get: () => parentScrollTop,
+            set: (v: number) => {
+              parentScrollTop = v;
+            },
+          });
+        }
+      }, []);
+
+      return (
+        <div
+          ref={parentRef}
+          data-testid="scroll-parent"
+          style={{ overflow: "auto", height: "200px" }}
+        >
+          <div data-testid="wrapper">
+            <textarea
+              ref={ref}
+              data-testid="ta"
+              value={value}
+              onChange={() => {}}
+              style={{ lineHeight: "20px", paddingTop: "0px", paddingBottom: "0px" }}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<ScrollParentHarness value="hello" />);
+    const ta = getByTestId("ta") as HTMLTextAreaElement;
+
+    stubScrollHeight(ta, 40);
+
+    // When ta collapses, Gecko might adjust parent.scrollTop
+    Object.defineProperty(ta, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        if (ta.style.height === "auto") {
+          parentScrollTop = 0;
+        }
+        return 40;
+      },
+    });
+
+    roCallback?.([], {} as ResizeObserver);
+    expect(ta.style.height).toBe("40px");
+    expect(parentScrollTop).toBe(150);
+  });
+
+  it("skips style.height = auto collapse when text is appending", () => {
+    let collapsedToAutoCount = 0;
+    function DynamicHarness({ value }: { value: string }) {
+      const ref = useRef<HTMLTextAreaElement>(null);
+      useAutoGrowTextarea(ref, value, 10);
+      return (
+        <div data-testid="wrapper">
+          <textarea
+            ref={ref}
+            data-testid="ta"
+            value={value}
+            onChange={() => {}}
+            style={{ lineHeight: "20px", paddingTop: "0px", paddingBottom: "0px" }}
+          />
+        </div>
+      );
+    }
+
+    const { getByTestId, rerender } = render(<DynamicHarness value="line 1" />);
+    const ta = getByTestId("ta") as HTMLTextAreaElement;
+    stubScrollHeight(ta, 20);
+
+    let observedHeight = "";
+    Object.defineProperty(ta, "scrollHeight", {
+      configurable: true,
+      get: () => {
+        if (ta.style.height === "auto") {
+          collapsedToAutoCount++;
+        }
+        return observedHeight === "40px" ? 40 : 20;
+      },
+    });
+
+    // Mount measure runs with testForHeightReduction=true
+    roCallback?.([], {} as ResizeObserver);
+    const initialCollapses = collapsedToAutoCount;
+
+    // Now append text: "line 1" -> "line 1\nline 2"
+    observedHeight = "40px";
+    rerender(<DynamicHarness value="line 1\nline 2" />);
+
+    // Appending must NOT have collapsed ta.style.height to "auto"
+    expect(collapsedToAutoCount).toBe(initialCollapses);
+    expect(ta.style.height).toBe("40px");
   });
 });

--- a/web/src/hooks/useAutoGrowTextarea.ts
+++ b/web/src/hooks/useAutoGrowTextarea.ts
@@ -1,25 +1,72 @@
 import { type RefObject, useLayoutEffect, useRef } from "react";
 
 /**
+ * Cache scrollTop of all ancestor elements up to document.documentElement.
+ * When a textarea's height collapses (style.height = "auto"), Gecko/Firefox
+ * may adjust or reset scroll positions on scrollable ancestor containers
+ * due to scroll anchoring or sudden viewport enlargement. Restoring them
+ * after setting the new height prevents layout jumps.
+ */
+function cacheAncestorScrollTops(el: HTMLElement): () => void {
+  const entries: [Element, number][] = [];
+  let current = el.parentElement;
+  while (current && current instanceof Element) {
+    if (current.scrollTop > 0) {
+      entries.push([current, current.scrollTop]);
+    }
+    current = current.parentElement;
+  }
+  if (
+    typeof document !== "undefined" &&
+    document.documentElement &&
+    document.documentElement.scrollTop > 0
+  ) {
+    entries.push([document.documentElement, document.documentElement.scrollTop]);
+  }
+
+  return () => {
+    for (const [node, scrollTop] of entries) {
+      const elNode = node as HTMLElement;
+      const prevBehavior = elNode.style?.scrollBehavior;
+      if (elNode.style) elNode.style.scrollBehavior = "auto";
+      node.scrollTop = scrollTop;
+      if (elNode.style) elNode.style.scrollBehavior = prevBehavior ?? "";
+    }
+  };
+}
+
+/**
  * Measure ``ta`` and set its height to fit its content, capped at
  * ``maxRows`` rows (after which it scrolls). When ``scrollHeight`` is 0 the
  * element isn't laid out yet (e.g. mid client-side route swap), so the
  * natural height is left untouched rather than collapsed to 0px, which
  * would clip the content/placeholder.
  *
- * Reading the content height means collapsing to ``auto`` — a one-row box,
- * since these textareas are ``rows={1}`` — and that collapse must not escape
- * the composer. For the one layout it lasts the composer is short, so the
+ * Reading the content height requires collapsing to ``auto`` — a one-row box,
+ * since these textareas are ``rows={1}`` — when checking for potential height
+ * shrinkage (e.g. deletions or non-appending edits). That collapse must not
+ * escape the composer. For the one layout it lasts the composer is short, so the
  * transcript's scroll viewport is correspondingly taller, and the browser
  * clamps its ``scrollTop`` against that larger viewport's smaller maximum.
- * The clamp sticks once the composer springs back, so every re-measure shunts
- * the transcript down a line. Pinning and clipping the wrapper keeps the
- * collapse inside the composer.
+ * Pinning and clipping the wrapper keeps the collapse inside the composer.
+ *
+ * The textarea's own overflow is pinned for the same window: the collapsed
+ * one-row box momentarily overflows its draft, and Gecko paints that overflow
+ * as a caret jump (the bounce Firefox/Zen users see on wrapped lines) before
+ * the new height lands. Blink suppresses the intermediate paint, so the
+ * wrapper pin alone reads as fixed there. The scroll offset of the textarea
+ * itself and of all scrollable ancestor nodes is preserved across the measure.
+ *
+ * When pure text appending occurs (`testForHeightReduction` is false), collapsing
+ * to `height: auto` is skipped completely because the content height can only
+ * grow or stay equal. Skipping the collapse eliminates Gecko scroll-anchoring
+ * jitter entirely during normal typing.
  */
 function measureTextarea(
   ta: HTMLTextAreaElement,
   maxRows: number,
   onGrowth?: (px: number) => void,
+  testForHeightReduction = true,
 ): void {
   const wrapper = ta.parentElement;
   const wrapperHeight = wrapper?.getBoundingClientRect().height ?? 0;
@@ -30,35 +77,54 @@ function measureTextarea(
     wrapper.style.height = `${wrapperHeight}px`;
     wrapper.style.overflow = "hidden";
   }
+  const restoreOverflowY = ta.style.overflowY;
+  ta.style.overflowY = "hidden";
+  // Captured before the collapse: setting ``height:auto`` clamps the box's
+  // scroll offset to 0, and Gecko doesn't restore it when the height lands.
+  const restoreScrollTop = ta.scrollTop;
+  let restoreAncestorScrollTops: (() => void) | undefined;
+  let growth = 0;
   try {
-    ta.style.height = "auto";
-    if (ta.scrollHeight === 0) {
-      // Not laid out, so there's no growth to report either — say so rather
-      // than leave a stale offset applied across a route swap.
-      onGrowth?.(0);
-      return;
+    if (testForHeightReduction) {
+      restoreAncestorScrollTops = cacheAncestorScrollTops(ta);
+      ta.style.height = "auto";
     }
-    const cs = getComputedStyle(ta);
-    const lineHeight = parseFloat(cs.lineHeight);
-    const paddingTop = parseFloat(cs.paddingTop);
-    const paddingBottom = parseFloat(cs.paddingBottom);
-    const maxHeight = lineHeight * maxRows + paddingTop + paddingBottom;
-    const height = Math.min(ta.scrollHeight, maxHeight);
-    ta.style.height = height + "px";
-    // Resting height is a single row — or a CSS floor, for a composer that
-    // sets one, so its empty height doesn't read as growth.
-    const resting = Math.max(
-      lineHeight + paddingTop + paddingBottom,
-      parseFloat(cs.minHeight) || 0,
-    );
-    onGrowth?.(Math.max(0, height - resting));
+    if (ta.scrollHeight > 0) {
+      const cs = getComputedStyle(ta);
+      const lineHeight = parseFloat(cs.lineHeight);
+      const paddingTop = parseFloat(cs.paddingTop);
+      const paddingBottom = parseFloat(cs.paddingBottom);
+      const maxHeight = lineHeight * maxRows + paddingTop + paddingBottom;
+      const height = Math.min(ta.scrollHeight, maxHeight);
+      ta.style.height = height + "px";
+      // Restore the offset the collapse clamped away, bounded by the new box
+      // the same way the browser would — the height can land below the old
+      // offset (a large deletion, or re-measuring a draft that just capped).
+      ta.scrollTop = Math.min(restoreScrollTop, Math.max(0, ta.scrollHeight - ta.clientHeight));
+      if (restoreAncestorScrollTops) {
+        restoreAncestorScrollTops();
+      }
+      // Resting height is a single row — or a CSS floor, for a composer that
+      // sets one, so its empty height doesn't read as growth.
+      const resting = Math.max(
+        lineHeight + paddingTop + paddingBottom,
+        parseFloat(cs.minHeight) || 0,
+      );
+      growth = Math.max(0, height - resting);
+    }
   } finally {
     // Release both guards before the next layout so the composer resizes once.
+    ta.style.overflowY = restoreOverflowY;
     if (pinned) {
       wrapper.style.height = restoreHeight;
       wrapper.style.overflow = restoreOverflow;
     }
   }
+  // Reported only after the guards release: a caller re-pinning a sibling
+  // viewport (the transcript under a growing composer) must read the
+  // post-release geometry — while the wrapper is still pinned, the sibling
+  // hasn't shrunk yet and a pin written then is a silent no-op.
+  onGrowth?.(growth);
 }
 
 /**
@@ -91,20 +157,32 @@ export function useAutoGrowTextarea(
     onGrowthRef.current = onGrowth;
   });
 
+  const prevValueRef = useRef(value);
+
   // Re-measure on content / maxRows change.
   useLayoutEffect(() => {
-    if (ref.current) measureTextarea(ref.current, maxRows, onGrowthRef.current);
+    const ta = ref.current;
+    if (!ta) return;
+    const prev = prevValueRef.current;
+    prevValueRef.current = value;
+
+    // Only test for height reduction if value shrunk or changed in a non-append way.
+    // If empty, test reduction because placeholder or reset might need re-measurement.
+    const isAppend = prev !== "" && value.startsWith(prev);
+    const testForHeightReduction = !isAppend;
+
+    measureTextarea(ta, maxRows, onGrowthRef.current, testForHeightReduction);
   }, [ref, value, maxRows]);
 
-  // Install one observer per element (not per keystroke — value isn't a
-  // dep) so the box recovers once layout settles after a 0-height mount.
-  // Setting height in measureTextarea converges (auto → fixed → same
-  // fixed), so the observer settles rather than looping. Guarded for
-  // environments (jsdom) without ResizeObserver.
+  // Install one observer per element (not per keystroke — value isn't a dep)
+  // so the box recovers once layout settles after a 0-height mount.
+  // Setting height in measureTextarea converges (auto → fixed → same fixed),
+  // so the observer settles rather than looping. Guarded for environments (jsdom)
+  // without ResizeObserver.
   useLayoutEffect(() => {
     const ta = ref.current;
     if (!ta || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => measureTextarea(ta, maxRows, onGrowthRef.current));
+    const ro = new ResizeObserver(() => measureTextarea(ta, maxRows, onGrowthRef.current, true));
     ro.observe(ta);
     return () => ro.disconnect();
   }, [ref, maxRows]);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3005,7 +3005,13 @@ export function Composer({
   useLayoutEffect(() => {
     onGrowthRef.current = onViewportShrinkPinScroll;
   });
-  const onGrowth = useCallback(() => {
+  // The hook measures on every keystroke, but growth only changes at line
+  // wraps: skip the spacer re-measure and transcript pin while the box rests
+  // at an unchanged height.
+  const lastGrowthPxRef = useRef<number | null>(null);
+  const onGrowth = useCallback((px: number) => {
+    if (lastGrowthPxRef.current === px) return;
+    lastGrowthPxRef.current = px;
     onGrowthRef.current?.();
   }, []);
   useAutoGrowTextarea(textareaRef, value, 10, onGrowth);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1524,6 +1524,50 @@ function MainAgentSurface({
     [onSendSlashCommand, isNativeWrapper],
   );
 
+  // Synchronous bottom re-pin for the composer's growth, called in the same
+  // task as the height change (before any paint — the only ordering Gecko
+  // doesn't paint past; every async pin leaves one intermediate frame).
+  // Guarded by the live lock state, not the public isAtBottom alias, so a
+  // reader who scrolled up mid-stream is never yanked down. The spacer
+  // re-measures first: its reserved height tracks the viewport, so it must
+  // shrink in this same task — otherwise the pin reads a stale scrollHeight
+  // and the browser paints the spacer's later RO settle as a visible shift.
+  const spacerMeasureRef = useRef<(() => void) | null>(null);
+  // Whether the transcript was physically at the bottom as of its last scroll
+  // event. Evaluated lazily-per-event (not at pin time) so the write never
+  // reads the just-shrunk viewport, where any distance readouts are already
+  // off the bottom by the growth amount — an escaped reader must be detected
+  // from their escape scroll, not from the shrink it preceded.
+  const pinnedToBottomRef = useRef(false);
+  useEffect(() => {
+    const scrollEl = scroller?.el;
+    if (!scrollEl) return;
+    const update = () => {
+      pinnedToBottomRef.current =
+        scrollEl.scrollHeight - scrollEl.clientHeight - scrollEl.scrollTop <= 1;
+    };
+    update();
+    scrollEl.addEventListener("scroll", update, { passive: true });
+    return () => scrollEl.removeEventListener("scroll", update);
+  }, [scroller]);
+
+  const pinScrollOnComposerGrowth = useCallback(() => {
+    spacerMeasureRef.current?.();
+    // Read through a local so the linter doesn't flag the DOM write as
+    // a mutation of the outer `scroller` state ref.
+    const scrollEl = scroller?.el;
+    if (!scrollEl) return;
+    const lockState = scroller?.state;
+    if (!lockState?.isAtBottom || lockState.escapedFromLock) return;
+    // A reader who escaped the bottom (or never arrived) keeps their
+    // position: growth must not yank it down.
+    if (!pinnedToBottomRef.current) return;
+    // Park at the same position stick-to-bottom settles on (one pixel short
+    // of the maximum); writing the exact bottom would leave the settle one
+    // pixel lower than the library's park and trail a 1px snap-back.
+    scrollEl.scrollTop = Math.max(0, scrollEl.scrollHeight - scrollEl.clientHeight - 1);
+  }, [scroller]);
+
   // Persistent terminal surfaces for terminal-first sessions. Each is
   // mounted from the moment its terminal is reachable — not just when the
   // view is open — and kept mounted as a visibility-toggled overlay, so
@@ -1616,6 +1660,7 @@ function MainAgentSurface({
             agentsError={agentsError}
             sandboxLaunching={sandboxLaunching}
             terminalFirst={terminalFirst}
+            spacerMeasureRef={spacerMeasureRef}
           />
           {/* Floating reply button — scoped to the conversation container. */}
           <SelectionPopup
@@ -1663,6 +1708,7 @@ function MainAgentSurface({
             subagentRoutingEligible={subagentRoutingEligible}
             subAgentLabel={subAgentLabel}
             wrapperLabel={wrapperLabel}
+            onViewportShrinkPinScroll={pinScrollOnComposerGrowth}
           />
 
           {/* Reconnect-or-fork banner when unreachable, nothing otherwise.
@@ -1824,6 +1870,15 @@ interface ComposerProps {
    * keep using ``modelPickerKind`` / ``isNativeWrapper``.
    */
   wrapperLabel?: string | null;
+  /**
+   * Synchronous pin: called in the same task as the composer's height
+   * change so the transcript stays bottom-locked before the browser
+   * paints the now-smaller viewport with the scroll offset stale — Gecko
+   * visibly paints that intermediate frame, bouncing the last visible
+   * message. A same-task write is the only ordering no engine paints past.
+   * The callback itself decides whether the reader is bottom-locked.
+   */
+  onViewportShrinkPinScroll?: () => void;
 }
 
 /**
@@ -2408,6 +2463,7 @@ export function Composer({
   subagentRoutingEligible = false,
   subAgentLabel = null,
   wrapperLabel = null,
+  onViewportShrinkPinScroll,
 }: ComposerProps) {
   const [value, setValue] = useState("");
   const [submitWithModEnter] = useState(() => readSubmitWithModEnter());
@@ -2943,7 +2999,16 @@ export function Composer({
   // Auto-grow the textarea from 1 row up to 10 rows, then let it scroll.
   // Growth stays in the flex column so the transcript viewport ends where the
   // composer begins instead of letting the card cover visible output.
-  useAutoGrowTextarea(textareaRef, value, 10);
+  // The onGrowth pin re-locks the transcript bottom in the same task as the
+  // height change, before any paint — see the prop doc on ComposerProps.
+  const onGrowthRef = useRef(onViewportShrinkPinScroll);
+  useLayoutEffect(() => {
+    onGrowthRef.current = onViewportShrinkPinScroll;
+  });
+  const onGrowth = useCallback(() => {
+    onGrowthRef.current?.();
+  }, []);
+  useAutoGrowTextarea(textareaRef, value, 10, onGrowth);
 
   // Scope recall to the active conversation so ArrowUp surfaces only this
   // chat's prompts, not the last thing typed in any other chat.


### PR DESCRIPTION
## Related issue

Closes #6304

## Summary

Fixes visible text jumping and bouncing in the composer and transcript while typing multiline drafts in Gecko-based browsers (Firefox, Zen).

- **Bypass collapse to `auto` on append**: In `useAutoGrowTextarea`, pure character appends skip collapsing `height = "auto"`, avoiding Gecko's scroll-anchoring recalculation and momentary micro-overflow.
- **Preserve scroll offsets**: Pins `overflow-y: hidden` on the textarea during measurement, preserves/restores `ta.scrollTop`, and caches/restores ancestor scroll offsets on height-reducing measurements.
- **Synchronous spacer re-measure & transcript pin**: Exposes a `measure()` handle on `LatestTurnSpacer` and wires it to `onGrowth` so the spacer shrinks and the transcript bottom-lock is updated synchronously in the same input task, preventing late `ResizeObserver` settle bounces.
- **Exact-bottom follow-up**: `KeepBottomOnViewportResize` now writes exact bottom synchronously and in follow-up frames.

## Test Plan

- **Automated**: Ran unit and regression test suites in `web`:
  ```bash
  pnpm --prefix web test src/hooks/useAutoGrowTextarea.test.tsx src/pages/ChatPage.historyLoad.test.tsx
  ```
  Verified all 54 tests pass.
- **Manual**: Tested in Zen browser (Gecko) on Linux by typing multiline drafts wrapping across 2, 3, and more lines. Verified that text expands smoothly with no caret bounce, transcript jump, or scrollbar flicker.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

**Before (bug reproduction, from #6304):** typing a multiline draft in Zen/Firefox makes the composer text and transcript jump and bounce on each wrap/keystroke:

https://github.com/user-attachments/assets/c4824cfc-50ad-49aa-a68d-1a82c5ffb8b2

**After (fix at head `9e37fed3d`):** typing the same multiline drafts expands the composer smoothly with no caret bounce, transcript jump, or scrollbar flicker (manually verified in Zen browser on Linux). Validating checks on this head: `web test` (unit suites incl. `useAutoGrowTextarea.test.tsx`), `E2E UI Tests` shards 0–3, and `UI Snapshot (visual baselines)` — all green. A post-fix screen recording still needs to be uploaded by a human (agents cannot attach media inline); see the PR comment requesting it.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was conducted in Zen Browser (Gecko engine) on Linux, exercising multiline wrapping, continuous typing at stable height, backspacing/deletions, and transcript follow-through.

## Changelog

Fix composer and transcript text jumping while typing multiline text in Firefox and Zen browsers
