### PR TITLE
Resolve fork/triangular PRs in the GitHub tab's branch→PR lookup

### DIFF
--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -17,11 +17,14 @@ Design notes:
 - Only the on-demand per-file expand-context reader (:func:`github_file_diff`)
   still uses ``git show`` for full before/after content — a unified-diff blob
   can't drive the viewer's context expansion.
-- The branch→PR lookup resolves in one ``gh`` call: when the branch has an
-  upstream, ``gh pr list --head <pushed-ref>`` matches on the head ref name
-  alone, so it finds the PR whether the head is in the base repo or a fork —
-  unlike a bare ``gh pr view``, whose head-repo-owner guess misses fork heads.
-  A bare ``gh pr view`` is used only when there's no upstream to name the head.
+- The branch→PR lookup resolves in one ``gh`` call, picked by whether the pushed
+  ref (``branch.<name>.merge``) was renamed from the local branch — the mark of
+  a fork / triangular push (Databricks prefixes it with ``<user>/``). Renamed →
+  ``gh pr list --head <pushed-ref>``, which matches the head ref name alone and
+  so finds a fork head a bare ``gh pr view`` misses. Not renamed → a bare ``gh pr
+  view``, which is correct and more precise for same-repo branches and returns
+  nothing for a base branch like ``master`` (``gh pr list --head master`` would
+  wrongly match a stranger's PR whose head merely shares the name).
 - ``available: false`` payloads let the tab render a message ("gh not installed",
   "not a git repo") instead of surfacing an error.
 """
@@ -177,17 +180,14 @@ def _current_branch(root: str) -> str | None:
     return out.strip() or None
 
 
-def _pushed_head_ref(root: str) -> str | None:
-    """Return the current branch's pushed head ref name, or ``None``.
+def _pushed_head_ref(root: str, branch: str) -> str | None:
+    """Return ``branch``'s pushed head ref name, or ``None``.
 
     Reads the configured upstream (``branch.<name>.merge``), whose value is the
     ref that was actually pushed — which may carry a ``<user>/`` prefix under a
     fork / triangular push flow and so differ from the local branch name.
-    ``None`` when detached or with no upstream configured.
+    ``None`` with no upstream configured.
     """
-    branch = _current_branch(root)
-    if branch is None:
-        return None
     rc, out, _ = _git(["config", f"branch.{branch}.merge"], cwd=root)
     if rc != 0 or not out.strip():
         return None
@@ -197,19 +197,37 @@ def _pushed_head_ref(root: str) -> str | None:
 def _pr_view_json(root: str, fields: str) -> dict[str, Any] | None:
     """Return the branch's PR as a ``gh``-JSON object for ``fields``, or ``None``.
 
-    Resolves the PR in a single ``gh`` call. When the branch has an upstream,
-    ``gh pr list --head <pushed-ref>`` matches on the head ref name alone, so it
-    finds the PR whether the head is in the base repo or a fork — unlike a bare
-    ``gh pr view``, whose head-repo-owner guess misses fork heads. ``--state
-    all`` keeps merged/closed PRs visible, as a bare ``gh pr view`` would.
-    ``gh pr list --json`` accepts the same fields and its rows share the shape of
-    a ``gh pr view`` object, so the first row parses identically. Only with no
-    upstream to name the head does it fall back to a bare ``gh pr view``.
+    Resolves the PR in a single ``gh`` call, choosing the query from a cheap git
+    signal: whether the pushed ref (``branch.<name>.merge``) was *renamed* from
+    the local branch name. A fork / triangular push renames it (Databricks pushes
+    carry a ``<user>/`` prefix), and only then does a bare ``gh pr view`` miss the
+    PR — its head-repo-owner guess looks in the wrong place. There we resolve by
+    the pushed ref with ``gh pr list --head`` (``--json`` takes the same fields,
+    and a row shares the shape of a ``gh pr view`` object, so it parses
+    identically; ``--state all`` keeps merged/closed PRs visible).
+
+    Otherwise a bare ``gh pr view`` is correct and *more precise*: it resolves
+    same-repo and standard-fork PRs, and returns nothing for a base branch like
+    ``master``. Using ``gh pr list --head`` there would be wrong — it matches on
+    the head ref name alone, so on ``master`` it returns a stranger's unrelated
+    PR whose head merely happens to be named ``master``.
     """
-    head_ref = _pushed_head_ref(root)
-    if head_ref is not None:
+    branch = _current_branch(root)
+    pushed_ref = _pushed_head_ref(root, branch) if branch is not None else None
+    if pushed_ref is not None and pushed_ref != branch:
         rc, out, _ = _gh(
-            ["pr", "list", "--head", head_ref, "--state", "all", "--limit", "1", "--json", fields],
+            [
+                "pr",
+                "list",
+                "--head",
+                pushed_ref,
+                "--state",
+                "all",
+                "--limit",
+                "1",
+                "--json",
+                fields,
+            ],
             cwd=root,
         )
         if rc != 0:

--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -17,6 +17,10 @@ Design notes:
 - Only the on-demand per-file expand-context reader (:func:`github_file_diff`)
   still uses ``git show`` for full before/after content — a unified-diff blob
   can't drive the viewer's context expansion.
+- The branch→PR lookup tries a bare ``gh pr view`` first, then retries with the
+  head named explicitly as ``<owner>:<head-ref>`` when that finds nothing — the
+  fallback catches a PR whose head is a fork branch under a renamed ref, which a
+  bare ``gh pr view`` misses because it guesses the head repo owner.
 - ``available: false`` payloads let the tab render a message ("gh not installed",
   "not a git repo") instead of surfacing an error.
 """
@@ -26,6 +30,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -164,6 +169,80 @@ def _summarize_checks(rollup: Any) -> dict[str, Any]:
     }
 
 
+def _current_branch(root: str) -> str | None:
+    """Return the workspace's current branch name, or ``None`` (detached / not a repo)."""
+    rc, out, _ = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
+    if rc != 0:
+        return None
+    return out.strip() or None
+
+
+def _remote_owner(url: str) -> str | None:
+    """Parse ``<owner>`` from a GitHub remote URL (ssh scp-like, ``ssh://``, https)."""
+    # Strip the transport + host prefix, leaving ``<owner>/<repo>[.git]``.
+    path = re.sub(r"^(?:git@[^:]+:|ssh://[^/]+/|https?://[^/]+/)", "", url)
+    return path.split("/", 1)[0] or None
+
+
+def _pushed_pr_selector(root: str, branch: str) -> str | None:
+    """Build an ``<owner>:<head-ref>`` selector naming the branch's PR head.
+
+    A bare ``gh pr view`` guesses the head repo owner and so misses a PR whose
+    head is a fork branch under a renamed ref (the triangular push flow). Naming
+    the head explicitly bypasses the guess: the head ref is the configured
+    upstream (``branch.<name>.merge``) and the owner is the push remote's repo
+    owner — both exactly what was pushed. ``None`` if either can't be derived.
+    """
+    rc, merge, _ = _git(["config", f"branch.{branch}.merge"], cwd=root)
+    if rc != 0 or not merge.strip():
+        return None
+    head_ref = merge.strip().removeprefix("refs/heads/")
+
+    rc, remote, _ = _git(["config", f"branch.{branch}.remote"], cwd=root)
+    if rc != 0 or not remote.strip():
+        return None
+    rc, url, _ = _git(["remote", "get-url", remote.strip()], cwd=root)
+    if rc != 0 or not url.strip():
+        return None
+    owner = _remote_owner(url.strip())
+    return f"{owner}:{head_ref}" if owner else None
+
+
+def _loads_pr_object(out: str) -> dict[str, Any] | None:
+    """Parse ``gh pr view --json`` stdout into a PR object, or ``None``."""
+    try:
+        data = json.loads(out)
+    except ValueError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _pr_view_json(root: str, fields: str) -> dict[str, Any] | None:
+    """Return the branch's PR as a ``gh``-JSON object for ``fields``, or ``None``.
+
+    Tries a bare ``gh pr view`` first (its own branch→PR resolution). Only when
+    that finds nothing does it touch git and retry with the head named as
+    ``<owner>:<head-ref>`` (see :func:`_pushed_pr_selector`) — the bare form
+    guesses the head repo owner and so misses a PR whose head is a fork branch
+    under a renamed ref (the triangular push flow). Both forms return one PR
+    object, so the result parses identically.
+    """
+    rc, out, _ = _gh(["pr", "view", "--json", fields], cwd=root)
+    if rc == 0:
+        data = _loads_pr_object(out)
+        if data is not None:
+            return data
+
+    branch = _current_branch(root)
+    if branch is None:
+        return None
+    selector = _pushed_pr_selector(root, branch)
+    if selector is None:
+        return None
+    rc, out, _ = _gh(["pr", "view", selector, "--json", fields], cwd=root)
+    return _loads_pr_object(out) if rc == 0 else None
+
+
 def github_info(root: str) -> dict[str, Any]:
     """Resolve GitHub context for the workspace: repo, branch, base, and PR.
 
@@ -215,24 +294,20 @@ def github_info(root: str) -> dict[str, Any]:
             pass
 
     pr: dict[str, Any] | None = None
-    rc, out, _ = _gh(["pr", "view", "--json", _PR_VIEW_FIELDS], cwd=root)
-    if rc == 0:
-        try:
-            data = json.loads(out)
-            author = data.get("author")
-            pr = {
-                "number": data.get("number"),
-                "title": data.get("title"),
-                "state": data.get("state"),
-                "url": data.get("url"),
-                "is_draft": data.get("isDraft", False),
-                "author": author.get("login") if isinstance(author, dict) else None,
-                "base_ref": data.get("baseRefName"),
-                "head_ref": data.get("headRefName"),
-                "checks": _summarize_checks(data.get("statusCheckRollup")),
-            }
-        except (ValueError, AttributeError):
-            pr = None
+    data = _pr_view_json(root, _PR_VIEW_FIELDS)
+    if data is not None:
+        author = data.get("author")
+        pr = {
+            "number": data.get("number"),
+            "title": data.get("title"),
+            "state": data.get("state"),
+            "url": data.get("url"),
+            "is_draft": data.get("isDraft", False),
+            "author": author.get("login") if isinstance(author, dict) else None,
+            "base_ref": data.get("baseRefName"),
+            "head_ref": data.get("headRefName"),
+            "checks": _summarize_checks(data.get("statusCheckRollup")),
+        }
     payload["pr"] = pr
 
     # A pure PR view: the base is the PR's base branch, else null (no PR).
@@ -297,16 +372,13 @@ def _pr_number(root: str) -> int | None:
     """Return the PR number for the workspace's branch, or ``None``.
 
     :param root: Absolute workspace path.
-    :returns: The associated PR's number, or ``None`` when ``gh`` finds no PR
-        (none for the branch, ``gh`` missing, or not authenticated).
+    :returns: The associated PR's number, or ``None`` when no PR resolves (none
+        for the branch, ``gh`` missing, or not authenticated).
     """
-    rc, out, _ = _gh(["pr", "view", "--json", "number"], cwd=root)
-    if rc != 0:
+    data = _pr_view_json(root, "number")
+    if data is None:
         return None
-    try:
-        number = json.loads(out).get("number")
-    except (ValueError, AttributeError):
-        return None
+    number = data.get("number")
     return number if isinstance(number, int) else None
 
 

--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -17,10 +17,11 @@ Design notes:
 - Only the on-demand per-file expand-context reader (:func:`github_file_diff`)
   still uses ``git show`` for full before/after content — a unified-diff blob
   can't drive the viewer's context expansion.
-- The branch→PR lookup tries a bare ``gh pr view`` first, then retries with the
-  head named explicitly as ``<owner>:<head-ref>`` when that finds nothing — the
-  fallback catches a PR whose head is a fork branch under a renamed ref, which a
-  bare ``gh pr view`` misses because it guesses the head repo owner.
+- The branch→PR lookup resolves in one ``gh`` call: when the branch has an
+  upstream, ``gh pr list --head <pushed-ref>`` matches on the head ref name
+  alone, so it finds the PR whether the head is in the base repo or a fork —
+  unlike a bare ``gh pr view``, whose head-repo-owner guess misses fork heads.
+  A bare ``gh pr view`` is used only when there's no upstream to name the head.
 - ``available: false`` payloads let the tab render a message ("gh not installed",
   "not a git repo") instead of surfacing an error.
 """
