### PR TITLE
feat(runtime): preserve inline attachment content order

### DIFF
--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -5518,8 +5518,17 @@ def _claude_user_content_from_api_blocks(
     :returns: A string for simple text prompts, a Claude content block
         list for multi-block prompts, or ``None`` when no text exists.
     """
-    blocks = _claude_attachment_text_blocks_from_api_content(content, bridge_dir)
-    blocks += _claude_text_blocks_from_api_content(content, api_type="input_text")
+    blocks: list[_JsonObject] = []
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "input_text":
+                text = block.get("text")
+                if isinstance(text, str) and text:
+                    blocks.append({"type": "text", "text": text})
+            elif block.get("type") in {"input_image", "input_file"}:
+                blocks.extend(_claude_attachment_text_blocks_from_api_content([block], bridge_dir))
     if not blocks:
         return None
     if len(blocks) == 1:

--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -1129,6 +1129,28 @@ class AcpExecutor(Executor):
         return "\n".join(parts)
 
     @classmethod
+    def _ordered_prompt_blocks(
+        cls,
+        blocks: list[object],
+        *,
+        image_supported: bool,
+    ) -> list[_AcpJsonObject]:
+        """Translate message blocks to ACP blocks without changing their order."""
+        out: list[_AcpJsonObject] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "input_image" and image_supported:
+                images = cls._image_blocks_from_content([block])
+                if images:
+                    out.extend(images)
+                    continue
+            text = cls._text_from_blocks([block], emit_image_marker=not image_supported)
+            if text:
+                out.append({"type": "text", "text": text})
+        return out
+
+    @classmethod
     def _history_prefix(cls, prior: Sequence[object]) -> str:
         """Serialize prior conversation turns into a text prefix.
 
@@ -1479,6 +1501,7 @@ class AcpExecutor(Executor):
 
         user_text = ""
         image_blocks: list[_AcpJsonObject] = []
+        ordered_prompt_blocks: list[_AcpJsonObject] | None = None
         latest_user_idx: int | None = None
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
@@ -1491,10 +1514,16 @@ class AcpExecutor(Executor):
                 elif isinstance(content, list):
                     if self._image_supported:
                         image_blocks = self._image_blocks_from_content(content)
+                    ordered_prompt_blocks = self._ordered_prompt_blocks(
+                        content,
+                        image_supported=self._image_supported,
+                    )
                     user_text = self._text_from_blocks(
                         content, emit_image_marker=not self._image_supported
                     )
                 break
+
+        latest_text = user_text
 
         # On a fresh session, replay prior conversation so a subprocess restart
         # (after the agent process exits) or a session reset doesn't drop the
@@ -1515,10 +1544,22 @@ class AcpExecutor(Executor):
                 user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
             self._system_prompt_sent = True
 
-        prompt_blocks: list[_AcpJsonObject] = []
-        if user_text or not image_blocks:
-            prompt_blocks.append({"type": "text", "text": user_text})
-        prompt_blocks.extend(image_blocks)
+        if ordered_prompt_blocks is None:
+            prompt_blocks: list[_AcpJsonObject] = []
+            if user_text or not image_blocks:
+                prompt_blocks.append({"type": "text", "text": user_text})
+            prompt_blocks.extend(image_blocks)
+        else:
+            prefix = (
+                user_text[: -len(latest_text)]
+                if latest_text and user_text.endswith(latest_text)
+                else user_text
+            )
+            prompt_blocks = (
+                [{"type": "text", "text": prefix}] if prefix else []
+            ) + ordered_prompt_blocks
+            if not prompt_blocks:
+                prompt_blocks = [{"type": "text", "text": ""}]
 
         # Drain stale items from a prior turn; answer any leftover server request.
         while not self._queue.empty():

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -411,14 +411,13 @@ def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
         or ``input_file`` blocks with a ``file_data`` data URI.
     :param bridge_dir: Bridge directory path for writing attachment
         files, e.g. ``Path("/tmp/omnigent/claude-native/<digest>")``.
-    :returns: Plain text content with file-path references prepended
-        for any materialized attachments.
+    :returns: Plain text content with file-path references kept at their
+        authored positions.
     """
     if isinstance(content, str):
         return content
     if isinstance(content, list):
-        attachment_lines: list[str] = []
-        text_parts: list[str] = []
+        parts: list[str] = []
         for block in content:
             if not isinstance(block, dict):
                 continue
@@ -426,9 +425,8 @@ def _content_to_text(content: EnqueuedContent, bridge_dir: Path) -> str:
             if block_type == "input_text":
                 text = block.get("text")
                 if isinstance(text, str):
-                    text_parts.append(text)
+                    parts.append(text)
             elif block_type in ("input_image", "input_file"):
-                attachment_lines.append(attachment_reference_line(block, bridge_dir))
-        parts = attachment_lines + text_parts
+                parts.append(attachment_reference_line(block, bridge_dir))
         return "\n\n".join(parts)
     return ""

--- a/omnigent/inner/goose_executor.py
+++ b/omnigent/inner/goose_executor.py
@@ -953,6 +953,28 @@ class GooseExecutor(Executor):
         return "\n".join(parts)
 
     @classmethod
+    def _ordered_prompt_blocks(
+        cls,
+        blocks: list[object],
+        *,
+        image_supported: bool,
+    ) -> list[_AcpJsonObject]:
+        """Translate message blocks to ACP blocks without changing their order."""
+        out: list[_AcpJsonObject] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "input_image" and image_supported:
+                images = cls._image_blocks_from_content([block])
+                if images:
+                    out.extend(images)
+                    continue
+            text = cls._text_from_blocks([block], emit_image_marker=not image_supported)
+            if text:
+                out.append({"type": "text", "text": text})
+        return out
+
+    @classmethod
     def _history_prefix(cls, prior: Sequence[object]) -> str:
         """Serialize prior conversation turns into a text prefix.
 
@@ -1118,6 +1140,7 @@ class GooseExecutor(Executor):
         # Build the prompt payload from the most recent user message.
         user_text = ""
         image_blocks: list[_AcpJsonObject] = []
+        ordered_prompt_blocks: list[_AcpJsonObject] | None = None
         latest_user_idx: int | None = None
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
@@ -1130,10 +1153,16 @@ class GooseExecutor(Executor):
                 elif isinstance(content, list):
                     if self._image_supported:
                         image_blocks = self._image_blocks_from_content(content)
+                    ordered_prompt_blocks = self._ordered_prompt_blocks(
+                        content,
+                        image_supported=self._image_supported,
+                    )
                     user_text = self._text_from_blocks(
                         content, emit_image_marker=not self._image_supported
                     )
                 break
+
+        latest_text = user_text
 
         # On a fresh session, replay the prior conversation so a model switch
         # (which respawns the subprocess) or a session reset doesn't drop the
@@ -1152,10 +1181,22 @@ class GooseExecutor(Executor):
                 user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
             self._system_prompt_sent = True
 
-        prompt_blocks: list[_AcpJsonObject] = []
-        if user_text or not image_blocks:
-            prompt_blocks.append({"type": "text", "text": user_text})
-        prompt_blocks.extend(image_blocks)
+        if ordered_prompt_blocks is None:
+            prompt_blocks: list[_AcpJsonObject] = []
+            if user_text or not image_blocks:
+                prompt_blocks.append({"type": "text", "text": user_text})
+            prompt_blocks.extend(image_blocks)
+        else:
+            prefix = (
+                user_text[: -len(latest_text)]
+                if latest_text and user_text.endswith(latest_text)
+                else user_text
+            )
+            prompt_blocks = (
+                [{"type": "text", "text": prefix}] if prefix else []
+            ) + ordered_prompt_blocks
+            if not prompt_blocks:
+                prompt_blocks = [{"type": "text", "text": ""}]
 
         # Drain stale items from a prior turn; answer any leftover server request.
         while not self._queue.empty():

--- a/omnigent/inner/qwen_executor.py
+++ b/omnigent/inner/qwen_executor.py
@@ -1230,6 +1230,28 @@ class QwenExecutor(Executor):
         return "\n".join(parts)
 
     @classmethod
+    def _ordered_prompt_blocks(
+        cls,
+        blocks: list[object],
+        *,
+        image_supported: bool,
+    ) -> list[_AcpJsonObject]:
+        """Translate message blocks to ACP blocks without changing their order."""
+        out: list[_AcpJsonObject] = []
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "input_image" and image_supported:
+                images = cls._image_blocks_from_content([block])
+                if images:
+                    out.extend(images)
+                    continue
+            text = cls._text_from_blocks([block], emit_image_marker=not image_supported)
+            if text:
+                out.append({"type": "text", "text": text})
+        return out
+
+    @classmethod
     def _history_prefix(cls, prior: Sequence[object]) -> str:
         """Serialize prior conversation turns into a text prefix.
 
@@ -1344,6 +1366,7 @@ class QwenExecutor(Executor):
         # Build the prompt payload from the most recent user message.
         user_text = ""
         image_blocks: list[_AcpJsonObject] = []
+        ordered_prompt_blocks: list[_AcpJsonObject] | None = None
         latest_user_idx: int | None = None
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
@@ -1359,10 +1382,16 @@ class QwenExecutor(Executor):
                     # fall back to a text marker so they aren't silently dropped.
                     if self._image_supported:
                         image_blocks = self._image_blocks_from_content(content)
+                    ordered_prompt_blocks = self._ordered_prompt_blocks(
+                        content,
+                        image_supported=self._image_supported,
+                    )
                     user_text = self._text_from_blocks(
                         content, emit_image_marker=not self._image_supported
                     )
                 break
+
+        latest_text = user_text
 
         # On a fresh session, replay the prior conversation so a model switch
         # (which respawns the subprocess) or a session reset doesn't drop the
@@ -1383,11 +1412,22 @@ class QwenExecutor(Executor):
                 user_text = f"{system_prompt}\n\n{user_text}" if user_text else system_prompt
             self._system_prompt_sent = True
 
-        # Text first, then any image blocks (ACP prompt is an ordered array).
-        prompt_blocks: list[_AcpJsonObject] = []
-        if user_text or not image_blocks:
-            prompt_blocks.append({"type": "text", "text": user_text})
-        prompt_blocks.extend(image_blocks)
+        if ordered_prompt_blocks is None:
+            prompt_blocks: list[_AcpJsonObject] = []
+            if user_text or not image_blocks:
+                prompt_blocks.append({"type": "text", "text": user_text})
+            prompt_blocks.extend(image_blocks)
+        else:
+            prefix = (
+                user_text[: -len(latest_text)]
+                if latest_text and user_text.endswith(latest_text)
+                else user_text
+            )
+            prompt_blocks = (
+                [{"type": "text", "text": prefix}] if prefix else []
+            ) + ordered_prompt_blocks
+            if not prompt_blocks:
+                prompt_blocks = [{"type": "text", "text": ""}]
 
         # Drain stale items from a prior turn. Notifications (no ``id``) are
         # safe to drop, but a server-initiated *request* left in the queue is

--- a/omnigent/runtime/pending_inputs.py
+++ b/omnigent/runtime/pending_inputs.py
@@ -41,11 +41,12 @@ stuck pending and double-rendered. Per-session SSE ordering guarantees
 the i-th persisted user message corresponds to the i-th queued one, so
 each persisted native user message drains the oldest pending entry.
 
-The one imperfect case is interleaving a web-composer message with a
-message typed directly in the TUI: the TUI message (which has no pending
-entry) drains the oldest web entry, so that web bubble briefly
-disappears and reappears once it persists. It self-heals; the committed
-bubble always renders the just-persisted content regardless.
+When an attachment-bearing web message is interleaved with direct TUI
+input, :func:`resolve_oldest_for_mirrored_text` compares the visible text
+after removing materialized attachment markers. A clear mismatch leaves
+the web entry pending so its ordered content cannot overwrite the direct
+terminal message. Plain text messages retain FIFO matching because native
+transcripts may reformat quotes and whitespace.
 
 Limitations (identical to :mod:`pending_elicitations`):
 
@@ -66,17 +67,26 @@ evicted lazily on the next :func:`record` / :func:`snapshot_for` /
 from __future__ import annotations
 
 import copy
+import re
 import threading
 import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from omnigent.inner.native_attachments import UNRESOLVED_ATTACHMENT_MARKER_PATTERN
+
 # A pending entry is evicted this many seconds after it was recorded
 # if it was never drained by a matching persisted message. Covers the
 # vendor-TUI-never-accepted-the-message ghost; long enough that a slow
 # transcript round-trip on a busy session still drains normally.
 _TTL_S: float = 600.0
+_ATTACHED_MARKER_RE = re.compile(
+    rf"(?:\[Attached(?: file)?:\s*[^\]]*\]"
+    rf"|{UNRESOLVED_ATTACHMENT_MARKER_PATTERN})\s*",
+    re.IGNORECASE,
+)
+_BLOCKQUOTE_PREFIX_RE = re.compile(r"^[ \t]*>[ \t]?", re.MULTILINE)
 
 
 def _now() -> float:
@@ -327,6 +337,48 @@ def restore(conversation_id: str, drained: DrainedInput) -> None:
         _pending[conversation_id] = {drained.pending_id: entry, **entries}
 
 
+def resolve_oldest_for_mirrored_text(
+    conversation_id: str,
+    mirrored_text: str,
+) -> DrainedInput | None:
+    """Drain the FIFO head unless an attachment-bearing head clearly differs.
+
+    Native terminals provide no correlation id. Plain pending messages retain
+    the established FIFO behavior because transcript formatting may change
+    them. Attachment-bearing messages need a stricter guard: merging their
+    complete ordered content into unrelated direct-terminal text would replace
+    that message. Materialized ``[Attached: ...]`` lines, failed-materialization
+    markers, and Markdown blockquote prefixes are removed before comparison
+    because the pending content already represents those files and native
+    reply transcripts drop the quote markers. An attachment-only entry drains
+    only when a recognized marker supplies correlation evidence.
+    """
+    with _lock:
+        _evict_stale_locked(conversation_id, _now())
+        entries = _pending.get(conversation_id)
+        if entries is None:
+            return None
+        oldest_id = next(iter(entries))
+        entry = entries[oldest_id]
+        has_files = any(
+            isinstance(block, dict) and block.get("type") in ("input_image", "input_file")
+            for block in entry.content
+        )
+        if has_files:
+            marker_match = _ATTACHED_MARKER_RE.search(mirrored_text)
+            pending_text = _normalize_attachment_text(_content_text(entry.content))
+            observed_text = _normalize_attachment_text(_ATTACHED_MARKER_RE.sub("", mirrored_text))
+            if mirrored_text and (
+                (pending_text and pending_text != observed_text)
+                or (not pending_text and marker_match is None)
+            ):
+                return None
+        entries.pop(oldest_id)
+        if not entries:
+            _pending.pop(conversation_id, None)
+        return _drained_input(entry)
+
+
 def resolve_matching_text(conversation_id: str, text: str) -> MatchedDrain:
     """
     Drain through the first pending entry whose text matches ``text``.
@@ -459,6 +511,11 @@ def _content_text(content: list[dict[str, Any]]) -> str:
 def _normalize_text(text: str) -> str:
     """Normalize text enough to compare pending input with Kiro Prompt text."""
     return " ".join(text.split())
+
+
+def _normalize_attachment_text(text: str) -> str:
+    """Normalize the known native reply-quote transform for guarded matching."""
+    return _normalize_text(_BLOCKQUOTE_PREFIX_RE.sub("", text))
 
 
 def reset_for_tests() -> None:

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3920,14 +3920,15 @@ def _merge_pending_file_blocks(
     pending_content: list[dict[str, Any]],
 ) -> NewConversationItem:
     """
-    Prepend a pending entry's file blocks onto a user-message item.
+    Restore a pending entry's ordered content onto a user-message item.
 
     The claude-native transcript mirrors a user message back as
     text-only — ``input_image`` / ``input_file`` blocks are dropped. The
-    optimistic pending-input entry still carries them (with real
-    ``file_id``s, assigned at upload), so we fold them into the durable
-    item here. Without it the image renders only on the optimistic
-    bubble and vanishes from history on the next reload.
+    optimistic pending-input entry still carries the complete ordered content
+    (with real ``file_id``s, assigned at upload), so it becomes the durable
+    item here. Without it the image renders only on the optimistic bubble and
+    vanishes from history on the next reload; restoring only its file blocks
+    would move every attachment ahead of the text.
 
     No-op when the pending entry has no file blocks, or when the item
     already carries file blocks (defensive — a future transcript that
@@ -3940,8 +3941,8 @@ def _merge_pending_file_blocks(
     :param pending_content: The drained pending entry's content blocks,
         e.g. ``[{"type": "input_image", "file_id": "file_x",
         "filename": "a.png"}, {"type": "input_text", "text": "hi"}]``.
-    :returns: A copy of *item* with the file blocks prepended, or *item*
-        unchanged when there is nothing to merge.
+    :returns: A copy of *item* with the pending ordered content restored, or
+        *item* unchanged when there is nothing to merge.
     """
     if not isinstance(item.data, MessageData):
         return item
@@ -3958,7 +3959,16 @@ def _merge_pending_file_blocks(
     )
     if already_has_files:
         return item
-    merged_data = item.data.model_copy(update={"content": [*file_blocks, *item.data.content]})
+    pending_has_text = any(
+        isinstance(block, dict)
+        and block.get("type") in ("input_text", "output_text", "text")
+        and isinstance(block.get("text"), str)
+        for block in pending_content
+    )
+    # A complete ordered entry is the only surviving record of attachment
+    # seams. Legacy entries contain files only, so retain the mirrored text.
+    content = list(pending_content) if pending_has_text else [*file_blocks, *item.data.content]
+    merged_data = item.data.model_copy(update={"content": content})
     return item.model_copy(update={"data": merged_data})
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2287,7 +2287,10 @@ async def _persist_external_conversation_item(
             drained = matched.matched
             skipped_kiro_pending = matched.skipped
         else:
-            drained = pending_inputs.resolve_oldest(session_id)
+            drained = pending_inputs.resolve_oldest_for_mirrored_text(
+                session_id,
+                _message_text(item.data.content) or "",
+            )
         if drained is not None:
             cleared_pending_id = drained.pending_id
             item = _merge_pending_file_blocks(item, drained.content)

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -1931,3 +1931,16 @@ async def test_close_reaps_the_agents_forked_children(tmp_path: Path) -> None:
     while _proc.process_alive(grandchild):
         assert time.monotonic() < deadline, f"agent child {grandchild} survived close()"
         await asyncio.sleep(0.05)
+
+
+def test_ordered_prompt_blocks_preserve_text_image_text_order() -> None:
+    blocks = [
+        {"type": "input_text", "text": "before"},
+        {"type": "input_image", "image_url": "data:image/png;base64,AAAB"},
+        {"type": "input_text", "text": "after"},
+    ]
+    assert AcpExecutor._ordered_prompt_blocks(blocks, image_supported=True) == [
+        {"type": "text", "text": "before"},
+        {"type": "image", "mimeType": "image/png", "data": "AAAB"},
+        {"type": "text", "text": "after"},
+    ]

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -504,6 +504,43 @@ async def test_run_turn_materializes_image_to_bridge_dir(
 
 
 @pytest.mark.asyncio
+async def test_run_turn_keeps_image_between_surrounding_text(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The live native turn preserves text-image-text semantic order."""
+    sent: list[dict[str, Any]] = []
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", _stub_inject(sent))
+
+    executor = ClaudeNativeExecutor(tmp_path)
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "before"},
+                        {
+                            "type": "input_image",
+                            "image_url": _TINY_PNG_DATA_URI,
+                            "filename": "middle.png",
+                        },
+                        {"type": "input_text", "text": "after"},
+                    ],
+                }
+            ],
+            tools=[],
+            system_prompt="ignored",
+        )
+    ]
+
+    assert events == [TurnComplete(response=None)]
+    injected = sent[0]["content"]
+    assert injected.index("before") < injected.index("[Attached:") < injected.index("after")
+
+
+@pytest.mark.asyncio
 async def test_run_turn_image_only_no_text_still_injects(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/inner/test_goose_executor.py
+++ b/tests/inner/test_goose_executor.py
@@ -1498,3 +1498,16 @@ def test_create_app_returns_fastapi() -> None:
     from omnigent.inner import goose_harness
 
     assert isinstance(goose_harness.create_app(), FastAPI)
+
+
+def test_ordered_prompt_blocks_preserve_text_image_text_order() -> None:
+    blocks = [
+        {"type": "input_text", "text": "before"},
+        {"type": "input_image", "image_url": "data:image/png;base64,AAAB"},
+        {"type": "input_text", "text": "after"},
+    ]
+    assert GooseExecutor._ordered_prompt_blocks(blocks, image_supported=True) == [
+        {"type": "text", "text": "before"},
+        {"type": "image", "mimeType": "image/png", "data": "AAAB"},
+        {"type": "text", "text": "after"},
+    ]

--- a/tests/inner/test_qwen_agent_integration.py
+++ b/tests/inner/test_qwen_agent_integration.py
@@ -253,7 +253,9 @@ async def test_turn_with_file_attachment_reaches_agent() -> None:
         events.append(ev)
 
     prompt_msg = next(m for m in sent if m.get("method") == "session/prompt")
-    prompt_text = prompt_msg["params"]["prompt"][0]["text"]
+    prompt = prompt_msg["params"]["prompt"]
+    assert [block["type"] for block in prompt] == ["text", "text", "text"]
+    prompt_text = "\n".join(block["text"] for block in prompt)
     assert "review this file" in prompt_text
     assert "[attached file: foo.py]" in prompt_text
     assert any(isinstance(e, TurnComplete) for e in events)

--- a/tests/inner/test_qwen_executor.py
+++ b/tests/inner/test_qwen_executor.py
@@ -2321,3 +2321,16 @@ async def test_ensure_initialized_image_capability_defaults_false() -> None:
     await executor._ensure_initialized()
     assert executor._initialized is True
     assert executor._image_supported is False
+
+
+def test_ordered_prompt_blocks_preserve_text_image_text_order() -> None:
+    blocks = [
+        {"type": "input_text", "text": "before"},
+        {"type": "input_image", "image_url": "data:image/png;base64,AAAB"},
+        {"type": "input_text", "text": "after"},
+    ]
+    assert QwenExecutor._ordered_prompt_blocks(blocks, image_supported=True) == [
+        {"type": "text", "text": "before"},
+        {"type": "image", "mimeType": "image/png", "data": "AAAB"},
+        {"type": "text", "text": "after"},
+    ]

--- a/tests/runtime/test_pending_inputs.py
+++ b/tests/runtime/test_pending_inputs.py
@@ -177,6 +177,51 @@ def test_resolve_oldest_returns_content_with_file_blocks() -> None:
     assert drained.content == content
 
 
+def test_attachment_pending_does_not_consume_unrelated_terminal_text() -> None:
+    """Direct terminal input cannot steal an attachment-bearing web entry."""
+    content = [
+        _text_block("before after"),
+        {"type": "input_image", "file_id": "file_real", "filename": "a.png"},
+    ]
+    pending_id = pending_inputs.record("conv_a", content)
+
+    assert pending_inputs.resolve_oldest_for_mirrored_text("conv_a", "typed in terminal") is None
+    assert pending_inputs.snapshot_for("conv_a")[0]["pending_id"] == pending_id
+
+
+def test_attachment_pending_matches_after_materialized_marker_is_removed() -> None:
+    """The native attachment marker does not prevent the real FIFO match."""
+    content = [
+        _text_block("before after"),
+        {"type": "input_image", "file_id": "file_real", "filename": "a.png"},
+    ]
+    pending_id = pending_inputs.record("conv_a", content)
+
+    drained = pending_inputs.resolve_oldest_for_mirrored_text(
+        "conv_a",
+        "[Attached: /tmp/uploads/a.png]\n\nbefore after",
+    )
+    assert drained is not None and drained.pending_id == pending_id
+
+
+def test_attachment_pending_matches_after_native_reply_quote_reformat() -> None:
+    """Native removing Markdown quote prefixes must not strand the web entry."""
+    content = [
+        _text_block("> quoted line\n\nIs this still correct?"),
+        {"type": "input_image", "file_id": "file_real", "filename": "a.png"},
+    ]
+    pending_id = pending_inputs.record("conv_a", content)
+
+    drained = pending_inputs.resolve_oldest_for_mirrored_text(
+        "conv_a",
+        "[Attached: /tmp/uploads/a.png]\n\nquoted line Is this still correct?",
+    )
+
+    assert drained is not None and drained.pending_id == pending_id
+    assert drained.content == content
+    assert pending_inputs.snapshot_for("conv_a") == []
+
+
 def test_resolve_matching_text_skips_older_unmatched_entries() -> None:
     """Kiro can match the accepted prompt and identify older failed inputs."""
     first = pending_inputs.record(

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -1914,15 +1914,17 @@ async def test_external_user_message_folds_pending_image_into_durable_item(
 
         items = (await client.get(f"/v1/sessions/{session['id']}/items")).json()["data"]
         user_msg = next(item for item in items if item["type"] == "message")
-        # The image block was folded back in, ahead of the transcript text
-        # — so reloading history shows the image, not just the caption.
+        # The complete pending document becomes durable, so reload preserves
+        # the exact image/caption order without leaking the native marker.
         assert user_msg["content"][0] == {
             "type": "input_image",
             "file_id": "b08c893483887826e2b9f67165106700",
             "filename": "diagram.png",
         }
-        expected_text = "[Attached: /tmp/diagram.png]\n\nexplain this diagram"
-        assert user_msg["content"][1]["text"] == expected_text
+        assert user_msg["content"][1] == {
+            "type": "input_text",
+            "text": "explain this diagram",
+        }
         # The pending entry was drained — it won't double-render on rebind.
         assert pending_inputs.snapshot_for(session["id"]) == []
     finally:
@@ -1986,9 +1988,14 @@ async def test_external_user_message_drain_publishes_cleared_pending_id(
     "interrupt_text",
     ["[Request interrupted by user]", "[Request interrupted by user for tool use]"],
 )
+@pytest.mark.parametrize(
+    "attachment_echo",
+    ["[Attached: /tmp/uploads/shot.png]", "[Attachment shot.png could not be loaded]", ""],
+)
 async def test_external_interrupt_record_leaves_pending_input_for_real_message(
     client: httpx.AsyncClient,
     interrupt_text: str,
+    attachment_echo: str,
 ) -> None:
     """
     Regression: steering with an upload must not feed it to the interrupt marker.
@@ -2018,7 +2025,7 @@ async def test_external_interrupt_record_leaves_pending_input_for_real_message(
     try:
         for text in (
             interrupt_text,
-            "[Attached: /tmp/uploads/shot.png]",
+            attachment_echo,
         ):
             resp = await client.post(
                 f"/v1/sessions/{session['id']}/events",
@@ -2028,7 +2035,7 @@ async def test_external_interrupt_record_leaves_pending_input_for_real_message(
                         "item_type": "message",
                         "item_data": {
                             "role": "user",
-                            "content": [{"type": "input_text", "text": text}],
+                            "content": [] if not text else [{"type": "input_text", "text": text}],
                         },
                         "response_id": "native_turn_1",
                     },
@@ -2049,7 +2056,9 @@ async def test_external_interrupt_record_leaves_pending_input_for_real_message(
             "file_id": "file_shot1",
             "filename": "shot.png",
         }
-        assert steered["content"][1]["text"] == "[Attached: /tmp/uploads/shot.png]"
+        assert steered["content"][1:] == (
+            [{"type": "input_text", "text": attachment_echo}] if attachment_echo else []
+        )
         # The real message drained the entry (the marker must not have).
         assert pending_inputs.snapshot_for(session["id"]) == []
         assert pid
@@ -2057,23 +2066,16 @@ async def test_external_interrupt_record_leaves_pending_input_for_real_message(
         pending_inputs.reset_for_tests()
 
 
-async def test_external_interrupt_lookalike_still_drains_pending_input(
+async def test_external_interrupt_lookalike_without_attachment_marker_keeps_pending_input(
     client: httpx.AsyncClient,
 ) -> None:
-    """
-    The interrupt-record exemption must not swallow real user messages.
-
-    A user can type a message that merely resembles the marker. Over-matching
-    would skip the drain for it, stranding the pending entry and dropping the
-    upload it carries — the same class of bug from the other direction. The
-    regex is anchored, so a bracketed question is a normal message.
-    """
+    """Attachment-only pending input needs a recognized marker before draining."""
     from omnigent.runtime import pending_inputs
 
     pending_inputs.reset_for_tests()
     agent = await create_test_agent(client)
     session = await _create_session(client, agent["id"])
-    pending_inputs.record(
+    pending_id = pending_inputs.record(
         session["id"],
         [{"type": "input_image", "file_id": "file_shot2", "filename": "shot.png"}],
     )
@@ -2098,12 +2100,10 @@ async def test_external_interrupt_lookalike_still_drains_pending_input(
 
         items = (await client.get(f"/v1/sessions/{session['id']}/items")).json()["data"]
         user_msg = next(item for item in items if item["type"] == "message")
-        assert user_msg["content"][0] == {
-            "type": "input_image",
-            "file_id": "file_shot2",
-            "filename": "shot.png",
-        }
-        assert pending_inputs.snapshot_for(session["id"]) == []
+        assert user_msg["content"] == [
+            {"type": "input_text", "text": "[Request interrupted by user?]"}
+        ]
+        assert pending_inputs.snapshot_for(session["id"])[0]["pending_id"] == pending_id
     finally:
         pending_inputs.reset_for_tests()
 

--- a/tests/server/routes/test_inline_attachment_order.py
+++ b/tests/server/routes/test_inline_attachment_order.py
@@ -1,0 +1,34 @@
+from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.server.routes._sessions.helpers import _merge_pending_file_blocks
+
+
+def test_native_pending_merge_retains_inline_attachment_position() -> None:
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_1",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "before after"}]),
+    )
+    pending = [
+        {"type": "input_text", "text": "before "},
+        {"type": "input_image", "file_id": "file_1", "filename": "middle.png"},
+        {"type": "input_text", "text": "after"},
+    ]
+
+    merged = _merge_pending_file_blocks(item, pending)
+
+    assert isinstance(merged.data, MessageData)
+    assert merged.data.content == pending
+
+
+def test_native_pending_merge_keeps_mirrored_text_for_legacy_file_only_entry() -> None:
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_1",
+        data=MessageData(role="user", content=[{"type": "input_text", "text": "explain"}]),
+    )
+    pending = [{"type": "input_image", "file_id": "file_1", "filename": "image.png"}]
+
+    merged = _merge_pending_file_blocks(item, pending)
+
+    assert isinstance(merged.data, MessageData)
+    assert merged.data.content == [*pending, {"type": "input_text", "text": "explain"}]

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -3175,6 +3175,27 @@ async def test_ensure_local_claude_resume_transcript_rematerializes_image_blocks
     assert "file_id" not in written.read_text(encoding="utf-8")
 
 
+def test_claude_resume_content_preserves_inline_attachment_order(tmp_path: Path) -> None:
+    """Rebuilt native prompts keep an attachment between its surrounding text."""
+    content = [
+        {"type": "input_text", "text": "before "},
+        {
+            "type": "input_image",
+            "image_url": "data:image/png;base64,cG5nLWJ5dGVz",
+            "filename": "middle.png",
+        },
+        {"type": "input_text", "text": " after"},
+    ]
+
+    converted = claude_native._claude_user_content_from_api_blocks(content, tmp_path)
+
+    assert isinstance(converted, list)
+    texts = [block["text"] for block in converted]
+    assert texts[0] == "before "
+    assert texts[1].startswith("[Attached: ")
+    assert texts[2] == " after"
+
+
 @pytest.mark.asyncio
 async def test_ensure_local_claude_resume_transcript_marks_unresolvable_attachment(
     tmp_path: Path,


### PR DESCRIPTION
## Related issue

Part of #6394

## Summary

- Preserves ordered text/image/text content blocks while pending input is merged and dispatched through ACP, Claude native, Goose, and Qwen executors.
- Keeps legacy file-only pending entries compatible without moving attachments to the end of the prompt.
- Correlates attachment-bearing native replies after their known Markdown quote and attachment-marker reformats, including failed-materialization markers. Attachment-only entries drain only for a recognized materialized/unresolved marker or Codex Native's intentionally empty file-only mirror; unrelated nonempty direct-terminal input leaves them queued.
- Updates the Server session helpers so the serialized content-block order remains the order the model receives. The visible inline editor is deliberately not included in this backend-only slice.

ELI5: if a client sends “text, image, more text,” the runtime no longer reshuffles it into “all text, then image.”

```text
ordered client blocks -> pending-input merge -> executor payload -> model
```

## Test Plan

- Clean standalone replay on `upstream/main` `a9feaa4ca2ca8c10b6f1e574d4dcc16dab23d317`.
- Seventeen focused order, compatibility, quote/marker-reformat, attachment-only, route, and direct-terminal guard tests passed.
- Before the final correlation hardening, the 978-test affected-file matrix passed 962 and skipped 2. Its 14 Windows-only failures (missing `sh`, POSIX signals/PTYs, and path spelling) reproduced 14-for-14 on a pristine `e4d33d6c8` control worktree; no candidate-only failure remained. The final localized guard delta is covered by the deterministic a9 tests above, including both route-level marker forms and Codex Native's empty image-only mirror.
- Ruff passed in the replay worktree.
- `git diff --check` passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The direct regression tests prove serialized model-input order. No Web UI is changed by this candidate.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

This is only the runtime half of #6394. The Web document/editor/integration work is frozen separately as sub-500 Draft successors and is intentionally outside this backend PR.

