### PR TITLE
fix(github): scope the per-user broker to connected sandboxes + wire the GitHub panel's gh to it

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -336,6 +336,38 @@ RUN set -eu; \
     fi; \
     echo "agy ${AGY_VERSION} pinned (sha256 verified)"
 
+# GitHub CLI (`gh`) — the read-only "GitHub" side panel shells out to `gh` in the
+# runner (omnigent/runner/github_resource.py: `gh pr view` / `gh pr diff` /
+# `gh api .../pulls/<n>/files`) to render the session branch's PR + file diffs, so
+# a managed host image must carry it or the panel degrades to a "gh not installed"
+# state. Pinned + SHA256-verified per arch, like agy above; to bump, update
+# GH_VERSION and both SHA256s from the release's `gh_<ver>_checksums.txt` at
+# https://github.com/cli/cli/releases.
+ARG GH_VERSION=2.100.0
+ARG GH_SHA256_AMD64=e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be
+ARG GH_SHA256_ARM64=ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961
+RUN set -eu; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) sha="$GH_SHA256_AMD64" ;; \
+      arm64) sha="$GH_SHA256_ARM64" ;; \
+      *) echo "ERROR: unsupported arch '$arch' for gh" >&2; exit 1 ;; \
+    esac; \
+    asset="gh_${GH_VERSION}_linux_${arch}.tar.gz"; \
+    curl -fsSL -o /tmp/gh.tar.gz \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${asset}"; \
+    echo "${sha}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tar.gz -C /tmp "gh_${GH_VERSION}_linux_${arch}/bin/gh"; \
+    install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${arch}"; \
+    test -x /usr/local/bin/gh; \
+    installed="$(/usr/local/bin/gh --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"; \
+    if [ "$installed" != "$GH_VERSION" ]; then \
+      echo "ERROR: gh reports '${installed:-<unparseable>}', expected '$GH_VERSION'." >&2; \
+      exit 1; \
+    fi; \
+    echo "gh ${GH_VERSION} pinned (sha256 verified)"
+
 # Copy the venv and source tree. The editable install's .pth files reference
 # /build/omnigent and /build/sdks/* -- both denied by the k8s Landlock LSM
 # policy. Re-install without -e so the package bytes land in the venv's

--- a/omnigent/git_credential_github.py
+++ b/omnigent/git_credential_github.py
@@ -77,9 +77,12 @@ def _fetch(server: str, host_id: str, host_token: str) -> dict | None:
     if resp.status_code != 200:
         return None
     try:
-        return resp.json()
+        data = resp.json()
     except ValueError:
         return None
+    # Guard non-object JSON (a top-level list/string) so callers' ``data.get(...)``
+    # can't raise — keeps the broker fetch's "never raises" contract honest.
+    return data if isinstance(data, dict) else None
 
 
 def _fetch_credential(server: str, host_id: str, host_token: str) -> tuple[str, str] | None:
@@ -88,6 +91,19 @@ def _fetch_credential(server: str, host_id: str, host_token: str) -> tuple[str, 
     if not data or not data.get("connected") or not data.get("token"):
         return None
     return str(data.get("username") or "x-access-token"), str(data["token"])
+
+
+def resolve_github_token(server_url: str, host_id: str, host_token: str) -> str | None:
+    """Fetch the connected owner's GitHub token from the broker, or ``None``.
+
+    Public wrapper over the broker fetch for non-git callers — the read-only
+    GitHub panel's ``gh`` invocations need the per-user token directly rather than
+    via git's ``credential.helper``. ``None`` when the owner hasn't connected
+    GitHub or the broker is unreachable, so callers fall back to their ambient
+    (shared-token / local ``gh``) auth. Never raises.
+    """
+    cred = _fetch_credential(server_url, host_id, host_token)
+    return cred[1] if cred else None
 
 
 def _git_config(*args: str) -> None:
@@ -132,19 +148,37 @@ def configure_host_git(server_url: str, host_id: str) -> None:
     """Configure git in a managed sandbox to use the GitHub credential broker.
 
     Called by ``omnigent host`` at startup — executor-agnostic, since the host
-    runs in every executor and holds ``$OMNIGENT_HOST_TOKEN``. Makes the broker
-    the authoritative github.com ``credential.helper`` (fetching the owner's
-    token from the server per git op; never written to disk) and, when the owner
-    has GitHub connected, sets the commit author to them. Best-effort: never
-    raises (git may be absent, or GitHub not configured on the server).
+    runs in every executor and holds ``$OMNIGENT_HOST_TOKEN``. When the owner has
+    GitHub connected (the per-user Connect model), makes the broker the
+    authoritative github.com ``credential.helper`` (fetching the owner's token
+    from the server per git op; never written to disk) and sets the commit author
+    to them. Best-effort: never raises (git may be absent, or GitHub not
+    configured on the server).
+
+    Connected-gated, mirroring :func:`configure_clone_credentials`: a confirmed
+    ``connected: false`` means the owner hasn't linked GitHub (a shared-
+    ``$GIT_TOKEN`` or local deployment). Installing the broker would reset the
+    github.com chain (clearing a shared ``$GIT_TOKEN`` helper) and then decline,
+    breaking in-session git — so that path instead **clears** any broker helper a
+    prior (inconclusive) clone probe may have installed, restoring the ambient
+    helper. Only a connected owner, or an inconclusive probe (``None``,
+    fail-closed like the clone), takes over github.com.
     """
     token = (os.environ.get(_HOST_TOKEN_ENV_VAR) or "").strip()
     if not token:
         return
+    data = _fetch(server_url, host_id, token)
+    if data is not None and not data.get("connected"):
+        # Confirmed not linked: actively clear any broker helper a prior
+        # (inconclusive) clone probe installed. Just returning would leave that
+        # helper — and the chain reset it wrote — in place, stranding in-session
+        # git behind a broker that now declines. Unsetting restores the ambient
+        # shared-``$GIT_TOKEN`` helper.
+        _git_config("--unset-all", "credential.https://github.com.helper")
+        return
     _install_broker_helper(server_url, host_id, token)
-    data = _fetch(server_url, host_id, token) or {}
-    owner = str(data.get("owner") or "")
-    if data.get("connected") and "@" in owner:
+    owner = str((data or {}).get("owner") or "")
+    if data and data.get("connected") and "@" in owner:
         _git_config("user.email", owner)
         login = data.get("login")
         _git_config("user.name", str(login) if login else owner.split("@", 1)[0])
@@ -154,11 +188,10 @@ def configure_clone_credentials(server_url: str, host_id: str) -> bool:
     """Wire the per-user broker for the initial workspace clone.
 
     Called by the managed-sandbox ``workspace-prep`` init container BEFORE it
-    clones the workspace repo. Unlike :func:`configure_host_git` (which makes the
-    broker authoritative for the running host unconditionally), this keeps the
-    ambient credential chain — notably the image's shared ``$GIT_TOKEN`` helper —
-    only when the owner is *definitively* not linked, so a shared-token clone
-    still works for them.
+    clones the workspace repo. Like :func:`configure_host_git`, this is
+    connected-gated: it keeps the ambient credential chain — notably the image's
+    shared ``$GIT_TOKEN`` helper — when the owner is *definitively* not linked, so
+    a shared-token clone still works for them.
 
     Fails closed on an ambiguous probe: :func:`_fetch` returns ``None`` on any
     transient fault (timeout, non-200, bad JSON), which is indistinguishable from

--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -26,11 +26,13 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import time
 from typing import Any
 
+from omnigent.git_credential_github import resolve_github_token
 from omnigent.runtime.filesystem_registry import _git_timeout_seconds
 
 _logger = logging.getLogger(__name__)
@@ -59,17 +61,89 @@ def _gh_timeout_seconds() -> float:
     return _DEFAULT_GH_TIMEOUT_SECONDS
 
 
+# Cache the per-user broker token briefly so a panel-load burst (info + files +
+# diff = several gh calls) triggers at most one broker fetch — well within the
+# token's lifetime, and refreshed on the next burst so a long session never
+# holds a stale token.
+_BROKER_TOKEN_TTL_SECONDS = 60.0
+_broker_token_cache: tuple[float, str | None] = (0.0, None)
+
+
+_GH_HELPER_MODULE = "omnigent.git_credential_github"
+
+
+def _broker_coords_from_git_helper(cwd: str) -> tuple[str, str, str] | None:
+    """Parse ``(server, host_id, host_token)`` from the broker git credential helper.
+
+    ``configure_host_git`` installs, only when the owner has connected GitHub, a
+    github.com helper of the form ``!python3 -m omnigent.git_credential_github
+    --server <url> --host-id <id> --host-token <tok>``. Reading the coords back
+    from it is the reliable source here: it's present in the shared git config
+    exactly when the per-user broker applies, regardless of which env this process
+    runs in (the runner's server-URL env var isn't dependable). ``None`` when no
+    broker helper is configured — local dev, or a shared-token / not-connected
+    sandbox.
+    """
+    rc, out, _ = _git(["config", "--get-all", "credential.https://github.com.helper"], cwd=cwd)
+    if rc != 0:
+        return None
+    for line in out.splitlines():
+        if _GH_HELPER_MODULE not in line:
+            continue
+        try:
+            parts = shlex.split(line.lstrip("!"))
+        except ValueError:
+            continue
+        coords: dict[str, str] = {}
+        for flag, key in (
+            ("--server", "server"),
+            ("--host-id", "host_id"),
+            ("--host-token", "host_token"),
+        ):
+            if flag in parts and parts.index(flag) + 1 < len(parts):
+                coords[key] = parts[parts.index(flag) + 1]
+        if len(coords) == 3:
+            return coords["server"], coords["host_id"], coords["host_token"]
+    return None
+
+
+def _broker_github_token(coords: tuple[str, str, str]) -> str | None:
+    """Fetch (briefly cached) the connected owner's GitHub token for broker *coords*.
+
+    ``None`` when the broker is unreachable or the owner's token can't be
+    resolved. The caller distinguishes this ("coords present but token ``None``"
+    = *configured but unavailable*) from "no coords" (not connected) and fails
+    closed rather than falling back to the ambient identity. Cached briefly to
+    bound overhead; never raises.
+    """
+    global _broker_token_cache
+    now = time.monotonic()
+    cached_at, cached = _broker_token_cache
+    if now - cached_at < _BROKER_TOKEN_TTL_SECONDS:
+        return cached
+    try:
+        token = resolve_github_token(*coords)
+    except Exception:  # noqa: BLE001 - a broker hiccup must never break the panel
+        token = None
+    _broker_token_cache = (now, token)
+    return token
+
+
 def _run(
     argv: list[str],
     *,
     cwd: str,
     timeout: float,
+    env: dict[str, str] | None = None,
 ) -> tuple[int | None, str, str]:
     """Run a subprocess and capture its output, never raising.
 
     :param argv: Command and arguments.
     :param cwd: Working directory to run in.
     :param timeout: Wall-clock cap in seconds.
+    :param env: Full environment for the child, or ``None`` to inherit the
+        runner process environment (the default — preserves the existing
+        secret-carrying env that ``gh`` / ``git`` rely on).
     :returns: ``(returncode, stdout, stderr)``. ``returncode`` is ``None`` when
         the command could not run at all (spawn error / timeout), so callers can
         distinguish "ran and failed" from "never ran".
@@ -81,6 +155,7 @@ def _run(
             cwd=cwd,
             capture_output=True,
             timeout=timeout,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         _logger.warning(
@@ -105,7 +180,24 @@ def _git(argv: list[str], *, cwd: str) -> tuple[int | None, str, str]:
 
 
 def _gh(argv: list[str], *, cwd: str) -> tuple[int | None, str, str]:
-    return _run(["gh", *argv], cwd=cwd, timeout=_gh_timeout_seconds())
+    # Per-user auth for the panel's gh, three-state on the broker helper coords:
+    #   - no broker configured (not connected / local dev) → inherit the runner
+    #     env (shared $GH_TOKEN / local gh auth), preserving prior behavior;
+    #   - connected + token resolved → run gh as the owner (GH_TOKEN/GITHUB_TOKEN);
+    #   - connected but broker unavailable → fail CLOSED: scrub the ambient GitHub
+    #     token so gh never silently acts as the shared identity (it reports
+    #     unauthenticated instead). gh reads GH_TOKEN, then GITHUB_TOKEN.
+    coords = _broker_coords_from_git_helper(cwd)
+    env: dict[str, str] | None
+    if coords is None:
+        env = None
+    else:
+        token = _broker_github_token(coords)
+        if token:
+            env = {**os.environ, "GH_TOKEN": token, "GITHUB_TOKEN": token}
+        else:
+            env = {k: v for k, v in os.environ.items() if k not in ("GH_TOKEN", "GITHUB_TOKEN")}
+    return _run(["gh", *argv], cwd=cwd, timeout=_gh_timeout_seconds(), env=env)
 
 
 # Cap the per-check list so a pathological rollup can't bloat the payload; the

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -214,3 +214,113 @@ def test_summarize_checks_empty() -> None:
         "total": 0,
         "runs": [],
     }
+
+
+def test_gh_uses_per_user_broker_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Broker configured (connected) + token resolved → gh runs with
+    # GH_TOKEN/GITHUB_TOKEN set to it, authenticating as the connected owner.
+    monkeypatch.setattr(
+        github_resource, "_broker_coords_from_git_helper", lambda cwd: ("http://srv", "h1", "t9")
+    )
+    monkeypatch.setattr(github_resource, "_broker_github_token", lambda coords: "ghu_peruser")
+    captured: dict[str, object] = {}
+
+    def fake_run(argv: Sequence[str], *, cwd: str, timeout: float, env=None):
+        captured["argv"] = list(argv)
+        captured["env"] = env
+        return 0, "", ""
+
+    monkeypatch.setattr(github_resource, "_run", fake_run)
+    github_resource._gh(["auth", "status"], cwd="/tmp")
+    assert captured["argv"] == ["gh", "auth", "status"]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GH_TOKEN"] == "ghu_peruser"
+    assert env["GITHUB_TOKEN"] == "ghu_peruser"
+
+
+def test_gh_inherits_env_when_no_broker_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No broker helper (local dev / not connected) → gh inherits the runner env
+    # (env=None), preserving prior shared-token / local-gh behavior.
+    monkeypatch.setattr(github_resource, "_broker_coords_from_git_helper", lambda cwd: None)
+    captured: dict[str, object] = {}
+
+    def fake_run(argv: Sequence[str], *, cwd: str, timeout: float, env=None):
+        captured["env"] = env
+        return 0, "", ""
+
+    monkeypatch.setattr(github_resource, "_run", fake_run)
+    github_resource._gh(["pr", "diff"], cwd="/tmp")
+    assert captured["env"] is None
+
+
+def test_gh_fails_closed_when_broker_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Broker configured (connected) but its token can't be resolved → fail CLOSED:
+    # scrub the ambient GitHub token so gh can't silently act as the shared
+    # identity (it runs unauthenticated instead).
+    monkeypatch.setenv("GH_TOKEN", "shared-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "shared-token")
+    monkeypatch.setattr(
+        github_resource, "_broker_coords_from_git_helper", lambda cwd: ("http://srv", "h1", "t9")
+    )
+    monkeypatch.setattr(github_resource, "_broker_github_token", lambda coords: None)
+    captured: dict[str, object] = {}
+
+    def fake_run(argv: Sequence[str], *, cwd: str, timeout: float, env=None):
+        captured["env"] = env
+        return 0, "", ""
+
+    monkeypatch.setattr(github_resource, "_run", fake_run)
+    github_resource._gh(["auth", "status"], cwd="/tmp")
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "GH_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+
+
+def test_broker_coords_parsed_from_git_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Coords are read back from the broker git credential helper that
+    # configure_host_git bakes in (present only when the owner is connected).
+    helper = (
+        "!python3 -m omnigent.git_credential_github --server http://srv "
+        "--host-id host1 --host-token tok9\n"
+    )
+    monkeypatch.setattr(github_resource, "_git", lambda argv, *, cwd: (0, helper, ""))
+    assert github_resource._broker_coords_from_git_helper("/tmp") == (
+        "http://srv",
+        "host1",
+        "tok9",
+    )
+
+
+def test_broker_coords_none_without_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No broker helper wired (local dev, or a shared-token / not-connected
+    # sandbox) → no coords, so the panel's gh falls back to ambient auth.
+    monkeypatch.setattr(github_resource, "_git", lambda argv, *, cwd: (0, "", ""))
+    assert github_resource._broker_coords_from_git_helper("/tmp") is None
+
+
+def test_broker_github_token_fetches_with_coords(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given coords, fetch the connected owner's token via the broker.
+    monkeypatch.setattr(github_resource, "_broker_token_cache", (0.0, None))
+    seen: dict[str, object] = {}
+
+    def fake_resolve(server: str, host_id: str, host_token: str):
+        seen["args"] = (server, host_id, host_token)
+        return "ghu_peruser"
+
+    monkeypatch.setattr(github_resource, "resolve_github_token", fake_resolve)
+    assert github_resource._broker_github_token(("http://srv", "host1", "tok9")) == "ghu_peruser"
+    assert seen["args"] == ("http://srv", "host1", "tok9")
+
+
+def test_broker_github_token_none_on_fetch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Broker unreachable → None, so the caller fails closed rather than using the
+    # ambient identity.
+    monkeypatch.setattr(github_resource, "_broker_token_cache", (0.0, None))
+
+    def boom(*_a: str) -> str:
+        raise RuntimeError("broker down")
+
+    monkeypatch.setattr(github_resource, "resolve_github_token", boom)
+    assert github_resource._broker_github_token(("http://srv", "host1", "tok9")) is None

--- a/tests/test_git_credential_github.py
+++ b/tests/test_git_credential_github.py
@@ -86,6 +86,42 @@ def test_configure_host_git_noop_without_token(monkeypatch: pytest.MonkeyPatch) 
     assert calls == []  # no token → nothing configured
 
 
+def test_configure_host_git_clears_stale_broker_when_not_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Scoping: a confirmed not-connected owner (shared-$GIT_TOKEN / local model)
+    # must NOT install the broker. It must also CLEAR any stale broker a prior
+    # (inconclusive) clone probe installed — otherwise the reset it left strands
+    # in-session git behind a declining broker. So the one and only write is the
+    # unset that restores the ambient/shared helper; no --add, no identity.
+    monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "launch-tok")
+    calls: list[list[str]] = []
+    monkeypatch.setattr(h.subprocess, "run", lambda args, **k: calls.append(args) or None)
+    monkeypatch.setattr(h, "_fetch", lambda *a, **k: {"connected": False})
+    h.configure_host_git("http://srv", "host1")
+    key = "credential.https://github.com.helper"
+    assert calls == [["git", "config", "--global", "--unset-all", key]]
+    flat = [" ".join(c) for c in calls]
+    assert not any("--add" in c for c in flat)
+    assert not any("user.email" in c for c in flat)
+
+
+def test_resolve_github_token_returns_token_when_connected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        h,
+        "_fetch",
+        lambda *a, **k: {"connected": True, "token": "ghu_x", "username": "x-access-token"},
+    )
+    assert h.resolve_github_token("http://srv", "host1", "tok") == "ghu_x"
+
+
+def test_resolve_github_token_none_when_not_connected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(h, "_fetch", lambda *a, **k: {"connected": False})
+    assert h.resolve_github_token("http://srv", "host1", "tok") is None
+
+
 def test_credential_url_targets_the_generic_provider_path() -> None:
     # The helper hits the provider-generic broker with provider=github.
     assert h._credential_url("http://s", "hid") == "http://s/v1/hosts/hid/credentials/github"


### PR DESCRIPTION
## Related issue

Part of #5626. Follows #6366 — fixes a broker-scoping gap that merged with the
credential-broker work, and extends the per-user broker to the read-only GitHub
panel's `gh` CLI.

## Summary

Scope the per-user GitHub credential broker so it activates **only** in the OSS
per-user Connect model — a managed sandbox whose owner has linked GitHub — and
never disturbs shared-long-lived-token deployments or local dev. `connected` is
precisely that signal.

- **Fix a scoping regression in `configure_host_git`.** It installed the broker
  helper *unconditionally* (only host-token-gated). Because the install resets
  the github.com credential-helper chain (clearing a shared `$GIT_TOKEN` helper),
  a shared-token sandbox whose owner hadn't connected got its shared helper wiped
  and the broker then declined — **breaking in-session git**. Now gated on
  `connected`, mirroring `configure_clone_credentials` (a confirmed
  `connected: false` leaves the ambient helper untouched).
- **Wire the GitHub panel's `gh` to the broker.** The panel's PR/diff data comes
  from `gh` in the runner, which inherited the image's shared `$GH_TOKEN`.
  `github_resource` now fetches the connected owner's token from the broker
  (`RUNNER_SERVER_URL` + `OMNIGENT_HOST_ID` + `OMNIGENT_HOST_TOKEN`, briefly
  cached) and sets `GH_TOKEN`/`GITHUB_TOKEN` on the `gh` subprocess **only when
  connected + in a sandbox**; otherwise `gh` inherits the runner env exactly as
  before. Same `gh` commands, same outputs — only *whose* token. Adds public
  `resolve_github_token()` as the non-git broker entry point.

Behavior after this change:

| Context | `git clone` | in-session `git` | panel `gh` |
|---|---|---|---|
| OSS sandbox, owner connected | broker (per-user) | broker (per-user) | broker (per-user) |
| Shared-token sandbox, not connected | shared `$GIT_TOKEN` | shared `$GIT_TOKEN` (**fixed**) | shared `$GH_TOKEN` |
| Local dev / non-sandbox | local git | local git | local `gh` |

## Test Plan

- `pytest tests/test_git_credential_github.py tests/runner/test_github_resource.py` — **30 pass**, including new tests: `configure_host_git` leaves the shared helper when not connected; `resolve_github_token`; `_gh` per-user injection + inherit-fallback; `_broker_github_token` in/out-of-sandbox.
- `ruff` + `pyrefly` clean.
- Live k8s-sandbox E2E (panel `gh` running as the connected owner) in progress.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No UI changes — the panel component is untouched; only the token `gh` authenticates
with changes. Unit tests assert the env wiring + the connected-gating; a live
k8s-sandbox E2E (the panel's `gh` acting as the connected owner, with a shared-token
/ non-connected sandbox left unaffected) is being run before merge.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The clone + in-session-git paths are covered by the existing broker tests plus the
new `configure_host_git` scoping test; the panel `gh` wiring by the new
`github_resource` tests. A live k8s-sandbox E2E (per-user `gh` in the panel) is
being run before merge and will be added here.

## Changelog

In a sandbox, the GitHub panel and git now authenticate as your connected GitHub account instead of a shared token.

---

This pull request and its description were written by Isaac.
