### PR TITLE
fix(claude-native): preserve compacted context on cold resume

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -5163,6 +5163,7 @@ def _claude_transcript_records_from_session_items(
                         parent_uuid=parent_uuid,
                         cwd=cwd,
                         bridge_dir=bridge_dir,
+                        allow_native_message_content=True,
                     )
                     if cm_record is not None:
                         records.append(cm_record)
@@ -5201,6 +5202,7 @@ def _claude_transcript_record_from_session_item(
     parent_uuid: str | None,
     cwd: Path,
     bridge_dir: Path,
+    allow_native_message_content: bool = False,
 ) -> _JsonObject | None:
     """
     Convert one Omnigent item into one Claude transcript record.
@@ -5224,6 +5226,8 @@ def _claude_transcript_record_from_session_item(
         ``Path("/home/me/repo")``.
     :param bridge_dir: Session bridge directory for re-materializing
         attachment blocks.
+    :param allow_native_message_content: Accept Claude-native string and
+        content-block shapes when API-block conversion finds no content.
     :returns: Claude transcript record, or ``None`` for unsupported or
         empty Omnigent items.
     """
@@ -5235,12 +5239,18 @@ def _claude_transcript_record_from_session_item(
         role = item.get("role")
         if role == "user":
             user_content = _claude_user_content_from_api_blocks(item.get("content"), bridge_dir)
+            if user_content is None and allow_native_message_content:
+                user_content = _claude_native_message_content(item.get("content"), role="user")
             if user_content is None:
                 return None
             record_type = "user"
             message = {"role": "user", "content": user_content}
         elif role == "assistant":
             assistant_content = _claude_assistant_content_from_api_blocks(item.get("content"))
+            if assistant_content is None and allow_native_message_content:
+                assistant_content = _claude_native_message_content(
+                    item.get("content"), role="assistant"
+                )
             if assistant_content is None:
                 return None
             record_type = "assistant"
@@ -5319,6 +5329,29 @@ def _claude_transcript_record_from_session_item(
         "message": message,
         **extra,
     }
+
+
+def _claude_native_message_content(
+    content: object,
+    *,
+    role: str,
+) -> str | list[_JsonObject] | None:
+    """Validate Claude-native message content for transcript reconstruction."""
+    if isinstance(content, str):
+        if not content:
+            return None
+        if role == "assistant":
+            return [{"type": "text", "text": content}]
+        return content
+    if not isinstance(content, list) or not content:
+        return None
+    blocks: list[_JsonObject] = []
+    for value in content:
+        block = _json_object(value)
+        if block is None or not isinstance(block.get("type"), str):
+            return None
+        blocks.append(block)
+    return blocks
 
 
 def _synthetic_claude_transcript_uuid(

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -15,6 +15,7 @@ import shlex
 import ssl
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from itertools import pairwise
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -8426,6 +8427,102 @@ def test_claude_transcript_records_handles_compaction_item() -> None:
     ]
     assert len(boundaries) == 1
     assert boundaries[0]["compactMetadata"]["postTokens"] == 4321
+
+
+def test_claude_transcript_records_handles_native_compaction_messages() -> None:
+    """Claude-native compacted messages survive cold-resume reconstruction."""
+    items: list[dict[str, Any]] = [
+        {
+            "id": "msg_before",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "discarded before compaction"}],
+        },
+        {
+            "id": "cmp_native",
+            "type": "compaction",
+            "token_count": 1234,
+            "compacted_messages": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": "native compact summary",
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "native reply"},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_native",
+                            "name": "Read",
+                            "input": {"file_path": "README.md"},
+                        },
+                    ],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_native",
+                            "content": "native tool result",
+                        }
+                    ],
+                },
+            ],
+        },
+        {
+            "id": "msg_after",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "after compaction"}],
+        },
+    ]
+
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_native",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+        bridge_dir=Path("/tmp/test-bridge"),
+    )
+
+    assert [record.get("type") for record in records] == [
+        "system",
+        "user",
+        "assistant",
+        "user",
+        "user",
+    ]
+    assert records[1]["message"] == {"role": "user", "content": "native compact summary"}
+    assert records[2]["message"] == {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "native reply"},
+            {
+                "type": "tool_use",
+                "id": "toolu_native",
+                "name": "Read",
+                "input": {"file_path": "README.md"},
+            },
+        ],
+    }
+    assert records[3]["message"] == {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_native",
+                "content": "native tool result",
+            }
+        ],
+    }
+    assert records[4]["message"] == {"role": "user", "content": "after compaction"}
+    assert all(record["parentUuid"] == previous["uuid"] for previous, record in pairwise(records))
+    assert "discarded before compaction" not in json.dumps(records)
 
 
 def test_websocket_connect_passes_ssl_context_for_wss(


### PR DESCRIPTION
## Related issue

N/A — no public issue.

## Summary

- Claude-native compaction stores message content as strings and `text` / `tool_use` / `tool_result` blocks, but cold-resume reconstruction only accepted `input_text` / `output_text`, dropping the entire compacted context.
- Accept native content only while reconstructing `compacted_messages`; regular session-item conversion remains unchanged.

ELI5: Claude saved the summary in its native format, but Omnigent read it as API format and discarded it.

`native compacted messages -> API-only converter -> dropped`  
`native compacted messages -> scoped native fallback -> restored`

## Test Plan

Live reproduction used Claude Code `2.1.260` and Omnigent `0.12.0.dev0` (`7f0886ad`). After native compaction, removing the local Claude transcript and cold-resuming caused Claude to answer `UNKNOWN` for a pre-compaction sentinel.

Exact replay of the exported session against this patch:

```text
ordinary_converter=0
native_converter=2151
compacted_messages=2151
reconstructed_records=2948
compacted_parent_chain=True
```

```text
uv run --frozen --group dev pytest -q tests/test_claude_native.py
349 passed, 3 warnings in 5.52s
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Replayed the full exported session locally without printing transcript content; all 2,151 compacted messages converted and formed a valid parent chain.

## Changelog

Claude Code sessions retain compacted context after a cold resume.
