### PR TITLE
fix(claude-native): fall back to the provider default when the picked model isn't served

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -487,22 +487,40 @@ def claude_catalog_serves_model(
     )
 
 
+def _endpoint_origin(url: str) -> str:
+    """
+    Reduce an endpoint URL to its scheme and host, for log lines.
+
+    :param url: An endpoint URL, e.g. ``"https://user:pw@gw.example/anthropic?sig=1"``.
+    :returns: The origin only, e.g. ``"https://gw.example"``; the URL itself
+        when it has no scheme.
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname:
+        return url
+    host = f"{parsed.hostname}:{parsed.port}" if parsed.port else parsed.hostname
+    return f"{parsed.scheme}://{host}"
+
+
 def claude_launch_endpoint_label(claude_config: ClaudeNativeUcodeConfig | None) -> str:
     """
     Name where a launch config sends Claude Code's inference, for log lines.
 
+    Only the endpoint's origin is named: a custom base URL can carry userinfo
+    or a signed query string that must not reach the logs.
+
     :param claude_config: The resolved launch config, or ``None`` (Claude
         Code's own login).
     :returns: A short phrase, e.g. ``"the gateway at
-        https://example.databricks.com/ai-gateway/anthropic"``.
+        https://example.databricks.com"``.
     """
     if claude_config is not None:
         bedrock_url = claude_config.env.get(_ANTHROPIC_BEDROCK_BASE_URL_ENV)
         if bedrock_url:
-            return f"the Bedrock endpoint at {bedrock_url}"
+            return f"the Bedrock endpoint at {_endpoint_origin(bedrock_url)}"
         base_url = claude_config.env.get(_UCODE_CLAUDE_BASE_URL_ENV)
         if base_url:
-            return f"the gateway at {base_url}"
+            return f"the gateway at {_endpoint_origin(base_url)}"
     return "Claude Code's own login"
 
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -1262,7 +1262,7 @@ async def claude_launch_catalog(
     )
 
 
-async def claude_refreshed_launch_catalog(
+async def claude_reprobed_launch_catalog(
     claude_config: ClaudeNativeUcodeConfig | None,
 ) -> list[dict[str, object]] | None:
     """
@@ -1278,7 +1278,7 @@ async def claude_refreshed_launch_catalog(
     from omnigent import model_catalog_store
 
     fingerprint = claude_catalog_fingerprint(claude_config)
-    return await model_catalog_store.refresh_catalog(
+    return await model_catalog_store.reprobe_catalog(
         "claude-native", fingerprint, lambda: claude_model_catalog(claude_config)
     )
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -487,6 +487,25 @@ def claude_catalog_serves_model(
     )
 
 
+def claude_launch_endpoint_label(claude_config: ClaudeNativeUcodeConfig | None) -> str:
+    """
+    Name where a launch config sends Claude Code's inference, for log lines.
+
+    :param claude_config: The resolved launch config, or ``None`` (Claude
+        Code's own login).
+    :returns: A short phrase, e.g. ``"the gateway at
+        https://example.databricks.com/ai-gateway/anthropic"``.
+    """
+    if claude_config is not None:
+        bedrock_url = claude_config.env.get(_ANTHROPIC_BEDROCK_BASE_URL_ENV)
+        if bedrock_url:
+            return f"the Bedrock endpoint at {bedrock_url}"
+        base_url = claude_config.env.get(_UCODE_CLAUDE_BASE_URL_ENV)
+        if base_url:
+            return f"the gateway at {base_url}"
+    return "Claude Code's own login"
+
+
 def resolve_claude_native_model_selection(
     model: str | None,
     claude_config: ClaudeNativeUcodeConfig | None,
@@ -1221,6 +1240,27 @@ async def claude_launch_catalog(
 
     fingerprint = claude_catalog_fingerprint(claude_config)
     return await model_catalog_store.ensure_catalog(
+        "claude-native", fingerprint, lambda: claude_model_catalog(claude_config)
+    )
+
+
+async def claude_refreshed_launch_catalog(
+    claude_config: ClaudeNativeUcodeConfig | None,
+) -> list[dict[str, object]] | None:
+    """
+    Re-probe this config's catalog now and return the fresh rows.
+
+    For the launch gate's destructive path: a stale entry may predate a
+    provider change, so a pick it does not serve is re-checked against a
+    probe that is awaited rather than left to the background.
+
+    :param claude_config: The resolved launch config, or ``None``.
+    :returns: The fresh rows, or ``None`` when the probe failed.
+    """
+    from omnigent import model_catalog_store
+
+    fingerprint = claude_catalog_fingerprint(claude_config)
+    return await model_catalog_store.refresh_catalog(
         "claude-native", fingerprint, lambda: claude_model_catalog(claude_config)
     )
 

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -255,6 +255,36 @@ def _refresh_in_background(
     _inflight[key] = asyncio.create_task(_run(), name=f"model-catalog-refresh-{harness}")
 
 
+async def refresh_catalog(
+    harness: str,
+    fingerprint: str,
+    resolve: Callable[[], Awaitable[list[dict[str, Any]] | None]],
+) -> list[dict[str, Any]] | None:
+    """
+    Re-probe now and return the fresh rows, joining a probe already in flight.
+
+    For a decision that must not rest on a stale entry (resetting a model pick
+    the stored rows do not serve), the refresh :func:`ensure_catalog` only
+    kicks in the background is awaited here. A failed probe returns ``None``
+    and leaves the stored rows in place.
+
+    :param harness: Canonical harness name.
+    :param fingerprint: The launch-config fingerprint.
+    :param resolve: Probe coroutine factory producing verbatim rows.
+    :returns: The fresh rows, or ``None`` when the probe failed.
+    """
+    key = (harness, fingerprint)
+    task = _inflight.get(key)
+    if task is None or task.done():
+        _refresh_in_background(harness, fingerprint, resolve)
+        task = _inflight[key]
+    try:
+        return await asyncio.shield(task)
+    except Exception:  # noqa: BLE001 — a joined miss probe may raise; stored rows keep serving
+        _logger.warning("%s catalog refresh failed", harness, exc_info=True)
+        return None
+
+
 def default_row(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
     """Return the catalog's single ``isDefault`` row, if any.
 
@@ -285,5 +315,6 @@ __all__ = [
     "ensure_catalog",
     "fingerprint_of",
     "read_catalog",
+    "refresh_catalog",
     "write_catalog",
 ]

--- a/omnigent/model_catalog_store.py
+++ b/omnigent/model_catalog_store.py
@@ -255,7 +255,7 @@ def _refresh_in_background(
     _inflight[key] = asyncio.create_task(_run(), name=f"model-catalog-refresh-{harness}")
 
 
-async def refresh_catalog(
+async def reprobe_catalog(
     harness: str,
     fingerprint: str,
     resolve: Callable[[], Awaitable[list[dict[str, Any]] | None]],
@@ -315,6 +315,6 @@ __all__ = [
     "ensure_catalog",
     "fingerprint_of",
     "read_catalog",
-    "refresh_catalog",
+    "reprobe_catalog",
     "write_catalog",
 ]

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -186,6 +186,11 @@ _logger = logging.getLogger(__name__)
 # tests can patch the pacing.
 _CLAUDE_MODEL_OPTIONS_INLINE_WAIT_S = 2.5
 
+# How long a claude-native session's model rows are served from the runner's
+# own cache before the shared catalog store is re-read, so a store refresh
+# (its background re-probe) reaches the picker without a runner restart.
+_CLAUDE_MODEL_OPTIONS_CACHE_TTL_S = 15.0
+
 # Claude-native model switch confirmation: how long to watch the pane's
 # statusLine snapshot for the switched model after typing ``/model``, and how
 # often to re-read it. Module-level so tests can patch the pacing.
@@ -2706,6 +2711,19 @@ def create_runner_app(
     _session_claude_launch_config_tasks: dict[
         str, asyncio.Task[ClaudeNativeUcodeConfig | None]
     ] = {}
+    # Claude's session listing IS the shared launch catalog: the same
+    # fingerprint-keyed store file the launch resolved against and the
+    # host's pre-launch picker serves — identical by construction, no
+    # separate composition. Rows are re-read from the store once
+    # ``_CLAUDE_MODEL_OPTIONS_CACHE_TTL_S`` passes (so its background
+    # re-probe reaches the picker) and dropped whenever the launch config is
+    # recorded or dropped, so a relaunch under another provider never serves
+    # the previous one's rows. Entries pair a ``time.monotonic()`` deadline
+    # with the rows. A cold store pays one probe: a short inline wait answers
+    # a warm one, past that the endpoint answers 503 (the server's fetch
+    # retries those) while the store's single-flight probe completes in the
+    # background.
+    _claude_model_options_rows: dict[str, tuple[float, list[dict[str, object]]]] = {}
 
     async def _resolve_session_claude_launch_config(
         session_id: str,
@@ -2737,9 +2755,19 @@ def create_runner_app(
 
     def _drop_session_claude_launch_config(session_id: str) -> None:
         _session_claude_launch_configs.pop(session_id, None)
+        _claude_model_options_rows.pop(session_id, None)
         task = _session_claude_launch_config_tasks.pop(session_id, None)
         if task is not None:
             task.cancel()
+
+    def _record_session_claude_launch_config(
+        session_id: str, config: ClaudeNativeUcodeConfig | None
+    ) -> None:
+        """
+        Memoize the config a launch resolved; rows listed under the old one retire.
+        """
+        _session_claude_launch_configs[session_id] = config
+        _claude_model_options_rows.pop(session_id, None)
 
     _session_agent_ids = _session_agent_ids_ref  # shared with module-level get_session_agent_id
     _session_sub_agent_names: dict[str, str] = {}
@@ -3868,7 +3896,7 @@ def create_runner_app(
                         resolve_launch_config=lambda: _resolve_session_claude_launch_config(
                             session_id
                         ),
-                        record_launch_config=_session_claude_launch_configs.__setitem__,
+                        record_launch_config=_record_session_claude_launch_config,
                     )
 
                 _launch_pre = _claude_pre_launch
@@ -5575,7 +5603,8 @@ def create_runner_app(
         # actually switched; the swallowed-dialog case answers non-2xx so the
         # server surfaces it instead of the row silently claiming the pick.
         expected = {value for value in (resolved_model, model_arg) if value}
-        for row in _claude_model_options_rows.get(conv_id) or []:
+        cached_rows = _claude_model_options_rows.get(conv_id)
+        for row in cached_rows[1] if cached_rows is not None else []:
             if row.get("id") in (selected_model, resolved_model) or row.get("model") in (
                 selected_model,
                 resolved_model,
@@ -9002,7 +9031,7 @@ def create_runner_app(
                         resolve_launch_config=lambda: _resolve_session_claude_launch_config(
                             session_id
                         ),
-                        record_launch_config=_session_claude_launch_configs.__setitem__,
+                        record_launch_config=_record_session_claude_launch_config,
                     )
 
                 _ensure_build = _claude_ensure_build
@@ -10287,16 +10316,6 @@ def create_runner_app(
             content={"models": _with_model_configuration_source(session_id, models)},
         )
 
-    # Claude's session listing IS the shared launch catalog: the same
-    # fingerprint-keyed store file the launch resolved against and the
-    # host's pre-launch picker serves — identical by construction, no
-    # separate composition. Cached per session for its lifetime (the launch
-    # config cannot change under it). A cold store pays one probe: a short
-    # inline wait answers a warm one, past that the endpoint answers 503
-    # (the server's fetch retries those) while the store's single-flight
-    # probe completes in the background.
-    _claude_model_options_rows: dict[str, list[dict[str, object]]] = {}
-
     def _model_configuration_source(session_id: str) -> dict[str, str] | None:
         """Return the session's non-secret model-provider coordinates."""
         from omnigent.model_catalog import model_configuration_source, resolve_model_provider
@@ -10323,7 +10342,9 @@ def create_runner_app(
             return JSONResponse(status_code=200, content={"models": []})
         cached = _claude_model_options_rows.get(session_id)
         if cached is not None:
-            return JSONResponse(status_code=200, content={"models": cached})
+            expires_at, cached_rows = cached
+            if time.monotonic() < expires_at:
+                return JSONResponse(status_code=200, content={"models": cached_rows})
         try:
             claude_config = await _resolve_session_claude_launch_config(session_id)
         except click.ClickException as exc:
@@ -10383,7 +10404,10 @@ def create_runner_app(
                 },
             )
         rows = _with_model_configuration_source(session_id, rows)
-        _claude_model_options_rows[session_id] = rows
+        _claude_model_options_rows[session_id] = (
+            time.monotonic() + _CLAUDE_MODEL_OPTIONS_CACHE_TTL_S,
+            rows,
+        )
         return JSONResponse(status_code=200, content={"models": rows})
 
     @app.get("/v1/sessions/{session_id}/model-options")

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -84,6 +84,7 @@ _logger = logging.getLogger("omnigent.runner.app")
 _OMNIGENT_PACKAGE_DIR = Path(__file__).resolve().parent.parent.parent
 
 _NATIVE_TERMINAL_START_FAILED_CODE = "native_terminal_start_failed"
+
 _REPL_TERMINAL_NAME = "tui"
 _REPL_TERMINAL_SESSION_KEY = "main"
 _NO_BODY_STATUS_CODES = {204, 304}
@@ -6361,6 +6362,35 @@ async def _load_claude_launch_metadata(
     return metadata
 
 
+async def _clear_session_model_override(
+    session_id: str,
+    server_client: httpx.AsyncClient,
+) -> None:
+    """
+    Reset a session's persisted model pick to Default.
+
+    The server clears the pick only for its explicit ``"default"`` alias; a
+    JSON ``null`` leaves it unchanged. Best-effort: a failed reset keeps the
+    pick, and the next relaunch repeats the fallback.
+
+    :param session_id: Session/conversation identifier.
+    :param server_client: Runner Omnigent server client.
+    """
+    try:
+        resp = await server_client.patch(
+            f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
+            json={"model_override": "default"},
+            timeout=10.0,
+        )
+        resp.raise_for_status()
+    except httpx.HTTPError:
+        _logger.warning(
+            "claude-native: could not reset the model pick for session %s",
+            session_id,
+            exc_info=True,
+        )
+
+
 async def _auto_create_claude_terminal(
     session_id: str,
     resource_registry: SessionResourceRegistry,
@@ -6793,11 +6823,18 @@ async def _auto_create_claude_terminal(
         from omnigent.server.smart_routing import task_v1_claude_arms
 
         claude_config = claude_config_with_routed_arms_pinned(claude_config, task_v1_claude_arms())
-    launch_model = resolve_claude_native_model_selection(
-        session_model_override
-        or _claude_native_model_from_spec(agent_spec)
+    # The launch model without the session's pick: the agent-spec pin, else
+    # the provider's own default. Also what a pick the provider cannot serve
+    # falls back to.
+    unpinned_launch_model = resolve_claude_native_model_selection(
+        _claude_native_model_from_spec(agent_spec)
         or (claude_config.model if claude_config is not None else None),
         claude_config,
+    )
+    launch_model = (
+        resolve_claude_native_model_selection(session_model_override, claude_config)
+        if session_model_override
+        else unpinned_launch_model
     )
     # Explicit launches (model-flows design §4): consult the shared catalog
     # only when it can change the outcome — to validate an explicit request,
@@ -6808,6 +6845,8 @@ async def _auto_create_claude_terminal(
             claude_catalog_serves_model,
             claude_launch_catalog,
             claude_launch_catalog_is_stale,
+            claude_launch_endpoint_label,
+            claude_refreshed_launch_catalog,
         )
         from omnigent.model_catalog_store import default_row
 
@@ -6827,21 +6866,46 @@ async def _auto_create_claude_terminal(
                 extra={"session_id": session_id},
             )
         if session_model_override and launch_catalog:
-            resolved_request = (
-                resolve_claude_native_model_selection(session_model_override, claude_config)
-                or session_model_override
-            )
-            # A pane's ``/model`` persists the exact id it runs; the catalog
-            # may spell that model only by its family alias.
-            if not (
-                claude_catalog_serves_model(launch_catalog, session_model_override, claude_config)
-                or claude_catalog_serves_model(launch_catalog, resolved_request, claude_config)
-            ):
-                raise click.ClickException(
-                    f"the requested model {session_model_override!r} is not in this "
-                    "host's current model list — it may have changed since the pick. "
-                    "Pick again from the model menu."
+            pick = session_model_override
+            resolved_request = resolve_claude_native_model_selection(pick, claude_config) or pick
+
+            def _serves_pick(rows: list[dict[str, object]]) -> bool:
+                """
+                Whether *rows* serve the pick by its persisted or resolved spelling.
+                """
+                # A pane's ``/model`` persists the exact id it runs; the catalog
+                # may spell that model only by its family alias.
+                return claude_catalog_serves_model(
+                    rows, pick, claude_config
+                ) or claude_catalog_serves_model(rows, resolved_request, claude_config)
+
+            if launch_catalog_was_stale and not _serves_pick(launch_catalog):
+                # A stale entry may predate a provider change, so only a fresh
+                # probe can justify resetting the pick: await it here.
+                refreshed = await claude_refreshed_launch_catalog(claude_config)
+                if refreshed:
+                    launch_catalog = refreshed
+                    launch_catalog_was_stale = False
+            if not _serves_pick(launch_catalog):
+                # The pick outlives the provider it was made under (a later
+                # ``omnigent setup`` can re-point the default). Launch on what
+                # this provider serves and reset the pick to Default, so the
+                # session comes back and the picker shows what it now runs.
+                offered = ", ".join(
+                    str(row.get("id") or row.get("model") or "") for row in launch_catalog
                 )
+                _logger.warning(
+                    "claude-native: model pick %r for session %s is not served by %s "
+                    "(it offers: %s); launching on the provider default and resetting "
+                    "the pick to Default",
+                    pick,
+                    session_id,
+                    claude_launch_endpoint_label(claude_config),
+                    offered,
+                    extra={"session_id": session_id},
+                )
+                launch_model = unpinned_launch_model
+                await _clear_session_model_override(session_id, server_client)
         if launch_model is None and launch_catalog:
             # A stale entry's default is yesterday's answer: pinning it as
             # ``--model`` turns a provider-side retirement or entitlement

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6836,6 +6836,9 @@ async def _auto_create_claude_terminal(
         if session_model_override
         else unpinned_launch_model
     )
+    # A pick the provider cannot serve is dropped only once the fallback
+    # terminal is actually up, so a failed launch never loses it.
+    reset_pick_after_launch = False
     # Explicit launches (model-flows design §4): consult the shared catalog
     # only when it can change the outcome — to validate an explicit request,
     # or to resolve a Default launch that would otherwise pass no ``--model``
@@ -6879,33 +6882,42 @@ async def _auto_create_claude_terminal(
                     rows, pick, claude_config
                 ) or claude_catalog_serves_model(rows, resolved_request, claude_config)
 
+            # Only rows that are fresh may retire the pick: a stale entry may
+            # predate a provider change, so it is re-probed first, and a
+            # failed probe leaves no trusted rows at all.
+            trusted_rows: list[dict[str, object]] | None = launch_catalog
             if launch_catalog_was_stale and not _serves_pick(launch_catalog):
-                # A stale entry may predate a provider change, so only a fresh
-                # probe can justify resetting the pick: await it here.
-                refreshed = await claude_refreshed_launch_catalog(claude_config)
-                if refreshed:
-                    launch_catalog = refreshed
+                trusted_rows = await claude_refreshed_launch_catalog(claude_config)
+                if trusted_rows:
+                    launch_catalog = trusted_rows
                     launch_catalog_was_stale = False
             if not _serves_pick(launch_catalog):
                 # The pick outlives the provider it was made under (a later
                 # ``omnigent setup`` can re-point the default). Launch on what
-                # this provider serves and reset the pick to Default, so the
-                # session comes back and the picker shows what it now runs.
+                # this provider serves; reset the pick to Default only on fresh
+                # evidence, so the picker shows what the session now runs.
                 offered = ", ".join(
                     str(row.get("id") or row.get("model") or "") for row in launch_catalog
                 )
+                if trusted_rows:
+                    reset_pick_after_launch = True
+                    outcome = "launching on the provider default and resetting the pick to Default"
+                else:
+                    outcome = (
+                        "the re-probe failed, so launching on the provider default and "
+                        "keeping the pick for the next relaunch"
+                    )
                 _logger.warning(
                     "claude-native: model pick %r for session %s is not served by %s "
-                    "(it offers: %s); launching on the provider default and resetting "
-                    "the pick to Default",
+                    "(it offers: %s); %s",
                     pick,
                     session_id,
                     claude_launch_endpoint_label(claude_config),
                     offered,
+                    outcome,
                     extra={"session_id": session_id},
                 )
                 launch_model = unpinned_launch_model
-                await _clear_session_model_override(session_id, server_client)
         if launch_model is None and launch_catalog:
             # A stale entry's default is yesterday's answer: pinning it as
             # ``--model`` turns a provider-side retirement or entitlement
@@ -7124,6 +7136,8 @@ async def _auto_create_claude_terminal(
             extra={"session_id": session_id},
         )
         raise
+    if reset_pick_after_launch:
+        await _clear_session_model_override(session_id, server_client)
     # Surface the terminal on the live SSE stream so an already-connected
     # web UI enables the Terminal toggle immediately. The required-terminal
     # launch helper registers the resource and starts the activity watcher but

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6884,12 +6884,12 @@ async def _auto_create_claude_terminal(
 
             # Only rows that are fresh may retire the pick: a stale entry may
             # predate a provider change, so it is re-probed first, and a
-            # failed probe leaves no trusted rows at all.
-            trusted_rows: list[dict[str, object]] | None = launch_catalog
+            # failed probe leaves no fresh rows at all.
+            fresh_rows: list[dict[str, object]] | None = launch_catalog
             if launch_catalog_was_stale and not _serves_pick(launch_catalog):
-                trusted_rows = await claude_reprobed_launch_catalog(claude_config)
-                if trusted_rows:
-                    launch_catalog = trusted_rows
+                fresh_rows = await claude_reprobed_launch_catalog(claude_config)
+                if fresh_rows:
+                    launch_catalog = fresh_rows
                     launch_catalog_was_stale = False
             if not _serves_pick(launch_catalog):
                 # The pick outlives the provider it was made under (a later
@@ -6899,7 +6899,7 @@ async def _auto_create_claude_terminal(
                 offered = ", ".join(
                     str(row.get("id") or row.get("model") or "") for row in launch_catalog
                 )
-                if trusted_rows:
+                if fresh_rows:
                     reset_pick_after_launch = True
                     outcome = "launching on the provider default and resetting the pick to Default"
                 else:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6849,7 +6849,7 @@ async def _auto_create_claude_terminal(
             claude_launch_catalog,
             claude_launch_catalog_is_stale,
             claude_launch_endpoint_label,
-            claude_refreshed_launch_catalog,
+            claude_reprobed_launch_catalog,
         )
         from omnigent.model_catalog_store import default_row
 
@@ -6887,7 +6887,7 @@ async def _auto_create_claude_terminal(
             # failed probe leaves no trusted rows at all.
             trusted_rows: list[dict[str, object]] | None = launch_catalog
             if launch_catalog_was_stale and not _serves_pick(launch_catalog):
-                trusted_rows = await claude_refreshed_launch_catalog(claude_config)
+                trusted_rows = await claude_reprobed_launch_catalog(claude_config)
                 if trusted_rows:
                     launch_catalog = trusted_rows
                     launch_catalog_was_stale = False

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -26,7 +26,7 @@ from tests.runner.helpers import NullServerClient
 # attribute back to this. (An assignment, not an alias import, so lint
 # autofixes can't strip it as unused.)
 REAL_CLAUDE_LAUNCH_CATALOG = claude_native.claude_launch_catalog
-REAL_CLAUDE_REFRESHED_LAUNCH_CATALOG = claude_native.claude_refreshed_launch_catalog
+REAL_CLAUDE_REPROBED_LAUNCH_CATALOG = claude_native.claude_reprobed_launch_catalog
 REAL_CODEX_LAUNCH_CATALOG = codex_native_app_server.codex_launch_catalog
 
 # Project root: two parents up from this conftest (tests/runner/ → repo root).
@@ -54,7 +54,7 @@ def _isolated_model_catalog_store(
         return None
 
     monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _no_catalog)
-    monkeypatch.setattr("omnigent.claude_native.claude_refreshed_launch_catalog", _no_catalog)
+    monkeypatch.setattr("omnigent.claude_native.claude_reprobed_launch_catalog", _no_catalog)
     monkeypatch.setattr("omnigent.codex_native_app_server.codex_launch_catalog", _no_catalog)
 
 

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -26,6 +26,7 @@ from tests.runner.helpers import NullServerClient
 # attribute back to this. (An assignment, not an alias import, so lint
 # autofixes can't strip it as unused.)
 REAL_CLAUDE_LAUNCH_CATALOG = claude_native.claude_launch_catalog
+REAL_CLAUDE_REFRESHED_LAUNCH_CATALOG = claude_native.claude_refreshed_launch_catalog
 REAL_CODEX_LAUNCH_CATALOG = codex_native_app_server.codex_launch_catalog
 
 # Project root: two parents up from this conftest (tests/runner/ → repo root).
@@ -42,7 +43,7 @@ def _isolated_model_catalog_store(
     a miss, probe the REAL harness CLIs — which a unit test must never do
     (a real ``claude`` boot takes ~6 s and writes the developer's real
     ``~/.omnigent`` store). Redirect the store's directory seam per test
-    and stub both launch-catalog resolvers to "no catalog" (the
+    and stub the launch-catalog resolvers to "no catalog" (the
     pre-catalog behavior); a test exercising catalogs re-patches them
     explicitly.
     """
@@ -53,6 +54,7 @@ def _isolated_model_catalog_store(
         return None
 
     monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _no_catalog)
+    monkeypatch.setattr("omnigent.claude_native.claude_refreshed_launch_catalog", _no_catalog)
     monkeypatch.setattr("omnigent.codex_native_app_server.codex_launch_catalog", _no_catalog)
 
 

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -1346,6 +1346,205 @@ async def test_claude_native_model_options_config_error_is_not_retryable(
 
 
 @pytest.mark.asyncio
+async def test_claude_native_model_options_expire_and_reread_the_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The session listing follows the store once its cache TTL passes.
+
+    A store refresh (the background re-probe) must reach the picker without
+    a runner restart: an expired entry re-reads the store instead of serving
+    the rows it cached at first read, and a warm store costs no new probe.
+    """
+    from omnigent import model_catalog_store
+    from omnigent.claude_native import (
+        ClaudeModelProbe,
+        ClaudeNativeUcodeConfig,
+        claude_catalog_fingerprint,
+    )
+    from tests.runner.conftest import REAL_CLAUDE_LAUNCH_CATALOG
+
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", REAL_CLAUDE_LAUNCH_CATALOG)
+    monkeypatch.setattr("omnigent.runner.app._CLAUDE_MODEL_OPTIONS_CACHE_TTL_S", 0.0)
+    conv_id = "8c1f2e3d4a5b46c7d8e9f0a1b2c3d4e5"
+    claude_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return claude_spec
+
+    config = ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_DEFAULT_OPUS_MODEL": "system.ai.claude-opus-4-10"},
+        api_key_helper="printf token",
+        model="system.ai.claude-opus-4-10",
+    )
+
+    def _resolve(*, spec: AgentSpec | None) -> ClaudeNativeUcodeConfig:
+        del spec
+        return config
+
+    monkeypatch.setattr("omnigent.claude_native.resolve_native_claude_config", _resolve)
+    probe_calls: list[int] = []
+
+    async def _probe(claude_config: object) -> ClaudeModelProbe:
+        del claude_config
+        probe_calls.append(1)
+        return ClaudeModelProbe(
+            alias_rows=[
+                {"id": "opus", "model": "system.ai.claude-opus-4-10", "displayName": "Opus 4.10"}
+            ],
+            default_model="system.ai.claude-opus-4-10",
+            default_label="Opus 4.10",
+        )
+
+    monkeypatch.setattr("omnigent.claude_native.probe_claude_model_options", _probe)
+
+    async def _fake_auto_create(
+        session_id: str,
+        resource_registry: Any,
+        publish_event: Any,
+        **kwargs: Any,
+    ) -> SessionResourceView:
+        del resource_registry, publish_event, kwargs
+        return SessionResourceView(
+            id="terminal_claude_main",
+            type="terminal",
+            session_id=session_id,
+            name="claude:main",
+            metadata={"terminal_name": "claude", "session_key": "main", "running": True},
+        )
+
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_claude_terminal", _fake_auto_create
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    refreshed = [
+        {
+            "id": "opus",
+            "model": "system.ai.claude-opus-5",
+            "displayName": "Opus 5",
+            "isDefault": True,
+        }
+    ]
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        first = await client.get(f"/v1/sessions/{conv_id}/claude-model-options")
+        # The store converges on its own (a background re-probe); the
+        # expired entry must pick that up on the next read.
+        model_catalog_store.write_catalog(
+            "claude-native", claude_catalog_fingerprint(config), refreshed
+        )
+        second = await client.get(f"/v1/sessions/{conv_id}/claude-model-options")
+
+    assert first.status_code == 200
+    assert [row["model"] for row in first.json()["models"]] == ["system.ai.claude-opus-4-10"]
+    assert second.status_code == 200
+    assert [row["model"] for row in second.json()["models"]] == ["system.ai.claude-opus-5"]
+    # A warm store re-read costs no new harness probe.
+    assert probe_calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_claude_native_model_options_retire_when_a_launch_records_its_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relaunch under another provider lists that provider's rows at once.
+
+    The rows cache is keyed by session, not by launch config, so recording
+    the config a launch resolved must retire rows listed under the previous
+    one rather than serving them until the cache TTL passes.
+    """
+    from omnigent.claude_native import ClaudeModelProbe, ClaudeNativeUcodeConfig
+    from tests.runner.conftest import REAL_CLAUDE_LAUNCH_CATALOG
+
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", REAL_CLAUDE_LAUNCH_CATALOG)
+    conv_id = "9d2e3f4a5b6c47d8e9f0a1b2c3d4e5f6"
+    claude_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return claude_spec
+
+    def _config(model: str) -> ClaudeNativeUcodeConfig:
+        return ClaudeNativeUcodeConfig(
+            env={"ANTHROPIC_DEFAULT_OPUS_MODEL": model},
+            api_key_helper="printf token",
+            model=model,
+        )
+
+    def _resolve(*, spec: AgentSpec | None) -> ClaudeNativeUcodeConfig:
+        del spec
+        return _config("system.ai.claude-opus-4-10")
+
+    monkeypatch.setattr("omnigent.claude_native.resolve_native_claude_config", _resolve)
+
+    async def _probe(claude_config: ClaudeNativeUcodeConfig) -> ClaudeModelProbe:
+        return ClaudeModelProbe(
+            alias_rows=[{"id": "opus", "model": claude_config.model, "displayName": "Opus"}],
+            default_model=claude_config.model,
+            default_label="Opus",
+        )
+
+    monkeypatch.setattr("omnigent.claude_native.probe_claude_model_options", _probe)
+    recorders: list[Any] = []
+
+    async def _fake_auto_create(
+        session_id: str,
+        resource_registry: Any,
+        publish_event: Any,
+        **kwargs: Any,
+    ) -> SessionResourceView:
+        del resource_registry, publish_event
+        recorders.append(kwargs["record_launch_config"])
+        return SessionResourceView(
+            id="terminal_claude_main",
+            type="terminal",
+            session_id=session_id,
+            name="claude:main",
+            metadata={"terminal_name": "claude", "session_key": "main", "running": True},
+        )
+
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_claude_terminal", _fake_auto_create
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    async with _runner_client(app) as client:
+        create_resp = await client.post(
+            "/v1/sessions",
+            json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        before = await client.get(f"/v1/sessions/{conv_id}/claude-model-options")
+        # The next launch resolves another provider (a re-pointed default).
+        recorders[-1](conv_id, _config("system.ai.claude-opus-5"))
+        after = await client.get(f"/v1/sessions/{conv_id}/claude-model-options")
+
+    assert [row["model"] for row in before.json()["models"]] == ["system.ai.claude-opus-4-10"]
+    assert [row["model"] for row in after.json()["models"]] == ["system.ai.claude-opus-5"]
+
+
+@pytest.mark.asyncio
 async def test_events_codex_native_plan_mode_requires_loaded_bridge(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3672,7 +3672,7 @@ async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_rese
     from omnigent.claude_native import claude_catalog_fingerprint
     from tests.runner.conftest import (
         REAL_CLAUDE_LAUNCH_CATALOG,
-        REAL_CLAUDE_REFRESHED_LAUNCH_CATALOG,
+        REAL_CLAUDE_REPROBED_LAUNCH_CATALOG,
     )
 
     monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
@@ -3688,8 +3688,8 @@ async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_rese
     )
     monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", REAL_CLAUDE_LAUNCH_CATALOG)
     monkeypatch.setattr(
-        "omnigent.claude_native.claude_refreshed_launch_catalog",
-        REAL_CLAUDE_REFRESHED_LAUNCH_CATALOG,
+        "omnigent.claude_native.claude_reprobed_launch_catalog",
+        REAL_CLAUDE_REPROBED_LAUNCH_CATALOG,
     )
     stale_rows = [
         {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5"},

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import click
 import httpx
 import pytest
 
@@ -3379,7 +3378,7 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
     the catalog spells that family as alias rows and the 1M default. On a
     canonical endpoint the relaunch must pass the id through as ``--model``
     rather than refuse the resume; a gateway, which routes only its own
-    spellings, keeps refusing it.
+    spellings, launches on its own default instead and resets the pick to Default.
     """
     from omnigent.claude_native import ClaudeNativeUcodeConfig
 
@@ -3439,7 +3438,11 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
                 metadata={"terminal_name": "claude", "session_key": "main", "running": True},
             )
 
-    def _handle_request(_request: httpx.Request) -> httpx.Response:
+    patches: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "PATCH":
+            patches.append(json.loads(request.content))
         return httpx.Response(200, json={"model_override": "claude-opus-4-8", "labels": {}})
 
     fake_client = httpx.AsyncClient(
@@ -3460,26 +3463,254 @@ async def test_auto_create_claude_terminal_launch_gate_folds_a_canonical_overrid
         return config
 
     session_id = "0f2d3d5c9a6b4e1f8c7d6e5f4a3b2c1d"
+    await _auto_create_claude_terminal(
+        session_id,
+        _FakeResourceRegistry(),
+        lambda _sid, _evt: None,
+        server_client=fake_client,
+        resolve_launch_config=_resolve,
+    )
+    args = captured["spec"].args
+    pick_resets = [body for body in patches if "model_override" in body]
     if endpoint == "subscription":
-        await _auto_create_claude_terminal(
-            session_id,
-            _FakeResourceRegistry(),
-            lambda _sid, _evt: None,
-            server_client=fake_client,
-            resolve_launch_config=_resolve,
-        )
-        args = captured["spec"].args
         assert args[args.index("--model") + 1] == "claude-opus-4-8"
+        assert pick_resets == []
     else:
-        with pytest.raises(click.ClickException, match="not in this host's current model list"):
-            await _auto_create_claude_terminal(
-                session_id,
-                _FakeResourceRegistry(),
-                lambda _sid, _evt: None,
-                server_client=fake_client,
-                resolve_launch_config=_resolve,
+        assert args[args.index("--model") + 1] == "system.ai.claude-opus-5"
+        assert pick_resets == [{"model_override": "default"}]
+
+    await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auto_create_claude_terminal_unserved_pick_resets_to_the_catalog_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A pick no row can serve launches on the catalog's default and resets the pick.
+
+    The pick outlives the provider it was made under, so a relaunch that
+    cannot honor it must still bring the session back: it takes the Default
+    launch (the fresh catalog's ``isDefault`` row) and clears the persisted
+    pick, so the picker shows the Default the session now runs.
+    """
+    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+
+    async def _no_op_forwarder(**kwargs: Any) -> None:
+        del kwargs
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_forwarder.supervise_forwarder",
+        _no_op_forwarder,
+    )
+    catalog = [
+        {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5"},
+        {
+            "id": "claude-opus-4-8[1m]",
+            "model": "claude-opus-4-8[1m]",
+            "displayName": "Opus 4.8 (1M context)",
+            "isDefault": True,
+        },
+    ]
+
+    async def _catalog(config: object) -> list[dict[str, object]]:
+        del config
+        return catalog
+
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _catalog)
+    monkeypatch.setattr(
+        "omnigent.claude_native.claude_launch_catalog_is_stale", lambda config: False
+    )
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        """Captures the launched terminal spec."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            """Record the spec and return a terminal resource view."""
+            del terminal_name, session_key
+            captured["spec"] = spec
+            return SessionResourceView(
+                id="terminal_claude_main",
+                type="terminal",
+                session_id=session_id,
+                name="claude:main",
+                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
             )
-        assert "spec" not in captured, "a refused launch must not start a terminal"
+
+    patches: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "PATCH":
+            patches.append(json.loads(request.content))
+        return httpx.Response(200, json={"model_override": "gpt-5.4", "labels": {}})
+
+    fake_client = httpx.AsyncClient(
+        base_url="http://test-server",
+        transport=httpx.MockTransport(_handle_request),
+    )
+
+    async def _resolve() -> None:
+        return None
+
+    await _auto_create_claude_terminal(
+        "1a2b3c4d5e6f47a8b9c0d1e2f3a4b5c6",
+        _FakeResourceRegistry(),
+        lambda _sid, _evt: None,
+        server_client=fake_client,
+        resolve_launch_config=_resolve,
+    )
+    args = captured["spec"].args
+    assert args[args.index("--model") + 1] == "claude-opus-4-8[1m]"
+    assert [body for body in patches if "model_override" in body] == [
+        {"model_override": "default"}
+    ]
+
+    await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("served_after_refresh", [True, False])
+async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_resetting_the_pick(
+    served_after_refresh: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A pick the stale catalog does not serve is re-checked against a fresh probe.
+
+    The stored rows may predate a provider change, so resetting the pick on
+    them alone could discard a model the provider serves today. The launch
+    awaits the re-probe: a fresh row serving the pick keeps it, and only a
+    fresh catalog that still lacks it falls back and resets the pick.
+    """
+    import os
+    import time
+
+    from omnigent import model_catalog_store
+    from omnigent.claude_native import claude_catalog_fingerprint
+    from tests.runner.conftest import (
+        REAL_CLAUDE_LAUNCH_CATALOG,
+        REAL_CLAUDE_REFRESHED_LAUNCH_CATALOG,
+    )
+
+    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+
+    async def _no_op_forwarder(**kwargs: Any) -> None:
+        del kwargs
+
+    monkeypatch.setattr(
+        "omnigent.claude_native_forwarder.supervise_forwarder",
+        _no_op_forwarder,
+    )
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", REAL_CLAUDE_LAUNCH_CATALOG)
+    monkeypatch.setattr(
+        "omnigent.claude_native.claude_refreshed_launch_catalog",
+        REAL_CLAUDE_REFRESHED_LAUNCH_CATALOG,
+    )
+    stale_rows = [
+        {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5"},
+        {
+            "id": "claude-opus-4-8[1m]",
+            "model": "claude-opus-4-8[1m]",
+            "displayName": "Opus 4.8 (1M context)",
+            "isDefault": True,
+        },
+    ]
+    refreshed_rows = list(stale_rows)
+    if served_after_refresh:
+        refreshed_rows.append({"id": "haiku", "model": "claude-haiku-4-5-20251001"})
+    probes: list[int] = []
+
+    async def _probe(config: object) -> list[dict[str, object]]:
+        del config
+        probes.append(1)
+        return refreshed_rows
+
+    monkeypatch.setattr("omnigent.claude_native.claude_model_catalog", _probe)
+    fingerprint = claude_catalog_fingerprint(None)
+    model_catalog_store.write_catalog("claude-native", fingerprint, stale_rows)
+    path = model_catalog_store.catalog_path("claude-native", fingerprint)
+    old = time.time() - (model_catalog_store.CATALOG_STALE_AFTER_S + 60)
+    os.utime(path, (old, old))
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResourceRegistry:
+        """Captures the launched terminal spec."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            """Record the spec and return a terminal resource view."""
+            del terminal_name, session_key
+            captured["spec"] = spec
+            return SessionResourceView(
+                id="terminal_claude_main",
+                type="terminal",
+                session_id=session_id,
+                name="claude:main",
+                metadata={"terminal_name": "claude", "session_key": "main", "running": True},
+            )
+
+    patches: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "PATCH":
+            patches.append(json.loads(request.content))
+        return httpx.Response(200, json={"model_override": "claude-haiku-4-5", "labels": {}})
+
+    fake_client = httpx.AsyncClient(
+        base_url="http://test-server",
+        transport=httpx.MockTransport(_handle_request),
+    )
+
+    async def _resolve() -> None:
+        return None
+
+    await _auto_create_claude_terminal(
+        "2b3c4d5e6f7a48b9c0d1e2f3a4b5c6d7",
+        _FakeResourceRegistry(),
+        lambda _sid, _evt: None,
+        server_client=fake_client,
+        resolve_launch_config=_resolve,
+    )
+    args = captured["spec"].args
+    assert probes == [1], "the launch must await exactly one re-probe"
+    assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed_rows
+    pick_resets = [body for body in patches if "model_override" in body]
+    if served_after_refresh:
+        assert args[args.index("--model") + 1] == "claude-haiku-4-5"
+        assert pick_resets == []
+    else:
+        assert args[args.index("--model") + 1] == "claude-opus-4-8[1m]"
+        assert pick_resets == [{"model_override": "default"}]
 
     await fake_client.aclose()
 

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3585,9 +3585,74 @@ async def test_auto_create_claude_terminal_unserved_pick_resets_to_the_catalog_d
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("served_after_refresh", [True, False])
+async def test_auto_create_claude_terminal_keeps_the_pick_when_the_terminal_fails_to_launch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A pick is reset only once the fallback terminal is up.
+
+    The reset would otherwise outlive a launch that failed after the gate, so
+    a tmux or bridge failure must leave the persisted pick untouched.
+    """
+    monkeypatch.setattr(claude_native_bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(claude_native_bridge, "_BRIDGE_ROOT", tmp_path / "root")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:8000")
+    catalog = [
+        {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5", "isDefault": True}
+    ]
+
+    async def _catalog(config: object) -> list[dict[str, object]]:
+        del config
+        return catalog
+
+    monkeypatch.setattr("omnigent.claude_native.claude_launch_catalog", _catalog)
+    monkeypatch.setattr(
+        "omnigent.claude_native.claude_launch_catalog_is_stale", lambda config: False
+    )
+
+    class _FailingResourceRegistry:
+        """Fails the tmux launch after the gate has run."""
+
+        terminal_registry = None
+
+        async def launch_required_terminal(self, **kwargs: Any) -> SessionResourceView:
+            """Raise the way a tmux launch failure does."""
+            del kwargs
+            raise RuntimeError("tmux exited")
+
+    patches: list[dict[str, Any]] = []
+
+    def _handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "PATCH":
+            patches.append(json.loads(request.content))
+        return httpx.Response(200, json={"model_override": "gpt-5.4", "labels": {}})
+
+    fake_client = httpx.AsyncClient(
+        base_url="http://test-server",
+        transport=httpx.MockTransport(_handle_request),
+    )
+
+    async def _resolve() -> None:
+        return None
+
+    with pytest.raises(RuntimeError, match="tmux exited"):
+        await _auto_create_claude_terminal(
+            "3c4d5e6f7a8b49c0d1e2f3a4b5c6d7e8",
+            _FailingResourceRegistry(),
+            lambda _sid, _evt: None,
+            server_client=fake_client,
+            resolve_launch_config=_resolve,
+        )
+    assert [body for body in patches if "model_override" in body] == []
+
+    await fake_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("refresh", ["serves_pick", "lacks_pick", "fails"])
 async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_resetting_the_pick(
-    served_after_refresh: bool,
+    refresh: str,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3596,8 +3661,9 @@ async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_rese
 
     The stored rows may predate a provider change, so resetting the pick on
     them alone could discard a model the provider serves today. The launch
-    awaits the re-probe: a fresh row serving the pick keeps it, and only a
-    fresh catalog that still lacks it falls back and resets the pick.
+    awaits the re-probe: a fresh row serving the pick keeps it, only a fresh
+    catalog that still lacks it resets the pick, and a failed probe launches
+    on the default while keeping the pick for the next relaunch.
     """
     import os
     import time
@@ -3635,13 +3701,15 @@ async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_rese
         },
     ]
     refreshed_rows = list(stale_rows)
-    if served_after_refresh:
+    if refresh == "serves_pick":
         refreshed_rows.append({"id": "haiku", "model": "claude-haiku-4-5-20251001"})
     probes: list[int] = []
 
     async def _probe(config: object) -> list[dict[str, object]]:
         del config
         probes.append(1)
+        if refresh == "fails":
+            raise OSError("provider unreachable")
         return refreshed_rows
 
     monkeypatch.setattr("omnigent.claude_native.claude_model_catalog", _probe)
@@ -3703,14 +3771,21 @@ async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_rese
     )
     args = captured["spec"].args
     assert probes == [1], "the launch must await exactly one re-probe"
-    assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed_rows
     pick_resets = [body for body in patches if "model_override" in body]
-    if served_after_refresh:
+    if refresh == "serves_pick":
+        assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed_rows
         assert args[args.index("--model") + 1] == "claude-haiku-4-5"
         assert pick_resets == []
-    else:
+    elif refresh == "lacks_pick":
+        assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed_rows
         assert args[args.index("--model") + 1] == "claude-opus-4-8[1m]"
         assert pick_resets == [{"model_override": "default"}]
+    else:
+        # No fresh rows: the stale entry stays, the Default launch of a stale
+        # catalog goes bare, and the pick survives for the next relaunch.
+        assert model_catalog_store.read_catalog("claude-native", fingerprint) == stale_rows
+        assert "--model" not in args
+        assert pick_resets == []
 
     await fake_client.aclose()
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -10203,6 +10203,35 @@ def test_claude_catalog_serves_model(
     )
 
 
+@pytest.mark.parametrize(
+    ("config", "label"),
+    [
+        (None, "Claude Code's own login"),
+        (
+            claude_native.ClaudeNativeUcodeConfig(
+                env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+                api_key_helper="printf sk-key",
+            ),
+            "the gateway at https://gateway.example/anthropic",
+        ),
+        (
+            claude_native.ClaudeNativeUcodeConfig(
+                env={"ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock.example"},
+                api_key_helper=None,
+            ),
+            "the Bedrock endpoint at https://bedrock.example",
+        ),
+    ],
+)
+def test_claude_launch_endpoint_label_names_where_inference_goes(
+    config: claude_native.ClaudeNativeUcodeConfig | None, label: str
+) -> None:
+    """
+    The label names the endpoint a launch resolved to, for the fallback log line.
+    """
+    assert claude_native.claude_launch_endpoint_label(config) == label
+
+
 # ── Bare --resume picker: host scoping and concise errors ────────────
 
 

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -10209,14 +10209,16 @@ def test_claude_catalog_serves_model(
         (None, "Claude Code's own login"),
         (
             claude_native.ClaudeNativeUcodeConfig(
-                env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+                env={
+                    "ANTHROPIC_BASE_URL": "https://user:secret@gateway.example:8443/anthropic?sig=1"
+                },
                 api_key_helper="printf sk-key",
             ),
-            "the gateway at https://gateway.example/anthropic",
+            "the gateway at https://gateway.example:8443",
         ),
         (
             claude_native.ClaudeNativeUcodeConfig(
-                env={"ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock.example"},
+                env={"ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock.example/v1"},
                 api_key_helper=None,
             ),
             "the Bedrock endpoint at https://bedrock.example",
@@ -10227,7 +10229,7 @@ def test_claude_launch_endpoint_label_names_where_inference_goes(
     config: claude_native.ClaudeNativeUcodeConfig | None, label: str
 ) -> None:
     """
-    The label names the endpoint a launch resolved to, for the fallback log line.
+    The label names only the endpoint's origin: no path, userinfo, or query.
     """
     assert claude_native.claude_launch_endpoint_label(config) == label
 

--- a/tests/test_model_catalog_store.py
+++ b/tests/test_model_catalog_store.py
@@ -134,7 +134,7 @@ async def test_ensure_catalog_stale_refresh_failure_keeps_serving() -> None:
     assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
 
 
-async def test_refresh_catalog_joins_the_background_probe_and_persists() -> None:
+async def test_reprobe_catalog_joins_the_background_probe_and_persists() -> None:
     """
     An awaited refresh reuses the stale hit's in-flight probe and returns its rows.
     """
@@ -148,13 +148,13 @@ async def test_refresh_catalog_joins_the_background_probe_and_persists() -> None
         return refreshed
 
     assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
-    assert await store.refresh_catalog("claude-native", "abc123", _probe) == refreshed
+    assert await store.reprobe_catalog("claude-native", "abc123", _probe) == refreshed
     assert probes == [1], "the awaited refresh must join the probe already in flight"
     assert store.read_catalog("claude-native", "abc123") == refreshed
     assert store.catalog_is_stale("claude-native", "abc123") is False
 
 
-async def test_refresh_catalog_failure_returns_none_and_keeps_serving() -> None:
+async def test_reprobe_catalog_failure_returns_none_and_keeps_serving() -> None:
     """
     A failed awaited refresh reports ``None`` and leaves the stored rows alone.
     """
@@ -163,7 +163,7 @@ async def test_refresh_catalog_failure_returns_none_and_keeps_serving() -> None:
     async def _probe() -> list[dict[str, object]]:
         raise OSError("provider unreachable")
 
-    assert await store.refresh_catalog("claude-native", "abc123", _probe) is None
+    assert await store.reprobe_catalog("claude-native", "abc123", _probe) is None
     assert store.read_catalog("claude-native", "abc123") == _ROWS
 
 

--- a/tests/test_model_catalog_store.py
+++ b/tests/test_model_catalog_store.py
@@ -134,6 +134,39 @@ async def test_ensure_catalog_stale_refresh_failure_keeps_serving() -> None:
     assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
 
 
+async def test_refresh_catalog_joins_the_background_probe_and_persists() -> None:
+    """
+    An awaited refresh reuses the stale hit's in-flight probe and returns its rows.
+    """
+    store.write_catalog("claude-native", "abc123", _ROWS)
+    _age_entry("claude-native", "abc123", store.CATALOG_STALE_AFTER_S + 60)
+    refreshed = [{"id": "haiku", "model": "claude-haiku-4-5", "isDefault": True}]
+    probes: list[int] = []
+
+    async def _probe() -> list[dict[str, object]]:
+        probes.append(1)
+        return refreshed
+
+    assert await store.ensure_catalog("claude-native", "abc123", _probe) == _ROWS
+    assert await store.refresh_catalog("claude-native", "abc123", _probe) == refreshed
+    assert probes == [1], "the awaited refresh must join the probe already in flight"
+    assert store.read_catalog("claude-native", "abc123") == refreshed
+    assert store.catalog_is_stale("claude-native", "abc123") is False
+
+
+async def test_refresh_catalog_failure_returns_none_and_keeps_serving() -> None:
+    """
+    A failed awaited refresh reports ``None`` and leaves the stored rows alone.
+    """
+    store.write_catalog("claude-native", "abc123", _ROWS)
+
+    async def _probe() -> list[dict[str, object]]:
+        raise OSError("provider unreachable")
+
+    assert await store.refresh_catalog("claude-native", "abc123", _probe) is None
+    assert store.read_catalog("claude-native", "abc123") == _ROWS
+
+
 # ── binary_identity ──────────────────────────────────────
 
 

--- a/web/src/hooks/useHosts.test.tsx
+++ b/web/src/hooks/useHosts.test.tsx
@@ -395,6 +395,27 @@ describe("useHostModelOptions", () => {
     await Promise.resolve();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("polls the host's catalog every 15 s while mounted", async () => {
+    // The host re-resolves its provider per request, so an open picker must
+    // follow a provider change on the host without being remounted.
+    fetchMock.mockResolvedValue(
+      mockResponse({ models: [{ id: "opus", model: "claude-opus-5", displayName: "Opus 5" }] }),
+    );
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { result } = renderHook(() => useHostModelOptions("host_1", "claude-native"), {
+        wrapper,
+      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("useStoreCredential", () => {

--- a/web/src/hooks/useHosts.ts
+++ b/web/src/hooks/useHosts.ts
@@ -107,7 +107,11 @@ export function useHostModelOptions(hostId: string | null, harness: string, enab
     queryKey: ["host-model-options", hostId, harness],
     queryFn: () => fetchHostModelOptions(hostId as string, harness),
     enabled: enabled && hostId !== null,
-    staleTime: 30_000,
+    // The host's provider can change underneath an open picker (`omni setup`
+    // re-pointing the Claude default): poll while mounted so the list follows
+    // the host's current catalog, which it re-resolves on every request.
+    staleTime: 15_000,
+    refetchInterval: enabled && hostId !== null ? 15_000 : false,
     // A request racing the host's boot probe gets an honest empty answer
     // with an error string; the probe itself completes shortly after
     // (single-flight in the host's catalog store). Retry with backoff so a

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1734,6 +1734,45 @@ describe("NewChatLandingScreen", () => {
     expect(screen.getByText("Bypass permissions")).toBeTruthy();
   });
 
+  it("falls back to Default when the host catalog stops listing the picked model", async () => {
+    authenticatedFetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    openAgentConfig("a1");
+    pickSelectOption("new-chat-landing-config-model", "Haiku 4.5");
+    expect(screen.getByTestId("new-chat-landing-config-model").textContent).toContain("Haiku 4.5");
+
+    // The host's provider changes under the open modal: its next poll of the
+    // catalog no longer lists the pick.
+    const shrunk = {
+      data: CLAUDE_MODEL_OPTIONS_RESULT.data.filter((model) => model.id !== "haiku"),
+      isLoading: false,
+      isError: false,
+    };
+    useHostModelOptionsMock.mockImplementation(
+      (_hostId, harness) =>
+        (harness === "codex-native" ? CODEX_MODEL_OPTIONS_RESULT : shrunk) as unknown as ReturnType<
+          typeof useHostModelOptions
+        >,
+    );
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
+      target: { value: "run the build" },
+    });
+    const trigger = screen.getByTestId("new-chat-landing-config-model");
+    expect(trigger.textContent).toContain("Default");
+    expect(trigger.textContent).not.toContain("Haiku 4.5");
+
+    // Saving the fallback sends no override, so the launch uses the provider's default.
+    saveConfig();
+    fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+    await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = authenticatedFetchMock.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
+    expect(body.model_override).toBeUndefined();
+  });
+
   it("shows the Codex approval-mode knob in the gear modal", () => {
     renderLanding();
     // Open Codex's (a2) config modal — it carries the approval-mode select.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -1540,6 +1540,18 @@ function HarnessConfigModal({
     () => codexModelOptions.map((m) => ({ id: m.id, label: nativeModelLabel(m) })),
     [codexModelOptions],
   );
+  // The host catalog re-polls while the modal is open (a provider switch under
+  // it). A draft the new catalog no longer lists would render a blank trigger,
+  // so it falls back to Default.
+  const draftModelOptions = hasPermission
+    ? claudeModelSelectOptions
+    : hasApproval
+      ? codexModelSelectOptions
+      : piModelOptions;
+  useEffect(() => {
+    if (!open || !draftModel || draftModelOptions.length === 0) return;
+    if (!draftModelOptions.some((m) => m.id === draftModel)) setDraftModel("");
+  }, [open, draftModel, draftModelOptions]);
   const onModelChange = (value: string) => {
     if (value === MODEL_SELECT_SMART) {
       setDraftRouting("on");


### PR DESCRIPTION
## Related issue

N/A — no tracking issue. Root-caused from a live session on 2026-09-02 (details in Summary).

## Summary

A native Claude session's model pick (`model_override`) persists on the session while the host's Claude provider can be re-pointed underneath it (`omnigent setup` making the Databricks profile the default). A session picked on Fable under the Claude subscription then relaunches through a gateway that serves no Fable model. The launch gate refused every relaunch with "the requested model 'fable' is not in this host's current model list — it may have changed since the pick", stranding the session until the pick was changed by hand.

- **Launch gate falls back instead of refusing.** When the catalog doesn't serve the pick, the relaunch first re-probes a stale catalog (new `model_catalog_store.reprobe_catalog` / `claude_reprobed_launch_catalog`, awaited rather than left to the background), then launches on the provider's own default and resets the persisted pick to Default (`PATCH /v1/sessions/{id}` with the `"default"` clear alias). One runner log line names the endpoint and the picks it serves.
- **Runner picker rows follow the catalog.** The per-session `claude-model-options` rows were cached for the runner's lifetime; they now expire after 15 s (`_CLAUDE_MODEL_OPTIONS_CACHE_TTL_S`) and retire when a launch records a new config or the session's config is dropped, so a relaunch under another provider never serves the previous provider's rows.
- **Web pickers follow the host.** `useHostModelOptions` polls every 15 s while mounted (the host re-resolves its provider per request), and the landing "Configure" modal drops a draft pick the re-polled catalog no longer lists back to Default instead of rendering a blank select.

ELI5: your session remembered "Fable", you moved the host to a provider that has no Fable, and the old code slammed the door. Now it opens the door with the provider's default model, forgets the stale pick, and the model menus catch up on their own.

```mermaid
flowchart LR
    A[relaunch with persisted pick] --> B{catalog serves pick?}
    B -- yes --> C[launch on pick]
    B -- no, catalog stale --> D[await re-probe] --> B2{fresh catalog serves pick?}
    B2 -- yes --> C
    B2 -- no --> E[launch on provider default<br/>PATCH model_override=default]
    B -- no, catalog fresh --> E
```

## Test Plan

Unit (all green in a clean worktree from `origin/main`):

- `tests/test_model_catalog_store.py` — `reprobe_catalog` joins an in-flight probe, persists, and returns `None` on failure.
- `tests/test_claude_native.py` — endpoint label; full file passes (339).
- `tests/runner/test_app_sessions_native_terminals_autocreate.py` — the gateway branch of the launch-gate test now launches on the provider default and sends exactly one reset PATCH; new tests for the catalog-default fallback and for "stale catalog → awaited re-probe → keep the pick if served, else reset". Full file passes (67).
- `tests/runner/test_app_sessions_native_events_lifecycle.py` — rows expire and re-read the store; rows retire when a launch records a new config.
- `web/src/hooks/useHosts.test.tsx` — the host catalog query polls every 15 s while mounted.
- `web/src/shell/NewChatDialog.test.tsx` — a draft pick the host catalog stops listing falls back to Default and the create sends no override.

Live, on a sandbox server + host booted from this branch with the real Claude login and a Databricks profile (recording and screenshots below):

1. New session with Fable 5.1 picked replies on `claude-fable-5-1`.
2. Claude default switched to the Databricks profile, runner restarted, pane killed, next message sent: the session relaunches on Opus 4.8, `model_override` is `None`, and the runner logs `model pick 'fable' … not served by the gateway at … (it offers: sonnet, opus, haiku, sonnet[1m], opus[1m]); launching on the provider default and resetting the pick to Default`.
3. A row appended to the stored catalog file shows up in the in-session gear 21 s later with nothing restarted.
4. With the new-session model dropdown open, the provider switched back: the list re-polled to the subscription catalog (Fable listed again) within 12 s.
5. With the landing modal open on Fable 5.1, the provider switched to the Databricks profile: the trigger read "Default (Opus 4.8)" within 14 s instead of going blank.

To reproduce by hand: pick Fable in a Claude Code session on a host whose Claude default is `claude-subscription`, run `omnigent setup` and make a Databricks profile the Claude default, stop the session (or restart its runner), and send a message. The session comes back on the gateway's default with the gear reading Default.

Note: `web/src/shell/NewChatDialog.test.tsx` has three sandbox-chrome tests ("swaps the workspace chrome", "shows 'Create custom agent' on a host", "drops a selected pending custom agent") that fail identically on a pristine `origin/main` checkout on my machine; they are unrelated to this change.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Recording of the full flow (2.5 min): https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/repro.mp4

Session on Fable under the subscription default:

![session on Fable](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/02-session-on-fable.png)

After the provider switch and relaunch — on Opus 4.8 with the pick reset, gear listing the gateway's models:

![after provider switch](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/04-session-after-provider-switch.png)

![gear on the gateway](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/05-gear-databricks.png)

Catalog row appended on disk, visible in the gear within the 15 s runner cache with no restart:

![gear after catalog edit](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/06-gear-after-catalog-edit.png)

Open new-session picker re-polled after switching the provider back:

![landing picker re-polled](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/08-landing-picker-repolled.png)

Landing modal: Fable picked, then the provider switched underneath the open modal — falls back to Default instead of a blank select:

![landing fable picked](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/landing-01-fable-picked.png)

![landing fallback to default](https://raw.githubusercontent.com/dbczumar/omnigent/pr-assets/claude-model-pick-fallback/landing-02-after-provider-switch.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran the five live scenarios in Test Plan against a sandbox server + host booted from this branch (isolated config home and data dir, real Claude login and Databricks profile), driving the real SPA with Playwright and reading harness truth from the tmux pane and the runner logs. The unit suites cover the launch-gate decisions, the store refresh, the runner cache expiry and retirement, the host query polling, and the landing-modal fallback.

## Changelog

A Claude Code session whose picked model is no longer served by the host's Claude provider relaunches on the provider's default model with the pick reset instead of failing to start, and the model pickers follow a provider change within 15 seconds.

https://claude.ai/code/session_01Kvq5Aez3Pokzup9PeLPmvK
