### PR TITLE
docs: tweak README tagline wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # <img src="https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg" alt="" height="38" valign="middle" /> Omnigent
 
-### The open-source meta-harness for all your AI agents.
+### The open-source orchestration layer for all your AI agents.
 
 Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
 


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Changed "meta-harness" to "orchestration layer" in the README tagline. Test PR — not for merging.

## Test Plan

- [x] Not applicable — copy-only change

## Demo

- [x] Not applicable — no behavioral change

## Type of change

- [x] Docs

## Test coverage

- [x] Not applicable

## Coverage notes

Docs-only wording change, no code affected.