### PR TITLE
ci: bump the pinned Claude Code CLI to 2.1.236

### DIFF
--- a/.github/actions/run-omnigent-agent/action.yml
+++ b/.github/actions/run-omnigent-agent/action.yml
@@ -39,7 +39,7 @@ inputs:
   claude-code-version:
     description: "@anthropic-ai/claude-code npm version to install."
     required: false
-    default: 2.1.212
+    default: 2.1.236
 
 runs:
   using: composite

--- a/.github/ci-deps/package.json
+++ b/.github/ci-deps/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Pinned npm CLIs the e2e workflow installs (claude-code, codex, pi).",
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.212",
+    "@anthropic-ai/claude-code": "2.1.236",
     "@earendil-works/pi-coding-agent": "0.84.2",
     "@openai/codex": "0.139.0"
   }

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -260,7 +260,7 @@ jobs:
           # this dir's node_modules empty.
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.236
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -235,19 +235,17 @@ jobs:
       # native render-parity tests boot a real Claude Code / Codex CLI. The
       # rest of the e2e-ui suite (openai-agents) ignores them.
       - name: Install Claude Code CLI
-        # claude-code 2.1.170, NOT the 2.1.124 in .github/ci-deps: 2.1.124
-        # doesn't recognise the hook events the native bridge configures and
-        # shows a blocking startup modal that swallows the first message.
-        # Runs the package's install script so the platform-specific binary is
-        # linked into the temporary CLI directory and put on PATH.
-        # (The install.cjs script was removed in the same version the upstream
-        # npm package no longer ships it, so lifecycle scripts are required.)
+        # Same claude-code pin as .github/ci-deps. The native bridge needs a
+        # release that recognises its hook events (older ones show a blocking
+        # startup modal that swallows the first message). Runs the package's
+        # install script so the platform-specific binary is linked into the
+        # temporary CLI directory and put on PATH.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
+          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.236
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Install Codex CLI

--- a/.github/workflows/flake-stress-ui.yml
+++ b/.github/workflows/flake-stress-ui.yml
@@ -276,15 +276,15 @@ jobs:
           pnpm --filter web run build
 
       - name: Install Claude Code CLI
-        # Pinned to match e2e-ui.yml (2.1.170 recognises the native bridge
-        # hook events). Runs lifecycle scripts so the platform-specific binary
-        # is linked and put on PATH.
+        # Pinned to match e2e-ui.yml (the native bridge needs a release that
+        # recognises its hook events). Runs lifecycle scripts so the
+        # platform-specific binary is linked and put on PATH.
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
         run: |
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
+          npm install --no-audit --no-fund @anthropic-ai/claude-code@2.1.236
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Install Codex CLI

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -238,7 +238,7 @@ jobs:
           # this dir's node_modules empty.
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.236
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -235,7 +235,7 @@ jobs:
           # this dir's node_modules empty.
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.236
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/security-triage.yml
+++ b/.github/workflows/security-triage.yml
@@ -201,7 +201,7 @@ jobs:
           # this dir's node_modules empty.
           CC_CLI_DIR="${RUNNER_TEMP}/omnigent-cc-cli"
           mkdir -p "$CC_CLI_DIR" && cd "$CC_CLI_DIR"
-          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.212
+          npm install --ignore-scripts --no-audit --no-fund @anthropic-ai/claude-code@2.1.236
           node node_modules/@anthropic-ai/claude-code/install.cjs
           echo "$CC_CLI_DIR/node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   .github/ci-deps:
     dependencies:
       '@anthropic-ai/claude-code':
-        specifier: 2.1.212
-        version: 2.1.212
+        specifier: 2.1.236
+        version: 2.1.236
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.2
         version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(supports-color@10.2.2)(ws@8.21.1)(zod@4.4.3)
