### PR TITLE
fix(claude-native): downgrade compaction-stripped images on cold resume

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -27,6 +27,7 @@ from omnigent.llms.adapters._content import redact_binary_payloads
 from omnigent.runtime.tool_result_replay import (
     blocks_from_parsed_list,
     image_payloads_in_blocks,
+    sanitize_replayed_image_blocks,
     strip_unparseable_image_output,
     tool_result_content_blocks,
 )
@@ -5351,7 +5352,11 @@ def _claude_native_message_content(
         if block is None or not isinstance(block.get("type"), str):
             return None
         blocks.append(block)
-    return blocks
+    # A compaction snapshot strips image base64 to a marker; replayed verbatim
+    # that marker reaches the provider as source.data and fails the resume, so
+    # downgrade any unusable image block to its omitted-image placeholder.
+    sanitized = sanitize_replayed_image_blocks(blocks)
+    return cast(list[_JsonObject], sanitized)
 
 
 def _synthetic_claude_transcript_uuid(

--- a/omnigent/runtime/tool_result_replay.py
+++ b/omnigent/runtime/tool_result_replay.py
@@ -497,6 +497,71 @@ def _blocks_from_newline_joined(output: str) -> RehydratedContent:
     return RehydratedContent(blocks, dropped_oversized_image=dropped)
 
 
+def _image_block_media_type(block: JsonObject) -> str | None:
+    """Return an image block's declared media type, from either shape.
+
+    :param block: An ``{"type": "image", ...}`` block.
+    :returns: The media type, e.g. ``"image/png"``, or ``None``.
+    """
+    source = block.get("source")
+    if isinstance(source, dict):
+        media_type = source.get("media_type")
+        if isinstance(media_type, str) and media_type:
+            return media_type
+    mime = block.get("mimeType")
+    return mime if isinstance(mime, str) and mime else None
+
+
+def _image_block_has_valid_payload(block: JsonObject) -> bool:
+    """Whether an image block still carries a base64 image payload.
+
+    Validates against the declared media type, so a compaction marker or any
+    other non-base64 string fails. Unlike :func:`_image_block_from_object`, a
+    source-shaped block is not passed through on failure — the payload must
+    actually decode to the declared image type.
+
+    :param block: An ``{"type": "image", ...}`` block, either the Anthropic
+        ``source`` shape or the bare ``data``/``mimeType`` MCP shape.
+    :returns: True when the payload is a usable image of its declared type.
+    """
+    source = block.get("source")
+    data = source.get("data") if isinstance(source, dict) else block.get("data")
+    media_type = _image_block_media_type(block)
+    if not isinstance(data, str) or not data or media_type is None:
+        return False
+    return _is_supported_image_payload(data, media_type)
+
+
+def sanitize_replayed_image_blocks(content: object) -> object:
+    """Downgrade image blocks whose base64 payload is no longer usable.
+
+    A compaction snapshot replaces each image block's base64 with a short marker
+    (``[image/png content omitted from the compaction snapshot]``). Replayed
+    verbatim into a ``--resume`` transcript that marker reaches the provider as
+    ``source.data`` and the whole request is rejected (``invalid base64 image
+    data: Invalid symbol 91, offset 0`` — the leading ``[``). Any image block
+    whose payload no longer validates is turned into the omitted-image text
+    placeholder; a still-valid one is canonicalized so a wrapped or unpadded
+    spelling cannot fail the resume either. Recurses so image blocks nested
+    inside a ``tool_result``'s ``content`` are reached too.
+
+    :param content: Arbitrarily nested message content (blocks, lists, scalars).
+    :returns: A copy with unusable image blocks replaced by text placeholders.
+    """
+    if isinstance(content, list):
+        return [sanitize_replayed_image_blocks(item) for item in content]
+    if isinstance(content, dict):
+        if content.get("type") == "image":
+            if _image_block_has_valid_payload(content):
+                return _image_block_from_object(content) or content
+            return {
+                "type": "text",
+                "text": image_omitted_placeholder(_image_block_media_type(content)),
+            }
+        return {key: sanitize_replayed_image_blocks(value) for key, value in content.items()}
+    return content
+
+
 def image_payloads_in_blocks(blocks: list[JsonObject]) -> list[str]:
     """
     Return the base64 payloads carried by a block list's image blocks.

--- a/omnigent/runtime/tool_result_replay.py
+++ b/omnigent/runtime/tool_result_replay.py
@@ -542,24 +542,61 @@ def sanitize_replayed_image_blocks(content: object) -> object:
     data: Invalid symbol 91, offset 0`` — the leading ``[``). Any image block
     whose payload no longer validates is turned into the omitted-image text
     placeholder; a still-valid one is canonicalized so a wrapped or unpadded
-    spelling cannot fail the resume either. Recurses so image blocks nested
-    inside a ``tool_result``'s ``content`` are reached too.
+    spelling cannot fail the resume either.
 
-    :param content: Arbitrarily nested message content (blocks, lists, scalars).
+    Traversal is deliberately narrow — a message content list and, within it, a
+    ``tool_result``'s ``content`` list. It does not descend into a
+    ``tool_use.input`` or other arbitrary structured value, so a nested payload
+    that merely *looks* like ``{"type": "image", ...}`` (e.g. an image tool's
+    arguments) is never rewritten.
+
+    :param content: A message ``content`` value — a block list, or a string that
+        is returned untouched.
     :returns: A copy with unusable image blocks replaced by text placeholders.
     """
     if isinstance(content, list):
-        return [sanitize_replayed_image_blocks(item) for item in content]
-    if isinstance(content, dict):
-        if content.get("type") == "image":
-            if _image_block_has_valid_payload(content):
-                return _image_block_from_object(content) or content
-            return {
-                "type": "text",
-                "text": image_omitted_placeholder(_image_block_media_type(content)),
-            }
-        return {key: sanitize_replayed_image_blocks(value) for key, value in content.items()}
+        return [_sanitize_replayed_block(item) for item in content]
     return content
+
+
+def _sanitize_replayed_block(block: object) -> object:
+    """Sanitize one content block, recursing only into ``tool_result.content``.
+
+    :param block: One entry from a message ``content`` list.
+    :returns: The block, downgraded when it is an unusable image block, with a
+        ``tool_result``'s nested content sanitized in turn.
+    """
+    parsed = _json_object(block)
+    if parsed is None:
+        return block
+    block_type = parsed.get("type")
+    if block_type == "image":
+        return _sanitize_image_block(parsed)
+    if block_type == "tool_result":
+        inner = parsed.get("content")
+        if isinstance(inner, list):
+            return {**parsed, "content": [_sanitize_replayed_block(item) for item in inner]}
+    return block
+
+
+def _sanitize_image_block(block: JsonObject) -> JsonObject:
+    """Canonicalize a usable image block, else downgrade it to a placeholder.
+
+    A non-base64 ``source`` type (e.g. ``url``) carries no base64 to validate,
+    so it is preserved rather than dropped.
+
+    :param block: A block whose ``type`` is ``"image"``.
+    :returns: The canonical image block, the original block for a non-base64
+        source, or an omitted-image text block.
+    """
+    source = block.get("source")
+    if isinstance(source, dict):
+        source_type = source.get("type")
+        if isinstance(source_type, str) and source_type != "base64":
+            return block
+    if _image_block_has_valid_payload(block):
+        return _image_block_from_object(block) or block
+    return {"type": "text", "text": image_omitted_placeholder(_image_block_media_type(block))}
 
 
 def image_payloads_in_blocks(blocks: list[JsonObject]) -> list[str]:

--- a/tests/runtime/test_tool_result_replay.py
+++ b/tests/runtime/test_tool_result_replay.py
@@ -327,3 +327,46 @@ def test_sanitize_replayed_image_blocks_preserves_valid_images() -> None:
     assert sanitized[0] == {"type": "text", "text": "keep me"}
     assert sanitized[1]["type"] == "image"
     assert sanitized[1]["source"]["media_type"] == "image/png"
+
+
+def test_sanitize_replayed_image_blocks_downgrades_bare_mcp_shape() -> None:
+    """A stripped MCP ``data``/``mimeType`` image block becomes text too."""
+    marker = "[image/png content omitted from the compaction snapshot]"
+    content = [{"type": "image", "data": marker, "mimeType": "image/png"}]
+
+    sanitized = trc.sanitize_replayed_image_blocks(content)
+
+    assert sanitized[0]["type"] == "text"
+    assert "image/png" in sanitized[0]["text"]
+    assert marker not in json.dumps(sanitized)
+
+
+def test_sanitize_replayed_image_blocks_leaves_tool_use_input_untouched() -> None:
+    """A ``tool_use.input`` shaped like an image block is not rewritten.
+
+    The compacted-message path runs for assistant content, which carries
+    ``tool_use`` blocks. Their ``input`` is opaque structured data — a value
+    that merely looks like ``{"type": "image", ...}`` must survive verbatim.
+    """
+    tool_input = {"type": "image", "data": "not-base64", "media_type": "image/png"}
+    content = [
+        {
+            "type": "tool_use",
+            "id": "toolu_gen",
+            "name": "generate_image",
+            "input": tool_input,
+        }
+    ]
+
+    sanitized = trc.sanitize_replayed_image_blocks(content)
+
+    assert sanitized[0]["input"] == tool_input
+
+
+def test_sanitize_replayed_image_blocks_preserves_url_source() -> None:
+    """A non-base64 ``source`` (e.g. url) carries no payload and is kept."""
+    content = [{"type": "image", "source": {"type": "url", "url": "https://example.com/a.png"}}]
+
+    sanitized = trc.sanitize_replayed_image_blocks(content)
+
+    assert sanitized[0] == content[0]

--- a/tests/runtime/test_tool_result_replay.py
+++ b/tests/runtime/test_tool_result_replay.py
@@ -286,3 +286,44 @@ def test_unusable_payloads_stay_omitted() -> None:
             b"\x89PNG\r\n\x1a\n"
         )
     )
