### PR TITLE
fix(terminal): re-enable tmux mouse so a native attach can scroll

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -84,7 +84,7 @@ def _tmux_command_sequence(commands: list[list[str]]) -> list[str]:
     file.
 
     :param commands: Tmux commands without the leading ``tmux`` argv,
-        e.g. ``[["set-option", "-g", "mouse", "off"], ["new-session"]]``.
+        e.g. ``[["set-option", "-g", "mouse", "on"], ["new-session"]]``.
     :returns: Flattened argv suffix with command separators.
     """
     sequence: list[str] = []
@@ -168,9 +168,15 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
 
     ``history-limit`` is generated per terminal because it comes from
     ``TerminalEnvSpec.scrollback``. ``set-clipboard external`` exports tmux
-    copy-mode selections without trusting pane OSC 52 requests. ``mouse off``
-    leaves scrolling and text selection to the attached terminal instead of
-    tmux copy mode. ``focus-events on`` lets interactive programs observe pane
+    copy-mode selections without trusting pane OSC 52 requests. ``mouse on``
+    is what lets a native ``tmux attach`` client reach the pane's scrollback:
+    tmux's default ``WheelUpPane`` binding forwards the wheel to the pane when
+    it is on the alternate screen or tracking the mouse, and only scrolls tmux
+    history for the inline CLIs that ignore it. The cost is that click-drag
+    selection on such a pane goes through tmux copy mode (which exports to the
+    attached terminal via ``set-clipboard``) rather than the terminal's own
+    selection, so native selection uses its Shift/Option-drag override.
+    ``focus-events on`` lets interactive programs observe pane
     focus changes. ``extended-keys`` with CSI-u formatting
     lets programs inside tmux receive Kitty Keyboard Protocol keys such
     as Shift+Enter when the attached terminal supports them. Terminals
@@ -189,7 +195,7 @@ def _tmux_input_option_commands(scrollback: int) -> list[list[str]]:
         # Export tmux copy-mode selections to attached terminals without letting
         # pane applications create tmux buffers through OSC 52.
         ["set-option", "-sq", "set-clipboard", "external"],
-        ["set-option", "-g", "mouse", "off"],
+        ["set-option", "-g", "mouse", "on"],
         ["set-option", "-g", "focus-events", "on"],
         ["set-option", "-g", "escape-time", "0"],
     ]
@@ -199,14 +205,14 @@ def _tmux_scrollback_key_commands() -> list[list[str]]:
     """
     Build root-table bindings that let attached users reach scrollback.
 
