### PR TITLE
fix(databricks): gate Canvas behind environment opt-in

### DIFF
--- a/deploy/databricks/README.md
+++ b/deploy/databricks/README.md
@@ -138,7 +138,18 @@ The script builds wheels, archives the SPA as `dist/web-ui.tar.gz`, copies the
 wheels and the single UI archive into `src/`, regenerates `src/pyproject.toml`
 and `src/uv.lock`, runs `databricks bundle deploy --target prod`, runs
 `databricks bundle run omnigent --target prod`, and polls `/health`
-with backoff until 200.
+with backoff until 200. Canvas is disabled by default. Enable the first-party
+Canvas extension for a specific app by setting the deployment environment
+variable when invoking the script:
+
+```bash
+OMNIGENT_ENABLE_CANVAS=true uv run python deploy/databricks/deploy.py \
+    --app-name <canvas-enabled-app> ...
+```
+
+Keep the variable unset for every other app. `--skip-web-ui` remains API-only
+and ignores the Canvas opt-in. Use repeatable `--extension-wheel` arguments for
+additional extensions.
 
 Databricks Apps rejects any single source file over 10 MB. The SPA is
 therefore shipped as one `src/web-ui.tar.gz` archive instead of inside the

--- a/deploy/databricks/build.sh
+++ b/deploy/databricks/build.sh
@@ -6,11 +6,15 @@
 #   SKIP_WEB_UI=1         Skip the web SPA build for API-only deployments.
 #   EXTERNALIZE_WEB_UI=1  Build the SPA, then archive it outside the wheel so
 #                         the Databricks Apps source sync uploads one file.
+#   OMNIGENT_ENABLE_CANVAS=true
+#                         Build the first-party Canvas extension wheel. Canvas
+#                         is disabled by default.
 #
 # Outputs:
 #   dist/omnigent-<version>-py3-none-any.whl
 #   dist/omnigent_client-<version>-py3-none-any.whl
 #   dist/omnigent_ui_sdk-<version>-py3-none-any.whl
+#   dist/omnigent_canvas-<version>-py3-none-any.whl (when explicitly enabled)
 #   dist/web-ui.tar.gz    SPA archive, when EXTERNALIZE_WEB_UI=1
 
 set -euo pipefail
@@ -60,6 +64,16 @@ uv build --wheel --out-dir dist/ sdks/ui/
 
 echo "==> Building omnigent wheel"
 uv build --wheel --out-dir dist/ .
