### PR TITLE
feat(native): publish bounded Codex child inventories

### DIFF
--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -58,6 +58,7 @@ from omnigent.native._native_post_delivery import (
     post_may_have_been_delivered,
     replay_dead_letters,
 )
+from omnigent.native.subagent_snapshot import NativeSubagentSnapshotPublisher
 from omnigent.util.json_types import JsonObject as _JsonObject
 
 _logger = logging.getLogger(__name__)
@@ -414,6 +415,9 @@ class _CodexForwarderState:
     parent_session_id: str | None = None
     codex_client: CodexAppServerClient | None = None
     subagents_by_thread: dict[str, str] = field(default_factory=dict)
+    subagent_parent_by_thread: dict[str, str | None] = field(default_factory=dict)
+    subagent_status_by_thread: dict[str, str] = field(default_factory=dict)
+    snapshot_publisher: NativeSubagentSnapshotPublisher | None = None
     pending_child_threads: dict[str, str | None] = field(default_factory=dict)
     subscribed_child_threads: set[str] = field(default_factory=set)
     synced_item_keys: set[str] = field(default_factory=set)
@@ -562,7 +566,17 @@ class _CodexForwarderState:
         :returns: None.
         """
         self.subagents_by_thread[thread_id] = session_id
+        self.subagent_parent_by_thread.setdefault(thread_id, self.parent_session_id)
+        self.subagent_status_by_thread.setdefault(thread_id, "running")
+        self.publish_child_snapshot()
         self.pending_child_threads.pop(thread_id, None)
+
+    def publish_child_snapshot(self) -> None:
+        if self.snapshot_publisher is not None and self.parent_session_id is not None:
+            self.snapshot_publisher.update(
+                self.parent_session_id,
+                _codex_native_subagent_snapshot(self),
+            )
 
     def note_parent_rotation(self, session_id: str) -> None:
         """
