### PR TITLE
feat: cross-harness sys_ask_user_question builtin tool

### DIFF
--- a/integrations/slack/pyproject.toml
+++ b/integrations/slack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-slack"
-version = "0.12.0.dev0"
+version = "0.12.0"
 description = "Slack Socket Mode bot that drives Omnigent sessions."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -435,6 +435,24 @@ _BROWSER_TIMEOUT_ERROR = (
     '{"error": "browser action timed out — is the session open in the Omnigent desktop app?"}'
 )
 
+# Cross-harness builtin: pause the turn and ask the human 1-4 structured
+# questions. Execution lives HERE (not in Tool.invoke) for the same reason as
+# ``_BROWSER_TOOLS`` — the elicitation protocol needs the runner's
+# ``server_client`` to POST a blocking request to the server, and
+# ``ToolContext`` carries none. See omnigent/tools/builtins/ask_user_question.py
+# for the schema-only class and omnigent/server/routes/_ask_user_question.py
+# for the request/response shaping that reuses the platform's existing
+# elicitation engine end to end.
+_ASK_USER_QUESTION_TOOLS = frozenset({"sys_ask_user_question"})
+
+# Runner-side outer HTTP read timeout for the ask_user_question POST. Held at
+# one day — matching ``omnigent.spec.types.DEFAULT_ASK_TIMEOUT`` and the same
+# ``_ASK_GATE_DELIVERY_TIMEOUT`` rationale in omnigent/runner/app.py — so the
+# POST WAITS for the server's real verdict instead of severing the parked
+# elicitation at a short read timeout. Fast connect (30s) so an unreachable
+# server still fails out promptly.
+_ASK_USER_QUESTION_TIMEOUT = httpx.Timeout(86400.0, connect=30.0)
+
 # Builtin tools the claude-native / codex-native relay advertises to the
 # real CLI, beyond the always-relayed ``sys_os_*`` family. Native harnesses
 # ignore the harness ``tools`` list, so the relay is their ONLY tool
@@ -478,6 +496,11 @@ _NATIVE_RELAY_BUILTIN_TOOLS = (
     # what discovers host-scope skills (``.agents/skills`` and friends), and a
     # native session's only tool surface is this relay.
     | _SKILL_TOOLS
+    # sys_ask_user_question must ride the native relay too: native harnesses
+    # ignore ``request.tools`` entirely, so without this union member the
+    # tool is invisible to claude-native, codex-native, opencode-native,
+    # cursor-native, hermes-native, and antigravity-native sessions.
+    | _ASK_USER_QUESTION_TOOLS
 )
 
 
