### PR TITLE
feat(web): deep-link New Chat to a specific host via ?host=<host_id>

### DIFF
--- a/tests/e2e_ui/start_session/test_host_query_param_deep_link.py
+++ b/tests/e2e_ui/start_session/test_host_query_param_deep_link.py
@@ -1,0 +1,283 @@
+"""E2E: the home composer deep-links directly to a host via ``?host=<host_id>``.
+
+Visiting ``/?host=<host_id>`` pre-selects that host in the new-session
+composer (``web/src/shell/NewChatDialog.tsx``) when it resolves to a
+currently *online* host — ahead of both the persisted last-choice/first-online
+default and a ``?project=``'s stored host default. This lets a dashboard tile
+on a shared, multi-host ``omnigent-server`` deployment deep-link straight to
+one specific registered host instead of making the user pick it out of a
+growing list every time (issue #5869).
+
+Heavy ``page.route`` stubbing mirrors ``test_start_session``/
+``test_project_config_prefill`` and is required for the same reason: the
+e2e_ui harness's tunneled runner registers no *host*, so ``/v1/hosts``,
+``/v1/agents``, the project config, and the create ``POST`` are faked (the
+POST handler *captures the body* — the thing under test — and returns a real
+seeded session id so post-send navigation lands somewhere real).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+from collections.abc import Coroutine
+from typing import Any
+
+from playwright.async_api import Route, async_playwright, expect
+
+# Two online hosts: without ``?host=``, the composer auto-selects the FIRST
+# one (alpha) when there's no persisted pick — so selecting beta via the
+# query param, rather than alpha, is the proof the deep link won.
+_HOST_ALPHA = ("host_e2e_alpha", "e2e-host-alpha")
+_HOST_BETA = ("host_e2e_beta", "e2e-host-beta")
+_PROJECT_ID = "proj_e2e_hostlink"
+_PROJECT_NAME = "HostLinkProject"
+# Bare create endpoint (POST captured); NOT the /{id}/... sub-routes.
+_SESSIONS_RE = re.compile(r"/v1/sessions(\?.*)?$")
+# One project config endpoint: /v1/projects/<id> (not the bare list).
+_PROJECT_CFG_RE = re.compile(r"/v1/projects/[^/?]+")
+
+
+def _run_in_fresh_loop(coro: Coroutine[Any, Any, None]) -> None:
+    """Run *coro* in a dedicated thread with its own loop (see test_start_session)."""
+    captured: dict[str, Exception] = {}
+
+    def _worker() -> None:
+        try:
+            asyncio.run(coro)
+        except Exception as exc:
+            captured["error"] = exc
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+    if "error" in captured:
+        raise captured["error"]
+
+
+async def _wait_until(predicate, *, timeout_s: float = 15.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"condition not met within {timeout_s:.0f}s")
+
+
+def _two_hosts_body() -> str:
+    return json.dumps(
+        {
+            "hosts": [
+                {"host_id": hid, "name": name, "owner": "e2e", "status": "online"}
+                for hid, name in (_HOST_ALPHA, _HOST_BETA)
+            ]
+        }
+    )
+
+
+def _agents_body() -> str:
+    return json.dumps(
+        {
+            "data": [
+                {
+                    "id": "ag_claude_e2e",
+                    "name": "claude-native-ui",
+                    "display_name": "Claude Code",
+                    "description": "Anthropic's coding agent",
+                    "harness": None,
+                    "skills": [],
+                }
+            ]
+        }
+    )
+
+
+def _projects_list_body() -> str:
+    return json.dumps([{"id": _PROJECT_ID, "name": _PROJECT_NAME}])
+
+
+def _project_config_body(*, host_id: str) -> str:
+    return json.dumps(
+        {
+            "id": _PROJECT_ID,
+            "name": _PROJECT_NAME,
+            "config": {"host_id": host_id},
+        }
+    )
+
+
+async def _register_routes(
+    page,
+    *,
+    created_session_id: str,
+    create_bodies: list[dict[str, Any]],
+    project_host_id: str | None = None,
+) -> None:
+    """Register the host/agent/create/events stubs shared by both tests.
+
+    :param page: The Playwright page to install routes on.
+    :param created_session_id: Real pre-seeded session id the faked create
+        returns, so post-send navigation lands on a real page.
+    :param create_bodies: Sink the create ``POST /v1/sessions`` body is
+        appended to — the assertion target.
+    :param project_host_id: When set, also stubs ``?project=`` resolution
+        (``/v1/sessions/projects`` + ``/v1/projects/{id}``) with this host
+        pinned as the project's stored default.
+    """
+
+    async def handle_hosts(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_two_hosts_body())
+
+    async def handle_agents(route: Route) -> None:
+        await route.fulfill(status=200, content_type="application/json", body=_agents_body())
+
+    async def handle_events(route: Route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
+        )
+
+    async def handle_sessions(route: Route) -> None:
+        if route.request.method == "POST":
+            create_bodies.append(route.request.post_data_json)
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"id": created_session_id}),
+            )
+        else:
+            await route.continue_()
+
+    # Neutralize agent discovery so a leaked native agent from another test
+    # can't switch the picker mid-flow.
+    async def handle_agent_scan(route: Route) -> None:
+        await route.fulfill(
+            status=200, content_type="application/json", body=json.dumps({"data": []})
+        )
+
+    await page.route("**/v1/hosts", handle_hosts)
+    await page.route("**/v1/agents", handle_agents)
+    await page.route("**/v1/sessions/*/events", handle_events)
+    await page.route(_SESSIONS_RE, handle_sessions)
+    await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+
+    if project_host_id is not None:
+
+        async def handle_projects_list(route: Route) -> None:
+            await route.fulfill(
+                status=200, content_type="application/json", body=_projects_list_body()
+            )
+
+        async def handle_project_config(route: Route) -> None:
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=_project_config_body(host_id=project_host_id),
+            )
+
+        await page.route("**/v1/sessions/projects", handle_projects_list)
+        await page.route(_PROJECT_CFG_RE, handle_project_config)
+
+
+async def _seed_recent_workspaces(page) -> None:
+    """Seed a recent workspace for both stub hosts so the working-directory
+    chip auto-fills and Send is enabled without opening the (host-less) file
+    browser (mirrors ``test_start_session``'s two-host test)."""
+    alpha_id, _ = _HOST_ALPHA
+    beta_id, _ = _HOST_BETA
+    await page.add_init_script(
+        f"""window.localStorage.setItem(
+            "omnigent:recent-workspaces",
+            JSON.stringify({{
+                "{alpha_id}": ["/work/repo"],
+                "{beta_id}": ["/work/repo"]
+            }})
+        );"""
+    )
+
+
+def test_host_query_param_selects_named_host_over_default(
+    seeded_session: tuple[str, str],
+) -> None:
+    """``?host=<beta_id>`` selects beta, not the first-online default (alpha)."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_host_param(base_url, session_id))
+
+
+async def _drive_host_param(base_url: str, session_id: str) -> None:
+    beta_id, beta_name = _HOST_BETA
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+            await _seed_recent_workspaces(page)
+
+            await page.goto(f"{base_url}/?host={beta_id}")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            await expect(chip).to_contain_text(beta_name, timeout=15_000)
+
+            await page.get_by_test_id("new-chat-landing-input").fill("start here")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["host_id"] == beta_id, body
+        finally:
+            await browser.close()
+
+
+def test_host_query_param_wins_over_project_config_host(
+    seeded_session: tuple[str, str],
+) -> None:
+    """``?host=<beta_id>&project=<name>`` selects beta, not the project's
+    stored default host (alpha) — the deep link is more specific than a
+    project's generic stored config, so it wins.
+    """
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_host_beats_project(base_url, session_id))
+
+
+async def _drive_host_beats_project(base_url: str, session_id: str) -> None:
+    alpha_id, _alpha_name = _HOST_ALPHA
+    beta_id, beta_name = _HOST_BETA
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_routes(
+                page,
+                created_session_id=session_id,
+                create_bodies=create_bodies,
+                project_host_id=alpha_id,
+            )
+            await _seed_recent_workspaces(page)
+
+            await page.goto(f"{base_url}/?host={beta_id}&project={_PROJECT_NAME}")
+            await page.get_by_test_id("new-chat-landing-input").wait_for(
+                state="visible", timeout=30_000
+            )
+
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            await expect(chip).to_contain_text(beta_name, timeout=15_000)
+
+            await page.get_by_test_id("new-chat-landing-input").fill("start here")
+            await page.get_by_test_id("new-chat-landing-submit").click()
+
+            await _wait_until(lambda: len(create_bodies) == 1)
+            body = create_bodies[0]
+            assert body["host_id"] == beta_id, body
+        finally:
+            await browser.close()

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -108,13 +108,18 @@ vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useRunnerHealthRegistration: vi.fn(),
 }));
 // The composer's project chip lists projects via useProjects; stub it to an
-// empty list so it doesn't fire its own authenticatedFetch (which would skew
-// the create-POST call-count / call-order assertions below).
+// empty list by default so it doesn't fire its own authenticatedFetch (which
+// would skew the create-POST call-count / call-order assertions below).
+// Wrapped in a mock function (rather than a bare arrow) so the `?host=` +
+// `?project=` precedence tests can override it per-test to exercise project
+// name→id resolution (real useProjectConfig then reads the id's stored config
+// through authenticatedFetch, which is already globally stubbed).
+const { useProjectsMock } = vi.hoisted(() => ({
+  useProjectsMock: vi.fn(() => ({ data: [] as { id: string; name: string }[] })),
+}));
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof UseConversationsModule>()),
-  // Empty projects list → no ?project= name resolves to an id, so the project
-  // prefill stays inert and the generic host/workspace defaults under test apply.
-  useProjects: () => ({ data: [] }),
+  useProjects: () => useProjectsMock(),
   // The landing reads useConversations for hasNoSessions; stub it so it doesn't
   // fire an authenticatedFetch that skews create-POST call assertions.
   useConversations: () => ({ data: undefined }),
@@ -705,6 +710,10 @@ function setupLandingMocks() {
   useHostWorktreesMock.mockReset();
   useDirectorySessionsMock.mockReset();
   useRunnerHealthMock.mockReset();
+  // Back to the empty-list default; per-test overrides (the `?host=` +
+  // `?project=` precedence tests) must not leak into the next test.
+  useProjectsMock.mockReset();
+  useProjectsMock.mockReturnValue({ data: [] });
   // Reset the install hooks to their inert defaults: per-test overrides
   // (a pending install set, a callback-firing mutate) must not leak into the
   // next test — a stale pending set would disable the Install button and make
@@ -2474,6 +2483,79 @@ describe("NewChatLandingScreen", () => {
     expect(heading.className).toContain("min-w-0");
     expect(heading.className).toContain("line-clamp-2");
     expect(heading.className).toContain("break-words");
+  });
+
+  it("selects the host named by a ?host= deep link, over the first-online default", async () => {
+    // Two online hosts: without ?host=, the auto-select effect would default to
+    // the first one (host_1 / "machine-1"). ?host=host_2 must win instead.
+    mockHosts([host("online", 1), host("online", 2)]);
+    renderLanding({}, "/?host=host_2");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("machine-2"),
+    );
+  });
+
+  it("falls back to the default host pick when ?host= names an unknown host id", async () => {
+    // Unrecognized id → same fallback as a plain `/` visit: the sole online
+    // host (host_1), which the "this machine" heuristic labels distinctly
+    // since it's the only online host on a local single-host server.
+    mockHosts([host("online", 1)]);
+    renderLanding({}, "/?host=does-not-exist");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
+        "This machine",
+      ),
+    );
+  });
+
+  it("falls back to the default host pick when ?host= names a currently-offline host", async () => {
+    // host_2 exists but is offline — the deep link must not select it; the
+    // online host_1 wins via the existing default logic instead (labeled "This
+    // machine" — the sole *online* host on a local single-host server).
+    mockHosts([host("online", 1), host("offline", 2)]);
+    renderLanding({}, "/?host=host_2");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
+        "This machine",
+      ),
+    );
+    expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain("machine-2");
+  });
+
+  it("overrides a ?project='s stored host default", async () => {
+    // `?host=` must win over a project's stored host default. The auto-select
+    // effect checks hostParam before `prefillSettled`, so the deep link is
+    // honored even while the project-prefill machine is still resolving.
+    mockHosts([host("online", 1), host("online", 2)]);
+    useProjectsMock.mockReturnValue({ data: [{ id: "p_alpha", name: "alpha" }] });
+    authenticatedFetchMock.mockImplementation(async (url) => {
+      if (url === "/v1/projects/p_alpha") {
+        return {
+          ok: true,
+          json: async () => ({ id: "p_alpha", name: "alpha", config: { host_id: "host_1" } }),
+        } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    });
+    renderLanding({}, "/?host=host_2&project=alpha");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("machine-2"),
+    );
+  });
+
+  it("keeps the default host pick unchanged with no ?host= param (regression guard)", async () => {
+    mockHosts([host("online", 1)]);
+    renderLanding({}, "/");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
+        "This machine",
+      ),
+    );
   });
 
   it.each([

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2021,6 +2021,12 @@ export function NewChatLandingScreen() {
   // Project driving this visit, when the sidebar's per-project "new session"
   // pencil landed here with a `?project=` query param. Empty otherwise.
   const projectParam = searchParams.get("project") ?? "";
+  // Host driving this visit via `?host=<host_id>` (e.g. a deep link that
+  // targets a specific registered host). Takes precedence over the
+  // last-choice/first-online default and over `?project=`'s stored host, but
+  // only when the referenced host is actually online — an unknown or offline
+  // id falls through to the existing default logic untouched.
+  const hostParam = searchParams.get("host") ?? "";
   // Project prefill source: a project-driven visit seeds the composer from the
   // project's stored defaults (host / working directory / agent / worktree).
   // `?project=` carries the project NAME, so resolve it to the first-class id
@@ -2646,9 +2652,25 @@ export function NewChatLandingScreen() {
   // already in state (or restored from the in-memory draft) is never
   // overridden. Holds off while a project prefill is deciding.
   useEffect(() => {
-    if (!prefillSettled) return;
     if (sandboxSelected) return;
     if (selectedHostId !== null) return;
+
+    // A `?host=` deep link wins over both the persisted last choice and
+    // `?project=`'s stored host — but only when it resolves to a currently
+    // online host; otherwise fall through to the existing default logic.
+    // Checked ahead of `prefillSettled` deliberately: the project-prefill
+    // effect writes its own stored host into `selectedHostId` in the same
+    // tick it flips `prefillSettled` to true, which would otherwise win the
+    // race and block this branch from ever running.
+    if (hostParam !== "") {
+      const linked = (hosts ?? []).find((h) => h.host_id === hostParam && h.status === "online");
+      if (linked) {
+        setSelectedHostId(linked.host_id);
+        return;
+      }
+    }
+
+    if (!prefillSettled) return;
 
     // Read the persisted pick once, as a mount-time seed — deliberately NOT a
     // dependency: it only matters until the slot is filled, and re-running on
@@ -2698,6 +2720,7 @@ export function NewChatLandingScreen() {
     info,
     prefillSettled,
     defaultSandboxProvider,
+    hostParam,
   ]);
 
   // Fall back to the host's home directory when it has no recorded recents, so


### PR DESCRIPTION
Closes #5869

> **Replaces #5881**, which was closed by an accidental cross-reference collision
> (an unrelated merged PR's `Closes #5881 <!-- OMNI-5881 -->` referenced an
> internal ticket ID that happened to match this repo's PR number, and GitHub's
> closing keyword auto-closed it as a side effect — not a review decision on
> this change). Same branch, same commits, no maintainer responded to reopen it
> after a few days, so opening fresh per the fallback in
> [CONTRIBUTING.md](https://github.com/omnigent-ai/omnigent/blob/main/CONTRIBUTING.md#reopening-a-closed-pr).
> All prior review context (demo screenshot, E2E UI coverage, CI green) carries
> over unchanged.

## Summary

- Add a `?host=<host_id>` query param to the New Chat landing screen. When it resolves to a currently online host, that host is pre-selected in the composer — no more hunting through a long host list on a shared multi-host server.
- Unknown or offline host ids fall through unchanged to the existing last-choice/first-online default logic.
- `?host=` takes precedence over a `?project=`'s stored host default (fixed a precedence race surfaced by the new tests — see Coverage notes).

## Test Plan

0. `uv run --no-sync pytest tests/e2e_ui/start_session/test_host_query_param_deep_link.py -v` (real Playwright e2e_ui suite, spawns a real `omnigent server` + runner) → **2/2 passed**: `?host=` selects the named host over the first-online default, and wins over a `?project=`'s stored host default.
1. `web/`: `npx oxlint --deny-warnings --report-unused-disable-directives src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx` → clean
2. `web/`: `npx prettier --check src/shell/NewChatDialog.tsx src/shell/NewChatDialog.test.tsx` → clean
3. `web/`: `npm run type-check` (`tsc -b`) → clean
4. `web/`: `npx vitest run src/shell/NewChatDialog.test.tsx` → **286/286 passed** (5 new tests)
5. Real E2E (no mocks): started an isolated `omnigent server` + a real `omnigent host` daemon in a throwaway config/data dir, registered a real online host, ran the actual `vite` dev server against it, and used Playwright to load `/?host=<real_host_id>` and `/?host=does-not-exist` — the real host is pre-selected via a real network round trip; an unknown id falls back safely with no crash.

## Demo

New Chat landing screen loaded at `/?host=5cc4c0b67dd64973ba6e901fe947b2c9` against a real, freshly-registered host on a throwaway local server — the host chip reads "This machine" (the real, only registered host in this test server), pre-selected via the `?host=<host_id>` deep link with no manual pick:

![New Chat landing screen with the host chip pre-selected via the ?host= deep link](https://raw.githubusercontent.com/tbrandenburg/omnigent/pr-5881-assets/new-chat-host-deeplink.png)

## Type of change

- [x] Feature
- [x] UI / frontend change

## Test coverage

- [x] Unit tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed

## Coverage notes

Component tests cover the full precedence matrix with mocked multi-host data (this repo's existing convention for `NewChatDialog.tsx` tests): `?host=` selecting a named host over the first-online default, unknown-id fallback, offline-id fallback, `?host=` winning over a `?project=`'s stored host, and a no-param regression guard. The precedence-over-`?project=` test initially caught a real bug (the `?host=` branch was gated behind `prefillSettled`, which the project-prefill effect flips to `true` in the same tick it writes its own stored host — so `?host=` never got a chance to run); fixed by checking `hostParam` before the `prefillSettled` gate.

Live E2E used a single real registered host (a second host daemon can't run alongside the first on the same machine — single-instance lock), so it validates the real network/UI wiring end-to-end but not the multi-host precedence itself; that's covered by the component tests above.

## Changelog

New Chat can be deep-linked directly to a specific registered host with `?host=<host_id>`
