### PR TITLE
fix(claude-native): drop premature paste-commit raise; rely on delivery ack

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -3250,13 +3250,14 @@ def inject_user_message(
     The submit is **acknowledged, not fire-and-forget**: Claude Code
     coalesces rapid stdin bursts into a paste, so an Enter that lands
     while the TUI is still consuming the paste is folded in as a
-    newline and the draft sits unsent. This helper first polls
-    ``capture-pane`` until the draft is visible in the input box (the
-    paste was committed), sends Enter, then polls that the draft left
-    the box — re-sending Enter while it hasn't — and raises if the
-    message never submits. An empty composer is not sufficient evidence:
-    after it clears, this helper also waits for the matching
-    ``UserPromptSubmit`` hook from the active Claude session.
+    newline and the draft sits unsent. This helper polls ``capture-pane``
+    until the draft is visible in the input box (best-effort — a large
+    paste collapses to a ``[Pasted text]`` placeholder that may not match),
+    sends Enter, then polls that the draft left the box — re-sending Enter
+    while it hasn't — and raises if the message never submits. An empty
+    composer is not sufficient evidence: after it clears, this helper also
+    waits for the matching ``UserPromptSubmit`` hook from the active Claude
+    session, which is the authoritative delivery check.
 
     :param bridge_dir: Bridge directory path.
     :param content: User text from the Omnigent web UI. Must be non-empty.
@@ -3265,11 +3266,9 @@ def inject_user_message(
     :returns: None.
     :raises RuntimeError: If the tmux target is not advertised in time,
         if Claude's input prompt never renders, if a ``tmux send-keys``
-        invocation fails, if the paste draft was never confirmed in the
-        input box after ``_PASTE_COMMIT_TIMEOUT_S`` (the TUI was still
-        consuming the paste — message not submitted), or if the draft
-        never leaves the input box after repeated submit Enters, or Claude
-        never acknowledges the submitted prompt.
+        invocation fails, if the draft never leaves the input box after
+        repeated submit Enters, or if Claude never acknowledges the
+        submitted prompt via ``UserPromptSubmit``.
     """
     info = _wait_for_tmux_info(bridge_dir, timeout_s=timeout_s)
     # A surface left occupying the composer swallows everything typed
@@ -3343,32 +3342,17 @@ def inject_user_message(
     # the paste becomes a newline inside the draft instead of a submit,
     # and the message sits unsent. A fixed sleep raced this (lost under
     # load / large payloads); polling is deterministic.
-    # When the draft never becomes visible (timeout expired) AND the
-    # content has an identifiable needle, raise rather than submit blind:
-    # a blind Enter races the still-consuming TUI and would silently drop
-    # the message (the caller gets no error but the turn never runs).
-    # When the needle is empty (whitespace-only content) the draft cannot
-    # be confirmed either way; fall through to best-effort blind submit.
-    draft_seen = False
+    # The draft-visibility poll is best-effort, not a gate: large or
+    # multi-line pastes render as a collapsed ``[Pasted text]`` placeholder
+    # whose glyph row may not match the needle within the window, so a
+    # timeout here does not mean the paste failed. Fall through to submit
+    # regardless — the ``UserPromptSubmit`` acknowledgement below is the
+    # authoritative delivery check and surfaces a genuine non-delivery.
     deadline = time.monotonic() + _PASTE_COMMIT_TIMEOUT_S
     while time.monotonic() < deadline:
         if _draft_in_input_box(_capture_pane(info["socket_path"], info["tmux_target"]), needle):
-            draft_seen = True
             break
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    if not draft_seen:
-        if not needle:
-            # Content has no identifiable first line (e.g. whitespace-only).
-            # The draft position cannot be confirmed, so fall through to a
-            # best-effort blind submit rather than hard-failing.
-            time.sleep(_PASTE_SETTLE_S)
-            _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
-            return
-        raise RuntimeError(
-            f"The pasted draft was never visible in Claude Code's input box after "
-            f"{_PASTE_COMMIT_TIMEOUT_S}s (needle={needle!r}). The TUI may still be "
-            "consuming the paste — the message was not submitted. Retry the send."
-        )
     time.sleep(_PASTE_SETTLE_S)
     _run_tmux(info["socket_path"], "send-keys", "-t", info["tmux_target"], "Enter")
     # Verify the submit took: a successful Enter clears the input box.

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -9329,22 +9329,22 @@ async def test_curl_evaluate_policy_command_round_trips(
 
 
 # ---------------------------------------------------------------------------
-# OMNI-3699 regression: a continuation paste whose draft is never confirmed
-# by ``_draft_in_input_box`` must raise RuntimeError, not silently drop.
+# Regression: a large paste whose collapsed ``[Pasted text]`` placeholder
+# never matches the needle within ``_PASTE_COMMIT_TIMEOUT_S`` must NOT raise.
 #
 # Background: ``inject_user_message`` polls up to ``_PASTE_COMMIT_TIMEOUT_S``
-# for the paste to become visible as a draft in the input box.  When that
-# window expires before the TUI shows the ``[Pasted text]`` placeholder
-# (e.g. a large paste on a loaded machine), the old code sent a single blind
-# Enter and returned silently.  That Enter was absorbed into the still-
-# processing paste burst as a newline, so the message sat unsent, the harness
-# returned success, and the session latched at ``status: "running"``
-# indefinitely.
+# for the draft to become visible as its first-line needle in the input box.
+# A large or multi-line paste (e.g. a message opening with a long URL) is
+# rendered by Claude Code as a collapsed ``[Pasted text #N +M lines]``
+# placeholder, so the verbatim needle is never on the glyph row and the poll
+# window simply expires.  A prior fix hard-raised in that path, which turned
+# ordinary large pastes into repeated "The pasted draft was never visible …"
+# errors and blocked delivery.
 #
-# The fix raises ``RuntimeError`` in that path so the caller cannot silently
-# lose the message.  The "draft unidentifiable" fall-through (empty-needle
-# whitespace-only content) is preserved as a best-effort path that emits a
-# warning rather than hard-failing.
+# The draft poll is now best-effort: it falls through to submit regardless,
+# and the ``UserPromptSubmit`` acknowledgement is the authoritative delivery
+# check.  This test proves the placeholder-paste path submits and does not
+# raise.
 # ---------------------------------------------------------------------------
 
 
@@ -9370,27 +9370,29 @@ def _post_turn_pane(draft: str = "") -> str:
     )
 
 
-def test_inject_user_message_continuation_paste_draft_timeout_raises(
+def test_inject_user_message_placeholder_paste_never_matched_does_not_raise(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """inject_user_message raises when the paste-commit timeout expires and draft is unseen.
+    """A large paste whose needle never appears submits without raising.
 
-    The pane after a completed turn has a ``❯ [Pasted text]`` line in scrollback
-    that looks like it could contain a paste placeholder, but the *live* input box
-    (the last ``❯`` row) is empty.  ``_draft_in_input_box`` correctly matches only
-    the last glyph line, so it never returns True, and the poll window expires
-    with ``draft_seen=False``.
-
-    Before the fix: the function sent a single blind Enter and returned without
-    error, silently dropping the message.
-
-    After the fix: the function raises ``RuntimeError`` describing that the draft
-    was never confirmed, preventing the caller from losing the message silently.
+    The live input box only ever shows an empty ``❯`` row (the large paste
+    collapsed to a ``[Pasted text]`` placeholder that this fake omits), so
+    ``_draft_in_input_box`` never matches the needle and the paste-commit
+    poll window expires.  The helper must fall through and submit rather
+    than hard-fail: ``_draft_in_input_box`` on the empty box then reports the
+    draft gone, the submit-verify loop breaks, and delivery is confirmed by
+    the stubbed ``UserPromptSubmit`` acknowledgement.
     """
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_wait_for_user_prompt_submit_ack",
+        lambda *_args, **_kwargs: None,
+    )
     monkeypatch.setattr("omnigent.claude_native_bridge._TRUSTED_PARENT", tmp_path)
     monkeypatch.setattr("omnigent.claude_native_bridge._CLAUDE_READY_POLL_INTERVAL_S", 0.01)
     monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_COMMIT_TIMEOUT_S", 0.1)
+    monkeypatch.setattr("omnigent.claude_native_bridge._SUBMIT_VERIFY_TIMEOUT_S", 0.2)
     monkeypatch.setattr("omnigent.claude_native_bridge._PASTE_SETTLE_S", 0.0)
 
     bridge_dir = tmp_path / "bridge"
@@ -9400,46 +9402,30 @@ def test_inject_user_message_continuation_paste_draft_timeout_raises(
         tmux_target="claude:0.0",
     )
 
-    # Build a large multi-line prompt that exceeds the paste-placeholder threshold:
-    # > 1 937 chars, >= 14 newlines (the range where Claude Code's TUI renders the
-    # paste as ``[Pasted text #N +M lines]`` instead of verbatim text, and which
-    # all observed OMNI-3699 failures shared).
-    continuation_prompt = "\n".join(
-        [
-            "Please implement the following feature:",
-            "",
-            "The system needs to handle continuation messages sent to an existing",
-            "claude-native sub-agent session.  These are second or later calls to",
-            "sys_session_send for a session that has already completed at least one turn.",
-            "",
-        ]
-        + [
-            f"Step {i}: perform the necessary action for this item in the sequence."
-            for i in range(1, 30)
-        ]
+    # A message that opens with a long URL — Claude Code collapses this to a
+    # ``[Pasted text]`` placeholder, so the needle is never rendered verbatim.
+    large_prompt = (
+        "Can you take a look at https://docs.google.com/document/d/"
+        + "A" * 60
+        + "/edit?tab=t.0 and draft a plan based on the matrix?"
     )
-    assert len(continuation_prompt) > 1_500
-    assert continuation_prompt.count("\n") >= 14
 
-    # Simulate the pane state after a completed turn: the live input box is empty,
-    # but there is a ``❯ [Pasted text]`` entry in scrollback from the prior turn.
-    # ``_draft_in_input_box`` only inspects the *last* ``❯`` row, so the
-    # scrollback placeholder does not satisfy the poll, and ``draft_seen`` stays
-    # False until the timeout fires.
-    tui: dict[str, str] = {"pane": _post_turn_pane()}
+    enter_calls: list[list[str]] = []
 
     def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         del kwargs
         if "capture-pane" in cmd:
-            return SimpleNamespace(returncode=0, stdout=tui["pane"], stderr="")
+            # The live input box never shows the needle: only an empty ``❯`` row.
+            return SimpleNamespace(returncode=0, stdout=_post_turn_pane(), stderr="")
+        if "send-keys" in cmd and cmd[-1] == "Enter":
+            enter_calls.append(cmd)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr("subprocess.run", _fake_run)
 
-    # The fix: must raise RuntimeError when the draft was never confirmed.
-    # (Before the fix this returned silently — the regression the test guards.)
-    with pytest.raises(RuntimeError, match="draft"):
-        inject_user_message(bridge_dir, content=continuation_prompt)
+    # Must not raise: the placeholder paste falls through to a submit.
+    inject_user_message(bridge_dir, content=large_prompt)
+    assert enter_calls, "expected at least one submit Enter"
 
 
 def test_inject_user_message_whitespace_only_content_submits_blind(


### PR DESCRIPTION
## Related issue

Follow-up to #5494 (and #4847). Not reverting the whole PR — see Summary.

## Summary

PR #5494 made `inject_user_message` (claude-native) **raise** `RuntimeError`
when the pasted draft's first-line "needle" wasn't spotted in the input box
within `_PASTE_COMMIT_TIMEOUT_S` (5s). But Claude Code collapses a large or
multi-line paste into a `[Pasted text #N]` placeholder, so the needle is
**never rendered verbatim**, the poll always expires, and ordinary sends
failed with repeated *"The pasted draft was never visible … Retry the send"*
errors — the message never got submitted. This reproduced reliably with a
message that opens with a long URL.

- Make the draft-visibility poll **best-effort** again: on timeout, fall
  through and submit (the pre-#5494 behavior) instead of hard-failing.
- Keep #6297's `UserPromptSubmit` delivery-acknowledgement as the
  **authoritative** delivery check — it catches genuine non-delivery
  (including the in-pane-restart race) and is what #5494 was crudely trying
  to approximate. #5494's premature raise is now redundant.

**ELI5:** #5494 gave up after 5 seconds if it couldn't literally *see* your
message in the box — but big pastes (like a long URL) show up as
`[Pasted text]`, not the words, so it wrongly declared failure and refused to
send. This removes that too-early check; Claude's own "I received it" receipt
(added in #6297) is now the sole judge of delivery.

## Test Plan

- `pytest tests/test_claude_native_bridge.py` — **304 passed** (replaced
  #5494's raise-asserting test with a regression proving a URL-opening
  placeholder paste submits without raising).
- `pytest tests/e2e/test_claude_native_inpane_restart_e2e.py` — **3 passed**
  (#6297's restart delivery-ack protection intact).
- `pre-commit run` on changed files — ruff format/check, pyrefly, model-id
  guard all pass.

Manual: on a claude-native session, send a message opening with a long
Google Docs URL and confirm it delivers with no *"pasted draft was never
visible"* error; a short control message also delivers normally.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — backend/TUI-delivery change; evidence in Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated

## Coverage notes

Unit + e2e regression coverage; no manual-only paths.

## Changelog

claude-native: large pastes (e.g. messages opening with a long URL) no longer
fail to send with a spurious "pasted draft was never visible" error

This pull request and its description were written by Isaac.
