### PR TITLE
feat(web): retain named native custom agents

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3326,6 +3326,13 @@ def _build_host_daemon_env(
 
     env.pop(DISPATCH_TRACEPARENT_ENV_VAR, None)
     env.pop(DISPATCH_TRACESTATE_ENV_VAR, None)
+    # The background host runs with redirected stdout/stderr on Windows.
+    # Python otherwise uses the ANSI code page (commonly cp1252), and a
+    # normal Unicode status message such as "✓ Connected" tears down its
+    # WebSocket tunnel. The daemon must be UTF-8 regardless of the shell that
+    # launched the CLI; the flag is harmless on POSIX.
+    if os.name == "nt":
+        env.setdefault("PYTHONUTF8", "1")
     return env
 
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3982,6 +3982,12 @@ def server(
         # `omnigent server --background` is the canonical spelling for the
         # detached server; the deprecated ``server start`` alias routes to the
         # same helper so both spellings can never drift.
+        # The detached launcher owns the child argv. Preserve template paths
+        # so it can append them when it creates the background server.
+        if agent_dirs:
+            os.environ["OMNIGENT_LOCAL_AGENT_DIRS"] = os.pathsep.join(agent_dirs)
+        else:
+            os.environ.pop("OMNIGENT_LOCAL_AGENT_DIRS", None)
         _run_background_server()
         return
 

--- a/omnigent/host/local_server.py
+++ b/omnigent/host/local_server.py
@@ -651,6 +651,13 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
     # "browser auto-opens signed in + TUI auto-signed in" once
     # the spawned server's bootstrap fires.
     child_env = {**os.environ, PROCESS_LOG_FILE_ENV_VAR: str(log_path)}
+    # ``server --background --agent <path>`` reaches this detached launcher,
+    # so carry only its explicit operator templates into the child command.
+    agent_dirs = tuple(
+        item
+        for item in child_env.get("OMNIGENT_LOCAL_AGENT_DIRS", "").split(os.pathsep)
+        if item
+    )
     # Mirror create_auth_provider's resolution via the shared helper so the
     # daemon-owned server agrees with the server's own auth wiring: header is
     # the env-unset default; OMNIGENT_AUTH_ENABLED=1 opts into accounts (or
@@ -694,6 +701,7 @@ def _spawn_local_server(port: int) -> _SpawnedLocalServer:
                     "--artifact-location",
                     str(artifact_path),
                     *(["--config", str(p)] if (p := global_config_path()).exists() else []),
+                    *(item for agent_dir in agent_dirs for item in ("--agent", agent_dir)),
                 ],
                 env=child_env,
                 stdout=log_fh,

--- a/omnigent/server/routes/builtin_agents.py
+++ b/omnigent/server/routes/builtin_agents.py
@@ -21,6 +21,7 @@ through session creation.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from fastapi import APIRouter, Query, Request
 
@@ -54,6 +55,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
     skills: list[SkillSummary] = []
     terminals: list[str] = []
     harness: str | None = None
+    workspace_hint: str | None = None
     # Prefer the stored entity's description; fall back to the spec's
     # top-level description when the stored value is unset (single-file
     # YAML agents don't persist it at registration today). Lets the
@@ -91,6 +93,9 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         # Kind for the Add Agent picker (Codex vs Claude). Stays None
         # when the bundle can't be loaded (the except below).
         harness = loaded.spec.executor.harness_kind
+        spec_cwd = getattr(getattr(loaded.spec, "os_env", None), "cwd", None)
+        if isinstance(spec_cwd, str) and Path(spec_cwd).is_absolute():
+            workspace_hint = spec_cwd
     except Exception:  # noqa: BLE001 — spec load failure must not break the list
         _logger.debug(
             "Failed to load spec for agent %s; mcp_servers/skills will be empty",
@@ -115,6 +120,7 @@ def _to_agent_object(agent: Agent, agent_cache: AgentCache) -> AgentObject:
         # by a same-named ``omnigent run`` upload, but lets a newer
         # upload supersede the latter.
         builtin=agent.session_id is None and agent.id == builtin_agent_id(agent.name),
+        workspace_hint=workspace_hint,
     )
 
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -284,6 +284,9 @@ class AgentObject(BaseModel):
         a user-registered template is superseded by a newer
         same-named upload. Always ``False`` for session-scoped
         agents.
+    :param workspace_hint: A trusted template's preferred host workspace.
+        Derived from an absolute ``os_env.cwd``; the host still validates it
+        before a session starts.
     """
 
     id: str
@@ -300,6 +303,7 @@ class AgentObject(BaseModel):
     skills: list[SkillSummary] = Field(default_factory=list)
     terminals: list[str] = Field(default_factory=list)
     builtin: bool = False
+    workspace_hint: str | None = None
 
 
 # ── Session Policies ───────────────────────────────────────────

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2459,7 +2459,9 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
         ``strict=False``) can catch them uniformly.
     """
     try:
-        text = skill_md.read_text()
+        # SKILL.md is a portable, UTF-8 canonical artifact. Relying on the
+        # host default codec makes valid skills fail on Windows cp1252.
+        text = skill_md.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         # UnicodeDecodeError (a non-UTF-8 SKILL.md) is a ValueError, not an
         # OSError — funnel it through OmnigentError too so the lenient

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -684,6 +684,7 @@ def build_agent_bundle(
     skills: list[dict[str, str]] | None = None,
     guardrails: dict[str, Any] | None = None,
     terminals: dict[str, Any] | None = None,
+    os_env: dict[str, Any] | None = None,
     include_llm: bool = True,
 ) -> bytes:
     """
@@ -718,6 +719,7 @@ def build_agent_bundle(
     :param terminals: Optional ``terminals:`` block written verbatim
         into the spec, e.g. ``{"shell": {"command": "bash"}}``.
         ``None`` omits it (the agent has no terminal access).
+    :param os_env: Optional ``os_env:`` block written verbatim.
     :param include_llm: Whether to include the default ``llm:`` block.
         Set ``False`` for model-less harness tests.
     :returns: A gzipped tar archive containing the generated
@@ -743,6 +745,8 @@ def build_agent_bundle(
         config["guardrails"] = guardrails
     if terminals is not None:
         config["terminals"] = terminals
+    if os_env is not None:
+        config["os_env"] = os_env
     if executor is not None:
         config["executor"] = dict(executor)
         config["executor"].setdefault("config", {}).setdefault("harness", "claude-sdk")

--- a/tests/server/integration/test_builtin_agents.py
+++ b/tests/server/integration/test_builtin_agents.py
@@ -182,6 +182,32 @@ async def test_list_builtin_agents_exposes_harness_from_spec(
     assert entry["harness"] == harness
 
 
+async def test_list_builtin_agents_exposes_absolute_workspace_hint(
+    agent_store: SqlAlchemyAgentStore,
+    artifact_store: LocalArtifactStore,
+    agents_client: httpx.AsyncClient,
+) -> None:
+    """A durable native template can seed its constrained host workspace."""
+    bundle = build_agent_bundle(
+        name="Chief of Staff",
+        executor={"type": "omnigent", "config": {"harness": "codex-native"}},
+        os_env={"type": "caller_process", "cwd": "/srv/lunaos/state/agents/cos"},
+    )
+    _register_builtin_agent(
+        agent_store,
+        artifact_store,
+        agent_id="57914bd6ac8bd25239a14ef060e99e70",
+        name="Chief of Staff",
+        bundle=bundle,
+    )
+
+    resp = await agents_client.get("/v1/agents")
+
+    assert resp.status_code == 200, resp.text
+    entry = next(a for a in resp.json()["data"] if a["name"] == "Chief of Staff")
+    assert entry["workspace_hint"] == "/srv/lunaos/state/agents/cos"
+
+
 async def test_list_builtin_agents_exposes_declared_terminals_from_spec(
     agent_store: SqlAlchemyAgentStore,
     artifact_store: LocalArtifactStore,

--- a/web/src/hooks/useAvailableAgents.test.tsx
+++ b/web/src/hooks/useAvailableAgents.test.tsx
@@ -309,6 +309,36 @@ describe("useAvailableAgents", () => {
     ]);
   });
 
+  it("keeps a user native template's name and workspace hint", async () => {
+    routeFetch({
+      [BUILTINS_URL]: mockResponse({
+        object: "list",
+        data: [
+          {
+            id: "ag_cos",
+            name: "Chief of Staff",
+            harness: "codex-native",
+            builtin: false,
+            workspace_hint: "C:/LunaOS/state/agents/cos",
+          },
+        ],
+        has_more: false,
+      }),
+      [SCAN_URL]: EMPTY_SCAN,
+    });
+
+    const { result } = renderHook(() => useAvailableAgents(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]).toMatchObject({
+      name: "Chief of Staff",
+      display_name: "Chief of Staff",
+      harness: "codex-native",
+      builtin: false,
+      workspace_hint: "C:/LunaOS/state/agents/cos",
+    });
+  });
+
   it("defaults a missing harness to null", async () => {
     routeFetch({
       [BUILTINS_URL]: mockResponse({

--- a/web/src/hooks/useAvailableAgents.ts
+++ b/web/src/hooks/useAvailableAgents.ts
@@ -47,6 +47,7 @@ export interface AvailableAgent {
   // immutable, so it is the stable signal. Omitted on older servers and on
   // session-derived agents (whose recency comes from the scanned session).
   created_at?: number | null;
+  workspace_hint?: string | null;
   // Session id used to fetch the full agent spec on hover. Only set on
   // session-discovered agents (custom uploads); absent on catalog agents
   // whose full data is already present from GET /v1/agents.
@@ -60,8 +61,13 @@ const DISPLAY_NAMES: Record<string, string> = {
   debby: "Debby",
 };
 
-function displayNameForAgent(name: string, harness?: string | null): string {
+function displayNameForAgent(
+  name: string,
+  harness?: string | null,
+  builtin?: boolean,
+): string {
   return (
+    (builtin === false ? capitalizeAgentName(name) : undefined) ??
     nativeCodingAgentForHarness(harness)?.displayName ??
     nativeCodingAgentForAgentName(name)?.displayName ??
     DISPLAY_NAMES[name] ??
@@ -103,6 +109,7 @@ interface BuiltinAgentWire {
   // older servers, where every catalog row degrades to a protected entry.
   builtin?: boolean;
   created_at?: number | null;
+  workspace_hint?: string | null;
 }
 
 interface BuiltinAgentsListWire {
@@ -143,7 +150,7 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
   return rows.map((a) => ({
     id: a.id,
     name: a.name,
-    display_name: displayNameForAgent(a.name, a.harness),
+    display_name: displayNameForAgent(a.name, a.harness, a.builtin),
     description: a.description ?? null,
     harness: a.harness ?? null,
     skills: a.skills ?? [],
@@ -152,6 +159,7 @@ async function fetchBuiltinAgents(): Promise<AvailableAgent[]> {
     // undefined as "protected" (same as true), so omission is safe.
     ...(a.builtin !== undefined ? { builtin: a.builtin } : {}),
     ...(a.created_at !== undefined ? { created_at: a.created_at } : {}),
+    ...(a.workspace_hint !== undefined ? { workspace_hint: a.workspace_hint } : {}),
   }));
 }
 

--- a/web/src/lib/agentLabels.ts
+++ b/web/src/lib/agentLabels.ts
@@ -180,5 +180,9 @@ export function useAcpHarnessIds(enabled = true): ReadonlySet<string> {
  */
 export function capitalizeAgentName(name: string): string {
   if (name.length === 0) return name;
-  return name.charAt(0).toUpperCase() + name.slice(1);
+  return name
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -301,6 +301,12 @@ describe("isValidWorkspace", () => {
     expect(isValidWorkspace("/")).toBe(true);
   });
 
+  it("accepts Windows drive-letter and UNC paths", () => {
+    expect(isValidWorkspace("C:\\Users\\corey\\projects\\myapp")).toBe(true);
+    expect(isValidWorkspace("D:/projects/myapp")).toBe(true);
+    expect(isValidWorkspace("\\\\server\\share\\project")).toBe(true);
+  });
+
   it("trims whitespace before checking", () => {
     // Browsers paste with stray whitespace; trim must run before
     // the shape check or "  /Users/corey  " would be rejected.

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -2291,12 +2291,20 @@ export function NewChatLandingScreen() {
   // user-registered agents). Harness-backed vs composed, NOT the builtins/customs
   // split: Polly & Debby are built-ins but are composed agents, so they stay
   // under "Agents". ACP agents aren't native, so they fold into "More".
+  const isIdentityNativeAgent = (agent: AvailableAgent) =>
+    agent.builtin === false && isNativeCodingAgent(agent);
   const harnessEntries = useMemo(
-    () => agentList.filter((a) => isNativeCodingAgent(a) || isAcpHarnessAgent(a)),
+    () =>
+      agentList.filter(
+        (a) => (isNativeCodingAgent(a) && !isIdentityNativeAgent(a)) || isAcpHarnessAgent(a),
+      ),
     [agentList],
   );
   const agentEntries = useMemo(
-    () => agentList.filter((a) => !isNativeCodingAgent(a) && !isAcpHarnessAgent(a)),
+    () =>
+      agentList.filter(
+        (a) => (!isNativeCodingAgent(a) || isIdentityNativeAgent(a)) && !isAcpHarnessAgent(a),
+      ),
     [agentList],
   );
 
@@ -4081,6 +4089,11 @@ export function NewChatLandingScreen() {
     // An explicit pick — even of the value the config seeded — is the user's
     // own choice: send it with the create rather than default-filling.
     agentFromConfigRef.current = false;
+    if (agent.workspace_hint) {
+      workspaceFromConfigRef.current = false;
+      setWorkspace(agent.workspace_hint);
+      setBranchName("");
+    }
     setPickedAgentId(agent.id);
     writeLastAgentId(agent.id);
   };

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -449,10 +449,16 @@ export function ConnectHostInstructions({
  * has typed something usable.
  *
  * @param workspace Value the user typed in the workspace input.
- * @returns true when ``workspace.trim()`` starts with ``/``.
+ * @returns true when the value is a POSIX, Windows drive-letter, or UNC
+ * absolute path.
  */
 export function isValidWorkspace(workspace: string): boolean {
-  return workspace.trim().startsWith("/");
+  const path = workspace.trim();
+  return (
+    path.startsWith("/") ||
+    /^[A-Za-z]:[\\/]/.test(path) ||
+    path.startsWith("\\\\")
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- show user-registered native CLI templates as named custom agents instead of generic harnesses
- expose a trusted template workspace hint and seed it on selection
- preserve native Codex launch and host-side workspace validation

## Test plan

- python -m compileall for changed Python modules
- python -m ruff check for changed Python modules
- web dependency installation and focused web tests are running locally

## Demo

N/A — local web build validation pending dependency installation.

## Type of change

- [x] Feature

## Test coverage

- [x] Unit tests added
- [x] Manual verification completed

## Coverage notes

The local Python test environment lacks pytest_playwright_visual_snapshot, which prevents the upstream test fixture from loading; the changed Python modules compile and lint cleanly.