+
+
+def test_sanitize_replayed_image_blocks_downgrades_the_compaction_marker() -> None:
+    """A compaction-stripped image nested in a tool_result becomes text."""
+    marker = "[image/png content omitted from the compaction snapshot]"
+    content = [
+        {
+            "type": "tool_result",
+            "tool_use_id": "toolu_img",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": "image/png", "data": marker},
+                }
+            ],
+        }
+    ]
+
+    sanitized = trc.sanitize_replayed_image_blocks(content)
+
+    inner = sanitized[0]["content"][0]
+    assert inner["type"] == "text"
+    assert "image/png" in inner["text"]
+    assert marker not in json.dumps(sanitized)
+
+
+def test_sanitize_replayed_image_blocks_preserves_valid_images() -> None:
+    """A still-valid image survives sanitization, canonicalized in place."""
+    content = [
+        {"type": "text", "text": "keep me"},
+        {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": _TINY_PNG_BASE64},
+        },
+    ]
+
+    sanitized = trc.sanitize_replayed_image_blocks(content)
+
+    assert sanitized[0] == {"type": "text", "text": "keep me"}
+    assert sanitized[1]["type"] == "image"
+    assert sanitized[1]["source"]["media_type"] == "image/png"

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -8525,6 +8525,60 @@ def test_claude_transcript_records_handles_native_compaction_messages() -> None:
     assert "discarded before compaction" not in json.dumps(records)
 
 
