### PR TITLE
fix(imports): route host-mediated import to the host's own replica

### DIFF
--- a/omnigent/server/routes/_host_launch.py
+++ b/omnigent/server/routes/_host_launch.py
@@ -80,6 +80,30 @@ def resolve_host_owner(
     return host
 
 
+def host_absent_error(host: Host) -> OmnigentError:
+    """Classify a "host not on this replica" miss for a host-scoped route.
+
+    Every route that reaches a host over its live tunnel looks it up in the
+    local (this-replica) ``HostRegistry``. When replicas are sharded by host, a
+    request keyed to ``host_id`` can land on a replica that doesn't hold the
+    tunnel — the same wrong-replica case ``RunnerRouter`` handles for runner
+    dispatch. Tell the two apart from the host record the caller already loaded:
+
+    - still **live** (online + fresh heartbeat) → up on some replica, just not
+      here → :data:`~ErrorCode.WRONG_REPLICA` (400) so the client re-addresses
+      WITHOUT the key.
+    - otherwise → genuinely offline → ``CONFLICT`` (409).
+
+    :param host: The host's persistent record (owner-checked by the caller).
+    :returns: The ``OmnigentError`` to raise; the global handler maps its code
+        to the HTTP status and the ``{"error": {"code": ...}}`` body the
+        client's re-address matches on.
+    """
+    if host_is_live(host):
+        return OmnigentError("host is on another replica", code=ErrorCode.WRONG_REPLICA)
+    return OmnigentError("host is offline", code=ErrorCode.CONFLICT)
+
+
 def resolve_host_launch(
     *,
     user_id: str | None,
@@ -129,15 +153,7 @@ def resolve_host_launch(
 
     conn = host_registry.get(host_id)
     if conn is None:
-        # The host's tunnel isn't on this replica. If the store shows it still
-        # live (online + fresh heartbeat), it's up on another replica — a
-        # wrong-replica landing — so surface WRONG_REPLICA (400, distinct code)
-        # and let the client re-address keyless. Otherwise it's genuinely
-        # offline → CONFLICT (409). Mirrors RunnerRouter._runner_absent_code
-        # and hosts._host_absent_error.
-        if host_is_live(host):
-            raise OmnigentError("host is on another replica", code=ErrorCode.WRONG_REPLICA)
-        raise OmnigentError("host is offline", code=ErrorCode.CONFLICT)
+        raise host_absent_error(host)
 
     conv = conversation_store.get_conversation(session_id)
     if conv is None:

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -51,14 +51,14 @@ from omnigent.server.auth import AuthProvider
 from omnigent.server.feature_flags import Feature, FeatureFlags, resolve_feature_flags
 from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes._auth_helpers import require_user
-from omnigent.server.routes._host_launch import resolve_host_launch
+from omnigent.server.routes._host_launch import host_absent_error, resolve_host_launch
 from omnigent.server.routes._workspace_validation import (
     _is_windows_absolute_path,
     restore_host_filesystem_url_path,
 )
 from omnigent.server.schemas import SessionGitOptions
 from omnigent.stores import AgentStore, ConversationStore
-from omnigent.stores.host_store import Host, HostStore, host_is_live
+from omnigent.stores.host_store import HostStore, host_is_live
 from omnigent.stores.permission_store import PermissionStore
 
 _logger = logging.getLogger(__name__)
@@ -86,29 +86,10 @@ _MODEL_OPTIONS_TIMEOUT_S = 15.0
 _INSTALL_HARNESS_TIMEOUT_S = 420.0
 
 
-def _host_absent_error(host: Host) -> OmnigentError:
-    """Classify a "host not on this replica" miss for a host-scoped route.
-
-    Every ``/v1/hosts/{id}/*`` route reaches the host over its live tunnel in
-    the local (this-replica) ``HostRegistry``. When replicas are sharded by
-    host, a request keyed to ``host_id`` can land on a replica that doesn't
-    hold the tunnel — the same wrong-replica case ``RunnerRouter`` handles for
-    runner dispatch (see ``_runner_absent_code``). Tell the two apart using the
-    host record the caller already loaded:
-
-    - still **live** (online + fresh heartbeat) → up on some replica, just not
-      here → :data:`~ErrorCode.WRONG_REPLICA` (400) so the client re-addresses
-      WITHOUT the key.
-    - otherwise → genuinely offline → ``CONFLICT`` (409).
-
-    :param host: The host's persistent record (owner-checked by the caller).
-    :returns: The ``OmnigentError`` to raise; the global handler maps its code
-        to the HTTP status and the ``{"error": {"code": ...}}`` body the
-        client's re-address matches on.
-    """
-    if host_is_live(host):
-        return OmnigentError("host is on another replica", code=ErrorCode.WRONG_REPLICA)
-    return OmnigentError("host is offline", code=ErrorCode.CONFLICT)
+# ``/v1/hosts/{id}/*`` routes share the wrong-replica-vs-offline classification
+# with the runner-launch and import paths; the one implementation lives in
+# ``_host_launch`` so the sites can't drift.
+_host_absent_error = host_absent_error
 
 
 async def _proxy_model_options(

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -24,7 +24,7 @@ from omnigent.server.auth import LEVEL_OWNER, AuthProvider
 from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes._auth_helpers import require_access, require_user
 from omnigent.server.routes._content_type import require_json_content_type
-from omnigent.server.routes._host_launch import resolve_host_owner
+from omnigent.server.routes._host_launch import host_absent_error, resolve_host_owner
 from omnigent.server.routes._session_create_validation import resolve_project_session_create
 from omnigent.server.schemas import SessionCreateRequest
 from omnigent.session_import import (
@@ -429,13 +429,13 @@ def create_imports_router(
             )
         user_id = require_user(request, auth_provider)
         # Owns-host check + live connection, mirroring the runner-launch path.
-        resolve_host_owner(user_id=user_id, host_id=body.host_id, host_store=host_store)
+        host = resolve_host_owner(user_id=user_id, host_id=body.host_id, host_store=host_store)
         host_conn = host_registry.get(body.host_id)
         if host_conn is None:
-            raise OmnigentError(
-                f"host '{body.host_id}' is not connected",
-                code=ErrorCode.CONFLICT,
-            )
+            # A live host absent from THIS replica is a wrong-replica landing, not
+            # an offline host: WRONG_REPLICA (400) so the client re-addresses
+            # keyless, CONFLICT (409) only when the row is genuinely stale.
+            raise host_absent_error(host)
         return user_id, host_conn
 
     async def _import_local_core(

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -8,12 +8,16 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 from omnigent.db.utils import builtin_agent_id
-from omnigent.errors import OmnigentError
-from omnigent.server.routes.imports import _stream_local_sessions_from_host
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.host_registry import HostRegistry
+from omnigent.server.routes.imports import _stream_local_sessions_from_host, create_imports_router
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.host_store import HostStore
 
 
 def _seed_claude_agent(db_uri: str) -> str:
@@ -504,3 +508,66 @@ async def test_local_import_stream_emits_ndjson_session_then_done(
     # Each streamed session was actually persisted.
     for e in session_events:
         assert conversation_store.get_conversation(e["session_id"]) is not None
+
+
+def _host_import_client(db_uri: str, host_registry: HostRegistry) -> httpx.AsyncClient:
+    """Mount only the imports router with host support wired, auth disabled.
+
+    The default ``client`` fixture builds the app with ``host_store=None``, so
+    ``/imports/local`` short-circuits before the host lookup. Here host_store is
+    real (holds the seeded row) and the registry is caller-supplied (empty = the
+    host's tunnel is not on this replica), which is what exercises the
+    wrong-replica-vs-offline classification.
+    """
+    app = FastAPI()
+    app.include_router(
+        create_imports_router(
+            SqlAlchemyConversationStore(db_uri),
+            SqlAlchemyAgentStore(db_uri),
+            host_registry=host_registry,
+            host_store=HostStore(db_uri),
+        ),
+        prefix="/v1",
+    )
+
+    @app.exception_handler(OmnigentError)
+    async def _handle(_request: Request, exc: OmnigentError) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.http_status,
+            content={"error": {"code": exc.code, "message": exc.message}},
+        )
+
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
+
+
+async def test_import_local_live_host_off_replica_is_wrong_replica(db_uri: str) -> None:
+    """A live host absent from this replica is WRONG_REPLICA, not "not connected".
+
+    Regression: the route used to flatten every registry miss into a 409
+    CONFLICT, so a host live on another replica never got the 400 wrong_replica
+    signal the client re-addresses on — the import failed permanently.
+    """
+    host_id = "host_0123456789abcdef0123456789abcdef"
+    HostStore(db_uri).upsert_on_connect(host_id, "laptop", "alice@example.com")
+    async with _host_import_client(db_uri, HostRegistry()) as client:
+        res = await client.post(
+            "/v1/imports/local",
+            json={"host_id": host_id, "source": "all", "limit": 5},
+        )
+    assert res.status_code == 400
+    assert res.json()["error"]["code"] == ErrorCode.WRONG_REPLICA
+
+
+async def test_import_local_offline_host_is_conflict(db_uri: str) -> None:
+    """A genuinely offline host stays a 409 CONFLICT (not re-addressable)."""
+    host_id = "host_fedcba9876543210fedcba9876543210"
+    store = HostStore(db_uri)
+    store.upsert_on_connect(host_id, "laptop", "alice@example.com")
+    store.set_offline(host_id)
+    async with _host_import_client(db_uri, HostRegistry()) as client:
+        res = await client.post(
+            "/v1/imports/local",
+            json={"host_id": host_id, "source": "all", "limit": 5},
+        )
+    assert res.status_code == 409
+    assert res.json()["error"]["code"] == ErrorCode.CONFLICT

--- a/web/src/lib/identity.test.ts
+++ b/web/src/lib/identity.test.ts
@@ -313,6 +313,40 @@ describe("authenticatedFetch", () => {
       expect(secondHeaders.get("X-Databricks-Omnigent-Slice-Key")).toBeNull();
       expect(response.status).toBe(200);
     });
+
+    it("keys /v1/imports/local by its body host_id, not the modal host", async () => {
+      // The import reads the CHOSEN host's transcripts over that host's tunnel,
+      // so it must route to the replica keyed by the body host_id — never the
+      // importing user's modal host (a different host, or null for a fresh user),
+      // which would land off-replica and 409 "host is not connected".
+      vi.doMock("./sessionHost", () => ({
+        getSessionHost: vi.fn(() => null),
+        setSessionHost: vi.fn(),
+        isHostKeyless: vi.fn(() => false),
+        markHostKeyless: vi.fn(),
+        clearHostKeyless: vi.fn(),
+        modalHostId: vi.fn(() => "host_modal"),
+        resolveModalHost: vi.fn(),
+        isModalHostResolved: vi.fn(() => true),
+      }));
+      vi.doMock("./host", () => ({
+        getOmnigentHostConfig: vi.fn(() => ({ fetcher: () => fetch })),
+        hostFetch: fetchMock,
+        isDatabricksWorkspace: vi.fn(() => true),
+      }));
+
+      fetchMock.mockResolvedValueOnce(mockJsonResponse({}));
+      const { authenticatedFetch } = await import("./identity");
+
+      await authenticatedFetch("/v1/imports/local/stream", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ host_id: "host_target", source: "all", limit: 5 }),
+      });
+
+      const headers = new Headers((fetchMock.mock.calls[0][1] as RequestInit).headers);
+      expect(headers.get("X-Databricks-Omnigent-Slice-Key")).toBe("host_target");
+    });
   });
 });
 

