### PR TITLE
fix(claude-native): idempotent transcript-forwarder persists + resume-transcript duplicate defense

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -5106,7 +5106,18 @@ def _claude_transcript_records_from_session_items(
     records: list[_JsonObject] = []
     parent_uuid: str | None = None
     tool_parent_by_call_id: dict[str, str] = {}
+    previous_item: _JsonObject | None = None
     for index, item in enumerate(items):
+        # A forwarder retry that slipped past idempotency persists as an
+        # adjacent row identical in everything but the store envelope
+        # (id/created_at). Drop it so store duplicates don't become
+        # duplicated model context on every resume; genuine adjacent
+        # repeats differ in payload or response_id and survive.
+        if previous_item is not None and _transcript_items_equal_ignoring_envelope(
+            item, previous_item
+        ):
+            continue
+        previous_item = item
         # Compaction items carry the post-compaction context. Replace
         # all prior records with the compacted messages so the
         # reconstructed transcript reflects the compacted state.
@@ -5318,6 +5329,31 @@ def _claude_transcript_record_from_session_item(
         "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "message": message,
         **extra,
+    }
+
+
+def _transcript_items_equal_ignoring_envelope(
+    item: _JsonObject,
+    other: _JsonObject,
+) -> bool:
+    """
+    Compare two session items ignoring store-envelope fields.
+
+    A duplicate row created by a forwarder retry re-post is byte-identical
+    in payload but differs in the store-assigned ``id`` and ``created_at``.
+    Everything else — including ``response_id``, which differs across
+    genuine turns — participates in the comparison, so a user legitimately
+    repeating the same message in a later turn is not collapsed.
+
+    :param item: Flat API item dict, e.g.
+        ``{"type": "message", "role": "user", "content": [...]}``.
+    :param other: The item to compare against.
+    :returns: ``True`` when the items are equal apart from ``id`` and
+        ``created_at``.
+    """
+    envelope = ("id", "created_at")
+    return {k: v for k, v in item.items() if k not in envelope} == {
+        k: v for k, v in other.items() if k not in envelope
     }
 
 

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -5343,7 +5343,9 @@ def _transcript_items_equal_ignoring_envelope(
     in payload but differs in the store-assigned ``id`` and ``created_at``.
     Everything else — including ``response_id``, which differs across
     genuine turns — participates in the comparison, so a user legitimately
-    repeating the same message in a later turn is not collapsed.
+    repeating the same message in a later turn is not collapsed. The filter
+    assumes a turn never legitimately emits byte-identical adjacent payloads
+    within the same ``response_id``; such a repeat would be collapsed too.
 
     :param item: Flat API item dict, e.g.
         ``{"type": "message", "role": "user", "content": [...]}``.

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -4089,6 +4089,11 @@ async def _post_external_conversation_item(
                     "item_type": item.item_type,
                     "item_data": item.data,
                     "response_id": item.response_id,
+                    # Server-side idempotency key: the forwarder retries a
+                    # timed-out POST it cannot know the disposition of, so
+                    # the server derives the item's id from this and treats
+                    # a re-post as a no-op instead of a duplicate.
+                    "source_id": item.source_id,
                 },
             },
         )

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -793,6 +793,13 @@ class NewConversationItem(BaseModel):
     response_id: str
     data: ItemData
     created_by: str | None = None
+    # Deterministic item id for idempotent appends. When set, the store uses
+    # it as the item's id and treats an already-persisted item with this id
+    # as the append's result instead of inserting a duplicate — the retry
+    # contract for at-least-once producers (a transcript forwarder cannot
+    # know whether a timed-out POST committed). Same 32-hex shape the store
+    # mints itself; ``None`` keeps the store-assigned random id.
+    stable_id: str | None = None
 
     @model_validator(mode="after")
     def check_type_matches_data(self) -> NewConversationItem:
@@ -803,6 +810,8 @@ class NewConversationItem(BaseModel):
         :raises ValueError: If ``type`` does not match ``data``.
         """
         _validate_type_matches_data(self.type, self.data)
+        if self.stable_id is not None and not re.fullmatch(r"[0-9a-f]{32}", self.stable_id):
+            raise ValueError("stable_id must be a 32-char lowercase hex string")
         return self
 
 
@@ -829,6 +838,10 @@ class ConversationItem(BaseModel):
     created_at: int
     data: ItemData
     created_by: str | None = None
+    # In-process signal only (excluded from every dump / API shape): ``True``
+    # when an idempotent append found this item already persisted under its
+    # ``stable_id``, so the caller can skip a duplicate's side effects.
+    deduplicated: bool = Field(default=False, exclude=True)
 
     @model_validator(mode="after")
     def check_type_matches_data(self) -> ConversationItem:

--- a/omnigent/runtime/pending_inputs.py
+++ b/omnigent/runtime/pending_inputs.py
@@ -284,6 +284,30 @@ def resolve_oldest(conversation_id: str) -> DrainedInput | None:
         )
 
 
+def restore(conversation_id: str, drained: DrainedInput) -> None:
+    """
+    Put a drained entry back at the FRONT of the pending queue.
+
+    Compensation for a drain whose persist turned out to be a duplicate
+    (an idempotent external-item append deduplicated the retry): the
+    entry belongs to the NEXT user message, and it was the oldest when
+    drained, so it returns to the head to keep FIFO intact.
+
+    :param conversation_id: Conversation/session id, e.g.
+        ``"conv_abc123"``.
+    :param drained: The entry returned by :func:`resolve_oldest` or
+        :func:`resolve_matching_text`.
+    """
+    entry = _Entry(
+        pending_id=drained.pending_id,
+        content=copy.deepcopy(drained.content),
+        created_by=drained.created_by,
+    )
+    with _lock:
+        entries = _pending.get(conversation_id, {})
+        _pending[conversation_id] = {drained.pending_id: entry, **entries}
+
+
 def resolve_matching_text(conversation_id: str, text: str) -> MatchedDrain:
     """
     Drain through the first pending entry whose text matches ``text``.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3086,11 +3086,12 @@ def _parse_external_conversation_item(
             "external_conversation_item data.response_id must be a non-empty string",
             code=ErrorCode.INVALID_INPUT,
         )
-    # NOTE: external conversation items are persisted with a random
-    # primary key like any other item — there is no server-side dedup.
-    # Producers (the claude-native / codex-native forwarders) are
-    # responsible for not re-posting records they have already sent;
-    # they no longer emit a ``source_id`` dedup key to the server.
+    # NOTE: producers that can re-post (the native transcript forwarders
+    # retry timed-out POSTs whose disposition they cannot know) send a
+    # ``data.source_id`` dedup key; the persist path derives the item's
+    # stable id from it so the append is idempotent (see
+    # ``_persist_external_conversation_item``). Items without one keep the
+    # store-assigned random id and no server-side dedup.
     # Cap a native tool result so a multi-MB output isn't persisted + broadcast as one frame.
     if item_type == "function_call_output" and isinstance(item_data.get("output"), str):
         item_data = {**item_data, "output": cap_tool_output(item_data["output"])}

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -13,6 +13,7 @@ import json
 import math
 import secrets
 import time
+import uuid
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, cast
 
