### PR TITLE
feat(github): auto-refresh the GitHub tab on git activity

### DIFF
--- a/web/src/hooks/useGithub.test.ts
+++ b/web/src/hooks/useGithub.test.ts
@@ -1,8 +1,14 @@
 // Tests for the pure helpers in useGithub — the 404 → reason classifier that
-// steers an outdated host to the "update your host" panel state.
+// steers an outdated host to the "update your host" panel state, and the
+// panel's poll-interval decision.
 
 import { describe, expect, it } from "vitest";
-import { githubNotFoundReason } from "@/hooks/useGithub";
+import {
+  computeGithubPollInterval,
+  githubNotFoundReason,
+  type GithubChecks,
+  type GithubInfo,
+} from "@/hooks/useGithub";
 
 describe("githubNotFoundReason", () => {
   it("flags an outdated host from its 'resource not found' message", () => {
@@ -17,5 +23,79 @@ describe("githubNotFoundReason", () => {
     expect(githubNotFoundReason("Resource 'terminal' not found")).toBe("no_os_env");
     expect(githubNotFoundReason(undefined)).toBe("no_os_env");
     expect(githubNotFoundReason("")).toBe("no_os_env");
+  });
+});
+
+describe("computeGithubPollInterval", () => {
+  const checks = (over: Partial<GithubChecks> = {}): GithubChecks => ({
+    passing: 0,
+    failing: 0,
+    pending: 0,
+    total: 0,
+    runs: [],
+    ...over,
+  });
+  // A fully-resolved, ready session: git repo + gh + auth + repo + open PR.
+  const ready = (over: Partial<GithubInfo> = {}): GithubInfo => ({
+    object: "session.github.info",
+    available: true,
+    gh_available: true,
+    authenticated: true,
+    branch: "feature",
+    repo: { name_with_owner: "o/r" },
+    base_ref: "main",
+    pr: {
+      number: 1,
+      title: "t",
+      state: "OPEN",
+      url: "u",
+      is_draft: false,
+      author: null,
+      base_ref: "main",
+      head_ref: "feature",
+      checks: checks({ total: 2, passing: 2 }),
+    },
+    ...over,
+  });
+
+  it("polls setup/availability states the user fixes outside the app", () => {
+    // No info yet (initial error / transient failure with no cache).
+    expect(computeGithubPollInterval(undefined)).toBe(5_000);
+    // Not a git repo / no workspace / outdated host.
+    expect(computeGithubPollInterval(ready({ available: false, pr: null }))).toBe(5_000);
+    // gh not installed.
+    expect(computeGithubPollInterval(ready({ gh_available: false, pr: null }))).toBe(5_000);
+    // Not authenticated (the `gh auth switch` / `gh auth login` prompt).
+    expect(computeGithubPollInterval(ready({ authenticated: false, pr: null }))).toBe(5_000);
+    // Repo unresolved (no upstream).
+    expect(computeGithubPollInterval(ready({ repo: null, pr: null }))).toBe(5_000);
+    expect(computeGithubPollInterval(ready({ repo: { name_with_owner: null }, pr: null }))).toBe(
+      5_000,
+    );
+  });
+
+  it("polls while waiting for a PR and while an open PR's checks are unsettled", () => {
+    // Set up, no PR yet — waiting for one to appear.
+    expect(computeGithubPollInterval(ready({ pr: null }))).toBe(5_000);
+    // Open PR, checks running.
+    expect(
+      computeGithubPollInterval(ready({ pr: { ...ready().pr!, checks: checks({ pending: 1 }) } })),
+    ).toBe(5_000);
+    // Open PR, checks not registered yet (total 0).
+    expect(computeGithubPollInterval(ready({ pr: { ...ready().pr!, checks: checks() } }))).toBe(
+      5_000,
+    );
+  });
+
+  it("rests once there is nothing left to watch", () => {
+    // Open PR, all checks settled.
+    expect(computeGithubPollInterval(ready())).toBe(false);
+    // Merged / closed PR — terminal.
+    expect(computeGithubPollInterval(ready({ pr: { ...ready().pr!, state: "MERGED" } }))).toBe(
+      false,
+    );
+    expect(computeGithubPollInterval(ready({ pr: { ...ready().pr!, state: "CLOSED" } }))).toBe(
+      false,
+    );
   });
 });

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -20,6 +20,8 @@ import {
   RunnerOfflineError,
   runnerOfflineRetryDelay,
   shouldRetryRunnerOffline,
+  useSessionActive,
+  useTrailingInvalidate,
   useWorkspaceServeable,
   type WorkspaceChangedFile,
 } from "@/hooks/useWorkspaceChangedFiles";
@@ -163,15 +165,75 @@ async function fetchGithubInfo(conversationId: string): Promise<GithubInfo> {
   return (await res.json()) as GithubInfo;
 }
 
+/** Poll cadence while the panel is open and the GitHub state can still change.
+ *  Covers both the setup/availability states the user resolves outside the app
+ *  (install `gh`, `gh auth login`/`switch`, `cd` into a repo) — cheap local
+ *  git/gh checks — and the waiting-for-a-PR / CI-running states, which cost a
+ *  `gh` API call but only while the panel is actually focused. */
+const GITHUB_POLL_MS = 5_000;
+
+/**
+ * The panel's poll interval for the current GitHub info, or `false` to stop.
+ *
+ * While the panel is open we keep polling in every state that can still change
+ * from something the user does outside the app — the setup/availability states
+ * (no repo, `gh` missing, not authenticated, repo unresolved) as well as
+ * waiting for a PR and watching an open PR's checks. It rests (returns `false`)
+ * only at a stable end state: an open PR whose checks have all settled, or a
+ * merged/closed PR. A resting panel still refreshes on the turn-end invalidate
+ * (see {@link useGithubInfo}); resting only forgoes the interval poll. Kept pure
+ * and exported so each state is unit-testable.
+ *
+ * Note: an open PR on a repo with no CI stays at `total === 0` and so keeps
+ * polling while the panel is open+focused — we can't tell "no CI" from "checks
+ * haven't registered yet", and freshness wins for the cost of a focused poll.
+ */
+export function computeGithubPollInterval(info: GithubInfo | undefined): number | false {
+  // No usable info yet — an initial error, or a transient fetch failure with no
+  // cached data. Keep trying; runner-offline is gated off by `enabled`.
+  if (!info) return GITHUB_POLL_MS;
+  // Setup / availability states, all resolved outside the app.
+  if (
+    !info.available ||
+    info.gh_available === false ||
+    info.authenticated === false ||
+    !info.repo?.name_with_owner
+  ) {
+    return GITHUB_POLL_MS;
+  }
+  const pr = info.pr;
+  if (!pr) return GITHUB_POLL_MS; // set up, waiting for a PR to appear
+  if (pr.state !== "OPEN") return false; // merged/closed → nothing left to watch
+  // Open PR: poll while checks run or haven't registered; stop once settled.
+  return pr.checks.pending > 0 || pr.checks.total === 0 ? GITHUB_POLL_MS : false;
+}
+
 /**
  * Fetch GitHub context (repo, branch, base ref, PR + CI summary) for a session.
  *
  * Disabled when the runner is known offline. Retries the runner-offline case
  * with capped backoff so a cold-booting runner resolves before any error UI.
- * No polling — the panel refetches on a manual Refresh.
+ *
+ * Refetch is driven two ways, both harness-agnostic:
+ *   - Turn end: a trailing invalidate on the focused session's active→idle
+ *     transition, so a PR the agent opened during the turn shows up (in the
+ *     status-line indicator and the panel) without a manual refresh. This is
+ *     the always-on path — the status line uses it even with the tab closed.
+ *   - Panel poll: pass `{ poll: true }` (the GitHub panel does) to also poll
+ *     while the panel is open — see {@link computeGithubPollInterval} for which
+ *     states poll and which rest. It catches changes a turn boundary can't
+ *     (setup fixed outside the app, CI progressing after the turn). Backgrounded
+ *     tabs pause (`refetchIntervalInBackground: false`).
+ *
+ * Disabled when the runner is known offline. Retries the runner-offline case
+ * with capped backoff so a cold-booting runner resolves before any error UI.
  */
-export function useGithubInfo(conversationId: string | undefined) {
+export function useGithubInfo(conversationId: string | undefined, options?: { poll?: boolean }) {
   const serveable = useWorkspaceServeable(conversationId);
+  // Turn-end backstop: refetch when the focused session goes active→idle, so a
+  // just-opened PR appears without opening the tab. Keys off the turn lifecycle,
+  // so it works for every harness (no per-harness tool detection).
+  useTrailingInvalidate(conversationId, useSessionActive(conversationId), "github-info");
   return useQuery({
     queryKey: ["github-info", conversationId],
     queryFn: () => fetchGithubInfo(conversationId!),
@@ -179,6 +241,8 @@ export function useGithubInfo(conversationId: string | undefined) {
     retry: shouldRetryRunnerOffline,
     retryDelay: runnerOfflineRetryDelay,
     staleTime: 30_000,
+    refetchInterval: options?.poll ? (query) => computeGithubPollInterval(query.state.data) : false,
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/web/src/hooks/useGithub.turnEnd.test.tsx
+++ b/web/src/hooks/useGithub.turnEnd.test.tsx
@@ -1,0 +1,112 @@
+// The GitHub info query refetches on the focused session's turn end
+// (active → idle), so a PR the agent opened during the turn appears in the
+// status-line indicator without opening the tab. This is the harness-agnostic
+// replacement for the old per-tool git/gh signal — mirrors the trailing-edge
+// invalidate proven in useWorkspaceChangedFiles.test.tsx.
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/RunnerHealthProvider", () => ({
+  useSessionRunnerOnline: vi.fn(),
+  useSessionHostOnline: vi.fn(),
+}));
+vi.mock("@/store/chatStore", () => ({
+  useChatStore: vi.fn(),
+}));
+
+import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { useChatStore } from "@/store/chatStore";
+import { useGithubInfo } from "./useGithub";
+
+const onlineMock = vi.mocked(useSessionRunnerOnline);
+const hostOnlineMock = vi.mocked(useSessionHostOnline);
+const chatStoreMock = vi.mocked(useChatStore);
+const fetchMock = vi.fn();
+
+type StubStatus = "idle" | "running" | "waiting" | "failed";
+
+function stubChatStore(conversationId: string | null, sessionStatus: StubStatus) {
+  chatStoreMock.mockImplementation((selector: unknown) => {
+    if (typeof selector === "function") {
+      return (
+        selector as (s: { conversationId: string | null; sessionStatus: StubStatus }) => unknown
+      )({ conversationId, sessionStatus });
+    }
+    return undefined;
+  });
+}
+
+function githubInfoResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({ object: "session.github.info", available: true }),
+  } as unknown as Response;
+}
+
+function Probe({ id }: { id: string | undefined }) {
+  useGithubInfo(id);
+  return null;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(githubInfoResponse());
+  vi.stubGlobal("fetch", fetchMock);
+  onlineMock.mockReturnValue(true);
+  hostOnlineMock.mockReturnValue(null);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.resetAllMocks();
+});
+
+describe("useGithubInfo turn-end invalidate", () => {
+  it("refetches github info when the focused session goes running → idle", async () => {
+    stubChatStore("conv_live", "running");
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 0 } } });
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <Probe id="conv_live" />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // Turn ends: the trailing invalidate fires one more github-info fetch.
+    stubChatStore("conv_live", "idle");
+    rerender(
+      <QueryClientProvider client={qc}>
+        <Probe id="conv_live" />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(fetchMock.mock.calls[1][0]).toBe("/v1/sessions/conv_live/resources/github");
+  });
+
+  it("does not refetch when status stays idle across renders", async () => {
+    // Guard against a spurious refetch on every render — only the
+    // active → idle transition triggers the trailing edge.
+    stubChatStore("conv_live", "idle");
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 0 } } });
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <Probe id="conv_live" />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <QueryClientProvider client={qc}>
+        <Probe id="conv_live" />
+      </QueryClientProvider>,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -21,7 +21,7 @@ import { authenticatedFetch } from "@/lib/identity";
 import { useChatStore } from "@/store/chatStore";
 
 /** True when `id` is the focused conversation and its agent loop is live. */
