### PR TITLE
feat(web): show project name on inbox cards

### DIFF
--- a/web/src/pages/InboxPage.test.tsx
+++ b/web/src/pages/InboxPage.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@/components/blocks/ApprovalCard", () => ({
 vi.mock("@/hooks/useConversations", async (importActual) => ({
   ...(await importActual<typeof conversationsHook>()),
   useConversations: vi.fn(),
+  useProjects: vi.fn(),
 }));
 vi.mock("@/hooks/useCommentInbox", () => ({ useCommentInbox: vi.fn() }));
 vi.mock("@/lib/sessionsApi", () => ({ getSession: vi.fn(), approve: vi.fn() }));
@@ -88,6 +89,11 @@ function conversationsStub(rows: Conversation[], overrides: Record<string, unkno
   } as unknown as ReturnType<typeof conversationsHook.useConversations>;
 }
 
+/** Build a useProjects stub for the given project summaries. */
+function projectsStub(projects: { id: string | null; name: string }[]) {
+  return { data: projects } as unknown as ReturnType<typeof conversationsHook.useProjects>;
+}
+
 /** Build a CommentInbox stub; empty and settled by default. */
 function commentInboxStub(overrides: Partial<CommentInbox> = {}): CommentInbox {
   return {
@@ -115,6 +121,9 @@ function renderPage() {
 
 beforeEach(() => {
   vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([]));
+  vi.mocked(conversationsHook.useProjects).mockReturnValue({
+    data: [],
+  } as unknown as ReturnType<typeof conversationsHook.useProjects>);
   vi.mocked(commentInboxHook.useCommentInbox).mockReturnValue(commentInboxStub());
   vi.mocked(sessionsApi.getSession).mockResolvedValue({
     pendingElicitations: [],
@@ -324,6 +333,110 @@ describe("InboxPage approval items", () => {
     await waitFor(() =>
       expect(sessionsApi.approve).toHaveBeenCalledWith("child", "eli_child", { action: "accept" }),
     );
+  });
+});
+
+describe("InboxPage project names", () => {
+  it("renders the project name on an approval card when project_id resolves via useProjects", async () => {
+    // WHY: a session filed via the first-class project_id shows its owning
+    // project's name next to the title, without hiding the title itself.
+    const row = conversation({ id: "sess_1", title: "My Session", project_id: "proj_1" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(conversationsHook.useProjects).mockReturnValue(
+      projectsStub([{ id: "proj_1", name: "Website Redesign" }]),
+    );
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    expect(await screen.findByTestId("inbox-project")).toHaveTextContent("Website Redesign");
+    expect(screen.getByText("My Session")).toBeInTheDocument();
+  });
+
+  it("renders no project tag for a session with no project_id and no omni_project label", async () => {
+    // WHY: an unfiled session's card stays exactly as it renders today —
+    // no folder icon, no separator, no empty element.
+    const row = conversation({ id: "sess_1", title: "My Session" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    await screen.findByText("My Session");
+    expect(screen.queryByTestId("inbox-project")).not.toBeInTheDocument();
+  });
+
+  it("renders the project name for a session filed only via the legacy omni_project label", async () => {
+    // WHY: sessions filed before the first-class project_id migration still
+    // resolve their project name from the legacy label.
+    const row = conversation({
+      id: "sess_1",
+      title: "My Session",
+      labels: { omni_project: "Legacy Project" },
+    });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    expect(await screen.findByTestId("inbox-project")).toHaveTextContent("Legacy Project");
+  });
+
+  it("carries the full project name in a title attribute for a long name", async () => {
+    // WHY: the project segment truncates visually via CSS, but the full
+    // name must stay available on hover via a native title attribute.
+    const longName =
+      "A Very Long Project Name That Should Truncate Visually But Not In The Title Attribute";
+    const row = conversation({ id: "sess_1", title: "My Session", project_id: "proj_1" });
+    vi.mocked(conversationsHook.useConversations).mockReturnValue(conversationsStub([row]));
+    vi.mocked(conversationsHook.useProjects).mockReturnValue(
+      projectsStub([{ id: "proj_1", name: longName }]),
+    );
+    vi.mocked(sessionsApi.getSession).mockResolvedValue({
+      pendingElicitations: [rawElicitation("eli_1", "Approve this?")],
+    } as unknown as Awaited<ReturnType<typeof sessionsApi.getSession>>);
+    renderPage();
+
+    const tag = await screen.findByTestId("inbox-project");
+    expect(within(tag).getByTitle(longName)).toHaveClass("truncate");
+  });
+
+  it("shows the project name next to the session name on a comment card", async () => {
+    // WHY: comment cards resolve the same project name as approval cards,
+    // rendered next to the session name line.
+    vi.mocked(conversationsHook.useProjects).mockReturnValue(
+      projectsStub([{ id: "proj_1", name: "Website Redesign" }]),
+    );
+    vi.mocked(commentInboxHook.useCommentInbox).mockReturnValue(
+      commentInboxStub({
+        items: [
+          {
+            row: conversation({
+              id: "sess_1",
+              title: "My Session",
+              pending_elicitations_count: 0,
+              project_id: "proj_1",
+            }),
+            comment: {
+              id: "cm_1",
+              path: "src/app.ts",
+              body: "Please reconsider this line.",
+              created_by: "alice",
+              created_at: 1_700_000_000,
+              updated_at: 1_700_000_000_000,
+              status: "draft",
+            } as CommentInbox["items"][number]["comment"],
+          },
+        ],
+      }),
+    );
+    renderPage();
+
+    expect(await screen.findByTestId("inbox-project")).toHaveTextContent("Website Redesign");
+    expect(screen.getByText("My Session")).toBeInTheDocument();
   });
 });
 

--- a/web/src/pages/InboxPage.tsx
+++ b/web/src/pages/InboxPage.tsx
@@ -35,12 +35,13 @@
  * the prompt timing out) is what clears an approval.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangleIcon,
   ArrowRightIcon,
   ChevronDownIcon,
+  FolderIcon,
   InboxIcon,
   Loader2Icon,
 } from "lucide-react";
@@ -49,7 +50,7 @@ import { PageScroll } from "@/components/PageScroll";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { useCommentInbox } from "@/hooks/useCommentInbox";
-import { useConversations } from "@/hooks/useConversations";
+import { useConversations, useProjects } from "@/hooks/useConversations";
 import { collectInboxItems, type InboxItem, type InboxSource } from "@/lib/inbox";
 import { relativeTime } from "@/lib/relativeTime";
 import { Link } from "@/lib/routing";
@@ -57,7 +58,28 @@ import { useOmnigentAnalytics } from "@/lib/analytics";
 import { approve, getSession } from "@/lib/sessionsApi";
 import { userColor, userInitials } from "@/lib/userBadge";
 import { cn } from "@/lib/utils";
-import { conversationDisplayLabel, getConversationAgentType } from "@/shell/sidebarNav";
+import {
+  conversationDisplayLabel,
+  conversationProjectName,
+  getConversationAgentType,
+} from "@/shell/sidebarNav";
+
+/** The owning project's folder icon + truncated name, shown on inbox cards for
+    a filed session. Mirrors the muted small-icon look of the sidebar's
+    pinned-project flyout (`PinnedProjectFlyoutContent`). */
+function InboxProjectTag({ name }: { name: string }) {
+  return (
+    <span
+      data-testid="inbox-project"
+      className="flex min-w-0 shrink items-center gap-1 text-sm text-muted-foreground"
+    >
+      <FolderIcon className="size-3.5 shrink-0" />
+      <span className="max-w-[12rem] truncate" title={name}>
+        {name}
+      </span>
+    </span>
+  );
+}
 
 /** Optimistic verdicts keyed by elicitation id, mirroring the chat store's flip. */
 type RespondedMap = Record<
@@ -74,6 +96,17 @@ export function InboxPage() {
   const { trackClick } = useOmnigentAnalytics();
   const conversationsQuery = useConversations("", false, { reconcileWhileConnected: true });
   const [responded, setResponded] = useState<RespondedMap>({});
+
+  // id → name for resolving each row's first-class `project_id` into a
+  // display name, same construction the sidebar uses.
+  const { data: projects = [] } = useProjects();
+  const projectNamesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects) {
+      if (p.id !== null) map.set(p.id, p.name);
+    }
+    return map;
+  }, [projects]);
   // Manual expand/collapse toggles keyed by elicitation id. Anything
   // not in the map falls back to the default: expanded only for the
   // first (newest) item. Keying by id (not index) keeps a user's
@@ -266,6 +299,7 @@ export function InboxPage() {
           // sessions, where the wrapper label IS the display label).
           const title = conversationDisplayLabel(item.row);
           const agentLabel = getConversationAgentType(item.row);
+          const projectName = conversationProjectName(item.row, projectNamesById);
           return (
             <div
               key={elicitationId}
@@ -292,6 +326,14 @@ export function InboxPage() {
                       !expanded && "-rotate-90",
                     )}
                   />
+                  {projectName != null && (
+                    <>
+                      <InboxProjectTag name={projectName} />
+                      <span aria-hidden className="shrink-0 text-muted-foreground">
+                        /
+                      </span>
+                    </>
+                  )}
                   <span className="min-w-0 shrink-0 truncate text-ui font-medium">
                     {title}
                     {agentLabel !== title && (
@@ -348,6 +390,7 @@ export function InboxPage() {
           // "You" fallback (the only human in that mode is the viewer).
           const author = comment.created_by ?? "You";
           const sessionTitle = conversationDisplayLabel(item.row);
+          const projectName = conversationProjectName(item.row, projectNamesById);
           return (
             <div
               key={comment.id}
@@ -398,7 +441,15 @@ export function InboxPage() {
                 <p className="line-clamp-3 text-ui break-words whitespace-pre-wrap">
                   {comment.body}
                 </p>
-                <span className="text-sm text-muted-foreground">{sessionTitle}</span>
+                {projectName != null ? (
+                  <span className="flex min-w-0 items-center gap-1 text-sm text-muted-foreground">
+                    <InboxProjectTag name={projectName} />
+                    <span aria-hidden>/</span>
+                    <span className="truncate">{sessionTitle}</span>
+                  </span>
+                ) : (
+                  <span className="text-sm text-muted-foreground">{sessionTitle}</span>
+                )}
               </div>
             </div>
           );

--- a/web/src/pages/InboxPage.tsx
+++ b/web/src/pages/InboxPage.tsx
@@ -334,7 +334,12 @@ export function InboxPage() {
                       </span>
                     </>
                   )}
-                  <span className="min-w-0 shrink-0 truncate text-ui font-medium">
+                  {/* No shrink-0 here: a filed session's project tag eats into this
+                      row's width budget, and a long title needs to be able to
+                      truncate under that pressure — otherwise it overflows and
+                      visually collides with the time/Open-session group instead
+                      of giving way. */}
+                  <span className="min-w-0 truncate text-ui font-medium">
                     {title}
                     {agentLabel !== title && (
                       <span className="ml-2 text-sm font-normal text-muted-foreground">

--- a/web/src/shell/sidebarNav.test.ts
+++ b/web/src/shell/sidebarNav.test.ts
@@ -6,6 +6,7 @@ import {
   bareConversationId,
   computeNextActiveOverride,
   conversationDisplayLabel,
+  conversationProjectName,
   dedupeConversationsById,
   filterConversations,
   getConversationIconKind,
@@ -19,7 +20,12 @@ function conversation(
   id: string,
   title: string | null,
   createdAt: Date,
-  options: { labels?: Record<string, string>; updatedAt?: Date; archived?: boolean } = {},
+  options: {
+    labels?: Record<string, string>;
+    updatedAt?: Date;
+    archived?: boolean;
+    projectId?: string | null;
+  } = {},
 ): Conversation {
   return {
     id,
@@ -30,6 +36,7 @@ function conversation(
     labels: options.labels ?? {},
     permission_level: null,
     archived: options.archived,
+    project_id: options.projectId,
   };
 }
 
@@ -461,6 +468,50 @@ describe("conversationDisplayLabel", () => {
         }),
       ),
     ).toBe("Claude Code");
+  });
+});
+
+describe("conversationProjectName", () => {
+  it("resolves the first-class project name via the id map", () => {
+    const conv = conversation("conv_a", "Title", new Date(2026, 4, 14, 9), {
+      projectId: "proj_1",
+    });
+    const projectNamesById = new Map([["proj_1", "Website Redesign"]]);
+    expect(conversationProjectName(conv, projectNamesById)).toBe("Website Redesign");
+  });
+
+  it("falls through to the legacy label when the project_id isn't in the map", () => {
+    const conv = conversation("conv_a", "Title", new Date(2026, 4, 14, 9), {
+      projectId: "proj_missing",
+      labels: { omni_project: "Legacy Name" },
+    });
+    expect(conversationProjectName(conv, new Map())).toBe("Legacy Name");
+  });
+
+  it("returns null when the project_id isn't in the map and there's no label", () => {
+    const conv = conversation("conv_a", "Title", new Date(2026, 4, 14, 9), {
+      projectId: "proj_missing",
+    });
+    expect(conversationProjectName(conv, new Map())).toBeNull();
+  });
+
+  it("resolves the legacy omni_project label when there's no first-class project_id", () => {
+    const conv = conversation("conv_a", "Title", new Date(2026, 4, 14, 9), {
+      labels: { omni_project: "Legacy Only" },
+    });
+    expect(conversationProjectName(conv, new Map())).toBe("Legacy Only");
+  });
+
+  it("treats an empty-string label as unfiled", () => {
+    const conv = conversation("conv_a", "Title", new Date(2026, 4, 14, 9), {
+      labels: { omni_project: "" },
+    });
+    expect(conversationProjectName(conv, new Map())).toBeNull();
+  });
+
+  it("returns null when neither a project_id nor a label is present", () => {
+    const conv = conversation("conv_a", "Title", new Date(2026, 4, 14, 9));
+    expect(conversationProjectName(conv, new Map())).toBeNull();
   });
 });
 

--- a/web/src/shell/sidebarNav.ts
+++ b/web/src/shell/sidebarNav.ts
@@ -1,7 +1,7 @@
 import type { Conversation } from "@/hooks/useConversations";
 import { nativeCodingAgentForWrapper, WRAPPER_LABEL_KEY } from "@/lib/nativeCodingAgents";
 import { getOptimisticTitle } from "@/lib/optimisticTitles";
-import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
+import { PINNED_LABEL_KEY, PROJECT_LABEL_KEY } from "@/lib/sessionListCache";
 
 export const PINNED_CONVERSATION_IDS_STORAGE_KEY = "omnigent:pinned-conversation-ids";
 
@@ -164,6 +164,24 @@ export function conversationDisplayLabel(conversation: Conversation): string {
   const label = nativeWrapperLabel(conversation);
   if (label !== null) return label;
   return UNTITLED_CONVERSATION_LABEL;
+}
+
+/**
+ * The project a session is filed under, or `null` when unfiled. Dual-read:
+ * prefer the first-class `project_id` membership (resolved via the caller's
+ * id → name map), falling back to the legacy `omni_project` label. An
+ * empty-string label reads as unfiled — the app clears membership by
+ * PATCHing that label to `""` rather than removing it.
+ */
+export function conversationProjectName(
+  conversation: Conversation,
+  projectNamesById: ReadonlyMap<string, string>,
+): string | null {
+  const firstClassName =
+    conversation.project_id != null ? projectNamesById.get(conversation.project_id) : undefined;
+  if (firstClassName !== undefined) return firstClassName;
+  const label = conversation.labels?.[PROJECT_LABEL_KEY];
+  return label ? label : null;
 }
 
 export function filterConversations(


### PR DESCRIPTION
## Related issue

Closes #6326

## Summary

- Inbox approval and comment cards now show the owning project's name. Each card shows a folder icon, then the name, then a slash, right before the session title or name. This shows a filed session's project without opening it.
- Adds `conversationProjectName()` to `sidebarNav.ts`. This pure helper repeats the sidebar's existing dual-read logic:
  - It prefers the first-class `project_id`, resolved through `useProjects()`.
  - If that is not available, it uses the legacy `omni_project` label.
  - If neither is available, it returns `null`.
  An empty-string label means the session is unfiled. This matches how the app clears project membership.
- A session with no project renders exactly as it does today: no icon, no separator, no extra element.

## Test Plan

Ran this command:

`pnpm --filter web exec vitest run src/pages/InboxPage.test.tsx src/shell/sidebarNav.test.ts`

All 72 tests passed. The run includes 6 new tests for `conversationProjectName`:

- a first-class project match
- a `project_id` missing from the map, which falls back to the label
- a legacy label only, with no `project_id`
- an empty-string label
- neither a `project_id` nor a label

The run also includes 5 new `InboxPage` tests:

- an approval card shows its first-class project
- a session with no project shows no project tag
- a session shows its legacy-label-only project
- a long project name shows the full text in a `title` attribute
- a comment card shows its session's project

Also ran, both clean:

- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `uv run --no-sync pre-commit run --from-ref HEAD~1 --to-ref HEAD`

## Demo

- [x] Visual demo attached below
<img width="1100" height="700" alt="inbox-project-name-demo" src="https://github.com/user-attachments/assets/54244db3-5ff5-44f5-aa2b-51b089320e3f" />

- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the helper and both card types. The manual browser check above has not run yet. A human should complete it and attach the screenshot or video before merge.

## Changelog

Inbox cards now show which project a filed session belongs to.