-    The managed lockdown removes every default entry point into tmux copy
-    mode — ``mouse off``, ``prefix None``, and an emptied prefix table — and
-    native clients attach with ``-f /dev/null`` so a user's own tmux.conf
-    cannot restore one, leaving output above the viewport unreachable.
-    Page Up enters copy mode scrolled up one page (``-e`` returns to the
-    live view once the user scrolls back to the bottom). On the alternate
-    screen the key passes through instead, so full-screen programs keep
-    their own Page Up handling.
+    The managed lockdown removes the prefix-key routes into tmux copy mode
+    (``prefix None``, ``prefix2 None``, an emptied prefix table), and native
+    clients attach with ``-f /dev/null`` so a user's own tmux.conf cannot
+    restore one. The wheel reaches history through ``mouse on``; Page Up is
+    the keyboard equivalent, entering copy mode scrolled up one page (``-e``
+    returns to the live view once the user scrolls back to the bottom). On the
+    alternate screen the key passes through instead, so full-screen programs
+    keep their own Page Up handling.
 
     :returns: Tmux commands binding scrollback entry keys in the root table.
     """

--- a/tests/e2e/test_codex_native_tmux_scrollback_e2e.py
+++ b/tests/e2e/test_codex_native_tmux_scrollback_e2e.py
@@ -1,19 +1,25 @@
-"""E2E regression: native attach to an Omnigent-managed tmux terminal cannot
-reach the formatted scrollback above the viewport.
+"""E2E regression: a native attach to an Omnigent-managed tmux terminal must be
+able to reach the formatted scrollback above the viewport.
 
 The reported journey: run ``omnigent codex`` from a native terminal, produce
 more conversation output than fits the viewport, then scroll up with the mouse
-wheel or press Page Up. Nothing moves — the view stays pinned at the bottom and
-earlier formatted output is unreachable, even though tmux's history buffer
-holds it (an affected session reported ``history=288`` with
+wheel or press Page Up. Nothing moved — the view stayed pinned at the bottom and
+earlier formatted output was unreachable, even though tmux's history buffer
+held it (an affected session reported ``history=288`` with
 ``history-limit 100000``).
 
-Why: the managed tmux server disables every entry point into tmux copy mode —
-``mouse off`` (so wheel events never trigger ``WheelUpPane``), ``prefix None``
-+ ``prefix2 None`` + an emptied prefix table (so ``prefix [`` is gone), and no
-root-table binding maps Page Up to ``copy-mode`` (so the key passes through to
-the inner CLI, which ignores it). The user's own ``~/.tmux.conf`` cannot
-restore any of this because the native client attaches with ``-f /dev/null``.
+Why: the managed tmux server had disabled every entry point into tmux copy
+mode — ``mouse off`` (so wheel events never reached ``WheelUpPane``),
+``prefix None`` + ``prefix2 None`` + an emptied prefix table (so ``prefix [``
+is gone), and no root-table binding mapped Page Up to ``copy-mode`` (so the key
+passed through to the inner CLI, which ignores it: Codex handles neither the
+wheel nor Page Up, since it renders inline and leaves scrolling to the host
+terminal). The user's own ``~/.tmux.conf`` cannot restore any of this because
+the native client attaches with ``-f /dev/null``.
+
+Both routes are now open: ``mouse on`` for the wheel and a root-table Page Up
+binding for the keyboard. The wheel must still be *forwarded* to a pane that
+tracks the mouse, so a full-screen TUI keeps its own wheel handling.
 
 This test drives the real product path end-to-end, with no LLM and no codex
 binary (codex-native needs an interactive OAuth login, so the inner CLI is a
@@ -31,12 +37,9 @@ configuration and the attach command are the production ones):
 4. Assert some gesture reached the scrollback — the pane enters a scrolled
    (copy-mode) state with a non-zero scroll offset.
 
-Before a fix: no gesture enters copy mode (``pane_in_mode`` stays ``0``,
-``scroll_position`` stays empty), the earliest visible line is still the last
-screenful, and this test FAILS.
-After a fix (a root-table Page Up binding into copy-mode, tmux mouse support,
-or any other scrollback entry point): at least one gesture scrolls the view
-into history and it PASSES.
+Without a scrollback route no gesture enters copy mode (``pane_in_mode`` stays
+``0``, ``scroll_position`` stays empty), the earliest visible line is still the
+last screenful, and these tests FAIL.
 
 Runs with only ``tmux`` and ``pexpect``::
 
@@ -104,68 +107,100 @@ def _scrolled_state(socket_path: str) -> tuple[bool, str]:
     return scrolled, detail
 
 
+def _filler_pane_spec(cwd: Path) -> TerminalEnvSpec:
+    """Build a pane spec that overflows the viewport, then idles like a TUI.
+
+    :param cwd: Working directory for the pane process.
+    :returns: A managed-terminal spec emitting :data:`FILLER_LINES` lines.
+    """
+    return TerminalEnvSpec(
+        command="bash",
+        args=[
+            "-c",
+            f'for i in $(seq 1 {FILLER_LINES}); do echo "CODEX OUTPUT LINE $i"; done; '
+            "exec sleep 600",
+        ],
+        os_env=OSEnvSpec(
+            type="caller_process",
+            cwd=str(cwd),
+            sandbox=OSEnvSandboxSpec(type="none"),
+        ),
+    )
+
+
+def _await_filled_history(socket_path: str) -> int:
+    """Wait until the pane has pushed real content into tmux history.
+
+    The precondition the bug report confirmed (``history=288``): without it a
+    scrollback assertion passes vacuously because there is nothing above the
+    viewport to reach.
+
+    :param socket_path: The managed terminal's private socket path.
+    :returns: The observed ``history_size``.
+    """
+    history_size = 0
+    for _ in range(120):
+        raw = _tmux_out(socket_path, "display-message", "-p", "-t", "main", "#{history_size}")
+        history_size = int(raw) if raw.isdigit() else 0
+        if history_size >= FILLER_LINES // 2:
+            break
+        time.sleep(0.25)
+    assert history_size >= FILLER_LINES // 2, (
+        f"pane never filled tmux history (history_size={history_size}); "
+        "the scrollback-gesture assertion below would be vacuous"
+    )
+    return history_size
+
+
+def _attach_native_client(socket_path: str) -> pexpect.spawn:
+    """Attach a real client PTY with the production native attach command.
+
+    Mirrors ``omnigent.codex_native._attach_direct_tmux``: ``tmux -S <sock>
+    -f /dev/null attach -t main`` with ``TMUX`` stripped so an outer user tmux
+    does not nest. ``TERM`` is forced because a bare CI shell may carry
+    ``TERM=dumb``, which tmux refuses to attach to.
+
+    :param socket_path: The managed terminal's private socket path.
+    :returns: The spawned client, for the caller to close.
+    """
+    env = dict(os.environ)
+    env.pop("TMUX", None)
+    env["TERM"] = "xterm-256color"
+    return pexpect.spawn(
+        "tmux",
+        ["-S", socket_path, "-f", os.devnull, "attach", "-t", "main"],
+        env=env,
+        dimensions=(24, 80),
+        timeout=10,
+    )
+
+
 async def test_native_attach_can_scroll_back_through_managed_tmux_history(
     tmp_path: Path,
 ) -> None:
     """A user attached to the managed tmux can scroll back to earlier output.
 
