### PR TITLE
fix(antigravity-native): gate turn completion on agy actually finishing the turn

### DIFF
--- a/omnigent/antigravity_native_reader.py
+++ b/omnigent/antigravity_native_reader.py
@@ -85,16 +85,23 @@ from omnigent.antigravity_native_rpc import (
 # (relocated from the retired transcript forwarder). The reader reuses the SAME
 # event shape so the mapped events post identically.
 from omnigent.antigravity_native_steps import (
+    CASCADE_RUN_STATUS_IDLE,
     OutboundEvent,
     PendingInteraction,
     _execution_discriminator,
     _step_index,
     _tool_call_id,
     _trajectory_id,
+    cascade_is_idle,
+    is_assistant_text_close_step,
+    is_planner_error_step,
+    is_turn_close_step,
+    is_user_turn_step,
     map_step_to_events,
     output_reasoning_delta_event,
     output_text_delta_event,
     pending_interaction,
+    planner_response_text,
 )
 from omnigent.claude_native_bridge import url_component
 from omnigent.entities.session_resources import terminal_resource_id
@@ -168,10 +175,9 @@ _STATUS_IDLE = "idle"
 # agy's OWN per-cascade run status, published in every ``GetAllCascadeTrajectories``
 # summary. This is the authoritative "is this turn over" signal — the step-type
 # close detection below only INFERS it, and every agy step type it does not know
-# about is a turn that never closes. Live-verified against agy 1.1.8: RUNNING both
-# while working AND for the whole time a permission gate is parked (75s observed),
-# so IDLE never means "waiting for the human".
-_CASCADE_RUN_STATUS_IDLE = "CASCADE_RUN_STATUS_IDLE"
+# about is a turn that never closes. Defined in the mapper module (shared with the
+# write path's completion gate); re-exported here under the reader's private name.
+_CASCADE_RUN_STATUS_IDLE = CASCADE_RUN_STATUS_IDLE
 # Consecutive idle observations required before the backstop closes a turn. One
 # reading can catch the gap between delivering a turn and agy starting it.
 _QUIESCENT_TICKS_TO_CLOSE = 2
@@ -439,20 +445,15 @@ def _cascade_is_idle(summaries: dict[str, object], bound_cascade_id: str) -> boo
     """
     Whether agy itself reports the bound cascade as no longer running.
 
-    Reads :data:`_CASCADE_RUN_STATUS_IDLE` from the cascade's own summary rather
-    than inferring the turn's end from step types. Missing or malformed entries
-    are NOT idle: closing a turn on incomplete information would be worse than
-    leaving the step-based close to do it.
+    Thin alias for :func:`omnigent.antigravity_native_steps.cascade_is_idle`, the
+    shared implementation the write path's completion gate also consults.
 
     :param summaries: ``trajectorySummaries`` from
         :func:`~omnigent.antigravity_native_rpc.get_all_cascade_trajectories`.
     :param bound_cascade_id: The cascade this reader is bound to.
     :returns: ``True`` only on an explicit idle status for the bound cascade.
     """
-    summary = summaries.get(bound_cascade_id)
-    if not isinstance(summary, dict):
-        return False
-    return summary.get("status") == _CASCADE_RUN_STATUS_IDLE
+    return cascade_is_idle(summaries, bound_cascade_id)
 
 
 def _summary_is_child_trajectory(cascade_id: str, summary: dict[str, object]) -> bool:
@@ -612,59 +613,40 @@ def _is_user_turn_step(step: dict[str, object]) -> bool:
     """
     Return whether a step opens a turn (a USER_INPUT step).
 
-    The RPC equivalent of the transcript forwarder's
-    :func:`_is_turn_boundary_running`: a user input step starts a turn (agy then
-    runs the model + tools).
+    Thin alias for :func:`omnigent.antigravity_native_steps.is_user_turn_step`:
+    a user input step starts a turn (agy then runs the model + tools).
 
     :param step: One RPC step dict.
     :returns: ``True`` for a ``CORTEX_STEP_TYPE_USER_INPUT`` step.
     """
-    return step.get("type") == _TYPE_USER_INPUT
+    return is_user_turn_step(step)
 
 
 def _is_assistant_text_close_step(step: dict[str, object]) -> bool:
     """
     Return whether a step closes a turn (assistant text, no further tool calls).
 
-    The RPC equivalent of the transcript forwarder's
-    :func:`_is_assistant_text_step`: a PLANNER_RESPONSE that carries assistant
-    text (``modifiedResponse`` or ``response``) is the closing edge of a turn —
-    agy answered and stopped. A planner step that only invokes a tool does not
-    close the turn (the tool result, and possibly more planner steps, follow).
-
-    The TEXT is what separates the two: a dispatching planner carries none, in
-    either RPC shape. The ``toolCalls`` test below is a poll-shape-only
-    belt-and-braces guard for a planner that somehow carried both — it cannot
-    fire on the stream, where the field is stripped (see
-    :func:`_is_turn_close_step`).
+    Thin alias for
+    :func:`omnigent.antigravity_native_steps.is_assistant_text_close_step`, the
+    shared implementation the write path's completion gate also consults: a
+    PLANNER_RESPONSE that carries assistant text (``modifiedResponse`` or
+    ``response``) is the closing edge of a turn — agy answered and stopped. A
+    planner step that only invokes a tool does not close the turn (the tool
+    result, and possibly more planner steps, follow).
 
     :param step: One RPC step dict.
     :returns: ``True`` when the step is a DONE PLANNER_RESPONSE with non-empty
         text and an empty/absent ``toolCalls`` list.
     """
-    # The turn-close edge must fire only on the DONE closing step. A GENERATING
-    # planner frame already carries growing ``modifiedResponse`` text with no
-    # ``toolCalls`` yet, so without this gate ``_emit_step`` would fire the IDLE
-    # status edge mid-response (the spinner closes early) on the stream path.
-    if step.get("status") != _STATUS_DONE:
-        return False
-    if step.get("type") != _TYPE_PLANNER_RESPONSE:
-        return False
-    planner = step.get("plannerResponse")
-    if not isinstance(planner, dict):
-        return False
-    modified = planner.get("modifiedResponse")
-    response = planner.get("response")
-    text = modified if isinstance(modified, str) and modified else response
-    if not isinstance(text, str) or not text.strip():
-        return False
-    tool_calls = planner.get("toolCalls")
-    return not (isinstance(tool_calls, list) and tool_calls)
+    return is_assistant_text_close_step(step)
 
 
 def _is_turn_close_step(step: dict[str, object]) -> bool:
     """
     Return whether a step ends the current turn (fire the IDLE edge).
+
+    Thin alias for :func:`omnigent.antigravity_native_steps.is_turn_close_step`,
+    the shared implementation the write path's completion gate also consults.
 
     A turn opens on USER_INPUT and stays open until agy stops working. Exactly
     two steps close it:
@@ -695,11 +677,7 @@ def _is_turn_close_step(step: dict[str, object]) -> bool:
     :param step: One RPC step dict.
     :returns: ``True`` when this step ends the turn.
     """
-    if _is_assistant_text_close_step(step):
-        return True
-    if step.get("type") != _TYPE_PLANNER_RESPONSE:
-        return False
-    return step.get("status") == _STATUS_ERROR
+    return is_turn_close_step(step)
 
 
 def _status_event(status: str) -> OutboundEvent:
@@ -1995,16 +1973,7 @@ def _committed_planner_text(step: dict[str, object]) -> str | None:
     :returns: The committed assistant text, or ``None`` for a non-planner step or
         one carrying no text (an intermediate planner that only made tool calls).
     """
-    if step.get("type") != _TYPE_PLANNER_RESPONSE:
-        return None
-    planner = step.get("plannerResponse")
-    if not isinstance(planner, dict):
-        return None
-    for key in ("modifiedResponse", "response"):
-        text = planner.get(key)
-        if isinstance(text, str) and text:
-            return text
-    return None
+    return planner_response_text(step)
 
 
 async def _close_planner_delta_stream(
@@ -2309,12 +2278,14 @@ def _step_is_error_planner(step: dict[str, object]) -> bool:
     Return whether a step is a PLANNER_RESPONSE that ended in ERROR.
 
     Used to close the turn as ``failed`` (not ``idle``) so a model/turn error is
-    not mistaken for a clean empty reply.
+    not mistaken for a clean empty reply. Thin alias for
+    :func:`omnigent.antigravity_native_steps.is_planner_error_step`, which the
+    write path's completion gate consults for the same decision.
 
     :param step: One RPC step dict.
     :returns: ``True`` for an ERROR-status planner step.
     """
-    return step.get("type") == _TYPE_PLANNER_RESPONSE and step.get("status") == _STATUS_ERROR
+    return is_planner_error_step(step)
 
 
 def _maybe_handle_interaction(

--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -42,7 +42,13 @@ Key differences from the retired transcript-based ``step_to_events`` mapper:
    ``toolCalls`` is never mirrored, so a stream→poll fallback cannot re-key a
    pair mid-conversation.
 
-:func:`map_step_to_events` is the public API; all other symbols are private.
+:func:`map_step_to_events` is the item-mapping public API. Alongside it the
+module publishes the pure **turn-state classification** helpers
+(:func:`find_turn_start_index`, :func:`classify_turn_outcome`,
+:func:`is_turn_close_step`, :func:`cascade_is_idle`, …) that answer "has agy
+finished this turn, and how did it end?" — shared by the read driver's status
+edges and the write path's completion gate so the two can never disagree. Other
+symbols are private.
 """
 
 from __future__ import annotations
@@ -1116,3 +1122,306 @@ def map_step_to_events(
 
     # CHECKPOINT / CONVERSATION_HISTORY / unrecognized system steps → skip.
     return []
+
+
+# ---------------------------------------------------------------------------
+# Turn-state classification
+#
+# The predicates below answer "has agy finished the turn, and how did it end?"
+# from the same RPC trajectory this module maps to items. They live here — pure,
+# no I/O — because TWO callers need the identical answer:
+#
+# * the read driver (:mod:`omnigent.antigravity_native_reader`), which fires the
+#   ``idle`` / ``failed`` session-status edges; and
+# * the write path's completion gate
+#   (:mod:`omnigent.inner.antigravity_native_executor`), which must not report a
+#   web/orchestrator turn complete until agy has actually finished the work.
+#
+# Before the gate existed the write path reported completion as soon as the text
+# was typed into the TUI, so a dispatched implementation task returned an empty
+# success before agy had run a single tool.
+# ---------------------------------------------------------------------------
+
+# agy's OWN per-cascade run status, published in every ``GetAllCascadeTrajectories``
+# summary. Live-verified against agy 1.1.8: RUNNING both while working AND for the
+# whole time a permission gate is parked (75s observed), so IDLE never means
+# "waiting for the human".
+CASCADE_RUN_STATUS_IDLE = "CASCADE_RUN_STATUS_IDLE"
+
+# Terminal-state vocabulary for one agy turn, as reported by :class:`TurnOutcome`.
+TurnState = Literal["running", "done", "error"]
+
+
+@dataclass(frozen=True)
+class TurnOutcome:
+    """
+    How one agy turn currently stands, derived from its trajectory steps.
+
+    :param state: ``"running"`` while agy is still working the turn, ``"done"``
+        once it answered and stopped, ``"error"`` when its planner step ended in
+        ``CORTEX_STEP_STATUS_ERROR``.
+    :param text: The turn's assistant text — the closing planner's text at
+        ``"done"``, the newest partial/intermediate planner text while
+        ``"running"``, ``None`` when the turn has produced no text yet.
+    :param error: agy's own error detail for an ``"error"`` state, or ``None``
+        when agy reported the failure without a message.
+    :param waiting_on_user: ``True`` when a step in this turn is currently
+        ``CORTEX_STEP_STATUS_WAITING`` — agy is parked on an ask-question /
+        permission gate. Only ever set alongside ``"running"``; a caller that
+        gives up on a turn uses it to say WHY it never finished.
+    """
+
+    state: TurnState
+    text: str | None = None
+    error: str | None = None
+    waiting_on_user: bool = False
+
+
+def is_user_turn_step(step: dict[str, object]) -> bool:
+    """
+    Return whether a step OPENS a turn (a USER_INPUT step).
+
+    :param step: One RPC step dict.
+    :returns: ``True`` for a ``CORTEX_STEP_TYPE_USER_INPUT`` step.
+    """
+    return step.get("type") == _TYPE_USER_INPUT
+
+
+def user_turn_text(step: dict[str, object]) -> str:
+    """
+    Return the user text agy recorded for a USER_INPUT step.
+
+    :param step: One RPC step dict.
+    :returns: The turn's user text, or ``""`` for a non-USER_INPUT step or one
+        whose ``userInput`` is missing/unparseable.
+    """
+    if not is_user_turn_step(step):
+        return ""
+    return _user_input_text(step.get("userInput"))
+
+
+def planner_response_text(step: dict[str, object]) -> str | None:
+    """
+    Return a planner step's assistant text, or ``None`` when it carries none.
+
+    Mirrors :func:`map_step_to_events`' precedence — ``modifiedResponse`` (the
+    post-moderation text) over ``response`` — so the gate reports byte-identical
+    text to the item the mapper commits.
+
+    :param step: One RPC step dict.
+    :returns: The assistant text, or ``None`` for a non-planner step or an
+        intermediate planner that only dispatched tools.
+    """
+    if step.get("type") != _TYPE_PLANNER_RESPONSE:
+        return None
+    planner = step.get("plannerResponse")
+    if not isinstance(planner, dict):
+        return None
+    for key in ("modifiedResponse", "response"):
+        text = planner.get(key)
+        if isinstance(text, str) and text:
+            return text
+    return None
+
+
+def planner_error_detail(step: dict[str, object]) -> str | None:
+    """
+    Return agy's own error detail from an ERROR planner step.
+
+    :param step: One RPC step dict.
+    :returns: The trimmed ``plannerResponse.error`` / ``.errorMessage`` string,
+        or ``None`` when agy reported the failure without a message.
+    """
+    planner = step.get("plannerResponse")
+    if not isinstance(planner, dict):
+        return None
+    for key in ("error", "errorMessage"):
+        detail = planner.get(key)
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()
+    return None
+
+
+def is_planner_error_step(step: dict[str, object]) -> bool:
+    """
+    Return whether a step is a PLANNER_RESPONSE that ended in ERROR.
+
+    A model / safety-policy / rate-limit / provider-overload failure lands here.
+    It closes the turn as FAILED, never as a clean empty reply.
+
+    :param step: One RPC step dict.
+    :returns: ``True`` for an ERROR-status planner step.
+    """
+    return step.get("type") == _TYPE_PLANNER_RESPONSE and step.get("status") == _STATUS_ERROR
+
+
+def is_assistant_text_close_step(step: dict[str, object]) -> bool:
+    """
+    Return whether a step closes a turn (assistant text, no further tool calls).
+
+    A DONE ``PLANNER_RESPONSE`` carrying assistant text is the closing edge of a
+    turn — agy answered and stopped. A planner step that only invokes a tool does
+    not close the turn (the tool result, and possibly more planner steps, follow).
+
+    The TEXT is what separates the two: a dispatching planner carries none, in
+    either RPC shape. The ``toolCalls`` test is a poll-shape-only belt-and-braces
+    guard for a planner that somehow carried both; it cannot fire on the stream,
+    where the field is stripped (see :func:`is_turn_close_step`).
+
+    :param step: One RPC step dict.
+    :returns: ``True`` when the step is a DONE PLANNER_RESPONSE with non-empty
+        text and an empty/absent ``toolCalls`` list.
+    """
+    # The turn-close edge must fire only on the DONE closing step. A GENERATING
+    # planner frame already carries growing ``modifiedResponse`` text with no
+    # ``toolCalls`` yet, so without this gate the reader would fire the IDLE
+    # status edge mid-response (the spinner closes early) on the stream path.
+    if step.get("status") != _STATUS_DONE:
+        return False
+    text = planner_response_text(step)
+    if text is None or not text.strip():
+        return False
+    planner = step.get("plannerResponse")
+    tool_calls = planner.get("toolCalls") if isinstance(planner, dict) else None
+    return not (isinstance(tool_calls, list) and tool_calls)
+
+
+def is_turn_close_step(step: dict[str, object]) -> bool:
+    """
+    Return whether a step ends the current turn.
+
+    A turn opens on USER_INPUT and stays open until agy stops working. Exactly
+    two steps close it:
+
+    * a DONE PLANNER_RESPONSE carrying assistant text
+      (:func:`is_assistant_text_close_step`) — agy answered and stopped; and
+    * a terminal-ERROR PLANNER_RESPONSE (:func:`is_planner_error_step`) — agy's
+      model step failed, so no tool result or recovery planner follows.
+
+    **Assistant text is the close signal, not the absence of ``toolCalls``.**
+    Text is the one discriminator that holds in BOTH RPC shapes: a planner that
+    dispatches a tool carries no text on the poll shape *or* the stream shape,
+    while an answering planner carries text on both. ``toolCalls`` exists only on
+    the poll shape (the stream strips it, as does ``metadata.toolCall``), so a
+    "closes unless it dispatched" rule read a STREAMED dispatch — DONE, no
+    toolCalls, no text — as a degenerate close and fired IDLE the moment agy
+    called a tool, clearing the spinner for the rest of the turn.
+
+    A DONE planner with neither text nor a dispatch is therefore NOT treated as a
+    close: that shape is indistinguishable from a streamed dispatch, and guessing
+    wrong strands every streamed tool turn. The genuinely degenerate turn is
+    reconciled against agy's own cascade status (:func:`cascade_is_idle`) by both
+    callers — the reader's idle backstop and the executor's completion gate.
+
+    Non-planner steps never close a turn here (a tool result is followed by a
+    recovery/answer planner; closing on it would pre-empt that planner).
+
+    :param step: One RPC step dict.
+    :returns: ``True`` when this step ends the turn.
+    """
+    return is_assistant_text_close_step(step) or is_planner_error_step(step)
+
+
+def cascade_is_idle(summaries: dict[str, object], cascade_id: str) -> bool:
+    """
+    Whether agy itself reports a cascade as no longer running.
+
+    Reads :data:`CASCADE_RUN_STATUS_IDLE` from the cascade's own summary rather
+    than inferring the turn's end from step types. Missing or malformed entries
+    are NOT idle: concluding "finished" on incomplete information is exactly the
+    false success both callers exist to prevent.
+
+    :param summaries: ``trajectorySummaries`` from
+        :func:`~omnigent.antigravity_native_rpc.get_all_cascade_trajectories`.
+    :param cascade_id: The cascade to read.
+    :returns: ``True`` only on an explicit idle status for that cascade.
+    """
+    summary = summaries.get(cascade_id)
+    if not isinstance(summary, dict):
+        return False
+    return summary.get("status") == CASCADE_RUN_STATUS_IDLE
+
+
+def find_turn_start_index(
+    steps: list[dict[str, object]],
+    *,
+    baseline_step_count: int | None,
+    delivered_text: str | None = None,
+) -> int | None:
+    """
+    Locate the USER_INPUT step that opened the turn a caller just delivered.
+
+    Only the NEWEST USER_INPUT step can be the caller's: deliveries are
+    serialized and agy appends, so this walks back to the newest USER_INPUT and
+    tests THAT one — never an older turn, which is what would let a previous
+    turn's closing planner be mistaken for this turn's completion.
+
+    Two tiers, in order:
+
+    #. **Position** (``baseline_step_count``): the caller snapshotted the step
+       count before delivering, so any USER_INPUT at or after that index is
+       necessarily new. This is the reliable tier and the only one consulted when
+       the snapshot succeeded.
+    #. **Text** (``delivered_text``): used only when the caller could NOT
+       snapshot (``baseline_step_count is None`` — the pre-delivery read failed).
+       Matching agy's recorded turn text against what was delivered still
+       identifies the turn, without a false "already complete" read of the
+       previous one. Compared on stripped text because agy round-trips the paste.
+
+    A caller with neither signal gets ``None`` (turn not identified) rather than
+    a guess.
+
+    :param steps: The full ordered trajectory from
+        :func:`~omnigent.antigravity_native_rpc.get_trajectory_steps`.
+    :param baseline_step_count: ``len(steps)`` observed before delivery, ``0``
+        for a conversation agy has not minted yet, or ``None`` when the
+        pre-delivery read failed.
+    :param delivered_text: The exact text the caller delivered, used only for
+        the text tier.
+    :returns: Index of this turn's USER_INPUT step, or ``None`` when agy has not
+        recorded it yet.
+    """
+    for index in range(len(steps) - 1, -1, -1):
+        step = steps[index]
+        if not isinstance(step, dict) or not is_user_turn_step(step):
+            continue
+        if baseline_step_count is not None:
+            return index if index >= baseline_step_count else None
+        if delivered_text is not None and user_turn_text(step).strip() == delivered_text.strip():
+            return index
+        return None
+    return None
+
+
+def classify_turn_outcome(steps: list[dict[str, object]], *, start_index: int) -> TurnOutcome:
+    """
+    Classify how the turn opened at ``start_index`` currently stands.
+
+    Scans only the steps AFTER the turn's own USER_INPUT step, so nothing from a
+    previous turn can satisfy it, and returns at the first terminal step:
+    :func:`is_planner_error_step` → ``"error"``, :func:`is_assistant_text_close_step`
+    → ``"done"``. Everything else (tool steps, dispatching planners, a WAITING
+    interaction gate, a mid-turn steering USER_INPUT) leaves the turn
+    ``"running"`` — a tool step that ERRORs does NOT end the turn, because agy
+    routinely recovers from one and keeps working.
+
+    :param steps: The full ordered trajectory.
+    :param start_index: Index of this turn's USER_INPUT step, from
+        :func:`find_turn_start_index`.
+    :returns: The turn's current :class:`TurnOutcome`.
+    """
+    latest_text: str | None = None
+    waiting = False
+    for step in steps[start_index + 1 :]:
+        if not isinstance(step, dict):
+            continue
+        if is_planner_error_step(step):
+            return TurnOutcome(state="error", text=latest_text, error=planner_error_detail(step))
+        text = planner_response_text(step)
+        if text:
+            latest_text = text
+        if is_assistant_text_close_step(step):
+            return TurnOutcome(state="done", text=text)
+        if step.get("status") == _STATUS_WAITING:
+            waiting = True
+    return TurnOutcome(state="running", text=latest_text, waiting_on_user=waiting)

--- a/omnigent/antigravity_native_steps.py
+++ b/omnigent/antigravity_native_steps.py
@@ -1169,12 +1169,19 @@ class TurnOutcome:
         ``CORTEX_STEP_STATUS_WAITING`` — agy is parked on an ask-question /
         permission gate. Only ever set alongside ``"running"``; a caller that
         gives up on a turn uses it to say WHY it never finished.
+    :param model_started: ``True`` once agy has recorded a planner or tool step
+        FOR THIS TURN, i.e. positive evidence the model actually began working on
+        it. A bare recorded USER_INPUT does NOT set this: agy publishes the user
+        step before it starts generating, and during that window its cascade
+        still reports idle. Any caller inferring completion from an idle cascade
+        must require this first, or the pre-start gap reads as a finished turn.
     """
 
     state: TurnState
     text: str | None = None
     error: str | None = None
     waiting_on_user: bool = False
+    model_started: bool = False
 
 
 def is_user_turn_step(step: dict[str, object]) -> bool:
@@ -1185,19 +1192,6 @@ def is_user_turn_step(step: dict[str, object]) -> bool:
     :returns: ``True`` for a ``CORTEX_STEP_TYPE_USER_INPUT`` step.
     """
     return step.get("type") == _TYPE_USER_INPUT
-
-
-def user_turn_text(step: dict[str, object]) -> str:
-    """
-    Return the user text agy recorded for a USER_INPUT step.
-
-    :param step: One RPC step dict.
-    :returns: The turn's user text, or ``""`` for a non-USER_INPUT step or one
-        whose ``userInput`` is missing/unparseable.
-    """
-    if not is_user_turn_step(step):
-        return ""
-    return _user_input_text(step.get("userInput"))
 
 
 def planner_response_text(step: dict[str, object]) -> str | None:
@@ -1345,39 +1339,34 @@ def cascade_is_idle(summaries: dict[str, object], cascade_id: str) -> bool:
 def find_turn_start_index(
     steps: list[dict[str, object]],
     *,
-    baseline_step_count: int | None,
-    delivered_text: str | None = None,
+    baseline_step_count: int,
 ) -> int | None:
     """
     Locate the USER_INPUT step that opened the turn a caller just delivered.
 
-    Only the NEWEST USER_INPUT step can be the caller's: deliveries are
-    serialized and agy appends, so this walks back to the newest USER_INPUT and
-    tests THAT one — never an older turn, which is what would let a previous
-    turn's closing planner be mistaken for this turn's completion.
+    **Position is the only signal, deliberately.** The caller snapshots the step
+    count BEFORE delivering, so a USER_INPUT at or after that index necessarily
+    appeared afterwards and is therefore the caller's own turn. Only the NEWEST
+    USER_INPUT is ever tested — deliveries are serialized and agy appends — so an
+    older turn, whose closing planner is already sitting in the same trajectory,
+    can never be adopted.
 
-    Two tiers, in order:
-
-    #. **Position** (``baseline_step_count``): the caller snapshotted the step
-       count before delivering, so any USER_INPUT at or after that index is
-       necessarily new. This is the reliable tier and the only one consulted when
-       the snapshot succeeded.
-    #. **Text** (``delivered_text``): used only when the caller could NOT
-       snapshot (``baseline_step_count is None`` — the pre-delivery read failed).
-       Matching agy's recorded turn text against what was delivered still
-       identifies the turn, without a false "already complete" read of the
-       previous one. Compared on stripped text because agy round-trips the paste.
-
-    A caller with neither signal gets ``None`` (turn not identified) rather than
-    a guess.
+    An earlier revision fell back to matching the delivered TEXT when the
+    snapshot failed. That fallback was unsound: when the identical text had been
+    sent in the previous turn and the new USER_INPUT step had not yet appeared,
+    the OLD turn matched and its DONE planner was accepted as this turn's
+    completion — the exact false success this whole gate exists to prevent. There
+    is no text-only rule that separates two identical turns, so a caller that
+    cannot snapshot has no way to identify its turn and must report that rather
+    than guess (see
+    :meth:`omnigent.inner.antigravity_native_executor.AntigravityNativeExecutor._snapshot_step_count`,
+    which retries before giving up).
 
     :param steps: The full ordered trajectory from
         :func:`~omnigent.antigravity_native_rpc.get_trajectory_steps`.
-    :param baseline_step_count: ``len(steps)`` observed before delivery, ``0``
-        for a conversation agy has not minted yet, or ``None`` when the
-        pre-delivery read failed.
-    :param delivered_text: The exact text the caller delivered, used only for
-        the text tier.
+    :param baseline_step_count: ``len(steps)`` observed before delivery; ``0``
+        for a conversation agy has not minted yet (nothing earlier exists to be
+        confused with).
     :returns: Index of this turn's USER_INPUT step, or ``None`` when agy has not
         recorded it yet.
     """
@@ -1385,11 +1374,7 @@ def find_turn_start_index(
         step = steps[index]
         if not isinstance(step, dict) or not is_user_turn_step(step):
             continue
-        if baseline_step_count is not None:
-            return index if index >= baseline_step_count else None
-        if delivered_text is not None and user_turn_text(step).strip() == delivered_text.strip():
-            return index
-        return None
+        return index if index >= baseline_step_count else None
     return None
 
 
@@ -1405,6 +1390,14 @@ def classify_turn_outcome(steps: list[dict[str, object]], *, start_index: int) -
     ``"running"`` — a tool step that ERRORs does NOT end the turn, because agy
     routinely recovers from one and keeps working.
 
+    It also reports ``model_started``: whether agy has recorded a planner or tool
+    step for this turn. A recorded USER_INPUT alone does NOT count. agy publishes
+    the user step before it begins generating, and its cascade still reports idle
+    in that window, so a caller that closes a turn on an idle cascade must wait
+    for this evidence — otherwise the pre-start gap reads as a finished turn. A
+    mid-turn steering USER_INPUT is likewise not evidence: it is another
+    delivery, not the model working.
+
     :param steps: The full ordered trajectory.
     :param start_index: Index of this turn's USER_INPUT step, from
         :func:`find_turn_start_index`.
@@ -1412,16 +1405,29 @@ def classify_turn_outcome(steps: list[dict[str, object]], *, start_index: int) -
     """
     latest_text: str | None = None
     waiting = False
+    model_started = False
     for step in steps[start_index + 1 :]:
         if not isinstance(step, dict):
             continue
+        if step.get("type") == _TYPE_PLANNER_RESPONSE or _is_tool_step(step):
+            model_started = True
         if is_planner_error_step(step):
-            return TurnOutcome(state="error", text=latest_text, error=planner_error_detail(step))
+            return TurnOutcome(
+                state="error",
+                text=latest_text,
+                error=planner_error_detail(step),
+                model_started=True,
+            )
         text = planner_response_text(step)
         if text:
             latest_text = text
         if is_assistant_text_close_step(step):
-            return TurnOutcome(state="done", text=text)
+            return TurnOutcome(state="done", text=text, model_started=True)
         if step.get("status") == _STATUS_WAITING:
             waiting = True
-    return TurnOutcome(state="running", text=latest_text, waiting_on_user=waiting)
+    return TurnOutcome(
+        state="running",
+        text=latest_text,
+        waiting_on_user=waiting,
+        model_started=model_started,
+    )

--- a/omnigent/inner/antigravity_native_executor.py
+++ b/omnigent/inner/antigravity_native_executor.py
@@ -56,15 +56,31 @@ classified by the shared, pure helpers in
   rate-limit / provider failure is never collapsed into a success;
 * a degenerate turn that closes without a text planner → reconciled against agy's
   OWN cascade run status (``GetAllCascadeTrajectories``), the same idle backstop
-  the read driver uses, confirmed over consecutive checks;
+  the read driver uses, confirmed over consecutive checks AND only once agy has
+  recorded a planner or tool step for this turn (agy reports the cascade idle
+  between recording the user step and starting the model, so consecutive idle
+  readings alone would let that pre-start gap pass as a finished turn);
 * neither, within the budget → :class:`ExecutorError` naming the timeout.
 
+**Which turn is "this turn".** The trajectory holds every previous turn too, each
+already ending in its own closing planner, so the gate must know exactly which
+USER_INPUT step is its own or it will read a stale close as this turn's success.
+The executor snapshots the step count BEFORE delivering; only a USER_INPUT step
+at or past that index can be the one it just delivered. That snapshot is retried
+(:data:`_SNAPSHOT_TIMEOUT_S`) because nothing else can substitute for it — an
+earlier revision fell back to matching the delivered TEXT, which silently
+accepted the PREVIOUS turn whenever the same text was sent twice and the new step
+had not yet appeared. A turn whose snapshot never succeeds is reported as
+delivered-but-unverifiable, never guessed at.
+
 The gate is bounded by two named budgets, :data:`_TURN_START_TIMEOUT_S` and
-:data:`_TURN_COMPLETION_TIMEOUT_S`. Note that the bridge's tmux timeouts
-(``_TMUX_SEND_TIMEOUT_S`` / ``_TMUX_READY_TIMEOUT_S`` / ``_PASTE_COMMIT_TIMEOUT_S``
-/ ``_SUBMIT_VERIFY_TIMEOUT_S``) cover only local TUI delivery, and agy's own
-``--print-timeout`` never applies because this path does not use ``--print`` — so
-before the gate there was NO task-completion budget of any kind here.
+:data:`_TURN_COMPLETION_TIMEOUT_S`; the latter documents why the harness idle
+watchdog, not this constant, is the real outer bound. Note that the bridge's tmux
+timeouts (``_TMUX_SEND_TIMEOUT_S`` / ``_TMUX_READY_TIMEOUT_S`` /
+``_PASTE_COMMIT_TIMEOUT_S`` / ``_SUBMIT_VERIFY_TIMEOUT_S``) cover only local TUI
+delivery, and agy's own ``--print-timeout`` never applies because this path does
+not use ``--print`` — so before the gate there was NO task-completion budget of
+any kind here.
 
 Mid-turn steering (:meth:`AntigravityNativeExecutor.enqueue_session_message`) is
 deliberately NOT gated: it is a delivery, not a turn, and the ``run_turn`` gate
@@ -119,6 +135,7 @@ from omnigent.antigravity_native_steps import (
     cascade_is_idle,
     classify_turn_outcome,
     find_turn_start_index,
+    is_user_turn_step,
 )
 from omnigent.inner.executor import (
     EnqueuedContent,
@@ -155,32 +172,57 @@ _USER_INPUT_STEP_TYPE = "CORTEX_STEP_TYPE_USER_INPUT"
 _TURN_POLL_INTERVAL_S = 2.0
 
 # Seconds after a SUCCESSFUL delivery in which agy must record the turn — a
-# USER_INPUT step for our text must appear on a reachable cascade. The submit was
-# already footer-verified by the injector, so this only has to absorb agy minting
-# its cascade on a first turn plus RPC-port discovery. Blowing this budget means
-# the paste landed somewhere that is not a turn, which is a failure, not a slow
-# agent: it is reported as one rather than waiting out the full completion
-# budget.
+# USER_INPUT step past the pre-delivery baseline must appear on a reachable
+# cascade. The submit was already footer-verified by the injector, so this only
+# has to absorb agy minting its cascade on a first turn plus RPC-port discovery.
+# Blowing this budget means the paste landed somewhere that is not a turn, which
+# is a failure, not a slow agent: it is reported as one rather than waiting out
+# the full completion budget.
 _TURN_START_TIMEOUT_S = 180.0
 
-# Total seconds an OPEN turn may run before the gate gives up. Sized for
-# long-running implementation work, which is the case that motivated the gate: a
-# dispatched worker editing several files, running a build and a test suite is
-# routinely tens of minutes, so anything in the low minutes (agy's own 5-minute
-# ``--print-timeout`` default, say) would abort real work and be worse than the
-# bug. One hour is long enough that a legitimate implementation turn finishes
-# inside it, and short enough that a wedged agy — one parked forever on a
-# permission gate, or hung mid-tool — frees the caller's slot the same day
-# instead of never. A turn that hits this yields an ExecutorError naming the
-# budget; it never degrades into a success.
-_TURN_COMPLETION_TIMEOUT_S = 3600.0
+# Total seconds an OPEN turn may run before the gate gives up.
+#
+# **This is NOT the effective production budget on its own.** The harness wraps
+# every ``run_turn`` in an IDLE watchdog (``_scaffold._TURN_IDLE_TIMEOUT_S``, env
+# ``HARNESS_TURN_TIMEOUT_S``, default 3600s at the time of writing — raised from
+# 600s in #6204). That watchdog is reset only by a NON-HEARTBEAT ``ctx.emit``,
+# and this gate emits nothing while it polls: the read driver mirrors agy's
+# output by POSTing session events directly, not through the harness stream. So
+# a healthy but silent gated turn is racing the harness watchdog, and the real
+# ceiling is whichever of the two fires first.
+#
+# The gate budget therefore sits deliberately BELOW the harness default, so a
+# turn that overruns fails with the diagnosable message below rather than an
+# opaque harness ``response.failed``. Raising it past ``HARNESS_TURN_TIMEOUT_S``
+# buys nothing: the watchdog would win. Emitting a real progress signal from here
+# would need a change in the harness adapter (out of this change's scope), and
+# every event the adapter currently translates would double-render against the
+# read driver's mirror.
+#
+# 50 minutes is sized for the case that motivated the gate — a dispatched worker
+# editing several files, running a build and a test suite, routinely tens of
+# minutes. Anything in the low minutes (agy's own 5-minute ``--print-timeout``
+# default, say) would abort real work and be worse than the bug; anything past
+# the harness watchdog is fiction. A turn that hits this yields an ExecutorError
+# naming the budget; it never degrades into a success.
+_TURN_COMPLETION_TIMEOUT_S = 3000.0
+
+# Budget for the PRE-delivery trajectory snapshot, which is the sole signal that
+# identifies this turn's USER_INPUT step (see :func:`find_turn_start_index` — the
+# unsound text-matching fallback was removed). Without it the turn cannot be
+# verified at all, so a transient RPC blip is retried rather than accepted; a
+# failure that outlives this budget is reported, never guessed around.
+_SNAPSHOT_TIMEOUT_S = 10.0
+_SNAPSHOT_RETRY_INTERVAL_S = 1.0
 
 # The idle backstop. A turn can close without a text-carrying planner step (the
 # degenerate shape the read driver documents), which no step-based rule can tell
-# apart from a dispatch. agy's own cascade run status settles it, but a single
-# reading can catch the gap between the turn being recorded and agy starting it,
-# so the gate requires consecutive idle readings, spaced by whole poll cycles,
-# and consults it only AFTER the turn is confirmed open.
+# apart from a dispatch. agy's own cascade run status settles it — but agy
+# publishes the USER_INPUT step BEFORE it starts generating and reports the
+# cascade idle throughout that window, so consecutive idle readings alone do not
+# close the gap; they only require it to persist. The backstop is therefore
+# gated on ``TurnOutcome.model_started`` (a planner or tool step recorded FOR
+# THIS TURN) as well as on consecutive idle readings spaced by whole poll cycles.
 _IDLE_CHECK_EVERY_N_POLLS = 5
 _IDLE_CONFIRM_CHECKS = 2
 
@@ -388,25 +430,59 @@ class AntigravityNativeExecutor(Executor):
         if not text:
             yield ExecutorError(message="Antigravity native turn had no user text to send")
             return
-        self._interrupted.clear()
-        # Snapshot BEFORE delivering: the step count is what tells this turn's
-        # USER_INPUT step apart from the previous turn's, whose closing planner
-        # would otherwise satisfy the gate instantly.
-        baseline = await self._snapshot_step_count()
-        failure = await self._deliver(text)
-        if failure is not None:
-            yield ExecutorError(message=failure)
-            return
-        result = await self._await_turn_completion(delivered_text=text, baseline=baseline)
-        if result.cancelled:
+        # A stop that arrived before this turn began running (the harness
+        # registers the turn context before it starts iterating ``run_turn``, so
+        # an interrupt CAN land in that window). Honour it here instead of
+        # clearing it: clearing at entry is what dropped such a stop, and
+        # delivering text for a request the user already cancelled is worse than
+        # reporting it cancelled.
+        if self._interrupted.is_set():
+            self._interrupted.clear()
             yield TurnCancelled()
-        elif result.completed:
-            yield TurnComplete(response=result.text)
-        else:
-            yield ExecutorError(
-                message=result.error or "Antigravity native turn did not complete",
-                retryable=result.retryable,
-            )
+            return
+        try:
+            # Snapshot BEFORE delivering: the step count is the ONLY signal that
+            # tells this turn's USER_INPUT step apart from the previous turn's,
+            # whose closing planner would otherwise satisfy the gate instantly.
+            baseline = await self._snapshot_step_count()
+            failure = await self._deliver(text)
+            if failure is not None:
+                yield ExecutorError(message=failure)
+                return
+            if baseline is None:
+                # Delivered, but unverifiable: agy's trajectory stayed unreadable
+                # across the whole snapshot budget, so there is no way to tell
+                # this turn's USER_INPUT step from an earlier one. Guessing is
+                # what produced the original false success, so this reports the
+                # truth instead. NOT retryable: the text was already typed into
+                # the TUI, and a retry would deliver it twice.
+                yield ExecutorError(
+                    message=(
+                        "Antigravity native turn was delivered to the agy TUI but could not be "
+                        "verified: agy's trajectory was unreadable for "
+                        f"{_SNAPSHOT_TIMEOUT_S:.0f}s before delivery, so this turn cannot be "
+                        "told apart from the previous one. agy may still run the turn; its "
+                        "completion is NOT confirmed"
+                    ),
+                )
+                return
+            result = await self._await_turn_completion(baseline=baseline)
+            if result.cancelled:
+                yield TurnCancelled()
+            elif result.completed:
+                yield TurnComplete(response=result.text)
+            else:
+                yield ExecutorError(
+                    message=result.error or "Antigravity native turn did not complete",
+                    retryable=result.retryable,
+                )
+        finally:
+            # Consume the interrupt HERE rather than at entry. The harness calls
+            # ``interrupt_session`` a second time once it sees the cancelled
+            # event, and that call lands before this generator is closed — so
+            # clearing on the way out leaves no stale stop for the next turn,
+            # while an interrupt racing the START of a turn is no longer lost.
+            self._interrupted.clear()
 
     async def _deliver(self, text: str) -> str | None:
         """
@@ -467,9 +543,7 @@ class AntigravityNativeExecutor(Executor):
             )
             return None
 
-    async def _await_turn_completion(
-        self, *, delivered_text: str, baseline: int | None
-    ) -> _GateResult:
+    async def _await_turn_completion(self, *, baseline: int) -> _GateResult:
         """
         Block until agy finishes the delivered turn, or a budget runs out.
 
@@ -481,32 +555,42 @@ class AntigravityNativeExecutor(Executor):
         Two phases, each with its own budget:
 
         #. **Start** (:data:`_TURN_START_TIMEOUT_S`): agy must record the delivery
-           as a USER_INPUT step (:func:`find_turn_start_index`). Until that step
-           exists there is no turn to wait on, and a delivery that never becomes
-           one is a failure worth reporting promptly rather than waiting out the
-           full completion budget.
+           as a USER_INPUT step past ``baseline`` (:func:`find_turn_start_index`).
+           Until that step exists there is no turn to wait on, and a delivery that
+           never becomes one is a failure worth reporting promptly rather than
+           waiting out the full completion budget.
         #. **Completion** (:data:`_TURN_COMPLETION_TIMEOUT_S`, measured from
            delivery): the open turn must reach a terminal state — a DONE planner
            with text, an ERROR planner, or agy's own cascade status settling to
-           idle across :data:`_IDLE_CONFIRM_CHECKS` consecutive checks for the
-           degenerate close.
+           idle across :data:`_IDLE_CONFIRM_CHECKS` consecutive checks once the
+           model has demonstrably started (the degenerate close).
 
         A trajectory read that fails (transport, non-2xx, non-JSON body, no
         resolvable RPC port yet) is transient: it is logged, the cached port is
         dropped so the next pass re-resolves, and the loop retries until a budget
         expires. It never short-circuits into a success.
 
-        :param delivered_text: The exact text delivered, used to identify this
-            turn's USER_INPUT step when the pre-delivery snapshot was unavailable.
-        :param baseline: Step count observed before delivery, or ``None`` when it
-            could not be read (see :meth:`_snapshot_step_count`).
+        .. note:: **Positional assumption.** ``start_index`` is an index into the
+           ``steps`` LIST, and the gate keeps using it across polls. That assumes
+           agy only ever APPENDS to a cascade's trajectory — which is what has
+           been observed, but is not guaranteed: the read driver keys step
+           identity on ``(trajectory_id, step_index)`` precisely because those are
+           the stable fields, and whether agy ever prunes, compacts or reorders
+           the list is UNVERIFIED. So the position is re-validated on every poll
+           (the step there must still be a USER_INPUT step); when it is not, the
+           gate reports a failure naming the mutation rather than classifying a
+           window that may belong to a different turn. Moving to
+           ``(trajectory_id, step_index)`` identity would remove the assumption
+           and is the right fix if agy is ever seen mutating the list.
+
+        :param baseline: Step count observed before delivery (see
+            :meth:`_snapshot_step_count`).
         :returns: The turn's :class:`_GateResult`.
         """
         started_at = time.monotonic()
         start_index: int | None = None
         # Counted from the poll that first saw the turn OPEN, not from gate
-        # entry, so the idle backstop can never fire on the very reading that
-        # discovered the turn — the one reading agy may not have started yet.
+        # entry, so the idle backstop's spacing is measured from the turn.
         polls_since_open = -1
         idle_checks = 0
         latest_text: str | None = None
@@ -518,10 +602,21 @@ class AntigravityNativeExecutor(Executor):
             steps = await self._read_trajectory()
             if steps is not None:
                 if start_index is None:
-                    start_index = find_turn_start_index(
-                        steps,
-                        baseline_step_count=baseline,
-                        delivered_text=delivered_text,
+                    start_index = find_turn_start_index(steps, baseline_step_count=baseline)
+                elif not _still_opens_a_turn(steps, start_index):
+                    # The list changed shape under us (see the positional note
+                    # above). Everything after ``start_index`` now describes some
+                    # other turn, so classifying it could report a stale close as
+                    # this turn's completion. Fail loudly instead.
+                    return _GateResult(
+                        completed=False,
+                        text=latest_text,
+                        error=(
+                            "Antigravity native turn could not be tracked: agy's trajectory "
+                            f"changed shape under the completion gate (step {start_index} is no "
+                            "longer this turn's user input). The turn was delivered and may "
+                            "still be running; its completion is NOT confirmed"
+                        ),
                     )
                 if start_index is not None:
                     polls_since_open += 1
@@ -550,10 +645,21 @@ class AntigravityNativeExecutor(Executor):
                         )
                     # Still running. The degenerate close (a turn that ends with
                     # no text-carrying planner) is only visible in agy's own
-                    # cascade status, and only after enough consecutive idle
-                    # readings that a not-yet-started turn cannot masquerade as a
-                    # finished one.
-                    if polls_since_open > 0 and polls_since_open % _IDLE_CHECK_EVERY_N_POLLS == 0:
+                    # cascade status — but that status is ALSO idle in the window
+                    # between agy recording the user step and the model starting,
+                    # and consecutive readings do not close that window, they only
+                    # require it to persist. So the backstop additionally demands
+                    # positive evidence the model started on THIS turn: a planner
+                    # or tool step recorded after its user input. (A non-idle
+                    # cascade reading is deliberately NOT accepted as that
+                    # evidence — ``_cascade_reports_idle`` fails closed, so False
+                    # is indistinguishable from a failed read.)
+                    ready_to_check = (
+                        outcome.model_started
+                        and polls_since_open > 0
+                        and polls_since_open % _IDLE_CHECK_EVERY_N_POLLS == 0
+                    )
+                    if ready_to_check:
                         if await self._cascade_reports_idle():
                             idle_checks += 1
                             if idle_checks >= _IDLE_CONFIRM_CHECKS:
@@ -599,21 +705,37 @@ class AntigravityNativeExecutor(Executor):
         Read the cascade's step count before delivering, for turn identification.
 
         The gate needs to tell THIS turn's USER_INPUT step from the previous
-        turn's; the pre-delivery step count does that positionally.
+        turn's, and the pre-delivery step count is the ONLY signal that does it
+        (:func:`find_turn_start_index`). Since nothing else can substitute, a
+        failed read is RETRIED within :data:`_SNAPSHOT_TIMEOUT_S` rather than
+        waved through — a transient RPC blip must not cost the turn its only
+        means of verification.
 
         :returns: ``0`` when agy has not minted the conversation yet (a first
             turn has no earlier step to be confused with), the current step count
-            when the trajectory reads cleanly, or ``None`` when it could not be
-            read — in which case the gate identifies the turn by its text instead
-            (see :func:`find_turn_start_index`).
+            when the trajectory reads cleanly, or ``None`` when it stayed
+            unreadable for the whole budget — the caller reports that turn as
+            unverifiable rather than guessing which USER_INPUT step is its own.
         """
-        state = await asyncio.to_thread(read_bridge_state, self._bridge_dir)
-        if state is None:
-            return None
-        if is_placeholder_conversation_id(state.conversation_id):
-            return 0
-        steps = await self._read_trajectory()
-        return None if steps is None else len(steps)
+        deadline = time.monotonic() + _SNAPSHOT_TIMEOUT_S
+        while True:
+            state = await asyncio.to_thread(read_bridge_state, self._bridge_dir)
+            if state is None:
+                # Broken wiring, not a transient fault; ``_deliver`` reports it.
+                return None
+            if is_placeholder_conversation_id(state.conversation_id):
+                return 0
+            steps = await self._read_trajectory()
+            if steps is not None:
+                return len(steps)
+            if time.monotonic() >= deadline:
+                _logger.warning(
+                    "antigravity native could not snapshot the trajectory in %.0fs; "
+                    "this turn will be delivered but cannot be verified",
+                    _SNAPSHOT_TIMEOUT_S,
+                )
+                return None
+            await _sleep(_SNAPSHOT_RETRY_INTERVAL_S)
 
     async def _resolve_rpc_target(self) -> tuple[int, str] | None:
         """
@@ -696,6 +818,27 @@ class AntigravityNativeExecutor(Executor):
         if not isinstance(summaries, dict):
             return False
         return cascade_is_idle(summaries, cascade_id)
+
+
+def _still_opens_a_turn(steps: list[dict[str, object]], start_index: int) -> bool:
+    """
+    Whether ``start_index`` still points at the USER_INPUT step the gate recorded.
+
+    The completion gate holds a LIST index across polls, which is only valid
+    while agy appends to the trajectory (see the note on
+    :meth:`AntigravityNativeExecutor._await_turn_completion`). This is the cheap
+    re-validation: if the slot no longer holds a turn-opening step, the list was
+    pruned, compacted or reordered underneath the gate and the index now
+    addresses someone else's turn.
+
+    :param steps: The trajectory as read on this poll.
+    :param start_index: The index recorded when the turn was identified.
+    :returns: ``True`` when the position is still this turn's user input.
+    """
+    if start_index >= len(steps):
+        return False
+    step = steps[start_index]
+    return isinstance(step, dict) and is_user_turn_step(step)
 
 
 def _bridge_dir_from_env() -> Path:

--- a/omnigent/inner/antigravity_native_executor.py
+++ b/omnigent/inner/antigravity_native_executor.py
@@ -28,11 +28,47 @@ executor:
 
 * does NOT stream (``supports_streaming() -> False``) — the read driver posts the
   assistant message;
-* yields a single :class:`TurnComplete` with ``response=None`` on a successful
-  send (fabricating text here would double the read driver's mirrored message);
+* yields ONE terminal event per turn, and only once agy has actually FINISHED the
+  turn (see the completion gate below);
 * supports a live message queue (``supports_live_message_queue() -> True``) — a
   mid-turn web message is delivered over the same RPC, which is how web steering
   works.
+
+**The completion gate (the load-bearing correctness detail).** Delivery and
+completion are two different events, and this executor used to conflate them: it
+yielded ``TurnComplete`` the moment ``_deliver`` returned, i.e. as soon as the
+text had been TYPED AND SUBMITTED in the TUI. Nothing waited for agy to do the
+work. A caller that dispatches an implementation task — a polly orchestrator
+running agy as a worker — therefore collected an immediate, empty success before
+agy had run a single tool, and read "no changes" as "the task is done". Unlike
+the claude/codex harnesses there is no headless per-turn subprocess whose exit
+supplies that signal, so this executor supplies it itself: after a successful
+delivery it polls agy's own RPC trajectory (``GetCascadeTrajectorySteps``, the
+same surface the read driver mirrors) until the turn reaches a TERMINAL state,
+classified by the shared, pure helpers in
+:mod:`omnigent.antigravity_native_steps`:
+
+* a DONE ``PLANNER_RESPONSE`` carrying assistant text → :class:`TurnComplete`,
+  carrying agy's final text (the harness adapter does not re-emit it as a
+  conversation item, so the read driver stays the sole mirror source and nothing
+  double-renders);
+* an ERROR ``PLANNER_RESPONSE`` → :class:`ExecutorError`, so a model / safety /
+  rate-limit / provider failure is never collapsed into a success;
+* a degenerate turn that closes without a text planner → reconciled against agy's
+  OWN cascade run status (``GetAllCascadeTrajectories``), the same idle backstop
+  the read driver uses, confirmed over consecutive checks;
+* neither, within the budget → :class:`ExecutorError` naming the timeout.
+
+The gate is bounded by two named budgets, :data:`_TURN_START_TIMEOUT_S` and
+:data:`_TURN_COMPLETION_TIMEOUT_S`. Note that the bridge's tmux timeouts
+(``_TMUX_SEND_TIMEOUT_S`` / ``_TMUX_READY_TIMEOUT_S`` / ``_PASTE_COMMIT_TIMEOUT_S``
+/ ``_SUBMIT_VERIFY_TIMEOUT_S``) cover only local TUI delivery, and agy's own
+``--print-timeout`` never applies because this path does not use ``--print`` — so
+before the gate there was NO task-completion budget of any kind here.
+
+Mid-turn steering (:meth:`AntigravityNativeExecutor.enqueue_session_message`) is
+deliberately NOT gated: it is a delivery, not a turn, and the ``run_turn`` gate
+that is already open is what waits for the steered work to finish.
 
 **Per-turn model (the load-bearing detail).** ``SendUserCascadeMessage`` REQUIRES
 a ``planModel`` enum per turn (omitting it errors "neither PlanModel nor
@@ -59,8 +95,12 @@ import asyncio
 import json
 import logging
 import os
+import time
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from pathlib import Path
+
+import httpx
 
 from omnigent.antigravity_native_bridge import (
     ANTIGRAVITY_NATIVE_BRIDGE_DIR_ENV_VAR,
@@ -71,7 +111,14 @@ from omnigent.antigravity_native_bridge import (
 )
 from omnigent.antigravity_native_rpc import (
     cancel_cascade_steps,
+    get_all_cascade_trajectories,
+    get_trajectory_steps,
     resolve_language_server_port,
+)
+from omnigent.antigravity_native_steps import (
+    cascade_is_idle,
+    classify_turn_outcome,
+    find_turn_start_index,
 )
 from omnigent.inner.executor import (
     EnqueuedContent,
@@ -81,6 +128,7 @@ from omnigent.inner.executor import (
     ExecutorEvent,
     Message,
     ToolSpec,
+    TurnCancelled,
     TurnComplete,
     describe_exception,
 )
@@ -92,6 +140,90 @@ _logger = logging.getLogger(__name__)
 # agy step type for a committed user turn; its ``userConfig`` carries the model
 # the user was on for that turn (the tier-1 model-echo source, design §10.4).
 _USER_INPUT_STEP_TYPE = "CORTEX_STEP_TYPE_USER_INPUT"
+
+# --- Completion-gate budgets (see the module docstring) --------------------
+#
+# These are the ONLY task-completion budgets on this path. The bridge's tmux
+# timeouts bound local TUI delivery, not the work; agy's ``--print-timeout``
+# never applies because this path does not use ``--print``.
+
+# Seconds between trajectory polls while waiting for the turn to finish. agy's
+# steps finalize at DONE (no token streaming on this surface) and the gate only
+# needs the terminal edge, not a live mirror — that is the read driver's job at
+# its own much faster cadence — so this is deliberately slow enough to be free
+# next to a multi-minute agent turn.
+_TURN_POLL_INTERVAL_S = 2.0
+
+# Seconds after a SUCCESSFUL delivery in which agy must record the turn — a
+# USER_INPUT step for our text must appear on a reachable cascade. The submit was
+# already footer-verified by the injector, so this only has to absorb agy minting
+# its cascade on a first turn plus RPC-port discovery. Blowing this budget means
+# the paste landed somewhere that is not a turn, which is a failure, not a slow
+# agent: it is reported as one rather than waiting out the full completion
+# budget.
+_TURN_START_TIMEOUT_S = 180.0
+
+# Total seconds an OPEN turn may run before the gate gives up. Sized for
+# long-running implementation work, which is the case that motivated the gate: a
+# dispatched worker editing several files, running a build and a test suite is
+# routinely tens of minutes, so anything in the low minutes (agy's own 5-minute
+# ``--print-timeout`` default, say) would abort real work and be worse than the
+# bug. One hour is long enough that a legitimate implementation turn finishes
+# inside it, and short enough that a wedged agy — one parked forever on a
+# permission gate, or hung mid-tool — frees the caller's slot the same day
+# instead of never. A turn that hits this yields an ExecutorError naming the
+# budget; it never degrades into a success.
+_TURN_COMPLETION_TIMEOUT_S = 3600.0
+
+# The idle backstop. A turn can close without a text-carrying planner step (the
+# degenerate shape the read driver documents), which no step-based rule can tell
+# apart from a dispatch. agy's own cascade run status settles it, but a single
+# reading can catch the gap between the turn being recorded and agy starting it,
+# so the gate requires consecutive idle readings, spaced by whole poll cycles,
+# and consults it only AFTER the turn is confirmed open.
+_IDLE_CHECK_EVERY_N_POLLS = 5
+_IDLE_CONFIRM_CHECKS = 2
+
+
+@dataclass(frozen=True)
+class _GateResult:
+    """
+    Outcome of the post-delivery completion gate for one turn.
+
+    :param completed: ``True`` when agy reached a terminal DONE state for this
+        turn. ``False`` for every non-success — an agy ERROR, a timeout, or a
+        turn that never became observable — which the caller surfaces as an
+        :class:`ExecutorError`.
+    :param text: agy's final assistant text for the turn, when the closing step
+        carried any.
+    :param error: Human-readable, diagnosable failure description. Always set
+        when ``completed`` is ``False``.
+    :param retryable: ``True`` when the failure is one a retry might survive
+        (agy reported a model/provider ERROR), ``False`` for structural failures
+        (the turn never started, or it exhausted its budget — retrying either
+        would just burn the budget again).
+    :param cancelled: ``True`` when the gate stopped because the turn was
+        interrupted. Neither a success nor a failure of the turn's work.
+    """
+
+    completed: bool
+    text: str | None = None
+    error: str | None = None
+    retryable: bool = False
+    cancelled: bool = False
+
+
+async def _sleep(seconds: float) -> None:
+    """
+    Stubbable indirection for the completion gate's poll delay.
+
+    Exists so tests can drive the gate without real delays without patching
+    ``asyncio.sleep`` globally (mirrors the read driver's ``_sleep``).
+
+    :param seconds: Delay in seconds.
+    :returns: None after the sleep completes.
+    """
+    await asyncio.sleep(seconds)
 
 
 class AntigravityNativeExecutor(Executor):
@@ -113,6 +245,15 @@ class AntigravityNativeExecutor(Executor):
         # enqueue_session_message (mid-turn steer, live message queue) don't send
         # to agy at once or deliver out of order.
         self._send_lock = asyncio.Lock()
+        # Completion-gate RPC target cache. Port discovery scans processes, so it
+        # is resolved once per cascade and re-resolved only when a read fails or
+        # the bridge rebinds to a different cascade (a TUI ``/clear``).
+        self._rpc_port: int | None = None
+        self._rpc_cascade_id: str | None = None
+        # Set by interrupt_session so the completion gate stops waiting as soon
+        # as the user hits stop. Without it a cancelled turn would sit in the gate
+        # until agy's own trajectory reflected the cancel.
+        self._interrupted = asyncio.Event()
 
     def supports_streaming(self) -> bool:
         """:returns: ``False`` — assistant output is emitted by the RPC read driver."""
@@ -126,9 +267,13 @@ class AntigravityNativeExecutor(Executor):
         """
         Steer an active native Antigravity turn by delivering another message.
 
-        Mid-turn web steering uses the exact same RPC turn-send path as
-        :meth:`run_turn` (``SendUserCascadeMessage``), so the two need no
-        special-casing.
+        Mid-turn web steering uses the exact same delivery path as
+        :meth:`run_turn`, so the two need no special-casing.
+
+        This deliberately does NOT wait for completion. A steer is a delivery
+        into a turn that is already open, and the ``run_turn`` completion gate
+        holding that turn is what waits for the steered work to finish; gating
+        here too would block the caller that is trying to steer.
 
         :param session_key: Adapter session key. Unused; the native bridge is
             per conversation.
@@ -170,6 +315,10 @@ class AntigravityNativeExecutor(Executor):
             failed.
         """
         del session_key
+        # Release the completion gate FIRST and unconditionally: the user asked
+        # to stop, so the turn must stop being waited on whether or not agy
+        # accepts the cancel below.
+        self._interrupted.set()
         state = await asyncio.to_thread(read_bridge_state, self._bridge_dir)
         if state is None or not _session_is_active(state.session_id, self._request_session_id):
             return False
@@ -203,14 +352,15 @@ class AntigravityNativeExecutor(Executor):
         """
         Deliver the latest web/mobile user message to the running agy over RPC.
 
-        Resolves agy's conversation/cascade id (waiting briefly for the runner to
-        mint it on the first turn), discovers the connect-RPC port, resolves the
-        per-turn model, and delivers the message via ``SendUserCascadeMessage``
-        (:func:`omnigent.antigravity_native_rpc.send_user_cascade_message`), which
-        agy records as a real ``USER_INPUT`` turn. The assistant reply is mirrored
-        back by the RPC read driver, so this yields a single :class:`TurnComplete`
-        with no text on success (never a fabricated reply). On any failure it
-        yields one :class:`ExecutorError`.
+        Delivers the latest user message by typing it into the agy TUI, then
+        WAITS for agy to finish the turn before reporting anything
+        (:meth:`_await_turn_completion`). Successful delivery is not completion:
+        reporting on delivery alone is what let a dispatched implementation task
+        return an immediate empty success (see the module docstring). Exactly one
+        terminal event is yielded — :class:`TurnComplete` carrying agy's final
+        text once the turn reaches a terminal DONE state, or
+        :class:`ExecutorError` when delivery fails, when agy's turn ends in ERROR,
+        or when the turn exhausts its budget.
 
         :param messages: Conversation history in executor message shape; the
             latest user message is delivered.
@@ -238,11 +388,25 @@ class AntigravityNativeExecutor(Executor):
         if not text:
             yield ExecutorError(message="Antigravity native turn had no user text to send")
             return
-        outcome = await self._deliver(text)
-        if outcome is not None:
-            yield ExecutorError(message=outcome)
+        self._interrupted.clear()
+        # Snapshot BEFORE delivering: the step count is what tells this turn's
+        # USER_INPUT step apart from the previous turn's, whose closing planner
+        # would otherwise satisfy the gate instantly.
+        baseline = await self._snapshot_step_count()
+        failure = await self._deliver(text)
+        if failure is not None:
+            yield ExecutorError(message=failure)
+            return
+        result = await self._await_turn_completion(delivered_text=text, baseline=baseline)
+        if result.cancelled:
+            yield TurnCancelled()
+        elif result.completed:
+            yield TurnComplete(response=result.text)
         else:
-            yield TurnComplete(response=None)
+            yield ExecutorError(
+                message=result.error or "Antigravity native turn did not complete",
+                retryable=result.retryable,
+            )
 
     async def _deliver(self, text: str) -> str | None:
         """
@@ -302,6 +466,236 @@ class AntigravityNativeExecutor(Executor):
                 state.session_id,
             )
             return None
+
+    async def _await_turn_completion(
+        self, *, delivered_text: str, baseline: int | None
+    ) -> _GateResult:
+        """
+        Block until agy finishes the delivered turn, or a budget runs out.
+
+        The completion gate. Polls ``GetCascadeTrajectorySteps`` — the same
+        surface the read driver mirrors — and classifies the turn with the shared
+        pure helpers in :mod:`omnigent.antigravity_native_steps`, so the gate and
+        the mirrored session status can never disagree about whether a turn ended.
+
+        Two phases, each with its own budget:
+
+        #. **Start** (:data:`_TURN_START_TIMEOUT_S`): agy must record the delivery
+           as a USER_INPUT step (:func:`find_turn_start_index`). Until that step
+           exists there is no turn to wait on, and a delivery that never becomes
+           one is a failure worth reporting promptly rather than waiting out the
+           full completion budget.
+        #. **Completion** (:data:`_TURN_COMPLETION_TIMEOUT_S`, measured from
+           delivery): the open turn must reach a terminal state — a DONE planner
+           with text, an ERROR planner, or agy's own cascade status settling to
+           idle across :data:`_IDLE_CONFIRM_CHECKS` consecutive checks for the
+           degenerate close.
+
+        A trajectory read that fails (transport, non-2xx, non-JSON body, no
+        resolvable RPC port yet) is transient: it is logged, the cached port is
+        dropped so the next pass re-resolves, and the loop retries until a budget
+        expires. It never short-circuits into a success.
+
+        :param delivered_text: The exact text delivered, used to identify this
+            turn's USER_INPUT step when the pre-delivery snapshot was unavailable.
+        :param baseline: Step count observed before delivery, or ``None`` when it
+            could not be read (see :meth:`_snapshot_step_count`).
+        :returns: The turn's :class:`_GateResult`.
+        """
+        started_at = time.monotonic()
+        start_index: int | None = None
+        # Counted from the poll that first saw the turn OPEN, not from gate
+        # entry, so the idle backstop can never fire on the very reading that
+        # discovered the turn — the one reading agy may not have started yet.
+        polls_since_open = -1
+        idle_checks = 0
+        latest_text: str | None = None
+        waiting_on_user = False
+        while True:
+            if self._interrupted.is_set():
+                _logger.info("antigravity native completion gate released by interrupt")
+                return _GateResult(completed=False, text=latest_text, cancelled=True)
+            steps = await self._read_trajectory()
+            if steps is not None:
+                if start_index is None:
+                    start_index = find_turn_start_index(
+                        steps,
+                        baseline_step_count=baseline,
+                        delivered_text=delivered_text,
+                    )
+                if start_index is not None:
+                    polls_since_open += 1
+                    outcome = classify_turn_outcome(steps, start_index=start_index)
+                    latest_text = outcome.text or latest_text
+                    waiting_on_user = outcome.waiting_on_user
+                    if outcome.state == "done":
+                        _logger.info(
+                            "antigravity native turn completed (DONE planner) after %.1fs",
+                            time.monotonic() - started_at,
+                        )
+                        return _GateResult(completed=True, text=outcome.text)
+                    if outcome.state == "error":
+                        detail = f": {outcome.error}" if outcome.error else ""
+                        return _GateResult(
+                            completed=False,
+                            text=outcome.text,
+                            error=(
+                                "Antigravity native turn ended in an agy ERROR state"
+                                f"{detail} (the model did not complete the turn)"
+                            ),
+                            # A model / safety / rate-limit / provider-overload
+                            # failure is exactly the transient class the workflow
+                            # may retry; a structural gate failure below is not.
+                            retryable=True,
+                        )
+                    # Still running. The degenerate close (a turn that ends with
+                    # no text-carrying planner) is only visible in agy's own
+                    # cascade status, and only after enough consecutive idle
+                    # readings that a not-yet-started turn cannot masquerade as a
+                    # finished one.
+                    if polls_since_open > 0 and polls_since_open % _IDLE_CHECK_EVERY_N_POLLS == 0:
+                        if await self._cascade_reports_idle():
+                            idle_checks += 1
+                            if idle_checks >= _IDLE_CONFIRM_CHECKS:
+                                _logger.info(
+                                    "antigravity native turn completed (cascade idle) after %.1fs",
+                                    time.monotonic() - started_at,
+                                )
+                                return _GateResult(completed=True, text=latest_text)
+                        else:
+                            idle_checks = 0
+
+            elapsed = time.monotonic() - started_at
+            if start_index is None and elapsed >= _TURN_START_TIMEOUT_S:
+                return _GateResult(
+                    completed=False,
+                    error=(
+                        "Antigravity native turn was delivered to the agy TUI but agy never "
+                        f"recorded it as a turn within {_TURN_START_TIMEOUT_S:.0f}s "
+                        "(no matching USER_INPUT step; the agy connect-RPC may be unreachable "
+                        "or the submitted text never opened a cascade turn)"
+                    ),
+                )
+            if elapsed >= _TURN_COMPLETION_TIMEOUT_S:
+                blocked = (
+                    " — agy is parked on a WAITING interaction (an ask-question or "
+                    "permission gate nobody answered)"
+                    if waiting_on_user
+                    else ""
+                )
+                return _GateResult(
+                    completed=False,
+                    text=latest_text,
+                    error=(
+                        "Antigravity native turn did not reach a terminal state within "
+                        f"{_TURN_COMPLETION_TIMEOUT_S:.0f}s{blocked}. The turn was delivered "
+                        "and may still be running in the agy TUI; its work is NOT confirmed"
+                    ),
+                )
+            await _sleep(_TURN_POLL_INTERVAL_S)
+
+    async def _snapshot_step_count(self) -> int | None:
+        """
+        Read the cascade's step count before delivering, for turn identification.
+
+        The gate needs to tell THIS turn's USER_INPUT step from the previous
+        turn's; the pre-delivery step count does that positionally.
+
+        :returns: ``0`` when agy has not minted the conversation yet (a first
+            turn has no earlier step to be confused with), the current step count
+            when the trajectory reads cleanly, or ``None`` when it could not be
+            read — in which case the gate identifies the turn by its text instead
+            (see :func:`find_turn_start_index`).
+        """
+        state = await asyncio.to_thread(read_bridge_state, self._bridge_dir)
+        if state is None:
+            return None
+        if is_placeholder_conversation_id(state.conversation_id):
+            return 0
+        steps = await self._read_trajectory()
+        return None if steps is None else len(steps)
+
+    async def _resolve_rpc_target(self) -> tuple[int, str] | None:
+        """
+        Resolve the ``(port, cascade_id)`` the gate should query, using a cache.
+
+        Re-reads bridge state every call so a cascade rotation (a TUI ``/clear``
+        rebinding the bridge) invalidates the cached port rather than polling a
+        stale conversation.
+
+        :returns: The connect-RPC port and cascade id, or ``None`` when there is
+            no real cascade yet (missing state / an ``agy_conv_*`` placeholder) or
+            no agy port could be discovered.
+        """
+        state = await asyncio.to_thread(read_bridge_state, self._bridge_dir)
+        if state is None:
+            return None
+        cascade_id = state.conversation_id
+        if is_placeholder_conversation_id(cascade_id):
+            return None
+        if self._rpc_port is not None and self._rpc_cascade_id == cascade_id:
+            return self._rpc_port, cascade_id
+        port = await asyncio.to_thread(resolve_language_server_port, cascade_id)
+        if port is None:
+            return None
+        self._rpc_port, self._rpc_cascade_id = port, cascade_id
+        return port, cascade_id
+
+    async def _read_trajectory(self) -> list[dict[str, object]] | None:
+        """
+        Read the bound cascade's trajectory steps, or ``None`` when unavailable.
+
+        :returns: The ordered step list, or ``None`` when no cascade/port is
+            resolvable yet or the read failed. ``None`` is "unknown", never
+            "finished" — the caller keeps waiting on it.
+        """
+        target = await self._resolve_rpc_target()
+        if target is None:
+            return None
+        port, cascade_id = target
+        try:
+            return await asyncio.to_thread(get_trajectory_steps, port, cascade_id)
+        except (httpx.HTTPError, ValueError) as exc:
+            # Transport / non-2xx / non-JSON 200. Drop the cached port so the
+            # next pass rediscovers agy (it may have restarted on a new port).
+            self._rpc_port = None
+            _logger.warning(
+                "antigravity native completion gate trajectory read failed; retrying: "
+                "cascade=%s port=%s error=%r",
+                cascade_id,
+                port,
+                exc,
+            )
+            return None
+
+    async def _cascade_reports_idle(self) -> bool:
+        """
+        Whether agy's own run status says the bound cascade is no longer working.
+
+        The idle backstop for a turn that closes without a text-carrying planner
+        step. Fails closed: any read failure reports "not idle", so an unreadable
+        agy can never be mistaken for a finished turn.
+
+        :returns: ``True`` only on an explicit idle status for the bound cascade.
+        """
+        target = await self._resolve_rpc_target()
+        if target is None:
+            return False
+        port, cascade_id = target
+        try:
+            body = await asyncio.to_thread(get_all_cascade_trajectories, port)
+        except (httpx.HTTPError, ValueError) as exc:
+            self._rpc_port = None
+            _logger.warning(
+                "antigravity native completion gate idle check failed: cascade=%s error=%r",
+                cascade_id,
+                exc,
+            )
+            return False
+        summaries = body.get("trajectorySummaries")
+        if not isinstance(summaries, dict):
+            return False
+        return cascade_is_idle(summaries, cascade_id)
 
 
 def _bridge_dir_from_env() -> Path:

--- a/tests/inner/test_antigravity_native_executor.py
+++ b/tests/inner/test_antigravity_native_executor.py
@@ -85,6 +85,9 @@ def _tool_step(status: str) -> dict[str, Any]:
         "type": "CORTEX_STEP_TYPE_RUN_COMMAND",
         "status": status,
         "runCommand": {"command": "pytest"},
+        # ``metadata.toolAction`` is what marks a step as a tool call on the live
+        # wire, in both RPC shapes (see ``_is_tool_step``).
+        "metadata": {"toolAction": "Running command"},
     }
 
 
@@ -743,15 +746,15 @@ def test_idle_status_alone_never_completes_an_unrecorded_turn(
     assert injected["idle_checks"] == 0
 
 
-def test_gate_identifies_the_turn_by_text_when_the_snapshot_failed(
+def test_snapshot_is_retried_through_a_transient_failure(
     tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    With no pre-delivery snapshot, the delivered text identifies this turn.
+    The pre-delivery snapshot is retried rather than abandoned on a blip.
 
-    The pre-delivery read fails, so the positional signal is unavailable. The
-    gate must still find THIS turn (not the previous one, whose closing planner
-    is right there in the trajectory) and wait for its own terminal step.
+    The step count is the ONLY signal that identifies this turn, so a transient
+    RPC failure must not cost the turn its verification. The first read fails and
+    the retry succeeds, and the turn then completes normally.
     """
     _seed_state(tmp_path)
     injected["steps"] = [
@@ -759,15 +762,141 @@ def test_gate_identifies_the_turn_by_text_when_the_snapshot_failed(
         _planner_step(status="CORTEX_STEP_STATUS_DONE", text="previous answer"),
     ]
 
-    def _fail_snapshot(index: int) -> Exception | None:
+    def _fail_first_snapshot_read(index: int) -> Exception | None:
         return httpx.ConnectError("agy not up yet") if index == 0 else None
 
-    injected["read_error"] = _fail_snapshot
+    injected["read_error"] = _fail_first_snapshot_read
 
     events = _drive_gate(tmp_path, monkeypatch)
     assert len(events) == 1
     assert isinstance(events[0], TurnComplete)
     assert events[0].response == _DEFAULT_REPLY_TEXT
+
+
+def test_repeated_text_with_no_snapshot_never_adopts_the_previous_turn(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    REGRESSION: identical consecutive text must not resolve to the finished turn.
+
+    The previous turn used the SAME text and is already closed by its own DONE
+    planner. With the pre-delivery snapshot failing for the whole budget there is
+    no positional signal, and an earlier revision fell back to matching the
+    delivered text — which selects that old turn and reports its completion as
+    this one's. The gate must instead report the turn as unverifiable, and must
+    never hand back the prior turn's reply.
+    """
+    _seed_state(tmp_path)
+    repeated = "implement the thing"
+    injected["steps"] = [
+        _user_step(repeated),
+        _planner_step(status="CORTEX_STEP_STATUS_DONE", text="stale answer from last turn"),
+    ]
+    # agy has not yet recorded the new turn when the gate would look.
+    injected["reply"] = []
+    injected["read_error"] = lambda _index: httpx.ConnectError("agy unreachable")
+
+    monkeypatch.setattr(executor_mod, "_SNAPSHOT_TIMEOUT_S", 0.0)
+    events = _drive_gate(tmp_path, monkeypatch, text=repeated)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert not any(isinstance(event, TurnComplete) for event in events)
+    assert "could not be verified" in events[0].message
+    assert "NOT confirmed" in events[0].message
+    assert "stale answer from last turn" not in events[0].message
+    # The turn was still delivered; only its completion is unverified.
+    assert _injected(injected)[0]["content"] == repeated
+
+
+def test_idle_backstop_waits_for_evidence_the_model_started(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    REGRESSION: a recorded USER_INPUT plus an idle cascade is NOT a completion.
+
+    agy publishes the user step before it starts generating and reports the
+    cascade idle throughout that window. Consecutive idle readings do not close
+    that gap — they only require it to persist — so a delayed model start would
+    otherwise be reported as a finished turn with no terminal evidence at all.
+    Here the turn is recorded, the cascade is idle, and the model does not start
+    until well past the consecutive-check window: no success may be reported.
+    """
+    _seed_state(tmp_path)
+    # agy records the user step, then sits: no planner, no tool, cascade idle.
+    injected["reply"] = [_user_step("implement the thing")]
+    injected["cascade_status"] = "CASCADE_RUN_STATUS_IDLE"
+
+    def _start_the_model_late(rec: dict[str, object], index: int) -> None:
+        # Poll 0 is the snapshot and poll 1 identifies the turn, so by poll 6 the
+        # backstop has had four opportunities — twice the confirmations it needs.
+        if index == 6:
+            rec["idle_checks_before_model_started"] = rec["idle_checks"]
+            steps = rec["steps"]
+            assert isinstance(steps, list)
+            steps.append(
+                _planner_step(status="CORTEX_STEP_STATUS_DONE", text="finally got started")
+            )
+
+    injected["on_poll"] = _start_the_model_late
+
+    events = _drive_gate(tmp_path, monkeypatch, idle_every=1, idle_confirmations=2)
+    # The backstop was never consulted while the turn had no model activity, so
+    # no amount of idle could have closed it early.
+    assert injected["idle_checks_before_model_started"] == 0
+    # And the turn completes on real terminal evidence, not on the idle window.
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response == "finally got started"
+
+
+def test_trajectory_mutation_under_the_gate_fails_rather_than_guesses(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Pin behaviour when agy's trajectory LIST changes shape mid-turn.
+
+    The gate holds a list index across polls, which is only valid while agy
+    appends. Whether agy ever prunes, compacts or reorders is unverified (the
+    read driver keys identity on ``(trajectory_id, step_index)`` for exactly that
+    reason). If the recorded position stops pointing at this turn's user input,
+    the window after it may describe a different turn — so the gate reports a
+    failure naming the mutation instead of classifying it. The failure direction
+    is the point: never a success on a window the gate can no longer trust.
+    """
+    _seed_state(tmp_path)
+    injected["steps"] = [
+        _user_step("previous question"),
+        _planner_step(status="CORTEX_STEP_STATUS_DONE", text="previous answer"),
+    ]
+    injected["reply"] = [
+        _user_step("implement the thing"),
+        _tool_step("CORTEX_STEP_STATUS_RUNNING"),
+    ]
+
+    def _prune_history_after_the_gate_locks_on(rec: dict[str, object], index: int) -> None:
+        # Poll 0 = snapshot, poll 1 = the gate identifying the turn at index 2.
+        # Drop the two history steps before poll 2, shifting every later index.
+        if index == 2:
+            steps = rec["steps"]
+            assert isinstance(steps, list)
+            del steps[0:2]
+
+    injected["on_poll"] = _prune_history_after_the_gate_locks_on
+
+    # A real (if tiny) poll delay so that, WITHOUT the re-validation, the gate
+    # merely runs out its budget instead of spinning: the assertions below then
+    # distinguish "detected the mutation" from "gave up eventually".
+    async def _short_sleep(_seconds: float) -> None:
+        await asyncio.sleep(0.01)
+
+    monkeypatch.setattr(executor_mod, "_sleep", _short_sleep)
+
+    events = _drive_gate(tmp_path, monkeypatch, completion_timeout_s=0.5)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert not any(isinstance(event, TurnComplete) for event in events)
+    assert "changed shape under the completion gate" in events[0].message
+    assert "NOT confirmed" in events[0].message
 
 
 # ---------------------------------------------------------------------------
@@ -1187,3 +1316,45 @@ def test_gate_releases_on_interrupt_without_claiming_completion(
     assert len(events) == 1
     assert isinstance(events[0], TurnCancelled)
     assert not any(isinstance(event, TurnComplete) for event in events)
+
+
+def test_interrupt_arriving_before_the_turn_starts_is_not_lost(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A stop that lands before ``run_turn`` begins cancels that turn, and only it.
+
+    The harness registers the turn context before it starts iterating
+    ``run_turn``, so an interrupt can arrive in that window. Clearing the
+    interrupt flag at turn entry dropped such a stop and left the gate waiting
+    out its budget. The turn must be reported cancelled WITHOUT delivering text
+    for a request the user already stopped — and the NEXT turn must be
+    unaffected, or a consumed stop would poison every later turn.
+    """
+    from omnigent.inner.executor import TurnCancelled
+
+    _seed_state(tmp_path)
+    monkeypatch.setattr(executor_mod, "cancel_cascade_steps", lambda _p, _c: True)
+    executor = _executor(tmp_path)
+
+    async def _stop_then_run() -> list[ExecutorEvent]:
+        await executor.interrupt_session("main")
+        return [
+            event
+            async for event in executor.run_turn(
+                messages=[{"role": "user", "content": "cancelled before it started"}],
+                tools=[],
+                system_prompt="",
+            )
+        ]
+
+    events = asyncio.run(_stop_then_run())
+    assert len(events) == 1
+    assert isinstance(events[0], TurnCancelled)
+    assert _injected(injected) == [], "a stopped turn must not be typed into the TUI"
+
+    # The stop was consumed by that turn; a fresh turn runs normally.
+    follow_up = asyncio.run(_run(executor, "the next turn"))
+    assert len(follow_up) == 1
+    assert isinstance(follow_up[0], TurnComplete)
+    assert _injected(injected)[0]["content"] == "the next turn"

--- a/tests/inner/test_antigravity_native_executor.py
+++ b/tests/inner/test_antigravity_native_executor.py
@@ -3,19 +3,26 @@
 These pin the write path: a web/mobile turn is delivered to the running agy by
 TYPING IT INTO the agy TUI pane over tmux (``inject_user_message_via_tui``,
 mocked here), which agy records as a real ``USER_INPUT`` step on the cascade the
-TUI displays; agy's reply is mirrored back by the read driver — so the executor
-yields a ``TurnComplete`` with no text rather than fabricating a reply. Typing
-into the TUI (not headless ``SendUserCascadeMessage`` RPC) is what unifies the
-agy TUI and the web mirror onto ONE cascade, giving claude/codex-native parity
-(#1156/#1158). Here the inject is stubbed so the tests assert the executor's
-wiring — what text it delivers and how it maps success/failure to events.
+TUI displays. Typing into the TUI (not headless ``SendUserCascadeMessage`` RPC)
+is what unifies the agy TUI and the web mirror onto ONE cascade, giving
+claude/codex-native parity (#1156/#1158).
+
+They also pin the **completion gate**. Delivery is not completion: the executor
+used to yield ``TurnComplete`` the instant the text had been typed and
+submitted, so a dispatched implementation task returned an immediate empty
+success before agy had run a single tool. The gate polls agy's own RPC
+trajectory until the turn reaches a terminal state, and the ``agy`` fixture below
+fakes that trajectory — a turn OPENS when the inject lands and only ever
+completes when the faked trajectory says agy finished.
 """
 
 from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 
+import httpx
 import pytest
 
 import omnigent.inner.antigravity_native_executor as executor_mod
@@ -31,6 +38,54 @@ _PLACEHOLDER_ID = "agy_conv_placeholder123"
 _PORT = 52548
 _ECHOED_MODEL = "MODEL_PLACEHOLDER_M20"
 _RECOMMENDED_MODEL = "MODEL_PLACEHOLDER_M132"
+_DEFAULT_REPLY_TEXT = "all done"
+
+
+def _user_step(text: str) -> dict[str, Any]:
+    """
+    Build the USER_INPUT step agy records for a delivered turn.
+
+    :param text: The delivered text agy echoed back onto the cascade.
+    :returns: One USER_INPUT step dict.
+    """
+    return {"type": "CORTEX_STEP_TYPE_USER_INPUT", "userInput": {"userResponse": text}}
+
+
+def _planner_step(
+    *, status: str, text: str | None = None, error: str | None = None
+) -> dict[str, Any]:
+    """
+    Build a PLANNER_RESPONSE step at ``status``.
+
+    :param status: ``CORTEX_STEP_STATUS_*`` value.
+    :param text: Assistant text the planner carries, if any.
+    :param error: agy error detail, for the ERROR shape.
+    :returns: One PLANNER_RESPONSE step dict.
+    """
+    planner: dict[str, Any] = {}
+    if text is not None:
+        planner["response"] = text
+    if error is not None:
+        planner["error"] = error
+    return {
+        "type": "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+        "status": status,
+        "plannerResponse": planner,
+    }
+
+
+def _tool_step(status: str) -> dict[str, Any]:
+    """
+    Build a RUN_COMMAND tool step at ``status``.
+
+    :param status: ``CORTEX_STEP_STATUS_*`` value.
+    :returns: One tool step dict.
+    """
+    return {
+        "type": "CORTEX_STEP_TYPE_RUN_COMMAND",
+        "status": status,
+        "runCommand": {"command": "pytest"},
+    }
 
 
 def _executor(tmp_path: Path) -> AntigravityNativeExecutor:
@@ -88,17 +143,47 @@ def _steps_with_model(model: str) -> list[dict[str, object]]:
 @pytest.fixture
 def injected(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
     """
-    Stub the agy TUI inject, recording each turn the executor delivers.
+    Fake one running agy: the TUI inject AND the RPC trajectory the gate polls.
 
     The write path types the turn into the agy TUI pane via
     ``inject_user_message_via_tui``; this records every ``{bridge_dir, content}``
     call and, when ``rec["raise"]`` is set, raises it (modeling a dead/unavailable
-    TUI pane).
+    TUI pane) WITHOUT recording a turn — a failed delivery never opens one.
+
+    A successful inject appends ``rec["reply"]`` to ``rec["steps"]``, which is
+    what ``GetCascadeTrajectorySteps`` then returns, so the completion gate sees
+    exactly the turn shape a test asks for. The default reply is a completed turn
+    (USER_INPUT + a DONE planner carrying text) so tests that are not about the
+    gate read as before.
+
+    Knobs, all mutable by the test before it drives ``run_turn``:
+
+    * ``steps`` — the trajectory BEFORE delivery (default empty).
+    * ``reply`` — steps appended on a successful inject; ``None`` means agy
+      records nothing at all.
+    * ``cascade_status`` — agy's own run status for the idle backstop.
+    * ``on_poll`` — ``callable(rec, poll_index)`` run before each trajectory read,
+      for a trajectory that evolves across polls. Poll 0 is the executor's
+      pre-delivery snapshot; poll 1 is the gate's first read.
+    * ``read_error`` — ``callable(poll_index) -> Exception | None``, to fail
+      specific reads.
+    * ``port`` — resolved connect-RPC port, or ``None`` for "agy not found".
 
     :param monkeypatch: pytest monkeypatch fixture.
-    :returns: A mutable dict: ``calls`` (recorded injects) + ``raise`` (optional).
+    :returns: The mutable fake-agy record described above.
     """
-    rec: dict[str, object] = {"calls": [], "raise": None}
+    rec: dict[str, object] = {
+        "calls": [],
+        "raise": None,
+        "steps": [],
+        "reply": None,
+        "cascade_status": "CASCADE_RUN_STATUS_RUNNING",
+        "on_poll": None,
+        "read_error": None,
+        "port": _PORT,
+        "polls": 0,
+        "idle_checks": 0,
+    }
 
     def _inject(bridge_dir: Path, *, content: str, **_kw: object) -> None:
         calls = rec["calls"]
@@ -108,8 +193,46 @@ def injected(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
         if exc is not None:
             assert isinstance(exc, BaseException)
             raise exc
+        reply = rec["reply"]
+        if reply is None:
+            reply = [
+                _user_step(content),
+                _planner_step(status="CORTEX_STEP_STATUS_DONE", text=_DEFAULT_REPLY_TEXT),
+            ]
+        steps = rec["steps"]
+        assert isinstance(steps, list) and isinstance(reply, list)
+        steps.extend(reply)
+
+    def _steps(_port: int, _cascade_id: str) -> list[dict[str, object]]:
+        index = rec["polls"]
+        assert isinstance(index, int)
+        rec["polls"] = index + 1
+        on_poll = rec["on_poll"]
+        if callable(on_poll):
+            on_poll(rec, index)
+        read_error = rec["read_error"]
+        if callable(read_error):
+            exc = read_error(index)
+            if exc is not None:
+                raise exc
+        steps = rec["steps"]
+        assert isinstance(steps, list)
+        return list(steps)
+
+    def _trajectories(_port: int) -> dict[str, object]:
+        checks = rec["idle_checks"]
+        assert isinstance(checks, int)
+        rec["idle_checks"] = checks + 1
+        return {"trajectorySummaries": {_CONVERSATION_ID: {"status": rec["cascade_status"]}}}
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
 
     monkeypatch.setattr(executor_mod, "inject_user_message_via_tui", _inject)
+    monkeypatch.setattr(executor_mod, "get_trajectory_steps", _steps)
+    monkeypatch.setattr(executor_mod, "get_all_cascade_trajectories", _trajectories)
+    monkeypatch.setattr(executor_mod, "resolve_language_server_port", lambda _c: rec["port"])
+    monkeypatch.setattr(executor_mod, "_sleep", _no_sleep)
     return rec
 
 
@@ -174,12 +297,12 @@ def test_run_turn_delivers_via_tui_and_completes(
     tmp_path: Path, injected: dict[str, object]
 ) -> None:
     """
-    ``run_turn`` types the user text into the agy TUI and yields a text-less TurnComplete.
+    ``run_turn`` types the user text into the agy TUI and completes on agy's DONE turn.
 
     The turn is injected into the TUI pane (#1156/#1158) — agy records it as a
-    real USER_INPUT on the cascade the TUI displays and the read driver mirrors
-    the reply, so the executor yields ``TurnComplete`` with ``response=None``
-    (fabricating text here would duplicate the mirrored reply).
+    real USER_INPUT on the cascade the TUI displays — and the executor then waits
+    for agy's terminal DONE planner before reporting completion, carrying that
+    step's text so the caller receives the agent's actual answer.
     """
     _seed_state(tmp_path)
     events = asyncio.run(_run(_executor(tmp_path), "what is 2+2?"))
@@ -189,7 +312,7 @@ def test_run_turn_delivers_via_tui_and_completes(
     assert calls[0]["bridge_dir"] == tmp_path
     assert len(events) == 1
     assert isinstance(events[0], TurnComplete)
-    assert events[0].response is None
+    assert events[0].response == _DEFAULT_REPLY_TEXT
 
 
 def test_run_turn_flattens_content_blocks(tmp_path: Path, injected: dict[str, object]) -> None:
@@ -371,7 +494,9 @@ def test_run_turn_tui_inject_error_surfaces(tmp_path: Path, injected: dict[str, 
 
     The inject raises when the agy pane is gone / never advertised / the submit
     never started a turn; the executor must surface it (so the UI can prompt a
-    restart) rather than report a fake success the mirror never fills.
+    restart) rather than report a fake success the mirror never fills. The
+    completion gate must not swallow or soften that — a delivery failure is still
+    a failure, reported without waiting on a turn that was never delivered.
     """
     _seed_state(tmp_path)
     injected["raise"] = RuntimeError("the agy terminal is no longer running (the TUI exited)")
@@ -379,6 +504,270 @@ def test_run_turn_tui_inject_error_surfaces(tmp_path: Path, injected: dict[str, 
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
     assert "the agy TUI" in events[0].message
+    # Only the pre-delivery snapshot ran; the gate was never entered.
+    assert injected["polls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_turn — the completion gate
+#
+# The defect these pin: the executor reported a turn complete as soon as the
+# text was typed into the TUI, so an orchestrator dispatching an implementation
+# task collected an immediate empty success before agy had done any work.
+# ---------------------------------------------------------------------------
+
+
+def _drive_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    start_timeout_s: float = 180.0,
+    completion_timeout_s: float = 3600.0,
+    idle_every: int = 5,
+    idle_confirmations: int = 2,
+    text: str = "implement the thing",
+) -> list[ExecutorEvent]:
+    """
+    Run one gated turn with the gate's budgets pinned for the test.
+
+    :param tmp_path: Bridge directory.
+    :param monkeypatch: pytest monkeypatch fixture.
+    :param start_timeout_s: Budget for agy to record the delivery as a turn.
+    :param completion_timeout_s: Budget for the open turn to reach a terminal state.
+    :param idle_every: Polls between idle-backstop checks.
+    :param idle_confirmations: Consecutive idle readings required to close.
+    :param text: User text to deliver.
+    :returns: The yielded executor events.
+    """
+    monkeypatch.setattr(executor_mod, "_TURN_START_TIMEOUT_S", start_timeout_s)
+    monkeypatch.setattr(executor_mod, "_TURN_COMPLETION_TIMEOUT_S", completion_timeout_s)
+    monkeypatch.setattr(executor_mod, "_IDLE_CHECK_EVERY_N_POLLS", idle_every)
+    monkeypatch.setattr(executor_mod, "_IDLE_CONFIRM_CHECKS", idle_confirmations)
+    return asyncio.run(_run(_executor(tmp_path), text))
+
+
+def test_gate_waits_for_a_terminal_done_state(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    REGRESSION: the turn completes only once agy's trajectory reaches DONE.
+
+    agy is still running a tool on the first gate poll and only closes the turn
+    on a later one. The old executor yielded ``TurnComplete`` straight off the
+    successful inject, which here would mean completing while the tool was still
+    running and returning no text at all.
+    """
+    _seed_state(tmp_path)
+    injected["reply"] = [
+        _user_step("implement the thing"),
+        _tool_step("CORTEX_STEP_STATUS_RUNNING"),
+    ]
+
+    def _finish_on_third_read(rec: dict[str, object], index: int) -> None:
+        if index == 3:
+            steps = rec["steps"]
+            assert isinstance(steps, list)
+            steps.append(_planner_step(status="CORTEX_STEP_STATUS_DONE", text="refactor applied"))
+
+    injected["on_poll"] = _finish_on_third_read
+
+    events = _drive_gate(tmp_path, monkeypatch)
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response == "refactor applied"
+    # Poll 0 was the pre-delivery snapshot, so the gate itself polled repeatedly
+    # instead of completing off the inject.
+    assert injected["polls"] == 4
+
+
+def test_gate_does_not_complete_on_the_previous_turns_close(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    REGRESSION: an earlier turn's DONE planner never satisfies the new turn.
+
+    The trajectory already ends in a completed turn when the new one is
+    delivered. Scanning the whole trajectory (rather than only the steps after
+    THIS turn's USER_INPUT) would report the new turn complete immediately, with
+    the old turn's text.
+    """
+    _seed_state(tmp_path)
+    injected["steps"] = [
+        _user_step("previous question"),
+        _planner_step(status="CORTEX_STEP_STATUS_DONE", text="previous answer"),
+    ]
+    injected["reply"] = [
+        _user_step("implement the thing"),
+        _tool_step("CORTEX_STEP_STATUS_RUNNING"),
+    ]
+
+    events = _drive_gate(tmp_path, monkeypatch, completion_timeout_s=0.0)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "did not reach a terminal state" in events[0].message
+
+
+def test_gate_reports_an_agy_error_state_as_a_failure(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A turn whose planner ends in ERROR is a failure, distinguishable from success.
+
+    agy's own error detail is carried through so the caller can tell a
+    rate-limit from a safety block, and the failure is marked retryable because
+    that class of error often survives a retry.
+    """
+    _seed_state(tmp_path)
+    injected["reply"] = [
+        _user_step("implement the thing"),
+        _planner_step(status="CORTEX_STEP_STATUS_ERROR", error="resource exhausted"),
+    ]
+
+    events = _drive_gate(tmp_path, monkeypatch)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert not any(isinstance(event, TurnComplete) for event in events)
+    assert "ERROR state" in events[0].message
+    assert "resource exhausted" in events[0].message
+    assert events[0].retryable is True
+
+
+def test_gate_times_out_with_a_diagnosable_failure(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A turn that never reaches a terminal state fails, naming the budget and the cause.
+
+    agy is parked on a WAITING permission gate that nobody answers. The result
+    must be a bounded, explicit failure — never a hang, and never a success that
+    claims unconfirmed work was done.
+    """
+    _seed_state(tmp_path)
+    injected["reply"] = [
+        _user_step("implement the thing"),
+        _tool_step("CORTEX_STEP_STATUS_WAITING"),
+    ]
+
+    events = _drive_gate(tmp_path, monkeypatch, completion_timeout_s=0.0)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "did not reach a terminal state within 0s" in events[0].message
+    assert "WAITING interaction" in events[0].message
+    assert "NOT confirmed" in events[0].message
+    assert events[0].retryable is False
+
+
+def test_gate_fails_when_agy_never_records_the_turn(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A delivery agy never turns into a USER_INPUT step fails on the start budget.
+
+    The submit was footer-verified, so nothing appearing on the cascade means the
+    text did not open a turn. Reporting that promptly beats waiting out the full
+    completion budget — and beats reporting success.
+    """
+    _seed_state(tmp_path)
+    injected["reply"] = []
+
+    events = _drive_gate(tmp_path, monkeypatch, start_timeout_s=0.0)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "never recorded it as a turn" in events[0].message
+
+
+def test_gate_keeps_waiting_through_transient_rpc_failures(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    An unreadable trajectory is "unknown", never "finished".
+
+    The first gate reads fail (transport error, then no resolvable agy port).
+    Neither may end the turn: the gate retries and completes only when agy's
+    trajectory actually says DONE.
+    """
+    _seed_state(tmp_path)
+
+    def _fail_first_gate_read(index: int) -> Exception | None:
+        return httpx.ConnectError("connection refused") if index == 1 else None
+
+    injected["read_error"] = _fail_first_gate_read
+
+    events = _drive_gate(tmp_path, monkeypatch)
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response == _DEFAULT_REPLY_TEXT
+    assert injected["polls"] >= 3
+
+
+def test_gate_closes_a_degenerate_turn_on_agys_own_idle_status(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    A turn that closes without a text planner is settled by agy's cascade status.
+
+    No step-based rule can tell that shape from a streamed dispatch, so the gate
+    falls back to agy's own run status — and only after consecutive idle
+    readings, so a turn agy has not started yet can never pass as finished.
+    """
+    _seed_state(tmp_path)
+    injected["reply"] = [
+        _user_step("implement the thing"),
+        _planner_step(status="CORTEX_STEP_STATUS_DONE"),
+    ]
+    injected["cascade_status"] = "CASCADE_RUN_STATUS_IDLE"
+
+    events = _drive_gate(tmp_path, monkeypatch, idle_every=1, idle_confirmations=2)
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert injected["idle_checks"] == 2
+
+
+def test_idle_status_alone_never_completes_an_unrecorded_turn(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    An idle cascade with no recorded turn is not a completion.
+
+    agy reports idle in the window between a delivery and the turn being
+    recorded; treating that as terminal would reinstate the false success in its
+    worst form.
+    """
+    _seed_state(tmp_path)
+    injected["reply"] = []
+    injected["cascade_status"] = "CASCADE_RUN_STATUS_IDLE"
+
+    events = _drive_gate(tmp_path, monkeypatch, start_timeout_s=0.0, idle_every=1)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert injected["idle_checks"] == 0
+
+
+def test_gate_identifies_the_turn_by_text_when_the_snapshot_failed(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    With no pre-delivery snapshot, the delivered text identifies this turn.
+
+    The pre-delivery read fails, so the positional signal is unavailable. The
+    gate must still find THIS turn (not the previous one, whose closing planner
+    is right there in the trajectory) and wait for its own terminal step.
+    """
+    _seed_state(tmp_path)
+    injected["steps"] = [
+        _user_step("previous question"),
+        _planner_step(status="CORTEX_STEP_STATUS_DONE", text="previous answer"),
+    ]
+
+    def _fail_snapshot(index: int) -> Exception | None:
+        return httpx.ConnectError("agy not up yet") if index == 0 else None
+
+    injected["read_error"] = _fail_snapshot
+
+    events = _drive_gate(tmp_path, monkeypatch)
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response == _DEFAULT_REPLY_TEXT
 
 
 # ---------------------------------------------------------------------------
@@ -755,3 +1144,46 @@ def test_content_to_text_handles_string_blocks_none_and_other(tmp_path: Path) ->
     assert _content_to_text(None, tmp_path) == ""
     # Defensive fallback for an unexpected shape: encoded, not crashed.
     assert _content_to_text(123, tmp_path) == "123"
+
+
+def test_gate_releases_on_interrupt_without_claiming_completion(
+    tmp_path: Path, injected: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Interrupting a gated turn releases the gate as CANCELLED, not as complete.
+
+    Stop must not have to wait out the completion budget, and an interrupted
+    turn must never be reported as finished work.
+    """
+    from omnigent.inner.executor import TurnCancelled
+
+    _seed_state(tmp_path)
+    injected["reply"] = [
+        _user_step("implement the thing"),
+        _tool_step("CORTEX_STEP_STATUS_RUNNING"),
+    ]
+    monkeypatch.setattr(executor_mod, "cancel_cascade_steps", lambda _p, _c: True)
+    monkeypatch.setattr(executor_mod, "_TURN_COMPLETION_TIMEOUT_S", 3600.0)
+    executor = _executor(tmp_path)
+
+    # Interrupt between the gate's first and second polls, the way a user hitting
+    # stop mid-turn does.
+    async def _interrupt_instead_of_sleeping(_seconds: float) -> None:
+        await executor.interrupt_session("main")
+
+    monkeypatch.setattr(executor_mod, "_sleep", _interrupt_instead_of_sleeping)
+
+    async def _drive() -> list[ExecutorEvent]:
+        return [
+            event
+            async for event in executor.run_turn(
+                messages=[{"role": "user", "content": "implement the thing"}],
+                tools=[],
+                system_prompt="",
+            )
+        ]
+
+    events = asyncio.run(_drive())
+    assert len(events) == 1
+    assert isinstance(events[0], TurnCancelled)
+    assert not any(isinstance(event, TurnComplete) for event in events)

--- a/tests/test_antigravity_native_steps.py
+++ b/tests/test_antigravity_native_steps.py
@@ -1263,3 +1263,235 @@ class TestStreamProjection:
                 item = event.data.get("item_data")
                 call_id = item.get("call_id", "") if isinstance(item, dict) else ""
                 assert "orphan" not in str(call_id), f"{path.stem} minted {call_id}"
+
+
+# ---------------------------------------------------------------------------
+# Turn-state classification (the completion gate's pure core)
+#
+# These pin the answer both callers depend on — the read driver's session-status
+# edges and the write path's completion gate. The gate exists because the
+# executor used to report a turn complete as soon as the text was typed into the
+# agy TUI; every case below distinguishes "delivered" from "finished".
+# ---------------------------------------------------------------------------
+
+
+def _user_step(text: str) -> dict[str, Any]:
+    """
+    Build a USER_INPUT step carrying ``text``.
+
+    :param text: The user turn text agy recorded.
+    :returns: One USER_INPUT step dict.
+    """
+    return {"type": "CORTEX_STEP_TYPE_USER_INPUT", "userInput": {"userResponse": text}}
+
+
+def _planner_step(
+    *, status: str, text: str | None = None, error: str | None = None
+) -> dict[str, Any]:
+    """
+    Build a PLANNER_RESPONSE step at ``status``.
+
+    :param status: ``CORTEX_STEP_STATUS_*`` value.
+    :param text: Assistant text the planner carries, if any.
+    :param error: agy error detail, for the ERROR shape.
+    :returns: One PLANNER_RESPONSE step dict.
+    """
+    planner: dict[str, Any] = {}
+    if text is not None:
+        planner["response"] = text
+    if error is not None:
+        planner["error"] = error
+    return {
+        "type": "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+        "status": status,
+        "plannerResponse": planner,
+    }
+
+
+def _tool_step(status: str) -> dict[str, Any]:
+    """
+    Build a RUN_COMMAND tool step at ``status``.
+
+    :param status: ``CORTEX_STEP_STATUS_*`` value.
+    :returns: One tool step dict.
+    """
+    return {
+        "type": "CORTEX_STEP_TYPE_RUN_COMMAND",
+        "status": status,
+        "runCommand": {"command": "pytest"},
+    }
+
+
+class TestFindTurnStartIndex:
+    """``find_turn_start_index`` identifies the caller's OWN turn, never an older one."""
+
+    def test_positional_tier_finds_the_new_user_step(self) -> None:
+        """A USER_INPUT at or after the pre-delivery step count is this turn's."""
+        from omnigent.antigravity_native_steps import find_turn_start_index
+
+        steps = [
+            _user_step("old"),
+            _planner_step(status="CORTEX_STEP_STATUS_DONE", text="old answer"),
+            _user_step("new"),
+        ]
+        assert find_turn_start_index(steps, baseline_step_count=2) == 2
+
+    def test_previous_turns_user_step_is_not_this_turn(self) -> None:
+        """
+        REGRESSION: an older USER_INPUT must never open the gate's turn.
+
+        Before delivery is reflected in the trajectory the newest USER_INPUT is
+        still the PREVIOUS turn's — and it is already followed by that turn's
+        closing planner. Accepting it is exactly the false success the gate
+        exists to prevent, so this returns ``None`` (not yet recorded).
+        """
+        from omnigent.antigravity_native_steps import find_turn_start_index
+
+        steps = [
+            _user_step("old"),
+            _planner_step(status="CORTEX_STEP_STATUS_DONE", text="old answer"),
+        ]
+        assert find_turn_start_index(steps, baseline_step_count=2) is None
+
+    def test_text_tier_used_only_without_a_baseline(self) -> None:
+        """
+        With no pre-delivery snapshot, the delivered text identifies the turn.
+
+        The positional tier is unavailable when the pre-delivery read failed, so
+        matching agy's recorded turn text is what keeps the gate from waiting on
+        a turn it cannot see — and it still cannot match an older turn's text
+        while ours is unrecorded, because only the NEWEST USER_INPUT is tested.
+        """
+        from omnigent.antigravity_native_steps import find_turn_start_index
+
+        steps = [_user_step("old"), _user_step("  build the thing\n")]
+        found = find_turn_start_index(
+            steps, baseline_step_count=None, delivered_text="build the thing"
+        )
+        assert found == 1
+        missed = find_turn_start_index(
+            steps, baseline_step_count=None, delivered_text="something else"
+        )
+        assert missed is None
+
+    def test_no_signals_or_no_user_step_yields_none(self) -> None:
+        """Without either signal — or without any USER_INPUT — the turn is unidentified."""
+        from omnigent.antigravity_native_steps import find_turn_start_index
+
+        assert find_turn_start_index([], baseline_step_count=0) is None
+        unidentified = find_turn_start_index(
+            [_user_step("hi")], baseline_step_count=None, delivered_text=None
+        )
+        assert unidentified is None
+
+
+class TestClassifyTurnOutcome:
+    """``classify_turn_outcome`` reports DONE / ERROR / still-running for one turn."""
+
+    def test_done_planner_with_text_completes_and_carries_the_text(self) -> None:
+        """A DONE planner carrying text is the terminal success, and supplies the reply."""
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [
+            _user_step("go"),
+            _tool_step("CORTEX_STEP_STATUS_DONE"),
+            _planner_step(status="CORTEX_STEP_STATUS_DONE", text="finished the refactor"),
+        ]
+        outcome = classify_turn_outcome(steps, start_index=0)
+        assert outcome.state == "done"
+        assert outcome.text == "finished the refactor"
+
+    def test_error_planner_is_an_error_not_a_success(self) -> None:
+        """
+        An ERROR planner surfaces as ``"error"`` with agy's own detail.
+
+        Collapsing it into a success is what makes a rate-limited or
+        safety-blocked turn indistinguishable from a completed one.
+        """
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [
+            _user_step("go"),
+            _planner_step(status="CORTEX_STEP_STATUS_ERROR", error="resource exhausted"),
+        ]
+        outcome = classify_turn_outcome(steps, start_index=0)
+        assert outcome.state == "error"
+        assert outcome.error == "resource exhausted"
+
+    def test_work_in_progress_is_still_running(self) -> None:
+        """A dispatched tool, a GENERATING planner and a running tool all keep the turn open."""
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [
+            _user_step("go"),
+            _planner_step(status="CORTEX_STEP_STATUS_GENERATING", text="I'll start by"),
+            _tool_step("CORTEX_STEP_STATUS_RUNNING"),
+        ]
+        outcome = classify_turn_outcome(steps, start_index=0)
+        assert outcome.state == "running"
+        assert outcome.text == "I'll start by"
+
+    def test_errored_tool_step_does_not_end_the_turn(self) -> None:
+        """
+        A tool that ERRORs is not a turn outcome — agy routinely recovers from one.
+
+        Only the planner's own terminal state ends the turn.
+        """
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [_user_step("go"), _tool_step("CORTEX_STEP_STATUS_ERROR")]
+        assert classify_turn_outcome(steps, start_index=0).state == "running"
+
+    def test_waiting_interaction_is_reported_while_running(self) -> None:
+        """A WAITING step keeps the turn running and flags WHY it is not progressing."""
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [_user_step("go"), _tool_step("CORTEX_STEP_STATUS_WAITING")]
+        outcome = classify_turn_outcome(steps, start_index=0)
+        assert outcome.state == "running"
+        assert outcome.waiting_on_user is True
+
+    def test_previous_turns_close_is_never_scanned(self) -> None:
+        """
+        Only steps AFTER this turn's USER_INPUT count.
+
+        The previous turn's closing planner sits earlier in the same trajectory;
+        scanning it would report a brand-new turn complete before agy touched it.
+        """
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [
+            _user_step("old"),
+            _planner_step(status="CORTEX_STEP_STATUS_DONE", text="old answer"),
+            _user_step("new"),
+        ]
+        assert classify_turn_outcome(steps, start_index=2).state == "running"
+
+    def test_degenerate_close_stays_running_for_the_idle_backstop(self) -> None:
+        """
+        A DONE planner with NO text is not a close — it is indistinguishable from
+        a streamed dispatch, so agy's own cascade status settles it instead.
+        """
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [_user_step("go"), _planner_step(status="CORTEX_STEP_STATUS_DONE")]
+        assert classify_turn_outcome(steps, start_index=0).state == "running"
+
+
+class TestCascadeIsIdle:
+    """``cascade_is_idle`` fails closed on anything but an explicit idle status."""
+
+    def test_explicit_idle_only(self) -> None:
+        """Only agy's own IDLE status reports idle; anything else does not."""
+        from omnigent.antigravity_native_steps import cascade_is_idle
+
+        assert cascade_is_idle({"c1": {"status": "CASCADE_RUN_STATUS_IDLE"}}, "c1") is True
+        assert cascade_is_idle({"c1": {"status": "CASCADE_RUN_STATUS_RUNNING"}}, "c1") is False
+
+    def test_missing_or_malformed_is_not_idle(self) -> None:
+        """An absent or non-dict summary is unknown, and unknown is never finished."""
+        from omnigent.antigravity_native_steps import cascade_is_idle
+
+        assert cascade_is_idle({}, "c1") is False
+        assert cascade_is_idle({"c1": "nope"}, "c1") is False
+        assert cascade_is_idle({"c1": {}}, "c1") is False

--- a/tests/test_antigravity_native_steps.py
+++ b/tests/test_antigravity_native_steps.py
@@ -1319,6 +1319,9 @@ def _tool_step(status: str) -> dict[str, Any]:
         "type": "CORTEX_STEP_TYPE_RUN_COMMAND",
         "status": status,
         "runCommand": {"command": "pytest"},
+        # ``metadata.toolAction`` is what marks a step as a tool call on the live
+        # wire, in both RPC shapes (see ``_is_tool_step``).
+        "metadata": {"toolAction": "Running command"},
     }
 
 
@@ -1353,36 +1356,40 @@ class TestFindTurnStartIndex:
         ]
         assert find_turn_start_index(steps, baseline_step_count=2) is None
 
-    def test_text_tier_used_only_without_a_baseline(self) -> None:
+    def test_identical_text_in_the_previous_turn_is_not_this_turn(self) -> None:
         """
-        With no pre-delivery snapshot, the delivered text identifies the turn.
+        REGRESSION: repeated text must not resolve to the earlier, finished turn.
 
-        The positional tier is unavailable when the pre-delivery read failed, so
-        matching agy's recorded turn text is what keeps the gate from waiting on
-        a turn it cannot see — and it still cannot match an older turn's text
-        while ours is unrecorded, because only the NEWEST USER_INPUT is tested.
+        A text-matching rule cannot separate two identical turns. When the same
+        text was sent last turn and the new USER_INPUT step has not yet appeared,
+        matching on text selects the OLD turn — whose DONE planner is sitting
+        right there — and reports it as this turn's completion. Position is the
+        only signal, so this is ``None`` until the new step actually lands.
         """
         from omnigent.antigravity_native_steps import find_turn_start_index
 
-        steps = [_user_step("old"), _user_step("  build the thing\n")]
-        found = find_turn_start_index(
-            steps, baseline_step_count=None, delivered_text="build the thing"
-        )
-        assert found == 1
-        missed = find_turn_start_index(
-            steps, baseline_step_count=None, delivered_text="something else"
-        )
-        assert missed is None
+        same_text = "run the test suite"
+        steps = [
+            _user_step(same_text),
+            _planner_step(status="CORTEX_STEP_STATUS_DONE", text="ran it, all green"),
+        ]
+        assert find_turn_start_index(steps, baseline_step_count=2) is None
+        # Once agy records the repeat, the NEW step is found — not the old one.
+        steps.append(_user_step(same_text))
+        assert find_turn_start_index(steps, baseline_step_count=2) == 2
 
-    def test_no_signals_or_no_user_step_yields_none(self) -> None:
-        """Without either signal — or without any USER_INPUT — the turn is unidentified."""
+    def test_no_user_step_yields_none(self) -> None:
+        """Without any USER_INPUT step the turn is unidentified."""
         from omnigent.antigravity_native_steps import find_turn_start_index
 
         assert find_turn_start_index([], baseline_step_count=0) is None
-        unidentified = find_turn_start_index(
-            [_user_step("hi")], baseline_step_count=None, delivered_text=None
+        assert (
+            find_turn_start_index(
+                [_planner_step(status="CORTEX_STEP_STATUS_DONE", text="x")],
+                baseline_step_count=0,
+            )
+            is None
         )
-        assert unidentified is None
 
 
 class TestClassifyTurnOutcome:
@@ -1470,12 +1477,46 @@ class TestClassifyTurnOutcome:
     def test_degenerate_close_stays_running_for_the_idle_backstop(self) -> None:
         """
         A DONE planner with NO text is not a close — it is indistinguishable from
-        a streamed dispatch, so agy's own cascade status settles it instead.
+        a streamed dispatch, so agy's own cascade status settles it instead. The
+        planner step IS evidence the model ran, which is what permits that
+        backstop.
         """
         from omnigent.antigravity_native_steps import classify_turn_outcome
 
         steps = [_user_step("go"), _planner_step(status="CORTEX_STEP_STATUS_DONE")]
-        assert classify_turn_outcome(steps, start_index=0).state == "running"
+        outcome = classify_turn_outcome(steps, start_index=0)
+        assert outcome.state == "running"
+        assert outcome.model_started is True
+
+    def test_a_bare_recorded_user_step_is_not_model_activity(self) -> None:
+        """
+        REGRESSION: a recorded USER_INPUT alone is NOT evidence the model started.
+
+        agy publishes the user step before it begins generating and reports the
+        cascade idle throughout that window. Treating the bare step as "the turn
+        is under way" is what lets an idle-based backstop declare success before
+        any work happens, so ``model_started`` stays False until a planner or
+        tool step exists.
+        """
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        outcome = classify_turn_outcome([_user_step("go")], start_index=0)
+        assert outcome.state == "running"
+        assert outcome.model_started is False
+
+    def test_a_steering_user_step_is_not_model_activity(self) -> None:
+        """A mid-turn steering USER_INPUT is another delivery, not the model working."""
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [_user_step("go"), _user_step("actually, do it this way")]
+        assert classify_turn_outcome(steps, start_index=0).model_started is False
+
+    def test_a_tool_step_is_model_activity(self) -> None:
+        """A tool step recorded for this turn proves agy started working on it."""
+        from omnigent.antigravity_native_steps import classify_turn_outcome
+
+        steps = [_user_step("go"), _tool_step("CORTEX_STEP_STATUS_RUNNING")]
+        assert classify_turn_outcome(steps, start_index=0).model_started is True
 
 
 class TestCascadeIsIdle:


### PR DESCRIPTION
## The defect

`AntigravityNativeExecutor.run_turn` reported a turn complete as soon as `_deliver()` returned, i.e. as soon as the turn's text had been typed and submitted into the agy TUI. Delivery is not completion. Unlike the claude/codex harnesses there is no headless per-turn subprocess whose exit supplies a completion signal on this path, so nothing waited for agy to do any work:

```python
outcome = await self._deliver(text)
...
yield TurnComplete(response=None)
```

An orchestrator dispatching an implementation task to an agy worker therefore collected an immediate, empty success before agy had run a single tool, and read "no changes applied" as "task done".

There was also no task-completion budget of any kind here. The bridge's tmux timeouts (`_TMUX_SEND_TIMEOUT_S`, `_TMUX_READY_TIMEOUT_S`, `_PASTE_COMMIT_TIMEOUT_S`, `_SUBMIT_VERIFY_TIMEOUT_S`) bound local TUI delivery only, and agy's own `--print-timeout` never applies because this path does not use `--print`.

## Completion semantics

After a successful delivery the executor polls agy's own RPC trajectory (`GetCascadeTrajectorySteps` — the same surface the read driver mirrors) until the turn reaches a terminal state:

| Trajectory state | Result |
|---|---|
| DONE `PLANNER_RESPONSE` carrying assistant text | `TurnComplete(response=<agy's final text>)` |
| ERROR `PLANNER_RESPONSE` | `ExecutorError(retryable=True)` with agy's own error detail |
| Degenerate close (turn ends with no text-carrying planner) | agy's own cascade run status, over consecutive checks, **and only once the model has demonstrably started** |
| None of the above within budget | `ExecutorError` naming the budget |

Design points worth reviewing:

- **Which turn is "this turn".** The executor snapshots the trajectory step count *before* delivering; only a `USER_INPUT` step at or after that index is this turn's. Without that, the previous turn's closing planner — already sitting in the trajectory — satisfies the gate instantly and reinstates the false success with stale text. Position is the **only** identification signal (see the cross-review section below for why the text fallback was removed), so the snapshot is retried within `_SNAPSHOT_TIMEOUT_S` rather than abandoned on a blip.
- **Unknown is never finished.** A failed trajectory read (transport, non-2xx, non-JSON body, no resolvable agy port yet) is transient: log, drop the cached port, retry. It never short-circuits into a success. The idle backstop likewise fails closed.
- **Errors stay errors.** An agy `ERROR` planner is reported as a failure, marked retryable (rate limit / provider overload / safety block is the class that survives a retry), distinct from the non-retryable structural failures.
- **The delivery path is unchanged.** Missing bridge state, an inactive session, and a `RuntimeError` from the TUI inject still surface as `ExecutorError` — now without even entering the gate.
- **Mid-turn steering stays ungated.** `enqueue_session_message` is a delivery into an already-open turn; the `run_turn` gate holding that turn is what waits for the steered work.
- **`response` now carries agy's text.** The harness adapter's `TurnComplete` branch does not re-emit `event.response` as a conversation item, so the read driver remains the sole mirror source and nothing double-renders; the text enriches the agent span and gives the caller something better than `None`.
- **Stop is responsive.** `interrupt_session` releases the gate, so a user hitting stop does not wait out the budget.

The pure turn-state predicates (`is_turn_close_step`, `is_assistant_text_close_step`, `is_planner_error_step`, `planner_response_text`, `cascade_is_idle`, plus `find_turn_start_index` / `classify_turn_outcome`) live in `antigravity_native_steps.py`, shared with the read driver so the completion gate and the mirrored session status cannot disagree about whether a turn ended. `antigravity_native_reader.py` keeps its private names as thin aliases, so its existing behaviour and tests are untouched.

## Cross-review fixes (second commit)

An independent review found two remaining paths to an unverified success. Both are the original bug in a narrower window, and both are fixed at the root.

### 1. The duplicate-text fallback could accept the previous turn

When the pre-delivery snapshot failed, the gate fell back to identifying its turn by matching the delivered **text** against the newest `USER_INPUT` step. If the identical text had been sent in the previous turn and the new step had not yet appeared, that match selected the **old** turn — already closed by its own DONE planner — and returned its reply as this turn's result. The original fallback test used *different* text, so it could not catch this.

No text-only rule separates two identical turns, so **the fallback is removed**. Position is now the only signal, and because nothing can substitute for it the snapshot is retried within `_SNAPSHOT_TIMEOUT_S` (10s) instead of being waved through. A turn whose snapshot never succeeds is reported as delivered-but-unverifiable, and is **not** retryable — the text was already typed into the TUI, so a retry would deliver it twice.

New regression: `test_repeated_text_with_no_snapshot_never_adopts_the_previous_turn` sends the same text twice with the snapshot forced to fail for its whole budget, and asserts the prior turn's terminal state is not accepted and its reply never surfaces. Plus `test_identical_text_in_the_previous_turn_is_not_this_turn` at the pure level, and `test_snapshot_is_retried_through_a_transient_failure` for the retry.

### 2. The idle backstop could fire before the model started

Once any new `USER_INPUT` was found, consecutive idle readings of agy's cascade could close the turn with no post-input evidence at all. agy publishes the user step *before* it starts generating and reports the cascade idle throughout that window, so consecutive reads did not close the gap — they only required it to persist, which a delayed model start does. The existing test only covered idle with *no* recorded turn, so the window was untested.

`TurnOutcome` now reports **`model_started`** — a planner or tool step recorded for *this* turn. A bare recorded user step does not count, and neither does a mid-turn steering `USER_INPUT` (that is another delivery, not the model working). The backstop is gated on it as well as on consecutive idle readings. A non-idle cascade reading is deliberately **not** accepted as evidence: `_cascade_reports_idle` fails closed, so `False` is indistinguishable from a failed read.

New regression: `test_idle_backstop_waits_for_evidence_the_model_started` records the user step, holds the cascade idle, delays the model start well past the consecutive-check window, and asserts zero idle checks occurred before the model started and that the turn completes on real terminal evidence. Plus three pure-level tests for `model_started`.

### 3. Trajectory list mutation (pinned, not re-architected)

The gate holds a **list index** across polls, while the read driver keys step identity on `(trajectory_id, step_index)` precisely because those are the stable fields. Whether agy ever prunes, compacts or reorders the list is unverified, so this does not re-architect onto trajectory identity. Instead the position is re-validated each poll (the slot must still hold a `USER_INPUT` step); a mutation is reported as a failure naming it rather than classifying a window the gate can no longer trust. The assumption and the identity-based alternative are stated at the call site. Pinned by `test_trajectory_mutation_under_the_gate_fails_rather_than_guesses`.

### 4. Cancellation race

`interrupt_session` set the interrupt flag while a concurrently starting `run_turn` cleared it, dropping a stop that arrived in that window. `run_turn` now consumes the interrupt on the way **out** (in a `finally`, which runs after the harness's second `interrupt_session` call, so no stale stop leaks to the next turn) and honours one already pending at entry by reporting the turn cancelled **without delivering** text for a request the user already stopped. Pinned by `test_interrupt_arriving_before_the_turn_starts_is_not_lost`, which also asserts the following turn is unaffected.

## Timeout defaults and the real effective budget

Both budgets are named, documented module constants.

- **`_TURN_START_TIMEOUT_S = 180.0`** — after a successful delivery, agy must record the turn. The submit was already footer-verified by the injector, so this only has to absorb agy minting its cascade on a first turn plus RPC-port discovery. Blowing it means the paste landed somewhere that is not a turn: a failure, not a slow agent.
- **`_TURN_COMPLETION_TIMEOUT_S = 3000.0`** (was 3600.0) — **this constant is not the effective budget on its own.** The harness wraps every `run_turn` in an idle watchdog (`_scaffold._TURN_IDLE_TIMEOUT_S`, env `HARNESS_TURN_TIMEOUT_S`) that is reset only by a **non-heartbeat** `ctx.emit`. This gate emits nothing while it polls — the read driver mirrors agy's output by POSTing session events directly, not through the harness stream — so a healthy but silent gated turn is racing that watchdog, and the real ceiling is whichever fires first.

  On this base the watchdog default is **3600s** (raised from 600s in #6204, merged 2026-09-02, which is in this branch's base `dc989062b`), so the reviewer's "aborted after about ten minutes" no longer holds. The concern does, in a sharper form: at 3600s the gate budget *tied* the watchdog exactly, and an opaque harness `response.failed` could win the race instead of the gate's diagnosable message. The gate budget now sits deliberately below it.

  50 minutes still covers the case that motivated the gate — a dispatched worker editing several files, running a build and a test suite, routinely tens of minutes. Anything in the low minutes (agy's own 5-minute `--print-timeout` default, say) would abort real work and be worse than the bug; anything past the harness watchdog is fiction.

  **Follow-up required to raise it further:** emitting a real progress signal from the gate needs a change in `_executor_adapter.py` (out of this change's file scope), and every event the adapter currently translates would double-render against the read driver's mirror. Raising `_TURN_COMPLETION_TIMEOUT_S` past `HARNESS_TURN_TIMEOUT_S` buys nothing until then.

Poll cadence is `_TURN_POLL_INTERVAL_S = 2.0`; the idle backstop runs every `_IDLE_CHECK_EVERY_N_POLLS = 5` polls and needs `_IDLE_CONFIRM_CHECKS = 2` consecutive idle readings *plus* `model_started`.

## Verification

**Live `agy` end-to-end was not exercised.** agy authentication is currently broken for harness-spawned workers and is being fixed separately, so a real session could not be driven. Everything below is unit-level against the trajectory/status layer, with agy's RPC surface faked at the module boundary (`get_trajectory_steps`, `get_all_cascade_trajectories`, `resolve_language_server_port`, `inject_user_message_via_tui`). The step shapes used are the live wire shapes the existing mapper and reader already key on — including `metadata.toolAction`, which is what actually marks a tool step (`_is_tool_step`).

Each new regression test was checked against the flaw it targets by reverting that one fix and re-running:

| Fix reverted | Failing test |
|---|---|
| text fallback reinstated | `test_repeated_text_with_no_snapshot_never_adopts_the_previous_turn` |
| `model_started` requirement dropped | `test_idle_backstop_waits_for_evidence_the_model_started` |
| positional re-validation removed | `test_trajectory_mutation_under_the_gate_fails_rather_than_guesses` |
| interrupt cleared at entry | `test_interrupt_arriving_before_the_turn_starts_is_not_lost` |

Each reverted flaw produced exactly one failure and left the other 46 tests passing. (The first version of the `model_started` test passed against its own flaw because a zero-length completion budget tripped before the backstop could accumulate its checks; it was rewritten to be poll-deterministic and now fails correctly.)

The first commit's claim also still holds: reverting only the completion path to `yield TurnComplete(response=None)` fails every gate test while the pre-existing delivery tests pass.

### Gate output

Commands run from the worktree in its own `uv` environment (`uv sync --extra all --group dev`):

```
$ uv run --no-sync ruff check omnigent/inner/antigravity_native_executor.py omnigent/inner/antigravity_native_harness.py omnigent/antigravity_native_steps.py omnigent/antigravity_native_reader.py tests/inner/test_antigravity_native_executor.py tests/test_antigravity_native_steps.py
All checks passed!

$ uv run --no-sync ruff format --check <same six files>
6 files already formatted

$ uv run --no-sync pyrefly check
 INFO Checking project configured at `.../pyrefly.toml`
 INFO 0 errors (420 suppressed, 219 warnings not shown)

$ uv run --no-sync pytest $(find tests -iname "*antigravity*" -name "*.py" | sort | tr '\n' ' ') -q
697 passed, 9 skipped in 20.73s
```

The two directly-changed test modules collect **150 test cases from 145 test functions** — 47 cases / 42 functions in `tests/inner/test_antigravity_native_executor.py` (the two parametrized `reasoning_effort` tests expand 2 functions into 7 cases) and 103 / 103 in `tests/test_antigravity_native_steps.py`. `pyrefly check` is the whole project, not just the changed files.

## Follow-ups (out of scope here)

- The harness adapter's `TurnComplete` branch is a deliberate no-op on `event.response` (`omnigent/runtime/harnesses/_executor_adapter.py`), so the text the gate now carries reaches the trace span but not the session transcript. Threading it through would be a change in that file.
- A non-heartbeat progress signal from the gate (see the budget section) needs the same file, and must not duplicate what the read driver already mirrors.
- If agy is ever observed mutating a trajectory list rather than appending, the gate should move from a list index to `(trajectory_id, step_index)` identity.
- The claude/codex/cursor/kimi/qwen native executors have the same shape — `TurnComplete` on successful injection — and may warrant the same treatment. Only antigravity is addressed here.