@@ -3850,6 +3873,55 @@ async def _execute_browser_tool(
     return resp.text
 
 
+async def _execute_ask_user_question_tool(
+    args: _JsonObject,
+    *,
+    server_client: httpx.AsyncClient | None,
+    conversation_id: str | None,
+) -> str:
+    """
+    Runner-local handler for ``sys_ask_user_question``.
+
+    Does the blocking round-trip that reuses the platform's existing
+    elicitation engine end to end: POST ``/v1/sessions/{conversation_id}/
+    ask_user_question`` with the tool call's raw ``{"questions": [...]}``
+    arguments and return the server's reconstructed JSON response verbatim
+    as the tool output. The server validates the questions, publishes a
+    ``response.elicitation_request`` event (the same one every other
+    harness ASK gate publishes), and parks until a human answers or the
+    request times out — so this POST stays open for as long as that takes,
+    up to one day (:data:`_ASK_USER_QUESTION_TIMEOUT`).
+
+    Mirrors the ``server_client.post`` pattern in :func:`_execute_browser_tool`,
+    with a read budget sized for a human response instead of a live renderer.
+
+    :param args: Parsed tool arguments from the LLM, e.g.
+        ``{"questions": [{"question": "...", "header": "...",
+        "options": [...], "multiSelect": False}]}``.
+    :param server_client: HTTP client pointed at the Omnigent server.
+    :param conversation_id: Current session id, e.g. ``"conv_abc123"``.
+    :returns: The server's reconstructed answer JSON, or an error JSON.
+    """
+    if server_client is None:
+        return json.dumps({"error": "sys_ask_user_question requires server access"})
+    if conversation_id is None:
+        return json.dumps({"error": "sys_ask_user_question requires a session id"})
+
+    try:
+        resp = await server_client.post(
+            f"/v1/sessions/{conversation_id}/ask_user_question",
+            json=args,
+            timeout=_ASK_USER_QUESTION_TIMEOUT,
+        )
+    except httpx.HTTPError as exc:
+        return json.dumps({"error": f"sys_ask_user_question failed: {type(exc).__name__}: {exc}"})
+    if resp.status_code >= 400:
+        return json.dumps(
+            {"error": f"sys_ask_user_question returned {resp.status_code}: {resp.text[:500]}"}
+        )
+    return resp.text
+
+
 async def _execute_policy_tool(
     tool_name: str,
     arguments: str,
@@ -5961,6 +6033,12 @@ async def execute_tool(
         elif tool_name in _BROWSER_TOOLS:
             output = await _execute_browser_tool(
                 tool_name,
+                args,
+                server_client=server_client,
+                conversation_id=conversation_id,
+            )
+        elif tool_name in _ASK_USER_QUESTION_TOOLS:
+            output = await _execute_ask_user_question_tool(
                 args,
                 server_client=server_client,
                 conversation_id=conversation_id,

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -744,16 +744,23 @@ def _ensure_default_acp_agents(
     agent_cache: Any,
 ) -> None:
     """
-    Seed a picker agent for each ACP harness set up on THIS server's host.
+    Seed a picker agent per builtin ACP CLI row and per configured ``acp:`` agent.
 
     Native harnesses seed a fixed ``<harness>-ui`` agent each
-    (:func:`_ensure_default_native_agents`). ACP agents are host config rather
-    than a fixed catalog, so seed one agent per user-configured ``acp:<slug>``
-    agent (``harness_is_configured("acp:...")`` treats "in config" as set up) and
-    per builtin ACP CLI harness whose binary is on PATH (its readiness gate). On a
-    host with no ACP setup — the common remote-server case, where the server holds
-    no ``acp:`` config — this seeds nothing. When both sources name the same
-    harness, the configured agent wins (see :func:`shadowed_builtin_acp_rows`).
+    (:func:`_ensure_default_native_agents`) unconditionally; the picker hides a row
+    the selected host cannot launch, reading that host's ``configured_harnesses``
+    readiness map. Builtin ACP CLI harnesses follow the same model, because the
+    vendor CLI runs on the *executing* host (the attached runner) rather than on the
+    server: gating the row on the server's own PATH left Devin and Grok missing from
+    the picker on every remote server, even when the runner had them installed.
+
+    User-configured ``acp:<slug>`` agents stay config-gated. Their launch command is
+    resolved from the *host's* own ``acp:`` block at spawn time, so a row naming a
+    slug the executing host does not define could never launch; surfacing those on a
+    remote server first needs the host to advertise its configured slugs.
+
+    When both sources name the same harness, the configured agent wins (see
+    :func:`shadowed_builtin_acp_rows`).
 
     Purely additive: it only adds picker rows and never touches native seeding.
     A malformed ``acp:`` block is logged and skipped, never fatal to startup
@@ -767,7 +774,6 @@ def _ensure_default_acp_agents(
     :param artifact_store: Store for agent bundles.
     :param agent_cache: Cache for loaded agent specs.
     """
-    from omnigent._platform import resolve_cli_binary
     from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 
     # (1) User-configured acp:<slug> agents — "set up" == present in config.
@@ -793,12 +799,12 @@ def _ensure_default_acp_agents(
             bundle_bytes=_build_acp_bundle(harness=f"acp:{agent.slug}", name=agent.slug),
         )
 
-    # (2) Builtin ACP CLI harnesses (e.g. grok) — "set up" == binary on PATH. Keyed
-    # by the catalog id (already a valid slug), not the display label. A row a
-    # configured agent already claims is skipped: both seed the same
-    # ``builtin_agent_id``, so the row would overwrite the user's chosen command.
-    for key, row in ACP_CLI_HARNESSES.items():
-        if key in shadowed or resolve_cli_binary(row.binary) is None:
+    # (2) Builtin ACP CLI harnesses — one row each, seeded like the natives because
+    # the vendor CLI runs on the executing host, not here. Keyed by the catalog id
+    # (already a valid slug), not the display label. A row a configured agent already
+    # claims is skipped: both seed the same ``builtin_agent_id``.
+    for key in ACP_CLI_HARNESSES:
+        if key in shadowed:
             continue
         _ensure_builtin_agent(
             agent_store,

--- a/omnigent/server/routes/_ask_user_question.py
+++ b/omnigent/server/routes/_ask_user_question.py
@@ -1,0 +1,272 @@
+"""``sys_ask_user_question`` protocol adapter for session routes.
+
+Pure functions that bridge the cross-harness ``sys_ask_user_question``
+builtin tool to the platform's existing elicitation engine — the same
+``ElicitationRequestParams`` / ``ElicitationResult`` machinery the
+Claude-native ``PermissionRequest`` ASK gate uses (see
+:func:`omnigent.server.routes._sessions.orchestration._publish_and_wait_for_harness_elicitation`).
+No new plumbing: this module only shapes the request going in and
+reconstructs the answer coming out.
+
+Modeled closely on Claude Code's own ``AskUserQuestionInput`` /
+``AskUserQuestionOutput`` contract (see ``sdk-tools.d.ts`` in the
+``@anthropic-ai/claude-code`` package), with one deliberate addition:
+a boolean ``recommended`` flag on individual options, which neither
+Claude Code's tool nor this platform's existing ``ElicitationRequestParams``
+/ ``ElicitationResult`` schemas carry. It rides through as an ordinary
+JSON field — no schema change needed, since ``ElicitationRequestParams``
+already allows extra fields.
+
+The wire format in between is flat: ``ElicitationResult.content`` is a
+``dict[str, str | int | float | bool | list[str] | None]`` (MCP's
+``ElicitResult.content`` shape — no nested objects). The web form
+(``AskUserQuestionForm.tsx``) submits one key per question (the question
+text), valued as the selected option label(s) — a list for multi-select,
+a scalar for single-select. :func:`build_ask_user_question_params` shapes
+the *request* side of that flat contract; :func:`reconstruct_ask_user_question_output`
+reverses it, rebuilding the rich, Claude-Code-shaped output the calling
+agent expects — including a top-level ``response`` free-text fallback for
+a reply that doesn't key off any known question (e.g. a client that
+answers with one blob of typed text instead of the structured form).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.schemas import ElicitationRequestParams, ElicitationResult
+
+MIN_QUESTIONS = 1
+MAX_QUESTIONS = 4
+MIN_OPTIONS = 2
+MAX_OPTIONS = 4
+
+_PHASE = "tool_call"
+_POLICY_NAME = "sys_ask_user_question"
+_PREVIEW_PREFIX = "AskUserQuestion("
+
+
+def validate_ask_user_question_questions(raw: Any) -> list[dict[str, Any]]:
+    """
+    Validate and normalize the tool call's ``questions`` argument.
+
+    Mirrors the shape Claude Code's own ``AskUserQuestionInput`` enforces
+    (1-4 questions, 2-4 options each) plus the platform-specific
+    ``recommended`` option flag. Unlike the permissive server-side
+    parsers for harness-originated payloads (e.g.
+    ``_structured_ask_user_question``, which silently drops malformed
+    entries because Claude already validated them client-side), this
+    function is the FIRST validation the tool's own arguments see, so it
+    fails loudly on a malformed shape rather than quietly dropping
+    questions the agent asked for.
+
+    At most one option per question should be marked ``recommended`` —
+    if the caller marks more than one (a model mistake, not a contract
+    violation), only the first is kept; the rest are normalized to
+    ``False`` rather than failing the call.
+
+    :param raw: The tool call's ``questions`` argument, e.g.
+        ``[{"question": "...", "header": "...", "options": [...],
+        "multiSelect": False}]``.
+    :returns: Normalized question dicts, each with ``question``,
+        ``header``, ``options`` (each with ``label``, ``description``,
+        optional ``preview``, ``recommended``), and ``multiSelect``.
+    :raises OmnigentError: If the shape doesn't satisfy the contract.
+    """
+    if not isinstance(raw, list) or not (MIN_QUESTIONS <= len(raw) <= MAX_QUESTIONS):
+        raise OmnigentError(
+            f"sys_ask_user_question requires {MIN_QUESTIONS}-{MAX_QUESTIONS} questions.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    questions: list[dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise OmnigentError(
+                "sys_ask_user_question: each question must be an object.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        question_text = entry.get("question")
+        if not isinstance(question_text, str) or not question_text:
+            raise OmnigentError(
+                "sys_ask_user_question: each question requires a non-empty 'question' string.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        header = entry.get("header")
+        if not isinstance(header, str) or not header:
+            raise OmnigentError(
+                "sys_ask_user_question: each question requires a non-empty 'header' string.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        options_raw = entry.get("options")
+        valid_option_count = isinstance(options_raw, list) and (
+            MIN_OPTIONS <= len(options_raw) <= MAX_OPTIONS
+        )
+        if not valid_option_count:
+            raise OmnigentError(
+                f"sys_ask_user_question: each question requires "
+                f"{MIN_OPTIONS}-{MAX_OPTIONS} options.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        options: list[dict[str, Any]] = []
+        seen_recommended = False
+        for opt in options_raw:
+            if not isinstance(opt, dict):
+                raise OmnigentError(
+                    "sys_ask_user_question: each option must be an object.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            label = opt.get("label")
+            description = opt.get("description")
+            if not isinstance(label, str) or not label:
+                raise OmnigentError(
+                    "sys_ask_user_question: each option requires a non-empty 'label' string.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            if not isinstance(description, str) or not description:
+                raise OmnigentError(
+                    "sys_ask_user_question: each option requires a "
+                    "non-empty 'description' string.",
+                    code=ErrorCode.INVALID_INPUT,
+                )
+            option: dict[str, Any] = {"label": label, "description": description}
+            preview = opt.get("preview")
+            if isinstance(preview, str) and preview:
+                option["preview"] = preview
+            recommended = opt.get("recommended") is True and not seen_recommended
+            if recommended:
+                seen_recommended = True
+            option["recommended"] = recommended
+            options.append(option)
+        questions.append(
+            {
+                "question": question_text,
+                "header": header,
+                "options": options,
+                "multiSelect": entry.get("multiSelect") is True,
+            }
+        )
+    return questions
+
+
+def build_ask_user_question_params(questions: list[dict[str, Any]]) -> ElicitationRequestParams:
+    """
+    Build ``ElicitationRequestParams`` for a ``sys_ask_user_question`` call.
+
+    Reuses the exact ``ask_user_question`` extra the web UI's
+    ``ApprovalCard`` / ``AskUserQuestionForm`` already know how to render
+    (see ``_structured_ask_user_question`` in
+    ``omnigent/server/routes/_sessions/helpers.py`` and
+    ``@/lib/askUserQuestion.ts``), so no new UI render mode is needed —
+    only the ``recommended`` field is new. ``requestedSchema`` is left
+    ``None`` (matching the Claude-native AskUserQuestion PermissionRequest
+    stamp and Codex's ``requestUserInput`` params): the structured
+    ``ask_user_question`` extra is the authoritative payload, not the MCP
+    form schema.
+
+    :param questions: Normalized questions from
+        :func:`validate_ask_user_question_questions`.
+    :returns: Params ready for
+        :func:`~omnigent.server.routes._sessions.orchestration._publish_and_wait_for_harness_elicitation`.
+    """
+    ask_payload = {"questions": questions}
+    message = (
+        "Claude wants to ask you a question"
+        if len(questions) == 1
+        else f"Claude wants to ask you {len(questions)} questions"
+    )
+    content_preview = f"{_PREVIEW_PREFIX}{json.dumps(ask_payload, ensure_ascii=False)[:1000]})"
+    return ElicitationRequestParams(
+        mode="form",
+        message=message,
+        requestedSchema=None,
+        url=None,
+        phase=_PHASE,
+        policy_name=_POLICY_NAME,
+        content_preview=content_preview,
+        ask_user_question=ask_payload,
+    )
+
+
+def _question_key(question: dict[str, Any]) -> str:
+    """Stable answer key for one question — matches the web form's ``questionKey``."""
+    return question["question"]
+
+
+def reconstruct_ask_user_question_output(
+    questions: list[dict[str, Any]],
+    result: ElicitationResult | None,
+) -> dict[str, Any]:
+    """
+    Reconstruct the tool's return value from a flat elicitation verdict.
+
+    The inverse of the flatten step in :func:`build_ask_user_question_params`:
+    ``ElicitationResult.content`` is a flat ``{question_text: answer}``
+    map (MCP's ``ElicitResult.content`` shape — no nested objects,
+    matching what ``AskUserQuestionForm.handleSubmit`` posts). This
+    rebuilds the rich, Claude-Code-``AskUserQuestionOutput``-shaped
+    object the calling agent expects: the echoed ``questions``, an
+    ``answers`` map keyed by question text (list value for multi-select,
+    scalar for single-select — richer than Claude Code's own
+    comma-joined-string convention, since our wire format natively
+    supports string lists), and an optional top-level ``response`` for a
+    free-text reply that doesn't key off any known question (e.g. a
+    minimal client that replies with one blob of text instead of driving
+    the structured form).
+
+    :param questions: The same normalized questions passed to
+        :func:`build_ask_user_question_params` — echoed back to the
+        agent so it doesn't have to recall its own call arguments.
+    :param result: The verdict from
+        :func:`~omnigent.server.routes._sessions.orchestration._publish_and_wait_for_harness_elicitation`,
+        or ``None`` on timeout / upstream disconnect.
+    :returns: ``{"questions": [...], "answers": {...}}`` on a normal
+        accept, with an optional ``response`` key; ``{"questions": [...],
+        "answers": {}, "error": "..."}`` on timeout / decline / cancel.
+    """
+    if result is None:
+        return {"questions": questions, "answers": {}, "error": "timed out waiting for a response"}
+    if result.action == "decline":
+        return {"questions": questions, "answers": {}, "error": "the user declined to answer"}
+    if result.action != "accept":
+        return {
+            "questions": questions,
+            "answers": {},
+            "error": "the user cancelled without answering",
+        }
+
+    content = result.content or {}
+    known_keys = {_question_key(q) for q in questions}
+    answers: dict[str, str | list[str]] = {}
+    response: str | None = None
+    for key, value in content.items():
+        if key in known_keys:
+            answers[key] = _normalize_answer_value(value)
+        else:
+            # A reply that doesn't key off any known question — e.g. a
+            # minimal/legacy client that submits ``{"response": "..."}``
+            # instead of driving the structured per-question form.
+            response = _stringify(value) if response is None else response
+    output: dict[str, Any] = {"questions": questions, "answers": answers}
+    if response is not None:
+        output["response"] = response
+    return output
+
+
+def _normalize_answer_value(value: object) -> str | list[str]:
+    """Normalize one flat content value to an answer (string or string list)."""
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return _stringify(value)
+
+
+def _stringify(value: object) -> str:
+    """Render a flat content scalar as a display string."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return ""
+    return str(value)

--- a/omnigent/server/routes/sessions/routes_elicitations.py
+++ b/omnigent/server/routes/sessions/routes_elicitations.py
@@ -27,6 +27,11 @@ from omnigent.server.auth import (
     LEVEL_EDIT,
     AuthProvider,
 )
+from omnigent.server.routes._ask_user_question import (
+    build_ask_user_question_params,
+    reconstruct_ask_user_question_output,
+    validate_ask_user_question_questions,
+)
 from omnigent.server.routes._auth_helpers import (
     get_user_id as _get_user_id,
 )
@@ -43,11 +48,13 @@ from omnigent.server.routes._sessions.helpers import (
     _apply_pending_policy_ask_writes,
 )
 from omnigent.server.routes._sessions.orchestration import (
+    _publish_and_wait_for_harness_elicitation,
     _resolve_elicitation,
 )
 from omnigent.server.schemas import (
     ElicitationResult,
 )
+from omnigent.spec.types import DEFAULT_ASK_TIMEOUT
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.permission_store import PermissionStore
 
@@ -129,6 +136,61 @@ def register_elicitations_routes(
             session_id, conv, conversation_store, agent_store, _resolve_data
         )
         return {"queued": False}
+
+    @router.post(
+        "/sessions/{session_id}/ask_user_question",
+        # Internal builtin-tool dispatch flow — hidden from the public API reference.
+        include_in_schema=False,
+        response_model=None,
+    )
+    async def ask_user_question(
+        request: Request,
+        session_id: str,
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Run one ``sys_ask_user_question`` builtin-tool call end to end.
+
+        Runner-invoked (see the ``_ASK_USER_QUESTION_TOOLS`` branch of
+        ``execute_tool()`` in ``omnigent/runner/tool_dispatch.py``), not
+        reachable by the LLM directly. Validates the tool call's
+        ``questions`` argument, publishes a
+        ``response.elicitation_request`` through the SAME elicitation
+        engine every other harness ASK gate uses (
+        :func:`_publish_and_wait_for_harness_elicitation` — no bespoke
+        plumbing), and blocks until a human answers, declines, or the
+        request times out (one day, matching the platform's
+        :data:`~omnigent.spec.types.DEFAULT_ASK_TIMEOUT`). The verdict is
+        reconstructed into the tool's rich, Claude-Code-shaped return
+        value by :func:`~omnigent.server.routes._ask_user_question.reconstruct_ask_user_question_output`.
+
+        :param request: The inbound request, used for identity extraction
+            and upstream-disconnect detection inside the parking helper.
+        :param session_id: Session/conversation identifier, e.g.
+            ``"conv_abc123"``.
+        :param body: ``{"questions": [...]}`` — the tool call's raw
+            arguments, per Claude Code's ``AskUserQuestionInput`` contract
+            plus the platform's ``recommended`` option extension.
+        :returns: ``{"questions": [...], "answers": {...}}`` (optionally
+            with ``response``) on a normal accept, or ``{"questions": [...],
+            "answers": {}, "error": "..."}`` on decline / cancel / timeout.
+        :raises OmnigentError: 400 if ``questions`` doesn't satisfy the
+            1-4 questions / 2-4 options contract; 404 if no session exists.
+        """
+        user_id = _get_user_id(request, auth_provider)
+        await _require_access_and_level(
+            user_id, session_id, LEVEL_EDIT, permission_store, conversation_store
+        )
+        questions = validate_ask_user_question_questions(body.get("questions"))
+        params = build_ask_user_question_params(questions)
+        result = await _publish_and_wait_for_harness_elicitation(
+            request,
+            session_id=session_id,
+            params=params,
+            timeout_s=float(DEFAULT_ASK_TIMEOUT),
+            conversation_store=conversation_store,
+        )
+        return reconstruct_ask_user_question_output(questions, result)
 
     @router.get(
         "/sessions/{session_id}/elicitations/{elicitation_id}",

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -30,6 +30,7 @@ from omnigent.tools.builtins.agents import (
     SysAgentGetTool,
     SysAgentListTool,
 )
+from omnigent.tools.builtins.ask_user_question import SysAskUserQuestionTool
 from omnigent.tools.builtins.async_inbox import (
     SysCallAsyncTool,
     SysCancelAsyncTool,
@@ -84,6 +85,7 @@ __all__ = [
     "SysAgentDownloadTool",
     "SysAgentGetTool",
     "SysAgentListTool",
+    "SysAskUserQuestionTool",
     "SysCallAsyncTool",
     "SysCancelAsyncTool",
     "SysListModelsTool",
@@ -184,6 +186,17 @@ def _create_export_agent(config: dict[str, str]) -> Tool:
     return ExportAgentTool()
 
 
+def _create_ask_user_question(config: dict[str, str]) -> Tool:
+    """
+    Lazy factory for SysAskUserQuestionTool.
+
+    :param config: Tool config (unused — the tool takes no spec-level
+        config; every field it needs comes from the per-call arguments).
+    :returns: A SysAskUserQuestionTool instance.
+    """
+    return SysAskUserQuestionTool()
+
+
 def _hindsight_available() -> bool:
     """
     Return ``True`` if the optional ``hindsight-client`` SDK is installed.
@@ -257,6 +270,13 @@ _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
     "download_file": _create_download_file,
     "search_conversations": _create_search_conversations,
     "export_agent": _create_export_agent,
+    # Schema-only — execution is runner-dispatched (see
+    # ``_ASK_USER_QUESTION_TOOLS`` in omnigent/runner/tool_dispatch.py),
+    # like ``browser_*``, because it needs the runner's ``server_client``
+    # to publish/park a session elicitation. Registered with a factory
+    # (not ``None``) so it stays spec-gated / user-enablable via
+    # ``tools.builtins`` rather than auto-registered for every agent.
+    "sys_ask_user_question": _create_ask_user_question,
     # Framework-owned: need runtime context. ``web_fetch`` is
     # constructed by ToolManager before reaching this registry.
     # ``list_comments`` and ``update_comment`` are auto-registered by

--- a/omnigent/tools/builtins/ask_user_question.py
+++ b/omnigent/tools/builtins/ask_user_question.py
@@ -1,0 +1,151 @@
+"""Schema-only ``sys_ask_user_question`` builtin tool class.
+
+Lets any sub-agent harness pause its turn and present the human operator
+with 1-4 structured multiple-choice questions, then resume with the
+human's structured answers. Modeled closely on Claude Code's own
+``AskUserQuestionInput`` / ``AskUserQuestionOutput`` contract (see
+``sdk-tools.d.ts`` in the ``@anthropic-ai/claude-code`` package), with
+one deliberate addition: a boolean ``recommended`` flag on individual
+options, marking the suggested default — a field that exists in neither
+Claude Code's own tool nor this platform's existing
+``ElicitationRequestParams`` / ``ElicitationResult`` schemas.
+
+This class is the **tool surface only** — ``name()``, ``description()``
+and ``get_schema()``. It deliberately does NOT implement ``invoke()``:
+execution needs the session's elicitation machinery (publish a
+``response.elicitation_request`` event, park until a human answers),
+which lives on the server and needs the runner's ``server_client`` —
+``ToolContext`` carries neither. Execution lives in the runner dispatch
+layer (``omnigent/runner/tool_dispatch.py`` — the
+``_ASK_USER_QUESTION_TOOLS`` branch of ``execute_tool()``), which POSTs
+to ``/v1/sessions/{id}/ask_user_question`` (see
+``omnigent/server/routes/_ask_user_question.py`` for the request/response
+shaping and ``omnigent/server/routes/sessions/routes_elicitations.py``
+for the route itself). Any call that reaches ``Tool.invoke`` here means
+the tool was misrouted to the server-side path — the base class raises
+``NotImplementedError`` loudly in that case.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from omnigent.tools.base import Tool
+
+
+class SysAskUserQuestionTool(Tool):
+    """Pause the turn and ask the human 1-4 structured questions (schema only)."""
+
+    @classmethod
+    def name(cls) -> str:
+        """:returns: ``"sys_ask_user_question"``."""
+        return "sys_ask_user_question"
+
+    @classmethod
+    def description(cls) -> str:
+        """:returns: Human-readable description of the tool."""
+        return (
+            "Pause your turn and ask the human operator 1-4 structured "
+            "multiple-choice questions, then resume with their answers. "
+            "Each question offers 2-4 options with a label, a description "
+            "of what choosing it means, and an optional longer preview "
+            "shown when the option is focused. Mark exactly one option per "
+            "question 'recommended' when you have a suggested default — "
+            "the human sees it called out and pre-selected, but can pick "
+            "differently. Set 'multiSelect' when a question's options "
+            "aren't mutually exclusive. The human may also type a free-text "
+            "answer instead of picking an option. Works across every "
+            "harness this platform supports — use it whenever you'd "
+            "otherwise have to guess at an ambiguous choice."
+        )
+
+    def get_schema(self) -> dict[str, Any]:
+        """
+        Return the OpenAI-format tool schema.
+
+        :returns: Dict with ``"type": "function"`` and a
+            ``"function"`` sub-dict.
+        """
+        option_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string",
+                    "description": (
+                        "The display text for this option. Concise (1-5 words), "
+                        "clearly describing the choice."
+                    ),
+                },
+                "description": {
+                    "type": "string",
+                    "description": (
+                        "Explanation of what this option means or what happens if chosen."
+                    ),
+                },
+                "preview": {
+                    "type": "string",
+                    "description": (
+                        "Optional longer snippet (a mockup, code, or a fuller "
+                        "comparison) shown when this option is focused."
+                    ),
+                },
+                "recommended": {
+                    "type": "boolean",
+                    "description": (
+                        "Marks this as the suggested default. Set true on at most "
+                        "one option per question."
+                    ),
+                },
+            },
+            "required": ["label", "description"],
+            "additionalProperties": False,
+        }
+        question_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": ("The complete question to ask, ending with a question mark."),
+                },
+                "header": {
+                    "type": "string",
+                    "description": "Very short label displayed as a chip/tag (max 12 chars).",
+                },
+                "options": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 4,
+                    "items": option_schema,
+                    "description": (
+                        "2-4 distinct, mutually exclusive choices (unless multiSelect)."
+                    ),
+                },
+                "multiSelect": {
+                    "type": "boolean",
+                    "description": "True to let the human select multiple options.",
+                },
+            },
+            "required": ["question", "header", "options", "multiSelect"],
+            "additionalProperties": False,
+        }
+        return {
+            "type": "function",
+            "function": {
+                "name": SysAskUserQuestionTool.name(),
+                "description": SysAskUserQuestionTool.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "questions": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 4,
+                            "items": question_schema,
+                            "description": "1-4 questions to ask the human, in order.",
+                        },
+                    },
+                    "required": ["questions"],
+                    "additionalProperties": False,
+                },
+            },
+        }