--- a/web/src/lib/identity.ts
+++ b/web/src/lib/identity.ts
@@ -185,20 +185,28 @@ function beginSessionHostResolve(url: string): Promise<void> | null {
   return resolveSessionHost(decodeURIComponent(match[1]));
 }
 
+// Requests whose target host lives in a JSON body, not the URL, so
+// {@link hostScopeForUrl} can't see it: the session create (POST /v1/sessions)
+// and the host-mediated local import (POST /v1/imports/local[/stream]).
+const BODY_HOST_KEYED_RE = /\/v1\/(?:sessions(?:\?|$)|imports\/local(?:[/?]|$))/;
+
 /**
- * The create endpoint (``POST /v1/sessions``) carries its target host_id in the
- * request body, not the URL, so {@link hostScopeForUrl} can't see it. Left unkeyed,
- * the create round-robins and can miss the replica holding the host's runner
- * tunnel — the server notifies the runner inline over that pod-local tunnel, so
- * an off-replica create fails with "runner is offline". Recover the host_id from
- * a JSON create body so the create is pinned like every other host-scoped
- * request. Bundled (multipart) creates are hostless here — they only write rows
- * and bind the runner via a separate ``POST /v1/hosts/{id}/runners`` — and a
- * sandbox create carries ``host_type`` but no ``host_id``; both yield null.
+ * Recover the target host_id from a JSON request body for a body-host-keyed
+ * request ({@link isBodyHostKeyedRequest}), or null when the body names none.
+ *
+ * These requests carry the host in the body, not the URL, so left unkeyed they
+ * round-robin and can miss the replica holding that host's runner tunnel. A
+ * session create fails "runner is offline" (the server notifies the runner
+ * inline over its pod-local tunnel); an import fails "host is not connected"
+ * (the import reads the host's transcripts over that same tunnel). Keying by the
+ * body host_id pins both to the right replica like every other host-scoped
+ * request. Bundled (multipart) creates are hostless here (non-string body) and a
+ * managed-sandbox create carries ``host_type`` but no ``host_id``; both yield
+ * null → unkeyed (see {@link isBodyHostKeyedRequest}).
  */
