### PR TITLE
fix(agy): enable unattended native worker authentication

### DIFF
--- a/examples/polly/agents/agy/config.yaml
+++ b/examples/polly/agents/agy/config.yaml
@@ -3,15 +3,15 @@ name: agy
 description: Google Antigravity CLI coding sub-agent — implements, cross-vendor reviews, or explores a scoped task in its own worktree.
 
 # Native Google Antigravity (`agy`) TUI/CLI harness: drives the `agy` binary
-# in its own terminal the human can open in the UI's Subagents panel and TAKE
-# OVER. Antigravity's in-terminal approval prompt still fires for dangerous
-# commands and is mirrored to the web UI, so risky actions surface as approval
-# cards rather than being auto-bypassed. agy is Gemini-native (own Google
+# in its own terminal. This worker runs unattended with tool approvals
+# bypassed; risky actions are bounded by the dedicated worktree and task scope
+# rather than surfaced as approval cards. agy is Gemini-native (own Google
 # account auth via ~/.gemini) and does not run Claude/GPT-family models.
 executor:
   type: omnigent
   config:
     harness: antigravity-native
+    permission_mode: bypassPermissions
 
 prompt: |
   You are agy, Google Antigravity's CLI coding sub-agent, dispatched by the

--- a/omnigent/antigravity_native_launch.py
+++ b/omnigent/antigravity_native_launch.py
@@ -24,11 +24,12 @@ Key design points:
   ``scratch`` dir). The launcher pins the terminal cwd to the session working
   directory, so no ``--add-dir`` flag is required.
 
-* **No usable env knobs** — agy also ignores ``ANTIGRAVITY_SIDECAR_WEB_PORT``
-  (it binds its own ephemeral ports) and ``ANTIGRAVITY_EXECUTABLE_DATA_DIR``
-  (its conversation store stays under the default ``~/.gemini/antigravity-cli``)
-  for the host process; both are sidecar-plugin-scoped no-ops. So
-  :func:`build_agy_launch` emits no env overrides for a fresh session.
+* **Auth inheritance** — when local Google Application Default Credentials are
+  available, the launcher enables agy's ADC auth mode without overwriting an
+  operator-provided ``AGY_ADC_AUTH`` value. agy ignores
+  ``ANTIGRAVITY_SIDECAR_WEB_PORT`` and ``ANTIGRAVITY_EXECUTABLE_DATA_DIR`` for
+  the host process, so :func:`build_agy_launch` emits only the ADC override
+  when appropriate.
 
 * **Auth is inherited** — current agy releases accept either their persisted
   Google OAuth login or ``GEMINI_API_KEY``. The isolated settings prepared by
@@ -37,7 +38,9 @@ Key design points:
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -65,6 +68,30 @@ _AGY_INSTALL_HINT = (
     "  curl -fsSL https://antigravity.google/cli/install.sh | bash\n"
     "Then restart your shell so ~/.local/bin is on PATH."
 )
+
+
+def _adc_credentials_path() -> Path:
+    """Return the ADC file path selected by the ambient Google auth setup."""
+    explicit_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if explicit_path:
+        return Path(explicit_path).expanduser()
+    config_dir = os.environ.get("CLOUDSDK_CONFIG")
+    if config_dir:
+        return Path(config_dir).expanduser() / "application_default_credentials.json"
+    return Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
+
+
+def _adc_credentials_available() -> bool:
+    """Return whether a readable, non-empty ADC JSON object is available."""
+    path = _adc_credentials_path()
+    try:
+        if not path.is_file():
+            return False
+        with path.open(encoding="utf-8") as credentials_file:
+            credentials = json.load(credentials_file)
+    except (OSError, ValueError):
+        return False
+    return isinstance(credentials, dict) and bool(credentials)
 
 
 def agy_binary_path() -> str:
@@ -226,11 +253,12 @@ def build_agy_launch(
     gate for this harness is post-hoc/audit-only). The flag is not duplicated
     when *extra_args* already carries it.
 
-    In both modes auth is inherited from the ambient environment / agy state,
-    and the workspace is the agy process cwd (set by the terminal spec), so no
-    ``--add-dir`` is emitted. No env overrides are produced: agy ignores
-    ``ANTIGRAVITY_SIDECAR_WEB_PORT`` / ``ANTIGRAVITY_CONVERSATION_ID`` /
-    ``ANTIGRAVITY_EXECUTABLE_DATA_DIR`` for the host process.
+    In both modes the workspace is the agy process cwd (set by the terminal
+    spec), so no ``--add-dir`` is emitted. ADC auth is enabled through the
+    returned environment overrides when local credentials are available;
+    agy ignores ``ANTIGRAVITY_SIDECAR_WEB_PORT`` /
+    ``ANTIGRAVITY_CONVERSATION_ID`` / ``ANTIGRAVITY_EXECUTABLE_DATA_DIR`` for
+    the host process.
 
     :param conversation_id: agy's real conversation id to resume, e.g.
         ``"68caaeac-..."``. Required (non-``None``) when ``resume=True``;