@@ -2232,6 +2233,29 @@ async def _persist_external_conversation_item(
     :returns: Store-assigned conversation item id.
     """
     item = _parse_external_conversation_item(body)
+    # An at-least-once producer (the native transcript forwarders) retries a
+    # timed-out POST it cannot know the disposition of, so the item's id is
+    # derived from its ``source_id`` and the append is idempotent — the
+    # dedupe check rides the append's own transaction, under its
+    # conversation lock, costing the hot path no extra query. A dedupe hit
+    # comes back flagged so the duplicate's side effects are unwound below
+    # (no re-broadcast, and a wrongly-drained pending input is restored).
+    source_id = body.data.get("source_id")
+    if source_id is not None:
+        if not isinstance(source_id, str) or not source_id.strip() or len(source_id) > 256:
+            raise OmnigentError(
+                "external_conversation_item data.source_id must be a "
+                "non-empty string of at most 256 characters",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        item = item.model_copy(
+            update={
+                "stable_id": uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"omnigent-external-item:{session_id}:{source_id.strip()}",
+                ).hex
+            }
+        )
     # A native user message round-tripping back from the transcript:
     # drain its optimistic pending-input entry (FIFO) and fold the
     # entry's file blocks (image / file) into the item BEFORE persisting.
@@ -2241,6 +2265,7 @@ async def _persist_external_conversation_item(
     # Claude (not a queued web message) and has no pending entry, so
     # draining for it would hand the queued message's uploads to the marker.
     cleared_pending_id: str | None = None
+    drained: pending_inputs.DrainedInput | None = None
     skipped_kiro_pending: list[pending_inputs.DrainedInput] = []
     if (
         item.type == "message"
@@ -2271,22 +2296,32 @@ async def _persist_external_conversation_item(
             # No pending entry — direct terminal input. Fall back to the
             # identity authenticated on the forwarder's own request.
             item = item.model_copy(update={"created_by": created_by})
-    for skipped in skipped_kiro_pending:
-        await _persist_skipped_kiro_pending_input(
-            session_id,
-            skipped,
-            conversation_store,
-        )
     pending_background_title = prepare_background_session_title(
         coordinator=background_title_coordinator,
         conversation=conv,
         event=SessionEventInput(type=item.type, data=item.data.model_dump()),
     )
     persisted_items = await asyncio.to_thread(conversation_store.append, session_id, [item])
+    persisted = persisted_items[0]
+    if persisted.deduplicated:
+        # A re-post of an already-committed item: nothing new to render or
+        # title, and every pending entry the drain above consumed belongs
+        # to a LATER user message — put them back at the front in their
+        # original queue order (skipped entries preceded the match; restore
+        # prepends, so restore in reverse).
+        for entry in reversed([*skipped_kiro_pending, drained]):
+            if entry is not None:
+                pending_inputs.restore(session_id, entry)
+        return persisted.id
+    for skipped in skipped_kiro_pending:
+        await _persist_skipped_kiro_pending_input(
+            session_id,
+            skipped,
+            conversation_store,
+        )
     await _seed_missing_title_from_user_message(conv, item, conversation_store)
     if pending_background_title is not None:
         pending_background_title.schedule()
-    persisted = persisted_items[0]
     _publish_external_conversation_item(
         session_id, persisted, cleared_pending_id=cleared_pending_id
     )

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2296,6 +2296,23 @@ async def _persist_external_conversation_item(
             # No pending entry — direct terminal input. Fall back to the
             # identity authenticated on the forwarder's own request.
             item = item.model_copy(update={"created_by": created_by})
+    # Skipped Kiro entries persist BEFORE the matched item so their stored
+    # positions precede it, matching the live broadcast order — unless the
+    # matched item is a duplicate re-post, in which case the skipped drains
+    # belong to LATER messages and are restored (below), not persisted.
+    skipped_persisted = False
+    if skipped_kiro_pending:
+        matched_already_persisted = item.stable_id is not None and await asyncio.to_thread(
+            conversation_store.has_item, session_id, item.stable_id
+        )
+        if not matched_already_persisted:
+            for skipped in skipped_kiro_pending:
+                await _persist_skipped_kiro_pending_input(
+                    session_id,
+                    skipped,
+                    conversation_store,
+                )
+            skipped_persisted = True
     pending_background_title = prepare_background_session_title(
         coordinator=background_title_coordinator,
         conversation=conv,
@@ -2308,17 +2325,22 @@ async def _persist_external_conversation_item(
         # title, and every pending entry the drain above consumed belongs
         # to a LATER user message — put them back at the front in their
         # original queue order (skipped entries preceded the match; restore
-        # prepends, so restore in reverse).
-        for entry in reversed([*skipped_kiro_pending, drained]):
+        # prepends, so restore in reverse). Skipped entries persisted above
+        # (the probe raced a concurrent retry) stay persisted.
+        restorable = [drained] if skipped_persisted else [*skipped_kiro_pending, drained]
+        for entry in reversed(restorable):
             if entry is not None:
                 pending_inputs.restore(session_id, entry)
         return persisted.id
-    for skipped in skipped_kiro_pending:
-        await _persist_skipped_kiro_pending_input(
-            session_id,
-            skipped,
-            conversation_store,
-        )
+    if not skipped_persisted:
+        # Probe said duplicate but the append inserted anyway (row vanished
+        # in between): persist the skipped drains late rather than lose them.
+        for skipped in skipped_kiro_pending:
+            await _persist_skipped_kiro_pending_input(
+                session_id,
+                skipped,
+                conversation_store,
+            )
     await _seed_missing_title_from_user_message(conv, item, conversation_store)
     if pending_background_title is not None:
         pending_background_title.schedule()

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -629,6 +629,12 @@ class ConversationStore(ABC):
         Append items to a conversation. Assigns a globally unique
         ID and timestamp to each item.
 
+        An item carrying ``stable_id`` appends idempotently: its id is the
+        stable id, and when an item with that id already exists the stored
+        item is returned in its place — flagged ``deduplicated`` — instead
+        of inserting a duplicate. The existence check rides the append's
+        own transaction, so idempotency costs no extra query.
+
         :param conversation_id: Unique conversation identifier,
             e.g. ``"conv_abc123"``.
         :param items: List of :class:`NewConversationItem` objects

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -645,6 +645,24 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def has_item(self, conversation_id: str, item_id: str) -> bool:
+        """
+        Return whether an item with ``item_id`` exists in a conversation.
+
+        Existence probe for idempotent-append callers that must know
+        *before* appending whether a stable-id item is a duplicate
+        re-post, e.g. to decide whether order-sensitive sibling persists
+        that precede the append should run at all.
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Item id to probe, e.g. a stable id derived
+            from a forwarder ``source_id``.
+        :returns: ``True`` when the item is already persisted.
+        """
+        ...
+
+    @abstractmethod
     def list_conversations(
         self,
         limit: int = 20,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2127,12 +2127,12 @@ class SqlAlchemyConversationStore(ConversationStore):
                         for row, data in zip(existing_rows, decoded, strict=True)
                     }
                 )
-                if len(existing_by_id) == len(items):
+                if all(item.stable_id in existing_by_id for item in items):
                     # Pure duplicate re-post: nothing inserts, so leave
                     # ``updated_at`` and the position counter untouched — a
                     # retry must not make an old conversation look active.
-                    # Equality with len(items) implies every item carried a
-                    # stable id and every one was found.
+                    # Membership (not a length compare) so a batch repeating
+                    # one persisted stable id still counts as pure.
                     return [
                         deduped_by_id[item.stable_id]
                         for item in items
@@ -2242,6 +2242,30 @@ class SqlAlchemyConversationStore(ConversationStore):
                 conv_row.next_position = next_pos
 
         return persisted
+
+    def has_item(self, conversation_id: str, item_id: str) -> bool:
+        """
+        Return whether an item with ``item_id`` exists in a conversation.
+
+        Point lookup on the (workspace_id, conversation_id, id) primary
+        key; loads no item data. Used as the pre-append duplicate probe
+        for stable-id items (see :meth:`append`).
+
+        :param conversation_id: Unique conversation identifier,
+            e.g. ``"conv_abc123"``.
+        :param item_id: Item id to probe, e.g. a stable id derived
+            from a forwarder ``source_id``.
+        :returns: ``True`` when the item is already persisted.
+        """
+        with self._conv_session("has_conversation_item") as session:
+            row = session.execute(
+                select(SqlConversationItem.id).where(
+                    SqlConversationItem.workspace_id == current_workspace_id(),
+                    SqlConversationItem.conversation_id == conversation_id,
+                    SqlConversationItem.id == item_id,
+                )
+            ).first()
+            return row is not None
 
     def list_projects(
         self,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -2099,6 +2099,46 @@ class SqlAlchemyConversationStore(ConversationStore):
             # SQLite the database-level lock already serializes.
             self._lock_conversation(session, conversation_id)
 
+            # Idempotent-append probe: one query for the whole batch. Rows
+            # already persisted under a stable id ARE those items' append
+            # result; running under the lock just taken serializes with a
+            # concurrent retry (READ COMMITTED gives this statement a fresh
+            # snapshot after the lock wait), so it cannot double-insert.
+            stable_ids = [item.stable_id for item in items if item.stable_id is not None]
+            existing_by_id: dict[str, SqlConversationItem] = {}
+            deduped_by_id: dict[str, ConversationItem] = {}
+            if stable_ids:
+                existing_rows = (
+                    session.execute(
+                        select(SqlConversationItem).where(
+                            SqlConversationItem.workspace_id == current_workspace_id(),
+                            SqlConversationItem.conversation_id == conversation_id,
+                            SqlConversationItem.id.in_(stable_ids),
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                decoded = self._decode_item_data_batch([row.data for row in existing_rows])
+                existing_by_id = {row.id: row for row in existing_rows}
+                deduped_by_id.update(
+                    {
+                        row.id: _to_item(row, data).model_copy(update={"deduplicated": True})
+                        for row, data in zip(existing_rows, decoded, strict=True)
+                    }
+                )
+                if len(existing_by_id) == len(items):
+                    # Pure duplicate re-post: nothing inserts, so leave
+                    # ``updated_at`` and the position counter untouched — a
+                    # retry must not make an old conversation look active.
+                    # Equality with len(items) implies every item carried a
+                    # stable id and every one was found.
+                    return [
+                        deduped_by_id[item.stable_id]
+                        for item in items
+                        if item.stable_id is not None
+                    ]
+
             # Bump updated_at on the conversation.
             conv_row = session.get(SqlConversation, (current_workspace_id(), conversation_id))
             if conv_row is not None:
@@ -2134,11 +2174,24 @@ class SqlAlchemyConversationStore(ConversationStore):
             completed_status = encode_item_status("completed")  # items are final on append
             fts_rows: list[tuple[str, str, str]] = []
             row_values: list[dict[str, object]] = []
+            batch_stable: dict[str, ConversationItem] = {}
             for item, data in zip(items, encoded_data, strict=True):
+                if item.stable_id is not None:
+                    if item.stable_id in existing_by_id:
+                        persisted.append(deduped_by_id[item.stable_id])
+                        continue
+                    if item.stable_id in batch_stable:
+                        # Same stable id twice in one batch: the first
+                        # occurrence is this one's result too (inserting both
+                        # would collide on the primary key).
+                        persisted.append(
+                            batch_stable[item.stable_id].model_copy(update={"deduplicated": True})
+                        )
+                        continue
                 position = next_pos
                 next_pos += 1
                 search = self._item_search_text(item)
-                item_id = generate_item_id(item.type)
+                item_id = item.stable_id or generate_item_id(item.type)
                 values: dict[str, object] = {
                     "workspace_id": workspace_id,
                     "id": item_id,
@@ -2173,6 +2226,8 @@ class SqlAlchemyConversationStore(ConversationStore):
                         created_by=item.created_by,
                     )
                 )
+                if item.stable_id is not None:
+                    batch_stable[item.stable_id] = persisted[-1]
             # One executemany for the batch: positions are pre-allocated above so
             # the rows carry no inter-row dependency, and a single round-trip
             # persists all N. A per-row ORM add round-trips per item, which

--- a/tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py
+++ b/tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py
@@ -1,0 +1,357 @@
+"""End-to-end regression: transcript-forwarder retry re-posts must not
+duplicate conversation items, and cold-resume transcript synthesis must not
+copy pre-existing store duplicates into model context.
+
+Bug
+---
+``_post_external_conversation_item`` in ``omnigent/claude_native_forwarder.py``
+posts each mirrored transcript item as an ``external_conversation_item`` event.
+When the host is under load a POST can time out client-side after the server
+has already committed the item; the forwarder's retry loop then re-posts the
+identical payload. Without a server-side idempotency key each retry created a
+new, byte-identical ``conversation_items`` row. The duplicates rendered in the
+web UI and — because ``_ensure_local_claude_resume_transcript`` rebuilds
+Claude Code's local JSONL verbatim from server items — became real model
+context on every cold resume, inflating per-turn input cost.
+
+Two facets
+----------
+A. **Server-side**: re-posting the same ``external_conversation_item`` (same
+   ``source_id``) must persist exactly one row and return the same item id.
+B. **Client-side defense in depth**: ``_claude_transcript_records_from_session_items``
+   must drop adjacent byte-identical duplicates when synthesizing the resume
+   transcript, so a store already corrupted with duplicates stops compounding
+   them into context.
+
+Both tests FAIL on the unfixed build (three duplicate rows / three duplicate
+records) and PASS once the fix lands.
+
+Usage::
+
+    pytest tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py -v
+
+No ``--llm-api-key`` or ``--profile`` needed — no LLM is invoked.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from collections import Counter
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_free_port() -> int:
+    """Return an ephemeral TCP port the OS considers free right now."""
+    s = socket.socket()
+    s.bind(("", 0))
+    port: int = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _build_minimal_agent_bundle() -> bytes:
+    """Return a minimal agent bundle (tar.gz bytes) accepted by POST /v1/sessions."""
+    config = yaml.dump(
+        {
+            "spec_version": 1,
+            "name": "forwarder-dedup-test",
+            "executor": {
+                "type": "omnigent",
+                "config": {"harness": "openai-agents"},
+            },
+            "llm": {
+                "model": "forwarder-dedup-test",
+                "connection": {"api_key": "test-key"},
+            },
+        }
+    ).encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="config.yaml")
+        info.size = len(config)
+        tf.addfile(info, io.BytesIO(config))
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Fixture: minimal Omnigent server subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def forwarder_dedup_server() -> Iterator[str]:
+    """Start a minimal Omnigent server subprocess; yield its base URL.
+
+    Self-contained: does not use the session-scoped ``live_server`` fixture
+    (which needs ``--llm-api-key``).  Uses the same ``omnigent.cli server``
+    entrypoint the production server uses, backed by a throw-away SQLite DB.
+
+    :yields: Base URL, e.g. ``"http://127.0.0.1:<port>"``.
+    """
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    tmp_root = Path(tempfile.mkdtemp(prefix="forwarder-dedup-e2e-"))
+    db_path = tmp_root / "ap.db"
+    artifact_dir = tmp_root / "artifacts"
+    artifact_dir.mkdir()
+    log_path = tmp_root / "server.log"
+
+    env = os.environ.copy()
+    env["OPENAI_API_KEY"] = "stub-not-used"
+    # Pin single-user header auth: the test drives headerless requests, and
+    # an ambient developer/CI shell exporting OMNIGENT_AUTH_ENABLED (or OIDC
+    # vars) would boot the server in login mode and 401 every call.
+    env["OMNIGENT_AUTH_PROVIDER"] = "header"
+    env["OMNIGENT_LOCAL_SINGLE_USER"] = "1"
+    # Strip credentials/config that would alter server behaviour in CI.
+    for var in (
+        "DATABRICKS_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "OMNIGENT_AUTH_ENABLED",
+        "OMNIGENT_OIDC_ISSUER",
+        "OMNIGENT_ACCOUNTS_COOKIE_SECRET",
+        "OMNIGENT_RUNNER_TUNNEL_TOKEN",
+    ):
+        env.pop(var, None)
+    # Always prepend the worktree so the server imports the branch under test.
+    existing_pp = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{_REPO_ROOT}{os.pathsep}{existing_pp}" if existing_pp else str(_REPO_ROOT)
+    )
+
+    log_handle = open(log_path, "w")  # noqa: SIM115 — subprocess holds the FD
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent.cli",
+            "server",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{db_path}",
+            "--artifact-location",
+            str(artifact_dir),
+        ],
+        env=env,
+        cwd=str(_REPO_ROOT),
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            try:
+                resp = httpx.get(f"{base_url}/health", timeout=2.0)
+                if resp.status_code == 200:
+                    break
+            except (httpx.ConnectError, httpx.ReadError):
+                pass
+            time.sleep(0.2)
+        else:
+            proc.terminate()
+            log_handle.close()
+            log_text = log_path.read_text(errors="replace")
+            raise RuntimeError(
+                f"Omnigent server failed to start within 30 s. Log tail:\n{log_text[-2000:]}"
+            )
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        log_handle.close()
+
+
+@pytest.fixture(scope="module")
+def forwarder_dedup_client(forwarder_dedup_server: str) -> Iterator[httpx.Client]:
+    """HTTP client pointed at the test server.
+
+    :param forwarder_dedup_server: Base URL from :func:`forwarder_dedup_server`.
+    :yields: A configured :class:`httpx.Client`.
+    """
+    with httpx.Client(base_url=forwarder_dedup_server, timeout=30.0) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def forwarder_dedup_session_id(forwarder_dedup_client: httpx.Client) -> str:
+    """Create a real session and return its id.
+
+    Uploads a minimal agent bundle so the session row exists in the DB
+    (the events route checks session existence before accepting).
+
+    :param forwarder_dedup_client: Live server HTTP client.
+    :returns: The session/conversation id string.
+    """
+    bundle = _build_minimal_agent_bundle()
+    resp = forwarder_dedup_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+    assert resp.status_code in (200, 201), (
+        f"Session create failed {resp.status_code}: {resp.text[:400]}"
+    )
+    data = resp.json()
+    session_id: str = data.get("id") or data.get("session_id") or ""
+    assert session_id, f"No session id in response: {data}"
+    return session_id
+
+
+# ---------------------------------------------------------------------------
+# Facet A: server-side idempotent persistence keyed on source_id
+# ---------------------------------------------------------------------------
+
+
+def test_external_item_retry_reposts_persist_once(
+    forwarder_dedup_client: httpx.Client,
+    forwarder_dedup_session_id: str,
+) -> None:
+    """Re-posting the same ``external_conversation_item`` stores one row.
+
+    Simulates the forwarder's retry loop after a client-side timeout whose
+    server disposition is unknown: the identical payload (same ``source_id``
+    idempotency key, as the fixed forwarder sends) is POSTed three times.
+
+    The server must treat the retries as re-posts of the committed item:
+    every POST returns the same ``item_id`` and the items list contains
+    exactly one copy.  On the unfixed build each POST inserted a distinct,
+    byte-identical row (this test then fails with sentinel_count == 3).
+    """
+    payload = {
+        "type": "external_conversation_item",
+        "data": {
+            "item_type": "message",
+            "item_data": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "retry-duplicate-sentinel-server",
+                    }
+                ],
+            },
+            "response_id": "resp_forwarder_retry_facet_a",
+            # The forwarder's stable per-item idempotency key, re-sent
+            # verbatim on every retry of the same item.
+            "source_id": "11111111-2222-3333-4444-555555555555:0:message",
+        },
+    }
+
+    item_ids: list[str] = []
+    for attempt in range(3):
+        resp = forwarder_dedup_client.post(
+            f"/v1/sessions/{forwarder_dedup_session_id}/events",
+            json=payload,
+        )
+        assert resp.status_code in (200, 202), (
+            f"POST attempt {attempt} failed {resp.status_code}: {resp.text[:400]}"
+        )
+        item_id = resp.json().get("item_id", "")
+        assert item_id, f"No item_id in response on attempt {attempt}: {resp.json()}"
+        item_ids.append(item_id)
+
+    items_resp = forwarder_dedup_client.get(
+        f"/v1/sessions/{forwarder_dedup_session_id}/items",
+        params={"limit": 100, "order": "asc"},
+    )
+    assert items_resp.status_code == 200, (
+        f"GET items failed {items_resp.status_code}: {items_resp.text[:400]}"
+    )
+    items = items_resp.json().get("data", [])
+
+    sentinel = "retry-duplicate-sentinel-server"
+    counts = Counter(
+        block.get("text", "")
+        for item in items
+        for block in item.get("content", [])
+        if isinstance(block, dict) and block.get("type") == "input_text"
+    )
+    sentinel_count = counts.get(sentinel, 0)
+
+    assert sentinel_count == 1, (
+        f"Expected exactly 1 persisted copy of a retried external item, got "
+        f"{sentinel_count}. Multiple copies mean the server appended a new row "
+        f"per retry instead of deduplicating on source_id. item_ids: {item_ids}"
+    )
+    assert len(set(item_ids)) == 1, (
+        f"Expected every retry POST to return the same item_id, got {set(item_ids)}. "
+        f"Distinct ids mean the server created a new row per POST — the bug."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Facet B: resume-transcript synthesis must drop adjacent duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_resume_transcript_drops_adjacent_duplicate_items() -> None:
+    """``_claude_transcript_records_from_session_items`` collapses adjacent
+    byte-identical items into one record.
+
+    Defense in depth for a store already corrupted with retry duplicates:
+    ``_ensure_local_claude_resume_transcript`` rebuilds Claude Code's JSONL
+    from server items on cold resume, and without adjacent-duplicate
+    filtering every duplicate became real model context on every subsequent
+    turn.  On the unfixed build three identical inputs produced three
+    records (this test then fails with sentinel_count == 3).
+    """
+    from omnigent.claude_native import _claude_transcript_records_from_session_items
+
+    duplicate_item = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": "resume-duplicate-sentinel-client",
+            }
+        ],
+    }
+    # Simulate three identical store rows (the result of three retry re-posts).
+    items = [duplicate_item, duplicate_item, duplicate_item]
+
+    records = _claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_forwarder_dedup_test",
+        external_session_id="12345678-0000-0000-0000-000000000001",
+        cwd=Path(tempfile.gettempdir()),
+        bridge_dir=Path(tempfile.gettempdir()) / "bridge",
+    )
+
+    sentinel = "resume-duplicate-sentinel-client"
+    sentinel_count = sum(1 for r in records if sentinel in json.dumps(r))
+
+    assert sentinel_count == 1, (
+        f"Expected 1 record from 3 byte-identical adjacent items (adjacent-"
+        f"duplicate filtering), got {sentinel_count}. Every surplus record is "
+        f"duplicated model context replayed on each resumed turn. "
+        f"Records: {records}"
+    )
+    assert len(records) == 1, (
+        f"Expected 1 output record from 3 identical input items, got "
+        f"{len(records)}. Records: {records}"
+    )

