### PR TITLE
perf(web): make conversation switching feel instant

### DIFF
--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -99,6 +99,13 @@ const ARCHIVED_PROJECT_NAMES_KEY = ["archived-project-names"] as const;
 
 export interface UseConversationsOptions {
   reconcileWhileConnected?: boolean;
+  /**
+   * Which result fields trigger a consumer re-render (passed to the infinite
+   * query). Lets a consumer that holds the whole query object avoid re-rendering
+   * on the live-updates merge's per-frame result-object churn. Omit to notify on
+   * any observed field.
+   */
+  notifyOnChangeProps?: readonly (keyof ReturnType<typeof useInfiniteQuery>)[];
 }
 
 export class BulkConversationMutationError extends Error {
@@ -546,6 +553,12 @@ export function useConversations(
         ? CONNECTED_STREAM_REFETCH_INTERVAL_MS
         : false
       : DISCONNECTED_STREAM_REFETCH_INTERVAL_MS,
+    // Coalesce the live-updates object churn for consumers that opt in (see
+    // UseConversationsOptions.notifyOnChangeProps). Mutable copy — the query
+    // options type wants a mutable array.
+    ...(options.notifyOnChangeProps
+      ? { notifyOnChangeProps: [...options.notifyOnChangeProps] }
+      : {}),
   });
 }
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1347,6 +1347,18 @@ export function AppShell() {
   // embedded build we claim the chord ahead of any host-page ⌘K listener.
   // Bound here where the palette's open-state lives.
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  // Stable handlers so the memoized Sidebar doesn't re-render on AppShell's
+  // frequent re-renders (chatStore status churn during a bind). Inline
+  // callbacks would give it fresh props each time and defeat the memo.
+  const handleSidebarClose = useCallback(() => {
+    setSidebarOpen(false);
+    setSidebarPeek(false);
+  }, []);
+  const handleSidebarOpen = useCallback(() => {
+    setSidebarOpen(true);
+    setSidebarPeek(false);
+  }, []);
+  const handleOpenSearch = useCallback(() => setCommandPaletteOpen(true), []);
   const isEmbedded = useIsEmbedded();
   useCommandPaletteHotkey(() => setCommandPaletteOpen((prev) => !prev));
   useNewSessionHotkey(!isEmbedded);
@@ -1882,17 +1894,11 @@ export function AppShell() {
           cluster on a narrow window. The strip stays pure drag surface. */}
             <Sidebar
               open={sidebarOpen}
-              onOpen={() => {
-                setSidebarOpen(true);
-                setSidebarPeek(false);
-              }}
+              onOpen={handleSidebarOpen}
               peek={sidebarPeek}
               dragProgress={sidebarDragProgress}
-              onClose={() => {
-                setSidebarOpen(false);
-                setSidebarPeek(false);
-              }}
-              onOpenSearch={() => setCommandPaletteOpen(true)}
+              onClose={handleSidebarClose}
+              onOpenSearch={handleOpenSearch}
             />
 
             {/* Content region (everything right of the sidebar): a relative

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -586,7 +586,12 @@ describe("Sidebar session list", () => {
     // show. A regression to false would leave that filter perpetually empty.
     expect(useConvMock.mock.calls.length).toBeGreaterThanOrEqual(1);
     for (const call of useConvMock.mock.calls) {
-      expect(call).toEqual(["", true, { reconcileWhileConnected: true }]);
+      // searchQuery empty + includeArchived hard-wired true is the contract this
+      // guards; the options arg (reconcile poll, notifyOnChangeProps coalescing)
+      // is an implementation detail, so assert the first two args only.
+      expect(call[0]).toBe("");
+      expect(call[1]).toBe(true);
+      expect(call[2]).toMatchObject({ reconcileWhileConnected: true });
     }
   });
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
   type RefObject,
   createContext,
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -232,6 +233,12 @@ const DROP_TARGET_HIGHLIGHT = SIDEBAR_ACTIVE_HIGHLIGHT;
 // a query observer per row (which would also re-run on every project mutation).
 const ProjectNamesContext = createContext<Map<string, string>>(new Map());
 const HostsByIdContext = createContext<ReadonlyMap<string, Host>>(new Map());
+// Row-invariant values resolved once at the list owner and shared, so a row
+// doesn't run `useIsMobileViewport` (a matchMedia-on-every-render store) or
+// `useViewerId` (an identity-resolve effect) per instance.
+const IsMobileContext = createContext<boolean>(false);
+const ViewerIdContext = createContext<string | null>(null);
+const ServerInfoContext = createContext<ReturnType<typeof useServerInfo>>("loading");
 // Rows report an in-progress inline-rename edit here so ConversationList can
 // hold the sort order for the edit's whole duration — the pointer often
 // leaves the list while typing, and a reorder then would shuffle rows around
@@ -239,18 +246,38 @@ const HostsByIdContext = createContext<ReadonlyMap<string, Host>>(new Map());
 // title). See the order-freeze block in ConversationList.
 const RowEditHoldContext = createContext<(id: string, editing: boolean) => void>(() => {});
 
+// Stable callback identity that always runs the latest `fn` — keeps the row
+// handlers from changing on every Sidebar render and defeating the row memo.
+function useStableCallback<A extends unknown[], R>(fn: (...args: A) => R): (...args: A) => R {
+  const ref = useRef(fn);
+  ref.current = fn;
+  return useCallback((...args: A) => ref.current(...args), []);
+}
+
 function SidebarRowDataProvider({
   projectNamesById,
   hostsById,
+  isMobile,
+  viewerId,
+  serverInfo,
   children,
 }: {
   projectNamesById: Map<string, string>;
   hostsById: ReadonlyMap<string, Host>;
+  isMobile: boolean;
+  viewerId: string | null;
+  serverInfo: ReturnType<typeof useServerInfo>;
   children: ReactNode;
 }) {
   return (
     <ProjectNamesContext.Provider value={projectNamesById}>
-      <HostsByIdContext.Provider value={hostsById}>{children}</HostsByIdContext.Provider>
+      <HostsByIdContext.Provider value={hostsById}>
+        <IsMobileContext.Provider value={isMobile}>
+          <ViewerIdContext.Provider value={viewerId}>
+            <ServerInfoContext.Provider value={serverInfo}>{children}</ServerInfoContext.Provider>
+          </ViewerIdContext.Provider>
+        </IsMobileContext.Provider>
+      </HostsByIdContext.Provider>
     </ProjectNamesContext.Provider>
   );
 }
@@ -497,7 +524,7 @@ export function useMigrateLocalPinsToServer(
   }, [pinnedLoaded, filterHonored]);
 }
 
-export function Sidebar({
+function SidebarImpl({
   open,
   onClose,
   onOpen,
@@ -590,6 +617,19 @@ export function Sidebar({
   // below), so the sidebar list itself is unfiltered.
   const conversationsQuery = useConversations("", true, {
     reconcileWhileConnected: true,
+    // Re-render only on fields the sidebar/ConversationList read, so the
+    // live-updates merge's per-frame result-object churn doesn't re-render the
+    // whole row list. Keep in sync with `conversationsQuery.*` reads.
+    notifyOnChangeProps: [
+      "data",
+      "error",
+      "hasNextPage",
+      "isError",
+      "isFetching",
+      "isFetchingNextPage",
+      "isLoading",
+      "fetchNextPage",
+    ],
   });
 
   // The scrollable list container — used as the IntersectionObserver root for
@@ -610,17 +650,15 @@ export function Sidebar({
   const unseenComments = useCommentInbox(loadedRows).items.length;
   const inboxCount = pendingApprovals + unseenComments;
 
-  // Click handler for conversation-row Links in the sidebar. The Link
-  // handles navigation natively, so cmd/ctrl/middle-click opens new
-  // tabs. We still want to close on mobile after a plain primary click,
-  // but NOT for modifier/middle clicks that open a new tab — those
-  // don't change the current view.
-  function onNavClick(e: MouseEvent<HTMLAnchorElement>) {
+  // Row-Link click handler. The Link navigates natively (so modifier/middle
+  // clicks open tabs); we only close the drawer on a plain primary click on
+  // mobile. Stable identity (useStableCallback) so it doesn't defeat the row memo.
+  const onNavClick = useStableCallback((e: MouseEvent<HTMLAnchorElement>) => {
     if (e.defaultPrevented) return;
     if (e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     if (isMobileViewport()) onClose();
-  }
+  });
 
   // Which top-level nav button to highlight for the current route.
   const { isNewChatPage, isInboxPage, isTasksPage, isUsagePage, newSessionProjectName } =
@@ -677,15 +715,13 @@ export function Sidebar({
     () => new Set(pinnedConversations.map((c) => c.id)),
     [pinnedConversations],
   );
-  const togglePinnedConversation = useCallback(
-    (conversationId: string) => {
-      togglePinnedMutation.mutate({
-        id: conversationId,
-        pinned: !pinnedIdSet.has(conversationId),
-      });
-    },
-    [togglePinnedMutation, pinnedIdSet],
-  );
+  // Stable identity (useStableCallback) so its changing deps don't defeat the row memo.
+  const togglePinnedConversation = useStableCallback((conversationId: string) => {
+    togglePinnedMutation.mutate({
+      id: conversationId,
+      pinned: !pinnedIdSet.has(conversationId),
+    });
+  });
 
   // One-time migration: pins used to live only in localStorage. Push any
   // still-local pins up to the server (as the `omnigent.pinned` label) the
@@ -1091,6 +1127,11 @@ export function Sidebar({
   );
 }
 
+// Memoized so AppShell's frequent re-renders (chatStore status churn during a
+// bind) don't re-render the whole sidebar — its props are stable per switch
+// (AppShell stabilizes the callbacks with useCallback).
+export const Sidebar = memo(SidebarImpl);
+
 /**
  * Auto-loading pagination control. An IntersectionObserver fetches the next
  * page when this nears view (rooted on the scroll container, pre-fetching 200px
@@ -1164,6 +1205,7 @@ function ProjectFolder({
   projectId,
   icon,
   windowConversations,
+  activeConversationId,
   expanded,
   active,
   marker,
@@ -1190,6 +1232,9 @@ function ProjectFolder({
       the folder's own pages — e.g. a just-moved row carries its optimistic
       membership here before the folder query returns it). */
   windowConversations: Conversation[];
+  /** The active conversation's resolved top-level root id (see
+      ConversationSection) — forwarded to the folder's section for row highlight. */
+  activeConversationId: string | null;
   expanded: boolean;
   /** Whether the new-session composer is currently scoped to this project. */
   active: boolean;
@@ -1291,6 +1336,7 @@ function ProjectFolder({
         active={active}
         marker={marker}
         conversations={conversations}
+        activeConversationId={activeConversationId}
         pinnedConversationIds={pinnedConversationIds}
         // Projects default collapsed: shown only when explicitly expanded.
         collapsed={!expanded}
@@ -1446,8 +1492,11 @@ function ConversationList({
   onExitSelectionMode,
   getVisibleIdsRef,
 }: ConversationListProps) {
-  // Viewer id for the owner-based My/Shared split below.
+  // Row-invariant values resolved once here and shared with rows via context
+  // (see IsMobileContext etc.), so each row doesn't run its own copy.
   const viewerId = useViewerId();
+  const isMobile = useIsMobileViewport();
+  const serverInfo = useServerInfo();
   // Host metadata is shared by every row tooltip. Resolve it once at the list
   // owner so ordinary rows do not each create their own polling observer.
   const { data: hosts = [] } = useHosts({ includeSandbox: true });
@@ -1481,6 +1530,11 @@ function ConversationList({
   // out from under you. Snapshot is dropped on navigate-away so the
   // chat snaps back to its real position once you've left.
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
+  // Resolve the active conversation's top-level root once here (rows get a plain
+  // `isActive` prop, not their own query). Falls back to the raw id while the
+  // parent walk loads — a top-level session resolves to itself.
+  const activeRootSessionId = useActiveRootSessionId(activeId ?? null);
+  const resolvedActiveId = activeRootSessionId ?? activeId ?? null;
   const [activeOverride, setActiveOverride] = useState<ActiveChatOverride | null>(null);
   useEffect(() => {
     setActiveOverride((prev) => computeNextActiveOverride(activeId, allConversations, prev));
@@ -1951,7 +2005,13 @@ function ConversationList({
   // alone (Linear-style) — no icons or counts in the headers, no divider
   // rules between groups.
   return (
-    <SidebarRowDataProvider projectNamesById={projectNamesById} hostsById={hostsById}>
+    <SidebarRowDataProvider
+      projectNamesById={projectNamesById}
+      hostsById={hostsById}
+      isMobile={isMobile}
+      viewerId={viewerId}
+      serverInfo={serverInfo}
+    >
       <DndContext
         sensors={sensors}
         collisionDetection={pointerWithin}
@@ -2007,6 +2067,7 @@ function ConversationList({
                     <ConversationSection
                       title="Pinned"
                       conversations={sections.pinned}
+                      activeConversationId={resolvedActiveId}
                       pinnedConversationIds={pinnedConversationIds}
                       collapsed={effectiveCollapsedSections.includes("Pinned")}
                       onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
@@ -2065,6 +2126,7 @@ function ConversationList({
                       projectId={group.id}
                       icon={group.icon}
                       windowConversations={group.conversations}
+                      activeConversationId={resolvedActiveId}
                       expanded={expandedProjects.includes(group.name)}
                       active={newSessionProjectName === group.name}
                       // Best-effort marker from the globally-loaded window: a
@@ -2105,6 +2167,7 @@ function ConversationList({
                     <ConversationSection
                       title="Sessions"
                       conversations={sections.sessions}
+                      activeConversationId={resolvedActiveId}
                       emptyMessage={SIDEBAR_FILTER_EMPTY[activeTab]}
                       pinnedConversationIds={pinnedConversationIds}
                       collapsed={effectiveCollapsedSections.includes("Chats")}
@@ -2675,6 +2738,7 @@ function ConversationSection({
   marker,
   active,
   conversations,
+  activeConversationId,
   pinnedConversationIds,
   collapsed,
   onToggleCollapsed,
@@ -2701,6 +2765,10 @@ function ConversationSection({
   /** Whether this section header represents the current page context. */
   active?: boolean;
   conversations: Conversation[];
+  /** The active conversation's resolved top-level root id, or null — each row
+      derives its own `isActive` by comparing against this. Resolved once by the
+      list owner so a row never runs the (multi-step) active-root query itself. */
+  activeConversationId: string | null;
   pinnedConversationIds: string[];
   /** Whether this section is currently collapsed. */
   collapsed: boolean;
@@ -2832,6 +2900,7 @@ function ConversationSection({
                 <ConversationRow
                   key={conv.id}
                   conversation={conv}
+                  isActive={conv.id === activeConversationId}
                   isPinned={pinnedConversationIds.includes(conv.id)}
                   onClick={onRowClick}
                   onTogglePinned={onTogglePinned}
@@ -3289,8 +3358,9 @@ function SessionTooltipContent({
 // Browsers pair clicks within ~500ms; the margin absorbs event-loop delay.
 const DOUBLE_CLICK_PAIR_WINDOW_MS = 750;
 
-function ConversationRow({
+function ConversationRowImpl({
   conversation,
+  isActive,
   isPinned,
   onClick,
   onTogglePinned,
@@ -3300,6 +3370,10 @@ function ConversationRow({
   onProjectAssigned,
 }: {
   conversation: Conversation;
+  // Computed by the list owner against the resolved top-level root (so a
+  // sub-agent view keeps its owning row highlighted). A prop, not a per-row
+  // read, so only the two rows whose value flips re-render on a switch.
+  isActive: boolean;
   isPinned: boolean;
   onClick: (e: MouseEvent<HTMLAnchorElement>) => void;
   onTogglePinned: (conversationId: string) => void;
@@ -3309,25 +3383,11 @@ function ConversationRow({
   onProjectAssigned?: (projectName: string) => void;
 }) {
   const hostsById = useContext(HostsByIdContext);
-  // `useParams` reads from the active matched route. On `/`, the param is
-  // undefined; on `/c/:conversationId`, it carries the active id.
-  const { conversationId: activeId } = useParams<{ conversationId: string }>();
-  // The sidebar lists only top-level sessions; child (sub-agent) rows are
-  // omitted. When the user clicks a sub-agent in the Agents rail the active
-  // id becomes the child's, which matches no row here — so highlighting on
-  // the raw id alone would leave the owning session unhighlighted. Resolve
-  // the active conversation's top-level root and highlight against that, so
-  // the parent row stays selected while viewing any of its descendants.
-  // While the resolution loads (`null`), fall back to the raw id for that
-  // render — a top-level session resolves to itself, so the common case is
-  // unaffected.
-  const activeRootId = useActiveRootSessionId(activeId ?? null);
-  const isActive = (activeRootId ?? activeId) === conversation.id;
   const navigate = useNavigate();
   // Mobile has no real hover, so a tap that navigates would also trip the
   // project flyout's HoverCard and leave it lingering over the chat. Gate the
   // flyout off below the `md` breakpoint (see `projectFlyoutName`).
-  const isMobile = useIsMobileViewport();
+  const isMobile = useContext(IsMobileContext);
   // When this row becomes the active conversation (e.g. a freshly created
   // session navigated to via `/c/:id`), scroll it toward the center of the
   // sidebar so it's comfortably in view rather than pinned to an edge.
@@ -3376,13 +3436,13 @@ function ConversationRow({
   // live on the open-session view, which fetches the caller's real level.)
   // Also the id Leave revokes: leaving is a self-revoke, so it needs the
   // viewer's own id — resolved by the time a non-owned row renders, since
-  // `isOwner` below is derived from it.
-  const viewerId = useViewerId();
+  // `isOwner` below is derived from it. From context (ViewerIdContext).
+  const viewerId = useContext(ViewerIdContext);
   const isOwner = isOwnedByViewer(conversation, viewerId);
   // Server-wide sharing kill switch (OMNIGENT_SHARING_MODE=off) reported by
   // /v1/info — disables the row's Share item even for managers. Fail open
-  // (share enabled) while the capability probe is still loading.
-  const serverInfo = useServerInfo();
+  // (share enabled) while the capability probe is still loading. From context.
+  const serverInfo = useContext(ServerInfoContext);
   const sharingOff = serverInfo !== "loading" && serverInfo.sharing_mode === "off";
   // Single-user mode has no other users to share with, so the Share item is
   // hidden entirely (not just disabled) — mirrors the header Share button.
@@ -3974,7 +4034,15 @@ function ConversationRow({
           </DropdownMenu>
         </div>
       )}
-      <PermissionsModal sessionId={conversation.id} open={shareOpen} onOpenChange={setShareOpen} />
+      {/* Mount only while open — one per row, its hook tree + JSX would
+          otherwise run closed on every row re-render. */}
+      {shareOpen && (
+        <PermissionsModal
+          sessionId={conversation.id}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
       <Dialog
         open={deleteOpen}
         onOpenChange={(open) => {
@@ -3983,153 +4051,205 @@ function ConversationRow({
           if (!open) setDeleteBranch(false);
         }}
       >
-        <DialogContent
-          // Don't trigger the surrounding Link when the modal opens
-          // — the dialog content is a portal, but defensively belt-
-          // and-braces the click path.
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DialogHeader>
-            <DialogTitle>Delete conversation?</DialogTitle>
-            <DialogDescription>
-              <span className="font-medium break-all">{label}</span> and all of its history will be
-              removed. This cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {gitBranch !== null && (
-            <div className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
-              <p className="text-sm text-muted-foreground">
-                Optionally clean up the git worktree. These actions are{" "}
-                <span className="font-semibold text-destructive">irreversible</span>.
-              </p>
-              <label className="flex cursor-pointer items-start gap-2 text-ui">
-                <input
-                  type="checkbox"
-                  data-testid="delete-branch-checkbox"
-                  checked={deleteBranch}
-                  onChange={(e) => setDeleteBranch(e.target.checked)}
-                  className="mt-0.5 size-4 shrink-0 accent-destructive"
-                />
-                <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-                <span className="min-w-0">
-                  Delete local branch{" "}
-                  <code className="break-all rounded bg-muted px-1 py-0.5 text-sm">
-                    {gitBranch}
-                  </code>
-                </span>
-              </label>
-            </div>
-          )}
-          {/* Drop the default footer divider + muted bar so the actions
+        {/* Body only while open — see the share modal above. */}
+        {deleteOpen && (
+          <DialogContent
+            // Don't trigger the surrounding Link when the modal opens
+            // — the dialog content is a portal, but defensively belt-
+            // and-braces the click path.
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DialogHeader>
+              <DialogTitle>Delete conversation?</DialogTitle>
+              <DialogDescription>
+                <span className="font-medium break-all">{label}</span> and all of its history will
+                be removed. This cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            {gitBranch !== null && (
+              <div className="flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+                <p className="text-sm text-muted-foreground">
+                  Optionally clean up the git worktree. These actions are{" "}
+                  <span className="font-semibold text-destructive">irreversible</span>.
+                </p>
+                <label className="flex cursor-pointer items-start gap-2 text-ui">
+                  <input
+                    type="checkbox"
+                    data-testid="delete-branch-checkbox"
+                    checked={deleteBranch}
+                    onChange={(e) => setDeleteBranch(e.target.checked)}
+                    className="mt-0.5 size-4 shrink-0 accent-destructive"
+                  />
+                  <GitBranchIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0">
+                    Delete local branch{" "}
+                    <code className="break-all rounded bg-muted px-1 py-0.5 text-sm">
+                      {gitBranch}
+                    </code>
+                  </span>
+                </label>
+              </div>
+            )}
+            {/* Drop the default footer divider + muted bar so the actions
               blend into the dialog body (same background). */}
-          <DialogFooter className="border-t-0 bg-transparent">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setDeleteOpen(false)}
-              disabled={del.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={confirmDelete}
-              disabled={del.isPending}
-              componentId="sidebar.conversation.delete"
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
+            <DialogFooter className="border-t-0 bg-transparent">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setDeleteOpen(false)}
+                disabled={del.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={confirmDelete}
+                disabled={del.isPending}
+                componentId="sidebar.conversation.delete"
+              >
+                Delete
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
       </Dialog>
       <Dialog open={leaveOpen} onOpenChange={setLeaveOpen}>
-        <DialogContent
-          // Keep dialog clicks off the surrounding Link (same defensive
-          // handling as the delete dialog above).
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DialogHeader>
-            <DialogTitle>Leave session?</DialogTitle>
-            <DialogDescription>
-              <span className="font-medium break-all">{label}</span> will be removed from your
-              sidebar. Nothing is deleted — the session and its history stay with its owner, who can
-              share it with you again.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="border-t-0 bg-transparent">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setLeaveOpen(false)}
-              disabled={leave.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              data-testid="confirm-leave-conversation"
-              onClick={confirmLeave}
-              disabled={leave.isPending}
-              componentId="sidebar.conversation.leave"
-            >
-              Leave
-            </Button>
-          </DialogFooter>
-        </DialogContent>
+        {leaveOpen && (
+          <DialogContent
+            // Keep dialog clicks off the surrounding Link (same defensive
+            // handling as the delete dialog above).
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DialogHeader>
+              <DialogTitle>Leave session?</DialogTitle>
+              <DialogDescription>
+                <span className="font-medium break-all">{label}</span> will be removed from your
+                sidebar. Nothing is deleted — the session and its history stay with its owner, who
+                can share it with you again.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="border-t-0 bg-transparent">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setLeaveOpen(false)}
+                disabled={leave.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                data-testid="confirm-leave-conversation"
+                onClick={confirmLeave}
+                disabled={leave.isPending}
+                componentId="sidebar.conversation.leave"
+              >
+                Leave
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
       </Dialog>
       {/* The stale-error reset lives on the kebab item's onSelect (the only
           open path) — onOpenChange only fires for Radix-initiated closes. */}
       <Dialog open={stopOpen} onOpenChange={setStopOpen}>
-        <DialogContent
-          // Keep dialog clicks off the surrounding Link (same defensive
-          // handling as the delete dialog above).
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DialogHeader>
-            <DialogTitle>Stop session?</DialogTitle>
-            <DialogDescription>
-              This terminates the running session for <span className="font-medium">{label}</span>{" "}
-              and stops its runner. The conversation and its history are kept.
-            </DialogDescription>
-          </DialogHeader>
-          {stopSession.isError && (
-            <p className="text-ui text-destructive" role="alert">
-              Couldn't stop the session
-              {stopSession.error instanceof Error && stopSession.error.message
-                ? `: ${stopSession.error.message}`
-                : " — it may still be running"}
-              . Try again in a moment.
-            </p>
-          )}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setStopOpen(false)}
-              disabled={stopSession.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              data-testid="stop-session-confirm"
-              onClick={() =>
-                stopSession.mutate(conversation.id, { onSuccess: () => setStopOpen(false) })
-              }
-              loading={stopSession.isPending}
-              componentId="sidebar.conversation.stop"
-            >
-              Stop session
-            </Button>
-          </DialogFooter>
-        </DialogContent>
+        {stopOpen && (
+          <DialogContent
+            // Keep dialog clicks off the surrounding Link (same defensive
+            // handling as the delete dialog above).
+            onClick={(e) => e.stopPropagation()}
+          >
+            <DialogHeader>
+              <DialogTitle>Stop session?</DialogTitle>
+              <DialogDescription>
+                This terminates the running session for <span className="font-medium">{label}</span>{" "}
+                and stops its runner. The conversation and its history are kept.
+              </DialogDescription>
+            </DialogHeader>
+            {stopSession.isError && (
+              <p className="text-ui text-destructive" role="alert">
+                Couldn't stop the session
+                {stopSession.error instanceof Error && stopSession.error.message
+                  ? `: ${stopSession.error.message}`
+                  : " — it may still be running"}
+                . Try again in a moment.
+              </p>
+            )}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setStopOpen(false)}
+                disabled={stopSession.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                data-testid="stop-session-confirm"
+                onClick={() =>
+                  stopSession.mutate(conversation.id, { onSuccess: () => setStopOpen(false) })
+                }
+                loading={stopSession.isPending}
+                componentId="sidebar.conversation.stop"
+              >
+                Stop session
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
       </Dialog>
     </li>
   );
 }
+
+// The `conversation` fields the row renders. The comparator below compares
+// these (not object identity), so a live-updates merge that only touches an
+// unrendered field (e.g. an updated_at bump) doesn't re-render the row.
+// Keep in sync with the row + its helpers (conversationDisplayLabel,
+// getSessionState, isOwnedByViewer, isSessionStoppable).
+const RENDERED_CONVERSATION_FIELDS: readonly (keyof Conversation)[] = [
+  "id",
+  "title",
+  "archived",
+  "status",
+  "updated_at",
+  "git_branch",
+  "host_id",
+  "runner_id",
+  "project_id",
+  "owner",
+  "pending_elicitations_count",
+];
+
+function conversationRenderEqual(a: Conversation, b: Conversation): boolean {
+  if (a === b) return true;
+  for (const key of RENDERED_CONVERSATION_FIELDS) {
+    if (a[key] !== b[key]) return false;
+  }
+  // `labels` is an object; compare by value (rename/project moves ride here).
+  return JSON.stringify(a.labels) === JSON.stringify(b.labels);
+}
+
+// Memoized with a render-field comparator (not shallow identity): a row
+// re-renders only when its displayed data or `isActive` changes. Handler props
+// are stabilized at the list owner so they don't defeat it.
+const ConversationRow = memo(ConversationRowImpl, (prev, next) => {
+  return (
+    prev.isActive === next.isActive &&
+    prev.isPinned === next.isPinned &&
+    prev.selectionMode === next.selectionMode &&
+    prev.isSelected === next.isSelected &&
+    prev.onClick === next.onClick &&
+    prev.onTogglePinned === next.onTogglePinned &&
+    prev.onToggleSelected === next.onToggleSelected &&
+    prev.onProjectAssigned === next.onProjectAssigned &&
+    conversationRenderEqual(prev.conversation, next.conversation)
+  );
+});
 
 /**
  * Hover flyout body for a pinned, project-owned conversation row.
@@ -4526,15 +4646,19 @@ function useProjectFolderMenu(
           </form>
         </DialogContent>
       </Dialog>
-      <ProjectSettingsDialog
-        open={settingsOpen}
-        onOpenChange={(o) => {
-          setSettingsOpen(o);
-          if (!o) setMenuOpen(false);
-        }}
-        projectId={projectId}
-        projectName={projectName}
-      />
+      {/* Mount the settings dialog only while open — like the row share modal,
+          it runs a full hook tree even when closed. */}
+      {settingsOpen && (
+        <ProjectSettingsDialog
+          open={settingsOpen}
+          onOpenChange={(o) => {
+            setSettingsOpen(o);
+            if (!o) setMenuOpen(false);
+          }}
+          projectId={projectId}
+          projectName={projectName}
+        />
+      )}
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent onClick={(e) => e.stopPropagation()}>
           <DialogHeader>


### PR DESCRIPTION
## Related issue

<!-- Refactor/perf change; no issue required. -->

Closes #

## Summary

Switching the active conversation in the sidebar re-rendered the entire row
list (~40 rows) synchronously on the click, blocking the frame. This PR removes
the wasted work so the switch stays responsive:

- **Stop the whole sidebar re-rendering on switch** — rows read the active route
  id themselves and weren't memoized, so a switch re-rendered all ~40 rows.
  Resolve the active root once in `ConversationList`, pass each row a plain
  `isActive` prop, memo the row with a rendered-field comparator, and add
  `notifyOnChangeProps` so the live-updates query's object churn doesn't
  re-render the list. Stabilize the `AppShell`→`Sidebar` callbacks + memo the
  `Sidebar` so `AppShell`'s frequent re-renders don't cascade.
- **Render sidebar row dialogs only while open** — each row rendered its Share
  modal (a full hook tree) + delete/leave/stop confirm dialogs even while
  closed, ~40×. Gate each on its open flag.
- **Hoist row-invariant hooks** out of the row (`useIsMobileViewport`,
  `useViewerId`, `useServerInfo`) — resolved once at the list owner and shared
  via context.

xterm was investigated and confirmed a non-factor (already lazy-loaded); the
remaining cost is the sidebar/shell commit itself.

> **Changed since first push:** the original PR also deferred the `ChatPage`
> body render behind `startTransition`. Polly's review flagged that it decoupled
> the message-send target from the URL for the transcript-render window (a send
> could land in the previously-active conversation). That change is **removed** —
> `ChatPage.tsx` is now identical to `main`. This PR is the sidebar work only.

## Test Plan

Measured conversation-switch responsiveness (INP) with a `PerformanceObserver`
on `event` timings — same server/backend, same 6 conversations, same click
sequence, right workspace panel closed — comparing raw `main` vs. this branch.
Cold = first visit this session (also fetches); warm = revisiting a conversation
whose stream is already open. 18 samples per pass (6 switches × pointerdown/up/click).

**Production build (`vite build` + `vite preview`)** — the numbers that ship
(measured with the full PR incl. the since-removed transition split; the sidebar
work below is the bulk of the win and the numbers are dominated by it):

| Scenario | main | this branch | Δ |
|---|---|---|---|
| Cold switch — median | 88 ms | 64 ms | −27% |
| Warm switch — median | 80 ms | 48 ms | −40% |
| Warm switch — max | 96 ms | 56 ms | −42% |

Warm switches (the everyday case) drop ~40% to a ~48 ms floor. Cold switches
drop ~27%; the smaller relative gain is because a cold switch is partly
network-bound (the session fetch), which this PR doesn't touch — it removes the
*render* cost, not the fetch.

Also verified functionally: after a switch the transcript updates to the new
conversation, the active sidebar row matches the URL, and there's no stale/stuck
state. (I'll re-run the A/B on the sidebar-only branch and update these numbers.)

Gates green: `tsc -b`, `oxlint --deny-warnings`, `prettier --check`, and the
existing Vitest suites (Sidebar / ChatPage / AppShell / useConversations, 997
tests) all pass.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Perf-only optimization: the UI is visually and behaviorally identical, just
faster. Evidence is the before/after INP table in Test Plan (no visual change
to record).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Behavior is unchanged, so the existing Sidebar / ChatPage / AppShell / useConversations
Vitest suites (which cover active-row highlight, row actions, dialogs, and switch
navigation) already exercise these code paths and all pass. The improvement is
render scheduling / re-render count, verified manually via the INP measurements
in the Test Plan rather than by a new automated assertion.

## Changelog

Conversation switching in the sidebar is noticeably faster — the sidebar no
longer re-renders its whole row list on every switch

This pull request and its description were written by Isaac.