@@ -572,7 +586,10 @@ class _CodexForwarderState:
             ``"conv_new_parent"``.
         :returns: None.
         """
+        if self.snapshot_publisher is not None and self.parent_session_id is not None:
+            self.snapshot_publisher.update(self.parent_session_id, {}, retired=True)
         self.parent_session_id = session_id
+        self.publish_child_snapshot()
         self.pending_child_threads.clear()
 
     def note_pending_child_thread(
@@ -1902,6 +1919,8 @@ async def supervise_forwarder(
             parent_session_id=session_id,
             codex_client=client,
         )
+        snapshots = NativeSubagentSnapshotPublisher(ap_client)
+        forwarder_state.snapshot_publisher = snapshots
         # Released when the live event stream shows the thread became
         # active (its first turn materializes the rollout). Lets the
         # subscribe task park instead of blind-polling ``thread/resume``
@@ -1922,6 +1941,7 @@ async def supervise_forwarder(
             name="codex-native-forwarder-subscribe",
         )
         await _sleep(0)
+        await snapshots.__aenter__()
         try:
             async for event in client.iter_events():
                 try:
@@ -1976,6 +1996,7 @@ async def supervise_forwarder(
                 except Exception:  # noqa: BLE001 - keep the long-lived mirror alive.
                     _logger.warning("Codex forwarder event handling failed", exc_info=True)
         finally:
+            await snapshots.__aexit__()
             if mcp_settle_timer is not None:
                 mcp_settle_timer.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
@@ -2604,6 +2625,22 @@ async def _handle_event(
     )
     if route_session_id is None:
         return
+    if is_child and forwarder_state is not None:
+        child_thread = _thread_id_from_params(params)
+        observed_status = None
+        if method == "turn/started":
+            observed_status = "running"
+        elif method in {"turn/completed", "turn/failed"}:
+            observed_status = (
+                "failed"
+                if method == "turn/failed"
+                or _turn_status_is_failed(params)
+                or _terminal_error_from_turn(params) is not None
+                else "idle"
+            )
+        if child_thread is not None and observed_status is not None:
+            forwarder_state.subagent_status_by_thread[child_thread] = observed_status
+            forwarder_state.publish_child_snapshot()
     # First model-produced item settles the synthesized MCP startup round
     # mid-turn — codex defers turn execution until the round ends, so
     # assistant-side output proves startup is over before the idle edge.
@@ -5196,7 +5233,18 @@ async def _post_collab_agent_statuses(
             continue
         ap_status = _omnigent_status_from_collab_state(state)
         if ap_status is not None:
+            forwarder_state.subagent_status_by_thread[thread_id] = ap_status
+            forwarder_state.publish_child_snapshot()
             await _post_status(client, child_session_id, ap_status)
+
+
+def _codex_native_subagent_snapshot(state: _CodexForwarderState) -> dict[str, str]:
+    """Keep late-event mappings while excluding children of rotated parents."""
+    return {
+        child_id: state.subagent_status_by_thread.get(thread_id, "activity_unverified")
+        for thread_id, child_id in state.subagents_by_thread.items()
+        if state.subagent_parent_by_thread.get(thread_id) == state.parent_session_id
+    }
 
 
 def _omnigent_status_from_collab_state(state: _JsonObject) -> str | None:

--- a/omnigent/native/subagent_snapshot.py
+++ b/omnigent/native/subagent_snapshot.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import quote
+
+import httpx
+
+_logger = logging.getLogger(__name__)
+
+NATIVE_SUBAGENT_SNAPSHOT_EVENT = "external_native_subagent_snapshot"
+NATIVE_SUBAGENT_ACTIVE_STATUSES = frozenset({"running", "waiting", "activity_unverified"})
+NATIVE_SUBAGENT_STATUSES = NATIVE_SUBAGENT_ACTIVE_STATUSES | frozenset(
+    {"idle", "completed", "failed", "stopped", "killed"}
+)
+MAX_NATIVE_SNAPSHOT_CHILDREN = 512
+
+
+@dataclass(frozen=True)
+class NativeSubagentSnapshot:
+    """A source-fenced inventory whose omissions never prove task outcomes."""
+
+    generation: int
+    sequence: int
+    children: dict[str, str]
+    complete: bool = True
+    retired: bool = False
+
+    @property
+    def active_child_ids(self) -> frozenset[str]:
+        return frozenset(
+            child
+            for child, status in self.children.items()
+            if status in NATIVE_SUBAGENT_ACTIVE_STATUSES
+        )
+
+
+def parse_native_subagent_snapshot(payload: object) -> NativeSubagentSnapshot:
+    """Reject malformed/oversized inventories instead of silently truncating."""
+    if not isinstance(payload, Mapping):
+        raise ValueError("snapshot data must be an object")
+    generation, sequence = payload.get("generation"), payload.get("sequence")
+    for name, value in (("generation", generation), ("sequence", sequence)):
+        if type(value) is not int or not 0 < value < 2**63:
+            raise ValueError(f"snapshot {name} must be a positive 63-bit integer")
+    complete, retired = payload.get("complete", True), payload.get("retired", False)
+    if not isinstance(complete, bool) or not isinstance(retired, bool):
+        raise ValueError("snapshot complete/retired must be booleans")
+    raw = payload.get("children")
+    if not isinstance(raw, list) or len(raw) > MAX_NATIVE_SNAPSHOT_CHILDREN:
+        raise ValueError("snapshot children must be a list of at most 512 entries")
+    children: dict[str, str] = {}
+    for row in raw:
+        if not isinstance(row, Mapping):
+            raise ValueError("snapshot child must be an object")
+        child, status = row.get("session_id"), row.get("status")
+        if not isinstance(child, str) or not child or len(child) > 512:
+            raise ValueError("invalid snapshot child session_id")
+        if child in children:
+            raise ValueError("duplicate snapshot child session_id")
+        if not isinstance(status, str) or status not in NATIVE_SUBAGENT_STATUSES:
+            raise ValueError("invalid snapshot child status")
+        children[child] = status
+    if retired and children:
+        raise ValueError("retired snapshot must have no children")
+    assert isinstance(generation, int) and isinstance(sequence, int)
+    return NativeSubagentSnapshot(generation, sequence, children, complete, retired)
+
+
+@dataclass
+class _PendingInventory:
+    children: tuple[tuple[str, str], ...]
+    complete: bool
+    retired: bool
+    changed_at: float
+    sent: bool = False
+    next_attempt: float = 0.0
+
+
+class NativeSubagentSnapshotPublisher:
+    """Bounded heartbeat/retry sender; unsupported old Servers disable it."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        heartbeat_s: float = 15.0,
+        retry_s: float = 5.0,
+    ) -> None:
+        self._client = client
+        self._heartbeat_s = heartbeat_s
+        self._retry_s = retry_s
+        self._generation = time.time_ns()
+        self._sequence = 0
+        self._inventories: dict[str, _PendingInventory] = {}
+        self._changed = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._disabled = False
+
+    async def __aenter__(self) -> NativeSubagentSnapshotPublisher:
+        self._task = asyncio.create_task(self._run(), name="native-child-snapshots")
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001 - optional telemetry cannot break cleanup.
+            _logger.warning("Native child snapshot publisher failed", exc_info=True)
+
+    def update(
+        self,
+        parent_id: str,
+        children: Mapping[str, str],
+        *,
+        retired: bool = False,
+    ) -> None:
+        if self._disabled:
+            return
+        if retired:
+            children = {}
+        complete = len(children) <= MAX_NATIVE_SNAPSHOT_CHILDREN
+        rows = tuple(sorted(children.items()))[:MAX_NATIVE_SNAPSHOT_CHILDREN]
+        now = time.monotonic()
+        old = self._inventories.get(parent_id)
+        if old is None and not rows and not retired:
+            return
+        if old and (old.children, old.complete, old.retired) == (rows, complete, retired):
+            old.changed_at = now
+            return
+        if old is None and len(self._inventories) >= 64:
+            if retired:
+                return
+            victim = next(
+                (key for key, pending in self._inventories.items() if pending.retired),
+                next(iter(self._inventories)),
+            )
+            self._inventories.pop(victim)
+        self._inventories[parent_id] = _PendingInventory(
+            rows,
+            complete,
+            retired,
+            now,
+            next_attempt=old.next_attempt if old is not None and not old.sent else 0.0,
+        )
+        self._changed.set()
+
+    async def _run(self) -> None:
+        while not self._disabled:
+            self._changed.clear()
+            next_due = float("inf")
+            for parent_id, pending in list(self._inventories.items()):
+                now = time.monotonic()
+                active = any(s in NATIVE_SUBAGENT_ACTIVE_STATUSES for _, s in pending.children)
+                if pending.sent and not active:
+                    continue
+                if pending.next_attempt > now:
+                    next_due = min(next_due, pending.next_attempt)
+                    continue
+                self._sequence += 1
+                status, terminal = 0, False
+                try:
+                    response = await self._client.post(
+                        f"/v1/sessions/{quote(parent_id, safe='')}/events",
+                        json={
+                            "type": NATIVE_SUBAGENT_SNAPSHOT_EVENT,
+                            "data": {
+                                "generation": self._generation,
+                                "sequence": self._sequence,
+                                "children": [
+                                    {"session_id": child, "status": status}
+                                    for child, status in pending.children
+                                ],
+                                "complete": pending.complete,
+                                "retired": pending.retired,
+                            },
+                        },
+                        timeout=10.0,
+                    )
+                    err: object = None
+                    if response.status_code == 400:
+                        with contextlib.suppress(ValueError):
+                            body = response.json()
+                            if isinstance(body, Mapping):
+                                err = body.get("error")
+                    unsupported = isinstance(err, Mapping) and str(err.get("message")).startswith(
+                        "Unknown event type:"
+                    )
+                    if unsupported:
+                        self._disabled = True
+                        return
+                    status = response.status_code
+                    accepted = 200 <= status < 300 or (status == 404 and pending.retired)
+                    terminal = status in {400, 401, 403, 404, 405, 413, 415, 422}
+                    if status == 404 and pending.retired:
+                        _logger.info("Native child snapshot parent already retired: %s", parent_id)
+                except (httpx.HTTPError, ConnectionError):
+                    accepted = False
+                if terminal:
+                    _logger.warning(
+                        "Native child snapshot rejected parent %s with HTTP %s",
+                        parent_id,
+                        status,
+                    )
+                    self._inventories.pop(parent_id, None)
+                    continue
+                current = self._inventories.get(parent_id)
+                if current is not pending:
+                    if current is not None and not accepted:
+                        current.next_attempt = max(
+                            current.next_attempt,
+                            time.monotonic() + self._retry_s,
+                        )
+                    continue
+                if accepted:
+                    pending.sent = True
+                    if pending.retired:
+                        self._inventories.pop(parent_id, None)
+                        continue
+                pending.next_attempt = time.monotonic() + (
+                    self._heartbeat_s if accepted else self._retry_s
+                )
+                next_due = min(next_due, pending.next_attempt)
+            delay = max(0.0, next_due - time.monotonic())
+            if delay == float("inf"):
+                await self._changed.wait()
+            else:
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(self._changed.wait(), timeout=delay)

