### PR TITLE
Enable Fable during ucode setup

### DIFF
--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -69,6 +69,7 @@ def build_ucode_configure_command(
         ",".join(normalize_workspace_url(url) for url in workspace_urls),
         "--agents",
         ",".join(agents),
+        "--enable-fable",
     ]
 
 

--- a/tests/onboarding/test_ucode_setup.py
+++ b/tests/onboarding/test_ucode_setup.py
@@ -79,6 +79,7 @@ def test_build_ucode_configure_command_uses_workspaces() -> None:
         "https://one.example.databricks.com,https://two.example.databricks.com",
         "--agents",
         "claude,codex,pi",
+        "--enable-fable",
     ]
 
 
@@ -104,6 +105,7 @@ def test_build_ucode_configure_command_supports_uvx_prefix() -> None:
         "https://one.example.databricks.com",
         "--agents",
         "claude,codex,pi",
+        "--enable-fable",
     ]
 
 
@@ -189,6 +191,7 @@ def test_configure_ucode_for_workspace_targets_single_workspace() -> None:
             "https://example.cloud.databricks.com",
             "--agents",
             "claude,codex,pi",
+            "--enable-fable",
         ]
     ]
 
@@ -227,4 +230,5 @@ def test_build_ucode_configure_command_normalizes_pasted_url() -> None:
         "https://example.cloud.databricks.com",
         "--agents",
         "claude",
+        "--enable-fable",
     ]


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Pass `--enable-fable` whenever Omnigent configures ucode.
- Keep Fable available across both multi-workspace setup and single-workspace Databricks provider setup.

## Test Plan

- `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest tests/onboarding/test_ucode_setup.py -q`
- `.venv/bin/pre-commit run --files omnigent/onboarding/ucode_setup.py tests/onboarding/test_ucode_setup.py`
- Ran `ucode configure --profiles oss --agent claude --enable-fable --skip-upgrade` and confirmed validation succeeds and `system.ai.claude-fable-5-1` is recorded.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Updated every exact-argv unit assertion for the shared command builder and manually verified ucode discovers, records, and validates Fable 5.1 against the OSS workspace.

## Changelog

Databricks setup now makes Claude Fable models available through ucode.
