### PR TITLE
fix(native): label reconnect messages by wrapper

### DIFF
--- a/omnigent/antigravity_native.py
+++ b/omnigent/antigravity_native.py
@@ -1159,6 +1159,7 @@ async def _attach_terminal(
                 attach_url=_attach_url(base_url, prepared.session_id, prepared.terminal_id),
                 headers=headers,
                 recover=recover,
+                session_name="Antigravity",
                 base_url=base_url,
                 session_id=prepared.session_id,
                 terminal_id=prepared.terminal_id,

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -3587,6 +3587,7 @@ async def _attach_with_transcript_forwarder(
                 attach_url=attach_url,
                 headers=headers,
                 recover=recover,
+                session_name="Claude",
                 base_url=base_url,
                 session_id=prepared.session_id,
                 terminal_id=prepared.terminal_id,
@@ -3630,6 +3631,7 @@ async def _attach_with_reconnect(
     attach_url: str,
     headers: dict[str, str],
     recover: Callable[[], Awaitable[None]] | None,
+    session_name: str = "Claude",
     base_url: str | None = None,
     session_id: str | None = None,
     terminal_id: str | None = None,
@@ -3660,6 +3662,8 @@ async def _attach_with_reconnect(
         (not before the first). ``None`` disables reconnect; the
         loop returns after one ``attach`` call. Callback exceptions
         are logged and the loop still retries.
+    :param session_name: User-facing native session name used in reconnect
+        messages, e.g. ``"Claude"`` or ``"Codex"``.
     :param base_url: Omnigent server URL for the post-close terminal probe;
         ``None`` disables the probe.
     :param session_id: Session/conversation id for the probe path.
@@ -3697,7 +3701,8 @@ async def _attach_with_reconnect(
                 await recover()
             except Exception:  # noqa: BLE001
                 _logger.warning(
-                    "claude-native reconnect recovery callback raised; retrying attach anyway",
+                    "%s-native reconnect recovery callback raised; retrying attach anyway",
+                    session_name.lower(),
                     exc_info=True,
                 )
         first_attempt = False
@@ -3756,14 +3761,15 @@ async def _attach_with_reconnect(
             if recover is None:
                 raise
             click.echo(
-                f"\nClaude session connection lost ({exc}); reconnecting...",
+                f"\n{session_name} session connection lost ({exc}); reconnecting...",
                 err=True,
             )
         except (WebSocketException, OSError, ConnectionError) as exc:
             if recover is None:
                 raise
             click.echo(
-                f"\nClaude session connection lost ({type(exc).__name__}: {exc}); reconnecting...",
+                f"\n{session_name} session connection lost "
+                f"({type(exc).__name__}: {exc}); reconnecting...",
                 err=True,
             )
         else:
@@ -3782,7 +3788,7 @@ async def _attach_with_reconnect(
                     )
                     return _AttachOutcome.EXITED
             click.echo(
-                "\nClaude session connection closed by server; reconnecting...",
+                f"\n{session_name} session connection closed by server; reconnecting...",
                 err=True,
             )
         await _sleep(delay)

--- a/omnigent/codex_native.py
+++ b/omnigent/codex_native.py
@@ -1538,6 +1538,7 @@ async def _attach_terminal_resource(
         attach_url=_attach_url(base_url, prepared.session_id, prepared.terminal_id),
         headers=headers,
         recover=recover,
+        session_name="Codex",
         base_url=base_url,
         session_id=prepared.session_id,
         terminal_id=prepared.terminal_id,

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -3441,7 +3441,7 @@ async def test_attach_with_reconnect_exits_immediately_on_user_request(
         attach=attach,
         attach_url="wss://example.com/attach",
         headers={"Authorization": "Bearer tok"},
-        recover=lambda: _noop_async(),
+        recover=_noop_async,
     )
 
     # Exactly one attach call — no retries after a clean user exit.
@@ -3581,6 +3581,28 @@ async def test_attach_with_reconnect_retries_after_websocket_exception(
         f"expected 3 attach calls (2 fail + 1 succeed), got {len(attach.calls)}; "
         "the reconnect loop is not retrying after a transient WS error"
     )
+
+
+@pytest.mark.asyncio
+async def test_attach_with_reconnect_uses_session_name_in_clean_close_message(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Shared reconnect messages identify the active native wrapper."""
+    monkeypatch.setattr(claude_native, "_sleep", _noop_sleep)
+    attach = _ScriptedAttach(script=[False, True])
+
+    await claude_native._attach_with_reconnect(
+        attach=attach,
+        attach_url="wss://example.com/attach",
+        headers={"Authorization": "Bearer tok"},
+        recover=lambda: _noop_async(),
+        session_name="Codex",
+    )
+
+    captured = capsys.readouterr()
+    assert "Codex session connection closed by server; reconnecting..." in captured.err
+    assert "Claude session" not in captured.err
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -9202,6 +9202,7 @@ def test_attach_with_forwarder_falls_back_when_tmux_socket_is_not_local(
         """
         attach_url = kwargs["attach_url"]
         assert isinstance(attach_url, str)
+        assert kwargs["session_name"] == "Codex"
         active_session_id_reader = kwargs["active_session_id_reader"]
         assert callable(active_session_id_reader)
         assert active_session_id_reader() == "conv_rotated"


### PR DESCRIPTION
## Related issue

N/A — user-reported behavior; no matching open issue was found.

## Summary

- Make the shared native terminal reconnect helper use the active wrapper's session name instead of hard-coding Claude.
- Wire Codex and Antigravity labels explicitly and add regression coverage for the Codex server-disconnect message.

## Test Plan

- `.venv/bin/python -m pytest tests/test_claude_native.py -k 'attach_with_reconnect' tests/test_codex_native.py::test_attach_with_forwarder_falls_back_when_tmux_socket_is_not_local -q --tb=short`
- `.venv/bin/pyrefly check omnigent/claude_native.py omnigent/codex_native.py omnigent/antigravity_native.py`
- `PYTHONPATH="$PWD/sdks/python-client:$PWD/sdks/ui" .venv/bin/pre-commit run`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before: a disconnected Codex terminal printed `Claude session connection closed by server; reconnecting...`.

After: it prints `Codex session connection closed by server; reconnecting...`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test exercises the clean server-close reconnect path with a Codex session name, while the existing reconnect-loop tests cover abnormal close, terminal-gone, detach, backoff, and recovery behavior.

## Changelog

Codex and Antigravity reconnect notices now name the active native session instead of Claude.