--- a/omnigent/version.py
+++ b/omnigent/version.py
@@ -12,4 +12,4 @@ the two in sync, so releases are cut by bumping pyproject alone (via
 ``scripts/update_versions.py``).
 """
 
-VERSION = "0.12.0.dev0"
+VERSION = "0.12.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "omnigent"
 # Keep in sync with omnigent/version.py's VERSION constant.
-version = "0.12.0.dev0"
+version = "0.12.0"
 description = "Omnigent: declarative agent authoring and runtime framework"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,8 +26,8 @@ dependencies = [
     # one version, so a published `omnigent==X` must resolve the SDK wheels
     # built alongside it (release-omnigent.yml verifies these pins match the
     # release tag). Local/editable installs still resolve via tool.uv.sources.
-    "omnigent-client==0.12.0.dev0",
-    "omnigent-ui-sdk==0.12.0.dev0",
+    "omnigent-client==0.12.0",
+    "omnigent-ui-sdk==0.12.0",
     # Merged from omnigent + omnigent.
     "pyyaml>=6.0,<7",
     # OpenClaw stores its wrapped acpx registry as JSON5.
@@ -268,7 +268,7 @@ nimble = ["nimble-python>=1.2.0,<2"]
 # (`omnigent-client`, `omnigent-ui-sdk`) and the sub-package's own
 # `[project].version` in `integrations/slack/pyproject.toml`.
 slack = [
-    "omnigent-slack==0.12.0.dev0",
+    "omnigent-slack==0.12.0",
 ]
 databricks = [
     # Floor matches what core code was tested against when the SDK was a

--- a/sdks/python-client/pyproject.toml
+++ b/sdks/python-client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-client"
-version = "0.12.0.dev0"
+version = "0.12.0"
 description = "Python client SDK for the omnigent server API"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -16,7 +16,7 @@ dependencies = [
     # editable alongside the root ``omnigent`` package. Version-locked
     # (==) so a published SDK always pairs with the server release it
     # shipped with (release-omnigent.yml verifies the pin).
-    "omnigent==0.12.0.dev0",
+    "omnigent==0.12.0",
     "httpx>=0.27",
     "pydantic>=2.0,<3",
 ]

--- a/sdks/ui/pyproject.toml
+++ b/sdks/ui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omnigent-ui-sdk"
-version = "0.12.0.dev0"
+version = "0.12.0"
 description = "Terminal UI components (Rich + prompt_toolkit) for building omnigent frontends"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -13,7 +13,7 @@ dependencies = [
     # at one version (release-omnigent.yml verifies the pin). A `>=`
     # floor would also reject pre-releases (e.g. 0.1.0rc1 < 0.1.0 in
     # PEP 440).
-    "omnigent-client==0.12.0.dev0",
+    "omnigent-client==0.12.0",
     "rich>=13",
     "prompt_toolkit>=3",
     "pyyaml>=6.0,<7",

--- a/tests/runner/test_ask_user_question_tool_dispatch.py
+++ b/tests/runner/test_ask_user_question_tool_dispatch.py
@@ -1,0 +1,249 @@
+"""Tests for the cross-harness ``sys_ask_user_question`` tool surface.
+
+Covers the runner-side half of the feature:
+
+- ``_execute_ask_user_question_tool``: the blocking ``server_client.post``
+  to the server ``/ask_user_question`` route — correct URL / body
+  passthrough, verbatim JSON response, and clean error JSON on failure.
+- Registration in ``omnigent.tools.builtins``: spec-gated (unlike
+  ``browser_*``, NOT auto-registered).
+- Native-relay exposure: ``build_native_relay_tool_schemas`` surfaces the
+  tool's schema when the spec declares it — native harnesses (claude-native,
+  codex-native, opencode-native, cursor-native, hermes-native,
+  antigravity-native) ignore ``request.tools`` entirely, so a miss here
+  means the tool is invisible to them even though it's "registered".
+- ``execute_tool()`` actually dispatches the call (not just advertises it).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+import omnigent.tools.builtins as builtins_mod
+from omnigent.runner.tool_dispatch import (
+    _ASK_USER_QUESTION_TOOLS,
+    _NATIVE_RELAY_BUILTIN_TOOLS,
+    _execute_ask_user_question_tool,
+    build_native_relay_tool_schemas,
+    execute_tool,
+)
+from omnigent.spec.types import AgentSpec, BuiltinToolConfig, ToolsConfig
+
+_QUESTIONS_ARGS = {
+    "questions": [
+        {
+            "question": "Which framework?",
+            "header": "Framework",
+            "options": [
+                {"label": "React", "description": "Component-based UI library."},
+                {"label": "Vue", "description": "Progressive framework.", "recommended": True},
+            ],
+            "multiSelect": False,
+        }
+    ]
+}
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+class _RecordingResponse:
+    """Minimal httpx response stub with a scripted body."""
+
+    def __init__(self, *, status_code: int = 200, body: dict[str, object] | None = None) -> None:
+        self.status_code = status_code
+        self._body = body if body is not None else {}
+
+    @property
+    def text(self) -> str:
+        """Return the JSON body as text (what the tool returns verbatim)."""
+        return json.dumps(self._body)
+
+
+class _RecordingClient:
+    """httpx.AsyncClient stub that records the POST and returns a script."""
+
+    def __init__(self, response: _RecordingResponse | None = None) -> None:
+        self.calls: list[tuple[str, dict[str, object], object]] = []
+        self._response = response or _RecordingResponse(body={"questions": [], "answers": {}})
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, object] | None = None,
+        timeout: object = None,
+    ) -> _RecordingResponse:
+        """Record the call and return the scripted response."""
+        self.calls.append((url, json or {}, timeout))
+        return self._response
+
+
+class _ErrorClient:
+    """httpx.AsyncClient stub whose POST raises a generic HTTPError."""
+
+    async def post(self, url: str, **_: object) -> _RecordingResponse:
+        """Raise a connect error the tool must surface as an error string."""
+        raise httpx.ConnectError("connection refused")
+
+
+# ── _execute_ask_user_question_tool ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_posts_questions_to_ask_user_question_route() -> None:
+    """The tool POSTs the raw arguments verbatim to the session route."""
+    scripted = {
+        "questions": _QUESTIONS_ARGS["questions"],
+        "answers": {"Which framework?": "Vue"},
+    }
+    client = _RecordingClient(_RecordingResponse(body=scripted))
+    out = await _execute_ask_user_question_tool(
+        _QUESTIONS_ARGS,
+        server_client=client,
+        conversation_id="conv_abc",
+    )
+
+    assert len(client.calls) == 1
+    url, body, timeout = client.calls[0]
+    assert url == "/v1/sessions/conv_abc/ask_user_question"
+    assert body == _QUESTIONS_ARGS
+    # Read budget must be long enough to wait for a human — a day, like the
+    # platform's default ask_timeout.
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.read == 86400.0
+    assert json.loads(out) == scripted
+
+
+@pytest.mark.asyncio
+async def test_http_error_returns_error_json() -> None:
+    """A generic HTTP error is surfaced as an error JSON, not raised."""
+    out = await _execute_ask_user_question_tool(
+        _QUESTIONS_ARGS,
+        server_client=_ErrorClient(),
+        conversation_id="conv_abc",
+    )
+    parsed = json.loads(out)
+    assert "sys_ask_user_question failed" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_4xx_returns_error_json() -> None:
+    """A >=400 response body is reported as an error string, not raised."""
+    client = _RecordingClient(_RecordingResponse(status_code=400, body={"detail": "bad input"}))
+    out = await _execute_ask_user_question_tool(
+        _QUESTIONS_ARGS,
+        server_client=client,
+        conversation_id="conv_abc",
+    )
+    parsed = json.loads(out)
+    assert "sys_ask_user_question returned 400" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_requires_server_and_session() -> None:
+    """Missing server_client or conversation_id fails loud with JSON."""
+    out_no_client = await _execute_ask_user_question_tool(
+        _QUESTIONS_ARGS, server_client=None, conversation_id="conv"
+    )
+    assert "requires server access" in json.loads(out_no_client)["error"]
+
+    out_no_conv = await _execute_ask_user_question_tool(
+        _QUESTIONS_ARGS, server_client=_RecordingClient(), conversation_id=None
+    )
+    assert "requires a session id" in json.loads(out_no_conv)["error"]
+
+
+# ── execute_tool() actually dispatches (not just advertises) ─────
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_dispatches_to_ask_user_question_branch() -> None:
+    """``execute_tool()`` routes ``sys_ask_user_question`` to the handler
+    above — being visible in the schema without this branch means it
+    silently fails for every caller."""
+    scripted = {"questions": [], "answers": {"Which framework?": "Vue"}}
+    client = _RecordingClient(_RecordingResponse(body=scripted))
+    out = await execute_tool(
+        tool_name="sys_ask_user_question",
+        arguments=json.dumps(_QUESTIONS_ARGS),
+        server_client=client,
+        terminal_registry=None,
+        resource_registry=None,
+        agent_spec=None,
+        conversation_id="conv_abc",
+        task_id="task_abc",
+        agent_id="agent_abc",
+        agent_name=None,
+        runner_workspace=None,
+        mcp_manager=None,
+        session_inbox=None,
+        session_async_tasks=None,
+        harness_client=None,
+        publish_event=None,
+        filesystem_registry=None,
+    )
+    assert json.loads(out) == scripted
+    assert len(client.calls) == 1
+    assert client.calls[0][0] == "/v1/sessions/conv_abc/ask_user_question"
+
+
+# ── Registration: spec-gated, not framework-owned ─────────────────
+
+
+def test_reserved_but_not_framework_owned() -> None:
+    """
+    Unlike ``browser_*`` (framework-owned, always-on), ``sys_ask_user_question``
+    IS instantiable via the registry — an agent spec must declare it in
+    ``tools.builtins`` to get it, following the ``web_search`` /
+    ``upload_file`` pattern.
+    """
+    assert "sys_ask_user_question" in builtins_mod.BUILTIN_NAMES
+    assert "sys_ask_user_question" in builtins_mod.INSTANTIABLE_BUILTINS
+    tool = builtins_mod.get_builtin_tool("sys_ask_user_question")
+    assert tool is not None
+    assert tool.name() == "sys_ask_user_question"
+
+
+def test_toolmanager_does_not_auto_register_without_opt_in() -> None:
+    """A bare spec (no ``tools.builtins``) does NOT register the tool."""
+    from omnigent.tools.manager import ToolManager
+
+    mgr = ToolManager(AgentSpec(spec_version=1))
+    assert mgr.get_tool("sys_ask_user_question") is None
+
+
+# ── Native-relay exposure ────────────────────────────────────────
+
+
+def test_ask_user_question_in_native_relay_union() -> None:
+    """The relay builtin union must include the tool name."""
+    assert _ASK_USER_QUESTION_TOOLS <= _NATIVE_RELAY_BUILTIN_TOOLS
+
+
+def test_native_relay_surfaces_schema_when_spec_declares_it() -> None:
+    """
+    A spec that declares ``sys_ask_user_question`` in ``tools.builtins``
+    surfaces its schema on the native relay — the ONLY tool surface every
+    native harness (claude-native, codex-native, opencode-native,
+    cursor-native, hermes-native, antigravity-native) sees.
+    """
+    spec = AgentSpec(
+        spec_version=1,
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="sys_ask_user_question")]),
+    )
+    schemas = build_native_relay_tool_schemas(spec)
+    matching = [s for s in schemas if s["name"] == "sys_ask_user_question"]
+    assert len(matching) == 1
+    assert matching[0]["description"]
+    assert matching[0]["parameters"]["type"] == "object"
+
+
+def test_native_relay_omits_schema_for_bare_spec() -> None:
+    """Without the spec opt-in, the relay does not advertise the tool."""
+    schemas = build_native_relay_tool_schemas(AgentSpec(spec_version=1))
+    names = {s["name"] for s in schemas}
+    assert "sys_ask_user_question" not in names

