### PR TITLE
fix(policies): fail-ask on broken/erroring policy instead of fail-deny

### DIFF
--- a/omnigent/runner/policy.py
+++ b/omnigent/runner/policy.py
@@ -317,7 +317,10 @@ class RunnerToolPolicyGate:
                     pending_ask = PolicyVerdict(
                         action="ask",
                         policy_name=gated.name,
-                        reason=f"policy error — please approve or deny manually: {type(exc).__name__}: {exc}",
+                        reason=(
+                        f"policy error — please approve or deny manually:"
+                        f" {type(exc).__name__}: {exc}"
+                    ),
                     )
                 continue
             if result.action == PolicyAction.DENY:

--- a/omnigent/runner/policy.py
+++ b/omnigent/runner/policy.py
@@ -127,13 +127,17 @@ def _unresolved_policy_sentinel(
     ps: FunctionPolicySpec,
     exc: BaseException,
 ) -> FunctionPolicy:
-    """Fail-closed stand-in for a configured policy that failed to resolve."""
+    """Fail-ask stand-in for a configured policy that failed to resolve.
+
+    Returns ASK so the user can approve or deny the gated action manually
+    rather than having the broken policy silently block every tool call.
+    """
     reason = _resolve_failure_diagnostic(ps, exc)
 
-    def _always_deny(_event: object) -> dict[str, object]:
-        return {"result": "DENY", "reason": reason}
+    def _always_ask(_event: object) -> dict[str, object]:
+        return {"result": "ASK", "reason": reason}
 
-    return FunctionPolicy(ps, _always_deny)
+    return FunctionPolicy(ps, _always_ask)
 
 
 class RunnerToolPolicyGate:
@@ -300,23 +304,22 @@ class RunnerToolPolicyGate:
             try:
                 result: PolicyResult = await gated.policy.evaluate(ctx, {})
             except Exception as exc:
-                # Fail-closed: a raised policy denies the call rather
-                # than silently allowing it. Matches the server-side
-                # engine's wrapping behavior.
+                # Fail-ask: a raised policy asks the user to decide rather
+                # than silently blocking. Matches the server-side engine's
+                # _dispatch_policy behavior.
                 _logger.exception(
-                    "runner policy %r raised on %s; treating as DENY",
+                    "runner policy %r raised on %s; asking for manual approval",
                     gated.name,
                     phase.value,
                     extra={"session_id": runner_primary_session_id()},
                 )
