### PR TITLE
feat(github): authenticate the sandbox gh CLI as the connected user

### DIFF
--- a/omnigent/git_credential_github.py
+++ b/omnigent/git_credential_github.py
@@ -216,10 +216,7 @@ def _write_gh_hosts(login: str, token: str) -> bool:
     """
     hosts_path = _gh_config_dir() / "hosts.yml"
     body = (
-        "github.com:\n"
-        f'    oauth_token: "{token}"\n'
-        f'    user: "{login}"\n'
-        "    git_protocol: https\n"
+        f'github.com:\n    oauth_token: "{token}"\n    user: "{login}"\n    git_protocol: https\n'
     )
     try:
         hosts_path.parent.mkdir(parents=True, exist_ok=True)

--- a/omnigent/git_credential_github.py
+++ b/omnigent/git_credential_github.py
@@ -8,8 +8,12 @@ the sandbox's existing authenticated channel and prints back ``username`` /
 ``password``.
 
 Why this shape:
-- The **GitHub token is never persisted** in the sandbox — it's fetched fresh
-  per git operation and lives only in this short-lived process's stdout.
+- For **git**, the **GitHub token is never persisted** in the sandbox — it's
+  fetched fresh per git operation and lives only in this short-lived process's
+  stdout. (The gh CLI has no per-op credential hook, so
+  :func:`configure_host_gh` does materialize the token into gh's ``hosts.yml``
+  at launch — a within-sandbox persistence the threat model below already
+  admits, matching how ``~/.databrickscfg`` is written.)
 - It is **executor-agnostic**: every executor already starts the host with a
   server URL + launch token, so nothing GitHub-specific is injected per
   executor. The host bakes the endpoint coordinates (server URL, host id, launch
@@ -39,6 +43,7 @@ import os
 import shlex
 import subprocess
 import sys
+from pathlib import Path
 
 import httpx
 
@@ -182,6 +187,73 @@ def configure_host_git(server_url: str, host_id: str) -> None:
         _git_config("user.email", owner)
         login = data.get("login")
         _git_config("user.name", str(login) if login else owner.split("@", 1)[0])
+
+
+def _gh_config_dir() -> Path:
+    """The gh CLI config dir (``GH_CONFIG_DIR`` override, else ``~/.config/gh``)."""
+    override = (os.environ.get("GH_CONFIG_DIR") or "").strip()
+    if override:
+        return Path(override)
+    return Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config")) / "gh"
+
+
+def _write_gh_hosts(login: str, token: str) -> bool:
+    """Write ``<gh config>/hosts.yml`` so the gh CLI authenticates as the owner.
+
+    The gh CLI does not consult git's ``credential.helper`` for its own API
+    calls (``gh api`` / ``gh pr`` / ``gh issue``); it reads ``oauth_token`` from
+    ``hosts.yml`` (or ``GH_TOKEN``). This is a small, fixed document, so it is
+    written directly rather than shelling out to ``gh auth login`` (no gh binary
+    or network dependency at setup time). Values are quoted defensively.
+
+    NB deliberately no ``gh auth setup-git``: that would register gh as a git
+    credential helper and compete with the per-user broker, which must stay
+    authoritative for github.com so git ops fetch the token fresh per op.
+    """
+    hosts_path = _gh_config_dir() / "hosts.yml"
+    body = (
+        "github.com:\n"
+        f'    oauth_token: "{token}"\n'
+        f'    user: "{login}"\n'
+        "    git_protocol: https\n"
+    )
+    try:
+        hosts_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(hosts_path, "w", encoding="utf-8") as handle:
+            handle.write(body)
+        with contextlib.suppress(OSError):
+            os.chmod(hosts_path, 0o600)
+    except OSError:
+        return False
+    return True
+
+
+def configure_host_gh(server_url: str, host_id: str) -> bool:
+    """Authenticate the sandbox's gh CLI as the session owner.
+
+    Companion to :func:`configure_host_git` (which wires git's per-op broker):
+    the gh CLI has no per-op credential hook, so — like
+    :func:`omnigent.host.databricks_credential.configure_host_databricks`
+    writing ``~/.databrickscfg`` — the owner's brokered GitHub token is
+    materialized into ``hosts.yml`` at host startup. The token is a short-lived,
+    server-refreshed user token; it is re-fetched on each host launch, so a
+    long-lived session should relaunch to refresh it.
+
+    Best-effort: a no-op when the host token is absent, the broker is
+    unreachable, or the owner hasn't linked GitHub (any ambient gh auth is left
+    untouched). Never raises.
+
+    :returns: ``True`` when gh was authenticated; ``False`` otherwise.
+    """
+    token = (os.environ.get(_HOST_TOKEN_ENV_VAR) or "").strip()
+    if not token:
+        return False
+    data = _fetch(server_url, host_id, token)
+    if not data or not data.get("connected") or not data.get("token"):
+        return False
+    gh_token = str(data["token"])
+    login = str(data.get("login") or data.get("username") or "x-access-token")
+    return _write_gh_hosts(login, gh_token)
 
 
 def configure_clone_credentials(server_url: str, host_id: str) -> bool:

--- a/omnigent/git_credential_github.py
+++ b/omnigent/git_credential_github.py
@@ -13,7 +13,9 @@ Why this shape:
   stdout. (The gh CLI has no per-op credential hook, so
   :func:`configure_host_gh` does materialize the token into gh's ``hosts.yml``
   at launch — a within-sandbox persistence the threat model below already
-  admits, matching how ``~/.databrickscfg`` is written.)
+  admits, matching how ``~/.databrickscfg`` is written — and
+  :func:`start_host_gh_refresh` re-writes it on an interval so gh stays fresh
+  across the ~8h token expiry the git broker otherwise handles per-op.)
 - It is **executor-agnostic**: every executor already starts the host with a
   server URL + launch token, so nothing GitHub-specific is injected per
   executor. The host bakes the endpoint coordinates (server URL, host id, launch
@@ -43,6 +45,8 @@ import os
 import shlex
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 
 import httpx
@@ -254,6 +258,59 @@ def configure_host_gh(server_url: str, host_id: str) -> bool:
     gh_token = str(data["token"])
     login = str(data.get("login") or data.get("username") or "x-access-token")
     return _write_gh_hosts(login, gh_token)
+
+
+# How often the background refresher re-materializes gh's hosts.yml, in seconds.
+# NB the name deliberately avoids a TOKEN/KEY/SECRET/PASSWORD/CREDENTIAL segment:
+# the managed-sandbox launcher rejects env-passthrough names that look like a
+# credential (they would land in the Pod spec/etcd), and this is a plain integer.
+_GH_REFRESH_INTERVAL_ENV_VAR: str = "OMNIGENT_GH_REFRESH_INTERVAL_S"
+_GH_REFRESH_DEFAULT_S: int = 1800
+
+
+def _gh_refresh_interval_s() -> int:
+    """Resolve the gh-token refresh interval (env override, else 30 min).
+
+    Non-positive disables the refresher.
+    """
+    raw = (os.environ.get(_GH_REFRESH_INTERVAL_ENV_VAR) or "").strip()
+    if not raw:
+        return _GH_REFRESH_DEFAULT_S
+    try:
+        return int(raw)
+    except ValueError:
+        return _GH_REFRESH_DEFAULT_S
+
+
+def start_host_gh_refresh(server_url: str, host_id: str) -> threading.Thread | None:
+    """Keep the gh CLI's ``hosts.yml`` token fresh over a long-lived host.
+
+    Unlike git (whose per-op broker helper re-fetches the server-refreshed
+    token on every operation), the gh CLI reads a **static** ``hosts.yml``, so
+    the token :func:`configure_host_gh` writes at startup goes stale when the
+    GitHub App user token expires (~8h) and the server rotates it — a
+    long-running session would then hit ``gh api`` 401s. This best-effort daemon
+    thread re-materializes ``hosts.yml`` on an interval well under the token
+    lifetime, so gh stays authenticated for the life of the host. (An
+    agent-sandbox resume already refreshes it by re-running host startup; this
+    covers a session that stays live without ever suspending.)
+
+    :returns: The started daemon thread, or ``None`` when disabled (a
+        non-positive interval) — the return is mainly for tests.
+    """
+    interval = _gh_refresh_interval_s()
+    if interval <= 0:
+        return None
+
+    def _loop() -> None:
+        while True:
+            time.sleep(interval)
+            with contextlib.suppress(Exception):
+                configure_host_gh(server_url, host_id)
+
+    thread = threading.Thread(target=_loop, name="gh-token-refresh", daemon=True)
+    thread.start()
+    return thread
 
 
 def configure_clone_credentials(server_url: str, host_id: str) -> bool:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4031,9 +4031,12 @@ def run_host_process(
     # broker and attribute commits to the owner. Best-effort; the host runs in
     # every executor and holds the launch token, so no launcher needs to inject
     # anything GitHub-specific.
-    from omnigent.git_credential_github import configure_host_git
+    from omnigent.git_credential_github import configure_host_gh, configure_host_git
 
     configure_host_git(server_url, identity.host_id)
+    # gh CLI ignores git's credential.helper for its own API calls, so also
+    # materialize the owner's brokered token into gh's hosts.yml (best-effort).
+    configure_host_gh(server_url, identity.host_id)
 
     if lifecycle_lock is None and daemon_target is not None:
         lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4031,12 +4031,20 @@ def run_host_process(
     # broker and attribute commits to the owner. Best-effort; the host runs in
     # every executor and holds the launch token, so no launcher needs to inject
     # anything GitHub-specific.
-    from omnigent.git_credential_github import configure_host_gh, configure_host_git
+    from omnigent.git_credential_github import (
+        configure_host_gh,
+        configure_host_git,
+        start_host_gh_refresh,
+    )
 
     configure_host_git(server_url, identity.host_id)
     # gh CLI ignores git's credential.helper for its own API calls, so also
-    # materialize the owner's brokered token into gh's hosts.yml (best-effort).
+    # materialize the owner's brokered token into gh's hosts.yml (best-effort),
+    # then keep it fresh: git re-fetches per op via the broker, but gh reads a
+    # static hosts.yml, so a background thread re-writes it before the GitHub
+    # token expires (~8h) so a long-lived session's gh doesn't 401.
     configure_host_gh(server_url, identity.host_id)
+    start_host_gh_refresh(server_url, identity.host_id)
 
     if lifecycle_lock is None and daemon_target is not None:
         lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)

--- a/tests/test_git_credential_github.py
+++ b/tests/test_git_credential_github.py
@@ -48,7 +48,9 @@ def test_store_and_erase_are_noops(monkeypatch: pytest.MonkeyPatch) -> None:
         assert h.main(["--server", "http://s", "--host-id", "h", "--host-token", "t", op]) == 0
 
 
-def test_configure_host_gh_writes_hosts_yml(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_configure_host_git_resets_then_adds_broker_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "launch-tok")
     calls: list[list[str]] = []
     monkeypatch.setattr(h.subprocess, "run", lambda args, **k: calls.append(args) or None)

--- a/tests/test_git_credential_github.py
+++ b/tests/test_git_credential_github.py
@@ -247,3 +247,54 @@ def test_configure_host_gh_noop_without_token(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "gh"))
     assert h.configure_host_gh("http://srv", "host1") is False
     assert not (tmp_path / "gh" / "hosts.yml").exists()
+
+
+def test_gh_refresh_interval_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(h._GH_REFRESH_INTERVAL_ENV_VAR, raising=False)
+    assert h._gh_refresh_interval_s() == h._GH_REFRESH_DEFAULT_S
+    monkeypatch.setenv(h._GH_REFRESH_INTERVAL_ENV_VAR, "60")
+    assert h._gh_refresh_interval_s() == 60
+    monkeypatch.setenv(h._GH_REFRESH_INTERVAL_ENV_VAR, "garbage")
+    assert h._gh_refresh_interval_s() == h._GH_REFRESH_DEFAULT_S
+
+
+def test_start_host_gh_refresh_disabled_when_nonpositive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A non-positive interval disables the refresher (returns no thread).
+    monkeypatch.setenv(h._GH_REFRESH_INTERVAL_ENV_VAR, "0")
+    assert h.start_host_gh_refresh("http://srv", "host1") is None
+
+
+def test_start_host_gh_refresh_rewrites_hosts_on_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The daemon loop re-materializes hosts.yml each tick. Drive exactly one
+    # refresh, then park the (daemon) thread harmlessly on a never-set event so
+    # the loop neither spins nor raises.
+    import threading as _threading
+
+    calls: list[tuple[str, str]] = []
+    refreshed = _threading.Event()
+    parked = _threading.Event()
+    monkeypatch.setenv(h._GH_REFRESH_INTERVAL_ENV_VAR, "1")
+
+    def _record(server: str, host_id: str) -> bool:
+        calls.append((server, host_id))
+        refreshed.set()
+        return True
+
+    monkeypatch.setattr(h, "configure_host_gh", _record)
+
+    ticks = {"n": 0}
+
+    def fake_sleep(_secs: float) -> None:
+        ticks["n"] += 1
+        if ticks["n"] >= 2:  # after one refresh, park forever (daemon → harmless)
+            parked.wait()
+
+    monkeypatch.setattr(h.time, "sleep", fake_sleep)
+    t = h.start_host_gh_refresh("http://srv", "host1")
+    assert t is not None
+    assert refreshed.wait(timeout=5), "refresher never re-materialized hosts.yml"
+    assert calls == [("http://srv", "host1")]

--- a/tests/test_git_credential_github.py
+++ b/tests/test_git_credential_github.py
@@ -209,3 +209,41 @@ def test_configure_clone_credentials_fails_closed_when_probe_fails(
     assert any(
         c[:5] == ["git", "config", "--global", "--add", key] and "host1" in c[-1] for c in calls
     )
+
+
+def test_configure_host_gh_writes_hosts_yml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # A connected owner: gh's hosts.yml is materialized with the brokered token
+    # and the owner's login, 0600, so `gh api` authenticates as them.
+    monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "launch-tok")
+    monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "gh"))
+    monkeypatch.setattr(
+        h,
+        "_fetch",
+        lambda *a, **k: {"connected": True, "token": "gho_user", "login": "octo"},
+    )
+    assert h.configure_host_gh("http://srv", "host1") is True
+    hosts = (tmp_path / "gh" / "hosts.yml").read_text()
+    assert "github.com:" in hosts
+    assert 'oauth_token: "gho_user"' in hosts
+    assert 'user: "octo"' in hosts
+    assert "git_protocol: https" in hosts
+
+
+def test_configure_host_gh_noop_when_not_connected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # Not linked → leave any ambient gh auth untouched; write nothing.
+    monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "launch-tok")
+    monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "gh"))
+    monkeypatch.setattr(h, "_fetch", lambda *a, **k: {"connected": False})
+    assert h.configure_host_gh("http://srv", "host1") is False
+    assert not (tmp_path / "gh" / "hosts.yml").exists()
+
+
+def test_configure_host_gh_noop_without_token(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.delenv(HOST_TOKEN_ENV_VAR, raising=False)
+    monkeypatch.setenv("GH_CONFIG_DIR", str(tmp_path / "gh"))
+    assert h.configure_host_gh("http://srv", "host1") is False
+    assert not (tmp_path / "gh" / "hosts.yml").exists()

--- a/tests/test_git_credential_github.py
+++ b/tests/test_git_credential_github.py
@@ -209,9 +209,7 @@ def test_configure_clone_credentials_fails_closed_when_probe_fails(
     )
 
 
-def test_configure_host_gh_writes_hosts_yml(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
+def test_configure_host_gh_writes_hosts_yml(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     # A connected owner: gh's hosts.yml is materialized with the brokered token
     # and the owner's login, 0600, so `gh api` authenticates as them.
     monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "launch-tok")

--- a/tests/test_git_credential_github.py
+++ b/tests/test_git_credential_github.py
@@ -48,9 +48,7 @@ def test_store_and_erase_are_noops(monkeypatch: pytest.MonkeyPatch) -> None:
         assert h.main(["--server", "http://s", "--host-id", "h", "--host-token", "t", op]) == 0
 
 
-def test_configure_host_git_resets_then_adds_broker_helper(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_configure_host_gh_writes_hosts_yml(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     monkeypatch.setenv(HOST_TOKEN_ENV_VAR, "launch-tok")
     calls: list[list[str]] = []
     monkeypatch.setattr(h.subprocess, "run", lambda args, **k: calls.append(args) or None)


### PR DESCRIPTION
## Related issue
N/A — makes the in-sandbox `gh` CLI act as the connected GitHub user.

## Summary
git in a managed sandbox authenticates through the per-user credential broker (installed as git's `credential.helper` by `configure_host_git`). But the **gh CLI does not consult git's credential helper** for its own API calls (`gh api` / `gh pr` / `gh issue`) — it reads `oauth_token` from `~/.config/gh/hosts.yml` (or `GH_TOKEN`). So `gh` was unauthenticated even though `git clone`/`push` worked as the user.

Two commits:

1. **`configure_host_gh`** — a companion to `configure_host_git`, run at host startup: it fetches the same brokered GitHub token and materializes gh's `hosts.yml` (the same launch-time pattern as `configure_host_databricks` writing `~/.databrickscfg`; gh has no per-op hook). Deliberately **no** `gh auth setup-git` — the per-user broker stays git's authoritative `github.com` helper.

2. **`start_host_gh_refresh`** — git re-fetches the server-refreshed token per-op via the broker, but gh reads a *static* file, so the written token would go stale when the ~8h GitHub App user token rotates and a long-lived session would hit `gh api` 401s. A best-effort daemon thread re-materializes `hosts.yml` on an interval (`OMNIGENT_GH_REFRESH_INTERVAL_S`, default 1800s). (The name deliberately avoids a TOKEN/KEY/SECRET segment so it passes the sandbox env-passthrough credential guard.)

Requires `gh` to be present in the host image (separate PR).

## Test Plan
- `tests/test_git_credential_github.py` (unit): hosts.yml is written for a connected owner, skipped otherwise; the refresher interval/disable and one refresh tick.
- Manual: in a managed sandbox, `gh auth status` shows the connected login from `~/.config/gh/hosts.yml`, `gh api user` returns it, and the file's mtime advances on the configured cadence.

## Demo
N/A (backend).

## Type of change
- [x] New feature

## Test coverage
- [x] Unit tests added

## Coverage notes
Unit tests cover the materializer and refresher; end-to-end gh auth + refresh verified in a live managed sandbox.