### PR TITLE
feat(host): add `omnigent host reset-id` to recover from an HTTP 409 lockout

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -8130,8 +8130,8 @@ class _HostGroup(click.Group):
     --server <url>`` when ``<url>`` is URL-like or the empty local-mode
     marker. A leading positional token that matches a registered
     management subcommand (``enable``, ``disable``, ``status``, ``stop``,
-    ``stop-session``) still dispatches to that subcommand, and other unknown
-    tokens fall through to Click's normal unknown-command error.
+    ``stop-session``, ``reset-id``) still dispatches to that subcommand, and
+    other unknown tokens fall through to Click's normal unknown-command error.
     """
 
     def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
@@ -8515,8 +8515,8 @@ def host(
 
     The server URL may be given positionally (``omnigent host
     <url>``) or via ``--server <url>``. A leading ``status``, ``stop``,
-    ``enable``, ``disable``, or ``stop-session`` token still runs that
-    management subcommand.
+    ``enable``, ``disable``, ``stop-session``, or ``reset-id`` token still
+    runs that management subcommand.
 
     When the target server is Databricks-fronted and you are not signed
     in, ``host`` runs the same flow ``omnigent login`` would before
@@ -9882,6 +9882,45 @@ def host_stop_session(
             click.echo(f"Failed to stop session {session_id!r}.", err=True)
             continue
         click.echo(f"Stopped session {session_id}.")
+
+
+@host.command("reset-id")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+def host_reset_id(yes: bool) -> None:
+    """
+    Mint a fresh host id for this machine.
+
+    The recovery path for ``HTTP 409: this machine is already registered
+    to a different account``: the server keys host registrations by the
+    persisted host id, so once another identity owns it, this machine
+    cannot re-register under yours. Resetting the id lets the next
+    ``omnigent host`` register as a brand-new host under the identity you
+    are signed in as. The host name and other config are preserved.
+
+    :param yes: When ``True``, skip the confirmation prompt.
+    """
+    from omnigent.host.identity import CONFIG_PATH, reset_host_id
+
+    running = [record for record in _list_daemon_records() if _pid_alive(record.pid)]
+    if running:
+        raise click.ClickException(
+            "A host daemon is running; stop it first with "
+            f"`{cli_invocation()} host stop --all`, then re-run "
+            f"`{cli_invocation()} host reset-id`."
+        )
+    if not yes:
+        click.confirm(
+            "Mint a fresh host id? Servers will see this machine as a new "
+            "host; the registration owned by the previous id is left behind "
+            "for an administrator to clean up",
+            abort=True,
+        )
+    old_host_id, new_host_id = reset_host_id(CONFIG_PATH)
+    if old_host_id is None:
+        click.echo(f"No previous host id was persisted; created {new_host_id}.")
+    else:
+        click.echo(f"Host id reset: {old_host_id} -> {new_host_id}.")
+    click.echo(f"Run `{cli_invocation()} host` to register this machine under the new id.")
 
 
 @cli.command(hidden=True)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1526,10 +1526,12 @@ class HostProcess:
                 "registered to a different account on this server, so the "
                 "account you authenticated as cannot claim it. This usually "
                 "means the host was first registered under another identity "
-                "(e.g. the single-user 'local' owner before the server "
-                "switched to accounts auth). Ask an administrator to remove "
-                "the existing host registration, or reset this machine's host "
-                "id, then retry. " + self._login_fix_hint()
+                "(e.g. an M2M service principal selected from "
+                "~/.databrickscfg, or the single-user 'local' owner before "
+                "the server switched to accounts auth). Run "
+                f"`{cli_invocation()} host reset-id` to mint a fresh host id "
+                "for this machine and retry, or ask an administrator to "
+                "remove the existing host registration. " + self._login_fix_hint()
             )
         # Any other permanent 4xx (e.g. a 400 for a malformed host id, or an
         # edge/proxy rejection): the server's own body is the authoritative

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -185,6 +185,44 @@ def load_or_create_host_identity(
     return identity
 
 
+def reset_host_id(path: Path = CONFIG_PATH) -> tuple[str | None, str]:
+    """Replace this machine's persisted ``host_id`` with a fresh one.
+
+    The recovery path for a host registration owned by another identity:
+    the server keys hosts by ``host_id``, so once that id is claimed by a
+    different account (e.g. a service principal), re-registering under the
+    signed-in user is refused with HTTP 409. Minting a fresh id lets the
+    machine register as a brand-new host under the current identity.
+
+    The host ``name`` (and every other config key) is preserved; only
+    ``host_id`` changes. A missing config or host section is created, same
+    as :func:`load_or_create_host_identity`.
+
+    :param path: Path to the config YAML file. Defaults to :data:`CONFIG_PATH`.
+    :returns: ``(old_host_id, new_host_id)`` — ``old_host_id`` is ``None``
+        when no identity was persisted before.
+    """
+    cfg: dict[str, object] = {}
+    if path.exists():
+        with open(path) as f:
+            cfg = yaml.safe_load(f) or {}
+
+    host_section = cfg.get("host")
+    if not isinstance(host_section, dict):
+        host_section = {}
+
+    old_host_id = host_section.get("host_id")
+    new_host_id = uuid.uuid4().hex
+    host_section["host_id"] = new_host_id
+    host_section.setdefault("name", socket.gethostname())
+    cfg["host"] = host_section
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
+
+    return (old_host_id if isinstance(old_host_id, str) else None), new_host_id
+
+
 def load_host_identity_if_present(
     path: Path = CONFIG_PATH,
 ) -> HostIdentity | None:

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1062,6 +1062,74 @@ def test_foreground_connect_local_prompt_aborted_leaves_server(
     assert "Left the local server running at http://127.0.0.1:8000." in result.output
 
 
+def test_host_reset_id_mints_fresh_id_when_no_daemon_runs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`host reset-id --yes` replaces the persisted host id.
+
+    The recovery path for the 409 "already registered to a different
+    account" refusal: the machine must be able to mint a fresh id and
+    re-register under the signed-in identity without an administrator.
+    """
+    import yaml
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"host": {"host_id": "a" * 32, "name": "my-laptop"}}))
+    monkeypatch.setattr("omnigent.host.identity.CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_list_daemon_records", lambda **_kw: [])
+
+    result = CliRunner().invoke(cli_group, ["host", "reset-id", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "Host id reset:" in result.output
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["host"]["host_id"] != "a" * 32
+    assert cfg["host"]["name"] == "my-laptop"
+
+
+def test_host_reset_id_refuses_while_a_daemon_is_running(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A live daemon still holds the old id — the reset must ask for a stop first.
+
+    Resetting under a running daemon would desync the persisted identity
+    from the registered tunnel; failing loud with the stop command is the
+    actionable path.
+    """
+    import yaml
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"host": {"host_id": "a" * 32, "name": "my-laptop"}}))
+    monkeypatch.setattr("omnigent.host.identity.CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_list_daemon_records", lambda **_kw: [_online_record()])
+    monkeypatch.setattr(cli, "_pid_alive", lambda _pid: True)
+
+    result = CliRunner().invoke(cli_group, ["host", "reset-id", "--yes"])
+
+    assert result.exit_code != 0
+    assert "host stop" in result.output
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["host"]["host_id"] == "a" * 32, "a refused reset must not touch the id"
+
+
+def test_host_reset_id_declined_prompt_leaves_id_untouched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Answering no at the confirmation keeps the persisted id."""
+    import yaml
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"host": {"host_id": "a" * 32, "name": "my-laptop"}}))
+    monkeypatch.setattr("omnigent.host.identity.CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_list_daemon_records", lambda **_kw: [])
+
+    result = CliRunner().invoke(cli_group, ["host", "reset-id"], input="n\n")
+
+    assert result.exit_code != 0  # click.Abort
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["host"]["host_id"] == "a" * 32
+
+
 def test_foreground_connect_local_prompts_after_keyboard_interrupt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -3707,6 +3707,28 @@ async def test_non_auth_permanent_4xx_omits_login_hint(
     assert "omnigent login" not in message
 
 
+async def test_409_rejection_names_the_self_service_reset_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 409 refusal points at `omnigent host reset-id`, not just an admin.
+
+    The 409 means the machine's host id is owned by another identity (e.g.
+    an M2M service principal that won credential resolution earlier). The
+    user must get a copy-pasteable self-service recovery command instead of
+    being told only to find an administrator.
+    """
+    spy = _ConnectSpy([_invalid_status(409)])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    with pytest.raises(HostConnectError) as excinfo:
+        await host.run()
+
+    message = str(excinfo.value)
+    assert "HTTP 409" in message
+    assert "host reset-id" in message
+
+
 @pytest.mark.parametrize("status", [408, 429, 500, 503])
 async def test_run_reconnects_on_transient_upgrade_failure(
     monkeypatch: pytest.MonkeyPatch, status: int

--- a/tests/host/test_identity.py
+++ b/tests/host/test_identity.py
@@ -11,6 +11,7 @@ import yaml
 from omnigent.host.identity import (
     load_host_identity_if_present,
     load_or_create_host_identity,
+    reset_host_id,
 )
 
 
@@ -289,3 +290,67 @@ def test_if_present_config_non_uuid_host_id_returns_none(tmp_path: Path) -> None
     )
 
     assert load_host_identity_if_present(config_path) is None
+
+
+def test_reset_host_id_mints_fresh_id_and_keeps_name(tmp_path: Path) -> None:
+    """Resetting replaces host_id but preserves the host name and other config.
+
+    This is the recovery path for a host registration owned by another
+    identity (HTTP 409): the machine must come back as a NEW host id while
+    keeping its human-readable name and unrelated config keys.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "host": {"host_id": "a" * 32, "name": "my-laptop"},
+                "server": "https://example.databricksapps.com",
+            }
+        )
+    )
+
+    old_id, new_id = reset_host_id(config_path)
+
+    assert old_id == "a" * 32
+    assert new_id != old_id
+    assert len(new_id) == 32
+    int(new_id, 16)  # raises ValueError if not valid hex
+
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["host"]["host_id"] == new_id
+    assert cfg["host"]["name"] == "my-laptop", "reset must not clobber the host name"
+    assert cfg["server"] == "https://example.databricksapps.com", (
+        "reset must not touch unrelated config keys"
+    )
+
+
+def test_reset_host_id_without_existing_identity_creates_one(tmp_path: Path) -> None:
+    """Resetting on a machine with no persisted identity still yields a valid one."""
+    config_path = tmp_path / "config.yaml"
+
+    old_id, new_id = reset_host_id(config_path)
+
+    assert old_id is None
+    assert len(new_id) == 32
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["host"]["host_id"] == new_id
+    assert cfg["host"]["name"] == socket.gethostname()
+
+
+def test_reset_host_id_next_load_returns_the_new_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After a reset, the normal load path picks up the fresh id."""
+    # The load path honors the managed-host env override; clear it so the
+    # test reads the file identity regardless of the ambient environment.
+    monkeypatch.delenv("OMNIGENT_HOST_ID", raising=False)
+    monkeypatch.delenv("OMNIGENT_HOST_NAME", raising=False)
+    config_path = tmp_path / "config.yaml"
+    before = load_or_create_host_identity(config_path)
+
+    _old, new_id = reset_host_id(config_path)
+    after = load_or_create_host_identity(config_path)
+
+    assert after.host_id == new_id
+    assert after.host_id != before.host_id
+    assert after.name == before.name


### PR DESCRIPTION
## Related issue

Closes #4683

## Summary

**PR 3 of 3** splitting #6254. Orthogonal self-service recovery for a machine already locked out.

A host registration is keyed by the machine's persisted host id. Once that id is claimed by another identity (e.g. a service principal that won credential resolution before **#6410**, or the single-user 'local' owner before the server switched to accounts auth), re-registering under the signed-in user is refused with **HTTP 409** — and the only advice was "ask an administrator."

Add **`omnigent host reset-id`**: mints a fresh host id (preserving the host name and other config), refuses to run while a daemon is live (pointing at `host stop --all`), and prompts for confirmation unless `--yes`. The next `omnigent host` then registers as a brand-new host under the current identity. The HTTP 409 connect error now names this command instead of a dead end.

## Test Plan

```
pytest tests/cli/test_backend.py -k reset_id \
       tests/host/test_identity.py tests/host/test_connect.py
```
New tests: `reset-id --yes` mints a fresh id (preserving name); refuses while a daemon runs; declining the prompt leaves the id untouched; `reset_host_id` unit behavior; and the 409 connect error names the self-service command.

Manual: on a machine stuck on 409, run `omnigent host stop --all` → `omnigent host reset-id` → `omnigent host <url>` and confirm it registers fresh.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

CLI-only; evidence is the suites above + the manual recovery flow.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the end-to-end 409 recovery against a live server; the id-minting, daemon-guard, prompt, and 409 message are all unit-tested.

## Changelog

`omnigent host reset-id` mints a fresh host id to recover a machine refused with "already registered to a different account" (HTTP 409)