-    Regression guard: with the managed lockdown options (``mouse off``,
-    ``prefix None``, emptied prefix table, ``-f /dev/null`` attach) neither the
-    mouse wheel nor Page Up reaches tmux's history, so the conversation above
-    the viewport is unreachable from the native terminal.
+    Regression guard: the managed lockdown (``prefix None``, emptied prefix
+    table, ``-f /dev/null`` attach) leaves no prefix route into copy mode, so
+    at least one of the user's two gestures — the wheel or Page Up — has to
+    reach tmux's history or the conversation above the viewport is unreachable
+    from the native terminal.
+
+    :param tmp_path: Working directory for the managed terminal.
     """
     reg = TerminalRegistry()
     child: pexpect.spawn | None = None
     try:
         # 1. Launch the managed terminal exactly as the codex-native runner
-        #    does, with a pane command that overflows the viewport the way a
-        #    Codex conversation does, then stays alive like an idle TUI.
-        spec = TerminalEnvSpec(
-            command="bash",
-            args=[
-                "-c",
-                f'for i in $(seq 1 {FILLER_LINES}); do echo "CODEX OUTPUT LINE $i"; done; '
-                "exec sleep 600",
-            ],
-            os_env=OSEnvSpec(
-                type="caller_process",
-                cwd=str(tmp_path),
-                sandbox=OSEnvSandboxSpec(type="none"),
-            ),
-        )
-        instance = await reg.launch("conv_scrollback", "codex", "s1", spec)
+        #    does, with a pane that overflows the viewport the way a Codex
+        #    conversation does, then stays alive like an idle TUI.
+        instance = await reg.launch("conv_scrollback", "codex", "s1", _filler_pane_spec(tmp_path))
         socket_path = str(instance.socket_path)
+        _await_filled_history(socket_path)
 
-        # Wait for the pane to have pushed real content into tmux history —
-        # the precondition the bug report confirmed (``history=288``).
-        history_size = 0
-        for _ in range(120):
-            raw = _tmux_out(socket_path, "display-message", "-p", "-t", "main", "#{history_size}")
-            history_size = int(raw) if raw.isdigit() else 0
-            if history_size >= FILLER_LINES // 2:
-                break
-            time.sleep(0.25)
-        assert history_size >= FILLER_LINES // 2, (
-            f"pane never filled tmux history (history_size={history_size}); "
-            "the scrollback-gesture assertion below would be vacuous"
-        )
-
-        # 2. Attach a real client PTY with the exact production attach command
-        #    from ``_attach_direct_tmux``: tmux -S <sock> -f /dev/null attach
-        #    -t main, with TMUX stripped so an outer user tmux doesn't nest.
-        env = dict(os.environ)
-        env.pop("TMUX", None)
-        # The user's terminal always advertises a capable TERM; a bare CI
-        # shell may carry TERM=dumb, which tmux refuses to attach to.
-        env["TERM"] = "xterm-256color"
-        child = pexpect.spawn(
-            "tmux",
-            ["-S", socket_path, "-f", os.devnull, "attach", "-t", "main"],
-            env=env,
-            dimensions=(24, 80),
-            timeout=10,
-        )
-        # Let the attach settle and the client render the bottom of the pane.
+        # 2. Attach a real client PTY with the production attach command, then
+        #    let it render the bottom of the pane.
+        child = _attach_native_client(socket_path)
         child.expect("CODEX OUTPUT LINE", timeout=10)
         time.sleep(1.0)
 
@@ -189,11 +224,111 @@ async def test_native_attach_can_scroll_back_through_managed_tmux_history(
         assert scrolled, (
             "native attach cannot reach the managed tmux scrollback: neither "
             "Page Up nor the mouse wheel moved the view off the bottom "
-            f"({'; '.join(results)}). The managed options disable every "
-            "copy-mode entry point (mouse off, prefix None, emptied prefix "
-            "table, no root-table Page Up binding), and -f /dev/null blocks "
-            "the user's tmux.conf from restoring one, so earlier formatted "
-            "output above the viewport is unreachable."
+            f"({'; '.join(results)}). The managed options must keep a "
+            "copy-mode entry point (mouse on for the wheel, a root-table Page "
+            "Up binding for the keyboard) — -f /dev/null blocks the user's "
+            "tmux.conf from restoring one, so earlier formatted output above "
+            "the viewport is otherwise unreachable."
+        )
+    finally:
+        if child is not None:
+            child.close(force=True)
+        await reg.shutdown()
+
+
+async def test_native_attach_wheel_alone_reaches_scrollback(tmp_path: Path) -> None:
+    """The wheel on its own scrolls a native attach into managed tmux history.
+
+    The sibling test stops at the first gesture that works, so a Page Up
+    binding alone satisfies it and the wheel stays unguarded. This delivers
+    only wheel-up: with ``mouse off`` the report bytes pass through to the
+    inline pane program, which ignores them and nothing scrolls.
+
+    :param tmp_path: Working directory for the managed terminal.
+    """
+    reg = TerminalRegistry()
+    child: pexpect.spawn | None = None
+    try:
+        instance = await reg.launch("conv_wheel", "codex", "s1", _filler_pane_spec(tmp_path))
+        socket_path = str(instance.socket_path)
+        _await_filled_history(socket_path)
+
+        child = _attach_native_client(socket_path)
+        child.expect("CODEX OUTPUT LINE", timeout=10)
+        time.sleep(1.0)
+
+        child.send(WHEEL_UP * 4)
+        time.sleep(1.0)
+
+        scrolled, detail = _scrolled_state(socket_path)
+        assert scrolled, (
+            "the mouse wheel did not reach managed tmux scrollback from a "
+            f"native attach ({detail}). Without tmux mouse mode the wheel "
+            "reports are forwarded to the inline pane program, which ignores "
+            "them, so the wheel is dead for the whole conversation."
+        )
+    finally:
+        if child is not None:
+            child.close(force=True)
+        await reg.shutdown()
+
+
+async def test_native_attach_wheel_reaches_a_mouse_tracking_pane(
+    tmp_path: Path,
+) -> None:
+    """A pane that tracks the mouse keeps the wheel instead of losing it to tmux.
+
+    Enabling tmux mouse mode must not hijack the wheel from a full-screen TUI
+    that does its own scrolling (Claude Code, an editor): tmux's
+    ``WheelUpPane`` binding forwards the report when ``mouse_any_flag`` is set
+    and only takes the pane into copy mode when it is not. Guards the cost side
+    of ``mouse on``.
+
+    :param tmp_path: Working directory for the managed terminal.
+    """
+    reg = TerminalRegistry()
+    child: pexpect.spawn | None = None
+    try:
+        # DECSET 1002 + 1006: button/drag tracking with SGR reports, the modes
+        # a TUI that scrolls on the wheel requests at startup.
+        spec = TerminalEnvSpec(
+            command="bash",
+            args=["-c", 'printf "\\033[?1002h\\033[?1006h"; echo TRACKING; exec sleep 600'],
+            os_env=OSEnvSpec(
+                type="caller_process",
+                cwd=str(tmp_path),
+                sandbox=OSEnvSandboxSpec(type="none"),
+            ),
+        )
+        instance = await reg.launch("conv_tracking", "codex", "s1", spec)
+        socket_path = str(instance.socket_path)
+
+        tracking = ""
+        for _ in range(40):
+            tracking = _tmux_out(
+                socket_path, "display-message", "-p", "-t", "main", "#{mouse_any_flag}"
+            )
+            if tracking == "1":
+                break
+            time.sleep(0.25)
+        assert tracking == "1", (
+            f"pane never entered mouse tracking (mouse_any_flag={tracking!r}); "
+            "the forwarding assertion below would be vacuous"
+        )
+
+        child = _attach_native_client(socket_path)
+        child.expect("TRACKING", timeout=10)
+        time.sleep(1.0)
+
+        child.send(WHEEL_UP * 4)
+        time.sleep(1.0)
+
+        in_mode = _tmux_out(socket_path, "display-message", "-p", "-t", "main", "#{pane_in_mode}")
+        assert in_mode == "0", (
+            "tmux took a mouse-tracking pane into copy mode on wheel-up "
+            f"(pane_in_mode={in_mode!r}). The wheel belongs to the pane "
+            "program whenever it tracks the mouse, or a full-screen TUI's own "
+            "scrolling stops working under a managed terminal."
         )
     finally:
         if child is not None:

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -667,14 +667,24 @@ async def test_launch_omits_keep_alive_options_by_default(
 
 
 @pytest.mark.asyncio
-async def test_launch_disables_tmux_mouse_mode(
+async def test_launch_enables_tmux_mouse_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Managed terminals leave scrolling and text selection to the client."""
+    """
+    Managed terminals enable tmux mouse mode so a native attach can scroll.
+
+    With ``mouse off`` a wheel gesture from a native ``tmux attach`` client is
+    passed through to the pane program, which for an inline CLI such as Codex
+    ignores it, leaving tmux's history unreachable. ``mouse on`` routes the
+    wheel through tmux's ``WheelUpPane`` binding instead.
+
+    :param tmp_path: Temporary directory for the fake tmux socket.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    """
     cmd = await _capture_launch_argv(tmp_path, monkeypatch, keep_alive_after_exit=False)
