### PR TITLE
fix(triage): coerce reusable workflow issue number

### DIFF
--- a/.github/triage_v2/tests/test_bundle_configuration.py
+++ b/.github/triage_v2/tests/test_bundle_configuration.py
@@ -60,6 +60,10 @@ def test_v2_owns_intake_when_enabled_and_manual_dispatch_is_dry_by_default() -> 
     assert "remove in 0.12.0" in legacy
     assert "cancel-in-progress: false" in intake
     assert "github.event.action == 'opened'" in prioritize
+    assert (
+        "issue_number: ${{ fromJSON(format('{0}', "
+        "github.event.issue.number || inputs.issue_number)) }}" in prioritize
+    )
     apply_expression = (
         "apply: ${{ github.event_name != 'workflow_dispatch' || inputs.apply_labels }}"
     )

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -792,7 +792,7 @@ jobs:
       )
     uses: ./.github/workflows/issue-prioritization-v2.yml
     with:
-      issue_number: ${{ github.event.issue.number || inputs.issue_number }}
+      issue_number: ${{ fromJSON(format('{0}', github.event.issue.number || inputs.issue_number)) }}
       intake: ${{ github.event_name == 'workflow_dispatch' || github.event.action == 'opened' }}
       apply: ${{ github.event_name != 'workflow_dispatch' || inputs.apply_labels }}
       manual_dispatch: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Related issue

N/A — urgent regression fix for #5996.

## Summary

After #5996, GitHub rejected every V2 call during workflow planning because the mixed issue-number expression was passed to a reusable input declared as `number` without an explicit conversion. Coerce the selected event/dispatch value through `format` and `fromJSON`, and lock the contract into the workflow configuration test.

## Test Plan

- `pre-commit run --files .github/workflows/issue-triage.yml .github/triage_v2/tests/test_bundle_configuration.py`
- `uv run --frozen --project .github/triage_v2 pytest .github/triage_v2/tests/test_bundle_configuration.py`
- Dry-run dispatch against issue #6355 with `apply_labels=false`: https://github.com/omnigent-ai/omnigent/actions/runs/33838114438
  - Reusable V2 job started successfully.
  - Classification and artifact upload completed successfully.
  - No issue mutations were enabled.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Successful production-shaped dry run: https://github.com/omnigent-ai/omnigent/actions/runs/33838114438

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually dispatched the complete `Issue Triage` workflow from the signed final commit in dry-run mode. The V2 job completed in 41 seconds; the same job never started before this conversion.