### PR TITLE
ci(approval): attribute pushes by authenticated actor; stop carrying approvals across fork heads

### DIFF
--- a/.github/scripts/maintainer_approval.py
+++ b/.github/scripts/maintainer_approval.py
@@ -201,9 +201,7 @@ def pull_request_target_pushers(
                 page_runs = runs.get("workflow_runs") or []
                 # `actor` is the original pusher; `triggering_actor` becomes whoever
                 # re-ran the check, e.g. the approval relay.
-                actors |= {
-                    str((run.get("actor") or {}).get("login") or "") for run in page_runs
-                }
+                actors |= {str((run.get("actor") or {}).get("login") or "") for run in page_runs}
                 if len(page_runs) < 100:
                     break
                 page += 1

--- a/.github/scripts/maintainer_approval.py
+++ b/.github/scripts/maintainer_approval.py
@@ -188,17 +188,26 @@ def pull_request_target_pushers(
 
     def pushers(sha: str) -> set[str]:
         if sha not in cache:
-            runs = request(
-                [
-                    "api",
-                    f"repos/{repository}/actions/runs"
-                    f"?head_sha={sha}&event=pull_request_target&per_page=100",
-                ]
-            )
-            cache[sha] = {
-                str((run.get("actor") or {}).get("login") or "")
-                for run in runs.get("workflow_runs") or []
-            } - {""}
+            actors: set[str] = set()
+            page = 1
+            while True:
+                runs = request(
+                    [
+                        "api",
+                        f"repos/{repository}/actions/runs?head_sha={sha}"
+                        f"&event=pull_request_target&per_page=100&page={page}",
+                    ]
+                )
+                page_runs = runs.get("workflow_runs") or []
+                # `actor` is the original pusher; `triggering_actor` becomes whoever
+                # re-ran the check, e.g. the approval relay.
+                actors |= {
+                    str((run.get("actor") or {}).get("login") or "") for run in page_runs
+                }
+                if len(page_runs) < 100:
+                    break
+                page += 1
+            cache[sha] = actors - {""}
         return cache[sha]
 
     return pushers

--- a/.github/scripts/maintainer_approval.py
+++ b/.github/scripts/maintainer_approval.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Evaluate maintainer approval, including trusted bot authors and commits."""
+"""Evaluate maintainer approval, including trusted bot authors and pushes."""
 
 from __future__ import annotations
 
@@ -46,9 +46,16 @@ def approval_decision(
     trusted_successors: set[str],
     reviews: list[dict[str, Any]],
     commits: list[dict[str, Any]],
+    pushers: Callable[[str], set[str]],
     timeline: list[dict[str, Any]] | None = None,
 ) -> ApprovalDecision:
-    """Accept trusted authors, current approval, or trusted successor commits."""
+    """
+    Accept trusted authors, current approval, or trusted successor pushes.
+
+    ``pushers`` maps a commit SHA to the logins GitHub authenticated as pushing
+    it. Commit author/committer logins are derived from the commit email, which
+    anyone who can push to the head branch can set to the bot's address.
+    """
     maintainers = {login.casefold() for login in maintainers}
     trusted_authors = {login.casefold() for login in trusted_authors}
     trusted_successors = {login.casefold() for login in trusted_successors}
@@ -60,9 +67,6 @@ def approval_decision(
     commit_positions = {
         str(commit.get("sha") or ""): index for index, commit in enumerate(commits)
     }
-    head_scope = (
-        "same-repository" if head_repository.casefold() == repository.casefold() else "fork"
-    )
     failures: list[str] = []
     for login, review in latest_decisive_reviews(reviews).items():
         if login.casefold() not in maintainers:
@@ -73,6 +77,14 @@ def approval_decision(
         approved_sha = str(review.get("commit_id") or "")
         if review_state == "APPROVED" and approved_sha == head_sha:
             return ApprovalDecision(True, f"Current head approved by maintainer @{login}.")
+        # Only the contributor can push a fork head, so nothing there is
+        # attributable to trusted automation.
+        if head_repository.casefold() != repository.casefold():
+            failures.append(
+                f"@{login}'s approval predates commits on a fork head; "
+                f"a maintainer must approve {head_sha[:9]}"
+            )
+            continue
         position = commit_positions.get(approved_sha)
         if position is None:
             failures.append(f"@{login}'s approved commit is no longer in PR history")
@@ -83,29 +95,39 @@ def approval_decision(
             continue
         untrusted = []
         for commit in successors:
+            sha = str(commit.get("sha") or "")
             author_login = str((commit.get("author") or {}).get("login") or "").casefold()
             committer_login = str((commit.get("committer") or {}).get("login") or "").casefold()
-            if author_login not in trusted_successors or committer_login not in trusted_successors:
-                untrusted.append(str(commit.get("sha") or "")[:9])
-        if not untrusted:
-            if review_state == "DISMISSED" and not trusted_automatic_dismissal(
-                review=review,
-                successor_commits={str(commit.get("sha") or ""): commit for commit in successors},
-                trusted_successors=trusted_successors,
-                timeline=timeline or [],
+            actors = {actor.casefold() for actor in pushers(sha)}
+            if (
+                author_login not in trusted_successors
+                or committer_login not in trusted_successors
+                or actors - trusted_successors
             ):
-                failures.append(
-                    f"@{login}'s approval was not auto-dismissed by trusted automation"
-                )
-                continue
-            return ApprovalDecision(
-                True,
-                f"Maintainer @{login} approved {approved_sha[:9]}; only trusted "
-                f"automation committed on the {head_scope} head through "
-                f"{head_sha[:9]}.",
+                untrusted.append(sha[:9])
+        if untrusted:
+            failures.append(
+                f"@{login}'s approval predates untrusted commit(s): {', '.join(untrusted)}"
             )
-        failures.append(
-            f"@{login}'s approval predates untrusted commit(s): {', '.join(untrusted)}"
+            continue
+        if not {actor.casefold() for actor in pushers(head_sha)} & trusted_successors:
+            failures.append(
+                f"@{login}'s approval predates {head_sha[:9]}, which has no push "
+                "recorded from trusted automation"
+            )
+            continue
+        if review_state == "DISMISSED" and not trusted_automatic_dismissal(
+            review=review,
+            successor_shas={str(commit.get("sha") or "") for commit in successors},
+            trusted_successors=trusted_successors,
+            timeline=timeline or [],
+        ):
+            failures.append(f"@{login}'s approval was not auto-dismissed by trusted automation")
+            continue
+        return ApprovalDecision(
+            True,
+            f"Maintainer @{login} approved {approved_sha[:9]}; only trusted "
+            f"automation pushed and committed through {head_sha[:9]}.",
         )
 
     reason = "; ".join(failures) if failures else "awaiting approval from a maintainer"
@@ -115,7 +137,7 @@ def approval_decision(
 def trusted_automatic_dismissal(
     *,
     review: dict[str, Any],
-    successor_commits: dict[str, dict[str, Any]],
+    successor_shas: set[str],
     trusted_successors: set[str],
     timeline: list[dict[str, Any]],
 ) -> bool:
@@ -130,14 +152,11 @@ def trusted_automatic_dismissal(
             continue
         if dismissed.get("dismissal_message") not in {None, ""}:
             continue
-        dismissal_commit = successor_commits.get(str(dismissed.get("dismissal_commit_id") or ""))
-        if dismissal_commit is None:
+        # GitHub records the authenticated pusher as the actor of a stale-review
+        # dismissal.
+        if str((event.get("actor") or {}).get("login") or "").casefold() not in trusted_successors:
             continue
-        author_login = str((dismissal_commit.get("author") or {}).get("login") or "").casefold()
-        committer_login = str(
-            (dismissal_commit.get("committer") or {}).get("login") or ""
-        ).casefold()
-        if author_login in trusted_successors and committer_login in trusted_successors:
+        if str(dismissed.get("dismissal_commit_id") or "") in successor_shas:
             return True
     return False
 
@@ -159,6 +178,30 @@ def paginated(endpoint: str, request: Callable[[list[str]], Any] = gh_json) -> l
         if len(value) < 100:
             return items
         page += 1
+
+
+def pull_request_target_pushers(
+    repository: str, request: Callable[[list[str]], Any] = gh_json
+) -> Callable[[str], set[str]]:
+    """Map a head SHA to the logins GitHub authenticated as triggering its runs."""
+    cache: dict[str, set[str]] = {}
+
+    def pushers(sha: str) -> set[str]:
+        if sha not in cache:
+            runs = request(
+                [
+                    "api",
+                    f"repos/{repository}/actions/runs"
+                    f"?head_sha={sha}&event=pull_request_target&per_page=100",
+                ]
+            )
+            cache[sha] = {
+                str((run.get("actor") or {}).get("login") or "")
+                for run in runs.get("workflow_runs") or []
+            } - {""}
+        return cache[sha]
+
+    return pushers
 
 
 def maintainers(repository: str) -> set[str]:
@@ -194,6 +237,7 @@ def main() -> int:
         trusted_successors=set(args.trusted_successor),
         reviews=reviews,
         commits=commits,
+        pushers=pull_request_target_pushers(args.repository),
         timeline=timeline,
     )
     if decision.approved:

--- a/.github/scripts/maintainer_approval_test.py
+++ b/.github/scripts/maintainer_approval_test.py
@@ -170,7 +170,9 @@ def test_pushers_come_from_every_page_of_pull_request_target_run_actors():
     pushers = pull_request_target_pushers(REPOSITORY, request)
     assert pushers("abc") == {"omni-resolve-agent[bot]", "contributor"}
     assert pushers("abc") == {"omni-resolve-agent[bot]", "contributor"}
-    endpoint = f"repos/{REPOSITORY}/actions/runs?head_sha=abc&event=pull_request_target&per_page=100"
+    endpoint = (
+        f"repos/{REPOSITORY}/actions/runs?head_sha=abc&event=pull_request_target&per_page=100"
+    )
     assert calls == [f"{endpoint}&page=1", f"{endpoint}&page=2"]
 
 

--- a/.github/scripts/maintainer_approval_test.py
+++ b/.github/scripts/maintainer_approval_test.py
@@ -1,4 +1,8 @@
-from maintainer_approval import approval_decision, latest_decisive_reviews
+from maintainer_approval import (
+    approval_decision,
+    latest_decisive_reviews,
+    pull_request_target_pushers,
+)
 
 REPOSITORY = "omnigent-ai/omnigent"
 MAINTAINERS = {"maintainer"}
@@ -50,6 +54,7 @@ def decide(
     head="new",
     head_repository=REPOSITORY,
     author="contributor",
+    pushers=None,
 ):
     return approval_decision(
         repository=REPOSITORY,
@@ -61,6 +66,7 @@ def decide(
         trusted_successors=TRUSTED,
         reviews=reviews,
         commits=commits,
+        pushers=pushers or (lambda _sha: set(TRUSTED)),
         timeline=timeline or [],
     )
 
@@ -87,7 +93,7 @@ def test_approval_survives_trusted_same_repo_successor_commits():
         commits=[commit("old"), commit("new")],
     )
     assert decision.approved
-    assert "only trusted automation committed" in decision.reason
+    assert "only trusted automation pushed and committed" in decision.reason
 
 
 def test_auto_dismissed_approval_survives_the_trusted_push_that_dismissed_it():
@@ -97,28 +103,78 @@ def test_auto_dismissed_approval_survives_the_trusted_push_that_dismissed_it():
         timeline=[dismissal_event()],
     )
     assert decision.approved
-    assert "only trusted automation committed" in decision.reason
+    assert "only trusted automation pushed and committed" in decision.reason
 
 
-def test_trusted_fork_push_preserves_approval():
+def test_fork_head_requires_a_fresh_approval():
     decision = decide(
         reviews=[review("APPROVED", "old")],
         commits=[commit("old"), commit("new")],
         head_repository="contributor/omnigent",
     )
-    assert decision.approved
-    assert "only trusted automation committed" in decision.reason
+    assert not decision.approved
     assert "fork head" in decision.reason
 
 
-def test_auto_dismissed_fork_approval_accepts_human_push_token_actor():
+def test_successor_pushed_by_untrusted_actor_is_rejected_despite_bot_commit_identity():
+    decision = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("new")],
+        pushers=lambda sha: {"contributor"} if sha == "new" else set(TRUSTED),
+    )
+    assert not decision.approved
+    assert "untrusted commit" in decision.reason
+
+
+def test_intermediate_untrusted_push_is_rejected_even_when_automation_pushed_last():
+    decision = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("mid"), commit("new")],
+        pushers=lambda sha: {"contributor"} if sha == "mid" else set(TRUSTED),
+    )
+    assert not decision.approved
+    assert "mid" in decision.reason
+
+
+def test_head_without_a_trusted_push_record_is_rejected():
+    decision = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("new")],
+        pushers=lambda _sha: set(),
+    )
+    assert not decision.approved
+    assert "no push recorded from trusted automation" in decision.reason
+
+
+def test_dismissal_by_untrusted_actor_is_rejected_despite_bot_commit_identity():
     decision = decide(
         reviews=[review("DISMISSED", "old")],
         commits=[commit("old"), commit("new")],
-        timeline=[dismissal_event(actor="fork-push-token-owner")],
-        head_repository="contributor/omnigent",
+        timeline=[dismissal_event(actor="contributor")],
     )
-    assert decision.approved
+    assert not decision.approved
+    assert "not auto-dismissed by trusted automation" in decision.reason
+
+
+def test_pushers_come_from_pull_request_target_run_actors():
+    calls = []
+
+    def request(arguments):
+        calls.append(arguments[1])
+        return {
+            "workflow_runs": [
+                {"actor": {"login": "omni-resolve-agent[bot]"}},
+                {"actor": {"login": "contributor"}},
+                {"actor": None},
+            ]
+        }
+
+    pushers = pull_request_target_pushers(REPOSITORY, request)
+    assert pushers("abc") == {"omni-resolve-agent[bot]", "contributor"}
+    assert pushers("abc") == {"omni-resolve-agent[bot]", "contributor"}
+    assert calls == [
+        f"repos/{REPOSITORY}/actions/runs?head_sha=abc&event=pull_request_target&per_page=100"
+    ]
 
 
 def test_dismissed_approval_requires_a_trusted_matching_dismissal_event():
@@ -150,7 +206,7 @@ def test_approval_does_not_survive_untrusted_updates():
         head_repository="contributor/omnigent",
     )
     assert not untrusted_fork.approved
-    assert "untrusted commit" in untrusted_fork.reason
+    assert "fork head" in untrusted_fork.reason
 
 
 def test_approval_does_not_survive_rewritten_history():
@@ -182,5 +238,6 @@ def test_maintainer_authored_pr_still_passes():
         trusted_successors=TRUSTED,
         reviews=[],
         commits=[commit("new", "maintainer")],
+        pushers=lambda _sha: set(),
     )
     assert decision.approved

--- a/.github/scripts/maintainer_approval_test.py
+++ b/.github/scripts/maintainer_approval_test.py
@@ -156,25 +156,22 @@ def test_dismissal_by_untrusted_actor_is_rejected_despite_bot_commit_identity():
     assert "not auto-dismissed by trusted automation" in decision.reason
 
 
-def test_pushers_come_from_pull_request_target_run_actors():
+def test_pushers_come_from_every_page_of_pull_request_target_run_actors():
     calls = []
+    pages = {
+        1: [{"actor": {"login": "omni-resolve-agent[bot]"}}] * 99 + [{"actor": None}],
+        2: [{"actor": {"login": "contributor"}}],
+    }
 
     def request(arguments):
         calls.append(arguments[1])
-        return {
-            "workflow_runs": [
-                {"actor": {"login": "omni-resolve-agent[bot]"}},
-                {"actor": {"login": "contributor"}},
-                {"actor": None},
-            ]
-        }
+        return {"workflow_runs": pages[int(arguments[1].rsplit("page=", 1)[1])]}
 
     pushers = pull_request_target_pushers(REPOSITORY, request)
     assert pushers("abc") == {"omni-resolve-agent[bot]", "contributor"}
     assert pushers("abc") == {"omni-resolve-agent[bot]", "contributor"}
-    assert calls == [
-        f"repos/{REPOSITORY}/actions/runs?head_sha=abc&event=pull_request_target&per_page=100"
-    ]
+    endpoint = f"repos/{REPOSITORY}/actions/runs?head_sha=abc&event=pull_request_target&per_page=100"
+    assert calls == [f"{endpoint}&page=1", f"{endpoint}&page=2"]
 
 
 def test_dismissed_approval_requires_a_trusted_matching_dismissal_event():

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -16,6 +16,10 @@ name: Maintainer Approval
 #
 # `pull_request_target` doesn't fire on reviews, so maintainer-approval-rerun.yml
 # + -rerun-run.yml re-run this workflow on an approving review to flip it green.
+#
+# An approval is carried across later commits only when every push since it was
+# made by trusted automation, judged by the authenticated actor of each head's
+# `pull_request_target` run (hence `actions: read`), never by the commit email.
 
 on:
   pull_request_target:
@@ -35,6 +39,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- The `Maintainer Approval` check carried a maintainer's approval across later commits whenever those commits' author/committer logins were `omni-resolve-agent[bot]`. GitHub derives those logins from the commit email, so anyone who can push to a PR branch can author commits the API attributes to the bot (verified: an unsigned commit with the bot's noreply email pushed from a human account reports `author.login=omni-resolve-agent[bot]`, `type=Bot`). On a fork PR, a contributor could therefore push arbitrary code after a single approval and keep the required check green.
- Pushes since the approval are now attributed by the **authenticated actor** of each head's `pull_request_target` run (the job gains `actions: read`). Every successor commit that has a run must have been pushed by trusted automation, and the current head must have a trusted push on record; the commit-identity check stays as a second condition.
- Approvals are no longer carried across commits on **fork heads** at all: only the contributor can push there, so nothing on a fork head is attributable to Otto. A maintainer must approve the new head.
- A dismissed approval is accepted only when GitHub's authenticated dismissal actor is trusted automation, not when the dismissal commit merely looks bot-authored.

ELI5: we used to trust the name written on the envelope; now we trust who GitHub saw drop it in the mailbox.

```mermaid
flowchart LR
  A[maintainer approves SHA A] --> B{later commits?}
  B -->|fork head| F[fail: re-approve]
  B -->|same repo| C{every push since A by trusted bot?<br/>pull_request_target run actor}
  C -->|no / unknown| F
  C -->|yes| D{commit identities trusted?}
  D -->|no| F
  D -->|yes| P[pass]
```

## Test Plan

- `uv run --no-project --with pytest python -m pytest .github/scripts/maintainer_approval_test.py -q` — 15 passed. New cases: successor pushed by an untrusted actor is rejected even though its commit identity is the bot; an intermediate untrusted push is rejected even when the bot pushed last; a head with no trusted push record is rejected; a dismissal by an untrusted actor is rejected; fork heads require a fresh approval; `pull_request_target_pushers` reads run actors and memoizes.
- Live replay of the new evaluator against real PRs with the trusted-author shortcut disabled and the automation-restored reviews stripped: #5842 and #6286 approve via delegation with live `pushers(head) == {'omni-resolve-agent[bot]'}`; fork PR #2712 is rejected with "a maintainer must approve 20b949b52".
- `python3 .github/scripts/maintainer_approval.py --repository omnigent-ai/omnigent --pr-number 6286 --trusted-author 'omni-resolve-agent[bot]' --trusted-successor 'omni-resolve-agent[bot]'` → `Author @omni-resolve-agent[bot] is trusted automation.`
- `ruff check` / `ruff format --check` clean; pre-commit hooks pass.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before, on a fork PR approved at commit A, a contributor push of a commit authored with `omni-resolve-agent[bot]@users.noreply.github.com` kept this check green. After, the check fails with `@<maintainer>'s approval predates commits on a fork head; a maintainer must approve <sha>`, and on same-repo heads a push whose run actor is not the bot fails with `predates untrusted commit(s)`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The Actions-runs lookup (`pull_request_target_pushers`) is exercised with a fake request in the unit tests and live against #5842, #6286 and #2712 as described above; the check's own run for a head is the run whose actor it reads, so the first real exercise is this PR's own `Maintainer Approval` run.
