### PR TITLE
fix(web): flush stale attachment carry-over on /clear supersede

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -3646,6 +3646,36 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       expect(state.pendingUserMessages).toEqual([]);
     });
 
+    it("flushes stale attachment carry-over so it can't ride into the fresh conversation", () => {
+      const staleFile = new File(["x"], "screenshot.png", { type: "image/png" });
+      useChatStore.setState({
+        conversationId: "conv_old",
+        redirectToConversationId: null,
+        failedSendDraft: { conversationId: "conv_old", text: "look at this", files: [staleFile] },
+        queuedMessages: [
+          { queueId: "q_1", text: "queued", conversationId: "conv_old", files: [staleFile] },
+          { queueId: "q_2", text: "other", conversationId: "conv_keep", files: [] },
+        ],
+        pendingComposerAttachments: [{ path: "src/a.ts", isDir: false }],
+      });
+      handleSessionEvent({
+        type: "session_superseded",
+        conversationId: "conv_old",
+        targetConversationId: "conv_new",
+        reason: "clear",
+      });
+      const state = useChatStore.getState();
+      // Both the failed-send draft and the queued message for the superseded
+      // conversation held a File handle; leaving them would re-attach the image
+      // to the new conversation's first turn. They must be dropped here, while
+      // carry-over bound to OTHER conversations survives untouched.
+      expect(state.failedSendDraft).toBeNull();
+      expect(state.queuedMessages).toEqual([
+        { queueId: "q_2", text: "other", conversationId: "conv_keep", files: [] },
+      ]);
+      expect(state.pendingComposerAttachments).toEqual([]);
+    });
+
     it("ignores a superseded frame from a switched-away conversation", () => {
       useChatStore.setState({ conversationId: "conv_current", redirectToConversationId: null });
       handleSessionEvent({

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -5632,6 +5632,33 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
       // runner moved to the new one — so its optimistic bubble would otherwise
       // spin forever. Drop it; resuming starts a fresh turn.
       applyToNamedConversation(event.conversationId, { pendingUserMessages: [] });
+      // The same rotation orphans the app-global composer carry-over that still
+      // holds attachment `File` handles bound to the superseded conversation: a
+      // retained failed-send draft and any queued (not-yet-POSTed) messages.
+      // Left in place, those files ride into the fresh conversation's first turn
+      // — a stale image/screenshot re-attached after `/clear` (the model then
+      // "sees" an attachment the user never sent this turn). Flush them here,
+      // mirroring the REPL's `_pending_bang_blocks.clear()` on `/clear`/`/new`
+      // and the `pendingUserMessages` drop just above.
+      useChatStore.setState((s) => {
+        const next: Partial<ChatState> = {};
+        if (s.failedSendDraft?.conversationId === event.conversationId) {
+          next.failedSendDraft = null;
+        }
+        const keptQueued = s.queuedMessages.filter(
+          (m) => m.conversationId !== event.conversationId,
+        );
+        if (keptQueued.length !== s.queuedMessages.length) {
+          next.queuedMessages = keptQueued;
+        }
+        // Composer @-mention chips are staged for the on-screen composer, which
+        // is being redirected to the new conversation — drop any staged for the
+        // superseded one so they can't leak into the fresh turn.
+        if (s.pendingComposerAttachments.length > 0) {
+          next.pendingComposerAttachments = [];
+        }
+        return next;
+      });
       return;
     case "session_resource_created":
       if (event.resource.type === "terminal") {


### PR DESCRIPTION
## Related issue

Closes #6422

## Summary

- `/clear` rotates the conversation via a `session.superseded` event. The web
  handler in `web/src/store/chatStore.ts` dropped the orphaned optimistic bubble
  (`pendingUserMessages: []`) but left the app-global composer carry-over that
  still holds attachment `File` handles bound to the superseded conversation:
  `failedSendDraft`, queued (not-yet-POSTed) `queuedMessages`, and staged
  `pendingComposerAttachments`.
- Those `File` handles rode into the fresh conversation's first turn, so the
  model "saw" a stale image/screenshot the user never attached that turn
  (phantom `[Image: …]` after `/clear`).
- Fix: flush that carry-over at the supersede site — mirroring the REPL's
  existing `_pending_bang_blocks.clear()` on `/clear`/`/new` and the
  `pendingUserMessages` drop right above it — and add a chatStore regression
  test.

### ELI5

`/clear` is supposed to start a clean chat. It cleared the visible message but
forgot to throw away a picture that was still sitting in the "send box" from the
old chat, so the picture got stapled onto your next message. This throws that
leftover picture away when the chat rotates.

### Secondary (server-side) vector — investigated, not reachable

The runner's pending-replay path (`omnigent/runner/turn_routing.py`) and the
bridge `uploads/` dir outlive a conversation across a `/clear` rotation, so I
checked them as a possible server-side re-injection path:

- `PendingReplay` carries **only the prompt text** (plus session id, blocked
  turn id, routed model) — no `File` handles, image/file content blocks, or
  `uploads/` references. No attachment payload exists to leak.
- Recovery is session-scoped: `schedule_pending_replay_recovery` bails when the
  record's session id doesn't match the current session, and a `/clear`
  rotation re-keys the superseded session to a new id on the same bridge dir, so
  a stale record can't reach the new conversation. A session-scoped marker and
  an "already-ran" probe gate it further.
- `uploads/` is a write-only materialization target keyed per content block;
  nothing sweeps it to auto-attach files to a new turn, so a stale file is inert
  unless a message content block references it — which only originates from the
  client path fixed here.

So no server-side flush is warranted; the fix belongs in the client store.

## Test Plan

- `cd web && pnpm vitest run src/store/chatStore.test.ts`
  - New test `flushes stale attachment carry-over so it can't ride into the
    fresh conversation` passes; the existing `session.superseded` tests stay
    green (5/5 in that group pass).
- `just lint-ts` — clean: oxlint 0 warnings/0 errors, `web` `tsc -b` clean,
  `omnigent-vscode` type-check clean.
- Manual repro: attach an image + send (or leave it queued/failed with an
  attachment staged) → `/clear` → send a first message in the new conversation →
  the earlier image is no longer re-attached.

## Demo

N/A — store-level logic fix with no visible UI surface change; the observable
behavior is covered by the new regression test and the manual repro above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a chatStore regression test asserting that on `session_superseded` the
`failedSendDraft` and queued message bound to the superseded conversation (both
holding a `File` handle) are dropped, carry-over bound to other conversations is
preserved, and staged `pendingComposerAttachments` are cleared. Manually
verified the phantom-attachment repro no longer occurs after `/clear`.

## Changelog

`/clear` no longer carries a previously attached image into the new
conversation's first turn