@@ -30,7 +31,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -177,70 +177,59 @@ def _current_branch(root: str) -> str | None:
     return out.strip() or None
 
 
-def _remote_owner(url: str) -> str | None:
-    """Parse ``<owner>`` from a GitHub remote URL (ssh scp-like, ``ssh://``, https)."""
-    # Strip the transport + host prefix, leaving ``<owner>/<repo>[.git]``.
-    path = re.sub(r"^(?:git@[^:]+:|ssh://[^/]+/|https?://[^/]+/)", "", url)
-    return path.split("/", 1)[0] or None
+def _pushed_head_ref(root: str) -> str | None:
+    """Return the current branch's pushed head ref name, or ``None``.
 
-
-def _pushed_pr_selector(root: str, branch: str) -> str | None:
-    """Build an ``<owner>:<head-ref>`` selector naming the branch's PR head.
-
-    A bare ``gh pr view`` guesses the head repo owner and so misses a PR whose
-    head is a fork branch under a renamed ref (the triangular push flow). Naming
-    the head explicitly bypasses the guess: the head ref is the configured
-    upstream (``branch.<name>.merge``) and the owner is the push remote's repo
-    owner — both exactly what was pushed. ``None`` if either can't be derived.
+    Reads the configured upstream (``branch.<name>.merge``), whose value is the
+    ref that was actually pushed — which may carry a ``<user>/`` prefix under a
+    fork / triangular push flow and so differ from the local branch name.
+    ``None`` when detached or with no upstream configured.
     """
-    rc, merge, _ = _git(["config", f"branch.{branch}.merge"], cwd=root)
-    if rc != 0 or not merge.strip():
+    branch = _current_branch(root)
+    if branch is None:
         return None
-    head_ref = merge.strip().removeprefix("refs/heads/")
-
-    rc, remote, _ = _git(["config", f"branch.{branch}.remote"], cwd=root)
-    if rc != 0 or not remote.strip():
+    rc, out, _ = _git(["config", f"branch.{branch}.merge"], cwd=root)
+    if rc != 0 or not out.strip():
         return None
-    rc, url, _ = _git(["remote", "get-url", remote.strip()], cwd=root)
-    if rc != 0 or not url.strip():
-        return None
-    owner = _remote_owner(url.strip())
-    return f"{owner}:{head_ref}" if owner else None
-
-
-def _loads_pr_object(out: str) -> dict[str, Any] | None:
-    """Parse ``gh pr view --json`` stdout into a PR object, or ``None``."""
-    try:
-        data = json.loads(out)
-    except ValueError:
-        return None
-    return data if isinstance(data, dict) else None
+    return out.strip().removeprefix("refs/heads/") or None
 
 
 def _pr_view_json(root: str, fields: str) -> dict[str, Any] | None:
     """Return the branch's PR as a ``gh``-JSON object for ``fields``, or ``None``.
 
