### PR TITLE
Open brand new conversation page instantly

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -713,9 +713,7 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
             await expect(composer).to_be_disabled()
             await expect(composer).to_have_attribute("placeholder", "Starting the session…")
             await expect(
-                page.get_by_test_id("message-bubble").get_by_text(
-                    "set up the project", exact=True
-                )
+                page.get_by_test_id("message-bubble").get_by_text("set up the project", exact=True)
             ).to_be_visible()
 
             # Release the create: the same chat hydrates onto the real id.

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -723,39 +723,26 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
-def test_start_session_opens_before_the_create_responds(seeded_session: tuple[str, str]) -> None:
-    """Send opens the session on the stream's announcement, not the response.
+def test_start_session_ignores_uncorrelated_announcement_while_create_pending(
+    seeded_session: tuple[str, str],
+) -> None:
+    """The temp chat waits for the create response's authoritative session id.
 
-    ``POST /v1/sessions`` doesn't answer until the host has finished spawning a
-    runner — a process boot, seconds of it — and the landing screen used to sit
-    on that whole wait before routing anywhere. But the server writes the
-    session row and announces it on ``WS /v1/sessions/updates`` almost
-    immediately, so the id is available long before the response is. This holds
-    the create POST open for the entire test and announces the session over the
-    stream: the chat page must open anyway.
-
-    A regression that goes back to awaiting the response would never leave the
-    landing screen here, since the create never answers.
-
-    The announcement is injected through a mocked updates socket rather than a
-    real create, because this suite has no host daemon for a host-bound create
-    to actually succeed against. The row carries the stubbed agent/host the
-    composer just asked for — that pairing is what the screen matches on to
-    tell its own new session apart from every other session the stream
-    announces to this user.
+    A session update with the same agent and host is not correlated to this
+    request, so it must not replace the temporary route. Once the create
+    responds, the temp chat hydrates onto that returned id.
     """
     base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_open_before_create_responds(base_url, session_id))
+    _run_in_fresh_loop(_drive_ignore_uncorrelated_announcement(base_url, session_id))
 
 
-async def _drive_open_before_create_responds(base_url: str, session_id: str) -> None:
+async def _drive_ignore_uncorrelated_announcement(base_url: str, session_id: str) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
         try:
             create_seen = asyncio.Event()
-            # Released only at teardown, so the create is pending for every
-            # assertion below.
+            # Held until the uncorrelated announcement has been observed.
             release_create = asyncio.Event()
             sockets: list[Any] = []
 
@@ -827,9 +814,8 @@ async def _drive_open_before_create_responds(base_url: str, session_id: str) -> 
             # The create is in flight and will stay that way.
             await _wait_until(create_seen.is_set)
 
-            # A brand-new session the page has never seen, on the agent and
-            # host the composer just asked for: the server's announcement of
-            # the row it wrote before starting the runner.
+            # Another same-agent/host session is indistinguishable from this
+            # create without a request correlation token.
             announced_id = "conv_announced_e2e"
             sockets[0].send(
                 json.dumps(
@@ -853,13 +839,16 @@ async def _drive_open_before_create_responds(base_url: str, session_id: str) -> 
                 )
             )
 
-            # KEY ASSERTION: routed to the announced session while the create
-            # is still pending — the landing composer is gone and the URL is
-            # the announced id, not the one the (unanswered) create would
-            # eventually return.
-            await expect(page).to_have_url(f"{base_url}/c/{announced_id}", timeout=20_000)
+            # Stay on the already-open temp chat; never guess that the pushed
+            # row belongs to this request.
+            await expect(page).to_have_url(
+                re.compile(rf"{re.escape(base_url)}/c/temp:[0-9a-f]{{8}}")
+            )
             await expect(page.get_by_test_id("new-chat-landing-input")).to_have_count(0)
             assert not release_create.is_set(), "the create must still be unanswered here"
+
+            release_create.set()
+            await expect(page).to_have_url(f"{base_url}/c/{session_id}", timeout=30_000)
         finally:
             release_create.set()
             await browser.close()

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -619,16 +619,13 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
-def test_start_session_send_shows_busy_spinner(seeded_session: tuple[str, str]) -> None:
-    """Send shows a busy spinner while the create is in flight, then navigates.
+def test_start_session_navigates_while_create_is_pending(seeded_session: tuple[str, str]) -> None:
+    """Send immediately opens a temporary chat, then hydrates its real id.
 
-    The create awaits the backend (session bootstrap + git worktree setup)
-    before navigating, so the landing screen lingers for the whole round-trip.
-    Without feedback the Send button just goes inert and the typed message sits
-    in the composer, so the click reads as "frozen". This holds the create POST
-    open with a gate so that in-flight window is observable, and asserts the
-    Send button flips to a busy/spinning state (disabled + ``aria-busy`` +
-    "Starting session" label) before the response lands and navigation happens.
+    The create response is held so the test can verify the navigate-first
+    window: the landing composer is already gone, the URL uses a client-only
+    ``temp:`` id, and the optimistic prompt is visible in a read-only chat.
+    Releasing the response must replace that temporary URL with the real id.
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_send_busy_spinner(base_url, session_id))
@@ -641,8 +638,7 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
         try:
             create_bodies: list[dict[str, Any]] = []
             # A gate the create handler awaits before responding, so the POST
-            # stays pending long enough to observe the button's busy state. The
-            # test opens it after asserting the spinner, letting navigation run.
+            # stays pending long enough to observe the temporary chat.
             release_create = asyncio.Event()
 
             async def handle_hosts(route: Route) -> None:
@@ -665,8 +661,7 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
             async def handle_sessions(route: Route) -> None:
                 if route.request.method == "POST":
                     create_bodies.append(route.request.post_data_json)
-                    # Hold the create open so the composer stays in its
-                    # `creating` state — the window under test.
+                    # Hold the create open so the temp-id chat remains visible.
                     await release_create.wait()
                     await route.fulfill(
                         status=200,
@@ -704,29 +699,28 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
                 state="visible", timeout=30_000
             )
 
-            submit = page.get_by_test_id("new-chat-landing-submit")
             await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
-            # Idle with a message typed: enabled, not busy (arrow, no spin).
-            await expect(submit).to_be_enabled()
-            await expect(submit).to_have_attribute("aria-busy", "false")
+            await page.get_by_test_id("new-chat-landing-submit").click()
 
-            await submit.click()
-
-            # The POST reached the server (proving we're truly in flight, not
-            # blocked by a disabled button) and the button shows the busy state.
+            # The create is still in flight, but the landing screen is gone and
+            # the optimistic prompt is already visible under a temporary URL.
             await _wait_until(lambda: len(create_bodies) == 1)
-            await expect(submit).to_be_disabled()
-            await expect(submit).to_have_attribute("aria-busy", "true")
-            await expect(submit).to_have_attribute("aria-label", "Starting session")
-            # Still on the landing screen — the "frozen"-looking window.
-            await expect(page.get_by_test_id("new-chat-landing-input")).to_be_visible()
-
-            # Release the create: the flow completes and navigates to the
-            # session, so the landing composer unmounts.
-            release_create.set()
-            await expect(page.get_by_test_id("new-chat-landing-input")).to_have_count(
-                0, timeout=30_000
+            await expect(page).to_have_url(
+                re.compile(rf"{re.escape(base_url)}/c/temp:[0-9a-f]{{8}}")
             )
+            await expect(page.get_by_test_id("new-chat-landing-input")).to_have_count(0)
+            composer = page.get_by_role("textbox", name="Message the agent")
+            await expect(composer).to_be_disabled()
+            await expect(composer).to_have_attribute("placeholder", "Starting the session…")
+            await expect(
+                page.get_by_test_id("message-bubble").get_by_text(
+                    "set up the project", exact=True
+                )
+            ).to_be_visible()
+
+            # Release the create: the same chat hydrates onto the real id.
+            release_create.set()
+            await expect(page).to_have_url(f"{base_url}/c/{session_id}", timeout=30_000)
         finally:
             await browser.close()
 

--- a/web/src/hooks/RunnerHealthProvider.tsx
+++ b/web/src/hooks/RunnerHealthProvider.tsx
@@ -32,6 +32,7 @@ import {
   useState,
 } from "react";
 import { useActiveConversationId } from "@/hooks/useActiveConversationId";
+import { isTempConvId } from "@/store/chatStore";
 import { useConversations } from "@/hooks/useConversations";
 import { type RunnerHealthInput, useRunnerHealth } from "@/hooks/useRunnerHealth";
 import { useSession } from "@/hooks/useSession";
@@ -61,7 +62,12 @@ export function RunnerHealthProvider({ children }: { children: ReactNode }) {
   // cover it. Fold the open session into the fallback poll set so it
   // resolves to a real liveness state even when off-sidebar. Its snapshot
   // is already cached by the chat stream bind, so this is a cache hit.
-  const activeSession = useSession(useActiveConversationId()).session;
+  // A client-only temp id (`temp:*`, mid-create) has no server session — skip
+  // the fetch so it doesn't hit `/v1/sessions/temp:*` during the create window.
+  const activeConversationId = useActiveConversationId();
+  const activeSession = useSession(
+    isTempConvId(activeConversationId) ? undefined : activeConversationId,
+  ).session;
   const activeId = activeSession?.id;
 
   // Sessions registered by transient views (e.g. the new-session dialog)

--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -118,6 +118,13 @@ describe("SessionUpdatesProvider watch-set", () => {
     expect(lastWatched()).toEqual(["conv_b", "conv_open"]);
   });
 
+  it("does not send client-only temp ids in the watch-set", () => {
+    const client = new QueryClient();
+    seedConversations(client, ["conv_real", "temp:12345678"]);
+    renderProvider(client, ["/c/temp:12345678"]);
+    expect(lastWatched()).toEqual(["conv_real"]);
+  });
+
   it("re-pushes the watch-set with the new open id on navigation", () => {
     // Navigating between off-sidebar children doesn't touch the
     // conversations cache, so the watch-set must re-push from the activeId

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/sessionListCache";
 import { isModalHostResolved, resolveModalHost } from "@/lib/sessionHost";
 import { type SessionUpdatesFrame, sessionUpdatesSocket } from "@/lib/sessionUpdatesSocket";
+import { isTempConvId } from "@/lib/tempConversationId";
 
 // Coalesce bursts of structural changes / watch-set recomputes into one
 // action. 250 ms is short enough to feel live, long enough to batch the
@@ -218,7 +219,7 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
         }
       }
     }
-    sessionUpdatesSocket.setWatched(ids);
+    sessionUpdatesSocket.setWatched(ids.filter((id) => !isTempConvId(id)));
   }, [queryClient]);
 
   // Navigating to an off-sidebar child changes the open session without

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -9,6 +9,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { isTempConvId } from "@/lib/tempConversationId";
 
 export interface McpServerSummary {
   name: string;
@@ -160,10 +161,13 @@ async function fetchSessionAgent(sessionId: string): Promise<Agent> {
  * sessions-derived agent list. Only fires when `sessionId` is non-null.
  */
 export function useSessionAgent(sessionId: string | null) {
+  // A `temp:*` id (navigate-first new-chat window) has no server session —
+  // never fetch its agent.
+  const serverId = isTempConvId(sessionId) ? null : sessionId;
   return useQuery({
-    queryKey: ["session-agent", sessionId],
-    queryFn: () => fetchSessionAgent(sessionId!),
-    enabled: sessionId !== null,
+    queryKey: ["session-agent", serverId],
+    queryFn: () => fetchSessionAgent(serverId!),
+    enabled: serverId !== null,
     staleTime: Infinity,
   });
 }

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -34,6 +34,7 @@ import {
   PINNED_LABEL_KEY,
   PROJECT_FOLDER_FILTERS,
   PROJECT_LABEL_KEY,
+  recentlyCreatedSessions,
   removeIdsFromPages,
   type ConversationsInfiniteData,
   type SessionListWireItem,
@@ -312,30 +313,10 @@ function withoutDeletingSessions(page: ConversationsPage): ConversationsPage {
   };
 }
 
-// ── Recently-created keep-alive ───────────────────────────────────────
-//
-// The push stream inserts a just-created session into the sidebar instantly
-// (SessionUpdatesProvider → insertNewRowsIntoPages), but the create path also
-// fires a `["conversations"]` refetch, and on the search-indexed deployment
-// that fetch lags the write — so it comes back WITHOUT the new session and
-// replaces the cache, dropping the row until the index catches up (it flashes
-// in, then out). We keep the row in the first-page fetch until the index
-// reflects it — the additive mirror of the delete tombstone above.
-const recentlyCreatedSessions = new Map<string, Conversation>();
-
-/** Grace window for the server's async create reindex. */
-const CREATED_KEEPALIVE_MS = 60_000;
-
-/** Keep a just-created session in the first-page list fetch until it's indexed. */
-export function markRecentlyCreated(conv: Conversation): void {
-  recentlyCreatedSessions.set(conv.id, conv);
-  setTimeout(() => recentlyCreatedSessions.delete(conv.id), CREATED_KEEPALIVE_MS);
-}
-
-/** Clear the keep-alive map — exported for test cleanup (mirrors `unmarkSessionsDeleting`). */
-export function clearRecentlyCreated(): void {
-  recentlyCreatedSessions.clear();
-}
+// The recently-created keep-alive map + its mutators live in the leaf
+// `sessionListCache` module (so the chat store can arm it on optimistic create
+// without an import cycle); re-exported here for existing callers.
+export { markRecentlyCreated, clearRecentlyCreated } from "@/lib/sessionListCache";
 
 /**
  * Prepend recently-created rows the first page doesn't yet include (the index

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -189,6 +189,14 @@ export interface Conversation {
    */
   archived?: boolean;
   /**
+   * Client-only: a `temp:` row shown while `createSession` is in flight (the
+   * navigate-first new-chat window). There is no server session behind it yet,
+   * so the sidebar disables per-row mutations (rename / delete / archive / pin /
+   * move) until it's rekeyed to the real id — otherwise they'd hit
+   * `/v1/sessions/temp:*`. Never set on a server row.
+   */
+  provisional?: boolean;
+  /**
    * Total review comments (any status) on this session. Together with
    * `comments_updated_at` it forms a change fingerprint: an add or edit
    * bumps the timestamp, a delete changes the count. SessionUpdatesProvider

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -15,6 +15,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { isTempConvId } from "@/lib/tempConversationId";
 import {
   isRunnerUnavailable503,
   RunnerOfflineError,
@@ -246,7 +247,9 @@ export function computeGithubPollInterval(info: GithubInfo | undefined): number 
  * Disabled when the runner is known offline. Retries the runner-offline case
  * with capped backoff so a cold-booting runner resolves before any error UI.
  */
-export function useGithubInfo(conversationId: string | undefined, options?: { poll?: boolean }) {
+export function useGithubInfo(rawConversationId: string | undefined, options?: { poll?: boolean }) {
+  // A `temp:*` id (navigate-first new-chat window) has no server session.
+  const conversationId = isTempConvId(rawConversationId) ? undefined : rawConversationId;
   const serveable = useWorkspaceServeable(conversationId);
   // Turn-end backstop: refetch when the focused session goes active→idle, so a
   // just-opened PR appears without opening the tab. Keys off the turn lifecycle,

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -13,6 +13,7 @@ import {
   listPermissions,
   revokePermission,
 } from "@/lib/permissionsApi";
+import { isTempConvId } from "@/lib/tempConversationId";
 import { useConversations } from "./useConversations";
 import { useSession } from "./useSession";
 
@@ -25,7 +26,9 @@ function sessionOwnerKey(sessionId: string) {
 }
 
 /** Fetch all permission grants for a session. */
-export function usePermissions(sessionId: string | null) {
+export function usePermissions(rawSessionId: string | null) {
+  // A `temp:*` id (navigate-first new-chat window) has no server session.
+  const sessionId = isTempConvId(rawSessionId) ? null : rawSessionId;
   return useQuery({
     queryKey: permissionsKey(sessionId ?? ""),
     queryFn: () => listPermissions(sessionId!),

--- a/web/src/hooks/useSession.test.tsx
+++ b/web/src/hooks/useSession.test.tsx
@@ -64,6 +64,15 @@ describe("useSession — refresh_state", () => {
     expect(refreshFlags()).toEqual([true]);
   });
 
+  it("never fetches for a client-only temp id (no /v1/sessions/temp:*)", async () => {
+    const { Wrapper } = harness();
+    renderHook(() => useSession("temp:0a1b2c3d"), { wrapper: Wrapper });
+    await flush();
+    // The navigate-first invariant: a temp id has no server session, so the
+    // query is disabled by construction — no request is issued.
+    expect(getSessionSlimMock).not.toHaveBeenCalled();
+  });
+
   // Switching the session's agent invalidates this query. The refetch has to
   // re-read runner-backed state too, or `model_options` comes back from the
   // runner's process cache and the picker keeps showing the PREVIOUS agent's

--- a/web/src/hooks/useSession.ts
+++ b/web/src/hooks/useSession.ts
@@ -13,6 +13,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getSessionSlim } from "@/lib/sessionsApi";
+import { isTempConvId } from "@/lib/tempConversationId";
 import type { Session } from "@/lib/types";
 
 /**
@@ -48,10 +49,15 @@ interface UseSessionResult {
  * for the refresh to thrash those caches.
  */
 export function useSession(conversationId: string | null | undefined): UseSessionResult {
+  // A `temp:*` id is a client-only routing token with no server session behind
+  // it (navigate-first new-chat window). Disable the fetch by construction so no
+  // caller can leak a `GET /v1/sessions/temp:*` — cheaper than gating every
+  // call site.
+  const serverId = isTempConvId(conversationId) ? null : (conversationId ?? null);
   const { data, isLoading, error } = useQuery({
-    queryKey: conversationId ? ["session", conversationId] : ["session", null],
-    queryFn: () => getSessionSlim(conversationId as string, { refreshState: true }),
-    enabled: Boolean(conversationId),
+    queryKey: serverId ? ["session", serverId] : ["session", null],
+    queryFn: () => getSessionSlim(serverId as string, { refreshState: true }),
+    enabled: serverId !== null,
     staleTime: Infinity,
     retry: false,
   });

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { authenticatedFetch } from "../lib/identity";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { isTempConvId } from "@/lib/tempConversationId";
 import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 import { showToast } from "@/components/ui/toast";
 
@@ -368,9 +369,13 @@ export function useDeleteTerminal(conversationId: string) {
  * the fetched list with whatever is already cached, deduped by id.
  */
 export function useTerminals(
-  conversationId: string | null,
+  rawConversationId: string | null,
   options?: UseTerminalsOptions,
 ): UseTerminalsResult {
+  // A `temp:*` id is a client-only routing token (navigate-first new-chat
+  // window) with no server session — normalize it to null so no fetch/poll
+  // hits `/v1/sessions/temp:*/resources/terminals`, by construction.
+  const conversationId = isTempConvId(rawConversationId) ? null : rawConversationId;
   const queryClient = useQueryClient();
   const reconcileWhilePending = options?.reconcileWhilePending ?? false;
   // The terminal list is SSE-primary: live `session.resource.{created,deleted}`

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { authenticatedFetch } from "@/lib/identity";
+import { isTempConvId } from "@/lib/tempConversationId";
 import { useChatStore } from "@/store/chatStore";
 
 /** True when `id` is the focused conversation and its agent loop is live. */
@@ -845,9 +846,13 @@ async function fetchWorkspaceEnvironment(conversationId: string): Promise<Worksp
  * (``metadata.root`` absent in the 200 response).
  */
 export function useWorkspaceEnvironment(
-  conversationId: string | undefined,
+  rawConversationId: string | undefined,
   options: WorkspaceQueryOptions = {},
 ) {
+  // A `temp:*` id (navigate-first new-chat window) has no server workspace —
+  // normalize to undefined so nothing (env, and the changed/all-files queries
+  // that gate on its result) hits `/v1/sessions/temp:*/resources/*`.
+  const conversationId = isTempConvId(rawConversationId) ? undefined : rawConversationId;
   const serveable = useWorkspaceServeable(conversationId);
   return useQuery({
     queryKey: ["workspace-environment", conversationId],

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -312,6 +312,33 @@ export function mergeItemsIntoPages(
   return { data: { ...data, pages }, found, needsRefetch };
 }
 
+// ── Recently-created keep-alive ───────────────────────────────────────
+//
+// The push stream inserts a just-created session into the sidebar instantly
+// (SessionUpdatesProvider → insertNewRowsIntoPages), but the create path also
+// fires a `["conversations"]` refetch, and on the search-indexed deployment
+// that fetch lags the write — so it comes back WITHOUT the new session and
+// replaces the cache, dropping the row until the index catches up (it flashes
+// in, then out). We keep the row in the first-page fetch until the index
+// reflects it — the additive mirror of the delete tombstone. Lives in this
+// leaf module so both `useConversations` (the reader) and the chat store (the
+// optimistic-create writer) can reach it without an import cycle.
+export const recentlyCreatedSessions = new Map<string, Conversation>();
+
+/** Grace window for the server's async create reindex. */
+const CREATED_KEEPALIVE_MS = 60_000;
+
+/** Keep a just-created session in the first-page list fetch until it's indexed. */
+export function markRecentlyCreated(conv: Conversation): void {
+  recentlyCreatedSessions.set(conv.id, conv);
+  setTimeout(() => recentlyCreatedSessions.delete(conv.id), CREATED_KEEPALIVE_MS);
+}
+
+/** Clear the keep-alive map — exported for test cleanup (mirrors `unmarkSessionsDeleting`). */
+export function clearRecentlyCreated(): void {
+  recentlyCreatedSessions.clear();
+}
+
 /**
  * Prepend brand-new rows (a create here or elsewhere, a share) to page 0 so the
  * sidebar shows them the instant the push lands, instead of after the debounced

--- a/web/src/lib/tempConversationId.test.ts
+++ b/web/src/lib/tempConversationId.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isTempConvId, newTempConvId, TEMP_CONV_ID_PREFIX } from "./tempConversationId";
+
+describe("tempConversationId", () => {
+  it("isTempConvId recognizes temp ids and rejects real ones", () => {
+    expect(isTempConvId("temp:0a1b2c3d")).toBe(true);
+    expect(isTempConvId(TEMP_CONV_ID_PREFIX)).toBe(true);
+    expect(isTempConvId("conv_abc123")).toBe(false);
+    expect(isTempConvId("pend_conv_1")).toBe(false);
+    expect(isTempConvId(null)).toBe(false);
+    expect(isTempConvId(undefined)).toBe(false);
+  });
+
+  it("newTempConvId mints a temp: id with 8 hex chars, and isTempConvId accepts it", () => {
+    for (let i = 0; i < 50; i++) {
+      const id = newTempConvId();
+      expect(id).toMatch(/^temp:[0-9a-f]{8}$/);
+      expect(isTempConvId(id)).toBe(true);
+    }
+  });
+});

--- a/web/src/lib/tempConversationId.ts
+++ b/web/src/lib/tempConversationId.ts
@@ -1,0 +1,25 @@
+// Client-only conversation ids used by the navigate-first "instant new chat"
+// flow: while `createSession` is in flight the UI mints a `temp:<hex>` id,
+// paints the optimistic first message and navigates into it, then rekeys to the
+// real server id once the create returns.
+//
+// A temp id is a routing/registry token only — it never names a server session,
+// so every server-scoped session hook must treat it as "no session yet". This
+// lives in a leaf module (no store/React imports) so those low-level query hooks
+// can enforce that by construction, without an import cycle back to the store.
+
+/** Prefix of a client-only conversation id. */
+export const TEMP_CONV_ID_PREFIX = "temp:";
+
+/** Whether an id is a client-only temp conversation id (not a server session). */
+export function isTempConvId(id: string | null | undefined): boolean {
+  return typeof id === "string" && id.startsWith(TEMP_CONV_ID_PREFIX);
+}
+
+/** Mint a fresh client-only conversation id: `temp:<32-bit hex>`. */
+export function newTempConvId(): string {
+  const hex = Math.floor(Math.random() * 0x1_0000_0000)
+    .toString(16)
+    .padStart(8, "0");
+  return `${TEMP_CONV_ID_PREFIX}${hex}`;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -67,6 +67,7 @@ import { modelConfigurationSourceRows } from "@/lib/modelConfigurationSource";
 import {
   composerAttachmentKey,
   consumePendingInitialPrompt,
+  isStaleTempConvId,
   isTempConvId,
   type PendingInitialPrompt,
   type QueuedMessage,
@@ -434,8 +435,16 @@ export function ChatPage() {
   // intentionally don't await it here. The store's `loadingConversation` flag
   // drives the loading UI below; `conversationLoadError` drives the error UI.
   useEffect(() => {
+    // A stale temp URL (reload / fresh tab onto `/c/temp:*` whose client-only
+    // conversation is gone) has no forward path: landing is URL-keyed, so the
+    // page would sit on a permanently read-only phantom chat. Redirect to
+    // landing instead of binding a nonexistent session.
+    if (isStaleTempConvId(urlConvId)) {
+      navigate("/", { replace: true });
+      return;
+    }
     void useChatStore.getState().switchTo(urlConvId ?? null);
-  }, [urlConvId]);
+  }, [urlConvId, navigate]);
 
   // Server-driven redirect: when the active conversation is superseded
   // (a `session.superseded` event — e.g. a Claude `/clear` rotated it
@@ -2182,6 +2191,10 @@ function ComposerStatusLine({
   onHostReconnect?: () => void;
 }) {
   const conversationId = useChatStore((s) => s.conversationId);
+  // A client-only temp id has no server session — gate the server-scoped hooks
+  // below on it so they never fetch `/v1/sessions/temp:*` during the create
+  // window (mirrors ChatPage's top-level `sessionConvId`).
+  const sessionId = isTempConvId(conversationId) ? null : conversationId;
   const contextWindow = useChatStore((s) => s.contextWindow);
   const tokensUsed = useChatStore((s) => s.tokensUsed);
   const codexPlanMode = useChatStore((s) => s.codexPlanMode);
@@ -2192,12 +2205,12 @@ function ComposerStatusLine({
 
   // Host binding drives whether the HostBadge has anything to show — read it
   // from the same source the badge does so the tray's render guard matches.
-  const { session } = useSession(conversationId);
+  const { session } = useSession(sessionId);
   const isHostBound = !!session?.hostId;
 
   // PR link → opens the workspace rail's GitHub tab. Shares the info query's
   // cache with the GitHub panel, so opening the tab is instant.
-  const github = useGithubInfo(conversationId ?? undefined);
+  const github = useGithubInfo(sessionId ?? undefined);
   const openGithubTab = useOpenGithubTab();
   const prNumber = github.data?.pr?.number ?? null;
   const showPr = !!conversationId && !isSubAgentSession && prNumber !== null && !!openGithubTab;
@@ -2658,7 +2671,10 @@ function ComposerImpl({
     unreachable,
     maybeFlushQueuedHead,
   ]);
-  const { goal, setGoal: setGoalState } = useGoalState(conversationId, showGoalControl);
+  // No server session behind a temp id — gate goal/workspace fetches on it so
+  // the create window issues no `/v1/sessions/temp:*` requests.
+  const composerSessionId = isTempConvId(conversationId) ? null : conversationId;
+  const { goal, setGoal: setGoalState } = useGoalState(composerSessionId, showGoalControl);
   // "@"-file-mention is scoped to the native coding-agent harnesses: their
   // vendor CLIs run in the workspace and read an on-disk file from an
   // attachment marker the executor already emits. In-process SDK sessions
@@ -2671,7 +2687,7 @@ function ComposerImpl({
   // so the composer's "@" entry point can't split-brain from the file viewer's
   // "Attach to agent" gate (``canAttachToAgent``), which already uses it.
   const mentionEnabled = nativeCodingAgentForHarness(sessionHarness) !== undefined;
-  const workspaceFilesQuery = useWorkspaceAllFiles(conversationId ?? undefined, {
+  const workspaceFilesQuery = useWorkspaceAllFiles(composerSessionId ?? undefined, {
     enabled: mentionEnabled,
   });
   const valueRef = useRef(value);

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -67,6 +67,7 @@ import { modelConfigurationSourceRows } from "@/lib/modelConfigurationSource";
 import {
   composerAttachmentKey,
   consumePendingInitialPrompt,
+  isTempConvId,
   type PendingInitialPrompt,
   type QueuedMessage,
   useChatStore,
@@ -363,6 +364,10 @@ function truncateTitle(raw: string, max = 60): string {
  */
 export function ChatPage() {
   const { conversationId: urlConvId } = useParams<{ conversationId: string }>();
+  // The id for every server-scoped fetch/hook — `undefined` while the URL holds
+  // a client-only temp id, so none of them hit `/v1/sessions/<temp>/*` before
+  // the session exists. `switchTo` still gets the raw `urlConvId`.
+  const sessionConvId = isTempConvId(urlConvId) ? undefined : urlConvId;
   const navigate = useNavigate();
   const appName = useAppName();
   // Optional first message handed off by the landing composer through the
@@ -413,7 +418,10 @@ export function ChatPage() {
   // Clear the "unseen messages" sidebar dot for the conversation the
   // user is currently viewing. Re-fires when conversations refresh
   // (every 4 s) so messages arriving while viewing are marked seen.
-  useMarkConversationSeen(urlConvId, conversations?.find((c) => c.id === urlConvId)?.updated_at);
+  useMarkConversationSeen(
+    sessionConvId,
+    conversations?.find((c) => c.id === sessionConvId)?.updated_at,
+  );
 
   // Sync the store's active conversation to the URL. Single source of
   // truth: URL is what's "current"; store mirrors it. The effect is
@@ -490,8 +498,8 @@ export function ChatPage() {
   // Read runner liveness from the app-level batch poller (see
   // RunnerHealthProvider). `undefined` = not yet polled — the indicator
   // stays hidden until the first poll for this session resolves.
-  const runnerOnline = useSessionRunnerOnline(urlConvId);
-  useRefreshSessionStateOnRunnerOnline(urlConvId, runnerOnline);
+  const runnerOnline = useSessionRunnerOnline(sessionConvId);
+  useRefreshSessionStateOnRunnerOnline(sessionConvId, runnerOnline);
   // OR'd into "Working…" so cross-client turns surface a shimmer.
   const sessionStatus = useChatStore((s) => s.sessionStatus);
   const backgroundTaskCount = useChatStore((s) => s.backgroundTaskCount);
@@ -504,7 +512,7 @@ export function ChatPage() {
   // agent object for the active session. Drives the picker's
   // name/description; the same react-query cache also feeds the header
   // info icon (AgentInfoButton) its tools & policies.
-  const { data: boundAgentBySession } = useSessionAgent(urlConvId ?? null);
+  const { data: boundAgentBySession } = useSessionAgent(sessionConvId ?? null);
   const hasMoreHistory = useChatStore((s) => s.hasMoreHistory);
   const loadingMoreHistory = useChatStore((s) => s.loadingMoreHistory);
 
@@ -624,7 +632,7 @@ export function ChatPage() {
   // Must be declared BEFORE the early-return guards below — otherwise
   // the hook is skipped on renders that hit the loading/error branches,
   // tripping React's "rendered fewer hooks than expected".
-  const { session: activeSession, isLoading: sessionLoading } = useSession(urlConvId ?? null);
+  const { session: activeSession, isLoading: sessionLoading } = useSession(sessionConvId ?? null);
 
   // Orchestrator-only: polly's children inherit its agentName, so the gate
   // needs the session predicate (parent linkage), not a bare name check. An
@@ -651,7 +659,7 @@ export function ChatPage() {
   const subAgentLabel = subAgentComposerLabel(activeSession);
 
   // Hoisted above the early-return guards so the title-update effect can read them.
-  const activeConv = urlConvId ? conversations?.find((c) => c.id === urlConvId) : null;
+  const activeConv = sessionConvId ? conversations?.find((c) => c.id === sessionConvId) : null;
 
   // `isWorking` gates the parent's OWN turn (Stop/Interrupt) and must NOT
   // include child-session activity. `showsWorking` is display-only (tab title
@@ -727,7 +735,7 @@ export function ChatPage() {
   const viewerId = getCurrentAuthorId();
   const sessionOwner = activeConv?.owner ?? null;
   const viewerOwnsSession = sessionOwner !== null && sessionOwner === viewerId;
-  const { data: ownerGrants } = usePermissions(viewerOwnsSession ? (urlConvId ?? null) : null);
+  const { data: ownerGrants } = usePermissions(viewerOwnsSession ? (sessionConvId ?? null) : null);
   const isSessionShared = isSessionSharedWithOthers(sessionOwner, viewerId, ownerGrants);
 
   // The open session's derived liveness — the single signal the chat
@@ -775,7 +783,7 @@ export function ChatPage() {
   // Host-switch launch marker; see the store field. Keeps this surface's
   // liveness in step with AppShell's, which drives the startup spinner.
   const runnerLaunchedAt = useChatStore((s) => s.runnerLaunchedAt);
-  const liveness = useSessionLiveness(urlConvId ?? undefined, livenessRow, {
+  const liveness = useSessionLiveness(sessionConvId ?? undefined, livenessRow, {
     turnActive: status === "streaming",
     launchedAt: runnerLaunchedAt,
   });
@@ -848,6 +856,8 @@ export function ChatPage() {
   const onSend = useCallback(
     (text: string, files?: File[]) => {
       if (!agentId) return;
+      // No server session yet (still creating) — nothing to POST to.
+      if (isTempConvId(urlConvId)) return;
       // An unbound coding clone (fork-source label) needs a directory before
       // it can run: open the picker and stash this message to replay after
       // the bind. Pin the prompt to THIS session so it replays here, never
@@ -948,7 +958,11 @@ export function ChatPage() {
     urlConvId,
     conversationsData !== undefined,
   );
-  const readOnlyReason = readOnlyReasonForSessionLabels(activeSession, activeConv);
+  // Client-only conversation: no server session to POST a follow-up to yet, so
+  // the composer stays read-only until the create resolves and the id hydrates.
+  const readOnlyReason = isTempConvId(urlConvId)
+    ? "Starting the session…"
+    : readOnlyReasonForSessionLabels(activeSession, activeConv);
   // Once present, the live session snapshot is authoritative. Memoized so the
   // derived props it feeds (modelPickerKind, effortLevels, wrapperLabel) keep a
   // stable identity across the switch's re-render burst.

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -570,6 +570,14 @@ describe("AppShell header", () => {
     expect(screen.getByRole("button", { name: /sidebar/i })).toBeInTheDocument();
   });
 
+  it("does not fetch child sessions for a temp id in debug mode", () => {
+    mockConversations([]);
+    renderShell("/c/temp:12345678?debug=1");
+
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("temp:12345678");
+    expect(screen.queryByTestId("execution-logs-card")).toBeNull();
+  });
+
   it("shows owner actions for a top-level session omitted from conversation pages", () => {
     mockConversations([]);
     useSessionMock.mockReturnValue({

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -462,6 +462,7 @@ function mockConversations(
     runner_id?: string | null;
     workspace?: string | null;
     created_at?: number;
+    provisional?: boolean;
   }[],
 ) {
   useConvMock.mockReturnValue({
@@ -479,6 +480,7 @@ function mockConversations(
             host_id: c.host_id ?? null,
             runner_id: c.runner_id ?? null,
             workspace: c.workspace ?? null,
+            provisional: c.provisional,
           })),
           first_id: null,
           last_id: null,
@@ -576,6 +578,15 @@ describe("AppShell header", () => {
 
     expect(useChildSessionsMock).not.toHaveBeenCalledWith("temp:12345678");
     expect(screen.queryByTestId("execution-logs-card")).toBeNull();
+  });
+
+  it("does not expose conversation actions for a provisional temp row", () => {
+    mockConversations([{ id: "temp:12345678", permission_level: null, provisional: true }]);
+    renderShell("/c/temp:12345678");
+
+    expect(screen.queryByRole("button", { name: "Conversation actions" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
+    expect(screen.getByTestId("fork-probe")).toHaveAttribute("data-can-fork", "false");
   });
 
   it("shows owner actions for a top-level session omitted from conversation pages", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -688,12 +688,15 @@ export function AppShell() {
   // resolution lands (a no-op transition once it does).
   const stickyRootRef = useRef<string | null>(null);
   const queryClient = useQueryClient();
-  const walkedRoot = useRootSessionId(conversationId ?? null, activeSession?.parentSessionId);
+  // Derive the root from `serverConversationId` (undefined for a temp id) so the
+  // fallback below never yields `temp:*` — otherwise `useChildSessions` would
+  // fetch `GET /v1/sessions/temp:*/child_sessions` during the create window.
+  const walkedRoot = useRootSessionId(serverConversationId ?? null, activeSession?.parentSessionId);
   const { rootSessionId, rootSessionResolved } = useMemo(() => {
-    if (!conversationId) return { rootSessionId: null, rootSessionResolved: false };
+    if (!serverConversationId) return { rootSessionId: null, rootSessionResolved: false };
     // Snapshot resolved for a top-level session → it is its own root.
     if (activeSession && activeSession.parentSessionId == null) {
-      return { rootSessionId: conversationId, rootSessionResolved: true };
+      return { rootSessionId: serverConversationId, rootSessionResolved: true };
     }
     // Snapshot resolved for a descendant + walk complete → authoritative.
     if (activeSession && walkedRoot) {
@@ -704,18 +707,18 @@ export function AppShell() {
     const sticky = stickyRootRef.current;
     if (
       sticky !== null &&
-      (sticky === conversationId ||
-        cachedTreeContains(queryClient, sticky, conversationId, MAX_TREE_DEPTH))
+      (sticky === serverConversationId ||
+        cachedTreeContains(queryClient, sticky, serverConversationId, MAX_TREE_DEPTH))
     ) {
       return { rootSessionId: sticky, rootSessionResolved: true };
     }
     // No sticky context (e.g. a deep link straight into a sub-agent):
     // fall back one hop until the walk resolves the true root.
     return {
-      rootSessionId: activeSession?.parentSessionId ?? conversationId,
+      rootSessionId: activeSession?.parentSessionId ?? serverConversationId,
       rootSessionResolved: false,
     };
-  }, [conversationId, activeSession, walkedRoot, queryClient]);
+  }, [serverConversationId, activeSession, walkedRoot, queryClient]);
   // One-shot fetch (no polling) for the Subagents tab's count badge.
   // SubagentsPanel mounts its own polling usage of the hook against
   // the same rootSessionId, so the cache is shared.

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -2058,10 +2058,10 @@ export function AppShell() {
               push panel is open (the panel itself becomes the focus). Only
               rendered in debug mode so the column doesn't occupy space in
               normal use. */}
-                {conversationId && debugMode && !panelOpen && !executionLogsOpen && (
+                {serverConversationId && debugMode && !panelOpen && !executionLogsOpen && (
                   <div className="hidden md:flex md:flex-col md:w-56 md:shrink-0 md:border-l md:border-border md:overflow-y-auto md:px-2 md:pb-2 md:pt-12 md:gap-2">
                     <SessionRail
-                      conversationId={conversationId}
+                      conversationId={serverConversationId}
                       onExpandExecutionLogs={openExecutionLogsPanel}
                       suppressed={false}
                     />

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -470,7 +470,7 @@ export function AppShell() {
   });
   // Full agent object (mcp_servers + policies) for the header info icon.
   // react-query-cached, so this shares the fetch ChatPage's picker makes.
-  const { data: boundAgent } = useSessionAgent(conversationId ?? null);
+  const { data: boundAgent } = useSessionAgent(serverConversationId ?? null);
   const permissionLevel = derivePermissionLevel(
     activeSession,
     sessionLoading,
@@ -938,7 +938,7 @@ export function AppShell() {
   // because it contains full relative paths like `web/src/shell/Foo.tsx`.
   // Disabled for a viewer who may not browse the workspace: the server refuses
   // the read, so the fetch would only 403.
-  const changedFilesQuery = useWorkspaceChangedFiles(conversationId, {
+  const changedFilesQuery = useWorkspaceChangedFiles(serverConversationId, {
     enabled: canBrowseWorkspace,
   });
   const changedFilePaths = useMemo(

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -440,11 +440,12 @@ export function AppShell() {
   );
   useSeedReadState(allConversations);
   const activeConv = useMemo(() => {
-    if (!conversationId) return null;
+    if (!serverConversationId) return null;
     return (
-      conversationsData?.pages.flatMap((p) => p.data).find((c) => c.id === conversationId) ?? null
+      conversationsData?.pages.flatMap((p) => p.data).find((c) => c.id === serverConversationId) ??
+      null
     );
-  }, [conversationId, conversationsData]);
+  }, [serverConversationId, conversationsData]);
   // Single-conversation snapshot (shared cache with chatStore.bindStream).
   // For sub-agent (child) sessions the sidebar list omits the row, so this
   // is the only path through which the UI learns the user's permission

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -82,7 +82,7 @@ import {
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode } from "@/lib/capabilities";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
-import { useChatStore } from "@/store/chatStore";
+import { isTempConvId, useChatStore } from "@/store/chatStore";
 import {
   STARTING_GRACE_S,
   livenessRowFromSession,
@@ -222,6 +222,11 @@ export function AppShell() {
     conversationId: string;
     extensionId: string;
   }>();
+  // A client-only temp id (`temp:*`, shown while `createSession` is in flight)
+  // has no server session behind it. Feed every server-scoped hook this instead
+  // of the raw route id so none of them fetch `/v1/sessions/temp:*` during the
+  // create window (or on a stale temp reload, before ChatPage redirects).
+  const serverConversationId = isTempConvId(conversationId) ? undefined : conversationId;
   const [fileViewerCommentsOpen, setFileViewerCommentsOpen] = useState(false);
   const [rightRailTab, setRightRailTab] = useState<RightRailTab>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
@@ -412,7 +417,7 @@ export function AppShell() {
   // terminal. The hook is react-query-backed and dedup'd with the rail.
   // reconcileWhilePending: self-heals if the live resource.created SSE was
   // missed (see UseTerminalsOptions for the why).
-  const { terminals } = useTerminals(conversationId ?? null, {
+  const { terminals } = useTerminals(serverConversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
   const agentTerminal = useMemo(() => findAgentTerminal(terminals), [terminals]);
@@ -444,7 +449,7 @@ export function AppShell() {
   // For sub-agent (child) sessions the sidebar list omits the row, so this
   // is the only path through which the UI learns the user's permission
   // level. ``derivePermissionLevel`` prefers this over ``activeConv``.
-  const { session: activeSession, isLoading: sessionLoading } = useSession(conversationId);
+  const { session: activeSession, isLoading: sessionLoading } = useSession(serverConversationId);
   // Same liveness the chat surface switches on (see ChatPage / useSessionLiveness).
   // AppShell reads it only to drive the Terminal pill's "loading" state: a session
   // in `starting` (a relaunch the moment a message is sent — `turnActive`) is
@@ -752,7 +757,7 @@ export function AppShell() {
   // resource instead of the root filesystem listing: it is enough to prove
   // availability without paying for directory contents. The probe is disabled
   // for a non-browsing viewer so it never fires a request the server refuses.
-  const environmentQuery = useWorkspaceEnvironment(conversationId, {
+  const environmentQuery = useWorkspaceEnvironment(serverConversationId, {
     enabled: canBrowseWorkspace,
   });
   const showFilesPanel = canBrowseWorkspace && environmentQuery.data?.available !== false;
@@ -763,7 +768,7 @@ export function AppShell() {
   // gate. While the info is still loading the tab stays, matching the Files
   // gate's no-flash default. Shares ChatPage's status-line query cache, so no
   // extra fetch.
-  const githubInfoQuery = useGithubInfo(conversationId);
+  const githubInfoQuery = useGithubInfo(serverConversationId);
   const showGithubTab = showFilesPanel && githubInfoQuery.data?.reason !== "not_a_git_repo";
   // Per-tab availability for the right workspace rail — the single source
   // of truth shared by the tab-fallback effect below, the rail's mount

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -27,6 +27,9 @@ import { writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 // layers are stubbed so the test isolates that wiring.
 const navigateMock = vi.fn();
 const setPendingInitialPromptMock = vi.fn();
+const beginLocalConversationMock = vi.fn();
+const hydrateLocalConversationMock = vi.fn();
+const removeLocalConversationMock = vi.fn();
 
 const RECENT_KEY = "omnigent:recent-workspaces";
 // Prompt history is scoped per conversation; the landing composer writes under
@@ -50,6 +53,9 @@ vi.mock("@/lib/routing", () => ({
 // The screen hands the first message to ChatPage through the chatStore
 // (keyed by conversation id), not router state — assert on that call.
 vi.mock("@/store/chatStore", () => ({
+  beginLocalConversation: (...args: unknown[]) => beginLocalConversationMock(...args),
+  hydrateLocalConversation: (...args: unknown[]) => hydrateLocalConversationMock(...args),
+  removeLocalConversation: (...args: unknown[]) => removeLocalConversationMock(...args),
   setPendingInitialPrompt: (...args: unknown[]) => setPendingInitialPromptMock(...args),
 }));
 
@@ -262,6 +268,11 @@ function saveConfig(): void {
 beforeEach(() => {
   navigateMock.mockReset();
   setPendingInitialPromptMock.mockReset();
+  beginLocalConversationMock.mockReset();
+  beginLocalConversationMock.mockReturnValue(null);
+  hydrateLocalConversationMock.mockReset();
+  removeLocalConversationMock.mockReset();
+  removeLocalConversationMock.mockReturnValue(false);
   pushMatchers.length = 0;
   announcePushedSession = null;
   vi.mocked(authenticatedFetch).mockReset();
@@ -321,6 +332,45 @@ describe("NewChatLandingScreen create flow", () => {
 
     // On success the screen routes to the freshly created session.
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
+  });
+
+  it("uses the response id for a navigate-first create instead of matching a pushed row", async () => {
+    let resolveCreate!: (response: Response) => void;
+    vi.mocked(authenticatedFetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveCreate = resolve;
+      }) as ReturnType<typeof authenticatedFetch>,
+    );
+    beginLocalConversationMock.mockReturnValue({
+      tempConvId: "temp:12345678",
+      pendingMsgTempId: "pend_1",
+    });
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("inspect the repo");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/temp:12345678"));
+    expect(pushMatchers).toHaveLength(0);
+
+    resolveCreate({
+      ok: true,
+      json: async () => ({ id: "conv_authoritative" }),
+    } as unknown as Response);
+    await waitFor(() =>
+      expect(hydrateLocalConversationMock).toHaveBeenCalledWith(
+        "temp:12345678",
+        "conv_authoritative",
+        "ag_hello",
+        "inspect the repo",
+        [],
+        "pend_1",
+        null,
+        navigateMock,
+        expect.any(Function),
+      ),
+    );
   });
 
   it("records the launched workspace under its host without corrupting other recents", async () => {

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -373,6 +373,67 @@ describe("NewChatLandingScreen create flow", () => {
     );
   });
 
+  it("keeps a failed create's restored draft when a newer create succeeds", async () => {
+    let resolveFirst!: (response: Response) => void;
+    let resolveSecond!: (response: Response) => void;
+    vi.mocked(authenticatedFetch)
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        }) as ReturnType<typeof authenticatedFetch>,
+      )
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveSecond = resolve;
+        }) as ReturnType<typeof authenticatedFetch>,
+      );
+    beginLocalConversationMock
+      .mockReturnValueOnce({ tempConvId: "temp:aaaaaaaa", pendingMsgTempId: "pend_a" })
+      .mockReturnValueOnce({ tempConvId: "temp:bbbbbbbb", pendingMsgTempId: "pend_b" });
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("restore this draft");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    cleanup();
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("newer successful create");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(2));
+    cleanup();
+
+    resolveFirst({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "first create failed" }),
+    } as unknown as Response);
+    await waitFor(() => expect(removeLocalConversationMock).toHaveBeenCalledWith("temp:aaaaaaaa"));
+
+    resolveSecond({
+      ok: true,
+      json: async () => ({ id: "conv_second" }),
+    } as unknown as Response);
+    await waitFor(() =>
+      expect(hydrateLocalConversationMock).toHaveBeenCalledWith(
+        "temp:bbbbbbbb",
+        "conv_second",
+        "ag_hello",
+        "newer successful create",
+        [],
+        "pend_b",
+        null,
+        navigateMock,
+        expect.any(Function),
+      ),
+    );
+
+    renderLanding();
+    expect(screen.getByTestId("new-chat-landing-input")).toHaveValue("restore this draft");
+  });
+
   it("records the launched workspace under its host without corrupting other recents", async () => {
     // Write-back hygiene for omnigent:recent-workspaces: the launched path
     // moves to the front of ITS host's list (deduplicated, not appended

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2538,20 +2538,15 @@ describe("NewChatLandingScreen", () => {
     // The sandbox option is pinned FIRST in the menu, above the host list —
     // DOCUMENT_POSITION_FOLLOWING means the host item comes after it.
     const sandboxOption = screen.getByTestId("new-chat-landing-sandbox-option");
-    const hostItem = screen
-      .getAllByText("This machine")
-      .find((el) => el.closest('[role="menuitem"]') !== null);
-    expect(hostItem).toBeTruthy();
+    const hostItem = screen.getByTestId("new-chat-landing-host-host_1");
     expect(
-      sandboxOption.compareDocumentPosition(hostItem!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      sandboxOption.compareDocumentPosition(hostItem) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     // Picking the host restores the workspace flow (file-browser chip,
     // worktree chip) — the sandbox default doesn't wedge the normal path.
-    fireEvent.click(hostItem!);
+    fireEvent.click(hostItem);
     await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
-        "This machine",
-      ),
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain("Sandbox"),
     );
     expect(screen.getByTestId("new-chat-landing-workspace-chip")).toBeTruthy();
     expect(screen.getByTestId("new-chat-landing-branch-chip")).toBeTruthy();
@@ -3812,15 +3807,9 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
       expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
     );
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
-    const hostItem = screen
-      .getAllByText("This machine")
-      .find((el) => el.closest('[role="menuitem"]') !== null);
-    expect(hostItem).toBeTruthy();
-    fireEvent.click(hostItem!);
+    fireEvent.click(screen.getByTestId("new-chat-landing-host-host_1"));
     await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
-        "This machine",
-      ),
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain("Sandbox"),
     );
     // With no custom agents yet, the create item is a top-level row (no
     // "Custom agents" submenu to hide it behind) and opens the dialog.
@@ -3839,14 +3828,9 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
       expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
     );
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
-    const hostItem = screen
-      .getAllByText("This machine")
-      .find((el) => el.closest('[role="menuitem"]') !== null);
-    fireEvent.click(hostItem!);
+    fireEvent.click(screen.getByTestId("new-chat-landing-host-host_1"));
     await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
-        "This machine",
-      ),
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain("Sandbox"),
     );
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-create-agent"));

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -101,7 +101,12 @@ import {
   rankedSlashCommandNames,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
-import { setPendingInitialPrompt } from "@/store/chatStore";
+import {
+  beginLocalConversation,
+  hydrateLocalConversation,
+  removeLocalConversation,
+  setPendingInitialPrompt,
+} from "@/store/chatStore";
 import { markSessionCreated } from "@/store/interactionTelemetry";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
@@ -4259,6 +4264,7 @@ export function NewChatLandingScreen() {
     }
     setCreating(true);
     setCreateError(null);
+    let localConv: { tempConvId: string; pendingMsgTempId: string } | null = null;
     // The draft is spent from the moment it is submitted: it belongs to the
     // session now being created, so a detour back to this screen must not
     // hand it back pre-filled. Flipped here rather than on the response
@@ -4316,6 +4322,22 @@ export function NewChatLandingScreen() {
       const initialPrompt =
         buildMentionPreamble(mentionedItems, selectedAgent?.harness ?? null) +
         sanitizeInitialPrompt(message);
+      // Navigate-first: mint a client-only conversation, show the prompt, and
+      // jump into it now; the create runs below and hydrates the temp id to the
+      // real one (`hydrateLocalConversation`). Skipped for a pending custom
+      // agent — it has no agent id to POST with until its create binds one, so
+      // that path stays server-first.
+      if (effectiveAgentId !== null && effectiveAgentId !== PENDING_AGENT_ID) {
+        try {
+          const local = beginLocalConversation(initialPrompt, files);
+          if (local !== null) {
+            localConv = local;
+            navigate(`/c/${local.tempConvId}`);
+          }
+        } catch {
+          /* non-fatal: falls through to the server-first path below */
+        }
+      }
 
       // Native terminal agents open terminal-first: `omnigent.ui: terminal`
       // tells the UI to render the terminal wrapper, and `omnigent.wrapper`
@@ -4645,42 +4667,54 @@ export function NewChatLandingScreen() {
       // next time. Recorded only on a successful create, so a harness the user
       // merely browsed past never earns a primary slot.
       if (selectedNativeHarness !== null) addRecentHarness(selectedNativeHarness);
-      // Fire-and-forget: don't block navigation on the sidebar list refresh.
-      // The background refetch (or the WS session_added push) backfills the
-      // new session's row within ~1s of landing in the chat; the chat itself
-      // loads from the session id and never reads the sidebar cache.
-      void queryClient.refetchQueries({ queryKey: ["conversations"] });
-      void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
-      // A first message matching one of the agent's bundled skills is
-      // handed off as a structured invocation so ChatPage auto-sends it
-      // as a `slash_command` event (server resolves the skill) instead
-      // of plain text the agent would see as a literal "/name". Native
-      // terminal agents keep plain text — their CLI owns slash commands.
-      setPendingInitialPrompt(data.id, {
-        text: initialPrompt,
-        skill: isNativeTerminalAgent
-          ? null
-          : matchSkillInvocation(initialPrompt, agent?.skills ?? []),
-        files,
-      });
-      // Label the new row with the prompt until the server's seed title lands.
-      recordOptimisticTitle(data.id, initialPrompt);
+      // A first message matching one of the agent's bundled skills is sent as a
+      // structured `slash_command` (server resolves the skill) rather than the
+      // literal "/name". Native terminal agents keep plain text — their CLI owns
+      // slash commands.
+      const skill = isNativeTerminalAgent
+        ? null
+        : matchSkillInvocation(initialPrompt, agent?.skills ?? []);
       // Scope the recall entry to the new session id so ArrowUp surfaces it in
-      // the freshly-opened chat (whose composer reads the same per-conversation
-      // key). Sanitized text so recall reproduces exactly what was sent.
+      // the freshly-opened chat. Sanitized text so recall reproduces what was sent.
       appendPromptHistoryEntry(initialPrompt, data.id);
       // The session was created — drop any draft a detour back to this
       // screen stashed, so the next visit starts clean.
       landingDraft = null;
-      // Only follow the create while the user is still on the landing
-      // screen. A create that outlived it means they moved on to another
-      // session; jumping them into this one now would hijack that. The
-      // session is created either way and its first message stays held
-      // for whenever they open it.
-      if (onScreenRef.current && window.location.href === createLocation) {
-        navigate(`/c/${data.id}`);
+      void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
+
+      // `localConv` is set only when a real agent id was resolved up front, so
+      // it's safe to POST the first message with it.
+      if (localConv !== null && effectiveAgentId !== null) {
+        // Hydrate the temp id onto the real id and POST the first message.
+        hydrateLocalConversation(
+          localConv.tempConvId,
+          data.id,
+          effectiveAgentId,
+          initialPrompt,
+          files,
+          localConv.pendingMsgTempId,
+          skill,
+          navigate,
+        );
+        void queryClient.refetchQueries({ queryKey: ["conversations"] });
+      } else {
+        // Server-first: a pending custom agent (or no client cache in tests).
+        // Label the row, stash the first message for ChatPage to send, navigate.
+        recordOptimisticTitle(data.id, initialPrompt);
+        void queryClient.refetchQueries({ queryKey: ["conversations"] });
+        setPendingInitialPrompt(data.id, { text: initialPrompt, skill, files });
+        if (onScreenRef.current && window.location.href === createLocation) {
+          navigate(`/c/${data.id}`);
+        }
       }
     } catch {
+      // Tear down the client-only conversation; if the user is still on it, send
+      // them back to landing so the restored draft has somewhere to go. Gated on
+      // `wasViewing` (not `onScreenRef` — the landing already unmounted).
+      if (localConv !== null) {
+        const wasViewing = removeLocalConversation(localConv.tempConvId);
+        if (wasViewing) navigate("/");
+      }
       returnDraftToUser();
       setCreateError("Couldn't reach the server. Check your connection and try again.");
     } finally {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4265,6 +4265,17 @@ export function NewChatLandingScreen() {
     setCreating(true);
     setCreateError(null);
     let localConv: { tempConvId: string; pendingMsgTempId: string } | null = null;
+    // Single teardown for EVERY create-failure exit (the `catch` and the
+    // `"error" in created` early return): drop the client-only conversation and,
+    // if the user is still on it, send them back to landing so the restored
+    // draft (and the create error) have somewhere to surface. Without this, a
+    // failure after the navigate-first jump strands a read-only phantom chat.
+    const tearDownLocalConversation = () => {
+      if (localConv === null) return;
+      const wasViewing = removeLocalConversation(localConv.tempConvId);
+      // Gated on `wasViewing` (not `onScreenRef` — the landing already unmounted).
+      if (wasViewing) navigate("/");
+    };
     // The draft is spent from the moment it is submitted: it belongs to the
     // session now being created, so a detour back to this screen must not
     // hand it back pre-filled. Flipped here rather than on the response
@@ -4593,7 +4604,12 @@ export function NewChatLandingScreen() {
         // error the user needed to see on this screen.
         if ("error" in created) {
           returnDraftToUser();
-          setCreateError(created.error);
+          // On the navigate-first path the landing screen is unmounted, so tear
+          // down the phantom chat, return to landing, and surface the error as a
+          // toast (survives the remount); inline error only when still on landing.
+          tearDownLocalConversation();
+          if (localConv !== null) showToast(created.error);
+          else setCreateError(created.error);
           return;
         }
         data = { id: created.id };
@@ -4708,15 +4724,12 @@ export function NewChatLandingScreen() {
         }
       }
     } catch {
-      // Tear down the client-only conversation; if the user is still on it, send
-      // them back to landing so the restored draft has somewhere to go. Gated on
-      // `wasViewing` (not `onScreenRef` — the landing already unmounted).
-      if (localConv !== null) {
-        const wasViewing = removeLocalConversation(localConv.tempConvId);
-        if (wasViewing) navigate("/");
-      }
+      const msg = "Couldn't reach the server. Check your connection and try again.";
+      tearDownLocalConversation();
       returnDraftToUser();
-      setCreateError("Couldn't reach the server. Check your connection and try again.");
+      // Toast when the landing screen is gone (navigate-first); inline otherwise.
+      if (localConv !== null) showToast(msg);
+      else setCreateError(msg);
     } finally {
       setCreating(false);
     }

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2200,12 +2200,18 @@ interface LandingDraft {
 }
 
 let landingDraft: LandingDraft | null = null;
+let landingDraftRevision = 0;
+
+function writeLandingDraft(draft: LandingDraft | null): void {
+  landingDraft = draft;
+  landingDraftRevision += 1;
+}
 
 // Test-only: clears the preserved landing draft so each case starts from a
 // clean module state (the draft is module-scoped and survives unmount by
 // design, which would otherwise leak between tests).
 export function resetLandingDraft(): void {
-  landingDraft = null;
+  writeLandingDraft(null);
 }
 
 export function NewChatLandingScreen() {
@@ -2690,6 +2696,7 @@ export function NewChatLandingScreen() {
   // `submittedRef` is flipped once the draft is sent to a create, so the
   // snapshot is dropped instead of resurrected.
   const submittedRef = useRef(false);
+  const submittedDraftRevisionRef = useRef<number | null>(null);
   // Whether this composer is still on screen. The create POST can outlive
   // it — the user opens another session while the session bootstraps — and
   // the post-create navigation must not follow them there.
@@ -2727,7 +2734,11 @@ export function NewChatLandingScreen() {
     onScreenRef.current = true;
     return () => {
       onScreenRef.current = false;
-      landingDraft = submittedRef.current ? null : draftRef.current;
+      if (!submittedRef.current) {
+        writeLandingDraft(draftRef.current);
+      } else if (submittedDraftRevisionRef.current === landingDraftRevision) {
+        writeLandingDraft(null);
+      }
     };
   }, []);
 
@@ -4239,7 +4250,8 @@ export function NewChatLandingScreen() {
   // dropped it on the strength of the submit.
   function returnDraftToUser() {
     submittedRef.current = false;
-    if (!onScreenRef.current) landingDraft = draftRef.current;
+    submittedDraftRevisionRef.current = null;
+    if (!onScreenRef.current) writeLandingDraft(draftRef.current);
   }
 
   async function handleCreate() {
@@ -4282,6 +4294,7 @@ export function NewChatLandingScreen() {
     // hand it back pre-filled. Flipped here rather than on the response
     // because the create outlives an unmount; a create that fails hands the
     // draft back via returnDraftToUser.
+    submittedDraftRevisionRef.current = landingDraftRevision;
     submittedRef.current = true;
     try {
       const trimmedBranch = branchName.trim();
@@ -4694,7 +4707,9 @@ export function NewChatLandingScreen() {
       appendPromptHistoryEntry(initialPrompt, data.id);
       // The session was created — drop any draft a detour back to this
       // screen stashed, so the next visit starts clean.
-      landingDraft = null;
+      if (submittedDraftRevisionRef.current === landingDraftRevision) {
+        writeLandingDraft(null);
+      }
       void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
 
       // `localConv` is set only when a real agent id was resolved up front, so

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4272,9 +4272,10 @@ export function NewChatLandingScreen() {
     // failure after the navigate-first jump strands a read-only phantom chat.
     const tearDownLocalConversation = () => {
       if (localConv === null) return;
+      const stillOnTempRoute = window.location.pathname.endsWith(`/c/${localConv.tempConvId}`);
       const wasViewing = removeLocalConversation(localConv.tempConvId);
       // Gated on `wasViewing` (not `onScreenRef` — the landing already unmounted).
-      if (wasViewing) navigate("/");
+      if (wasViewing && stillOnTempRoute) navigate("/");
     };
     // The draft is spent from the moment it is submitted: it belongs to the
     // session now being created, so a detour back to this screen must not
@@ -4465,7 +4466,7 @@ export function NewChatLandingScreen() {
         // A sandbox create has no host to match on until the sandbox
         // registers one, so it waits for the response like before.
         const matchOwnCreate =
-          sandboxSelected || !selectedHostId
+          localConv !== null || sandboxSelected || !selectedHostId
             ? null
             : (item: SessionListWireItem) =>
                 !knownSessionIds.has(item.id) &&
@@ -4565,12 +4566,10 @@ export function NewChatLandingScreen() {
               smartRoutingHarnessSelected || pinnedNativeRoutes ? initialPrompt : undefined,
           }),
         });
-        // The create doesn't answer until the host has spawned a runner — a
-        // process boot, seconds of it — but the session row exists (and is
-        // announced on the updates stream) almost immediately. Open the chat
-        // on whichever id lands first: the pushed row typically wins by
-        // seconds, and the chat page renders from the id alone, showing its
-        // own starting spinner while the runner comes up.
+        // The server-first fallback can still open from the pushed row before
+        // the create responds. Navigate-first is already showing its temp chat,
+        // so it waits for the response's authoritative id instead of guessing
+        // which same-agent/host push belongs to this request.
         const abortPush = new AbortController();
         const pushedRow =
           matchOwnCreate === null
@@ -4701,6 +4700,7 @@ export function NewChatLandingScreen() {
       // `localConv` is set only when a real agent id was resolved up front, so
       // it's safe to POST the first message with it.
       if (localConv !== null && effectiveAgentId !== null) {
+        const tempRouteSuffix = `/c/${localConv.tempConvId}`;
         // Hydrate the temp id onto the real id and POST the first message.
         hydrateLocalConversation(
           localConv.tempConvId,
@@ -4711,6 +4711,7 @@ export function NewChatLandingScreen() {
           localConv.pendingMsgTempId,
           skill,
           navigate,
+          () => window.location.pathname.endsWith(tempRouteSuffix),
         );
         void queryClient.refetchQueries({ queryKey: ["conversations"] });
       } else {

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -370,7 +370,9 @@ describe("Sidebar session list", () => {
     // A client-only temp row has no server session, so its per-row mutations
     // (kebab: rename/delete/archive/move/share) must be suppressed — invoking
     // them would POST to /v1/sessions/temp:* (Polly B-3).
-    mockConversations([conv("temp:0a1b2c3d", "Claude Code", { title: "new chat", provisional: true })]);
+    mockConversations([
+      conv("temp:0a1b2c3d", "Claude Code", { title: "new chat", provisional: true }),
+    ]);
     renderSidebar();
 
     // Navigable: the row is still a link into the (soon-to-exist) conversation.

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -366,6 +366,20 @@ describe("Sidebar session list", () => {
     expect(screen.queryByText("Claude Code")).not.toBeInTheDocument();
   });
 
+  it("renders a provisional (temp:) row as a bare navigable link with no mutating actions", () => {
+    // A client-only temp row has no server session, so its per-row mutations
+    // (kebab: rename/delete/archive/move/share) must be suppressed — invoking
+    // them would POST to /v1/sessions/temp:* (Polly B-3).
+    mockConversations([conv("temp:0a1b2c3d", "Claude Code", { title: "new chat", provisional: true })]);
+    renderSidebar();
+
+    // Navigable: the row is still a link into the (soon-to-exist) conversation.
+    const link = screen.getByRole("link", { name: /new chat/ });
+    expect(link).toHaveAttribute("href", expect.stringContaining("/c/temp:0a1b2c3d"));
+    // But no action affordances until it's rekeyed to the real id.
+    expect(screen.queryByRole("button", { name: "Conversation actions" })).not.toBeInTheDocument();
+  });
+
   it("uses the interface text token for session-list errors", () => {
     conversationsRef.current = [];
     useConvMock.mockReturnValue({

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3539,6 +3539,10 @@ function ConversationRowImpl({
 }) {
   const hostsById = useContext(HostsByIdContext);
   const navigate = useNavigate();
+  // A client-only `temp:` row (navigate-first create window): no server session
+  // yet, so per-row mutations are disabled until it's rekeyed to the real id —
+  // otherwise they'd POST to `/v1/sessions/temp:*`. The row still navigates.
+  const isProvisionalRow = conversation.provisional === true;
   // Mobile has no real hover, so a tap that navigates would also trip the
   // project flyout's HoverCard and leave it lingering over the chat. Gate the
   // flyout off below the `md` breakpoint (see `projectFlyoutName`).
@@ -3719,7 +3723,7 @@ function ConversationRowImpl({
   } = useDraggable({
     id: conversation.id,
     data: { type: "session", label, project: currentProject, isPinned },
-    disabled: !isOwner || selectionMode || isArchived || isEditing,
+    disabled: !isOwner || selectionMode || isArchived || isEditing || isProvisionalRow,
   });
   // A drag ends with a synthetic click on the row's <Link> (mousedown + mouseup
   // on the same anchor still fires a click); swallow that one click so a drag
@@ -3918,6 +3922,7 @@ function ConversationRowImpl({
       onDoubleClick={(e) => {
         if (selectionMode) return;
         if (!isOwner) return;
+        if (isProvisionalRow) return; // no rename before the real session exists
         e.preventDefault();
         // The dblclick's own second click was already recorded above, so
         // exactly ONE recent click means the first click landed on a different
@@ -3950,6 +3955,18 @@ function ConversationRowImpl({
       </div>
     </Link>
   );
+
+  // Provisional (`temp:`) row: navigable, but no mutating affordances (kebab,
+  // context menu, pin, archive, drag) until the real session exists — those
+  // would POST to `/v1/sessions/temp:*`. Rekey to the real id (`hydrateLocal-
+  // Conversation`) drops `provisional` and the full row renders.
+  if (isProvisionalRow) {
+    return (
+      <li ref={rowRef} className="group relative">
+        {rowLink}
+      </li>
+    );
+  }
 
   return (
     // Drag props on the <li> so the whole row is grabbable; `isDragging` dims
@@ -4390,6 +4407,7 @@ const RENDERED_CONVERSATION_FIELDS: readonly (keyof Conversation)[] = [
   "project_id",
   "owner",
   "pending_elicitations_count",
+  "provisional",
 ];
 
 function conversationRenderEqual(a: Conversation, b: Conversation): boolean {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -60,6 +60,7 @@ import {
   handleSessionEvent,
   hydrateLocalConversation,
   isStaleCompletedResponse,
+  isStaleTempConvId,
   isTempConvId,
   initChatStore,
   pumpStreamEvents,
@@ -562,6 +563,17 @@ describe("isTempConvId", () => {
     expect(isTempConvId("pend_conv_1")).toBe(false); // sidebar-only skeleton id
     expect(isTempConvId(null)).toBe(false);
     expect(isTempConvId(undefined)).toBe(false);
+  });
+
+  it("isStaleTempConvId: true for a temp id with no live entry, false once live", () => {
+    // No entry → stale (a reloaded/foreign temp URL that can't be re-created).
+    expect(isStaleTempConvId("temp:00001111")).toBe(true);
+    // A live entry (mid-create) is NOT stale.
+    conversationRegistry.acquire("temp:00001111");
+    expect(isStaleTempConvId("temp:00001111")).toBe(false);
+    // Real ids and empties are never stale-temp.
+    expect(isStaleTempConvId("conv_real")).toBe(false);
+    expect(isStaleTempConvId(null)).toBe(false);
   });
 });
 

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -58,6 +58,7 @@ import {
   consumePendingInitialPrompt,
   handleSessionEvent,
   isStaleCompletedResponse,
+  isTempConvId,
   initChatStore,
   pumpStreamEvents,
   SSE_STALE_RECYCLE_MS,
@@ -550,6 +551,17 @@ function seedPendingInputs(
 ): void {
   sessionPendingInputs.set(id, inputs);
 }
+
+describe("isTempConvId", () => {
+  it("recognizes client-only temp conversation ids and rejects real ones", () => {
+    expect(isTempConvId("temp:0a1b2c3d")).toBe(true);
+    expect(isTempConvId("temp:ffffffff")).toBe(true);
+    expect(isTempConvId("conv_abc123")).toBe(false);
+    expect(isTempConvId("pend_conv_1")).toBe(false); // sidebar-only skeleton id
+    expect(isTempConvId(null)).toBe(false);
+    expect(isTempConvId(undefined)).toBe(false);
+  });
+});
 
 describe("test harness teardown", () => {
   it("settles a parked SSE reader, which aborting alone cannot do", async () => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -2590,6 +2590,49 @@ describe("chatStore — navigate-first first send (B1/B2 regressions)", () => {
     expect(real.pendingUserMessages).toEqual([]);
     expect(real.blocks.filter((b) => b.type === "error")).toHaveLength(1);
   });
+
+  it("does not promote the visible store when the route already left the temp chat", () => {
+    seedSession("conv_real");
+    const { tempConvId, pendingMsgTempId } = beginLocalConversation("hi", undefined)!;
+    const navigate = vi.fn();
+
+    hydrateLocalConversation(
+      tempConvId,
+      "conv_real",
+      "agent_xyz",
+      "hi",
+      undefined,
+      pendingMsgTempId,
+      null,
+      navigate,
+      () => false,
+    );
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(useChatStore.getState().conversationId).toBe(tempConvId);
+  });
+
+  it("a pinned background send does not consume the visible conversation's retry id", async () => {
+    seedSession("conv_target");
+    seedSession("conv_visible");
+    await useChatStore.getState().switchTo("conv_target");
+    await useChatStore.getState().switchTo("conv_visible");
+    useChatStore.setState({ pendingRetryStableId: "retry_visible" });
+
+    await useChatStore.getState().send("background first message", "agent_xyz", undefined, {
+      pinnedConversationId: "conv_target",
+    });
+
+    expect(useChatStore.getState().pendingRetryStableId).toBe("retry_visible");
+    const post = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url) === "/v1/sessions/conv_target/events" &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(post).toBeDefined();
+    const body = JSON.parse((post![1] as RequestInit).body as string);
+    expect(body.data.stable_id).not.toBe("retry_visible");
+  });
 });
 
 describe("chatStore — sendSlashCommand", () => {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -55,8 +55,10 @@ import type { TerminalInfo } from "@/hooks/useTerminals";
 import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
+  beginLocalConversation,
   consumePendingInitialPrompt,
   handleSessionEvent,
+  hydrateLocalConversation,
   isStaleCompletedResponse,
   isTempConvId,
   initChatStore,
@@ -2409,6 +2411,172 @@ describe("chatStore — send (first-send ordering)", () => {
       String(u).endsWith("/v1/sessions/conv_new/stream"),
     );
     expect(streamOpens).toHaveLength(1);
+  });
+});
+
+describe("chatStore — navigate-first first send (B1/B2 regressions)", () => {
+  // Drives the navigate-first flow directly (NewChatDialog owns createSession;
+  // these exercise the store side): begin a client-only conversation, then
+  // hydrate it onto a real id, which fires the first-message `send` internally.
+  const noopNavigate = () => {};
+
+  // hydrateLocalConversation fires `void send(...)`; flush enough microtasks +
+  // the timer-based fetch acks for it to settle.
+  async function settle() {
+    await tick();
+    await tick();
+  }
+
+  it("happy path: reuses the bubble (no duplicate), stays streaming, arms the latch", async () => {
+    seedSession("conv_real");
+    const begun = beginLocalConversation("hello there", undefined);
+    expect(begun).not.toBeNull();
+    const { tempConvId, pendingMsgTempId } = begun!;
+    expect(isTempConvId(tempConvId)).toBe(true);
+    // One optimistic bubble is shown under the temp id, entry pre-streaming.
+    expect(useChatStore.getState().pendingUserMessages).toHaveLength(1);
+
+    hydrateLocalConversation(
+      tempConvId,
+      "conv_real",
+      "agent_xyz",
+      "hello there",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+    await settle();
+
+    const state = useChatStore.getState();
+    // The bubble was reused, not duplicated.
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.pendingUserMessages[0]!.tempId).toBe(pendingMsgTempId);
+    // The hydrating send armed the latch, so the stranded-latch watchdog is live.
+    const real = conversationRegistry.peek("conv_real")!.getState();
+    expect(real.sendLatchedAt).not.toBeNull();
+    // Exactly one POST /events for the real session (reuse ⇒ no second bubble/POST).
+    const posts = fetchMock.mock.calls.filter(
+      ([u, init]) =>
+        String(u) === "/v1/sessions/conv_real/events" &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(posts).toHaveLength(1);
+  });
+
+  it("B1: a failed first message settles to idle (not stuck streaming)", async () => {
+    seedSession("conv_real");
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url === "/v1/sessions/conv_real/events") {
+        return mockResponse(
+          { error: { code: "internal_error", message: "boom" } },
+          {
+            ok: false,
+            status: 500,
+          },
+        );
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const { tempConvId, pendingMsgTempId } = beginLocalConversation("hi", undefined)!;
+    hydrateLocalConversation(
+      tempConvId,
+      "conv_real",
+      "agent_xyz",
+      "hi",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+    await settle();
+
+    const real = conversationRegistry.peek("conv_real")!.getState();
+    // Without the fix the entry stays "streaming" forever with no latch; the
+    // fix arms the latch on the hydrating send and runs the failure-settle.
+    expect(real.status).toBe("idle");
+    expect(real.pendingUserMessages).toEqual([]);
+    // The failure is surfaced, not swallowed.
+    expect(real.blocks.filter((b) => b.type === "error")).toHaveLength(1);
+  });
+
+  it("B1: a policy-denied first message settles to idle", async () => {
+    seedSession("conv_real");
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url === "/v1/sessions/conv_real/events") {
+        return mockResponse({ queued: false, denied: true });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const { tempConvId, pendingMsgTempId } = beginLocalConversation("blocked", undefined)!;
+    hydrateLocalConversation(
+      tempConvId,
+      "conv_real",
+      "agent_xyz",
+      "blocked",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+    await settle();
+
+    const real = conversationRegistry.peek("conv_real")!.getState();
+    expect(real.status).toBe("idle");
+    expect(real.sessionStatus).toBe("idle");
+    expect(real.pendingUserMessages).toEqual([]);
+  });
+
+  it("B2: a bind failure after navigate-away settles the real session, not the visible one", async () => {
+    // The real session's snapshot fails, so ensureBoundSession rethrows the
+    // load error BEFORE postedSessionId is assigned — the catch's B2 path.
+    seedSession("conv_visible");
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/v1/sessions/conv_real" && (init?.method ?? "GET") === "GET") {
+        return mockResponse({}, { ok: false, status: 500 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const { tempConvId, pendingMsgTempId } = beginLocalConversation("hi", undefined)!;
+    // User navigates to another chat before the create resolves.
+    useChatStore.setState({
+      conversationId: "conv_visible",
+      abortController: new AbortController(),
+      status: "idle",
+      blocks: [],
+      pendingUserMessages: [],
+    });
+    conversationRegistry.setActive("conv_visible");
+
+    hydrateLocalConversation(
+      tempConvId,
+      "conv_real",
+      "agent_xyz",
+      "hi",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+    await settle();
+
+    const visible = useChatStore.getState();
+    // The visible conversation is untouched — no stray error block or status flip.
+    expect(visible.conversationId).toBe("conv_visible");
+    expect(visible.blocks.filter((b) => b.type === "error")).toHaveLength(0);
+    expect(visible.status).toBe("idle");
+    // The real (background) session carried the failure and settled to idle.
+    const real = conversationRegistry.peek("conv_real")!.getState();
+    expect(real.status).toBe("idle");
+    expect(real.pendingUserMessages).toEqual([]);
+    expect(real.blocks.filter((b) => b.type === "error")).toHaveLength(1);
   });
 });
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -103,6 +103,10 @@ import {
   type ConversationsInfiniteData,
 } from "@/lib/sessionListCache";
 import { recordOptimisticTitle } from "@/lib/optimisticTitles";
+// Re-exported below so existing `@/store/chatStore` importers keep working; the
+// pure helpers live in a leaf module so low-level session hooks can gate on temp
+// ids without an import cycle back to the store.
+import { isTempConvId, newTempConvId } from "@/lib/tempConversationId";
 import { useTerminalActivityStore } from "./terminalActivity";
 import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 import type {
@@ -1175,21 +1179,8 @@ const sendChains = new Map<string | symbol, SendChain>();
 // non-string key can never collide with a conversation id.
 const NEW_SESSION_SEND_CHAIN_KEY = Symbol("new-session");
 
-/** Prefix of a client-only conversation id, shown while `createSession` runs. */
-const TEMP_CONV_ID_PREFIX = "temp:";
-
-/** Mint a fresh client-only conversation id: `temp:<32-bit hex>`. */
-function newTempConvId(): string {
-  const hex = Math.floor(Math.random() * 0x1_0000_0000)
-    .toString(16)
-    .padStart(8, "0");
-  return `${TEMP_CONV_ID_PREFIX}${hex}`;
-}
-
-/** Whether an id is a client-only temp conversation id (not a server session). */
-export function isTempConvId(id: string | null | undefined): boolean {
-  return typeof id === "string" && id.startsWith(TEMP_CONV_ID_PREFIX);
-}
+// Re-export for callers that already import it from the store.
+export { isTempConvId } from "@/lib/tempConversationId";
 
 /**
  * A temp URL with no live registry entry — a reload or fresh tab landed on a

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -172,8 +172,12 @@ export interface SendOptions {
   pinnedConversationId?: string;
 }
 
-/** A title-less conversation row for the sidebar cache (renders like a fresh session). */
-function makeConvRow(id: string): Conversation {
+/**
+ * A title-less conversation row for the sidebar cache (renders like a fresh
+ * session). `provisional` marks the client-only `temp:` row so the sidebar
+ * disables per-row mutations until it's rekeyed to the real id.
+ */
+function makeConvRow(id: string, provisional = false): Conversation {
   const now = Math.floor(Date.now() / 1000);
   return {
     id,
@@ -183,6 +187,7 @@ function makeConvRow(id: string): Conversation {
     updated_at: now,
     labels: {},
     permission_level: null,
+    ...(provisional ? { provisional: true } : {}),
   };
 }
 
@@ -251,7 +256,7 @@ export function beginLocalConversation(
 
   // Sidebar row under the same id the URL shows.
   recordOptimisticTitle(tempConvId, text);
-  upsertConvRow(makeConvRow(tempConvId));
+  upsertConvRow(makeConvRow(tempConvId, true));
 
   const fileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
     const filename = file.name || "image.png";

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -301,10 +301,12 @@ export function hydrateLocalConversation(
   skill: { name: string; args: string } | null,
   navigate: (to: string, opts?: { replace?: boolean }) => void,
 ): void {
-  // Registry entry (with its bubble) + send chain, both id-addressed. Rekey the
-  // sidebar row BEFORE the caller's refetch so a lagging index can't drop it.
+  // Registry entry (carrying the optimistic bubble) + the sidebar row, both
+  // id-addressed. Rekey the row BEFORE the caller's refetch so a lagging index
+  // can't drop it. No send-chain migration: the composer is read-only for a temp
+  // id, so no send is ever keyed under it — the hydrating `send` below enters
+  // the chain under the real id directly.
   conversationRegistry.rekey(tempConvId, realId);
-  rekeySendChain(tempConvId, realId);
   rekeyConvRow(tempConvId, realId, text);
 
   const stillViewing = useChatStore.getState().conversationId === tempConvId;
@@ -1172,30 +1174,6 @@ const sendChains = new Map<string | symbol, SendChain>();
 // session is created inside the chained work, so they can't key by id. A
 // non-string key can never collide with a conversation id.
 const NEW_SESSION_SEND_CHAIN_KEY = Symbol("new-session");
-
-/**
- * Move any send chain from `oldId` to `newId`, preserving its queued followers.
- *
- * The navigate-first flow POSTs the first message only after rekeying to the
- * real id, so a chain under the temp id is usually absent — but a composer send
- * fired against the temp id before hydrate would key one, and it must follow the
- * conversation to its real id. No-op when no chain exists under `oldId`.
- */
-function rekeySendChain(oldId: string, newId: string): void {
-  const chain = sendChains.get(oldId);
-  if (chain === undefined) return;
-  const existing = sendChains.get(newId);
-  if (existing !== undefined && existing !== chain) {
-    // Splice ours behind an existing chain rather than dropping its queue.
-    // Capture the current tail into a local first: reading `chain.tail` inside
-    // the `.then` after reassigning it to that same promise is a self-cycle
-    // (`TypeError: Chaining cycle detected`).
-    const own = chain.tail;
-    chain.tail = existing.tail.then(() => own);
-  }
-  sendChains.delete(oldId);
-  sendChains.set(newId, chain);
-}
 
 /** Prefix of a client-only conversation id, shown while `createSession` runs. */
 const TEMP_CONV_ID_PREFIX = "temp:";

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1187,8 +1187,11 @@ function rekeySendChain(oldId: string, newId: string): void {
   const existing = sendChains.get(newId);
   if (existing !== undefined && existing !== chain) {
     // Splice ours behind an existing chain rather than dropping its queue.
-    const priorTail = existing.tail;
-    chain.tail = priorTail.then(() => chain.tail);
+    // Capture the current tail into a local first: reading `chain.tail` inside
+    // the `.then` after reassigning it to that same promise is a self-cycle
+    // (`TypeError: Chaining cycle detected`).
+    const own = chain.tail;
+    chain.tail = existing.tail.then(() => own);
   }
   sendChains.delete(oldId);
   sendChains.set(newId, chain);
@@ -1208,6 +1211,16 @@ function newTempConvId(): string {
 /** Whether an id is a client-only temp conversation id (not a server session). */
 export function isTempConvId(id: string | null | undefined): boolean {
   return typeof id === "string" && id.startsWith(TEMP_CONV_ID_PREFIX);
+}
+
+/**
+ * A temp URL with no live registry entry — a reload or fresh tab landed on a
+ * `temp:` id whose client-only conversation no longer exists (it can't be
+ * re-created). ChatPage redirects these to landing so the URL-keyed landing
+ * selection isn't stuck on a permanently read-only phantom chat.
+ */
+export function isStaleTempConvId(id: string | null | undefined): boolean {
+  return isTempConvId(id) && conversationRegistry.peek(id as string) === undefined;
 }
 
 /**
@@ -2334,11 +2347,12 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       return;
     }
 
-    // A client-only conversation (temp_conv_*) shown while `createSession` is in
+    // A client-only conversation (temp:*) shown while `createSession` is in
     // flight has no server session to bind — its entry holds the optimistic
     // first-message bubble locally. Paint it and return; the background create
     // rekeys it to the real id (which then binds). If the entry is gone (a stale
-    // temp URL survived a reload — it can't be re-created), fall back to landing.
+    // temp URL survived a reload — it can't be re-created), reset to landing
+    // state as a backstop; ChatPage redirects the URL to `/` (isStaleTempConvId).
     if (isTempConvId(conversationId)) {
       if (conversationRegistry.peek(conversationId) === undefined) {
         conversationRegistry.setActive(null);

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -319,9 +319,14 @@ export function hydrateLocalConversation(
   if (skill !== null) {
     // Slash command: the server resolves the skill and emits its own receipt +
     // echo, which `sendSlashCommand` renders. Drop the plain-text placeholder
-    // bubble first so it isn't duplicated by the command's own echo.
+    // bubble so it isn't duplicated, and clear the create-window "streaming"
+    // status (set by `beginLocalConversation`, no `sendLatchedAt`) so
+    // `sendSlashCommand` arms its own latch and owns the failure-settle — else a
+    // failed command would strand the conversation in "streaming" (see B1).
     setterFor(realId)((s) => ({
       pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== pendingMsgTempId),
+      status: "idle",
+      sendLatchedAt: null,
     }));
     void store.sendSlashCommand(skill.name, skill.args, agentId, { pinnedConversationId: realId });
     return;
@@ -1880,10 +1885,18 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // into the running task's inbox. Keep `activeResponse` untouched in
     // that case so the in-flight bubble keeps its "streaming" lifecycle
     // until its own `response.completed` arrives.
+    //
+    // `reusePendingTempId` is the navigate-first first turn: the entry was
+    // pre-set to "streaming" by `beginLocalConversation` (for the create-window
+    // shimmer) but has no `sendLatchedAt`. Treat it as NOT-already-streaming so
+    // this send arms the latch and owns the failure-settle — otherwise a failed
+    // first turn would strand the conversation in "streaming" with no watchdog.
     const alreadyStreaming =
-      pinnedId === null
-        ? get().status === "streaming"
-        : setterForState(pinnedId)?.status === "streaming";
+      opts?.reusePendingTempId != null
+        ? false
+        : pinnedId === null
+          ? get().status === "streaming"
+          : setterForState(pinnedId)?.status === "streaming";
     if (!alreadyStreaming) {
       // Latch on the SAME entry as `status`, in one patch, so they can't
       // diverge — a new chat buffers both on root and `adoptPreSessionState`
@@ -2068,12 +2081,16 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       }
       // Settle the conversation this send targeted, wherever the user is now:
       // its bubble must roll back and its status must not stay "streaming"
-      // forever. When the throw came from session setup itself
-      // (`postedSessionId` never resolved) there is no target conversation, so
-      // it belongs to the active one — the landing composer's own failure.
-      const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
+      // forever. Target `postedSessionId ?? submitConversationId` (mirroring the
+      // draft restore above): a bind failure throws before `postedSessionId` is
+      // assigned, but the pin/submit id already names the session — so a failed
+      // navigate-first first turn settles the REAL new session, not whatever
+      // chat the user has since switched to. Null id (the landing composer's own
+      // failure) falls back to the active conversation.
+      const failTarget = postedSessionId ?? submitConversationId;
+      const failSet = failTarget === null ? setActive : setterFor(failTarget);
       const failGet = (): ChatState =>
-        postedSessionId === null ? get() : (setterForState(postedSessionId) ?? get());
+        failTarget === null ? get() : (setterForState(failTarget) ?? get());
       // Roll back the optimistic bubble — no server idle will fire.
       failSet((s) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
@@ -2211,10 +2228,12 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       const message = err instanceof Error ? err.message : String(err);
       // Settle the conversation this command targeted, wherever the user is
       // now: its echo must roll back and its status must not stay "streaming"
-      // forever. A throw from session setup itself (`postedSessionId` never
-      // resolved) has no target conversation, so it belongs to the active one —
-      // the landing composer's own failure. Mirrors `send`'s catch.
-      const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
+      // forever. Target `postedSessionId ?? submitConversationId` (mirrors
+      // `send`'s catch): a bind failure throws before `postedSessionId` is set,
+      // but the pin/submit id already names the session, so a failed pinned
+      // command settles the real session, not the visible one. Null → active.
+      const failTarget = postedSessionId ?? submitConversationId;
+      const failSet = failTarget === null ? setActive : setterFor(failTarget);
       // Roll back the optimistic echo — no receipt will reconcile it.
       failSet((s) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -309,6 +309,7 @@ export function hydrateLocalConversation(
   pendingMsgTempId: string,
   skill: { name: string; args: string } | null,
   navigate: (to: string, opts?: { replace?: boolean }) => void,
+  isStillViewing: () => boolean = () => true,
 ): void {
   // Registry entry (carrying the optimistic bubble) + the sidebar row, both
   // id-addressed. Rekey the row BEFORE the caller's refetch so a lagging index
@@ -318,7 +319,7 @@ export function hydrateLocalConversation(
   conversationRegistry.rekey(tempConvId, realId);
   rekeyConvRow(tempConvId, realId, text);
 
-  const stillViewing = useChatStore.getState().conversationId === tempConvId;
+  const stillViewing = useChatStore.getState().conversationId === tempConvId && isStillViewing();
   if (stillViewing) {
     useChatStore.setState({ conversationId: realId });
     conversationRegistry.setActive(realId);
@@ -1858,15 +1859,18 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     if (!agentId) {
       throw new Error("chatStore.send: no agentId");
     }
-    const retryId = get().pendingRetryStableId;
-    if (retryId !== null) setActive({ pendingRetryStableId: null });
-    const stableId = opts?.stableId ?? retryId ?? randomUUID().replace(/-/g, "");
     // Target session: an explicit pin (navigate-first background POST) overrides
     // the visible conversation, so a send whose session was created while the
     // user moved to another chat still lands on the right one, not the one on
     // screen. `pinnedSetter` routes every write for this send there.
     const pinnedId = opts?.pinnedConversationId ?? null;
     const pinnedSetter: typeof setActive = pinnedId === null ? setActive : setterFor(pinnedId);
+    const retryId =
+      pinnedId === null
+        ? get().pendingRetryStableId
+        : (setterForState(pinnedId)?.pendingRetryStableId ?? null);
+    if (retryId !== null) pinnedSetter({ pendingRetryStableId: null });
+    const stableId = opts?.stableId ?? retryId ?? randomUUID().replace(/-/g, "");
     // Sending while a response is already streaming is allowed — the
     // session API queues item-typed events and the server delivers them
     // into the running task's inbox. Keep `activeResponse` untouched in

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -94,7 +94,15 @@ import { clearSseLog, pushSseEvent } from "@/lib/sseEventLog";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { sessionItemsQueryKey } from "@/hooks/useSessionItems";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
-import { overlayTitleIntoCaches, type ConversationsInfiniteData } from "@/lib/sessionListCache";
+import {
+  filtersFromConversationQueryKey,
+  insertNewRowsIntoPages,
+  markRecentlyCreated,
+  overlayTitleIntoCaches,
+  removeIdsFromPages,
+  type ConversationsInfiniteData,
+} from "@/lib/sessionListCache";
+import { recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { useTerminalActivityStore } from "./terminalActivity";
 import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 import type {
@@ -145,6 +153,203 @@ export interface SendOptions {
    * dedup recognises the retry and does not re-dispatch to the runner.
    */
   stableId?: string;
+  /**
+   * Reuse the optimistic bubble already on the target entry (pushed by
+   * `beginLocalConversation`) instead of pushing a fresh one, so the navigate-
+   * first flow's POST doesn't duplicate the message the user already sees. Its
+   * `content` is already set; `session.input.consumed` pops it FIFO as usual.
+   */
+  reusePendingTempId?: string;
+  /**
+   * Target session id, overriding the active `conversationId` — so the navigate-
+   * first background POST lands on the created session even after the user moves
+   * to another chat. Defaults to the active conversation.
+   */
+  pinnedConversationId?: string;
+}
+
+/** A title-less conversation row for the sidebar cache (renders like a fresh session). */
+function makeConvRow(id: string): Conversation {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id,
+    object: "conversation",
+    title: null,
+    created_at: now,
+    updated_at: now,
+    labels: {},
+    permission_level: null,
+  };
+}
+
+/** Upsert one row into every `["conversations", ...]` cache variant. */
+function upsertConvRow(row: Conversation, removeId?: string): void {
+  if (queryClient === null) return;
+  const rowMap = new Map([[row.id, row]]);
+  const removeSet = removeId ? new Set([removeId]) : null;
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    if (!data) continue;
+    const base = removeSet ? (removeIdsFromPages(data, removeSet).data ?? data) : data;
+    const { data: next } = insertNewRowsIntoPages(
+      base,
+      rowMap,
+      filtersFromConversationQueryKey(key),
+    );
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+}
+
+/**
+ * Move the sidebar row from the temp id to the real one. `markRecentlyCreated`
+ * keeps it in the first-page fetch until the search index catches up; the WS
+ * `session_added` frame then finds it present and skips it (no duplicate).
+ */
+function rekeyConvRow(tempId: string, realId: string, text: string): void {
+  if (queryClient === null) return;
+  const realConv = makeConvRow(realId);
+  recordOptimisticTitle(realId, text);
+  markRecentlyCreated(realConv);
+  upsertConvRow(realConv, tempId);
+}
+
+/** Drop the sidebar row for a temp id (on create failure). */
+function removeConvRow(tempId: string): void {
+  if (queryClient === null) return;
+  const tempIds = new Set([tempId]);
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    const { data: next } = removeIdsFromPages(data, tempIds);
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+}
+
+/**
+ * Start a client-only conversation synchronously, before `createSession` runs:
+ * one temp id (`temp:*`) shared by the sidebar row, the registry entry, and the
+ * URL; the optimistic first message pushed into the entry; made active so the
+ * caller can `navigate('/c/<tempConvId>')` at once. `switchTo` paints it and
+ * skips binding for a temp id; ChatPage suppresses server-scoped fetches for it.
+ *
+ * Returns the temp id + the bubble's `pendingMsgTempId` for
+ * `hydrateLocalConversation`, or `null` with no query cache (tests).
+ */
+export function beginLocalConversation(
+  text: string,
+  files: File[] | undefined,
+): { tempConvId: string; pendingMsgTempId: string } | null {
+  if (queryClient === null) return null;
+  const tempConvId = newTempConvId();
+  pendingSeq += 1;
+  const pendingMsgTempId = `pend_${pendingSeq}`;
+
+  // Sidebar row under the same id the URL shows.
+  recordOptimisticTitle(tempConvId, text);
+  upsertConvRow(makeConvRow(tempConvId));
+
+  const fileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
+    const filename = file.name || "image.png";
+    const fileId = `pending:${attachmentKey(file)}`;
+    return file.type.startsWith("image/")
+      ? { type: "input_image" as const, file_id: fileId, filename }
+      : { type: "input_file" as const, file_id: fileId, filename };
+  });
+  const content: MessageContentBlock[] = [
+    ...fileBlocks,
+    ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
+  ];
+  const selfAuthor = getCurrentAuthorId();
+  const bubble: PendingUserMessage = {
+    tempId: pendingMsgTempId,
+    content,
+    createdAtS: Math.floor(Date.now() / 1000),
+    ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+  };
+
+  const entry = conversationRegistry.acquire(tempConvId);
+  entry.setState({
+    pendingUserMessages: [bubble],
+    loadingConversation: false,
+    status: "streaming",
+  });
+  useChatStore.setState({ conversationId: tempConvId });
+  conversationRegistry.setActive(tempConvId);
+  mirrorActiveEntry();
+  return { tempConvId, pendingMsgTempId };
+}
+
+/**
+ * Hydrate a client-only conversation onto its real server id once
+ * `createSession` returns: rekey the registry entry (carrying the optimistic
+ * bubble), the send chain, and the sidebar row from `tempConvId` to `realId`;
+ * flip the store + URL when still viewing it; then POST the first message via
+ * `send` (reusing the already-shown bubble), which binds the real stream.
+ *
+ * Navigate-away safe: the registry/chain/sidebar rekey is id-addressed and
+ * always runs. The store flip + `navigate` run ONLY when still on `tempConvId`,
+ * so a background create can't yank a user who has moved to another chat.
+ */
+export function hydrateLocalConversation(
+  tempConvId: string,
+  realId: string,
+  agentId: string,
+  text: string,
+  files: File[] | undefined,
+  pendingMsgTempId: string,
+  skill: { name: string; args: string } | null,
+  navigate: (to: string, opts?: { replace?: boolean }) => void,
+): void {
+  // Registry entry (with its bubble) + send chain, both id-addressed. Rekey the
+  // sidebar row BEFORE the caller's refetch so a lagging index can't drop it.
+  conversationRegistry.rekey(tempConvId, realId);
+  rekeySendChain(tempConvId, realId);
+  rekeyConvRow(tempConvId, realId, text);
+
+  const stillViewing = useChatStore.getState().conversationId === tempConvId;
+  if (stillViewing) {
+    useChatStore.setState({ conversationId: realId });
+    conversationRegistry.setActive(realId);
+    mirrorActiveEntry();
+    navigate(`/c/${realId}`, { replace: true });
+  }
+
+  const store = useChatStore.getState();
+  if (skill !== null) {
+    // Slash command: the server resolves the skill and emits its own receipt +
+    // echo, which `sendSlashCommand` renders. Drop the plain-text placeholder
+    // bubble first so it isn't duplicated by the command's own echo.
+    setterFor(realId)((s) => ({
+      pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== pendingMsgTempId),
+    }));
+    void store.sendSlashCommand(skill.name, skill.args, agentId, { pinnedConversationId: realId });
+    return;
+  }
+  // Plain message: reuse the bubble already on the entry. `send` →
+  // `ensureBoundSession` (existing-session branch) binds the real stream (the
+  // rekeyed entry has no live pump), so no explicit bind here.
+  void store.send(text, agentId, files, {
+    pinnedConversationId: realId,
+    reusePendingTempId: pendingMsgTempId,
+  });
+}
+
+/**
+ * Discard a client-only conversation (create failed): drop the sidebar row and
+ * the registry entry. Returns whether the discarded conversation was still the
+ * one on screen, so the caller can navigate back to the landing route.
+ */
+export function removeLocalConversation(tempConvId: string): boolean {
+  const wasViewing = useChatStore.getState().conversationId === tempConvId;
+  removeConvRow(tempConvId);
+  if (wasViewing) {
+    // Reset the store to the landing state first (switchTo(null) does the full
+    // mirrored-field reset), THEN release the entry.
+    void useChatStore.getState().switchTo(null);
+  }
+  conversationRegistry.release(tempConvId);
+  return wasViewing;
 }
 
 /**
@@ -964,6 +1169,43 @@ const sendChains = new Map<string | symbol, SendChain>();
 const NEW_SESSION_SEND_CHAIN_KEY = Symbol("new-session");
 
 /**
+ * Move any send chain from `oldId` to `newId`, preserving its queued followers.
+ *
+ * The navigate-first flow POSTs the first message only after rekeying to the
+ * real id, so a chain under the temp id is usually absent — but a composer send
+ * fired against the temp id before hydrate would key one, and it must follow the
+ * conversation to its real id. No-op when no chain exists under `oldId`.
+ */
+function rekeySendChain(oldId: string, newId: string): void {
+  const chain = sendChains.get(oldId);
+  if (chain === undefined) return;
+  const existing = sendChains.get(newId);
+  if (existing !== undefined && existing !== chain) {
+    // Splice ours behind an existing chain rather than dropping its queue.
+    const priorTail = existing.tail;
+    chain.tail = priorTail.then(() => chain.tail);
+  }
+  sendChains.delete(oldId);
+  sendChains.set(newId, chain);
+}
+
+/** Prefix of a client-only conversation id, shown while `createSession` runs. */
+const TEMP_CONV_ID_PREFIX = "temp:";
+
+/** Mint a fresh client-only conversation id: `temp:<32-bit hex>`. */
+function newTempConvId(): string {
+  const hex = Math.floor(Math.random() * 0x1_0000_0000)
+    .toString(16)
+    .padStart(8, "0");
+  return `${TEMP_CONV_ID_PREFIX}${hex}`;
+}
+
+/** Whether an id is a client-only temp conversation id (not a server session). */
+export function isTempConvId(id: string | null | undefined): boolean {
+  return typeof id === "string" && id.startsWith(TEMP_CONV_ID_PREFIX);
+}
+
+/**
  * Take a slot in a conversation's send chain.
  *
  * :param conversationId: Conversation to serialize against, or ``null`` for a
@@ -1627,17 +1869,26 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     const retryId = get().pendingRetryStableId;
     if (retryId !== null) setActive({ pendingRetryStableId: null });
     const stableId = opts?.stableId ?? retryId ?? randomUUID().replace(/-/g, "");
+    // Target session: an explicit pin (navigate-first background POST) overrides
+    // the visible conversation, so a send whose session was created while the
+    // user moved to another chat still lands on the right one, not the one on
+    // screen. `pinnedSetter` routes every write for this send there.
+    const pinnedId = opts?.pinnedConversationId ?? null;
+    const pinnedSetter: typeof setActive = pinnedId === null ? setActive : setterFor(pinnedId);
     // Sending while a response is already streaming is allowed — the
     // session API queues item-typed events and the server delivers them
     // into the running task's inbox. Keep `activeResponse` untouched in
     // that case so the in-flight bubble keeps its "streaming" lifecycle
     // until its own `response.completed` arrives.
-    const alreadyStreaming = get().status === "streaming";
+    const alreadyStreaming =
+      pinnedId === null
+        ? get().status === "streaming"
+        : setterForState(pinnedId)?.status === "streaming";
     if (!alreadyStreaming) {
       // Latch on the SAME entry as `status`, in one patch, so they can't
       // diverge — a new chat buffers both on root and `adoptPreSessionState`
       // moves them onto the entry together.
-      setActive({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
+      pinnedSetter({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
     }
 
     // Push to `pendingUserMessages` BEFORE the POST so the bubble
@@ -1646,8 +1897,16 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // response (separate TCP connections; either can resolve first).
     // FIFO promotion in the consumed handler matches this pending
     // entry to the eventual server item id.
-    pendingSeq += 1;
-    const tempId = `pend_${pendingSeq}`;
+    // Reuse a bubble already on the entry (navigate-first flow) rather than
+    // mint a new one, so the message the user has already seen isn't duplicated.
+    const reuseTempId = opts?.reusePendingTempId ?? null;
+    let tempId: string;
+    if (reuseTempId !== null) {
+      tempId = reuseTempId;
+    } else {
+      pendingSeq += 1;
+      tempId = `pend_${pendingSeq}`;
+    }
     const pendingFileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
       const filename = file.name || "image.png";
       // Key the placeholder id on the File's stable identity, not its name:
@@ -1665,30 +1924,33 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
     ];
     const selfAuthor = getCurrentAuthorId();
-    setActive((s) => ({
-      pendingUserMessages: [
-        ...s.pendingUserMessages,
-        {
-          tempId,
-          content,
-          createdAtS: Math.floor(Date.now() / 1000),
-          ...(selfAuthor !== null ? { author: selfAuthor } : {}),
-        },
-      ],
-      // A new turn does NOT supersede the background-shell tally: shells
-      // launched in an earlier turn keep running across the turn boundary, so
-      // the composer pill must stay lit alongside the "Working…" shimmer rather
-      // than blink off the moment the user sends. The count is sticky (see the
-      // `session_status` handler) and the next Stop hook re-reports it
-      // authoritatively. Only the parked-dialog reason clears — a fresh send is
-      // not parked on a dialog.
-      blockedOn: null,
-    }));
+    if (reuseTempId === null) {
+      pinnedSetter((s) => ({
+        pendingUserMessages: [
+          ...s.pendingUserMessages,
+          {
+            tempId,
+            content,
+            createdAtS: Math.floor(Date.now() / 1000),
+            ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+          },
+        ],
+        // A new turn does NOT supersede the background-shell tally: shells
+        // launched in an earlier turn keep running across the turn boundary, so
+        // the composer pill must stay lit alongside the "Working…" shimmer rather
+        // than blink off the moment the user sends. The count is sticky (see the
+        // `session_status` handler) and the next Stop hook re-reports it
+        // authoritatively. Only the parked-dialog reason clears — a fresh send is
+        // not parked on a dialog.
+        blockedOn: null,
+      }));
+    }
 
     // Pin the destination before joining the send chain: a stalled prior
     // send can delay this POST past a session switch, and resolving the
     // target afterward would leak the message into the now-active session.
-    const submitConversationId = get().conversationId;
+    // An explicit pin (navigate-first background POST) wins over the visible id.
+    const submitConversationId = pinnedId ?? get().conversationId;
 
     // Take our place in THIS conversation's send chain: wait for its prior
     // send's network work, then hand off to the next via `releaseSend` in the
@@ -1854,12 +2116,19 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     if (!agentId) {
       throw new Error("chatStore.sendSlashCommand: no agentId");
     }
+    // See `send`: an explicit pin (navigate-first background dispatch) targets
+    // the just-created session even after the user moved to another chat.
+    const pinnedId = opts?.pinnedConversationId ?? null;
+    const pinnedSetter: typeof setActive = pinnedId === null ? setActive : setterFor(pinnedId);
     // Mirror `send`'s lifecycle scaffolding (streaming flag + send-chain
     // serialization) so a skill invocation behaves like any other turn.
-    const alreadyStreaming = get().status === "streaming";
+    const alreadyStreaming =
+      pinnedId === null
+        ? get().status === "streaming"
+        : setterForState(pinnedId)?.status === "streaming";
     if (!alreadyStreaming) {
       // See `send`: latch and status on one entry, in one patch.
-      setActive({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
+      pinnedSetter({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
     }
     // Optimistic echo of the typed command, mirroring `send`. Without it
     // the chat shows nothing until the server's `slash_command` receipt
@@ -1873,7 +2142,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     const tempId = `pend_${pendingSeq}`;
     const commandText = args ? `/${name} ${args}` : `/${name}`;
     const selfAuthor = getCurrentAuthorId();
-    setActive((s) => ({
+    pinnedSetter((s) => ({
       pendingUserMessages: [
         ...s.pendingUserMessages,
         {
@@ -1887,7 +2156,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
 
     // Pin the destination at submit time — see `send` above for why a late
     // resolve mis-routes to the session the user has since switched to.
-    const submitConversationId = get().conversationId;
+    const submitConversationId = pinnedId ?? get().conversationId;
 
     const { waitForPrior, rekey, releaseSend } = enterSendChain(submitConversationId);
 
@@ -2043,6 +2312,23 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // Landing route: nothing to project, so reset the mirrored fields to a
       // clean slate rather than leaving the last conversation painted.
       rootSetState(createInitialConversationState() as Parameters<typeof rootSetState>[0]);
+      return;
+    }
+
+    // A client-only conversation (temp_conv_*) shown while `createSession` is in
+    // flight has no server session to bind — its entry holds the optimistic
+    // first-message bubble locally. Paint it and return; the background create
+    // rekeys it to the real id (which then binds). If the entry is gone (a stale
+    // temp URL survived a reload — it can't be re-created), fall back to landing.
+    if (isTempConvId(conversationId)) {
+      if (conversationRegistry.peek(conversationId) === undefined) {
+        conversationRegistry.setActive(null);
+        rootSetState({ conversationId: null } as Parameters<typeof rootSetState>[0]);
+        rootSetState(createInitialConversationState() as Parameters<typeof rootSetState>[0]);
+        return;
+      }
+      conversationRegistry.acquire(conversationId);
+      mirrorActiveEntry();
       return;
     }
 

--- a/web/src/store/conversationRegistry.test.ts
+++ b/web/src/store/conversationRegistry.test.ts
@@ -276,4 +276,33 @@ describe("ConversationRegistry", () => {
     registry.release("conv_a");
     expect(registry.getActive()).toBeNull();
   });
+
+  it("rekey preserves state, moves the active pointer, and drops the old id", () => {
+    const temp = registry.acquire("temp_conv_1");
+    temp.setState({ status: "streaming" });
+    registry.setActive("temp_conv_1");
+
+    registry.rekey("temp_conv_1", "conv_real");
+
+    expect(registry.has("temp_conv_1")).toBe(false);
+    expect(temp.disposed).toBe(true);
+    const real = registry.peek("conv_real");
+    expect(real?.id).toBe("conv_real");
+    expect(real?.getState().status).toBe("streaming"); // carried over
+    expect(registry.getActive()?.id).toBe("conv_real"); // active pointer followed
+  });
+
+  it("rekey onto an already-live id keeps the existing entry and disposes the old", () => {
+    const temp = registry.acquire("temp_conv_1");
+    const existing = registry.acquire("conv_real");
+    registry.rekey("temp_conv_1", "conv_real");
+    expect(registry.peek("conv_real")).toBe(existing);
+    expect(temp.disposed).toBe(true);
+    expect(registry.has("temp_conv_1")).toBe(false);
+  });
+
+  it("rekey is a no-op when the old id is not live", () => {
+    registry.rekey("temp_conv_missing", "conv_real");
+    expect(registry.has("conv_real")).toBe(false);
+  });
 });

--- a/web/src/store/conversationRegistry.test.ts
+++ b/web/src/store/conversationRegistry.test.ts
@@ -278,13 +278,13 @@ describe("ConversationRegistry", () => {
   });
 
   it("rekey preserves state, moves the active pointer, and drops the old id", () => {
-    const temp = registry.acquire("temp_conv_1");
+    const temp = registry.acquire("temp:aaaa0001");
     temp.setState({ status: "streaming" });
-    registry.setActive("temp_conv_1");
+    registry.setActive("temp:aaaa0001");
 
-    registry.rekey("temp_conv_1", "conv_real");
+    registry.rekey("temp:aaaa0001", "conv_real");
 
-    expect(registry.has("temp_conv_1")).toBe(false);
+    expect(registry.has("temp:aaaa0001")).toBe(false);
     expect(temp.disposed).toBe(true);
     const real = registry.peek("conv_real");
     expect(real?.id).toBe("conv_real");
@@ -293,16 +293,16 @@ describe("ConversationRegistry", () => {
   });
 
   it("rekey onto an already-live id keeps the existing entry and disposes the old", () => {
-    const temp = registry.acquire("temp_conv_1");
+    const temp = registry.acquire("temp:aaaa0001");
     const existing = registry.acquire("conv_real");
-    registry.rekey("temp_conv_1", "conv_real");
+    registry.rekey("temp:aaaa0001", "conv_real");
     expect(registry.peek("conv_real")).toBe(existing);
     expect(temp.disposed).toBe(true);
-    expect(registry.has("temp_conv_1")).toBe(false);
+    expect(registry.has("temp:aaaa0001")).toBe(false);
   });
 
   it("rekey is a no-op when the old id is not live", () => {
-    registry.rekey("temp_conv_missing", "conv_real");
+    registry.rekey("temp:deadbeef", "conv_real");
     expect(registry.has("conv_real")).toBe(false);
   });
 });

--- a/web/src/store/conversationRegistry.test.ts
+++ b/web/src/store/conversationRegistry.test.ts
@@ -292,11 +292,25 @@ describe("ConversationRegistry", () => {
     expect(registry.getActive()?.id).toBe("conv_real"); // active pointer followed
   });
 
-  it("rekey onto an already-live id keeps the existing entry and disposes the old", () => {
+  it("rekey onto an already-live id keeps its state and carries pending messages", () => {
     const temp = registry.acquire("temp:aaaa0001");
+    temp.setState({
+      pendingUserMessages: [
+        {
+          tempId: "pend_1",
+          content: [{ type: "input_text", text: "optimistic first message" }],
+        },
+      ],
+    });
     const existing = registry.acquire("conv_real");
     registry.rekey("temp:aaaa0001", "conv_real");
     expect(registry.peek("conv_real")).toBe(existing);
+    expect(existing.getState().pendingUserMessages).toEqual([
+      {
+        tempId: "pend_1",
+        content: [{ type: "input_text", text: "optimistic first message" }],
+      },
+    ]);
     expect(temp.disposed).toBe(true);
     expect(registry.has("temp:aaaa0001")).toBe(false);
   });

--- a/web/src/store/conversationRegistry.ts
+++ b/web/src/store/conversationRegistry.ts
@@ -219,6 +219,30 @@ export class ConversationRegistry {
     this.activeId = null;
   }
 
+  /**
+   * Rename an entry `oldId` → `newId`, preserving its state — hydrates a
+   * client-only conversation (`temp:*`) onto its real id so the optimistic
+   * bubble carries over without a remount. `oldId` must be a stream-less local
+   * entry (no live SSE pump to transfer). If `newId` is already live, its entry
+   * wins and the old one is disposed. No-op if `oldId` isn't live.
+   */
+  rekey(oldId: string, newId: string): void {
+    const old = this.entries.get(oldId);
+    if (old === undefined) return;
+    if (oldId === newId) return;
+    if (this.entries.has(newId)) {
+      this.release(oldId);
+      if (this.activeId === oldId) this.activeId = newId;
+      return;
+    }
+    const next = this.createEntry(newId);
+    next.setState(old.getState());
+    this.entries.set(newId, next);
+    this.entries.delete(oldId);
+    old.dispose();
+    if (this.activeId === oldId) this.activeId = newId;
+  }
+
   /** Move `id` to the most-recently-viewed end of the LRU order. */
   private touch(id: string): void {
     const entry = this.entries.get(id);

--- a/web/src/store/conversationRegistry.ts
+++ b/web/src/store/conversationRegistry.ts
@@ -224,13 +224,27 @@ export class ConversationRegistry {
    * client-only conversation (`temp:*`) onto its real id so the optimistic
    * bubble carries over without a remount. `oldId` must be a stream-less local
    * entry (no live SSE pump to transfer). If `newId` is already live, its entry
-   * wins and the old one is disposed. No-op if `oldId` isn't live.
+   * wins but inherits any optimistic pending messages before the old one is
+   * disposed. No-op if `oldId` isn't live.
    */
   rekey(oldId: string, newId: string): void {
     const old = this.entries.get(oldId);
     if (old === undefined) return;
     if (oldId === newId) return;
-    if (this.entries.has(newId)) {
+    const existing = this.entries.get(newId);
+    if (existing !== undefined) {
+      const existingState = existing.getState();
+      const existingPendingIds = new Set(
+        existingState.pendingUserMessages.map((item) => item.tempId),
+      );
+      const missingPending = old
+        .getState()
+        .pendingUserMessages.filter((item) => !existingPendingIds.has(item.tempId));
+      if (missingPending.length > 0) {
+        existing.setState({
+          pendingUserMessages: [...missingPending, ...existingState.pendingUserMessages],
+        });
+      }
       this.release(oldId);
       if (this.activeId === oldId) this.activeId = newId;
       return;


### PR DESCRIPTION
## Related issue

Closes [OMNI-6078](https://linear.app/omnigent/issue/OMNI-6078/remove-intermediate-loading-spinner-on-sessionharness-startup)

<!-- No tracked issue — this is a UI/frontend UX change. -->

## Summary

Starting a session from the **New Chat** landing screen used to be server-first: the UI awaited `createSession`, then navigated to `/c/<realId>`, so you sat on the landing screen through a network round-trip before seeing your message. This makes it feel instant instead.

- On submit, mint a **client-only conversation** (`temp:<hex>`) shared by the sidebar row, the store's registry entry, and the URL; render the typed first message immediately and navigate to `/c/<tempId>` right away.
- Run `createSession` in the **background**, then hydrate the temp id → real server id in both the store and the URL (`replace`), and POST the first message reusing the already-shown bubble (no duplicate, no flicker).
- **Navigate-away safe:** the create keeps resolving even if you switch to another chat; the hydrate is id-addressed and never hijacks the visible conversation.
- The temp conversation is **navigable** (its sidebar row looks identical to any freshly-created session) and its composer is **read-only** ("Starting the session…") until the real session exists.
- Server-scoped fetches/binds are **suppressed** while the id is temp, so nothing hits `/v1/sessions/<temp>/*`.

**ELI5:** Instead of making you wait at the "new chat" screen while the server sets up the conversation, we open the chat instantly with your message already showing, and quietly swap in the real conversation once the server is ready — and you can walk away and come back meanwhile.

```mermaid
sequenceDiagram
    participant U as User
    participant D as NewChatDialog
    participant S as chatStore
    participant Srv as Server

    U->>D: hit Enter
    D->>S: beginLocalConversation() → temp:<hex> + optimistic bubble
    D->>U: navigate /c/temp:<hex> (message shown, composer read-only)
    D->>Srv: createSession()  (background)
    Srv-->>D: real session id
    D->>S: hydrateLocalConversation(temp, real)
    S->>S: rekey registry entry + send chain + sidebar row
    alt still viewing the temp conv
        S->>U: flip store + URL → /c/<realId> (no flicker)
    end
    S->>Srv: POST first message (reuse bubble), bind stream
```

## Test Plan

Manual, in the web app (`just dev`):

1. New Chat → type a prompt → Enter. **Expect:** instant nav to `/c/temp:xxxxxxxx`, the message shown as the first bubble, a sidebar row identical to a fresh session, composer read-only ("Starting the session…"), and **no** `/v1/sessions/temp:*` 404s in the console.
2. A beat later the URL flips to `/c/<realId>` with no flicker, the composer unlocks, and the agent's reply streams in.
3. Repeat, but click another conversation immediately after submit. **Expect:** you stay on the other chat; the new one still completes and hydrates in the background; navigating back to it works.
4. DevTools → offline → submit. **Expect:** temp row + message appear, then on create failure you're returned to the landing screen with your draft restored and the temp row removed.
5. Regression: slash-command first messages (e.g. `/review …`), sessions started with a custom/bundled agent (server-first path), and existing-session sends behave as before.

Automated: `npx vitest run src/store src/lib/sessionListCache.test.ts` — added coverage for `ConversationRegistry.rekey` and `isTempConvId`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<!-- Screen recording to be attached; the Test Plan above lists the exact reproduction steps. -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the two new pure/store units: `ConversationRegistry.rekey` (state carried over, active-pointer follow, already-live and missing-id cases) and the `isTempConvId` guard. The end-to-end navigate-first flow (navigation timing, URL hydrate, navigate-away, offline failure) is verified manually per the Test Plan — it spans routing, the query cache, and live SSE binding, which the unit layer can't exercise faithfully.

## Known limitations / follow-up

- **Concurrent same-agent+host creates (pre-existing race, deferred).** Two rapid **New Chat** submits with the *same agent + host* while the first create is still resolving can cross-wire: the second create's push-match (`matchOwnCreate`, keyed on `agent_id` + `host_id`, not correlated to the specific request) may resolve onto the first session's row, so one session receives both prompts and the other receives none. This race lives in the existing create/push-matching path, not the temp-id work; navigate-first only makes it easier to reach because the landing screen now unmounts instantly. Fixing it properly means correlating each create to its own request (a client-minted token echoed on the pushed row) or serializing concurrent background creates — tracked as a **follow-up PR** rather than expanding this one's scope.

## Changelog

New conversations open instantly — your first message shows right away while the session is created in the background.

## Issues

Resolves [OMNI-4254](https://linear.app/omnigent/issue/OMNI-4254/takes-12-secs-to-load-new-session-after-firing-first-prompt)
