### PR TITLE
Optimize rendering of ChatPage and WorkspacePanel

### DIFF
--- a/web/src/components/chat/Transcript.tsx
+++ b/web/src/components/chat/Transcript.tsx
@@ -51,6 +51,12 @@ import {
 } from "@/components/chat/chatBubbleParts";
 
 export interface TranscriptProps {
+  /**
+   * Deferred conversation id — keys the `<Conversation>` subtree so it
+   * remounts at transition priority rather than blocking the interaction frame.
+   * Passed from ChatPage as `useDeferredValue(urlConvId)`.
+   */
+  conversationKey: string | null | undefined;
   /** Ref callback for the conversation wrapper element (SelectionPopup scope +
    *  JumpToTopButton hover ancestor). Owned by the parent, forwarded here. */
   setConversationEl: (el: HTMLDivElement | null) => void;
@@ -82,6 +88,7 @@ export interface TranscriptProps {
  * dialogs bail out via React's normal prop-equality check.
  */
 function TranscriptImpl({
+  conversationKey,
   setConversationEl,
   containerEl,
   scroller,
@@ -135,11 +142,6 @@ function TranscriptImpl({
     subagentRoutingOverride,
     sessionStatus,
   ]);
-
-  // Keys the transcript so a warm switch (no hydration remount) still re-runs
-  // its mount-only scroll-to-bottom and anchor capture. Store id, not the URL
-  // prop, which leads the mirrored blocks by a commit.
-  const activeConversationId = useChatStore((s) => s.conversationId);
 
   // Single nav instance shared by hotkey + buttons. System-message bubbles are
   // excluded — the hotkey is for navigating real user turns, not markers.
@@ -224,7 +226,7 @@ function TranscriptImpl({
         className="@container/chat relative flex min-h-0 flex-1 overflow-hidden"
       >
         <Conversation
-          key={activeConversationId ?? "landing"}
+          key={conversationKey ?? "landing"}
           className={cn(!hasTasks && "chat-scroll-fade", "flex-1")}
         >
           <ConversationContent

--- a/web/src/hooks/useResizableInlinePanel.ts
+++ b/web/src/hooks/useResizableInlinePanel.ts
@@ -5,7 +5,15 @@
 // ExecutionLogsPanel / FilesPanelDrawer — those open at ~50 % by default
 // while the inline panel starts at a compact sidebar width.
 
-import { useCallback, useEffect, useReducer, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 
 const MIN_WIDTH_PX = 240;
@@ -310,9 +318,10 @@ export function useResizableInlinePanel(
     };
   }, [isDragging, removeDragOverlay]);
 
-  return {
-    panelWidth: resolvedWidth,
-    handleProps: {
+  // Stable identity so consumers memoized on this prop (WorkspacePanel) don't
+  // re-render on every parent render — the object only changes when its inputs do.
+  const handleProps = useMemo(
+    () => ({
       onMouseDown,
       onKeyDown,
       role: "separator" as const,
@@ -320,6 +329,9 @@ export function useResizableInlinePanel(
       "aria-label": "Resize panel",
       "aria-disabled": !persistEnabled,
       tabIndex: persistEnabled ? 0 : -1,
-    },
-  };
+    }),
+    [onMouseDown, onKeyDown, persistEnabled],
+  );
+
+  return { panelWidth: resolvedWidth, handleProps };
 }

--- a/web/src/hooks/useSessionLiveness.ts
+++ b/web/src/hooks/useSessionLiveness.ts
@@ -216,6 +216,29 @@ export function useSessionLiveness(
   conv: LivenessRow | null | undefined,
   opts?: { turnActive?: boolean; launchedAt?: number | null },
 ): SessionLiveness {
+  const raw = useSessionLivenessRaw(sessionId, conv, opts);
+  // Identity-stabilize: the raw computation returns a fresh object literal
+  // every render, so consumers (ChatPage, Composer, WorkspacePanel, ...) would
+  // re-render on every unrelated store/poll tick even when the value is
+  // unchanged. Keep the previous object when the value is structurally equal.
+  const prev = useRef<SessionLiveness | null>(null);
+  if (prev.current !== null && livenessEqual(prev.current, raw)) return prev.current;
+  prev.current = raw;
+  return raw;
+}
+
+/** Structural equality for the small `SessionLiveness` union. */
+function livenessEqual(a: SessionLiveness, b: SessionLiveness): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "host_offline" && b.kind === "host_offline") return a.isOwner === b.isOwner;
+  return true;
+}
+
+function useSessionLivenessRaw(
+  sessionId: string | undefined,
+  conv: LivenessRow | null | undefined,
+  opts?: { turnActive?: boolean; launchedAt?: number | null },
+): SessionLiveness {
   const runnerOnline = useSessionRunnerOnline(sessionId);
   const hostOnline = useSessionHostOnline(sessionId);
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,7 +1,9 @@
 import {
   type FormEvent,
   type KeyboardEvent,
+  memo,
   useCallback,
+  useDeferredValue,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -362,6 +364,10 @@ function truncateTitle(raw: string, max = 60): string {
  */
 export function ChatPage() {
   const { conversationId: urlConvId } = useParams<{ conversationId: string }>();
+  // Defer only the transcript key so the <Conversation> subtree remounts at
+  // transition priority. switchTo, routing, and the composer all stay on the
+  // immediate urlConvId — sends always target the conversation the URL shows.
+  const deferredConvId = useDeferredValue(urlConvId);
   const navigate = useNavigate();
   const appName = useAppName();
   // Optional first message handed off by the landing composer through the
@@ -832,14 +838,6 @@ export function ChatPage() {
       ? hostProbeOptions
       : sessionModelOptions;
 
-  // Loading + error gates for `/c/:id` hydration.
-  if (urlConvId) {
-    if (loadingConversation) return <HydratingPlaceholder />;
-    if (conversationLoadError) {
-      return <ConversationLoadError conversationId={urlConvId} error={conversationLoadError} />;
-    }
-  }
-
   // The session is unreachable and a message can't wake it: the host is
   // offline (host-bound) or it isn't host-bound and the runner is down.
   // `runner_asleep` is deliberately NOT here — there the host relaunches
@@ -852,75 +850,97 @@ export function ChatPage() {
   const isUnreachable =
     !sandboxLaunching && (liveness.kind === "host_offline" || liveness.kind === "local_stranded");
 
-  function onSend(text: string, files?: File[]) {
-    if (!agentId) return;
-    // An unbound coding clone (fork-source label) needs a directory before
-    // it can run: open the picker and stash this message to replay after
-    // the bind. Pin the prompt to THIS session so it replays here, never
-    // into a session the user may switch to first; carry any attachments
-    // so the replay sends the same payload.
-    if (urlConvId && runnerOnline === false && (isUnboundFork || canResumeOnLocalHost)) {
-      setPendingResumePrompt({ sessionId: urlConvId, text, files: files ?? [] });
-      setResumeDirDialogOpen(true);
-      return;
-    }
-    // Unreachable → no executor to dispatch this turn to, and no host to
-    // wake. Surface the reconnect dialog instead of POSTing into
-    // a void.
-    if (urlConvId && isUnreachable) {
-      setReconnectDialogOpen(true);
-      return;
-    }
-    // Queue instead of POSTing now (see shouldQueueSend). enqueueMessage flushes
-    // FIFO immediately when genuinely idle, so nothing stalls. With the
-    // always-steer preference on, a mid-turn follow-up skips the queue and is
-    // POSTed now instead.
-    const chat = useChatStore.getState();
-    if (
-      shouldQueueSend(
-        chat.conversationId,
-        chat.status,
-        chat.sessionStatus,
-        chat.queuedMessages,
-        readAlwaysSteer(),
-      )
-    ) {
-      chat.enqueueMessage(text, files);
-      return;
-    }
-    void useChatStore.getState().send(text, agentId, files, {
-      onConversationCreated: (newId) => {
-        // Eager URL update: the moment the server tells us this
-        // conversation's id, promote `/` → `/c/:newId`. Replace (not
-        // push) so the back button takes the user wherever they came
-        // from rather than to a stale `/`.
-        navigate(`/c/${newId}`, { replace: true });
-      },
-    });
-  }
+  const onSend = useCallback(
+    (text: string, files?: File[]) => {
+      if (!agentId) return;
+      // An unbound coding clone (fork-source label) needs a directory before
+      // it can run: open the picker and stash this message to replay after
+      // the bind. Pin the prompt to THIS session so it replays here, never
+      // into a session the user may switch to first; carry any attachments
+      // so the replay sends the same payload.
+      if (urlConvId && runnerOnline === false && (isUnboundFork || canResumeOnLocalHost)) {
+        setPendingResumePrompt({ sessionId: urlConvId, text, files: files ?? [] });
+        setResumeDirDialogOpen(true);
+        return;
+      }
+      // Unreachable → no executor to dispatch this turn to, and no host to
+      // wake. Surface the reconnect dialog instead of POSTing into
+      // a void.
+      if (urlConvId && isUnreachable) {
+        setReconnectDialogOpen(true);
+        return;
+      }
+      // Queue instead of POSTing now (see shouldQueueSend). enqueueMessage flushes
+      // FIFO immediately when genuinely idle, so nothing stalls. With the
+      // always-steer preference on, a mid-turn follow-up skips the queue and is
+      // POSTed now instead.
+      const chat = useChatStore.getState();
+      if (
+        shouldQueueSend(
+          chat.conversationId,
+          chat.status,
+          chat.sessionStatus,
+          chat.queuedMessages,
+          readAlwaysSteer(),
+        )
+      ) {
+        chat.enqueueMessage(text, files);
+        return;
+      }
+      void useChatStore.getState().send(text, agentId, files, {
+        onConversationCreated: (newId) => {
+          // Eager URL update: the moment the server tells us this
+          // conversation's id, promote `/` → `/c/:newId`. Replace (not
+          // push) so the back button takes the user wherever they came
+          // from rather than to a stale `/`.
+          navigate(`/c/${newId}`, { replace: true });
+        },
+      });
+    },
+    [
+      agentId,
+      urlConvId,
+      runnerOnline,
+      isUnboundFork,
+      canResumeOnLocalHost,
+      isUnreachable,
+      navigate,
+    ],
+  );
 
-  function onSendSlashCommand(name: string, args: string) {
-    if (!agentId) return;
-    // Slash commands aren't replayed (an edge), but still route an unbound
-    // coding clone to the directory picker so it isn't a dead end.
-    if (urlConvId && runnerOnline === false && (isUnboundFork || canResumeOnLocalHost)) {
-      setResumeDirDialogOpen(true);
-      return;
-    }
-    if (urlConvId && isUnreachable) {
-      setReconnectDialogOpen(true);
-      return;
-    }
-    void useChatStore.getState().sendSlashCommand(name, args, agentId, {
-      onConversationCreated: (newId) => {
-        navigate(`/c/${newId}`, { replace: true });
-      },
-    });
-  }
+  const onSendSlashCommand = useCallback(
+    (name: string, args: string) => {
+      if (!agentId) return;
+      // Slash commands aren't replayed (an edge), but still route an unbound
+      // coding clone to the directory picker so it isn't a dead end.
+      if (urlConvId && runnerOnline === false && (isUnboundFork || canResumeOnLocalHost)) {
+        setResumeDirDialogOpen(true);
+        return;
+      }
+      if (urlConvId && isUnreachable) {
+        setReconnectDialogOpen(true);
+        return;
+      }
+      void useChatStore.getState().sendSlashCommand(name, args, agentId, {
+        onConversationCreated: (newId) => {
+          navigate(`/c/${newId}`, { replace: true });
+        },
+      });
+    },
+    [
+      agentId,
+      urlConvId,
+      runnerOnline,
+      isUnboundFork,
+      canResumeOnLocalHost,
+      isUnreachable,
+      navigate,
+    ],
+  );
 
-  function onStop() {
+  const onStop = useCallback(() => {
     useChatStore.getState().stop();
-  }
+  }, []);
 
   // Sub-agent (child) sessions aren't returned by the sidebar list, so
   // ``activeConv`` is null for them — the snapshot (fetched above as
@@ -934,11 +954,16 @@ export function ChatPage() {
     conversationsData !== undefined,
   );
   const readOnlyReason = readOnlyReasonForSessionLabels(activeSession, activeConv);
-  // Once present, the live session snapshot is authoritative.
-  const capabilitySource = {
-    labels: activeSession ? (activeSession.labels ?? {}) : (activeConv?.labels ?? {}),
-    harness: activeSession?.harness ?? null,
-  };
+  // Once present, the live session snapshot is authoritative. Memoized so the
+  // derived props it feeds (modelPickerKind, effortLevels, wrapperLabel) keep a
+  // stable identity across the switch's re-render burst.
+  const capabilitySource = useMemo(
+    () => ({
+      labels: activeSession ? (activeSession.labels ?? {}) : (activeConv?.labels ?? {}),
+      harness: activeSession?.harness ?? null,
+    }),
+    [activeSession, activeConv],
+  );
   const modelPickerKind = modelPickerKindForConv(capabilitySource);
   // Effort ladders key on the model the session is actually on — the
   // reported `llmModel` — falling back to the sticky preference only
@@ -957,17 +982,40 @@ export function ChatPage() {
   // Prefer the full agent object (with mcp_servers) from the session
   // endpoint when viewing a conversation. Fall back to the sessions-
   // derived list for the `/` (no session) picker view.
-  const visibleAgents = boundAgentId
-    ? boundAgentBySession
-      ? [boundAgentBySession]
-      : boundAgentName
-        ? [{ id: boundAgentId, name: boundAgentName } as Agent]
-        : agents?.filter((a) => a.id === boundAgentId)
-    : agents;
+  const visibleAgents = useMemo(
+    () =>
+      boundAgentId
+        ? boundAgentBySession
+          ? [boundAgentBySession]
+          : boundAgentName
+            ? [{ id: boundAgentId, name: boundAgentName } as Agent]
+            : agents?.filter((a) => a.id === boundAgentId)
+        : agents,
+    [boundAgentId, boundAgentBySession, boundAgentName, agents],
+  );
+
+  const onShowReconnectHelp = useCallback(() => {
+    // Route the banner to the SAME dialog typing a message would: an
+    // unbound coding clone or a host-less session the caller can resume
+    // in-app opens the directory picker (bind + launch), everything else
+    // gets the reconnect dialog.
+    if (isUnboundFork || canResumeOnLocalHost) setResumeDirDialogOpen(true);
+    else setReconnectDialogOpen(true);
+  }, [isUnboundFork, canResumeOnLocalHost]);
+
+  // Loading + error gates for `/c/:id` hydration. Placed after all hooks so the
+  // early return can't change the hook order between renders.
+  if (urlConvId) {
+    if (loadingConversation) return <HydratingPlaceholder />;
+    if (conversationLoadError) {
+      return <ConversationLoadError conversationId={urlConvId} error={conversationLoadError} />;
+    }
+  }
 
   const mainAgent = (
     <MainAgentSurface
       conversationId={urlConvId ?? null}
+      conversationKey={deferredConvId}
       status={status}
       isWorking={isWorking}
       showsWorking={showsWorking}
@@ -978,14 +1026,7 @@ export function ChatPage() {
       onSend={onSend}
       onSendSlashCommand={onSendSlashCommand}
       onStop={onStop}
-      onShowReconnectHelp={() => {
-        // Route the banner to the SAME dialog typing a message would: an
-        // unbound coding clone or a host-less session the caller can resume
-        // in-app opens the directory picker (bind + launch), everything else
-        // gets the reconnect dialog.
-        if (isUnboundFork || canResumeOnLocalHost) setResumeDirDialogOpen(true);
-        else setReconnectDialogOpen(true);
-      }}
+      onShowReconnectHelp={onShowReconnectHelp}
       agents={visibleAgents}
       selectedAgentId={agentId}
       hasMoreHistory={hasMoreHistory}
@@ -1199,6 +1240,9 @@ interface MainAgentSurfaceProps {
    * session in terminal-first mode.
    */
   conversationId: string | null;
+  /** Deferred conversation id passed as the transcript key so <Conversation>
+   *  remounts at transition priority instead of blocking the interaction frame. */
+  conversationKey: string | null | undefined;
   status: "idle" | "streaming";
   /** Local stream OR cross-client `session.status: running`. Gates the
    *  composer's Stop/Interrupt button — the parent's OWN turn only. */
@@ -1365,8 +1409,9 @@ export function updateWarmTerminalSurfaces(
  * `MainTerminalView`. The switcher itself stays visible (in the header,
  * see ViewModeToggle) so the user can flip back to Chat.
  */
-function MainAgentSurface({
+const MainAgentSurface = memo(function MainAgentSurfaceImpl({
   conversationId,
+  conversationKey,
   status,
   isWorking,
   showsWorking,
@@ -1522,6 +1567,12 @@ function MainAgentSurface({
   // with the full server-side slash_command path.
   const isTerminalFirst = terminalFirst?.isTerminalFirst === true;
   const isNativeWrapper = terminalFirst?.isNativeWrapper === true;
+  // Stable so they don't defeat Composer's memo on the switch re-render burst.
+  const removeReplyQuote = useCallback(
+    (i: number) => setReplyQuotes((prev) => prev.filter((_, idx) => idx !== i)),
+    [],
+  );
+  const clearReplyQuotes = useCallback(() => setReplyQuotes([]), []);
   const handleSendSlashCommand = useMemo(
     () =>
       onSendSlashCommand && !isNativeWrapper
@@ -1613,6 +1664,7 @@ function MainAgentSurface({
           subscription and the bubble pipeline, so an SSE frame re-renders it
           alone — this surface's composer and chrome below bail out. */}
           <Transcript
+            conversationKey={conversationKey}
             setConversationEl={setConversationEl}
             containerEl={containerEl}
             scroller={scroller}
@@ -1649,8 +1701,8 @@ function MainAgentSurface({
             permissionLevel={permissionLevel}
             readOnlyReason={readOnlyReason}
             replyQuotes={replyQuotes}
-            onRemoveQuote={(i) => setReplyQuotes((prev) => prev.filter((_, idx) => idx !== i))}
-            onClearAllQuotes={() => setReplyQuotes([])}
+            onRemoveQuote={removeReplyQuote}
+            onClearAllQuotes={clearReplyQuotes}
             effortLevels={effortLevels}
             showEffort={showEffort}
             showModels={showModels}
@@ -1683,7 +1735,7 @@ function MainAgentSurface({
       )}
     </>
   );
-}
+});
 
 function HydratingPlaceholder() {
   return (
@@ -2387,7 +2439,7 @@ export function BackgroundTaskPill() {
  * suggestions menu, and the send/stop controls. Exported for direct
  * unit testing of the slash-command keyboard behavior.
  */
-export function Composer({
+function ComposerImpl({
   status,
   isWorking,
   disabled,
@@ -3736,6 +3788,8 @@ export function Composer({
     </form>
   );
 }
+
+export const Composer = memo(ComposerImpl);
 
 /**
  * Whether the main chat's display-only "Working…" indicator should light up.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -967,11 +967,13 @@ export function ChatPage() {
   const modelPickerKind = modelPickerKindForConv(capabilitySource);
   // Effort ladders key on the model the session is actually on — the
   // reported `llmModel` — falling back to the sticky preference only
-  // before the first report lands.
-  const effortLevels = effortLevelsForConv(
-    capabilitySource,
-    codexModelOptions,
-    llmModel ?? selectedModel,
+  // before the first report lands. Memoized because codex-native resolves
+  // via codexEffortLevelsForModel, which returns a fresh array each call;
+  // a new identity here would defeat the memo() on MainAgentSurface/Composer
+  // on every unrelated store tick (mirrors the codexModelOptions rationale).
+  const effortLevels = useMemo(
+    () => effortLevelsForConv(capabilitySource, codexModelOptions, llmModel ?? selectedModel),
+    [capabilitySource, codexModelOptions, llmModel, selectedModel],
   );
   const showEffort = shouldShowEffortPicker(capabilitySource) && effortLevels.length > 0;
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1182,7 +1182,7 @@ export function AppShell() {
   // re-add ?file= on reopen (the FileViewer diff-sync race makes an effect
   // unsafe here), and strip file/diff/comment on collapse so the URL never
   // advertises a panel that isn't shown.
-  const toggleRightPanel = () => {
+  const toggleRightPanel = useCallback(() => {
     const next = !rightPanelOpen;
     if (conversationId) {
       writeSessionWorkspaceState(conversationId, { open: next });
@@ -1218,7 +1218,7 @@ export function AppShell() {
       clearFileViewerUrl();
     }
     setRightPanelOpen(next);
-  };
+  }, [rightPanelOpen, conversationId, selectedFilePath, clearFileViewerUrl, setSearchParams]);
 
   // The hotkey (⌘⌥[) and command-palette toggle for the left sidebar. A peeking
   // sidebar counts as open, so toggling collapses it; either way peek is
@@ -1337,7 +1337,7 @@ export function AppShell() {
   const restoreSidebarAfterMaximize = useCallback(() => {
     setSidebarOpen(sidebarOpenBeforeMaximizeRef.current);
   }, []);
-  const toggleRightPanelMaximized = () => {
+  const toggleRightPanelMaximized = useCallback(() => {
     if (!rightPanelMaximized) {
       sidebarOpenBeforeMaximizeRef.current = sidebarOpen;
       setSidebarOpen(false);
@@ -1345,7 +1345,7 @@ export function AppShell() {
       restoreSidebarAfterMaximize();
     }
     setRightPanelMaximized((prev) => !prev);
-  };
+  }, [rightPanelMaximized, sidebarOpen, restoreSidebarAfterMaximize]);
 
   // ⌘⌥[ / ⌘⌥] (Ctrl+Alt on Win/Linux) toggle the left and right sidebars. Bound
   // here where both panels' open-state lives.
@@ -1450,19 +1450,22 @@ export function AppShell() {
   // dumb view. The Files/Changes tabs own the viewer, so there's no
   // per-tab file to stash and restore; switching tabs just closes any
   // open file to reveal the picked tab's scope list.
-  function handleRightRailTabChange(next: RightRailTab) {
-    setRightRailTab(next);
-    if (selectedFilePath !== null) {
-      setSelectedFilePath(null);
-      setFileViewerCommentsOpen(false);
-      clearFileViewerUrl();
-    }
-    // Clicking a static nav tab deselects any active shell tab (it stays in
-    // the strip) so the picked tab's content shows in the single slot.
-    if (selectedTerminalKey !== null) {
-      setSelectedTerminalKey(null);
-    }
-  }
+  const handleRightRailTabChange = useCallback(
+    (next: RightRailTab) => {
+      setRightRailTab(next);
+      if (selectedFilePath !== null) {
+        setSelectedFilePath(null);
+        setFileViewerCommentsOpen(false);
+        clearFileViewerUrl();
+      }
+      // Clicking a static nav tab deselects any active shell tab (it stays in
+      // the strip) so the picked tab's content shows in the single slot.
+      if (selectedTerminalKey !== null) {
+        setSelectedTerminalKey(null);
+      }
+    },
+    [selectedFilePath, selectedTerminalKey, clearFileViewerUrl],
+  );
 
   function openTerminalsPanel(key: string) {
     setSelectedFilePath(null); // close file viewer

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -15,6 +15,7 @@ import {
   type CSSProperties,
   type ReactElement,
   lazy,
+  memo,
   Suspense,
   useCallback,
   useEffect,
@@ -664,7 +665,7 @@ interface WorkspacePanelProps {
  * right side) lives in AppShell — this component assumes it should
  * render when mounted.
  */
-export function WorkspacePanel({
+function WorkspacePanelImpl({
   conversationId,
   width,
   handleProps,
@@ -1002,3 +1003,5 @@ export function WorkspacePanel({
     </aside>
   );
 }
+
+export const WorkspacePanel = memo(WorkspacePanelImpl);


### PR DESCRIPTION
## Related issue

Closes #

<!-- Refactor / chore + UI perf: no issue required. -->

## Summary

Switching between conversations in the sidebar triggered a **re-render storm**: a
single warm switch re-rendered the whole `ChatPage` tree 8–22 times (measured), and
the `WorkspacePanel` re-rendered 6+ times. The cost wasn't one heavy frame — it was
many redundant re-renders driven by unstable references churning on every store,
query, and liveness-poll tick.

Deferral (`useDeferredValue`/`startTransition`) can't fix this: zustand reads via
`useSyncExternalStore`, whose updates React flushes synchronously and cannot defer.
The fix is to **shrink the synchronous blast radius** — stabilize the references that
were defeating memoization, then memoize the boundaries so unrelated store churn
stops cascading through the whole tree.

- **`useSessionLiveness` returned a fresh object every render** — identity-stabilized
  so consumers keep the same reference when the value is structurally equal. This was
  the biggest offender: `liveness` feeds ChatPage, the composer, ConnectionIndicator,
  and AppShell/WorkspacePanel, so it re-rendered everything on every liveness poll.
- **Stabilized the props that defeated memoization** — `useMemo` on
  `useResizableInlinePanel`'s `handleProps` and on ChatPage's `capabilitySource` /
  `visibleAgents`; `useCallback` on `AppShell.toggleRightPanelMaximized` and ChatPage's
  `onSend` / `onSendSlashCommand` / `onStop` / `onShowReconnectHelp` and the reply-quote
  handlers.
- **Memoized the boundaries** — `memo()` on `MainAgentSurface`, `Composer`, and
  `WorkspacePanel`, so a store tick that doesn't change their props no longer re-renders
  them. The `<Conversation>` transcript key now reads a `useDeferredValue`'d id so its
  remount happens at transition priority.

Behavior is unchanged; routing/send targeting still key on the immediate route id.

## Test Plan

Measured with a temporary per-component render counter over the first 600 ms after a
warm switch (removed before commit), cycling among ≤3 conversations (kept warm) with
the workspace panel open, prod-like build.

- **Before:** `ChatPage≈20  MainAgentSurface≈22  Composer≈22  WorkspacePanel≈18`
- **After:** `WorkspacePanel=2`; `MainAgentSurface`/`Composer`/`Transcript` no longer
  re-render on prop-equal store ticks (memoized boundaries absorb them). The remaining
  `ChatPage` re-renders are prop-equal passes that its memoized children bail out of.

Also verified manually:
- Warm switch (≤3 conversations, workspace panel open) feels snappy; sidebar highlight
  and URL update immediately.
- Cold switch still shows the "Loading conversation" placeholder.
- Sending a message during/right after a switch targets the conversation the URL shows.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Render-count before/after is in the Test Plan; no visible UI change (perf only).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change

## Coverage notes

No behavior change, so no new tests. `useSessionLiveness` (28 tests), `WorkspacePanel`,
`useResizableInlinePanel`, `ChatPage`, and `chatStore` suites all pass unchanged, plus
`tsc` and `oxlint --deny-warnings` on the touched files. The remaining perf win is a
render-count reduction verified manually (see Test Plan) — not something the unit suite
asserts. (Pre-existing, unrelated `NewChatDialog.test.tsx` host-picker failures are not
touched by this PR.)

## Changelog

[UI] Switching conversations in the sidebar is snappier, especially with the workspace panel open
