### PR TITLE
Fix managed sandbox relaunch race with session deletion

### DIFF
--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -16,7 +16,8 @@ survive a sandbox dying at the provider's lifetime cap.
 
 The sandbox host authenticates back with a dedicated launch token the
 server mints per launch (see
-:meth:`omnigent.stores.host_store.HostStore.register_managed_host` and
+:meth:`omnigent.stores.host_store.HostStore.register_managed_host`,
+:meth:`omnigent.stores.host_store.HostStore.replace_managed_host_sandbox`, and
 the managed-token branch in
 :mod:`omnigent.server.routes.host_tunnel`) — the user's own
 credentials never enter the sandbox.
@@ -2888,7 +2889,12 @@ async def relaunch_managed_host(
     # here), but terminate defensively so a transient tunnel outage
     # can never leave two live sandboxes claiming one host identity.
     if host.sandbox_id is not None:
-        await _terminate_sandbox_best_effort(launcher, host, host.sandbox_id)
+        await _terminate_sandbox_best_effort(
+            launcher,
+            host.sandbox_id,
+            host_id=host.host_id,
+            provider=host.sandbox_provider,
+        )
     try:
         await asyncio.to_thread(launcher.prepare)
         sandbox_id = await asyncio.to_thread(launcher.provision, host.name)
@@ -2914,7 +2920,7 @@ async def relaunch_managed_host(
     except ValueError as exc:
         raise HTTPException(
             status_code=409,
-            detail=f"managed sandbox relaunch conflicted with pending cleanup: {exc}",
+            detail=f"managed sandbox relaunch conflicted with host lifecycle: {exc}",
         ) from exc
     return ManagedHostLaunch(host_id=host.host_id, workspace=workspace)
 
@@ -3065,16 +3071,35 @@ async def _register_and_start_host(
         registration fails.
     """
     token = secrets.token_urlsafe(32)
-    record = await asyncio.to_thread(
-        host_store.register_managed_host,
-        host_id=host_id,
-        name=host_name,
-        user_id=owner,
-        token=token,
-        provider=launcher.provider,
-        sandbox_id=sandbox_id,
-        token_expires_at=now_epoch() + config.token_ttl_s,
-    )
+    if keep_host_on_failure:
+        record = await asyncio.to_thread(
+            host_store.replace_managed_host_sandbox,
+            host_id=host_id,
+            user_id=owner,
+            token=token,
+            provider=launcher.provider,
+            sandbox_id=sandbox_id,
+            token_expires_at=now_epoch() + config.token_ttl_s,
+        )
+        if record is None:
+            await _terminate_sandbox_best_effort(
+                launcher,
+                sandbox_id,
+                host_id=host_id,
+                provider=launcher.provider,
+            )
+            raise ValueError(f"managed host {host_id!r} no longer exists")
+    else:
+        record = await asyncio.to_thread(
+            host_store.register_managed_host,
+            host_id=host_id,
+            name=host_name,
+            user_id=owner,
+            token=token,
+            provider=launcher.provider,
+            sandbox_id=sandbox_id,
+            token_expires_at=now_epoch() + config.token_ttl_s,
+        )
     try:
         # Uniform across providers: provision() fixed the sandbox id and the
         # token was armed against it above, so start_host starts the host with
@@ -3105,7 +3130,12 @@ async def _register_and_start_host(
         # cap. Cleanup-then-reraise at a system boundary, not a
         # swallow: every path below re-raises as an HTTPException.
         if keep_host_on_failure:
-            await _terminate_sandbox_best_effort(launcher, record, sandbox_id)
+            await _terminate_sandbox_best_effort(
+                launcher,
+                sandbox_id,
+                host_id=record.host_id,
+                provider=record.sandbox_provider,
+            )
             await asyncio.to_thread(host_store.revoke_launch_token, host_id)
         else:
             # The row was just armed with THIS single-provider config, so a
@@ -3313,17 +3343,6 @@ async def resume_managed_host(
             return
         entry = config.recorded(host.sandbox_provider)
         sandbox_id = host.sandbox_id
-        token = secrets.token_urlsafe(32)
-        armed = await asyncio.to_thread(
-            host_store.rearm_managed_host,
-            host.host_id,
-            sandbox_id=sandbox_id,
-            expected_updated_at=host.updated_at,
-            token=token,
-            token_expires_at=now_epoch() + entry.token_ttl_s,
-        )
-        if armed is None:
-            return
         _logger.info(
             "Waking dormant managed host %s (sandbox %s, provider %s)",
             host.host_id,
@@ -3332,6 +3351,39 @@ async def resume_managed_host(
         )
         try:
             await asyncio.to_thread(launcher.resume, sandbox_id)
+            token = secrets.token_urlsafe(32)
+            armed = await asyncio.to_thread(
+                host_store.rearm_managed_host,
+                host.host_id,
+                sandbox_id=sandbox_id,
+                expected_updated_at=host.updated_at,
+                token=token,
+                token_expires_at=now_epoch() + entry.token_ttl_s,
+            )
+            if armed is None:
+                current = await asyncio.to_thread(host_store.get_host, host.host_id)
+                if current is None:
+                    await _terminate_sandbox_best_effort(
+                        launcher,
+                        sandbox_id,
+                        host_id=host.host_id,
+                        provider=host.sandbox_provider,
+                    )
+                    raise ValueError(f"managed host {host.host_id!r} no longer exists")
+                if current.sandbox_id != sandbox_id:
+                    terminated = await _terminate_sandbox_best_effort(
+                        launcher,
+                        sandbox_id,
+                        host_id=host.host_id,
+                        provider=host.sandbox_provider,
+                    )
+                    if terminated and current.terminating_sandbox_id == sandbox_id:
+                        await asyncio.to_thread(
+                            host_store.mark_terminating_sandbox_terminated,
+                            host.host_id,
+                            sandbox_id=sandbox_id,
+                        )
+                return
             await _start_sandbox_host(
                 launcher,
                 sandbox_id,
@@ -3348,8 +3400,8 @@ async def resume_managed_host(
             )
             await _wait_for_host_online(host_store, host.host_id)
         except Exception as exc:
-            # A failed wake must NOT tear the sandbox down (the volume is the
-            # user's); just surface it.
+            # An ordinary failed wake must NOT tear the sandbox down (the volume
+            # is the user's); just surface it. Full teardown is handled above.
             if isinstance(exc, HTTPException):
                 raise
             message = exc.message if isinstance(exc, click.ClickException) else str(exc)
@@ -3366,13 +3418,12 @@ async def terminate_managed_host(
     """
     Terminate a managed host's sandbox and delete its host row.
 
-    Deleting the row is both teardown and revocation in one operation:
-    the host disappears from the picker AND its launch token stops
-    resolving. Best-effort on the sandbox side: termination failures
-    (or a missing/mismatched launcher after a config change) are
-    logged, not raised — the provider's lifetime cap reaps stragglers,
-    and the caller (session delete / launch-failure cleanup) must not
-    be blocked by provider hiccups.
+    The latest row is locked and deleted before provider termination. This
+    serializes full teardown with generation replacement: either teardown takes
+    the newly registered generation, or replacement observes the missing row
+    and cleans up its unregistered sandbox. Deleting the row also removes the
+    host from the picker and revokes its launch token. Provider termination
+    remains best-effort and never blocks database teardown.
 
     :param host: The managed host to tear down. Active and pending sandbox ids
         are both terminated when present.
@@ -3381,25 +3432,34 @@ async def terminate_managed_host(
         the launcher for the provider-side terminate), or ``None``
         when managed hosts are no longer configured.
     """
-    launcher = _launcher_for_teardown(host, config)
-    sandbox_ids = dict.fromkeys((host.sandbox_id, host.terminating_sandbox_id))
+    deleted = await asyncio.to_thread(host_store.delete_host, host.host_id)
+    if deleted is None:
+        return
+    launcher = _launcher_for_teardown(deleted, config)
+    sandbox_ids = dict.fromkeys((deleted.sandbox_id, deleted.terminating_sandbox_id))
     for sandbox_id in sandbox_ids:
         if sandbox_id is not None:
-            await _terminate_sandbox_best_effort(launcher, host, sandbox_id)
-    await asyncio.to_thread(host_store.delete_host, host.host_id)
+            await _terminate_sandbox_best_effort(
+                launcher,
+                sandbox_id,
+                host_id=deleted.host_id,
+                provider=deleted.sandbox_provider,
+            )
 
 
 async def _terminate_sandbox_best_effort(
     launcher: SandboxHostLauncher | None,
-    host: Host,
     sandbox_id: str,
+    *,
+    host_id: str,
+    provider: str | None,
 ) -> bool:
-    """Terminate one explicit provider sandbox id without touching its row."""
+    """Terminate one provider sandbox id without touching its host row."""
     if launcher is None:
         _logger.warning(
             "No launcher available for managed sandbox provider %s; "
             "sandbox %s must be deleted with the provider's own tooling",
-            host.sandbox_provider,
+            provider,
             sandbox_id,
         )
         return False
@@ -3410,8 +3470,8 @@ async def _terminate_sandbox_best_effort(
         _logger.warning(
             "Failed to terminate managed sandbox %s (provider=%s) for host %s",
             sandbox_id,
-            host.sandbox_provider,
-            host.host_id,
+            provider,
+            host_id,
             exc_info=True,
         )
         return False

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -202,6 +202,11 @@ class HostStore:
             self._engine,
             query_name_prefix="omnigent.host_store",
         )
+        self._lifecycle_session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.host_store",
+            immediate=True,
+        )
 
     def upsert_on_connect(
         self,
@@ -761,7 +766,7 @@ class HostStore:
         token_expires_at: int,
     ) -> Host:
         """
-        Pre-register a server-managed sandbox host with its credential.
+        Create a server-managed sandbox host with its credential.
 
         Called by the managed-launch orchestration after the sandbox is
         provisioned and BEFORE the in-sandbox host process starts, so
@@ -769,13 +774,6 @@ class HostStore:
         the tunnel. The row is created ``"offline"``; the tunnel's
         normal ``upsert_on_connect`` flips it online when the host
         registers.
-
-        If a row already exists for *host_id* (a RELAUNCH: the host
-        identity is durable across sandbox generations so session
-        bindings survive a dead sandbox), the credential and sandbox
-        columns are overwritten in place — which atomically revokes the
-        previous generation's token, since its digest no longer matches
-        anything.
 
         :param host_id: Server-generated host identifier, e.g.
             ``"host_a1b2c3d4..."``.
@@ -792,48 +790,10 @@ class HostStore:
         :param token_expires_at: Unix epoch seconds after which the
             token no longer authenticates.
         :returns: The registered :class:`Host`.
-        :raises ValueError: If a row for *host_id* belongs to another user,
-            changes provider while cleanup is pending, or tries to re-arm the
-            exact sandbox id still awaiting termination.
         """
         now = now_epoch()
         token_hash = hash_host_launch_token(token)
         with self._session("register_managed_host") as session:
-            existing = session.execute(
-                select(SqlHost)
-                .where(SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id)
-                .with_for_update()
-            ).scalar_one_or_none()
-            if existing is not None:
-                if existing.user_id != user_id:
-                    # Fail closed (W2-class boundary): re-crediting a host
-                    # row hands its launch token holder the row owner's
-                    # identity, so a cross-owner overwrite would be a host
-                    # hijack. host_id is server-generated today (uuid4 per
-                    # launch), so this can only fire on a bug or a forged
-                    # id — refuse rather than re-own.
-                    raise ValueError(
-                        f"host {host_id!r} is registered to a different user; "
-                        "refusing to re-credential it"
-                    )
-                if (
-                    existing.terminating_sandbox_id is not None
-                    and existing.sandbox_provider != provider
-                ):
-                    raise ValueError(
-                        "cannot change managed sandbox provider while termination is pending"
-                    )
-                if existing.terminating_sandbox_id == sandbox_id:
-                    raise ValueError(
-                        f"sandbox {sandbox_id!r} is still pending termination; "
-                        "refusing to re-arm it"
-                    )
-                existing.token_hash = token_hash
-                existing.token_expires_at = token_expires_at
-                existing.sandbox_provider = provider
-                existing.sandbox_id = sandbox_id
-                existing.updated_at = now
-                return _row_to_host(existing)
             row = SqlHost(
                 user_id=user_id,
                 name=name,
@@ -848,6 +808,55 @@ class HostStore:
             )
             session.add(row)
             return _row_to_host(row)
+
+    def replace_managed_host_sandbox(
+        self,
+        *,
+        host_id: str,
+        user_id: str,
+        token: str,
+        provider: str,
+        sandbox_id: str,
+        token_expires_at: int,
+    ) -> Host | None:
+        """Replace the sandbox generation backing an existing managed host.
+
+        The row lock serializes replacement with :meth:`delete_host`. A missing
+        result means full teardown already removed the durable host, so the
+        caller must clean up the unregistered sandbox instead of recreating it.
+        """
+        now = now_epoch()
+        token_hash = hash_host_launch_token(token)
+        with self._lifecycle_session("replace_managed_host_sandbox") as session:
+            existing = session.execute(
+                select(SqlHost)
+                .where(SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id)
+                .with_for_update()
+            ).scalar_one_or_none()
+            if existing is None:
+                return None
+            if existing.user_id != user_id:
+                raise ValueError(
+                    f"host {host_id!r} is registered to a different user; "
+                    "refusing to re-credential it"
+                )
+            if (
+                existing.terminating_sandbox_id is not None
+                and existing.sandbox_provider != provider
+            ):
+                raise ValueError(
+                    "cannot change managed sandbox provider while termination is pending"
+                )
+            if existing.terminating_sandbox_id == sandbox_id:
+                raise ValueError(
+                    f"sandbox {sandbox_id!r} is still pending termination; refusing to re-arm it"
+                )
+            existing.token_hash = token_hash
+            existing.token_expires_at = token_expires_at
+            existing.sandbox_provider = provider
+            existing.sandbox_id = sandbox_id
+            existing.updated_at = now
+            return _row_to_host(existing)
 
     def rearm_managed_host(
         self,
@@ -935,20 +944,34 @@ class HostStore:
                 return None
             return _row_to_host(row)
 
-    def delete_host(self, host_id: str) -> None:
+    def delete_host(self, host_id: str) -> Host | None:
         """
-        Delete a host row entirely.
+        Atomically take and delete a host row.
 
         Managed-host teardown: removes the host from the picker AND
         revokes its launch token in one operation (the row IS the
         credential). Explicitly nulls ``conversations.host_id`` for any
         sessions still bound to this host — the DB no longer cascades
         this via FK. No-op when the row does not exist — deletion is
-        invoked from best-effort cleanup paths that may race.
+        invoked from best-effort cleanup paths that may race. The row lock
+        serializes deletion with managed-host generation replacement, and the
+        returned snapshot lets teardown target the generation actually removed.
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
+        :returns: The deleted host snapshot, or ``None`` when already absent.
         """
-        with self._session("delete_host") as session:
+        with self._lifecycle_session("delete_host") as session:
+            row = session.execute(
+                select(SqlHost)
+                .where(
+                    SqlHost.workspace_id == current_workspace_id(),
+                    SqlHost.host_id == host_id,
+                )
+                .with_for_update()
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+            deleted = _row_to_host(row)
             session.execute(
                 update(SqlConversationMetadata)
                 .where(
@@ -963,6 +986,7 @@ class HostStore:
                     SqlHost.host_id == host_id,
                 )
             )
+            return deleted
 
     def detach_stale_managed_sandbox(
         self,
@@ -1042,8 +1066,9 @@ class HostStore:
         the token it armed (the new sandbox never came up to use it)
         without deleting the durable host row — the session binding
         survives, and the next relaunch attempt re-arms a fresh token
-        via :meth:`register_managed_host`. Contrast :meth:`delete_host`,
-        which is full teardown. No-op when the row does not exist.
+        via :meth:`replace_managed_host_sandbox`. Contrast
+        :meth:`delete_host`, which is full teardown. No-op when the row
+        does not exist.
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
         """

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -2535,7 +2535,7 @@ async def test_relaunch_rejects_pending_reused_id_then_allows_retry(db_uri: str)
         await relaunch_managed_host(config=config, host=pending, host_store=host_store)
 
     assert exc.value.status_code == 409
-    assert "pending cleanup" in exc.value.detail
+    assert "host lifecycle" in exc.value.detail
     assert len(fake.host_starts) == 1
     assert fake.terminated == []
     still_pending = host_store.get_host(active.host_id)
@@ -2652,6 +2652,34 @@ async def test_relaunch_failure_keeps_host_row_and_revokes_token(db_uri: str) ->
         host_store.resolve_launch_token(fake.host_starts[0].host_id, fake.host_starts[0].token)
         is None
     )
+
+
+async def test_relaunch_does_not_recreate_deleted_host(db_uri: str) -> None:
+    """A relaunch that loses to full teardown cleans up its new sandbox."""
+    host_store = HostStore(db_uri)
+    host = host_store.register_managed_host(
+        host_id="c73ad22fd7be4fe2a62a36b7e0fbcaa8",
+        name="managed-deleted-relaunch",
+        user_id=_OWNER,
+        token="deleted-relaunch-token",
+        provider="modal",
+        sandbox_id="sb-deleted-old",
+        token_expires_at=now_epoch() + 3600,
+    )
+    host_store.delete_host(host.host_id)
+    fake = FakeSandboxLauncher()
+
+    with pytest.raises(HTTPException) as exc:
+        await relaunch_managed_host(
+            config=_injected_config(fake),
+            host=host,
+            host_store=host_store,
+        )
+
+    assert exc.value.status_code == 409
+    assert "no longer exists" in exc.value.detail
+    assert fake.terminated == ["sb-deleted-old", "sb-fake-1"]
+    assert host_store.get_host(host.host_id) is None
 
 
 async def test_relaunch_rejects_unconfigured_provider(db_uri: str) -> None:
@@ -2951,8 +2979,8 @@ async def test_resume_managed_host_noops_for_non_resumable_provider(db_uri: str)
     )
 
 
-async def test_resume_managed_host_failure_preserves_existing_row(db_uri: str) -> None:
-    """A failed wake leaves the dormant host generation retryable."""
+async def test_resume_managed_host_failure_preserves_existing_row_and_token(db_uri: str) -> None:
+    """A failed provider resume leaves the dormant generation unchanged."""
     host_store = HostStore(db_uri)
     host_store.register_managed_host(
         host_id="efbef7dede7be6577770cbb1287992f2",
@@ -2979,7 +3007,7 @@ async def test_resume_managed_host_failure_preserves_existing_row(db_uri: str) -
     assert host.sandbox_id == "sb-resume-fail"
     assert (
         host_store.resolve_launch_token("efbef7dede7be6577770cbb1287992f2", "tok-resume-fail")
-        is None
+        is not None
     )
 
 
@@ -2987,7 +3015,7 @@ async def test_resume_managed_host_does_not_resume_detached_generation(
     db_uri: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A reaper detach that wins the CAS prevents the provider resume call."""
+    """A reaper detach that wins the CAS cleans up the resumed stale generation."""
     host_store = HostStore(db_uri)
     host_id = "ade43acaaaf44af59388dc2109a8557f"
     host_store.register_managed_host(
@@ -3027,11 +3055,46 @@ async def test_resume_managed_host_does_not_resume_detached_generation(
 
     await resume_managed_host(host_id, host_store, _injected_config(fake))
 
-    assert fake.resumed == []
+    assert fake.resumed == ["sb-resume-race"]
+    assert fake.terminated == ["sb-resume-race"]
     detached = host_store.get_host(host_id)
     assert detached is not None
     assert detached.sandbox_id is None
-    assert detached.terminating_sandbox_id == "sb-resume-race"
+    assert detached.terminating_sandbox_id is None
+
+
+async def test_resume_managed_host_does_not_recreate_deleted_host(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wake that loses to full teardown cleans up the resumed sandbox."""
+    host_store = HostStore(db_uri)
+    host = host_store.register_managed_host(
+        host_id="463013d3d38d4096b2404962c48479b1",
+        name="managed-deleted-resume",
+        user_id=_OWNER,
+        token="deleted-resume-token",
+        provider="islo",
+        sandbox_id="sb-deleted-resume",
+        token_expires_at=now_epoch() + 3600,
+    )
+    host_store.set_offline(host.host_id)
+    fake = _IsloFakeLauncher(can_resume=True)
+
+    def _resume(sandbox_id: str) -> None:
+        fake.resumed.append(sandbox_id)
+        host_store.delete_host(host.host_id)
+
+    monkeypatch.setattr(fake, "resume", _resume)
+
+    with pytest.raises(HTTPException) as exc:
+        await resume_managed_host(host.host_id, host_store, _injected_config(fake))
+
+    assert exc.value.status_code == 502
+    assert "no longer exists" in exc.value.detail
+    assert fake.terminated == ["sb-deleted-resume"]
+    assert fake.host_starts == []
+    assert host_store.get_host(host.host_id) is None
 
 
 # ── terminate_managed_host ──────────────────────────────────
@@ -3083,15 +3146,15 @@ async def test_terminate_managed_host_cleans_active_and_pending_generations(db_u
         sandbox_id="sb-term-old",
         expected_updated_at=original.updated_at,
     )
-    host_store.register_managed_host(
+    replaced = host_store.replace_managed_host_sandbox(
         host_id=host_id,
-        name="managed-term-both",
         user_id=_OWNER,
         token="tok-term-new",
         provider="modal",
         sandbox_id="sb-term-new",
         token_expires_at=now_epoch() + 3600,
     )
+    assert replaced is not None
     host = host_store.get_host(host_id)
     assert host is not None
 
@@ -3099,6 +3162,63 @@ async def test_terminate_managed_host_cleans_active_and_pending_generations(db_u
 
     assert fake.terminated == ["sb-term-new", "sb-term-old"]
     assert host_store.get_host(host_id) is None
+
+
+async def test_terminate_managed_host_targets_latest_registered_generation(db_uri: str) -> None:
+    """A stale teardown snapshot removes and terminates the current generation."""
+    fake = FakeSandboxLauncher()
+    host_store = HostStore(db_uri)
+    stale = host_store.register_managed_host(
+        host_id="5233b41530ed474f9860ecf3acfc9131",
+        name="managed-term-current",
+        user_id=_OWNER,
+        token="tok-term-old",
+        provider="modal",
+        sandbox_id="sb-term-old",
+        token_expires_at=now_epoch() + 3600,
+    )
+    updated = host_store.replace_managed_host_sandbox(
+        host_id=stale.host_id,
+        user_id=stale.user_id,
+        token="tok-term-new",
+        provider="modal",
+        sandbox_id="sb-term-new",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert updated is not None
+
+    await terminate_managed_host(stale, host_store, _injected_config(fake))
+
+    assert fake.terminated == ["sb-term-new"]
+    assert host_store.get_host(stale.host_id) is None
+
+
+async def test_terminate_managed_host_deletes_row_before_provider_call(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider teardown runs only after the host can no longer be relaunched."""
+    fake = FakeSandboxLauncher()
+    host_store = HostStore(db_uri)
+    host = host_store.register_managed_host(
+        host_id="af48b60a7afb4c0696709403116c30c6",
+        name="managed-delete-first",
+        user_id=_OWNER,
+        token="tok-delete-first",
+        provider="modal",
+        sandbox_id="sb-delete-first",
+        token_expires_at=now_epoch() + 3600,
+    )
+
+    def _terminate(sandbox_id: str) -> None:
+        assert host_store.get_host(host.host_id) is None
+        fake.terminated.append(sandbox_id)
+
+    monkeypatch.setattr(fake, "terminate", _terminate)
+
+    await terminate_managed_host(host, host_store, _injected_config(fake))
+
+    assert fake.terminated == ["sb-delete-first"]
 
 
 async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
-from sqlalchemy import update
+from sqlalchemy import event, update
 from sqlalchemy.orm import Session
 
 from omnigent.db.db_models import SqlHost, workspace_scope
@@ -748,13 +750,10 @@ def test_resolve_launch_token_rejects_unknown_and_expired(db_uri: str) -> None:
     )
 
 
-def test_register_managed_host_relaunch_rotates_credential(db_uri: str) -> None:
+def test_replace_managed_host_sandbox_rotates_credential(db_uri: str) -> None:
     """
-    Relaunch: registering the SAME host_id again (a fresh sandbox
-    generation after the previous one died) overwrites the credential
-    and sandbox columns in place — the old token stops resolving the
-    instant the new one lands, the host identity (and created_at)
-    survives, and session bindings to the host_id stay valid.
+    Replacing the sandbox generation rotates its credential while preserving
+    the durable host identity and session bindings.
     """
     store = HostStore(db_uri)
     first = store.register_managed_host(
@@ -767,15 +766,15 @@ def test_register_managed_host_relaunch_rotates_credential(db_uri: str) -> None:
         token_expires_at=now_epoch() + 3600,
     )
 
-    second = store.register_managed_host(
+    second = store.replace_managed_host_sandbox(
         host_id="a687a760841c785578a03f4677f8db3c",
-        name="managed-m3",
         user_id="alice@example.com",
         token="generation-2-token",
         provider="modal",
         sandbox_id="sb-gen2",
         token_expires_at=now_epoch() + 3600,
     )
+    assert second is not None
 
     # Same durable identity, fresh backing sandbox.
     assert second.host_id == first.host_id
@@ -845,7 +844,9 @@ def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
         token_expires_at=now_epoch() + 3600,
     )
 
-    store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
+    deleted = store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
+    assert deleted is not None
+    assert deleted.sandbox_id == "sb-m5"
     assert store.get_host("dcf4eb5fc0b04985ec45f79cfda95566") is None
     assert (
         store.resolve_launch_token("dcf4eb5fc0b04985ec45f79cfda95566", "raw-launch-token-5")
@@ -853,7 +854,126 @@ def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
     )
     assert store.list_hosts("alice@example.com") == []
     # Second delete is a no-op, not an error.
-    store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
+    assert store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566") is None
+
+
+def test_replace_managed_host_sandbox_cannot_recreate_deleted_host(db_uri: str) -> None:
+    store = HostStore(db_uri)
+
+    assert (
+        store.replace_managed_host_sandbox(
+            host_id="c48e6fda4172492aa60ec299e5ce01d3",
+            user_id="alice@example.com",
+            token="too-late-token",
+            provider="modal",
+            sandbox_id="sb-too-late",
+            token_expires_at=now_epoch() + 3600,
+        )
+        is None
+    )
+    assert store.resolve_launch_token("c48e6fda4172492aa60ec299e5ce01d3", "too-late-token") is None
+
+
+def test_delete_host_serializes_with_sandbox_replacement(db_uri: str) -> None:
+    """Deletion and generation replacement cannot commit from stale snapshots."""
+    engine = get_or_create_engine(db_uri)
+    if engine.dialect.name != "sqlite":
+        pytest.skip("exercises SQLite BEGIN IMMEDIATE behavior")
+
+    store = HostStore(db_uri)
+    host_id = "d8881fae47e94a15a8f21688e0a5d1bf"
+    store.register_managed_host(
+        host_id=host_id,
+        name="managed-delete-replace-race",
+        user_id="alice@example.com",
+        token="generation-a-token",
+        provider="modal",
+        sandbox_id="generation-a",
+        token_expires_at=now_epoch() + 3600,
+    )
+
+    delete_before_write = threading.Event()
+    replacement_contending = threading.Event()
+    release_delete = threading.Event()
+    results: dict[str, Host | None] = {}
+    errors: list[BaseException] = []
+
+    def before_cursor_execute(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        normalized = statement.strip().upper()
+        thread_name = threading.current_thread().name
+        if thread_name == "delete-host" and normalized.startswith(
+            "UPDATE OMNIGENT_CONVERSATION_METADATA"
+        ):
+            delete_before_write.set()
+            assert release_delete.wait(timeout=10)
+        if thread_name == "replace-host" and normalized.startswith("BEGIN IMMEDIATE"):
+            replacement_contending.set()
+
+    def after_cursor_execute(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        if (
+            threading.current_thread().name == "replace-host"
+            and statement.strip().upper().startswith("UPDATE HOSTS")
+        ):
+            replacement_contending.set()
+
+    def delete() -> None:
+        try:
+            results["deleted"] = store.delete_host(host_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    def replace() -> None:
+        try:
+            results["replacement"] = store.replace_managed_host_sandbox(
+                host_id=host_id,
+                user_id="alice@example.com",
+                token="generation-b-token",
+                provider="modal",
+                sandbox_id="generation-b",
+                token_expires_at=now_epoch() + 3600,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    event.listen(engine, "before_cursor_execute", before_cursor_execute)
+    event.listen(engine, "after_cursor_execute", after_cursor_execute)
+    delete_thread = threading.Thread(target=delete, name="delete-host")
+    replace_thread = threading.Thread(target=replace, name="replace-host")
+    try:
+        delete_thread.start()
+        assert delete_before_write.wait(timeout=10)
+        replace_thread.start()
+        assert replacement_contending.wait(timeout=10)
+        release_delete.set()
+        delete_thread.join(timeout=10)
+        replace_thread.join(timeout=10)
+    finally:
+        release_delete.set()
+        event.remove(engine, "before_cursor_execute", before_cursor_execute)
+        event.remove(engine, "after_cursor_execute", after_cursor_execute)
+
+    assert not delete_thread.is_alive()
+    assert not replace_thread.is_alive()
+    assert errors == []
+    deleted = results["deleted"]
+    assert deleted is not None
+    assert deleted.sandbox_id == "generation-a"
+    assert results["replacement"] is None
+    assert store.get_host(host_id) is None
 
 
 def test_managed_sandbox_reaper_queries_and_compare_clear_span_workspaces(
@@ -1017,9 +1137,8 @@ def test_pending_cleanup_rejects_reused_active_sandbox_id(db_uri: str) -> None:
     )
 
     with pytest.raises(ValueError, match="still pending termination"):
-        store.register_managed_host(
+        store.replace_managed_host_sandbox(
             host_id=host_id,
-            name="managed-reused-id",
             user_id="alice@example.com",
             token="new-generation-token",
             provider="blaxel",
@@ -1051,15 +1170,15 @@ def test_pending_cleanup_does_not_block_rearming_new_generation(db_uri: str) -> 
         sandbox_id="sb-old",
         expected_updated_at=old.updated_at,
     )
-    current = store.register_managed_host(
+    current = store.replace_managed_host_sandbox(
         host_id=host_id,
-        name="managed-rearm-new",
         user_id="alice@example.com",
         token="new-generation-token",
         provider="modal",
         sandbox_id="sb-new",
         token_expires_at=now_epoch() + 3600,
     )
+    assert current is not None
 
     rearmed = store.rearm_managed_host(
         host_id,
@@ -1101,9 +1220,8 @@ def test_managed_connect_revalidates_token_after_detach(db_uri: str) -> None:
             managed_token="old-connect-token",
         )
 
-    store.register_managed_host(
+    store.replace_managed_host_sandbox(
         host_id=host_id,
-        name="managed-connect-race",
         user_id="alice@example.com",
         token="new-connect-token",
         provider="modal",
@@ -1189,13 +1307,10 @@ def test_managed_host_raw_token_never_stored(db_uri: str) -> None:
         assert row.token_hash != "raw-launch-token-6"
 
 
-def test_register_managed_host_refuses_cross_owner_recredential(db_uri: str) -> None:
+def test_replace_managed_host_sandbox_refuses_cross_owner(db_uri: str) -> None:
     """
-    Fail-closed boundary: re-registering an existing host_id under a
-    DIFFERENT owner must raise and leave the original credential
-    intact. host_id is server-generated today, so a mismatch can only
-    mean a bug or a forged id — silently re-owning would hand Bob's
-    launch token Alice's host identity (cross-user host hijack).
+    Replacing an existing host under another owner fails closed and leaves the
+    original credential intact.
     """
     store = HostStore(db_uri)
     store.register_managed_host(
@@ -1209,9 +1324,8 @@ def test_register_managed_host_refuses_cross_owner_recredential(db_uri: str) -> 
     )
 
     with pytest.raises(ValueError, match="different user"):
-        store.register_managed_host(
+        store.replace_managed_host_sandbox(
             host_id="58f80f7592c6a72ba121eb5aedde8a82",
-            name="managed-m7-bob",
             user_id="bob@example.com",
             token="bob-token-7",
             provider="modal",


### PR DESCRIPTION
## Related issue

N/A — fixes a lifecycle race found during managed sandbox testing.

## Summary

- Keep `register_managed_host()` create-only and add `replace_managed_host_sandbox()` for replacing the generation of an existing durable host without recreating a row deleted by full session teardown.
- Preserve the reaper's `rearm_managed_host()` compare-and-swap operation for resuming the same generation, including cleanup when deletion or reaper detachment wins.
- Make `delete_host()` lock, snapshot, and delete the latest row before provider teardown, then terminate both its active and pending sandbox generations.
- If full session deletion wins while a relaunch or wake is in progress, the losing operation cleans up its sandbox instead of recreating or orphaning the host.

**ELI5:** session deletion, relaunch, and reaper cleanup now agree on the durable host row. Once deletion removes it, no concurrent operation can put it back.

```text
generation replacement wins -> deletion removes the latest row -> terminate active + pending sandboxes
session deletion wins        -> replacement finds no row       -> terminate the unregistered sandbox
wake loses deletion          -> resumed sandbox is terminated  -> host stays deleted
```

## Test Plan

- `.venv/bin/pytest -q tests/stores/test_host_store.py tests/server/test_managed_hosts.py tests/server/test_managed_sandbox_reaper.py` (`333 passed`)
- Targeted deletion/relaunch/resume/reaper race coverage (`9 passed`)
- `.venv/bin/pytest -q tests/server/integration/test_host_tunnel_route.py tests/server/integration/test_host_session_binding.py tests/db/test_migration_managed_sandbox_reaper.py tests/db/test_migration_connections.py` (`46 passed`)
- `.venv/bin/pre-commit run --files omnigent/server/managed_hosts.py omnigent/stores/host_store.py tests/server/test_managed_hosts.py tests/stores/test_host_store.py` (all applicable hooks passed)

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes both deletion race orderings, latest-generation teardown, active-plus-pending tombstone cleanup, reaper detachment during wake, and delete-before-provider teardown.

## Changelog

Deleting a session no longer allows a concurrent managed sandbox relaunch or wake to recreate the host or leak replacement compute.

