### PR TITLE
Fix sharing revoke and jump-to-top E2E flakes

### DIFF
--- a/tests/e2e_ui/collaboration/test_sharing_journey.py
+++ b/tests/e2e_ui/collaboration/test_sharing_journey.py
@@ -145,16 +145,18 @@ def _goto_expecting_snapshot(page: Page, base_url: str, session_id: str) -> int:
     assertions deterministic: a 404 means the SPA cannot render a
     composer afterwards, with no settle-time race.
     """
+    request_id = uuid.uuid4().hex
+    page_url = f"{base_url}/c/{session_id}?e2e_snapshot_request={request_id}"
     with page.expect_response(
-        # Match on the path: the chat surface requests the slim snapshot
-        # (?include_items=false&include_liveness=false), so the URL no
-        # longer *ends* with the session id.
+        # A previous document can still have a snapshot in flight when the
+        # next navigation begins. Match the same-origin referrer of this load.
         lambda r: (
             r.url.split("?")[0].endswith(f"/v1/sessions/{session_id}")
             and r.request.method == "GET"
+            and f"e2e_snapshot_request={request_id}" in r.request.headers.get("referer", "")
         )
     ) as resp_info:
-        page.goto(f"{base_url}/c/{session_id}")
+        page.goto(page_url)
     return resp_info.value.status
 
 

--- a/web/src/components/chat/chatBubbleParts.tsx
+++ b/web/src/components/chat/chatBubbleParts.tsx
@@ -1349,13 +1349,17 @@ export function JumpToTopButton({
     const onScroll = () => {
       const top = scrollEl.scrollTop;
       const next = top <= 1;
+      const atBottom = top >= scrollEl.scrollHeight - scrollEl.clientHeight - 1;
       setAtTop((prev) => (prev === next ? prev : next));
       // Upward scroll (and not already pinned to the top): show the pill and
       // (re)arm the idle timer that fades it out once scrolling settles.
-      if (top < lastTop - 1 && top > 1) {
+      if (top < lastTop - 1 && top > 1 && !atBottom) {
         setScrolledUp(true);
         clearTimeout(hideTimer);
         hideTimer = setTimeout(() => setScrolledUp(false), SCROLL_REVEAL_MS);
+      } else if (top > lastTop + 1 || atBottom) {
+        clearTimeout(hideTimer);
+        setScrolledUp(false);
       }
       lastTop = top;
     };

--- a/web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/web/src/pages/ChatPage.historyLoad.test.tsx
@@ -1117,6 +1117,26 @@ describe("JumpToTopButton", () => {
     expect(pill().className).toContain("pointer-events-none");
   });
 
+  it("does not mistake bottom re-anchoring for an upward scroll", () => {
+    const metrics = {
+      scrollTop: 600,
+      scrollHeight: 1000,
+      clientHeight: 400,
+    };
+    const { container, scroll, scroller } = makeScroller(metrics);
+
+    render(<JumpToTopButton containerEl={container} scroller={scroller} hasMoreHistory={true} />);
+
+    // Removing transient content can reduce both scrollHeight and scrollTop
+    // while the viewport remains pinned to the bottom.
+    act(() => {
+      metrics.scrollHeight = 800;
+      metrics.scrollTop = 400;
+      fireEvent.scroll(scroll);
+    });
+    expect(pill().className).toContain("pointer-events-none");
+  });
+
   it("releases the bottom-lock, pages in all history, then scrolls to the top", async () => {
     const { container, scroller, scroll } = makeScroller({
       scrollTop: 500,


### PR DESCRIPTION
## Related issue

Closes #6374

## Summary

- Correlate each sharing journey navigation with the snapshot request initiated by that exact page load, so an older in-flight 200 cannot be mistaken for the post-revoke read. The permission store already commits and invalidates its local access cache before DELETE returns; the flake was in response selection.
- Keep the jump-to-top pill hidden when a reduced transcript height moves `scrollTop` upward while the viewport remains bottom-anchored. This preserves reveal-on-genuine-upward-scroll behavior and clears stale reveal state on downward/bottom movement.

ELI5: the sharing test now checks the receipt from the reload it just started, not an older receipt arriving late; the scroll control now distinguishes content shrinking under a parked viewport from a person scrolling up.

```text
revoke returns -> tagged reload snapshot -> 404
content shrinks -> scrollTop decreases + still at bottom -> pill stays hidden
```

## Test Plan

- `uv run --no-sync pytest tests/e2e_ui/collaboration/test_sharing_journey.py::test_share_grant_downgrade_revoke_journey tests/e2e_ui/chat/test_jump_to_top.py::test_jump_to_top_reveals_on_scroll_up_then_auto_hides -q` (passed once, five stress iterations, and once after rebase)
- `uv run --no-sync pytest tests/e2e/test_sharing_permissions_e2e.py::test_revoke_returns_404_for_bob -q`
- `pnpm exec vitest run src/pages/ChatPage.historyLoad.test.tsx` (41 tests)
- `pnpm run type-check`
- `uv run --no-sync pre-commit run --all-files`

## Demo

N/A — both changes preserve the intended existing UI and only remove race-dependent states.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new Vitest regression reproduces transcript-height shrinkage while bottom-anchored. Existing focused HTTP and Playwright tests cover immediate revoke visibility and both affected browser journeys; the two browser tests passed in seven consecutive local runs.

## Changelog

The jump-to-top control now stays hidden when a conversation is already at the bottom.