-    Tries a bare ``gh pr view`` first (its own branch→PR resolution). Only when
-    that finds nothing does it touch git and retry with the head named as
-    ``<owner>:<head-ref>`` (see :func:`_pushed_pr_selector`) — the bare form
-    guesses the head repo owner and so misses a PR whose head is a fork branch
-    under a renamed ref (the triangular push flow). Both forms return one PR
-    object, so the result parses identically.
+    Resolves the PR in a single ``gh`` call. When the branch has an upstream,
+    ``gh pr list --head <pushed-ref>`` matches on the head ref name alone, so it
+    finds the PR whether the head is in the base repo or a fork — unlike a bare
+    ``gh pr view``, whose head-repo-owner guess misses fork heads. ``--state
+    all`` keeps merged/closed PRs visible, as a bare ``gh pr view`` would.
+    ``gh pr list --json`` accepts the same fields and its rows share the shape of
+    a ``gh pr view`` object, so the first row parses identically. Only with no
+    upstream to name the head does it fall back to a bare ``gh pr view``.
     """
-    rc, out, _ = _gh(["pr", "view", "--json", fields], cwd=root)
-    if rc == 0:
-        data = _loads_pr_object(out)
-        if data is not None:
-            return data
+    head_ref = _pushed_head_ref(root)
+    if head_ref is not None:
+        rc, out, _ = _gh(
+            ["pr", "list", "--head", head_ref, "--state", "all", "--limit", "1", "--json", fields],
+            cwd=root,
+        )
+        if rc != 0:
+            return None
+        try:
+            rows = json.loads(out)
+        except ValueError:
+            return None
+        if isinstance(rows, list) and rows and isinstance(rows[0], dict):
+            return rows[0]
+        return None
 
-    branch = _current_branch(root)
-    if branch is None:
+    rc, out, _ = _gh(["pr", "view", "--json", fields], cwd=root)
+    if rc != 0:
         return None
-    selector = _pushed_pr_selector(root, branch)
-    if selector is None:
+    try:
+        data = json.loads(out)
+    except ValueError:
         return None
-    rc, out, _ = _gh(["pr", "view", selector, "--json", fields], cwd=root)
-    return _loads_pr_object(out) if rc == 0 else None
+    return data if isinstance(data, dict) else None
 
 
 def github_info(root: str) -> dict[str, Any]:

--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -458,13 +458,19 @@ def github_file_diff(root: str, base: str, path: str) -> dict[str, Any]:
 def github_pr_diff(root: str) -> dict[str, Any]:
     """Return the whole PR as one unified diff patch, straight from GitHub.
 
