### PR TITLE
Attribute errors by fault domain and progress impact in debug logs

### DIFF
--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 
 import httpx
 
+from omnigent.errors import classify_exception
 from omnigent.process_logging import redact_log_text
 from omnigent.version import VERSION
 
@@ -420,11 +421,32 @@ def _stack_trace(record: logging.LogRecord) -> str | None:
 
 def _attributes(record: logging.LogRecord) -> dict[str, str]:
     raw = getattr(record, "attributes", None)
-    if not isinstance(raw, dict):
-        return {}
-    # The target column is MAP<STRING,STRING>; coerce values, redact them, and
-    # drop nulls. Event attributes share the same privacy boundary as messages.
-    return {str(k): redact_log_text(str(v)) for k, v in raw.items() if v is not None}
+    attrs: dict[str, str] = {}
+    if isinstance(raw, dict):
+        # The target column is MAP<STRING,STRING>; coerce values, redact them,
+        # and drop nulls. Event attributes share the same privacy boundary as
+        # messages.
+        attrs = {str(k): redact_log_text(str(v)) for k, v in raw.items() if v is not None}
+    _stamp_error_dimensions(attrs, record)
+    return attrs
+
+
+def _stamp_error_dimensions(attrs: dict[str, str], record: logging.LogRecord) -> None:
+    """Auto-attribute a logged exception the callsite did not classify itself.
+
+    Any record carrying ``exc_info`` gains ``error_category`` / ``error_impact``
+    derived from the exception (see :func:`omnigent.errors.classify_exception`),
+    so every ``_logger.exception`` / ``exc_info=…`` site across the codebase is
+    covered without per-site edits. Explicit callsite values always win.
+    """
+    if "error_category" in attrs and "error_impact" in attrs:
+        return
+    exc = record.exc_info[1] if isinstance(record.exc_info, tuple) else None
+    if not isinstance(exc, BaseException):
+        return
+    category, impact = classify_exception(exc)
+    attrs.setdefault("error_category", category.value)
+    attrs.setdefault("error_impact", impact.value)
 
 
 def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 
 import httpx
 
-from omnigent.errors import classify_exception
+from omnigent.errors import ErrorPhase, OmnigentError, classify_exception
 from omnigent.process_logging import redact_log_text
 from omnigent.version import VERSION
 
@@ -68,6 +68,13 @@ _user_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_user_id", defa
 # so this never changes runner attribution. An explicit ``extra`` session id
 # always wins over this ambient value.
 _session_id_var: ContextVar[str | None] = ContextVar("omnigent_debug_session_id", default=None)
+
+# Ambient lifecycle phase for the code currently executing. Set with
+# ``phase_scope`` around each region (runner launch, harness setup/startup, turn)
+# so any error logged inside inherits where it failed. Propagates into awaited
+# coroutines and is copied into asyncio tasks at creation, so wrap the entry of a
+# background task, not the scheduler. Unset outside a scoped region.
+_phase_var: ContextVar[ErrorPhase | None] = ContextVar("omnigent_error_phase", default=None)
 
 # Request-scoped bag of extra audit attributes a handler can attach so they ride
 # the request's audit envelope end-event (e.g. POST /events' event type, a newly
@@ -280,6 +287,32 @@ def current_session_id() -> str | None:
     return _session_id_var.get() or None
 
 
+def set_current_phase(phase: ErrorPhase | None) -> None:
+    """Bind the ambient lifecycle phase for subsequently logged errors."""
+    _phase_var.set(phase)
+
+
+@contextlib.contextmanager
+def phase_scope(phase: ErrorPhase) -> Iterator[None]:
+    """Mark *phase* as active for the block, restoring the prior value on exit.
+
+    Wrap each lifecycle region (runner launch, harness setup/startup, turn) so an
+    error logged inside is located even when it carries no error code. For a
+    background task, wrap the task body, not the scheduler (the context is copied
+    at task creation).
+    """
+    token = _phase_var.set(phase)
+    try:
+        yield
+    finally:
+        _phase_var.reset(token)
+
+
+def current_phase() -> ErrorPhase | None:
+    """The ambient lifecycle phase, or ``None`` outside any ``phase_scope``."""
+    return _phase_var.get()
+
+
 def reset_request_audit_attrs() -> None:
     """Start a fresh per-request audit-attribute bag (server middleware).
 
@@ -439,14 +472,35 @@ def _stamp_error_dimensions(attrs: dict[str, str], record: logging.LogRecord) ->
     so every ``_logger.exception`` / ``exc_info=…`` site across the codebase is
     covered without per-site edits. Explicit callsite values always win.
     """
-    if "error_category" in attrs and "error_impact" in attrs:
-        return
     exc = record.exc_info[1] if isinstance(record.exc_info, tuple) else None
-    if not isinstance(exc, BaseException):
-        return
-    category, impact = classify_exception(exc)
-    attrs.setdefault("error_category", category.value)
-    attrs.setdefault("error_impact", impact.value)
+    if isinstance(exc, BaseException) and not (
+        "error_category" in attrs and "error_impact" in attrs
+    ):
+        category, impact = classify_exception(exc)
+        attrs.setdefault("error_category", category.value)
+        attrs.setdefault("error_impact", impact.value)
+    if "error_phase" not in attrs:
+        phase = _resolve_error_phase(exc)
+        if phase is not None:
+            attrs["error_phase"] = phase.value
+
+
+def _resolve_error_phase(exc: BaseException | None) -> ErrorPhase | None:
+    """Locate a logged error's lifecycle phase.
+
+    Precedence: a coded ``OmnigentError``'s own (concrete) phase, then the ambient
+    ``phase_scope`` for the region that was executing (covers uncoded exceptions
+    and non-exception error logs), then a coded error's UNKNOWN fallback. Returns
+    ``None`` when there is nothing to attribute (no code, no active scope), so the
+    column stays empty rather than guessing.
+    """
+    coded = exc.phase if isinstance(exc, OmnigentError) else None
+    if coded is not None and coded is not ErrorPhase.UNKNOWN:
+        return coded
+    ambient = current_phase()
+    if ambient is not None:
+        return ambient
+    return coded
 
 
 def record_to_row(record: logging.LogRecord, source: str) -> dict[str, object]:

--- a/omnigent/debug_logging.py
+++ b/omnigent/debug_logging.py
@@ -287,11 +287,6 @@ def current_session_id() -> str | None:
     return _session_id_var.get() or None
 
 
-def set_current_phase(phase: ErrorPhase | None) -> None:
-    """Bind the ambient lifecycle phase for subsequently logged errors."""
-    _phase_var.set(phase)
-
-
 @contextlib.contextmanager
 def phase_scope(phase: ErrorPhase) -> Iterator[None]:
     """Mark *phase* as active for the block, restoring the prior value on exit.
@@ -479,7 +474,12 @@ def _stamp_error_dimensions(attrs: dict[str, str], record: logging.LogRecord) ->
         category, impact = classify_exception(exc)
         attrs.setdefault("error_category", category.value)
         attrs.setdefault("error_impact", impact.value)
-    if "error_phase" not in attrs:
+    # Locate only rows that are actually errors: an exception to place, or a row
+    # already declaring itself an error via category/impact. Otherwise a benign
+    # INFO/DEBUG line emitted inside a phase_scope (the whole turn loop is one)
+    # would inherit a spurious error_phase from the ambient scope.
+    is_error_row = exc is not None or "error_category" in attrs or "error_impact" in attrs
+    if is_error_row and "error_phase" not in attrs:
         phase = _resolve_error_phase(exc)
         if phase is not None:
             attrs["error_phase"] = phase.value

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -73,6 +73,68 @@ class ErrorImpact(str, Enum):
     UNKNOWN = "unknown"
 
 
+class ErrorPhase(str, Enum):
+    """Where in the session/turn lifecycle an error happened.
+
+    The third axis, orthogonal to category (who) and impact (did it block): it
+    localizes the failure so "a blocking config error in HARNESS_SETUP" points at
+    a different fix than "a blocking upstream error in TURN". Members are declared
+    in lifecycle order; :func:`is_before_harness_start` splits them at the boundary
+    the operator usually cares about.
+
+    :cvar REQUEST: Request receipt, schema validation, auth (before any session
+        work): 422, invalid_input, unauthorized, forbidden.
+    :cvar ROUTING: Replica / runner routing (wrong_replica).
+    :cvar RUNNER_LAUNCH: The host is launching or connecting the runner process
+        (runner_unavailable, runner_capability_mismatch, launch failed).
+    :cvar HARNESS_SETUP: Harness preconditions on the runner before the process
+        starts (harness_not_configured, workspace_missing). Still before start.
+    :cvar HARNESS_STARTUP: The harness process is spawning / handshaking /
+        initializing. The start itself.
+    :cvar TURN: A turn is running after the harness is up (LLM calls, tool
+        dispatch, elicitations, harness_protocol_violation). After start.
+    :cvar TEARDOWN: Session/turn finalization, persistence, cleanup.
+    :cvar UNKNOWN: Not localized (e.g. a generic internal error with no active
+        phase scope).
+    """
+
+    REQUEST = "request"
+    ROUTING = "routing"
+    RUNNER_LAUNCH = "runner_launch"
+    HARNESS_SETUP = "harness_setup"
+    HARNESS_STARTUP = "harness_startup"
+    TURN = "turn"
+    TEARDOWN = "teardown"
+    UNKNOWN = "unknown"
+
+
+# Lifecycle order used only for the before/after-harness-start split.
+_PHASE_ORDER = (
+    ErrorPhase.REQUEST,
+    ErrorPhase.ROUTING,
+    ErrorPhase.RUNNER_LAUNCH,
+    ErrorPhase.HARNESS_SETUP,
+    ErrorPhase.HARNESS_STARTUP,
+    ErrorPhase.TURN,
+    ErrorPhase.TEARDOWN,
+)
+
+
+def is_before_harness_start(phase: ErrorPhase) -> bool:
+    """Whether *phase* precedes the harness process starting.
+
+    The boundary is :attr:`ErrorPhase.HARNESS_STARTUP` (the start itself is not
+    "before"). ``UNKNOWN`` returns ``False`` (we cannot claim it failed before
+    start).
+
+    :param phase: The lifecycle phase.
+    :returns: ``True`` for REQUEST..HARNESS_SETUP, ``False`` otherwise.
+    """
+    if phase not in _PHASE_ORDER:
+        return False
+    return _PHASE_ORDER.index(phase) < _PHASE_ORDER.index(ErrorPhase.HARNESS_STARTUP)
+
+
 class ErrorCode:
     """
     Error codes and their HTTP status mappings.
@@ -248,6 +310,38 @@ def impact_for_code(code: str) -> ErrorImpact:
     return _CODE_TO_IMPACT.get(code, ErrorImpact.BENIGN)
 
 
+# Lifecycle phase a code most likely failed in. A DEFAULT for coded errors; an
+# active phase_scope (ambient ContextVar) localizes uncoded exceptions. Generic
+# codes map to UNKNOWN (context, not the code, tells you where). Every ErrorCode
+# has an entry (a test asserts presence); UNKNOWN is allowed here, unlike the
+# other two axes, because a phase is genuinely context-dependent.
+_CODE_TO_PHASE: dict[str, ErrorPhase] = {
+    ErrorCode.UNAUTHORIZED: ErrorPhase.REQUEST,
+    ErrorCode.FORBIDDEN: ErrorPhase.REQUEST,
+    ErrorCode.NOT_FOUND: ErrorPhase.REQUEST,
+    ErrorCode.INVALID_INPUT: ErrorPhase.REQUEST,
+    ErrorCode.ALREADY_EXISTS: ErrorPhase.REQUEST,
+    ErrorCode.CONFLICT: ErrorPhase.REQUEST,
+    ErrorCode.WRONG_REPLICA: ErrorPhase.ROUTING,
+    ErrorCode.RUNNER_UNAVAILABLE: ErrorPhase.RUNNER_LAUNCH,
+    ErrorCode.RUNNER_CAPABILITY_MISMATCH: ErrorPhase.RUNNER_LAUNCH,
+    ErrorCode.HARNESS_NOT_CONFIGURED: ErrorPhase.HARNESS_SETUP,
+    ErrorCode.WORKSPACE_MISSING: ErrorPhase.HARNESS_SETUP,
+    ErrorCode.HARNESS_PROTOCOL_VIOLATION: ErrorPhase.TURN,
+    ErrorCode.INTERNAL_ERROR: ErrorPhase.UNKNOWN,
+}
+
+
+def phase_for_code(code: str) -> ErrorPhase:
+    """Return the likely lifecycle phase for an error code.
+
+    :param code: An :class:`ErrorCode` string value.
+    :returns: The mapped phase, or ``UNKNOWN`` for a generic/unrecognized code
+        (an active ``phase_scope`` localizes those at log time).
+    """
+    return _CODE_TO_PHASE.get(code, ErrorPhase.UNKNOWN)
+
+
 class OmnigentError(Exception):
     """
     Application-level error with a machine-readable code.
@@ -263,6 +357,7 @@ class OmnigentError(Exception):
         code: str = ErrorCode.INTERNAL_ERROR,
         category: ErrorCategory | None = None,
         impact: ErrorImpact | None = None,
+        phase: ErrorPhase | None = None,
     ) -> None:
         """
         Create a new application error.
