### PR TITLE
fix(host): make `host reset-id` env-override-aware and write atomically

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -9996,7 +9996,25 @@ def host_reset_id(yes: bool) -> None:
 
     :param yes: When ``True``, skip the confirmation prompt.
     """
-    from omnigent.host.identity import CONFIG_PATH, reset_host_id
+    from omnigent.host.identity import (
+        CONFIG_PATH,
+        HOST_ID_ENV_VAR,
+        HOST_NAME_ENV_VAR,
+        host_identity_env_override_active,
+        reset_host_id,
+    )
+
+    # An OMNIGENT_HOST_ID / OMNIGENT_HOST_NAME override makes the host read its
+    # identity from the env, ignoring config.yaml — so writing a fresh id to
+    # the file would be a silent no-op. Refuse rather than report false success.
+    if host_identity_env_override_active():
+        raise click.ClickException(
+            f"This machine's host identity is pinned by the {HOST_ID_ENV_VAR} / "
+            f"{HOST_NAME_ENV_VAR} environment variable(s), so resetting the id in "
+            "the config file would have no effect. This is normally a "
+            "server-managed sandbox host, whose identity the server owns. Unset "
+            f"{HOST_ID_ENV_VAR} and {HOST_NAME_ENV_VAR} to reset the persisted id."
+        )
 
     running = [record for record in _list_daemon_records() if _pid_alive(record.pid)]
     if running:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10004,16 +10004,18 @@ def host_reset_id(yes: bool) -> None:
         reset_host_id,
     )
 
-    # An OMNIGENT_HOST_ID / OMNIGENT_HOST_NAME override makes the host read its
-    # identity from the env, ignoring config.yaml — so writing a fresh id to
-    # the file would be a silent no-op. Refuse rather than report false success.
+    # With OMNIGENT_HOST_ID / OMNIGENT_HOST_NAME set, the host takes its
+    # identity from the environment, not config.yaml (both set → env identity
+    # used; only one set → startup errors). Either way resetting the id in the
+    # file will not change the machine's identity, so refuse and point at the
+    # env vars rather than let a config write mislead the user.
     if host_identity_env_override_active():
         raise click.ClickException(
-            f"This machine's host identity is pinned by the {HOST_ID_ENV_VAR} / "
-            f"{HOST_NAME_ENV_VAR} environment variable(s), so resetting the id in "
-            "the config file would have no effect. This is normally a "
-            "server-managed sandbox host, whose identity the server owns. Unset "
-            f"{HOST_ID_ENV_VAR} and {HOST_NAME_ENV_VAR} to reset the persisted id."
+            f"This machine's host identity is controlled by the {HOST_ID_ENV_VAR} / "
+            f"{HOST_NAME_ENV_VAR} environment variable(s), so resetting the id in the "
+            "config file will not change it. This is normally a server-managed "
+            f"sandbox host, whose identity the server owns. Unset {HOST_ID_ENV_VAR} "
+            f"and {HOST_NAME_ENV_VAR} first if you need to reset the persisted id."
         )
 
     running = [record for record in _list_daemon_records() if _pid_alive(record.pid)]

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -7,8 +7,10 @@ if the section does not exist.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import socket
+import tempfile
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -217,10 +219,35 @@ def reset_host_id(path: Path = CONFIG_PATH) -> tuple[str | None, str]:
     host_section.setdefault("name", socket.gethostname())
     cfg["host"] = host_section
     path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "w") as f:
-        yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
+    # Atomic write: reset-id is a recovery command run when things are already
+    # broken, so a crash mid-write must not truncate the whole config. Write a
+    # sibling temp file and rename it over the target (rename is atomic on the
+    # same filesystem).
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=True)
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
 
     return (old_host_id if isinstance(old_host_id, str) else None), new_host_id
+
+
+def host_identity_env_override_active() -> bool:
+    """Whether an ``OMNIGENT_HOST_ID`` / ``OMNIGENT_HOST_NAME`` override is set.
+
+    When either is set, :func:`load_or_create_host_identity` returns the
+    env-supplied identity *without reading config.yaml*, so a
+    :func:`reset_host_id` write to the file would be ignored by the next
+    ``omnigent host`` — a silent no-op. Callers use this to refuse the reset
+    with a clear message instead of reporting false success.
+
+    :returns: ``True`` when at least one of the identity env vars is set.
+    """
+    return bool(os.environ.get(HOST_ID_ENV_VAR) or os.environ.get(HOST_NAME_ENV_VAR))
 
 
 def load_host_identity_if_present(

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -237,17 +237,24 @@ def reset_host_id(path: Path = CONFIG_PATH) -> tuple[str | None, str]:
 
 
 def host_identity_env_override_active() -> bool:
-    """Whether an ``OMNIGENT_HOST_ID`` / ``OMNIGENT_HOST_NAME`` override is set.
+    """Whether either identity env var (``OMNIGENT_HOST_ID`` / ``_NAME``) is set.
 
-    When either is set, :func:`load_or_create_host_identity` returns the
-    env-supplied identity *without reading config.yaml*, so a
-    :func:`reset_host_id` write to the file would be ignored by the next
-    ``omnigent host`` — a silent no-op. Callers use this to refuse the reset
-    with a clear message instead of reporting false success.
+    These pin the host identity from the environment:
+    :func:`load_or_create_host_identity` returns the env identity *without
+    reading config.yaml* when both are set, and raises when exactly one is
+    set (they must be set together). Either way a :func:`reset_host_id`
+    write to the file does not fix the machine's identity, so callers refuse
+    the reset and tell the user to unset the env vars.
+
+    Uses ``is not None`` (not truthiness) to match the loader, which treats a
+    present-but-empty var as set.
 
     :returns: ``True`` when at least one of the identity env vars is set.
     """
