### PR TITLE
feat(scheduled): add active-range core module and persist columns

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1470,6 +1470,13 @@ class SqlScheduledTask(OmnigentBase):
         deterministic id at fire time, so there is nothing to pin).
     :param timezone: IANA timezone the trigger is evaluated in, e.g.
         ``"America/Los_Angeles"``.
+    :param active_range_start: Start of the daily time-of-day window (``"HH:MM"``,
+        24-hour) that gates which rule occurrences are allowed to fire,
+        evaluated in ``timezone``. ``None``, together with
+        ``active_range_end``, means unrestricted (fires on every rule
+        occurrence). Always set together with ``active_range_end``.
+    :param active_range_end: End of the active-range window (``"HH:MM"``),
+        evaluated in ``timezone``. See ``active_range_start``.
     :param state: Lifecycle state — ``active``/``paused``/``deleted``.
         The scheduler only dispatches ``active`` tasks.
         Stored as a stable int code (see omnigent.db.enum_codecs
@@ -1539,6 +1546,13 @@ class SqlScheduledTask(OmnigentBase):
     # there is nothing to pin here).
     host_id: Mapped[str | None] = mapped_column(Uuid16, nullable=True)
     timezone: Mapped[str] = mapped_column(String(64), nullable=False, server_default="UTC")
+    # Daily time-of-day window ("HH:MM", 24-hour) gating which rule
+    # occurrences are allowed to fire, evaluated in `timezone`. Both NULL
+    # means unrestricted (today's behavior); always set together. No CHECK
+    # constraint enforcing that pairing — SQLite regex CHECKs are unavailable
+    # under batch mode, and the route is the only writer, which validates.
+    active_range_start: Mapped[str | None] = mapped_column(String(5), nullable=True)
+    active_range_end: Mapped[str | None] = mapped_column(String(5), nullable=True)
     # Enum stored as a stable int code (see omnigent.db.enum_codecs
     # SCHEDULED_TASK_STATE: active=1, paused=2, deleted=3). The
     # store converts to/from the string name at the row↔entity boundary.

--- a/omnigent/db/migrations/versions/ga2b3c4d5e6f_add_scheduled_tasks_active_range.py
+++ b/omnigent/db/migrations/versions/ga2b3c4d5e6f_add_scheduled_tasks_active_range.py
@@ -1,0 +1,44 @@
+"""add active_range_start/active_range_end columns to scheduled_tasks
+
+Revision ID: ga2b3c4d5e6f
+Revises: ga1b2c3d4e5f
+Create Date: 2026-09-03 00:00:00.000000
+
+Adds an optional ``active_range_start`` / ``active_range_end`` pair (both
+``VARCHAR(5)``, nullable) to ``scheduled_tasks``: a daily time-of-day window
+("HH:MM", 24-hour) that gates which rule occurrences are allowed to fire. Both
+NULL means unrestricted (today's behavior); the route is the only writer and
+validates that they are always set together, so there is no CHECK constraint
+here (SQLite regex CHECKs are unavailable under batch mode).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "ga2b3c4d5e6f"
+down_revision: str | None = "ga1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add active_range_start/active_range_end to scheduled_tasks."""
+    op.add_column(
+        "scheduled_tasks",
+        sa.Column("active_range_start", sa.String(5), nullable=True),
+    )
+    op.add_column(
+        "scheduled_tasks",
+        sa.Column("active_range_end", sa.String(5), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove active_range_start/active_range_end from scheduled_tasks."""
+    with op.batch_alter_table("scheduled_tasks") as batch_op:
+        batch_op.drop_column("active_range_start")
+        batch_op.drop_column("active_range_end")

--- a/omnigent/entities/scheduled_task.py
+++ b/omnigent/entities/scheduled_task.py
@@ -41,6 +41,14 @@ class ScheduledTask:
     :param timezone: IANA timezone the trigger is evaluated in,
         e.g. ``"America/Los_Angeles"``.
     :param created_at: Unix epoch seconds at row creation.
+    :param active_range_start: Start of the daily time-of-day window
+        (``"HH:MM"``, 24-hour) that gates which ``rrule`` occurrences are
+        allowed to fire, evaluated in ``timezone``. ``None`` for both this and
+        ``active_range_end`` means unrestricted — the task fires on every
+        rule occurrence (today's behavior). Always set together with
+        ``active_range_end``.
+    :param active_range_end: End of the active-range window (``"HH:MM"``),
+        evaluated in ``timezone``. See ``active_range_start``.
     :param model_override: Per-task LLM model override, e.g.
         ``"claude-opus-4-7"``. ``None`` means use the agent default.
     :param reasoning_effort: Per-task reasoning-effort hint, e.g. ``"high"``.
@@ -82,6 +90,8 @@ class ScheduledTask:
     timezone: str
     created_at: int
     workspace_id: int = 0
+    active_range_start: str | None = None
+    active_range_end: str | None = None
     model_override: str | None = None
     reasoning_effort: str | None = None
     permission_mode: str | None = None

--- a/omnigent/server/scheduled/__init__.py
+++ b/omnigent/server/scheduled/__init__.py
@@ -1,10 +1,12 @@
 """Server-process scheduler for recurring scheduled tasks.
 
-Two pieces live here:
+Three pieces live here:
 
 * :mod:`omnigent.server.scheduled.rrule` — RRULE (RFC 5545) next-fire
   computation and the minimum-interval validator, backed by
   :mod:`dateutil.rrule`.
+* :mod:`omnigent.server.scheduled.active_range` — the optional time-of-day
+  window that further gates which rule occurrences are allowed to fire.
 * :mod:`omnigent.server.scheduled.scheduler` — the
   :class:`~omnigent.server.scheduled.scheduler.ScheduledTaskScheduler`, which
   arms one self-rearming timer per active scheduled task and invokes an injected
@@ -16,6 +18,14 @@ agent session) is supplied by the caller via the ``on_fire`` seam.
 
 from __future__ import annotations
 
+from omnigent.server.scheduled.active_range import (
+    ActiveRange,
+    ActiveRangeValidationError,
+    assert_fires_within_range,
+    next_fire_in_active_range,
+    parse_time_of_day,
+    validate_active_range,
+)
 from omnigent.server.scheduled.rrule import (
     MIN_INTERVAL_SECONDS,
     RRuleTrigger,
@@ -32,10 +42,16 @@ from omnigent.server.scheduled.scheduler import (
 __all__ = [
     "MIN_INTERVAL_SECONDS",
     "MISFIRE_GRACE_TIME_S",
+    "ActiveRange",
+    "ActiveRangeValidationError",
     "OnFire",
     "RRuleTrigger",
     "RRuleValidationError",
     "ScheduledTaskScheduler",
+    "assert_fires_within_range",
     "get_next_fire_time",
+    "next_fire_in_active_range",
+    "parse_time_of_day",
+    "validate_active_range",
     "validate_rrule",
 ]

--- a/omnigent/server/scheduled/active_range.py
+++ b/omnigent/server/scheduled/active_range.py
@@ -1,0 +1,192 @@
+"""Active-range gate on RRULE occurrences.
+
+A scheduled task's trigger is an RFC 5545 recurrence rule (see
+:mod:`omnigent.server.scheduled.rrule`) evaluated in a per-task IANA timezone.
+An "active range" is an optional time-of-day window (e.g. ``09:00``-``17:00``)
+that further restricts which rule occurrences are allowed to actually fire —
+so an hourly automation can be confined to business hours, for example. Both
+bounds are stored as ``"HH:MM"`` strings and are either both set or both
+unset; unset means the task is unrestricted (fires on every rule occurrence,
+today's behavior).
+
+This module is pure and has no dependency beyond :mod:`omnigent.server.scheduled.rrule`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from omnigent.server.scheduled.rrule import RRuleTrigger
+
+_TIME_OF_DAY_RE = re.compile(r"^([0-9]{2}):([0-9]{2})$")
+
+_UTC = ZoneInfo("UTC")
+
+# Fixed anchor for the reachability check in `assert_fires_within_range`,
+# mirroring `validate_rrule`'s fixed-anchor approach (rrule.py:34-39). A
+# constant UTC instant — rather than `datetime.now` — makes the verdict
+# deterministic: the same (trigger, range) pair always passes or fails
+# regardless of when the check runs. The anchor is a leap year (Jan 1, 2016)
+# so a rule pinned to Feb 29 still reaches an occurrence within the search
+# horizon.
+_REACHABILITY_ANCHOR = datetime(2016, 1, 1, tzinfo=_UTC)
+
+# Hard cap on how many candidate occurrences `next_fire_in_active_range` pulls
+# from the (lazily generated) trigger before giving up. Backstops the horizon
+# below against a sub-daily cadence that would otherwise walk many years of
+# candidates without ever tripping it.
+_MAX_RANGE_SKIPS = 2000
+
+# How far past `after` to search for a candidate landing inside the active
+# range before giving up. A full year covers any calendar-anchored rule (e.g.
+# a yearly BYMONTH/BYDAY combination) that only intersects the active range on
+# a handful of days a year.
+_RANGE_SEARCH_HORIZON = timedelta(days=366)
+
+
+class ActiveRangeValidationError(ValueError):
+    """Raised when an active-range bound is malformed or the range is invalid."""
+
+
+def parse_time_of_day(value: str) -> int:
+    """Parse a strict 24-hour ``"HH:MM"`` time-of-day string.
+
+    Both components must be exactly two digits (so ``"9:00"`` is rejected),
+    ``HH`` must be ``00``-``23``, and ``MM`` must be ``00``-``59``.
+
+    :param value: The time-of-day string to parse.
+    :returns: Minutes since midnight, ``0``-``1439``.
+    :raises ActiveRangeValidationError: If *value* is not a string, or is not
+        a valid strict ``HH:MM`` 24-hour time.
+    """
+    if not isinstance(value, str):
+        raise ActiveRangeValidationError(f"expected a string HH:MM time, got {value!r}")
+    match = _TIME_OF_DAY_RE.match(value)
+    if match is None:
+        raise ActiveRangeValidationError(
+            f"invalid time of day {value!r}; expected strict 24-hour HH:MM"
+        )
+    hour, minute = int(match.group(1)), int(match.group(2))
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ActiveRangeValidationError(
+            f"invalid time of day {value!r}; expected strict 24-hour HH:MM"
+        )
+    return hour * 60 + minute
+
+
+@dataclass(frozen=True)
+class ActiveRange:
+    """A time-of-day window, evaluated in whatever tzinfo the query moment carries.
+
+    :param start_minute: Range start, minutes since midnight (``0``-``1439``).
+    :param end_minute: Range end, minutes since midnight (``0``-``1439``).
+    """
+
+    start_minute: int
+    end_minute: int
+
+    def contains(self, moment: datetime) -> bool:
+        """Return whether *moment*'s wall-clock time falls inside this range.
+
+        Both endpoints are inclusive, at whole-minute resolution. When
+        ``start_minute < end_minute`` this is a same-day window (``start <= t
+        <= end``); when ``start_minute > end_minute`` the range wraps past
+        midnight (e.g. ``22:00``-``06:00``), so it admits ``t >= start`` OR
+        ``t <= end``. *moment* is read in its own ``tzinfo`` — callers pass a
+        datetime already localized to the task's timezone.
+
+        :param moment: A tz-aware datetime to test.
+        :returns: ``True`` if *moment* falls within the range.
+        """
+        t = moment.hour * 60 + moment.minute
+        if self.start_minute < self.end_minute:
+            return self.start_minute <= t <= self.end_minute
+        return t >= self.start_minute or t <= self.end_minute
+
+
+def validate_active_range(start: str | None, end: str | None) -> ActiveRange | None:
+    """Validate a pair of active-range bounds and build an :class:`ActiveRange`.
+
+    Both must be ``None`` (unrestricted — a task fires on every rule
+    occurrence, today's behavior) or both must be set.
+
+    :param start: Range start as ``"HH:MM"``, or ``None``.
+    :param end: Range end as ``"HH:MM"``, or ``None``.
+    :returns: An :class:`ActiveRange`, or ``None`` when both bounds are unset.
+    :raises ActiveRangeValidationError: If only one of *start*/*end* is set,
+        either is malformed, or they are equal.
+    """
+    if start is None and end is None:
+        return None
+    if start is None or end is None:
+        raise ActiveRangeValidationError(
+            "active_range_start and active_range_end must be set together"
+        )
+    start_minute = parse_time_of_day(start)
+    end_minute = parse_time_of_day(end)
+    if start_minute == end_minute:
+        raise ActiveRangeValidationError(
+            "start and end must differ; omit both for an always-active task"
+        )
+    return ActiveRange(start_minute=start_minute, end_minute=end_minute)
+
+
+def next_fire_in_active_range(
+    trigger: RRuleTrigger,
+    after: datetime,
+    tz: ZoneInfo,
+    active_range: ActiveRange | None,
+) -> datetime | None:
+    """Return the next occurrence of *trigger* after *after* that lands in *active_range*.
+
+    When *active_range* is ``None`` this delegates straight to
+    :meth:`RRuleTrigger.next_fire_after` — byte-identical to the unrestricted
+    behavior. Otherwise it walks candidate occurrences one at a time,
+    re-querying from the last rejected candidate, until one falls inside the
+    range. Bounded by :data:`_MAX_RANGE_SKIPS` and :data:`_RANGE_SEARCH_HORIZON`
+    past *after*, whichever trips first, so a rule that never lands in range
+    can't walk forever.
+
+    :param trigger: The validated RRULE trigger to search.
+    :param after: The instant to search after (tz-aware).
+    :param tz: The timezone occurrences are evaluated in.
+    :param active_range: The gating window, or ``None`` for unrestricted.
+    :returns: The next in-range occurrence, or ``None`` if the trigger is
+        exhausted or no occurrence lands in range within the search bound.
+    """
+    if active_range is None:
+        return trigger.next_fire_after(after, tz)
+    horizon = after + _RANGE_SEARCH_HORIZON
+    candidate = after
+    for _ in range(_MAX_RANGE_SKIPS):
+        candidate = trigger.next_fire_after(candidate, tz)
+        if candidate is None or candidate > horizon:
+            return None
+        if active_range.contains(candidate):
+            return candidate
+    return None
+
+
+def assert_fires_within_range(
+    trigger: RRuleTrigger,
+    active_range: ActiveRange,
+    tz: ZoneInfo,
+) -> None:
+    """Assert that *trigger* can ever land inside *active_range*.
+
+    A create/update-time guard: searches from a fixed anchor (rather than
+    "now") using the same bounded search as :func:`next_fire_in_active_range`,
+    so the verdict is wall-clock-independent — mirroring `validate_rrule`'s
+    fixed-anchor approach (rrule.py:34-39).
+
+    :param trigger: The validated RRULE trigger to check.
+    :param active_range: The gating window to check reachability against.
+    :param tz: The timezone occurrences are evaluated in.
+    :raises ActiveRangeValidationError: If no occurrence of *trigger* ever
+        lands inside *active_range*.
+    """
+    if next_fire_in_active_range(trigger, _REACHABILITY_ANCHOR, tz, active_range) is None:
+        raise ActiveRangeValidationError("schedule never fires inside the active range")

--- a/omnigent/stores/scheduled_task_store/__init__.py
+++ b/omnigent/stores/scheduled_task_store/__init__.py
@@ -55,6 +55,8 @@ class ScheduledTaskStore(ABC):
         workspace: str | None = None,
         host_id: str | None = None,
         state: str = "active",
+        active_range_start: str | None = None,
+        active_range_end: str | None = None,
     ) -> ScheduledTask:
         """
         Insert a new scheduled task.
@@ -77,6 +79,12 @@ class ScheduledTaskStore(ABC):
         :param host_id: The connected host to pin the run to.
         :param state: Lifecycle state — ``active``/``paused``/``deleted``.
             Defaults to ``"active"``.
+        :param active_range_start: Optional start of the daily time-of-day
+            window (``"HH:MM"``) gating which rule occurrences fire. Must be
+            set together with ``active_range_end``; ``None`` for both means
+            unrestricted.
+        :param active_range_end: Optional end of the active-range window
+            (``"HH:MM"``). See ``active_range_start``.
         :returns: The newly created :class:`ScheduledTask`.
         :raises ValueError: If ``state`` is not a recognized value.
         """
@@ -144,18 +152,23 @@ class ScheduledTaskStore(ABC):
         state: str | None = None,
         last_run_at: int | None = None,
         last_run_conversation_id: str | None = _UNSET,
+        active_range_start: str | None = _UNSET,
+        active_range_end: str | None = _UNSET,
     ) -> ScheduledTask | None:
         """
         Update mutable fields of a task.
 
         Most parameters use ``None`` to mean "leave unchanged". For the per-task
         overrides (``model_override``, ``reasoning_effort``,
-        ``permission_mode``), ``host_id``, ``max_cost_usd``, and
-        ``last_run_conversation_id``, the sentinel default means "not provided /
+        ``permission_mode``), ``host_id``, ``max_cost_usd``,
+        ``last_run_conversation_id``, ``active_range_start``, and
+        ``active_range_end``, the sentinel default means "not provided /
         leave unchanged"; passing ``None`` explicitly sets the column to NULL —
         so resetting an override to the agent default actually clears it (e.g.
-        turning a set ``bypassPermissions`` back off), and clearing a host
-        binding or nulling out a deleted last-run conversation.
+        turning a set ``bypassPermissions`` back off), clearing a host
+        binding or nulling out a deleted last-run conversation, and clearing
+        ``active_range_start``/``active_range_end`` back to an always-active
+        task.
 
         Passing ``rrule`` updates the recurring trigger; ``None``
         leaves it unchanged.

--- a/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
+++ b/omnigent/stores/scheduled_task_store/sqlalchemy_store.py
@@ -59,6 +59,8 @@ def _to_entity(row: SqlScheduledTask) -> ScheduledTask:
         base_branch=row.base_branch,
         execution_target=decode_scheduled_task_execution_target(row.execution_target),
         host_id=row.host_id,
+        active_range_start=row.active_range_start,
+        active_range_end=row.active_range_end,
         state=decode_scheduled_task_state(row.state),
         last_run_at=row.last_run_at,
         last_run_conversation_id=row.last_run_conversation_id,
@@ -134,6 +136,8 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         workspace: str | None = None,
         host_id: str | None = None,
         state: str = "active",
+        active_range_start: str | None = None,
+        active_range_end: str | None = None,
     ) -> ScheduledTask:
         """Insert a new scheduled task with a required recurring ``rrule``."""
         row = SqlScheduledTask(
@@ -152,6 +156,8 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
             base_branch=None,
             execution_target=encode_scheduled_task_execution_target("connected_host"),
             host_id=host_id,
+            active_range_start=active_range_start,
+            active_range_end=active_range_end,
             state=encode_scheduled_task_state(state),
             last_run_at=None,
             last_run_conversation_id=None,
@@ -260,19 +266,23 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
         state: str | None = None,
         last_run_at: int | None = None,
         last_run_conversation_id: str | None = _UNSET,
+        active_range_start: str | None = _UNSET,
+        active_range_end: str | None = _UNSET,
     ) -> ScheduledTask | None:
         """Update mutable fields.
 
         ``None`` leaves most fields unchanged. For the per-task overrides
         (``model_override``, ``reasoning_effort``, ``permission_mode``),
-        ``host_id``, ``max_cost_usd``, and ``last_run_conversation_id``, the
-        sentinel default means "not provided / leave unchanged"; passing
-        ``None`` explicitly sets the column to NULL — so resetting an override
-        to the agent default actually clears it (a set ``bypassPermissions``
-        can be turned back off). Passing ``rrule`` updates the recurring
-        trigger and ``agent_id`` rebinds the task to a different agent
-        (switching the harness future firings run); ``None`` leaves either
-        unchanged.
+        ``host_id``, ``max_cost_usd``, ``last_run_conversation_id``,
+        ``active_range_start``, and ``active_range_end``, the sentinel default
+        means "not provided / leave unchanged"; passing ``None`` explicitly
+        sets the column to NULL — so resetting an override to the agent
+        default actually clears it (a set ``bypassPermissions`` can be turned
+        back off), and explicitly passing ``None`` for both active-range bounds
+        clears the task back to always-active. Passing ``rrule`` updates the
+        recurring trigger and ``agent_id`` rebinds the task to a different
+        agent (switching the harness future firings run); ``None`` leaves
+        either unchanged.
         """
         with self._session("update_task") as session:
             row = session.get(SqlScheduledTask, (current_workspace_id(), scheduled_task_id))
@@ -311,6 +321,12 @@ class SqlAlchemyScheduledTaskStore(ScheduledTaskStore):
                 changed = True
             if host_id is not _UNSET and row.host_id != host_id:
                 row.host_id = host_id
+                changed = True
+            if active_range_start is not _UNSET and row.active_range_start != active_range_start:
+                row.active_range_start = active_range_start
+                changed = True
+            if active_range_end is not _UNSET and row.active_range_end != active_range_end:
+                row.active_range_end = active_range_end
                 changed = True
             if state is not None:
                 encoded_state = encode_scheduled_task_state(state)

--- a/tests/db/test_migration_scheduled_tasks.py
+++ b/tests/db/test_migration_scheduled_tasks.py
@@ -67,6 +67,8 @@ def test_scheduled_tasks_columns(db_engine: Engine) -> None:
         "execution_target",
         "host_id",
         "timezone",
+        "active_range_start",
+        "active_range_end",
         "state",
         "last_run_at",
         "last_run_conversation_id",

--- a/tests/server/scheduled/test_active_range.py
+++ b/tests/server/scheduled/test_active_range.py
@@ -1,0 +1,167 @@
+"""Tests for the active-range gate on RRULE occurrences.
+
+Exercises :func:`parse_time_of_day`, :class:`ActiveRange` boundary/overnight
+semantics, :func:`validate_active_range` rejections, and the bounded
+skip-search in :func:`next_fire_in_active_range` / :func:`assert_fires_within_range`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from omnigent.server.scheduled.active_range import (
+    ActiveRangeValidationError,
+    assert_fires_within_range,
+    next_fire_in_active_range,
+    parse_time_of_day,
+    validate_active_range,
+)
+from omnigent.server.scheduled.rrule import RRuleTrigger
+
+UTC = ZoneInfo("UTC")
+
+
+def _dt(y: int, mo: int, d: int, h: int = 0, mi: int = 0, tz: ZoneInfo = UTC) -> datetime:
+    return datetime(y, mo, d, h, mi, tzinfo=tz)
+
+
+# ── parse_time_of_day ─────────────────────────────────────────────────────────
+
+
+def test_parse_time_of_day_returns_minutes_since_midnight() -> None:
+    assert parse_time_of_day("00:00") == 0
+    assert parse_time_of_day("09:00") == 540
+    assert parse_time_of_day("23:59") == 1439
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["9:00", "25:00", "09:60", "", "9am", "09:0", "24:00"],
+)
+def test_parse_time_of_day_rejects_bad_format(value: str) -> None:
+    with pytest.raises(ActiveRangeValidationError):
+        parse_time_of_day(value)
+
+
+def test_parse_time_of_day_rejects_non_string() -> None:
+    with pytest.raises(ActiveRangeValidationError):
+        parse_time_of_day(540)  # type: ignore[arg-type]
+
+
+# ── ActiveRange.contains ───────────────────────────────────────────────────────
+
+
+def test_daytime_range_boundary_inclusive_at_both_ends() -> None:
+    rng = validate_active_range("09:00", "17:00")
+    assert rng is not None
+    assert rng.contains(_dt(2026, 1, 1, 9, 0))
+    assert rng.contains(_dt(2026, 1, 1, 17, 0))
+
+
+def test_daytime_range_excludes_just_outside_both_ends() -> None:
+    rng = validate_active_range("09:00", "17:00")
+    assert rng is not None
+    assert not rng.contains(_dt(2026, 1, 1, 8, 59))
+    assert not rng.contains(_dt(2026, 1, 1, 17, 1))
+
+
+def test_overnight_range_wraps_midnight() -> None:
+    rng = validate_active_range("22:00", "06:00")
+    assert rng is not None
+    assert rng.contains(_dt(2026, 1, 1, 23, 0))
+    assert rng.contains(_dt(2026, 1, 1, 2, 0))
+    assert rng.contains(_dt(2026, 1, 1, 6, 0))
+    assert not rng.contains(_dt(2026, 1, 1, 7, 0))
+    assert not rng.contains(_dt(2026, 1, 1, 21, 59))
+
+
+# ── validate_active_range ──────────────────────────────────────────────────────
+
+
+def test_validate_active_range_none_when_both_unset() -> None:
+    assert validate_active_range(None, None) is None
+
+
+def test_validate_active_range_rejects_one_sided() -> None:
+    with pytest.raises(ActiveRangeValidationError):
+        validate_active_range("09:00", None)
+    with pytest.raises(ActiveRangeValidationError):
+        validate_active_range(None, "17:00")
+
+
+def test_validate_active_range_rejects_bad_format() -> None:
+    with pytest.raises(ActiveRangeValidationError):
+        validate_active_range("9:00", "17:00")
+
+
+def test_validate_active_range_rejects_equal_start_and_end() -> None:
+    with pytest.raises(ActiveRangeValidationError):
+        validate_active_range("09:00", "09:00")
+
+
+# ── next_fire_in_active_range ──────────────────────────────────────────────────
+
+
+def test_no_range_delegates_to_next_fire_after() -> None:
+    trigger = RRuleTrigger(rule="FREQ=HOURLY")
+    after = _dt(2026, 1, 1, 8, 30)
+    assert next_fire_in_active_range(trigger, after, UTC, None) == trigger.next_fire_after(
+        after, UTC
+    )
+
+
+def test_hourly_skips_to_next_day_after_close_of_range() -> None:
+    trigger = RRuleTrigger(rule="FREQ=HOURLY")
+    rng = validate_active_range("09:00", "17:00")
+    assert rng is not None
+    got = next_fire_in_active_range(trigger, _dt(2026, 1, 1, 17, 0), UTC, rng)
+    assert got == _dt(2026, 1, 2, 9, 0)
+
+
+def test_overnight_range_admits_early_morning_and_late_night_fires() -> None:
+    trigger = RRuleTrigger(rule="FREQ=HOURLY")
+    rng = validate_active_range("22:00", "06:00")
+    assert rng is not None
+    assert next_fire_in_active_range(trigger, _dt(2026, 1, 1, 22, 30), UTC, rng) == _dt(
+        2026, 1, 1, 23, 0
+    )
+    assert next_fire_in_active_range(trigger, _dt(2026, 1, 2, 1, 30), UTC, rng) == _dt(
+        2026, 1, 2, 2, 0
+    )
+
+
+def test_exhausted_trigger_returns_none() -> None:
+    # COUNT=1 fires once, outside the range, then the trigger is exhausted.
+    trigger = RRuleTrigger(rule="FREQ=DAILY;BYHOUR=3;BYMINUTE=0;COUNT=1")
+    rng = validate_active_range("09:00", "17:00")
+    assert rng is not None
+    assert next_fire_in_active_range(trigger, _dt(2026, 1, 1, 0, 0), UTC, rng) is None
+
+
+def test_search_gives_up_when_never_in_range_within_horizon() -> None:
+    # Fires every day at 03:00, forever, never once landing in 09:00-17:00.
+    trigger = RRuleTrigger(rule="FREQ=DAILY;BYHOUR=3;BYMINUTE=0")
+    rng = validate_active_range("09:00", "17:00")
+    assert rng is not None
+    assert next_fire_in_active_range(trigger, _dt(2026, 1, 1, 0, 0), UTC, rng) is None
+
+
+# ── assert_fires_within_range ───────────────────────────────────────────────────
+
+
+def test_assert_fires_within_range_passes_for_reachable_schedule() -> None:
+    trigger = RRuleTrigger(rule="FREQ=HOURLY")
+    rng = validate_active_range("09:00", "17:00")
+    assert rng is not None
+    assert_fires_within_range(trigger, rng, UTC)
+
+
+def test_assert_fires_within_range_raises_when_never_reachable() -> None:
+    trigger = RRuleTrigger(rule="FREQ=DAILY;BYHOUR=3;BYMINUTE=0")
+    rng = validate_active_range("09:00", "17:00")
+    assert rng is not None
+    with pytest.raises(ActiveRangeValidationError):
+        assert_fires_within_range(trigger, rng, UTC)

--- a/tests/stores/test_scheduled_task_store.py
+++ b/tests/stores/test_scheduled_task_store.py
@@ -815,6 +815,118 @@ def test_update_clearing_already_null_field_is_noop_for_updated_at(
     assert result.updated_at is None
 
 
+# ── active range ─────────────────────────────────────────────────────────────
+
+
+def test_create_with_active_range_round_trips(store: SqlAlchemyScheduledTaskStore) -> None:
+    """``active_range_start``/``active_range_end`` round-trip through create."""
+    task = store.create(
+        scheduled_task_id=_uid("st_range_create"),
+        name="n",
+        prompt="p",
+        rrule="FREQ=HOURLY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+        active_range_start="09:00",
+        active_range_end="17:00",
+    )
+    assert task.active_range_start == "09:00"
+    assert task.active_range_end == "17:00"
+    fetched = store.get(_uid("st_range_create"))
+    assert fetched is not None
+    assert fetched.active_range_start == "09:00"
+    assert fetched.active_range_end == "17:00"
+
+
+def test_create_without_active_range_defaults_to_none(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """Omitting the active-range bounds leaves the task unrestricted."""
+    task = store.create(
+        scheduled_task_id=_uid("st_range_default"),
+        name="n",
+        prompt="p",
+        rrule="FREQ=HOURLY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+    )
+    assert task.active_range_start is None
+    assert task.active_range_end is None
+
+
+def test_update_active_range_reads_back(store: SqlAlchemyScheduledTaskStore) -> None:
+    """Setting the active range via ``update`` reads the new bounds back."""
+    store.create(
+        scheduled_task_id=_uid("st_range_update"),
+        name="n",
+        prompt="p",
+        rrule="FREQ=HOURLY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+    )
+    updated = store.update(
+        _uid("st_range_update"),
+        active_range_start="22:00",
+        active_range_end="06:00",
+    )
+    assert updated is not None
+    assert updated.active_range_start == "22:00"
+    assert updated.active_range_end == "06:00"
+
+
+def test_update_active_range_can_be_cleared_to_none(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """Explicitly passing ``None`` for both bounds clears the task back to always-active."""
+    store.create(
+        scheduled_task_id=_uid("st_range_clear"),
+        name="n",
+        prompt="p",
+        rrule="FREQ=HOURLY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+        active_range_start="09:00",
+        active_range_end="17:00",
+    )
+    updated = store.update(
+        _uid("st_range_clear"),
+        active_range_start=None,
+        active_range_end=None,
+    )
+    assert updated is not None
+    assert updated.active_range_start is None
+    assert updated.active_range_end is None
+    fetched = store.get(_uid("st_range_clear"))
+    assert fetched is not None
+    assert fetched.active_range_start is None
+    assert fetched.active_range_end is None
+
+
+def test_update_omitting_active_range_leaves_it_unchanged(
+    store: SqlAlchemyScheduledTaskStore,
+) -> None:
+    """Omitting the active-range params does NOT clear them (sentinel = unchanged)."""
+    store.create(
+        scheduled_task_id=_uid("st_range_keep"),
+        name="n",
+        prompt="p",
+        rrule="FREQ=HOURLY",
+        user_id="u",
+        agent_id=_uid("ag"),
+        timezone="UTC",
+        active_range_start="09:00",
+        active_range_end="17:00",
+    )
+    updated = store.update(_uid("st_range_keep"), name="renamed")
+    assert updated is not None
+    assert updated.active_range_start == "09:00"
+    assert updated.active_range_end == "17:00"
+
+
 # ── delete: cascade cleanup of runs (Finding 2) ──────────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #

Part of a 4-part change adding an optional per-task "active range" (a
time-of-day window, e.g. 09:00-17:00) that gates which RRULE occurrences of a
scheduled task are allowed to fire, so a tight cadence like hourly can be
confined to business hours. This PR is task 1: the core module and
persistence layer. Scheduler gating, the REST API/tools, and the web UI
follow in later PRs and depend on the names/signatures introduced here.

## Summary

- New `omnigent/server/scheduled/active_range.py`: `parse_time_of_day` (strict
  24-hour `HH:MM`), the frozen `ActiveRange` dataclass (`contains`, with
  inclusive same-day and overnight-wrap semantics), `validate_active_range`
  (both-or-neither bound validation), `next_fire_in_active_range` (bounded
  skip-search over `RRuleTrigger.next_fire_after`, byte-identical passthrough
  when unrestricted), and `assert_fires_within_range` (create/update-time
  reachability guard, fixed-anchor like `validate_rrule`). Re-exported from
  `omnigent/server/scheduled/__init__.py`.
- Adds nullable `active_range_start` / `active_range_end` (`VARCHAR(5)`,
  `"HH:MM"`) columns to `scheduled_tasks`, next to `timezone`. New Alembic
  migration `ga2b3c4d5e6f` (head was `ga1b2c3d4e5f`); no CHECK constraint —
  SQLite regex CHECKs aren't available under batch mode, and the route (added
  in a later PR) is the only writer and validates.
- Plumbs both fields through the `ScheduledTask` entity and
  `ScheduledTaskStore` (`create` takes plain `str | None` kwargs; `update` uses
  the existing `_UNSET` sentinel so an explicit `None` clears the range back to
  always-active while omitting the kwarg leaves it untouched).

## Test Plan

```
uv sync --extra all --group dev
uv run --no-sync pytest tests/server/scheduled/test_active_range.py tests/stores/test_scheduled_task_store.py tests/db/test_migration_scheduled_tasks.py
uv run --no-sync pre-commit run --from-ref origin/main --to-ref HEAD
```

96 tests collected and passing across the three files above (new
`test_active_range.py`, plus extended `test_scheduled_task_store.py` and
`test_migration_scheduled_tasks.py`). `pre-commit` (ruff format/check, pyrefly,
and the repo's other hooks) passes clean on the diff.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

Backend-only: this PR adds the module and columns but nothing yet reads
`active_range_start`/`active_range_end` at fire time (that's the scheduler
PR), so there is no observable behavior change.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover `parse_time_of_day`, `ActiveRange.contains` (same-day and
overnight-wrap boundaries), `validate_active_range` rejections, the bounded
skip-search in `next_fire_in_active_range` (including exhaustion and
horizon-bounded give-up), and `assert_fires_within_range`. The migration test's
exact column-set assertion and the store's create/update/round-trip tests are
extended to cover the two new columns.

<!-- Changelog intentionally omitted: no user-facing behavior change yet. -->