### PR TITLE
fix(claude-sdk): rewrite canonical model ids to the gateway's spellings

### DIFF
--- a/omnigent/claude_model_vocabulary.py
+++ b/omnigent/claude_model_vocabulary.py
@@ -82,6 +82,11 @@ MODEL_VOCABULARY_ENV_VARS: tuple[str, ...] = (
 #: this module stays stdlib-only for hook subprocesses, which also means it
 #: cannot honour a deployment's ``routing.model_prefix`` override.
 _CATALOG_PREFIXES: tuple[str, ...] = ("databricks-", "system.ai.")
+
+#: The vendor prefix every canonical Claude id starts with. Gateways spell
+#: their own ids around this core, so it is what maps a served id back to the
+#: canonical spelling Claude Code emits (see :func:`canonical_claude_id`).
+_CANONICAL_ID_PREFIX = "claude-"
 _SEGMENT_RE = re.compile(r"[^a-z0-9]+")
 
 
@@ -270,3 +275,53 @@ def served_alias_pins(model_ids: Iterable[str]) -> dict[str, str]:
         if alias not in pins or _model_version_key(model_id) > _model_version_key(pins[alias]):
             pins[alias] = model_id
     return pins
+
+
+def canonical_claude_id(model_id: str) -> str | None:
+    """The canonical vendor spelling a gateway's id wraps.
+
+    Every canonical Claude id starts at :data:`_CANONICAL_ID_PREFIX`, and a
+    gateway spells its own ids around that core. Claude Code canonicalizes the
+    same way — by finding that substring — so this is also how a served id maps
+    back to the spelling the CLI emits for it.
+
+    :param model_id: A served id, e.g. ``"databricks-claude-opus-4-8"``.
+    :returns: The canonical id (``"claude-opus-4-8"``), or ``None`` when
+        *model_id* spells no Claude model (``"databricks-gpt-5-6"``).
+    """
+    comparable = model_id.strip().lower()
+    index = comparable.rfind(_CANONICAL_ID_PREFIX)
+    return comparable[index:] if index != -1 else None
+
+
+def served_canonical_overrides(model_ids: Iterable[str]) -> dict[str, str]:
+    """Map each canonical Claude id to the gateway's spelling of it.
+
+    Claude Code names some models itself instead of through a family alias: its
+    refusal-fallback re-issues a safeguard-flagged turn on a canonical id read
+    from a route table internal to the CLI. A gateway that serves Claude under
+    its own ids rejects that spelling with ``model_not_found``, so the flagged
+    turn dies. Claude Code's ``modelOverrides`` setting exists for exactly this
+    — it rewrites a canonical id to the provider's spelling on the way out.
+
+    Deriving the map from the gateway's own listing keeps model ids out of
+    Omnigent entirely: whichever model the CLI's table names, and whichever
+    generation it moves to next, the rewrite covers it as long as the gateway
+    serves that model.
+
+    :param model_ids: The ids a gateway's model listing reports.
+    :returns: Canonical id → served id, e.g.
+        ``{"claude-opus-4-8": "databricks-claude-opus-4-8"}``, for served ids
+        that spell a Claude model differently from its canonical form. Empty
+        when the gateway already serves canonical spellings (nothing to
+        rewrite) or serves no Claude model. When two served ids share a
+        canonical form the first in the listing wins.
+    """
+    overrides: dict[str, str] = {}
+    for model_id in model_ids:
+        served = model_id.strip()
+        canonical = canonical_claude_id(served)
+        if canonical is None or canonical == served:
+            continue
+        overrides.setdefault(canonical, served)
+    return overrides

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -40,11 +40,15 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequen
 from contextlib import ExitStack, contextmanager, suppress
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Any, Protocol, TypeAlias, cast
+from typing import Any, NamedTuple, Protocol, TypeAlias, cast
 
 from omnigent import model_catalog
 from omnigent._platform import resolve_cli_binary, stable_user_id
-from omnigent.claude_model_vocabulary import ALIAS_MODEL_ENV_VARS, served_alias_pins
+from omnigent.claude_model_vocabulary import (
+    ALIAS_MODEL_ENV_VARS,
+    served_alias_pins,
+    served_canonical_overrides,
+)
 from omnigent.cli_invocation import cli_invocation
 from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 from omnigent.inner import _proc
@@ -1018,8 +1022,23 @@ def _resolve_databricks_claude_model(profile: str | None) -> str:
     return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
 
 
-def _gateway_alias_model_pins(base_url: str, auth_command: str | None) -> dict[str, str]:
-    """Pin Claude Code's family aliases to the ids a gateway serves.
+class _GatewayModelVocabulary(NamedTuple):
+    """How a gateway's served ids map onto Claude Code's model vocabulary.
+
+    :param alias_pins: ``{env_var: served_id}`` pinning each family alias.
+    :param model_overrides: ``{canonical_id: served_id}`` rewrites for the ids
+        Claude Code names itself.
+    """
+
+    alias_pins: dict[str, str]
+    model_overrides: dict[str, str]
+
+
+_EMPTY_GATEWAY_VOCABULARY = _GatewayModelVocabulary(alias_pins={}, model_overrides={})
+
+
+def _gateway_model_vocabulary(base_url: str, auth_command: str | None) -> _GatewayModelVocabulary:
+    """Read Claude Code's model vocabulary off a gateway's model listing.
 
     Claude Code resolves a family alias — ``opus`` / ``sonnet`` / ``haiku`` /
     ``fable`` — through ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL``, and every alias
@@ -1030,12 +1049,22 @@ def _gateway_alias_model_pins(base_url: str, auth_command: str | None) -> dict[s
     ``model_not_found``, and a refusal-fallback then kills the whole turn. List
     what the gateway serves and pin each alias to it.
 
+    Claude Code reaches a model two ways, and a gateway with its own ids
+    breaks both. Through a family alias — ``opus`` / ``sonnet`` / ``haiku`` /
+    ``fable``, resolved via ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL`` and spoken by
+    ``/model`` and ``Agent``-tool spawns — which resolves to a canonical vendor
+    id when unpinned. And by naming a canonical id itself: the refusal-fallback
+    re-issues a safeguard-flagged turn on a model from a route table internal
+    to the CLI. Either way the gateway answers ``model_not_found`` and the turn
+    dies. One listing answers both: pin the aliases, and hand Claude Code the
+    canonical-to-served rewrites for the ids it names on its own.
+
     :param base_url: The gateway's ``ANTHROPIC_BASE_URL``.
     :param auth_command: The gateway ``apiKeyHelper`` command; minted into the
         bearer the listing is fetched with.
-    :returns: ``{env_var: served_model_id}`` per served family. Empty — leaving
-        the aliases unpinned, today's behavior — when the gateway lists no
-        Claude models or the listing cannot be fetched.
+    :returns: The pins and rewrites the listing supports. Empty — leaving
+        today's behavior — when the gateway lists no Claude models or the
+        listing cannot be fetched.
     """
     from omnigent.onboarding.provider_config import ANTHROPIC_FAMILY, GATEWAY_KIND
 
@@ -1050,16 +1079,37 @@ def _gateway_alias_model_pins(base_url: str, auth_command: str | None) -> dict[s
         listing = model_catalog.listing_for_provider(provider)
     except Exception:  # noqa: BLE001 — best-effort; unpinned aliases are the safe default
         logger.warning(
-            "claude-sdk: could not list the gateway's models; "
-            "leaving ANTHROPIC_DEFAULT_*_MODEL unset",
+            "claude-sdk: could not list the gateway's models; leaving "
+            "ANTHROPIC_DEFAULT_*_MODEL and modelOverrides unset",
             exc_info=True,
         )
-        return {}
+        return _EMPTY_GATEWAY_VOCABULARY
     served = [entry.id for entry in listing.models if entry.family == "claude"]
-    return {
-        ALIAS_MODEL_ENV_VARS[alias]: model_id
-        for alias, model_id in served_alias_pins(served).items()
-    }
+    return _GatewayModelVocabulary(
+        alias_pins={
+            ALIAS_MODEL_ENV_VARS[alias]: model_id
+            for alias, model_id in served_alias_pins(served).items()
+        },
+        model_overrides=served_canonical_overrides(served),
+    )
+
+
+def _claude_settings_payload(
+    api_key_helper: str | None, model_overrides: dict[str, str]
+) -> str | None:
+    """Serialize the invocation-local settings Claude Code launches with.
+
+    :param api_key_helper: The gateway ``apiKeyHelper`` command, or ``None``.
+    :param model_overrides: Canonical-to-served model id rewrites.
+    :returns: Compact JSON for ``ClaudeAgentOptions.settings``, or ``None``
+        when there is nothing to configure.
+    """
+    settings: dict[str, Any] = {}
+    if api_key_helper:
+        settings["apiKeyHelper"] = api_key_helper
+    if model_overrides:
+        settings["modelOverrides"] = model_overrides
+    return json.dumps(settings, separators=(",", ":")) if settings else None
 
 
 def _resolve_gateway_env(
@@ -1679,12 +1729,12 @@ class ClaudeSDKExecutor(Executor):
         # Started on the first gateway turn — __init__ has no event loop.
         self._gateway_shim: ClaudeGatewayShim | None = None
 
-        # Cached ``ANTHROPIC_DEFAULT_*_MODEL`` pins for Claude Code's family
-        # aliases, read from the gateway's model listing on the first gateway
-        # turn (see :meth:`_apply_alias_model_pins`). ``None`` until
-        # resolved; the resolved value may be empty (discovery found nothing).
-        self._alias_model_pins: dict[str, str] | None = None
-        self._alias_model_pins_resolved = False
+        # Claude Code's model vocabulary for this gateway — alias pins and
+        # canonical-to-served rewrites — read from the gateway's model listing
+        # on the first gateway turn (see
+        # :meth:`_apply_gateway_model_vocabulary`). ``None`` until resolved;
+        # the resolved value may be empty (discovery found nothing).
+        self._gateway_vocabulary: _GatewayModelVocabulary | None = None
 
         # Eagerly resolve the gateway transport env so errors surface at
         # construction time.
@@ -2076,35 +2126,39 @@ class ClaudeSDKExecutor(Executor):
                 return str(metadata["session_id"])
         return "default"
 
-    async def _apply_alias_model_pins(self, env: dict[str, str], auth_command: str | None) -> None:
+    async def _apply_gateway_model_vocabulary(
+        self, env: dict[str, str], auth_command: str | None
+    ) -> dict[str, str]:
         """
-        Inject ``ANTHROPIC_DEFAULT_*_MODEL`` alias pins into the child env.
+        Pin the family aliases in *env* and report Claude Code's id rewrites.
 
-        On a gateway transport, list the gateway's models once and pin each of
-        Claude Code's family aliases to an id it serves, so the refusal-fallback
-        / ``/model`` / ``Agent``-tool spawns resolve an alias to a servable
-        model instead of a canonical vendor id the gateway may reject. A no-op
-        off the gateway (a direct Anthropic endpoint resolves aliases itself),
-        when every alias is already pinned, or when the listing yields nothing.
+        On a gateway transport, list the gateway's models once and derive both
+        halves of Claude Code's model vocabulary from that listing: the
+        ``ANTHROPIC_DEFAULT_*_MODEL`` pins that resolve a family alias to a
+        served id, and the canonical-to-served rewrites for the ids the CLI
+        names on its own (its refusal-fallback route table). A no-op off the
+        gateway, where a direct Anthropic endpoint speaks canonical ids itself.
 
-        :param env: The child-process env dict, mutated in place.
+        Pins already present are respected. The rewrites still apply to those
+        launches: pinning an alias does not teach Claude Code how this gateway
+        spells the canonical ids its own route table names.
+
+        :param env: The child-process env dict, mutated in place with the pins.
         :param auth_command: The gateway ``apiKeyHelper`` command used to mint
             a bearer for the model listing.
+        :returns: Canonical-to-served rewrites for the ``modelOverrides``
+            setting. Empty off the gateway or when discovery found nothing.
         """
         base_url = env.get("ANTHROPIC_BASE_URL")
         if not self._gateway or not base_url:
-            return
-        if all(var in env for var in ALIAS_MODEL_ENV_VARS.values()):
-            # Every alias already pinned (e.g. by a ucode launch config);
-            # respect the explicit values rather than re-deriving them.
-            return
-        if not self._alias_model_pins_resolved:
-            self._alias_model_pins = await run_sync_on_thread(
-                _gateway_alias_model_pins, base_url, auth_command
+            return {}
+        if self._gateway_vocabulary is None:
+            self._gateway_vocabulary = await run_sync_on_thread(
+                _gateway_model_vocabulary, base_url, auth_command
             )
-            self._alias_model_pins_resolved = True
-        for var, model_id in (self._alias_model_pins or {}).items():
+        for var, model_id in self._gateway_vocabulary.alias_pins.items():
             env.setdefault(var, model_id)
+        return self._gateway_vocabulary.model_overrides
 
     def _install_subagent_router_hook(
         self,
@@ -2452,15 +2506,12 @@ class ClaudeSDKExecutor(Executor):
         # ``""`` here would still leave an empty key in the child env.
         env = dict(self._extra_env)
         api_key_helper = env.pop(_CLAUDE_API_KEY_HELPER_ENV_KEY, None)
-        # Pin Claude Code's family aliases to ids the gateway serves so a
-        # refusal-fallback (or any alias surface) never routes to a canonical
-        # id the gateway rejects. No-op off the gateway transport.
-        await self._apply_alias_model_pins(env, api_key_helper)
-        settings_payload = (
-            json.dumps({"apiKeyHelper": api_key_helper}, separators=(",", ":"))
-            if api_key_helper
-            else None
-        )
+        # Teach Claude Code this gateway's spellings so no model surface routes
+        # to an id the gateway rejects: pins for the family aliases, rewrites
+        # for the canonical ids the CLI names itself (the refusal-fallback).
+        # No-op off the gateway transport.
+        model_overrides = await self._apply_gateway_model_vocabulary(env, api_key_helper)
+        settings_payload = _claude_settings_payload(api_key_helper, model_overrides)
 
         # Capture stderr from the CLI subprocess for diagnostics
         stderr_lines: list[str] = []

--- a/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
+++ b/tests/e2e/test_claude_sdk_refusal_fallback_e2e.py
@@ -13,8 +13,13 @@ the fallback request fails ``model_not_found`` and the whole turn dies with
 on the Databricks gateway, whose ids are ``databricks-claude-*``; any gateway
 with its own spellings has the same failure.)
 
-The fix lists the gateway's models and pins each family alias to a served id,
-so the fallback re-issues on the gateway's Opus and the turn completes.
+Pinning the ``opus`` alias is not enough on its own. The alias should track the
+newest Opus the gateway serves, while the CLI's refusal route table names an
+*older* canonical generation, so the two disagree exactly when a gateway serves
+both. The fix therefore also hands Claude Code a ``modelOverrides`` map derived
+from the same listing — canonical id to served spelling — so whichever id the
+route table names is rewritten to something the gateway answers. This test
+serves a newer Opus alongside the fallback target to hold that apart.
 
 This drives the real journey — register a claude-sdk agent on the mock
 gateway, create a runner-bound session (real ``claude`` CLI subprocess), send
@@ -53,9 +58,16 @@ from tests.e2e.conftest import (
 # real vendor's spelling: the fix must work for any gateway's ids.
 _LAUNCH_MODEL = "gw-claude-fable-5"
 _SERVED_FALLBACK_MODEL = "gw-claude-opus-4-8"
+# A newer Opus, served alongside the fallback target. The ``opus`` alias pins
+# to this one (newest per family), so the refusal-fallback can only reach the
+# older generation its route table names through the canonical rewrites — which
+# is the behavior under test. A gateway serving exactly this pair is where the
+# alias-only fix stopped working.
+_SERVED_NEWER_OPUS = "gw-claude-opus-5"
 _SERVED_MODELS = [
     _LAUNCH_MODEL,
     _SERVED_FALLBACK_MODEL,
+    _SERVED_NEWER_OPUS,
     "gw-claude-sonnet-5",
     "gw-claude-haiku-4-5",
 ]
@@ -114,9 +126,12 @@ def test_claude_sdk_refusal_fallback_routes_to_served_model(
     """A safeguard refusal on claude-sdk falls back to the served Opus id.
 
     The mock refuses the launch-model (Fable) turn with a ``cyber`` refusal.
-    With the alias pins the fix injects, Claude Code re-issues the turn on the
-    gateway's own Opus id and completes — instead of dying on a canonical
-    ``claude-opus-4-8`` the gateway rejects.
+    The gateway serves two Opus generations, so the ``opus`` alias points at the
+    newer one and cannot carry the fallback: Claude Code names the older
+    canonical id from its own route table. The canonical rewrites the fix
+    derives from the listing turn that id into the gateway's spelling, so the
+    turn re-issues on a served model and completes instead of dying on a
+    canonical id the gateway rejects.
     """
     reset_mock_llm(mock_llm_server_url)
     # What the gateway serves: the executor lists this once per session and
@@ -155,14 +170,22 @@ def test_claude_sdk_refusal_fallback_routes_to_served_model(
     assert _LAUNCH_MODEL in wire_models, (
         f"the launch model {_LAUNCH_MODEL!r} never reached the wire; models seen: {wire_models}"
     )
-    # The fix pinned the Opus alias to the served id, so the refusal-fallback
-    # re-issued on it. Without the fix the alias resolves to a bare
-    # ``claude-opus-4-8`` the gateway rejects, and no such request is made.
+    # The refusal-fallback re-issued on the gateway's spelling of the older
+    # Opus its route table names. Without the canonical rewrites the CLI sends
+    # the bare canonical id, the gateway rejects it, and no such request lands.
     assert _SERVED_FALLBACK_MODEL in wire_models, (
         f"the refusal-fallback did not re-issue on the served Opus id "
-        f"{_SERVED_FALLBACK_MODEL!r} — the ANTHROPIC_DEFAULT_OPUS_MODEL pin is "
-        f"missing, so the alias resolved to a canonical id the gateway rejects. "
-        f"Models seen on the wire: {wire_models}"
+        f"{_SERVED_FALLBACK_MODEL!r} — the canonical id Claude Code names was "
+        f"not rewritten to this gateway's spelling, so the fallback request "
+        f"named a model the gateway rejects. Models seen: {wire_models}"
+    )
+    # No canonical spelling ever reached the wire: the rewrite happened before
+    # the request, rather than the gateway happening to tolerate a vendor id.
+    canonical_leaks = [
+        model for model in wire_models if isinstance(model, str) and model.startswith("claude-")
+    ]
+    assert not canonical_leaks, (
+        f"canonical vendor ids reached the gateway unrewritten: {canonical_leaks}"
     )
     # And the turn completed rather than dying with the model_not_found error.
     assert body["status"] == "completed", (

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -805,7 +805,7 @@ class TestConstructor(unittest.TestCase):
         ``ANTHROPIC_DEFAULT_OPUS_MODEL``; unpinned it lands on a canonical
         vendor id a gateway serving its own ids rejects (``model_not_found``).
         The executor lists the gateway's models and pins each alias to a
-        served id. See ``_apply_alias_model_pins``.
+        served id. See ``_apply_gateway_model_vocabulary``.
         """
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
         from omnigent.model_catalog import ModelEntry, ModelListing
@@ -823,6 +823,7 @@ class TestConstructor(unittest.TestCase):
 
             async def fake_get_or_create_client(sdk, *, session_key, options, model):
                 captured["env"] = dict(options.env or {})
+                captured["settings"] = json.loads(options.settings or "{}")
                 raise RuntimeError("stop after env assembly")
 
             listing = ModelListing(
@@ -832,6 +833,11 @@ class TestConstructor(unittest.TestCase):
                     ModelEntry(id="gw-claude-fable-5", family="claude"),
                     ModelEntry(id="gw-claude-opus-4-7", family="claude"),
                     ModelEntry(id="gw-claude-opus-4-8", family="claude"),
+                    # A newer Opus alongside 4.8 — the shape that broke the
+                    # refusal-fallback: the alias must track the newest while
+                    # the rewrites still cover the older generation the CLI's
+                    # own route table can name.
+                    ModelEntry(id="gw-claude-opus-5", family="claude"),
                     ModelEntry(id="gw-claude-sonnet-5", family="claude"),
                     ModelEntry(id="gw-claude-haiku-4-5", family="claude"),
                     ModelEntry(id="gw-gpt-5-6", family="openai"),
@@ -852,10 +858,24 @@ class TestConstructor(unittest.TestCase):
 
             env = captured["env"]
             # Newest served generation per family; the non-Claude id is ignored.
-            self.assertEqual(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "gw-claude-opus-4-8")
+            self.assertEqual(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "gw-claude-opus-5")
             self.assertEqual(env["ANTHROPIC_DEFAULT_FABLE_MODEL"], "gw-claude-fable-5")
             self.assertEqual(env["ANTHROPIC_DEFAULT_SONNET_MODEL"], "gw-claude-sonnet-5")
             self.assertEqual(env["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "gw-claude-haiku-4-5")
+            # Every served Claude generation is reachable by its canonical
+            # spelling, so whichever id the CLI's route table names resolves —
+            # including the 4.8 the newest-Opus alias no longer points at.
+            self.assertEqual(
+                captured["settings"]["modelOverrides"],
+                {
+                    "claude-fable-5": "gw-claude-fable-5",
+                    "claude-opus-4-7": "gw-claude-opus-4-7",
+                    "claude-opus-4-8": "gw-claude-opus-4-8",
+                    "claude-opus-5": "gw-claude-opus-5",
+                    "claude-sonnet-5": "gw-claude-sonnet-5",
+                    "claude-haiku-4-5": "gw-claude-haiku-4-5",
+                },
+            )
 
         _run(_t())
 
@@ -909,9 +929,12 @@ class TestConstructor(unittest.TestCase):
         """Pre-set ``ANTHROPIC_DEFAULT_*_MODEL`` pins win over the listing.
 
         A launch config that already pins every alias must be respected
-        verbatim; the executor neither re-derives them nor lists the gateway.
+        verbatim. The gateway is still listed, because pinning an alias says
+        nothing about how this gateway spells the canonical ids Claude Code
+        names on its own — those rewrites are needed either way.
         """
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+        from omnigent.model_catalog import ModelEntry, ModelListing
 
         async def _t():
             executor = ClaudeSDKExecutor(
@@ -930,11 +953,17 @@ class TestConstructor(unittest.TestCase):
 
             async def fake_get_or_create_client(sdk, *, session_key, options, model):
                 captured["env"] = dict(options.env or {})
+                captured["settings"] = json.loads(options.settings or "{}")
                 raise RuntimeError("stop after env assembly")
 
-            listing = Mock()
+            listing = ModelListing(
+                source="openai-compatible",
+                verified=True,
+                models=(ModelEntry(id="gw-claude-opus-4-8", family="claude"),),
+                note="",
+            )
             with (
-                patch("omnigent.model_catalog.listing_for_provider", listing),
+                patch("omnigent.model_catalog.listing_for_provider", return_value=listing),
                 patch.object(
                     executor,
                     "_get_or_create_client",
@@ -945,8 +974,15 @@ class TestConstructor(unittest.TestCase):
                     async for _ in executor.run_turn([{"role": "user", "content": "hi"}], [], ""):
                         pass
 
-            self.assertEqual(captured["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"], "pinned-opus")
-            listing.assert_not_called()
+            for alias in ("FABLE", "OPUS", "SONNET", "HAIKU"):
+                self.assertEqual(
+                    captured["env"][f"ANTHROPIC_DEFAULT_{alias}_MODEL"],
+                    f"pinned-{alias.lower()}",
+                )
+            self.assertEqual(
+                captured["settings"]["modelOverrides"],
+                {"claude-opus-4-8": "gw-claude-opus-4-8"},
+            )
 
         _run(_t())
 
@@ -1526,13 +1562,13 @@ class TestResolveGatewayEnv(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Tests: Family-alias model pins (refusal-fallback routing)
+# Tests: Gateway model vocabulary (alias pins + canonical rewrites)
 # ---------------------------------------------------------------------------
 
 
-class TestAliasModelPins(unittest.TestCase):
+class TestGatewayModelVocabulary(unittest.TestCase):
     def test_pins_map_served_families_to_env_vars(self):
-        from omnigent.inner.claude_sdk_executor import _gateway_alias_model_pins
+        from omnigent.inner.claude_sdk_executor import _gateway_model_vocabulary
         from omnigent.model_catalog import ModelEntry, ModelListing
 
         listing = ModelListing(
@@ -1546,12 +1582,24 @@ class TestAliasModelPins(unittest.TestCase):
             note="",
         )
         with patch("omnigent.model_catalog.listing_for_provider", return_value=listing) as lister:
-            pins = _gateway_alias_model_pins("https://gw.example.com/anthropic", "printf tok")
+            vocabulary = _gateway_model_vocabulary(
+                "https://gw.example.com/anthropic", "printf tok"
+            )
         self.assertEqual(
-            pins,
+            vocabulary.alias_pins,
             {
                 "ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-8",
                 "ANTHROPIC_DEFAULT_FABLE_MODEL": "databricks-claude-fable-5",
+            },
+        )
+        # Same listing, second half of the vocabulary: the canonical spelling
+        # Claude Code names itself, rewritten to what this gateway serves. The
+        # non-Claude id contributes to neither half.
+        self.assertEqual(
+            vocabulary.model_overrides,
+            {
+                "claude-opus-4-8": "databricks-claude-opus-4-8",
+                "claude-fable-5": "databricks-claude-fable-5",
             },
         )
         # The listing is fetched as a gateway transport: the base URL and the
@@ -1561,39 +1609,90 @@ class TestAliasModelPins(unittest.TestCase):
         self.assertEqual(provider.auth_command, "printf tok")
         self.assertIsNone(provider.profile)
 
-    def test_no_pins_when_the_listing_has_no_claude_models(self):
-        from omnigent.inner.claude_sdk_executor import _gateway_alias_model_pins
+    def test_nothing_when_the_listing_has_no_claude_models(self):
+        from omnigent.inner.claude_sdk_executor import (
+            _EMPTY_GATEWAY_VOCABULARY,
+            _gateway_model_vocabulary,
+        )
         from omnigent.model_catalog import ModelListing
 
         listing = ModelListing(source="openai-compatible", verified=True, models=(), note="")
         with patch("omnigent.model_catalog.listing_for_provider", return_value=listing):
             self.assertEqual(
-                _gateway_alias_model_pins("https://gw.example.com/anthropic", "printf tok"), {}
+                _gateway_model_vocabulary("https://gw.example.com/anthropic", "printf tok"),
+                _EMPTY_GATEWAY_VOCABULARY,
             )
 
-    def test_no_pins_when_the_listing_fails(self):
-        """A failed listing is swallowed — unpinned aliases are the safe default."""
-        from omnigent.inner.claude_sdk_executor import _gateway_alias_model_pins
+    def test_nothing_when_the_listing_fails(self):
+        """A failed listing is swallowed — today's behavior is the safe default."""
+        from omnigent.inner.claude_sdk_executor import (
+            _EMPTY_GATEWAY_VOCABULARY,
+            _gateway_model_vocabulary,
+        )
 
         with patch(
             "omnigent.model_catalog.listing_for_provider",
             side_effect=RuntimeError("listing unavailable"),
         ):
             self.assertEqual(
-                _gateway_alias_model_pins("https://gw.example.com/anthropic", "printf tok"), {}
+                _gateway_model_vocabulary("https://gw.example.com/anthropic", "printf tok"),
+                _EMPTY_GATEWAY_VOCABULARY,
             )
 
     def test_direct_endpoint_never_lists_or_pins(self):
-        """Off the gateway transport the CLI resolves aliases itself."""
+        """Off the gateway transport the CLI resolves canonical ids itself."""
         from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
 
         executor = ClaudeSDKExecutor()
         env = {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"}
         listing = Mock()
         with patch("omnigent.model_catalog.listing_for_provider", listing):
-            _run(executor._apply_alias_model_pins(env, None))
+            overrides = _run(executor._apply_gateway_model_vocabulary(env, None))
         self.assertEqual(env, {"ANTHROPIC_BASE_URL": "https://api.anthropic.com"})
+        self.assertEqual(overrides, {})
         listing.assert_not_called()
+
+    def test_preset_pins_are_respected_but_rewrites_still_apply(self):
+        """A launch config that pins aliases still needs the id rewrites.
+
+        Pinning ``opus`` tells Claude Code which model the *alias* means. It
+        says nothing about how this gateway spells the canonical ids the CLI
+        names on its own, so the rewrites must be derived either way.
+        """
+        from omnigent.inner.claude_sdk_executor import ClaudeSDKExecutor
+        from omnigent.model_catalog import ModelEntry, ModelListing
+
+        listing = ModelListing(
+            source="openai-compatible",
+            verified=True,
+            models=(ModelEntry(id="gw-claude-opus-4-8", family="claude"),),
+            note="",
+        )
+        executor = ClaudeSDKExecutor.__new__(ClaudeSDKExecutor)
+        executor._gateway = True
+        executor._gateway_vocabulary = None
+        env = {
+            "ANTHROPIC_BASE_URL": "https://gw.example.com/anthropic",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "gw-claude-opus-5",
+        }
+        with patch("omnigent.model_catalog.listing_for_provider", return_value=listing):
+            overrides = _run(executor._apply_gateway_model_vocabulary(env, "printf tok"))
+        self.assertEqual(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "gw-claude-opus-5")
+        self.assertEqual(overrides, {"claude-opus-4-8": "gw-claude-opus-4-8"})
+
+    def test_settings_payload_carries_helper_and_rewrites(self):
+        from omnigent.inner.claude_sdk_executor import _claude_settings_payload
+
+        self.assertIsNone(_claude_settings_payload(None, {}))
+        self.assertEqual(
+            json.loads(_claude_settings_payload("printf tok", {"claude-opus-4-8": "gw-opus"})),
+            {"apiKeyHelper": "printf tok", "modelOverrides": {"claude-opus-4-8": "gw-opus"}},
+        )
+        # No credential helper, but a gateway that still needs the rewrites.
+        self.assertEqual(
+            json.loads(_claude_settings_payload(None, {"claude-opus-4-8": "gw-opus"})),
+            {"modelOverrides": {"claude-opus-4-8": "gw-opus"}},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_claude_model_vocabulary.py
+++ b/tests/test_claude_model_vocabulary.py
@@ -8,6 +8,7 @@ from omnigent.claude_model_vocabulary import (
     model_vocabulary_env,
     normalized_model_id,
     served_alias_pins,
+    served_canonical_overrides,
 )
 
 # A ucode-style launch pinning: each family alias mapped to a gateway id,
@@ -211,3 +212,69 @@ def test_served_alias_pins_pick_the_newest_served_id_per_family() -> None:
 
 def test_served_alias_pins_ignore_ids_of_no_claude_family() -> None:
     assert served_alias_pins(["databricks-gpt-5-6", "gemini-3-pro", ""]) == {}
+
+
+def test_served_canonical_overrides_map_canonical_ids_to_gateway_spellings() -> None:
+    """Every served generation becomes reachable by its canonical spelling.
+
+    Claude Code names a model itself when its refusal-fallback re-issues a
+    flagged turn, using a canonical id from a route table internal to the CLI.
+    The map has to cover whichever id that is, so it covers all of them.
+    """
+    assert served_canonical_overrides(
+        [
+            "databricks-claude-opus-4-8",
+            "databricks-claude-opus-5",
+            "anthropic/claude-sonnet-5",
+            "gw-claude-haiku-4-5",
+            "system.ai.claude-fable-5-1",
+        ]
+    ) == {
+        "claude-opus-4-8": "databricks-claude-opus-4-8",
+        "claude-opus-5": "databricks-claude-opus-5",
+        "claude-sonnet-5": "anthropic/claude-sonnet-5",
+        "claude-haiku-4-5": "gw-claude-haiku-4-5",
+        "claude-fable-5-1": "system.ai.claude-fable-5-1",
+    }
+
+
+def test_served_canonical_overrides_need_no_knowledge_of_a_generation() -> None:
+    """A model the vocabulary has never heard of still maps.
+
+    The rewrite is derived from the served spelling alone, so a future
+    generation — or a family with no alias of its own, like Mythos — is
+    covered without touching this module.
+    """
+    assert served_canonical_overrides(
+        ["databricks-claude-opus-6", "databricks-claude-mythos-5"]
+    ) == {
+        "claude-opus-6": "databricks-claude-opus-6",
+        "claude-mythos-5": "databricks-claude-mythos-5",
+    }
+
+
+@pytest.mark.parametrize(
+    "served",
+    [
+        pytest.param(["claude-opus-4-8"], id="already-canonical"),
+        pytest.param(["claude-opus-4-8[1m]"], id="context-marker-is-not-a-spelling"),
+        pytest.param(["databricks-gpt-5-6", "gemini-3-pro", ""], id="no-claude-model"),
+        pytest.param([], id="empty-listing"),
+    ],
+)
+def test_served_canonical_overrides_stay_empty_when_there_is_nothing_to_rewrite(
+    served: list[str],
+) -> None:
+    """No entry unless the gateway's spelling actually differs.
+
+    An empty map leaves Claude Code exactly as it behaves today, which is the
+    right outcome when the listing is unhelpful or unreachable.
+    """
+    assert served_canonical_overrides(served) == {}
+
+
+def test_served_canonical_overrides_keep_the_first_of_two_equal_spellings() -> None:
+    """Two served ids sharing a canonical form resolve deterministically."""
+    assert served_canonical_overrides(["databricks-claude-opus-4-8", "gw-claude-opus-4-8"]) == {
+        "claude-opus-4-8": "databricks-claude-opus-4-8"
+    }


### PR DESCRIPTION
## Related issue

Closes #6265

## Summary

- Claude Code reaches a model two ways. Through a **family alias**, which #6236 already pins from the gateway's model listing. And by **naming a canonical vendor id itself**: its refusal-fallback re-issues a safeguard-flagged turn on a model read from a route table internal to the CLI. A gateway that serves Claude under its own ids answers that second path `model_not_found`, so the flagged turn dies even when the alias is pinned correctly.
- This derives Claude Code's [`modelOverrides`](https://code.claude.com/docs/en/model-config#override-model-ids-per-version) map from the same listing and passes it in the invocation-local settings: each canonical Claude id maps to the spelling the gateway serves. The family aliases keep tracking the newest served generation, so `/model` and `Agent`-tool spawns are unchanged.
- **No model id enters Omnigent.** The map is the served ids inverted, so whichever generation the CLI's route table names, now or later, the rewrite covers it as long as the gateway serves that model.

ELI5: the CLI asks for "Coke", the gateway only sells "Coca-Cola". Rather than telling everyone to order Coca-Cola from now on (which is what pinning the alias to the older model does), we hand the CLI a note saying "Coke means Coca-Cola here", built from the gateway's own menu.

### Why not pin `opus` to Opus 4.8 instead (#6266)

That works, but it types `claude-opus-4-8` into Omnigent and pays for it by moving the `opus` alias onto the older model — so every `Agent`-tool `opus` spawn and every `/model opus` pick downgrades on a gateway that serves both. It also encodes a constant we don't own: the route table already differs across CLI builds (2.1.212 sends both `cyber` and `bio` to Opus 4.8; 2.1.259 sends `bio` to Opus 5), so a pinned id silently stops matching when Anthropic moves the target. Superseding #6266; I'll close it.

### How the map is built

```
served id                      canonical (the key)   entry?
databricks-claude-opus-4-8  →  claude-opus-4-8       yes
databricks-claude-opus-5    →  claude-opus-5         yes
claude-opus-4-8             →  claude-opus-4-8       no (already canonical)
databricks-gpt-5-6          →  (no claude- core)     no
```

The only literals involved are `claude-` (the vendor name) and the catalog prefixes the module already had. No version number appears anywhere. Verified against the live Databricks `oss` gateway: 12 served ids in, all 12 pairs out. A listing carrying a generation the code has never heard of (`claude-opus-6`, or `claude-mythos-5`, which has no family alias at all) maps automatically; an unreachable or canonical-serving listing yields an empty map, which is exactly today's behavior.

## Test Plan

- **E2E, red/green proven** — `tests/e2e/test_claude_sdk_refusal_fallback_e2e.py` now serves `gw-claude-opus-5` alongside `gw-claude-opus-4-8`, so the `opus` alias pins to the newer one and the fallback can only land through the rewrites. Green with this change (11s). Reverting **only** `omnigent/` and keeping the test fails with the bare canonical id on the wire, which is precisely the id that 404s in production:
  ```
  AssertionError: the refusal-fallback did not re-issue on the served Opus id 'gw-claude-opus-4-8'
  Models seen: ['gw-claude-haiku-4-5', 'gw-claude-haiku-4-5', 'gw-claude-haiku-4-5',
                'gw-claude-fable-5', 'claude-opus-4-8']
  ```
  The test also asserts no `claude-`-prefixed id ever reaches the wire, so it fails if a canonical id leaks rather than being rewritten.
- **Live against the real Databricks gateway** with the CLI CI pins (2.1.236) and the newer 2.1.259: a cyber-flagged turn on `databricks-claude-fable-5` emits `model_refusal_fallback` and completes on Opus 4.8 with the `opus` alias left on `databricks-claude-opus-5` plus this map. Without the map, same setup, the CLI requests bare `claude-opus-4-8` and the gateway returns `404 'claude-opus-4-8' does not exist`.
- **Unit** — 5 new cases in `tests/test_claude_model_vocabulary.py` (all served spellings, a generation the vocabulary has never seen, the four nothing-to-rewrite shapes, duplicate-canonical determinism); `tests/inner/test_claude_sdk_executor.py` gains the settings-payload serializer, the pre-set-pins case, and asserts both halves of the vocabulary come off one listing.
- `tests/inner/test_claude_sdk_executor.py` + `tests/test_claude_model_vocabulary.py` + `tests/test_claude_native_bridge.py` + `tests/test_model_catalog.py`: **576 passed, 1 xfailed**. `pre-commit` clean on the changed files, including the `no new hardcoded LLM model ids` hook.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the live A/B against the real Databricks gateway and the real Claude Code binary, which is the only place the CLI's refusal route table is exercised for real; the e2e covers the same decision against the mock gateway and is proven red without the source change.

Two behavior notes for reviewers:

1. **The listing is now consulted even when a launch config pins every alias.** Previously that case short-circuited before listing. Pinning an alias says nothing about how the gateway spells the canonical ids Claude Code names on its own, so the rewrites have to be derived either way. Pre-set pins are still respected verbatim — `test_explicit_family_pins_are_not_overwritten` was updated to assert that alongside the rewrites rather than asserting the old short-circuit.
2. **claude-native is not covered here.** It has the same latent gap, but its settings reach the CLI through the bridge's sidecar (`build_hook_settings` → `augment_claude_args`), so wiring it means threading a new argument through two layers and both production call sites on the runner launch path. That is a separate, higher-blast-radius change and I'd rather it land on its own; I misjudged it as a one-liner when scoping this. Filing a follow-up.

## Changelog

claude-sdk agents on a gateway with its own model ids recover from a safeguard refusal instead of failing the turn, without downgrading what the `opus` alias means
