### PR TITLE
fix(kimi): steer queued messages with ctrl-s

### DIFF
--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -1,9 +1,4 @@
 name: UI Preview
-run-name: >-
-  ${{ github.event_name == 'workflow_dispatch'
-      && format('Delete UI preview PR {0}', inputs.pr_number)
-      || github.event.pull_request.title
-      || github.event.head_commit.message }}
 
 # Per-PR live preview of the Omnigent web UI, deployed to Databricks Apps.
 # The preview is ephemeral (SQLite + local artifacts) and ships no LLM/runner --
@@ -36,28 +31,6 @@ run-name: >-
 # configured for guard #2 to take effect. See .github/ui-preview/README.md.
 
 on:
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR whose preview should be deleted'
-        required: true
-        type: string
-      expected_id:
-        description: 'App ID observed by the cleanup reconciler'
-        required: true
-        type: string
-      expected_create_time:
-        description: 'App creation timestamp observed by the cleanup reconciler'
-        required: true
-        type: string
-      expected_update_time:
-        description: 'App update timestamp observed by the cleanup reconciler'
-        required: true
-        type: string
-      expected_creator:
-        description: 'App creator observed by the cleanup reconciler'
-        required: true
-        type: string
   push:
     branches:
       - main
@@ -74,11 +47,7 @@ on:
       - closed
 
 concurrency:
-  group: >-
-    ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch'
-        && format('cleanup-{0}', inputs.pr_number)
-        || github.event.pull_request.number
-        || 'main' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'main' }}
   cancel-in-progress: true
 
 defaults:
@@ -444,11 +413,8 @@ jobs:
     # and workspace files forever. Run on every close; the delete step is a cheap
     # no-op (one existence check) for PRs that never had a preview.
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || (
-        github.event_name != 'push'
-        && github.event.action == 'closed'
-      )
+      github.event_name != 'push'
+      && github.event.action == 'closed'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -460,114 +426,28 @@ jobs:
           databricks --version
 
       - name: Delete app
-        id: delete
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
           DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
           DATABRICKS_AUTH_TYPE: oauth-m2m
-          DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
-          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
-          EXPECTED_ID: ${{ inputs.expected_id }}
-          EXPECTED_CREATE_TIME: ${{ inputs.expected_create_time }}
-          EXPECTED_UPDATE_TIME: ${{ inputs.expected_update_time }}
-          EXPECTED_CREATOR: ${{ inputs.expected_creator }}
-          REPO: ${{ github.repository }}
+          APP_NAME: omnigent-ui-preview-pr-${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
-          RESULT="$RUNNER_TEMP/ui-preview-cleanup-result.json"
-          INVENTORY="$RUNNER_TEMP/ui-preview-apps.json"
-          APP_JSON="$RUNNER_TEMP/ui-preview-app.json"
-          record_result() {
-            jq -n --arg action "$1" --arg reason "$2" \
-              '{action: $action, reason: $reason}' > "$RESULT"
-            echo "action=$1" >> "$GITHUB_OUTPUT"
-          }
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            record_result error 'invalid PR number'
-            exit 1
-          fi
-          APP_NAME="omnigent-ui-preview-pr-$PR_NUMBER"
-
-          databricks apps list -o json > "$INVENTORY"
-          if ! jq -e --arg name "$APP_NAME" '.[] | select(.name == $name)' \
-              "$INVENTORY" > "$APP_JSON"; then
-            echo "App is already absent: $APP_NAME"
-            record_result absent 'app was already absent'
-            exit 0
-          fi
-
-          databricks apps get "$APP_NAME" -o json > "$APP_JSON"
-          if [[ "$DISPATCHED" == true ]]; then
-            EXPECTED_URL="https://github.com/$REPO/pull/$PR_NUMBER"
-            jq -e \
-              --arg name "$APP_NAME" \
-              --arg id "$EXPECTED_ID" \
-              --arg create_time "$EXPECTED_CREATE_TIME" \
-              --arg update_time "$EXPECTED_UPDATE_TIME" \
-              --arg creator "$EXPECTED_CREATOR" \
-              --arg description "$EXPECTED_URL" \
-              '
-                .name == $name
-                and .id == $id
-                and .create_time == $create_time
-                and .update_time == $update_time
-                and .description == $description
-                and .creator == $creator
-                and .default_source_code_path == ("/Workspace/Users/" + .creator + "/apps/" + $name)
-                and ((.resources // []) | length == 0)
-                and (.compute_status.state | IN("ACTIVE", "STOPPED", "ERROR"))
-                and (.pending_deployment == null)
-                and (.pending_update == null)
-              ' "$APP_JSON" > /dev/null || {
-                echo 'App changed after cleanup review; refusing deletion'
-                record_result error 'app changed after cleanup review'
-                exit 1
-              }
-            if [[ "$EXPECTED_CREATOR" != "$DATABRICKS_CLIENT_ID" ]]; then
-              echo 'App belongs to another deployment principal; retaining it'
-              record_result retain 'app belongs to another deployment principal'
-              exit 0
+          if databricks apps get "$APP_NAME" > /dev/null 2>&1; then
+            SOURCE_PATH=$(databricks apps get "$APP_NAME" -o json \
+              | jq -r '.default_source_code_path // empty')
+            databricks apps delete "$APP_NAME" --auto-approve
+            if [ -n "$SOURCE_PATH" ]; then
+              WS_PATH="${SOURCE_PATH#/Workspace}"
+              databricks workspace delete "$WS_PATH" --recursive 2>/dev/null || true
             fi
           fi
-
-          SOURCE_PATH=$(jq -r '.default_source_code_path // empty' "$APP_JSON")
-          databricks apps delete "$APP_NAME" --auto-approve
-          for _ in $(seq 1 20); do
-            databricks apps list -o json > "$INVENTORY"
-            if ! jq -e --arg name "$APP_NAME" '.[] | select(.name == $name)' \
-                "$INVENTORY" > /dev/null; then
-              break
-            fi
-            sleep 3
-          done
-          if jq -e --arg name "$APP_NAME" '.[] | select(.name == $name)' \
-              "$INVENTORY" > /dev/null; then
-            echo "App still exists after deletion: $APP_NAME"
-            record_result error 'app still exists after deletion'
-            exit 1
-          fi
-          if [[ "$DISPATCHED" != true && -n "$SOURCE_PATH" ]]; then
-            WS_PATH="${SOURCE_PATH#/Workspace}"
-            databricks workspace delete "$WS_PATH" --recursive 2>/dev/null || true
-          fi
-          record_result deleted 'app deleted and absence verified'
-
-      - name: Upload cleanup result
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ui-preview-cleanup-result
-          path: ${{ runner.temp }}/ui-preview-cleanup-result.json
-          retention-days: 1
-          if-no-files-found: warn
 
       - name: Update PR comment
-        if: steps.delete.outputs.action == 'deleted' || steps.delete.outputs.action == 'absent'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           BODY="${COMMENT_MARKER}
 

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -1,4 +1,9 @@
 name: UI Preview
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('Delete UI preview PR {0}', inputs.pr_number)
+      || github.event.pull_request.title
+      || github.event.head_commit.message }}
 
 # Per-PR live preview of the Omnigent web UI, deployed to Databricks Apps.
 # The preview is ephemeral (SQLite + local artifacts) and ships no LLM/runner --
@@ -31,6 +36,28 @@ name: UI Preview
 # configured for guard #2 to take effect. See .github/ui-preview/README.md.
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR whose preview should be deleted'
+        required: true
+        type: string
+      expected_id:
+        description: 'App ID observed by the cleanup reconciler'
+        required: true
+        type: string
+      expected_create_time:
+        description: 'App creation timestamp observed by the cleanup reconciler'
+        required: true
+        type: string
+      expected_update_time:
+        description: 'App update timestamp observed by the cleanup reconciler'
+        required: true
+        type: string
+      expected_creator:
+        description: 'App creator observed by the cleanup reconciler'
+        required: true
+        type: string
   push:
     branches:
       - main
@@ -47,7 +74,11 @@ on:
       - closed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'main' }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch'
+        && format('cleanup-{0}', inputs.pr_number)
+        || github.event.pull_request.number
+        || 'main' }}
   cancel-in-progress: true
 
 defaults:
@@ -413,8 +444,11 @@ jobs:
     # and workspace files forever. Run on every close; the delete step is a cheap
     # no-op (one existence check) for PRs that never had a preview.
     if: >-
-      github.event_name != 'push'
-      && github.event.action == 'closed'
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event_name != 'push'
+        && github.event.action == 'closed'
+      )
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -426,28 +460,114 @@ jobs:
           databricks --version
 
       - name: Delete app
+        id: delete
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
           DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
           DATABRICKS_AUTH_TYPE: oauth-m2m
-          APP_NAME: omnigent-ui-preview-pr-${{ github.event.pull_request.number }}
+          DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
+          EXPECTED_ID: ${{ inputs.expected_id }}
+          EXPECTED_CREATE_TIME: ${{ inputs.expected_create_time }}
+          EXPECTED_UPDATE_TIME: ${{ inputs.expected_update_time }}
+          EXPECTED_CREATOR: ${{ inputs.expected_creator }}
+          REPO: ${{ github.repository }}
         run: |
-          if databricks apps get "$APP_NAME" > /dev/null 2>&1; then
-            SOURCE_PATH=$(databricks apps get "$APP_NAME" -o json \
-              | jq -r '.default_source_code_path // empty')
-            databricks apps delete "$APP_NAME" --auto-approve
-            if [ -n "$SOURCE_PATH" ]; then
-              WS_PATH="${SOURCE_PATH#/Workspace}"
-              databricks workspace delete "$WS_PATH" --recursive 2>/dev/null || true
+          set -euo pipefail
+          RESULT="$RUNNER_TEMP/ui-preview-cleanup-result.json"
+          INVENTORY="$RUNNER_TEMP/ui-preview-apps.json"
+          APP_JSON="$RUNNER_TEMP/ui-preview-app.json"
+          record_result() {
+            jq -n --arg action "$1" --arg reason "$2" \
+              '{action: $action, reason: $reason}' > "$RESULT"
+            echo "action=$1" >> "$GITHUB_OUTPUT"
+          }
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            record_result error 'invalid PR number'
+            exit 1
+          fi
+          APP_NAME="omnigent-ui-preview-pr-$PR_NUMBER"
+
+          databricks apps list -o json > "$INVENTORY"
+          if ! jq -e --arg name "$APP_NAME" '.[] | select(.name == $name)' \
+              "$INVENTORY" > "$APP_JSON"; then
+            echo "App is already absent: $APP_NAME"
+            record_result absent 'app was already absent'
+            exit 0
+          fi
+
+          databricks apps get "$APP_NAME" -o json > "$APP_JSON"
+          if [[ "$DISPATCHED" == true ]]; then
+            EXPECTED_URL="https://github.com/$REPO/pull/$PR_NUMBER"
+            jq -e \
+              --arg name "$APP_NAME" \
+              --arg id "$EXPECTED_ID" \
+              --arg create_time "$EXPECTED_CREATE_TIME" \
+              --arg update_time "$EXPECTED_UPDATE_TIME" \
+              --arg creator "$EXPECTED_CREATOR" \
+              --arg description "$EXPECTED_URL" \
+              '
+                .name == $name
+                and .id == $id
+                and .create_time == $create_time
+                and .update_time == $update_time
+                and .description == $description
+                and .creator == $creator
+                and .default_source_code_path == ("/Workspace/Users/" + .creator + "/apps/" + $name)
+                and ((.resources // []) | length == 0)
+                and (.compute_status.state | IN("ACTIVE", "STOPPED", "ERROR"))
+                and (.pending_deployment == null)
+                and (.pending_update == null)
+              ' "$APP_JSON" > /dev/null || {
+                echo 'App changed after cleanup review; refusing deletion'
+                record_result error 'app changed after cleanup review'
+                exit 1
+              }
+            if [[ "$EXPECTED_CREATOR" != "$DATABRICKS_CLIENT_ID" ]]; then
+              echo 'App belongs to another deployment principal; retaining it'
+              record_result retain 'app belongs to another deployment principal'
+              exit 0
             fi
           fi
 
+          SOURCE_PATH=$(jq -r '.default_source_code_path // empty' "$APP_JSON")
+          databricks apps delete "$APP_NAME" --auto-approve
+          for _ in $(seq 1 20); do
+            databricks apps list -o json > "$INVENTORY"
+            if ! jq -e --arg name "$APP_NAME" '.[] | select(.name == $name)' \
+                "$INVENTORY" > /dev/null; then
+              break
+            fi
+            sleep 3
+          done
+          if jq -e --arg name "$APP_NAME" '.[] | select(.name == $name)' \
+              "$INVENTORY" > /dev/null; then
+            echo "App still exists after deletion: $APP_NAME"
+            record_result error 'app still exists after deletion'
+            exit 1
+          fi
+          if [[ "$DISPATCHED" != true && -n "$SOURCE_PATH" ]]; then
+            WS_PATH="${SOURCE_PATH#/Workspace}"
+            databricks workspace delete "$WS_PATH" --recursive 2>/dev/null || true
+          fi
+          record_result deleted 'app deleted and absence verified'
+
+      - name: Upload cleanup result
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-preview-cleanup-result
+          path: ${{ runner.temp }}/ui-preview-cleanup-result.json
+          retention-days: 1
+          if-no-files-found: warn
+
       - name: Update PR comment
+        if: steps.delete.outputs.action == 'deleted' || steps.delete.outputs.action == 'absent'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}
         run: |
           BODY="${COMMENT_MARKER}
 

--- a/omnigent/harnesses/kimi_native/bridge.py
+++ b/omnigent/harnesses/kimi_native/bridge.py
@@ -1119,6 +1119,8 @@ def inject_user_message(
                     "resolve it in the terminal before sending another message"
                 )
             if state.editor_content is not None and draft_seen and not state.editor_content:
+                # The accepted queued draft is now safe to steer into the running turn.
+                _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
                 return
             if state.exit_armed and state.editor_content:
                 raise RuntimeError("Kimi terminal is exit-armed; press Escape and retry")