@@ -278,12 +373,16 @@ class OmnigentError(Exception):
             ``code`` (see :func:`impact_for_code`); pass it where the raise site
             knows the actual outcome, e.g. a normally-benign code that this time
             aborted the turn.
+        :param phase: Lifecycle-phase override. Defaults to the mapping for
+            ``code`` (see :func:`phase_for_code`); pass it where the raise site
+            knows the stage better than the code does.
         """
         super().__init__(message)
         self.code = code
         self.message = message
         self._category_override = category
         self._impact_override = impact
+        self._phase_override = phase
 
     @property
     def http_status(self) -> int:
@@ -311,6 +410,12 @@ class OmnigentError(Exception):
     def blocking(self) -> bool:
         """True when this error halts the turn/task (``impact`` is BLOCKING)."""
         return self.impact is ErrorImpact.BLOCKING
+
+    @property
+    def phase(self) -> ErrorPhase:
+        """Lifecycle phase: the constructor override if given, else the code's
+        mapping."""
+        return self._phase_override or phase_for_code(self.code)
 
 
 class ElicitationDeclinedError(Exception):

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -11,6 +11,67 @@ New code should prefer OmnigentError for consistency.
 
 from __future__ import annotations
 
+from enum import Enum
+
+
+class ErrorCategory(str, Enum):
+    """Fault attribution for an error: who must change something to prevent it.
+
+    Orthogonal to the HTTP-status / retryable axis. Emitted on error logs as a
+    queryable ``error_category`` so failures can be split by owner for
+    fault-share, alerting, and remediation.
+
+    :cvar USER: The human's input, choice, or action. Declined an elicitation, a
+        bad path, a stale id, deleted their own workspace, a prompt too large.
+        Working as designed; no software fix.
+    :cvar CLIENT: The calling software (web UI, SDK, integration) formed a bad
+        request: wrong shape, missing field, a token it held but dropped. A
+        correct client would not hit it.
+    :cvar CONFIG: Deployment, credentials, or install is wrong or incomplete: no
+        runner deployed, harness not configured, a bad provider key.
+    :cvar SERVER: Our bug or internal/infra failure, at a site that knows the
+        fault is ours. A confirmed server fault.
+    :cvar UPSTREAM: A provider or dependency failed: LLM 429/5xx, a provider
+        timeout.
+    :cvar UNKNOWN: Not attributable where observed, with no rule written yet.
+        Legal ONLY where no error code exists (the catch-all handler, an uncoded
+        frame failure); never for a named :class:`ErrorCode`. A measured
+        burn-down bucket, not a resting place.
+    """
+
+    USER = "user"
+    CLIENT = "client"
+    CONFIG = "config"
+    SERVER = "server"
+    UPSTREAM = "upstream"
+    UNKNOWN = "unknown"
+
+
+class ErrorImpact(str, Enum):
+    """Whether an error actually halted progress on the session/task.
+
+    Orthogonal to :class:`ErrorCategory`. ``category`` answers "whose fault";
+    ``impact`` answers "did the unit of work actually stop". A server-owned
+    ``wrong_replica`` or a recovered retry is not blocking despite looking
+    alarming, so the two axes must be read together.
+
+    :cvar BLOCKING: Halted the current turn/task, or left the session unable to
+        proceed without intervention. The lost-progress signal for SLOs.
+    :cvar TRANSIENT: Interrupted but self-recovering (a retry, a reconnect wait,
+        a re-address). Progress is delayed, not lost, unless it later escalates
+        to BLOCKING at the turn's terminal boundary.
+    :cvar BENIGN: Surfaced or rejected without threatening progress (a bad
+        request the session shrugs off, a single denied action, informational).
+    :cvar UNKNOWN: Could not be determined. Used when an arbitrary logged
+        exception has no code to read impact from; never for a named
+        :class:`ErrorCode`. The turn's terminal outcome stays authoritative.
+    """
+
+    BLOCKING = "blocking"
+    TRANSIENT = "transient"
+    BENIGN = "benign"
+    UNKNOWN = "unknown"
+
 
 class ErrorCode:
     """
@@ -108,6 +169,85 @@ _CODE_TO_HTTP_STATUS: dict[str, int] = {
 }
 
 
+# Fault attribution per error code. Single source of truth, paired with
+# _CODE_TO_HTTP_STATUS above. Every ErrorCode MUST have a concrete (non-UNKNOWN)
+# entry; a test asserts it so a new code cannot merge uncategorized.
+_CODE_TO_CATEGORY: dict[str, ErrorCategory] = {
+    # A human presented no credential, lacks permission, or referenced something
+    # absent or already-taken. INVALID_INPUT defaults to user (a business-rule
+    # rejection of a well-formed request); the schema/transport layer raises it
+    # with category=CLIENT instead (a malformed request is the caller's bug).
+    ErrorCode.UNAUTHORIZED: ErrorCategory.USER,
+    ErrorCode.FORBIDDEN: ErrorCategory.USER,
+    ErrorCode.NOT_FOUND: ErrorCategory.USER,
+    ErrorCode.INVALID_INPUT: ErrorCategory.USER,
+    ErrorCode.ALREADY_EXISTS: ErrorCategory.USER,
+    ErrorCode.CONFLICT: ErrorCategory.USER,
+    # Our fault, raised where the site knows it is ours.
+    ErrorCode.INTERNAL_ERROR: ErrorCategory.SERVER,
+    ErrorCode.HARNESS_PROTOCOL_VIOLATION: ErrorCategory.SERVER,
+    # WRONG_REPLICA is a routing/sharding artifact we own. It is expected and
+    # self-healing, so it must not page: keep alert severity a separate axis.
+    ErrorCode.WRONG_REPLICA: ErrorCategory.SERVER,
+    # A valid request the caller cannot fix by retry or re-input; the
+    # deployment/host must change.
+    ErrorCode.RUNNER_UNAVAILABLE: ErrorCategory.CONFIG,
+    ErrorCode.RUNNER_CAPABILITY_MISMATCH: ErrorCategory.CONFIG,
+    ErrorCode.HARNESS_NOT_CONFIGURED: ErrorCategory.CONFIG,
+    # The human deleted their own workspace on the host.
+    ErrorCode.WORKSPACE_MISSING: ErrorCategory.USER,
+}
+
+
+def category_for_code(code: str) -> ErrorCategory:
+    """Return the fault attribution for an error code.
+
+    :param code: An :class:`ErrorCode` string value.
+    :returns: The mapped category, or ``UNKNOWN`` for a code outside the
+        :class:`ErrorCode` namespace. A named ``ErrorCode`` is always mapped
+        (enforced by test), so ``UNKNOWN`` here means the code is not one.
+    """
+    return _CODE_TO_CATEGORY.get(code, ErrorCategory.UNKNOWN)
+
+
+# Typical progress impact per error code. This is a DEFAULT: the authoritative
+# blocking signal for a session/task is the turn's terminal outcome (see
+# omnigent.runtime.session_stream._log_turn_outcome), which overrides a
+# nominally-TRANSIENT error that ultimately fails the turn. Every ErrorCode MUST
+# have an entry (a test asserts it).
+_CODE_TO_IMPACT: dict[str, ErrorImpact] = {
+    # Nothing proceeds until the caller authenticates.
+    ErrorCode.UNAUTHORIZED: ErrorImpact.BLOCKING,
+    ErrorCode.INTERNAL_ERROR: ErrorImpact.BLOCKING,
+    ErrorCode.HARNESS_PROTOCOL_VIOLATION: ErrorImpact.BLOCKING,
+    # Launch-time hard stops: the task cannot start until the host/deploy changes.
+    ErrorCode.RUNNER_CAPABILITY_MISMATCH: ErrorImpact.BLOCKING,
+    ErrorCode.HARNESS_NOT_CONFIGURED: ErrorImpact.BLOCKING,
+    ErrorCode.WORKSPACE_MISSING: ErrorImpact.BLOCKING,
+    # Self-healing: a session state that resumes on reconnect, and a routing
+    # artifact the client re-addresses. No progress is lost.
+    ErrorCode.RUNNER_UNAVAILABLE: ErrorImpact.TRANSIENT,
+    ErrorCode.WRONG_REPLICA: ErrorImpact.TRANSIENT,
+    # A single rejected request; the session stays healthy and usable.
+    ErrorCode.FORBIDDEN: ErrorImpact.BENIGN,
+    ErrorCode.NOT_FOUND: ErrorImpact.BENIGN,
+    ErrorCode.INVALID_INPUT: ErrorImpact.BENIGN,
+    ErrorCode.ALREADY_EXISTS: ErrorImpact.BENIGN,
+    ErrorCode.CONFLICT: ErrorImpact.BENIGN,
+}
+
+
+def impact_for_code(code: str) -> ErrorImpact:
+    """Return the typical progress impact for an error code.
+
+    :param code: An :class:`ErrorCode` string value.
+    :returns: The mapped impact, or ``BENIGN`` for a code outside the
+        :class:`ErrorCode` namespace (an unrecognized code has not shown itself
+        to block; the turn's terminal outcome stays the authoritative override).
+    """
+    return _CODE_TO_IMPACT.get(code, ErrorImpact.BENIGN)
+
+
 class OmnigentError(Exception):
     """
     Application-level error with a machine-readable code.
@@ -116,17 +256,34 @@ class OmnigentError(Exception):
     exception handler converts it to a JSON response automatically.
     """
 
-    def __init__(self, message: str, *, code: str = ErrorCode.INTERNAL_ERROR) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = ErrorCode.INTERNAL_ERROR,
+        category: ErrorCategory | None = None,
+        impact: ErrorImpact | None = None,
+    ) -> None:
         """
         Create a new application error.
 
         :param message: Human-readable error description.
         :param code: Machine-readable error code from
             :class:`ErrorCode`, e.g. ``ErrorCode.NOT_FOUND``.
+        :param category: Fault-attribution override. Defaults to the mapping for
+            ``code`` (see :func:`category_for_code`); pass it only where the same
+            code has two causes, e.g. a schema-layer ``INVALID_INPUT`` that is a
+            client bug rather than a user typo.
+        :param impact: Progress-impact override. Defaults to the mapping for
+            ``code`` (see :func:`impact_for_code`); pass it where the raise site
+            knows the actual outcome, e.g. a normally-benign code that this time
+            aborted the turn.
         """
         super().__init__(message)
         self.code = code
         self.message = message
+        self._category_override = category
+        self._impact_override = impact
 
     @property
     def http_status(self) -> int:
@@ -137,6 +294,23 @@ class OmnigentError(Exception):
             Defaults to 500 for unknown codes.
         """
         return _CODE_TO_HTTP_STATUS.get(self.code, 500)
+
+    @property
+    def category(self) -> ErrorCategory:
+        """Fault attribution: the constructor override if given, else the code's
+        mapping."""
+        return self._category_override or category_for_code(self.code)
+
+    @property
+    def impact(self) -> ErrorImpact:
+        """Progress impact: the constructor override if given, else the code's
+        mapping."""
+        return self._impact_override or impact_for_code(self.code)
+
+    @property
+    def blocking(self) -> bool:
+        """True when this error halts the turn/task (``impact`` is BLOCKING)."""
+        return self.impact is ErrorImpact.BLOCKING
 
 
 class ElicitationDeclinedError(Exception):
@@ -156,3 +330,47 @@ class ElicitationDeclinedError(Exception):
     def __init__(self, message: str = "", *, policy_name: str | None = None) -> None:
         super().__init__(message)
         self.policy_name = policy_name
+
+
+# Exception type names (matched across the MRO) treated as a transient upstream
+# transport blip. Matched by name so this module imports no httpx / starlette.
+_TRANSPORT_EXC_NAMES = frozenset(
+    {
+        "HTTPError",
+        "TransportError",
+        "TimeoutException",
+        "NetworkError",
+        "ConnectError",
+        "ConnectTimeout",
+        "ReadTimeout",
+        "PoolTimeout",
+        "RemoteProtocolError",
+        "WebSocketDisconnect",
+    }
+)
+
+
+def classify_exception(exc: BaseException) -> tuple[ErrorCategory, ErrorImpact]:
+    """Best-effort (category, impact) for any logged exception.
+
+    The debug-log sink calls this for every record carrying ``exc_info`` that a
+    callsite did not already attribute, so exception logs across the whole
+    codebase are covered without per-site edits.
+
+    - :class:`OmnigentError` (and its subclasses) keep their own axes.
+    - Transport failures (connection/timeout, plus httpx / WebSocket disconnects
+      matched by type name) read as a transient upstream blip.
+    - Anything else is genuinely unattributed: UNKNOWN on both axes rather than a
+      guessed owner. The turn's terminal outcome remains the authoritative
+      blocking signal.
+
+    :param exc: The exception to classify.
+    :returns: A ``(category, impact)`` pair.
+    """
+    if isinstance(exc, OmnigentError):
+        return exc.category, exc.impact
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return ErrorCategory.UPSTREAM, ErrorImpact.TRANSIENT
+    if _TRANSPORT_EXC_NAMES.intersection(klass.__name__ for klass in type(exc).__mro__):
+        return ErrorCategory.UPSTREAM, ErrorImpact.TRANSIENT
+    return ErrorCategory.UNKNOWN, ErrorImpact.UNKNOWN

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -439,6 +439,10 @@ class ElicitationDeclinedError(Exception):
 
 # Exception type names (matched across the MRO) treated as a transient upstream
 # transport blip. Matched by name so this module imports no httpx / starlette.
+# Best-effort and deliberately coarse: a same-named exception from unrelated code
+# (e.g. urllib's HTTPError on a fetch that is really our bug) mis-buckets as
+# upstream. Acceptable for an aggregate fault-share signal, not an exact ledger;
+# a raise site that knows better raises OmnigentError with explicit axes.
 _TRANSPORT_EXC_NAMES = frozenset(
     {
         "HTTPError",
@@ -474,6 +478,9 @@ def classify_exception(exc: BaseException) -> tuple[ErrorCategory, ErrorImpact]:
     """
     if isinstance(exc, OmnigentError):
         return exc.category, exc.impact
+    # ConnectionError/TimeoutError are OSError subclasses: this also catches an
+    # internal asyncio timeout on a slow server-side call (really ours) as
+    # upstream. Same best-effort trade-off as the name set below.
     if isinstance(exc, (ConnectionError, TimeoutError)):
         return ErrorCategory.UPSTREAM, ErrorImpact.TRANSIENT
     if _TRANSPORT_EXC_NAMES.intersection(klass.__name__ for klass in type(exc).__mro__):

--- a/omnigent/errors.py
+++ b/omnigent/errors.py
@@ -21,12 +21,17 @@ class ErrorCategory(str, Enum):
     queryable ``error_category`` so failures can be split by owner for
     fault-share, alerting, and remediation.
 
-    :cvar USER: The human's input, choice, or action. Declined an elicitation, a
-        bad path, a stale id, deleted their own workspace, a prompt too large.
-        Working as designed; no software fix.
-    :cvar CLIENT: The calling software (web UI, SDK, integration) formed a bad
-        request: wrong shape, missing field, a token it held but dropped. A
-        correct client would not hit it.
+    :cvar USER: The human's input, choice, or action, including a malformed
+        request from their client. Declined an elicitation, a bad path, a stale
+        id, deleted their own workspace, a prompt too large, a schema-invalid
+        request body. Working as designed; no software fix.
+    :cvar HOST: The host daemon (the machine-side process that spawns runners and
+        owns workspace/harness state): its tunnel dropped, a frame handler
+        crashed, a readiness probe failed.
+    :cvar RUNNER: The runner process (which runs the harness and executes turns):
+        it crashed, exited nonzero, failed to launch, or its tunnel went silent.
+        Distinct from CONFIG, which is "a runner was never provisioned"; RUNNER
+        is "a runner existed and failed".
     :cvar CONFIG: Deployment, credentials, or install is wrong or incomplete: no
         runner deployed, harness not configured, a bad provider key.
     :cvar SERVER: Our bug or internal/infra failure, at a site that knows the
@@ -40,7 +45,8 @@ class ErrorCategory(str, Enum):
     """
 
     USER = "user"
-    CLIENT = "client"
+    HOST = "host"
+    RUNNER = "runner"
     CONFIG = "config"
     SERVER = "server"
     UPSTREAM = "upstream"
@@ -236,9 +242,8 @@ _CODE_TO_HTTP_STATUS: dict[str, int] = {
 # entry; a test asserts it so a new code cannot merge uncategorized.
 _CODE_TO_CATEGORY: dict[str, ErrorCategory] = {
     # A human presented no credential, lacks permission, or referenced something
-    # absent or already-taken. INVALID_INPUT defaults to user (a business-rule
-    # rejection of a well-formed request); the schema/transport layer raises it
-    # with category=CLIENT instead (a malformed request is the caller's bug).
+    # absent or already-taken. All caller-side: USER covers both a business-rule
+    # rejection of a well-formed request and a schema-invalid request body.
     ErrorCode.UNAUTHORIZED: ErrorCategory.USER,
     ErrorCode.FORBIDDEN: ErrorCategory.USER,
     ErrorCode.NOT_FOUND: ErrorCategory.USER,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2132,8 +2132,9 @@ class HostProcess:
             _logger.info("Runner %s exited cleanly (code 0); no crash report", runner_id)
             return
         error = _runner_exit_error(handle.proc.returncode, handle.log_path)
-        # A non-zero runner exit blocks the session; the cause lives in the
-        # unparsed log tail, so the owner and lifecycle stage are unknown.
+        # A non-zero runner exit is a runner-process fault that blocks the
+        # session; the specific cause lives in the unparsed log tail (lifecycle
+        # stage unknown).
         _logger.warning(
             "Runner %s died unexpectedly: %s",
             runner_id,
@@ -2141,7 +2142,7 @@ class HostProcess:
             extra=debug_event(
                 "runner_died",
                 runner_id=runner_id,
-                error_category=ErrorCategory.UNKNOWN.value,
+                error_category=ErrorCategory.RUNNER.value,
                 error_impact=ErrorImpact.BLOCKING.value,
                 error_phase=ErrorPhase.UNKNOWN.value,
             ),

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -33,7 +33,9 @@ from omnigent.debug_logging import (
     ORIGIN_WORKSPACE_ID_ENV_VAR,
     PRIMARY_SESSION_ID_ENV_VAR,
     USER_ID_ENV_VAR,
+    debug_event,
 )
+from omnigent.errors import ErrorCategory, ErrorImpact, ErrorPhase
 from omnigent.gateway_inference import gateway_inference_map
 from omnigent.harness_aliases import canonicalize_harness, is_claude_sdk_harness_name
 from omnigent.harness_availability import HARNESS_BINARY_MISSING, HarnessAvailability
@@ -2130,7 +2132,20 @@ class HostProcess:
             _logger.info("Runner %s exited cleanly (code 0); no crash report", runner_id)
             return
         error = _runner_exit_error(handle.proc.returncode, handle.log_path)
-        _logger.warning("Runner %s died unexpectedly: %s", runner_id, error)
+        # A non-zero runner exit blocks the session; the cause lives in the
+        # unparsed log tail, so the owner and lifecycle stage are unknown.
+        _logger.warning(
+            "Runner %s died unexpectedly: %s",
+            runner_id,
+            error,
+            extra=debug_event(
+                "runner_died",
+                runner_id=runner_id,
+                error_category=ErrorCategory.UNKNOWN.value,
+                error_impact=ErrorImpact.BLOCKING.value,
+                error_phase=ErrorPhase.UNKNOWN.value,
+            ),
+        )
         await self._report_runner_exit(runner_id, error)
 
     async def _report_runner_exit(self, runner_id: str, error: str) -> None:

--- a/omnigent/llms/errors.py
+++ b/omnigent/llms/errors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from omnigent.errors import OmnigentError
+from omnigent.errors import ErrorCategory, ErrorImpact, OmnigentError
 
 # Provider ``exc.code`` / ``exc.body.error.code`` values that signal
 # a context-window overflow.  Currently OpenAI-origin codes; add
@@ -54,6 +54,35 @@ def is_context_length_exceeded(exc: BaseException) -> bool:
     return False
 
 
+def llm_error_category(code: str) -> ErrorCategory:
+    """Fault attribution for an LLM adapter error code.
+
+    LLM codes are a separate namespace from :class:`~omnigent.errors.ErrorCode`
+    (HTTP-status strings plus sentinel words), so they resolve here rather than
+    through ``category_for_code``.
+
+    :param code: The ``code`` on a :class:`RetryableLLMError` /
+        :class:`PermanentLLMError`, e.g. ``"429"``, ``"timeout"``,
+        ``"context_length_exceeded"``.
+    :returns: The mapped :class:`~omnigent.errors.ErrorCategory`.
+    """
+    if code in CONTEXT_EXCEEDED_CODES:
+        return ErrorCategory.USER
+    if code in ("timeout", "connection_error"):
+        # Transport failure. A provider-side network error/timeout is upstream; a
+        # runner tunnel disconnect is really ours, but the code alone can't tell
+        # them apart, so bias away from over-booking SERVER.
+        return ErrorCategory.UPSTREAM
+    if code.isdigit():
+        status = int(code)
+        if status in (401, 403):
+            return ErrorCategory.CONFIG  # bad provider key / gateway
+        if status == 429 or 500 <= status <= 599:
+            return ErrorCategory.UPSTREAM
+        return ErrorCategory.UNKNOWN  # other 4xx: our bad request vs provider policy
+    return ErrorCategory.UNKNOWN
+
+
 @dataclass
 class LLMErrorDetail:
     """
@@ -101,6 +130,17 @@ class RetryableLLMError(OmnigentError):
         super().__init__(message, code=code)
         self.detail = detail
 
+    @property
+    def category(self) -> ErrorCategory:
+        """Resolve attribution from the LLM code namespace, not ``ErrorCode``."""
+        return llm_error_category(self.code)
+
+    @property
+    def impact(self) -> ErrorImpact:
+        """Retryable by definition: transient unless retries exhaust and the turn
+        fails, which the turn's terminal outcome records as blocking."""
+        return ErrorImpact.TRANSIENT
+
 
 class PermanentLLMError(OmnigentError):
     """
@@ -125,6 +165,21 @@ class PermanentLLMError(OmnigentError):
     ) -> None:
         super().__init__(message, code=code)
         self.detail = detail
+
+    @property
+    def category(self) -> ErrorCategory:
+        """Resolve attribution from the LLM code namespace, not ``ErrorCode``.
+
+        ``ContextWindowExceededError`` inherits this; its
+        ``context_length_exceeded`` code resolves to ``USER``.
+        """
+        return llm_error_category(self.code)
+
+    @property
+    def impact(self) -> ErrorImpact:
+        """Not retried, so blocking by default. ``ContextWindowExceededError``
+        overrides this back to transient (it recovers via compaction)."""
+        return ErrorImpact.BLOCKING
 
 
 class ContextWindowExceededError(PermanentLLMError):
@@ -163,3 +218,10 @@ class ContextWindowExceededError(PermanentLLMError):
         super().__init__(message, code=code, detail=detail)
         self.max_context_tokens = max_context_tokens
         self.actual_tokens = actual_tokens
+
+    @property
+    def impact(self) -> ErrorImpact:
+        """Recoverable by compacting the history and retrying, so transient. The
+        turn's terminal outcome still records blocking if the workflow does not
+        catch it and the turn fails."""
+        return ErrorImpact.TRANSIENT

--- a/omnigent/llms/errors.py
+++ b/omnigent/llms/errors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from omnigent.errors import ErrorCategory, ErrorImpact, OmnigentError
+from omnigent.errors import ErrorCategory, ErrorImpact, ErrorPhase, OmnigentError
 
 # Provider ``exc.code`` / ``exc.body.error.code`` values that signal
 # a context-window overflow.  Currently OpenAI-origin codes; add
@@ -141,6 +141,11 @@ class RetryableLLMError(OmnigentError):
         fails, which the turn's terminal outcome records as blocking."""
         return ErrorImpact.TRANSIENT
 