--- a/tests/server/integration/test_sessions_ask_user_question_api.py
+++ b/tests/server/integration/test_sessions_ask_user_question_api.py
@@ -1,0 +1,125 @@
+"""
+Integration tests for ``POST /v1/sessions/{id}/ask_user_question``.
+
+Exercises the actual FastAPI route (not just the pure
+``_ask_user_question`` helpers unit-tested in
+``tests/server/routes/test_ask_user_question.py``): the runner-invoked
+POST publishes a ``response.elicitation_request`` SSE event through the
+SAME elicitation engine the Claude-native ``PermissionRequest`` ASK gate
+uses, and blocks until the human answers via the existing
+``POST /v1/sessions/{id}/elicitations/{eid}/resolve`` endpoint —
+proving the round trip is wired end to end, not just unit-correct.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.server.helpers import create_test_agent
+from tests.server.integration.test_sessions_elicitation_resolve_url import (
+    _drain_until_elicitation,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_QUESTIONS = [
+    {
+        "question": "Which framework?",
+        "header": "Framework",
+        "options": [
+            {"label": "React", "description": "Component-based UI library."},
+            {"label": "Vue", "description": "Progressive framework.", "recommended": True},
+        ],
+        "multiSelect": False,
+    }
+]
+
+
+async def _create_session(client: httpx.AsyncClient, agent_id: str) -> str:
+    """Create a minimal session and return its id."""
+    resp = await client.post("/v1/sessions", json={"agent_id": agent_id})
+    assert resp.status_code == 201, f"create failed: {resp.status_code} {resp.text}"
+    return resp.json()["id"]
+
+
+async def test_accept_round_trip_reconstructs_answers(client: httpx.AsyncClient) -> None:
+    """
+    A human accept with a flat answers map comes back as the tool's
+    rich, reconstructed ``{questions, answers}`` output — proving the
+    route wires ``validate`` -> ``build_ask_user_question_params`` ->
+    the shared elicitation engine -> ``reconstruct`` end to end.
+    """
+    agent = await create_test_agent(client, "test-ask-user-question-accept")
+    session_id = await _create_session(client, agent["id"])
+
+    subscribed = asyncio.Event()
+    drain_task = asyncio.ensure_future(_drain_until_elicitation(session_id, subscribed=subscribed))
+    await subscribed.wait()
+
+    ask_task = asyncio.ensure_future(
+        client.post(
+            f"/v1/sessions/{session_id}/ask_user_question",
+            json={"questions": _QUESTIONS},
+        )
+    )
+    elicitation_id = await drain_task
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "accept", "content": {"Which framework?": "Vue"}},
+    )
+    assert verdict.status_code == 202, verdict.text
+
+    resp = await ask_task
+    assert resp.status_code == 200, resp.text
+    body: dict[str, Any] = resp.json()
+    assert body["answers"] == {"Which framework?": "Vue"}
+    assert body["questions"][0]["options"][1]["recommended"] is True
+    assert "error" not in body
+
+
+async def test_decline_round_trip_returns_error_shape(client: httpx.AsyncClient) -> None:
+    """A human decline comes back as a clean error, not a raised exception."""
+    agent = await create_test_agent(client, "test-ask-user-question-decline")
+    session_id = await _create_session(client, agent["id"])
+
+    subscribed = asyncio.Event()
+    drain_task = asyncio.ensure_future(_drain_until_elicitation(session_id, subscribed=subscribed))
+    await subscribed.wait()
+
+    ask_task = asyncio.ensure_future(
+        client.post(
+            f"/v1/sessions/{session_id}/ask_user_question",
+            json={"questions": _QUESTIONS},
+        )
+    )
+    elicitation_id = await drain_task
+
+    verdict = await client.post(
+        f"/v1/sessions/{session_id}/elicitations/{elicitation_id}/resolve",
+        json={"action": "decline"},
+    )
+    assert verdict.status_code == 202, verdict.text
+
+    resp = await ask_task
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["answers"] == {}
+    assert "declined" in body["error"]
+
+
+async def test_invalid_questions_returns_400(client: httpx.AsyncClient) -> None:
+    """A malformed ``questions`` argument is rejected before any elicitation
+    is published — 400, not a hang."""
+    agent = await create_test_agent(client, "test-ask-user-question-invalid")
+    session_id = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/ask_user_question",
+        json={"questions": []},
+    )
+    assert resp.status_code == 400, resp.text

--- a/tests/server/routes/test_ask_user_question.py
+++ b/tests/server/routes/test_ask_user_question.py
@@ -1,0 +1,214 @@
+"""Tests for the ``sys_ask_user_question`` protocol adapter.
+
+These are pure-function tests — no HTTP or runtime needed. Covers the
+flatten (request-building) and reconstruct (response-building) halves of
+the round trip, plus the ``recommended`` extension surviving both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omnigent.errors import OmnigentError
+from omnigent.server.routes._ask_user_question import (
+    build_ask_user_question_params,
+    reconstruct_ask_user_question_output,
+    validate_ask_user_question_questions,
+)
+from omnigent.server.schemas import ElicitationResult
+
+_ONE_QUESTION = [
+    {
+        "question": "Which framework?",
+        "header": "Framework",
+        "options": [
+            {"label": "React", "description": "Component-based UI library."},
+            {"label": "Vue", "description": "Progressive framework.", "recommended": True},
+        ],
+        "multiSelect": False,
+    }
+]
+
+_MULTI_SELECT_QUESTION = [
+    {
+        "question": "Which features?",
+        "header": "Features",
+        "options": [
+            {"label": "Auth", "description": "User accounts."},
+            {"label": "Billing", "description": "Payments."},
+            {"label": "Search", "description": "Full-text search."},
+        ],
+        "multiSelect": True,
+    }
+]
+
+
+# ── validate_ask_user_question_questions ──────────────────────────
+
+
+class TestValidateAskUserQuestionQuestions:
+    def test_valid_single_question(self) -> None:
+        result = validate_ask_user_question_questions(_ONE_QUESTION)
+        assert len(result) == 1
+        assert result[0]["question"] == "Which framework?"
+        assert result[0]["options"][0]["recommended"] is False
+        assert result[0]["options"][1]["recommended"] is True
+
+    def test_rejects_zero_questions(self) -> None:
+        with pytest.raises(OmnigentError, match="1-4 questions"):
+            validate_ask_user_question_questions([])
+
+    def test_rejects_more_than_four_questions(self) -> None:
+        with pytest.raises(OmnigentError, match="1-4 questions"):
+            validate_ask_user_question_questions(_ONE_QUESTION * 5)
+
+    def test_rejects_non_list(self) -> None:
+        with pytest.raises(OmnigentError, match="1-4 questions"):
+            validate_ask_user_question_questions("not a list")
+
+    def test_rejects_missing_question_text(self) -> None:
+        bad = [{**_ONE_QUESTION[0], "question": ""}]
+        with pytest.raises(OmnigentError, match="non-empty 'question'"):
+            validate_ask_user_question_questions(bad)
+
+    def test_rejects_missing_header(self) -> None:
+        bad = [{**_ONE_QUESTION[0], "header": ""}]
+        with pytest.raises(OmnigentError, match="non-empty 'header'"):
+            validate_ask_user_question_questions(bad)
+
+    def test_rejects_one_option(self) -> None:
+        bad = [{**_ONE_QUESTION[0], "options": _ONE_QUESTION[0]["options"][:1]}]
+        with pytest.raises(OmnigentError, match="2-4 options"):
+            validate_ask_user_question_questions(bad)
+
+    def test_rejects_five_options(self) -> None:
+        base_option = _ONE_QUESTION[0]["options"][0]
+        bad = [{**_ONE_QUESTION[0], "options": [base_option] * 5}]
+        with pytest.raises(OmnigentError, match="2-4 options"):
+            validate_ask_user_question_questions(bad)
+
+    def test_rejects_option_missing_description(self) -> None:
+        bad_option = {"label": "React"}
+        bad = [{**_ONE_QUESTION[0], "options": [bad_option, _ONE_QUESTION[0]["options"][1]]}]
+        with pytest.raises(OmnigentError, match="non-empty 'description'"):
+            validate_ask_user_question_questions(bad)
+
+    def test_preserves_preview(self) -> None:
+        options = [
+            {"label": "React", "description": "UI lib.", "preview": "import React"},
+            {"label": "Vue", "description": "Progressive."},
+        ]
+        result = validate_ask_user_question_questions([{**_ONE_QUESTION[0], "options": options}])
+        assert result[0]["options"][0]["preview"] == "import React"
+        assert "preview" not in result[0]["options"][1]
+
+    def test_demotes_extra_recommended_options_to_at_most_one(self) -> None:
+        """A model mistake (multiple 'recommended: true') is normalized,
+        not rejected: only the first stays true."""
+        options = [
+            {"label": "React", "description": "UI lib.", "recommended": True},
+            {"label": "Vue", "description": "Progressive.", "recommended": True},
+        ]
+        result = validate_ask_user_question_questions([{**_ONE_QUESTION[0], "options": options}])
+        assert result[0]["options"][0]["recommended"] is True
+        assert result[0]["options"][1]["recommended"] is False
+
+    def test_defaults_recommended_to_false(self) -> None:
+        options = [
+            {"label": "React", "description": "UI lib."},
+            {"label": "Vue", "description": "Progressive."},
+        ]
+        result = validate_ask_user_question_questions([{**_ONE_QUESTION[0], "options": options}])
+        assert all(opt["recommended"] is False for opt in result[0]["options"])
+
+    def test_multi_select_flag_preserved(self) -> None:
+        result = validate_ask_user_question_questions(_MULTI_SELECT_QUESTION)
+        assert result[0]["multiSelect"] is True
+
+
+# ── build_ask_user_question_params ────────────────────────────────
+
+
+class TestBuildAskUserQuestionParams:
+    def test_builds_form_mode_params_with_no_requested_schema(self) -> None:
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        params = build_ask_user_question_params(questions)
+        assert params.mode == "form"
+        assert params.requestedSchema is None
+        assert params.url is None
+
+    def test_ask_user_question_extra_carries_recommended_flag(self) -> None:
+        """The recommended flag survives from validated input into the
+        elicitation params extra the web UI's ApprovalCard reads."""
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        params = build_ask_user_question_params(questions)
+        extra = params.model_extra or {}
+        ask_payload = extra["ask_user_question"]
+        options = ask_payload["questions"][0]["options"]
+        assert options[0]["recommended"] is False
+        assert options[1]["recommended"] is True
+
+    def test_message_mentions_question_count(self) -> None:
+        one = build_ask_user_question_params(validate_ask_user_question_questions(_ONE_QUESTION))
+        assert "question" in one.message.lower()
+        two_questions = _ONE_QUESTION + _MULTI_SELECT_QUESTION
+        two = build_ask_user_question_params(validate_ask_user_question_questions(two_questions))
+        assert "2" in two.message
+
+
+# ── reconstruct_ask_user_question_output ──────────────────────────
+
+
+class TestReconstructAskUserQuestionOutput:
+    def test_timeout_returns_error_with_echoed_questions(self) -> None:
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        output = reconstruct_ask_user_question_output(questions, None)
+        assert output["questions"] == questions
+        assert output["answers"] == {}
+        assert "timed out" in output["error"]
+
+    def test_decline_returns_error(self) -> None:
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        result = ElicitationResult(action="decline")
+        output = reconstruct_ask_user_question_output(questions, result)
+        assert output["answers"] == {}
+        assert "declined" in output["error"]
+
+    def test_cancel_returns_error(self) -> None:
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        result = ElicitationResult(action="cancel")
+        output = reconstruct_ask_user_question_output(questions, result)
+        assert output["answers"] == {}
+        assert "cancelled" in output["error"]
+
+    def test_single_select_accept_round_trips_scalar_answer(self) -> None:
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        result = ElicitationResult(action="accept", content={"Which framework?": "Vue"})
+        output = reconstruct_ask_user_question_output(questions, result)
+        assert output["questions"] == questions
+        assert output["answers"] == {"Which framework?": "Vue"}
+        assert "response" not in output
+
+    def test_multi_select_accept_round_trips_list_answer(self) -> None:
+        questions = validate_ask_user_question_questions(_MULTI_SELECT_QUESTION)
+        result = ElicitationResult(
+            action="accept", content={"Which features?": ["Auth", "Billing"]}
+        )
+        output = reconstruct_ask_user_question_output(questions, result)
+        assert output["answers"] == {"Which features?": ["Auth", "Billing"]}
+
+    def test_free_text_fallback_becomes_top_level_response(self) -> None:
+        """A reply keyed off something other than a known question text
+        (e.g. a minimal client answering with one blob of text) surfaces
+        as the top-level ``response`` field instead of an answer."""
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        result = ElicitationResult(action="accept", content={"response": "Just use Vue please"})
+        output = reconstruct_ask_user_question_output(questions, result)
+        assert output["answers"] == {}
+        assert output["response"] == "Just use Vue please"
+
+    def test_accept_with_no_content_is_lossless_empty(self) -> None:
+        questions = validate_ask_user_question_questions(_ONE_QUESTION)
+        result = ElicitationResult(action="accept", content=None)
+        output = reconstruct_ask_user_question_output(questions, result)
+        assert output == {"questions": questions, "answers": {}}

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1103,17 +1103,26 @@ def test_ensure_default_acp_agents_seeds_configured_agent(
     assert seed_stores.artifact_store.get(seeded.bundle_location) is not None
 
 
-def test_ensure_default_acp_agents_seeds_installed_builtin_cli(
+def test_ensure_default_acp_agents_seeds_builtin_cli_rows_without_a_local_binary(
     seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A builtin ACP CLI harness whose binary is on PATH seeds a picker built-in."""
+    """Every builtin ACP CLI row seeds even when no vendor CLI is on this host.
+
+    The vendor CLI runs on the *executing* host (the attached runner), not on the
+    server, so the server's own PATH says nothing about launchability. The picker
+    hides a row the selected host can't run via that host's ``configured_harnesses``
+    readiness map — the same way natives are seeded unconditionally and filtered.
+
+    **What breaks if this fails**: on a remote server (no vendor CLI in its
+    container) Devin and Grok vanish from the New Chat picker even though the Mac
+    runner attached to it has them installed — the row is never seeded, so no
+    per-host filter can bring it back.
+    """
     from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 
     monkeypatch.setattr("omnigent.onboarding.acp_auth.acp_agents", lambda *a, **k: [])
-    # Every builtin ACP CLI resolves on PATH in this test.
-    monkeypatch.setattr(
-        "omnigent._platform.resolve_cli_binary", lambda _b, **k: "/usr/local/bin/x"
-    )
+    # No vendor CLI resolves here — the remote-server / app-container shape.
+    monkeypatch.setattr("omnigent._platform.resolve_cli_binary", lambda _b, **k: None)
 
     server_app._ensure_default_acp_agents(
         seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
@@ -1121,7 +1130,7 @@ def test_ensure_default_acp_agents_seeds_installed_builtin_cli(
     # Keyed by the catalog id (a valid slug), not the display label.
     for key in ACP_CLI_HARNESSES:
         assert seed_stores.agent_store.get_by_name(key) is not None, (
-            f"installed builtin ACP CLI {key!r} was not seeded"
+            f"builtin ACP CLI {key!r} was not seeded"
         )
 
 
@@ -1174,13 +1183,17 @@ def test_ensure_default_acp_agents_configured_agent_beats_same_slug_builtin(
     assert load(dest).executor.config["harness"] == "acp:devin"
 
 
-def test_ensure_default_acp_agents_noop_when_nothing_set_up(
+def test_ensure_default_acp_agents_seeds_no_slug_rows_without_acp_config(
     seed_stores: _SeedStores, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """No configured agents + no installed builtin CLI → nothing seeded.
+    """An empty ``acp:`` block seeds no ``acp:<slug>`` row — only catalog rows.
 
-    **What breaks if this fails**: a remote server (no ``acp:`` config, ACP CLIs
-    absent) shows phantom ACP picker rows that can't launch there.
+    Unlike a builtin row, a configured agent's launch command is resolved from the
+    host's own ``acp:`` block at spawn time, so a slug this host never defined could
+    not launch anywhere. Only the fixed catalog rows are host-independent.
+
+    **What breaks if this fails**: the picker grows a row for a slug no config
+    defines, and choosing it fails at spawn with an unresolvable ACP command.
     """
     from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 
@@ -1190,9 +1203,13 @@ def test_ensure_default_acp_agents_noop_when_nothing_set_up(
     server_app._ensure_default_acp_agents(
         seed_stores.agent_store, seed_stores.artifact_store, seed_stores.agent_cache
     )
-    assert seed_stores.agent_store.get_by_name("devin") is None
-    for key in ACP_CLI_HARNESSES:
-        assert seed_stores.agent_store.get_by_name(key) is None
+    assert seed_stores.agent_store.get_by_name("kilocode") is None, (
+        "a slug absent from config must not be seeded"
+    )
+    seeded = {
+        key for key in ACP_CLI_HARNESSES if seed_stores.agent_store.get_by_name(key) is not None
+    }
+    assert seeded == set(ACP_CLI_HARNESSES), "catalog rows are host-independent and always seed"
 
 
 def test_ensure_default_acp_agents_survives_unreadable_config(

--- a/tests/tools/builtins/test_registry_unified.py
+++ b/tests/tools/builtins/test_registry_unified.py
@@ -122,6 +122,13 @@ def test_builtin_names_size_matches_registry() -> None:
                 "download_file",
                 "search_conversations",
                 "export_agent",
+                # Cross-harness question tool: schema-only Tool class
+                # (like browser_*), but INSTANTIABLE (factory present) —
+                # spec-gated / user-enablable via `tools.builtins`, not
+                # auto-registered for every agent. Execution is
+                # runner-dispatched via the _ASK_USER_QUESTION_TOOLS
+                # branch in runner/tool_dispatch.py.
+                "sys_ask_user_question",
                 # Hindsight long-term memory tools (optional `hindsight`
                 # extra; factories probe for hindsight-client).
                 "hindsight_retain",

--- a/tests/tools/test_manager.py
+++ b/tests/tools/test_manager.py
@@ -1374,3 +1374,45 @@ def test_read_skill_file_registered_for_root_level_resources(tmp_path: Path) -> 
     )
 
     assert any_skill_has_resources([skill]) is True
+
+
+# ── sys_ask_user_question: spec-gated registration ───────────────
+
+
+def test_sys_ask_user_question_not_registered_without_opt_in() -> None:
+    """A bare spec (no ``tools.builtins`` entry) does not register the tool.
+
+    Unlike the always-on ``browser_*`` family, ``sys_ask_user_question`` is
+    spec-gated / user-enablable — an agent must opt in via
+    ``tools.builtins``.
+    """
+    mgr = ToolManager(_make_spec())
+    assert mgr.get_tool("sys_ask_user_question") is None
+
+
+def test_sys_ask_user_question_registered_and_schema_exposed_when_declared() -> None:
+    """Declaring the builtin registers it and surfaces its schema.
+
+    This is the generic pickup path every SDK-track executor (claude-sdk,
+    codex, pi, openai-agents-sdk) reads tool definitions from
+    (``ToolManager(spec).get_tool_schemas()``) — no harness-specific
+    wiring needed once the tool is registered here.
+    """
+    spec = AgentSpec(
+        spec_version=1,
+        tools=ToolsConfig(builtins=[BuiltinToolConfig(name="sys_ask_user_question")]),
+    )
+    mgr = ToolManager(spec)
+    tool = mgr.get_tool("sys_ask_user_question")
+    assert tool is not None
+
+    schemas = mgr.get_tool_schemas()
+    matching = [s for s in schemas if s["function"]["name"] == "sys_ask_user_question"]
+    assert len(matching) == 1
+    params = matching[0]["function"]["parameters"]
+    questions_schema = params["properties"]["questions"]
+    assert questions_schema["minItems"] == 1
+    assert questions_schema["maxItems"] == 4
+    option_schema = questions_schema["items"]["properties"]["options"]["items"]
+    assert "recommended" in option_schema["properties"]
+    assert option_schema["properties"]["recommended"]["type"] == "boolean"

--- a/uv.lock
+++ b/uv.lock
@@ -3110,7 +3110,7 @@ wheels = [
 
 [[package]]
 name = "omnigent"
-version = "0.12.0.dev0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -3440,7 +3440,7 @@ test = [
 
 [[package]]
 name = "omnigent-client"
-version = "0.12.0.dev0"
+version = "0.12.0"
 source = { editable = "sdks/python-client" }
 dependencies = [
     { name = "httpx" },
@@ -3485,7 +3485,7 @@ dev = [
 
 [[package]]
 name = "omnigent-slack"
-version = "0.12.0.dev0"
+version = "0.12.0"
 source = { editable = "integrations/slack" }
 dependencies = [
     { name = "aiohttp" },
@@ -3510,7 +3510,7 @@ requires-dist = [
 
 [[package]]
 name = "omnigent-ui-sdk"
-version = "0.12.0.dev0"
+version = "0.12.0"
 source = { editable = "sdks/ui" }
 dependencies = [
     { name = "omnigent-client" },
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "omnigent-client", specifier = "==0.12.0.dev0" },
+    { name = "omnigent-client", specifier = "==0.12.0" },
     { name = "prompt-toolkit", specifier = ">=3" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "rich", specifier = ">=13" },

--- a/web/electron/package.json
+++ b/web/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omnigent-desktop-electron",
   "productName": "Omnigent",
-  "version": "0.12.0-dev.0",
+  "version": "0.12.0",
   "description": "Omnigent desktop shell (Electron edition) — a thin native wrapper around the server-served web UI.",
   "private": true,
   "main": "src/main.js",

--- a/web/src/components/blocks/ApprovalCard.tsx
+++ b/web/src/components/blocks/ApprovalCard.tsx
@@ -11,11 +11,17 @@
 //     actions — see `ExitPlanModeReview`.
 //
 //   - **AskUserQuestion form** — when the elicitation carries a
-//     structured `askUserQuestion` payload (the PermissionRequest
-//     endpoint stamps this when the gated tool is Claude's built-in
-//     AskUserQuestion). Renders a multi-question form with radio
-//     inputs for single-select, checkboxes for multi-select. Submit
-//     posts the gathered answers as `content.answers`.
+//     structured `askUserQuestion` payload. Two producers stamp this:
+//     the PermissionRequest endpoint (when the gated tool is Claude's
+//     built-in AskUserQuestion) and the cross-harness
+//     `sys_ask_user_question` builtin tool (any harness — see
+//     `omnigent/server/routes/_ask_user_question.py`), which adds one
+//     field Claude's own tool doesn't have: `recommended` on an
+//     option, marking the suggested default. `AskUserQuestionForm`
+//     pre-selects that option and shows a "Recommended" badge. Renders
+//     a multi-question form with radio inputs for single-select,
+//     checkboxes for multi-select. Submit posts the gathered answers
+//     as the flat `content` map (MCP `ElicitResult.content` shape).
 //
 //   - **Option buttons** — when `requestedSchema` is
 //     `{properties: {answer: {enum: [...]}}}`. Currently no

--- a/web/src/components/blocks/AskUserQuestionForm.test.tsx
+++ b/web/src/components/blocks/AskUserQuestionForm.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ClaudeQuestion } from "@/lib/askUserQuestion";
+import { AskUserQuestionForm } from "./AskUserQuestionForm";
+
+afterEach(() => {
+  cleanup();
+});
+
+const SINGLE_SELECT_QUESTION: ClaudeQuestion = {
+  question: "Which framework?",
+  header: "Framework",
+  multiSelect: false,
+  options: [
+    { label: "React", description: "Component-based UI library." },
+    { label: "Vue", description: "Progressive framework.", recommended: true },
+  ],
+};
+
+const MULTI_SELECT_QUESTION: ClaudeQuestion = {
+  question: "Which features?",
+  header: "Features",
+  multiSelect: true,
+  options: [
+    { label: "Auth", description: "User accounts." },
+    { label: "Billing", description: "Payments.", recommended: true },
+    { label: "Search", description: "Full-text search." },
+  ],
+};
+
+const NO_RECOMMENDATION_QUESTION: ClaudeQuestion = {
+  question: "Pick one",
+  header: "Header",
+  multiSelect: false,
+  options: [
+    { label: "A", description: "a" },
+    { label: "B", description: "b" },
+  ],
+};
+
+describe("AskUserQuestionForm — recommended option", () => {
+  it("shows a Recommended badge next to the marked option", () => {
+    render(
+      <AskUserQuestionForm
+        questions={[SINGLE_SELECT_QUESTION]}
+        onSubmit={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    const badges = screen.getAllByTestId("ask-user-question-recommended-badge");
+    expect(badges).toHaveLength(1);
+  });
+
+  it("does not show a badge when no option is recommended", () => {
+    render(
+      <AskUserQuestionForm
+        questions={[NO_RECOMMENDATION_QUESTION]}
+        onSubmit={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("ask-user-question-recommended-badge")).toBeNull();
+  });
+
+  it("pre-selects the recommended option for single-select", () => {
+    render(
+      <AskUserQuestionForm
+        questions={[SINGLE_SELECT_QUESTION]}
+        onSubmit={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    const vueRadio = screen.getByRole("radio", { name: /Vue/ });
+    const reactRadio = screen.getByRole("radio", { name: /React/ });
+    expect(vueRadio).toBeChecked();
+    expect(reactRadio).not.toBeChecked();
+    // Submit is enabled immediately — the pre-selection counts as an answer.
+    expect(screen.getByTestId("ask-user-question-submit")).not.toBeDisabled();
+  });
+
+  it("pre-selects the recommended option for multi-select", () => {
+    render(
+      <AskUserQuestionForm
+        questions={[MULTI_SELECT_QUESTION]}
+        onSubmit={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    const billingCheckbox = screen.getByRole("checkbox", { name: /Billing/ });
+    const authCheckbox = screen.getByRole("checkbox", { name: /Auth/ });
+    expect(billingCheckbox).toBeChecked();
+    expect(authCheckbox).not.toBeChecked();
+  });
+
+  it("submits the pre-selected recommended answer when accepted as-is", () => {
+    const onSubmit = vi.fn();
+    render(
+      <AskUserQuestionForm
+        questions={[SINGLE_SELECT_QUESTION]}
+        onSubmit={onSubmit}
+        onReject={vi.fn()}
+      />,
+    );
+    screen.getByTestId("ask-user-question-submit").click();
+    expect(onSubmit).toHaveBeenCalledWith({ "Which framework?": "Vue" });
+  });
+
+  it("leaves no pre-selection when the question has no recommended option", () => {
+    render(
+      <AskUserQuestionForm
+        questions={[NO_RECOMMENDATION_QUESTION]}
+        onSubmit={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("ask-user-question-submit")).toBeDisabled();
+  });
+});

--- a/web/src/components/blocks/AskUserQuestionForm.tsx
+++ b/web/src/components/blocks/AskUserQuestionForm.tsx
@@ -82,16 +82,47 @@ function questionKey(question: ClaudeQuestion): string {
   return question.id && question.id.length > 0 ? question.id : question.question;
 }
 
+/**
+ * The label of the option marked ``recommended``, or ``null`` when none is.
+ *
+ * ``recommended`` is an Omnigent-only extension (see
+ * ``@/lib/askUserQuestion``'s ``ClaudeQuestionOption`` doc) — at most one
+ * option per question should carry it. Used to pre-select a sensible
+ * default so the human can just hit Submit when the suggestion is fine.
+ */
+function recommendedLabel(question: ClaudeQuestion): string | null {
+  return question.options.find((opt) => opt.recommended === true)?.label ?? null;
+}
+
+/** Small pill marking an option as the ``sys_ask_user_question`` caller's suggested default. */
+function RecommendedBadge() {
+  return (
+    <span
+      className="text-success text-sm font-medium rounded bg-muted px-1.5 py-0.5"
+      data-testid="ask-user-question-recommended-badge"
+    >
+      Recommended
+    </span>
+  );
+}
+
 export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQuestionFormProps) {
   // Currently-visible question (carousel index).
   const [currentIndex, setCurrentIndex] = useState(0);
 
   // Per-question option selection. Single-select stores a string;
-  // multi-select stores a deduped array.
+  // multi-select stores a deduped array. Pre-seeded with the
+  // ``recommended`` option (if any) so the human can accept the
+  // suggested default with just a Submit click.
   const [selections, setSelections] = useState<Record<string, string | string[]>>(() => {
     const initial: Record<string, string | string[]> = {};
     for (const q of questions) {
-      initial[questionKey(q)] = q.multiSelect ? [] : "";
+      const recommended = recommendedLabel(q);
+      initial[questionKey(q)] = q.multiSelect
+        ? recommended
+          ? [recommended]
+          : []
+        : (recommended ?? "");
     }
     return initial;
   });
@@ -259,7 +290,10 @@ export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQu
                     className="mt-1"
                   />
                   <span className="flex flex-col">
-                    <span>{opt.label}</span>
+                    <span className="flex items-center gap-1.5">
+                      {opt.label}
+                      {opt.recommended && <RecommendedBadge />}
+                    </span>
                     {opt.description && (
                       <span className="text-muted-foreground text-sm">{opt.description}</span>
                     )}
@@ -284,7 +318,10 @@ export function AskUserQuestionForm({ questions, onSubmit, onReject }: AskUserQu
                   className="mt-1"
                 />
                 <span className="flex flex-col">
-                  <span>{opt.label}</span>
+                  <span className="flex items-center gap-1.5">
+                    {opt.label}
+                    {opt.recommended && <RecommendedBadge />}
+                  </span>
                   {opt.description && (
                     <span className="text-muted-foreground text-sm">{opt.description}</span>
                   )}

--- a/web/src/lib/askUserQuestion.ts
+++ b/web/src/lib/askUserQuestion.ts
@@ -29,11 +29,18 @@
  * renaming. ``description`` and ``label`` are required in Claude's
  * wire format; ``preview`` is an optional longer/alternative
  * snippet some Claude builds attach for richer rendering.
+ *
+ * ``recommended`` is an Omnigent-only extension — it does not exist in
+ * Claude Code's own AskUserQuestion contract. Set by the cross-harness
+ * ``sys_ask_user_question`` builtin tool (see
+ * ``omnigent/tools/builtins/ask_user_question.py``) to mark the
+ * suggested default; the form pre-selects it and shows a badge.
  */
 export interface ClaudeQuestionOption {
   label: string;
   description?: string;
   preview?: string;
+  recommended?: boolean;
 }
 
 /**
@@ -142,6 +149,9 @@ export function parseAskUserQuestionPreview(preview: string): AskUserQuestionPay
       };
       if (typeof optionPreview === "string" && optionPreview) {
         option.preview = optionPreview;
+      }
+      if (optRec.recommended === true) {
+        option.recommended = true;
       }
       options.push(option);
     }


### PR DESCRIPTION
## Summary

Adds a new builtin tool, `sys_ask_user_question`, callable by any sub-agent harness this platform supports. It lets an agent pause its turn and present the human operator with 1-4 structured multiple-choice questions, then resume with the human's structured answers.

Modeled closely on Claude Code's own `AskUserQuestionInput` / `AskUserQuestionOutput` contract (read from `sdk-tools.d.ts` in the installed `@anthropic-ai/claude-code` npm package), with one deliberate addition: a boolean **`recommended`** flag on individual options, marking the suggested default. This field exists in neither Claude Code's own tool nor this platform's existing `ElicitationRequestParams` / `ElicitationResult` schemas — it's added as a first-class field here, not encoded in prose. It rides through as an ordinary extra field (`ElicitationRequestParams` already allows extras), so no schema migration was needed.

### Design: reuses the existing elicitation engine end to end

No new plumbing. `omnigent/server/routes/_ask_user_question.py` is a small, pure-function adapter (mirroring the existing `_codex_elicitation.py` pattern) that:

- **Flattens** the tool call's `questions` argument into the same `ask_user_question` structured extra the web UI's `ApprovalCard` / `AskUserQuestionForm` already know how to render (the extra the Claude-native `PermissionRequest` endpoint stamps for Claude's own built-in `AskUserQuestion` tool), and builds an `ElicitationRequestParams`.
- Calls the **existing** `_publish_and_wait_for_harness_elicitation` helper — the same one every other harness ASK gate (Claude-native `PermissionRequest`, Codex app-server elicitation, Antigravity, ...) uses to publish a `response.elicitation_request` SSE event and park until a human answers.
- **Reconstructs** the flat `ElicitationResult.content` (MCP's `ElicitResult.content` shape — a flat `dict[str, scalar | list[str]]`, no nested objects) back into a rich, `AskUserQuestionOutput`-shaped return value: echoed `questions`, an `answers` map keyed by question text (a list for multi-select, a scalar for single-select — richer than Claude Code's own comma-joined-string convention, since the wire format natively supports string lists), and an optional top-level `response` free-text fallback for a reply that doesn't key off any known question.

A new route, `POST /v1/sessions/{id}/ask_user_question`, ties this together — the runner POSTs the tool call's raw arguments and blocks (up to `DEFAULT_ASK_TIMEOUT`, one day) for the reconstructed answer.

### Cross-harness wiring

1. **Registered as a spec-gated, user-enablable builtin** in `omnigent/tools/builtins/__init__.py` (`_BUILTIN_REGISTRY`), following the `web_search` / `upload_file` pattern — an agent spec must declare it in `tools.builtins` to get it. The `SysAskUserQuestionTool` class (`omnigent/tools/builtins/ask_user_question.py`) is schema-only, like `browser_*` — its `invoke()` raises `NotImplementedError` by design, since execution needs the runner's `server_client` (not available on `ToolContext`).
2. **Execution branch** added to `execute_tool()` in `omnigent/runner/tool_dispatch.py` (the `_ASK_USER_QUESTION_TOOLS` branch, mirroring `_BROWSER_TOOLS`) — being visible in the schema without this branch means the tool silently fails for callers, so this was required, not optional.
3. **Unioned into `_NATIVE_RELAY_BUILTIN_TOOLS`** so all six native-relay harnesses (claude-native, codex-native, opencode-native, cursor-native, hermes-native, antigravity-native) both advertise and can execute it — verified via `build_native_relay_tool_schemas()` tests.
4. **SDK-track executors** (claude-sdk, codex, pi, openai-agents-sdk) pick the tool up automatically once step 1 lands, because they read the tool list generically off `ToolManager(spec).get_tool_schemas()`, and `execute_tool()` is the same function the generic MCP-tool-dispatch endpoint (`omnigent/runner/app.py`) calls for these tracks too. Verified with a `ToolManager(spec).get_tool_schemas()` test in `tests/tools/test_manager.py` and an `execute_tool()` dispatch test.
5. **Bare `pi`** needs no special wiring per the above (it shares the same `execute_tool()` path) — verified with the same `execute_tool()` dispatch test.

### Frontend

Small, targeted change to `AskUserQuestionForm.tsx` (rendered inside `ApprovalCard`'s existing "AskUserQuestion structured form" mode): the `recommended` option is now pre-selected (both single- and multi-select) and shows a "Recommended" badge. `web/src/lib/askUserQuestion.ts`'s `ClaudeQuestionOption` type gained the optional `recommended` field; `ApprovalCard.tsx` itself needed no logic change (it already delegates rendering to `AskUserQuestionForm`) — its top-of-file doc comment was updated to describe the new field and its producer.

### Explicitly out of scope (follow-ups)

- The plain `omni` REPL's binary y/a/n approval renderer (`omnigent/repl/_repl.py`) does not render the rich multi-question form for this tool — it falls back to its existing binary behavior. Left as a known limitation.
- This work does not touch, rebuild, or reinstall the live-running installed package, and does not restart any running `omnigent-host`/`omnigent-server` processes — it stays entirely inside this branch/worktree.

## Test plan

- **Pure-function unit tests** (`tests/server/routes/test_ask_user_question.py`, 23 tests): `validate_ask_user_question_questions` (1-4 questions, 2-4 options, required fields, `recommended` normalization when a model marks more than one true), `build_ask_user_question_params` (form mode, no `requestedSchema`, `recommended` surviving into the `ask_user_question` extra), and `reconstruct_ask_user_question_output` (accept/single-select, accept/multi-select as a list, free-text fallback, decline, cancel, timeout) — the flatten/reconstruct round trip is lossless for both single- and multi-select plus the free-text case.
- **Runner dispatch tests** (`tests/runner/test_ask_user_question_tool_dispatch.py`, 10 tests): `_execute_ask_user_question_tool`'s POST shape and error handling; registry presence (`BUILTIN_NAMES`, `INSTANTIABLE_BUILTINS`, spec-gated — not auto-registered like `browser_*`); `execute_tool()` actually dispatches (not just advertises); `_NATIVE_RELAY_BUILTIN_TOOLS` membership; `build_native_relay_tool_schemas()` surfaces the schema only when the spec opts in.
- **Real end-to-end integration test** (`tests/server/integration/test_sessions_ask_user_question_api.py`, 3 tests) against the actual FastAPI route (not just the pure helpers): accept round trip through the real SSE `response.elicitation_request` event + the existing `/elicitations/{id}/resolve` endpoint, decline round trip, and 400 on invalid input.
- **ToolManager pickup test** (`tests/tools/test_manager.py`): confirms `ToolManager(spec).get_tool_schemas()` surfaces the tool (with the `recommended` field in its schema) once the spec declares it — this is the mechanism every SDK-track executor reads from — and confirms it's absent for a bare spec.
- **Frontend**: colocated Vitest test (`AskUserQuestionForm.test.tsx`, 6 tests) covering the badge and pre-selection for both single- and multi-select, plus no-op when nothing is recommended. `pnpm run type-check`, `oxlint`, and `prettier --check` all pass on touched files.

Ran (all green):
```
uv run --no-sync pytest tests/server/routes/test_ask_user_question.py tests/runner/test_ask_user_question_tool_dispatch.py tests/server/integration/test_sessions_ask_user_question_api.py tests/tools/test_manager.py tests/tools/builtins/test_registry_unified.py
# 92 + 3 = 95 passed

uv run --no-sync pytest tests/tools/ tests/runner/ tests/server/routes/ tests/server/integration/
# full sweep of every touched-area suite (per CONTRIBUTING.md's area->suite mapping): 4954/4966 passed;
# the 12 failures are pre-existing and environmental (missing `tmux` on this dev machine / a
# "Terminal registry not configured" runtime gap in Codex-native terminal tests) — confirmed by
# reproducing two of them identically on the pristine v0.12.0 tree before this branch's changes.

uv run --no-sync ruff check . && uv run --no-sync ruff format --check .   # clean on touched files
uv run --no-sync pyrefly check                                            # 0 errors
pre-commit run --files <all touched files>                                # all hooks pass

cd web && pnpm run type-check && pnpm exec oxlint --deny-warnings . && pnpm exec prettier --check . && pnpm test
# typecheck clean, lint clean, format clean, 55 tests passed
```

🤖 Generated with a Claude Code coding sub-agent, worktree-isolated from the canonical checkout, based on tag `v0.12.0`.