-    assert contains_subsequence(cmd, ["set-option", "-g", "mouse", "off"])
-    assert not contains_subsequence(cmd, ["set-option", "-g", "mouse", "on"])
+    assert contains_subsequence(cmd, ["set-option", "-g", "mouse", "on"])
+    assert not contains_subsequence(cmd, ["set-option", "-g", "mouse", "off"])
 
 
 @pytest.mark.asyncio
@@ -685,11 +695,11 @@ async def test_launch_binds_page_up_scrollback_entry_point(
     """
     Managed terminals keep one route into tmux scrollback for attached users.
 
-    The lockdown removes every default copy-mode entry point (``mouse off``,
-    ``prefix None``, emptied prefix table) and native clients attach with
-    ``-f /dev/null``, so without a root-table Page Up binding the formatted
-    output above the viewport is unreachable. The binding must pass Page Up
-    through on the alternate screen so full-screen programs keep the key.
+    The lockdown removes the prefix-key copy-mode entry points (``prefix
+    None``, emptied prefix table) and native clients attach with
+    ``-f /dev/null``, so a keyboard route into the formatted output above the
+    viewport has to be bound explicitly. The binding must pass Page Up through
+    on the alternate screen so full-screen programs keep the key.
 
     :param tmp_path: Temporary directory for the fake tmux socket.
     :param monkeypatch: Pytest monkeypatch fixture.


### PR DESCRIPTION
## Related issue

No filed issue. Restores mouse-wheel scrollback in the native terminal, which regressed when managed terminals moved to `mouse off` (#5466 / OMNI-5586).

## Summary

Running `omnigent codex` from a native terminal and scrolling up did nothing: the view stayed pinned at the bottom while tmux's history held the conversation (an affected session reported `history=288` against `history-limit 100000`).

Managed terminals set tmux `mouse off`, so tmux forwards wheel reports to the pane program rather than acting on them. I probed the real binary (`codex-cli 0.149.1`) to confirm what the pane does with them:

```
alt=0  hist=34  mouse_standard=0  mouse_button=0  mouse_all=0  mouse_sgr=0
```

Codex renders on the **normal screen**, requests **no mouse tracking**, and handles neither the wheel nor Page Up — it leaves scrolling to the host terminal. Under tmux that scrollback is tmux's history, and the managed lockdown (`prefix None`, `prefix2 None`, emptied prefix table) plus a `-f /dev/null` attach left no route into it. #6220 opened the keyboard route; the wheel was still dead.

- Set `mouse on`. tmux's default `WheelUpPane` binding forwards the wheel to panes on the alternate screen or tracking the mouse (`#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}`), so a full-screen TUI such as Claude Code keeps its own wheel handling, and only scrolls tmux history for the inline CLIs that ignore it. Page Up stays bound as the keyboard route.
- **The web client is unaffected.** It attaches in control mode, where xterm.js owns the grid and scrollback, and browser input is injected with `send-keys -H` — which writes straight to the pane without passing through tmux's key tables. Verified rather than assumed (below).
- The cost, stated plainly: click-drag selection on a non-tracking native pane now goes through tmux copy mode instead of the terminal's own selection. Text still reaches the system clipboard (copy mode exports via `set-clipboard external`, already set), and native selection remains available through the terminal's Shift/Option-drag override. That is the trade `mouse off` was chosen to avoid in #5466, and it is inherent — tmux cannot route the wheel without also claiming the drag.

## Test Plan

- `uv run pytest tests/inner/test_terminal.py tests/terminals -q` — 140 passed, 1 skipped
- `uv run pytest tests/e2e/test_codex_native_tmux_scrollback_e2e.py -q` — 3 passed
- **Proved the new coverage fails without the fix.** Flipping the option back to `mouse off` and re-running: `1 failed, 2 passed`, with `AssertionError: the mouse wheel did not reach managed tmux scrollback from a native attach (pane_in_mode='0' scroll_position='')`.
- Manual, real `codex` 0.149.1 in a managed-options tmux with a real attached client PTY:
  ```
  baseline:                 alt=0 hist=11 in_mode=0 scroll=
  after PageUp (mouse off): alt=0 hist=21 in_mode=0 scroll=      ← nothing
  after wheel-up (mouse off):alt=0 hist=21 in_mode=0 scroll=     ← nothing
  after the fix:                        in_mode=1 scroll=21      ← scrolls
  ```
  And paging behaves correctly on a 200-line pane: `scroll=21 → 42 → 63`, with PageDown back to the bottom leaving copy mode (via `-e`).
- Manual, web transport unchanged: with `mouse on`, feeding an SGR wheel report the way `control_bridge` does (`send-keys -H 1b 5b 3c 36 34 ...`) lands in the pane verbatim (`^[[<64;40;12M`) and leaves `pane_in_mode=0` — tmux does not intercept browser input.
- `uv run pre-commit run --files <changed>` — clean apart from pre-existing `pyrefly` `missing-import` errors for optional `opentelemetry` extras in unrelated modules (none in the changed files).

Not run: the browser suite (`tests/e2e_ui/shells/test_new_shell.py::test_shell_wheel_scroll_reaches_mouse_tracking_program`). `vite build` fails on `main` in my environment on an unrelated unresolved import (`@pierre/diffs/react` from `web/src/shell/GithubPanel.tsx`), so I could not produce a bundle. The diff touches no web code, and the transport-level probe above covers the mechanism that test guards.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Native-TTY behavior with no UI surface; the tmux state transitions above (`pane_in_mode`, `scroll_position`) are the observable evidence.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`test_launch_enables_tmux_mouse_mode` pins the launch argv. Two new e2e guards cover both halves of the trade: `test_native_attach_wheel_alone_reaches_scrollback` delivers *only* wheel-up (the pre-existing test stops at the first gesture that works, so a Page Up binding alone satisfied it and left the wheel unguarded), and `test_native_attach_wheel_reaches_a_mouse_tracking_pane` launches a pane that requests DECSET 1002+1006 and asserts `pane_in_mode` stays `0`, so enabling mouse mode can never start stealing the wheel from a TUI that scrolls itself. Manual verification drove the real codex binary and a real attach client PTY, as transcribed in the Test Plan; the web-transport claim was verified by injecting wheel bytes through the exact `send-keys -H` path the control bridge uses.

## Changelog

Restore mouse-wheel scrollback in the native terminal — scrolling up in `omnigent codex` (and other inline CLIs) reaches earlier conversation output again.
