### PR TITLE
fix(terminal): re-enable tmux mouse so a native attach can scroll

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -83,7 +83,7 @@ def _tmux_command_sequence(commands: list[list[str]]) -> list[str]:
     file.
 
     :param commands: Tmux commands without the leading ``tmux`` argv,
-        e.g. ``[["set-option", "-g", "mouse", "off"], ["new-session"]]``.
+        e.g. ``[["set-option", "-g", "mouse", "on"], ["new-session"]]``.
     :returns: Flattened argv suffix with command separators.
     """
     sequence: list[str] = []
@@ -167,9 +167,15 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
 
     ``history-limit`` is generated per terminal because it comes from
     ``TerminalEnvSpec.scrollback``. ``set-clipboard external`` exports tmux
-    copy-mode selections without trusting pane OSC 52 requests. ``mouse off``
-    leaves scrolling and text selection to the attached terminal instead of
-    tmux copy mode. ``focus-events on`` lets interactive programs observe pane
+    copy-mode selections without trusting pane OSC 52 requests. ``mouse on``
+    lets a native ``tmux attach`` client reach tmux scrollback with the wheel;
+    tmux's ``WheelUpPane`` binding forwards the wheel to the pane program when
+    it tracks the mouse (``mouse_any_flag``, e.g. a full-screen TUI) and only
+    scrolls tmux history for panes that don't (inline CLIs, shells). It does
+    not affect the web control-mode client, whose xterm owns scrollback. The
+    cost is that plain click-drag selection on a non-tracking pane goes to tmux
+    copy mode, so native selection uses Shift-drag / Option-drag.
+    ``focus-events on`` lets interactive programs observe pane
     focus changes. ``extended-keys`` with CSI-u formatting
     lets programs inside tmux receive Kitty Keyboard Protocol keys such
     as Shift+Enter when the attached terminal supports them. Terminals
@@ -188,7 +194,7 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
         # Export tmux copy-mode selections to attached terminals without letting
         # pane applications create tmux buffers through OSC 52.
         ["set-option", "-sq", "set-clipboard", "external"],
-        ["set-option", "-g", "mouse", "off"],
+        ["set-option", "-g", "mouse", "on"],
         ["set-option", "-g", "focus-events", "on"],
         ["set-option", "-g", "escape-time", "0"],
     ]
@@ -198,14 +204,14 @@ def _tmux_scrollback_key_commands() -> list[list[str]]:
     """
     Build root-table bindings that let attached users reach scrollback.
 
-    The managed lockdown removes every default entry point into tmux copy
-    mode — ``mouse off``, ``prefix None``, and an emptied prefix table — and
+    The managed lockdown removes the prefix-key routes into tmux copy mode
+    (``prefix None``, ``prefix2 None``, and an emptied prefix table), and
     native clients attach with ``-f /dev/null`` so a user's own tmux.conf
-    cannot restore one, leaving output above the viewport unreachable.
-    Page Up enters copy mode scrolled up one page (``-e`` returns to the
-    live view once the user scrolls back to the bottom). On the alternate
-    screen the key passes through instead, so full-screen programs keep
-    their own Page Up handling.
+    cannot restore one. The wheel reaches scrollback via ``mouse on``, but a
+    keyboard path is still wanted, so Page Up enters copy mode scrolled up one
+    page (``-e`` returns to the live view once the user scrolls back to the
+    bottom). On the alternate screen the key passes through instead, so
+    full-screen programs keep their own Page Up handling.
 
     :returns: Tmux commands binding scrollback entry keys in the root table.
     """

--- a/tests/e2e/test_codex_native_tmux_scrollback_e2e.py
+++ b/tests/e2e/test_codex_native_tmux_scrollback_e2e.py
@@ -109,10 +109,11 @@ async def test_native_attach_can_scroll_back_through_managed_tmux_history(
 ) -> None:
     """A user attached to the managed tmux can scroll back to earlier output.
 
