### PR TITLE
feat(web): accept codex's `$skill` spelling in the composer

### DIFF
--- a/tests/e2e_ui/chat/test_codex_dollar_skill_menu.py
+++ b/tests/e2e_ui/chat/test_codex_dollar_skill_menu.py
@@ -1,0 +1,131 @@
+"""E2E: codex's ``$skill`` spelling in the in-session composer.
+
+Codex splits the two namespaces in its own composer — ``/`` for built-in
+commands, ``$`` for skills — so someone driving a codex session from the
+Web UI reaches for ``$deslop`` and, before this change, got nothing: the
+suggestions menu only opened on ``/``. These tests drive that journey in a
+real browser: type ``$`` in a codex session's composer, see the session's
+skills (and only the skills — codex has no ``$`` spelling for the
+built-ins), and complete one with Tab.
+
+The sigil is harness-gated, so the second test is the control: the same
+draft on a non-codex session leaves ``$`` as prose, with no menu.
+
+Both patch the browser-visible session snapshot's ``harness`` and
+``skills`` (the same route-patch convention as
+``test_custom_codex_native_controls.py``): skills reach the snapshot from
+the server's background *runner* fetch, so a live-discovered list would
+make the menu's contents depend on whatever the host happens to carry.
+Nothing on the server side is under test here — the sigil lives entirely
+in ``ChatPage``/``SlashCommandMenu``.
+
+Selectors mirror the component: rows are
+``data-testid="slash-menu-item-<name-sans-sigil>"`` and the highlighted
+row carries ``data-active="true"`` (see ``SlashCommandMenu.tsx``).
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, Route, expect
+
+from tests.e2e_ui.conftest import fetch_with_retry
+
+# Two skills, so the menu is filtered rather than trivially single-rowed.
+_SKILLS = [
+    {"name": "deslop", "description": "Remove AI slop from the current changes"},
+    {"name": "deep-research", "description": "Run a deep research sweep"},
+]
+
+
+def _patch_session_harness_and_skills(page: Page, session_id: str, harness: str) -> None:
+    """Overlay ``harness`` + ``skills`` onto the session GET snapshot.
+
+    :param page: Playwright page, before navigation.
+    :param session_id: Session id whose GET snapshot to overlay.
+    :param harness: Harness id to report, e.g. ``"codex-native"``.
+    """
+
+    def _handle(route: Route) -> None:
+        request = route.request
+        if urlparse(request.url).path != f"/v1/sessions/{session_id}" or request.method != "GET":
+            route.continue_()
+            return
+        response = fetch_with_retry(route)
+        payload = response.json()
+        payload["harness"] = harness
+        payload["skills"] = _SKILLS
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route("**/v1/sessions/**", _handle)
+
+
+def test_codex_session_completes_a_dollar_skill(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """``$`` opens the skills menu on a codex session, and Tab completes it.
+
+    While the sigil is unsupported, typing ``$des`` opens nothing and the
+    first ``expect`` below times out.
+
+    :param page: Playwright page (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` from the fixture.
+    """
+    base_url, session_id = seeded_session
+    _patch_session_harness_and_skills(page, session_id, "codex-native")
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+
+    # A bare "$" lists the skills — and only the skills. The built-ins are
+    # Omnigent's "/" commands; codex has no "$" spelling for them.
+    composer.fill("$")
+    expect(page.get_by_test_id("slash-menu-item-deslop")).to_be_visible(timeout=15_000)
+    expect(page.get_by_test_id("slash-menu-item-deep-research")).to_be_visible()
+    expect(page.get_by_test_id("slash-menu-item-context")).to_have_count(0)
+
+    # Narrowing highlights the single match (the highlight is driven by the
+    # keyboard-nav filter, so this pins it to the rendered row), and Tab
+    # completes it WITH its sigil plus a trailing space for arguments —
+    # skills fill rather than execute.
+    composer.fill("$des")
+    expect(page.get_by_test_id("slash-menu-item-deslop")).to_have_attribute("data-active", "true")
+    composer.press("Tab")
+    expect(composer).to_have_value("$deslop ")
+
+
+def test_non_codex_session_leaves_a_dollar_draft_as_prose(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The same draft on a non-codex session opens no menu.
+
+    ``$`` is codex's spelling, so everywhere else it stays prose — a draft
+    that starts with one must not sprout a suggestions menu.
+
+    :param page: Playwright page (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` from the fixture.
+    """
+    base_url, session_id = seeded_session
+    _patch_session_harness_and_skills(page, session_id, "claude-sdk")
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+
+    # Same skill name, same session shape — only the harness differs.
+    composer.fill("$des")
+    expect(page.get_by_test_id("slash-menu-item-deslop")).to_have_count(0)
+    # "/" still works here, which is what proves the skills reached the
+    # snapshot and the empty "$" menu above is the harness gate, not a
+    # missing skill list.
+    composer.fill("/des")
+    expect(page.get_by_test_id("slash-menu-item-deslop")).to_be_visible(timeout=15_000)

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -40,6 +40,47 @@ export function isSlashCommandText(text: string): boolean {
 }
 
 /**
+ * Sigil that also opens the skills menu on a codex-backed session. Codex's
+ * own composer splits the namespaces — ``/`` for built-in commands, ``$``
+ * for skills — so a codex session takes ``$deslop`` alongside ``/deslop``
+ * and the muscle memory carries over. Skills only: the built-ins here are
+ * Omnigent's, and codex has no ``$`` spelling for them.
+ */
+export const SKILL_SIGIL = "$";
+
+// The shape of SLASH_COMMAND_RE over the "$" sigil. Neither "/" nor "$" is
+// allowed in the name, so `$HOME/bin` and `$$x$$` don't match and prose
+// dollars stay prose.
+const SKILL_SIGIL_RE = /^\$[A-Za-z0-9][\w:-]*(\s|$)/;
+
+/**
+ * True when a draft reads as a ``$skill`` invocation. Callers gate on the
+ * session's harness being codex before consulting this — on every other
+ * harness a leading ``$`` is just prose.
+ */
+export function isSkillSigilText(text: string): boolean {
+  return SKILL_SIGIL_RE.test(text.trim());
+}
+
+/**
+ * The session's skills keyed as ``$name``, for the ``$``-triggered menu.
+ * Sigil-prefixed keys let the rest of the menu machinery
+ * (:func:`slashCommandMatches`, :func:`rankedSlashCommandNames`, the
+ * Commands/Skills section split) run unchanged — none of it reads the
+ * leading character beyond dropping it.
+ *
+ * :param skills: ``Session.skills`` from the snapshot.
+ * :returns: ``Record<"$name", description>``.
+ */
+export function buildSkillSigilCommandMap(
+  skills: readonly { name: string; description: string }[],
+): Record<string, string> {
+  const m: Record<string, string> = {};
+  for (const skill of skills) m[`${SKILL_SIGIL}${skill.name}`] = skill.description;
+  return m;
+}
+
+/**
  * True when `query` is a case-insensitive substring of the command name
  * (sans the leading `/`). Matches on the name only — not the description —
  * because the web menu never shows descriptions inline, so a

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -914,6 +914,121 @@ describe("Composer slash-command submit routing", () => {
   });
 });
 
+// Codex spells a skill invocation "$name" in its own composer, reserving "/"
+// for its built-in commands. These pin that spelling for codex-backed
+// sessions: "$" opens the same suggestions menu (skills only) and submits by
+// the same route as "/", without letting prose dollars read as commands.
+describe("Composer codex $skill menu", () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      conversationId: "conv_test",
+      sessionHarness: "codex-native",
+      skills: [
+        { name: "deep-research", description: "Run a deep research sweep" },
+        { name: "deslop", description: "Remove AI slop" },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useChatStore.setState({ sessionHarness: null });
+  });
+
+  it('opens the menu on "$" and lists skills only', () => {
+    render(<Composer {...composerProps({ isNativeWrapper: true })} />);
+    fireEvent.change(textarea(), { target: { value: "$" } });
+    expect(screen.getByTestId("slash-menu-item-deslop")).toBeInTheDocument();
+    expect(screen.getByTestId("slash-menu-item-deep-research")).toBeInTheDocument();
+    // Built-ins are Omnigent's "/" commands — codex has no "$" spelling for
+    // them, so they stay out of this menu (they still show under "/").
+    expect(screen.queryByTestId("slash-menu-item-compact")).toBeNull();
+    expect(screen.queryByTestId("slash-menu-item-context")).toBeNull();
+  });
+
+  it("Tab completes the highlighted skill with its $ prefix", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "$des" } });
+    expect(activeRow()?.textContent).toContain("$deslop");
+    fireEvent.keyDown(ta, { key: "Tab" });
+    // Skills fill and keep focus so the user can append args — never execute.
+    expect(ta.value).toBe("$deslop ");
+  });
+
+  it("routes a known $skill through onSendSlashCommand with parsed args", () => {
+    const onSend = vi.fn();
+    const onSendSlashCommand = vi.fn();
+    render(<Composer {...composerProps({ onSend, onSendSlashCommand })} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "$deslop fix the bug" } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    // Same wire shape as "/deslop": the name without its sigil, plus args.
+    expect(onSendSlashCommand).toHaveBeenCalledWith("deslop", "fix the bug");
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("leaves prose dollars alone", () => {
+    const onSend = vi.fn();
+    const onSendSlashCommand = vi.fn();
+    render(<Composer {...composerProps({ onSend, onSendSlashCommand })} />);
+    const ta = textarea();
+    // Command-shaped but not a skill: sent verbatim, with no overlay tint.
+    fireEvent.change(ta, { target: { value: "$5 per PR is the budget" } });
+    expect(screen.queryByTestId("composer-highlight-overlay")).toBeNull();
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(onSendSlashCommand).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith("$5 per PR is the budget", undefined);
+  });
+
+  it("treats an env-var path as plaintext, not a command", () => {
+    const onSend = vi.fn();
+    const onSendSlashCommand = vi.fn();
+    render(<Composer {...composerProps({ onSend, onSendSlashCommand })} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "$HOME/bin is missing" } });
+    // The "/" inside the token keeps the menu shut, mirroring "/etc/hosts".
+    expect(screen.queryByTestId("slash-menu-item-deslop")).toBeNull();
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(onSendSlashCommand).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith("$HOME/bin is missing", undefined);
+  });
+
+  it("tints only the $skill token, leaving args in the default color", () => {
+    render(<Composer {...composerProps()} />);
+    fireEvent.change(textarea(), { target: { value: "$deslop clean up ChatPage" } });
+    const overlay = screen.getByTestId("composer-highlight-overlay");
+    expect(overlay.querySelector(".text-brand-accent")?.textContent).toBe("$deslop");
+    expect(overlay.textContent).toBe("$deslop clean up ChatPage");
+  });
+
+  it("stays inert on a non-codex session", () => {
+    const onSend = vi.fn();
+    const onSendSlashCommand = vi.fn();
+    useChatStore.setState({ sessionHarness: "claude-native" });
+    render(<Composer {...composerProps({ onSend, onSendSlashCommand })} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "$deslop" } });
+    // No menu, no tint, and the draft sends as written — "$" is codex's
+    // spelling, so elsewhere it's just prose.
+    expect(screen.queryByTestId("slash-menu-item-deslop")).toBeNull();
+    expect(screen.queryByTestId("composer-highlight-overlay")).toBeNull();
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(onSendSlashCommand).not.toHaveBeenCalled();
+    expect(onSend).toHaveBeenCalledWith("$deslop", undefined);
+  });
+
+  it('still offers the built-ins and skills under "/"', () => {
+    render(<Composer {...composerProps({ isNativeWrapper: true })} />);
+    fireEvent.change(textarea(), { target: { value: "/" } });
+    expect(screen.getByTestId("slash-menu-item-compact")).toBeInTheDocument();
+    expect(screen.getByTestId("slash-menu-item-deslop")).toBeInTheDocument();
+  });
+});
+
 describe("Composer model/effort label", () => {
   beforeEach(() => {
     useChatStore.setState({

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -155,8 +155,11 @@ import { useFileDropTarget } from "@/hooks/useFileDropTarget";
 import { HostBadge } from "@/components/HostBadge";
 import {
   BUILTIN_SLASH_COMMANDS,
+  buildSkillSigilCommandMap,
+  isSkillSigilText,
   isSlashCommandText,
   rankedSlashCommandNames,
+  SKILL_SIGIL,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
 import { FileMentionMenu } from "@/components/FileMentionMenu";
@@ -218,6 +221,7 @@ import {
   codexApprovalModeLabel,
 } from "@/lib/codexApprovalMode";
 import { isCodexNativeSession } from "@/lib/codexPlanMode";
+import { isCodexHarness } from "@/lib/harnessSetup";
 import { getCliServerUrl } from "@/lib/host";
 import { useOmnigentAnalytics } from "@/lib/analyticsEmit";
 import { GoalControl, GoalStatusPill, useGoalState, type Goal } from "@/components/goal";
@@ -288,14 +292,15 @@ export function isSubagentRoutingEligible(
 }
 
 // Leading whitespace + the command token, so the composer overlay can tint
-// just the `/skill` and leave any args in the default color.
-const SLASH_COMMAND_SPLIT_RE = /^(\s*)(\/[A-Za-z0-9][\w:-]*)/;
+// just the `/skill` (or codex's `$skill`) and leave any args in the default
+// color.
+const SLASH_COMMAND_SPLIT_RE = /^(\s*)([/$][A-Za-z0-9][\w:-]*)/;
 
 /**
  * Split a slash-command draft into the command token and the rest, for the
  * composer highlight overlay. Returns null when the text isn't a command
- * (callers gate on `isSlashCommandText`, so a returned token is the full
- * command — never a `/etc/hosts`-style path prefix).
+ * (callers gate on `isSlashCommandText` / `isSkillSigilText`, so a returned
+ * token is the full command — never a `/etc/hosts`-style path prefix).
  */
 export function splitSlashCommand(
   value: string,
@@ -2645,21 +2650,44 @@ export function Composer({
     [skills, showEffort, showModel],
   );
 
+  // Codex spells a skill invocation `$name` in its own composer, so a
+  // codex-backed session takes `$` as a second trigger for the skills menu.
+  // `/` keeps working (and keeps the built-ins); `$` lists skills only,
+  // matching codex, which reserves `/` for its own commands. Empty on every
+  // other harness, which is what gates the `$` paths below.
+  const skillSigilEnabled = isCodexHarness(sessionHarness ?? "");
+  const skillSigilCommands = useMemo(
+    () => (skillSigilEnabled ? buildSkillSigilCommandMap(skills) : {}),
+    [skills, skillSigilEnabled],
+  );
+
   // Suggestions menu is open while the user is still typing the command
-  // name — i.e. the value starts with "/" with no spaces yet (once a
+  // name — i.e. the value starts with a sigil, with no spaces yet (once a
   // space appears the command name is done and args follow) and no second
-  // "/" (guards against file-path-like strings).
+  // "/" (guards against file-path-like strings, and against `$HOME/bin`).
   const trimmedValue = value.trimStart();
-  const menuOpen =
-    trimmedValue.startsWith("/") &&
-    !trimmedValue.slice(1).includes("/") &&
-    !trimmedValue.includes(" ") &&
-    files.length === 0;
-  // Query = what the user typed after the leading "/".
+  const menuSigil: "/" | typeof SKILL_SIGIL | null =
+    files.length > 0 || trimmedValue.includes(" ") || trimmedValue.slice(1).includes("/")
+      ? null
+      : trimmedValue.startsWith("/")
+        ? "/"
+        : skillSigilEnabled && trimmedValue.startsWith(SKILL_SIGIL)
+          ? SKILL_SIGIL
+          : null;
+  const menuOpen = menuSigil !== null;
+  // "$" lists the session's skills; "/" the built-ins plus the same skills.
+  const menuCommands = menuSigil === SKILL_SIGIL ? skillSigilCommands : slashCommands;
+  // Query = what the user typed after the leading sigil.
   const menuQuery = menuOpen ? trimmedValue.slice(1) : "";
   // Tint the `/skill` token blue while the draft reads as a slash command, so
-  // the command shape is signalled as the user types it.
-  const composerIsCommand = files.length === 0 && isSlashCommandText(value);
+  // the command shape is signalled as the user types it. A `$skill` draft
+  // tints only once the name matches a real skill — "$5" and "$HOME " are
+  // command-shaped but overwhelmingly prose, so shape alone would paint
+  // stray dollars blue.
+  const composerIsCommand =
+    files.length === 0 &&
+    (isSlashCommandText(value) ||
+      (isSkillSigilText(value) && (splitSlashCommand(value)?.token ?? "") in skillSigilCommands));
   const toggleCodexPlanMode = async () => {
     if (planModeBusy) return;
     setCommandError(null);
@@ -2675,7 +2703,7 @@ export function Composer({
   };
   // Filtered matches — kept in sync with what SlashCommandMenu renders so
   // keyboard nav indexes into the same list.
-  const menuMatches = menuOpen ? rankedSlashCommandNames(slashCommands, menuQuery) : [];
+  const menuMatches = menuOpen ? rankedSlashCommandNames(menuCommands, menuQuery) : [];
 
   // Pre-select the first match whenever the filtered list changes — both
   // when the menu first opens (matches go [] → non-empty) and as the query
@@ -2939,7 +2967,8 @@ export function Composer({
    */
   const applyMenuSelection = (cmd: string) => {
     setMenuIndex(-1);
-    if (slashCommandsWithArgs.has(cmd)) {
+    // Every `$` entry is a skill, and skills always fill rather than execute.
+    if (cmd in skillSigilCommands || slashCommandsWithArgs.has(cmd)) {
       // Fill in "cmd " and let the user type the argument.
       setValue(cmd + " ");
       dirtyRef.current = true;
@@ -3059,6 +3088,30 @@ export function Composer({
         const skillArgs = trimmed.slice(parts[0].length).trim();
         appendEntry(trimmed);
         onSendSlashCommand(parts[0].slice(1), skillArgs);
+        dirtyRef.current = true;
+        setValue("");
+        setCommandError(null);
+        onClearAllQuotes();
+        return;
+      }
+    }
+
+    // Codex's `$skill` spelling, on a codex session. A known skill routes
+    // exactly like `/skill`; everything else falls through to the plaintext
+    // send below — a prose dollar ("$5 per PR"), and any `$skill` on a
+    // native-terminal session, where `onSendSlashCommand` is undefined and
+    // codex's own CLI resolves the name.
+    if (
+      onSendSlashCommand &&
+      isSkillSigilText(trimmed) &&
+      files.length === 0 &&
+      mentionedItems.length === 0
+    ) {
+      const token = trimmed.split(/\s+/)[0]!;
+      if (token in skillSigilCommands) {
+        const skillArgs = trimmed.slice(token.length).trim();
+        appendEntry(trimmed);
+        onSendSlashCommand(token.slice(1), skillArgs);
         dirtyRef.current = true;
         setValue("");
         setCommandError(null);
@@ -3329,7 +3382,7 @@ export function Composer({
             query={menuQuery}
             activeIndex={menuIndex}
             onSelect={applyMenuSelection}
-            commands={slashCommands}
+            commands={menuCommands}
           />
         )}
         {/* "@"-file-mention browser — native coding-agent sessions only.


### PR DESCRIPTION
## Related issue

Closes #

<!-- No issue: raised directly ("I know / works too, but since $ is valid
syntax in codex, I would really prefer, if the model is codex, for
autocomplete to work with $ too for skills"). -->

## Summary

Codex splits the two namespaces in its own composer — `/` for built-in
commands, `$` for skills. Driving a codex session from Omnigent Web, `$deslop`
gets you nothing: the suggestions menu only opens on `/`, and the draft sends
as plain prose.

- **`$` is now a second trigger for the skills menu when the session's harness
  is codex** (`codex`, `codex-native`, `native-codex`). It lists skills only —
  codex has no `$` spelling for `/model`, `/compact`, `/context`, `/effort`,
  `/help`, which stay on `/`. `/` itself is unchanged and still offers the
  built-ins *plus* the same skills, so nothing anyone types today moves.
- **Selecting fills `$name ` for arguments** (skills never auto-execute), and a
  known `$skill` submits by the same route `/skill` takes: a `slash_command`
  event on in-process sessions, or plaintext into the vendor TUI on
  codex-native, where codex resolves the name itself.
- **Prose dollars stay prose.** A `$` name may hold neither `/` nor `$`, so
  `$HOME/bin` and `$$x$$` never open the menu; an unmatched `$token` ("$5 per
  PR") sends verbatim rather than erroring; and the composer's blue token tint
  waits for the name to match a real skill instead of painting `$5` on shape
  alone. On every non-codex harness a leading `$` is inert.

Mechanically, the sigil-keyed map (`$name` → description) reuses the whole
existing menu machinery — `slashCommandMatches`, `rankedSlashCommandNames`, the
Commands/Skills section split — none of which reads the leading character
beyond dropping it.

```
codex session          other harness
  "/…" → commands + skills      "/…" → commands + skills
  "$…" → skills                 "$…" → prose
```

**Not included:** the new-chat landing composer. Its skills menu is already
suppressed entirely for native-terminal agents (codex-native included), so `$`
there would have nothing to show; happy to extend it in a follow-up if the
in-process codex SDK case matters.

## Test Plan

- `web/src/pages/ChatPage.composer.test.tsx` — 8 new unit tests (`Composer
  codex $skill menu`): menu opens on `$` with skills only, Tab completes
  `$deslop `, submit routes `("deslop", "fix the bug")`, prose dollars and
  `$HOME/bin` fall through to plaintext with no tint, `$` inert on
  `claude-native`, `/` unaffected. Whole file: **169 passed**.
- `tests/e2e_ui/chat/test_codex_dollar_skill_menu.py` — 2 new e2e UI tests in a
  real browser: a codex session's composer lists both skills on `$`, highlights
  the narrowed match, and Tab-completes it; the same draft on a non-codex
  session opens nothing while `/des` still does (proving the empty `$` menu is
  the harness gate, not a missing skill list).
- **Proved non-vacuous.** With the two source files reverted to `origin/main`
  and the bundle rebuilt, 4 of the 8 unit tests and the codex e2e test fail:

  ```
  × opens the menu on "$" and lists skills only
  × Tab completes the highlighted skill with its $ prefix
  × routes a known $skill through onSendSlashCommand with parsed args
  × tints only the $skill token, leaving args in the default color

  E  AssertionError: Locator expected to be visible
  E    - waiting for get_by_test_id("slash-menu-item-deslop")
  ```

  The negative controls pass before and after, as they should.
- `pre-commit run --files <changed>` — prettier, oxlint, tsc, ruff all pass.

Manual check on a live codex session: type `$` in the composer → the Skills
menu appears with no Commands section → `$des` + Tab → `$deslop ` → Enter runs
the skill. `$5 per PR` and `$HOME/bin is missing` send as written, untinted.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The e2e test above is the recorded evidence for this UI change: it drives the
real browser through the journey (`$` → menu → Tab → `$deslop `) and fails
without the diff. Screen recording to follow if a reviewer wants one.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the parts a test can't judge: that the `$` menu
reads as codex's own (Skills section only, no Commands header) and that the
token tint looks right on a prose dollar. The behavioral surface — trigger,
filter, completion, submit routing, harness gate, prose fall-through — is
covered by the unit and e2e tests above, each shown failing without the fix.

## Changelog

Codex sessions accept codex's own `$skill` spelling in the composer, with
autocomplete, alongside `/skill`
