### PR TITLE
Add knos to .mcp.json for a shared decision record across agent sessions

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
+}

--- a/examples/knos-decisions.example.md
+++ b/examples/knos-decisions.example.md
@@ -1,0 +1,16 @@
+# Decisions and current work
+
+<!-- Example record. `knos export` writes this file in an adopting repo; it is
+     plain markdown, so a fresh clone reads it with nothing installed. -->
+
+## Decisions
+
+- **prerequisites via just** - `just ensure` installs and checks prerequisites. _(source: CLAUDE.md)_
+- **lint through pre-commit** - `just lint` / `just lint-all` run pre-commit. _(source: CLAUDE.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>One record every agent on the machine reads. Claims lapse after 30 minutes or on `knos done`.</sub>


### PR DESCRIPTION
Refs #5358 - related, not a fix for it: that issue asks for built-in memory in omnigent, this adds a third-party MCP server alongside it.

omnigent spans several agent surfaces (editors, extensions, integrations).
A decision recorded in one session is not visible to the next one, or to a
different surface, unless something outside the session holds it.

**What this adds**

- `knos` in `.mcp.json` - a local MCP server (`pip install knos`, Python 3.10+).
  No network, no account, no model download; one SQLite file.
- `examples/knos-decisions.example.md` - the shape of the record it writes, so
  the format is visible without installing anything.

**What it does**

When one agent claims a piece of work, another agent asking about that topic is
told who holds it instead of being handed the answer. Claims lapse after 30
minutes, so a crashed agent cannot hold work forever.

**Runtime note:** the server needs Python 3.10+ and `pip install knos`. Nothing
else in the repo depends on it - if it is absent, the example file still reads
normally and no other tooling changes.

Disclosure: I wrote knos. Happy to drop either half, or close this, if it is not
a fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