+    @property
+    def phase(self) -> ErrorPhase:
+        """LLM calls happen while a turn is running."""
+        return ErrorPhase.TURN
+
 
 class PermanentLLMError(OmnigentError):
     """
@@ -180,6 +185,12 @@ class PermanentLLMError(OmnigentError):
         """Not retried, so blocking by default. ``ContextWindowExceededError``
         overrides this back to transient (it recovers via compaction)."""
         return ErrorImpact.BLOCKING
+
+    @property
+    def phase(self) -> ErrorPhase:
+        """LLM calls happen while a turn is running (inherited by the context
+        overflow subclass)."""
+        return ErrorPhase.TURN
 
 
 class ContextWindowExceededError(PermanentLLMError):

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -45,7 +45,7 @@ from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
-from omnigent.debug_logging import runner_primary_session_id
+from omnigent.debug_logging import phase_scope, runner_primary_session_id
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
     SessionResourceView,
@@ -53,7 +53,7 @@ from omnigent.entities.session_resources import (
     session_resource_view_to_dict,
     terminal_resource_id,
 )
-from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.errors import ErrorCode, ErrorPhase, OmnigentError
 from omnigent.harness_aliases import (
     canonicalize_harness,
     is_native_harness,
@@ -7237,47 +7237,50 @@ def create_runner_app(
         # can't suppress this turn's legitimate terminal publish.
         _desynced_sessions.discard(conv)
         _desync_terminalized.pop(conv, None)
-        try:
-            await _run_turn_bg_setup_and_stream(msg_body, conv)
-        except _ContextWindowOverflow:
-            # Re-raise so the streaming-phase handler (which publishes the
-            # error event) is never shadowed by the generic except below.
-            raise
-        except asyncio.CancelledError as exc:
-            _logger.error(
-                "turn cancelled for %s: %s",
-                conv,
-                exc,
-                exc_info=True,
-                extra={"session_id": conv},
-            )
-            _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
-            raise
-        except Exception as exc:
-            _logger.error(
-                "turn setup failed for %s: %s",
-                conv,
-                exc,
-                exc_info=True,
-                extra={"session_id": conv},
-            )
-            _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
-        finally:
-            # Permanent-wedge floor: guarantee _active_turns is never left stale,
-            # however the body exits — including a BaseException that escapes
-            # ``except Exception``. A setup-phase abnormal exit otherwise leaves
-            # the slot set and every later message buffers forever.
-            #
-            # Identity compare-and-clear: only finalize when the slot STILL holds
-            # THIS turn's own task. A turn that ended cleanly already popped its
-            # slot via _on_proxy_stream_end, which schedules a continuation that
-            # can bind a NEW turn's task under the same conv — a bare
-            # ``conv in _active_turns`` check would then let this stale finally
-            # clobber the newer turn (the same class of bug the ExecutorAdapter
-            # identity CAS fixes). When the slot is a None sentinel or a
-            # different task, this turn is already accounted for — skip.
-            if _active_turns.get(conv) is _own_task and _own_task is not None:
-                _on_proxy_stream_end(conv)
+        # Locate any uncoded exception logged below in the turn phase (this task's
+        # context carries it for its lifetime). Coded errors keep their own phase.
+        with phase_scope(ErrorPhase.TURN):
+            try:
+                await _run_turn_bg_setup_and_stream(msg_body, conv)
+            except _ContextWindowOverflow:
+                # Re-raise so the streaming-phase handler (which publishes the
+                # error event) is never shadowed by the generic except below.
+                raise
+            except asyncio.CancelledError as exc:
+                _logger.error(
+                    "turn cancelled for %s: %s",
+                    conv,
+                    exc,
+                    exc_info=True,
+                    extra={"session_id": conv},
+                )
+                _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
+                raise
+            except Exception as exc:
+                _logger.error(
+                    "turn setup failed for %s: %s",
+                    conv,
+                    exc,
+                    exc_info=True,
+                    extra={"session_id": conv},
+                )
+                _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
+            finally:
+                # Permanent-wedge floor: guarantee _active_turns is never left stale,
+                # however the body exits — including a BaseException that escapes
+                # ``except Exception``. A setup-phase abnormal exit otherwise leaves
+                # the slot set and every later message buffers forever.
+                #
+                # Identity compare-and-clear: only finalize when the slot STILL holds
+                # THIS turn's own task. A turn that ended cleanly already popped its
+                # slot via _on_proxy_stream_end, which schedules a continuation that
+                # can bind a NEW turn's task under the same conv — a bare
+                # ``conv in _active_turns`` check would then let this stale finally
+                # clobber the newer turn (the same class of bug the ExecutorAdapter
+                # identity CAS fixes). When the slot is a None sentinel or a
+                # different task, this turn is already accounted for — skip.
+                if _active_turns.get(conv) is _own_task and _own_task is not None:
+                    _on_proxy_stream_end(conv)
 
     def _turn_reasoning(conv: str, msg_body: _JsonObject) -> _JsonObject | None:
         """Reasoning block to forward on a turn, or ``None`` when unset.

--- a/omnigent/runtime/harnesses/_executor_adapter.py
+++ b/omnigent/runtime/harnesses/_executor_adapter.py
@@ -21,7 +21,8 @@ from typing import Any
 
 from fastapi import Response
 
