### PR TITLE
chore(cli): deprecate `omni update`, keep `omni upgrade` as the one spelling

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2079,9 +2079,9 @@ def _should_skip_update_check(argv: list[str]) -> bool:
 
     Skipped for help / version requests, internal TUI subcommands
     (``pane-split`` / ``pane-picker``, invoked by the terminal UI rather
-    than the user), and ``upgrade`` itself along with its deprecated
-    ``update`` spelling — pointing the user at ``omni upgrade`` while they
-    are running it is noise.
+    than the user), and ``upgrade`` (and its deprecated ``update`` spelling)
+    itself (pointing the user at ``omni upgrade`` while they are running it
+    is noise).
 
     :param argv: CLI arguments without the program name, e.g.
         ``["run", "agent.yaml"]``.
@@ -5552,12 +5552,9 @@ def _update_deprecated(ctx: click.Context, **kwargs: object) -> None:
     ctx.invoke(upgrade, **kwargs)
 
 
-# ``update`` was a silent second name for the same Command object; ``upgrade``
-# is the canonical spelling, so ``update`` is now hidden and warns. Deprecated
-# rather than deleted because ``server start`` was deleted outright in v0.7.0
-# (#3105) and had to be restored (#3578) when older clients hard-failed on it —
-# and the desktop About window shipped this same ``omni update`` hint. Reusing
-# ``upgrade.params`` keeps the option surface identical by construction.
+# Deprecated rather than deleted: the desktop About window shipped this same
+# ``omni update`` hint, and ``server start`` was deleted outright in v0.7.0
+# (#3105) then restored (#3578) when older clients hard-failed on it.
 cli.add_command(
     click.Command(
         "update",

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1715,8 +1715,7 @@ _ACCENT_RGB = (244, 59, 166)
 # Command names that are pure aliases of another command (the same Click
 # object registered under a second name, e.g. ``antigravity`` -> ``agy``).
 # Kept runnable/registered but omitted from the ``--help`` listing so the
-# alias isn't shown as a duplicate line. Deprecated spellings do NOT belong
-# here — they carry ``hidden=True`` themselves, which already excludes them.
+# alias isn't shown as a duplicate line.
 _ALIAS_COMMANDS: frozenset[str] = frozenset({"antigravity"})
 
 
@@ -5542,12 +5541,7 @@ def upgrade(
 def _update_deprecated(ctx: click.Context, **kwargs: object) -> None:
     """Warn that ``update`` is deprecated, then run the ``upgrade`` flow.
 
-    The callback behind the hidden ``update`` command registered below. Runs
-    ``upgrade`` through ``ctx.invoke`` rather than re-implementing anything, so
-    the deprecated spelling cannot drift from the canonical one in behavior or
-    exit status (``--check`` still exits 1 when a release is available).
-
-    :param ctx: The click context, used to invoke ``upgrade``'s callback.
+    :param ctx: The click context, used to invoke ``upgrade``.
     :param kwargs: ``upgrade``'s own parsed options, forwarded verbatim.
     :returns: None.
     """
@@ -5558,29 +5552,19 @@ def _update_deprecated(ctx: click.Context, **kwargs: object) -> None:
     ctx.invoke(upgrade, **kwargs)
 
 
-# ``upgrade`` is the one canonical spelling: it is what ``--help`` lists and
-# what every hint in this file and in ``omnigent.update_check`` points at.
-# ``update`` was a silent second name for the same Command object; it is now
-# deprecated — hidden from ``--help`` and warning on stderr so users migrate.
-#
-# Deprecated rather than deleted, deliberately. ``update`` is a common mistype
-# of ``upgrade``, and this is the wrapped CLI reached as ``isaac omni update``,
-# so a hard removal turns it into a bare "No such command 'update'" — and this
-# repo already has the scar: ``server start`` was removed outright in v0.7.0
-# (#3105) and had to be restored (#3578) when older clients hard-failed on it.
-#
-# Built from ``upgrade``'s own parameter objects so the option surface
-# (``--check`` / ``--force`` / ``--pre`` / ``--nightly`` / ``--extra`` /
-# ``--target-version`` / ``--dry-run``) stays identical by construction; there
-# is nothing to keep in sync when ``upgrade`` grows a flag.
+# ``update`` was a silent second name for the same Command object; ``upgrade``
+# is the canonical spelling, so ``update`` is now hidden and warns. Deprecated
+# rather than deleted because ``server start`` was deleted outright in v0.7.0
+# (#3105) and had to be restored (#3578) when older clients hard-failed on it —
+# and the desktop About window shipped this same ``omni update`` hint. Reusing
+# ``upgrade.params`` keeps the option surface identical by construction.
 cli.add_command(
     click.Command(
         "update",
         params=list(upgrade.params),
         callback=_update_deprecated,
         hidden=True,
-        # Static, unlike the runtime warning: a module-level f-string would
-        # freeze the wrapper spelling at import time.
+        # Static: a module-level f-string would freeze the wrapper spelling.
         help="Deprecated spelling of `upgrade`. Use `upgrade` instead.",
     )
 )

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1713,10 +1713,11 @@ _HARNESS_COMMANDS: frozenset[str] = frozenset(
 _ACCENT_RGB = (244, 59, 166)
 
 # Command names that are pure aliases of another command (the same Click
-# object registered under a second name, e.g. ``update`` -> ``upgrade``).
+# object registered under a second name, e.g. ``antigravity`` -> ``agy``).
 # Kept runnable/registered but omitted from the ``--help`` listing so the
-# alias isn't shown as a duplicate line.
-_ALIAS_COMMANDS: frozenset[str] = frozenset({"update", "antigravity"})
+# alias isn't shown as a duplicate line. Deprecated spellings do NOT belong
+# here — they carry ``hidden=True`` themselves, which already excludes them.
+_ALIAS_COMMANDS: frozenset[str] = frozenset({"antigravity"})
 
 
 def _harness_extra_checks() -> dict[str, Callable[[], bool]]:
@@ -1792,7 +1793,7 @@ class _OmnigentCLI(click.Group):
             cmd = self.get_command(ctx, subcommand)
             if cmd is None or cmd.hidden:
                 continue
-            # Skip pure aliases (e.g. ``update`` -> ``upgrade``) so the
+            # Skip pure aliases (e.g. ``antigravity`` -> ``agy``) so the
             # listing doesn't show a duplicate line; still runnable.
             if subcommand in _ALIAS_COMMANDS:
                 continue
@@ -2079,9 +2080,9 @@ def _should_skip_update_check(argv: list[str]) -> bool:
 
     Skipped for help / version requests, internal TUI subcommands
     (``pane-split`` / ``pane-picker``, invoked by the terminal UI rather
-    than the user), and ``upgrade`` (and its ``update`` alias) itself
-    (pointing the user at ``omni upgrade`` while they are running it is
-    noise).
+    than the user), and ``upgrade`` itself along with its deprecated
+    ``update`` spelling — pointing the user at ``omni upgrade`` while they
+    are running it is noise.
 
     :param argv: CLI arguments without the program name, e.g.
         ``["run", "agent.yaml"]``.
@@ -5537,11 +5538,52 @@ def upgrade(
     )
 
 
-# ``omni update`` is an alias for ``omni upgrade`` — mistyping the latter as
-# the former is common, and silently doing nothing is annoying. Registering
-# the same Command object under a second name shares the exact callback,
-# options, and semantics; there is no duplicated implementation to drift.
-cli.add_command(upgrade, name="update")
+@click.pass_context
+def _update_deprecated(ctx: click.Context, **kwargs: object) -> None:
+    """Warn that ``update`` is deprecated, then run the ``upgrade`` flow.
+
+    The callback behind the hidden ``update`` command registered below. Runs
+    ``upgrade`` through ``ctx.invoke`` rather than re-implementing anything, so
+    the deprecated spelling cannot drift from the canonical one in behavior or
+    exit status (``--check`` still exits 1 when a release is available).
+
+    :param ctx: The click context, used to invoke ``upgrade``'s callback.
+    :param kwargs: ``upgrade``'s own parsed options, forwarded verbatim.
+    :returns: None.
+    """
+    click.echo(
+        f"omnigent: `update` is deprecated; use `{cli_invocation(name='omni')} upgrade`.",
+        err=True,
+    )
+    ctx.invoke(upgrade, **kwargs)
+
+
+# ``upgrade`` is the one canonical spelling: it is what ``--help`` lists and
+# what every hint in this file and in ``omnigent.update_check`` points at.
+# ``update`` was a silent second name for the same Command object; it is now
+# deprecated — hidden from ``--help`` and warning on stderr so users migrate.
+#
+# Deprecated rather than deleted, deliberately. ``update`` is a common mistype
+# of ``upgrade``, and this is the wrapped CLI reached as ``isaac omni update``,
+# so a hard removal turns it into a bare "No such command 'update'" — and this
+# repo already has the scar: ``server start`` was removed outright in v0.7.0
+# (#3105) and had to be restored (#3578) when older clients hard-failed on it.
+#
+# Built from ``upgrade``'s own parameter objects so the option surface
+# (``--check`` / ``--force`` / ``--pre`` / ``--nightly`` / ``--extra`` /
+# ``--target-version`` / ``--dry-run``) stays identical by construction; there
+# is nothing to keep in sync when ``upgrade`` grows a flag.
+cli.add_command(
+    click.Command(
+        "update",
+        params=list(upgrade.params),
+        callback=_update_deprecated,
+        hidden=True,
+        # Static, unlike the runtime warning: a module-level f-string would
+        # freeze the wrapper spelling at import time.
+        help="Deprecated spelling of `upgrade`. Use `upgrade` instead.",
+    )
+)
 
 
 def _bundle(source: Path) -> bytes:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1095,16 +1095,21 @@ def test_help_groups_harnesses_and_other_commands() -> None:
     assert commands_at < result.output.index("server")
 
 
-def test_help_hides_update_alias_but_keeps_it_runnable() -> None:
-    """The ``update`` alias is omitted from --help but stays registered."""
+def test_help_hides_deprecated_update_spelling_but_keeps_it_runnable() -> None:
+    """``update`` is omitted from --help but stays registered and runnable.
+
+    ``upgrade`` is the one canonical spelling users should learn from the
+    listing; ``update`` is deprecated (it warns on stderr) rather than deleted,
+    so it must still resolve to a command.
+    """
     result = CliRunner().invoke(cli, ["--help"])
 
     assert result.exit_code == 0, result.output
     assert "upgrade" in result.output
-    # The alias line is suppressed so it doesn't duplicate ``upgrade``...
+    # The deprecated spelling is suppressed so it doesn't duplicate ``upgrade``...
     assert "\n  update " not in result.output
-    # ...but it's still a real, invokable command.
-    assert cli.commands["update"] is cli.commands["upgrade"]
+    # ...but it's still a real, invokable command, kept hidden rather than gone.
+    assert cli.commands["update"].hidden is True
 
 
 def test_help_hides_extras_gated_harness_when_sdk_missing(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1096,19 +1096,13 @@ def test_help_groups_harnesses_and_other_commands() -> None:
 
 
 def test_help_hides_deprecated_update_spelling_but_keeps_it_runnable() -> None:
-    """``update`` is omitted from --help but stays registered and runnable.
-
-    ``upgrade`` is the one canonical spelling users should learn from the
-    listing; ``update`` is deprecated (it warns on stderr) rather than deleted,
-    so it must still resolve to a command.
-    """
+    """``update`` is omitted from --help but stays registered and runnable."""
     result = CliRunner().invoke(cli, ["--help"])
 
     assert result.exit_code == 0, result.output
     assert "upgrade" in result.output
-    # The deprecated spelling is suppressed so it doesn't duplicate ``upgrade``...
+    # Suppressed from the listing, but still a real command — deprecated, not gone.
     assert "\n  update " not in result.output
-    # ...but it's still a real, invokable command, kept hidden rather than gone.
     assert cli.commands["update"].hidden is True
 
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1101,7 +1101,6 @@ def test_help_hides_deprecated_update_spelling_but_keeps_it_runnable() -> None:
 
     assert result.exit_code == 0, result.output
     assert "upgrade" in result.output
-    # Suppressed from the listing, but still a real command — deprecated, not gone.
     assert "\n  update " not in result.output
     assert cli.commands["update"].hidden is True
 

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from omnigent.cli import cli
+from omnigent.cli_invocation import WRAPPER_COMMAND_ENV
 from omnigent.host.local_server import LocalServerInfo
 from omnigent.update_check import (
     _build_nightly_upgrade_suggestion,
@@ -332,27 +333,31 @@ def test_upgrade_pre_passes_prerelease_flag_to_installer(
     assert ran == ["uv tool upgrade omnigent --prerelease allow"]
 
 
-# ── ``omni update`` alias ────────────────────────────────────────────
+# ── deprecated ``omni update`` spelling ──────────────────────────────
 
 
-def test_update_is_alias_for_upgrade_same_callback() -> None:
-    """``update`` and ``upgrade`` resolve to the exact same Click command.
+def test_update_is_hidden_and_shares_upgrade_options() -> None:
+    """``update`` is a hidden shim over ``upgrade``, not a second command.
 
-    The alias is registered by handing the *same* Command object to the
-    group under a second name, so its callback, options and help must be
-    identical — there is no second implementation to drift from ``upgrade``.
+    It is its own Click object now (it has to be, to warn), so the guard is
+    that it is built from ``upgrade``'s own parameter objects: the option
+    surface is identical by construction and cannot drift when ``upgrade``
+    grows a flag. ``hidden`` is what keeps it out of the ``--help`` listing.
     """
     update_cmd = cli.commands["update"]
     upgrade_cmd = cli.commands["upgrade"]
 
-    assert update_cmd is upgrade_cmd
-    assert update_cmd.callback is upgrade_cmd.callback
-    # Same option surface (--check / --force / --pre).
-    assert [p.name for p in update_cmd.params] == [p.name for p in upgrade_cmd.params]
+    assert update_cmd is not upgrade_cmd
+    assert update_cmd.hidden is True
+    assert upgrade_cmd.hidden is False
+    # The very same Parameter objects, not merely equally-named ones.
+    assert all(a is b for a, b in zip(update_cmd.params, upgrade_cmd.params, strict=True))
 
 
-def test_update_up_to_date(monkeypatch: pytest.MonkeyPatch, _wheel_install: None) -> None:
-    """``omni update`` runs the upgrade flow end-to-end (up-to-date path)."""
+def test_update_warns_then_runs_upgrade(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """``omni update`` still works, but warns and names ``upgrade``."""
     monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.1.0")
 
     def _must_not_run(*_a: object, **_k: object) -> int:
@@ -363,14 +368,44 @@ def test_update_up_to_date(monkeypatch: pytest.MonkeyPatch, _wheel_install: None
     result = CliRunner().invoke(cli, ["update"])
 
     assert result.exit_code == 0, result.output
-    assert "up to date" in result.output
-    assert "0.1.0" in result.output
+    assert "`update` is deprecated" in result.stderr
+    assert "upgrade" in result.stderr
+    # The upgrade flow itself still ran to completion.
+    assert "up to date" in result.stdout
+    assert "0.1.0" in result.stdout
+
+
+def test_update_deprecation_notice_honors_the_wrapper_command(
+    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
+) -> None:
+    """Under a wrapper the notice says ``isaac omni upgrade``, not ``omni``.
+
+    Most users reach this CLI wrapped (``isaac omni update``), and the wrapper
+    guard rejects naked ``omnigent`` calls — so a hint spelling the naked
+    binary would name a command that cannot run. Same contract as every other
+    followup hint in ``omnigent.cli``.
+    """
+    monkeypatch.setenv(WRAPPER_COMMAND_ENV, "isaac omni")
+    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.1.0")
+    monkeypatch.setattr(
+        "omnigent.update_check._run_upgrade_command",
+        lambda *_a, **_k: pytest.fail("upgrade ran while already up to date"),
+    )
+
+    result = CliRunner().invoke(cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "`isaac omni upgrade`" in result.stderr
 
 
 def test_update_check_matches_upgrade_check(
     monkeypatch: pytest.MonkeyPatch, _wheel_install: None
 ) -> None:
-    """``update --check`` behaves identically to ``upgrade --check``."""
+    """``update --check`` behaves identically to ``upgrade --check``.
+
+    Identical stdout and exit status (1 when a release is available) — the
+    deprecation only adds a stderr line, it does not change the flow.
+    """
     monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.2.0")
 
     def _must_not_run(*_a: object, **_k: object) -> int:
@@ -383,8 +418,11 @@ def test_update_check_matches_upgrade_check(
     upgrade_result = runner.invoke(cli, ["upgrade", "--check"])
 
     assert update_result.exit_code == upgrade_result.exit_code == 1
-    assert update_result.output == upgrade_result.output
-    assert "v0.1.0 → v0.2.0" in update_result.output
+    assert update_result.stdout == upgrade_result.stdout
+    assert "v0.1.0 → v0.2.0" in update_result.stdout
+    # The warning is the only difference, and only on the deprecated spelling.
+    assert "`update` is deprecated" in update_result.stderr
+    assert "deprecated" not in upgrade_result.stderr
 
 
 def test_update_suppresses_update_check_like_upgrade() -> None:

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -339,10 +339,8 @@ def test_upgrade_pre_passes_prerelease_flag_to_installer(
 def test_update_is_hidden_and_shares_upgrade_options() -> None:
     """``update`` is a hidden shim over ``upgrade``, not a second command.
 
-    It is its own Click object now (it has to be, to warn), so the guard is
-    that it is built from ``upgrade``'s own parameter objects: the option
-    surface is identical by construction and cannot drift when ``upgrade``
-    grows a flag. ``hidden`` is what keeps it out of the ``--help`` listing.
+    It has to be its own Click object to warn, so the guard is that it reuses
+    ``upgrade``'s parameter objects — the option surface cannot drift.
     """
     update_cmd = cli.commands["update"]
     upgrade_cmd = cli.commands["upgrade"]
@@ -380,10 +378,8 @@ def test_update_deprecation_notice_honors_the_wrapper_command(
 ) -> None:
     """Under a wrapper the notice says ``isaac omni upgrade``, not ``omni``.
 
-    Most users reach this CLI wrapped (``isaac omni update``), and the wrapper
-    guard rejects naked ``omnigent`` calls — so a hint spelling the naked
-    binary would name a command that cannot run. Same contract as every other
-    followup hint in ``omnigent.cli``.
+    The wrapper guard rejects naked ``omnigent`` calls, so a hint spelling the
+    naked binary would name a command that cannot run.
     """
     monkeypatch.setenv(WRAPPER_COMMAND_ENV, "isaac omni")
     monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.1.0")
@@ -403,8 +399,7 @@ def test_update_check_matches_upgrade_check(
 ) -> None:
     """``update --check`` behaves identically to ``upgrade --check``.
 
-    Identical stdout and exit status (1 when a release is available) — the
-    deprecation only adds a stderr line, it does not change the flow.
+    The deprecation adds a stderr line; it does not change the flow.
     """
     monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.2.0")
 

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -368,7 +368,6 @@ def test_update_warns_then_runs_upgrade(
     assert result.exit_code == 0, result.output
     assert "`update` is deprecated" in result.stderr
     assert "upgrade" in result.stderr
-    # The upgrade flow itself still ran to completion.
     assert "up to date" in result.stdout
     assert "0.1.0" in result.stdout
 
@@ -397,10 +396,7 @@ def test_update_deprecation_notice_honors_the_wrapper_command(
 def test_update_check_matches_upgrade_check(
     monkeypatch: pytest.MonkeyPatch, _wheel_install: None
 ) -> None:
-    """``update --check`` behaves identically to ``upgrade --check``.
-
-    The deprecation adds a stderr line; it does not change the flow.
-    """
+    """``update --check`` behaves identically to ``upgrade --check``."""
     monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.2.0")
 
     def _must_not_run(*_a: object, **_k: object) -> int:
@@ -415,7 +411,7 @@ def test_update_check_matches_upgrade_check(
     assert update_result.exit_code == upgrade_result.exit_code == 1
     assert update_result.stdout == upgrade_result.stdout
     assert "v0.1.0 → v0.2.0" in update_result.stdout
-    # The warning is the only difference, and only on the deprecated spelling.
+    # The warning is the only difference between the two.
     assert "`update` is deprecated" in update_result.stderr
     assert "deprecated" not in upgrade_result.stderr
 

--- a/tests/e2e_ui/desktop/test_about_dialog.py
+++ b/tests/e2e_ui/desktop/test_about_dialog.py
@@ -62,7 +62,7 @@ def test_about_dialog_update_flow(page: Page) -> None:
     expect(page.get_by_text("0.13.0", exact=True)).to_be_visible()
     expect(page.get_by_text("0.13.0.dev0", exact=True)).to_be_visible()
     expect(page.get_by_text("/Users/alice/.local/bin/omnigent", exact=True)).to_be_visible()
-    expect(page.get_by_text("omni update", exact=True)).to_be_visible()
+    expect(page.get_by_text("omni upgrade", exact=True)).to_be_visible()
 
     update_now = page.get_by_role("button", name="Update now")
     expect(update_now).to_be_visible()

--- a/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
+++ b/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
@@ -147,9 +147,12 @@ def test_new_session_shows_first_prompt_optimistically(
 
     # Sanity: the real auto-send handoff ran (its POST was intercepted),
     # so a green run isn't a composer that silently never sent.
+    # Pump the driver with wait_for_timeout, not time.sleep: the sync API
+    # dispatches route handlers only inside Playwright calls, so a bare
+    # sleep loop never runs handle_events for a late-landing POST.
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline and _PROMPT not in event_texts:
-        time.sleep(0.05)
+        page.wait_for_timeout(50)
     assert _PROMPT in event_texts, (
         f"the initial prompt was never POSTed to the session's /events "
         f"(observed: {event_texts}) — the auto-send path did not run"

--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -51,7 +51,7 @@ adds native niceties:
   native `Cmd+,` accelerator on macOS (`Ctrl+,` elsewhere) and routes the
   focused connected window through the SPA without reloading it. On macOS,
   **About Omnigent** opens a shell-owned modal showing the platform app and
-  detected CLI versions; the CLI section points users to `omni update`.
+  detected CLI versions; the CLI section points users to `omni upgrade`.
   **Check for Updates…** in
   the Server menu opens the same modal and starts a check. **Update now** in the
   shell update prompt opens the modal, hides the prompt, and starts the download;

--- a/web/electron/about/index.html
+++ b/web/electron/about/index.html
@@ -389,7 +389,7 @@
             <dt>Path</dt>
             <dd><code id="cli-path">Loading…</code></dd>
           </dl>
-          <p class="cli-update">Run <code>omni update</code> to update.</p>
+          <p class="cli-update">Run <code>omni upgrade</code> to update.</p>
         </section>
 
         <footer class="footer">

--- a/web/electron/test/about_window.test.js
+++ b/web/electron/test/about_window.test.js
@@ -244,7 +244,7 @@ describe("About window", () => {
     assert.match(html, /id="desktop-update-now"[^>]*>Update now<\/button>/);
     assert.match(html, /aria-label="Update download progress"/);
     assert.match(html, /id="desktop-restart"[^>]*>Restart to update<\/button>/);
-    assert.match(html, /Run <code>omni update<\/code> to update\./);
+    assert.match(html, /Run <code>omni upgrade<\/code> to update\./);
     assert.match(html, /id="close"[^>]*>Close<\/button>/);
     assert.match(script, /info\.appIconDataUrl\.startsWith\("data:image\/"\)/);
     assert.match(script, /desktopHeading\.textContent = `Omnigent \$\{platformName\} app`/);


### PR DESCRIPTION
## Related issue

Not required — `Refactor / chore`.

## Summary

`update` and `upgrade` were both fully valid spellings of the same command:
`cli.add_command(upgrade, name="update")` registered the *same* Command object
under a second name. But only `upgrade` is canonical — it is what `--help`
lists, and what every hint in `cli.py` and `omnigent/update_check.py` points at
(its `--check` hint, its pip / `uv pip` guidance, and its source-checkout
error all name `omni upgrade`).

- `update` becomes a **hidden shim** that warns on stderr and forwards to
  `upgrade`, following the `server start` pattern already in this file. It is
  built from `upgrade`'s own `params`, so the option surface (`--check` /
  `--force` / `--pre` / `--nightly` / `--extra` / `--target-version` /
  `--dry-run`) is identical by construction and cannot drift.
- The notice goes through `cli_invocation()`, so a wrapped install says
  points at `isaac omni upgrade` rather than naming a binary the wrapper
  guard rejects.
- `update` leaves `_ALIAS_COMMANDS` — that registry is for *pure* aliases
  (`antigravity` → `agy`); `hidden=True` is what excludes a deprecated
  spelling from the listing now.

**Deprecated rather than deleted, deliberately.** Two reasons:

1. The Electron About window told users to run `omni update` — a real caller,
   on its own update channel. It now says `omni upgrade`, but builds already
   out there will keep saying `update`.
2. This repo has the scar: `server start` was removed outright in v0.7.0
   (#3105) and had to be restored (#3578) when a pre-v0.7.0 desktop client
   hard-failed with `No such command 'start'`.

So `update` stays runnable, just unadvertised and noisy.

```
$ omni update --check
omnigent: `update` is deprecated; use `omni upgrade`.     # stderr
Omnigent v0.1.0 → v0.2.0 available.                       # stdout, exit 1
```

## Test Plan

- `pytest tests/cli/` → **1219 passed**
- `node --test test/about_window.test.js` (from `web/electron/`) → **13 passed**
- `ruff check` + `ruff format --check` on the touched files → clean
- `pyrefly check` → **0 errors in `omnigent/cli.py`** (remaining errors are
  pre-existing, in untouched modules)
- Manual, wrapped: `OMNIGENT_WRAPPER_COMMAND="isaac omni" omni update --check`
  prints ``use `isaac omni upgrade` `` and exits 1 — same exit status and stdout
  as `omni upgrade --check`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The alias test block in `tests/cli/test_upgrade_command.py` is rewritten for the
new contract: `update` is a distinct hidden command sharing `upgrade`'s exact
`Parameter` objects; it warns then runs the flow; `--check` produces identical
stdout and exit status with the warning as the only difference; and the notice
honors `OMNIGENT_WRAPPER_COMMAND`. `test_help_hides_update_alias_but_keeps_it_runnable`
in `tests/cli/test_cli.py` is updated to assert `hidden` rather than object
identity with `upgrade`.

Manual verification covered the wrapped invocation, since the wrapper spelling
depends on process env that the unit test sets via `monkeypatch`.

One user-visible copy change rides along outside the CLI: the Electron About
modal's `omni update` → `omni upgrade` (one word, asserted in
`web/electron/test/about_window.test.js`). Happy to attach a screenshot if a
reviewer wants the UI box checked.

## Changelog

`omnigent update` is deprecated in favor of `omnigent upgrade` — it still runs, but prints a deprecation notice pointing at the canonical spelling.