--- a/tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py
+++ b/tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py
@@ -122,16 +122,21 @@ def forwarder_dedup_server() -> Iterator[str]:
     # vars) would boot the server in login mode and 401 every call.
     env["OMNIGENT_AUTH_PROVIDER"] = "header"
     env["OMNIGENT_LOCAL_SINGLE_USER"] = "1"
-    # Strip credentials/config that would alter server behaviour in CI.
-    for var in (
-        "DATABRICKS_TOKEN",
-        "ANTHROPIC_API_KEY",
-        "OMNIGENT_AUTH_ENABLED",
-        "OMNIGENT_OIDC_ISSUER",
-        "OMNIGENT_ACCOUNTS_COOKIE_SECRET",
-        "OMNIGENT_RUNNER_TUNNEL_TOKEN",
-    ):
-        env.pop(var, None)
+    # Strip ambient credentials/config that would alter server behaviour in
+    # CI: any Databricks or OIDC setting, any cookie/signing secret, and the
+    # specific provider/tunnel vars below.
+    for var in list(env):
+        if (
+            var.startswith(("DATABRICKS_", "OMNIGENT_OIDC_"))
+            or var.endswith("_SECRET")
+            or var
+            in (
+                "ANTHROPIC_API_KEY",
+                "OMNIGENT_AUTH_ENABLED",
+                "OMNIGENT_RUNNER_TUNNEL_TOKEN",
+            )
+        ):
+            env.pop(var, None)
     # Always prepend the worktree so the server imports the branch under test.
     existing_pp = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = (

--- a/tests/runtime/test_pending_inputs.py
+++ b/tests/runtime/test_pending_inputs.py
@@ -347,3 +347,25 @@ def test_stale_entries_evicted_after_ttl(monkeypatch: pytest.MonkeyPatch) -> Non
     # Past the TTL: the lazy sweep on the next access evicts the ghost.
     clock["t"] = 1000.0 + pending_inputs._TTL_S + 0.1
     assert pending_inputs.snapshot_for("conv_a") == []
+
+
+def test_restore_returns_a_drained_entry_to_the_front() -> None:
+    """A restored entry reclaims the head of the FIFO.
+
+    Compensation for a drain whose persist deduplicated (the entry
+    belongs to the NEXT user message): the entry was the oldest when
+    drained, so it must come back ahead of everything queued after it.
+    """
+    first = pending_inputs.record("conv_r", [_text_block("first")])
+    second = pending_inputs.record("conv_r", [_text_block("second")])
+
+    drained = pending_inputs.resolve_oldest("conv_r")
+    assert drained is not None and drained.pending_id == first
+
+    pending_inputs.restore("conv_r", drained)
+    order = [e["pending_id"] for e in pending_inputs.snapshot_for("conv_r")]
+    assert order == [first, second]
+
+    # The restored entry drains again as the oldest.
+    redrained = pending_inputs.resolve_oldest("conv_r")
+    assert redrained is not None and redrained.pending_id == first

--- a/tests/server/integration/test_sessions_external_item_idempotency.py
+++ b/tests/server/integration/test_sessions_external_item_idempotency.py
@@ -1,0 +1,153 @@
+"""A re-posted external item with a ``source_id`` must persist exactly once.
+
+The native transcript forwarders deliver at-least-once: a timed-out POST's
+disposition is unknown, so the same item may be re-posted — and leaked
+concurrent forwarders tailing one transcript post the same records in
+parallel. ``data.source_id`` makes the persist idempotent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runtime import pending_inputs
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_session(client: httpx.AsyncClient, name: str) -> str:
+    agent = await create_test_agent(client, name=name)
+    resp = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _post_item(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    text: str,
+    source_id: str | None,
+    role: str = "user",
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "item_type": "message",
+        "item_data": {
+            "role": role,
+            "content": [{"type": "input_text", "text": text}],
+            **({"agent": "worker"} if role == "assistant" else {}),
+        },
+        "response_id": "resp_claude_echo",
+    }
+    if source_id is not None:
+        data["source_id"] = source_id
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_conversation_item", "data": data},
+    )
+    assert resp.status_code in (200, 201, 202), resp.text
+    return resp.json()
+
+
+async def _message_texts(client: httpx.AsyncClient, session_id: str) -> list[str]:
+    items = (await client.get(f"/v1/sessions/{session_id}/items")).json()["data"]
+    return [
+        block.get("text", "")
+        for item in items
+        if item.get("type") == "message"
+        for block in item.get("content", [])
+    ]
+
+
+async def test_reposted_item_with_source_id_persists_once(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id = await _create_session(client, "idem-repost")
+    first = await _post_item(client, session_id, text="hello once", source_id="rec-1:0:message")
+    second = await _post_item(client, session_id, text="hello once", source_id="rec-1:0:message")
+    assert first["item_id"] == second["item_id"]
+    assert await _message_texts(client, session_id) == ["hello once"]
+
+
+async def test_distinct_source_ids_persist_separately(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id = await _create_session(client, "idem-distinct")
+    await _post_item(client, session_id, text="same text", source_id="rec-1:0:message")
+    await _post_item(client, session_id, text="same text", source_id="rec-2:0:message")
+    assert await _message_texts(client, session_id) == ["same text", "same text"]
+
+
+async def test_repost_without_source_id_keeps_legacy_behavior(
+    client: httpx.AsyncClient,
+) -> None:
+    session_id = await _create_session(client, "idem-legacy")
+    await _post_item(client, session_id, text="legacy", source_id=None)
+    await _post_item(client, session_id, text="legacy", source_id=None)
+    assert await _message_texts(client, session_id) == ["legacy", "legacy"]
+
+
+async def test_duplicate_repost_restores_the_drained_pending_input(
+    client: httpx.AsyncClient,
+) -> None:
+    """A duplicate must not consume the NEXT queued web message's entry.
+
+    The persist path drains the oldest pending input before it knows the
+    item is a duplicate; the dedupe result restores that entry to the
+    front of the queue so the next genuine message still claims it.
+    """
+    session_id = await _create_session(client, "idem-pending")
+    await _post_item(client, session_id, text="first msg", source_id="rec-1:0:message")
+
+    next_pending = pending_inputs.record(
+        session_id,
+        [{"type": "input_text", "text": "second msg"}],
+        created_by="alice@example.com",
+    )
+    # Duplicate of the already-persisted first message arrives late.
+    await _post_item(client, session_id, text="first msg", source_id="rec-1:0:message")
+
+    snapshot = pending_inputs.snapshot_for(session_id)
+    assert [entry["pending_id"] for entry in snapshot] == [next_pending]
+    assert await _message_texts(client, session_id) == ["first msg"]
+
+
+async def test_bad_source_id_is_rejected(client: httpx.AsyncClient) -> None:
+    session_id = await _create_session(client, "idem-bad")
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "message",
+                "item_data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "x"}],
+                },
+                "response_id": "resp_claude_echo",
+                "source_id": "x" * 300,
+            },
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_client_cannot_smuggle_a_stable_id() -> None:
+    """``stable_id`` is internal-only: a client key inside event data is
+    dropped by the item builder, never bound onto the entity."""
+    from omnigent.server.routes._sessions.helpers import _build_new_item
+    from omnigent.server.schemas import SessionEventInput
+
+    body = SessionEventInput(
+        type="message",
+        data={
+            "role": "user",
+            "content": [{"type": "input_text", "text": "x"}],
+            "stable_id": "ab" * 16,
+        },
+    )
+    assert _build_new_item(body, "resp").stable_id is None

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -233,6 +233,16 @@ class _ConversationStore:
             result.append(persisted)
         return result
 
+    def has_item(self, conversation_id: str, item_id: str) -> bool:
+        """Return whether an appended item carries ``item_id``.
+
+        :param conversation_id: The conversation id (unused).
+        :param item_id: Item id to probe.
+        :returns: ``True`` when a recorded item has that id.
+        """
+        del conversation_id
+        return any(item.id == item_id for item in self.appended_items)
+
     def list_items(
         self,
         conversation_id: str,
@@ -4268,6 +4278,130 @@ async def test_kiro_external_prompt_matches_pending_and_reports_skipped_input() 
         assert matched_user.data.content == [{"type": "input_text", "text": "tell me a joke"}]
         assert matched_user.created_by == "alice@example.com"
         assert first != second
+    finally:
+        pending_inputs.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_kiro_skipped_entries_persist_before_the_matched_item() -> None:
+    """Failed Kiro prompts must precede the accepted prompt in stored order."""
+    from omnigent.runtime import pending_inputs
+    from omnigent.server.routes.sessions import _persist_external_conversation_item
+
+    pending_inputs.reset_for_tests()
+    store = _ConversationStore()
+    sid = "823dbd1aab969b5a813fac59bb977a77"
+    conv = store.get_conversation(sid)
+    assert conv is not None
+    for text in ("first failed", "second failed", "tell me a joke"):
+        pending_inputs.record(
+            sid, [{"type": "input_text", "text": text}], created_by="alice@example.com"
+        )
+    body = SessionEventInput(
+        type="external_conversation_item",
+        data={
+            "item_type": "message",
+            "item_data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "tell me a joke"}],
+            },
+            "response_id": "kiro:prompt-joke",
+            "source_id": "kiro:prompt-joke:0",
+        },
+    )
+
+    try:
+        item_id = await _persist_external_conversation_item(
+            sid,
+            conv,
+            body,
+            store,  # type: ignore[arg-type]
+        )
+
+        # Stored order mirrors the live broadcast: both skipped web inputs
+        # (each a user message + error pair) precede the accepted prompt.
+        assert [i.type for i in store.appended_items] == [
+            "message",
+            "error",
+            "message",
+            "error",
+            "message",
+        ]
+        first_user, _err1, second_user, _err2, matched_user = store.appended_items
+        assert first_user.data.content == [{"type": "input_text", "text": "first failed"}]
+        assert second_user.data.content == [{"type": "input_text", "text": "second failed"}]
+        assert matched_user.data.content == [{"type": "input_text", "text": "tell me a joke"}]
+        assert item_id == matched_user.id
+        assert pending_inputs.snapshot_for(sid) == []
+    finally:
+        pending_inputs.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_kiro_duplicate_repost_restores_skipped_entries_unpersisted() -> None:
+    """A duplicate re-post restores skipped drains instead of persisting them."""
+    from omnigent.runtime import pending_inputs
+    from omnigent.server.routes.sessions import _persist_external_conversation_item
+
+    class _DedupingStore(_ConversationStore):
+        """Store whose matched item is already persisted: every append dedupes."""
+
+        def has_item(self, conversation_id: str, item_id: str) -> bool:
+            del conversation_id, item_id
+            return True
+
+        def append(self, conversation_id: str, items: list[Any]) -> list[Any]:
+            del conversation_id
+            return [
+                ConversationItem(
+                    id=item.stable_id,
+                    type=item.type,
+                    status="completed",
+                    response_id=item.response_id,
+                    created_at=1,
+                    data=item.data,
+                    deduplicated=True,
+                )
+                for item in items
+            ]
+
+    pending_inputs.reset_for_tests()
+    store = _DedupingStore()
+    sid = "823dbd1aab969b5a813fac59bb977a77"
+    conv = store.get_conversation(sid)
+    assert conv is not None
+    recorded = [
+        pending_inputs.record(
+            sid, [{"type": "input_text", "text": text}], created_by="alice@example.com"
+        )
+        for text in ("first failed", "second failed", "tell me a joke")
+    ]
+    body = SessionEventInput(
+        type="external_conversation_item",
+        data={
+            "item_type": "message",
+            "item_data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "tell me a joke"}],
+            },
+            "response_id": "kiro:prompt-joke",
+            "source_id": "kiro:prompt-joke:0",
+        },
+    )
+
+    try:
+        await _persist_external_conversation_item(
+            sid,
+            conv,
+            body,
+            store,  # type: ignore[arg-type]
+        )
+
+        # Nothing persisted (no error items for the skipped drains), and the
+        # queue is back in its original order for the next genuine message.
+        assert store.appended_items == []
+        snapshot = pending_inputs.snapshot_for(sid)
+        assert [entry["pending_id"] for entry in snapshot] == recorded
     finally:
         pending_inputs.reset_for_tests()
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -6137,3 +6137,121 @@ def test_get_conversation_keeps_distinct_query_names(
         "omnigent.conversation_store.select_conversation_metadata_by_id",
         "omnigent.conversation_store.select_conversation_labels",
     ], names
+
+
+# ── Idempotent append (stable_id) ─────────────────────
+
+
+def test_append_with_stable_id_is_idempotent(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A re-append under the same stable id returns the stored item once.
+
+    The retry contract for at-least-once producers (transcript
+    forwarders): a timed-out POST's disposition is unknown, so the same
+    item may arrive again — and concurrent forwarders tailing one
+    transcript derive the same stable id for the same record.
+    """
+    conv = conversation_store.create_conversation()
+    stable = "ab" * 16
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id=stable,
+    )
+    [first] = conversation_store.append(conv.id, [item])
+    assert first.id == stable
+    assert first.deduplicated is False
+
+    [second] = conversation_store.append(conv.id, [item])
+    assert second.id == stable
+    assert second.deduplicated is True
+
+    page = conversation_store.list_items(conv.id)
+    assert [i.id for i in page.data if i.id == stable] == [stable]
+
+
+def test_append_without_stable_id_still_duplicates(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """No stable id keeps the legacy contract: every append inserts."""
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+    )
+    [a] = conversation_store.append(conv.id, [item])
+    [b] = conversation_store.append(conv.id, [item])
+    assert a.id != b.id
+    assert b.deduplicated is False
+
+
+def test_append_dedupe_does_not_burn_a_position(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A dedupe hit allocates no position: later items stay contiguous."""
+    conv = conversation_store.create_conversation()
+    stable = "cd" * 16
+    dup = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "one"}]),
+        stable_id=stable,
+    )
+    conversation_store.append(conv.id, [dup])
+    # duplicate + a genuinely new item in one batch
+    fresh = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(
+            role="assistant",
+            content=[{"type": "output_text", "text": "two"}],
+            agent="worker",
+        ),
+    )
+    [got_dup, got_fresh] = conversation_store.append(conv.id, [dup, fresh])
+    assert got_dup.deduplicated is True
+    assert got_fresh.deduplicated is False
+    page = conversation_store.list_items(conv.id)
+    assert len(page.data) == 2
+
+
+def test_pure_dedupe_append_leaves_conversation_metadata_alone(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A duplicate-only re-post must not make the conversation look active."""
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id="ef" * 16,
+    )
+    conversation_store.append(conv.id, [item])
+    before = conversation_store.get_conversation(conv.id)
+    assert before is not None
+
+    conversation_store.append(conv.id, [item])
+    after = conversation_store.get_conversation(conv.id)
+    assert after is not None
+    assert after.updated_at == before.updated_at
+
+
+def test_same_stable_id_twice_in_one_batch_inserts_once(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """In-batch twins collapse instead of colliding on the primary key."""
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id="0a" * 16,
+    )
+    [a, b] = conversation_store.append(conv.id, [item, item])
+    assert a.id == b.id
+    assert a.deduplicated is False
+    assert b.deduplicated is True
+    assert len(conversation_store.list_items(conv.id).data) == 1

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -6255,3 +6255,55 @@ def test_same_stable_id_twice_in_one_batch_inserts_once(
     assert a.deduplicated is False
     assert b.deduplicated is True
     assert len(conversation_store.list_items(conv.id).data) == 1
+
+
+def test_repeated_persisted_twin_batch_leaves_conversation_metadata_alone(
+    conversation_store: SqlAlchemyConversationStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry batch repeating one already-persisted stable id is a pure duplicate.
+
+    Concurrent forwarders can deliver the same record twice in one batch
+    after it already persisted: every item resolves to the stored row, so
+    nothing inserts and the conversation must not look active.
+    """
+    import omnigent.stores.conversation_store.sqlalchemy_store as store_mod
+
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 1000)
+    conv = conversation_store.create_conversation()
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id="1b" * 16,
+    )
+    conversation_store.append(conv.id, [item])
+
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 2000)
+    [a, b] = conversation_store.append(conv.id, [item, item])
+    assert a.deduplicated is True
+    assert b.deduplicated is True
+    assert a.id == b.id
+    after = conversation_store.get_conversation(conv.id)
+    assert after is not None
+    assert after.updated_at == 1000
+    assert len(conversation_store.list_items(conv.id).data) == 1
+
+
+def test_has_item_probes_persisted_ids(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """``has_item`` sees a persisted stable id, scoped to its conversation."""
+    conv = conversation_store.create_conversation()
+    other = conversation_store.create_conversation()
+    stable = "2c" * 16
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_x",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "hi"}]),
+        stable_id=stable,
+    )
+    assert conversation_store.has_item(conv.id, stable) is False
+    conversation_store.append(conv.id, [item])
+    assert conversation_store.has_item(conv.id, stable) is True
+    assert conversation_store.has_item(other.id, stable) is False

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -8428,6 +8428,124 @@ def test_claude_transcript_records_handles_compaction_item() -> None:
     assert boundaries[0]["compactMetadata"]["postTokens"] == 4321
 
 
+def test_transcript_records_drop_adjacent_store_duplicates() -> None:
+    """Adjacent items identical apart from id/created_at collapse to one record.
+
+    A forwarder retry re-post persists as an adjacent row that differs only
+    in the store envelope (id, created_at). The resume-transcript builder
+    must emit one record for the run so store duplicates don't become
+    duplicated model context on every cold resume.
+    """
+    items: list[dict[str, Any]] = [
+        {
+            "id": "msg_1",
+            "created_at": 100,
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "same payload"}],
+            "response_id": "resp_1",
+        },
+        {
+            "id": "msg_2",
+            "created_at": 105,
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "same payload"}],
+            "response_id": "resp_1",
+        },
+        {
+            "id": "msg_3",
+            "created_at": 110,
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "reply"}],
+            "response_id": "resp_1",
+        },
+    ]
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+        bridge_dir=Path("/tmp/test-bridge"),
+    )
+    user_records = [r for r in records if r.get("type") == "user"]
+    assert len(user_records) == 1, f"Expected 1 user record, got {user_records}"
+    assert len(records) == 2
+    # Parent chain stays intact across the dropped duplicate.
+    assert records[1]["parentUuid"] == records[0]["uuid"]
+
+
+def test_transcript_records_keep_genuine_repeats_across_turns() -> None:
+    """A user genuinely repeating a message in a later turn is NOT collapsed.
+
+    Genuine repeats differ in ``response_id`` (a new turn), so the
+    envelope-ignoring comparison keeps both. Only retry re-posts — same
+    payload AND same response_id — collapse.
+    """
+    items: list[dict[str, Any]] = [
+        {
+            "id": "msg_1",
+            "created_at": 100,
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "try again"}],
+            "response_id": "resp_1",
+        },
+        {
+            "id": "msg_2",
+            "created_at": 200,
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "try again"}],
+            "response_id": "resp_2",
+        },
+    ]
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+        bridge_dir=Path("/tmp/test-bridge"),
+    )
+    assert len(records) == 2, f"Genuine repeats must both survive: {records}"
+
+
+def test_transcript_records_collapse_runs_of_three_or_more_duplicates() -> None:
+    """A run of N adjacent duplicates (multi-retry) collapses to one record,
+    and the item after the run still chains to the survivor."""
+    duplicate = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "retried thrice"}],
+        "response_id": "resp_1",
+    }
+    items: list[dict[str, Any]] = [
+        {**duplicate, "id": f"msg_{n}", "created_at": 100 + n} for n in range(4)
+    ]
+    items.append(
+        {
+            "id": "msg_after",
+            "created_at": 300,
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "done"}],
+            "response_id": "resp_1",
+        }
+    )
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_test",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+        bridge_dir=Path("/tmp/test-bridge"),
+    )
+    assert len(records) == 2
+    assert records[0]["type"] == "user"
+    assert records[1]["type"] == "assistant"
+    assert records[1]["parentUuid"] == records[0]["uuid"]
+
+
 def test_websocket_connect_passes_ssl_context_for_wss(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -1205,6 +1205,9 @@ async def test_forwarder_posts_visible_transcript_items(tmp_path: Path) -> None:
         "terminal_command",
         "terminal_command",
     ]
+    # Every item carries its server-side idempotency key: a retried or
+    # concurrently re-posted record must dedupe on the server.
+    assert all(isinstance(item.get("source_id"), str) and item["source_id"] for item in posted)
     assert posted[0]["item_data"] == {
         "role": "user",
         "content": [{"type": "input_text", "text": "read TODO"}],


### PR DESCRIPTION
<!-- maintenance-decision-6368 -->
> [!NOTE]
> **Maintenance decision — 2026-09-05:** Closing this draft and removing it from the personal staging and production ring pin lists. The timeout-after-server-commit followed by a client retry is a real edge case and has occurred, but it is rare. Keeping a separate contributor copy rebased across fast-moving session and store code is not worth the continuing maintenance cost. [#5955](https://github.com/omnigent-ai/omnigent/pull/5955) remains the canonical upstream proposal; this branch will not be rebased or maintained further.## Related issue

Closes #5180 (the GitHub mirror of Linear OMNI-4486)

Supersedes #5955 — the resolve agent's carry of my #5181. That branch is bot-owned (no `maintainerCanModify`, no push from a fork), and it went CONFLICTING against `main` once the store started batch-encoding item payloads before the write transaction. This PR carries the same five commits, rebased onto current `main` with the conflicts resolved; the bot's commits keep their authorship and now carry a DCO `Signed-off-by`.

**Rebase resolution (2 files):**
- `omnigent/stores/conversation_store/sqlalchemy_store.py` — the stable-id dedup branch is folded into `main`'s new `for item, data in zip(items, encoded_data, strict=True)` loop. Encoding runs before the transaction and depends only on item data, so a deduplicated item simply skips its pre-encoded payload; no behaviour change.
- `tests/stores/test_conversation_store.py` — `main`'s connection-checkout-budget section and this PR's idempotent-append section were appended at the same spot; both kept.

## Summary

A claude-native session accumulated ~20% duplicated history (byte-identical `conversation_items` rows), which cold resume then replayed as **real model context** every turn. Root cause and fix, in two facets:

- **Server-side (root cause):** the transcript forwarder posts `external_conversation_item` events, and a client-side timeout after the server had already committed made its retry loop re-post the identical payload; the server had no idempotency key, so each retry inserted a new row. Fix: the forwarder now sends its per-item `source_id`; the server derives the item id via `uuid5(conversation_id, source_id)` and treats a persist of an already-existing stable id as that append's result (side effects unwound), so every retry returns the same `item_id` and exactly one row exists. Pure-duplicate batches and Kiro skipped-entry ordering are kept intact.
- **Client-side amplifier:** `_claude_transcript_records_from_session_items` copied *all* store duplicates verbatim into Claude Code's cold-resume JSONL. It now drops adjacent items that are identical apart from the store envelope (`id`/`created_at`), so stores already corrupted with duplicates — and legacy producers without a `source_id` — stop compounding duplicates into resumed model context (parent-uuid chain kept intact).

**ELI5:** the app sometimes hiccuped and saved the same chat message twice; then, when you reopened the chat, it read the double message back to the AI forever (and you paid for it). Now saving the same message twice is a no-op, and reopening skips accidental doubles.

```
forwarder ── POST external_conversation_item (source_id) ──▶ server
   │   timeout, retry                                          │ uuid5(conv, source_id)
   └── POST identical payload ────────────────────────────────▶│ same id → no new row
cold resume: store items ──▶ _claude_transcript_records… ──▶ JSONL
                              └─ adjacent byte-dup? drop ──────┘
```

Known, documented trade-offs (flagged in the #5955 review): the pending-input drain-before-append window and the Kiro has_item→append TOCTOU are pre-existing in structure and strictly less harmful than the status quo (previously every duplicate permanently consumed a pending entry *and* inserted a row); left as follow-ups.

## Test Plan

Re-verified on the rebased head against current `main`:

- `uv run pytest tests/stores/test_conversation_store.py tests/server/routes/test_session_resources.py tests/server/integration/test_sessions_external_item_idempotency.py tests/test_claude_native.py tests/test_claude_native_forwarder.py tests/runtime/test_pending_inputs.py tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py` — 902 passed, 1 skipped.
- `ruff check` / `ruff format --check` clean; `pyrefly check` reports the same pre-existing errors as `main`, none in touched files.

Fail→pass proof carried from #5955 (each fails on unfixed `main`, passes on this branch):

- **E2E** `tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py` — boots a real server; facet A: POSTs the same `external_conversation_item` (same `source_id`) 3× — unfixed: 3 distinct `item_id`s / 3 byte-identical rows → fixed: same `item_id` each time, exactly 1 row. Facet B: 3 identical store items → unfixed: 3 resume records → fixed: 1 record, parent chain intact. No LLM needed.
- **Unit/integration:** idempotent append under a stable id, in-batch twins collapse, pure-duplicate re-post leaves `updated_at` and the position counter untouched, pending-input restore on a deduplicated persist, adjacent-dedup on resume (drops store duplicates, keeps genuine repeats across turns, collapses runs of ≥3).

## Validate the fix live

This fix runs in the **runner/host process as well as the server**, so check out the PR — attaching a local runner to a deployed preview would run an *unfixed* runner half:

```
gh pr checkout 6368
omnigent claude -p 'Reproduce and validate a bug fix. Steps: in a claude-native session, POST the same external_conversation_item event (same data.source_id) to /v1/sessions/{id}/events three times, then GET /v1/sessions/{id}/items. Before this fix, three byte-identical rows appeared and cold resume replayed them as duplicated model context. Confirm the fix: all three POSTs return the same item_id, the items list has exactly one copy, and after killing the pane and cold-resuming, the rebuilt transcript contains no adjacent duplicate records. Report whether each step now behaves correctly.' --server ''
```

`--server ''` runs a local server from this checkout so the server *and* runner are the PR build.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Backend-only fix (no UI surface changed): the reproduction is API/transcript-level. Evidence: the E2E test's fail→pass transition in Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

All three layers carry fail→pass tests keyed to the concrete failure (duplicate rows / duplicate resume records), not existence checks.

## Changelog

Claude Code sessions no longer duplicate transcript items on forwarder retries, and cold resume no longer replays accidental duplicates as model context