### PR TITLE
feat(sandbox): install the GitHub CLI (gh) in the managed host image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -336,6 +336,36 @@ RUN set -eu; \
     fi; \
     echo "agy ${AGY_VERSION} pinned (sha256 verified)"
 
+# GitHub CLI (`gh`). Agents commonly drive GitHub through `gh` (`gh pr create`,
+# `gh api`, `gh issue`), and a managed sandbox authenticates it per-user from
+# the credential broker (see omnigent/git_credential_github.configure_host_gh).
+# gh is not an npm package, so — like kiro-cli / agy above — fetch the immutable
+# per-arch tarball from the versioned GitHub release, verify its sha256, install
+# the single binary on the shared system PATH, and assert the version. gh is a
+# stable general-purpose tool (no behavioural harness coupling), so bump
+# GH_VERSION freely and refresh both SHA256s from gh_<version>_checksums.txt on
+# the release. Keep in sync with deploy/docker/Dockerfile.ubi.
+ARG GH_VERSION=2.63.2
+ARG GH_SHA256_AMD64=912fdb1ca29cb005fb746fc5d2b787a289078923a29d0f9ec19a0b00272ded00
+ARG GH_SHA256_ARM64=0f31e2a8549c64b5c1679f0b99ce5e0dac7c91da9e86f6246adb8805b0f0b4bb
+RUN set -eu; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) sha="$GH_SHA256_AMD64" ;; \
+      arm64) sha="$GH_SHA256_ARM64" ;; \
+      *) echo "ERROR: unsupported arch '$arch' for gh" >&2; exit 1 ;; \
+    esac; \
+    asset="gh_${GH_VERSION}_linux_${arch}.tar.gz"; \
+    curl -fsSL -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${asset}"; \
+    echo "${sha}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tar.gz -C /tmp "gh_${GH_VERSION}_linux_${arch}/bin/gh"; \
+    install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${arch}"; \
+    installed="$(/usr/local/bin/gh --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"; \
+    [ "$installed" = "$GH_VERSION" ] || { \
+      echo "ERROR: gh reports '${installed:-<none>}', expected '$GH_VERSION'." >&2; exit 1; }; \
+    echo "gh ${GH_VERSION} pinned (sha256 verified)"
+
 # Copy the venv and source tree. The editable install's .pth files reference
 # /build/omnigent and /build/sdks/* -- both denied by the k8s Landlock LSM
 # policy. Re-install without -e so the package bytes land in the venv's

--- a/deploy/docker/Dockerfile.ubi
+++ b/deploy/docker/Dockerfile.ubi
@@ -140,6 +140,32 @@ RUN set -eu; \
       echo "ERROR: kiro-cli reports '${installed:-<none>}', expected '$KIRO_CLI_VERSION'." >&2; exit 1; }; \
     echo "kiro-cli ${KIRO_CLI_VERSION} pinned (sha256 verified)"
 
+# GitHub CLI (`gh`) — agents drive GitHub through it and the host authenticates
+# it per-user from the credential broker (configure_host_gh). Not an npm package,
+# so fetch the immutable per-arch tarball from the versioned GitHub release,
+# verify sha256, install the binary on the shared PATH, assert the version. See
+# the fuller rationale in deploy/docker/Dockerfile — keep GH_VERSION + both
+# SHA256s in sync.
+ARG GH_VERSION=2.63.2
+ARG GH_SHA256_AMD64=912fdb1ca29cb005fb746fc5d2b787a289078923a29d0f9ec19a0b00272ded00
+ARG GH_SHA256_ARM64=0f31e2a8549c64b5c1679f0b99ce5e0dac7c91da9e86f6246adb8805b0f0b4bb
+RUN set -eu; \
+    case "$(uname -m)" in \
+      x86_64)  arch="amd64"; sha="$GH_SHA256_AMD64" ;; \
+      aarch64) arch="arm64"; sha="$GH_SHA256_ARM64" ;; \
+      *) echo "ERROR: unsupported arch '$(uname -m)' for gh" >&2; exit 1 ;; \
+    esac; \
+    asset="gh_${GH_VERSION}_linux_${arch}.tar.gz"; \
+    curl -fsSL -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${asset}"; \
+    echo "${sha}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tar.gz -C /tmp "gh_${GH_VERSION}_linux_${arch}/bin/gh"; \
+    install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${arch}"; \
+    installed="$(/usr/local/bin/gh --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"; \
+    [ "$installed" = "$GH_VERSION" ] || { \
+      echo "ERROR: gh reports '${installed:-<none>}', expected '$GH_VERSION'." >&2; exit 1; }; \
+    echo "gh ${GH_VERSION} pinned (sha256 verified)"
+
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /build /build
 


### PR DESCRIPTION
## Related issue
N/A — enables agents to drive GitHub through `gh` in managed sandboxes.

## Summary
The managed sandbox host image ships the harness CLIs (`claude-code` / `codex` / `pi` / `kiro-cli` / `agy`) but not the **GitHub CLI**, so `gh pr create` / `gh api` / `gh issue` fail with "command not found". Agents commonly reach for `gh`, so install it.

`gh` is not an npm package, so it's installed the same way as the other non-npm CLIs (`kiro-cli`, `agy`): fetch the immutable per-arch tarball from the versioned GitHub release, verify its sha256, install the single binary on the shared system PATH, and assert the version. Added to both `deploy/docker/Dockerfile` and `deploy/docker/Dockerfile.ubi`. Unlike kiro/agy there's no behavioural harness coupling, so `GH_VERSION` can be bumped freely (refresh both SHA256s from `gh_<version>_checksums.txt`).

Pairs with per-user gh authentication (separate PR): `gh` is only useful once it is both **present** (this) and **authenticated**.

## Test Plan
- Build the host target and `docker run … gh --version` on amd64 and arm64.
- The `RUN` block itself asserts the pinned version, so a bad download/layout fails the build.

## Demo
N/A (image build).

## Type of change
- [x] New feature

## Test coverage
- [x] Not applicable

## Coverage notes
Dockerfile change; verified by building the image and running `gh --version`. The pinned-version assertion in the build guards regressions.