-    Regression guard: with the managed lockdown options (``mouse off``,
-    ``prefix None``, emptied prefix table, ``-f /dev/null`` attach) neither the
-    mouse wheel nor Page Up reaches tmux's history, so the conversation above
-    the viewport is unreachable from the native terminal.
+    Regression guard: the managed lockdown removes the prefix-key copy-mode
+    routes (``prefix None``, emptied prefix table) and attaches with
+    ``-f /dev/null``, so a scrollback route (``mouse on`` for the wheel, or the
+    root-table Page Up binding) must survive or the conversation above the
+    viewport is unreachable from the native terminal.
     """
     reg = TerminalRegistry()
     child: pexpect.spawn | None = None
@@ -194,6 +195,76 @@ async def test_native_attach_can_scroll_back_through_managed_tmux_history(
             "table, no root-table Page Up binding), and -f /dev/null blocks "
             "the user's tmux.conf from restoring one, so earlier formatted "
             "output above the viewport is unreachable."
+        )
+    finally:
+        if child is not None:
+            child.close(force=True)
+        await reg.shutdown()
+
+
+async def test_native_attach_mouse_wheel_alone_reaches_scrollback(
+    tmp_path: Path,
+) -> None:
+    """The mouse wheel alone scrolls a native attach into managed tmux history.
+
+    Focused guard for ``mouse on``: the sibling test tries Page Up first and
+    stops on success, so it never exercises the wheel. This one delivers ONLY
+    wheel-up. With ``mouse off`` the wheel bytes pass through to the inline pane
+    program (which ignores them) and nothing scrolls; with ``mouse on`` tmux's
+    ``WheelUpPane`` binding takes the non-tracking pane into copy-mode history.
+    """
+    reg = TerminalRegistry()
+    child: pexpect.spawn | None = None
+    try:
+        spec = TerminalEnvSpec(
+            command="bash",
+            args=[
+                "-c",
+                f'for i in $(seq 1 {FILLER_LINES}); do echo "CODEX OUTPUT LINE $i"; done; '
+                "exec sleep 600",
+            ],
+            os_env=OSEnvSpec(
+                type="caller_process",
+                cwd=str(tmp_path),
+                sandbox=OSEnvSandboxSpec(type="none"),
+            ),
+        )
+        instance = await reg.launch("conv_wheel", "codex", "s1", spec)
+        socket_path = str(instance.socket_path)
+
+        history_size = 0
+        for _ in range(120):
+            raw = _tmux_out(socket_path, "display-message", "-p", "-t", "main", "#{history_size}")
+            history_size = int(raw) if raw.isdigit() else 0
+            if history_size >= FILLER_LINES // 2:
+                break
+            time.sleep(0.25)
+        assert history_size >= FILLER_LINES // 2, (
+            f"pane never filled tmux history (history_size={history_size}); "
+            "the wheel assertion below would be vacuous"
+        )
+
+        env = dict(os.environ)
+        env.pop("TMUX", None)
+        env["TERM"] = "xterm-256color"
+        child = pexpect.spawn(
+            "tmux",
+            ["-S", socket_path, "-f", os.devnull, "attach", "-t", "main"],
+            env=env,
+            dimensions=(24, 80),
+            timeout=10,
+        )
+        child.expect("CODEX OUTPUT LINE", timeout=10)
+        time.sleep(1.0)
+
+        # Wheel-up only — no Page Up fallback.
+        child.send(WHEEL_UP * 4)
+        time.sleep(1.0)
+        scrolled, detail = _scrolled_state(socket_path)
+        assert scrolled, (
+            "the mouse wheel did not reach managed tmux scrollback on a native "
+            f"attach ({detail}). With `mouse off` the wheel bytes pass through "
+            "to the inline pane program instead of entering tmux copy-mode."
         )
     finally:
         if child is not None:

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -623,14 +623,22 @@ async def test_launch_omits_keep_alive_options_by_default(
 
 
 @pytest.mark.asyncio
-async def test_launch_disables_tmux_mouse_mode(
+async def test_launch_enables_tmux_mouse_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Managed terminals leave scrolling and text selection to the client."""
+    """Managed terminals enable tmux mouse so a native attach can wheel-scroll.
+
+    Regression guard: with ``mouse off`` a native ``tmux attach`` client cannot
+    reach tmux scrollback with the wheel (the wheel bytes pass through to an
+    inline CLI like codex, which ignores them). ``mouse on`` lets tmux catch the
+    wheel; its ``WheelUpPane`` binding forwards the wheel to mouse-tracking panes
+    and only scrolls history for non-tracking ones, so a full-screen TUI keeps
+    its own wheel.
+    """
     cmd = await _capture_launch_argv(tmp_path, monkeypatch, keep_alive_after_exit=False)
