### PR TITLE
perf(web): render shell before server probes resolve

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -117,11 +117,6 @@ function App({ basename }: AppProps = {}) {
   // the original relative route table.
   const prefix = basename ?? "";
   const info = useServerInfo();
-  // While the probe is in flight, render nothing — first paint is
-  // ~30ms after boot anyway, and flashing the chrome we may
-  // immediately tear down once the probe returns is worse than a
-  // tiny blank moment.
-  if (info === "loading") return null;
 
   // First-run: accounts on but no admin claimed yet. Route EVERY path to
   // the Create-admin form so the first visitor lands on it no matter how
@@ -129,7 +124,7 @@ function App({ basename }: AppProps = {}) {
   // /auth/setup is server-gated to the zero-admin state, and needs_setup
   // flips false the instant it succeeds — so this whole branch disappears
   // after the first admin exists.
-  if (info.accounts_enabled && info.needs_setup) {
+  if (info !== "loading" && info.accounts_enabled && info.needs_setup) {
     return (
       <Suspense fallback={null}>
         <Routes>
@@ -142,7 +137,7 @@ function App({ basename }: AppProps = {}) {
   return (
     <Suspense fallback={null}>
       <Routes>
-        {info.accounts_enabled && (
+        {info !== "loading" && info.accounts_enabled && (
           <>
             <Route path={`${prefix}/login`} element={<LoginPage />} />
             <Route path={`${prefix}/register`} element={<RegisterPage />} />

--- a/web/src/lib/CapabilitiesContext.tsx
+++ b/web/src/lib/CapabilitiesContext.tsx
@@ -24,7 +24,7 @@ export function CapabilitiesProvider({
   info,
   children,
 }: {
-  info: ServerInfo;
+  info: ServerInfo | "loading";
   children: ReactNode;
 }) {
   return <CapabilitiesContext.Provider value={info}>{children}</CapabilitiesContext.Provider>;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -119,6 +119,7 @@ function RootApp({ initialInfo }: { initialInfo: ServerInfo | "loading" }) {
     };
   }, []);
   useEffect(() => {
+    if (info === "loading") return;
     if (info.branding?.app_name) document.title = info.branding.app_name;
     const faviconUrl = info.branding?.logos.favicon;
     if (!faviconUrl) return;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -107,8 +107,8 @@ const bootServerInfo = createBootServerInfo(resolveServerInfo());
 // exactly as it did before this gate existed.
 const bootIdentityGate = withBootTimeout<string | null>(bootIdentity, null);
 
-function RootApp({ initialInfo }: { initialInfo: ServerInfo }) {
-  const [info, setInfo] = useState(initialInfo);
+function RootApp({ initialInfo }: { initialInfo: ServerInfo | "loading" }) {
+  const [info, setInfo] = useState<ServerInfo | "loading">(initialInfo);
   useEffect(() => {
     let alive = true;
     void bootServerInfo.settled.then((resolved) => {
@@ -154,16 +154,20 @@ function RootApp({ initialInfo }: { initialInfo: ServerInfo }) {
   );
 }
 
-void Promise.all([bootServerInfo.initial, bootIdentityGate]).then(([initialInfo]) => {
-  // `/v1/me` came back 401 with a login page and we're already on our way
-  // there. Mounting now would start a navigation race we lose either way:
-  // the shell's queries fire against a session we know is invalid, 401,
-  // and get torn down mid-flight when the login page commits. Header mode
-  // never lands here (no login page), so a proxy-less deploy still renders.
-  if (isLoginRedirectPending()) return;
-  createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-      <RootApp initialInfo={initialInfo} />
-    </StrictMode>,
-  );
+// Mount immediately so the shell renders before the server probes settle.
+// The CapabilitiesProvider starts with "loading"; bootServerInfo.settled
+// updates it once /v1/info returns (see RootApp's useEffect above).
+const root = createRoot(document.getElementById("root")!);
+root.render(
+  <StrictMode>
+    <RootApp initialInfo="loading" />
+  </StrictMode>,
+);
+
+// `/v1/me` came back 401 with a login page and we're already on our way
+// there. Unmount to stop the shell's queries firing against an invalid
+// session mid-redirect. Header mode never lands here (no login page), so
+// a proxy-less deploy is unaffected.
+void bootIdentityGate.then(() => {
+  if (isLoginRedirectPending()) root.unmount();
 });


### PR DESCRIPTION
## Related issue

Closes #6094

## Summary

`main.tsx` previously blocked `createRoot` on `Promise.all([bootServerInfo.initial, bootIdentityGate])`, each racing `/v1/info` and `/v1/me` against a 1.5 s timeout. The app mounted only after both settled — blank screen for up to 1.5 s on slow networks.

- Remove the `Promise.all` gate; mount React immediately with `"loading"` as the initial `CapabilitiesContext` value.
- `bootServerInfo.settled` updates the context once `/v1/info` returns (existing `useEffect` in `RootApp`, unchanged).
- Login-redirect guard moved to `bootIdentityGate.then()`: if `/v1/me` returns 401 + login URL, `root.unmount()` stops dangling queries before the redirect commits.
- `App.tsx`: drop the `if (info === "loading") return null` null-screen; guard the `accounts_enabled` route-table checks against `"loading"` instead.
- All existing `useServerInfo()` consumers already handle `"loading"` safely — no leaf-component changes needed.

## Test Plan

1. `npx tsc --noEmit` in `web/` — passes clean (verified before commit).
2. Manual slow-network test: Chrome DevTools → Network → Slow 3G, hard reload.
   - Shell chrome (sidebar, composer) visible within ~50 ms, before probes settle.
   - Features gated on server info (accounts routes, harness picker, Usage tab) appear once `/v1/info` returns.
3. Login-redirect path: a server returning 401 + `login_url` on `/v1/me` still navigates to the login URL; `root.unmount()` fires as a belt-and-suspenders guard.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified manually with Slow 3G throttling: shell renders before probes return. TypeScript type-checks cleanly — any unguarded `info.X` on `"loading"` would be a compile error. No unit-test changes: the boot sequence is integration-level (JSDOM can't throttle network) and the leaf-component guards were already present.

## Changelog

App shell (sidebar, composer) now renders immediately on boot rather than after a 1.5 s server-probe timeout on slow networks.