+def test_claude_transcript_records_downgrades_compaction_stripped_image() -> None:
+    """A compaction-stripped image block never resumes as an invalid image.
+
+    Compaction replaces an image block's base64 with the marker
+    ``[image/png content omitted from the compaction snapshot]``. Replayed
+    verbatim that marker reaches the provider as ``source.data`` and fails the
+    resume with ``invalid base64 image data: Invalid symbol 91, offset 0`` (the
+    leading ``[``). The rebuild must downgrade it to a text placeholder.
+    """
+    marker = "[image/png content omitted from the compaction snapshot]"
+    items: list[dict[str, Any]] = [
+        {
+            "id": "cmp",
+            "type": "compaction",
+            "token_count": 42,
+            "compacted_messages": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_img",
+                            "content": [
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "image/png",
+                                        "data": marker,
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        },
+    ]
+
+    records = claude_native._claude_transcript_records_from_session_items(
+        items,
+        session_id="conv_img",
+        external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+        cwd=Path("/tmp/test"),
+        bridge_dir=Path("/tmp/test-bridge"),
+    )
+
+    tool_result = records[1]["message"]["content"][0]
+    inner = tool_result["content"][0]
+    assert inner["type"] == "text", f"stripped image replayed as invalid image: {inner}"
+    assert marker not in json.dumps(records)
+
+
 def test_websocket_connect_passes_ssl_context_for_wss(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Fixes a `400 invalid base64 image data: Invalid symbol 91, offset 0` that broke **every turn** when continuing a claude-native session by cold resume (e.g. after a runner disconnect).

- A session's compaction snapshot replaces each image block's base64 with a marker (`[image/png content omitted from the compaction snapshot]`) to keep the stored snapshot small — correct for storage.
- But the cold-resume compacted-message replay path passed those blocks through **verbatim**, so a live image block whose `source.data` was that marker reached `claude --resume` and the provider rejected the request (`Invalid symbol 91` = the leading `[`).
- The normal tool-result replay path was already guarded by base64 validation; this closes the equivalent gap on the compacted-message path.

## Test Plan

- New unit tests (all green, lint clean):
  - `tests/runtime/test_tool_result_replay.py` — `sanitize_replayed_image_blocks` downgrades the compaction marker (including nested in a `tool_result`) and preserves valid images.
  - `tests/test_claude_native.py::test_claude_transcript_records_downgrades_compaction_stripped_image` — full transcript rebuild no longer emits an invalid image.
- Verified end-to-end against the actual broken session's transcript record: the marker is replaced with an omitted-image text placeholder and no invalid base64 reaches `source.data`.
- `ruff format` + `ruff check` + pre-commit hooks pass.

To reproduce manually: open a claude-native session that has compacted **and** contains an image tool result (e.g. a screenshot or image `Read`), force a cold resume (runner disconnect), and continue the session. Previously every turn errored with the 400; now the turn completes and the stripped image shows the `[image/png image omitted from history…]` placeholder.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Reproduced the failure against the real broken session's transcript record and confirmed the rebuilt transcript no longer emits an invalid image block; also added targeted unit tests at both the sanitizer level and the full transcript-rebuild level.

## Changelog

Continuing a Claude Code session after a runner disconnect no longer fails with an `invalid base64 image data` error when the session had compacted an image.

This pull request and its description were written by Isaac.