-function hostIdForCreateBody(url: string, body: BodyInit | null | undefined): string | null {
+function hostIdFromBody(url: string, body: BodyInit | null | undefined): string | null {
   if (typeof body !== "string") return null;
-  if (!/\/v1\/sessions(?:\?|$)/.test(url)) return null;
+  if (!BODY_HOST_KEYED_RE.test(url)) return null;
   try {
     const hostId = (JSON.parse(body) as { host_id?: unknown }).host_id;
     return typeof hostId === "string" && hostId ? hostId : null;
@@ -208,29 +216,27 @@ function hostIdForCreateBody(url: string, body: BodyInit | null | undefined): st
 }
 
 /**
- * Whether this request is a session create keyable only by its own body host_id.
+ * Whether this request is keyable only by its own body host_id, never the modal.
  *
- * A MANAGED SANDBOX create should never ride the modal host. The modal is a
- * cache-affinity hint for reads, but a create has a side effect pinned to a
- * replica: the managed launch task it spawns lives on whichever pod served it,
- * and that task needs the new host's tunnel in its LOCAL registry to send
- * ``host.launch_runner``. A managed create carries no ``host_id`` (the host does
- * not exist yet), so keying it to the modal host routes the launch task to a
- * replica unrelated to the session — the sandbox boots, its tunnel registers on
- * the default replica, and the launch task never sees it, so no runner is ever
- * spawned. Unkeyed, the create lands on the same default replica the host will
- * dial back to.
+ * The modal host is a cache-affinity hint for reads, but these requests have a
+ * side effect pinned to a replica and must key by their OWN target host:
  *
- * A create that NAMES a host in its body keeps its key (see
- * {@link hostIdForCreateBody}) — that host is a real target whose runner the
- * server notifies inline over its pod-local tunnel, so an off-replica create
- * would fail. A bundled (multipart) create has a non-string body and so is not
- * matched here: it only writes rows and binds the runner via a separate
- * ``POST /v1/hosts/{id}/runners`` (which keys itself from the URL), so it spawns
- * no replica-pinned launch task and may keep riding the modal.
+ * - A session create's managed launch task lives on whichever pod served it and
+ *   needs the new host's tunnel in its LOCAL registry to send
+ *   ``host.launch_runner``. A managed create carries no ``host_id`` (the host
+ *   doesn't exist yet) → null → unkeyed, landing on the same default replica the
+ *   host will dial back to. A create that NAMES a host keeps that key.
+ * - A local import reads the chosen host's transcripts over its tunnel, which is
+ *   registered on the replica keyed by that host_id — never the importing user's
+ *   modal host (null / a different host for a fresh user), which is why an
+ *   unkeyed import lands off-replica and 409s "host is not connected".
+ *
+ * A bundled (multipart) create has a non-string body and is not matched: it only
+ * writes rows and binds the runner via a separate ``POST /v1/hosts/{id}/runners``
+ * (keyed from the URL), so it spawns no replica-pinned work and may ride the modal.
  */
-function isSessionCreate(url: string, body: BodyInit | null | undefined): boolean {
-  return typeof body === "string" && /\/v1\/sessions(?:\?|$)/.test(url);
+function isBodyHostKeyedRequest(url: string, body: BodyInit | null | undefined): boolean {
+  return typeof body === "string" && BODY_HOST_KEYED_RE.test(url);
 }
 
 // Admin flag from the same `/v1/me` probe. Mode-agnostic (the shared
@@ -440,14 +446,15 @@ export async function authenticatedFetch(
     // host isn't known yet must send NO key rather than the modal — the modal
     // is the wrong guess for a SPECIFIC session, so it would route to a replica
     // that doesn't hold the tunnel; a keyless miss re-addresses instead. Only
-    // an unscoped route (list / updates) may ride the modal — a JSON create may
-    // not (see {@link isSessionCreate}): it is keyable ONLY by its own body
-    // host_id, so a managed sandbox create (no host_id yet) stays unkeyed.
+    // an unscoped route (list / updates) may ride the modal — a JSON request
+    // whose target host is in the body may not (see {@link isBodyHostKeyedRequest}):
+    // it is keyable ONLY by that body host_id (a managed create with none stays
+    // unkeyed).
     const scope = hostScopeForUrl(url);
     if (scope.scoped) {
       derivedHostId = scope.hostId;
-    } else if (isSessionCreate(url, init?.body)) {
-      derivedHostId = hostIdForCreateBody(url, init?.body);
+    } else if (isBodyHostKeyedRequest(url, init?.body)) {
+      derivedHostId = hostIdFromBody(url, init?.body);
     } else {
       derivedHostId = modalHostId();
     }


### PR DESCRIPTION
## Related issue

N/A — no tracking issue yet; found while triaging "host '###' is not connected" on `/v1/imports/local`. Happy to link one if a maintainer wants it filed first.

## Summary

Host-mediated local import (`POST /v1/imports/local[/stream]`) reads the chosen host's transcripts over **that host's** WebSocket tunnel, which registers on the replica keyed by its `host_id`. Two bugs kept the request from reaching that replica on a multi-replica server:

- **Client keyed by the wrong host.** `authenticatedFetch` keyed the import by the importing user's *modal* host (the host backing most of their own sessions), never the `host_id` in the request body. Body-host keying existed only for `/v1/sessions` creates. So the import landed on a replica that may not hold the selected host's tunnel.
- **Server hid the misroute.** On a registry miss the route raised a flat `409 CONFLICT` ("host is not connected") instead of `WRONG_REPLICA`. The client only re-addresses (retries keyless) on `400 wrong_replica`, so a 409 gave it nothing to self-heal from.

Net effect: import worked only when the user's modal host happened to equal the import target. It failed for anyone else on the same workspace — most visibly first-run importers, whose modal host is `null` (no prior sessions), so the request went keyless to the default replica while their fresh host's keyed tunnel lived elsewhere.

**ELI5:** you asked to import from *this* laptop, but the app routed the request using *your usual* laptop as the address. When they differ, it knocked on the wrong server and got told "no laptop here" with no way to recover.

```
import(host_target) ──key by modal host (guess)──▶ replica A ──miss──▶ 409 "not connected"  ✗ (dead)
                                                                 ▲
                                          host_target's tunnel ──┘ lives on replica B

after:
import(host_target) ──key by BODY host_id──▶ replica B ──hit──▶ import runs        ✓
                     └─ keyed host on another replica ─▶ 400 wrong_replica ─▶ retry keyless ─▶ hit  ✓
```

Fixes:
- **web** (`identity.ts`): key `/v1/imports/local[/stream]` by its body `host_id`, generalizing the existing session-create body-host keying.
- **server** (`imports.py`): raise the shared `host_absent_error` on a registry miss, so a live-elsewhere host yields `WRONG_REPLICA` (400) and only a genuinely stale row yields `CONFLICT` (409). The classifier is deduped into `_host_launch` so the hosts, launch, and import paths can't drift (removes a hand-copied third copy).

## Test Plan

```
uv run pytest tests/server/routes/test_imports.py \
              tests/server/routes/test_host_launch.py \
              tests/server/test_runner_routing_wrong_replica.py \
              tests/server/routes/test_hosts_routes.py        # all pass
uv run ruff check .   &&  uv run ruff format --check .        # clean

cd web && npx vitest run src/lib/identity.test.ts             # 23 pass
npx oxlint … src/lib/identity.ts src/lib/identity.test.ts     # clean
npx tsc --noEmit -p tsconfig.json                             # clean
```

New server regression tests fail on `origin/main` (they get 409 instead of 400): `test_import_local_live_host_off_replica_is_wrong_replica` and `test_import_local_offline_host_is_conflict`. New Vitest `keys /v1/imports/local by its body host_id, not the modal host` asserts the slice key is the body host, not the modal host.

**Live deploy validation:** beyond the unit suite, this change was built and rolled out to a live multi-replica server; both replicas came up healthy on the new build (readiness passing, no restarts), confirming the server path boots and serves cleanly with the fix. The full multi-replica *routing* path (a keyed request landing off-replica → keyless re-address) still isn't in an automated E2E — it needs a sharded multi-replica setup — so it stays covered by the route-level classification test and the existing `retries keyless on wrong_replica` client test.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No visual change — the fix is request routing. Reproducing the live failure needs a multi-replica (host-sharded) deployment; it's covered instead by the route-level classification test and the client keying test above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The wrong-replica-vs-offline classification is unit-tested at the route level (seeded live/offline host row + empty registry → 400 vs 409); the client keying is unit-tested in Vitest. The full multi-replica traffic path (keyed request landing off-replica → keyless re-address → correct replica) isn't in a live E2E because it requires a sharded multi-replica server, but both halves of that path — the server signal and the client re-address trigger — are exercised individually, and the client re-address mechanism itself is already covered by the existing `retries keyless on wrong_replica` test.

## Changelog

Fixed host-mediated session import failing with "host is not connected" on multi-replica servers when importing from a host other than your most-used one.