@@ -507,52 +507,52 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.212':
-    resolution: {integrity: sha512-QjQwqJU5XzAl1mdlnY+hQxK/pGx6/0q59BfHWiKsSeLyMBpK9avgwu+kap8kzSigSEdbo1rIABO8t2EKqzvvaA==}
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.236':
+    resolution: {integrity: sha512-CaGOnOXLFmecFc6td8SykfbYWo+P/o9Knh7fUYRpI0NTCG7edINaDaS1Eu9PeYUn8Sy91A4TwYRglko1WFpg4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-code-darwin-x64@2.1.212':
-    resolution: {integrity: sha512-dHnDk1jQHP1xG5hMEHHvgYqXHcgBapH/s1whqDw4KlAOxycgZKd4s2YQbRuygb7HNEpTLBnnLue5+Zv+RCfLzw==}
+  '@anthropic-ai/claude-code-darwin-x64@2.1.236':
+    resolution: {integrity: sha512-q6YsfH79686Amgy5Riw9Rv2dYh40BccUSSpxneZJtBHyaJqkEmijMg6OWZIRE1d++CbIiWDe9hkFFP6acvuYVA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.212':
-    resolution: {integrity: sha512-OmNXhGKaf1F3XrqYL5GnMIAFMv4Og3H4ehEREX6JLiZU2AC3ckyPawqvvhqyhoJx+a6KN59+6rEC97DyQMgo5Q==}
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.236':
+    resolution: {integrity: sha512-bXzIK4/LmVqzaQv87cdJC0w86sEqUuozJphULSkrPHukyl9gZJ1ZpwHbfxZPXGOopbM6uLiCOmp+J+hu3u0MtQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-code-linux-arm64@2.1.212':
-    resolution: {integrity: sha512-PcQptwO1t9q6tkL41yjmf5jxLU7Kzce4apW6KzuDvffN8ueKzGfR+9PecyQt2W1/dD2x1fAhWjAaQA6XiP2SyQ==}
+  '@anthropic-ai/claude-code-linux-arm64@2.1.236':
+    resolution: {integrity: sha512-3e8S69B1Nsb7eX3z9Eq0ngHpGyPIl/aVc+BaoSHGMs3gP1ucyon5YIM2VRHFE3lj+FOBsGId7dU9LpeBSWNGnA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.212':
-    resolution: {integrity: sha512-AXkXlvUd/SWydG8XSEIKgq0fUHh/5+zdVj43mv+Fv0+p3Yv3vc528+tQo0NPGH3fU0weVYHarII69TgRQasP1w==}
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.236':
+    resolution: {integrity: sha512-D/mlGvsiAmGQEli2lGTa5NNT+IF/0TwttqhCr+EuSnN99re54BBIekvp1FKBlRRW7WS4IeaMbjWlZmE5Le/rKA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-code-linux-x64@2.1.212':
-    resolution: {integrity: sha512-NCJ/EHcC1QfAm7EUH/F5m+cE6QQO5fhceCxtnySpFu0T4+eq6tORcJcbUY/bHGsKKa8MiAmjyv3nXFWnV5h/oA==}
+  '@anthropic-ai/claude-code-linux-x64@2.1.236':
+    resolution: {integrity: sha512-96GVEfl+2t2HWbKBlW4oIEubH6pkL27R5j9feWS+tQH6MWiGnr8jNsL5Fv2405ZiO3+SiX2eV/3sUkUWRV5h6w==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-code-win32-arm64@2.1.212':
-    resolution: {integrity: sha512-SYh28kyBjPj5HYnRJ6FSK7tAGxXip2qemGo15N1V31KBQVqPgt67vvCI4E8k1+7yeCV31j3mpq6pBJi+1LDFHw==}
+  '@anthropic-ai/claude-code-win32-arm64@2.1.236':
+    resolution: {integrity: sha512-mDqDsI1panxe3qw7U2Ixjr94yScqJDHfdMX7rGBCeHh1wxxfACddEYXzCMzEL3M4JwtcZarHqi0gvbG9qzNbmQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-code-win32-x64@2.1.212':
-    resolution: {integrity: sha512-Fz/A6+V1ezafl/Zk9DMLTpoc9yVSdUf5UT0ZNBp6m0y1PwRyq7EMXlGh9V8O+Cb5/qPJF5K01onArNkYczSjbg==}
+  '@anthropic-ai/claude-code-win32-x64@2.1.236':
+    resolution: {integrity: sha512-ijuHexQ4q0mhWXGw6M1dfeBkMuGSs5E0tVQ3Mlrh8d5XjjLVPqhiFiGW/vieITvwjmgu7m42prdDUJSCYp2deQ==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-code@2.1.212':
-    resolution: {integrity: sha512-MEasj1oaoARRKEWU7eHJ6DWC2TC8ogml9QUDihbmxYI2Ij5Ol1leW90DIj8/a0xX3lfHZOwT3gJr0JxVKa8Sxw==}
+  '@anthropic-ai/claude-code@2.1.236':
+    resolution: {integrity: sha512-sz+7GLMhFcwkN2tZHJIXGgon/g/29WMMV5UNYog9sl4OvdX5q3evM1mcXVQnasP4obP6ueItECMCpSk1MPhTDg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -9448,40 +9448,40 @@ snapshots:
       package-manager-detector: 1.7.0
       tinyexec: 1.2.4
 
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.212':
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code-darwin-x64@2.1.212':
+  '@anthropic-ai/claude-code-darwin-x64@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.212':
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-arm64@2.1.212':
+  '@anthropic-ai/claude-code-linux-arm64@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.212':
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code-linux-x64@2.1.212':
+  '@anthropic-ai/claude-code-linux-x64@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code-win32-arm64@2.1.212':
+  '@anthropic-ai/claude-code-win32-arm64@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code-win32-x64@2.1.212':
+  '@anthropic-ai/claude-code-win32-x64@2.1.236':
     optional: true
 
-  '@anthropic-ai/claude-code@2.1.212':
+  '@anthropic-ai/claude-code@2.1.236':
     optionalDependencies:
-      '@anthropic-ai/claude-code-darwin-arm64': 2.1.212
-      '@anthropic-ai/claude-code-darwin-x64': 2.1.212
-      '@anthropic-ai/claude-code-linux-arm64': 2.1.212
-      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.212
-      '@anthropic-ai/claude-code-linux-x64': 2.1.212
-      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.212
-      '@anthropic-ai/claude-code-win32-arm64': 2.1.212
-      '@anthropic-ai/claude-code-win32-x64': 2.1.212
+      '@anthropic-ai/claude-code-darwin-arm64': 2.1.236
+      '@anthropic-ai/claude-code-darwin-x64': 2.1.236
+      '@anthropic-ai/claude-code-linux-arm64': 2.1.236
+      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.236
+      '@anthropic-ai/claude-code-linux-x64': 2.1.236
+      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.236
+      '@anthropic-ai/claude-code-win32-arm64': 2.1.236
+      '@anthropic-ai/claude-code-win32-x64': 2.1.236
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Related issue

No issue (Test / CI change). Context: #6265, whose durable fix needs a CLI at or past 2.1.219.

## Summary

- Every CI pin of `@anthropic-ai/claude-code` moves from 2.1.212 to **2.1.236**: the `e2e-ci-deps` workspace package and its `pnpm-lock.yaml` entries, the six workflows that `npm install` the CLI directly (e2e-ui, flake-stress-ui, polly-review, issue-triage, doc-sync, security-triage), and the `run-omnigent-agent` action's `claude-code-version` default.
- 2.1.236 is Anthropic's current `stable` dist-tag (published 2026-08-19) and the newest release that also clears the workspace's 7-day dependency cooldown (`minimumReleaseAge`, mirroring `uv.toml`'s P7D); `latest` (2.1.259, published yesterday) is not resolvable under that policy.
- 2.1.212 predates the CLI's category-based refusal fallback (2.1.219+). On it, a safeguard-flagged claude-sdk turn cannot recover once the `opus` alias points at Opus 5, which is the situation #6265 describes; the fix for that needs the newer resolver.
- Two stale comments in e2e-ui.yml and flake-stress-ui.yml that still cited 2.1.170 / 2.1.124 now state the reason for the pin without version numbers.

## Test Plan

- `pnpm install --frozen-lockfile --ignore-scripts --filter e2e-ci-deps` + `install.cjs` (the ci.yml / flake-stress-e2e.yml path) → `claude --version` reports `2.1.236 (Claude Code)`.
- `npm install --ignore-scripts` against `.github/ci-deps/package.json` in a clean dir + `install.cjs` (the e2e-run / integration-run / compat-smoke-run action path) → `2.1.236 (Claude Code)`.
- Lockfile diff is confined to the `@anthropic-ai/claude-code*` entries (importer specifier/version plus the nine package integrity blocks).
- Live against the Databricks `oss` gateway with the real 2.1.236 binary: a benign turn on `databricks-claude-fable-5` completes; a cyber-flagged turn emits `model_refusal_fallback` and completes on Opus 4.8 (with the `opus` alias on `databricks-claude-opus-4-8`, and also with the alias on `databricks-claude-opus-5` plus a `modelOverrides` map). On 2.1.212 the same flagged turn ends in `model_refusal_no_fallback`.
- `pre-commit run --files <changed>` in a provisioned worktree: all applicable hooks pass, including the lockfile-triggered web oxlint / tsc / palette checks and the no-hardcoded-models lint.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is a version pin, so coverage is the CI suites that run the pinned CLI (e2e, e2e-ui, integration, compat-smoke) plus the manual checks above: both install paths resolve and run 2.1.236, and the binary was exercised live against the real gateway for the refusal-fallback behavior the bump is meant to unlock.

https://claude.ai/code/session_01Ny4VYmwTdXXvEQnyuhQ5vL