-from omnigent.errors import ElicitationDeclinedError
+from omnigent.debug_logging import phase_scope
+from omnigent.errors import ElicitationDeclinedError, ErrorPhase
 from omnigent.inner.executor import (
     CompactionComplete,
     CompactionStarted,
@@ -236,7 +237,7 @@ class ExecutorAdapter(HarnessApp):
                     trace_cm = trace_context_for_response(response_id=ctx.response_id)
                 except Exception:
                     _logger.debug("trace_context_for_response unavailable", exc_info=True)
-            with session_scope(turn_session_id), trace_cm:
+            with session_scope(turn_session_id), phase_scope(ErrorPhase.TURN), trace_cm:
                 if tctx is not None:
                     agent_span = tctx.start_agent_span(
                         agent_name=request.model or "unknown",

--- a/omnigent/runtime/llm_retry.py
+++ b/omnigent/runtime/llm_retry.py
@@ -364,6 +364,7 @@ def _emit_retry_and_sleep(
             "llm_retry",
             error_category=error.category.value,
             error_impact=error.impact.value,
+            error_phase=error.phase.value,
             error_code=error.code,
         ),
     )

--- a/omnigent/runtime/llm_retry.py
+++ b/omnigent/runtime/llm_retry.py
@@ -17,6 +17,7 @@ from typing import Any, TypeVar
 
 import httpx
 
+from omnigent.debug_logging import debug_event
 from omnigent.llms.errors import (
     ContextWindowExceededError,
     LLMErrorDetail,
@@ -359,5 +360,11 @@ def _emit_retry_and_sleep(
         total_tries,
         delay,
         error.code,
+        extra=debug_event(
+            "llm_retry",
+            error_category=error.category.value,
+            error_impact=error.impact.value,
+            error_code=error.code,
+        ),
     )
     time.sleep(delay)

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -39,6 +39,7 @@ from omnigent.debug_logging import (
     debug_sink_enabled,
     sse_event_logger,
 )
+from omnigent.errors import ErrorImpact
 from omnigent.runtime import inflight_text, pending_elicitations
 
 _logger = logging.getLogger(__name__)
@@ -102,6 +103,16 @@ _TURN_OUTCOME_BY_EVENT_TYPE = {
     "response.failed": "failed",
     "response.cancelled": "cancelled",
     "response.incomplete": "incomplete",
+}
+# The authoritative progress-impact per turn outcome: this is where "the task
+# actually stopped" is known, so it overrides any per-error code default (a
+# nominally-transient retry that ultimately failed the turn lands here as
+# blocking). ``completed`` carries no impact; ``cancelled`` is a user-initiated
+# stop, not lost progress.
+_TURN_OUTCOME_IMPACT = {
+    "failed": ErrorImpact.BLOCKING,
+    "incomplete": ErrorImpact.BLOCKING,
+    "cancelled": ErrorImpact.BENIGN,
 }
 # Top-level event fields safe to log — stable identifiers, closed enums, and
 # pure numerics only. Deliberately excludes human/LLM-authored free text
@@ -200,6 +211,9 @@ def _log_turn_outcome(conversation_id: str, event_type: str, event: dict[str, An
         error = event.get("error")
         if isinstance(error, dict) and error.get("code") is not None:
             attributes["error_code"] = str(error["code"])
+        impact = _TURN_OUTCOME_IMPACT.get(outcome)
+        if impact is not None:
+            attributes["error_impact"] = impact.value
     level = logging.WARNING if outcome in ("failed", "incomplete") else logging.INFO
     audit_event_logger().log(level, "turn %s", outcome, extra=extra)
 

--- a/omnigent/runtime/session_stream.py
+++ b/omnigent/runtime/session_stream.py
@@ -39,7 +39,7 @@ from omnigent.debug_logging import (
     debug_sink_enabled,
     sse_event_logger,
 )
-from omnigent.errors import ErrorImpact
+from omnigent.errors import ErrorImpact, ErrorPhase
 from omnigent.runtime import inflight_text, pending_elicitations
 
 _logger = logging.getLogger(__name__)
@@ -214,6 +214,8 @@ def _log_turn_outcome(conversation_id: str, event_type: str, event: dict[str, An
         impact = _TURN_OUTCOME_IMPACT.get(outcome)
         if impact is not None:
             attributes["error_impact"] = impact.value
+            # A terminal turn outcome is, by definition, in the turn phase.
+            attributes["error_phase"] = ErrorPhase.TURN.value
     level = logging.WARNING if outcome in ("failed", "incomplete") else logging.INFO
     audit_event_logger().log(level, "turn %s", outcome, extra=extra)
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Any, Literal, Protocol
 
 from fastapi import FastAPI, Query, Request
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -36,7 +38,7 @@ from omnigent.debug_logging import (
     set_current_session_id,
     set_current_user_id,
 )
-from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, OmnigentError
 from omnigent.extensions import ExtensionPluginState
 from omnigent.extensions.assets import (
     ResolvedBundle,
@@ -1848,7 +1850,12 @@ def create_app(
                 "Runner unavailable: %s",
                 exc.message,
                 extra=_error_audit_extra(
-                    request, phase="unavailable", code=str(exc.code), http_status="503"
+                    request,
+                    phase="unavailable",
+                    code=str(exc.code),
+                    http_status="503",
+                    error_category=exc.category.value,
+                    error_impact=exc.impact.value,
                 ),
             )
         elif exc.http_status >= 500:
@@ -1857,7 +1864,11 @@ def create_app(
                 exc.message,
                 exc_info=exc,
                 extra=_error_audit_extra(
-                    request, code=str(exc.code), http_status=str(exc.http_status)
+                    request,
+                    code=str(exc.code),
+                    http_status=str(exc.http_status),
+                    error_category=exc.category.value,
+                    error_impact=exc.impact.value,
                 ),
             )
         elif exc.http_status == 400 and request.url.path.endswith("/policies/evaluate"):
@@ -1866,13 +1877,45 @@ def create_app(
                 request.url.path,
                 exc.message,
                 extra=_error_audit_extra(
-                    request, phase="rejected", code=str(exc.code), http_status="400"
+                    request,
+                    phase="rejected",
+                    code=str(exc.code),
+                    http_status="400",
+                    error_category=exc.category.value,
+                    error_impact=exc.impact.value,
                 ),
             )
         return JSONResponse(
             status_code=exc.http_status,
             content={"error": {"code": exc.code, "message": exc.message}},
         )
+
+    @app.exception_handler(RequestValidationError)
+    async def _handle_validation_error(
+        request: Request,
+        exc: RequestValidationError,
+    ) -> JSONResponse:
+        """Log schema-validation rejections as client faults, then return the
+        stock 422 body.
+
+        A request that fails schema/transport validation is the calling
+        software's bug, not the human's (category=client), and it rejects one
+        request without harming the session (impact=benign). The response is
+        delegated to FastAPI's default handler so the 422 shape is unchanged.
+        """
+        _logger.warning(
+            "Request validation failed on %s",
+            request.url.path,
+            extra=_error_audit_extra(
+                request,
+                phase="rejected",
+                code=str(ErrorCode.INVALID_INPUT),
+                http_status="422",
+                error_category=ErrorCategory.CLIENT.value,
+                error_impact=ErrorImpact.BENIGN.value,
+            ),
+        )
+        return await request_validation_exception_handler(request, exc)
 
     @app.exception_handler(StatementError)
     async def _handle_statement_error(
@@ -1898,7 +1941,20 @@ def create_app(
             # Keep a trace: a malformed id is usually a client bug, but this
             # branch would otherwise mask a server-side id-generation defect
             # as a routine 404.
-            _logger.debug("Malformed id mapped to 404: %s", exc.orig)
+            _logger.debug(
+                "Malformed id mapped to 404: %s",
+                exc.orig,
+                extra=_error_audit_extra(
+                    request,
+                    phase="not_found",
+                    code=str(ErrorCode.NOT_FOUND),
+                    http_status="404",
+                    # A malformed id is the caller sending a value no row can
+                    # ever address, not a human referencing a real-but-gone one.
+                    error_category=ErrorCategory.CLIENT.value,
+                    error_impact=ErrorImpact.BENIGN.value,
+                ),
+            )
             return JSONResponse(
                 status_code=404,
                 content={"error": {"code": ErrorCode.NOT_FOUND, "message": "Not found."}},
@@ -1908,7 +1964,11 @@ def create_app(
             exc,
             exc_info=exc,
             extra=_error_audit_extra(
-                request, code=str(ErrorCode.INTERNAL_ERROR), http_status="500"
+                request,
+                code=str(ErrorCode.INTERNAL_ERROR),
+                http_status="500",
+                error_category=ErrorCategory.SERVER.value,
+                error_impact=ErrorImpact.BLOCKING.value,
             ),
         )
         return JSONResponse(
@@ -1936,12 +1996,21 @@ def create_app(
         :param exc: The unhandled exception.
         :returns: A 500 JSON response with ``internal_error`` code.
         """
+        # UNKNOWN, not SERVER: an uncaught exception has no code that confirms the
+        # fault is ours. Booking it as server would inflate our fault rate; the
+        # exception type is logged as a signature to rank for promotion to a real
+        # category. The client still gets internal_error / 500.
         _logger.error(
             "Unhandled exception: %s",
             exc,
             exc_info=exc,
             extra=_error_audit_extra(
-                request, code=str(ErrorCode.INTERNAL_ERROR), http_status="500"
+                request,
+                code=str(ErrorCode.INTERNAL_ERROR),
+                http_status="500",
+                error_category=ErrorCategory.UNKNOWN.value,
+                error_impact=ErrorImpact.BLOCKING.value,
+                error_type=type(exc).__name__,
             ),
         )
         return JSONResponse(

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -1913,20 +1913,19 @@ def create_app(
     ) -> JSONResponse:
         """Attribute schema-validation rejections, then return the stock 422 body.
 
-        A request that fails schema/transport validation is the calling
-        software's bug, not the human's (category=client), and it rejects one
-        request without harming the session (impact=benign). Attribution rides
-        the per-request audit row rather than a dedicated ERROR/WARN line; the
-        response is delegated to FastAPI's default handler so the 422 shape is
-        unchanged.
+        A schema/transport-invalid request is caller-side input (category=user),
+        and it rejects one request without harming the session (impact=benign).
+        Attribution rides the per-request audit row rather than a dedicated
+        ERROR/WARN line; the response is delegated to FastAPI's default handler
+        so the 422 shape is unchanged.
         """
         # Attribute on the per-request audit row, not the ERROR stream: a schema
-        # rejection is a client fault but expected and low-signal, so it should be
+        # rejection is expected, low-signal caller input, so it should be
         # queryable without adding noise where the 500s must stand out.
         add_audit_attrs(
             code=str(ErrorCode.INVALID_INPUT),
             http_status="422",
-            error_category=ErrorCategory.CLIENT.value,
+            error_category=ErrorCategory.USER.value,
             error_impact=ErrorImpact.BENIGN.value,
             error_phase=ErrorPhase.REQUEST.value,
         )
@@ -1953,12 +1952,12 @@ def create_app(
         :returns: 404 for a malformed id, otherwise a 500 JSON response.
         """
         if isinstance(exc.orig, InvalidUuidError):
-            # A malformed id is the caller sending a value no row can ever
-            # address, not a human referencing a real-but-gone one.
+            # A malformed id is caller-side input (a value no row can ever
+            # address), not a human referencing a real-but-gone one.
             add_audit_attrs(
                 code=str(ErrorCode.NOT_FOUND),
                 http_status="404",
-                error_category=ErrorCategory.CLIENT.value,
+                error_category=ErrorCategory.USER.value,
                 error_impact=ErrorImpact.BENIGN.value,
                 error_phase=ErrorPhase.REQUEST.value,
             )

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -30,6 +30,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from omnigent._platform import resolve_repo_symlink
 from omnigent.db.db_models import InvalidUuidError
 from omnigent.debug_logging import (
+    add_audit_attrs,
     audit_event_logger,
     current_request_audit_attrs,
     debug_event,
@@ -1840,6 +1841,18 @@ def create_app(
         :param exc: The application error.
         :returns: A JSON response with the error code and message.
         """
+        # Stamp attribution onto the per-request audit-envelope row (table-only,
+        # one per request) for EVERY code, so the 4xx we deliberately don't log
+        # to the ERROR stream are still queryable by owner/impact/phase. The
+        # dedicated ERROR/WARN logs below stay reserved for the 5xx and the
+        # offline-runner state, keeping the ERROR stream low-noise (see #6242).
+        add_audit_attrs(
+            code=str(exc.code),
+            http_status=str(exc.http_status),
+            error_category=exc.category.value,
+            error_impact=exc.impact.value,
+            error_phase=exc.phase.value,
+        )
         if exc.code == ErrorCode.RUNNER_UNAVAILABLE:
             # A session state, not a fault: the user's machine is asleep or
             # the host disconnected, and clients render it as a reconnect
@@ -1898,26 +1911,24 @@ def create_app(
         request: Request,
         exc: RequestValidationError,
     ) -> JSONResponse:
-        """Log schema-validation rejections as client faults, then return the
-        stock 422 body.
+        """Attribute schema-validation rejections, then return the stock 422 body.
 
         A request that fails schema/transport validation is the calling
         software's bug, not the human's (category=client), and it rejects one
-        request without harming the session (impact=benign). The response is
-        delegated to FastAPI's default handler so the 422 shape is unchanged.
+        request without harming the session (impact=benign). Attribution rides
+        the per-request audit row rather than a dedicated ERROR/WARN line; the
+        response is delegated to FastAPI's default handler so the 422 shape is
+        unchanged.
         """
-        _logger.warning(
-            "Request validation failed on %s",
-            request.url.path,
-            extra=_error_audit_extra(
-                request,
-                phase="rejected",
-                code=str(ErrorCode.INVALID_INPUT),
-                http_status="422",
-                error_category=ErrorCategory.CLIENT.value,
-                error_impact=ErrorImpact.BENIGN.value,
-                error_phase=ErrorPhase.REQUEST.value,
-            ),
+        # Attribute on the per-request audit row, not the ERROR stream: a schema
+        # rejection is a client fault but expected and low-signal, so it should be
+        # queryable without adding noise where the 500s must stand out.
+        add_audit_attrs(
+            code=str(ErrorCode.INVALID_INPUT),
+            http_status="422",
+            error_category=ErrorCategory.CLIENT.value,
+            error_impact=ErrorImpact.BENIGN.value,
+            error_phase=ErrorPhase.REQUEST.value,
         )
         return await request_validation_exception_handler(request, exc)
 
@@ -1942,24 +1953,19 @@ def create_app(
         :returns: 404 for a malformed id, otherwise a 500 JSON response.
         """
         if isinstance(exc.orig, InvalidUuidError):
+            # A malformed id is the caller sending a value no row can ever
+            # address, not a human referencing a real-but-gone one.
+            add_audit_attrs(
+                code=str(ErrorCode.NOT_FOUND),
+                http_status="404",
+                error_category=ErrorCategory.CLIENT.value,
+                error_impact=ErrorImpact.BENIGN.value,
+                error_phase=ErrorPhase.REQUEST.value,
+            )
             # Keep a trace: a malformed id is usually a client bug, but this
             # branch would otherwise mask a server-side id-generation defect
             # as a routine 404.
-            _logger.debug(
-                "Malformed id mapped to 404: %s",
-                exc.orig,
-                extra=_error_audit_extra(
-                    request,
-                    phase="not_found",
-                    code=str(ErrorCode.NOT_FOUND),
-                    http_status="404",
-                    # A malformed id is the caller sending a value no row can
-                    # ever address, not a human referencing a real-but-gone one.
-                    error_category=ErrorCategory.CLIENT.value,
-                    error_impact=ErrorImpact.BENIGN.value,
-                    error_phase=ErrorPhase.REQUEST.value,
-                ),
-            )
+            _logger.debug("Malformed id mapped to 404: %s", exc.orig)
             return JSONResponse(
                 status_code=404,
                 content={"error": {"code": ErrorCode.NOT_FOUND, "message": "Not found."}},

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -38,7 +38,7 @@ from omnigent.debug_logging import (
     set_current_session_id,
     set_current_user_id,
 )
-from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, OmnigentError
+from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, ErrorPhase, OmnigentError
 from omnigent.extensions import ExtensionPluginState
 from omnigent.extensions.assets import (
     ResolvedBundle,
@@ -1856,6 +1856,7 @@ def create_app(
                     http_status="503",
                     error_category=exc.category.value,
                     error_impact=exc.impact.value,
+                    error_phase=exc.phase.value,
                 ),
             )
         elif exc.http_status >= 500:
@@ -1869,6 +1870,7 @@ def create_app(
                     http_status=str(exc.http_status),
                     error_category=exc.category.value,
                     error_impact=exc.impact.value,
+                    error_phase=exc.phase.value,
                 ),
             )
         elif exc.http_status == 400 and request.url.path.endswith("/policies/evaluate"):
@@ -1883,6 +1885,7 @@ def create_app(
                     http_status="400",
                     error_category=exc.category.value,
                     error_impact=exc.impact.value,
+                    error_phase=exc.phase.value,
                 ),
             )
         return JSONResponse(
@@ -1913,6 +1916,7 @@ def create_app(
                 http_status="422",
                 error_category=ErrorCategory.CLIENT.value,
                 error_impact=ErrorImpact.BENIGN.value,
+                error_phase=ErrorPhase.REQUEST.value,
             ),
         )
         return await request_validation_exception_handler(request, exc)
@@ -1953,6 +1957,7 @@ def create_app(
                     # ever address, not a human referencing a real-but-gone one.
                     error_category=ErrorCategory.CLIENT.value,
                     error_impact=ErrorImpact.BENIGN.value,
+                    error_phase=ErrorPhase.REQUEST.value,
                 ),
             )
             return JSONResponse(
@@ -1969,6 +1974,7 @@ def create_app(
                 http_status="500",
                 error_category=ErrorCategory.SERVER.value,
                 error_impact=ErrorImpact.BLOCKING.value,
+                error_phase=ErrorPhase.UNKNOWN.value,
             ),
         )
         return JSONResponse(
@@ -2010,6 +2016,7 @@ def create_app(
                 http_status="500",
                 error_category=ErrorCategory.UNKNOWN.value,
                 error_impact=ErrorImpact.BLOCKING.value,
+                error_phase=ErrorPhase.UNKNOWN.value,
                 error_type=type(exc).__name__,
             ),
         )

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -599,13 +599,11 @@ async def _receive_loop(
             continue
 
         if isinstance(frame, HostRunnerExitedFrame):
-            # One-way report: a runner this host spawned died
-            # unexpectedly. Stash the cause so the runner status
-            # endpoint can answer "offline, and here is why" to the
-            # client still waiting for the runner to connect.
-            # A runner this host spawned died; the cause lives in the free-text
-            # tail we have not parsed, so the owner is unknown. It blocks a client
-            # waiting for that runner to connect.
+            # One-way report: a runner this host spawned died unexpectedly. Stash
+            # the cause so the runner status endpoint can answer "offline, and
+            # here is why" to the client still waiting for the runner to connect.
+            # The cause is a free-text tail we have not parsed, so the owner is
+            # unknown; it blocks that waiting client.
             _logger.warning(
                 "Host %s reported runner %s exited: %s",
                 host_id,

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -602,8 +602,8 @@ async def _receive_loop(
             # One-way report: a runner this host spawned died unexpectedly. Stash
             # the cause so the runner status endpoint can answer "offline, and
             # here is why" to the client still waiting for the runner to connect.
-            # The cause is a free-text tail we have not parsed, so the owner is
-            # unknown; it blocks that waiting client.
+            # A runner-process fault; the free-text cause is unparsed, so the
+            # lifecycle stage is unknown.
             _logger.warning(
                 "Host %s reported runner %s exited: %s",
                 host_id,
@@ -613,7 +613,7 @@ async def _receive_loop(
                     "runner_exited",
                     host_id=host_id,
                     runner_id=frame.runner_id,
-                    error_category=ErrorCategory.UNKNOWN.value,
+                    error_category=ErrorCategory.RUNNER.value,
                     error_impact=ErrorImpact.BLOCKING.value,
                     # The runner may have died before or during a turn; the host
                     # can't tell from the exit alone.

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 from omnigent.debug_logging import debug_event, set_current_user_id
-from omnigent.errors import ErrorCategory, ErrorImpact
+from omnigent.errors import ErrorCategory, ErrorImpact, ErrorPhase
 from omnigent.host.frames import (
     HostConnectionErrorFrame,
     HostCreateDirResultFrame,
@@ -617,6 +617,9 @@ async def _receive_loop(
                     runner_id=frame.runner_id,
                     error_category=ErrorCategory.UNKNOWN.value,
                     error_impact=ErrorImpact.BLOCKING.value,
+                    # The runner may have died before or during a turn; the host
+                    # can't tell from the exit alone.
+                    error_phase=ErrorPhase.UNKNOWN.value,
                 ),
             )
             if runner_exit_reports is not None:

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -27,6 +27,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from omnigent.db.db_models import InvalidUuidError, uuid_to_bytes
 from omnigent.debug_logging import debug_event, set_current_user_id
+from omnigent.errors import ErrorCategory, ErrorImpact
 from omnigent.host.frames import (
     HostConnectionErrorFrame,
     HostCreateDirResultFrame,
@@ -602,11 +603,21 @@ async def _receive_loop(
             # unexpectedly. Stash the cause so the runner status
             # endpoint can answer "offline, and here is why" to the
             # client still waiting for the runner to connect.
+            # A runner this host spawned died; the cause lives in the free-text
+            # tail we have not parsed, so the owner is unknown. It blocks a client
+            # waiting for that runner to connect.
             _logger.warning(
                 "Host %s reported runner %s exited: %s",
                 host_id,
                 frame.runner_id,
                 frame.error,
+                extra=debug_event(
+                    "runner_exited",
+                    host_id=host_id,
+                    runner_id=frame.runner_id,
+                    error_category=ErrorCategory.UNKNOWN.value,
+                    error_impact=ErrorImpact.BLOCKING.value,
+                ),
             )
             if runner_exit_reports is not None:
                 runner_exit_reports.record(frame.runner_id, frame.error, conn.owner)

--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -760,7 +760,7 @@ async def _ping_loop(
                 elapsed,
                 extra=debug_event(
                     "runner_ping_timeout",
-                    error_category=ErrorCategory.UPSTREAM.value,
+                    error_category=ErrorCategory.RUNNER.value,
                     error_impact=ErrorImpact.BLOCKING.value,
                     error_phase=ErrorPhase.UNKNOWN.value,
                 ),

--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -24,7 +24,7 @@ from ipaddress import ip_address
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
 
 from omnigent.debug_logging import debug_event
-from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, ErrorPhase, OmnigentError
 from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
 from omnigent.runner.transports.ws_tunnel.frames import (
     HelloFrame,
@@ -751,11 +751,19 @@ async def _ping_loop(
         if elapsed is None:
             return
         if elapsed > PING_INTERVAL_S * PING_MISS_THRESHOLD:
+            # Runner tunnel went silent past the liveness window: the runner or
+            # its network died, blocking sessions on it until it reconnects.
             _logger.warning(
                 "Runner %s missed %d ping intervals (%.0fs since last frame); declaring dead",
                 runner_id,
                 PING_MISS_THRESHOLD,
                 elapsed,
+                extra=debug_event(
+                    "runner_ping_timeout",
+                    error_category=ErrorCategory.UPSTREAM.value,
+                    error_impact=ErrorImpact.BLOCKING.value,
+                    error_phase=ErrorPhase.UNKNOWN.value,
+                ),
             )
             try:
                 await ws.close(code=4003, reason="ping timeout")

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -38,7 +38,7 @@ from omnigent.entities import (
     synthesize_conversation_title,
 )
 from omnigent.entities.permission import SessionPermission
-from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, OmnigentError
 from omnigent.models.model_override import validate_model_override
 from omnigent.runner.identity import (
     RUNNER_TUNNEL_TOKEN_HEADER,
@@ -455,11 +455,21 @@ def register_core_routes(
             launch_result = {"status": "failed", "error": "host launch timed out"}
         launch_failed = launch_result.get("status") == "failed"
         if launch_failed:
+            # No structured error_code on this generic launch-failure path, so
+            # the specific owner is unknown; it does block the session from
+            # starting. Coded failures (harness_not_configured, etc.) are
+            # attributed where they raise as OmnigentError.
             _logger.warning(
                 "Host %s failed to launch runner for session %s: %s",
                 host_id,
                 session_id,
                 launch_result.get("error"),
+                extra=debug_event(
+                    "runner_launch_failed",
+                    session_id=session_id,
+                    error_category=ErrorCategory.UNKNOWN.value,
+                    error_impact=ErrorImpact.BLOCKING.value,
+                ),
             )
         return runner_id, launch_failed
 

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -38,7 +38,7 @@ from omnigent.entities import (
     synthesize_conversation_title,
 )
 from omnigent.entities.permission import SessionPermission
-from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, OmnigentError
+from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, ErrorPhase, OmnigentError
 from omnigent.models.model_override import validate_model_override
 from omnigent.runner.identity import (
     RUNNER_TUNNEL_TOKEN_HEADER,
@@ -469,6 +469,7 @@ def register_core_routes(
                     session_id=session_id,
                     error_category=ErrorCategory.UNKNOWN.value,
                     error_impact=ErrorImpact.BLOCKING.value,
+                    error_phase=ErrorPhase.RUNNER_LAUNCH.value,
                 ),
             )
         return runner_id, launch_failed

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -455,10 +455,10 @@ def register_core_routes(
             launch_result = {"status": "failed", "error": "host launch timed out"}
         launch_failed = launch_result.get("status") == "failed"
         if launch_failed:
-            # No structured error_code on this generic launch-failure path, so
-            # the specific owner is unknown; it does block the session from
-            # starting. Coded failures (harness_not_configured, etc.) are
-            # attributed where they raise as OmnigentError.
+            # The runner failed to come up (generic launch-failure path with no
+            # structured error_code), blocking the session at launch. A coded
+            # deployment failure (harness_not_configured, etc.) is attributed
+            # CONFIG where it raises as OmnigentError.
             _logger.warning(
                 "Host %s failed to launch runner for session %s: %s",
                 host_id,
@@ -467,7 +467,7 @@ def register_core_routes(
                 extra=debug_event(
                     "runner_launch_failed",
                     session_id=session_id,
-                    error_category=ErrorCategory.UNKNOWN.value,
+                    error_category=ErrorCategory.RUNNER.value,
                     error_impact=ErrorImpact.BLOCKING.value,
                     error_phase=ErrorPhase.RUNNER_LAUNCH.value,
                 ),

--- a/tests/runtime/test_llm_retry.py
+++ b/tests/runtime/test_llm_retry.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from omnigent.errors import ErrorCategory, ErrorImpact
+from omnigent.errors import ErrorCategory, ErrorImpact, ErrorPhase
 from omnigent.llms.errors import (
     ContextWindowExceededError,
     LLMErrorDetail,
@@ -530,4 +530,19 @@ def test_llm_error_impact() -> None:
             actual_tokens=2000,
         ).impact
         is ErrorImpact.TRANSIENT
+    )
+
+
+def test_llm_error_phase_is_turn() -> None:
+    """LLM failures happen while a turn is running, regardless of code."""
+    assert RetryableLLMError("rate limited", code="429").phase is ErrorPhase.TURN
+    assert PermanentLLMError("bad key", code="401").phase is ErrorPhase.TURN
+    assert (
+        ContextWindowExceededError(
+            "too big",
+            code="context_length_exceeded",
+            max_context_tokens=1000,
+            actual_tokens=2000,
+        ).phase
+        is ErrorPhase.TURN
     )

--- a/tests/runtime/test_llm_retry.py
+++ b/tests/runtime/test_llm_retry.py
@@ -8,7 +8,14 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from omnigent.llms.errors import LLMErrorDetail, PermanentLLMError, RetryableLLMError
+from omnigent.errors import ErrorCategory, ErrorImpact
+from omnigent.llms.errors import (
+    ContextWindowExceededError,
+    LLMErrorDetail,
+    PermanentLLMError,
+    RetryableLLMError,
+    llm_error_category,
+)
 from omnigent.runtime.llm_retry import (
     classify_llm_error,
     compute_backoff_delay,
@@ -460,3 +467,67 @@ def test_detail_to_dict_with_empty_detail() -> None:
     # All fields are None → empty dict → collapsed to None.
     # Failure would mean empty dicts leak into the SSE event payload.
     assert result is None
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        ("timeout", ErrorCategory.UPSTREAM),
+        ("connection_error", ErrorCategory.UPSTREAM),
+        ("429", ErrorCategory.UPSTREAM),
+        ("503", ErrorCategory.UPSTREAM),
+        ("401", ErrorCategory.CONFIG),
+        ("403", ErrorCategory.CONFIG),
+        ("400", ErrorCategory.UNKNOWN),
+        ("unknown_error", ErrorCategory.UNKNOWN),
+        ("context_length_exceeded", ErrorCategory.USER),
+    ],
+)
+def test_llm_error_category(code: str, expected: ErrorCategory) -> None:
+    """LLM codes resolve in their own namespace, not through ErrorCode."""
+    assert llm_error_category(code) == expected
+
+
+def test_classified_llm_errors_carry_category(retryable_status_codes: list[int]) -> None:
+    """The classifier's results expose the right fault attribution.
+
+    A provider 429 is upstream, a provider 401 is config (bad key), a timeout is
+    upstream. This is what the retry log and any dashboard read off ``.category``.
+    """
+    rate_limited = classify_llm_error(
+        httpx.HTTPStatusError(
+            "429", request=MagicMock(), response=httpx.Response(429, text="slow down")
+        ),
+        retryable_status_codes,
+    )
+    assert rate_limited.category is ErrorCategory.UPSTREAM
+
+    bad_key = classify_llm_error(
+        httpx.HTTPStatusError(
+            "401", request=MagicMock(), response=httpx.Response(401, text="unauthorized")
+        ),
+        retryable_status_codes,
+    )
+    assert bad_key.category is ErrorCategory.CONFIG
+
+    timed_out = classify_llm_error(httpx.TimeoutException("slow"), retryable_status_codes)
+    assert timed_out.category is ErrorCategory.UPSTREAM
+
+
+def test_llm_error_impact() -> None:
+    """Retryable is transient; permanent blocks; context-overflow recovers.
+
+    The context-window case is the notable one: it subclasses PermanentLLMError
+    but is transient because the workflow can compact and retry.
+    """
+    assert RetryableLLMError("rate limited", code="429").impact is ErrorImpact.TRANSIENT
+    assert PermanentLLMError("bad key", code="401").impact is ErrorImpact.BLOCKING
+    assert (
+        ContextWindowExceededError(
+            "too big",
+            code="context_length_exceeded",
+            max_context_tokens=1000,
+            actual_tokens=2000,
+        ).impact
+        is ErrorImpact.TRANSIENT
+    )

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -926,4 +926,10 @@ def test_log_sse_event_emits_turn_finished_on_terminal(monkeypatch: pytest.Monke
     assert completed.attributes == {"outcome": "completed", "response_id": "resp_1"}
     failed = records[1]
     assert failed.levelno == logging.WARNING
-    assert failed.attributes == {"outcome": "failed", "error_code": "timeout"}  # no message text
+    # A failed turn is the authoritative blocking signal; error_impact rides the
+    # same row so "sessions actually blocked" is a direct query. No message text.
+    assert failed.attributes == {
+        "outcome": "failed",
+        "error_code": "timeout",
+        "error_impact": "blocking",
+    }

--- a/tests/runtime/test_session_stream.py
+++ b/tests/runtime/test_session_stream.py
@@ -932,4 +932,5 @@ def test_log_sse_event_emits_turn_finished_on_terminal(monkeypatch: pytest.Monke
         "outcome": "failed",
         "error_code": "timeout",
         "error_impact": "blocking",
+        "error_phase": "turn",
     }

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -253,6 +253,60 @@ def test_record_to_row_explicit_attributes_win_over_derived() -> None:
     assert attrs == {"error_category": "server", "error_impact": "blocking"}
 
 
+def test_phase_scope_stamps_error_phase_on_logged_exception() -> None:
+    """An error logged inside a phase_scope inherits where it failed, even when
+    the exception carries no error code."""
+    import sys
+
+    from omnigent.errors import ErrorPhase
+
+    with dl.phase_scope(ErrorPhase.HARNESS_STARTUP):
+        try:
+            raise ValueError("spawn blew up")
+        except ValueError:
+            record = logging.LogRecord(
+                "omnigent", logging.ERROR, __file__, 1, "failed", (), sys.exc_info()
+            )
+        attrs = dl.record_to_row(record, source="runner")["attributes"]
+    assert attrs["error_phase"] == "harness_startup"
+    # And the arbitrary exception still auto-attributes category/impact.
+    assert attrs["error_category"] == "unknown"
+
+
+def test_coded_error_phase_wins_over_ambient_scope() -> None:
+    """A coded OmnigentError's own (concrete) phase beats the ambient scope, so
+    a harness_not_configured raised during a runner-launch scope still reads
+    harness_setup (the useful, semantic location)."""
+    import sys
+
+    from omnigent.errors import ErrorCode, ErrorPhase, OmnigentError
+
+    with dl.phase_scope(ErrorPhase.RUNNER_LAUNCH):
+        try:
+            raise OmnigentError("no harness", code=ErrorCode.HARNESS_NOT_CONFIGURED)
+        except OmnigentError:
+            record = logging.LogRecord(
+                "omnigent", logging.ERROR, __file__, 1, "failed", (), sys.exc_info()
+            )
+        attrs = dl.record_to_row(record, source="server")["attributes"]
+    assert attrs["error_phase"] == "harness_setup"
+
+
+def test_no_phase_when_no_code_and_no_scope() -> None:
+    """Outside any scope, an uncoded exception gets no error_phase (we don't
+    guess a location)."""
+    import sys
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = logging.LogRecord(
+            "omnigent", logging.ERROR, __file__, 1, "failed", (), sys.exc_info()
+        )
+    attrs = dl.record_to_row(record, source="server")["attributes"]
+    assert "error_phase" not in attrs
+
+
 def test_debug_event_builds_extra() -> None:
     assert dl.debug_event("evt", a=1, b="x") == {
         "event_name": "evt",

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -200,6 +200,59 @@ def test_record_to_row_captures_stack_trace() -> None:
     assert "ValueError: boom" in (row["stack_trace"] or "")
 
 
+def test_record_to_row_auto_attributes_logged_exception() -> None:
+    """A record with exc_info gets error_category/error_impact derived from the
+    exception, so every exc_info=… log site is covered without per-site edits.
+
+    An arbitrary exception is UNKNOWN on both axes (no guessed owner); the sink
+    does not need the callsite to have classified it.
+    """
+    import sys
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = logging.LogRecord(
+            "omnigent", logging.ERROR, __file__, 1, "failed", (), sys.exc_info()
+        )
+    attrs = dl.record_to_row(record, source="server")["attributes"]
+    assert attrs == {"error_category": "unknown", "error_impact": "unknown"}
+
+
+def test_record_to_row_auto_attributes_omnigent_error_from_its_axes() -> None:
+    """An OmnigentError logged via exc_info carries its own code-derived axes."""
+    import sys
+
+    from omnigent.errors import ErrorCode, OmnigentError
+
+    try:
+        raise OmnigentError("gone", code=ErrorCode.RUNNER_UNAVAILABLE)
+    except OmnigentError:
+        record = logging.LogRecord(
+            "omnigent", logging.ERROR, __file__, 1, "failed", (), sys.exc_info()
+        )
+    attrs = dl.record_to_row(record, source="server")["attributes"]
+    # runner_unavailable is config-owned and self-healing.
+    assert attrs["error_category"] == "config"
+    assert attrs["error_impact"] == "transient"
+
+
+def test_record_to_row_explicit_attributes_win_over_derived() -> None:
+    """An explicit error_category/error_impact on the record is never overwritten
+    by the exception-derived fallback."""
+    import sys
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        record = logging.LogRecord(
+            "omnigent", logging.ERROR, __file__, 1, "failed", (), sys.exc_info()
+        )
+    record.attributes = {"error_category": "server", "error_impact": "blocking"}
+    attrs = dl.record_to_row(record, source="server")["attributes"]
+    assert attrs == {"error_category": "server", "error_impact": "blocking"}
+
+
 def test_debug_event_builds_extra() -> None:
     assert dl.debug_event("evt", a=1, b="x") == {
         "event_name": "evt",

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -307,6 +307,30 @@ def test_no_phase_when_no_code_and_no_scope() -> None:
     assert "error_phase" not in attrs
 
 
+def test_benign_row_in_phase_scope_is_not_stamped() -> None:
+    """A non-error log line inside a phase_scope must NOT inherit error_phase.
+
+    phase_scope wraps the whole turn loop, so benign INFO/DEBUG telemetry (and
+    high-volume SSE-event rows) flow through here. Stamping them would pollute
+    the error_phase column, so only rows that are actually errors (an exception,
+    or an explicit category/impact) get located.
+    """
+    from omnigent.errors import ErrorPhase
+
+    with dl.phase_scope(ErrorPhase.TURN):
+        info = logging.LogRecord("omnigent.runtime.x", logging.INFO, __file__, 1, "hi", (), None)
+        info_attrs = dl.record_to_row(info, source="runner")["attributes"]
+        # A bare WARNING with no exception and no explicit error attrs is not an
+        # error row either; it stays clean.
+        warn = logging.LogRecord(
+            "omnigent.runtime.x", logging.WARNING, __file__, 1, "hm", (), None
+        )
+        warn_attrs = dl.record_to_row(warn, source="runner")["attributes"]
+    assert "error_phase" not in info_attrs
+    assert "error_category" not in info_attrs
+    assert "error_phase" not in warn_attrs
+
+
 def test_debug_event_builds_extra() -> None:
     assert dl.debug_event("evt", a=1, b="x") == {
         "event_name": "evt",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,13 +8,17 @@ from omnigent.errors import (
     _CODE_TO_CATEGORY,
     _CODE_TO_HTTP_STATUS,
     _CODE_TO_IMPACT,
+    _CODE_TO_PHASE,
     ErrorCategory,
     ErrorCode,
     ErrorImpact,
+    ErrorPhase,
     OmnigentError,
     category_for_code,
     classify_exception,
     impact_for_code,
+    is_before_harness_start,
+    phase_for_code,
 )
 
 
@@ -239,3 +243,55 @@ def test_classify_exception_arbitrary_is_unknown() -> None:
         ErrorCategory.UNKNOWN,
         ErrorImpact.UNKNOWN,
     )
+
+
+def test_every_error_code_has_a_phase() -> None:
+    """Every named ErrorCode declares a lifecycle phase (UNKNOWN allowed).
+
+    Unlike category/impact, UNKNOWN is a valid phase for a generic code
+    (internal_error) because the phase is context-driven, not code-driven.
+    """
+    for code in _all_error_code_values():
+        assert code in _CODE_TO_PHASE, f"{code!r} missing from _CODE_TO_PHASE"
+        assert isinstance(_CODE_TO_PHASE[code], ErrorPhase)
+
+
+@pytest.mark.parametrize(
+    "code,expected_phase,before_start",
+    [
+        (ErrorCode.INVALID_INPUT, ErrorPhase.REQUEST, True),
+        (ErrorCode.UNAUTHORIZED, ErrorPhase.REQUEST, True),
+        (ErrorCode.WRONG_REPLICA, ErrorPhase.ROUTING, True),
+        (ErrorCode.RUNNER_UNAVAILABLE, ErrorPhase.RUNNER_LAUNCH, True),
+        (ErrorCode.HARNESS_NOT_CONFIGURED, ErrorPhase.HARNESS_SETUP, True),
+        (ErrorCode.WORKSPACE_MISSING, ErrorPhase.HARNESS_SETUP, True),
+        (ErrorCode.HARNESS_PROTOCOL_VIOLATION, ErrorPhase.TURN, False),
+        (ErrorCode.INTERNAL_ERROR, ErrorPhase.UNKNOWN, False),
+    ],
+)
+def test_code_phase_and_harness_boundary(
+    code: str, expected_phase: ErrorPhase, before_start: bool
+) -> None:
+    """Pin the phase per code and the before/after-harness-start split."""
+    assert phase_for_code(code) == expected_phase
+    assert is_before_harness_start(expected_phase) is before_start
+
+
+def test_omnigent_error_phase_default_and_override() -> None:
+    """`phase` follows the code by default; a raise-site override wins."""
+    assert (
+        OmnigentError("no harness", code=ErrorCode.HARNESS_NOT_CONFIGURED).phase
+        is ErrorPhase.HARNESS_SETUP
+    )
+    assert (
+        OmnigentError("boom", code=ErrorCode.INTERNAL_ERROR, phase=ErrorPhase.TURN).phase
+        is ErrorPhase.TURN
+    )
+
+
+def test_harness_boundary_is_startup_not_before() -> None:
+    """The harness *start* itself (HARNESS_STARTUP) is not 'before start'."""
+    assert is_before_harness_start(ErrorPhase.HARNESS_SETUP) is True
+    assert is_before_harness_start(ErrorPhase.HARNESS_STARTUP) is False
+    assert is_before_harness_start(ErrorPhase.TURN) is False
+    assert is_before_harness_start(ErrorPhase.UNKNOWN) is False

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,7 +4,27 @@ from __future__ import annotations
 
 import pytest
 
-from omnigent.errors import _CODE_TO_HTTP_STATUS, ErrorCode, OmnigentError
+from omnigent.errors import (
+    _CODE_TO_CATEGORY,
+    _CODE_TO_HTTP_STATUS,
+    _CODE_TO_IMPACT,
+    ErrorCategory,
+    ErrorCode,
+    ErrorImpact,
+    OmnigentError,
+    category_for_code,
+    classify_exception,
+    impact_for_code,
+)
+
+
+def _all_error_code_values() -> list[str]:
+    """Every string constant declared on :class:`ErrorCode`."""
+    return [
+        value
+        for name, value in vars(ErrorCode).items()
+        if not name.startswith("_") and isinstance(value, str)
+    ]
 
 
 def test_harness_protocol_violation_string_value() -> None:
@@ -65,3 +85,157 @@ def test_all_error_codes_have_http_status_mapping(code: str, expected_status: in
     default.
     """
     assert _CODE_TO_HTTP_STATUS[code] == expected_status
+
+
+def test_every_error_code_has_a_concrete_category() -> None:
+    """Anti-rot: a named ErrorCode may never be UNKNOWN or unmapped.
+
+    UNKNOWN is reserved for sites with no error code (the catch-all handler, an
+    uncoded frame failure). If a new ErrorCode is added without a
+    ``_CODE_TO_CATEGORY`` entry, this fails rather than letting it default into
+    the honesty-margin bucket and silently skew the fault-share numbers.
+    """
+    for code in _all_error_code_values():
+        assert code in _CODE_TO_CATEGORY, f"{code!r} missing from _CODE_TO_CATEGORY"
+        assert _CODE_TO_CATEGORY[code] is not ErrorCategory.UNKNOWN, (
+            f"{code!r} maps to UNKNOWN; a named code must attribute a concrete owner"
+        )
+
+
+@pytest.mark.parametrize(
+    "code,expected_category",
+    [
+        (ErrorCode.INTERNAL_ERROR, ErrorCategory.SERVER),
+        (ErrorCode.HARNESS_PROTOCOL_VIOLATION, ErrorCategory.SERVER),
+        (ErrorCode.WRONG_REPLICA, ErrorCategory.SERVER),
+        (ErrorCode.RUNNER_UNAVAILABLE, ErrorCategory.CONFIG),
+        (ErrorCode.HARNESS_NOT_CONFIGURED, ErrorCategory.CONFIG),
+        (ErrorCode.RUNNER_CAPABILITY_MISMATCH, ErrorCategory.CONFIG),
+        (ErrorCode.NOT_FOUND, ErrorCategory.USER),
+        (ErrorCode.INVALID_INPUT, ErrorCategory.USER),
+        (ErrorCode.UNAUTHORIZED, ErrorCategory.USER),
+        (ErrorCode.WORKSPACE_MISSING, ErrorCategory.USER),
+    ],
+)
+def test_code_category_mapping(code: str, expected_category: ErrorCategory) -> None:
+    """Pin the intent of the attribution for the codes that drive dashboards."""
+    assert category_for_code(code) == expected_category
+
+
+def test_omnigent_error_category_defaults_from_code() -> None:
+    """An OmnigentError inherits its code's category when none is passed."""
+    assert OmnigentError("boom").category is ErrorCategory.SERVER  # default code
+    assert OmnigentError("nope", code=ErrorCode.NOT_FOUND).category is ErrorCategory.USER
+
+
+def test_omnigent_error_category_override() -> None:
+    """The override wins, for a code whose cause is context-dependent.
+
+    A schema-layer INVALID_INPUT is a client bug, not the user's typo.
+    """
+    err = OmnigentError(
+        "bad request body",
+        code=ErrorCode.INVALID_INPUT,
+        category=ErrorCategory.CLIENT,
+    )
+    assert err.category is ErrorCategory.CLIENT
+    # The code's default is still USER when not overridden.
+    assert category_for_code(ErrorCode.INVALID_INPUT) is ErrorCategory.USER
+
+
+def test_category_for_unknown_code_is_unknown() -> None:
+    """A code outside the ErrorCode namespace attributes to UNKNOWN."""
+    assert category_for_code("not_a_real_code") is ErrorCategory.UNKNOWN
+
+
+def test_every_error_code_has_an_impact() -> None:
+    """Every named ErrorCode must declare a progress impact.
+
+    Adding a code without an ``_CODE_TO_IMPACT`` entry fails here rather than
+    silently defaulting; the value must be a real :class:`ErrorImpact`.
+    """
+    for code in _all_error_code_values():
+        assert code in _CODE_TO_IMPACT, f"{code!r} missing from _CODE_TO_IMPACT"
+        assert isinstance(_CODE_TO_IMPACT[code], ErrorImpact)
+        # UNKNOWN impact is only for arbitrary exceptions with no code.
+        assert _CODE_TO_IMPACT[code] is not ErrorImpact.UNKNOWN, (
+            f"{code!r} maps to UNKNOWN impact; a named code must declare a concrete one"
+        )
+
+
+@pytest.mark.parametrize(
+    "code,expected_impact",
+    [
+        # Blocking: the turn/task cannot proceed without intervention.
+        (ErrorCode.INTERNAL_ERROR, ErrorImpact.BLOCKING),
+        (ErrorCode.HARNESS_NOT_CONFIGURED, ErrorImpact.BLOCKING),
+        (ErrorCode.WORKSPACE_MISSING, ErrorImpact.BLOCKING),
+        (ErrorCode.UNAUTHORIZED, ErrorImpact.BLOCKING),
+        # Transient: self-healing, no lost progress.
+        (ErrorCode.RUNNER_UNAVAILABLE, ErrorImpact.TRANSIENT),
+        (ErrorCode.WRONG_REPLICA, ErrorImpact.TRANSIENT),
+        # Benign: a rejected request that leaves the session healthy.
+        (ErrorCode.NOT_FOUND, ErrorImpact.BENIGN),
+        (ErrorCode.INVALID_INPUT, ErrorImpact.BENIGN),
+        (ErrorCode.FORBIDDEN, ErrorImpact.BENIGN),
+    ],
+)
+def test_code_impact_mapping(code: str, expected_impact: ErrorImpact) -> None:
+    """Pin the intent: which codes actually block progress, which self-heal."""
+    assert impact_for_code(code) == expected_impact
+
+
+def test_omnigent_error_impact_and_blocking_flag() -> None:
+    """``impact`` defaults from the code; ``blocking`` is the simple boolean."""
+    internal = OmnigentError("boom")  # default code INTERNAL_ERROR
+    assert internal.impact is ErrorImpact.BLOCKING
+    assert internal.blocking is True
+
+    unavailable = OmnigentError("asleep", code=ErrorCode.RUNNER_UNAVAILABLE)
+    assert unavailable.impact is ErrorImpact.TRANSIENT
+    assert unavailable.blocking is False
+
+
+def test_omnigent_error_impact_override() -> None:
+    """A raise site that knows the real outcome can override the code default.
+
+    A normally-benign invalid_input that aborted the turn is blocking.
+    """
+    err = OmnigentError(
+        "aborted mid-turn",
+        code=ErrorCode.INVALID_INPUT,
+        impact=ErrorImpact.BLOCKING,
+    )
+    assert err.impact is ErrorImpact.BLOCKING
+    assert err.blocking is True
+
+
+def test_classify_exception_omnigent_error_passthrough() -> None:
+    """An OmnigentError classifies to its own axes."""
+    err = OmnigentError("gone", code=ErrorCode.HARNESS_NOT_CONFIGURED)
+    assert classify_exception(err) == (ErrorCategory.CONFIG, ErrorImpact.BLOCKING)
+
+
+def test_classify_exception_transport_is_transient_upstream() -> None:
+    """Stdlib transport failures read as a transient upstream blip.
+
+    ``ConnectionError`` / ``TimeoutError`` are caught directly; httpx / starlette
+    types are matched by name (see :data:`omnigent.errors._TRANSPORT_EXC_NAMES`)
+    without importing those packages, exercised in the debug-logging tests.
+    """
+    assert classify_exception(ConnectionError("reset")) == (
+        ErrorCategory.UPSTREAM,
+        ErrorImpact.TRANSIENT,
+    )
+    assert classify_exception(TimeoutError("slow")) == (
+        ErrorCategory.UPSTREAM,
+        ErrorImpact.TRANSIENT,
+    )
+
+
+def test_classify_exception_arbitrary_is_unknown() -> None:
+    """An unattributable exception is UNKNOWN on both axes, not a guessed owner."""
+    assert classify_exception(ValueError("nope")) == (
+        ErrorCategory.UNKNOWN,
+        ErrorImpact.UNKNOWN,
+    )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -133,23 +133,33 @@ def test_omnigent_error_category_defaults_from_code() -> None:
 
 
 def test_omnigent_error_category_override() -> None:
-    """The override wins, for a code whose cause is context-dependent.
+    """The override wins over the code's default category.
 
-    A schema-layer INVALID_INPUT is a client bug, not the user's typo.
+    A NOT_FOUND raised while the server itself generated a bad id is a server
+    fault, not the user's stale reference.
     """
     err = OmnigentError(
-        "bad request body",
-        code=ErrorCode.INVALID_INPUT,
-        category=ErrorCategory.CLIENT,
+        "internally generated id not found",
+        code=ErrorCode.NOT_FOUND,
+        category=ErrorCategory.SERVER,
     )
-    assert err.category is ErrorCategory.CLIENT
+    assert err.category is ErrorCategory.SERVER
     # The code's default is still USER when not overridden.
-    assert category_for_code(ErrorCode.INVALID_INPUT) is ErrorCategory.USER
+    assert category_for_code(ErrorCode.NOT_FOUND) is ErrorCategory.USER
 
 
 def test_category_for_unknown_code_is_unknown() -> None:
     """A code outside the ErrorCode namespace attributes to UNKNOWN."""
     assert category_for_code("not_a_real_code") is ErrorCategory.UNKNOWN
+
+
+def test_category_taxonomy_is_topology_aware() -> None:
+    """The owner set models deployment topology: host and runner are first-class,
+    and the ambiguous ``client`` bucket is gone."""
+    values = {c.value for c in ErrorCategory}
+    assert {"host", "runner"} <= values
+    assert "client" not in values
+    assert not hasattr(ErrorCategory, "CLIENT")
 
 
 def test_every_error_code_has_an_impact() -> None:


### PR DESCRIPTION
## Related issue

N/A — internal observability instrumentation (*Refactor / chore*). No user-facing behavior change: response bodies are unchanged; only debug-log rows gain fields.

## Summary

Classifies every error the server / runner / host logs along three orthogonal axes, emitted into the debug-log `attributes` map so failures are queryable by owner, by whether they stopped work, and by where they failed:

- **`error_category`** (whose fault): `user` / `client` / `config` / `server` / `upstream` / `unknown`
- **`error_impact`** (did it block progress): `blocking` / `transient` / `benign` / `unknown`
- **`error_phase`** (where in the lifecycle): `request` / `routing` / `runner_launch` / `harness_setup` / `harness_startup` / `turn` / `teardown` / `unknown`

`OmnigentError` carries all three, defaulted per error code (a single source of truth beside the HTTP-status map) and override-able at the raise site. LLM errors resolve category from their own code namespace (429/5xx → upstream, context-overflow → user, provider 401/403 → config) and are always `turn` phase. The FastAPI handlers, the LLM retry log, and the `turn_finished` audit row emit all three; `turn_finished` is the authoritative "did the task actually block" signal — a nominally-transient error that ends up failing the turn lands there as `blocking`.

To cover the many scattered `_logger.exception(...)` / `exc_info=` sites without per-site edits, the debug-log sink auto-derives category/impact from any record carrying an exception (`classify_exception`): an `OmnigentError` keeps its own axes, transport errors read `upstream/transient`, anything else is honestly `unknown/unknown`. Explicit call-site values always win. For phase, an ambient `phase_scope(...)` ContextVar marks the active lifecycle region (wired around the runner turn loop) so even an uncoded exception is located; the sink stamps `error_phase` with coded-phase-wins-over-scope precedence. `is_before_harness_start(phase)` gives the common "did it fail before or after the harness started" split. Tests enforce that every named `ErrorCode` maps to a concrete (non-`unknown`) category and impact.

**All 4xx are attributed too, not just the logged 5xx.** Only 5xx (and the offline-runner 503) were ever logged, so client/user rejections (`400`/`404`/`409`/`401`/`403`, `422`) carried no attributed row. The handlers now stamp the three axes onto the **per-request audit-envelope row** — which already fires once per request and is table-only — for every `OmnigentError`, plus the 422 and malformed-id 404 paths. No new log lines and no ERROR-stream noise (the 500s still stand out, the concern behind #6242); it reuses the existing row and drops the now-redundant dedicated 422 WARN / 404 DEBUG-extra. 4xx are captured at the default INFO level and filterable via `error_impact = benign` / `error_category in (user, client)`.

### ELI5

Every error gets three labels before it hits the logs table: whose fault it was, whether it actually stopped the user's work, and where in the flow it happened (e.g. before vs after the harness started). Most labels fill in automatically from the exception or the active region, so we don't touch every log line.

### Flow

```
raise / log ─┬─ OmnigentError(code[, category, impact, phase])  ─┐
             ├─ LLM error (RetryableLLMError, …)                 ├─ (category, impact, phase)
             └─ any exc_info log ── classify_exception ──────────┘        │
                              + ambient phase_scope(region)                │
                                                                           ▼
              debug_logging.record_to_row → attributes{error_category, error_impact, error_phase}
                 (4xx ride the per-request audit-envelope row instead of a dedicated log)
                                                                           ▼
                                        ZeroBus insert  →  Delta debug-logs table
```

The axes are independent: `wrong_replica` is `server`-owned, `transient`, in `routing`; `harness_not_configured` is `config`, `blocking`, in `harness_setup` (before start); an LLM 429 is `upstream`, `transient`, in `turn` (after start).

## Test Plan

- `pre-commit run --files <changed>` — ruff format/check, pyrefly types, and repo hooks all pass.
- **Unit + server** (`pytest tests/test_errors.py tests/test_debug_logging.py tests/runtime/test_llm_retry.py tests/runtime/test_session_stream.py tests/server/test_app.py` → **210 passed**, plus the executor-adapter and process-manager suites for the `phase_scope(TURN)` wrap): the code→(category, impact, phase) maps + enforcement, the harness-boundary helper, the LLM code namespace, `OmnigentError` overrides, the `turn_finished` blocking/turn row, and the sink auto-stamp (derive from exc, `OmnigentError` keeps its axes, `phase_scope` locates uncoded exceptions, coded-phase beats ambient, explicit wins).
- **Live E2E** (real `omnigent server` + local mock ZeroBus + OIDC capture): errors caused over HTTP land end-to-end (real token mint + insert POST) with correct dimensions. At default INFO, each previously-silent 4xx now emits one attributed row on its per-request audit envelope:
  - `GET /v1/sessions?limit=abc` → 422 → `client / benign / request`
  - `GET /v1/sessions/<malformed-id>` → 404 → `client / benign / request`
  - bogus event type (**was silent**) → 400 → `user / benign / request`
  - `POST /v1/sessions/{id}/events` (no runner) → 503 → `config / transient / runner_launch`
  - and, by logging real exceptions into the live sink, `server / blocking`, `upstream / transient`, `unknown / unknown`.

### Known follow-up

`error_phase` covers every coded error and uncoded exceptions inside the turn loop. Wrapping the harness-spawn (`_spawn_entry`) and the server/host runner-launch regions in `phase_scope` would also locate *uncoded* exceptions thrown there; the coded harness/launch errors are already phased. An optional aggregate path is emitting the axes as low-cardinality labels on the request metric for a per-response denominator independent of logging.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Non-visual: the live-E2E rows in the Test Plan.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the live E2E above (real server + mock ZeroBus capture), used to confirm the dimensions reach the Delta insert path with correct values and that the previously-silent 4xx now emit attributed rows at the default INFO level. An unhandled 500 (the catch-all handler) cannot be forced through external HTTP against the hardened server, so the sink auto-stamp path was exercised by logging real exceptions into the same live sink instead.

This pull request and its description were written by Isaac.
