### PR TITLE
fix(host): prefer the user profile over an M2M service principal for host auth

### DIFF
--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -834,29 +834,38 @@ def _read_databrickscfg_no_inheritance() -> configparser.ConfigParser | None:
 def _section_is_service_principal(options: configparser.SectionProxy) -> bool:
     """Whether a ``~/.databrickscfg`` section holds M2M service-principal creds.
 
-    A section is a service principal when it carries client credentials —
-    the generic ``client_id`` + ``client_secret`` or the Azure
-    ``azure_client_id`` + ``azure_client_secret`` pair — (or an explicit
-    machine ``auth_type`` such as ``oauth-m2m``) and no user-interactive
-    ``auth_type`` overrides that.
+    A section is a service principal when it names a machine (M2M)
+    ``auth_type`` — the OAuth-M2M/Azure secret and federated-OIDC flows —
+    or carries client credentials (the generic ``client_id`` +
+    ``client_secret`` or the Azure ``azure_client_id`` +
+    ``azure_client_secret`` pair), and no user-interactive ``auth_type``
+    overrides that.
 
     :param options: The section mapping (a ``ConfigParser`` section).
     :returns: ``True`` when the section is an M2M service principal.
     """
-    # auth_type literals mirror the databricks-sdk's known types. A future SDK
-    # auth type not listed here falls through to the client-credentials
-    # heuristic below, which still catches M2M SP sections.
+    # auth_type literals mirror the databricks-sdk's known types. Interactive
+    # (user) types short-circuit to non-SP; the machine set covers M2M secret
+    # and federated-OIDC flows (which carry no client_secret pair, so the
+    # heuristic below would miss them). A future SDK machine type not listed
+    # still falls through to the client-credentials heuristic.
     user_auth_types = {"databricks-cli", "external-browser", "pat", "runtime"}
+    machine_auth_types = {
+        "oauth-m2m",
+        "azure-client-secret",
+        "github-oidc",
+        "github-oidc-azure",
+        "env-oidc",
+        "file-oidc",
+        "azure-devops-oidc",
+    }
     auth_type = options.get("auth_type", "").strip().lower()
     if auth_type in user_auth_types:
         return False
     has_client_secret_pair = ("client_id" in options and "client_secret" in options) or (
         "azure_client_id" in options and "azure_client_secret" in options
     )
-    return (
-        auth_type in {"oauth-m2m", "azure-client-secret", "github-oidc-azure"}
-        or has_client_secret_pair
-    )
+    return auth_type in machine_auth_types or has_client_secret_pair
 
 
 def _databrickscfg_host_matches_and_sp_sections(host: str) -> tuple[list[str], set[str]]:
@@ -897,8 +906,11 @@ def _databrickscfg_host_matches_and_sp_sections(host: str) -> tuple[list[str], s
             # Ordered last, below, to mirror the file-order walk that keeps
             # [DEFAULT] a fallback behind named sections.
             continue
-        # A named section with no host of its own inherits [DEFAULT]'s host.
-        section_host = options.get("host", "") or default_host
+        # A named section with no host *key* of its own inherits [DEFAULT]'s
+        # host. Key-presence (not truthiness): an explicit ``host =`` (empty)
+        # overrides inheritance to no host, matching ConfigParser semantics —
+        # so an empty host does not fall back and does not match.
+        section_host = options.get("host", default_host)
         if _norm(section_host) == wanted:
             matches.append(section)
     if default_host and _norm(default_host) == wanted:

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -32,6 +32,8 @@ import httpx
 from omnigent.models import model_catalog
 
 if TYPE_CHECKING:
+    import configparser
+
     from openai import OpenAI, Stream
     from openai.types.chat import ChatCompletionChunk
 
@@ -733,6 +735,13 @@ def _resolve_databricks_auth_for_host(host: str) -> tuple[_DatabricksBearerAuth,
     exactly the requested host. The host-keyed ``databricks-cli``
     lookup remains as the last resort for cfg-less setups.
 
+    When several profiles match the host, they are tried in identity
+    preference order (see :func:`_order_profiles_by_identity_preference`):
+    the ``DATABRICKS_CONFIG_PROFILE`` profile first, then user (U2M)
+    profiles, then M2M service-principal profiles — so a machine with
+    both a user login and an SP for the same workspace authenticates
+    as the person, not the service principal.
+
     :param host: Workspace host, e.g.
         ``"https://example.databricks.com"``.
     :returns: ``(auth, host)`` — an httpx Auth and the workspace URL.
@@ -743,7 +752,15 @@ def _resolve_databricks_auth_for_host(host: str) -> tuple[_DatabricksBearerAuth,
         f"Databricks authentication failed for workspace {host}. "
         f"Run: databricks auth login --host {host}"
     )
-    for profile_name in _databrickscfg_profiles_for_host(host):
+    # One parse of ~/.databrickscfg yields both the host-matching profiles and
+    # which of them are service principals; ordering then works off those sets.
+    matches, sp_sections = _databrickscfg_host_matches_and_sp_sections(host)
+    # User profiles that matched the host but failed to authenticate (e.g. an
+    # expired OAuth grant). Tracked so we can warn if a lower-priority service
+    # principal is then selected — otherwise the host would silently register
+    # under the SP again, the exact wrong-identity symptom the ordering fixes.
+    failed_user_profiles: list[str] = []
+    for profile_name in _order_profiles_by_identity_preference(matches, sp_sections):
         try:
             cfg = _sdk_config(profile=profile_name)
             cfg.authenticate()
@@ -762,7 +779,22 @@ def _resolve_databricks_auth_for_host(host: str) -> tuple[_DatabricksBearerAuth,
                     profile_name,
                     host,
                 )
+                if profile_name not in sp_sections:
+                    failed_user_profiles.append(profile_name)
                 continue
+        if profile_name in sp_sections and failed_user_profiles:
+            logger.warning(
+                "Authenticating to %s as service principal %r because "
+                "your user profile(s) %s matched the host but failed to "
+                "authenticate (likely an expired login). This host will "
+                "register under the service principal, not you — run "
+                "`databricks auth login --host %s` (or pass the right "
+                "profile) to re-authenticate as yourself.",
+                host,
+                profile_name,
+                ", ".join(repr(p) for p in failed_user_profiles),
+                host,
+            )
         return _DatabricksBearerAuth(cfg, profile_name=profile_name), cfg.host or host
     try:
         host_cfg = _sdk_config(host=host, auth_type="databricks-cli")
@@ -772,12 +804,146 @@ def _resolve_databricks_auth_for_host(host: str) -> tuple[_DatabricksBearerAuth,
     return _DatabricksBearerAuth(host_cfg, failure_message=host_failure), host
 
 
+# Sentinel default_section: keeps [DEFAULT] a plain section carrying only its
+# own keys (no inheritance in either direction), so a [DEFAULT] user profile's
+# ``auth_type = databricks-cli`` cannot smear onto named SP sections and
+# misclassify them as user profiles.
+_NO_DEFAULT_INHERITANCE = "@omnigent-no-default-inheritance@"
+
+
+def _read_databrickscfg_no_inheritance() -> configparser.ConfigParser | None:
+    """Parse ``~/.databrickscfg`` with default-section inheritance disabled.
+
+    :returns: A ``ConfigParser`` whose ``[DEFAULT]`` is a plain section, or
+        ``None`` when the config file is missing or unparseable.
+    """
+    import configparser
+    from pathlib import Path
+
+    cfg_path = Path(os.environ.get("DATABRICKS_CONFIG_FILE") or (Path.home() / ".databrickscfg"))
+    if not cfg_path.exists():
+        return None
+    config = configparser.ConfigParser(default_section=_NO_DEFAULT_INHERITANCE)
+    try:
+        config.read(cfg_path)
+    except configparser.Error:
+        return None
+    return config
+
+
+def _section_is_service_principal(options: configparser.SectionProxy) -> bool:
+    """Whether a ``~/.databrickscfg`` section holds M2M service-principal creds.
+
+    A section is a service principal when it carries client credentials —
+    the generic ``client_id`` + ``client_secret`` or the Azure
+    ``azure_client_id`` + ``azure_client_secret`` pair — (or an explicit
+    machine ``auth_type`` such as ``oauth-m2m``) and no user-interactive
+    ``auth_type`` overrides that.
+
+    :param options: The section mapping (a ``ConfigParser`` section).
+    :returns: ``True`` when the section is an M2M service principal.
+    """
+    # auth_type literals mirror the databricks-sdk's known types. A future SDK
+    # auth type not listed here falls through to the client-credentials
+    # heuristic below, which still catches M2M SP sections.
+    user_auth_types = {"databricks-cli", "external-browser", "pat", "runtime"}
+    auth_type = options.get("auth_type", "").strip().lower()
+    if auth_type in user_auth_types:
+        return False
+    has_client_secret_pair = ("client_id" in options and "client_secret" in options) or (
+        "azure_client_id" in options and "azure_client_secret" in options
+    )
+    return (
+        auth_type in {"oauth-m2m", "azure-client-secret", "github-oidc-azure"}
+        or has_client_secret_pair
+    )
+
+
+def _databrickscfg_host_matches_and_sp_sections(host: str) -> tuple[list[str], set[str]]:
+    """Host-matching profiles and which of them are service principals.
+
+    Parses ``~/.databrickscfg`` once and derives both, so the resolver
+    doesn't read the file twice per credential resolution. Host matching
+    still honours ``[DEFAULT]`` inheritance (a named section with no ``host``
+    of its own inherits the default's), replicated here on the
+    no-inheritance parse so SP classification is not polluted.
+
+    :param host: Workspace host to match, e.g.
+        ``"https://example.databricks.com"``.
+    :returns: ``(matches, sp_sections)`` — matching section names in file
+        order (``"DEFAULT"`` included when it carries a matching host) and
+        the subset of *all* section names that are service principals.
+        ``([], set())`` when the file is missing or unparseable.
+    """
+
+    def _norm(value: str) -> str:
+        value = value.strip().rstrip("/")
+        return value.split("://", 1)[-1].lower()
+
+    config = _read_databrickscfg_no_inheritance()
+    if config is None:
+        return [], set()
+    wanted = _norm(host)
+    # With the sentinel default_section, the file's [DEFAULT] is a plain
+    # section named "DEFAULT"; its host is what named sections inherit.
+    default_host = config["DEFAULT"].get("host", "") if config.has_section("DEFAULT") else ""
+    matches: list[str] = []
+    sp_sections: set[str] = set()
+    for section in config.sections():
+        options = config[section]
+        if _section_is_service_principal(options):
+            sp_sections.add(section)
+        if section == "DEFAULT":
+            # Ordered last, below, to mirror the file-order walk that keeps
+            # [DEFAULT] a fallback behind named sections.
+            continue
+        # A named section with no host of its own inherits [DEFAULT]'s host.
+        section_host = options.get("host", "") or default_host
+        if _norm(section_host) == wanted:
+            matches.append(section)
+    if default_host and _norm(default_host) == wanted:
+        matches.append("DEFAULT")
+    return matches, sp_sections
+
+
+def _order_profiles_by_identity_preference(matches: list[str], sp_sections: set[str]) -> list[str]:
+    """Order host-matching profiles by identity preference.
+
+    File order is identity-blind: an M2M service-principal section listed
+    before the user's ``[DEFAULT]`` (U2M) section always wins a
+    first-successful-auth walk, because static client credentials never
+    fail to mint. On a machine holding both identities for one workspace
+    the host would then silently register as the service principal — a
+    different account from the signed-in app user, so the user sees no
+    live host. Order by intent instead:
+
+    1. The ``DATABRICKS_CONFIG_PROFILE`` profile, when it matches — an
+       explicit selection always wins (even naming an SP profile).
+    2. User (U2M / PAT) profiles, in file order.
+    3. M2M service-principal profiles, in file order — still reachable
+       when they are the only credential for the host.
+
+    :param matches: Host-matching profile names, in file order.
+    :param sp_sections: Section names classified as service principals.
+    :returns: The matching profile names, most-preferred first.
+    """
+    if len(matches) < 2:
+        return matches
+    env_profile = (os.environ.get("DATABRICKS_CONFIG_PROFILE") or "").strip()
+    explicit = [name for name in matches if name == env_profile]
+    users = [name for name in matches if name != env_profile and name not in sp_sections]
+    sps = [name for name in matches if name != env_profile and name in sp_sections]
+    return explicit + users + sps
+
+
 def _databrickscfg_profiles_for_host(host: str) -> list[str]:
     """List ``~/.databrickscfg`` profile names whose ``host`` is *host*.
 
     Comparison is scheme-insensitive and ignores trailing slashes, so
     ``my-ws.cloud.databricks.com`` in the cfg matches a
-    ``https://my-ws.cloud.databricks.com`` query.
+    ``https://my-ws.cloud.databricks.com`` query. Delegates to
+    :func:`_databrickscfg_host_matches_and_sp_sections` (dropping the
+    service-principal set) so host matching lives in one place.
 
     :param host: Workspace host to match, e.g.
         ``"https://example.databricks.com"``.
@@ -785,30 +951,7 @@ def _databrickscfg_profiles_for_host(host: str) -> list[str]:
         section included when it carries a matching host), or ``[]``
         when the config file is missing or unparseable.
     """
-    import configparser
-    from pathlib import Path
-
-    def _norm(value: str) -> str:
-        value = value.strip().rstrip("/")
-        return value.split("://", 1)[-1].lower()
-
-    cfg_path = Path(os.environ.get("DATABRICKS_CONFIG_FILE") or (Path.home() / ".databrickscfg"))
-    if not cfg_path.exists():
-        return []
-    config = configparser.ConfigParser()
-    try:
-        config.read(cfg_path)
-    except configparser.Error:
-        return []
-    wanted = _norm(host)
-    matches = [
-        section
-        for section in config.sections()
-        if _norm(config[section].get("host", "")) == wanted
-    ]
-    default_host = config.defaults().get("host")
-    if default_host and _norm(default_host) == wanted:
-        matches.append("DEFAULT")
+    matches, _sp_sections = _databrickscfg_host_matches_and_sp_sections(host)
     return matches
 
 

--- a/tests/e2e/test_host_auth_prefers_user_over_m2m_sp_e2e.py
+++ b/tests/e2e/test_host_auth_prefers_user_over_m2m_sp_e2e.py
@@ -1,0 +1,367 @@
+"""Host credential resolution must prefer the user over an M2M service principal.
+
+When ``~/.databrickscfg`` contains both a ``[DEFAULT]`` U2M user profile
+(``auth_type = databricks-cli``) and a second M2M service-principal profile
+(``client_id`` / ``client_secret``), both pointing at the **same** workspace
+host, the host credential resolver must honour the configured profile preference
+rather than silently picking the M2M SP because it is first in file order.
+
+Two sub-symptoms are guarded:
+
+1. **M2M SP selected over user**: ``_resolve_databricks_auth_for_host`` takes
+   the first host-matching profile that successfully authenticates.  An M2M SP
+   always authenticates (client_id + client_secret are static), so a plain
+   file-order walk lets it win even when ``[DEFAULT]`` (U2M) is also present.
+   The host then registers as the SP, which is a different identity to the
+   SSO-signed-in app user, so the user sees no live host, the "Connect New
+   Host" dropdown is empty, and "Run on this machine" silently no-ops.
+
+2. **DATABRICKS_CONFIG_PROFILE ignored in host= path**: When
+   ``omnigent login <apps-url>`` stores a Databricks Apps workspace pointer,
+   ``_make_auth_token_factory`` calls ``_resolve_databricks_auth(host=…)``
+   instead of ``_resolve_databricks_auth(profile=…)``.  The ``host=`` code
+   path must consult ``DATABRICKS_CONFIG_PROFILE`` when the named profile
+   matches the requested host, so exporting
+   ``DATABRICKS_CONFIG_PROFILE=DEFAULT`` forces the user profile.
+
+Both sub-symptoms are exercised here without spawning a real server or host
+daemon — the credential-resolution layer is the exact failure point.
+
+Run with::
+
+    pytest tests/e2e/test_host_auth_prefers_user_over_m2m_sp_e2e.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubSdkConfig:
+    """Minimal stand-in for ``databricks.sdk.config.Config``.
+
+    Real ``Config`` probes host metadata at construction time, which fails
+    offline for placeholder hosts.  The production seam ``_sdk_config``
+    exists precisely so tests can replace it.
+
+    :param host: Workspace host the config resolves to.
+    :param token: Bearer token returned by :meth:`authenticate`.
+    :param raises: When set to an exception class, :meth:`authenticate`
+        raises it instead of succeeding.  Simulates an SP whose
+        ``client_secret`` is wrong / expired.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        token: str,
+        raises: type[Exception] | None = None,
+    ) -> None:
+        self.host = host
+        self._token = token
+        self._raises = raises
+
+    def authenticate(self) -> dict[str, str]:
+        """Return Authorization headers, or raise if configured to fail."""
+        if self._raises is not None:
+            raise self._raises("stub authentication failure")
+        return {"Authorization": f"Bearer {self._token}"}
+
+
+def _write_two_profile_cfg(
+    tmp_path: Path,
+    *,
+    workspace_host: str = "https://myworkspace.cloud.databricks.com",
+    sp_profile: str = "sp-profile",
+    user_profile: str = "DEFAULT",
+) -> Path:
+    """Write a ``~/.databrickscfg`` with one M2M SP and one U2M user profile.
+
+    Both profiles point at *workspace_host* — this is the exact layout the
+    bug report describes.
+
+    The M2M SP profile (``[sp-profile]``) appears **before** the DEFAULT
+    (U2M) profile in file order, which is the scenario where the bug bites:
+    ``_databrickscfg_profiles_for_host`` returns them in file order, and
+    ``_resolve_databricks_auth_for_host`` takes the first one that
+    authenticates — the M2M SP always authenticates.
+
+    :param tmp_path: Temporary directory for the config file.
+    :param workspace_host: The shared workspace URL.
+    :param sp_profile: Section name for the M2M service principal.
+    :param user_profile: Section name for the U2M user (``DEFAULT`` in the
+        real-world scenario).
+    :returns: The path to the written config file.
+    """
+    cfg_path = tmp_path / "databrickscfg"
+    # sp-profile (M2M) comes first in file order — the bug manifests here.
+    lines = [
+        f"[{sp_profile}]",
+        f"host = {workspace_host}",
+        "client_id = svc-client-id-fake",
+        "client_secret = svc-client-secret-fake",
+        "",
+    ]
+    if user_profile == "DEFAULT":
+        # ConfigParser treats [DEFAULT] as the implicit defaults section, so
+        # we append it last.  This matches what ``databricks auth login``
+        # produces.
+        lines += [
+            "[DEFAULT]",
+            f"host = {workspace_host}",
+            "auth_type = databricks-cli",
+            "",
+        ]
+    else:
+        lines += [
+            f"[{user_profile}]",
+            f"host = {workspace_host}",
+            "auth_type = databricks-cli",
+            "",
+        ]
+    cfg_path.write_text("\n".join(lines))
+    return cfg_path
+
+
+# ---------------------------------------------------------------------------
+# Sub-symptom 1: M2M SP wins over U2M user in file-order walk
+# ---------------------------------------------------------------------------
+
+
+def test_profiles_for_host_includes_m2m_sp_and_default_for_same_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both the M2M SP profile and DEFAULT appear for the shared workspace.
+
+    This is the precondition for the bug: when both profiles match the
+    host, the resolver sees them and (absent a fix) picks the first one —
+    which is the M2M SP.
+    """
+    from omnigent.inner.databricks_executor import _databrickscfg_profiles_for_host
+
+    cfg_path = _write_two_profile_cfg(tmp_path)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+
+    matches = _databrickscfg_profiles_for_host("https://myworkspace.cloud.databricks.com")
+
+    # Both profiles match the shared workspace host.
+    assert "sp-profile" in matches, f"expected sp-profile in matches, got {matches}"
+    assert "DEFAULT" in matches, f"expected DEFAULT in matches, got {matches}"
+
+
+def test_resolve_auth_for_host_must_not_select_m2m_sp_over_user_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Host auth resolution must NOT pick the M2M SP ahead of the U2M user.
+
+    Both ``[sp-profile]`` (M2M, client_id/secret) and ``[DEFAULT]``
+    (U2M, auth_type=databricks-cli) point at the same workspace host.
+    The M2M SP profile appears first in file order and its stub always
+    authenticates successfully.  The resolver must prefer the U2M user
+    profile (either by honouring ``DATABRICKS_CONFIG_PROFILE``, by
+    deprioritising M2M SP profiles, or by preferring the explicit/DEFAULT
+    profile) rather than silently registering the host as the SP.
+
+    On a broken resolver this test fails: ``constructed[0]`` is
+    ``{"profile": "sp-profile"}`` (M2M SP selected) rather than
+    ``{"profile": "DEFAULT"}`` (U2M user selected).
+    """
+    from omnigent.inner import databricks_executor
+
+    cfg_path = _write_two_profile_cfg(tmp_path)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "DEFAULT")
+
+    constructed: list[dict[str, Any]] = []
+
+    def _fake_sdk_config(**kwargs: Any) -> _StubSdkConfig:
+        constructed.append(dict(kwargs))
+        profile = kwargs.get("profile", "")
+        if profile == "sp-profile":
+            # M2M SP — authenticates fine with client credentials.
+            return _StubSdkConfig(
+                host="https://myworkspace.cloud.databricks.com",
+                token="sp-token-fake",
+            )
+        # DEFAULT / user profile — also authenticates (U2M OAuth token).
+        return _StubSdkConfig(
+            host="https://myworkspace.cloud.databricks.com",
+            token="user-token-fake",
+        )
+
+    monkeypatch.setattr(databricks_executor, "_sdk_config", _fake_sdk_config)
+
+    auth, host = databricks_executor._resolve_databricks_auth(
+        host="https://myworkspace.cloud.databricks.com"
+    )
+
+    # The resolved token must be the USER's token, not the SP's.
+    resolved_token = auth.current_token()
+    assert resolved_token == "user-token-fake", (
+        f"Host registered as M2M service principal (token={resolved_token!r}) "
+        f"instead of the U2M user (expected 'user-token-fake'). "
+        f"Profile construction order: {constructed}. "
+        "An M2M SP in ~/.databrickscfg must not shadow the [DEFAULT] U2M user "
+        "profile just because it comes first in file order."
+    )
+    assert host == "https://myworkspace.cloud.databricks.com"
+
+
+def test_resolve_auth_for_host_config_profile_env_is_honoured_in_host_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DATABRICKS_CONFIG_PROFILE must be consulted when resolving by host.
+
+    When ``omnigent login <apps-url>`` stores a Databricks Apps workspace
+    pointer, ``_make_auth_token_factory`` calls
+    ``_resolve_databricks_auth(host=…)`` instead of the profile path.
+    The user exports ``DATABRICKS_CONFIG_PROFILE=DEFAULT`` to force their
+    U2M profile; the ``host=`` code path must honour it.
+
+    On a broken resolver this test fails: the first-in-file-order M2M SP
+    profile is selected instead of DEFAULT.
+    """
+    from omnigent.inner import databricks_executor
+
+    cfg_path = _write_two_profile_cfg(tmp_path)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    # The user sets DATABRICKS_CONFIG_PROFILE=DEFAULT explicitly to force
+    # their own (U2M) profile over the M2M SP.
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "DEFAULT")
+
+    selected_profiles: list[str] = []
+
+    def _fake_sdk_config(**kwargs: Any) -> _StubSdkConfig:
+        profile = kwargs.get("profile", "")
+        selected_profiles.append(profile or "<no-profile>")
+        return _StubSdkConfig(
+            host="https://myworkspace.cloud.databricks.com",
+            token=f"token-for-{profile or 'ambient'}",
+        )
+
+    monkeypatch.setattr(databricks_executor, "_sdk_config", _fake_sdk_config)
+
+    auth, _host = databricks_executor._resolve_databricks_auth(
+        host="https://myworkspace.cloud.databricks.com"
+    )
+
+    # The first profile tried must be DEFAULT (from DATABRICKS_CONFIG_PROFILE),
+    # NOT sp-profile (from file-order walk).
+    assert selected_profiles, "No SDK Config construction was attempted"
+    first_selected = selected_profiles[0]
+    assert first_selected == "DEFAULT", (
+        f"DATABRICKS_CONFIG_PROFILE=DEFAULT was ignored in the host= path. "
+        f"First profile tried: {first_selected!r}, all tried: {selected_profiles}. "
+        "When the env-named profile matches the requested host it must be "
+        "tried before any file-order walk."
+    )
+    resolved_token = auth.current_token()
+    assert resolved_token == "token-for-DEFAULT", (
+        f"Expected token for DEFAULT profile, got {resolved_token!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sub-symptom 2: M2M SP profiles should be deprioritised / skipped in the
+# file-order walk (complementary guard for when DATABRICKS_CONFIG_PROFILE
+# is NOT set).
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_auth_for_host_skips_m2m_sp_profiles_without_explicit_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without DATABRICKS_CONFIG_PROFILE, M2M SP profiles must not be selected.
+
+    When no explicit profile env var is set the resolver walks
+    ``~/.databrickscfg`` looking for a profile whose host matches.  If that
+    walk picks an M2M SP profile (client_id + client_secret) and
+    authenticates as a service principal, the user's desktop app (signed in
+    via SSO as a person) will see no live host.
+
+    The resolver must either skip profiles that look like M2M SPs (have
+    ``client_id``/``client_secret`` but no ``auth_type = databricks-cli``)
+    or prefer the U2M ``[DEFAULT]`` profile when one is present.
+
+    On a broken resolver this test fails: the first-in-file M2M SP is
+    selected.
+    """
+    from omnigent.inner import databricks_executor
+
+    cfg_path = _write_two_profile_cfg(tmp_path)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    # No DATABRICKS_CONFIG_PROFILE — the pure file-order-walk scenario.
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    selected_profiles: list[str] = []
+
+    def _fake_sdk_config(**kwargs: Any) -> _StubSdkConfig:
+        profile = kwargs.get("profile", "")
+        selected_profiles.append(profile or "<no-profile>")
+        return _StubSdkConfig(
+            host="https://myworkspace.cloud.databricks.com",
+            token=f"token-for-{profile or 'ambient'}",
+        )
+
+    monkeypatch.setattr(databricks_executor, "_sdk_config", _fake_sdk_config)
+
+    auth, _host = databricks_executor._resolve_databricks_auth(
+        host="https://myworkspace.cloud.databricks.com"
+    )
+
+    resolved_token = auth.current_token()
+    assert resolved_token != "token-for-sp-profile", (
+        f"M2M service-principal profile 'sp-profile' was selected (token={resolved_token!r}). "
+        f"Profile construction order: {selected_profiles}. "
+        "When both an M2M SP and a U2M user profile exist for the same workspace "
+        "host, the host must register under the user (U2M), not the service principal. "
+        "The M2M SP profile is first in the ~/.databrickscfg file-order list and always "
+        "authenticates successfully, so a simple file-order walk selects it."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Selection-order guard: user (U2M) profiles outrank M2M SP profiles
+# ---------------------------------------------------------------------------
+
+
+def test_host_profile_selection_order_puts_user_profiles_before_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The selection order tries the U2M user profile before the M2M SP.
+
+    ``_databrickscfg_profiles_for_host`` returns matches in file order
+    with DEFAULT appended last, so an SP section written first would win a
+    naive first-successful-auth walk.  The selection-order layer must
+    reorder: user (U2M) profiles first, M2M SP profiles last.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+        _order_profiles_by_identity_preference,
+    )
+
+    cfg_path = _write_two_profile_cfg(tmp_path)
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    ordered = _order_profiles_by_identity_preference(
+        *_databrickscfg_host_matches_and_sp_sections("https://myworkspace.cloud.databricks.com")
+    )
+
+    sp_idx = ordered.index("sp-profile") if "sp-profile" in ordered else -1
+    default_idx = ordered.index("DEFAULT") if "DEFAULT" in ordered else -1
+    assert sp_idx != -1 and default_idx != -1, (
+        f"Expected both 'sp-profile' and 'DEFAULT' in the order, got {ordered}"
+    )
+    assert default_idx < sp_idx, (
+        f"User profile DEFAULT (idx={default_idx}) must be tried before the M2M "
+        f"SP profile (idx={sp_idx}); got {ordered}. An SP that authenticates "
+        "first registers the host under the wrong identity."
+    )

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -1988,6 +1988,317 @@ def test_profiles_for_host_missing_file_returns_empty(
     assert _databrickscfg_profiles_for_host("https://example.databricks.com") == []
 
 
+def _write_sp_and_user_cfg(tmp_path: Path) -> Path:
+    """Write a cfg with an M2M SP section before the user's [DEFAULT] section.
+
+    Both point at the same workspace host — the layout where a naive
+    file-order walk selects the service principal over the user.
+
+    :param tmp_path: Temporary directory for the config file.
+    :returns: The path to the written config file.
+    """
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[sp]\n"
+        "host = https://example.databricks.com\n"
+        "client_id = svc-id\n"
+        "client_secret = svc-secret\n"
+        "[DEFAULT]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+    )
+    return cfg_path
+
+
+def test_host_selection_order_prefers_user_profile_over_m2m_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A U2M user profile outranks an M2M SP that comes first in the file.
+
+    An SP's static client credentials always authenticate, so if it is
+    tried first it silently wins and the host registers under the wrong
+    identity (invisible to the SSO-signed-in app user).
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+        _order_profiles_by_identity_preference,
+    )
+
+    def _host_profile_selection_order(host: str) -> list[str]:
+        return _order_profiles_by_identity_preference(
+            *_databrickscfg_host_matches_and_sp_sections(host)
+        )
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(_write_sp_and_user_cfg(tmp_path)))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    assert _host_profile_selection_order("https://example.databricks.com") == [
+        "DEFAULT",
+        "sp",
+    ]
+
+
+def test_host_selection_order_env_profile_wins_even_when_it_is_an_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DATABRICKS_CONFIG_PROFILE is an explicit choice — it goes first.
+
+    Explicit intent outranks the identity heuristic: a user who exports
+    the SP profile's name gets the SP, and one who exports DEFAULT gets
+    their own profile even when the SP is first in the file.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+        _order_profiles_by_identity_preference,
+    )
+
+    def _host_profile_selection_order(host: str) -> list[str]:
+        return _order_profiles_by_identity_preference(
+            *_databrickscfg_host_matches_and_sp_sections(host)
+        )
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(_write_sp_and_user_cfg(tmp_path)))
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "sp")
+    assert _host_profile_selection_order("https://example.databricks.com") == [
+        "sp",
+        "DEFAULT",
+    ]
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "DEFAULT")
+    assert _host_profile_selection_order("https://example.databricks.com") == [
+        "DEFAULT",
+        "sp",
+    ]
+
+
+def test_host_selection_order_env_profile_for_other_host_is_ignored(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An env profile pinned to a DIFFERENT workspace does not reorder.
+
+    The host= path resolves a specific workspace; a profile name that
+    doesn't match that host must not jump the queue (it isn't even a
+    candidate).
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+        _order_profiles_by_identity_preference,
+    )
+
+    def _host_profile_selection_order(host: str) -> list[str]:
+        return _order_profiles_by_identity_preference(
+            *_databrickscfg_host_matches_and_sp_sections(host)
+        )
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[sp]\n"
+        "host = https://example.databricks.com\n"
+        "client_id = svc-id\n"
+        "client_secret = svc-secret\n"
+        "[elsewhere]\n"
+        "host = https://other.databricks.com\n"
+        "auth_type = databricks-cli\n"
+        "[DEFAULT]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "elsewhere")
+
+    assert _host_profile_selection_order("https://example.databricks.com") == [
+        "DEFAULT",
+        "sp",
+    ]
+
+
+def test_host_selection_order_sp_only_config_still_offers_the_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An SP-only machine keeps working: the SP stays a candidate.
+
+    Deprioritising is not dropping — CI boxes whose only credential is a
+    service principal must still resolve auth for the host.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+        _order_profiles_by_identity_preference,
+    )
+
+    def _host_profile_selection_order(host: str) -> list[str]:
+        return _order_profiles_by_identity_preference(
+            *_databrickscfg_host_matches_and_sp_sections(host)
+        )
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[sp]\n"
+        "host = https://example.databricks.com\n"
+        "client_id = svc-id\n"
+        "client_secret = svc-secret\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    assert _host_profile_selection_order("https://example.databricks.com") == ["sp"]
+
+
+def test_sp_sections_not_polluted_by_default_section_inheritance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """[DEFAULT]'s auth_type must not leak into named SP sections.
+
+    ConfigParser inherits default-section keys into every section; a
+    [DEFAULT] carrying ``auth_type = databricks-cli`` would then make an
+    SP section (client_id/client_secret, no own auth_type) look like a
+    user profile and defeat the deprioritisation.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+    )
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(_write_sp_and_user_cfg(tmp_path)))
+
+    # The SP set (second element) classifies every section regardless of host.
+    _matches, sp_sections = _databrickscfg_host_matches_and_sp_sections(
+        "https://example.databricks.com"
+    )
+    assert sp_sections == {"sp"}
+
+
+def test_sp_section_with_explicit_user_auth_type_is_not_an_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A section with client creds but a user auth_type stays a user profile.
+
+    ``auth_type`` is the SDK's explicit selector; when it names an
+    interactive/user mode the stray client keys don't make it a machine
+    identity.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+    )
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[mixed]\n"
+        "host = https://example.databricks.com\n"
+        "client_id = stray-id\n"
+        "client_secret = stray-secret\n"
+        "auth_type = databricks-cli\n"
+        "[m2m]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = oauth-m2m\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+
+    _matches, sp_sections = _databrickscfg_host_matches_and_sp_sections(
+        "https://example.databricks.com"
+    )
+    assert sp_sections == {"m2m"}
+
+
+def test_azure_service_principal_fields_are_classified_as_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An Azure SP (azure_client_id/secret, no explicit auth_type) is an SP.
+
+    The databricks-sdk configures an Azure service principal with
+    ``azure_client_id`` / ``azure_client_secret`` and often no explicit
+    ``auth_type``. If it were not classified as an SP it would land in the
+    "user" bucket and could keep precedence over a real user profile for the
+    same host — re-weakening the ordering.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+    )
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[azure-sp]\n"
+        "host = https://example.databricks.com\n"
+        "azure_client_id = azure-id\n"
+        "azure_client_secret = azure-secret\n"
+        "azure_tenant_id = tenant\n"
+        "[DEFAULT]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+
+    _matches, sp_sections = _databrickscfg_host_matches_and_sp_sections(
+        "https://example.databricks.com"
+    )
+    assert sp_sections == {"azure-sp"}
+
+
+def test_resolve_auth_for_host_selects_user_token_over_sp_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through the host= path: the user's bearer wins, not the SP's."""
+    from omnigent.inner import databricks_executor
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(_write_sp_and_user_cfg(tmp_path)))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    def _fake_sdk_config(**kwargs: str) -> _StubSdkConfig:
+        token = "sp-token" if kwargs.get("profile") == "sp" else "user-token"
+        return _StubSdkConfig(host="https://example.databricks.com", token=token)
+
+    monkeypatch.setattr(databricks_executor, "_sdk_config", _fake_sdk_config)
+
+    auth, host = databricks_executor._resolve_databricks_auth(
+        host="https://example.databricks.com"
+    )
+
+    assert auth.current_token() == "user-token"
+    assert host == "https://example.databricks.com"
+
+
+def test_resolve_auth_for_host_warns_when_stale_user_falls_through_to_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A stale user profile that fails auth must warn before the SP wins.
+
+    Ordering deprioritizes the SP but does not drop it: if the preferred
+    user profile fails to authenticate (e.g. an expired OAuth grant) while
+    the SP's static creds still mint, the host would silently register
+    under the service principal again — the original wrong-identity bug,
+    just triggered by a stale token. The fallback must be loud so the user
+    is not left with an empty host picker without explanation.
+    """
+    from omnigent.inner import databricks_executor
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(_write_sp_and_user_cfg(tmp_path)))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+    def _fake_sdk_config(**kwargs: str) -> _StubSdkConfig:
+        # The user's [DEFAULT] OAuth grant is expired; only the SP mints.
+        if kwargs.get("profile") == "sp":
+            return _StubSdkConfig(host="https://example.databricks.com", token="sp-token")
+        raise ValueError("DEFAULT: token expired")
+
+    def _run_databricks(args: list[str], **kwargs: object) -> SimpleNamespace:
+        # The CLI fallback for the expired user profile also fails.
+        return SimpleNamespace(returncode=1, stdout="", stderr="expired")
+
+    monkeypatch.setattr(databricks_executor, "_sdk_config", _fake_sdk_config)
+    monkeypatch.setattr(databricks_executor.shutil, "which", lambda name: "/usr/bin/databricks")
+    monkeypatch.setattr(databricks_executor.subprocess, "run", _run_databricks)
+
+    with caplog.at_level("WARNING", logger=databricks_executor.logger.name):
+        auth, _host = databricks_executor._resolve_databricks_auth(
+            host="https://example.databricks.com"
+        )
+
+    # The SP is still used (SP-only reachability is preserved)...
+    assert auth.current_token() == "sp-token"
+    # ...but the fallback is announced, naming the SP and the failed user profile.
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("service principal 'sp'" in m and "DEFAULT" in m for m in warnings), warnings
+
+
 def test_stream_ended_without_finish_reason_with_content_completes() -> None:
     """A truncated stream that still produced text surfaces that text as a
     TurnComplete (not an error) — only the empty case is fatal (#1118)."""

--- a/tests/inner/test_databricks_executor.py
+++ b/tests/inner/test_databricks_executor.py
@@ -2233,6 +2233,74 @@ def test_azure_service_principal_fields_are_classified_as_sp(
     assert sp_sections == {"azure-sp"}
 
 
+def test_federated_oidc_machine_auth_types_are_classified_as_sp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Federated-OIDC machine flows are classified as SPs, not user profiles.
+
+    Machine flows like ``github-oidc`` / ``env-oidc`` carry no
+    client_secret pair, so the credential heuristic alone would miss them
+    and drop them in the "user" bucket — where they could outrank a real
+    U2M/PAT profile for the same host, the same mis-ranking this ordering
+    exists to prevent. They must be recognized by ``auth_type``.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+    )
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[gh-oidc]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = github-oidc\n"
+        "[env-oidc]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = env-oidc\n"
+        "[DEFAULT]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+
+    _matches, sp_sections = _databrickscfg_host_matches_and_sp_sections(
+        "https://example.databricks.com"
+    )
+    assert sp_sections == {"gh-oidc", "env-oidc"}
+
+
+def test_section_with_explicit_empty_host_does_not_inherit_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit empty ``host =`` overrides inheritance to no host.
+
+    Key-presence, not truthiness: a section that writes ``host =`` (empty)
+    has opted out of the workspace, so it must not fall back to [DEFAULT]'s
+    host and spuriously match — matching ConfigParser's own semantics.
+    """
+    from omnigent.inner.databricks_executor import (
+        _databrickscfg_host_matches_and_sp_sections,
+    )
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text(
+        "[blank-host]\n"
+        "host =\n"
+        "auth_type = databricks-cli\n"
+        "[inherits]\n"
+        "auth_type = databricks-cli\n"
+        "[DEFAULT]\n"
+        "host = https://example.databricks.com\n"
+        "auth_type = databricks-cli\n"
+    )
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+
+    matches, _sp = _databrickscfg_host_matches_and_sp_sections("https://example.databricks.com")
+    # `inherits` (no host key) inherits DEFAULT's host and matches; DEFAULT
+    # itself matches; `blank-host` (explicit empty) opted out and does not.
+    assert "blank-host" not in matches
+    assert set(matches) == {"inherits", "DEFAULT"}
+
+
 def test_resolve_auth_for_host_selects_user_token_over_sp_token(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Related issue

Relates #4683

## Summary

**PR 1 of 3** splitting #6254 into reviewable pieces. This is the core bug fix.

A machine whose `~/.databrickscfg` holds **both** the user's login (a U2M `[DEFAULT]` profile) **and** an M2M service-principal profile for the *same* workspace registered under the **wrong identity**. `_resolve_databricks_auth_for_host` walked the host-matching profiles in file order and took the first that authenticated — and a service principal's static `client_id`/`client_secret` *always* authenticate, so a first-in-file SP silently won. The host then registered as the SP, invisible to the SSO-signed-in app user (no live host, empty "Connect New Host" dropdown, "Run on this machine" no-ops), and the `host=` path never consulted `DATABRICKS_CONFIG_PROFILE`.

Resolve host-matching profiles in **identity-preference order** instead: `DATABRICKS_CONFIG_PROFILE` → user (U2M/PAT) → M2M service principal. SP-only machines still resolve (the SP is tried last, not dropped). A single parse of the cfg with `[DEFAULT]` inheritance disabled derives both the host matches and the SP set, so a `[DEFAULT]` user profile's `auth_type` can't leak into and misclassify named SP sections. Azure SP field names (`azure_client_id`/`azure_client_secret`) are classified as SPs too. When a matched user profile fails to authenticate (e.g. an expired login) and a lower-priority SP is selected, a warning is logged so the host is not silently registered under the SP again.

Follow-ups: **#6411** adds `--profile` (explicit identity), **#6412** adds `omnigent host reset-id` (409 recovery).

## Test Plan

```
pytest tests/inner/test_databricks_executor.py \
       tests/e2e/test_host_auth_prefers_user_over_m2m_sp_e2e.py
```
New tests cover: user-before-SP ordering, `DATABRICKS_CONFIG_PROFILE` wins, SP-only still resolves, `[DEFAULT]`-inheritance not polluting SP classification, Azure SP fields classified, and the stale-user→SP fallback warning.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Resolver-layer change; evidence is the unit + e2e suites above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated unit + e2e coverage at the credential-resolution seam, which is the exact failure point.

## Changelog

`omnigent host` now registers under your user identity instead of a co-resident Databricks service principal when both match the same workspace