@@ -251,7 +279,8 @@ def build_agy_launch(
     :returns: A ``(argv, env_overrides)`` tuple where *argv* is the full
         command list starting with the agy binary path and *env_overrides*
         is a dict of env variables to layer on top of the process
-        environment (always empty for the agy host process).
+        environment, including the ADC auth override when local credentials
+        are available.
     :raises ValueError: When ``resume=True`` but *conversation_id* is ``None``
         or empty (agy needs a real id to resume).
     """
@@ -271,7 +300,7 @@ def build_agy_launch(
         argv.append(_SKIP_PERMISSIONS_FLAG)
     argv.extend(extra_args)
 
-    # agy ignores every env knob we tried (sidecar port, conversation id, data
-    # dir) for the host process, so there is nothing to inject.
     env_overrides: dict[str, str] = {}
+    if "AGY_ADC_AUTH" not in os.environ and _adc_credentials_available():
+        env_overrides["AGY_ADC_AUTH"] = "1"
     return argv, env_overrides

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4813,16 +4813,11 @@ async def _auto_create_antigravity_terminal(
     over tmux whether or not a web client has opened the Terminal panel (see
     the ``tmux_start_on_attach`` note on the spec below).
 
-    **Permissions are web-attended, not headless.** The web client attaches
-    to the agy pane through the runner tunnel and answers agy's
-    ``request-review`` TUI prompt there, so the launch is treated as
-    *attended* (``headless=False``). Auto-bypass comes only from the user's
-    persisted ``terminal_launch_args`` (which carry
-    ``--dangerously-skip-permissions`` when the user asked for bypass) —
-    the same pass-through mechanism codex/claude use. A server-spawned
-    launch must NOT key headlessness on the runner process's (absent) TTY,
-    which would silently disable the per-tool prompt for a watching web
-    user.
+    **Permissions are explicit in the persisted launch configuration.** The
+    server derives ``--dangerously-skip-permissions`` from a trusted worker's
+    ``permission_mode: bypassPermissions`` declaration and persists it in
+    ``terminal_launch_args``. The runner passes that intent to the launch
+    builder, which appends the flag without relying on a human-attached TTY.
 
     Fresh sessions launch with no ``--conversation``: the runner cold-starts
     the conversation over connect-RPC (11a) so the reader binds agy's real id
@@ -4877,9 +4872,9 @@ async def _auto_create_antigravity_terminal(
         raise RuntimeError(f"Invalid workspace for Antigravity session {session_id!r}.")
     workspace = _codex_session_workspace(session_workspace)
 
-    # The user's pass-through agy args (e.g. ``--dangerously-skip-permissions``)
-    # persisted by the CLI/web launch. Appended verbatim — bypass only happens
-    # when the user put the flag here (see the docstring on web-attended perms).
+    # The server-derived agy args (e.g. ``--dangerously-skip-permissions``)
+    # persisted by the trusted worker spec. Appended verbatim and also used to
+    # preserve the declared permission mode at the launch-builder seam.
     raw_launch_args = snapshot.get("terminal_launch_args")
     terminal_launch_args: tuple[str, ...] = ()
     if raw_launch_args is not None:
@@ -4904,6 +4899,9 @@ async def _auto_create_antigravity_terminal(
     # agy model label from the session's model_override (None lets agy default).
     _model_override = snapshot.get("model_override")
     model = _model_override if isinstance(_model_override, str) and _model_override else None
+    permission_mode = (
+        "bypassPermissions" if "--dangerously-skip-permissions" in terminal_launch_args else None
+    )
 
     # Bridge id mirrors the CLI/harness derivation: the session's bridge-id
     # label when present (so the spawn env built by
@@ -4935,11 +4933,7 @@ async def _auto_create_antigravity_terminal(
         conversation_id=external_session_id if resume else None,
         model=model,
         resume=resume,
-        # Web-attended: a web client drives agy's request-review prompt over the
-        # tunnel, so this is NOT headless. Bypass comes only via the pass-through
-        # args below (see docstring). permission_mode is left unset for the same
-        # reason — the runner has no separate per-tool mode to map here.
-        permission_mode=None,
+        permission_mode=permission_mode,
         headless=False,
         extra_args=terminal_launch_args,
     )

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -1982,10 +1982,9 @@ async def test_auto_create_antigravity_forwards_launch_args_to_agy_argv(
     This is the seam the server-derived bypass flag rides: a named
     antigravity-native sub-agent with ``permission_mode: bypassPermissions``
     persists ``["--dangerously-skip-permissions"]`` on the session, and the
-    runner's auto-create must forward it verbatim into the agy argv (with the
-    web-attended stance kept: ``permission_mode=None`` / ``headless=False`` so
-    bypass comes ONLY from the pass-through args). A failure means the derived
-    flag is dropped and the worker parks on approval cards.
+    runner's auto-create must forward it verbatim into the agy argv while
+    preserving the declared mode at the launch-builder seam. A failure means
+    the derived flag is dropped and the worker parks on approval cards.
     """
     launch_calls: list[dict[str, Any]] = []
     await _run_antigravity_auto_create(
@@ -1999,8 +1998,7 @@ async def test_auto_create_antigravity_forwards_launch_args_to_agy_argv(
     assert len(launch_calls) == 1
     call = launch_calls[0]
     assert call["extra_args"] == ("--dangerously-skip-permissions",)
-    # Bypass must come only from the pass-through args on this attended path.
-    assert call["permission_mode"] is None
+    assert call["permission_mode"] == "bypassPermissions"
     assert call["headless"] is False
 
 

--- a/tests/server/integration/test_sessions_child_sessions.py
+++ b/tests/server/integration/test_sessions_child_sessions.py
@@ -1322,6 +1322,11 @@ async def test_native_subagent_session_stamps_terminal_ui_labels(
             ["--permission-mode", "bypassPermissions"],
         ),
         (
+            "antigravity-native",
+            {"permission_mode": "bypassPermissions"},
+            ["--dangerously-skip-permissions"],
+        ),
+        (
             "codex-native",
             {"yolo": True},
             ["--dangerously-bypass-approvals-and-sandbox"],
@@ -1343,7 +1348,7 @@ async def test_native_subagent_yolo_args_derived_from_trusted_spec(
     A YOLO-declaring native worker bundle gets bypass ``terminal_launch_args``.
 
     The worker sub-agent's own bundle declares its full-bypass intent
-    (``permission_mode: bypassPermissions`` for claude-native,
+    (``permission_mode: bypassPermissions`` for claude-native / antigravity-native,
     ``yolo: true`` for codex-native / cursor-native). On a sub-agent create,
     the server derives the matching flag list from that trusted,
     server-loaded spec and persists it as the child session's

--- a/tests/test_antigravity_native_launch.py
+++ b/tests/test_antigravity_native_launch.py
@@ -142,7 +142,22 @@ class TestResolveNativeAntigravityLaunch:
 
 
 @pytest.fixture
-def fake_agy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
+def adc_credentials_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point ADC lookup at an isolated test file."""
+    monkeypatch.delenv("AGY_ADC_AUTH", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.delenv("CLOUDSDK_CONFIG", raising=False)
+    credentials_path = tmp_path / "application_default_credentials.json"
+    monkeypatch.setattr(_mod, "_adc_credentials_path", lambda: credentials_path)
+    return credentials_path
+
+
+@pytest.fixture
+def fake_agy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    adc_credentials_path: Path,
+) -> str:
     """Monkeypatch agy_binary_path to a deterministic fake path."""
     fake = str(tmp_path / "agy")
     monkeypatch.setattr(_mod, "agy_binary_path", lambda: fake)
@@ -165,14 +180,33 @@ class TestBuildAgyLaunch:
     # Fresh-session path (resume=False)
     # ------------------------------------------------------------------
 
-    def test_fresh_env_is_empty(self, fake_agy: str) -> None:
-        """Fresh session emits no env overrides (agy ignores all knobs)."""
+    def test_adc_present_sets_auth_env(self, fake_agy: str, adc_credentials_path: Path) -> None:
+        """A valid local ADC file enables agy's non-TTY auth mode."""
+        adc_credentials_path.write_text('{"type": "authorized_user"}', encoding="utf-8")
+        _, env = build_agy_launch(conversation_id=None, model=None, resume=False)
+        assert env == {"AGY_ADC_AUTH": "1"}
+
+    def test_adc_absent_does_not_set_auth_env(self, fake_agy: str) -> None:
+        """Without ADC credentials, the existing auth path remains unchanged."""
         _, env = build_agy_launch(
             conversation_id=None,
             model=None,
             resume=False,
         )
         assert env == {}
+
+    def test_operator_auth_value_is_preserved(
+        self, fake_agy: str, adc_credentials_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An operator-provided AGY_ADC_AUTH value is never overwritten."""
+        adc_credentials_path.write_text('{"type": "authorized_user"}', encoding="utf-8")
+        monkeypatch.setenv("AGY_ADC_AUTH", "operator-choice")
+        _, env = build_agy_launch(conversation_id=None, model=None, resume=False)
+        assert "AGY_ADC_AUTH" not in env
+
+    def test_no_project_id_is_hardcoded(self, fake_agy: str) -> None:
+        """Auth setup leaves quota-project selection to the ADC file."""
+        assert "vt-gcp-00038" not in Path(_mod.__file__).read_text(encoding="utf-8")
 
     def test_fresh_env_has_no_conversation_id(self, fake_agy: str) -> None:
         """Fresh session does NOT set ANTIGRAVITY_CONVERSATION_ID (agy ignores it)."""


### PR DESCRIPTION
## Related issue

Not linked to an issue for this focused infrastructure fix.

## Summary

- Enable `AGY_ADC_AUTH=1` for `antigravity-native` launches when a readable local Google ADC JSON file is available, while preserving any operator-provided value and leaving quota-project selection to the ADC file.
- Declare `permission_mode: bypassPermissions` for the Polly `agy` worker and carry that intent through the runner as `--dangerously-skip-permissions`.
- Update the worker configuration comment so it no longer claims that approval cards protect risky unattended actions.

ELI5: the worker now uses the file-based Google login that works without a terminal, and it no longer waits for a person to approve tool calls in an unattended pane.

```text
Polly agy config
        |
        v
bypassPermissions -> --dangerously-skip-permissions -> agy argv

ADC file present -> AGY_ADC_AUTH=1 -> non-TTY agy authentication
```

## Test Plan

Focused tests:

- `uv run --no-sync pytest -q tests/test_antigravity_native_launch.py`
  - 34 collected cases, 34 passed in 0.09s.
- `uv run --no-sync pytest -q tests/runner/test_app_sessions_native_terminals_runtime.py -k 'antigravity and (forwards_launch_args_to_agy_argv or cold_start)'`
  - 9 collected cases, 9 passed, 33 deselected in 0.22s.
- `uv run --no-sync pytest -q tests/server/integration/test_sessions_child_sessions.py -k native_subagent_yolo_args_derived_from_trusted_spec`
  - 4 collected cases, 4 passed, 50 deselected in 2.46s.

Static gates:

- `uv run --no-sync ruff check omnigent/antigravity_native_launch.py omnigent/runner/native/orchestration.py tests/test_antigravity_native_launch.py tests/runner/test_app_sessions_native_terminals_runtime.py tests/server/integration/test_sessions_child_sessions.py` passed.
- `uv run --no-sync ruff format --check omnigent/antigravity_native_launch.py omnigent/runner/native/orchestration.py tests/test_antigravity_native_launch.py tests/runner/test_app_sessions_native_terminals_runtime.py tests/server/integration/test_sessions_child_sessions.py` passed.
- `uv run --no-sync pyrefly check` passed with `0 errors`.
- `uv run --no-sync pre-commit run` passed all applicable hooks.

The full relevant-file command collected 130 cases and produced 127 passed and 3 failed. The three failures are pre-existing unrelated Pi workspace tests:

- `test_create_session_threads_workspace_to_pi_cwd`
- `test_create_session_threads_runner_workspace_to_pi_cwd_when_session_workspace_missing[None]`
- `test_create_session_threads_runner_workspace_to_pi_cwd_when_session_workspace_missing[   ]`

Ruff emitted four pre-existing invalid `# noqa` directive warnings in untouched surrounding lines of `omnigent/runner/native/orchestration.py`; Ruff still passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable - no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

ADC present, ADC absent, operator-provided auth preservation, no hardcoded project ID, trusted permission translation, runner propagation, and agy argv construction are covered by the focused tests above. No visual evidence applies because this is a backend launch and configuration change.

## Reviewer attention

When ADC is available, every `antigravity-native` launch now uses `AGY_ADC_AUTH=1`, including interactive and web-attended launches. A machine with both a persisted Keychain OAuth login and gcloud ADC will therefore silently use the ADC identity and the quota project recorded in the ADC file. I consider this acceptable for the current change because ADC is the proven authentication path for non-TTY harness panes and the behavior is deterministic, file-backed, and reversible. Review should confirm that this broader identity choice is acceptable for attended launches as well. Operators can set `AGY_ADC_AUTH` themselves to preserve an explicit value, including disabling or selecting a different auth mode supported by agy.

## Changelog

Polly's Google Antigravity worker authenticates without a TTY and no longer stalls on unattended tool approvals.