### PR TITLE
feat(web): open GitHub PR links in the embedded browser

### DIFF
--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -457,6 +457,19 @@ export function supportsBrowser(): boolean {
 }
 
 /**
+ * Navigate the conversation's embedded browser view to a URL as a user action
+ * (not agent-issued, so it skips the agent navigation allowlist). Returns false
+ * and no-ops outside a browser-capable shell, so callers can fall back to the
+ * system browser.
+ */
+export function browserNavigate(conversationId: string, url: string): boolean {
+  const api = electronApi();
+  if (typeof api?.browserOpenOrNavigate !== "function") return false;
+  void api.browserOpenOrNavigate(conversationId, url, undefined, { force: true });
+  return true;
+}
+
+/**
  * True when running inside the Electron desktop shell on macOS — the one
  * platform where the shell hides the native title bar (titleBarStyle
  * "hiddenInset") and the web layer must reserve space for the traffic

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -22,6 +22,7 @@ import { useIOSViewportLock } from "@/hooks/useIOSViewportLock";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
 import { derivePermissionLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import {
+  browserNavigate,
   isAndroidShell,
   isIOSShell,
   isMacElectronShell,
@@ -814,6 +815,19 @@ export function AppShell() {
       setRightPanelOpen(true);
     });
   }, []);
+
+  // Open a URL in the conversation's embedded browser and surface it: navigate
+  // the view, then switch to the Browser tab and open the rail. Used for links
+  // (e.g. the GitHub tab's PR link) that should open in-app rather than the
+  // system browser. No-op off a browser-capable shell, so callers fall back.
+  const openUrlInEmbeddedBrowser = useCallback(
+    (url: string) => {
+      if (!conversationId || !browserNavigate(conversationId, url)) return;
+      setRightRailTab("browser");
+      setRightPanelOpen(true);
+    },
+    [conversationId],
+  );
 
   // Design-mode submit routing. Lives here (with the hoisted relay) because the
   // in-page popup posts back via preload IPC delivered to the always-mounted
@@ -2035,6 +2049,9 @@ export function AppShell() {
                     showFilesPanel={showFilesPanel}
                     showGithubTab={railTabsAvailable.github}
                     showBrowserTab={railTabsAvailable.browser}
+                    onOpenUrlInBrowser={
+                      railTabsAvailable.browser ? openUrlInEmbeddedBrowser : undefined
+                    }
                     changedCount={changedCount}
                     subagentsWorking={subagentsWorking}
                     agentCount={agentCount}

--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -75,11 +75,11 @@ function file(
   };
 }
 
-function renderPanel() {
+function renderPanel(props: { onOpenUrlInBrowser?: (url: string) => void } = {}) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <GithubPanel conversationId="conv_1" />
+      <GithubPanel conversationId="conv_1" {...props} />
     </QueryClientProvider>,
   );
 }
@@ -174,6 +174,24 @@ describe("GithubPanel", () => {
     expect(screen.getByText(/66\s*passed/)).toBeInTheDocument();
     expect(screen.getByText(/2\s*failed/)).toBeInTheDocument();
     expect(screen.queryByText(/pending/)).toBeNull();
+  });
+
+  it("opens the PR in the embedded browser and offers a system-browser fallback", async () => {
+    const onOpenUrlInBrowser = vi.fn();
+    renderPanel({ onOpenUrlInBrowser });
+    const link = await screen.findByRole("link", { name: /chore: dummy PR/ });
+    fireEvent.click(link);
+    expect(onOpenUrlInBrowser).toHaveBeenCalledWith("https://example.com/pr/6000");
+    // The explicit escape hatch to the system browser is present.
+    expect(screen.getByRole("button", { name: "Open in system browser" })).toBeInTheDocument();
+  });
+
+  it("links the PR out to the system browser when no embedded browser is available", async () => {
+    renderPanel();
+    const link = await screen.findByRole("link", { name: /chore: dummy PR/ });
+    expect(link).toHaveAttribute("href", "https://example.com/pr/6000");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(screen.queryByRole("button", { name: "Open in system browser" })).toBeNull();
   });
 
   it("stacks a diff section per changed file", async () => {

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -539,7 +539,14 @@ function SidebarNode({
   );
 }
 
-export function GithubPanel({ conversationId }: { conversationId: string }) {
+export function GithubPanel({
+  conversationId,
+  onOpenUrlInBrowser,
+}: {
+  conversationId: string;
+  /** Open a link in the embedded browser; absent off browser-capable shells. */
+  onOpenUrlInBrowser?: (url: string) => void;
+}) {
   // Poll for live CI status only while this panel is mounted (the status-line
   // indicator keeps the non-polling default). Self-limits to unsettled checks.
   const info = useGithubInfo(conversationId, { poll: true });
@@ -788,6 +795,16 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
   const pr = data.pr!;
   const checks = pr.checks;
 
+  // Left-click opens the PR in the embedded browser when available; modified
+  // clicks (new-tab/window intent) and non-browser shells fall through to the
+  // anchor's default target="_blank" → system browser.
+  const openPrInEmbeddedBrowser = (e: React.MouseEvent) => {
+    if (!onOpenUrlInBrowser) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+    e.preventDefault();
+    onOpenUrlInBrowser(pr.url);
+  };
+
   return (
     <TooltipProvider delayDuration={0}>
       <div className="flex h-full min-h-0 flex-col">
@@ -810,12 +827,23 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
               href={pr.url}
               target="_blank"
               rel="noreferrer"
+              onClick={openPrInEmbeddedBrowser}
               className="group inline-flex min-w-0 items-center gap-1 text-ui font-medium hover:underline"
             >
               <span className="truncate">{pr.title}</span>
               <span className="shrink-0 text-muted-foreground">#{pr.number}</span>
-              <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
+              {!onOpenUrlInBrowser && (
+                <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
+              )}
             </a>
+            {onOpenUrlInBrowser && (
+              <IconButton
+                label="Open in system browser"
+                onClick={() => window.open(pr.url, "_blank", "noreferrer")}
+              >
+                <ExternalLinkIcon className="size-3.5" />
+              </IconButton>
+            )}
           </div>
           {/* CI status checks (from the PR's statusCheckRollup), on their own
             line as pills; hover a pill to see the job names in that bucket. */}

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -577,6 +577,9 @@ interface WorkspacePanelProps {
   /** Whether the Browser tab is available — Electron shell only (hidden in a
    *  plain web build, which has no embedded WebContentsView). */
   showBrowserTab: boolean;
+  /** Open a URL in the embedded browser and surface the Browser tab. Provided
+   *  only on browser-capable shells; when absent, links open externally. */
+  onOpenUrlInBrowser?: (url: string) => void;
   /** Count of changed files, shown as the Changes tab badge. */
   changedCount: number;
   /** How many child agents are actively working (Agents tab badge). */
@@ -674,6 +677,7 @@ export function WorkspacePanel({
   showFilesPanel,
   showGithubTab,
   showBrowserTab,
+  onOpenUrlInBrowser,
   changedCount,
   subagentsWorking,
   agentCount,
@@ -982,7 +986,7 @@ export function WorkspacePanel({
           // measures this rail slot to position the native view over it.
           <BrowserPane conversationId={conversationId} className="min-h-0 flex-1" />
         ) : rightRailTab === "github" && showGithubTab ? (
-          <GithubPanel conversationId={conversationId} />
+          <GithubPanel conversationId={conversationId} onOpenUrlInBrowser={onOpenUrlInBrowser} />
         ) : rightRailTab === "subagents" && rootSessionId ? (
           <SubagentsPanel conversationId={conversationId} rootSessionId={rootSessionId} />
         ) : (


### PR DESCRIPTION
## Related issue

N/A — small desktop UX improvement; no separate tracking issue. Happy to link one if there's a matching request.

## Summary

- In the desktop app's **GitHub** tab, clicking the PR link now opens the PR in the conversation's **embedded browser** and surfaces the Browser tab, instead of handing off to the system browser.
- Adds an explicit **"Open in system browser"** icon button next to the PR title as the escape hatch (and a modifier-click — ⌘/Ctrl/Shift/Alt — on the title falls through to the system browser too).
- Fully backward compatible off Electron: on a plain web build (no embedded `WebContentsView`), the link keeps its previous `target="_blank"` behavior and the extra button is hidden.

Mechanically: a new `browserNavigate()` helper in `nativeBridge` performs a user-initiated navigation of the embedded view (no-ops off a browser-capable shell so callers can fall back). `AppShell` wires an `openUrlInEmbeddedBrowser` callback — mirroring the existing agent-`navigate` auto-surface — that navigates the view and switches to the Browser tab, threaded down through `WorkspacePanel` to `GithubPanel` only when the browser tab is available.

## Test Plan

Automated (from `web/`):
- `pnpm run type-check` — clean
- `pnpm exec oxlint --deny-warnings` on the changed files — clean
- `pnpm exec prettier --check` on the changed files — clean
- `pnpm exec vitest run src/shell/GithubPanel.test.tsx` — 20 passed (2 new: opens embedded + offers the system-browser button; falls back to a `target="_blank"` link when no embedded browser)
- `pnpm exec vitest run src/lib/nativeBridge.test.ts` — 55 passed

Manual (desktop shell — the native embedded browser can't be exercised in jsdom):
1. `just electron-dev`, open a session whose workspace has an open GitHub PR (so the GitHub tab shows the PR header).
2. Click the PR title → rail switches to the **Browser** tab and loads the PR in-app.
3. Click the **external-link icon** next to the title → PR opens in the default system browser.
4. ⌘/Ctrl-click the title → opens in the system browser.
5. Sanity-check a **private-repo** PR: the embedded view uses a per-conversation isolated session partition, so it does not share the system browser's GitHub cookies and may show a sign-in wall until you authenticate inside it. This is a known trade-off, not a regression — flagging for reviewer awareness.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

A screen recording of the in-app navigation is best captured in the running Electron shell against a live PR (steps above) and should be added before merge — it can't be captured in this headless environment.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New unit tests cover the renderer-side branch: with an embedded browser available, clicking the PR link calls the open-in-embedded-browser callback and renders the "Open in system browser" button; without one, the PR title stays a `target="_blank"` link and the button is absent. The native `WebContentsView` navigation itself (the Electron main-process side) is verified manually per the Test Plan, as it isn't reachable from jsdom.

## Changelog

GitHub tab PR links open in the app's embedded browser, with an option to open them in your system browser
