### PR TITLE
Require Otto approval after trusted bot pushes

### DIFF
--- a/.github/scripts/maintainer_approval.py
+++ b/.github/scripts/maintainer_approval.py
@@ -43,6 +43,7 @@ def approval_decision(
     head_sha: str,
     maintainers: set[str],
     trusted_authors: set[str],
+    trusted_approvers: set[str],
     trusted_successors: set[str],
     reviews: list[dict[str, Any]],
     commits: list[dict[str, Any]],
@@ -50,7 +51,7 @@ def approval_decision(
     timeline: list[dict[str, Any]] | None = None,
 ) -> ApprovalDecision:
     """
-    Accept trusted authors, current approval, or trusted successor pushes.
+    Accept trusted authors, current approval, or a trusted bot successor approval.
 
     ``pushers`` maps a commit SHA to the logins GitHub authenticated as pushing
     it. Commit author/committer logins are derived from the commit email, which
@@ -58,6 +59,7 @@ def approval_decision(
     """
     maintainers = {login.casefold() for login in maintainers}
     trusted_authors = {login.casefold() for login in trusted_authors}
+    trusted_approvers = {login.casefold() for login in trusted_approvers}
     trusted_successors = {login.casefold() for login in trusted_successors}
     if author.casefold() in maintainers:
         return ApprovalDecision(True, f"Author @{author} is a maintainer.")
@@ -66,6 +68,14 @@ def approval_decision(
 
     commit_positions = {
         str(commit.get("sha") or ""): index for index, commit in enumerate(commits)
+    }
+    current_bot_approvers = {
+        login
+        for login, review in latest_decisive_reviews(reviews).items()
+        if login.casefold() in trusted_approvers
+        and (review.get("user") or {}).get("type") == "Bot"
+        and str(review.get("state") or "").upper() == "APPROVED"
+        and str(review.get("commit_id") or "") == head_sha
     }
     failures: list[str] = []
     for login, review in latest_decisive_reviews(reviews).items():
@@ -124,10 +134,17 @@ def approval_decision(
         ):
             failures.append(f"@{login}'s approval was not auto-dismissed by trusted automation")
             continue
+        if not current_bot_approvers:
+            failures.append(
+                f"@{login} approved {approved_sha[:9]} before trusted automation updated "
+                f"the PR; awaiting Otto approval of {head_sha[:9]}"
+            )
+            continue
+        bot_names = ", ".join(f"@{name}" for name in sorted(current_bot_approvers))
         return ApprovalDecision(
             True,
-            f"Maintainer @{login} approved {approved_sha[:9]}; only trusted "
-            f"automation pushed and committed through {head_sha[:9]}.",
+            f"Maintainer @{login} approved {approved_sha[:9]}; {bot_names} approved "
+            f"the trusted automation changes at {head_sha[:9]}.",
         )
 
     reason = "; ".join(failures) if failures else "awaiting approval from a maintainer"
@@ -227,6 +244,7 @@ def main() -> int:
     parser.add_argument("--repository", required=True)
     parser.add_argument("--pr-number", type=int, required=True)
     parser.add_argument("--trusted-author", action="append", default=[])
+    parser.add_argument("--trusted-approver", action="append", default=[])
     parser.add_argument("--trusted-successor", action="append", default=[])
     args = parser.parse_args()
 
@@ -241,6 +259,7 @@ def main() -> int:
         head_sha=str((pull.get("head") or {}).get("sha") or ""),
         maintainers=maintainers(args.repository),
         trusted_authors=set(args.trusted_author),
+        trusted_approvers=set(args.trusted_approver),
         trusted_successors=set(args.trusted_successor),
         reviews=reviews,
         commits=commits,

--- a/.github/scripts/maintainer_approval_test.py
+++ b/.github/scripts/maintainer_approval_test.py
@@ -9,14 +9,25 @@ MAINTAINERS = {"maintainer"}
 TRUSTED = {"omni-resolve-agent[bot]"}
 
 
-def review(state: str, commit_id: str, *, submitted: str = "2026-09-01T00:00:00Z"):
+def review(
+    state: str,
+    commit_id: str,
+    *,
+    submitted: str = "2026-09-01T00:00:00Z",
+    login: str = "maintainer",
+    user_type: str = "User",
+):
     return {
         "id": 1,
         "state": state,
         "commit_id": commit_id,
         "submitted_at": submitted,
-        "user": {"login": "maintainer"},
+        "user": {"login": login, "type": user_type},
     }
+
+
+def bot_review(commit_id: str = "new", *, login: str = "omni-resolve-agent[bot]"):
+    return review("APPROVED", commit_id, login=login, user_type="Bot")
 
 
 def commit(sha: str, login: str = "omni-resolve-agent[bot]"):
@@ -63,6 +74,7 @@ def decide(
         head_sha=head,
         maintainers=MAINTAINERS,
         trusted_authors=TRUSTED,
+        trusted_approvers=TRUSTED,
         trusted_successors=TRUSTED,
         reviews=reviews,
         commits=commits,
@@ -89,21 +101,46 @@ def test_trusted_automation_author_passes_without_review():
 
 def test_approval_survives_trusted_same_repo_successor_commits():
     decision = decide(
-        reviews=[review("APPROVED", "old")],
+        reviews=[review("APPROVED", "old"), bot_review()],
         commits=[commit("old"), commit("new")],
     )
     assert decision.approved
-    assert "only trusted automation pushed and committed" in decision.reason
+    assert "omni-resolve-agent[bot]" in decision.reason
+
+
+def test_trusted_successors_require_a_current_otto_approval():
+    missing = decide(
+        reviews=[review("APPROVED", "old")],
+        commits=[commit("old"), commit("new")],
+    )
+    stale = decide(
+        reviews=[review("APPROVED", "old"), bot_review("old")],
+        commits=[commit("old"), commit("new")],
+    )
+    untrusted = decide(
+        reviews=[review("APPROVED", "old"), bot_review(login="other[bot]")],
+        commits=[commit("old"), commit("new")],
+    )
+    assert not missing.approved
+    assert not stale.approved
+    assert not untrusted.approved
+    assert "awaiting Otto approval" in missing.reason
+
+
+def test_otto_approval_without_a_human_predecessor_does_not_pass():
+    decision = decide(reviews=[bot_review()], commits=[commit("new")])
+    assert not decision.approved
+    assert "awaiting approval from a maintainer" in decision.reason
 
 
 def test_auto_dismissed_approval_survives_the_trusted_push_that_dismissed_it():
     decision = decide(
-        reviews=[review("DISMISSED", "old")],
+        reviews=[review("DISMISSED", "old"), bot_review()],
         commits=[commit("old"), commit("new")],
         timeline=[dismissal_event()],
     )
     assert decision.approved
-    assert "only trusted automation pushed and committed" in decision.reason
+    assert "omni-resolve-agent[bot]" in decision.reason
 
 
 def test_fork_head_requires_a_fresh_approval():
@@ -234,6 +271,7 @@ def test_maintainer_authored_pr_still_passes():
         head_sha="new",
         maintainers=MAINTAINERS,
         trusted_authors=TRUSTED,
+        trusted_approvers=TRUSTED,
         trusted_successors=TRUSTED,
         reviews=[],
         commits=[commit("new", "maintainer")],

--- a/.github/workflows/maintainer-approval.yml
+++ b/.github/workflows/maintainer-approval.yml
@@ -60,4 +60,5 @@ jobs:
             --repository "$REPO" \
             --pr-number "$PR" \
             --trusted-author 'omni-resolve-agent[bot]' \
+            --trusted-approver 'omni-resolve-agent[bot]' \
             --trusted-successor 'omni-resolve-agent[bot]'


### PR DESCRIPTION
## Related issue

N/A — Test / CI security hardening; no issue required.

## Summary

Depends on omnigent-ai/omnigent-internal#316 and must merge after it.

- Require a current-head approval from `omni-resolve-agent[bot]` when an earlier human approval is carried across trusted Otto-only pushes.
- Continue rejecting bot approval without a human predecessor, stale bot approval, untrusted bots, untrusted pushes, and fork-head carryover.
- Keep current human approvals and the existing trusted bot-author policy unchanged.

ELI5: the old human approval remains the authorization to let Otto work, while the new visible Otto review identifies who approved the code after Otto changed it.

```text
Human approves SHA A
        ↓
Otto pushes trusted SHA B
        ↓
Otto bot approves exact SHA B
        ↓
Maintainer Approval turns green
```

## Test Plan

- `uv run --no-sync pytest .github/scripts/maintainer_approval_test.py -q` — 17 passed.
- `pre-commit run --files .github/scripts/maintainer_approval.py .github/scripts/maintainer_approval_test.py .github/workflows/maintainer-approval.yml` — all applicable hooks passed.
- Confirmed the live `main` protection rule requires the custom `Maintainer Approval` check and has native required-review count set to zero.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover current, stale, missing, and untrusted bot reviews; missing human predecessors; trusted and untrusted pushes; forks; rewritten history; and review dismissal.