### PR TITLE
feat(sandbox): install gh in the UBI managed host image

### DIFF
--- a/deploy/docker/Dockerfile.ubi
+++ b/deploy/docker/Dockerfile.ubi
@@ -140,6 +140,32 @@ RUN set -eu; \
       echo "ERROR: kiro-cli reports '${installed:-<none>}', expected '$KIRO_CLI_VERSION'." >&2; exit 1; }; \
     echo "kiro-cli ${KIRO_CLI_VERSION} pinned (sha256 verified)"
 
+# GitHub CLI (`gh`) — the read-only "GitHub" side panel shells out to it (and
+# agents reach for it), authenticated per-user from the credential broker (see
+# omnigent/runner/github_resource.py). Not an npm package, so fetch the immutable
+# per-arch tarball from the versioned GitHub release, verify sha256, install the
+# binary on the shared PATH, and assert the version. Mirrors the block in
+# deploy/docker/Dockerfile — keep GH_VERSION + both SHA256s in sync with it.
+ARG GH_VERSION=2.100.0
+ARG GH_SHA256_AMD64=e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be
+ARG GH_SHA256_ARM64=ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961
+RUN set -eu; \
+    case "$(uname -m)" in \
+      x86_64)  arch="amd64"; sha="$GH_SHA256_AMD64" ;; \
+      aarch64) arch="arm64"; sha="$GH_SHA256_ARM64" ;; \
+      *) echo "ERROR: unsupported arch '$(uname -m)' for gh" >&2; exit 1 ;; \
+    esac; \
+    asset="gh_${GH_VERSION}_linux_${arch}.tar.gz"; \
+    curl -fsSL -o /tmp/gh.tar.gz "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${asset}"; \
+    echo "${sha}  /tmp/gh.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/gh.tar.gz -C /tmp "gh_${GH_VERSION}_linux_${arch}/bin/gh"; \
+    install -m 0755 "/tmp/gh_${GH_VERSION}_linux_${arch}/bin/gh" /usr/local/bin/gh; \
+    rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${arch}"; \
+    installed="$(/usr/local/bin/gh --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"; \
+    [ "$installed" = "$GH_VERSION" ] || { \
+      echo "ERROR: gh reports '${installed:-<none>}', expected '$GH_VERSION'." >&2; exit 1; }; \
+    echo "gh ${GH_VERSION} pinned (sha256 verified)"
+
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /build /build
 


### PR DESCRIPTION
## Related issue

N/A — image build. Makes the read-only GitHub panel's `gh` calls (shipped in
#6380) work in the **UBI / RHEL** managed image too. Takes over the UBI half of
#6437 — its plain-`Dockerfile` half is already on `main` via #6380.

## Summary

#6380 installed the GitHub CLI in `deploy/docker/Dockerfile` so the sandbox
GitHub panel's `gh` calls work — but not in the UBI/RHEL variant
(`deploy/docker/Dockerfile.ubi`), so `gh` was still missing there and the panel
would fall back to its "gh not installed" state on UBI hosts. Add the same
pinned + SHA256-verified per-arch install to `Dockerfile.ubi`:

- `uname -m` arch detection (matching the ubi file's `kiro-cli` block — the UBI
  base image has no `dpkg`), mapping to gh's `amd64` / `arm64` release assets.
- **`GH_VERSION 2.100.0` + both SHA256s kept identical to the `Dockerfile`
  block**, so the two image variants never drift.
- A post-install version assertion, so a bad download/layout fails the build.

Credit to @LittleChimera, whose #6437 wrote the original UBI block (bumped here
`2.63.2 → 2.100.0` to match the already-merged `Dockerfile` pin).

## Test Plan

- `pre-commit` clean on the changed file.
- The `RUN` block asserts the pinned `gh` version, so a bad download/layout fails
  the image build; CI's **Docker build** exercises the actual ubi build on both
  arches.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — image build, no runtime behavior change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

No runtime code changed — it's a Dockerfile-only install. CI's Docker build
validates the ubi target, and the in-`RUN` `gh --version` assertion fails the
build if the pinned version/layout is ever wrong. The install block mirrors the
already-merged `deploy/docker/Dockerfile` gh block (same version + SHA256s).

---

This pull request and its description were written by Isaac.