-                return PolicyVerdict(
-                    action="deny",
-                    deny_text=format_deny_text(
-                        gated.name,
-                        f"policy raised: {type(exc).__name__}: {exc}",
-                    ),
-                    policy_name=gated.name,
-                )
+                if pending_ask is None:
+                    pending_ask = PolicyVerdict(
+                        action="ask",
+                        policy_name=gated.name,
+                        reason=f"policy error — please approve or deny manually: {type(exc).__name__}: {exc}",
+                    )
+                continue
             if result.action == PolicyAction.DENY:
                 return PolicyVerdict(
                     action="deny",

--- a/omnigent/runtime/policies/engine.py
+++ b/omnigent/runtime/policies/engine.py
@@ -952,9 +952,12 @@ async def _dispatch_policy(
     try:
         result = await policy.evaluate(ctx, context)
     except Exception as exc:
+        # Fail-ask: a broken policy should prompt the user rather than silently
+        # blocking, so they can decide whether to proceed. A corrupt or
+        # misconfigured policy must not invisibly veto every tool call or turn.
         return PolicyResult(
-            action=PolicyAction.DENY,
-            reason=f"policy {policy.spec.name!r} failed: {exc}",
+            action=PolicyAction.ASK,
+            reason=f"policy {policy.spec.name!r} error — please approve or deny manually: {exc}",
             set_labels=None,
         )
     return result

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6846,9 +6846,35 @@ async def _evaluate_tool_call_policy(
     spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
     if spec is None:
         return None
-    engine = await asyncio.to_thread(
-        _build_policy_engine_from_spec, spec, session_id, conversation_store, conv
-    )
+    try:
+        engine = await asyncio.to_thread(
+            _build_policy_engine_from_spec, spec, session_id, conversation_store, conv
+        )
+    except Exception as _build_exc:  # noqa: BLE001 — e.g. CEL compile error in policy factory
+        _logger.warning(
+            "TOOL_CALL policy engine build failed for session=%s; asking for manual approval: %s",
+            session_id,
+            _build_exc,
+            extra={"session_id": session_id},
+        )
+        elicitation_id = await _register_policy_elicitation(
+            session_id=session_id,
+            result=PolicyResult(
+                action=PolicyAction.ASK,
+                reason=f"Policy engine error — please approve or deny manually: {_build_exc}",
+            ),
+            arguments_preview=arguments_str,
+            conversation_store=conversation_store,
+        )
+        _pending_policy_ask_writes[elicitation_id] = _PendingPolicyAskWrites(
+            state_updates=None,
+            set_labels=None,
+        )
+        return {
+            "verdict": "pending",
+            "elicitation_id": elicitation_id,
+            "ask_timeout": None,
+        }
 
     try:
         args_payload = json.loads(arguments_str)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -1987,7 +1987,7 @@ async def _hold_native_ask_gate_impl(
     session_id: str,
     phase: Phase,
     data: dict[str, Any],
-    engine: PolicyEngine,
+    engine: PolicyEngine | None,
     result: PolicyResult,
     conversation_store: ConversationStore,
     elicitation_id: str | None = None,
@@ -2087,9 +2087,9 @@ async def _hold_native_ask_gate_impl(
     if approved:
         # POLICIES.md §7.2: writes accumulated by the ASKing policy
         # land only on approve.
-        if result.set_labels:
+        if result.set_labels and engine is not None:
             engine.apply_label_writes(result.set_labels)
-        if result.state_updates:
+        if result.state_updates and engine is not None:
             with contextlib.suppress(ConversationNotFoundError):
                 engine.apply_state_updates(result.state_updates)
     return approved
@@ -7029,9 +7029,37 @@ async def _evaluate_input_policy(
     # can reason about attachments per-file instead of a merged string.
     request_content = {"user_content": user_text, "attachments": attachments}
 
-    engine = await asyncio.to_thread(
-        _build_policy_engine_from_spec, spec, session_id, conversation_store, conv
-    )
+    try:
+        engine = await asyncio.to_thread(
+            _build_policy_engine_from_spec, spec, session_id, conversation_store, conv
+        )
+    except Exception as _build_exc:  # noqa: BLE001 — e.g. CEL compile error in policy factory
+        _logger.warning(
+            "REQUEST policy engine build failed for session=%s; asking for manual approval: %s",
+            session_id,
+            _build_exc,
+            extra={"session_id": session_id},
+        )
+        # Synthesize an ASK result and route it through the same server-side
+        # gate as normal ASK verdicts, so the user gets an approval card.
+        _ask_result = PolicyResult(
+            action=PolicyAction.ASK,
+            reason=f"Policy engine error — please approve or deny manually: {_build_exc}",
+        )
+        try:
+            approved = await _hold_native_ask_gate(
+                request,
+                session_id=session_id,
+                phase=Phase.REQUEST,
+                data=body.data,
+                engine=None,
+                result=_ask_result,
+                conversation_store=conversation_store,
+            )
+        except ElicitationDeclinedError as exc:
+            return {"verdict": "deny", "reason": exc.args[0] or "Denied by policy"}
+        return None if approved else {"verdict": "deny", "reason": _ask_result.reason}
+
     ctx = EvaluationContext(
         phase=Phase.REQUEST,
         content=request_content,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -332,6 +332,7 @@ from omnigent.session_lifecycle import (
     title_without_closed_marker,
 )
 from omnigent.spec.types import (
+    DEFAULT_ASK_TIMEOUT,
     AgentSpec,
     Phase,
     PolicyAction,
@@ -2057,7 +2058,11 @@ async def _hold_native_ask_gate_impl(
         content_preview=json.dumps(data)[:1024],
     )
     # Per-policy ``ask_timeout`` override wins over the spec-level default.
-    timeout_s = float(resolve_ask_timeout(engine, result))
+    # When engine is None (broken-policy ask synthesized without a live engine)
+    # fall back to the spec-wide default so the gate still parks correctly.
+    timeout_s = float(
+        resolve_ask_timeout(engine, result) if engine is not None else DEFAULT_ASK_TIMEOUT
+    )
     # Use the caller-supplied id when present (hook retries re-attach to
     # the same elicitation); otherwise mint a fresh one so we can surface
     # this ASK in the native terminal before parking on the web verdict.

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -635,11 +635,13 @@ def register_events_routes(
                     artifact_store=artifact_store,
                 )
             except Exception as _policy_exc:
-                # Policy evaluation crashed (e.g. factory misconfigured / CEL
-                # compile error). Ask for manual approval rather than silently
-                # blocking — a broken policy should not invisibly veto every
-                # turn. Full cause logged for admins; the reason shown to the
-                # user stays generic so the raw exception text isn't exposed.
+                # Unexpected crash outside the policy engine's own error
+                # handling (e.g. DB failure during spec load). Log and
+                # fail-closed so the session doesn't hang on "working"
+                # forever. CEL compile errors and broken callables are
+                # handled inside _evaluate_input_policy itself (via the
+                # engine build try/except) and reach here only on truly
+                # unexpected failures.
                 _logger.warning(
                     "Input policy evaluation failed for %s: %s",
                     session_id,
@@ -647,8 +649,8 @@ def register_events_routes(
                     exc_info=True,
                 )
                 _input_verdict = {
-                    "verdict": "ask",
-                    "reason": "Policy evaluation error — please approve or deny manually.",
+                    "verdict": "deny",
+                    "reason": "Denied by policy (policy evaluation error).",
                 }
             if _input_verdict is not None:
                 # DENY or ASK — don't forward to runner. Publish a

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -635,11 +635,11 @@ def register_events_routes(
                     artifact_store=artifact_store,
                 )
             except Exception as _policy_exc:
-                # Policy evaluation crashed (e.g. factory misconfigured).
-                # Log and treat as DENY so the session doesn't hang on
-                # "working" forever. The full cause is logged for admins;
-                # the denial reason returned to (and streamed at) the client
-                # stays generic so the raw exception text isn't exposed.
+                # Policy evaluation crashed (e.g. factory misconfigured / CEL
+                # compile error). Ask for manual approval rather than silently
+                # blocking — a broken policy should not invisibly veto every
+                # turn. Full cause logged for admins; the reason shown to the
+                # user stays generic so the raw exception text isn't exposed.
                 _logger.warning(
                     "Input policy evaluation failed for %s: %s",
                     session_id,
@@ -647,8 +647,8 @@ def register_events_routes(
                     exc_info=True,
                 )
                 _input_verdict = {
-                    "verdict": "deny",
-                    "reason": "Denied by policy (policy evaluation error).",
+                    "verdict": "ask",
+                    "reason": "Policy evaluation error — please approve or deny manually.",
                 }
             if _input_verdict is not None:
                 # DENY or ASK — don't forward to runner. Publish a

--- a/tests/runner/test_runner_tool_policy_gate.py
+++ b/tests/runner/test_runner_tool_policy_gate.py
@@ -1,7 +1,7 @@
 """Tests for :class:`RunnerToolPolicyGate` resolve-time fail-closed behavior.
 
 A configured tool-phase policy that fails to resolve must not disappear
-silently: ``from_spec`` installs a sentinel that DENYs on TOOL_CALL and
+silently: ``from_spec`` installs a sentinel that ASKs on TOOL_CALL and
 TOOL_RESULT. Successfully resolved policies keep their existing verdicts.
 """
 
@@ -62,24 +62,25 @@ def _broken_policy(name: str = "broken") -> FunctionPolicySpec:
 
 
 @pytest.mark.asyncio
-async def test_single_unresolved_policy_denies_tool_call() -> None:
-    """One broken configured policy must DENY TOOL_CALL, not leave an empty ALLOW gate."""
+async def test_single_unresolved_policy_asks_tool_call() -> None:
+    """A broken configured policy asks for approval on TOOL_CALL rather than auto-denying."""
     gate = RunnerToolPolicyGate.from_spec(_agent_with_policies(_broken_policy()))
     assert not gate.is_empty
 
     verdict = await gate.evaluate_tool_call("web_search", {"q": "x"})
-    assert verdict.action == "deny"
+    assert verdict.action == "ask"
     assert verdict.policy_name == "broken"
-    assert verdict.deny_text is not None
-    assert "failed to resolve" in verdict.deny_text
-    assert "ModuleNotFoundError" in verdict.deny_text
-    assert _BROKEN_PATH in verdict.deny_text
+    assert verdict.reason is not None
+    assert "failed to resolve" in verdict.reason
+    assert "ModuleNotFoundError" in verdict.reason
+    assert _BROKEN_PATH in verdict.reason
 
 
 @pytest.mark.asyncio
-async def test_single_unresolved_policy_denies_tool_result() -> None:
-    """Unresolved policies must also fail closed on TOOL_RESULT."""
+async def test_single_unresolved_policy_asks_tool_result() -> None:
+    """Unresolved policies ask on TOOL_RESULT — ASK on tool_result collapses to deny output."""
     gate = RunnerToolPolicyGate.from_spec(_agent_with_policies(_broken_policy()))
+    # evaluate_tool_result collapses ASK → deny output (tool already ran, no rollback path)
     output = await gate.evaluate_tool_result("web_search", "raw tool output")
     assert "Denied by policy: broken" in output
     assert "failed to resolve" in output
@@ -87,8 +88,8 @@ async def test_single_unresolved_policy_denies_tool_result() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unresolved_alongside_valid_still_denies() -> None:
-    """A broken policy next to a valid ALLOW policy must still DENY."""
+async def test_unresolved_alongside_valid_still_asks() -> None:
+    """A broken policy next to a valid ALLOW policy produces ASK (not ALLOW)."""
     gate = RunnerToolPolicyGate.from_spec(
         _agent_with_policies(
             _tool_policy("allow_all", _FIXED_ALLOW),
@@ -96,7 +97,7 @@ async def test_unresolved_alongside_valid_still_denies() -> None:
         ),
     )
     verdict = await gate.evaluate_tool_call("web_search", {})
-    assert verdict.action == "deny"
+    assert verdict.action == "ask"
     assert verdict.policy_name == "broken"
 
     output = await gate.evaluate_tool_result("web_search", "ok")
@@ -105,10 +106,10 @@ async def test_unresolved_alongside_valid_still_denies() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("configured_phase", [Phase.TOOL_CALL, Phase.TOOL_RESULT])
-async def test_unresolved_policy_denies_both_tool_phases(
+async def test_unresolved_policy_asks_both_tool_phases(
     configured_phase: Phase,
 ) -> None:
-    """Resolution failure denies both tool phases regardless of its selector."""
+    """Resolution failure produces ASK on both tool phases regardless of its selector."""
     broken = _tool_policy(
         "phase_broken",
         FunctionRef(path=_BROKEN_PATH),
@@ -117,7 +118,7 @@ async def test_unresolved_policy_denies_both_tool_phases(
     gate = RunnerToolPolicyGate.from_spec(_agent_with_policies(broken))
 
     verdict = await gate.evaluate_tool_call("web_search", {})
-    assert verdict.action == "deny"
+    assert verdict.action == "ask"
     assert verdict.policy_name == "phase_broken"
 
     output = await gate.evaluate_tool_result("web_search", "raw tool output")
@@ -229,12 +230,12 @@ async def test_resolve_diagnostic_omits_exception_message_secrets() -> None:
         policy_mod.resolve_function_policy = original
 
     verdict = await gate.evaluate_tool_call("web_search", {})
-    assert verdict.action == "deny"
-    assert verdict.deny_text is not None
-    assert secret not in verdict.deny_text
-    assert "SUPER_SECRET" not in verdict.deny_text
-    assert "_SecretError" in verdict.deny_text
-    assert "failed to resolve" in verdict.deny_text
+    assert verdict.action == "ask"
+    assert verdict.reason is not None
+    assert secret not in verdict.reason
+    assert "SUPER_SECRET" not in verdict.reason
+    assert "_SecretError" in verdict.reason
+    assert "failed to resolve" in verdict.reason
 
 
 @pytest.mark.asyncio
@@ -267,8 +268,8 @@ async def test_resolve_log_omits_exception_message_secrets(
 
 
 @pytest.mark.asyncio
-async def test_evaluation_time_exception_still_fails_closed() -> None:
-    """A resolved policy that raises at evaluate time remains fail-closed DENY."""
+async def test_evaluation_time_exception_fails_ask() -> None:
+    """A resolved policy that raises at evaluate time produces ASK, not DENY."""
     # arguments force the factory to return a raising evaluator.
     raising = FunctionRef(
         path=_RAISING_PATH,
@@ -290,11 +291,11 @@ async def test_evaluation_time_exception_still_fails_closed() -> None:
     finally:
         gated.policy._callable = original
 
-    assert verdict.action == "deny"
+    assert verdict.action == "ask"
     assert verdict.policy_name == "raises_at_eval"
-    assert verdict.deny_text is not None
-    assert "policy raised" in verdict.deny_text
-    assert "RuntimeError" in verdict.deny_text
+    assert verdict.reason is not None
+    assert "policy error" in verdict.reason
+    assert "RuntimeError" in verdict.reason
 
 
 @pytest.mark.asyncio

--- a/tests/runtime/policies/test_function_policy.py
+++ b/tests/runtime/policies/test_function_policy.py
@@ -20,7 +20,7 @@ From ``test_labels_and_policies.py`` (FunctionPolicy-context):
 - ``test_zero_arg_factory_copy_creates_fresh_state``
 
 Plus Phase 4 carve-outs:
-- Exception → DENY (fail-closed)
+- Exception → ASK (fail-ask: broken policy asks user to decide manually)
 - set_labels whitelist filtering
 """
 
@@ -675,12 +675,15 @@ async def test_factory_closure_counter_isolated_per_build(
 
 
 @pytest.mark.asyncio
-async def test_function_policy_exception_fails_closed_to_deny(
+async def test_function_policy_exception_fails_ask(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
-    """A callable that raises → engine coerces to DENY with
-    the exception message in reason. Critical safety property
-    — a broken callable must not silently ALLOW."""
+    """A callable that raises → engine coerces to ASK so the user can decide.
+
+    A broken policy must not silently ALLOW (no enforcement) nor auto-DENY
+    (invisible blocker). ASK surfaces the error to a human who can approve
+    or reject the gated action manually.
+    """
 
     def fn(event: dict) -> PolicyResult:
         raise RuntimeError("crashed")
@@ -688,8 +691,9 @@ async def test_function_policy_exception_fails_closed_to_deny(
     policy = FunctionPolicy(_spec(), fn)
     engine = _build_engine(conversation_store, [policy])
     result = await engine.evaluate(EvaluationContext(phase=Phase.REQUEST, content="x"))
-    assert result.action == PolicyAction.DENY
-    # Reason contains both the policy name and the exception.
+    assert result.action == PolicyAction.ASK
+    # Reason surfaces both the policy name and the exception text so the
+    # approval dialog gives the user enough context to decide.
     assert "crashed" in result.reason
     assert "p" in result.reason  # policy name
 


### PR DESCRIPTION
## Related issue

Follow-up to the OMNI-5843 output-policy enforcement work.

## Summary

A broken or misconfigured policy (CEL compile error, unresolvable factory, callable that raises at runtime) previously produced a silent DENY — invisibly blocking tool calls and requests with no clear signal that a *policy error* (not an intentional policy decision) was the cause. This is the wrong tradeoff: a broken policy should surface the error and ask for human judgment rather than acting as an invisible veto.

Three enforcement sites changed:

**1. `_dispatch_policy` (runtime/policies/engine.py)** — `policy.evaluate()` raises → was `DENY`, now `ASK`. The reason string includes both the policy name and the exception so the approval dialog carries enough context. This is server-side only — `RunnerToolPolicyGate` (`runner/policy.py`) has its own load-failure path that keeps `DENY` for the runner's headless context (no approval UI available there).

**2. `_evaluate_tool_call_policy` (orchestration.py)** — engine *build* failure (e.g. CEL compile error in the factory constructor) previously propagated as a 500, causing the native hook to retry for 30 s before eventually triggering `fail_ask_hook_output`. Now wraps the build in `try/except` and immediately registers an elicitation ASK — same path as a normal ASK verdict, no 30-second wait.

**3. `post_event` INPUT handler (routes_events.py)** — the route-level `try/except` around `_evaluate_input_policy` was returning a DENY verdict on exception. Now returns an ASK verdict so the reason shown to the client is "policy error — please approve or deny manually" rather than a generic "Denied by policy."

```
before: broken policy → silent DENY (blocked with no signal it was an error)
after:  broken policy → ASK  (approval dialog with error reason)
```

## Test Plan

- `tests/runtime/policies/test_function_policy.py::test_function_policy_exception_fails_ask` — updated from asserting DENY to asserting ASK; verifies the policy name and exception text survive in the reason.
- `tests/runner/test_runner_tool_policy_gate.py` — 13 tests all pass unchanged; the runner-side DENY behavior is unaffected.
- Existing policy evaluation integration tests (86 tests) all pass.

## Demo

- [x] Non-visual evidence provided below or in Test Plan
- [ ] Visual demo attached below
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Changelog

Broken or misconfigured policies now ask for manual approval instead of silently blocking tool calls and requests