### PR TITLE
fix(claude-native): stop a healthy terminal from failing the turn and being killed

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -159,6 +159,12 @@ _COMPOSER_MODE_GLYPHS = (_CLAUDE_PROMPT_GLYPH, _SHELL_MODE_GLYPH)
 # :func:`_permission_mode_from_pane`). Corner glyphs are included because
 # Claude Code has framed the input box both ways across versions.
 _BOX_RULE_CHARS = frozenset("─━╭╮╰╯│┃╌╍")
+# Glyphs a labelled rule may begin or end with. Excludes the verticals, so a
+# framed body row (``│ some text``) can never read as a rule.
+_RULE_EDGE_CHARS = frozenset("─━╭╮╰╯╌╍")
+# Leading rule glyphs required before a rule's label, enough to rule out prose
+# that merely starts with a dash glyph.
+_TITLED_RULE_MIN_LEAD = 3
 # Footer rows the permission-mode reader falls back to scanning while the
 # input box has not mounted yet and no rule is on screen to anchor on.
 _PROMPT_SCAN_TAIL_LINES = 5
@@ -249,6 +255,10 @@ _FOREIGN_DIALOG_HINTS = (
     "Do you want to ",
     "Yes, and don't ask again",
 )
+# Footer under every Claude Code selection dialog's options. Matched instead of
+# the dialog titles, which are open-ended — each release adds prompts. Lowercase
+# and the confirm half only: the cancel half has several spellings.
+_PENDING_DIALOG_FOOTER = "enter to confirm"
 # Seconds to wait for a confirmation dialog before concluding none appears.
 # Bounds the common no-dialog case (a fresh session never pops one) while
 # still covering the slow warm-session render.
@@ -275,6 +285,15 @@ ToolExecutor = Callable[[str, _JsonObject], Awaitable[object]]
 
 class ClaudePromptTimeout(RuntimeError):
     """Claude Code's input box did not render before delivery timed out."""
+
+
+class ClaudePromptBlocked(ClaudePromptTimeout):
+    """Claude Code is waiting on a dialog only a person can answer.
+
+    A subclass because the delivery still failed, so existing
+    ``except ClaudePromptTimeout`` handlers stay correct. Only the remedy
+    differs: the terminal is healthy, so leave it alone instead of reaping it.
+    """
 
 
 class TmuxSessionNotAdvertised(RuntimeError):
@@ -4146,11 +4165,23 @@ def _is_box_rule(line: str) -> bool:
     the rule directly above the composer, so it is the position that
     identifies the box, not the corners.
 