--- a/tests/test_native_subagent_snapshots.py
+++ b/tests/test_native_subagent_snapshots.py
@@ -1,0 +1,215 @@
+"""Native inventory is delivery/liveness evidence, never a task outcome."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from omnigent.native.subagent_snapshot import (
+    NativeSubagentSnapshotPublisher,
+    parse_native_subagent_snapshot,
+)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("generation", True),
+        ("sequence", 0),
+        ("complete", "yes"),
+        ("children", [{"session_id": "x", "status": "fake"}]),
+        ("children", [{"session_id": "x", "status": "running"}] * 2),
+    ],
+)
+def test_invalid_inventory_is_rejected(field: str, value: object) -> None:
+    payload: dict[str, object] = {"generation": 1, "sequence": 1, "children": []}
+    payload[field] = value
+    with pytest.raises(ValueError):
+        parse_native_subagent_snapshot(payload)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("final", [{}, {"child": "completed"}])
+@pytest.mark.parametrize("failure", ["transport", 408, 429, 503])
+async def test_final_retry_then_negative_ack(final: dict[str, str], failure: str | int) -> None:
+    posts, acknowledged = [], asyncio.Event()
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        posts.append(json.loads(request.content))
+        if len(posts) == 1:
+            if failure == "transport":
+                raise httpx.ConnectError("offline", request=request)
+            return httpx.Response(int(failure))
+        acknowledged.set()
+        return httpx.Response(202, json={"accepted": False})
+
+    async with httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(transport)
+    ) as client:
+        async with NativeSubagentSnapshotPublisher(client, retry_s=0.005) as publisher:
+            if not final:
+                publisher.update("parent", {"child": "running"})
+            publisher.update("parent", final)
+            await asyncio.wait_for(acknowledged.wait(), 1)
+            await asyncio.sleep(0.015)
+    assert len(posts) == 2
+    assert posts[0]["data"]["children"] == posts[1]["data"]["children"]
+    assert posts[1]["data"]["sequence"] > posts[0]["data"]["sequence"]
+
+
+@pytest.mark.asyncio
+async def test_retirement_retries_and_does_not_retain_old_parent() -> None:
+    posts = []
+    done = asyncio.Event()
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        posts.append(json.loads(request.content)["data"])
+        if len(posts) == 1:
+            return httpx.Response(503)
+        done.set()
+        return httpx.Response(202)
+
+    async with httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(transport)
+    ) as client:
+        async with NativeSubagentSnapshotPublisher(client, retry_s=0.005) as publisher:
+            publisher.update("old", {}, retired=True)
+            await asyncio.wait_for(done.wait(), 1)
+            await asyncio.sleep(0)
+            assert "old" not in publisher._inventories
+    assert all(post["retired"] for post in posts)
+
+
+@pytest.mark.asyncio
+async def test_old_server_disables_optional_snapshots() -> None:
+    count = 0
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        return httpx.Response(400, json={"error": {"message": "Unknown event type: snapshot"}})
+
+    async with httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(transport)
+    ) as client:
+        async with NativeSubagentSnapshotPublisher(client, heartbeat_s=0.005) as publisher:
+            publisher.update("parent", {"child": "running"})
+            await asyncio.sleep(0.02)
+            publisher.update("parent", {"child": "completed"})
+            await asyncio.sleep(0.01)
+    assert count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [400, 403])
+async def test_permanent_parent_rejection_is_logged_and_dropped_once(status: int, caplog) -> None:
+    called, reconnected, count = asyncio.Event(), asyncio.Event(), 0
+
+    def transport(_request: httpx.Request) -> httpx.Response:
+        nonlocal count
+        count += 1
+        if count == 1:
+            called.set()
+            return httpx.Response(status, json={"error": {"message": "invalid snapshot"}})
+        reconnected.set()
+        return httpx.Response(202)
+
+    async with httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(transport)
+    ) as client:
+        with caplog.at_level("WARNING"):
+            async with NativeSubagentSnapshotPublisher(client, retry_s=0.005) as publisher:
+                publisher.update("parent", {"child": "running"})
+                await asyncio.wait_for(called.wait(), 1)
+                await asyncio.sleep(0.02)
+                assert "parent" not in publisher._inventories
+        assert count == 1
+        async with NativeSubagentSnapshotPublisher(client) as publisher:
+            publisher.update("parent", {"child": "running"})
+            await asyncio.wait_for(reconnected.wait(), 1)
+    assert count == 2
+    assert f"rejected parent parent with HTTP {status}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_retired_404_does_not_disable_current_parent() -> None:
+    posts, current_posted = [], asyncio.Event()
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        parent = request.url.path.split("/")[-2]
+        data = json.loads(request.content)["data"]
+        posts.append((parent, data["children"], data["retired"]))
+        if parent == "old":
+            return httpx.Response(404)
+        current_posted.set()
+        return httpx.Response(202)
+
+    async with httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(transport)
+    ) as client:
+        async with NativeSubagentSnapshotPublisher(client) as publisher:
+            publisher.update("old", {"stale": "running"}, retired=True)
+            publisher.update("current", {"child": "running"})
+            await asyncio.wait_for(current_posted.wait(), 1)
+    assert not publisher._disabled
+    assert posts == [
+        ("old", [], True),
+        ("current", [{"session_id": "child", "status": "running"}], False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_current_parent_displaces_oldest_retirement_at_capacity() -> None:
+    client = httpx.AsyncClient(base_url="http://test")
+    publisher = NativeSubagentSnapshotPublisher(client)
+    for index in range(64):
+        publisher.update(f"old-{index}", {}, retired=True)
+    publisher.update("current", {"child": "running"})
+    await client.aclose()
+    assert len(publisher._inventories) == 64
+    assert publisher._inventories["current"].children == (("child", "running"),)
+
+
+@pytest.mark.asyncio
+async def test_oversized_inventory_is_explicitly_partial() -> None:
+    posted = asyncio.Event()
+    payload = {}
+
+    def transport(request: httpx.Request) -> httpx.Response:
+        payload.update(json.loads(request.content)["data"])
+        posted.set()
+        return httpx.Response(202)
+
+    async with httpx.AsyncClient(
+        base_url="http://test", transport=httpx.MockTransport(transport)
+    ) as client:
+        async with NativeSubagentSnapshotPublisher(client) as publisher:
+            publisher.update("parent", {str(i): "running" for i in range(513)})
+            await asyncio.wait_for(posted.wait(), 1)
+    snapshot = parse_native_subagent_snapshot(payload)
+    assert not snapshot.complete
+    assert len(snapshot.children) == 512
+
+
+def test_codex_rotation_excludes_old_parent_children() -> None:
+    from omnigent.harnesses.codex_native.forwarder import (
+        _codex_native_subagent_snapshot,
+        _CodexForwarderState,
+    )
+
+    state = _CodexForwarderState(parent_session_id="old")
+    state.note_child_thread("t1", "c1")
+    state.note_parent_rotation("new")
+    state.note_child_thread("t2", "c2")
+    assert state.session_for_child_thread("t1") == "c1"
+    assert _codex_native_subagent_snapshot(state) == {"c2": "running"}
+
+
+def test_quiescence_is_not_a_terminal_outcome() -> None:
+    idle = parse_native_subagent_snapshot(
+        {"generation": 1, "sequence": 1, "children": [{"session_id": "c", "status": "idle"}]}
+    )
+    assert (idle.children, idle.active_child_ids) == ({"c": "idle"}, frozenset())


### PR DESCRIPTION
## Related issue

Part of #5687.

## Summary

Publish bounded, generation/sequence-fenced Codex native-child inventories without assigning task-outcome authority. The optional publisher caps snapshots at 512 children and pending parents at 64, marks truncation incomplete, retires rotated parents, heartbeats active observations, and sends changed acknowledged content immediately.

Transport failures plus HTTP 408/409/425/429/5xx retry. Explicit validation/auth/resource statuses are terminal for that parent; every 2xx is an acknowledgement. Generation uses wall-clock nanoseconds to normally advance across a process restart using the same token.

This first slice is intentionally observation-only. Token-bound transport, Server ingest, durable reconciliation, and user-visible lifecycle are separate successors; no silence, idle state, or missing observation is promoted to task completion here.

## Test Plan

- Exact `upstream/main@45601bae8d98a25bf4d193187481e0a79d49dde5` standalone replay: producer matrix `22 passed`.
- Exact-current complete three-slice proof: forwarder/snapshot/ingest `164 passed`; focused token, #6755 workspace-header, and #6772 title-setting neighbors `11 passed`.
- All 13 changed Python files pass Ruff check and format check; `compileall` passes.
- Focused Pyrefly over the eight changed production owners with the project interpreter and Linux platform reports `0 errors` (`7 suppressed`, `3 warnings`).
- DCO, stable patch IDs, `git range-diff`, `git diff --check`, and ordered replay pass.
- A real forwarder-to-ASGI successor-stack proof rejects a missing token with 403 and accepts the exact bound token with 202; that behavior is not claimed by this first slice.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided in Test Plan
- [ ] Not applicable — no behavioral change

Tests use synthetic child identifiers and mock HTTP. No real session, credential, or private topology is included.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This PR remains Draft and `Part of #5687`: it supplies the producer contract, while the authenticated Runner/CLI transport and Server consumer stay in reviewed successor slices until this prerequisite can be merged.

## Changelog

Codex native can publish bounded, generation-aware child inventories without treating quiescence or missing observations as task completion.

## Issues

Part of #5687