-    ``gh pr diff`` yields the PR's "Files changed" patch (server-computed against
-    the base's merge-base), which the web view parses client-side into per-file
-    diffs. Empty when the branch has no PR.
+    ``gh pr diff <number>`` yields the PR's "Files changed" patch (server-computed
+    against the base's merge-base), which the web view parses client-side into
+    per-file diffs. The PR is resolved by number first (via :func:`_pr_number`,
+    which handles fork / triangular heads a bare ``gh pr diff`` can't); empty when
+    the branch has no PR.
 
     :param root: Absolute workspace path.
     :returns: A ``session.github.pr_diff`` object with the ``patch`` text
         (empty when there's no PR / no changes).
     """
-    rc, out, _ = _gh(["pr", "diff"], cwd=root)
+    empty: dict[str, Any] = {"object": "session.github.pr_diff", "patch": ""}
+    number = _pr_number(root)
+    if number is None:
+        return empty
+    rc, out, _ = _gh(["pr", "diff", str(number)], cwd=root)
     return {"object": "session.github.pr_diff", "patch": out if rc == 0 else ""}

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -61,14 +61,12 @@ def _run(argv: list[str], cwd: Path) -> None:
     subprocess.run(argv, cwd=cwd, check=True, capture_output=True, env=_git_env())
 
 
-def _set_fork_push(repo: Path, *, owner: str, head_ref: str, remote: str = "origin") -> None:
-    """Mark the ``feature`` branch as pushed to ``owner``'s fork under ``head_ref``.
+def _set_pushed_ref(repo: Path, head_ref: str) -> None:
+    """Give the ``feature`` branch an upstream whose pushed ref is ``head_ref``.
 
-    Mirrors a triangular / fork push: an upstream (``branch.feature.merge``) whose
-    ref differs from the local name, tracking a remote whose URL owner is ``owner``.
+    Mirrors a fork / triangular push, where the pushed ref (``branch.feature.merge``)
+    differs from the local branch name.
     """
-    _run(["git", "remote", "add", remote, f"git@github.com:{owner}/repo.git"], repo)
-    _run(["git", "config", "branch.feature.remote", remote], repo)
     _run(["git", "config", "branch.feature.merge", f"refs/heads/{head_ref}"], repo)
 
 
@@ -121,21 +119,14 @@ def test_github_info_not_a_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert info["reason"] == "not_a_git_repo"
 
 
-def _is_bare_pr_view(argv: Sequence[str]) -> bool:
-    """True for ``gh pr view --json …`` (no selector), False for ``… <selector> --json``."""
-    return tuple(argv[:2]) == ("pr", "view") and (len(argv) <= 2 or argv[2] == "--json")
+def test_github_info_pr_via_pr_list_head(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The PR resolves in one ``gh pr list --head`` call keyed by the pushed ref.
 
-
-def test_github_info_pr_fallback_via_owner_head_selector(
-    repo: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A PR a bare ``gh pr view`` can't resolve is recovered via ``<owner>:<head-ref>``.
-
-    In a fork / triangular flow the head is ``acme:alice/feature`` — owner from
-    the push remote's URL, head ref from ``branch.<n>.merge`` — both differing
-    from the checkout's ``feature``, so the retry must name the head from those.
+    In a fork / triangular flow the pushed ref (``alice/feature``, from
+    ``branch.<n>.merge``) differs from the checkout's ``feature``; ``--head``
+    matches on the ref name alone, finding a PR a bare ``gh pr view`` would miss.
     """
-    _set_fork_push(repo, owner="acme", head_ref="alice/feature")
+    _set_pushed_ref(repo, "alice/feature")
     pr = {
         "number": 42,
         "title": "Add thing",
@@ -156,9 +147,8 @@ def test_github_info_pr_fallback_via_owner_head_selector(
             return (0, "", "")
         if head == ("repo", "view"):
             return (0, json.dumps({"nameWithOwner": "acme/repo"}), "")
-        if head == ("pr", "view"):
-            # The bare form finds nothing; the explicit selector resolves the PR.
-            return (1, "", "not found") if _is_bare_pr_view(argv) else (0, json.dumps(pr), "")
+        if head == ("pr", "list"):
+            return (0, json.dumps([pr]), "")
         return (1, "", "no stub")
 
     monkeypatch.setattr(github_resource, "_gh", fake_gh)
@@ -169,15 +159,20 @@ def test_github_info_pr_fallback_via_owner_head_selector(
     assert info["pr"]["head_ref"] == "alice/feature"
     assert info["pr"]["is_draft"] is True
     assert info["base_ref"] == "main"
-    # The retry named the head as <push-remote-owner>:<upstream-ref>.
-    selectors = [c[2] for c in calls if not _is_bare_pr_view(c) and c[:2] == ("pr", "view")]
-    assert selectors == ["acme:alice/feature"]
+    # One resolve call: gh pr list --head <pushed ref> --state all, no gh pr view.
+    list_calls = [c for c in calls if c[:2] == ("pr", "list")]
+    assert len(list_calls) == 1
+    args = list_calls[0]
+    assert args[args.index("--head") + 1] == "alice/feature"
+    assert args[args.index("--state") + 1] == "all"
+    assert not any(c[:2] == ("pr", "view") for c in calls)
 
 
-def test_github_info_pr_view_hit_skips_fallback(
+def test_github_info_pr_no_upstream_uses_pr_view(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When the bare ``gh pr view`` resolves the PR, no ``<owner>:<head-ref>`` retry runs."""
+    """With no upstream to name the head, fall back to a bare ``gh pr view``."""
+    # The fixture's `feature` branch has no configured upstream.
     view = {
         "number": 5,
         "title": "t",
@@ -207,29 +202,25 @@ def test_github_info_pr_view_hit_skips_fallback(
 
     info = github_info(str(repo))
     assert info["pr"]["number"] == 5
-    # Only the bare form ran; no explicit-selector retry.
-    assert all(_is_bare_pr_view(c) for c in calls if c[:2] == ("pr", "view"))
+    # No upstream → bare gh pr view, never gh pr list.
+    assert any(c[:2] == ("pr", "view") for c in calls)
+    assert not any(c[:2] == ("pr", "list") for c in calls)
 
 
-def test_github_changed_files_fallback_via_owner_head_selector(
+def test_github_changed_files_via_pr_list_head(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The changed-files list resolves a PR the bare ``gh pr view`` misses.
+    """The changed-files list resolves the PR number via ``gh pr list --head`` too.
 
-    Exercises the second call site (:func:`_pr_number`): the bare view finds
-    nothing, the ``<owner>:<head-ref>`` retry supplies the number, and the files
-    fetch runs.
+    Exercises the second call site (:func:`_pr_number`): ``gh pr list --head``
+    supplies the number, then the files fetch runs.
     """
-    _set_fork_push(repo, owner="acme", head_ref="alice/feature")
+    _set_pushed_ref(repo, "alice/feature")
     files = [{"filename": "a.py", "status": "added", "additions": 1, "deletions": 0}]
 
     def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
-        if tuple(argv[:2]) == ("pr", "view"):
-            return (
-                (1, "", "not found")
-                if _is_bare_pr_view(argv)
-                else (0, json.dumps({"number": 9}), "")
-            )
+        if tuple(argv[:2]) == ("pr", "list"):
+            return (0, json.dumps([{"number": 9}]), "")
         if argv and argv[0] == "api":
             return (0, json.dumps(files), "")
         return (1, "", "no stub")

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -290,16 +290,49 @@ def test_github_changed_files_no_pr(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_github_pr_diff_returns_gh_patch(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The whole-PR patch is ``gh pr diff`` verbatim (GitHub-computed)."""
+    """The whole-PR patch is ``gh pr diff <number>`` verbatim (GitHub-computed)."""
     patch = "diff --git a/fileA.py b/fileA.py\n@@ -1 +1 @@\n-A base\n+A changed\n"
-    _stub_gh(monkeypatch, {("pr", "diff"): (0, patch, "")})
+    _stub_gh(
+        monkeypatch,
+        {
+            ("pr", "view"): (0, json.dumps({"number": 7}), ""),
+            ("pr", "diff"): (0, patch, ""),
+        },
+    )
     assert github_pr_diff("/root") == {"object": "session.github.pr_diff", "patch": patch}
 
 
 def test_github_pr_diff_no_pr(monkeypatch: pytest.MonkeyPatch) -> None:
     """With no PR for the branch, the patch is empty rather than an error."""
-    _stub_gh(monkeypatch, {("pr", "diff"): (1, "", "no pull requests found")})
+    _stub_gh(monkeypatch, {("pr", "view"): (1, "", "no pull requests found")})
     assert github_pr_diff("/root") == {"object": "session.github.pr_diff", "patch": ""}
+
+
+def test_github_pr_diff_via_pr_list_head(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole-PR diff resolves the PR number via ``gh pr list --head``, then diffs it.
+
+    Mirrors the fork / triangular case: a bare ``gh pr diff`` can't resolve the
+    head, so the number is resolved by the pushed ref (``branch.<n>.merge``) and
+    passed to ``gh pr diff <number>``.
+    """
+    _set_pushed_ref(repo, "alice/feature")
+    patch = "diff --git a/a.py b/a.py\n@@ -1 +1 @@\n-x\n+y\n"
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        head = tuple(argv[:2])
+        if head == ("pr", "list"):
+            return (0, json.dumps([{"number": 9}]), "")
+        if head == ("pr", "diff"):
+            return (0, patch, "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    result = github_pr_diff(str(repo))
+    assert result == {"object": "session.github.pr_diff", "patch": patch}
+    # The diff was fetched by the resolved number, never a bare 'gh pr diff'.
+    assert [c for c in calls if c[:2] == ("pr", "diff")] == [("pr", "diff", "9")]
 
 
 def test_summarize_checks_mixed() -> None:

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -61,6 +61,17 @@ def _run(argv: list[str], cwd: Path) -> None:
     subprocess.run(argv, cwd=cwd, check=True, capture_output=True, env=_git_env())
 
 
+def _set_fork_push(repo: Path, *, owner: str, head_ref: str, remote: str = "origin") -> None:
+    """Mark the ``feature`` branch as pushed to ``owner``'s fork under ``head_ref``.
+
+    Mirrors a triangular / fork push: an upstream (``branch.feature.merge``) whose
+    ref differs from the local name, tracking a remote whose URL owner is ``owner``.
+    """
+    _run(["git", "remote", "add", remote, f"git@github.com:{owner}/repo.git"], repo)
+    _run(["git", "config", "branch.feature.remote", remote], repo)
+    _run(["git", "config", "branch.feature.merge", f"refs/heads/{head_ref}"], repo)
+
+
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
     """A repo with a ``main`` base and a ``feature`` branch that adds/edits/deletes.
@@ -108,6 +119,124 @@ def test_github_info_not_a_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     info = github_info(str(tmp_path))
     assert info["available"] is False
     assert info["reason"] == "not_a_git_repo"
+
+
+def _is_bare_pr_view(argv: Sequence[str]) -> bool:
+    """True for ``gh pr view --json …`` (no selector), False for ``… <selector> --json``."""
+    return tuple(argv[:2]) == ("pr", "view") and (len(argv) <= 2 or argv[2] == "--json")
+
+
+def test_github_info_pr_fallback_via_owner_head_selector(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A PR a bare ``gh pr view`` can't resolve is recovered via ``<owner>:<head-ref>``.
+
+    In a fork / triangular flow the head is ``acme:alice/feature`` — owner from
+    the push remote's URL, head ref from ``branch.<n>.merge`` — both differing
+    from the checkout's ``feature``, so the retry must name the head from those.
+    """
+    _set_fork_push(repo, owner="acme", head_ref="alice/feature")
+    pr = {
+        "number": 42,
+        "title": "Add thing",
+        "state": "OPEN",
+        "url": "https://github.com/acme/repo/pull/42",
+        "isDraft": True,
+        "author": {"login": "alice"},
+        "baseRefName": "main",
+        "headRefName": "alice/feature",
+        "statusCheckRollup": [],
+    }
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        head = tuple(argv[:2])
+        if head == ("auth", "status"):
+            return (0, "", "")
+        if head == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "acme/repo"}), "")
+        if head == ("pr", "view"):
+            # The bare form finds nothing; the explicit selector resolves the PR.
+            return (1, "", "not found") if _is_bare_pr_view(argv) else (0, json.dumps(pr), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"]["number"] == 42
+    assert info["pr"]["head_ref"] == "alice/feature"
+    assert info["pr"]["is_draft"] is True
+    assert info["base_ref"] == "main"
+    # The retry named the head as <push-remote-owner>:<upstream-ref>.
+    selectors = [c[2] for c in calls if not _is_bare_pr_view(c) and c[:2] == ("pr", "view")]
+    assert selectors == ["acme:alice/feature"]
+
+
+def test_github_info_pr_view_hit_skips_fallback(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the bare ``gh pr view`` resolves the PR, no ``<owner>:<head-ref>`` retry runs."""
+    view = {
+        "number": 5,
+        "title": "t",
+        "state": "OPEN",
+        "url": "u",
+        "isDraft": False,
+        "author": {"login": "a"},
+        "baseRefName": "main",
+        "headRefName": "feature",
+        "statusCheckRollup": [],
+    }
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        head = tuple(argv[:2])
+        if head == ("auth", "status"):
+            return (0, "", "")
+        if head == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "o/r"}), "")
+        if head == ("pr", "view"):
+            return (0, json.dumps(view), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"]["number"] == 5
+    # Only the bare form ran; no explicit-selector retry.
+    assert all(_is_bare_pr_view(c) for c in calls if c[:2] == ("pr", "view"))
+
+
+def test_github_changed_files_fallback_via_owner_head_selector(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The changed-files list resolves a PR the bare ``gh pr view`` misses.
+
+    Exercises the second call site (:func:`_pr_number`): the bare view finds
+    nothing, the ``<owner>:<head-ref>`` retry supplies the number, and the files
+    fetch runs.
+    """
+    _set_fork_push(repo, owner="acme", head_ref="alice/feature")
+    files = [{"filename": "a.py", "status": "added", "additions": 1, "deletions": 0}]
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        if tuple(argv[:2]) == ("pr", "view"):
+            return (
+                (1, "", "not found")
+                if _is_bare_pr_view(argv)
+                else (0, json.dumps({"number": 9}), "")
+            )
+        if argv and argv[0] == "api":
+            return (0, json.dumps(files), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    result = github_changed_files(str(repo))
+    assert [entry["path"] for entry in result["data"]] == ["a.py"]
 
 
 def test_github_changed_files_maps_pr_file_statuses(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -207,6 +207,42 @@ def test_github_info_pr_no_upstream_uses_pr_view(
     assert not any(c[:2] == ("pr", "list") for c in calls)
 
 
+def test_github_info_pushed_ref_matches_branch_uses_pr_view_not_list(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A branch pushed under its own name resolves via bare ``gh pr view``, not list.
+
+    Regression: on a base branch like ``master`` the pushed ref equals the local
+    name, so a bare ``gh pr view`` (which correctly finds no PR) must be used.
+    ``gh pr list --head`` matches the ref name alone and would return a
+    stranger's unrelated PR whose head merely shares the name — a false positive.
+    """
+    _set_pushed_ref(repo, "feature")  # pushed ref == local branch name
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        head = tuple(argv[:2])
+        if head == ("auth", "status"):
+            return (0, "", "")
+        if head == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "o/r"}), "")
+        if head == ("pr", "view"):
+            return (1, "", "no pull requests found for branch")
+        if head == ("pr", "list"):
+            # A stranger's PR sharing the ref name — must never be consulted here.
+            return (0, json.dumps([{"number": 999, "headRefName": "feature"}]), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"] is None
+    assert info["base_ref"] is None
+    assert not any(c[:2] == ("pr", "list") for c in calls)
+
+
 def test_github_changed_files_via_pr_list_head(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -429,12 +429,14 @@ def test_github_file_diff_returns_before_after(tmp_path: Path) -> None:
 
 
 def test_github_pr_diff_returns_whole_patch(tmp_path: Path, monkeypatch) -> None:
-    """``github_pr_diff`` delegates to ``gh pr diff``."""
+    """``github_pr_diff`` resolves the PR number, then delegates to ``gh pr diff <n>``."""
     from omnigent import workspace_fs
 
     _git_branch_repo(tmp_path)
 
     def fake_gh(argv, *, cwd):
+        if tuple(argv[:2]) == ("pr", "view"):
+            return (0, '{"number": 3}', "")
         if tuple(argv[:2]) == ("pr", "diff"):
             return (0, "diff --git a/app.txt b/app.txt\n+changed\n", "")
         return (1, "", "")


### PR DESCRIPTION
## Related issue

Closes #

_No issue linked yet — omnigent requires one for `Bug fix` PRs. Please link the tracking issue (or I can open one)._

## Summary

The GitHub-tab runner (`omnigent/runner/github_resource.py`) resolved the workspace branch's PR with bare `gh pr view` / `gh pr diff`. Those guess the head repository owner from local git config, so they find **nothing** when the branch was pushed to a fork under a renamed ref (the triangular push flow) — the tab then shows its "no PR" empty state (and an empty diff) even though an open PR exists.

The lookup now chooses its query from a cheap git signal — whether the pushed ref (`branch.<name>.merge`) was **renamed** from the local branch name:

- **Renamed** (fork / triangular push; Databricks prefixes the ref with `<user>/`) → resolve by the pushed ref with `gh pr list --head <ref> --state all --limit 1`. `--head` matches on the ref name alone, so it finds the fork head a bare `gh pr view` misses. `gh pr list --json` returns the same fields as `gh pr view` (including `statusCheckRollup`), so callers parse the first row identically — no follow-up detail fetch.
- **Not renamed** (same-repo branch, standard fork, or a base branch like `master`) → a bare `gh pr view`, which is correct and more precise here. This is important: `gh pr list --head` matches the ref name alone, so on `master` it would wrongly return a stranger's unrelated PR whose head merely happens to be named `master` — a false positive. A bare `gh pr view` correctly finds no PR there.

Both PR-resolution call sites (`github_info` for the PR summary, `_pr_number` for the changed-files / diff fetch) share one helper, and it's still one `gh` call per lookup.

**Whole-PR diff (`/resources/github/diff`):** `github_pr_diff` used a bare `gh pr diff` with the same fork blind spot. It now resolves the PR number first (via `_pr_number`) and passes it to `gh pr diff <number>`, mirroring how `github_changed_files` resolves.

**ELI5:** the tab asks GitHub "what PR is this branch?" A bare `gh pr view`/`gh pr diff` guesses wrong when the branch was pushed to a fork with a renamed branch. For those we look the PR up by its pushed branch name; for ordinary branches we keep the precise bare lookup, so a base branch like `master` doesn't accidentally match someone else's PR.

## Test Plan

- `uv run pytest tests/runner/test_github_resource.py` — 16 pass (11 existing + 5 new): the fork/triangular case resolves via `gh pr list --head <pushed-ref> --state all` (asserts no `gh pr view`); a branch pushed under its own name (e.g. `master`) uses a bare `gh pr view` and never `gh pr list` (regression guard against the false positive); the no-upstream case uses a bare `gh pr view`; the changed-files and whole-PR-diff call sites resolve the same way (diff via `gh pr diff <number>`).
- Manual against real checkouts: on `~/universe` (`master`) a bare `gh pr view` prints "no pull requests found", while `gh pr list --head master --state all` returns an unrelated closed PR — confirming why the base-branch path must use `gh pr view`. On a fork/triangular checkout (a `git pp` / stacked branch) a bare `gh pr diff` prints "no pull requests found for branch …", while resolving the number and running `gh pr diff <number>` returns the patch. In the GitHub tab: before — fork PRs showed "no PR"/empty diff, and `master` showed a phantom PR; after — fork PRs render summary + files + diff, and `master` shows no PR.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests in `tests/runner/test_github_resource.py` cover all three call sites (`github_info`, `github_changed_files`/`_pr_number`, `github_pr_diff`) across the renamed-ref (fork), same-name (base-branch regression), and no-upstream paths.

## Changelog

The workspace GitHub tab now finds a branch's PR — summary, changed files, and diff — when the branch was pushed to a fork under a renamed ref, and no longer shows a phantom PR on base branches like `master`.

---

This pull request and its description were written by Isaac.