-    :param line: A single pane line, e.g. ``"──────────"``.
+    A rule may also carry a label, which Claude Code draws inline on the
+    composer's opening rule (``─── my session ─``); the composer beneath such
+    a rule is unreachable unless it counts. A labelled rule is identified by
+    its edges — :data:`_TITLED_RULE_MIN_LEAD` leading glyphs and a trailing
+    one, from :data:`_RULE_EDGE_CHARS`.
+
+    :param line: A single pane line, e.g. ``"──────────"`` or
+        ``"─── my session ─"``.
     :returns: ``True`` when the line is a box-drawing rule.
     """
     stripped = line.strip()
-    return len(stripped) >= 3 and all(ch in _BOX_RULE_CHARS for ch in stripped)
+    if len(stripped) < 3:
+        return False
+    if all(ch in _BOX_RULE_CHARS for ch in stripped):
+        return True
+    lead = stripped[:_TITLED_RULE_MIN_LEAD]
+    return all(ch in _RULE_EDGE_CHARS for ch in lead) and stripped[-1] in _RULE_EDGE_CHARS
 
 
 def _submit_needle(content: str) -> str:
@@ -4296,7 +4327,17 @@ def _wait_for_claude_prompt_ready(
         if time.monotonic() >= deadline:
             break
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    # Timed out. The poll/empty-capture counts separate the failure modes:
+    # Timed out. A dialog awaiting a keypress is not a boot failure — the TUI
+    # is healthy and simply cannot mount the composer until someone answers —
+    # so it gets its own error, and the caller leaves the terminal alone.
+    if _PENDING_DIALOG_FOOTER in last_nonempty.lower():
+        raise ClaudePromptBlocked(
+            "Claude Code is waiting for an answer in its terminal, so the "
+            f"message was not delivered (waited {timeout_s}s). Open the "
+            "terminal and answer the prompt, then send again."
+            + _format_terminal_failure_tail(last_nonempty)
+        )
+    # The poll/empty-capture counts separate the remaining failure modes:
     # mostly-empty captures point at a torn read under a busy repaint (the
     # session is alive but capture-pane came back blank); non-empty captures
     # with no box point at Claude never rendering the prompt (a boot crash,

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -13,6 +13,7 @@ from omnigent.claude_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
     REQUEST_SESSION_ID_ENV_VAR,
     SWITCH_MODEL_DIALOG_HINT,
+    ClaudePromptBlocked,
     ClaudePromptTimeout,
     TmuxSessionNotAdvertised,
     inject_slash_command,
@@ -198,6 +199,15 @@ class ClaudeNativeExecutor(Executor):
                         self._bridge_dir,
                         content=text,
                     )
+        except ClaudePromptBlocked as exc:
+            # Parked on a dialog, so there is nothing to reap: killing the pane
+            # would discard the session and the prompt awaiting an answer.
+            _logger.warning(
+                "claude-native: harness is waiting on a dialog; message not delivered",
+                extra={"session_id": self._request_session_id},
+            )
+            yield ExecutorError(message=describe_exception(exc))
+            return
         except ClaudePromptTimeout as exc:
             _logger.exception(
                 "claude-native: prompt delivery to harness timed out",

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -12,6 +12,7 @@ import pytest
 
 from omnigent.claude_native_bridge import (
     REQUEST_SESSION_ID_ENV_VAR,
+    ClaudePromptBlocked,
     ClaudePromptTimeout,
     TmuxSessionNotAdvertised,
 )
@@ -1263,6 +1264,49 @@ async def test_run_turn_reaps_tmux_before_reporting_prompt_timeout(
     assert killed == [bridge_dir]
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
+
+
+@pytest.mark.asyncio
+async def test_run_turn_leaves_the_pane_alive_when_a_dialog_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A harness parked on a dialog is not reaped.
+
+    ``ClaudePromptBlocked`` means the terminal is alive and waiting on a
+    prompt, so the turn must fail without killing the session holding it.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Pytest temporary directory fixture.
+    :returns: None.
+    """
+    killed: list[Path] = []
+
+    def blocked_inject(bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise ClaudePromptBlocked("Claude Code is waiting for an answer in its terminal")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", blocked_inject)
+    monkeypatch.setattr(
+        claude_native_executor,
+        "kill_session",
+        lambda bridge_dir_arg, *, timeout_s: killed.append(bridge_dir_arg),
+    )
+
+    executor = ClaudeNativeExecutor(tmp_path / "bridge")
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            system_prompt="",
+        )
+    ]
+
+    assert killed == []
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "waiting for an answer" in events[0].message
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -28,6 +28,7 @@ from omnigent.claude_native_bridge import (
     _claude_prompt_rendered,
     _escape_unsupported_slash_command,
     _hook_record_from_jsonl_record,
+    _is_box_rule,
     _JsonlRecord,
     _occupying_surface,
     augment_claude_args,
@@ -6896,6 +6897,39 @@ def test_claude_prompt_rendered_ignores_custom_api_key_menu() -> None:
     assert _claude_prompt_rendered(pane) is False
 
 
+def test_claude_prompt_rendered_sees_prompt_under_titled_rule() -> None:
+    """A label drawn on the composer's opening rule still reads as ready.
+
+    Claude Code draws the session's name inline on the box's top rule, and a
+    frame that goes unrecognized hides the composer directly beneath it — a
+    healthy input box then reports "not ready" for the gate's whole timeout.
+    """
+    pane = "\n".join(
+        [
+            "  Ran 1 shell command",
+            "──────────────────────────── my session ─",
+            "❯",  # the live composer, under a LABELLED opening rule
+            "─────────────────────────────────────────",
+            "  ⏸ manual mode on",
+        ]
+    )
+    assert _claude_prompt_rendered(pane) is True
+
+
+def test_is_box_rule_rejects_a_framed_body_row() -> None:
+    """A framed body row is not a rule, however it starts.
+
+    The labelled-rule spelling widens :func:`_is_box_rule`, so the vertical
+    glyph must stay out of a rule's edges: ``│ some text`` would otherwise read
+    as a rule and offer the row beneath it as the composer.
+    """
+    assert _is_box_rule("│ some text") is False
+    assert _is_box_rule("  │ [note] a framed hint row") is False
+    # Still recognized: the plain and labelled spellings.
+    assert _is_box_rule("─────────") is True
+    assert _is_box_rule("──────── my session ─") is True
+
+
 def test_claude_prompt_rendered_sees_chat_input_below_menu_glyph() -> None:
     """A real chat prompt still reads ready even past a menu-shaped echo.
 
@@ -7394,6 +7428,45 @@ def test_wait_for_claude_prompt_ready_reports_empty_capture_count(
     assert "1 polls, 1 empty captures" in message
     # No pane text to surface when every capture was empty.
     assert "Last terminal output:" not in message
+
+
+def test_wait_for_claude_prompt_ready_reports_a_pending_dialog_separately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dialog awaiting a keypress raises ``ClaudePromptBlocked``, not a boot timeout.
+
+    A selection dialog blocks the composer until a person answers. Calling that
+    a failed boot misdiagnoses a healthy terminal and, via the executor's reap,
+    kills the session holding the unanswered prompt.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    dialog_pane = "\n".join(
+        [
+            "  New MCP server found in this project: example",
+            "  MCP servers may execute code or access system resources.",
+            "    Use this MCP server",
+            "  ❯ Continue without using this MCP server",
+            "  Enter to confirm · Esc to cancel",
+        ]
+    )
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._capture_pane",
+        lambda socket_path, tmux_target: dialog_pane,
+    )
+    with pytest.raises(claude_native_bridge.ClaudePromptBlocked) as excinfo:
+        claude_native_bridge._wait_for_claude_prompt_ready(
+            "/tmp/example/tmux.sock",
+            "claude:0.0",
+            timeout_s=0.0,
+        )
+    message = str(excinfo.value)
+    assert "waiting for an answer in its terminal" in message
+    # The boot-failure wording must not be used for a healthy terminal.
+    assert "did not become ready" not in message
+    # The dialog itself is attached so the person knows what to answer.
+    assert "New MCP server found in this project" in message
 
 
 def test_wait_for_claude_prompt_ready_tail_is_observed_not_recaptured(


### PR DESCRIPTION
## Related issue

Closes #

<!-- No tracking issue: found in production telemetry rather than a filed report. -->

## Summary

The claude-native readiness gate waits for the composer to render, treats any timeout as "Claude Code failed to boot", and the executor then **reaps the pane**. Two cases reach that path with a perfectly healthy terminal — and in both, the reap throws away the person's live session.

**1. A labelled composer rule.** Claude Code draws the session's name inline on the input box's opening rule (`─── my session ─`), but `_is_box_rule` required *every* glyph on the line to be box-drawing. The frame went unrecognized, `_composer_row` never located the row beneath it, and a fully mounted input box reported "not ready" for the gate's whole timeout. A labelled rule is now recognized by its edges, with the verticals kept out of `_RULE_EDGE_CHARS` so a framed body row (`│ some text`) still cannot read as a rule.

**2. A dialog awaiting a keypress.** The "New MCP server found in this project" trust prompt and the external-CLAUDE.md import approval park the TUI until a person answers, so the composer cannot mount. That is not a boot failure — the harness is alive and the remedy is to answer the prompt. The gate now raises a new `ClaudePromptBlocked`, which says what to answer and attaches the dialog, and the executor skips the reap: killing the pane there destroys the very prompt that needed answering.

`ClaudePromptBlocked` subclasses `ClaudePromptTimeout`, so every existing `except ClaudePromptTimeout` handler keeps catching it — the delivery still failed, only the remedy differs.

Detection matches the dialogs' shared `Enter to confirm` footer rather than their titles: titles are open-ended (each release adds prompts), while the footer is the stable tell that the TUI is parked.

```
before:  healthy terminal ──timeout──> "Claude Code failed to boot" ──> pane killed
after:   labelled rule    ──────────> composer found, turn proceeds
         pending dialog   ──────────> "answer the prompt, then send again", pane left alive
```

## Test Plan

Four tests added, each verified to fail with its own half of the fix reverted:

- `test_claude_prompt_rendered_sees_prompt_under_titled_rule` — a composer under a labelled opening rule reads ready.
- `test_is_box_rule_rejects_a_framed_body_row` — guards the widening: `│ some text` is still not a rule, and both rule spellings still are.
- `test_wait_for_claude_prompt_ready_reports_a_pending_dialog_separately` — an MCP-trust dialog raises `ClaudePromptBlocked`, not the boot-failure wording, and the dialog is attached.
- `test_run_turn_leaves_the_pane_alive_when_a_dialog_is_pending` — asserts `kill_session` is never called on that path.

```
$ pytest tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py
324 passed

$ pytest tests/test_claude_native.py tests/test_claude_native_status.py \
         tests/test_claude_native_state.py tests/test_claude_native_forwarder.py \
         tests/test_antigravity_native_bridge.py
622 passed
```

The wider run is there because `_is_box_rule` is shared pane-parsing infrastructure — the readiness gate, the permission-mode footer reader and the composer locator all anchor on it, so loosening it needed a regression sweep beyond the two files touched.

## Demo

N/A — terminal-side behaviour; the user-visible change is the error text and the session no longer being killed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

A message sent while Claude Code is waiting on a prompt in its terminal now tells you to answer it, instead of failing the turn and killing the session.
