### PR TITLE
docs: add the iOS app to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Omnigent is an open-source **meta-harness** that gives you a common orchestratio
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/omnigent)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
 
-[omnigent.ai](https://omnigent.ai) · **[⬇️ Download the macOS desktop app](https://omnigent.ai/download/mac)**
+[omnigent.ai](https://omnigent.ai) · **[⬇️ Download the macOS desktop app](https://omnigent.ai/download/mac)** · **[📱 Get the iOS app](https://omnigent.ai/download/ios)**
 
 </div>
 
@@ -430,6 +430,15 @@ Run Omnigent on a server with a stable URL
 become reachable from anywhere, including your phone. The web UI is built for
 mobile, so you get the same chat, sub-agents, terminals, and files, in sync
 with your laptop.
+
+On iPhone and iPad there is also a **native app** (currently a
+[TestFlight beta](https://omnigent.ai/download/ios)) that connects to your
+server and loads that same UI, so you don't have to keep a browser tab around:
+sign in through the system browser, pick a recent server on launch, and get
+local notifications plus an app badge when a session wants your attention.
+Administrators can preset the servers the app offers over MDM — see
+[`web/ios/README.md`](https://github.com/omnigent-ai/omnigent/blob/main/web/ios/README.md)
+to build it yourself.
 
 One `docker compose up` runs the server on any host you have (a VPS, a home
 server); **Render** and **Railway** deploy with one click; **Fly.io**, **Hugging


### PR DESCRIPTION
## Related issue

No issue — `Docs` change.

## Summary

The repo has shipped a native iPhone/iPad shell in `web/ios` for a while, but the
README only pointed at the macOS desktop app, so there was no way to discover it
from the front page.

- Add an iOS link to the header download line, next to the macOS desktop app.
- Describe the app in *4. Deploy a server (and use it from your phone📱)*, where
  the README already covers reaching your sessions from a phone.

Scoped to what `web/ios/README.md` actually claims today: a WKWebView shell that
loads the server-served UI, system-browser sign-in, recent-server picker, local
notifications and app badge, plus MDM-preset servers. It does **not** claim APNs
or background polling, since the app doesn't implement them.

## Test Plan

- Rendered the changed README locally and confirmed both the header line and the
  new paragraph render, with no broken markdown.
- `uv run pre-commit run --files README.md` — passes.
- Link check: `web/ios/README.md` resolves on `main`. **`https://omnigent.ai/download/ios`
  is a placeholder** mirroring the existing `/download/mac` pattern — there is no
  canonical iOS URL anywhere in the repo yet, so it needs to be pointed at the
  real TestFlight link before merge.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Header line, and the new paragraph:

```
[omnigent.ai](https://omnigent.ai) · **[⬇️ Download the macOS desktop app](...)** · **[📱 Get the iOS app](...)**
```

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Prose-only change to `README.md`; no code paths touched, so there is nothing to
cover with automated tests. Verified by rendering the README and running
pre-commit on the changed file.

## Changelog

The README now points to the Omnigent iOS app for iPhone and iPad.
