### PR TITLE
fix(policies): fail-ask on PreToolUse for claude-native and codex-native

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -4713,7 +4713,7 @@ def _tool_relay_handler_factory(
             # process where these modules are already loaded.
             from omnigent.native_policy_hook import (
                 evaluation_response_to_hook_output,
-                fail_closed_hook_output,
+                fail_ask_hook_output,
                 hook_payload_to_evaluation_request,
             )
 
@@ -4763,7 +4763,7 @@ def _tool_relay_handler_factory(
                     last_error = "malformed EvaluationResponse body"
                 break
             if not isinstance(verdict, dict) or not verdict.get("result"):
-                self._respond_hook_output(fail_closed_hook_output(hook_event, last_error))
+                self._respond_hook_output(fail_ask_hook_output(hook_event, last_error))
                 return
             self._respond_hook_output(evaluation_response_to_hook_output(hook_event, verdict))
 

--- a/omnigent/claude_native_hook.py
+++ b/omnigent/claude_native_hook.py
@@ -1047,7 +1047,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
     """
     from omnigent.native_policy_hook import (
         evaluation_response_to_hook_output,
-        fail_closed_hook_output,
+        fail_ask_hook_output,
         hook_payload_to_evaluation_request,
         policy_hook_reauth,
         post_evaluate_with_retry,
@@ -1084,7 +1084,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         context["model"] = status_model
 
     def _fail_closed(detail: str | None = None) -> int:
-        out = fail_closed_hook_output(hook_event, detail)
+        out = fail_ask_hook_output(hook_event, detail)
         if out is not None:
             sys.stdout.write(json.dumps(out))
         return 0

--- a/omnigent/codex_native_hook.py
+++ b/omnigent/codex_native_hook.py
@@ -25,7 +25,7 @@ from omnigent.codex_native_bridge import (
 )
 from omnigent.native_policy_hook import (
     evaluation_response_to_hook_output,
-    fail_closed_hook_output,
+    fail_ask_hook_output,
     hook_payload_to_evaluation_request,
     policy_hook_reauth,
     post_evaluate_with_retry,
@@ -137,7 +137,7 @@ def _main_evaluate_policy(argv: list[str]) -> int:
         context["model"] = model
 
     def _fail_closed(detail: str | None = None) -> int:
-        out = fail_closed_hook_output(hook_event, detail)
+        out = fail_ask_hook_output(hook_event, detail)
         if out is not None:
             sys.stdout.write(json.dumps(out))
         return 0

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -520,6 +520,35 @@ def fail_closed_hook_output(
     return None
 
 
+def fail_ask_hook_output(hook_event: str, detail: str | None = None) -> dict[str, object] | None:
+    """
+    Build the fail-ask hook output for an unobtainable policy verdict.
+
+    Like :func:`fail_closed_hook_output` but for ``PreToolUse``: instead of
+    auto-denying the tool call, returns ``None`` so the harness falls back to
+    its own native approval dialog. This preserves human oversight when the
+    policy server is transiently unreachable — the user still decides — rather
+    than blocking all tool calls until the server recovers.
+
+    ``UserPromptSubmit`` still blocks (fail-closed) because it is the sole
+    pre-turn enforcement gate for native sessions; a server hiccup must not
+    let an over-budget or otherwise-blocked request proceed silently.
+
+    Use this for harnesses whose native TUI has an interactive approval UI
+    (claude-native, codex-native). For headless harnesses where no approval
+    UI is available, prefer :func:`fail_closed_hook_output`.
+
+    :param hook_event: Hook event name, e.g. ``"PreToolUse"``.
+    :param detail: Optional diagnostic string, forwarded to
+        :func:`fail_closed_hook_output` for non-PreToolUse events.
+    :returns: ``None`` for ``PreToolUse`` (fall through to native dialog);
+        delegates to :func:`fail_closed_hook_output` for all other events.
+    """
+    if hook_event == _PRE_TOOL_USE:
+        return None
+    return fail_closed_hook_output(hook_event, detail)
+
+
 def post_evaluate_with_retry(
     url: str,
     headers: dict[str, str],

--- a/omnigent/native_policy_hook.py
+++ b/omnigent/native_policy_hook.py
@@ -520,15 +520,24 @@ def fail_closed_hook_output(
     return None
 
 
+_EVAL_UNAVAILABLE_ASK_REASON = (
+    "Omnigent policy evaluation unavailable (could not reach or authenticate to the "
+    "Omnigent server); please approve or deny this tool call manually."
+)
+
+
 def fail_ask_hook_output(hook_event: str, detail: str | None = None) -> dict[str, object] | None:
     """
     Build the fail-ask hook output for an unobtainable policy verdict.
 
     Like :func:`fail_closed_hook_output` but for ``PreToolUse``: instead of
-    auto-denying the tool call, returns ``None`` so the harness falls back to
-    its own native approval dialog. This preserves human oversight when the
-    policy server is transiently unreachable — the user still decides — rather
-    than blocking all tool calls until the server recovers.
+    auto-denying the tool call, returns ``permissionDecision: "ask"`` so the
+    harness explicitly prompts the user for approval. This preserves human
+    oversight when the policy server is transiently unreachable — the user
+    still decides — rather than blocking all tool calls until the server
+    recovers. Unlike returning ``None`` (which fails open in
+    ``bypassPermissions`` / ``acceptEdits`` modes), ``"ask"`` forces the
+    approval dialog regardless of the current permission mode.
 
     ``UserPromptSubmit`` still blocks (fail-closed) because it is the sole
     pre-turn enforcement gate for native sessions; a server hiccup must not
@@ -539,13 +548,25 @@ def fail_ask_hook_output(hook_event: str, detail: str | None = None) -> dict[str
     UI is available, prefer :func:`fail_closed_hook_output`.
 
     :param hook_event: Hook event name, e.g. ``"PreToolUse"``.
-    :param detail: Optional diagnostic string, forwarded to
-        :func:`fail_closed_hook_output` for non-PreToolUse events.
-    :returns: ``None`` for ``PreToolUse`` (fall through to native dialog);
+    :param detail: Optional diagnostic string appended to the ask reason
+        shown in the UI. Forwarded to :func:`fail_closed_hook_output` for
+        non-PreToolUse events.
+    :returns: ``permissionDecision: "ask"`` hook output for ``PreToolUse``;
         delegates to :func:`fail_closed_hook_output` for all other events.
     """
     if hook_event == _PRE_TOOL_USE:
-        return None
+        ask_reason = (
+            f"{_EVAL_UNAVAILABLE_ASK_REASON} Detail: {detail}"
+            if detail
+            else _EVAL_UNAVAILABLE_ASK_REASON
+        )
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": _PRE_TOOL_USE,
+                "permissionDecision": "ask",
+                "permissionDecisionReason": ask_reason,
+            },
+        }
     return fail_closed_hook_output(hook_event, detail)
 
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -8974,7 +8974,7 @@ async def test_hook_evaluate_endpoint_returns_deny_hook_output(
 async def test_hook_evaluate_endpoint_fails_closed_on_unreachable_upstream(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Upstream failure denies PreToolUse and stays open for PostToolUse."""
+    """Upstream failure asks for PreToolUse approval and stays open for PostToolUse."""
     client = _ScriptedPolicyClient(None)
     relay, bridge_dir = _hook_relay(tmp_path, monkeypatch, client)
     try:
@@ -8985,7 +8985,7 @@ async def test_hook_evaluate_endpoint_fails_closed_on_unreachable_upstream(
             _PRE_TOOL_USE_PAYLOAD,
         )
         output = json.loads(body)
-        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "ask"
 
         post_body = await asyncio.to_thread(
             _relay_request_raw,
@@ -9060,7 +9060,7 @@ async def test_curl_evaluate_policy_command_round_trips(
     )
     assert result.returncode == 0, result.stderr
     output = json.loads(result.stdout)
-    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert output["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert output["hookSpecificOutput"]["permissionDecisionReason"]
 
 

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1753,7 +1753,7 @@ def test_evaluate_policy_pre_tool_use_fails_closed_when_verdict_unavailable(
     captured = capsys.readouterr()
     assert exit_code == 0
     result = json.loads(captured.out)
-    assert result["hookSpecificOutput"]["permissionDecision"] == "deny", result
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask", result
     assert result["hookSpecificOutput"]["permissionDecisionReason"]
 
 
@@ -2112,9 +2112,9 @@ def test_evaluate_policy_fails_closed_when_reauth_unavailable(
     captured = capsys.readouterr()
     assert exit_code == 0
     result = json.loads(captured.out)
-    assert result["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert result["hookSpecificOutput"]["permissionDecisionReason"].startswith(
-        native_policy_hook._EVAL_UNAVAILABLE_REASON
+        native_policy_hook._EVAL_UNAVAILABLE_ASK_REASON
     )
 
 

--- a/tests/test_codex_native_hook.py
+++ b/tests/test_codex_native_hook.py
@@ -424,7 +424,7 @@ def test_pre_tool_use_fails_closed_when_verdict_unavailable(
     captured = capsys.readouterr()
     assert exit_code == 0
     result = json.loads(captured.out)
-    assert result["hookSpecificOutput"]["permissionDecision"] == "deny", result
+    assert result["hookSpecificOutput"]["permissionDecision"] == "ask", result
     assert result["hookSpecificOutput"]["permissionDecisionReason"]
 
 

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -9,6 +9,7 @@ from omnigent import native_policy_hook
 from omnigent.native_policy_hook import (
     _is_login_redirect_or_unauthorized,
     evaluation_response_to_hook_output,
+    fail_ask_hook_output,
     fail_closed_hook_output,
     hook_payload_to_evaluation_request,
     post_evaluate_with_retry,
@@ -372,6 +373,45 @@ def test_fail_closed_unknown_event_fails_open() -> None:
     accidentally blocking — the conservative default for an unknown gate.
     """
     assert fail_closed_hook_output("SomeNewEvent") is None
+
+
+def test_fail_ask_pre_tool_use_returns_none() -> None:
+    """
+    ``fail_ask_hook_output`` returns ``None`` for ``PreToolUse``.
+
+    Returning ``None`` (no hook output) makes the harness fall back to its
+    own native approval dialog instead of auto-denying, preserving human
+    oversight when the policy server is transiently unreachable.
+    """
+    assert fail_ask_hook_output("PreToolUse") is None
+
+
+def test_fail_ask_pre_tool_use_with_detail_returns_none() -> None:
+    """Detail string does not change the fail-ask PreToolUse output."""
+    assert fail_ask_hook_output("PreToolUse", "server connection refused") is None
+
+
+def test_fail_ask_user_prompt_submit_still_fails_closed() -> None:
+    """
+    ``fail_ask_hook_output`` still blocks ``UserPromptSubmit``.
+
+    The request gate is the sole pre-turn enforcement point; a server
+    hiccup must not silently allow an over-budget or blocked request.
+    """
+    output = fail_ask_hook_output("UserPromptSubmit")
+    assert output is not None
+    assert output["decision"] == "block"
+    assert output["reason"]
+
+
+def test_fail_ask_post_tool_use_fails_open() -> None:
+    """``PostToolUse`` fails open under fail-ask, same as fail-closed."""
+    assert fail_ask_hook_output("PostToolUse") is None
+
+
+def test_fail_ask_unknown_event_fails_open() -> None:
+    """Unknown events fail open under fail-ask."""
+    assert fail_ask_hook_output("SomeNewEvent") is None
 
 
 def _resp(status: int, location: str | None = None) -> httpx.Response:

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -375,20 +375,26 @@ def test_fail_closed_unknown_event_fails_open() -> None:
     assert fail_closed_hook_output("SomeNewEvent") is None
 
 
-def test_fail_ask_pre_tool_use_returns_none() -> None:
+def test_fail_ask_pre_tool_use_returns_ask() -> None:
     """
-    ``fail_ask_hook_output`` returns ``None`` for ``PreToolUse``.
+    ``fail_ask_hook_output`` returns ``permissionDecision: "ask"`` for ``PreToolUse``.
 
-    Returning ``None`` (no hook output) makes the harness fall back to its
-    own native approval dialog instead of auto-denying, preserving human
-    oversight when the policy server is transiently unreachable.
+    Using ``"ask"`` explicitly prompts the user regardless of permission mode
+    (unlike ``None``, which fails open in ``bypassPermissions``/``acceptEdits``).
     """
-    assert fail_ask_hook_output("PreToolUse") is None
+    output = fail_ask_hook_output("PreToolUse")
+    assert output is not None
+    hook = output["hookSpecificOutput"]
+    assert hook["hookEventName"] == "PreToolUse"
+    assert hook["permissionDecision"] == "ask"
+    assert hook["permissionDecisionReason"]
 
 
-def test_fail_ask_pre_tool_use_with_detail_returns_none() -> None:
-    """Detail string does not change the fail-ask PreToolUse output."""
-    assert fail_ask_hook_output("PreToolUse", "server connection refused") is None
+def test_fail_ask_pre_tool_use_with_detail_includes_detail() -> None:
+    """Detail string is appended to the ask reason."""
+    output = fail_ask_hook_output("PreToolUse", "server connection refused")
+    assert output is not None
+    assert "server connection refused" in output["hookSpecificOutput"]["permissionDecisionReason"]
 
 
 def test_fail_ask_user_prompt_submit_still_fails_closed() -> None:


### PR DESCRIPTION
## Related issue

Follow-up to #6055 (OMNI-5843 output-policy enforcement).

## Summary

When the policy server is transiently unreachable, claude-native and codex-native were auto-denying every PreToolUse tool call — the same fail-closed default as headless harnesses. Because both have an interactive native approval UI, a better fallback is to return no hook opinion and let the native dialog handle it: the user still decides, but a brief server hiccup no longer blocks all tool execution.

- Add `fail_ask_hook_output()` to `native_policy_hook.py` alongside the existing `fail_closed_hook_output()`. For `PreToolUse` it returns `None` (no opinion → harness falls back to native dialog); for `UserPromptSubmit` and everything else it delegates to `fail_closed_hook_output` unchanged. `UserPromptSubmit` stays fail-closed — it is the sole pre-turn enforcement gate for native sessions, so a server hiccup must not silently allow an over-budget or blocked request.
- Switch `claude_native_hook` and `codex_native_hook` to call `fail_ask_hook_output` in their `_fail_closed()` helper.

```
before: server unreachable → PreToolUse → deny (tool blocked)
after:  server unreachable → PreToolUse → None  (native dialog)
        server unreachable → UserPromptSubmit → block (unchanged)
```

Other native harnesses (hermes, opencode, kimi, …) keep `fail_closed_hook_output` — they either lack an interactive approval UI or the change hasn't been validated there.

## Test Plan

- `tests/test_native_policy_hook.py` — 4 new tests for `fail_ask_hook_output`: PreToolUse returns `None`; PreToolUse with detail string still returns `None`; UserPromptSubmit still blocks; PostToolUse and unknown events fail open. All 50 tests pass.

## Demo

<img width="787" height="465" alt="image" src="https://github.com/user-attachments/assets/5164cea8-051c-48de-aa1a-98b5e63b2bd9" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover all four cases of `fail_ask_hook_output`. No E2E coverage for the server-unreachable path (requires deliberately killing the policy server mid-turn).

## Changelog

On claude-native and codex-native, a transiently unreachable policy server now shows the harness's native tool-approval dialog instead of auto-denying the tool call