-    return bool(os.environ.get(HOST_ID_ENV_VAR) or os.environ.get(HOST_NAME_ENV_VAR))
+    return (
+        os.environ.get(HOST_ID_ENV_VAR) is not None
+        or os.environ.get(HOST_NAME_ENV_VAR) is not None
+    )
 
 
 def load_host_identity_if_present(

--- a/omnigent/host/identity.py
+++ b/omnigent/host/identity.py
@@ -222,7 +222,9 @@ def reset_host_id(path: Path = CONFIG_PATH) -> tuple[str | None, str]:
     # Atomic write: reset-id is a recovery command run when things are already
     # broken, so a crash mid-write must not truncate the whole config. Write a
     # sibling temp file and rename it over the target (rename is atomic on the
-    # same filesystem).
+    # same filesystem). The rename adopts mkstemp's 0600 mode intentionally —
+    # config.yaml holds only host identity, and 0600 is the right posture for a
+    # per-user file; do not "restore" a wider umask mode here.
     fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as f:

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1130,6 +1130,34 @@ def test_host_reset_id_declined_prompt_leaves_id_untouched(
     assert cfg["host"]["host_id"] == "a" * 32
 
 
+def test_host_reset_id_refuses_when_env_override_pins_identity(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With OMNIGENT_HOST_ID set, reset-id refuses instead of a silent no-op.
+
+    An env override makes the host read its identity from the environment,
+    ignoring config.yaml — so writing a fresh id to the file would be
+    ignored by the next `omnigent host`. The command must fail loud (naming
+    the env vars to unset) rather than print a reset that has no effect.
+    """
+    import yaml
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"host": {"host_id": "a" * 32, "name": "my-laptop"}}))
+    monkeypatch.setattr("omnigent.host.identity.CONFIG_PATH", config_path)
+    monkeypatch.setattr(cli, "_list_daemon_records", lambda **_kw: [])
+    monkeypatch.setenv("OMNIGENT_HOST_ID", "b" * 32)
+    monkeypatch.setenv("OMNIGENT_HOST_NAME", "managed-host")
+
+    result = CliRunner().invoke(cli_group, ["host", "reset-id", "--yes"])
+
+    assert result.exit_code != 0
+    assert "OMNIGENT_HOST_ID" in result.output
+    # The persisted id is untouched — no misleading "reset" happened.
+    cfg = yaml.safe_load(config_path.read_text())
+    assert cfg["host"]["host_id"] == "a" * 32
+
+
 def test_foreground_connect_local_prompts_after_keyboard_interrupt(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/host/test_identity.py
+++ b/tests/host/test_identity.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from omnigent.host.identity import (
+    host_identity_env_override_active,
     load_host_identity_if_present,
     load_or_create_host_identity,
     reset_host_id,
@@ -354,3 +355,55 @@ def test_reset_host_id_next_load_returns_the_new_identity(
     assert after.host_id == new_id
     assert after.host_id != before.host_id
     assert after.name == before.name
+
+
+def test_reset_host_id_write_is_atomic_and_preserves_config_on_dump_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure mid-write leaves the original config intact, not truncated.
+
+    reset-id is a recovery command run when things are already broken, so a
+    crash while serializing the new config must not destroy the existing one.
+    The atomic temp-file-plus-rename write guarantees the target is only
+    replaced once the new content is fully written.
+    """
+    config_path = tmp_path / "config.yaml"
+    original = yaml.safe_dump({"host": {"host_id": "a" * 32, "name": "my-laptop"}})
+    config_path.write_text(original)
+
+    # Blow up during serialization, after the target still holds the original.
+    import omnigent.host.identity as identity_mod
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(identity_mod.yaml, "safe_dump", _boom)
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        reset_host_id(config_path)
+
+    # The original config survives untouched, and no temp file is left behind.
+    assert config_path.read_text() == original
+    leftovers = [p for p in tmp_path.iterdir() if p.name != "config.yaml"]
+    assert leftovers == [], f"atomic write left temp files behind: {leftovers}"
+
+
+def test_host_identity_env_override_active_reflects_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The override predicate is true when either identity env var is set.
+
+    ``reset_host_id`` writes the config file, but the load path returns the
+    env identity without reading it — so the CLI must detect the override and
+    refuse rather than report a reset that the next load would ignore.
+    """
+    monkeypatch.delenv("OMNIGENT_HOST_ID", raising=False)
+    monkeypatch.delenv("OMNIGENT_HOST_NAME", raising=False)
+    assert host_identity_env_override_active() is False
+
+    monkeypatch.setenv("OMNIGENT_HOST_ID", "b" * 32)
+    assert host_identity_env_override_active() is True
+
+    monkeypatch.delenv("OMNIGENT_HOST_ID", raising=False)
+    monkeypatch.setenv("OMNIGENT_HOST_NAME", "managed-host")
+    assert host_identity_env_override_active() is True

--- a/tests/host/test_identity.py
+++ b/tests/host/test_identity.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+import omnigent.host.identity as identity_mod
 from omnigent.host.identity import (
     host_identity_env_override_active,
     load_host_identity_if_present,
@@ -372,8 +373,6 @@ def test_reset_host_id_write_is_atomic_and_preserves_config_on_dump_failure(
     config_path.write_text(original)
 
     # Blow up during serialization, after the target still holds the original.
-    import omnigent.host.identity as identity_mod
-
     def _boom(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("disk full")
 

--- a/tests/host/test_identity.py
+++ b/tests/host/test_identity.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-import omnigent.host.identity as identity_mod
 from omnigent.host.identity import (
     host_identity_env_override_active,
     load_host_identity_if_present,
@@ -376,7 +375,7 @@ def test_reset_host_id_write_is_atomic_and_preserves_config_on_dump_failure(
     def _boom(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("disk full")
 
-    monkeypatch.setattr(identity_mod.yaml, "safe_dump", _boom)
+    monkeypatch.setattr("omnigent.host.identity.yaml.safe_dump", _boom)
 
     with pytest.raises(RuntimeError, match="disk full"):
         reset_host_id(config_path)


### PR DESCRIPTION
## Related issue

Follow-up to #6412 (which merged the initial `omnigent host reset-id`).

## Summary

Addresses the two actionable non-blocking notes from Polly's review of #6412:

1. **Env-override silent no-op.** When `OMNIGENT_HOST_ID` / `OMNIGENT_HOST_NAME` is set, `load_or_create_host_identity` returns the env identity *without reading `config.yaml`*. So `reset_host_id` writing a fresh id to the file was ignored by the next `omnigent host` — the reset printed success but was a no-op. `host reset-id` now detects the override (`host_identity_env_override_active`) and **refuses with a clear message** naming the env vars to unset, instead of reporting false success. (The env path is the server-managed sandbox, whose identity the server owns.)

2. **Non-atomic config rewrite.** `reset_host_id` truncated `config.yaml` with `open(..., "w")` before serializing, so a crash mid-write destroyed the whole config — bad for a recovery command run when things are already broken. It now writes to a sibling temp file and `os.replace()`s it over the target (atomic on the same filesystem), cleaning up the temp file on failure.

The other two review notes (no cross-process lock; `_pid_alive` vs the reuse-safe `_daemon_owner_is_live`) were explicitly scoped as broader-than-this-command refactors and are left out.

## Test Plan

```
pytest tests/host/test_identity.py tests/cli/test_backend.py -k "reset_id or env_override or atomic"
```
New tests: `reset-id` refuses when an env override pins the identity (id left untouched); the config file survives a mid-write serialization failure with no temp file left behind; and the `host_identity_env_override_active` predicate reflects either env var.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

CLI-only; evidence is the suites above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — the env-override refusal, the atomic-write survival path, and the predicate are all unit-tested.

## Changelog

`omnigent host reset-id` refuses (instead of silently doing nothing) when the host identity is pinned by an environment variable, and writes the config atomically