-function useSessionActive(conversationId: string | undefined): boolean {
+export function useSessionActive(conversationId: string | undefined): boolean {
   const focusedId = useChatStore((s) => s.conversationId);
   const sessionStatus = useChatStore((s) => s.sessionStatus);
   if (!conversationId || conversationId !== focusedId) return false;
@@ -62,7 +62,7 @@ export function useWorkspaceServeable(conversationId: string | undefined): boole
  * invalidate refetches once so the panel reflects end-of-turn state without
  * the user having to reload the page.
  */
-function useTrailingInvalidate(
+export function useTrailingInvalidate(
   conversationId: string | undefined,
   sessionActive: boolean,
   queryKeyPrefix: string,

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -42,7 +42,6 @@ import {
   type LucideIcon,
   PanelLeftCloseIcon,
   PanelLeftOpenIcon,
-  RefreshCwIcon,
   Rows2Icon,
   TerminalIcon,
 } from "lucide-react";
@@ -52,7 +51,6 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useQueryClient } from "@tanstack/react-query";
 import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { useResizableColumn } from "@/hooks/useResizableColumn";
 import { RunnerOfflineError } from "@/hooks/useWorkspaceChangedFiles";
@@ -542,8 +540,9 @@ function SidebarNode({
 }
 
 export function GithubPanel({ conversationId }: { conversationId: string }) {
-  const queryClient = useQueryClient();
-  const info = useGithubInfo(conversationId);
+  // Poll for live CI status only while this panel is mounted (the status-line
+  // indicator keeps the non-polling default). Self-limits to unsettled checks.
+  const info = useGithubInfo(conversationId, { poll: true });
   // The tab is a pure PR view: the list + patch are the PR's, fetched only when
   // one exists. `baseRef` is kept for the on-demand expand-context loader
   // (git show <base>:<path>) and the "branch → base" label.
@@ -697,13 +696,6 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
     sectionEls.current.get(path)?.scrollIntoView({ block: "start" });
   }, []);
 
-  const refresh = () => {
-    void queryClient.invalidateQueries({ queryKey: ["github-info", conversationId] });
-    void queryClient.invalidateQueries({ queryKey: ["github-changed-files", conversationId] });
-    void queryClient.invalidateQueries({ queryKey: ["github-pr-diff", conversationId] });
-    void queryClient.invalidateQueries({ queryKey: ["github-file-diff", conversationId] });
-  };
-
   // ── Whole-panel states (before the header + stacked diff) ───────────────
   // One central switch: every non-`ready` kind returns its own whole-panel
   // state, so the diff below renders only when there's an open PR.
@@ -799,28 +791,20 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
   return (
     <TooltipProvider delayDuration={0}>
       <div className="flex h-full min-h-0 flex-col">
-        {/* Header: repo + PR metadata + Refresh. */}
+        {/* Header: repo + PR metadata. Refreshes on its own — via the
+            git-activity SSE signal and the panel's own CI poll — so there's no
+            manual Refresh control. */}
         <div className="shrink-0 border-b border-border p-2">
-          <div className="flex items-center justify-between gap-2">
-            <span className="min-w-0 truncate text-xs text-muted-foreground">
-              {data.repo?.name_with_owner ?? "GitHub"}
-              {data.branch && (
-                <>
-                  {" · "}
-                  <span className="font-mono">{data.branch}</span>
-                  {baseRef && <span className="text-muted-foreground"> → {baseRef}</span>}
-                </>
-              )}
-            </span>
-            <IconButton label="Refresh" onClick={refresh}>
-              <RefreshCwIcon
-                className={cn(
-                  "size-3.5",
-                  (info.isFetching || changes.isFetching || prDiff.isFetching) && "animate-spin",
-                )}
-              />
-            </IconButton>
-          </div>
+          <span className="block min-w-0 truncate text-xs text-muted-foreground">
+            {data.repo?.name_with_owner ?? "GitHub"}
+            {data.branch && (
+              <>
+                {" · "}
+                <span className="font-mono">{data.branch}</span>
+                {baseRef && <span className="text-muted-foreground"> → {baseRef}</span>}
+              </>
+            )}
+          </span>
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <a
               href={pr.url}


### PR DESCRIPTION
## Related issue

N/A — user-requested improvement to the session GitHub tab (no tracked issue).

## Summary

The GitHub panel and the composer's PR indicator only refreshed on a manual **Refresh** click — poor for monitoring a running session. This makes the session's GitHub context (PR / branch / CI) refresh on its own, without UI polling and without hammering the `gh` CLI:

- **Event-driven invalidation.** When the agent pushes or mutates a PR (`git push` / `gh pr {create,edit,ready,merge,close,reopen}`) the server emits a coarse `session.github.invalidated` SSE event and the web invalidates the GitHub queries. Because the always-mounted status line observes the same `github-info` query, the `#<PR>` indicator now appears **without opening the tab**. Detected in two places, mirroring the existing `session.changed_files.invalidated` signal: the Claude/Codex `PostToolUse` hooks (regex on the shell command → a throttled, best-effort POST to a new `POST /v1/sessions/{id}/hooks/github-activity` server route) and the runner's `sys_os_shell` dispatch.
- **Panel-scoped adaptive CI poll.** `useGithubInfo({ poll: true })` — passed only by `GithubPanel`, never the status line — refetches every 15s while a PR's checks are pending (30s while an open PR has no checks yet) and stops once they settle / the PR closes / the tab is backgrounded or closed.

**ELI5:** Before, you clicked Refresh to see if your agent had opened a PR or whether CI passed. Now the status line lights up on its own the moment the agent pushes, and the open panel watches CI finish.

**Coverage:** the push signal fires for Claude Code, Codex, and omnigent's built-in shell tool. Other harnesses don't emit the push signal, but the panel-scoped poll keeps their GitHub tab fresh while it's open.

```mermaid
flowchart LR
  A[agent runs git push / gh pr] -->|Claude/Codex PostToolUse hook| B[POST /hooks/github-activity]
  A -->|runner sys_os_shell dispatch| C[publish_event]
  B --> D[session.github.invalidated on SSE]
  C --> D
  D --> E[web invalidates github-info query]
  E --> F[status-line PR indicator and panel refetch — no tab click]
```

## Test Plan

**Automated**

- Python (175 pass):
  `uv run --no-sync pytest tests/test_native_policy_hook.py tests/test_claude_native_hook.py tests/test_codex_native_hook.py tests/runner/test_tool_dispatch_github_signal.py tests/server/integration/test_routing_hook_access.py -q`
  — matcher/regex, both hook wirings, the runner throttle, and the endpoint (publish + throttle + read-access) are covered.
- Web (525 pass): `pnpm -C web exec vitest run src/lib/sessionEvents.test.ts src/store/chatStore.test.ts`; `tsc` and oxlint clean — SSE parse + the coalesced query invalidation are covered.

**Manual (for the reviewer)**

1. Open a session on a Claude Code or Codex native harness in a git repo.
2. Have the agent `git push` / `gh pr create` → the status-line `#<PR>` indicator appears within ~1–2s **without** clicking the GitHub tab.
3. Open the GitHub tab on a PR with CI running → the check pills tick to pass/fail and polling stops once settled; closing the tab stops it.
4. Read-only commands (`git status`, `gh pr view`) trigger no refetch.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

A screen recording needs a live gh-authenticated, PR-creating session; the automated tests plus the manual repro above stand in for now. Happy to attach a recording.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The git-activity → SSE → query-invalidation path is covered end to end: the shared matcher and both hook wirings (`tests/test_native_policy_hook.py`, `tests/test_claude_native_hook.py`, `tests/test_codex_native_hook.py`), the runner `sys_os_shell` throttle (`tests/runner/test_tool_dispatch_github_signal.py`), the server route's publish + throttle + read-access (`tests/server/integration/test_routing_hook_access.py`), and the web SSE parse + coalesced invalidation (`sessionEvents.test.ts`, `chatStore.test.ts`). The live in-app behavior (status-line update, panel CI ticking) is left as the manual check above.

## Changelog

The GitHub tab and the composer's PR indicator now refresh automatically when the agent pushes or opens a PR, and CI status updates live while the panel is open.

This pull request and its description were written by Isaac.
