### PR TITLE
feat(databricks): per-user Databricks Connect (OAuth U2M) + broker-refreshed sandbox credentials

### DIFF
--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -465,6 +465,24 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
 
             github_store = GithubConnectionStore(database_url, cipher)
 
+    from omnigent.server.databricks_app import DatabricksConfig
+
+    databricks_config = DatabricksConfig.from_env()
+    databricks_store = None
+    if databricks_config is not None:
+        from omnigent.stores.credential_store import build_secret_cipher
+
+        dbx_cipher = build_secret_cipher()
+        if dbx_cipher is None:
+            logger.error(
+                "Databricks Connect is configured but disabled: set the credential "
+                "store's KMS key (OMNIGENT_CREDENTIAL_KMS_KEY_ID) to enable it."
+            )
+        else:
+            from omnigent.connections.databricks import DatabricksConnectionStore
+
+            databricks_store = DatabricksConnectionStore(database_url, dbx_cipher)
+
     app = create_app(
         agent_store=agent_store,
         file_store=file_store,
@@ -488,6 +506,8 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         server_config=cfg,
         github_config=github_config,
         github_store=github_store,
+        databricks_config=databricks_config,
+        databricks_store=databricks_store,
     )
 
     log_capabilities(sandbox_config, github_config, github_store)