+
+CANVAS_ENABLED=0
+case "${OMNIGENT_ENABLE_CANVAS:-}" in
+    1|true|TRUE|True|yes|YES|Yes) CANVAS_ENABLED=1 ;;
+esac
+
+if [[ "${SKIP_WEB_UI:-}" != "1" && "${CANVAS_ENABLED}" == "1" ]]; then
+    echo "==> Building Canvas extension wheel"
+    uv build --wheel --out-dir dist/ extensions/canvas/
+fi
 
 echo ""
 echo "Built wheels:"

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -65,6 +65,9 @@ _ENV_VARS_TO_CLEAR = (
 _BUNDLE_RESOURCE_KEY = "omnigent"
 
 _WHEEL_PREFIXES = ("omnigent-", "omnigent_client-", "omnigent_ui_sdk-")
+_BUILTIN_EXTENSION_WHEEL_PREFIXES = ("omnigent_canvas-",)
+_ENABLE_CANVAS_ENV_VAR = "OMNIGENT_ENABLE_CANVAS"
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes"})
 
 
 def _log(msg: str) -> None:
@@ -202,7 +205,12 @@ def _dist_web_ui_archive() -> Path:
     return _repo_root() / "dist" / _WEB_UI_ARCHIVE_NAME
 
 
-def _build_wheels(skip_web_ui: bool) -> list[Path]:
+def _env_var_is_truthy(name: str) -> bool:
+    """Return whether an environment variable contains a supported true value."""
+    return os.environ.get(name, "").strip().lower() in _TRUTHY_ENV_VALUES
+
+
+def _build_wheels(skip_web_ui: bool, *, enable_canvas: bool = False) -> list[Path]:
     """Invoke build.sh and return the resulting wheel paths."""
     root = _repo_root()
     build_sh = _deploy_dir() / "build.sh"
@@ -217,7 +225,14 @@ def _build_wheels(skip_web_ui: bool) -> list[Path]:
         env["EXTERNALIZE_WEB_UI"] = "1"
         env.pop("SKIP_WEB_UI", None)
         env.pop("OMNIGENT_SKIP_WEB_UI", None)
-    _log(f"$ {build_sh}" + (" (SKIP_WEB_UI=1)" if skip_web_ui else " (EXTERNALIZE_WEB_UI=1)"))
+    if enable_canvas and not skip_web_ui:
+        env[_ENABLE_CANVAS_ENV_VAR] = "1"
+    else:
+        env.pop(_ENABLE_CANVAS_ENV_VAR, None)
+    modes = ["SKIP_WEB_UI=1" if skip_web_ui else "EXTERNALIZE_WEB_UI=1"]
+    if enable_canvas and not skip_web_ui:
+        modes.append(f"{_ENABLE_CANVAS_ENV_VAR}=1")
+    _log(f"$ {build_sh} ({', '.join(modes)})")
     subprocess.run([str(build_sh)], cwd=root, env=env, check=True)
     wheels = sorted((root / "dist").glob("*.whl"))
     if not wheels:
@@ -253,6 +268,70 @@ def _classify_wheels(wheels: Iterable[Path]) -> _ClassifiedWheels:
         else:
             oversize.append(wheel)
     return _ClassifiedWheels(main=main_wheel, small=small, oversize=oversize)
+
+
+def _partition_built_wheels(
+    wheels: Iterable[Path], explicit_extensions: Iterable[Path] = ()
+) -> tuple[list[Path], list[Path]]:
+    """Separate core release wheels from bundled first-party extensions."""
+    explicit_paths = {wheel.resolve() for wheel in explicit_extensions}
+    core: list[Path] = []
+    extensions: list[Path] = []
+    unexpected: list[Path] = []
+    for wheel in wheels:
+        if wheel.name.startswith(_WHEEL_PREFIXES):
+            core.append(wheel)
+        elif wheel.name.startswith(_BUILTIN_EXTENSION_WHEEL_PREFIXES):
+            extensions.append(wheel)
+        elif wheel.resolve() in explicit_paths:
+            continue
+        else:
+            unexpected.append(wheel)
+    if unexpected:
+        names = ", ".join(wheel.name for wheel in unexpected)
+        raise SystemExit(
+            f"unexpected wheel(s) in dist/: {names}; pass additional extensions "
+            "with --extension-wheel from a separate output directory"
+        )
+    return core, extensions
+
+
+def _is_canvas_wheel(wheel: Path) -> bool:
+    """Return whether ``wheel`` is the first-party Canvas distribution."""
+    return wheel.name.startswith(_BUILTIN_EXTENSION_WHEEL_PREFIXES)
+
+
+def _select_extension_wheels(
+    builtin_extensions: Iterable[Path],
+    explicit_extensions: Iterable[Path],
+    *,
+    enable_canvas: bool,
+) -> list[Path]:
+    """Select deploy extensions while keeping Canvas behind its env opt-in."""
+    builtin = list(builtin_extensions)
+    explicit = list(explicit_extensions)
+    explicit_canvas = [wheel for wheel in explicit if _is_canvas_wheel(wheel)]
+    if explicit_canvas and not enable_canvas:
+        raise SystemExit(
+            f"Canvas is disabled; set {_ENABLE_CANVAS_ENV_VAR}=true instead of "
+            "passing its wheel directly"
+        )
+
+    canvas_wheels = list(
+        {wheel.resolve(): wheel for wheel in [*builtin, *explicit_canvas]}.values()
+    )
+    if enable_canvas and len(canvas_wheels) != 1:
+        names = ", ".join(wheel.name for wheel in canvas_wheels) or "none"
+        raise SystemExit(
+            f"{_ENABLE_CANVAS_ENV_VAR}=true requires exactly one Canvas wheel; "
+            f"found {names}. Rebuild without --skip-build or provide one with "
+            "--extension-wheel."
+        )
+
+    selected = [wheel for wheel in explicit if not _is_canvas_wheel(wheel)]
+    if enable_canvas:
+        selected.insert(0, canvas_wheels[0])
+    return selected
 
 
 def _wheel_version(wheel: Path, prefix: str) -> str:
@@ -1026,6 +1105,12 @@ def main() -> int:
     _clear_env_vars()
     _assert_clean_tree(skip=args.allow_dirty)
 
+    enable_canvas = _env_var_is_truthy(_ENABLE_CANVAS_ENV_VAR)
+    if enable_canvas and args.skip_web_ui:
+        _log(f"{_ENABLE_CANVAS_ENV_VAR}=true ignored with --skip-web-ui")
+        enable_canvas = False
+    _log(f"Canvas extension: {'enabled' if enable_canvas else 'disabled'}")
+
     base_version = _read_base_version()
     deploy_version = _compute_deploy_version(base_version, args.version)
     _log(f"deploy version: {deploy_version} (base: {base_version})")
@@ -1035,7 +1120,10 @@ def main() -> int:
         if not args.skip_build:
             _clean_build_artifacts()
             backups = _stamp_versions(deploy_version)
-            wheels = _build_wheels(skip_web_ui=args.skip_web_ui)
+            wheels = _build_wheels(
+                skip_web_ui=args.skip_web_ui,
+                enable_canvas=enable_canvas,
+            )
         else:
             dist = _repo_root() / "dist"
             wheels = sorted(dist.glob("*.whl"))
@@ -1054,11 +1142,25 @@ def main() -> int:
         if backups and not args.keep_version_bump:
             _restore_versions(backups)
 
-    classified = _classify_wheels(wheels)
+    explicit_extension_wheels = [wheel.resolve() for wheel in args.extension_wheel]
+    for wheel in explicit_extension_wheels:
+        if not wheel.is_file():
+            raise SystemExit(f"--extension-wheel {wheel} does not exist")
+    core_wheels, builtin_extension_wheels = _partition_built_wheels(
+        wheels, explicit_extension_wheels
+    )
+    classified = _classify_wheels(core_wheels)
+    extension_wheels = _select_extension_wheels(
+        builtin_extension_wheels,
+        explicit_extension_wheels,
+        enable_canvas=enable_canvas,
+    )
     for wheel in wheels:
         size_mb = wheel.stat().st_size / 1024 / 1024
         _log(f"  {wheel.name}  {size_mb:.2f} MB")
-    if classified.oversize:
+    if classified.oversize or any(
+        wheel.stat().st_size > _WORKSPACE_WHEEL_LIMIT_BYTES for wheel in extension_wheels
+    ):
         raise SystemExit(
             "uv-based Databricks Apps deploys require every Omnigent wheel to "
             "fit under the 10 MB Workspace file cap. Reduce the Python payload "
@@ -1074,10 +1176,6 @@ def main() -> int:
     # wheels locally, then copy the new small wheels in.
     src = _src_dir()
     src.mkdir(parents=True, exist_ok=True)
-    extension_wheels = [wheel.resolve() for wheel in args.extension_wheel]
-    for wheel in extension_wheels:
-        if not wheel.is_file():
-            raise SystemExit(f"--extension-wheel {wheel} does not exist")
     _sweep_local_src_wheels(keep={w.name for w in [*classified.small, *extension_wheels]})
     for wheel in [*classified.small, *extension_wheels]:
         dest = src / wheel.name

--- a/tests/deploy/test_databricks_build_script.py
+++ b/tests/deploy/test_databricks_build_script.py
@@ -9,17 +9,26 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    ("skip_web_ui", "expected_pnpm_calls", "expected_build_hook_setting"),
+    (
+        "skip_web_ui",
+        "enable_canvas",
+        "expected_pnpm_calls",
+        "expected_uv_calls",
+        "expected_build_hook_setting",
+    ),
     [
-        (False, 2, "<unset>"),
-        (True, 0, "true"),
+        (False, False, 2, 3, "<unset>"),
+        (False, True, 2, 4, "<unset>"),
+        (True, True, 0, 3, "true"),
     ],
 )
 def test_build_script_propagates_api_only_mode_to_wheel_builds(
     tmp_path: Path,
     *,
     skip_web_ui: bool,
+    enable_canvas: bool,
     expected_pnpm_calls: int,
+    expected_uv_calls: int,
     expected_build_hook_setting: str,
 ) -> None:
     repo = tmp_path / "repo"
@@ -58,14 +67,21 @@ def test_build_script_propagates_api_only_mode_to_wheel_builds(
         env["SKIP_WEB_UI"] = "1"
     else:
         env.pop("SKIP_WEB_UI", None)
+    if enable_canvas:
+        env["OMNIGENT_ENABLE_CANVAS"] = "true"
+    else:
+        env.pop("OMNIGENT_ENABLE_CANVAS", None)
 
     subprocess.run(["bash", str(script)], cwd=repo, env=env, check=True)
 
     commands = command_log.read_text().splitlines()
     assert sum(command.startswith("pnpm|") for command in commands) == expected_pnpm_calls
     uv_commands = [command for command in commands if command.startswith("uv|")]
-    assert len(uv_commands) == 3
+    assert len(uv_commands) == expected_uv_calls
     assert all(command.split("|", 2)[1] == expected_build_hook_setting for command in uv_commands)
+    assert any("extensions/canvas/" in command for command in uv_commands) is (
+        enable_canvas and not skip_web_ui
+    )
 
 
 def _write_executable(path: Path, content: str) -> None:

--- a/tests/deploy/test_databricks_extensions.py
+++ b/tests/deploy/test_databricks_extensions.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_DEPLOY_PY = _ROOT / "deploy" / "databricks" / "deploy.py"
+
+
+@pytest.fixture(scope="module")
+def deploy_mod() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("_databricks_deploy_extensions", _DEPLOY_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_canvas_wheel_is_a_bundled_extension(deploy_mod: ModuleType, tmp_path: Path) -> None:
+    wheels = [
+        tmp_path / "omnigent-0.13.0-py3-none-any.whl",
+        tmp_path / "omnigent_client-0.13.0-py3-none-any.whl",
+        tmp_path / "omnigent_ui_sdk-0.13.0-py3-none-any.whl",
+        tmp_path / "omnigent_canvas-0.1.0-py3-none-any.whl",
+    ]
+
+    core, extensions = deploy_mod._partition_built_wheels(wheels)
+
+    assert [wheel.name for wheel in core] == [wheel.name for wheel in wheels[:3]]
+    assert extensions == [wheels[3]]
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", " yes "])
+def test_canvas_env_accepts_supported_truthy_values(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("OMNIGENT_ENABLE_CANVAS", value)
+
+    assert deploy_mod._env_var_is_truthy("OMNIGENT_ENABLE_CANVAS") is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "on", "enabled"])
+def test_canvas_env_is_disabled_for_other_values(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("OMNIGENT_ENABLE_CANVAS", value)
+
+    assert deploy_mod._env_var_is_truthy("OMNIGENT_ENABLE_CANVAS") is False
+
+
+def test_canvas_env_is_disabled_when_unset(
+    deploy_mod: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("OMNIGENT_ENABLE_CANVAS", raising=False)
+
+    assert deploy_mod._env_var_is_truthy("OMNIGENT_ENABLE_CANVAS") is False
+
+
+def test_unknown_dist_wheel_is_not_installed_implicitly(
+    deploy_mod: ModuleType, tmp_path: Path
+) -> None:
+    wheel = tmp_path / "unrelated-1.0.0-py3-none-any.whl"
+
+    with pytest.raises(SystemExit, match="--extension-wheel"):
+        deploy_mod._partition_built_wheels([wheel])
+
+
+def test_explicit_extension_may_be_reused_from_dist(
+    deploy_mod: ModuleType, tmp_path: Path
+) -> None:
+    wheel = tmp_path / "custom_extension-1.0.0-py3-none-any.whl"
+
+    core, extensions = deploy_mod._partition_built_wheels([wheel], [wheel])
+
+    assert core == []
+    assert extensions == []
+
+
+def test_stale_canvas_wheel_is_ignored_without_opt_in(
+    deploy_mod: ModuleType, tmp_path: Path
+) -> None:
+    canvas = tmp_path / "omnigent_canvas-0.1.0-py3-none-any.whl"
+
+    selected = deploy_mod._select_extension_wheels(
+        [canvas],
+        [],
+        enable_canvas=False,
+    )
+
+    assert selected == []
+
+
+def test_canvas_opt_in_requires_exactly_one_wheel(deploy_mod: ModuleType) -> None:
+    with pytest.raises(SystemExit, match="requires exactly one Canvas wheel"):
+        deploy_mod._select_extension_wheels([], [], enable_canvas=True)
+
+
+def test_canvas_opt_in_selects_built_wheel(deploy_mod: ModuleType, tmp_path: Path) -> None:
+    canvas = tmp_path / "omnigent_canvas-0.1.0-py3-none-any.whl"
+
+    selected = deploy_mod._select_extension_wheels(
+        [canvas],
+        [],
+        enable_canvas=True,
+    )
+
+    assert selected == [canvas]
+
+
+def test_explicit_canvas_wheel_in_dist_is_not_counted_twice(
+    deploy_mod: ModuleType, tmp_path: Path
+) -> None:
+    canvas = tmp_path / "omnigent_canvas-0.1.0-py3-none-any.whl"
+
+    selected = deploy_mod._select_extension_wheels(
+        [canvas],
+        [canvas],
+        enable_canvas=True,
+    )
+
+    assert selected == [canvas]
+
+
+def test_explicit_canvas_wheel_cannot_bypass_env_opt_in(
+    deploy_mod: ModuleType, tmp_path: Path
+) -> None:
+    canvas = tmp_path / "omnigent_canvas-0.1.0-py3-none-any.whl"
+
+    with pytest.raises(SystemExit, match="Canvas is disabled"):
+        deploy_mod._select_extension_wheels([], [canvas], enable_canvas=False)
+
+
+def test_other_explicit_extension_does_not_require_canvas_opt_in(
+    deploy_mod: ModuleType, tmp_path: Path
+) -> None:
+    custom = tmp_path / "custom_extension-1.0.0-py3-none-any.whl"
+
+    selected = deploy_mod._select_extension_wheels(
+        [],
+        [custom],
+        enable_canvas=False,
+    )
+
+    assert selected == [custom]
+
+
+def test_canvas_wheel_is_locked_as_an_app_dependency(
+    deploy_mod: ModuleType, tmp_path: Path
+) -> None:
+    main = tmp_path / "omnigent-0.13.0-py3-none-any.whl"
+    client = tmp_path / "omnigent_client-0.13.0-py3-none-any.whl"
+    ui_sdk = tmp_path / "omnigent_ui_sdk-0.13.0-py3-none-any.whl"
+    canvas = tmp_path / "omnigent_canvas-0.1.0-py3-none-any.whl"
+    for wheel in (main, client, ui_sdk, canvas):
+        wheel.write_bytes(b"wheel")
+
+    pyproject = deploy_mod.build_uv_pyproject(
+        main,
+        [main, client, ui_sdk],
+        [],
+        "0.13.0",
+        [canvas],
+    )
+
+    assert '"omnigent-canvas==0.1.0"' in pyproject
+    assert 'omnigent-canvas = { path = "./omnigent_canvas-0.1.0-py3-none-any.whl" }' in pyproject

--- a/tests/deploy/test_databricks_web_ui.py
+++ b/tests/deploy/test_databricks_web_ui.py
@@ -331,11 +331,17 @@ def test_build_wheels_requests_the_spa_archive_outside_the_wheel(
     deploy_mod._build_wheels(skip_web_ui=False)
     assert captured["EXTERNALIZE_WEB_UI"] == "1"
     assert "SKIP_WEB_UI" not in captured
+    assert "OMNIGENT_ENABLE_CANVAS" not in captured
 
     captured.clear()
-    deploy_mod._build_wheels(skip_web_ui=True)
+    deploy_mod._build_wheels(skip_web_ui=False, enable_canvas=True)
+    assert captured["OMNIGENT_ENABLE_CANVAS"] == "1"
+
+    captured.clear()
+    deploy_mod._build_wheels(skip_web_ui=True, enable_canvas=True)
     assert captured["SKIP_WEB_UI"] == "1"
     assert "EXTERNALIZE_WEB_UI" not in captured
+    assert "OMNIGENT_ENABLE_CANVAS" not in captured
 
 
 def test_build_wheels_mode_ignores_the_ambient_environment(
@@ -361,10 +367,12 @@ def test_build_wheels_mode_ignores_the_ambient_environment(
 
     monkeypatch.setenv("SKIP_WEB_UI", "1")
     monkeypatch.setenv("EXTERNALIZE_WEB_UI", "stale")
+    monkeypatch.setenv("OMNIGENT_ENABLE_CANVAS", "true")
 
     deploy_mod._build_wheels(skip_web_ui=False)
     assert "SKIP_WEB_UI" not in captured
     assert captured["EXTERNALIZE_WEB_UI"] == "1"
+    assert "OMNIGENT_ENABLE_CANVAS" not in captured
 
     captured.clear()
     deploy_mod._build_wheels(skip_web_ui=True)


### PR DESCRIPTION
## Related issue

N/A — team Databricks App packaging regression.

## Summary

- Keep Canvas disabled in Databricks deployments by default.
- Build and install the first-party Canvas extension only when the deployment environment sets `OMNIGENT_ENABLE_CANVAS=true`.
- Preserve API-only deployments, cleanly ignore stale Canvas wheels, and keep explicitly supplied non-Canvas extensions working.

ELI5: Databricks can now ship Canvas to one opted-in app without turning it on for every Omnigent deployment.

```text
OMNIGENT_ENABLE_CANVAS=true
          |
       build.sh
          |
  Canvas wheel + core wheels
          |
       deploy.py
          |
   opted-in Databricks App
```

The deployment environment for `https://omnigents-3272836215725701.aws.databricksapps.com/` should set the variable; other app deployments should leave it unset.

## Test Plan

- `uv run --frozen --extra all --group test pytest tests/deploy -q` — 92 passed.
- `.venv/bin/pre-commit run --all-files` — all hooks passed.
- Direct `build.sh` tests cover default-off, explicit opt-in, and API-only behavior.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The deployment tests verify default-off behavior, env-enabled packaging, stale-wheel cleanup, `--skip-build`, API-only builds, and custom extension compatibility.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified the complete deployment test suite and all repository pre-commit hooks after rebasing onto current `main`.

## Changelog

Databricks deployments can opt into Canvas with `OMNIGENT_ENABLE_CANVAS=true`; Canvas remains off by default.