@@ -1145,6 +1147,8 @@ def inject_user_message(
             if _approval_pending(state) or not state.editor_present:
                 continue
             if state.editor_content is not None and draft_seen and not state.editor_content:
+                # The accepted queued draft is now safe to steer into the running turn.
+                _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
                 return
             if state.exit_armed:
                 raise RuntimeError("Kimi terminal is exit-armed; press Escape and retry")

--- a/omnigent/harnesses/kimi_native/bridge.py
+++ b/omnigent/harnesses/kimi_native/bridge.py
@@ -843,7 +843,8 @@ def inject_user_message(
 
     Clears any leftover draft, pastes *content* (multi-line safe via
     ``load-buffer``/``paste-buffer -p`` so interior newlines stay data, not
-    submits), settles, then submits with Enter.
+    submits), settles, then submits with Enter. Once accepted, C-s steers the
+    draft into a running turn.
 
     :param bridge_dir: The kimi-native bridge dir holding ``tmux.json``.
     :param content: User text (non-empty).
@@ -1091,6 +1092,17 @@ def inject_user_message(
                 "Kimi TUI input box disappeared before the message could be submitted; "
                 "the message was not delivered"
             )
+
+        def _steer_accepted_draft() -> None:
+            try:
+                _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
+            except RuntimeError as exc:
+                _logger.warning(
+                    "Kimi Ctrl-S steer failed after Enter submitted the message; "
+                    "the draft remains queued: %s",
+                    exc,
+                )
+
         post_submit_deadline = time.monotonic() + _SUBMIT_VERIFY_TIMEOUT_S
         last_enter = time.monotonic()
         while time.monotonic() < post_submit_deadline:
@@ -1120,7 +1132,7 @@ def inject_user_message(
                 )
             if state.editor_content is not None and draft_seen and not state.editor_content:
                 # Kimi >= 0.41 accepts C-s steering after the queued draft is accepted.
-                _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
+                _steer_accepted_draft()
                 return
             if state.exit_armed and state.editor_content:
                 raise RuntimeError("Kimi terminal is exit-armed; press Escape and retry")
@@ -1148,7 +1160,7 @@ def inject_user_message(
                 continue
             if state.editor_content is not None and draft_seen and not state.editor_content:
                 # Kimi >= 0.41 accepts C-s steering after the queued draft is accepted.
-                _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
+                _steer_accepted_draft()
                 return
             if state.exit_armed:
                 raise RuntimeError("Kimi terminal is exit-armed; press Escape and retry")

--- a/omnigent/harnesses/kimi_native/bridge.py
+++ b/omnigent/harnesses/kimi_native/bridge.py
@@ -1119,7 +1119,7 @@ def inject_user_message(
                     "resolve it in the terminal before sending another message"
                 )
             if state.editor_content is not None and draft_seen and not state.editor_content:
-                # The accepted queued draft is now safe to steer into the running turn.
+                # Kimi >= 0.41 accepts C-s steering after the queued draft is accepted.
                 _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
                 return
             if state.exit_armed and state.editor_content:
@@ -1147,7 +1147,7 @@ def inject_user_message(
             if _approval_pending(state) or not state.editor_present:
                 continue
             if state.editor_content is not None and draft_seen and not state.editor_content:
-                # The accepted queued draft is now safe to steer into the running turn.
+                # Kimi >= 0.41 accepts C-s steering after the queued draft is accepted.
                 _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
                 return
             if state.exit_armed:

--- a/omnigent/harnesses/kimi_native/bridge.py
+++ b/omnigent/harnesses/kimi_native/bridge.py
@@ -854,6 +854,8 @@ def inject_user_message(
     :raises RuntimeError: If the tmux target is never advertised or a tmux
         command fails before submission is accepted; a failed C-s steer is
         logged instead.
+    :raises OSError: If an OS-level tmux failure occurs before submission is
+        accepted.
     """
     if not content:
         raise RuntimeError("kimi-native injection requires non-empty content")

--- a/omnigent/harnesses/kimi_native/bridge.py
+++ b/omnigent/harnesses/kimi_native/bridge.py
@@ -1096,10 +1096,10 @@ def inject_user_message(
         def _steer_accepted_draft() -> None:
             try:
                 _run_tmux(socket_path, "send-keys", "-t", tmux_target, "C-s")
-            except RuntimeError as exc:
+            except (RuntimeError, OSError) as exc:
                 _logger.warning(
-                    "Kimi Ctrl-S steer failed after Enter submitted the message; "
-                    "the draft remains queued: %s",
+                    "Kimi Ctrl-S steer failed after Enter was accepted; "
+                    "the message may remain queued until the turn ends: %s",
                     exc,
                 )
 

--- a/omnigent/harnesses/kimi_native/bridge.py
+++ b/omnigent/harnesses/kimi_native/bridge.py
@@ -3,10 +3,10 @@
 The runner launches the ``kimi`` TUI in a private tmux pane and records
 that pane's socket + target here via :func:`write_tmux_target`. The harness
 executor then delivers Omnigent web-UI messages into the *same* pane via
-:func:`inject_user_message` (tmux bracketed paste + Enter) — the kimi analog
-of claude-native's tmux send-keys bridge. This is what wires the web-UI chat box
-to the running Kimi TUI (and, since the web UI embeds that pane, the message
-shows in both surfaces).
+:func:`inject_user_message` (tmux bracketed paste + Enter + C-s steer) — the
+kimi analog of claude-native's tmux send-keys bridge. This is what wires the
+web-UI chat box to the running Kimi TUI (and, since the web UI embeds that pane,
+the message shows in both surfaces).
 """
 
 from __future__ import annotations
@@ -852,7 +852,8 @@ def inject_user_message(
     :param cancel_event: Optional cancellation flag checked before delivery.
     :param turn_streaming: True when Kimi is already streaming and queues input.
     :raises RuntimeError: If the tmux target is never advertised or a tmux
-        command fails.
+        command fails before submission is accepted; a failed C-s steer is
+        logged instead.
     """
     if not content:
         raise RuntimeError("kimi-native injection requires non-empty content")

--- a/tests/e2e/test_kimi_native_steering_e2e.py
+++ b/tests/e2e/test_kimi_native_steering_e2e.py
@@ -16,12 +16,16 @@ the paste, so the executor-adapter tears down ``_watch_injections`` immediately
 
 Oracle: Kimi merges a steer locally and fires NO new model request until the
 blocked turn releases — identically on fixed and unfixed builds — so the mock
-cannot tell steered from queued. The queue affordance is therefore the sole
-discriminator (see the discriminator assertion, which must not be simplified
-away). The test first calibrates that the affordance both appears (a mid-turn
-Enter-only submit queues) and disappears (Ctrl-S flushes) on this binary, then
-requires it absent after the production steer, then confirms the steer reached
-the model conversation.
+cannot tell steered from queued. The queue affordance is the sole discriminator
+(the sustained-absence assertion below; do not replace it with a mock check). To
+make "affordance absent" a structural guarantee rather than a race, the test
+first calibrates that a mid-turn Enter-only submit makes the affordance appear
+and MEASURES that repaint latency, clears that draft with a direct ``Ctrl-S``
+(so the discriminator only ever depends on flushing a SINGLE draft), then
+requires the affordance to stay CONTINUOUSLY ABSENT for a window derived from the
+measured latency: an unfixed build re-queues and repaints inside the window
+(RED), a fixed build never queues (GREEN). It revalidates the turn is still in
+flight right before steering, and confirms the steer reached the model after.
 
 Opt in with ``OMNIGENT_E2E_KIMI=1``; needs the ``kimi`` CLI (>= 0.41.0, where
 ``Ctrl-S`` steers) and ``tmux``. Excluded from default ``pytest`` runs
@@ -34,13 +38,16 @@ Opt in with ``OMNIGENT_E2E_KIMI=1``; needs the ``kimi`` CLI (>= 0.41.0, where
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
+import warnings
 from collections.abc import Callable, Iterator
 from functools import cache
 from pathlib import Path
@@ -142,11 +149,26 @@ _CONTROL_TEXT = f"{_CONTROL_MARK} calibration only"
 # queue-vs-steer, not the mere presence of a Ctrl-S hint.
 _QUEUE_AFFORDANCE = "to steer immediately"
 
+# Moon-phase spinner glyphs Kimi animates WHILE a turn is streaming; absent when
+# idle (the transcript shows the assistant reply instead). A running-turn marker.
+_SPINNER_GLYPHS = ("🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘")
+
 _BOOT_TIMEOUT_S = 45.0
 _INPUT_READY_TIMEOUT_S = 45.0
 _MIDTURN_TIMEOUT_S = 60.0
 _AFFORDANCE_TIMEOUT_S = 20.0
+_RUNNING_SPINNER_TIMEOUT_S = 10.0
 _STEER_LLM_TIMEOUT_S = 30.0
+# The sustained-absence window is measured_repaint_latency × this multiplier,
+# floored — generous enough that an unfixed build's re-queued affordance always
+# repaints inside it, so RED is deterministic rather than a race.
+_ABSENCE_SAFETY_MULT = 4.0
+_MIN_ABSENCE_WINDOW_S = 4.0
+# Minimum non-empty captures across the absence window before "absent" is
+# trustworthy — an all-empty window (tmux failing) must not read as GREEN.
+_MIN_ABSENCE_OBSERVATIONS = 5
+_MEASURE_POLL_S = 0.1
+_ABSENCE_POLL_S = 0.25
 _SETTLE_S = 0.5
 _POLL_S = 0.5
 # Per-command tmux budget; a tmux server starved by a parallel boot can stall
@@ -191,31 +213,49 @@ def _send_keys(socket_path: str, target: str, *keys: str) -> None:
     _run_tmux(socket_path, "send-keys", "-t", target, *keys)
 
 
-def _await_pane(
-    socket_path: str, target: str, predicate: Callable[[str], bool], timeout_s: float
-) -> tuple[bool, str]:
-    """Poll captures until *predicate* holds on a NON-EMPTY pane.
+def _poll_window(
+    socket_path: str,
+    target: str,
+    predicate: Callable[[str], bool],
+    window_s: float,
+    poll_s: float,
+) -> tuple[float | None, str, int]:
+    """Poll captures for up to *window_s*, testing *predicate* on NON-EMPTY panes.
 
-    ``_capture`` returns ``""`` on any tmux failure (timeout, OSError, nonzero
-    exit), so an empty capture is never fed to *predicate*. A "the affordance is
-    gone" check therefore can't be flipped true by a transient tmux hiccup — it
-    keeps polling and times out loudly instead. Returns
-    ``(matched, last_non_empty_pane)`` so the caller reports what it actually saw.
+    Returns ``(first_hit_time, last_non_empty_pane, non_empty_count)``. ``first_hit_time``
+    is the monotonic time *predicate* first held (``None`` if it never did within the
+    window). ``_capture`` returns ``""`` on any tmux failure, and an empty pane is never
+    fed to *predicate* — so neither an appearance measurement nor a sustained-absence
+    check can be satisfied or falsified by a transient/persistent capture failure.
     """
-    deadline = time.monotonic() + timeout_s
+    deadline = time.monotonic() + window_s
     last = ""
+    non_empty = 0
     while time.monotonic() < deadline:
         pane = _capture(socket_path, target)
         if pane:
+            non_empty += 1
             last = pane
             if predicate(pane):
-                return True, pane
-        time.sleep(_POLL_S)
-    return False, last
+                return time.monotonic(), last, non_empty
+        time.sleep(poll_s)
+    return None, last, non_empty
 
 
-def _queue_via_enter_only(socket_path: str, target: str, bridge_dir: Path, text: str) -> None:
-    """Submit *text* mid-turn exactly as an UNFIXED build would: clear, paste, Enter (no C-s)."""
+def _await_pane(
+    socket_path: str, target: str, predicate: Callable[[str], bool], timeout_s: float
+) -> tuple[bool, str]:
+    """Wait for *predicate* to hold on a NON-EMPTY pane; return ``(matched, last_pane)``."""
+    hit, pane, _ = _poll_window(socket_path, target, predicate, timeout_s, _POLL_S)
+    return hit is not None, pane
+
+
+def _submit_enter_only(socket_path: str, target: str, bridge_dir: Path, text: str) -> float:
+    """Submit *text* mid-turn as an UNFIXED build would (clear, paste, Enter; no C-s).
+
+    Returns the monotonic time of the Enter send-key, so the caller can measure how
+    long Kimi takes to repaint the queue affordance.
+    """
     _send_keys(socket_path, target, "C-a")
     _send_keys(socket_path, target, "C-k")
     paste_path = bridge_dir / "calibration_paste.bin"
@@ -224,6 +264,7 @@ def _queue_via_enter_only(socket_path: str, target: str, bridge_dir: Path, text:
     _run_tmux(socket_path, "paste-buffer", "-p", "-d", "-b", "omni-calibration", "-t", target)
     time.sleep(_SETTLE_S)
     _send_keys(socket_path, target, "Enter")
+    return time.monotonic()
 
 
 def _wait_for(predicate: Callable[[], bool], timeout_s: float, *, poll_s: float = _POLL_S) -> bool:
@@ -249,6 +290,48 @@ def _steer_reached_llm(client: httpx.Client, mock_url: str, mark: str) -> bool:
     except httpx.HTTPError:
         return False
     return any(mark in json.dumps(req) for req in requests)
+
+
+def _server_alive(socket_path: str) -> bool:
+    """Whether a tmux server with the kimi session still exists on *socket_path*."""
+    try:
+        return (
+            subprocess.run(
+                ["tmux", "-S", socket_path, "has-session", "-t", "kimi:0.0"],
+                capture_output=True,
+                timeout=_TMUX_TIMEOUT_S,
+            ).returncode
+            == 0
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _teardown_tmux_server(socket_path: str) -> str | None:
+    """kill-server, verify termination, escalate once; return a note if it may be orphaned.
+
+    A nonzero kill-server rc usually just means "no server running" (already gone), so
+    only a server still live afterward is a real failure. On a live server, retry the
+    kill once as a fallback. The caller removes the socket dir regardless; a returned
+    note is surfaced (never masked). Returns ``None`` when nothing remains.
+    """
+
+    def _kill() -> None:
+        with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+            subprocess.run(
+                ["tmux", "-S", socket_path, "kill-server"],
+                capture_output=True,
+                text=True,
+                timeout=_TMUX_TIMEOUT_S,
+            )
+
+    _kill()
+    if not _server_alive(socket_path):
+        return None
+    _kill()  # fallback termination
+    if _server_alive(socket_path):
+        return f"tmux server survived kill-server + retry on {socket_path!r} (possible orphan)"
+    return None
 
 
 async def _drain_run_turn(executor: KimiNativeExecutor, text: str) -> list[object]:
@@ -387,18 +470,17 @@ def kimi_tui(
         assert ready, f"Kimi TUI never mounted its input box.\nPane:\n{pane}"
         yield socket_path, target, bridge_dir, mock_llm_server_url, version
     finally:
-        # kill-server in its own guard so a teardown timeout/OSError can't skip the
-        # socket-dir removal or mask the real test result.
-        try:
-            subprocess.run(
-                ["tmux", "-S", socket_path, "kill-server"],
-                capture_output=True,
-                timeout=_TMUX_TIMEOUT_S,
-            )
-        except (subprocess.TimeoutExpired, OSError):
-            pass
-        finally:
-            shutil.rmtree(socket_dir, ignore_errors=True)
+        # Inspect the kill outcome (G3): remove the socket dir unconditionally, but
+        # if a server survives the kill + fallback, surface it (annotate the in-flight
+        # error, else warn) rather than reporting a clean teardown over an orphan.
+        teardown_note = _teardown_tmux_server(socket_path)
+        shutil.rmtree(socket_dir, ignore_errors=True)
+        if teardown_note is not None:
+            in_flight = sys.exc_info()[1]
+            if in_flight is not None:
+                in_flight.add_note(f"kimi_tui teardown: {teardown_note}")
+            else:
+                warnings.warn(f"kimi_tui teardown: {teardown_note}", stacklevel=2)
 
 
 @pytest.mark.parametrize("steer_via", ["fresh_run_turn", "enqueue_session_message"])
@@ -446,26 +528,30 @@ def test_midturn_steer_is_applied_not_queued(
             f"steer.\nPane:\n{_capture(socket_path, target)}"
         )
 
-        # Calibrate the oracle against THIS live build: a mid-turn Enter-only submit
-        # (what an unfixed build sends) must show the queue affordance...
-        _queue_via_enter_only(socket_path, target, bridge_dir, _CONTROL_TEXT)
-        calibrated, cal_pane = _await_pane(
+        # Calibrate the oracle against THIS live build AND measure repaint latency:
+        # a mid-turn Enter-only submit (what an unfixed build sends) must show the
+        # queue affordance, and we time how long the repaint takes.
+        enter_at = _submit_enter_only(socket_path, target, bridge_dir, _CONTROL_TEXT)
+        appeared_at, cal_pane, _ = _poll_window(
             socket_path,
             target,
             lambda p: _QUEUE_AFFORDANCE in p and _CONTROL_MARK in p,
             _AFFORDANCE_TIMEOUT_S,
+            _MEASURE_POLL_S,
         )
-        assert calibrated, (
+        assert appeared_at is not None, (
             "Kimi did not show its queue affordance for a mid-turn Enter-only message, so "
             f"the queued-vs-steered oracle can't be trusted for kimi {version_str} (the "
             f"affordance {_QUEUE_AFFORDANCE!r} may have drifted).\nPane:\n{cal_pane}"
         )
+        repaint_latency = appeared_at - enter_at
+        absence_window = max(_MIN_ABSENCE_WINDOW_S, repaint_latency * _ABSENCE_SAFETY_MULT)
 
-        # ...and a direct Ctrl-S must clear that single queued draft. This proves the
-        # affordance both appears and disappears here, AND leaves the queue empty, so
-        # the discriminator below only ever depends on Ctrl-S flushing a SINGLE draft
-        # — never on a whole-queue flush the fix does not promise. This send is direct
-        # tmux, so removing the production Ctrl-S does not affect it.
+        # Clear the calibration draft with a direct Ctrl-S. This proves the affordance
+        # also disappears here AND leaves the queue empty, so the discriminator only
+        # ever depends on Ctrl-S flushing a SINGLE draft — never a whole-queue flush
+        # the fix doesn't promise. Direct tmux, so removing production Ctrl-S can't
+        # affect it.
         _send_keys(socket_path, target, "C-s")
         cleared, cal_pane = _await_pane(
             socket_path, target, lambda p: _QUEUE_AFFORDANCE not in p, _AFFORDANCE_TIMEOUT_S
@@ -473,6 +559,25 @@ def test_midturn_steer_is_applied_not_queued(
         assert cleared, (
             f"Direct Ctrl-S did not clear a single queued draft for kimi {version_str}; the "
             f"queue-flush the fix relies on has drifted.\nPane:\n{cal_pane}"
+        )
+
+        # Revalidate the turn is STILL in flight after that cleanup, so the production
+        # steer lands mid-stream and the test isn't vacuously green.
+        assert _gate_pending(proxy_blind_client, mock_url), (
+            "Turn is no longer in flight after the calibration Ctrl-S (the mock no longer holds "
+            f"the model request); a steer now would land on an idle session and prove nothing "
+            f"about mid-turn steering for kimi {version_str}."
+        )
+        running, running_pane = _await_pane(
+            socket_path,
+            target,
+            lambda p: any(glyph in p for glyph in _SPINNER_GLYPHS),
+            _RUNNING_SPINNER_TIMEOUT_S,
+        )
+        assert running, (
+            "Turn stopped rendering its running-turn spinner after the calibration cleanup, so "
+            f"it is no longer mid-stream for kimi {version_str}; a steer now proves nothing.\n"
+            f"Pane:\n{running_pane}"
         )
 
         # Steer mid-turn through the production path (queue now holds one draft).
@@ -483,20 +588,29 @@ def test_midturn_steer_is_applied_not_queued(
             steered = asyncio.run(executor.enqueue_session_message("main", _STEER_TEXT))
         assert steered, f"steer injection via {steer_via} reported failure"
 
-        # DISCRIMINATOR (load-bearing): the queue affordance must be gone. This is the
-        # ONLY assertion that separates steered from queued: Kimi merges the steer
-        # locally and fires no new model request until the blocked turn releases, so
-        # the mock sees identical requests on fixed and unfixed builds and cannot
-        # discriminate. Do NOT replace this with a mock-request check. ``_await_pane``
-        # requires a NON-EMPTY capture, so a tmux failure can't read as "gone".
-        applied, pane = _await_pane(
-            socket_path, target, lambda p: _QUEUE_AFFORDANCE not in p, _AFFORDANCE_TIMEOUT_S
+        # DISCRIMINATOR (load-bearing): the queue affordance must stay CONTINUOUSLY
+        # ABSENT for the calibration-derived window. This is the ONLY assertion that
+        # separates steered from queued: Kimi merges the steer locally and fires no new
+        # model request until release, so the mock sees identical requests on fixed and
+        # unfixed builds and cannot discriminate. Do NOT replace it with a mock check.
+        # An unfixed build re-queues on Enter and repaints the affordance within roughly
+        # the measured latency (well inside the window) → RED; a fixed build's Ctrl-S
+        # flushes before any repaint, so absence holds across the whole window → GREEN.
+        hit_at, last_pane, observations = _poll_window(
+            socket_path, target, lambda p: _QUEUE_AFFORDANCE in p, absence_window, _ABSENCE_POLL_S
         )
-        assert applied, (
+        assert hit_at is None, (
             "Mid-turn steer was QUEUED, not applied to the running turn: Kimi's queue-pane "
-            f"affordance {_QUEUE_AFFORDANCE!r} is still present for kimi {version_str}. Omnigent "
-            "committed the steer with Enter and never sent the CLI's Ctrl-S steer key.\n"
-            f"Pane:\n{pane}"
+            f"affordance {_QUEUE_AFFORDANCE!r} reappeared for kimi {version_str} within the "
+            f"{absence_window:.1f}s absence window (measured calibration repaint latency "
+            f"{repaint_latency:.2f}s). Omnigent committed the steer with Enter and never sent "
+            f"the CLI's Ctrl-S steer key.\nPane:\n{last_pane}"
+        )
+        # Absence is only trustworthy if we actually saw the pane throughout the window.
+        assert observations >= _MIN_ABSENCE_OBSERVATIONS, (
+            f"Only {observations} non-empty captures across the {absence_window:.1f}s absence "
+            "window; tmux may be failing, so 'affordance absent' is untrustworthy.\n"
+            f"Pane:\n{last_pane}"
         )
 
         # Corroborate the inject physically happened (guards an absent affordance from

--- a/tests/e2e/test_kimi_native_steering_e2e.py
+++ b/tests/e2e/test_kimi_native_steering_e2e.py
@@ -175,6 +175,9 @@ _POLL_S = 0.5
 # Per-command tmux budget; a tmux server starved by a parallel boot can stall
 # past 5s while healthy.
 _TMUX_TIMEOUT_S = 10.0
+# Grace between a teardown SIGTERM and SIGKILL, during which the PID's ownership
+# is re-validated so SIGKILL never lands on a recycled PID.
+_SIGKILL_GRACE_S = 0.5
 
 
 def _run_tmux(socket_path: str, *args: str) -> None:
@@ -315,9 +318,13 @@ def _server_pid(socket_path: str) -> int | None:
 def _pid_is_our_server(pid: int | None, socket_path: str) -> str:
     """Three-state check that *pid* is still OUR tmux server: ``alive``/``dead``/``unknown``.
 
-    Matches the process command to ``tmux`` + *socket_path*, so a recycled PID reads as
-    ``dead`` (our server is gone) and is never mistaken for a live server we'd wrongly
-    kill. A failed/timed-out ``ps`` is ``unknown`` (a possible survivor), never ``dead``.
+    ``alive`` requires the strict ``tmux`` + *socket_path* command match — the sole gate on
+    signalling, so a recycled or unrelated PID is never killed. ``dead`` is reserved for a
+    truly-gone PID (``ps`` returncode != 0). Everything else is ``unknown`` (a possible
+    survivor): a failed/timed-out ``ps``, OR a live PID whose proctitle doesn't confirm the
+    socket — notably Linux, which retitles the server to ``tmux: server`` without the socket.
+    Returning ``unknown`` (not a false ``dead``) makes :func:`_server_liveness` defer to
+    ``has-session`` for the authoritative answer instead of short-circuiting to "clean".
     """
     if pid is None:
         return "unknown"
@@ -331,9 +338,11 @@ def _pid_is_our_server(pid: int | None, socket_path: str) -> str:
     except (subprocess.TimeoutExpired, OSError):
         return "unknown"
     if proc.returncode != 0:
-        return "dead"
+        return "dead"  # PID truly gone
     command = proc.stdout
-    return "alive" if ("tmux" in command and socket_path in command) else "dead"
+    if "tmux" in command and socket_path in command:
+        return "alive"  # confirmed ours — safe to signal
+    return "unknown"  # PID exists but not confirmably ours; defer, never a false "dead"
 
 
 def _has_session_state(socket_path: str) -> str:
@@ -377,11 +386,16 @@ def _teardown_tmux_server(socket_path: str, server_pid: int | None) -> str | Non
     if _server_liveness(socket_path, server_pid) == "dead":
         return None
     # Not confirmed dead (alive OR unknown) → independent PID-based termination, but only
-    # when the PID is still confirmably OUR tmux server (never signal a recycled PID).
+    # while the PID is still confirmably OUR tmux server. Re-validate ownership before EACH
+    # signal: if SIGTERM ends tmux and the OS recycles the PID, the strict match no longer
+    # holds, so SIGKILL is skipped rather than landing on an unrelated recycled process.
     if server_pid is not None and _pid_is_our_server(server_pid, socket_path) == "alive":
-        for sig in (signal.SIGTERM, signal.SIGKILL):
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.kill(server_pid, signal.SIGTERM)
+        time.sleep(_SIGKILL_GRACE_S)
+        if _pid_is_our_server(server_pid, socket_path) == "alive":
             with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
-                os.kill(server_pid, sig)
+                os.kill(server_pid, signal.SIGKILL)
         if _server_liveness(socket_path, server_pid) == "dead":
             return None
     state = _server_liveness(socket_path, server_pid)

--- a/tests/e2e/test_kimi_native_steering_e2e.py
+++ b/tests/e2e/test_kimi_native_steering_e2e.py
@@ -43,6 +43,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -292,46 +293,107 @@ def _steer_reached_llm(client: httpx.Client, mock_url: str, mark: str) -> bool:
     return any(mark in json.dumps(req) for req in requests)
 
 
-def _server_alive(socket_path: str) -> bool:
-    """Whether a tmux server with the kimi session still exists on *socket_path*."""
+def _server_pid(socket_path: str) -> int | None:
+    """The tmux server PID for *socket_path*, captured while reachable, else ``None``.
+
+    Enables an independent, socket-free liveness check and kill at teardown, so a
+    tmux/socket probe that hangs can't make a live server look dead.
+    """
     try:
-        return (
-            subprocess.run(
-                ["tmux", "-S", socket_path, "has-session", "-t", "kimi:0.0"],
-                capture_output=True,
-                timeout=_TMUX_TIMEOUT_S,
-            ).returncode
-            == 0
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, "display-message", "-p", "#{pid}"],
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_TIMEOUT_S,
         )
     except (subprocess.TimeoutExpired, OSError):
-        return False
-
-
-def _teardown_tmux_server(socket_path: str) -> str | None:
-    """kill-server, verify termination, escalate once; return a note if it may be orphaned.
-
-    A nonzero kill-server rc usually just means "no server running" (already gone), so
-    only a server still live afterward is a real failure. On a live server, retry the
-    kill once as a fallback. The caller removes the socket dir regardless; a returned
-    note is surfaced (never masked). Returns ``None`` when nothing remains.
-    """
-
-    def _kill() -> None:
-        with contextlib.suppress(subprocess.TimeoutExpired, OSError):
-            subprocess.run(
-                ["tmux", "-S", socket_path, "kill-server"],
-                capture_output=True,
-                text=True,
-                timeout=_TMUX_TIMEOUT_S,
-            )
-
-    _kill()
-    if not _server_alive(socket_path):
         return None
-    _kill()  # fallback termination
-    if _server_alive(socket_path):
-        return f"tmux server survived kill-server + retry on {socket_path!r} (possible orphan)"
-    return None
+    out = proc.stdout.strip()
+    return int(out) if proc.returncode == 0 and out.isdigit() else None
+
+
+def _pid_is_our_server(pid: int | None, socket_path: str) -> str:
+    """Three-state check that *pid* is still OUR tmux server: ``alive``/``dead``/``unknown``.
+
+    Matches the process command to ``tmux`` + *socket_path*, so a recycled PID reads as
+    ``dead`` (our server is gone) and is never mistaken for a live server we'd wrongly
+    kill. A failed/timed-out ``ps`` is ``unknown`` (a possible survivor), never ``dead``.
+    """
+    if pid is None:
+        return "unknown"
+    try:
+        proc = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return "unknown"
+    if proc.returncode != 0:
+        return "dead"
+    command = proc.stdout
+    return "alive" if ("tmux" in command and socket_path in command) else "dead"
+
+
+def _has_session_state(socket_path: str) -> str:
+    """Three-state ``has-session`` probe: ``alive``/``dead``/``unknown`` (failure = unknown)."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, "has-session", "-t", "kimi:0.0"],
+            capture_output=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return "unknown"
+    return "alive" if proc.returncode == 0 else "dead"
+
+
+def _server_liveness(socket_path: str, server_pid: int | None) -> str:
+    """Combined three-state liveness: the reuse-safe PID probe wins, else has-session."""
+    pid_state = _pid_is_our_server(server_pid, socket_path)
+    if pid_state != "unknown":
+        return pid_state
+    return _has_session_state(socket_path)
+
+
+def _teardown_tmux_server(socket_path: str, server_pid: int | None) -> str | None:
+    """Terminate the tmux server; return a note if it may survive (never a false "clean").
+
+    A failed/timed-out probe is a POSSIBLE SURVIVOR (unknown), not "dead", so a hung
+    kill-server + hung verification can no longer report success over a live orphan.
+    kill-server is the normal path; if the server isn't confirmed dead, escalate to an
+    INDEPENDENT PID-based SIGTERM/SIGKILL — guarded by a command match so a recycled PID
+    is never signalled. The caller removes the socket dir regardless; a returned note
+    carries the PID + socket as a usable manual-cleanup path and is surfaced, never masked.
+    """
+    with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+        subprocess.run(
+            ["tmux", "-S", socket_path, "kill-server"],
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+    if _server_liveness(socket_path, server_pid) == "dead":
+        return None
+    # Not confirmed dead (alive OR unknown) → independent PID-based termination, but only
+    # when the PID is still confirmably OUR tmux server (never signal a recycled PID).
+    if server_pid is not None and _pid_is_our_server(server_pid, socket_path) == "alive":
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                os.kill(server_pid, sig)
+        if _server_liveness(socket_path, server_pid) == "dead":
+            return None
+    state = _server_liveness(socket_path, server_pid)
+    if server_pid is None:
+        return (
+            f"tmux server on {socket_path!r} may still be running (state={state}); kill-server "
+            "did not confirm termination and no server PID was captured for an independent kill"
+        )
+    return (
+        f"tmux server pid {server_pid} on {socket_path!r} may still be running (state={state}) "
+        "after kill-server and an independent PID kill; kill it manually if it lingers"
+    )
 
 
 async def _drain_run_turn(executor: KimiNativeExecutor, text: str) -> list[object]:
@@ -420,6 +482,9 @@ def kimi_tui(
 
     write_tmux_target(bridge_dir, socket_path=Path(socket_path), tmux_target=target)
 
+    # Captured once the server is reachable; teardown uses it for an independent,
+    # socket-free kill. ``None`` (boot failed before capture) falls back to probes.
+    server_pid: int | None = None
     # Enter the cleanup scope BEFORE launching so a failed/partial ``new-session``
     # (timeout, OSError, nonzero exit) still tears down any half-created server and
     # removes the socket dir instead of leaking them.
@@ -468,12 +533,14 @@ def kimi_tui(
             socket_path, target, lambda p: "context:" in p, _INPUT_READY_TIMEOUT_S
         )
         assert ready, f"Kimi TUI never mounted its input box.\nPane:\n{pane}"
+        # Server is up now — capture its PID for the independent teardown kill.
+        server_pid = _server_pid(socket_path)
         yield socket_path, target, bridge_dir, mock_llm_server_url, version
     finally:
-        # Inspect the kill outcome (G3): remove the socket dir unconditionally, but
-        # if a server survives the kill + fallback, surface it (annotate the in-flight
-        # error, else warn) rather than reporting a clean teardown over an orphan.
-        teardown_note = _teardown_tmux_server(socket_path)
+        # Terminate the server (independent PID kill if a probe can't confirm death) and
+        # remove the socket dir unconditionally; if the server may survive, surface it
+        # (annotate the in-flight error, else warn) rather than reporting a clean teardown.
+        teardown_note = _teardown_tmux_server(socket_path, server_pid)
         shutil.rmtree(socket_dir, ignore_errors=True)
         if teardown_note is not None:
             in_flight = sys.exc_info()[1]

--- a/tests/e2e/test_kimi_native_steering_e2e.py
+++ b/tests/e2e/test_kimi_native_steering_e2e.py
@@ -1,46 +1,31 @@
-"""E2E: a mid-turn steer must be applied to the running Kimi turn, not queued.
+"""E2E: a mid-turn steer must steer the running Kimi turn, not queue behind it.
 
-Guards against the mid-turn steer regression: steering a running ``kimi`` (Kimi
-Code, ``kimi-native``) session does not take effect immediately. Omnigent
-injects the steer text into the Kimi TUI via
-:func:`omnigent.harnesses.kimi_native.bridge.inject_user_message`, which
-commits the message with ``Enter``. On an UNFIXED build that is *all* it does — it never
-sends the CLI's steer key (``Ctrl-S``). Mid-turn, Kimi treats a bare ``Enter``
-as "queue this for after the turn": the steer lands in Kimi's queue (``↑ to
-edit · ctrl-s to steer immediately``) and is ignored until the turn ends,
-instead of steering the in-flight turn. The fix additionally sends ``Ctrl-S``,
-which flushes the queued text into the running turn (and no-ops while idle).
+Regression guard for kimi-native steering. Omnigent injects a steer into the
+Kimi TUI via :func:`omnigent.harnesses.kimi_native.bridge.inject_user_message`.
+An UNFIXED build commits it with ``Enter`` only; mid-turn, Kimi QUEUES a bare ``Enter``
+(shown as ``↑ to edit · ctrl-s to steer immediately``) and ignores it until the
+turn ends. The fix also sends ``Ctrl-S``, which flushes the draft into the
+running turn (and no-ops while idle).
 
-The seam this drives, and why it is the REAL one:
+Real seam: ``KimiNativeExecutor.run_turn`` yields ``TurnComplete`` right after
+the paste, so the executor-adapter tears down ``_watch_injections`` immediately
+— a steer arriving while Kimi streams lands as a FRESH ``run_turn``, not through
+``enqueue_session_message``. The test drives the steer through a fresh
+``run_turn`` (the real path) and, parametrized, through
+``enqueue_session_message`` (the brief initial-paste window).
 
-``KimiNativeExecutor.run_turn`` injects the message and then yields
-``TurnComplete`` immediately (``omnigent/inner/kimi_native_executor.py``), so
-the executor-adapter tears down its ``_watch_injections`` task in the ``finally``
-as soon as that generator completes
-(``omnigent/runtime/harnesses/_executor_adapter.py``). The
-``enqueue_session_message`` / ``_watch_injections`` window is therefore open only
-for the few seconds of the INITIAL paste; a steer that arrives while Kimi is
-actually streaming lands as a FRESH ``run_turn``, not through
-``enqueue_session_message``. So the primary check drives the steer through a
-fresh ``run_turn`` (the real mid-turn path); the enqueue path is covered too,
-via parametrization, to pin the brief initial-paste window.
+Oracle: Kimi merges a steer locally and fires NO new model request until the
+blocked turn releases — identically on fixed and unfixed builds — so the mock
+cannot tell steered from queued. The queue affordance is therefore the sole
+discriminator (see the discriminator assertion, which must not be simplified
+away). The test first calibrates that the affordance both appears (a mid-turn
+Enter-only submit queues) and disappears (Ctrl-S flushes) on this binary, then
+requires it absent after the production steer, then confirms the steer reached
+the model conversation.
 
-Oracle (Kimi's steer merges locally — no new model request fires until the
-blocked turn releases, identically on both fixed and unfixed builds, so the mock
-cannot discriminate queued-vs-steered on its own; the queue affordance is the
-discriminator):
-
-1. calibrate — a mid-turn ``Enter``-only submission (exactly what an unfixed
-   build sends) MUST show Kimi's queue affordance, proving the affordance string
-   is live for this binary so its later absence is meaningful, not a rename;
-2. discriminate — after the production steer (paste + ``Enter`` + ``Ctrl-S``) the
-   queue affordance MUST be gone (steer flushed into the running turn);
-3. corroborate — after the blocked turn releases, the steer marker MUST reach the
-   model conversation, so an absent affordance can't be a silently-dropped inject.
-
-Real-binary e2e. Opt in with ``OMNIGENT_E2E_KIMI=1``; needs the ``kimi`` CLI
-(>= 0.41.0, where ``Ctrl-S`` steers) and ``tmux``. Excluded from default
-``pytest`` runs (``--ignore=tests/e2e``). Invoke with::
+Opt in with ``OMNIGENT_E2E_KIMI=1``; needs the ``kimi`` CLI (>= 0.41.0, where
+``Ctrl-S`` steers) and ``tmux``. Excluded from default ``pytest`` runs
+(``--ignore=tests/e2e``)::
 
     OMNIGENT_E2E_KIMI=1 uv run --no-sync pytest \
         tests/e2e/test_kimi_native_steering_e2e.py -v --timeout=600
@@ -56,7 +41,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from functools import cache
 from pathlib import Path
 
@@ -102,21 +87,28 @@ _VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 
 
 @cache
-def _kimi_version() -> tuple[int, int, int] | None:
-    """Parse ``kimi --version`` into a release tuple, or ``None`` if undeterminable."""
+def _kimi_version() -> tuple[tuple[int, int, int] | None, str]:
+    """Return ``(release_tuple, "")`` from ``kimi --version``, or ``(None, why)``.
+
+    Rejects a nonzero exit (and OS/timeout failure) BEFORE parsing, so a version
+    string can't be scraped out of an error response; *why* carries the diagnostic.
+    """
     binary = _kimi_binary()
     if binary is None:
-        return None
+        return None, "kimi binary could not be resolved"
     try:
         proc = subprocess.run(
             [binary, "--version"], capture_output=True, text=True, timeout=30, check=False
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, f"`{binary} --version` did not run: {exc}"
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "<no output>"
+        return None, f"`{binary} --version` exited {proc.returncode}: {detail}"
     match = _VERSION_RE.search(proc.stdout) or _VERSION_RE.search(proc.stderr)
     if match is None:
-        return None
-    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        return None, f"no version in `{binary} --version` output: {proc.stdout.strip()!r}"
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3))), ""
 
 
 pytestmark = [
@@ -199,12 +191,31 @@ def _send_keys(socket_path: str, target: str, *keys: str) -> None:
     _run_tmux(socket_path, "send-keys", "-t", target, *keys)
 
 
-def _queue_via_enter_only(socket_path: str, target: str, bridge_dir: Path, text: str) -> None:
-    """Submit *text* mid-turn exactly as an UNFIXED build would: clear, paste, Enter (no C-s).
+def _await_pane(
+    socket_path: str, target: str, predicate: Callable[[str], bool], timeout_s: float
+) -> tuple[bool, str]:
+    """Poll captures until *predicate* holds on a NON-EMPTY pane.
 
-    Used to calibrate the oracle — a bare Enter mid-turn must queue, so the queue
-    affordance appears and its later absence (after the real steer) is meaningful.
+    ``_capture`` returns ``""`` on any tmux failure (timeout, OSError, nonzero
+    exit), so an empty capture is never fed to *predicate*. A "the affordance is
+    gone" check therefore can't be flipped true by a transient tmux hiccup — it
+    keeps polling and times out loudly instead. Returns
+    ``(matched, last_non_empty_pane)`` so the caller reports what it actually saw.
     """
+    deadline = time.monotonic() + timeout_s
+    last = ""
+    while time.monotonic() < deadline:
+        pane = _capture(socket_path, target)
+        if pane:
+            last = pane
+            if predicate(pane):
+                return True, pane
+        time.sleep(_POLL_S)
+    return False, last
+
+
+def _queue_via_enter_only(socket_path: str, target: str, bridge_dir: Path, text: str) -> None:
+    """Submit *text* mid-turn exactly as an UNFIXED build would: clear, paste, Enter (no C-s)."""
     _send_keys(socket_path, target, "C-a")
     _send_keys(socket_path, target, "C-k")
     paste_path = bridge_dir / "calibration_paste.bin"
@@ -215,7 +226,7 @@ def _queue_via_enter_only(socket_path: str, target: str, bridge_dir: Path, text:
     _send_keys(socket_path, target, "Enter")
 
 
-def _wait_for(predicate, timeout_s: float, *, poll_s: float = _POLL_S) -> bool:
+def _wait_for(predicate: Callable[[], bool], timeout_s: float, *, poll_s: float = _POLL_S) -> bool:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         if predicate():
@@ -277,9 +288,9 @@ def kimi_tui(
     if mock_llm_server_url is None:
         pytest.skip("mock LLM server required (run without --llm-api-key)")
 
-    version = _kimi_version()
+    version, version_detail = _kimi_version()
     if version is None:
-        pytest.skip(f"could not determine kimi version from {kimi_bin!r} --version")
+        pytest.skip(f"kimi version undeterminable: {version_detail}")
     if version < _MIN_KIMI_VERSION:
         observed = ".".join(str(part) for part in version)
         minimum = ".".join(str(part) for part in _MIN_KIMI_VERSION)
@@ -326,62 +337,68 @@ def kimi_tui(
 
     write_tmux_target(bridge_dir, socket_path=Path(socket_path), tmux_target=target)
 
-    launch = subprocess.run(
-        [
-            "tmux",
-            "-S",
-            socket_path,
-            "new-session",
-            "-d",
-            "-s",
-            "kimi",
-            "-x",
-            "200",
-            "-y",
-            "50",
-            kimi_bin,
-        ],
-        cwd=str(workspace),
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=_TMUX_TIMEOUT_S,
-    )
-    if launch.returncode != 0:
-        detail = launch.stderr.strip() or launch.stdout.strip() or "<no output>"
-        raise RuntimeError(f"tmux new-session for kimi failed (rc={launch.returncode}): {detail}")
+    # Enter the cleanup scope BEFORE launching so a failed/partial ``new-session``
+    # (timeout, OSError, nonzero exit) still tears down any half-created server and
+    # removes the socket dir instead of leaking them.
     try:
+        launch = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                socket_path,
+                "new-session",
+                "-d",
+                "-s",
+                "kimi",
+                "-x",
+                "200",
+                "-y",
+                "50",
+                kimi_bin,
+            ],
+            cwd=str(workspace),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+        if launch.returncode != 0:
+            detail = launch.stderr.strip() or launch.stdout.strip() or "<no output>"
+            raise RuntimeError(
+                f"tmux new-session for kimi failed (rc={launch.returncode}): {detail}"
+            )
+
         # First-run "Trust this folder?" gate: the trust option is pre-selected,
         # so Enter accepts it and mounts the input box. Only send Enter once we
         # positively see the prompt, so a changed startup UI can't eat a stray
-        # Enter (already-mounted input, seen via "context:", needs no Enter).
-        saw_gate = _wait_for(
-            lambda: (
-                "Trust this" in _capture(socket_path, target)
-                or "context:" in _capture(socket_path, target)
-            ),
+        # Enter (an already-mounted input, seen via "context:", needs no Enter).
+        saw_gate, pane = _await_pane(
+            socket_path,
+            target,
+            lambda p: "Trust this" in p or "context:" in p,
             _BOOT_TIMEOUT_S,
         )
-        assert saw_gate, (
-            "Kimi TUI never showed its trust prompt or input box.\n"
-            f"Pane:\n{_capture(socket_path, target)}"
-        )
-        if "Trust this" in _capture(socket_path, target):
+        assert saw_gate, f"Kimi TUI never showed its trust prompt or input box.\nPane:\n{pane}"
+        if "Trust this" in pane:
             _send_keys(socket_path, target, "Enter")
-        ready = _wait_for(
-            lambda: "context:" in _capture(socket_path, target), _INPUT_READY_TIMEOUT_S
+        ready, pane = _await_pane(
+            socket_path, target, lambda p: "context:" in p, _INPUT_READY_TIMEOUT_S
         )
-        assert ready, (
-            f"Kimi TUI never mounted its input box.\nPane:\n{_capture(socket_path, target)}"
-        )
+        assert ready, f"Kimi TUI never mounted its input box.\nPane:\n{pane}"
         yield socket_path, target, bridge_dir, mock_llm_server_url, version
     finally:
-        subprocess.run(
-            ["tmux", "-S", socket_path, "kill-server"],
-            capture_output=True,
-            timeout=_TMUX_TIMEOUT_S,
-        )
-        shutil.rmtree(socket_dir, ignore_errors=True)
+        # kill-server in its own guard so a teardown timeout/OSError can't skip the
+        # socket-dir removal or mask the real test result.
+        try:
+            subprocess.run(
+                ["tmux", "-S", socket_path, "kill-server"],
+                capture_output=True,
+                timeout=_TMUX_TIMEOUT_S,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+        finally:
+            shutil.rmtree(socket_dir, ignore_errors=True)
 
 
 @pytest.mark.parametrize("steer_via", ["fresh_run_turn", "enqueue_session_message"])
@@ -392,11 +409,10 @@ def test_midturn_steer_is_applied_not_queued(
 ) -> None:
     """A steer sent mid-turn must steer the running Kimi turn, not queue behind it.
 
-    ``fresh_run_turn`` is the real mid-turn path (a second ``run_turn`` while the
-    first turn streams); ``enqueue_session_message`` covers the brief initial-paste
-    window. Both go through ``inject_user_message`` (paste + Enter + Ctrl-S), so
-    both must flush the steer into the running turn. If Ctrl-S were narrowed to the
-    enqueue path only, the ``fresh_run_turn`` row would regress and fail here.
+    ``fresh_run_turn`` is the real mid-turn path; ``enqueue_session_message`` covers
+    the initial-paste window. Both go through ``inject_user_message`` (paste + Enter
+    + Ctrl-S), so narrowing Ctrl-S to the enqueue path alone would fail the
+    ``fresh_run_turn`` row here.
     """
     socket_path, target, bridge_dir, mock_url, version = kimi_tui
     version_str = ".".join(str(part) for part in version)
@@ -430,26 +446,36 @@ def test_midturn_steer_is_applied_not_queued(
             f"steer.\nPane:\n{_capture(socket_path, target)}"
         )
 
-        # Calibrate: a bare Enter mid-turn (what an unfixed build sends) must queue
-        # and show the affordance. Proves the affordance string is live for this
-        # kimi build, so its absence after the real steer is meaningful.
+        # Calibrate the oracle against THIS live build: a mid-turn Enter-only submit
+        # (what an unfixed build sends) must show the queue affordance...
         _queue_via_enter_only(socket_path, target, bridge_dir, _CONTROL_TEXT)
-        calibrated = _wait_for(
-            lambda: (
-                _QUEUE_AFFORDANCE in _capture(socket_path, target)
-                and _CONTROL_MARK in _capture(socket_path, target)
-            ),
+        calibrated, cal_pane = _await_pane(
+            socket_path,
+            target,
+            lambda p: _QUEUE_AFFORDANCE in p and _CONTROL_MARK in p,
             _AFFORDANCE_TIMEOUT_S,
         )
-        calibration_pane = _capture(socket_path, target)
         assert calibrated, (
             "Kimi did not show its queue affordance for a mid-turn Enter-only message, so "
             f"the queued-vs-steered oracle can't be trusted for kimi {version_str} (the "
-            f"affordance {_QUEUE_AFFORDANCE!r} may have drifted).\nPane:\n{calibration_pane}"
+            f"affordance {_QUEUE_AFFORDANCE!r} may have drifted).\nPane:\n{cal_pane}"
         )
 
-        # Steer mid-turn through the production path. Ctrl-S flushes the queued
-        # draft(s) into the running turn, so the affordance must disappear.
+        # ...and a direct Ctrl-S must clear that single queued draft. This proves the
+        # affordance both appears and disappears here, AND leaves the queue empty, so
+        # the discriminator below only ever depends on Ctrl-S flushing a SINGLE draft
+        # — never on a whole-queue flush the fix does not promise. This send is direct
+        # tmux, so removing the production Ctrl-S does not affect it.
+        _send_keys(socket_path, target, "C-s")
+        cleared, cal_pane = _await_pane(
+            socket_path, target, lambda p: _QUEUE_AFFORDANCE not in p, _AFFORDANCE_TIMEOUT_S
+        )
+        assert cleared, (
+            f"Direct Ctrl-S did not clear a single queued draft for kimi {version_str}; the "
+            f"queue-flush the fix relies on has drifted.\nPane:\n{cal_pane}"
+        )
+
+        # Steer mid-turn through the production path (queue now holds one draft).
         if steer_via == "fresh_run_turn":
             events = asyncio.run(_drain_run_turn(executor, _STEER_TEXT))
             steered = not any(isinstance(event, ExecutorError) for event in events)
@@ -457,11 +483,15 @@ def test_midturn_steer_is_applied_not_queued(
             steered = asyncio.run(executor.enqueue_session_message("main", _STEER_TEXT))
         assert steered, f"steer injection via {steer_via} reported failure"
 
-        applied = _wait_for(
-            lambda: _QUEUE_AFFORDANCE not in _capture(socket_path, target),
-            _AFFORDANCE_TIMEOUT_S,
+        # DISCRIMINATOR (load-bearing): the queue affordance must be gone. This is the
+        # ONLY assertion that separates steered from queued: Kimi merges the steer
+        # locally and fires no new model request until the blocked turn releases, so
+        # the mock sees identical requests on fixed and unfixed builds and cannot
+        # discriminate. Do NOT replace this with a mock-request check. ``_await_pane``
+        # requires a NON-EMPTY capture, so a tmux failure can't read as "gone".
+        applied, pane = _await_pane(
+            socket_path, target, lambda p: _QUEUE_AFFORDANCE not in p, _AFFORDANCE_TIMEOUT_S
         )
-        pane = _capture(socket_path, target)
         assert applied, (
             "Mid-turn steer was QUEUED, not applied to the running turn: Kimi's queue-pane "
             f"affordance {_QUEUE_AFFORDANCE!r} is still present for kimi {version_str}. Omnigent "
@@ -469,9 +499,10 @@ def test_midturn_steer_is_applied_not_queued(
             f"Pane:\n{pane}"
         )
 
-        # Corroborate: release the blocked turn, then the steer marker must reach
-        # the model conversation. Guards an absent affordance from meaning the
-        # inject was silently dropped rather than genuinely steered.
+        # Corroborate the inject physically happened (guards an absent affordance from
+        # meaning a silently-dropped inject rather than a real steer): after releasing
+        # the turn, the steer marker must reach the model. This does NOT discriminate
+        # steered-vs-queued — the discriminator above is the only leg that does.
         release_mock_gate(mock_url)
         gate_released = True
         reached = _wait_for(

--- a/tests/e2e/test_kimi_native_steering_e2e.py
+++ b/tests/e2e/test_kimi_native_steering_e2e.py
@@ -1,0 +1,310 @@
+"""E2E: a mid-turn steer must be applied to the running Kimi turn, not queued.
+
+Guards against a mid-turn steer regression: steering a running
+``kimi`` (Kimi Code, ``kimi-native``) session from Omnigent does not take
+effect immediately. Omnigent injects the steer text into the Kimi CLI's TUI
+via :func:`omnigent.harnesses.kimi_native.bridge.inject_user_message`, which
+commits the message with ``Enter`` and *never* sends the CLI's steer key (``Ctrl-S``).
+Mid-turn, Kimi treats ``Enter`` as "queue this message for after the turn" and
+only ``Ctrl-S`` steers the in-flight turn -- so the steer lands in Kimi's queue
+(``↑ to edit · ctrl-s to steer immediately``) instead of steering the running
+turn, and is ignored until the current turn ends.
+
+The reproduction drives the REAL user path, not a mock of it:
+
+1. launch the real ``kimi`` TUI in a private tmux pane (exactly as the runner
+   does), pointed at this session's mock LLM via the ``KIMI_MODEL_*`` env
+   custom-provider overlay,
+2. start a turn through the real :class:`~omnigent.inner.kimi_native_executor.
+   KimiNativeExecutor` (``run_turn`` -> the same tmux bracketed-paste + Enter
+   injection the web UI uses),
+3. hold that turn open mid-stream with a ``block``ing mock response, and
+4. steer it through the real live-steer entry point
+   (``KimiNativeExecutor.enqueue_session_message`` -- what the runner's
+   ``_watch_injections`` calls for an in-flight injection),
+
+then assert on what a user sees in the embedded Kimi terminal: the steer must
+be applied to the in-flight turn, evidenced by the absence of Kimi's queue-pane
+steer affordance (``to steer immediately``). On the buggy build the steer is
+queued (the affordance is present) and this test fails; once the bridge also
+sends the CLI's ``Ctrl-S`` steer key mid-turn, the queued text flushes into the
+running turn and the affordance is gone.
+
+Real-binary e2e, skipped unless the ``kimi`` CLI (0.41.0+) and ``tmux`` are
+available. Excluded from default ``pytest`` runs (``--ignore=tests/e2e``).
+Invoke with::
+
+    pytest tests/e2e/test_kimi_native_steering_e2e.py -v --timeout=600
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.harness_startup_config import resolve_harness_path
+from omnigent.harnesses.kimi_native.bridge import write_tmux_target
+from omnigent.inner.kimi_native_executor import KimiNativeExecutor
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    release_mock_gate,
+    reset_mock_llm,
+    set_fallback_mock_llm,
+)
+
+pytestmark = [pytest.mark.timeout(600, method="signal")]
+
+# A deliberately-unique token in the initiating prompt so the mock routes this
+# turn to our own (blocking) queue regardless of what model string Kimi sends.
+_MATCH_TOKEN = "KIMI_MIDTURN_STEER_REPRO_TOKEN"
+# A steer marker DISTINCT from the routing token: the "did the steer reach the
+# TUI?" guard must key on the steer message specifically, not on the echoed
+# initiating prompt (which also carries the routing token). Kept free of
+# substrings that overlap the routing token so neither check aliases the other.
+_STEER_MARK = "APPLY_GUIDANCE_NOW_MARK"
+_STEER_TEXT = f"{_STEER_MARK} stop everything and only reply BANANA"
+
+# Kimi's queue-pane affordance, shown ONLY when a message is QUEUED mid-turn
+# (i.e. NOT steered). Distinct from the footer spinner tip "ctrl-s to add
+# guidance without waiting for the turn to finish", which rotates in regardless
+# of queue state -- so keying on "to steer immediately" tests queue-vs-steer,
+# not the mere presence of a Ctrl-S hint.
+_QUEUE_AFFORDANCE = "to steer immediately"
+
+_BOOT_TIMEOUT_S = 45.0
+_INPUT_READY_TIMEOUT_S = 45.0
+_MIDTURN_TIMEOUT_S = 60.0
+_STEER_VISIBLE_TIMEOUT_S = 20.0
+_STEER_SETTLE_S = 2.0
+_POLL_S = 0.5
+
+# Proxy-blind client: CI forces an egress proxy that must not intercept the
+# loopback mock server.
+_client = httpx.Client(trust_env=False, timeout=10.0)
+
+
+def _kimi_binary() -> str | None:
+    """Resolve the ``kimi`` binary the harness would launch, or ``None``."""
+    explicit = resolve_harness_path("kimi")
+    if explicit:
+        return explicit if Path(explicit).exists() else None
+    return shutil.which("kimi")
+
+
+def _tmux_available() -> bool:
+    return shutil.which("tmux") is not None
+
+
+def _capture(socket_path: str, target: str) -> str:
+    """Return the visible text of the Kimi tmux pane."""
+    return subprocess.run(
+        ["tmux", "-S", socket_path, "capture-pane", "-t", target, "-p"],
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _send_keys(socket_path: str, target: str, *keys: str) -> None:
+    subprocess.run(
+        ["tmux", "-S", socket_path, "send-keys", "-t", target, *keys],
+        check=False,
+    )
+
+
+def _wait_for(predicate, timeout_s: float, *, poll_s: float = _POLL_S) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll_s)
+    return False
+
+
+def _gate_pending(mock_url: str) -> bool:
+    try:
+        return bool(_client.get(f"{mock_url}/gate/pending").json().get("pending"))
+    except httpx.HTTPError:
+        return False
+
+
+@pytest.fixture
+def kimi_tui(
+    mock_llm_server_url: str | None, tmp_path: Path
+) -> Iterator[tuple[str, str, Path, str]]:
+    """Launch the real Kimi TUI in tmux, wired to this session's mock LLM.
+
+    Yields ``(socket_path, tmux_target, bridge_dir, mock_url)``. The Kimi
+    process is configured through the CLI's ``KIMI_MODEL_*`` env overlay so it
+    speaks OpenAI Chat Completions to the mock server -- no real Kimi login or
+    network egress required.
+    """
+    kimi_bin = _kimi_binary()
+    if kimi_bin is None:
+        pytest.skip("kimi CLI (or OMNIGENT_KIMI_PATH) is required for the kimi-native steer repro")
+    if not _tmux_available():
+        pytest.skip("tmux is required for the kimi-native steer repro")
+    if mock_llm_server_url is None:
+        pytest.skip("mock LLM server required (run without --llm-api-key)")
+
+    kimi_home = tmp_path / "kimi-home"
+    kimi_home.mkdir()
+    # Model is supplied entirely by the KIMI_MODEL_* env overlay below.
+    (kimi_home / "config.toml").write_text("# model provided via KIMI_MODEL_* env overlay\n")
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+
+    socket_path = str(tmp_path / "tmux.sock")
+    target = "kimi:0.0"
+
+    env = {
+        **os.environ,
+        "KIMI_CODE_HOME": str(kimi_home),
+        "HOME": str(home),
+        "NO_PROXY": "127.0.0.1,localhost",
+        "no_proxy": "127.0.0.1,localhost",
+        # KIMI_MODEL_* synthesizes an in-memory provider + model alias and sets
+        # it as default_model, so the TUI talks OpenAI Chat Completions to the
+        # mock without a config-file model entry or a real login.
+        "KIMI_MODEL_NAME": "mock-kimi-steer",
+        "KIMI_MODEL_API_KEY": "mock-key",
+        "KIMI_MODEL_PROVIDER_TYPE": "openai",
+        "KIMI_MODEL_BASE_URL": f"{mock_llm_server_url}/v1",
+    }
+    for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        env.pop(proxy_var, None)
+
+    write_tmux_target(bridge_dir, socket_path=Path(socket_path), tmux_target=target)
+
+    subprocess.run(
+        [
+            "tmux",
+            "-S",
+            socket_path,
+            "new-session",
+            "-d",
+            "-s",
+            "kimi",
+            "-x",
+            "200",
+            "-y",
+            "50",
+            kimi_bin,
+        ],
+        cwd=str(workspace),
+        env=env,
+        check=True,
+    )
+    try:
+        # First-run "Trust this folder?" gate: the "Trust" option is
+        # pre-selected, so Enter accepts it and mounts the input box.
+        _wait_for(lambda: "Trust this" in _capture(socket_path, target), _BOOT_TIMEOUT_S)
+        _send_keys(socket_path, target, "Enter")
+        ready = _wait_for(
+            lambda: "context:" in _capture(socket_path, target), _INPUT_READY_TIMEOUT_S
+        )
+        assert ready, (
+            f"Kimi TUI never mounted its input box.\nPane:\n{_capture(socket_path, target)}"
+        )
+        yield socket_path, target, bridge_dir, mock_llm_server_url
+    finally:
+        subprocess.run(["tmux", "-S", socket_path, "kill-server"], capture_output=True)
+
+
+def test_midturn_steer_is_applied_not_queued(
+    kimi_tui: tuple[str, str, Path, str],
+    mock_llm_server_url: str | None,
+) -> None:
+    """A steer sent mid-turn must steer the running Kimi turn, not queue behind it.
+
+    Drives the real Omnigent steer path against a live Kimi TUI held mid-stream
+    and asserts the steer is applied to the in-flight turn (Kimi's queue-pane
+    steer affordance is absent). Fails on the buggy build, where Omnigent
+    commits the steer with Enter -- which Kimi queues -- and never sends the
+    CLI's ``Ctrl-S`` steer key.
+    """
+    socket_path, target, bridge_dir, mock_url = kimi_tui
+
+    # The initiating turn's answer BLOCKS (held open server-side) so the steer
+    # arrives while the turn is genuinely mid-stream. A fallback keeps any
+    # incidental request answered so nothing else hangs.
+    reset_mock_llm(mock_url)
+    set_fallback_mock_llm(mock_url, "default", "ok")
+    configure_mock_llm(
+        mock_url,
+        [{"text": "REPRO_TURN_DONE", "block": True}],
+        match=_MATCH_TOKEN,
+    )
+
+    executor = KimiNativeExecutor(bridge_dir=bridge_dir)
+
+    async def _start_turn() -> None:
+        # run_turn injects the initiating user message via the same tmux
+        # bracketed-paste + Enter path the web UI uses, then returns.
+        async for _ in executor.run_turn(
+            messages=[
+                {
+                    "role": "user",
+                    "content": f"Write a very long detailed essay. {_MATCH_TOKEN}",
+                }
+            ],
+            tools=[],
+            system_prompt="",
+        ):
+            pass
+
+    asyncio.run(_start_turn())
+
+    # The turn must be genuinely in flight before we steer, otherwise a steer
+    # that arrives idle proves nothing about mid-turn behavior.
+    midturn = _wait_for(lambda: _gate_pending(mock_url), _MIDTURN_TIMEOUT_S)
+    assert midturn, (
+        "Kimi turn never reached the mock LLM / mid-stream state; cannot test "
+        f"a mid-turn steer.\nPane:\n{_capture(socket_path, target)}"
+    )
+
+    # Steer mid-turn through the real live-steer entry point (what the runner's
+    # _watch_injections calls for an in-flight injection).
+    steered = asyncio.run(executor.enqueue_session_message("main", _STEER_TEXT))
+    assert steered, "enqueue_session_message reported the steer injection failed"
+
+    # The steer text must reach the pane at all (proves the inject path ran),
+    # whether it lands queued (bug) or steered (fixed).
+    landed = _wait_for(
+        lambda: _STEER_MARK in _capture(socket_path, target),
+        _STEER_VISIBLE_TIMEOUT_S,
+    )
+    assert landed, (
+        "Steer text never appeared in the Kimi pane; the injection did not "
+        f"reach the TUI.\nPane:\n{_capture(socket_path, target)}"
+    )
+    time.sleep(_STEER_SETTLE_S)
+
+    pane = _capture(socket_path, target)
+    try:
+        # BUG: Omnigent commits the steer with Enter, which Kimi queues
+        # mid-turn -- the pane shows the queue affordance
+        # "↑ to edit · ctrl-s to steer immediately" and the steer is NOT applied
+        # to the running turn. The fix additionally sends the CLI's Ctrl-S steer
+        # key, which flushes the queued text into the in-flight turn, so the
+        # affordance disappears.
+        assert _QUEUE_AFFORDANCE not in pane, (
+            "Mid-turn steer was QUEUED, not applied to the running turn: Kimi's "
+            f"queue-pane affordance {_QUEUE_AFFORDANCE!r} is present. Omnigent "
+            "committed the steer with Enter and never sent the CLI's Ctrl-S "
+            f"steer key.\nPane:\n{pane}"
+        )
+    finally:
+        # Let the held-open turn drain so teardown is clean.
+        release_mock_gate(mock_url)

--- a/tests/e2e/test_kimi_native_steering_e2e.py
+++ b/tests/e2e/test_kimi_native_steering_e2e.py
@@ -1,50 +1,63 @@
 """E2E: a mid-turn steer must be applied to the running Kimi turn, not queued.
 
-Guards against a mid-turn steer regression: steering a running
-``kimi`` (Kimi Code, ``kimi-native``) session from Omnigent does not take
-effect immediately. Omnigent injects the steer text into the Kimi CLI's TUI
-via :func:`omnigent.harnesses.kimi_native.bridge.inject_user_message`, which
-commits the message with ``Enter`` and *never* sends the CLI's steer key (``Ctrl-S``).
-Mid-turn, Kimi treats ``Enter`` as "queue this message for after the turn" and
-only ``Ctrl-S`` steers the in-flight turn -- so the steer lands in Kimi's queue
-(``↑ to edit · ctrl-s to steer immediately``) instead of steering the running
-turn, and is ignored until the current turn ends.
+Guards against the mid-turn steer regression: steering a running ``kimi`` (Kimi
+Code, ``kimi-native``) session does not take effect immediately. Omnigent
+injects the steer text into the Kimi TUI via
+:func:`omnigent.harnesses.kimi_native.bridge.inject_user_message`, which
+commits the message with ``Enter``. On an UNFIXED build that is *all* it does — it never
+sends the CLI's steer key (``Ctrl-S``). Mid-turn, Kimi treats a bare ``Enter``
+as "queue this for after the turn": the steer lands in Kimi's queue (``↑ to
+edit · ctrl-s to steer immediately``) and is ignored until the turn ends,
+instead of steering the in-flight turn. The fix additionally sends ``Ctrl-S``,
+which flushes the queued text into the running turn (and no-ops while idle).
 
-The reproduction drives the REAL user path, not a mock of it:
+The seam this drives, and why it is the REAL one:
 
-1. launch the real ``kimi`` TUI in a private tmux pane (exactly as the runner
-   does), pointed at this session's mock LLM via the ``KIMI_MODEL_*`` env
-   custom-provider overlay,
-2. start a turn through the real :class:`~omnigent.inner.kimi_native_executor.
-   KimiNativeExecutor` (``run_turn`` -> the same tmux bracketed-paste + Enter
-   injection the web UI uses),
-3. hold that turn open mid-stream with a ``block``ing mock response, and
-4. steer it through the real live-steer entry point
-   (``KimiNativeExecutor.enqueue_session_message`` -- what the runner's
-   ``_watch_injections`` calls for an in-flight injection),
+``KimiNativeExecutor.run_turn`` injects the message and then yields
+``TurnComplete`` immediately (``omnigent/inner/kimi_native_executor.py``), so
+the executor-adapter tears down its ``_watch_injections`` task in the ``finally``
+as soon as that generator completes
+(``omnigent/runtime/harnesses/_executor_adapter.py``). The
+``enqueue_session_message`` / ``_watch_injections`` window is therefore open only
+for the few seconds of the INITIAL paste; a steer that arrives while Kimi is
+actually streaming lands as a FRESH ``run_turn``, not through
+``enqueue_session_message``. So the primary check drives the steer through a
+fresh ``run_turn`` (the real mid-turn path); the enqueue path is covered too,
+via parametrization, to pin the brief initial-paste window.
 
-then assert on what a user sees in the embedded Kimi terminal: the steer must
-be applied to the in-flight turn, evidenced by the absence of Kimi's queue-pane
-steer affordance (``to steer immediately``). On the buggy build the steer is
-queued (the affordance is present) and this test fails; once the bridge also
-sends the CLI's ``Ctrl-S`` steer key mid-turn, the queued text flushes into the
-running turn and the affordance is gone.
+Oracle (Kimi's steer merges locally — no new model request fires until the
+blocked turn releases, identically on both fixed and unfixed builds, so the mock
+cannot discriminate queued-vs-steered on its own; the queue affordance is the
+discriminator):
 
-Real-binary e2e, skipped unless the ``kimi`` CLI (0.41.0+) and ``tmux`` are
-available. Excluded from default ``pytest`` runs (``--ignore=tests/e2e``).
-Invoke with::
+1. calibrate — a mid-turn ``Enter``-only submission (exactly what an unfixed
+   build sends) MUST show Kimi's queue affordance, proving the affordance string
+   is live for this binary so its later absence is meaningful, not a rename;
+2. discriminate — after the production steer (paste + ``Enter`` + ``Ctrl-S``) the
+   queue affordance MUST be gone (steer flushed into the running turn);
+3. corroborate — after the blocked turn releases, the steer marker MUST reach the
+   model conversation, so an absent affordance can't be a silently-dropped inject.
 
-    pytest tests/e2e/test_kimi_native_steering_e2e.py -v --timeout=600
+Real-binary e2e. Opt in with ``OMNIGENT_E2E_KIMI=1``; needs the ``kimi`` CLI
+(>= 0.41.0, where ``Ctrl-S`` steers) and ``tmux``. Excluded from default
+``pytest`` runs (``--ignore=tests/e2e``). Invoke with::
+
+    OMNIGENT_E2E_KIMI=1 uv run --no-sync pytest \
+        tests/e2e/test_kimi_native_steering_e2e.py -v --timeout=600
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import re
 import shutil
 import subprocess
+import tempfile
 import time
 from collections.abc import Iterator
+from functools import cache
 from pathlib import Path
 
 import httpx
@@ -52,6 +65,7 @@ import pytest
 
 from omnigent.harness_startup_config import resolve_harness_path
 from omnigent.harnesses.kimi_native.bridge import write_tmux_target
+from omnigent.inner.executor import ExecutorError
 from omnigent.inner.kimi_native_executor import KimiNativeExecutor
 from tests.e2e.conftest import (
     configure_mock_llm,
@@ -60,35 +74,9 @@ from tests.e2e.conftest import (
     set_fallback_mock_llm,
 )
 
-pytestmark = [pytest.mark.timeout(600, method="signal")]
-
-# A deliberately-unique token in the initiating prompt so the mock routes this
-# turn to our own (blocking) queue regardless of what model string Kimi sends.
-_MATCH_TOKEN = "KIMI_MIDTURN_STEER_REPRO_TOKEN"
-# A steer marker DISTINCT from the routing token: the "did the steer reach the
-# TUI?" guard must key on the steer message specifically, not on the echoed
-# initiating prompt (which also carries the routing token). Kept free of
-# substrings that overlap the routing token so neither check aliases the other.
-_STEER_MARK = "APPLY_GUIDANCE_NOW_MARK"
-_STEER_TEXT = f"{_STEER_MARK} stop everything and only reply BANANA"
-
-# Kimi's queue-pane affordance, shown ONLY when a message is QUEUED mid-turn
-# (i.e. NOT steered). Distinct from the footer spinner tip "ctrl-s to add
-# guidance without waiting for the turn to finish", which rotates in regardless
-# of queue state -- so keying on "to steer immediately" tests queue-vs-steer,
-# not the mere presence of a Ctrl-S hint.
-_QUEUE_AFFORDANCE = "to steer immediately"
-
-_BOOT_TIMEOUT_S = 45.0
-_INPUT_READY_TIMEOUT_S = 45.0
-_MIDTURN_TIMEOUT_S = 60.0
-_STEER_VISIBLE_TIMEOUT_S = 20.0
-_STEER_SETTLE_S = 2.0
-_POLL_S = 0.5
-
-# Proxy-blind client: CI forces an egress proxy that must not intercept the
-# loopback mock server.
-_client = httpx.Client(trust_env=False, timeout=10.0)
+# Kimi >= 0.41.0 binds Ctrl-S to "steer the running turn"; older builds don't,
+# so the fix is a no-op there and this test would false-fail a correct tree.
+_MIN_KIMI_VERSION = (0, 41, 0)
 
 
 def _kimi_binary() -> str | None:
@@ -103,20 +91,128 @@ def _tmux_available() -> bool:
     return shutil.which("tmux") is not None
 
 
+def _e2e_opt_in() -> bool:
+    """Sibling real-CLI convention: opt in with ``OMNIGENT_E2E_KIMI=1`` + tools present."""
+    if os.environ.get("OMNIGENT_E2E_KIMI") != "1":
+        return False
+    return _kimi_binary() is not None and _tmux_available()
+
+
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+
+
+@cache
+def _kimi_version() -> tuple[int, int, int] | None:
+    """Parse ``kimi --version`` into a release tuple, or ``None`` if undeterminable."""
+    binary = _kimi_binary()
+    if binary is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [binary, "--version"], capture_output=True, text=True, timeout=30, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = _VERSION_RE.search(proc.stdout) or _VERSION_RE.search(proc.stderr)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+pytestmark = [
+    pytest.mark.timeout(600, method="signal"),
+    pytest.mark.skipif(
+        not _e2e_opt_in(),
+        reason=(
+            "Real-binary e2e: requires OMNIGENT_E2E_KIMI=1 plus the ``kimi`` (or "
+            "OMNIGENT_KIMI_PATH) binary and ``tmux`` on PATH. Install kimi via "
+            "`curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash`, then re-run "
+            "with OMNIGENT_E2E_KIMI=1."
+        ),
+    ),
+]
+
+# Unique token in the initiating prompt so the mock routes this turn to our own
+# (blocking) queue regardless of the model string Kimi sends.
+_MATCH_TOKEN = "KIMI_MIDTURN_STEER_REPRO_TOKEN"
+# The steer marker, kept distinct from the routing token so the "did the steer
+# reach the model?" check keys on the steer text, not the echoed prompt.
+_STEER_MARK = "APPLY_GUIDANCE_NOW_MARK"
+_STEER_TEXT = f"{_STEER_MARK} stop everything and only reply BANANA"
+# Calibration marker: a mid-turn Enter-only submission used only to prove the
+# queue affordance is live for this Kimi build (distinct from the steer marker).
+_CONTROL_MARK = "STEER_ORACLE_CALIBRATION_MARK"
+_CONTROL_TEXT = f"{_CONTROL_MARK} calibration only"
+
+# Kimi's queue-pane affordance, shown ONLY for a message QUEUED mid-turn (i.e.
+# NOT steered). Distinct from the footer spinner tip about Ctrl-S, which rotates
+# in regardless of queue state — so keying on "to steer immediately" tests
+# queue-vs-steer, not the mere presence of a Ctrl-S hint.
+_QUEUE_AFFORDANCE = "to steer immediately"
+
+_BOOT_TIMEOUT_S = 45.0
+_INPUT_READY_TIMEOUT_S = 45.0
+_MIDTURN_TIMEOUT_S = 60.0
+_AFFORDANCE_TIMEOUT_S = 20.0
+_STEER_LLM_TIMEOUT_S = 30.0
+_SETTLE_S = 0.5
+_POLL_S = 0.5
+# Per-command tmux budget; a tmux server starved by a parallel boot can stall
+# past 5s while healthy.
+_TMUX_TIMEOUT_S = 10.0
+
+
+def _run_tmux(socket_path: str, *args: str) -> None:
+    """Invoke tmux, raising ``RuntimeError`` on a nonzero exit or timeout."""
+    label = args[0] if args else "tmux"
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, *args],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise RuntimeError(f"tmux {label} failed: {exc}") from exc
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "<no output>"
+        raise RuntimeError(f"tmux {label} failed (rc={proc.returncode}): {detail}")
+
+
 def _capture(socket_path: str, target: str) -> str:
-    """Return the visible text of the Kimi tmux pane."""
-    return subprocess.run(
-        ["tmux", "-S", socket_path, "capture-pane", "-t", target, "-p"],
-        capture_output=True,
-        text=True,
-    ).stdout
+    """Return the visible pane text; ``""`` on any tmux failure (treated as not-ready)."""
+    try:
+        proc = subprocess.run(
+            ["tmux", "-S", socket_path, "capture-pane", "-t", target, "-p"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""
 
 
 def _send_keys(socket_path: str, target: str, *keys: str) -> None:
-    subprocess.run(
-        ["tmux", "-S", socket_path, "send-keys", "-t", target, *keys],
-        check=False,
-    )
+    _run_tmux(socket_path, "send-keys", "-t", target, *keys)
+
+
+def _queue_via_enter_only(socket_path: str, target: str, bridge_dir: Path, text: str) -> None:
+    """Submit *text* mid-turn exactly as an UNFIXED build would: clear, paste, Enter (no C-s).
+
+    Used to calibrate the oracle — a bare Enter mid-turn must queue, so the queue
+    affordance appears and its later absence (after the real steer) is meaningful.
+    """
+    _send_keys(socket_path, target, "C-a")
+    _send_keys(socket_path, target, "C-k")
+    paste_path = bridge_dir / "calibration_paste.bin"
+    paste_path.write_bytes((text + "\n").encode("utf-8"))
+    _run_tmux(socket_path, "load-buffer", "-b", "omni-calibration", str(paste_path))
+    _run_tmux(socket_path, "paste-buffer", "-p", "-d", "-b", "omni-calibration", "-t", target)
+    time.sleep(_SETTLE_S)
+    _send_keys(socket_path, target, "Enter")
 
 
 def _wait_for(predicate, timeout_s: float, *, poll_s: float = _POLL_S) -> bool:
@@ -128,23 +224,50 @@ def _wait_for(predicate, timeout_s: float, *, poll_s: float = _POLL_S) -> bool:
     return False
 
 
-def _gate_pending(mock_url: str) -> bool:
+def _gate_pending(client: httpx.Client, mock_url: str) -> bool:
     try:
-        return bool(_client.get(f"{mock_url}/gate/pending").json().get("pending"))
+        return bool(client.get(f"{mock_url}/gate/pending").json().get("pending"))
     except httpx.HTTPError:
         return False
+
+
+def _steer_reached_llm(client: httpx.Client, mock_url: str, mark: str) -> bool:
+    """Whether any request the mock captured carries *mark* in its body."""
+    try:
+        requests = client.get(f"{mock_url}/mock/requests").json().get("requests", [])
+    except httpx.HTTPError:
+        return False
+    return any(mark in json.dumps(req) for req in requests)
+
+
+async def _drain_run_turn(executor: KimiNativeExecutor, text: str) -> list[object]:
+    """Drive one ``run_turn`` to completion, collecting its events."""
+    events: list[object] = []
+    async for event in executor.run_turn(
+        messages=[{"role": "user", "content": text}],
+        tools=[],
+        system_prompt="",
+    ):
+        events.append(event)
+    return events
+
+
+@pytest.fixture
+def proxy_blind_client() -> Iterator[httpx.Client]:
+    """Proxy-blind client: CI forces an egress proxy that must not intercept the loopback mock."""
+    with httpx.Client(trust_env=False, timeout=10.0) as client:
+        yield client
 
 
 @pytest.fixture
 def kimi_tui(
     mock_llm_server_url: str | None, tmp_path: Path
-) -> Iterator[tuple[str, str, Path, str]]:
+) -> Iterator[tuple[str, str, Path, str, tuple[int, int, int]]]:
     """Launch the real Kimi TUI in tmux, wired to this session's mock LLM.
 
-    Yields ``(socket_path, tmux_target, bridge_dir, mock_url)``. The Kimi
-    process is configured through the CLI's ``KIMI_MODEL_*`` env overlay so it
-    speaks OpenAI Chat Completions to the mock server -- no real Kimi login or
-    network egress required.
+    Yields ``(socket_path, tmux_target, bridge_dir, mock_url, kimi_version)``. Kimi
+    talks OpenAI Chat Completions to the mock via the CLI's ``KIMI_MODEL_*`` env
+    overlay — no real Kimi login or network egress required.
     """
     kimi_bin = _kimi_binary()
     if kimi_bin is None:
@@ -154,29 +277,41 @@ def kimi_tui(
     if mock_llm_server_url is None:
         pytest.skip("mock LLM server required (run without --llm-api-key)")
 
+    version = _kimi_version()
+    if version is None:
+        pytest.skip(f"could not determine kimi version from {kimi_bin!r} --version")
+    if version < _MIN_KIMI_VERSION:
+        observed = ".".join(str(part) for part in version)
+        minimum = ".".join(str(part) for part in _MIN_KIMI_VERSION)
+        pytest.skip(f"kimi Ctrl-S steer needs >= {minimum}; found {observed}")
+
     kimi_home = tmp_path / "kimi-home"
     kimi_home.mkdir()
     # Model is supplied entirely by the KIMI_MODEL_* env overlay below.
     (kimi_home / "config.toml").write_text("# model provided via KIMI_MODEL_* env overlay\n")
     workspace = tmp_path / "ws"
     workspace.mkdir()
-    home = tmp_path / "home"
-    home.mkdir()
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
 
-    socket_path = str(tmp_path / "tmux.sock")
+    # The tmux socket lives in a short-named temp dir, NOT under the deep pytest
+    # tmp_path: an AF_UNIX path over ~104 chars (which the nested pytest path plus
+    # the parametrize suffix blows past) fails to bind with "File name too long".
+    socket_dir = Path(tempfile.mkdtemp(prefix="okimi-"))
+    socket_path = str(socket_dir / "s")
     target = "kimi:0.0"
 
     env = {
         **os.environ,
+        # KIMI_CODE_HOME isolates kimi's own state (config, trust, sessions);
+        # HOME is left inherited so binary-resolving launcher shims still find
+        # their installed binary.
         "KIMI_CODE_HOME": str(kimi_home),
-        "HOME": str(home),
         "NO_PROXY": "127.0.0.1,localhost",
         "no_proxy": "127.0.0.1,localhost",
-        # KIMI_MODEL_* synthesizes an in-memory provider + model alias and sets
-        # it as default_model, so the TUI talks OpenAI Chat Completions to the
-        # mock without a config-file model entry or a real login.
+        # KIMI_MODEL_* synthesizes an in-memory provider + model alias and sets it
+        # as default_model, so the TUI speaks OpenAI Chat Completions to the mock
+        # without a config-file model entry or a real login.
         "KIMI_MODEL_NAME": "mock-kimi-steer",
         "KIMI_MODEL_API_KEY": "mock-key",
         "KIMI_MODEL_PROVIDER_TYPE": "openai",
@@ -184,10 +319,14 @@ def kimi_tui(
     }
     for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
         env.pop(proxy_var, None)
+    # Drop any inherited TMUX so this fresh, private tmux server isn't refused as
+    # a nested session (``new-session`` exits 1 when $TMUX points elsewhere).
+    for tmux_var in ("TMUX", "TMUX_PANE"):
+        env.pop(tmux_var, None)
 
     write_tmux_target(bridge_dir, socket_path=Path(socket_path), tmux_target=target)
 
-    subprocess.run(
+    launch = subprocess.run(
         [
             "tmux",
             "-S",
@@ -204,40 +343,66 @@ def kimi_tui(
         ],
         cwd=str(workspace),
         env=env,
-        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_TMUX_TIMEOUT_S,
     )
+    if launch.returncode != 0:
+        detail = launch.stderr.strip() or launch.stdout.strip() or "<no output>"
+        raise RuntimeError(f"tmux new-session for kimi failed (rc={launch.returncode}): {detail}")
     try:
-        # First-run "Trust this folder?" gate: the "Trust" option is
-        # pre-selected, so Enter accepts it and mounts the input box.
-        _wait_for(lambda: "Trust this" in _capture(socket_path, target), _BOOT_TIMEOUT_S)
-        _send_keys(socket_path, target, "Enter")
+        # First-run "Trust this folder?" gate: the trust option is pre-selected,
+        # so Enter accepts it and mounts the input box. Only send Enter once we
+        # positively see the prompt, so a changed startup UI can't eat a stray
+        # Enter (already-mounted input, seen via "context:", needs no Enter).
+        saw_gate = _wait_for(
+            lambda: (
+                "Trust this" in _capture(socket_path, target)
+                or "context:" in _capture(socket_path, target)
+            ),
+            _BOOT_TIMEOUT_S,
+        )
+        assert saw_gate, (
+            "Kimi TUI never showed its trust prompt or input box.\n"
+            f"Pane:\n{_capture(socket_path, target)}"
+        )
+        if "Trust this" in _capture(socket_path, target):
+            _send_keys(socket_path, target, "Enter")
         ready = _wait_for(
             lambda: "context:" in _capture(socket_path, target), _INPUT_READY_TIMEOUT_S
         )
         assert ready, (
             f"Kimi TUI never mounted its input box.\nPane:\n{_capture(socket_path, target)}"
         )
-        yield socket_path, target, bridge_dir, mock_llm_server_url
+        yield socket_path, target, bridge_dir, mock_llm_server_url, version
     finally:
-        subprocess.run(["tmux", "-S", socket_path, "kill-server"], capture_output=True)
+        subprocess.run(
+            ["tmux", "-S", socket_path, "kill-server"],
+            capture_output=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+        shutil.rmtree(socket_dir, ignore_errors=True)
 
 
+@pytest.mark.parametrize("steer_via", ["fresh_run_turn", "enqueue_session_message"])
 def test_midturn_steer_is_applied_not_queued(
-    kimi_tui: tuple[str, str, Path, str],
-    mock_llm_server_url: str | None,
+    kimi_tui: tuple[str, str, Path, str, tuple[int, int, int]],
+    proxy_blind_client: httpx.Client,
+    steer_via: str,
 ) -> None:
     """A steer sent mid-turn must steer the running Kimi turn, not queue behind it.
 
-    Drives the real Omnigent steer path against a live Kimi TUI held mid-stream
-    and asserts the steer is applied to the in-flight turn (Kimi's queue-pane
-    steer affordance is absent). Fails on the buggy build, where Omnigent
-    commits the steer with Enter -- which Kimi queues -- and never sends the
-    CLI's ``Ctrl-S`` steer key.
+    ``fresh_run_turn`` is the real mid-turn path (a second ``run_turn`` while the
+    first turn streams); ``enqueue_session_message`` covers the brief initial-paste
+    window. Both go through ``inject_user_message`` (paste + Enter + Ctrl-S), so
+    both must flush the steer into the running turn. If Ctrl-S were narrowed to the
+    enqueue path only, the ``fresh_run_turn`` row would regress and fail here.
     """
-    socket_path, target, bridge_dir, mock_url = kimi_tui
+    socket_path, target, bridge_dir, mock_url, version = kimi_tui
+    version_str = ".".join(str(part) for part in version)
 
     # The initiating turn's answer BLOCKS (held open server-side) so the steer
-    # arrives while the turn is genuinely mid-stream. A fallback keeps any
+    # arrives while the turn is genuinely mid-stream. A default fallback keeps any
     # incidental request answered so nothing else hangs.
     reset_mock_llm(mock_url)
     set_fallback_mock_llm(mock_url, "default", "ok")
@@ -249,62 +414,76 @@ def test_midturn_steer_is_applied_not_queued(
 
     executor = KimiNativeExecutor(bridge_dir=bridge_dir)
 
-    async def _start_turn() -> None:
-        # run_turn injects the initiating user message via the same tmux
-        # bracketed-paste + Enter path the web UI uses, then returns.
-        async for _ in executor.run_turn(
-            messages=[
-                {
-                    "role": "user",
-                    "content": f"Write a very long detailed essay. {_MATCH_TOKEN}",
-                }
-            ],
-            tools=[],
-            system_prompt="",
-        ):
-            pass
+    # run_turn injects the initiating user message via the same tmux paste + Enter
+    # + Ctrl-S path the web UI uses, then returns (Ctrl-S no-ops while idle).
+    asyncio.run(_drain_run_turn(executor, f"Write a very long detailed essay. {_MATCH_TOKEN}"))
 
-    asyncio.run(_start_turn())
-
-    # The turn must be genuinely in flight before we steer, otherwise a steer
-    # that arrives idle proves nothing about mid-turn behavior.
-    midturn = _wait_for(lambda: _gate_pending(mock_url), _MIDTURN_TIMEOUT_S)
-    assert midturn, (
-        "Kimi turn never reached the mock LLM / mid-stream state; cannot test "
-        f"a mid-turn steer.\nPane:\n{_capture(socket_path, target)}"
-    )
-
-    # Steer mid-turn through the real live-steer entry point (what the runner's
-    # _watch_injections calls for an in-flight injection).
-    steered = asyncio.run(executor.enqueue_session_message("main", _STEER_TEXT))
-    assert steered, "enqueue_session_message reported the steer injection failed"
-
-    # The steer text must reach the pane at all (proves the inject path ran),
-    # whether it lands queued (bug) or steered (fixed).
-    landed = _wait_for(
-        lambda: _STEER_MARK in _capture(socket_path, target),
-        _STEER_VISIBLE_TIMEOUT_S,
-    )
-    assert landed, (
-        "Steer text never appeared in the Kimi pane; the injection did not "
-        f"reach the TUI.\nPane:\n{_capture(socket_path, target)}"
-    )
-    time.sleep(_STEER_SETTLE_S)
-
-    pane = _capture(socket_path, target)
+    gate_released = False
     try:
-        # BUG: Omnigent commits the steer with Enter, which Kimi queues
-        # mid-turn -- the pane shows the queue affordance
-        # "↑ to edit · ctrl-s to steer immediately" and the steer is NOT applied
-        # to the running turn. The fix additionally sends the CLI's Ctrl-S steer
-        # key, which flushes the queued text into the in-flight turn, so the
-        # affordance disappears.
-        assert _QUEUE_AFFORDANCE not in pane, (
-            "Mid-turn steer was QUEUED, not applied to the running turn: Kimi's "
-            f"queue-pane affordance {_QUEUE_AFFORDANCE!r} is present. Omnigent "
-            "committed the steer with Enter and never sent the CLI's Ctrl-S "
-            f"steer key.\nPane:\n{pane}"
+        # The turn must be genuinely in flight before we steer; a steer that
+        # arrives idle proves nothing about mid-turn behavior.
+        midturn = _wait_for(
+            lambda: _gate_pending(proxy_blind_client, mock_url), _MIDTURN_TIMEOUT_S
+        )
+        assert midturn, (
+            "Kimi turn never reached the mock LLM / mid-stream state; cannot test a mid-turn "
+            f"steer.\nPane:\n{_capture(socket_path, target)}"
+        )
+
+        # Calibrate: a bare Enter mid-turn (what an unfixed build sends) must queue
+        # and show the affordance. Proves the affordance string is live for this
+        # kimi build, so its absence after the real steer is meaningful.
+        _queue_via_enter_only(socket_path, target, bridge_dir, _CONTROL_TEXT)
+        calibrated = _wait_for(
+            lambda: (
+                _QUEUE_AFFORDANCE in _capture(socket_path, target)
+                and _CONTROL_MARK in _capture(socket_path, target)
+            ),
+            _AFFORDANCE_TIMEOUT_S,
+        )
+        calibration_pane = _capture(socket_path, target)
+        assert calibrated, (
+            "Kimi did not show its queue affordance for a mid-turn Enter-only message, so "
+            f"the queued-vs-steered oracle can't be trusted for kimi {version_str} (the "
+            f"affordance {_QUEUE_AFFORDANCE!r} may have drifted).\nPane:\n{calibration_pane}"
+        )
+
+        # Steer mid-turn through the production path. Ctrl-S flushes the queued
+        # draft(s) into the running turn, so the affordance must disappear.
+        if steer_via == "fresh_run_turn":
+            events = asyncio.run(_drain_run_turn(executor, _STEER_TEXT))
+            steered = not any(isinstance(event, ExecutorError) for event in events)
+        else:
+            steered = asyncio.run(executor.enqueue_session_message("main", _STEER_TEXT))
+        assert steered, f"steer injection via {steer_via} reported failure"
+
+        applied = _wait_for(
+            lambda: _QUEUE_AFFORDANCE not in _capture(socket_path, target),
+            _AFFORDANCE_TIMEOUT_S,
+        )
+        pane = _capture(socket_path, target)
+        assert applied, (
+            "Mid-turn steer was QUEUED, not applied to the running turn: Kimi's queue-pane "
+            f"affordance {_QUEUE_AFFORDANCE!r} is still present for kimi {version_str}. Omnigent "
+            "committed the steer with Enter and never sent the CLI's Ctrl-S steer key.\n"
+            f"Pane:\n{pane}"
+        )
+
+        # Corroborate: release the blocked turn, then the steer marker must reach
+        # the model conversation. Guards an absent affordance from meaning the
+        # inject was silently dropped rather than genuinely steered.
+        release_mock_gate(mock_url)
+        gate_released = True
+        reached = _wait_for(
+            lambda: _steer_reached_llm(proxy_blind_client, mock_url, _STEER_MARK),
+            _STEER_LLM_TIMEOUT_S,
+        )
+        assert reached, (
+            "Steer text never reached the model conversation after the turn released; the "
+            f"injection did not join the running turn.\nPane:\n{_capture(socket_path, target)}"
         )
     finally:
-        # Let the held-open turn drain so teardown is clean.
-        release_mock_gate(mock_url)
+        # Always release so a failure mid-flight can't leave the gate pending and
+        # contaminate later e2e tests.
+        if not gate_released:
+            release_mock_gate(mock_url)

--- a/tests/inner/test_kimi_native_executor.py
+++ b/tests/inner/test_kimi_native_executor.py
@@ -787,6 +787,28 @@ class TestUserMessageInjection:
         enter_index = max(index for index, args in enumerate(sent) if args[-1] == "Enter")
         assert sent[enter_index + 1 : enter_index + 2] == [("send-keys", "-t", "main", "C-s")]
 
+    def test_ctrl_s_failure_keeps_submitted_message_delivered(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        sent = self._stub_tui(monkeypatch, tmp_path, submit_after_enters=1)
+        run_tmux = kimi_native_bridge._run_tmux
+
+        def _run_tmux(socket_path: str, *args: str) -> None:
+            run_tmux(socket_path, *args)
+            if args == ("send-keys", "-t", "main", "C-s"):
+                raise RuntimeError("tmux socket disappeared")
+
+        monkeypatch.setattr(kimi_native_bridge, "_run_tmux", _run_tmux)
+        inject_user_message(tmp_path / "bridge", content="fix the flaky test")
+        assert sent[-2:] == [
+            ("send-keys", "-t", "main", "Enter"),
+            ("send-keys", "-t", "main", "C-s"),
+        ]
+        assert "the draft remains queued: tmux socket disappeared" in caplog.text
+
     def test_raises_when_draft_never_submits(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/inner/test_kimi_native_executor.py
+++ b/tests/inner/test_kimi_native_executor.py
@@ -787,11 +787,19 @@ class TestUserMessageInjection:
         enter_index = max(index for index, args in enumerate(sent) if args[-1] == "Enter")
         assert sent[enter_index + 1 : enter_index + 2] == [("send-keys", "-t", "main", "C-s")]
 
+    @pytest.mark.parametrize(
+        "injected_error",
+        [
+            pytest.param(RuntimeError("tmux socket disappeared"), id="runtime-error"),
+            pytest.param(OSError("tmux socket disappeared"), id="os-error"),
+        ],
+    )
     def test_ctrl_s_failure_keeps_submitted_message_delivered(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
         caplog: pytest.LogCaptureFixture,
+        injected_error: RuntimeError | OSError,
     ) -> None:
         sent = self._stub_tui(monkeypatch, tmp_path, submit_after_enters=1)
         run_tmux = kimi_native_bridge._run_tmux
@@ -799,7 +807,7 @@ class TestUserMessageInjection:
         def _run_tmux(socket_path: str, *args: str) -> None:
             run_tmux(socket_path, *args)
             if args == ("send-keys", "-t", "main", "C-s"):
-                raise RuntimeError("tmux socket disappeared")
+                raise injected_error
 
         monkeypatch.setattr(kimi_native_bridge, "_run_tmux", _run_tmux)
         inject_user_message(tmp_path / "bridge", content="fix the flaky test")
@@ -807,7 +815,7 @@ class TestUserMessageInjection:
             ("send-keys", "-t", "main", "Enter"),
             ("send-keys", "-t", "main", "C-s"),
         ]
-        assert "the draft remains queued: tmux socket disappeared" in caplog.text
+        assert "the message may remain queued until the turn ends" in caplog.text
 
     def test_raises_when_draft_never_submits(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/inner/test_kimi_native_executor.py
+++ b/tests/inner/test_kimi_native_executor.py
@@ -784,6 +784,8 @@ class TestUserMessageInjection:
             "Enter",
             "C-s",
         ]
+        enter_index = max(index for index, args in enumerate(sent) if args[-1] == "Enter")
+        assert sent[enter_index + 1 : enter_index + 2] == [("send-keys", "-t", "main", "C-s")]
 
     def test_raises_when_draft_never_submits(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/inner/test_kimi_native_executor.py
+++ b/tests/inner/test_kimi_native_executor.py
@@ -769,6 +769,22 @@ class TestUserMessageInjection:
         inject_user_message(tmp_path / "bridge", content="fix the flaky test")
         assert [args[-1] for args in sent if args[-1] == "Enter"] == ["Enter", "Enter"]
 
+    def test_steer_follows_confirmed_submit(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        sent = self._stub_tui(
+            monkeypatch,
+            tmp_path,
+            submit_after_enters=2,
+            content="steer now",
+        )
+        inject_user_message(tmp_path / "bridge", content="steer now", turn_streaming=True)
+        assert [args[-1] for args in sent if args[0] == "send-keys"] == [
+            "Enter",
+            "Enter",
+            "C-s",
+        ]
+
     def test_raises_when_draft_never_submits(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Related issue

Closes #6433

## Summary

- Kimi-native returns from `run_turn` after terminal injection while the external Kimi TUI may still be generating, so a subsequent web message can arrive through the normal fresh-turn injection path.
- Send `Ctrl-S` immediately after the existing `Enter`: while streaming, Enter queues the draft and Ctrl-S promotes it into the running turn; while idle, Ctrl-S is a no-op and the Enter submission behaves normally.
- If the post-Enter Ctrl-S tmux call fails, log the failed steer and preserve successful delivery instead of inviting a duplicate web retry.
- Add a focused tmux-argv unit test without adding streaming flags, pane-state detection, or executor changes.

## Test Plan

- `uv run --python 3.13 --group test --no-sync pytest tests/inner/test_kimi_native_executor.py` — 27 passed. (`--no-sync` reused the worktree's Python 3.12 environment and emitted the corresponding uv warning.)
- `ruff check omnigent/kimi_native_bridge.py tests/inner/test_kimi_native_executor.py` — passed.
- `ruff format --check omnigent/kimi_native_bridge.py tests/inner/test_kimi_native_executor.py` — passed.
- `uv run --no-sync pyrefly check omnigent/kimi_native_bridge.py` — 0 errors.
- `uv run --no-sync pre-commit run --all-files` — all hooks passed after installing the locked Python and pnpm workspace dependencies.

Mutation check:
- RED: inserted a non-key `display-message` tmux call between Enter and Ctrl-S, then ran `uv run --python 3.13 --group test --no-sync pytest tests/inner/test_kimi_native_executor.py::TestApprovalKeystroke::test_message_submit_sends_enter_then_ctrl_s` — failed only at the adjacency assertion; the older filtered send-key sequence assertion still passed.
- GREEN: removed the intervening call and reran the identical command — 1 passed.

Post-Enter failure mutation check:
- RED: narrowed the Ctrl-S guard back to `RuntimeError` only, then ran `uv run --python 3.13 --group test --no-sync pytest 'tests/inner/test_kimi_native_executor.py::TestApprovalKeystroke::test_ctrl_s_failure_keeps_submitted_message_delivered[os-error]'` — failed with the simulated `OSError` propagating after Enter.
- GREEN: restored the `(RuntimeError, OSError)` guard and reran the identical command — 1 passed and the warning was captured. The parametrized test also covers the normalized `RuntimeError` path.

Live Kimi 0.41.0 check in a detached tmux session:
- Started `~/.kimi-code/bin/kimi` in a throwaway directory, submitted a long prompt, captured the pane actively streaming, then pasted the steer and ran `tmux send-keys Enter` followed by `tmux send-keys C-s`.
- Kimi's session log recorded the original generation as `turnStep=0.1`, then processed the steer as `turnStep=0.2/0.3` before finalizing that turn. A later idle Enter→Ctrl-S injection began `turnStep=1.1` and returned the requested `IDLE_SUCCESS_6433` response normally. Output continued throughout, confirming Ctrl-S did not trigger PTY/XOFF flow-control suspension.

Manual verification:
1. Start a long kimi-native turn under Omnigent.
2. Send guidance from the web UI while the Kimi TUI is still working and confirm it is incorporated into the same running turn.
3. Send another message at the turn boundary or while idle and confirm it starts normally, with no terminal freeze or lost draft.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No video was captured because this verification used a detached scratch tmux pane. The reproducible command sequence and Kimi session-step evidence are included in the Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit tests lock the overall send-key sequence, direct Enter→Ctrl-S tmux-call adjacency, and non-propagation of a post-Enter Ctrl-S failure while preserving the existing approval-key sequence. Manual testing covers both a live streaming turn and an idle submission. The Kimi 0.41.0 safety rationale is supported by readable source embedded in the installed binary; this is strong direct evidence for that version, but it is not an official published source contract.

## Follow-ups

- `omnigent/onboarding/harness_install.py:129` — Kimi readiness currently permits `>=0.7.0` (wired at `:271` and enforced at `:872`), which does not cover the `>=0.41.0` Ctrl-S semantics relied on here; an older Kimi silently degrades to the original queued-draft bug with no log or signal — raise the floor in a separately scoped compatibility change.
- `omnigent/runner/native/orchestration.py:3731` — the Kimi terminal spawn does not explicitly disable tty IXON, leaving a narrow cooked-tty XOFF corner for Ctrl-S — consider running `stty -ixon` when preparing the pane in a separate terminal-lifecycle change.

## Changelog

Steering messages sent to a busy Kimi session now join the running turn instead of waiting for a new turn.

## Issues

Resolves [OMNI-6240](https://linear.app/omnigent/issue/OMNI-6240/fixkimi-native-steering-does-not-send-the-clis-steer-key-ctrl-s-so)