--- a/designs/DATABRICKS_CONNECT.md
+++ b/designs/DATABRICKS_CONNECT.md
@@ -1,0 +1,156 @@
+# Connect Databricks (per-user) + MCP through the AI Gateway
+
+## Motivation
+
+Today a user connects **GitHub** (per-user OAuth) and the sandbox gets a GitHub
+MCP wired directly to GitHub's hosted MCP. We want the same "Connect …" flow for
+**Databricks**, so that:
+
+1. The user authenticates to their Databricks workspace once (like GitHub), and
+2. The sandbox's MCP tools are routed through the **Databricks AI Gateway (AIGW)**
+   — GitHub and other tools are configured there as MCP Services — instead of
+   each tool being wired up directly. So the direct GitHub MCP is **replaced** by
+   the AIGW MCP when Databricks is connected. (GitHub *clone* still uses the
+   GitHub credential broker — MCP can't `git clone`.)
+
+This is the "AIGW-primary MCP" track anticipated in
+[CREDENTIAL_STORE.md](CREDENTIAL_STORE.md); this doc pins the decisions and the
+concrete shape.
+
+## Decisions (settled)
+
+- **Auth = OAuth U2M authorization-code + PKCE**, `offline_access` for
+  server-side refresh — a mirror of the GitHub App connect flow.
+- **MCP = replace the direct GitHub MCP** with an AIGW-routed MCP when Databricks
+  is connected.
+
+## Reuse: no new storage
+
+The credential store is already provider-agnostic (`integration_connections`
+keyed by `(workspace_id, user_id, provider, account_id)`), so Databricks is a new
+`provider="databricks"` façade over the **existing** `IntegrationCredentialStore`
+— **no new table, no migration**, and it inherits the KMS-backed
+`SecretCipher` at rest.
+
+- secret (encrypted): `{access_token, refresh_token}`
+- metadata (plain): `{workspace_host, databricks_user, token_expires_at,
+  refresh_token_expires_at, scopes}`
+
+## Databricks OAuth U2M
+
+Databricks is multi-workspace, so the user supplies their **workspace host** at
+connect time (like `omni login <workspace-url>`), and the OAuth endpoints are
+workspace-relative:
+
+- authorize: `https://<workspace-host>/oidc/v1/authorize`
+- token: `https://<workspace-host>/oidc/v1/token`
+
+Flow (parallels `integrations_github.py`, with two Databricks-specific twists):
+
+1. `GET /v1/integrations/databricks/connect?workspace=<host>&return_to=…` →
+   generate a PKCE `code_verifier`/`code_challenge`, sign a state JWT carrying
+   `{sub, workspace_host, code_verifier, return_to, nonce, exp}` (HS256, same
+   `_sign_state` pattern), redirect to the workspace authorize URL with
+   `response_type=code`, `client_id`, `redirect_uri`, `scope`,
+   `code_challenge`, `code_challenge_method=S256`, `state`.
+2. `GET /v1/integrations/databricks/callback` → verify state (rebind `sub` to the
+   authenticated caller), POST to the workspace token URL with the `code` +
+   `code_verifier` (+ `client_secret` if confidential), store the token set via
+   `DatabricksConnectionStore.upsert`, redirect with `?databricks=connected`.
+3. `GET /v1/integrations/databricks/status`, `POST …/disconnect` — as GitHub.
+
+**Twists vs GitHub:** (a) per-workspace host means the host is data, carried in
+state and stored in metadata; (b) PKCE means the `code_verifier` must survive the
+round trip — carried inside the signed state (it never leaves our server in a
+usable form, and the state is short-TTL + signed).
+
+Config (`DatabricksConfig.from_env`, mirroring `GitHubAppConfig`):
+`OMNIGENT_DATABRICKS_CLIENT_ID` (required — the account custom-app-integration
+id), `OMNIGENT_DATABRICKS_CLIENT_SECRET` (optional; omit for a public/PKCE
+client), `OMNIGENT_DATABRICKS_SCOPES` (default `all-apis offline_access`),
+redirect derived from `OMNIGENT_DOMAIN`
+(`/v1/integrations/databricks/callback`). Unset client id ⇒ feature dormant.
+
+Refresh: `databricks_identity.resolve_databricks_access_token(user_id)` mirrors
+`github_identity.resolve_access_token` — refresh when within the expiry margin via
+the workspace token endpoint using the stored refresh token, persist with
+`update_secret`, return a valid token or `None`.
+
+## Credential broker
+
+`GET /v1/hosts/{host_id}/databricks-credential` (new `routes/host_databricks.py`,
+mirrors `host_github.py`): resolve `(host_id, launch_token)` → owner →
+`resolve_databricks_access_token`, return `{connected, token, workspace_host}`
+with `Cache-Control: no-store`. The raw token never lands on sandbox disk; the
+proxy fetches it per-connection via the broker (the same
+broker-coords-in-env-not-token pattern the GitHub MCP uses).
+
+## MCP through AIGW (replaces the GitHub MCP)
+
+AIGW MCP is Streamable HTTP with `Authorization: Bearer <databricks-token>` — the
+same transport/auth shape the GitHub hosted MCP uses, so this mirrors
+`github_mcp_proxy.py`:
+
+- `databricks_mcp_proxy.py` — a local stdio MCP server that forwards to the AIGW
+  MCP URL(s), with `_BrokerAuth` fetching the Databricks token from the databricks
+  broker and refreshing on 401. AIGW URL forms:
+  - managed: `https://<workspace-host>/api/2.0/mcp/{functions|genie|ai-search}/…`
+  - MCP Service (third-party tools, e.g. GitHub):
+    `https://<workspace-host>/ai-gateway/mcp-services/<service-name>`
+- `databricks_mcp.py` — `databricks_mcp_server_config(...)` producing the injected
+  `MCPServerConfig` (`name="databricks"`, stdio, `-m
+  omnigent.databricks_mcp_proxy`, broker-coords env). Which AIGW MCP endpoints to
+  expose is config-driven (`OMNIGENT_DATABRICKS_MCP_SERVICES`).
+
+**Injection (replace):** at the two existing sites —
+`omnigent/runner/native/orchestration.py` (~line 995, opencode) and
+`omnigent/claude_native_bridge.py` (~line 1120, claude) — when the launching
+user has a Databricks connection, inject the `databricks` server **instead of**
+the `github` server. Selection is by connection state (Databricks connected ⇒
+AIGW), so it's a runtime choice, not a redeploy. GitHub clone is untouched (still
+the git credential helper via the GitHub broker).
+
+## Server + frontend wiring
+
+- `create_app`: `databricks_config`/`databricks_store`/`databricks_client` in
+  `app.state`, a `databricks_enabled` gate, mount `create_host_databricks_router`
+  + `create_integrations_databricks_router`, and a **new** ServerInfo field
+  `databricks_app_enabled` (distinct from the existing `databricks_features`
+  deploy-mode hint). `cli.py` constructs `DatabricksConfig.from_env()` +
+  `DatabricksConnectionStore(db_uri, build_secret_cipher())` next to the GitHub
+  block (same KMS cipher instance).
+- Frontend: `web/src/lib/databricksIntegration.ts` + a `DatabricksIntegration
+  Control` added to the existing `IntegrationsSection` in `SettingsPage.tsx`
+  (workspace-URL input → connect); `databricks_app_enabled` in `capabilities.ts`
+  + nav gating.
+
+## Provisioning prerequisites (blockers for E2E)
+
+1. **A Databricks OAuth custom app integration** must be registered (admin) to
+   get a `client_id` (+ secret if confidential) and to register the redirect URI
+   `https://<omni-domain>/v1/integrations/databricks/callback`:
+   ```
+   databricks account custom-app-integration create --json '{
+     "name": "omnigent-github-mvp",
+     "redirect_urls": ["https://omnigent-github-mvp.sandbox.caffeine.ai/v1/integrations/databricks/callback"],
+     "scopes": ["all-apis", "offline_access"],
+     "confidential": true
+   }'
+   ```
+2. **An AIGW MCP Service** (e.g. GitHub) configured in the target workspace, so
+   there is something to route MCP through.
+
+Neither can be done from omnigent — both are Databricks account/workspace admin
+actions, exactly as the GitHub App had to be registered before the GitHub
+connect flow could be verified.
+
+## Open questions
+
+- **Account- vs workspace-level OAuth app:** workspace-level authorize is simplest
+  and matches `omni login <workspace-url>`; an account-level app would let one
+  registration span workspaces (authorize at
+  `https://accounts.cloud.databricks.com/oidc/accounts/<account-id>/v1/authorize`).
+- **Which AIGW MCP endpoints to expose by default** — just the GitHub MCP Service
+  (to replace today's GitHub MCP), or also managed UC/Genie MCP.
+- **Scopes** — `all-apis` is broad; narrow to the specific scopes AIGW MCP needs
+  once confirmed.

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4373,6 +4373,26 @@ def server(
 
             github_store = GithubConnectionStore(db_uri, cipher)
 
+    # Databricks Connect (per-user OAuth U2M). Shares the credential store's
+    # cipher; inert unless OMNIGENT_DATABRICKS_CLIENT_ID/_SECRET are set.
+    from omnigent.server.databricks_app import DatabricksConfig
+
+    databricks_config = DatabricksConfig.from_env()
+    databricks_store = None
+    if databricks_config is not None:
+        from omnigent.stores.credential_store import build_secret_cipher
+
+        dbx_cipher = build_secret_cipher()
+        if dbx_cipher is None:
+            logging.getLogger(__name__).error(
+                "Databricks Connect is configured but disabled: set the credential "
+                "store's KMS key (OMNIGENT_CREDENTIAL_KMS_KEY_ID) to enable it."
+            )
+        else:
+            from omnigent.connections.databricks import DatabricksConnectionStore
+
+            databricks_store = DatabricksConnectionStore(db_uri, dbx_cipher)
+
     # Accounts mode ergonomics: when accounts mode is selected
     # (OMNIGENT_AUTH_ENABLED=1 without OIDC config, or an explicit
     # OMNIGENT_AUTH_PROVIDER=accounts), supply sensible defaults
@@ -4442,6 +4462,8 @@ def server(
         sandbox_config=sandbox_config,
         github_config=github_config,
         github_store=github_store,
+        databricks_config=databricks_config,
+        databricks_store=databricks_store,
         server_config=title_server_config,
     )
 

--- a/omnigent/connections/databricks/__init__.py
+++ b/omnigent/connections/databricks/__init__.py
@@ -1,0 +1,114 @@
+"""Per-user Databricks connection store.
+
+A Databricks-typed :class:`~omnigent.connections.ConnectionStore`
+façade (``provider="databricks"``): it maps a :class:`DatabricksConnection`
+to/from the generic ``(secret, metadata)`` shape. Reuses the same table and
+cipher as every other provider — no new schema. Mirrors
+:class:`~omnigent.connections.github.GithubConnectionStore`. See
+``designs/DATABRICKS_CONNECT.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from omnigent.connections import ConnectionStore
+from omnigent.entities import DatabricksConnection, ProviderConnection
+from omnigent.server.databricks_app import DatabricksTokenSet
+
+
+class DatabricksConnectionStore(ConnectionStore[DatabricksConnection]):
+    """Databricks-typed façade over the shared credential store.
+
+    Inherits the uniform ``get`` / ``delete`` / ``list_all`` from
+    :class:`ConnectionStore`; adds the Databricks-specific ``upsert`` /
+    ``update_tokens`` writes and the row → :class:`DatabricksConnection` mapping.
+    """
+
+    _PROVIDER: ClassVar[str] = "databricks"
+
+    @staticmethod
+    def _to_entity(conn: ProviderConnection) -> DatabricksConnection:
+        secret = conn.secret or {}
+        meta = conn.metadata
+        return DatabricksConnection(
+            user_id=conn.user_id,
+            workspace_host=str(meta.get("workspace_host") or ""),
+            databricks_user=str(meta.get("databricks_user") or ""),
+            databricks_user_id=str(meta.get("databricks_user_id") or ""),
+            access_token=secret.get("access_token") if conn.secret is not None else None,
+            refresh_token=secret.get("refresh_token") if conn.secret is not None else None,
+            token_expires_at=meta.get("token_expires_at"),
+            refresh_token_expires_at=meta.get("refresh_token_expires_at"),
+            scopes=str(meta.get("scopes") or ""),
+            created_at=conn.created_at,
+            updated_at=conn.updated_at,
+        )
+
+    @staticmethod
+    def _secret(tokens: DatabricksTokenSet) -> dict[str, Any]:
+        return {"access_token": tokens.access_token, "refresh_token": tokens.refresh_token}
+
+    @staticmethod
+    def _metadata(
+        tokens: DatabricksTokenSet,
+        *,
+        workspace_host: str,
+        databricks_user: str,
+        databricks_user_id: str,
+    ) -> dict[str, Any]:
+        return {
+            "workspace_host": workspace_host,
+            "databricks_user": databricks_user,
+            "databricks_user_id": databricks_user_id,
+            "token_expires_at": tokens.expires_at,
+            "refresh_token_expires_at": tokens.refresh_token_expires_at,
+            "scopes": tokens.scopes,
+        }
+
+    def upsert(
+        self,
+        user_id: str,
+        *,
+        workspace_host: str,
+        databricks_user: str,
+        databricks_user_id: str,
+        tokens: DatabricksTokenSet,
+    ) -> DatabricksConnection:
+        """Create or replace a user's Databricks connection (idempotent on ``user_id``)."""
+        conn = self._store.upsert(
+            user_id,
+            self._PROVIDER,
+            secret=self._secret(tokens),
+            metadata=self._metadata(
+                tokens,
+                workspace_host=workspace_host,
+                databricks_user=databricks_user,
+                databricks_user_id=databricks_user_id,
+            ),
+        )
+        return self._to_entity(conn)
+
+    def update_tokens(self, user_id: str, tokens: DatabricksTokenSet) -> bool:
+        """Persist a refreshed token set, preserving the connected workspace/user.
+
+        Returns ``True`` if a row was present to update, ``False`` if it was
+        removed between read and refresh.
+        """
+        # with_secret=True: we may need the stored refresh token to preserve it
+        # when the provider's refresh response omits a rotated one.
+        existing = self._store.get(user_id, self._PROVIDER, with_secret=True)
+        if existing is None:
+            return False
+        meta = dict(existing.metadata)
+        meta["token_expires_at"] = tokens.expires_at
+        if tokens.scopes:
+            meta["scopes"] = tokens.scopes
+        secret = self._secret(tokens)
+        if tokens.refresh_token:
+            meta["refresh_token_expires_at"] = tokens.refresh_token_expires_at
+        else:
+            # An OAuth refresh may omit a rotated refresh token; keep the stored
+            # one (and its expiry) so the next refresh doesn't wedge the user.
+            secret["refresh_token"] = (existing.secret or {}).get("refresh_token")
+        return self._store.update_secret(user_id, self._PROVIDER, secret=secret, metadata=meta)

--- a/omnigent/entities/__init__.py
+++ b/omnigent/entities/__init__.py
@@ -26,6 +26,7 @@ from omnigent.entities.conversation import (
     parse_item_data,
     synthesize_conversation_title,
 )
+from omnigent.entities.databricks_connection import DatabricksConnection
 from omnigent.entities.device_grant import DeviceGrant
 from omnigent.entities.file import StoredFile
 from omnigent.entities.github_connection import GithubConnection
@@ -55,6 +56,7 @@ __all__ = [
     "CompactionData",
     "Conversation",
     "ConversationItem",
+    "DatabricksConnection",
     "DeviceGrant",
     "ErrorData",
     "FunctionCallData",

--- a/omnigent/entities/databricks_connection.py
+++ b/omnigent/entities/databricks_connection.py
@@ -1,0 +1,46 @@
+"""Per-user Databricks connection entity.
+
+Plain dataclass returned from
+:class:`~omnigent.connections.databricks.DatabricksConnectionStore`. Token
+material is carried encrypted in the store row; the token fields here hold the
+*decrypted* values and are only ever populated on the server-side vend path,
+never serialized to a client.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class DatabricksConnection:
+    """A user's connected Databricks workspace.
+
+    :param user_id: The omnigent user id the connection belongs to.
+    :param workspace_host: The connected workspace origin (``https://…``); the
+        OAuth + AI Gateway MCP endpoints are relative to it.
+    :param databricks_user: The connected Databricks user name (email).
+    :param databricks_user_id: The connected Databricks SCIM user id.
+    :param access_token: Decrypted OAuth access token, or ``None`` on a
+        metadata-only view (status endpoints).
+    :param refresh_token: Decrypted refresh token, or ``None``.
+    :param token_expires_at: Unix epoch seconds the access token expires at, or
+        ``None``.
+    :param refresh_token_expires_at: Unix epoch seconds the refresh token expires
+        at, or ``None``.
+    :param scopes: Space-separated granted scopes.
+    :param created_at: Unix epoch seconds the connection was first made.
+    :param updated_at: Unix epoch seconds of the last refresh / reconnect.
+    """
+
+    user_id: str
+    workspace_host: str
+    databricks_user: str
+    databricks_user_id: str
+    access_token: str | None
+    refresh_token: str | None
+    token_expires_at: int | None
+    refresh_token_expires_at: int | None
+    scopes: str
+    created_at: int
+    updated_at: int

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4279,6 +4279,14 @@ def run_host_process(
     configure_host_gh(server_url, identity.host_id)
     start_host_gh_refresh(server_url, identity.host_id)
 
+    # Executor-agnostic Databricks setup: when the owner has linked a workspace,
+    # materialize their per-user token as a ``~/.databrickscfg`` profile so the
+    # agent's model serving + MCP route through their Databricks AI Gateway.
+    # Best-effort; a no-op when Databricks isn't connected/configured.
+    from omnigent.host.databricks_credential import configure_host_databricks
+
+    configure_host_databricks(server_url, identity.host_id)
+
     if lifecycle_lock is None and daemon_target is not None:
         lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)
     host = HostProcess(identity, server_url, lifecycle_lock=lifecycle_lock)

--- a/omnigent/host/databricks_credential.py
+++ b/omnigent/host/databricks_credential.py
@@ -1,0 +1,278 @@
+"""Point a managed sandbox's Databricks auth at the owner's per-user broker.
+
+Called by ``omnigent host`` at startup (executor-agnostic, like
+:func:`omnigent.git_credential_github.configure_host_git`). When the owner has
+linked a Databricks workspace via the OAuth U2M connect flow, the host writes a
+host-only ``[omnigent]`` ``~/.databrickscfg`` profile (workspace ``host`` only,
+**no token**), exports ``DATABRICKS_CONFIG_PROFILE``, and drops a private
+sidecar recording the broker coordinates (server URL, host id, launch token).
+
+The Databricks **bearer is never persisted in the sandbox**. Instead, the
+command-based harnesses (codex / claude / pi) mint it on demand: their gateway
+auth command falls back to :func:`main` here, which fetches the owner's
+server-refreshed token from the generic credential broker
+(:mod:`omnigent.server.routes.host_credentials`, ``provider=databricks``) each
+time it runs — the same per-op broker fetch the GitHub credential helper uses.
+The harness re-runs that command as tokens near expiry, so a long session
+refreshes without relaunch.
+
+The launch token in the sidecar is a lesser, expiring credential already present
+in this disposable sandbox (git's credential helper bakes the same token into
+``~/.gitconfig``); the owner's Databricks token is not. Best-effort throughout:
+a no-op when the host token is absent, the broker is unreachable, the feature is
+off, or the owner hasn't connected Databricks (the sandbox then keeps whatever
+ambient ``~/.databrickscfg`` it already had).
+
+Scope: this wires the *command-based* gateway harnesses. The opencode-native
+gateway and the Databricks MCP resolver read a static profile token via the SDK
+and are intentionally not wired here; a host-only profile makes them fall back
+to their ambient config until a broker-backed resolver lands for them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import contextlib
+import json
+import logging
+import os
+import shlex
+import sys
+from pathlib import Path
+
+import httpx
+
+from omnigent.host.identity import HOST_TOKEN_ENV_VAR, MANAGED_HOST_TOKEN_HEADER
+
+_logger = logging.getLogger(__name__)
+
+_TIMEOUT_S = 15.0
+
+# The profile our host section is written under. Distinct from any ambient
+# profile so merging never clobbers an operator's existing sections.
+HOST_DATABRICKS_PROFILE = "omnigent"
+
+# Broker coordinates live next to the config file, not in the profile (the
+# Databricks CLI would reject unknown keys) and not in the env (the launch token
+# is a bearer secret kept off the runner env allowlist, like git's).
+_SIDECAR_NAME = ".omnigent-databricks-broker.json"
+
+
+def _credential_url(server: str, host_id: str) -> str:
+    # Generic, provider-keyed host-credential broker (host_credentials.py); the
+    # dedicated per-provider route was removed in favor of this one.
+    return f"{server.rstrip('/')}/v1/hosts/{host_id}/credentials/databricks"
+
+
+def _fetch(server: str, host_id: str, host_token: str) -> dict | None:
+    """Fetch the broker JSON, or ``None`` on any failure."""
+    try:
+        resp = httpx.get(
+            _credential_url(server, host_id),
+            headers={MANAGED_HOST_TOKEN_HEADER: host_token},
+            timeout=_TIMEOUT_S,
+        )
+    except httpx.HTTPError:
+        return None
+    if resp.status_code != 200:
+        return None
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+def fetch_broker_bearer(server: str, host_id: str, host_token: str) -> tuple[str, str] | None:
+    """Return ``(workspace_host, bearer)`` from the broker, or ``None``.
+
+    The broker refreshes the OAuth token server-side before vending it, so the
+    bearer is always current. ``None`` when the owner hasn't connected, the
+    broker is unreachable, or the response is missing either field.
+    """
+    data = _fetch(server, host_id, host_token)
+    if not data or not data.get("connected"):
+        return None
+    workspace_host = str(data.get("workspace_host") or "").rstrip("/")
+    bearer = str(data.get("token") or "")
+    if not workspace_host or not bearer:
+        return None
+    return workspace_host, bearer
+
+
+def _default_cfg_path() -> Path:
+    return Path(os.environ.get("DATABRICKS_CONFIG_FILE") or (Path.home() / ".databrickscfg"))
+
+
+def _sidecar_path(cfg_path: Path | None = None) -> Path:
+    """Sidecar path derived from the databricks config location.
+
+    The runner and the host both resolve ``DATABRICKS_CONFIG_FILE`` (allowlisted)
+    or ``~/.databrickscfg``, so both compute the same path on the shared sandbox
+    filesystem.
+    """
+    return (cfg_path or _default_cfg_path()).parent / _SIDECAR_NAME
+
+
+def _write_profile(cfg_path: Path, host: str) -> bool:
+    """Merge a host-only ``[omnigent]`` section into *cfg_path*.
+
+    Writes ``host`` only — no ``token``. The profile is a workspace selector for
+    the gateway base URL and ``databricks auth token --profile``; the bearer is
+    fetched from the broker, never written here. Preserves other profiles.
+    Returns ``True`` on success, ``False`` if the file can't be read or written.
+    """
+    parser = configparser.ConfigParser()
+    try:
+        if cfg_path.exists():
+            parser.read(cfg_path)
+    except (OSError, configparser.Error):
+        return False
+    # Replace any prior section wholesale so a stale ``token`` from an older
+    # build never lingers on disk.
+    parser[HOST_DATABRICKS_PROFILE] = {"host": host}
+    try:
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(cfg_path, "w", encoding="utf-8") as handle:
+            parser.write(handle)
+        with contextlib.suppress(OSError):
+            os.chmod(cfg_path, 0o600)
+    except OSError:
+        return False
+    return True
+
+
+_SIDECAR_KEYS = ("server", "host_id", "host_token", "workspace_host")
+
+
+def _write_sidecar(
+    cfg_path: Path, server: str, host_id: str, host_token: str, workspace_host: str
+) -> bool:
+    """Persist the broker coordinates (0600) so :func:`main` can refetch."""
+    path = _sidecar_path(cfg_path)
+    payload = {
+        "server": server,
+        "host_id": host_id,
+        "host_token": host_token,
+        "workspace_host": workspace_host,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Create 0600 atomically so the launch token is never briefly world/group
+        # readable, and fail closed if secure perms can't be guaranteed.
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+    except OSError:
+        return False
+    return True
+
+
+def _read_sidecar(path: Path) -> dict[str, str] | None:
+    """Read the broker-coordinate sidecar, or ``None`` when absent/malformed."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    coords = {key: data.get(key) for key in _SIDECAR_KEYS}
+    if not all(isinstance(value, str) and value for value in coords.values()):
+        return None
+    return coords  # type: ignore[return-value]
+
+
+def broker_token_command(host: str, cfg_path: Path | None = None) -> str | None:
+    """Gateway auth-command fallback that mints *host*'s bearer from the broker.
+
+    Returns the command **only** when a broker sidecar exists and its workspace
+    matches *host* — so a gateway pinned to the owner's connected workspace falls
+    back to the broker, while one pinned to a different workspace (a spec's own
+    ``profile``) is left to its own credentials. When
+    ``databricks auth token`` yields nothing (the host-only ``[omnigent]`` profile
+    has no OAuth cache), this fetches a fresh token from the broker instead.
+
+    The sidecar path is baked as an absolute literal so the command works in the
+    harness process regardless of its inherited environment (like git's
+    credential helper baking its coordinates).
+    """
+    path = _sidecar_path(cfg_path)
+    coords = _read_sidecar(path)
+    if coords is None or coords["workspace_host"].rstrip("/") != host.rstrip("/"):
+        return None
+    module = "omnigent.host.databricks_credential"
+    return f"python3 -m {module} token --coords {shlex.quote(str(path))}"
+
+
+def configure_host_databricks(server_url: str, host_id: str) -> bool:
+    """Point the sandbox's Databricks auth at the owner's per-user broker.
+
+    When the owner has Databricks connected, writes a host-only ``[omnigent]``
+    ``~/.databrickscfg`` profile, records the broker coordinates in a private
+    sidecar, and exports ``DATABRICKS_CONFIG_PROFILE`` so the runner (which
+    inherits it via the env allowlist) resolves the gateway workspace as them.
+    The bearer itself is fetched on demand from the broker, never persisted.
+
+    Sandbox-only: this is an auto-applied *sandbox integration*, so it no-ops
+    unless ``IS_SANDBOX=1``. ``omnigent host`` also runs on a developer's laptop,
+    where writing a brokered ``[omnigent]`` profile into their real
+    ``~/.databrickscfg`` is an unwanted local-machine footprint. ``IS_SANDBOX``
+    is baked into the managed-sandbox host image (and set on the k8s Pod) and is
+    never present on a laptop, so it scopes the write to managed sandboxes on top
+    of the owner-connected gate.
+
+    :returns: ``True`` when the per-user profile was written; ``False`` otherwise
+        (no-op — ambient config, if any, is left untouched).
+    """
+    if os.environ.get("IS_SANDBOX") != "1":
+        return False
+    token = (os.environ.get(HOST_TOKEN_ENV_VAR) or "").strip()
+    if not token:
+        return False
+    resolved = fetch_broker_bearer(server_url, host_id, token)
+    if resolved is None:
+        return False
+    # The bearer confirms the owner is connected and is discarded — only the
+    # workspace host is persisted; the bearer is refetched per use.
+    workspace_host, _bearer = resolved
+    cfg_path = _default_cfg_path()
+    if not _write_profile(cfg_path, workspace_host):
+        _logger.info("Databricks credential: could not write %s", cfg_path)
+        return False
+    if not _write_sidecar(cfg_path, server_url, host_id, token, workspace_host):
+        _logger.info("Databricks credential: could not write broker sidecar")
+        return False
+    os.environ["DATABRICKS_CONFIG_PROFILE"] = HOST_DATABRICKS_PROFILE
+    _logger.info("Databricks credential: profile %r → %s", HOST_DATABRICKS_PROFILE, workspace_host)
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the owner's current Databricks bearer, fetched from the broker.
+
+    Invoked as ``python3 -m omnigent.host.databricks_credential token`` by the
+    gateway auth command's fallback. Prints the bearer on stdout, or nothing (so
+    the caller falls through) when the sidecar is absent or the broker declines.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--coords")
+    parser.add_argument("operation", nargs="?", default="token")
+    args, _ = parser.parse_known_args(argv)
+    if args.operation != "token":
+        return 0
+    coords = _read_sidecar(Path(args.coords) if args.coords else _sidecar_path())
+    if coords is None:
+        return 0
+    resolved = fetch_broker_bearer(coords["server"], coords["host_id"], coords["host_token"])
+    if resolved is None:
+        return 0
+    _workspace_host, bearer = resolved
+    sys.stdout.write(bearer + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1083,6 +1083,8 @@ def create_app(
     sandbox_config: ManagedSandboxDeployment | None = None,
     github_config: Any | None = None,  # GitHubAppConfig — GitHub App integration
     github_store: Any | None = None,  # GithubConnectionStore — GitHub App integration
+    databricks_config: Any | None = None,  # DatabricksConfig — Databricks Connect
+    databricks_store: Any | None = None,  # DatabricksConnectionStore — Databricks Connect
     sharing_mode: SharingMode | Callable[[], SharingMode] | None = None,
     public_sharing: bool | Callable[[], bool] | None = None,
     server_config: dict[str, Any] | None = None,
@@ -1572,7 +1574,10 @@ def create_app(
     # enabled_connections list and the router mounting below both read these.
     from omnigent.server.connections_registry import connection_providers
 
-    _connection_inputs = {"github": (github_config, github_store)}
+    _connection_inputs = {
+        "github": (github_config, github_store),
+        "databricks": (databricks_config, databricks_store),
+    }
     for _provider in connection_providers():
         _cfg, _store = _connection_inputs.get(_provider.name, (None, None))
         _on = _cfg is not None and _store is not None
@@ -2382,7 +2387,7 @@ def create_app(
         # and its connection store are present.
         enabled_connections = [
             provider
-            for provider in ("github",)
+            for provider in ("github", "databricks")
             if getattr(app.state, f"{provider}_config", None) is not None
             and getattr(app.state, f"{provider}_store", None) is not None
         ]

--- a/omnigent/server/connections_registry.py
+++ b/omnigent/server/connections_registry.py
@@ -43,8 +43,13 @@ def connection_providers() -> list[ConnectionProvider]:
     Imports are deferred so importing this module stays cheap and free of import
     cycles through the route modules.
     """
+    from omnigent.server.databricks_app_client import DatabricksAppClient
+    from omnigent.server.databricks_identity import resolve_databricks_credential
     from omnigent.server.github_app_client import GitHubAppClient
     from omnigent.server.github_identity import resolve_github_credential
+    from omnigent.server.routes.connections_databricks import (
+        create_connections_databricks_router,
+    )
     from omnigent.server.routes.connections_github import (
         create_connections_github_router,
     )
@@ -55,5 +60,11 @@ def connection_providers() -> list[ConnectionProvider]:
             client_factory=GitHubAppClient,
             router_factory=create_connections_github_router,
             credential_resolver=resolve_github_credential,
+        ),
+        ConnectionProvider(
+            name="databricks",
+            client_factory=DatabricksAppClient,
+            router_factory=create_connections_databricks_router,
+            credential_resolver=resolve_databricks_credential,
         ),
     ]

--- a/omnigent/server/databricks_app.py
+++ b/omnigent/server/databricks_app.py
@@ -1,0 +1,263 @@
+"""Databricks OAuth (U2M) configuration and credential handling.
+
+Config half of the *Connect Databricks* integration: it lets a signed-in user
+authorize their Databricks workspace (OAuth U2M authorization-code + PKCE) so
+their managed sandboxes reach the Databricks **AI Gateway** MCP as them. Mirrors
+:mod:`omnigent.server.github_app`. See ``designs/DATABRICKS_CONNECT.md``.
+
+This module owns everything that *touches the app's secret* — reading it from
+env, building the OAuth form fields, deriving the PKCE verifier — but makes **no
+network calls**; the HTTP client lives in
+:mod:`omnigent.server.databricks_app_client`.
+
+Two Databricks-specific twists vs GitHub:
+
+* **Per-workspace host.** Databricks is multi-workspace, so the OAuth endpoints
+  are workspace-relative (``https://<workspace-host>/oidc/v1/{authorize,token}``)
+  and the workspace host is supplied by the user at connect time, carried in the
+  signed state, and stored in the connection metadata.
+* **PKCE.** The ``code_verifier`` is derived deterministically from
+  ``(client_secret, nonce)`` via :func:`derive_pkce`, so only the ``nonce`` need
+  ride in the (signed, short-TTL) state — the verifier itself never travels in
+  the browser and is recomputed at the callback.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+_logger = logging.getLogger(__name__)
+
+# Workspace-relative OAuth endpoints (OIDC). Joined onto the per-connection
+# workspace host, which is validated to be an https origin before use.
+_AUTHORIZE_PATH = "/oidc/v1/authorize"
+_TOKEN_PATH = "/oidc/v1/token"
+
+#: Default scopes. ``all-apis`` covers the AI Gateway MCP surface; ``offline_access``
+#: is required to receive a refresh token (server-side refresh, like GitHub).
+_DEFAULT_SCOPES = "all-apis offline_access"
+
+
+@dataclass(frozen=True)
+class DatabricksTokenSet:
+    """Result of a code exchange or refresh.
+
+    :param access_token: The Databricks user OAuth access token.
+    :param refresh_token: The refresh token (present when ``offline_access`` was
+        granted), or ``None``.
+    :param expires_at: Unix epoch seconds the access token expires at, or ``None``.
+    :param refresh_token_expires_at: Unix epoch seconds the refresh token expires
+        at, or ``None`` (Databricks does not always report this).
+    :param scopes: Space-separated granted scopes reported by the token endpoint.
+    """
+
+    access_token: str
+    refresh_token: str | None
+    expires_at: int | None
+    refresh_token_expires_at: int | None
+    scopes: str
+
+
+@dataclass(frozen=True)
+class DatabricksConfig:
+    """Validated Databricks OAuth (custom app integration) configuration.
+
+    Built once at startup via :meth:`from_env`; ``None`` when unconfigured (the
+    feature stays dormant and the connect UI is hidden). The client secret is
+    required — it both authenticates the confidential app at the token endpoint
+    and signs the OAuth state / derives the PKCE verifier.
+
+    :param client_id: The account custom-app-integration id (OAuth client id).
+    :param client_secret: The app's client secret (confidential app).
+    :param redirect_uri: OAuth callback URL registered on the app.
+    :param scopes: Space-separated scopes to request.
+    """
+
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    scopes: str
+
+    def code_exchange_fields(self, code: str, *, code_verifier: str) -> dict[str, str]:
+        """Form fields for exchanging an authorization code for tokens (PKCE)."""
+        return {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_uri,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "code_verifier": code_verifier,
+        }
+
+    def token_refresh_fields(self, refresh_token: str) -> dict[str, str]:
+        """Form fields for refreshing an access token."""
+        return {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "scope": self.scopes,
+        }
+
+    @staticmethod
+    def from_env() -> DatabricksConfig | None:
+        """Build config from ``OMNIGENT_DATABRICKS_*`` env, or ``None``.
+
+        Requires a client id, a client secret, and a resolvable redirect URI
+        (explicit ``OMNIGENT_DATABRICKS_REDIRECT_URI`` or derived from
+        ``OMNIGENT_DOMAIN``). Missing any of these disables the feature.
+        """
+        client_id = os.environ.get("OMNIGENT_DATABRICKS_CLIENT_ID", "").strip()
+        client_secret = os.environ.get("OMNIGENT_DATABRICKS_CLIENT_SECRET", "").strip()
+        if not client_id or not client_secret:
+            return None
+
+        redirect_uri = os.environ.get("OMNIGENT_DATABRICKS_REDIRECT_URI", "").strip()
+        if not redirect_uri:
+            domain = os.environ.get("OMNIGENT_DOMAIN", "").strip()
+            if not domain:
+                _logger.warning(
+                    "Databricks client id/secret are set but neither "
+                    "OMNIGENT_DATABRICKS_REDIRECT_URI nor OMNIGENT_DOMAIN is — "
+                    "Databricks integration stays disabled."
+                )
+                return None
+            redirect_uri = f"https://{domain}/v1/connections/databricks/callback"
+
+        scopes = os.environ.get("OMNIGENT_DATABRICKS_SCOPES", "").strip() or _DEFAULT_SCOPES
+        return DatabricksConfig(
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+            scopes=scopes,
+        )
+
+
+def _b64url(raw: bytes) -> str:
+    """URL-safe base64 without padding (the OAuth/PKCE encoding)."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def derive_pkce(signing_secret: str, nonce: str) -> tuple[str, str]:
+    """Deterministically derive ``(code_verifier, code_challenge)`` from a nonce.
+
+    The verifier is ``base64url(SHA256(secret:nonce))`` (43 chars, all in the
+    PKCE charset) and the challenge is ``base64url(SHA256(verifier))``
+    (``S256``). Because the verifier depends on the app's client secret, only the
+    ``nonce`` needs to travel in the signed state — the callback recomputes the
+    verifier, so it never appears in the browser. Not hand-rolled crypto: SHA-256
+    + base64url per RFC 7636.
+    """
+    verifier = _b64url(hashlib.sha256(f"{signing_secret}:{nonce}".encode()).digest())
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+# Databricks workspace hosts live under these registrable domains: AWS
+# `*.cloud.databricks.com`, GCP `*.gcp.databricks.com`, and the accounts console
+# `accounts.cloud.databricks.com` (all under `.databricks.com`), plus Azure
+# `adb-*.azuredatabricks.net`. The host is user-supplied at connect time and the
+# OAuth code/refresh exchange POSTs the shared `client_secret` to
+# `{host}/oidc/v1/token`, so an unrestricted host lets any authenticated caller
+# exfiltrate that server-wide secret to an arbitrary origin (and drive SSRF). An
+# operator on a private/gov region can extend the set via
+# OMNIGENT_DATABRICKS_ALLOWED_HOST_SUFFIXES (comma-separated `.`-prefixed suffixes).
+_DEFAULT_ALLOWED_HOST_SUFFIXES = (".databricks.com", ".azuredatabricks.net")
+
+
+def _allowed_host_suffixes() -> tuple[str, ...]:
+    raw = os.environ.get("OMNIGENT_DATABRICKS_ALLOWED_HOST_SUFFIXES", "").strip()
+    if not raw:
+        return _DEFAULT_ALLOWED_HOST_SUFFIXES
+    # Force a leading dot so a bare "databricks.com" can't match "evildatabricks.com".
+    suffixes = []
+    for entry in raw.split(","):
+        entry = entry.strip().lower()
+        if not entry:
+            continue
+        suffixes.append(entry if entry.startswith(".") else f".{entry}")
+    return tuple(suffixes) or _DEFAULT_ALLOWED_HOST_SUFFIXES
+
+
+def normalize_workspace_host(raw: str) -> str | None:
+    """Return a clean ``https://host`` origin for a user-supplied workspace, or None.
+
+    Accepts ``host``, ``https://host``, or ``https://host/path``; rejects
+    non-https schemes, anything without a hostname, and — critically — any host
+    not under an allowed Databricks domain suffix (see
+    :data:`_DEFAULT_ALLOWED_HOST_SUFFIXES`). The result has no trailing slash so
+    the OIDC paths join cleanly.
+    """
+    import re
+    from urllib.parse import urlparse
+
+    value = (raw or "").strip()
+    if not value:
+        return None
+    if "://" not in value:
+        value = f"https://{value}"
+    parsed = urlparse(value)
+    # Require https and a hostname[:port] netloc (no spaces, credentials, or junk
+    # — a Databricks workspace host is a plain DNS name).
+    if parsed.scheme != "https" or not re.fullmatch(
+        r"[A-Za-z0-9.\-]+(?::\d+)?", parsed.netloc or ""
+    ):
+        return None
+    # Gate to Databricks domains: the client_secret is POSTed to this host, so an
+    # arbitrary/internal origin would leak it. Match the hostname (port stripped).
+    host = (parsed.hostname or "").lower()
+    if not any(host.endswith(suffix) for suffix in _allowed_host_suffixes()):
+        return None
+    return f"https://{parsed.netloc}"
+
+
+def authorize_url(
+    config: DatabricksConfig, *, workspace_host: str, state: str, code_challenge: str
+) -> str:
+    """Build the workspace authorization URL to redirect the user to."""
+    from urllib.parse import urlencode
+
+    params = {
+        "response_type": "code",
+        "client_id": config.client_id,
+        "redirect_uri": config.redirect_uri,
+        "scope": config.scopes,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{workspace_host}{_AUTHORIZE_PATH}?{urlencode(params)}"
+
+
+def token_url(workspace_host: str) -> str:
+    """The workspace token endpoint."""
+    return f"{workspace_host}{_TOKEN_PATH}"
+
+
+def token_set_from_payload(payload: dict) -> DatabricksTokenSet:
+    """Parse a token-endpoint JSON payload into a :class:`DatabricksTokenSet`."""
+    if "error" in payload:
+        detail = payload.get("error_description", payload["error"])
+        raise DatabricksAppError(f"Databricks token exchange failed: {detail}")
+    access = payload.get("access_token")
+    if not access:
+        raise DatabricksAppError("Databricks token response missing access_token")
+    now = int(time.time())
+    expires_in = payload.get("expires_in")
+    refresh_expires_in = payload.get("refresh_token_expires_in")
+    return DatabricksTokenSet(
+        access_token=str(access),
+        refresh_token=payload.get("refresh_token") or None,
+        expires_at=now + int(expires_in) if expires_in else None,
+        refresh_token_expires_at=(now + int(refresh_expires_in) if refresh_expires_in else None),
+        scopes=str(payload.get("scope", "")),
+    )
+
+
+class DatabricksAppError(Exception):
+    """Raised when a Databricks OAuth interaction fails."""

--- a/omnigent/server/databricks_app_client.py
+++ b/omnigent/server/databricks_app_client.py
@@ -1,0 +1,87 @@
+"""Async HTTP client for the Databricks OAuth (U2M) flow.
+
+Network half of the Connect Databricks integration: it POSTs the OAuth token
+requests to the per-workspace token endpoint and reads the SCIM ``Me`` endpoint
+for the connected user, but never constructs credentials itself — the app secret
+and the form fields that carry it are owned by
+:class:`~omnigent.server.databricks_app.DatabricksConfig`. Mirrors
+:mod:`omnigent.server.github_app_client`. See ``designs/DATABRICKS_CONNECT.md``.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from omnigent.server.databricks_app import (
+    DatabricksAppError,
+    DatabricksConfig,
+    DatabricksTokenSet,
+    token_set_from_payload,
+    token_url,
+)
+
+# SCIM "current user" on the workspace host — reports the connected identity.
+_ME_PATH = "/api/2.0/preview/scim/v2/Me"
+_HTTP_TIMEOUT_S = 15.0
+
+
+class DatabricksAppClient:
+    """Async HTTP client for the Databricks OAuth token + identity calls.
+
+    Stateless beyond holding the config; every method opens its own short-lived
+    :class:`httpx.AsyncClient`, so it is safe to build once and reuse. All calls
+    are workspace-scoped — the ``workspace_host`` (an ``https://…`` origin) is
+    passed per call, since Databricks OAuth endpoints are workspace-relative.
+    """
+
+    def __init__(
+        self, config: DatabricksConfig, *, transport: httpx.AsyncBaseTransport | None = None
+    ) -> None:
+        self._config = config
+        self._transport = transport
+
+    def _http_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=_HTTP_TIMEOUT_S, transport=self._transport)
+
+    async def exchange_code(
+        self, workspace_host: str, code: str, *, code_verifier: str
+    ) -> DatabricksTokenSet:
+        """Exchange an authorization ``code`` (+ PKCE verifier) for tokens."""
+        return await self._token_request(
+            workspace_host, self._config.code_exchange_fields(code, code_verifier=code_verifier)
+        )
+
+    async def refresh_token(self, workspace_host: str, refresh_token: str) -> DatabricksTokenSet:
+        """Exchange a refresh token for a fresh access token."""
+        return await self._token_request(
+            workspace_host, self._config.token_refresh_fields(refresh_token)
+        )
+
+    async def fetch_user(self, workspace_host: str, access_token: str) -> tuple[str, str]:
+        """Fetch the authenticated user's ``(user_name, id)`` from SCIM ``Me``."""
+        async with self._http_client() as client:
+            resp = await client.get(
+                f"{workspace_host}{_ME_PATH}",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+        if resp.status_code != 200:
+            raise DatabricksAppError(f"Databricks SCIM Me returned {resp.status_code}")
+        data = resp.json()
+        user_name = data.get("userName")
+        user_id = data.get("id")
+        if not user_name or user_id is None:
+            raise DatabricksAppError("Databricks SCIM Me response missing userName/id")
+        return str(user_name), str(user_id)
+
+    async def _token_request(
+        self, workspace_host: str, fields: dict[str, str]
+    ) -> DatabricksTokenSet:
+        async with self._http_client() as client:
+            resp = await client.post(
+                token_url(workspace_host),
+                data=fields,
+                headers={"Accept": "application/json"},
+            )
+        if resp.status_code != 200:
+            raise DatabricksAppError(f"Databricks token endpoint returned {resp.status_code}")
+        return token_set_from_payload(resp.json())

--- a/omnigent/server/databricks_identity.py
+++ b/omnigent/server/databricks_identity.py
@@ -1,0 +1,83 @@
+"""Resolve a user's Databricks access token for the credential broker.
+
+Bridges the connection store and the Databricks OAuth client: reads the stored
+connection and transparently refreshes an expired access token, so the broker
+always vends a currently-valid token together with its workspace host (needed to
+build the AI Gateway MCP URL). Mirrors :mod:`omnigent.server.github_identity`.
+See ``designs/DATABRICKS_CONNECT.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from omnigent.connections.databricks import DatabricksConnectionStore
+from omnigent.db.utils import now_epoch
+from omnigent.server.databricks_app import DatabricksAppError
+from omnigent.server.databricks_app_client import DatabricksAppClient
+
+_logger = logging.getLogger(__name__)
+
+# Refresh a token that expires within this margin so it does not lapse
+# mid-launch (or shortly after) inside the sandbox.
+_REFRESH_MARGIN_S = 300
+
+
+async def resolve_databricks_token(
+    user_id: str,
+    *,
+    store: DatabricksConnectionStore,
+    client: DatabricksAppClient,
+) -> tuple[str, str] | None:
+    """Resolve a valid ``(access_token, workspace_host)`` for *user_id*, or ``None``.
+
+    Reads the stored connection and transparently refreshes a token at/near
+    expiry (persisting the refresh, workspace-scoped). Best-effort: any failure
+    (no connection, no refresh token, refresh rejected) returns ``None``.
+    """
+    connection = await _run_sync(store.get, user_id, with_tokens=True)
+    if connection is None or not connection.access_token or not connection.workspace_host:
+        return None
+    access_token = connection.access_token
+    workspace_host = connection.workspace_host
+    expires_at = connection.token_expires_at
+    if expires_at is not None and expires_at <= now_epoch() + _REFRESH_MARGIN_S:
+        if not connection.refresh_token:
+            return None
+        try:
+            refreshed = await client.refresh_token(workspace_host, connection.refresh_token)
+        except DatabricksAppError as exc:
+            _logger.warning("Databricks token refresh failed for %s: %s", user_id, exc)
+            return None
+        await _run_sync(store.update_tokens, user_id, refreshed)
+        access_token = refreshed.access_token
+    return access_token, workspace_host
+
+
+async def resolve_databricks_credential(
+    user_id: str,
+    *,
+    store: DatabricksConnectionStore,
+    client: DatabricksAppClient,
+) -> dict[str, object] | None:
+    """Resolve the Databricks broker payload for *user_id*, or ``None``.
+
+    The provider adapter the generic credential broker
+    (:mod:`omnigent.server.routes.host_credentials`) calls: returns the vended
+    (server-refreshed) access token plus the ``workspace_host`` the sandbox
+    needs to target the AI Gateway, or ``None`` when the owner has not linked
+    Databricks. Mirrors
+    :func:`omnigent.server.github_identity.resolve_github_credential`.
+    """
+    resolved = await resolve_databricks_token(user_id, store=store, client=client)
+    if resolved is None:
+        return None
+    access_token, workspace_host = resolved
+    return {"token": access_token, "workspace_host": workspace_host}
+
+
+async def _run_sync(func, /, *args, **kwargs):
+    """Run a synchronous store call off the event loop."""
+    import asyncio
+
+    return await asyncio.to_thread(lambda: func(*args, **kwargs))

--- a/omnigent/server/routes/connections_databricks.py
+++ b/omnigent/server/routes/connections_databricks.py
@@ -1,0 +1,123 @@
+"""Databricks integration routes: connect / callback / status / disconnect.
+
+Mounted under ``/v1`` so paths are ``/v1/connections/databricks/...``. Only
+mounted when a :class:`DatabricksConfig` is configured. Lets a signed-in user
+authorize their Databricks workspace (OAuth U2M + PKCE) so their managed
+sandboxes reach the Databricks AI Gateway MCP as them. The shared OAuth flow
+lives in :mod:`omnigent.server.routes.connections_base`; this module is the
+Databricks adapter (per-workspace host + PKCE). See
+``designs/DATABRICKS_CONNECT.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from typing import Any
+
+from fastapi import Request
+from httpx import HTTPError
+
+from omnigent.connections.databricks import DatabricksConnectionStore
+from omnigent.server.auth import AuthProvider
+from omnigent.server.databricks_app import (
+    DatabricksAppError,
+    DatabricksConfig,
+    authorize_url,
+    derive_pkce,
+    normalize_workspace_host,
+)
+from omnigent.server.databricks_app_client import DatabricksAppClient
+from omnigent.server.routes.connections_base import (
+    ConnectionError,
+    ConnectStart,
+    create_connection_router,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class DatabricksConnectionHooks:
+    """Databricks half of the shared connection flow: OAuth U2M + PKCE against a
+    per-user workspace host, and the non-secret status fields (workspace, user).
+
+    Unlike GitHub, Databricks is multi-workspace, so ``begin`` reads a
+    ``workspace`` query param and binds the workspace host + PKCE nonce into the
+    signed state; ``complete`` recomputes the PKCE verifier from that nonce (the
+    verifier never rides in the browser)."""
+
+    provider = "databricks"
+
+    def __init__(
+        self,
+        config: DatabricksConfig,
+        store: DatabricksConnectionStore,
+        client: DatabricksAppClient | None = None,
+    ) -> None:
+        self.config = config
+        self.store = store
+        self.api = client if client is not None else DatabricksAppClient(config)
+
+    def signing_key(self) -> str:
+        return self.config.client_secret
+
+    def status_fields(self, connection: Any | None) -> dict[str, Any]:
+        return {
+            "workspace_host": connection.workspace_host if connection is not None else None,
+            "databricks_user": connection.databricks_user if connection is not None else None,
+        }
+
+    def begin(self, request: Request, build_state: Any) -> ConnectStart | None:
+        workspace_host = normalize_workspace_host(request.query_params.get("workspace") or "")
+        if workspace_host is None:
+            return None
+        nonce = secrets.token_urlsafe(32)
+        _verifier, challenge = derive_pkce(self.config.client_secret, nonce)
+        state = build_state({"workspace_host": workspace_host, "nonce": nonce})
+        return ConnectStart(
+            authorize_url(
+                self.config,
+                workspace_host=workspace_host,
+                state=state,
+                code_challenge=challenge,
+            )
+        )
+
+    async def complete(self, user_id: str, code: str, claims: dict[str, Any]) -> None:
+        workspace_host = normalize_workspace_host(str(claims.get("workspace_host") or ""))
+        nonce = claims.get("nonce")
+        if workspace_host is None or not nonce:
+            raise ConnectionError("missing workspace host or PKCE nonce in state")
+        verifier, _challenge = derive_pkce(self.config.client_secret, str(nonce))
+        try:
+            tokens = await self.api.exchange_code(workspace_host, code, code_verifier=verifier)
+            user_name, databricks_user_id = await self.api.fetch_user(
+                workspace_host, tokens.access_token
+            )
+        except (DatabricksAppError, HTTPError, ValueError) as exc:
+            raise ConnectionError(str(exc)) from exc
+        await asyncio.to_thread(
+            self.store.upsert,
+            user_id,
+            workspace_host=workspace_host,
+            databricks_user=user_name,
+            databricks_user_id=databricks_user_id,
+            tokens=tokens,
+        )
+        _logger.info("Databricks workspace %s connected for %s", workspace_host, user_id)
+
+
+def create_connections_databricks_router(
+    config: DatabricksConfig,
+    store: DatabricksConnectionStore,
+    *,
+    auth_provider: AuthProvider | None = None,
+    client: DatabricksAppClient | None = None,
+):
+    """Build the Databricks integration router — the Databricks adapter over the
+    shared ``/connections/{provider}/*`` flow."""
+    return create_connection_router(
+        DatabricksConnectionHooks(config, store, client),
+        auth_provider=auth_provider,
+    )

--- a/tests/host/test_databricks_credential.py
+++ b/tests/host/test_databricks_credential.py
@@ -1,0 +1,246 @@
+"""Tests for the host-side Databricks credential materializer."""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import stat
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.host import databricks_credential as dc
+from omnigent.host.identity import HOST_TOKEN_ENV_VAR
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: dict | None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # These tests model a managed sandbox host, where IS_SANDBOX=1 is baked into
+    # the image; see test_noop_off_sandbox for the local-host (unset) no-op.
+    monkeypatch.setenv("IS_SANDBOX", "1")
+    monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "host-tok")
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(tmp_path / ".databrickscfg"))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+
+def _patch_get(monkeypatch: pytest.MonkeyPatch, resp_or_exc) -> dict:
+    seen: dict = {}
+
+    def fake_get(url: str, headers: dict, timeout: float):
+        seen["url"] = url
+        seen["headers"] = headers
+        if isinstance(resp_or_exc, Exception):
+            raise resp_or_exc
+        return resp_or_exc
+
+    monkeypatch.setattr(dc.httpx, "get", fake_get)
+    return seen
+
+
+def _connected(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch the broker to return a connected credential; return the seen dict."""
+    return _patch_get(
+        monkeypatch,
+        _Resp(
+            200, {"connected": True, "token": "dbx-tok", "workspace_host": "https://ws.example/"}
+        ),
+    )
+
+
+def test_writes_host_only_profile_and_sets_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    seen = _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example/", "host-1") is True
+    # Broker hit with the host token header, generic provider-keyed URL.
+    assert seen["url"] == "https://omni.example/v1/hosts/host-1/credentials/databricks"
+    assert seen["headers"]["X-Omnigent-Host-Token"] == "host-tok"
+    # Profile written with only the host (trailing slash stripped) — no token.
+    cfg = configparser.ConfigParser()
+    cfg.read(tmp_path / ".databrickscfg")
+    assert cfg["omnigent"]["host"] == "https://ws.example"
+    assert "token" not in cfg["omnigent"]
+    assert os.environ["DATABRICKS_CONFIG_PROFILE"] == "omnigent"
+
+
+def test_bearer_is_never_persisted_to_disk(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    # The broker returned "dbx-tok"; it must appear nowhere on disk.
+    assert "dbx-tok" not in (tmp_path / ".databrickscfg").read_text()
+    assert "dbx-tok" not in (tmp_path / dc._SIDECAR_NAME).read_text()
+
+
+def test_sidecar_records_broker_coords_privately(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "host-1") is True
+    sidecar = tmp_path / dc._SIDECAR_NAME
+    assert json.loads(sidecar.read_text()) == {
+        "server": "https://omni.example",
+        "host_id": "host-1",
+        "host_token": "host-tok",
+        "workspace_host": "https://ws.example",
+    }
+    assert stat.S_IMODE(os.stat(sidecar).st_mode) == 0o600
+
+
+def test_preserves_existing_profiles(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    cfg_path = tmp_path / ".databrickscfg"
+    cfg_path.write_text("[other]\nhost = https://keep.example\ntoken = keep\n")
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    cfg = configparser.ConfigParser()
+    cfg.read(cfg_path)
+    assert cfg["other"]["host"] == "https://keep.example"  # untouched
+    assert cfg["other"]["token"] == "keep"
+    assert cfg["omnigent"]["host"] == "https://ws.example"
+
+
+def test_replaces_stale_token_from_older_build(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # An older build wrote a static token; the new write must drop it.
+    cfg_path = tmp_path / ".databrickscfg"
+    cfg_path.write_text("[omnigent]\nhost = https://old.example\ntoken = stale\n")
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    cfg = configparser.ConfigParser()
+    cfg.read(cfg_path)
+    assert cfg["omnigent"]["host"] == "https://ws.example"
+    assert "token" not in cfg["omnigent"]
+    assert "stale" not in cfg_path.read_text()
+
+
+def test_noop_when_not_connected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _patch_get(monkeypatch, _Resp(200, {"connected": False}))
+    assert dc.configure_host_databricks("https://omni.example", "h") is False
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
+    assert not (tmp_path / dc._SIDECAR_NAME).exists()
+
+
+def test_noop_without_host_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(HOST_TOKEN_ENV_VAR, raising=False)
+    called = _patch_get(monkeypatch, _Resp(200, {"connected": True, "token": "t"}))
+    assert dc.configure_host_databricks("https://omni.example", "h") is False
+    assert called == {}  # broker never hit
+
+
+def test_noop_off_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Local-host safety: a connected owner running ``omnigent host`` on a laptop
+    (no IS_SANDBOX) must not get their real ~/.databrickscfg written. This is an
+    auto-applied sandbox integration — it no-ops entirely off a managed sandbox,
+    even with a valid host token and a connected broker, and never hits the broker."""
+    monkeypatch.delenv("IS_SANDBOX", raising=False)
+    called = _patch_get(
+        monkeypatch,
+        _Resp(200, {"connected": True, "token": "t", "workspace_host": "https://ws.example"}),
+    )
+    assert dc.configure_host_databricks("https://omni.example", "h") is False
+    assert called == {}  # broker never hit — pure no-op
+    assert not (tmp_path / ".databrickscfg").exists()  # no local footprint
+    assert not (tmp_path / dc._SIDECAR_NAME).exists()
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
+
+
+def test_noop_on_broker_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, httpx.ConnectError("down"))
+    assert dc.configure_host_databricks("https://omni.example", "h") is False
+
+
+def test_noop_on_non_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_get(monkeypatch, _Resp(404, None))
+    assert dc.configure_host_databricks("https://omni.example", "h") is False
+
+
+def test_broker_token_command_none_without_sidecar() -> None:
+    assert dc.broker_token_command("https://ws.example") is None
+
+
+def test_broker_token_command_bakes_sidecar_path_for_the_connected_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    # Trailing-slash-insensitive match against the connected workspace host.
+    cmd = dc.broker_token_command("https://ws.example/")
+    assert cmd is not None
+    assert "python3 -m omnigent.host.databricks_credential token" in cmd
+    assert str(tmp_path / dc._SIDECAR_NAME) in cmd
+
+
+def test_broker_token_command_none_for_a_different_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    # A gateway pinned to another workspace must not borrow the broker token.
+    assert dc.broker_token_command("https://other.example") is None
+
+
+def test_main_prints_broker_bearer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    capsys.readouterr()  # discard configure-time log output
+    assert dc.main(["token"]) == 0
+    assert capsys.readouterr().out.strip() == "dbx-tok"
+
+
+def test_main_uses_explicit_coords_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    sidecar = tmp_path / dc._SIDECAR_NAME
+    capsys.readouterr()  # discard configure-time log output
+    assert dc.main(["token", "--coords", str(sidecar)]) == 0
+    assert capsys.readouterr().out.strip() == "dbx-tok"
+
+
+def test_main_silent_without_sidecar(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    called = _connected(monkeypatch)
+    assert dc.main(["token"]) == 0  # no sidecar on disk
+    assert capsys.readouterr().out == ""
+    assert called == {}  # never reached the broker
+
+
+def test_main_silent_when_broker_declines(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    # Owner later disconnects: broker now returns not-connected.
+    _patch_get(monkeypatch, _Resp(200, {"connected": False}))
+    capsys.readouterr()  # discard configure-time log output
+    assert dc.main(["token"]) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_main_ignores_unknown_operation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _connected(monkeypatch)
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    capsys.readouterr()  # discard configure-time log output
+    assert dc.main(["store"]) == 0
+    assert capsys.readouterr().out == ""

--- a/tests/server/test_databricks_app.py
+++ b/tests/server/test_databricks_app.py
@@ -1,0 +1,162 @@
+"""Tests for the Databricks OAuth config / PKCE / payload helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+
+from omnigent.server.databricks_app import (
+    DatabricksAppError,
+    DatabricksConfig,
+    authorize_url,
+    derive_pkce,
+    normalize_workspace_host,
+    token_set_from_payload,
+)
+
+
+def _config() -> DatabricksConfig:
+    return DatabricksConfig(
+        client_id="cid",
+        client_secret="sekret",
+        redirect_uri="https://omni.example/v1/connections/databricks/callback",
+        scopes="all-apis offline_access",
+    )
+
+
+def test_derive_pkce_is_deterministic_and_s256() -> None:
+    v1, c1 = derive_pkce("sekret", "nonce-1")
+    v2, c2 = derive_pkce("sekret", "nonce-1")
+    assert (v1, c1) == (v2, c2)  # deterministic → recomputable at callback
+    # Different nonce or secret → different verifier.
+    assert derive_pkce("sekret", "nonce-2")[0] != v1
+    assert derive_pkce("other", "nonce-1")[0] != v1
+    # challenge == base64url(SHA256(verifier)), no padding (RFC 7636 S256).
+    expected = base64.urlsafe_b64encode(hashlib.sha256(v1.encode()).digest()).rstrip(b"=").decode()
+    assert c1 == expected
+    # verifier is in the PKCE charset and length range.
+    assert 43 <= len(v1) <= 128 and "=" not in v1
+
+
+def test_normalize_workspace_host() -> None:
+    # Databricks workspace hosts across the public clouds are accepted.
+    assert (
+        normalize_workspace_host("dbc-abc.cloud.databricks.com")
+        == "https://dbc-abc.cloud.databricks.com"
+    )
+    assert (
+        normalize_workspace_host("https://dbc-abc.cloud.databricks.com/")
+        == "https://dbc-abc.cloud.databricks.com"
+    )
+    assert (
+        normalize_workspace_host("https://adb-123.4.azuredatabricks.net")
+        == "https://adb-123.4.azuredatabricks.net"
+    )
+    assert (
+        normalize_workspace_host("accounts.cloud.databricks.com")
+        == "https://accounts.cloud.databricks.com"
+    )
+    assert normalize_workspace_host("http://insecure.example") is None  # non-https rejected
+    assert normalize_workspace_host("") is None
+    assert normalize_workspace_host("not a url") is None
+
+
+def test_normalize_workspace_host_rejects_non_databricks_domains() -> None:
+    # SSRF / client_secret exfiltration guard: the client_secret is POSTed to
+    # this host, so only Databricks domains are allowed.
+    assert normalize_workspace_host("https://attacker.example.com") is None
+    assert normalize_workspace_host("https://host/some/path") is None
+    assert normalize_workspace_host("https://169.254.169.254") is None  # metadata IP
+    assert normalize_workspace_host("https://localhost:8080") is None
+    # Look-alikes that must NOT slip past the suffix match.
+    assert normalize_workspace_host("https://evildatabricks.com") is None
+    assert normalize_workspace_host("https://databricks.com.attacker.net") is None
+
+
+def test_normalize_workspace_host_honors_operator_suffix_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An operator on a private/gov region can extend the allowed suffixes.
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_ALLOWED_HOST_SUFFIXES", ".internal.example.com")
+    assert (
+        normalize_workspace_host("https://ws.internal.example.com")
+        == "https://ws.internal.example.com"
+    )
+    # The override replaces the default set (public Databricks domains no longer match).
+    assert normalize_workspace_host("https://dbc-abc.cloud.databricks.com") is None
+
+
+def test_operator_suffix_allowlist_forces_leading_dot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A bare (no-dot) operator suffix must be normalized to dot-prefixed so it
+    # can't match a look-alike registrable domain (evilinternal.example.com).
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_ALLOWED_HOST_SUFFIXES", "internal.example.com")
+    assert (
+        normalize_workspace_host("https://ws.internal.example.com")
+        == "https://ws.internal.example.com"
+    )
+    assert normalize_workspace_host("https://evilinternal.example.com") is None
+
+
+def test_authorize_url_carries_pkce_and_scopes() -> None:
+    url = authorize_url(
+        _config(),
+        workspace_host="https://dbc-abc.cloud.databricks.com",
+        state="STATE",
+        code_challenge="CHAL",
+    )
+    assert url.startswith("https://dbc-abc.cloud.databricks.com/oidc/v1/authorize?")
+    for frag in (
+        "response_type=code",
+        "client_id=cid",
+        "code_challenge=CHAL",
+        "code_challenge_method=S256",
+        "state=STATE",
+        "scope=all-apis+offline_access",
+    ):
+        assert frag in url
+
+
+def test_exchange_and_refresh_fields() -> None:
+    cfg = _config()
+    ex = cfg.code_exchange_fields("the-code", code_verifier="ver")
+    assert ex["grant_type"] == "authorization_code"
+    assert ex["code"] == "the-code" and ex["code_verifier"] == "ver"
+    assert ex["client_id"] == "cid" and ex["client_secret"] == "sekret"
+    rf = cfg.token_refresh_fields("rt")
+    assert rf["grant_type"] == "refresh_token" and rf["refresh_token"] == "rt"
+
+
+def test_token_set_from_payload() -> None:
+    ts = token_set_from_payload(
+        {"access_token": "at", "refresh_token": "rt", "expires_in": 3600, "scope": "all-apis"}
+    )
+    assert ts.access_token == "at" and ts.refresh_token == "rt"
+    assert ts.expires_at is not None and ts.scopes == "all-apis"
+    with pytest.raises(DatabricksAppError):
+        token_set_from_payload({"error": "invalid_grant", "error_description": "nope"})
+    with pytest.raises(DatabricksAppError):
+        token_set_from_payload({"token_type": "Bearer"})  # missing access_token
+
+
+def test_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in (
+        "OMNIGENT_DATABRICKS_CLIENT_ID",
+        "OMNIGENT_DATABRICKS_CLIENT_SECRET",
+        "OMNIGENT_DATABRICKS_REDIRECT_URI",
+        "OMNIGENT_DOMAIN",
+        "OMNIGENT_DATABRICKS_SCOPES",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    assert DatabricksConfig.from_env() is None  # unconfigured → dormant
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_CLIENT_ID", "cid")
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_CLIENT_SECRET", "sek")
+    assert DatabricksConfig.from_env() is None  # no redirect and no domain
+    monkeypatch.setenv("OMNIGENT_DOMAIN", "omni.example")
+    cfg = DatabricksConfig.from_env()
+    assert cfg is not None
+    assert cfg.redirect_uri == "https://omni.example/v1/connections/databricks/callback"
+    assert cfg.scopes == "all-apis offline_access"

--- a/tests/server/test_databricks_store.py
+++ b/tests/server/test_databricks_store.py
@@ -1,0 +1,122 @@
+"""Tests for the Databricks connection store façade."""
+
+from __future__ import annotations
+
+from omnigent.connections.databricks import DatabricksConnectionStore
+from omnigent.server.databricks_app import DatabricksTokenSet
+
+
+class SecretBox:  # test double for the KMS SecretCipher: key- and context-bound
+    def __init__(self, key: str) -> None:
+        self._key = key
+
+    def encrypt(self, plaintext: str, *, context) -> str:
+        import base64
+        import json
+
+        return base64.b64encode(
+            json.dumps({"k": self._key, "c": dict(context), "p": plaintext}).encode()
+        ).decode("ascii")
+
+    def decrypt(self, ciphertext: str, *, context):
+        import base64
+        import json
+
+        try:
+            d = json.loads(base64.b64decode(ciphertext.encode("ascii")))
+        except ValueError:
+            return None
+        return d["p"] if d["k"] == self._key and d["c"] == dict(context) else None
+
+
+def _store(db_uri: str) -> DatabricksConnectionStore:
+    return DatabricksConnectionStore(db_uri, SecretBox("enc-secret"))
+
+
+def _tokens(access: str = "at", refresh: str = "rt") -> DatabricksTokenSet:
+    return DatabricksTokenSet(
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=1000,
+        refresh_token_expires_at=2000,
+        scopes="all-apis offline_access",
+    )
+
+
+def test_upsert_get_roundtrip(db_uri: str) -> None:
+    store = _store(db_uri)
+    store.upsert(
+        "alice",
+        workspace_host="https://dbc-abc.cloud.databricks.com",
+        databricks_user="alice@corp.com",
+        databricks_user_id="42",
+        tokens=_tokens(),
+    )
+    # Metadata-only view hides tokens but keeps workspace/user.
+    meta_only = store.get("alice")
+    assert meta_only is not None
+    assert meta_only.access_token is None and meta_only.refresh_token is None
+    assert meta_only.workspace_host == "https://dbc-abc.cloud.databricks.com"
+    assert meta_only.databricks_user == "alice@corp.com"
+    # With-tokens view decrypts.
+    full = store.get("alice", with_tokens=True)
+    assert full is not None and full.access_token == "at" and full.refresh_token == "rt"
+    assert full.token_expires_at == 1000
+
+
+def test_update_tokens_preserves_workspace(db_uri: str) -> None:
+    store = _store(db_uri)
+    store.upsert(
+        "bob",
+        workspace_host="https://ws.example",
+        databricks_user="bob@corp.com",
+        databricks_user_id="7",
+        tokens=_tokens("old", "oldr"),
+    )
+    assert store.update_tokens("bob", _tokens("new", "newr")) is True
+    conn = store.get("bob", with_tokens=True)
+    assert conn is not None and conn.access_token == "new"
+    assert conn.workspace_host == "https://ws.example"  # preserved
+    assert conn.databricks_user == "bob@corp.com"  # preserved
+    # Missing row → False (removed between read and refresh).
+    assert store.update_tokens("ghost", _tokens()) is False
+
+
+def test_update_tokens_keeps_refresh_token_when_response_omits_it(db_uri: str) -> None:
+    """An OAuth refresh may omit a rotated refresh token; the stored one (and its
+    expiry) must survive so the next refresh doesn't permanently wedge the user."""
+    store = _store(db_uri)
+    store.upsert(
+        "dave",
+        workspace_host="https://ws.example",
+        databricks_user="dave@corp.com",
+        databricks_user_id="11",
+        tokens=_tokens("old", "keep-me"),
+    )
+    rotated = DatabricksTokenSet(
+        access_token="fresh",
+        refresh_token=None,  # provider omitted a new refresh token
+        expires_at=5000,
+        refresh_token_expires_at=None,
+        scopes="all-apis offline_access",
+    )
+    assert store.update_tokens("dave", rotated) is True
+    conn = store.get("dave", with_tokens=True)
+    assert conn is not None
+    assert conn.access_token == "fresh"  # access token rotated
+    assert conn.refresh_token == "keep-me"  # prior refresh token preserved
+    assert conn.refresh_token_expires_at == 2000  # prior expiry preserved
+
+
+def test_delete_and_isolation_from_github(db_uri: str) -> None:
+    store = _store(db_uri)
+    store.upsert(
+        "carol",
+        workspace_host="https://ws.example",
+        databricks_user="carol",
+        databricks_user_id="9",
+        tokens=_tokens(),
+    )
+    assert len(store.list_all()) == 1
+    assert store.delete("carol") is True
+    assert store.get("carol") is None

--- a/web/src/lib/databricksIntegration.ts
+++ b/web/src/lib/databricksIntegration.ts
@@ -1,0 +1,56 @@
+/**
+ * Client for the Databricks integration endpoints
+ * (``/v1/connections/databricks/*``).
+ *
+ * Lets a signed-in user connect their Databricks workspace so their managed
+ * sandboxes reach the Databricks AI Gateway (MCP + model serving) as them. The
+ * connect flow is a full-page redirect to the workspace's OAuth endpoint (the
+ * server owns the U2M + PKCE handshake); status and disconnect are JSON.
+ * Mirrors ``githubIntegration.ts``.
+ */
+
+import { authenticatedFetch } from "./identity";
+
+/** Shape of ``GET /v1/connections/databricks/status``. */
+export interface DatabricksConnectionStatus {
+  /** Whether Databricks Connect is configured on the server. */
+  enabled: boolean;
+  /** Whether the current user has connected a workspace. */
+  connected: boolean;
+  /** Connected workspace origin (``https://…``), or null. */
+  workspace_host: string | null;
+  /** Connected Databricks user (email), or null. */
+  databricks_user: string | null;
+  /** Unix epoch seconds the workspace was connected, or null. */
+  connected_at: number | null;
+}
+
+/** Fetch the current user's Databricks connection status. */
+export async function fetchDatabricksStatus(): Promise<DatabricksConnectionStatus> {
+  const res = await authenticatedFetch("/v1/connections/databricks/status");
+  if (!res.ok) {
+    throw new Error(`Databricks status failed: ${res.status}`);
+  }
+  return (await res.json()) as DatabricksConnectionStatus;
+}
+
+/**
+ * Begin the connect flow by navigating to the server's connect endpoint, which
+ * redirects the browser to the workspace's OAuth consent. Databricks is
+ * multi-workspace, so the user supplies their workspace URL (host or full
+ * ``https://…``). ``returnTo`` is where the callback lands afterwards.
+ */
+export function beginDatabricksConnect(workspace: string, returnTo: string): void {
+  const params = new URLSearchParams({ workspace, return_to: returnTo });
+  window.location.href = `/v1/connections/databricks/connect?${params.toString()}`;
+}
+
+/** Disconnect the current user's Databricks workspace. */
+export async function disconnectDatabricks(): Promise<void> {
+  const res = await authenticatedFetch("/v1/connections/databricks/disconnect", {
+    method: "POST",
+  });
+  if (!res.ok) {
+    throw new Error(`Databricks disconnect failed: ${res.status}`);
+  }
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -105,6 +105,12 @@ import {
   fetchGithubStatus,
   type GithubConnectionStatus,
 } from "@/lib/githubIntegration";
+import {
+  beginDatabricksConnect,
+  disconnectDatabricks,
+  fetchDatabricksStatus,
+  type DatabricksConnectionStatus,
+} from "@/lib/databricksIntegration";
 import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { useOmnigentAnalytics, useOmnigentPageView } from "@/lib/analytics";
@@ -1026,6 +1032,7 @@ function GithubMark({ className }: { className?: string }) {
  */
 const CONNECTION_PANELS: Record<string, ComponentType> = {
   github: GithubIntegrationControl,
+  databricks: DatabricksIntegrationControl,
 };
 
 /**
@@ -1207,6 +1214,131 @@ function AlwaysUseWorktreeControl() {
         className="mt-0.5 shrink-0"
         componentId="settings.git.always_use_worktree"
       />
+    </div>
+  );
+}
+
+/**
+ * Connect / disconnect a Databricks workspace. Once connected, a managed
+ * sandbox launched by this user reaches the Databricks AI Gateway (MCP + model
+ * serving) as them, using their per-user OAuth token. Databricks is
+ * multi-workspace, so the user supplies their workspace URL. The connect action
+ * is a full-page redirect to the workspace OAuth consent; on return the callback
+ * lands here with ``?databricks=connected|error``.
+ */
+function DatabricksIntegrationControl() {
+  const [status, setStatus] = useState<DatabricksConnectionStatus | null | "loading">("loading");
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<"connected" | "error" | null>(null);
+  const [workspace, setWorkspace] = useState("");
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await fetchDatabricksStatus());
+    } catch {
+      setStatus(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const params = new URLSearchParams(window.location.search);
+    const outcome = params.get("databricks");
+    if (outcome === "connected" || outcome === "error") {
+      setNotice(outcome);
+      params.delete("databricks");
+      const qs = params.toString();
+      window.history.replaceState({}, "", `${window.location.pathname}${qs ? `?${qs}` : ""}`);
+    }
+  }, [refresh]);
+
+  const onDisconnect = useCallback(async () => {
+    setBusy(true);
+    try {
+      await disconnectDatabricks();
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }, [refresh]);
+
+  const returnTo = `${window.location.pathname}${window.location.search}`;
+
+  // Feature not configured on this server: render nothing (like a build without it).
+  if (status !== "loading" && status !== null && !status.enabled) {
+    return null;
+  }
+  if (status === "loading") {
+    return <p className="text-sm text-muted-foreground">Checking…</p>;
+  }
+  if (status === null) {
+    return <p className="text-sm text-muted-foreground">Databricks status is unavailable.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {notice === "connected" && (
+        <div
+          role="status"
+          className="rounded-md border border-success/40 bg-success/10 px-3 py-2 text-sm"
+        >
+          Databricks workspace connected.
+        </div>
+      )}
+      {notice === "error" && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          Couldn't connect your Databricks workspace. Please try again.
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="text-sm font-medium">Databricks</span>
+          <span className="text-sm text-muted-foreground">
+            {status.connected && status.workspace_host
+              ? `Connected to ${status.workspace_host}${status.databricks_user ? ` as ${status.databricks_user}` : ""}. New sandboxes reach the Databricks AI Gateway (MCP + model serving) as you.`
+              : "Connect your Databricks workspace so new sandboxes reach its AI Gateway (MCP + model serving) as you."}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {status.connected ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-9"
+              disabled={busy}
+              data-testid="databricks-disconnect"
+              onClick={() => void onDisconnect()}
+            >
+              Disconnect
+            </Button>
+          ) : (
+            <>
+              <Input
+                type="text"
+                inputMode="url"
+                placeholder="workspace-host.cloud.databricks.com"
+                className="h-9 w-64"
+                value={workspace}
+                onChange={(e) => setWorkspace(e.target.value)}
+                data-testid="databricks-workspace"
+              />
+              <Button
+                size="sm"
+                className="h-9"
+                disabled={busy || workspace.trim() === ""}
+                data-testid="databricks-connect"
+                onClick={() => beginDatabricksConnect(workspace.trim(), returnTo)}
+              >
+                Connect Databricks
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Related issue

Continues / takes over **#5203** — *per-user Databricks Connect (OAuth U2M)*, originally by **@LittleChimera** (his connect-base commit is preserved). Rebased onto current `main`.

> **This stack supersedes #5203**, split into two PRs:
> - **This PR (#6382)** — the connector + broker + the standalone command to mint a token from inside a sandbox.
> - **#6889** (stacked on this branch) — wiring that command into the harnesses (native Claude Code, opencode, the ucode bearer path) for model serving.

## Summary

A user links their Databricks workspace via OAuth U2M + PKCE; the token set is stored encrypted (`SecretCipher`) in the generic connections registry. A managed sandbox gets a host-only `[omnigent]` `~/.databrickscfg` profile (workspace host, **no token**) plus a private broker sidecar, and can then **run one command to obtain a fresh, server-refreshed access token** — `python3 -m omnigent.host.databricks_credential token` — which calls the credential broker (`GET /v1/hosts/{id}/credentials/databricks`). The bearer is never written to disk. Mirrors the GitHub connector.

- **Connect flow + store + resolver** — OAuth/PKCE connect, the connection store, and `resolve_databricks_credential` on the generic connection registry; vended through main's provider-generic `/credentials/{provider}` broker.
- **Sandbox delivery + standalone command** — `configure_host_databricks` writes the host-only profile + broker sidecar; `broker_token_command()` / the `token` CLI entry mint on demand, refreshed server-side near expiry (the ~1h OAuth token no longer strands a long session).
- **Sandbox-only gate** — the credential write no-ops unless `IS_SANDBOX=1`, so it never touches a developer's real `~/.databrickscfg`.
- **Security** — the user-supplied workspace host is restricted to Databricks domain suffixes (operator-extendable via `OMNIGENT_DATABRICKS_ALLOWED_HOST_SUFFIXES`, forced to dot-prefixed form), closing an SSRF / `client_secret`-exfiltration path.
- **UI** — a "Connect Databricks" panel that slots into main's generic `CONNECTION_PANELS` registry.

> **Note on "no consumer":** by design, this PR delivers the token-minting *command*; wiring it into harnesses for model serving is the stacked **#6889**. The connect flow and the command are independently verifiable (see Test Plan).

## Review fixes folded in

- Preserve the stored refresh token (and its expiry) when an OAuth refresh response omits a rotated one — previously it was overwritten with `None`, permanently breaking refresh.
- `update_tokens` now returns the store's real success signal instead of unconditional `True`.
- Dropped an unused `getCurrentUserId` import that broke the TypeScript `noUnusedLocals` build.
- Operator suffix override is normalized to dot-prefixed form so a bare `databricks.com` can't match `evildatabricks.com`.
- Sidecar (holds the launch token) is created `0600` atomically and fails closed if secure perms can't be set.

## Test Plan

- **Unit** (`uv run --group test pytest`): databricks-app / databricks-store / databricks-credential — 31 pass with a clean env, including new regression tests for refresh-token preservation and the dot-prefix suffix normalization.
- **Live** (local server + Vault `SecretCipher` + a real Databricks OAuth app on an ai-oss workspace): OAuth connect; the broker vends the (Vault-encrypted-at-rest) token; **running the standalone command in an agent_sandbox pod returned a valid bearer that served model completions**; forcing the stored token to expire made the next mint rotate it (expiry advanced) with serving uninterrupted — server-side refresh confirmed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified end-to-end against a live ai-oss Databricks workspace (see Test Plan): OAuth connect, encrypted-at-rest storage via Vault `SecretCipher`, broker vend via the standalone command inside an agent_sandbox pod, model serving, and server-side token refresh (forced-expiry → rotated token → serving continued). The SSRF fix, refresh-token preservation, and the sandbox-only scoping are covered by unit tests.

## Changelog

Users can connect a personal Databricks workspace; a managed sandbox can then mint a per-user OAuth token on demand (server-refreshed) to reach Databricks, instead of relying on a shared or static token.

---
This pull request and its description were written by Isaac.
