### PR TITLE
docs(readme): minor wording tweak in agents bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Omnigent lets you:
   follow you: start in your terminal, continue in the browser, pick it up on
   your phone. Messages, sub-agents, terminals, and files stay in sync.
 
-- **🤖 Supervise multiple agents.** Mix Claude Code, Codex, Cursor, OpenCode,
+- **🤖 Supervise multiple agents at once.** Mix Claude Code, Codex, Cursor, OpenCode,
   Hermes, Pi, and custom agents (defined in YAML) together in the same
   session. Ask one agent to review another's work, or split a task across
   agents that are each good at different things.


### PR DESCRIPTION
## Related issue

<!-- Docs change — no issue required. -->

N/A — trivial docs wording change.

## Summary

- Minor README wording tweak: the "Supervise multiple agents" bullet now reads "Supervise multiple agents at once." No behavioral change.

## Test Plan

- N/A — Markdown copy edit only. Rendered README to confirm the bullet reads correctly.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

Docs-only copy edit; no automated coverage applicable.
