### PR TITLE
fix(docker): read .default.provider in the capabilities log line

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from omnigent.server.managed_hosts import ManagedSandboxDeployment
     from omnigent.stores.artifact_store import ArtifactStore
 
 logging.basicConfig(level=logging.INFO, stream=sys.stderr, force=True)
@@ -309,6 +310,35 @@ def _resolve_execution_timeout(cfg: dict[str, Any]) -> int:
     return int(cfg.get("execution_timeout") or 7200)
 
 
+def log_capabilities(
+    sandbox_config: ManagedSandboxDeployment | None,
+    github_config: object | None,
+    github_store: object | None,
+) -> None:
+    """
+    Log the same flags ``/v1/info`` exposes, so a missing ``sandbox:``
+    block or GitHub App env shows up in pod logs without curling.
+
+    Reads ``sandbox_config.default.provider``, not ``.provider``:
+    :class:`ManagedSandboxDeployment` wraps one config PER PROVIDER and has
+    no ``provider`` of its own, so the bare attribute raises
+    ``AttributeError`` and kills the server at boot. Split out of
+    :func:`build_app` so the expression is reachable from a test without
+    standing up a database.
+
+    :param sandbox_config: The resolved sandbox deployment, or ``None``.
+    :param github_config: The GitHub App config, or ``None``.
+    :param github_store: The GitHub connection store, or ``None``.
+    """
+    managed = sandbox_config is not None and sandbox_config.managed_launch_supported
+    logger.info(
+        "Capabilities: managed_sandboxes=%s provider=%s github_app=%s",
+        managed,
+        sandbox_config.default.provider if managed and sandbox_config else None,
+        github_config is not None and github_store is not None,
+    )
+
+
 def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     """Resolve config if needed, wire the stores, and build the app.
 
@@ -460,15 +490,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         github_store=github_store,
     )
 
-    # Surface the same flags /v1/info exposes so a missing sandbox:
-    # block or GitHub App env shows up in pod logs without curling.
-    managed = sandbox_config is not None and sandbox_config.managed_launch_supported
-    logger.info(
-        "Capabilities: managed_sandboxes=%s provider=%s github_app=%s",
-        managed,
-        sandbox_config.provider if managed else None,
-        github_config is not None and github_store is not None,
-    )
+    log_capabilities(sandbox_config, github_config, github_store)
 
     return _BuiltApp(app=app, host=resolved_config.host, port=resolved_config.port)
 

--- a/tests/deploy/test_docker_entrypoint_capabilities.py
+++ b/tests/deploy/test_docker_entrypoint_capabilities.py
@@ -1,0 +1,88 @@
+"""Guard: the boot-time capabilities log line survives a managed sandbox.
+
+``build_app`` logs the flags ``/v1/info`` exposes so a missing ``sandbox:``
+block shows up in pod logs without curling. That line reads the sandbox
+deployment, and reading the wrong attribute there is fatal: it raises inside
+``build_app``, before uvicorn binds, so the container crash-loops with the
+server never becoming ready.
+
+The expression is guarded by ``managed``, so it is only evaluated when a
+sandbox block is configured AND launch-capable. A deployment with no managed
+sandboxes never reaches it — which is why an ``AttributeError`` here can ship
+green. These tests evaluate it directly, with and without a launch-capable
+provider.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+
+import pytest
+
+from omnigent.server.managed_hosts import ManagedSandboxConfig, ManagedSandboxDeployment
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def entrypoint():
+    """The Docker entrypoint module, imported from its real path."""
+    import sys
+
+    sys.path.insert(0, str(_REPO_ROOT))
+    try:
+        return importlib.import_module("deploy.docker.entrypoint")
+    finally:
+        sys.path.remove(str(_REPO_ROOT))
+
+
+def _deployment(*, launch_supported: bool) -> ManagedSandboxDeployment:
+    """A single-provider deployment, as ``parse_sandbox_config`` builds one."""
+    return ManagedSandboxDeployment.single(
+        ManagedSandboxConfig(
+            server_url="http://omnigent.example.svc.cluster.local",
+            launcher_factory=lambda: None,  # never called: nothing launches here
+            token_ttl_s=600,
+            managed_launch_supported=launch_supported,
+            provider="kubernetes",
+        )
+    )
+
+
+def test_capabilities_logs_the_provider_for_a_launch_capable_deployment(
+    entrypoint, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The line must not raise, and must name the provider.
+
+    Regression: ``ManagedSandboxDeployment`` wraps one config PER PROVIDER and
+    exposes no ``provider`` of its own, so a bare ``sandbox_config.provider``
+    raises ``AttributeError`` and kills the server at boot.
+    """
+    with caplog.at_level(logging.INFO, logger="omnigent-docker"):
+        entrypoint.log_capabilities(_deployment(launch_supported=True), None, None)
+
+    assert "managed_sandboxes=True" in caplog.text
+    assert "provider=kubernetes" in caplog.text
+
+
+def test_capabilities_reports_no_provider_when_launch_is_unsupported(
+    entrypoint, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A staged-only provider reports the flag false and no provider."""
+    with caplog.at_level(logging.INFO, logger="omnigent-docker"):
+        entrypoint.log_capabilities(_deployment(launch_supported=False), None, None)
+
+    assert "managed_sandboxes=False" in caplog.text
+    assert "provider=None" in caplog.text
+
+
+def test_capabilities_handles_no_sandbox_block(
+    entrypoint, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No ``sandbox:`` block at all is the common deployment, and must be safe."""
+    with caplog.at_level(logging.INFO, logger="omnigent-docker"):
+        entrypoint.log_capabilities(None, None, None)
+
+    assert "managed_sandboxes=False" in caplog.text


### PR DESCRIPTION
Closes #6343.

## The failure

`deploy/docker/entrypoint.py:469` reads `sandbox_config.provider`. `ManagedSandboxDeployment` has no such attribute, so the Docker entrypoint raises inside `build_app`, **before uvicorn binds** — from a log line.

```
AttributeError: 'ManagedSandboxDeployment' object has no attribute 'provider'
  File "/app/entrypoint.py", line 492, in main
    resolved = build_app(resolved_config)
  File "/app/entrypoint.py", line 469, in build_app
    sandbox_config.provider if managed else None,
```

The container crash-loops and the server never becomes ready. Migrations have already run by that point, so a deployment that hits this is left on the new schema with no working image — recovery means fixing forward or an Alembic downgrade.

## Why it exists

`#4006` (`d03b06f16`, 12 Aug) introduced `ManagedSandboxDeployment`, which wraps one `ManagedSandboxConfig` **per provider**:

```python
>>> [f.name for f in dataclasses.fields(ManagedSandboxDeployment)]
['configs']
>>> hasattr(dep, "provider")   → False
>>> dep.default.provider       → 'kubernetes'
```

`#4235` (`336207801`, 2 Sep) added the capabilities line reading `.provider`. The refactor is an ancestor of that commit and `entrypoint.py` went from 0 → 1 occurrences in it, so **the line has never worked** — it was written against an attribute that had been gone for three weeks.

## Why CI does not catch it

The expression is guarded:

```python
managed = sandbox_config is not None and sandbox_config.managed_launch_supported
...
    sandbox_config.provider if managed else None,   # only evaluated when managed
```

A deployment with no `sandbox:` block, or one whose provider is not launch-capable, never evaluates it. `tests/deploy/test_docker_entrypoint_import.py` asserts the module **imports**, which passes with the bug present.

So reaching it needs the Docker entrypoint *and* a configured, launch-capable provider — a combination exercised by deployment rather than by CI.

## The change

`.default` returns the config a request naming no provider launches on, which is what the line intends to report.

The line is split into `log_capabilities()` so it is reachable from a test without standing up a database. Three tests: a launch-capable deployment (the regression), a staged-only provider, and no sandbox block at all.

**Verified the guard works** — restoring the previous expression fails the first test with the exact `AttributeError`, and the fix makes it pass.

## Open question for you

On a multi-provider deployment `.default.provider` under-reports: the line exists to surface capabilities without curling `/v1/info`, and `launchable_providers` may be what you actually want there. I took the minimal change that restores the original intent. Happy to switch to listing all offered providers if you prefer — say which and I will amend.

## Checks

- `tests/deploy/` — 13 passed, including the existing no-side-effects suite (the `TYPE_CHECKING` import keeps that intact).
- `ruff check` and `ruff format --check` clean on both files.

## Environment where it surfaced

Kubernetes managed-sandbox provider, `OMNIGENT_AUTH_PROVIDER=oidc`, Postgres, server built from `main` at `951ef519e`.