-    assert contains_subsequence(cmd, ["set-option", "-g", "mouse", "off"])
-    assert not contains_subsequence(cmd, ["set-option", "-g", "mouse", "on"])
+    assert contains_subsequence(cmd, ["set-option", "-g", "mouse", "on"])
+    assert not contains_subsequence(cmd, ["set-option", "-g", "mouse", "off"])
 
 
 @pytest.mark.asyncio
@@ -641,11 +649,11 @@ async def test_launch_binds_page_up_scrollback_entry_point(
     """
     Managed terminals keep one route into tmux scrollback for attached users.
 
-    The lockdown removes every default copy-mode entry point (``mouse off``,
-    ``prefix None``, emptied prefix table) and native clients attach with
-    ``-f /dev/null``, so without a root-table Page Up binding the formatted
-    output above the viewport is unreachable. The binding must pass Page Up
-    through on the alternate screen so full-screen programs keep the key.
+    The lockdown removes the prefix-key copy-mode routes (``prefix None``,
+    emptied prefix table) and native clients attach with ``-f /dev/null``, so
+    the wheel (``mouse on``) is the only route into scrollback without this
+    keyboard one. The binding must pass Page Up through on the alternate screen
+    so full-screen programs keep the key.
 
     :param tmp_path: Temporary directory for the fake tmux socket.
     :param monkeypatch: Pytest monkeypatch fixture.


### PR DESCRIPTION
## Related issue

Closes #

<!-- No filed issue; this restores mouse-wheel scrollback that regressed when
managed terminals switched to `mouse off`. -->

## Summary

- Managed terminals set tmux `mouse off`, which broke wheel-scroll for a native `tmux attach` (e.g. `omnigent codex`): the wheel bytes pass through to the inline CLI, which ignores them, so output above the viewport was unreachable by wheel/trackpad.
- Set `mouse on`. tmux's `WheelUpPane` binding forwards the wheel to panes that track the mouse (a full-screen TUI like Claude keeps its own wheel) and only scrolls tmux history for panes that don't, so it is correct for every harness.
- The web control-mode client is unaffected — xterm.js owns its own scrollback and selection, and the control stream is independent of the tmux mouse option. The one cost is that plain click-drag selection on a non-tracking native pane enters tmux copy mode, so native text selection uses Shift-drag / Option-drag.

## Test Plan

- `pytest tests/inner/test_terminal.py::test_launch_enables_tmux_mouse_mode tests/inner/test_terminal.py::test_launch_binds_page_up_scrollback_entry_point` — pass
- `pytest tests/e2e/test_codex_native_tmux_scrollback_e2e.py` — 2 passed (includes the new wheel-only regression test)
- `ruff check` / `ruff format --check` on the changed files — clean
- Manual: drove real `codex` 0.146 through the production managed-tmux options and a native `tmux attach` client PTY. Confirmed the wheel enters copy-mode history on a non-tracking pane (`pane_in_mode=1`), is forwarded to a mouse-tracking pane (`pane_in_mode=0`, via `mouse_any_flag`), and that a control-mode (`tmux -C`) client's `%output` stream is byte-identical with `mouse on` vs `off` (web path unaffected).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Native-TTY behavior; verified by the e2e test and the manual probes in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification drove real codex through the production managed-tmux options and a native `tmux attach` client PTY, confirming: the wheel reaches copy-mode history on a non-tracking pane; the wheel is forwarded to a mouse-tracking pane instead of hijacked; and the control-mode (web) output stream is unchanged by the mouse option.

## Changelog

Restore mouse-wheel scrollback in the native terminal (`omnigent codex` and other inline CLIs).
