### PR TITLE
fix(claude-native): pass provider model overrides to Claude

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -1538,6 +1538,7 @@ def build_hook_settings(
     ap_server_url: str | None = None,
     ap_auth_headers: dict[str, str] | None = None,
     api_key_helper: str | None = None,
+    model_overrides: Mapping[str, str] | None = None,
     launch_model: str | None = None,
     launch_permission_mode: str | None = None,
     launch_bypass_permissions: bool = False,
@@ -1563,6 +1564,11 @@ def build_hook_settings(
     :param api_key_helper: Optional Claude Code ``apiKeyHelper``
         command from ucode state, e.g. ``"databricks auth token
         --host https://example.databricks.com ..."``.
+    :param model_overrides: Canonical-to-served model id rewrites for
+        Claude Code's ``modelOverrides`` setting, e.g.
+        ``{"claude-opus-4-8": "databricks-claude-opus-4-8"}``. Empty or
+        ``None`` writes no ``modelOverrides`` (the endpoint already
+        speaks canonical ids, or the catalog was not enumerated).
     :param launch_model: Effective launch model from ``--model``. Mirrored
         into the invocation-local settings sidecar so a wrapped Claude Code
         re-exec that preserves ``--settings`` but rebuilds argv cannot fall
@@ -1840,6 +1846,8 @@ def build_hook_settings(
         settings["effortLevel"] = launch_effort
     if api_key_helper:
         settings["apiKeyHelper"] = api_key_helper
+    if model_overrides:
+        settings["modelOverrides"] = dict(model_overrides)
     # Override Claude Code's statusLine so we receive its stdin (the
     # only place ``context_window`` surfaces). A /bin/sh shim captures
     # the raw payload atomically (no interpreter spawn on Claude's
@@ -1929,6 +1937,7 @@ def augment_claude_args(
     ap_server_url: str | None = None,
     ap_auth_headers: dict[str, str] | None = None,
     api_key_helper: str | None = None,
+    model_overrides: Mapping[str, str] | None = None,
     bundle_dir: Path | None = None,
     agent_name: str | None = None,
     skills_filter: str | list[str] = "all",
@@ -1958,6 +1967,10 @@ def augment_claude_args(
     :param api_key_helper: Optional Claude Code ``apiKeyHelper``
         command from ucode state, e.g. ``"databricks auth token
         --host https://example.databricks.com ..."``.
+    :param model_overrides: Canonical-to-served model id rewrites
+        threaded to :func:`build_hook_settings` so the sidecar carries
+        Claude Code's ``modelOverrides`` map. ``None`` or empty omits
+        the key.
     :param bundle_dir: Materialized agent-bundle root, when the
         session's agent ships a ``skills/`` directory. Triggers
         ``--plugin-dir <bundle>`` so Claude Code discovers bundled
@@ -1993,6 +2006,7 @@ def augment_claude_args(
         ap_server_url=ap_server_url,
         ap_auth_headers=ap_auth_headers,
         api_key_helper=api_key_helper,
+        model_overrides=model_overrides,
         launch_model=_arg_value(claude_args, "--model"),
         launch_permission_mode=_arg_value(claude_args, "--permission-mode"),
         launch_bypass_permissions=_args_request_bypass_permissions(claude_args),

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -39,7 +39,7 @@ if sys.platform != "win32":
     import termios
     import tty
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -117,6 +117,7 @@ from omnigent.models.claude_model_vocabulary import (
     CUSTOM_MODEL_OPTION_NAME_ENV_VAR,
     LEGACY_CUSTOM_SLOT_ROW_ID,
     claude_model_alias,
+    served_canonical_overrides,
 )
 from omnigent.native._native_resume_hint import echo_native_resume_hint
 from omnigent.native.native_coding_agents import native_shell_terminal_spec
@@ -415,12 +416,17 @@ class ClaudeNativeUcodeConfig:
         so a router may pick it. Empty when the endpoint's catalog was
         not enumerated (cached ucode state, managed settings, a
         non-Databricks provider).
+    :param model_overrides: Provider-scoped canonical-to-served rewrites for
+        Claude Code's ``modelOverrides`` setting. Consumers treat both sides
+        as opaque ids; an empty map means the provider supplied no reliable
+        equivalence information.
     """
 
     env: dict[str, str]
     api_key_helper: str | None = None
     model: str | None = None
     routable_models: tuple[str, ...] = ()
+    model_overrides: dict[str, str] = field(default_factory=dict)
 
 
 def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig) -> bool:
@@ -2811,6 +2817,9 @@ def _ucode_config_for_profile(
         or configured_default
         or model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
         routable_models=routable_models,
+        # Databricks discovery reports ids that wrap the canonical Claude id.
+        # Keep that translation here; launch consumers treat ids as opaque.
+        model_overrides=served_canonical_overrides(routable_models),
     )
 
 
@@ -6017,6 +6026,7 @@ def _claude_terminal_request(
         ap_server_url=ap_server_url,
         ap_auth_headers=ap_auth_headers,
         api_key_helper=claude_config.api_key_helper if claude_config is not None else None,
+        model_overrides=claude_config.model_overrides if claude_config is not None else None,
         append_system_prompt=append_system_prompt,
         allowed_tools=allowed_tools,
     )

--- a/omnigent/runner/background_titles/claude_native.py
+++ b/omnigent/runner/background_titles/claude_native.py
@@ -64,8 +64,14 @@ async def generate_background_title(context: BackgroundTitleContext) -> str | No
     ]
     if effective_model:
         args.extend(("--model", effective_model))
-    if claude_config is not None and claude_config.api_key_helper:
-        args.extend(("--settings", json.dumps({"apiKeyHelper": claude_config.api_key_helper})))
+    settings: dict[str, object] = {}
+    if claude_config is not None:
+        if claude_config.api_key_helper:
+            settings["apiKeyHelper"] = claude_config.api_key_helper
+        if claude_config.model_overrides:
+            settings["modelOverrides"] = claude_config.model_overrides
+    if settings:
+        args.extend(("--settings", json.dumps(settings)))
 
     command, launch_args = resolve_claude_launch("claude", args)
     if command == "claude":

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -7203,6 +7203,7 @@ async def _auto_create_claude_terminal(
         agent_name=agent_name,
         skills_filter=skills_filter,
         api_key_helper=claude_config.api_key_helper if claude_config is not None else None,
+        model_overrides=claude_config.model_overrides if claude_config is not None else None,
         subagent_router_dir=subagent_router_dir,
         append_system_prompt="\n\n".join(
             x

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -1310,6 +1310,16 @@ async def test_auto_create_claude_terminal_injects_ucode_gateway_config(
         env=dict(gateway_env),
         api_key_helper="printf %s sk-sentinel-do-not-use",
         model="databricks-claude-opus-4-7",
+        routable_models=(
+            "databricks-claude-opus-4-7",
+            "databricks-claude-opus-4-8",
+            "databricks-claude-sonnet-5",
+        ),
+        model_overrides={
+            "claude-opus-4-7": "databricks-claude-opus-4-7",
+            "claude-opus-4-8": "databricks-claude-opus-4-8",
+            "claude-sonnet-5": "databricks-claude-sonnet-5",
+        },
     )
     # The runner imports ``_ucode_config_for_profile`` from
     # ``omnigent.harnesses.claude_native.main`` per call, so patch it at the source.
@@ -1380,6 +1390,11 @@ async def test_auto_create_claude_terminal_injects_ucode_gateway_config(
     assert all("sk-sentinel-do-not-use" not in arg for arg in spec.args)
     settings = _load_claude_invocation_settings(spec.args)
     assert settings["apiKeyHelper"] == "printf %s sk-sentinel-do-not-use"
+    assert settings["modelOverrides"] == {
+        "claude-opus-4-7": "databricks-claude-opus-4-7",
+        "claude-opus-4-8": "databricks-claude-opus-4-8",
+        "claude-sonnet-5": "databricks-claude-sonnet-5",
+    }
     assert recorded_configs == {"13efa494411f3ae60211e6be5635062a": ucode}
 
     await fake_client.aclose()

--- a/tests/runner/test_background_session_title.py
+++ b/tests/runner/test_background_session_title.py
@@ -457,7 +457,17 @@ async def test_claude_native_title_uses_tool_free_print_mode(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
+    from omnigent.harnesses.claude_native.main import ClaudeNativeUcodeConfig
+
     captured: dict[str, Any] = {}
+    claude_config = ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+        api_key_helper="printf token",
+        model_overrides={
+            "claude-opus-5": "deployment-current",
+            "claude-opus-4-8": "deployment-17",
+        },
+    )
 
     class FakeProcess:
         returncode = 0
@@ -471,7 +481,7 @@ async def test_claude_native_title_uses_tool_free_print_mode(
 
     monkeypatch.setattr(
         "omnigent.harnesses.claude_native.main.resolve_native_claude_config",
-        lambda spec=None: None,
+        lambda spec=None: claude_config,
     )
     monkeypatch.setattr(
         "omnigent.claude_launcher.resolve_claude_launch",
@@ -497,6 +507,14 @@ async def test_claude_native_title_uses_tool_free_print_mode(
     assert args[args.index("--tools") + 1] == ""
     assert args[args.index("--output-format") + 1] == "text"
     assert args[args.index("--model") + 1] == "claude-sonnet-4-6"
+    settings = json.loads(args[args.index("--settings") + 1])
+    assert settings == {
+        "apiKeyHelper": "printf token",
+        "modelOverrides": {
+            "claude-opus-5": "deployment-current",
+            "claude-opus-4-8": "deployment-17",
+        },
+    }
     assert "--no-session-persistence" in args
     assert captured["kwargs"]["cwd"] == str(tmp_path)
     assert "CLAUDECODE" not in captured["kwargs"]["env"]

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -256,6 +256,73 @@ def test_claude_terminal_request_injects_claude_config(tmp_path, monkeypatch) ->
     assert all("sk-sentinel-do-not-use" not in arg for arg in args)
     assert settings["apiKeyHelper"] == "printf %s sk-sentinel-do-not-use"
     assert "hooks" in settings
+    assert "modelOverrides" not in settings
+
+
+def test_native_config_does_not_infer_overrides_from_routable_models() -> None:
+    """Provider-local ids remain opaque without a provider-supplied map."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+        api_key_helper="printf token",
+        model="deployment-current",
+        routable_models=(
+            "deployment-current",
+            "name-containing-claude-opus-4-8",
+        ),
+    )
+
+    assert config.model_overrides == {}
+
+
+def test_claude_terminal_request_threads_provider_model_overrides_into_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI terminal writes an explicit provider map without parsing ids."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+        api_key_helper="printf token",
+        model="deployment-current",
+        routable_models=("deployment-current", "deployment-17"),
+        model_overrides={
+            "claude-opus-5": "deployment-current",
+            "claude-opus-4-8": "deployment-17",
+        },
+    )
+
+    body = claude_native._claude_terminal_request(
+        ("--print", "hi"),
+        command="claude",
+        bridge_dir=_test_bridge_dir(tmp_path, monkeypatch),
+        claude_config=config,
+    )
+
+    settings = _load_invocation_settings(body["spec"]["args"])
+    assert settings["modelOverrides"] == {
+        "claude-opus-5": "deployment-current",
+        "claude-opus-4-8": "deployment-17",
+    }
+
+
+def test_claude_terminal_request_does_not_infer_gateway_model_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gateway model name alone is not authoritative identity metadata."""
+    config = claude_native.ClaudeNativeUcodeConfig(
+        env={"ANTHROPIC_BASE_URL": "https://gateway.example/anthropic"},
+        api_key_helper="printf token",
+        model="name-containing-claude-opus-4-8",
+        routable_models=("name-containing-claude-opus-4-8",),
+    )
+
+    body = claude_native._claude_terminal_request(
+        ("--print", "hi"),
+        command="claude",
+        bridge_dir=_test_bridge_dir(tmp_path, monkeypatch),
+        claude_config=config,
+    )
+
+    settings = _load_invocation_settings(body["spec"]["args"])
+    assert "modelOverrides" not in settings
 
 
 def test_claude_terminal_request_preserves_user_model_arg(tmp_path, monkeypatch) -> None:
@@ -704,6 +771,11 @@ def test_ucode_config_refreshes_live_models_and_builds_picker_options(
     assert config.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "system.ai.claude-opus-4-10"
     assert config.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "system.ai.claude-sonnet-5"
     assert "ANTHROPIC_DEFAULT_FABLE_MODEL" not in config.env
+    assert config.model_overrides == {
+        "claude-opus-4-10": "system.ai.claude-opus-4-10",
+        "claude-sonnet-5": "system.ai.claude-sonnet-5",
+        "claude-sonnet-4-6": "system.ai.claude-sonnet-4-6",
+    }
     assert claude_native.claude_native_model_options(config) == [
         {
             "id": "opus",

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -3113,6 +3113,31 @@ def test_augment_claude_args_materializes_api_key_helper(
     assert settings_path.stat().st_mode & 0o777 == 0o600
 
 
+def test_augment_claude_args_threads_model_overrides_into_settings(tmp_path: Path) -> None:
+    """``model_overrides`` is written into the invocation-local sidecar."""
+    overrides = {
+        "claude-opus-4-8": "databricks-claude-opus-4-8",
+        "claude-opus-5": "databricks-claude-opus-5",
+    }
+
+    args = augment_claude_args(
+        (),
+        bridge_dir=tmp_path,
+        api_key_helper="printf tok",
+        model_overrides=overrides,
+    )
+
+    settings = _load_invocation_settings(args)
+    assert settings["apiKeyHelper"] == "printf tok"
+    assert settings["modelOverrides"] == overrides
+
+
+def test_augment_claude_args_omits_model_overrides_when_unsupplied(tmp_path: Path) -> None:
+    """Existing call sites that omit ``model_overrides`` write no such key."""
+    settings = _load_invocation_settings(augment_claude_args((), bridge_dir=tmp_path))
+    assert "modelOverrides" not in settings
+
+
 def test_augment_claude_args_mirrors_launch_overrides_into_settings(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1919,6 +1919,40 @@ def test_build_hook_settings_omits_apikeyhelper_when_none(
     assert with_helper["apiKeyHelper"] == "printf tok"
 
 
+def test_build_hook_settings_merges_model_overrides_next_to_apikeyhelper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Canonical-to-served rewrites land next to ``apiKeyHelper``."""
+    monkeypatch.setattr("omnigent.harnesses.claude_native.bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.harnesses.claude_native.bridge._BRIDGE_ROOT", tmp_path / "root")
+    bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_test", workspace=tmp_path)
+    overrides = {"claude-opus-4-8": "databricks-claude-opus-4-8"}
+
+    settings = build_hook_settings(
+        bridge_dir,
+        api_key_helper="printf tok",
+        model_overrides=overrides,
+    )
+
+    assert settings["apiKeyHelper"] == "printf tok"
+    assert settings["modelOverrides"] == overrides
+
+
+def test_build_hook_settings_omits_model_overrides_when_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty map leaves Claude Code as it behaves today."""
+    monkeypatch.setattr("omnigent.harnesses.claude_native.bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr("omnigent.harnesses.claude_native.bridge._BRIDGE_ROOT", tmp_path / "root")
+    bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="bridge_test", workspace=tmp_path)
+
+    assert "modelOverrides" not in build_hook_settings(bridge_dir)
+    assert "modelOverrides" not in build_hook_settings(bridge_dir, model_overrides=None)
+    assert "modelOverrides" not in build_hook_settings(bridge_dir, model_overrides={})
+
+
 def test_evaluate_policy_retries_5xx_and_succeeds(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Related issue

Closes #6337

## Summary

- Claude Code can retry a safeguard-refused turn using a canonical Anthropic model ID. Databricks serves that model under a catalog-specific ID, so the retry previously failed with `model_not_found` even though the selected family alias worked.
- Carry an explicit provider-supplied `modelOverrides` map through the invocation-local settings used by CLI terminals, runner-created terminals, and background-title launches.
- Populate the map only in the Databricks/ucode producer, from live Databricks model discovery. Other providers leave it empty unless they supply authoritative identity metadata: launch consumers do not parse model names, infer from `routable_models`, or probe a generic `/v1/models` endpoint. Opaque target IDs such as `deployment-17` are transported unchanged.

ELI5: Databricks supplies a small translation card for model IDs it owns. The launchers pass that card to Claude Code without trying to guess what any name means.

```text
Databricks live catalog ──> explicit model_overrides ──> Claude --settings
                                                       ├─ CLI terminal
                                                       ├─ runner terminal
                                                       └─ background title

Generic gateway ──> no authoritative mapping ──> no inferred overrides
```

## Test Plan

```bash
uv run --group test pytest \
  tests/runner/test_background_session_title.py \
  tests/test_claude_native.py \
  tests/test_claude_native_bridge.py \
  tests/test_claude_native_hook.py \
  tests/runner/test_app_sessions_native_terminals_autocreate.py -q
# 876 passed, 3 pre-existing deprecation warnings
```

After rebasing onto the latest `main`, the 10 exact model-override regression cases also passed. Pre-commit passed on all nine changed files, including Ruff, Pyrefly, secret scanning, and the hardcoded-model-ID guard.

Coverage verifies that generic `routable_models` do not imply identity, explicit opaque mappings survive unchanged, Databricks live discovery produces the map, and each native launch path writes it into Claude Code settings.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The sidecar settings payload is non-visual; the automated assertions inspect the exact `modelOverrides` JSON passed to Claude Code.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No live safeguard refusal was triggered against a production Databricks workspace; automated tests cover discovery, serialization, omission without authority, and all native process launch boundaries.

## Changelog

Claude-native agents using Databricks can recover from safeguard refusals without failing on the gateway's model ID.
