### PR TITLE
feat(web): on-screen terminal key bar for mobile

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -442,11 +442,12 @@ describe("wheelReportPayload", () => {
 // ---------------------------------------------------------------------------
 describe("terminalMobileKeyPayload", () => {
   it("encodes mode-independent keys", () => {
-    // Esc and Shift+Tab (CSI Z backtab) don't depend on cursor-key mode, so
-    // both mode arguments must yield the same bytes.
+    // Esc, Shift+Tab (CSI Z backtab), and Enter (CR) don't depend on
+    // cursor-key mode, so both mode arguments must yield the same bytes.
     for (const appCursor of [false, true]) {
       expect(terminalMobileKeyPayload("escape", appCursor)).toBe("\x1b");
       expect(terminalMobileKeyPayload("shift-tab", appCursor)).toBe("\x1b[Z");
+      expect(terminalMobileKeyPayload("enter", appCursor)).toBe("\r");
     }
   });
 

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -22,6 +22,7 @@ import {
   sgrWheelReports,
   terminalTheme,
   terminalKeyEventPayload,
+  terminalMobileKeyPayload,
   type ConnectionState,
   wheelReportPayload,
   type WheelMouseState,
@@ -439,6 +440,36 @@ describe("wheelReportPayload", () => {
 });
 
 // ---------------------------------------------------------------------------
+describe("terminalMobileKeyPayload", () => {
+  it("encodes mode-independent keys", () => {
+    // Esc and Shift+Tab (CSI Z backtab) don't depend on cursor-key mode, so
+    // both mode arguments must yield the same bytes.
+    for (const appCursor of [false, true]) {
+      expect(terminalMobileKeyPayload("escape", appCursor)).toBe("\x1b");
+      expect(terminalMobileKeyPayload("shift-tab", appCursor)).toBe("\x1b[Z");
+    }
+  });
+
+  it("encodes arrows as CSI in normal cursor-key mode", () => {
+    // A pane not in DECCKM expects ESC [ x — the same bytes xterm's own
+    // onData emits for a physical arrow press in that mode.
+    expect(terminalMobileKeyPayload("up", false)).toBe("\x1b[A");
+    expect(terminalMobileKeyPayload("down", false)).toBe("\x1b[B");
+    expect(terminalMobileKeyPayload("right", false)).toBe("\x1b[C");
+    expect(terminalMobileKeyPayload("left", false)).toBe("\x1b[D");
+  });
+
+  it("encodes arrows as SS3 in application cursor-key mode", () => {
+    // A pane that requested DECCKM (application cursor keys) expects ESC O x;
+    // sending CSI there would read as an unrecognized sequence, so the mode
+    // must switch the encoding.
+    expect(terminalMobileKeyPayload("up", true)).toBe("\x1bOA");
+    expect(terminalMobileKeyPayload("down", true)).toBe("\x1bOB");
+    expect(terminalMobileKeyPayload("right", true)).toBe("\x1bOC");
+    expect(terminalMobileKeyPayload("left", true)).toBe("\x1bOD");
+  });
+});
+
 // TerminalSession class — wired up against a fake WebSocket + ResizeObserver.
 // The real xterm Terminal runs (it already does in jsdom for loadWebglRenderer
 // above), but the WebSocket and ResizeObserver globals are stubbed so the
@@ -576,6 +607,29 @@ describe("TerminalSession", () => {
     socket.open();
 
     expect(focusSpy).not.toHaveBeenCalled();
+    session.dispose();
+  });
+
+  it("sends a mobile key through the onData path over the socket", () => {
+    // WHY: the on-screen key bar calls sendMobileKey, which must route through
+    // term.input → onData so the bytes hit the WS send and the input listener
+    // like a real keystroke. Default xterm cursor-key mode is normal, so an up
+    // arrow encodes as CSI (ESC [ A).
+    const onInput = vi.fn();
+    const { socket, session } = makeSession(undefined, onInput);
+    socket.open();
+    socket.sent.length = 0; // drop the open handshake's resize frame
+
+    session.sendMobileKey("up");
+
+    // Keystroke frames are binary (the encoder's bytes); resize frames are
+    // JSON strings. `instanceof Uint8Array` is unreliable here — the encoder
+    // and the test run in different realms under jsdom — so select by the
+    // string/binary split and decode the bytes.
+    const binary = socket.sent.filter((m) => typeof m !== "string");
+    expect(binary).toHaveLength(1);
+    expect(new TextDecoder().decode(binary[0] as Uint8Array)).toBe("\x1b[A");
+    expect(onInput).toHaveBeenCalled();
     session.dispose();
   });
 

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -221,6 +221,49 @@ export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
   return null;
 }
 
+/**
+ * Keys the on-screen (mobile) key bar can send — the ones a phone soft
+ * keyboard has no dedicated key for.
+ */
+export type TerminalMobileKey = "escape" | "shift-tab" | "up" | "down" | "left" | "right";
+
+/**
+ * Terminal byte sequence for a {@link TerminalMobileKey}.
+ *
+ * Arrow keys are mode-sensitive: a program that requested DECCKM
+ * (application cursor keys — xterm's ``applicationCursorKeysMode``) expects the
+ * ``ESC O x`` form; everything else expects plain ``ESC [ x``. Encoding against
+ * the pane's live mode makes a tapped arrow byte-identical to a physical arrow
+ * press, which is exactly what xterm's own ``onData`` emits. Escape (``ESC``)
+ * and Shift+Tab (CSI ``Z`` — "backtab") are mode-independent.
+ *
+ * Pure helper — exported for direct unit testing.
+ *
+ * :param key: The key the user tapped.
+ * :param applicationCursorKeys: The pane's current DECCKM state
+ *     (``term.modes.applicationCursorKeysMode``).
+ * :returns: The bytes to feed to the terminal input.
+ */
+export function terminalMobileKeyPayload(
+  key: TerminalMobileKey,
+  applicationCursorKeys: boolean,
+): string {
+  switch (key) {
+    case "escape":
+      return "\x1b";
+    case "shift-tab":
+      return "\x1b[Z";
+    case "up":
+      return applicationCursorKeys ? "\x1bOA" : "\x1b[A";
+    case "down":
+      return applicationCursorKeys ? "\x1bOB" : "\x1b[B";
+    case "right":
+      return applicationCursorKeys ? "\x1bOC" : "\x1b[C";
+    case "left":
+      return applicationCursorKeys ? "\x1bOD" : "\x1b[D";
+  }
+}
+
 // Reused across keystrokes — allocating a fresh TextEncoder per keypress
 // is needless churn on the input hot path.
 const INPUT_ENCODER = new TextEncoder();
@@ -747,6 +790,22 @@ export class TerminalSession {
    */
   focus(): void {
     this.term.focus();
+  }
+
+  /**
+   * Send a {@link TerminalMobileKey} as if the user pressed it — used by the
+   * on-screen key bar for keys a mobile soft keyboard lacks (Esc, arrows,
+   * Shift+Tab).
+   *
+   * Routes through ``term.input`` (like the wheel handler) so it takes the
+   * normal ``onData`` path — WS send plus input/clipboard bookkeeping — and
+   * encodes arrows against the pane's current cursor-key mode so a tap is
+   * byte-identical to a physical key press. Does not steal focus: the bar's
+   * buttons suppress their own focus so the soft keyboard stays put, and
+   * ``term.input`` fires regardless of focus.
+   */
+  sendMobileKey(key: TerminalMobileKey): void {
+    this.term.input(terminalMobileKeyPayload(key, this.term.modes.applicationCursorKeysMode), true);
   }
 
   /**

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -225,7 +225,7 @@ export function terminalKeyEventPayload(event: KeyboardEvent): string | null {
  * Keys the on-screen (mobile) key bar can send — the ones a phone soft
  * keyboard has no dedicated key for.
  */
-export type TerminalMobileKey = "escape" | "shift-tab" | "up" | "down" | "left" | "right";
+export type TerminalMobileKey = "escape" | "shift-tab" | "enter" | "up" | "down" | "left" | "right";
 
 /**
  * Terminal byte sequence for a {@link TerminalMobileKey}.
@@ -234,8 +234,8 @@ export type TerminalMobileKey = "escape" | "shift-tab" | "up" | "down" | "left" 
  * (application cursor keys — xterm's ``applicationCursorKeysMode``) expects the
  * ``ESC O x`` form; everything else expects plain ``ESC [ x``. Encoding against
  * the pane's live mode makes a tapped arrow byte-identical to a physical arrow
- * press, which is exactly what xterm's own ``onData`` emits. Escape (``ESC``)
- * and Shift+Tab (CSI ``Z`` — "backtab") are mode-independent.
+ * press, which is exactly what xterm's own ``onData`` emits. Escape (``ESC``),
+ * Shift+Tab (CSI ``Z`` — "backtab"), and Enter (``CR``) are mode-independent.
  *
  * Pure helper — exported for direct unit testing.
  *
@@ -253,6 +253,10 @@ export function terminalMobileKeyPayload(
       return "\x1b";
     case "shift-tab":
       return "\x1b[Z";
+    case "enter":
+      // Carriage return, matching a physical Return key; the pane's tty
+      // translates CR→LF as needed.
+      return "\r";
     case "up":
       return applicationCursorKeys ? "\x1bOA" : "\x1b[A";
     case "down":

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -825,6 +825,11 @@ describe("mobile terminal key bar", () => {
     ]) {
       expect(within(bar).getByRole("button", { name: label })).toBeInTheDocument();
     }
+    // Shift+Tab shows its label as stacked words (no glyph); the accessible
+    // name stays "Shift + Tab" via aria-label.
+    const shiftTab = within(bar).getByRole("button", { name: "Shift + Tab" });
+    expect(shiftTab).toHaveTextContent("SHIFT");
+    expect(shiftTab).toHaveTextContent("TAB");
   });
 
   it("does not render the key bar on a desktop viewport", async () => {

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -814,17 +814,19 @@ describe("mobile terminal key bar", () => {
   it("renders the key bar on a mobile viewport", async () => {
     await renderOn(true);
     const bar = screen.getByTestId("terminal-mobile-keys");
-    // The six keys the phone keyboard lacks, in the requested order.
-    for (const label of [
+    // The keys the phone keyboard lacks, in the requested left→right order.
+    const order = within(bar)
+      .getAllByRole("button")
+      .map((b) => b.getAttribute("aria-label"));
+    expect(order).toEqual([
+      "Shift + Tab",
       "Escape",
       "Left arrow",
       "Up arrow",
       "Down arrow",
       "Right arrow",
-      "Shift + Tab",
-    ]) {
-      expect(within(bar).getByRole("button", { name: label })).toBeInTheDocument();
-    }
+      "Enter",
+    ]);
     // Shift+Tab shows its label as stacked words (no glyph); the accessible
     // name stays "Shift + Tab" via aria-label.
     const shiftTab = within(bar).getByRole("button", { name: "Shift + Tab" });
@@ -851,9 +853,11 @@ describe("mobile terminal key bar", () => {
 
     fireEvent.click(within(bar).getByRole("button", { name: "Escape" }));
     fireEvent.click(within(bar).getByRole("button", { name: "Up arrow" }));
+    fireEvent.click(within(bar).getByRole("button", { name: "Enter" }));
 
     expect(sendMobileKey).toHaveBeenNthCalledWith(1, "escape");
     expect(sendMobileKey).toHaveBeenNthCalledWith(2, "up");
+    expect(sendMobileKey).toHaveBeenNthCalledWith(3, "enter");
   });
 
   it("suppresses the pointer-down focus grab so the soft keyboard stays up", async () => {

--- a/web/src/components/blocks/TerminalView.test.tsx
+++ b/web/src/components/blocks/TerminalView.test.tsx
@@ -38,6 +38,7 @@ const terminalSessionMock = vi.hoisted(() => ({
     setTheme: ReturnType<typeof vi.fn>;
     setClipboardEnabled: ReturnType<typeof vi.fn>;
     focus: ReturnType<typeof vi.fn>;
+    sendMobileKey: ReturnType<typeof vi.fn>;
   }[],
 }));
 
@@ -50,6 +51,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
     setTheme = vi.fn();
     setClipboardEnabled = vi.fn();
     focus = vi.fn();
+    sendMobileKey = vi.fn();
 
     constructor(
       container: HTMLDivElement,
@@ -71,6 +73,7 @@ vi.mock("./TerminalSession", async (importOriginal) => ({
         setTheme: this.setTheme,
         setClipboardEnabled: this.setClipboardEnabled,
         focus: this.focus,
+        sendMobileKey: this.sendMobileKey,
       });
     }
   },
@@ -770,5 +773,92 @@ describe("automatic reconnect", () => {
     await act(async () => {});
     expect(terminalSessionMock.instances).toHaveLength(1);
     expect(screen.getByText("Bridge closed: code 4405")).toBeInTheDocument();
+  });
+});
+
+/** Point `matchMedia` at a phone-width (mobile) or desktop-width viewport. */
+function setViewport(mobile: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: mobile && query.includes("max-width"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+describe("mobile terminal key bar", () => {
+  // Overriding matchMedia via defineProperty outlives the test; restore the
+  // desktop default so no later suite inherits the mobile viewport.
+  afterEach(() => setViewport(false));
+
+  /** Mount on the given viewport and flush the deferred (microtask) attach. */
+  async function renderOn(mobile: boolean, props?: { readOnly?: boolean }): Promise<void> {
+    setViewport(mobile);
+    render(
+      <TerminalView
+        sessionId="conv_abc"
+        terminalId="terminal_bash_s1"
+        readOnly={props?.readOnly}
+      />,
+    );
+    await act(async () => {});
+  }
+
+  it("renders the key bar on a mobile viewport", async () => {
+    await renderOn(true);
+    const bar = screen.getByTestId("terminal-mobile-keys");
+    // The six keys the phone keyboard lacks, in the requested order.
+    for (const label of [
+      "Escape",
+      "Left arrow",
+      "Up arrow",
+      "Down arrow",
+      "Right arrow",
+      "Shift + Tab",
+    ]) {
+      expect(within(bar).getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("does not render the key bar on a desktop viewport", async () => {
+    await renderOn(false);
+    expect(screen.queryByTestId("terminal-mobile-keys")).toBeNull();
+  });
+
+  it("hides the key bar for a read-only attach even on mobile", async () => {
+    // A read-only viewer can't type, so on-screen keys would be inert chrome.
+    await renderOn(true, { readOnly: true });
+    expect(screen.queryByTestId("terminal-mobile-keys")).toBeNull();
+  });
+
+  it("sends the mapped key to the live session on tap", async () => {
+    await renderOn(true);
+    expect(terminalSessionMock.instances).toHaveLength(1);
+    const bar = screen.getByTestId("terminal-mobile-keys");
+    const sendMobileKey = terminalSessionMock.instances[0].sendMobileKey;
+
+    fireEvent.click(within(bar).getByRole("button", { name: "Escape" }));
+    fireEvent.click(within(bar).getByRole("button", { name: "Up arrow" }));
+
+    expect(sendMobileKey).toHaveBeenNthCalledWith(1, "escape");
+    expect(sendMobileKey).toHaveBeenNthCalledWith(2, "up");
+  });
+
+  it("suppresses the pointer-down focus grab so the soft keyboard stays up", async () => {
+    // The tap must not blur the xterm textarea (which would dismiss the phone
+    // keyboard). The button cancels its own pointerdown to keep focus put;
+    // fireEvent returns false when the default action was prevented.
+    await renderOn(true);
+    const escape = within(screen.getByTestId("terminal-mobile-keys")).getByRole("button", {
+      name: "Escape",
+    });
+    expect(fireEvent.pointerDown(escape)).toBe(false);
   });
 });

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -8,9 +8,17 @@
 // returned cleanup directly — no `useEffect` + `useRef` dance, no
 // guard against a missing `ref.current`.
 
-import { Loader2Icon } from "lucide-react";
+import {
+  ArrowDownIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ArrowUpIcon,
+  Loader2Icon,
+  type LucideIcon,
+} from "lucide-react";
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
+import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { copyText } from "@/lib/clipboard";
@@ -28,6 +36,7 @@ import {
   type ConnectionState,
   type TerminalActivityListener,
   type TerminalInputListener,
+  type TerminalMobileKey,
   isUnexpectedTerminalClose,
   TerminalSession,
   WS_CLOSE_WRONG_REPLICA,
@@ -138,6 +147,10 @@ export function TerminalView({
   const [state, setState] = useState<ConnectionState>({ kind: "connecting" });
   const [connectAttempt, setConnectAttempt] = useState(0);
   const [resumeError, setResumeError] = useState<string | null>(null);
+  // Show an on-screen key bar for the keys a phone soft keyboard lacks
+  // (Esc, arrows, Shift+Tab) only on the mobile layout, and only for a
+  // writable attach — a read-only viewer can't type anyway.
+  const isMobile = useIsMobileViewport();
   const clipboardScope = `${sessionId}\0${terminalId}\0${readOnly ? "read-only" : "writable"}`;
   const [clipboardPrompt, setClipboardPrompt] = useState<{
     scope: string;
@@ -757,6 +770,9 @@ export function TerminalView({
       <div className="min-h-0 flex-1 overflow-hidden p-1">
         <div key={connectAttempt} ref={attachSession} className="h-full w-full overflow-hidden" />
       </div>
+      {isMobile && !readOnly && (
+        <MobileKeyBar onKey={(key) => sessionRef.current?.sendMobileKey(key)} />
+      )}
       {state.kind !== "connected" && (
         <StatusOverlay
           state={state}
@@ -766,6 +782,67 @@ export function TerminalView({
           resumeError={resumeError}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * The on-screen keys, left→right. Arrows render as icons; Esc and Shift+Tab
+ * as glyphs (lucide has no icon for either), grouped so the arrow cluster
+ * reads as a unit between them.
+ */
+const MOBILE_KEYS: readonly {
+  key: TerminalMobileKey;
+  label: string;
+  icon?: LucideIcon;
+  glyph?: string;
+}[] = [
+  { key: "escape", label: "Escape", glyph: "esc" },
+  { key: "left", label: "Left arrow", icon: ArrowLeftIcon },
+  { key: "up", label: "Up arrow", icon: ArrowUpIcon },
+  { key: "down", label: "Down arrow", icon: ArrowDownIcon },
+  { key: "right", label: "Right arrow", icon: ArrowRightIcon },
+  { key: "shift-tab", label: "Shift + Tab", glyph: "⇧⇥" },
+];
+
+/**
+ * Touch key bar under the xterm grid for the keys a mobile soft keyboard
+ * omits. Sits in the terminal-view's flex column as a fixed row, so the
+ * xterm grid re-fits above it (the session's ResizeObserver picks up the
+ * height change). While the bridge is connecting or closed the
+ * {@link StatusOverlay} covers it — the keys are only live once connected.
+ */
+function MobileKeyBar({ onKey }: { onKey: (key: TerminalMobileKey) => void }) {
+  return (
+    <div
+      data-testid="terminal-mobile-keys"
+      className="flex shrink-0 items-stretch gap-1 border-border border-t px-1 pt-1"
+    >
+      {MOBILE_KEYS.map(({ key, label, icon: Icon, glyph }) => (
+        <Button
+          key={key}
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={label}
+          title={label}
+          // Suppress the button's focus grab so the tap never blurs the
+          // xterm textarea — otherwise the soft keyboard would dismiss on
+          // every press. term.input still delivers the key without focus.
+          onPointerDown={(e) => e.preventDefault()}
+          onClick={() => onKey(key)}
+          className="h-9 flex-1 touch-manipulation px-0 text-muted-foreground"
+          componentId="diagnostics.terminal.mobile-key"
+        >
+          {Icon ? (
+            <Icon className="size-4" aria-hidden />
+          ) : (
+            <span aria-hidden className="text-sm">
+              {glyph}
+            </span>
+          )}
+        </Button>
+      ))}
     </div>
   );
 }

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -839,9 +839,12 @@ function MobileKeyBar({ onKey }: { onKey: (key: TerminalMobileKey) => void }) {
           {Icon ? (
             <Icon className="size-4" aria-hidden />
           ) : lines ? (
+            // `leading-none` stacks the words tightly; `translate-y-px` nudges
+            // the block down 1px to optically center it — all-caps text with no
+            // descenders otherwise reads top-heavy in the line box.
             <span
               aria-hidden
-              className="flex flex-col items-center font-semibold text-[9px] leading-tight tracking-tight"
+              className="flex translate-y-px flex-col items-center font-semibold text-[9px] leading-none tracking-tight"
             >
               {lines.map((line) => (
                 <span key={line}>{line}</span>

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -787,22 +787,24 @@ export function TerminalView({
 }
 
 /**
- * The on-screen keys, left→right. Arrows render as icons; Esc and Shift+Tab
- * as glyphs (lucide has no icon for either), grouped so the arrow cluster
- * reads as a unit between them.
+ * The on-screen keys, left→right. Arrows render as icons; Esc renders as a
+ * glyph and Shift+Tab as stacked words (lucide has no icon for either),
+ * grouped so the arrow cluster reads as a unit between them.
  */
 const MOBILE_KEYS: readonly {
   key: TerminalMobileKey;
   label: string;
   icon?: LucideIcon;
   glyph?: string;
+  /** Stacked text lines, for keys with no single glyph (e.g. Shift+Tab). */
+  lines?: readonly string[];
 }[] = [
   { key: "escape", label: "Escape", glyph: "esc" },
   { key: "left", label: "Left arrow", icon: ArrowLeftIcon },
   { key: "up", label: "Up arrow", icon: ArrowUpIcon },
   { key: "down", label: "Down arrow", icon: ArrowDownIcon },
   { key: "right", label: "Right arrow", icon: ArrowRightIcon },
-  { key: "shift-tab", label: "Shift + Tab", glyph: "⇧⇥" },
+  { key: "shift-tab", label: "Shift + Tab", lines: ["SHIFT", "TAB"] },
 ];
 
 /**
@@ -818,7 +820,7 @@ function MobileKeyBar({ onKey }: { onKey: (key: TerminalMobileKey) => void }) {
       data-testid="terminal-mobile-keys"
       className="flex shrink-0 items-stretch gap-1 border-border border-t px-1 pt-1"
     >
-      {MOBILE_KEYS.map(({ key, label, icon: Icon, glyph }) => (
+      {MOBILE_KEYS.map(({ key, label, icon: Icon, glyph, lines }) => (
         <Button
           key={key}
           type="button"
@@ -836,6 +838,15 @@ function MobileKeyBar({ onKey }: { onKey: (key: TerminalMobileKey) => void }) {
         >
           {Icon ? (
             <Icon className="size-4" aria-hidden />
+          ) : lines ? (
+            <span
+              aria-hidden
+              className="flex flex-col items-center font-semibold text-[9px] leading-tight tracking-tight"
+            >
+              {lines.map((line) => (
+                <span key={line}>{line}</span>
+              ))}
+            </span>
           ) : (
             <span aria-hidden className="text-sm">
               {glyph}

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -13,6 +13,7 @@ import {
   ArrowLeftIcon,
   ArrowRightIcon,
   ArrowUpIcon,
+  CornerDownLeftIcon,
   Loader2Icon,
   type LucideIcon,
 } from "lucide-react";
@@ -787,9 +788,9 @@ export function TerminalView({
 }
 
 /**
- * The on-screen keys, left→right. Arrows render as icons; Esc renders as a
- * glyph and Shift+Tab as stacked words (lucide has no icon for either),
- * grouped so the arrow cluster reads as a unit between them.
+ * The on-screen keys, left→right. Arrows and Enter render as icons; Esc as a
+ * glyph and Shift+Tab as stacked words (lucide has no icon for either), with
+ * the arrow cluster reading as a unit in the middle.
  */
 const MOBILE_KEYS: readonly {
   key: TerminalMobileKey;
@@ -799,12 +800,13 @@ const MOBILE_KEYS: readonly {
   /** Stacked text lines, for keys with no single glyph (e.g. Shift+Tab). */
   lines?: readonly string[];
 }[] = [
+  { key: "shift-tab", label: "Shift + Tab", lines: ["SHIFT", "TAB"] },
   { key: "escape", label: "Escape", glyph: "esc" },
   { key: "left", label: "Left arrow", icon: ArrowLeftIcon },
   { key: "up", label: "Up arrow", icon: ArrowUpIcon },
   { key: "down", label: "Down arrow", icon: ArrowDownIcon },
   { key: "right", label: "Right arrow", icon: ArrowRightIcon },
-  { key: "shift-tab", label: "Shift + Tab", lines: ["SHIFT", "TAB"] },
+  { key: "enter", label: "Enter", icon: CornerDownLeftIcon },
 ];
 
 /**


### PR DESCRIPTION
## Related issue

N/A — no tracking issue.

## Summary

- Phone soft keyboards have no **Esc**, **arrow**, **Shift+Tab**, or a reliably-placed **Enter** key, so driving a TUI (menus, prompts, back-tab, submitting input) in the web terminal is painful on mobile.
- Adds a row of on-screen keys under the xterm grid on mobile-width viewports (`< 768px`), for writable attaches only:

```
┌─────────┬─────┬─────┬─────┬─────┬─────┬─────┐
│ SHIFT   │ esc │  ←  │  ↑  │  ↓  │  →  │  ↵  │
│  TAB    │     │     │     │     │     │     │
└─────────┴─────┴─────┴─────┴─────┴─────┴─────┘
```

- Keys route through a new `TerminalSession.sendMobileKey`, which feeds `term.input` so a tap takes the same `onData` path as a real keystroke (WS send + input bookkeeping). Arrows are encoded against the pane's **live cursor-key mode** (`ESC O A` in DECCKM, `ESC [ A` otherwise); Esc = `ESC`, Shift+Tab = `ESC [ Z` (backtab), Enter = `CR` (`\r`). So each tap is byte-identical to the physical key.

**ELI5:** Your phone keyboard can't press Escape, the arrow keys, Shift+Tab, or always reach Enter — so we put little buttons for them right under the terminal, but only on small screens.

The bar lives in the shared `TerminalView`, so it shows on every mobile terminal surface (agent terminal, opened shells, terminals panel). Each button suppresses its own `pointerdown` so a tap never blurs the xterm textarea and dismisses the soft keyboard. Enter shows the ↵ return glyph and arrows show arrow icons; Esc is a glyph and Shift+Tab renders as two stacked words (`leading-none` + a 1px nudge to optically center the all-caps block, which otherwise reads top-heavy against the empty descender space).

## Test Plan

- `cd web && pnpm exec vitest run src/components/blocks/TerminalSession.test.ts src/components/blocks/TerminalView.test.tsx` → **86 passed**
- `pnpm exec tsc -b`, `pnpm exec oxlint …`, `pnpm exec prettier --check …`, and `pre-commit run --files …` all pass.
- Rendered the bar headlessly at phone width (380px) to confirm all 7 keys are evenly sized with no overflow and the stacked SHIFT/TAB label is centered.
- Deployed to a Databricks App (`daniel-lok-test`) and confirmed `/health` 200; the bar is exercisable there on a mobile viewport.
- Manual (phone / narrow viewport `< 768px`):
  - Open a terminal-first session; confirm the key row appears below 768px and is absent above it, and does **not** render for a read-only (non-owner) session.
  - Tap **↑/↓** inside a TUI select menu (validates cursor-key-mode encoding, in a plain shell and a full-screen TUI), **Esc** to dismiss, **⇧⇥** to back-tab, **↵** to submit.
  - Tap a key while the soft keyboard is up — the keyboard stays up.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

ASCII layout above; verified with a headless render at 380px and a live Databricks App deploy. A mobile screen recording against a running session is the ideal artifact and can be added.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover both new seams:
- `terminalMobileKeyPayload` — every key in both cursor-key modes (Esc/Shift+Tab/Enter mode-independent; arrows CSI vs SS3).
- `sendMobileKey` — round-trips through `onData` to the WebSocket and fires the input listener.
- `TerminalView` — bar renders on mobile, is absent on desktop, is hidden for read-only attaches, dispatches the mapped key on tap (Esc/↑/Enter), pins the left→right key order, renders the stacked SHIFT/TAB label, and cancels its `pointerdown` (keyboard-preserving).

Live on-device behavior (soft-keyboard persistence, real TUI navigation) is best confirmed by a human on a phone; see the Test Plan steps.

## Changelog

Mobile web terminal gains an on-screen key row: Shift+Tab, Esc, arrows, and Enter
