### PR TITLE
fix(codex-native): make managed startup transactional

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -1173,6 +1173,9 @@ class CodexNativeAppServer:
         trust keeps that interactive screen from stranding a resumed web
         session (see :func:`trust_all_codex_hooks`). Interactive CLI
         sessions leave it disabled so a human reviews their own hooks.
+    :param readiness_timeout_seconds: Maximum time for app-server readiness.
+        Managed callers may replace the local 10-second default with the
+        remaining portion of their shared startup deadline.
     :param policy_notice_pending: One-shot flag: ``True`` once a degrade
         reason is recorded, until the runner's terminal-ensure handler
         surfaces it to Omnigent (which posts a single durable banner). Prevents
@@ -1204,6 +1207,7 @@ class CodexNativeAppServer:
     trust_project: bool = False
     trust_all_hooks: bool = False
     router_hooks_registered: bool = False
+    readiness_timeout_seconds: float = _CONNECT_TIMEOUT_SECONDS
 
     async def start(self) -> None:
         """
@@ -1567,7 +1571,7 @@ class CodexNativeAppServer:
         :raises RuntimeError: If the app-server exits or never
             becomes ready before the timeout.
         """
-        deadline = asyncio.get_running_loop().time() + _CONNECT_TIMEOUT_SECONDS
+        deadline = asyncio.get_running_loop().time() + self.readiness_timeout_seconds
         last_error: Exception | None = None
         while asyncio.get_running_loop().time() < deadline:
             if self.proc is not None and self.proc.returncode is not None:

--- a/omnigent/codex_native_bridge.py
+++ b/omnigent/codex_native_bridge.py
@@ -22,10 +22,16 @@ from omnigent import native_bridge_common
 CODEX_NATIVE_BRIDGE_ID_LABEL_KEY = "omnigent.codex_native.bridge_id"
 CODEX_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_CODEX_NATIVE_BRIDGE_DIR"
 CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_ID"
+# One end-to-end budget for a managed Codex launch to publish its app-server
+# thread and bridge state. Keep every startup participant on this value.
+CODEX_NATIVE_THREAD_START_TIMEOUT_SECONDS = 180.0
+# Bridge publication may trail the runner deadline by one scheduling handoff.
+CODEX_NATIVE_BRIDGE_STATE_TIMEOUT_SECONDS = CODEX_NATIVE_THREAD_START_TIMEOUT_SECONDS + 5.0
 
 _STATE_FILE = "state.json"
 _STATE_LOCK_FILE = "state.lock"
 _STARTUP_ERROR_FILE = "startup_error.json"
+_STARTUP_GENERATION_FILE = "startup_generation"
 # Per-MCP-server startup state mirrored from Codex's
 # ``mcpServer/startupStatus/updated`` notifications. Written by the
 # forwarder (and by ``wait_for_thread_started`` while it drains startup
@@ -645,6 +651,29 @@ def write_bridge_state(bridge_dir: Path, state: CodexNativeBridgeState) -> None:
         _write_bridge_state_unlocked(bridge_dir, state)
 
 
+def write_bridge_startup_generation(bridge_dir: Path, generation: str) -> None:
+    """Claim bridge runtime ownership for one managed startup generation.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :param generation: Opaque unique token for this launch.
+    :returns: None.
+    """
+    bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with _bridge_state_lock(bridge_dir):
+        path = bridge_dir / _STARTUP_GENERATION_FILE
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f"{_STARTUP_GENERATION_FILE}.",
+            dir=str(bridge_dir),
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(f"{generation}\n")
+            os.replace(tmp_name, path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+
+
 def clear_bridge_state(bridge_dir: Path) -> None:
     """
     Remove stale native Codex runtime state for a bridge directory.
@@ -663,12 +692,46 @@ def clear_bridge_state(bridge_dir: Path) -> None:
         for name in (
             _STATE_FILE,
             _STARTUP_ERROR_FILE,
+            _STARTUP_GENERATION_FILE,
             _MCP_STARTUP_FILE,
         ):
             try:
                 (bridge_dir / name).unlink()
             except FileNotFoundError:
                 continue
+
+
+def clear_bridge_runtime_state(
+    bridge_dir: Path,
+    *,
+    expected_generation: str,
+) -> bool:
+    """Remove live runtime pointers while preserving an actionable startup error.
+
+    Rollback calls this after recording why startup failed. Using
+    :func:`clear_bridge_state` there would also delete ``startup_error.json``
+    and replace the specific runner diagnosis with the executor's generic
+    timeout message. The generation comparison prevents a delayed predecessor
+    from deleting a successor launch's state.
+
+    :param bridge_dir: Native Codex bridge directory.
+    :param expected_generation: Generation token owned by the cleanup caller.
+    :returns: ``True`` when this generation still owned and cleared the runtime
+        files; ``False`` when a successor owns them or no claim exists.
+    """
+    with _bridge_state_lock(bridge_dir):
+        try:
+            current_generation = (
+                (bridge_dir / _STARTUP_GENERATION_FILE).read_text(encoding="utf-8").strip()
+            )
+        except OSError:
+            return False
+        if current_generation != expected_generation:
+            return False
+        for name in (_STATE_FILE, _MCP_STARTUP_FILE, _STARTUP_GENERATION_FILE):
+            with contextlib.suppress(FileNotFoundError):
+                (bridge_dir / name).unlink()
+    return True
 
 
 def write_bridge_startup_error(bridge_dir: Path, message: str) -> None:

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -19,6 +19,7 @@ from omnigent.codex_native_app_server import (
 )
 from omnigent.codex_native_bridge import (
     CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
+    CODEX_NATIVE_BRIDGE_STATE_TIMEOUT_SECONDS,
     CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
     CodexNativeBridgeState,
     cancel_pending_mcp_startup,
@@ -56,6 +57,7 @@ _logger = logging.getLogger(__name__)
 
 _NO_ACTIVE_TURN_ERROR_CODE = -32600
 _NO_ACTIVE_TURN_ERROR_MESSAGE = "no active turn to steer"
+_BRIDGE_STATE_POLL_INTERVAL_SECONDS = 1.0
 
 
 def _is_no_active_turn_to_steer(error: CodexAppServerResponseError) -> bool:
@@ -366,20 +368,23 @@ class CodexNativeExecutor(Executor):
         # Wait for the bridge to boot OUTSIDE the injection lock: this is a
         # one-time poll for the state file to appear (first turn, app-server
         # starting), with no shared-state mutation, so holding the lock
-        # across its up-to-60s wait would needlessly block concurrent
+        # across its bounded startup wait would needlessly block concurrent
         # steering (enqueue_session_message). Once the state exists, the
         # decision/RPC/write below runs under the lock — re-reading state so
         # it's atomic with respect to a steer that landed during the wait.
         state = read_bridge_state(self._bridge_dir)
         if state is None:
-            for _ in range(60):
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + CODEX_NATIVE_BRIDGE_STATE_TIMEOUT_SECONDS
+            while state is None:
                 # Startup already failed; the runner recorded the cause — stop waiting.
                 if read_bridge_startup_error(self._bridge_dir) is not None:
                     break
-                await asyncio.sleep(1.0)
-                state = read_bridge_state(self._bridge_dir)
-                if state is not None:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
                     break
+                await asyncio.sleep(min(_BRIDGE_STATE_POLL_INTERVAL_SECONDS, remaining))
+                state = read_bridge_state(self._bridge_dir)
 
         # No client-side wait for Codex MCP startup: the app-server accepts
         # ``turn/start`` mid-startup and defers execution until the round

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -21,7 +21,7 @@ import urllib.parse
 import uuid
 from collections.abc import Awaitable, Callable, Mapping, MutableMapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, Protocol
+from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, Self
 
 from omnigent.json_types import JsonObject as _JsonObject
 
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from omnigent.claude_native import ClaudeNativeUcodeConfig
     from omnigent.codex_native_app_server import CodexAppServerClient, CodexNativeAppServer
     from omnigent.inner.datamodel import OSEnvSpec
+    from omnigent.inner.terminal import TerminalInstance
     from omnigent.opencode_native_app_server import OpenCodeNativeServer
     from omnigent.opencode_native_client import OpenCodeClient, OpenCodeSession
     from omnigent.opencode_native_forwarder import OpenCodeNativeForwarder
@@ -43,6 +44,7 @@ import httpx
 from fastapi.responses import JSONResponse, Response
 
 from omnigent._platform import IS_WINDOWS
+from omnigent.codex_native_bridge import CODEX_NATIVE_THREAD_START_TIMEOUT_SECONDS
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.entities.session_resources import (
     SessionResourceView,
@@ -88,6 +90,52 @@ _NATIVE_TERMINAL_START_FAILED_CODE = "native_terminal_start_failed"
 _REPL_TERMINAL_NAME = "tui"
 _REPL_TERMINAL_SESSION_KEY = "main"
 _NO_BODY_STATUS_CODES = {204, 304}
+
+
+@dataclasses.dataclass(frozen=True)
+class _CodexManagedStartupDeadline:
+    """One monotonic deadline shared by every managed Codex startup gate."""
+
+    expires_at: float
+    timeout_seconds: float
+
+    @classmethod
+    def start(
+        cls,
+        timeout_seconds: float = CODEX_NATIVE_THREAD_START_TIMEOUT_SECONDS,
+    ) -> Self:
+        """Start a deadline from the current event loop's monotonic clock."""
+        return cls(
+            expires_at=asyncio.get_running_loop().time() + timeout_seconds,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def remaining(self, stage: str) -> float:
+        """Return the remaining budget or raise an actionable stage error."""
+        remaining = self.expires_at - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise TimeoutError(
+                f"Codex managed startup exceeded {self.timeout_seconds:g}s "
+                f"before {stage}. Retry the session; if this repeats, inspect "
+                "the runner log for the named startup stage."
+            )
+        return remaining
+
+    async def run(self, stage: str, operation: Callable[[], Awaitable[Any]]) -> Any:
+        """Run one startup operation within this deadline's remaining budget."""
+        timeout = self.remaining(stage)
+        timeout_context = asyncio.timeout(timeout)
+        try:
+            async with timeout_context:
+                return await operation()
+        except TimeoutError as exc:
+            if not timeout_context.expired():
+                raise
+            raise TimeoutError(
+                f"Codex managed startup exceeded {self.timeout_seconds:g}s "
+                f"while {stage}. Retry the session; if this repeats, inspect "
+                "the runner log for the named startup stage."
+            ) from exc
 
 
 class _EnsureCommentRelay(Protocol):
@@ -216,10 +264,11 @@ async def teardown_codex_native_app_server(session_id: str) -> None:
     :param session_id: Session/conversation id, e.g. ``"conv_abc123"``.
     :returns: None.
     """
-    if session_id not in _AUTO_CODEX_APP_SERVERS:
+    expected_app_server = _AUTO_CODEX_APP_SERVERS.get(session_id)
+    if expected_app_server is None:
         return
     await _cancel_auto_forwarder_task(session_id)
-    leftover_app_server = _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+    leftover_app_server = _pop_expected_codex_app_server(session_id, expected_app_server)
     if leftover_app_server is not None:
         with contextlib.suppress(Exception):
             await leftover_app_server.close()
@@ -249,6 +298,75 @@ async def teardown_all_codex_native_app_servers() -> None:
     for session_id in list(_AUTO_CODEX_APP_SERVERS):
         with contextlib.suppress(Exception):
             await teardown_codex_native_app_server(session_id)
+
+
+def _pop_expected_codex_app_server(
+    session_id: str,
+    expected: CodexNativeAppServer,
+) -> CodexNativeAppServer | None:
+    """Remove an app-server only when this launch still owns the registry slot."""
+    if _AUTO_CODEX_APP_SERVERS.get(session_id) is not expected:
+        return None
+    return _AUTO_CODEX_APP_SERVERS.pop(session_id)
+
+
+async def _rollback_codex_managed_startup(
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    startup_generation: str,
+    resource_registry: SessionResourceRegistry,
+    publish_event: Callable[[str, _JsonObject], None],
+    app_server: CodexNativeAppServer,
+    event_client: CodexAppServerClient | None = None,
+    terminal_instance: TerminalInstance | None = None,
+    terminal_resource_published: bool = False,
+    subagent_router: SubagentRouter | None = None,
+    turn_router: TurnRouter | None = None,
+    clear_bridge: bool = True,
+) -> None:
+    """Roll back exactly one failed managed Codex startup generation."""
+    from omnigent.codex_native_bridge import clear_bridge_runtime_state
+
+    # A resume publishes bridge state before its TUI launch. Retract it first so
+    # a concurrent turn cannot discover the app-server while rollback closes it.
+    if clear_bridge:
+        clear_bridge_runtime_state(
+            bridge_dir,
+            expected_generation=startup_generation,
+        )
+
+    if terminal_instance is not None:
+        terminal_id = terminal_resource_id("codex", "main")
+        closed = False
+        with contextlib.suppress(Exception):
+            closed = await resource_registry.close_terminal(
+                session_id,
+                terminal_id,
+                expected=terminal_instance,
+            )
+        if closed and terminal_resource_published:
+            with contextlib.suppress(Exception):
+                publish_event(
+                    session_id,
+                    {
+                        "type": "session.resource.deleted",
+                        "resource_id": terminal_id,
+                        "resource_type": "terminal",
+                        "session_id": session_id,
+                    },
+                )
+
+    if event_client is not None:
+        with contextlib.suppress(Exception):
+            await event_client.close()
+
+    _pop_expected_codex_app_server(session_id, app_server)
+    with contextlib.suppress(Exception):
+        await app_server.close()
+
+    await _shutdown_session_router_async(session_id, subagent_router)
+    await _shutdown_session_turn_router_async(session_id, turn_router)
 
 
 def _register_auto_forwarder_task(session_id: str, task: asyncio.Task[object]) -> None:
@@ -3850,6 +3968,7 @@ async def _auto_create_codex_terminal(
         codex_home_for_bridge_dir,
         prepare_bridge_dir,
         socket_path_for_bridge_dir,
+        write_bridge_startup_generation,
     )
     from omnigent.inner.codex_executor import codex_extended_catalog_env
     from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
@@ -4192,6 +4311,12 @@ async def _auto_create_codex_terminal(
         # review. See trust_all_codex_hooks.
         trust_all_hooks=True,
     )
+    # From this point onward, every asynchronous launch gate spends from one
+    # monotonic budget. Rollback ownership begins before either router starts.
+    _startup_deadline = _CodexManagedStartupDeadline.start()
+    _startup_generation = uuid.uuid4().hex
+    write_bridge_startup_generation(bridge_dir, _startup_generation)
+
     # Generate routing hooks.json (and bypass codex's hook-trust prompt): the
     # app-server reads the endpoint out of its own process env at start, and
     # the server decides per spawn whether to route. Any Smart Routing session,
@@ -4219,15 +4344,45 @@ async def _auto_create_codex_terminal(
     # ``UserPromptSubmit`` hook is pointed at (so the hook needs no env of
     # its own), and live before the app-server starts because the hook can
     # fire on the very first prompt.
-    _codex_turn_router = _start_turn_router_for_native_session(
-        session_id,
-        bridge_dir=bridge_dir,
-        harness="codex-native",
-        server_client=server_client,
-        turn_routing=launch_config.turn_routing,
-    )
+    try:
+        _codex_turn_router = _start_turn_router_for_native_session(
+            session_id,
+            bridge_dir=bridge_dir,
+            harness="codex-native",
+            server_client=server_client,
+            turn_routing=launch_config.turn_routing,
+        )
+    except BaseException:
+        await _rollback_codex_managed_startup(
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            startup_generation=_startup_generation,
+            resource_registry=resource_registry,
+            publish_event=publish_event,
+            app_server=app_server,
+            subagent_router=_codex_router,
+        )
+        raise
     app_server.listen_url = codex_ws_url
-    await app_server.start()
+    try:
+        # Keep the local CLI/model-discovery 10-second default unchanged; only
+        # this managed instance may wait through the shared cold-start budget.
+        app_server.readiness_timeout_seconds = _startup_deadline.remaining(
+            "waiting for app-server readiness"
+        )
+        await _startup_deadline.run("starting the app-server", app_server.start)
+    except BaseException:
+        await _rollback_codex_managed_startup(
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            startup_generation=_startup_generation,
+            resource_registry=resource_registry,
+            publish_event=publish_event,
+            app_server=app_server,
+            subagent_router=_codex_router,
+            turn_router=_codex_turn_router,
+        )
+        raise
     _AUTO_CODEX_APP_SERVERS[session_id] = app_server
 
     event_client = CodexAppServerClient(
@@ -4238,19 +4393,40 @@ async def _auto_create_codex_terminal(
         from omnigent.codex_native_bridge import CodexNativeBridgeState, write_bridge_state
 
         try:
-            await preload_codex_thread_for_resume(
-                codex_ws_url,
-                launch_config.external_session_id,
-                terminal_launch_args=launch_config.terminal_launch_args,
+            await _startup_deadline.run(
+                "preloading the Codex resume thread",
+                lambda: preload_codex_thread_for_resume(
+                    codex_ws_url,
+                    launch_config.external_session_id,
+                    terminal_launch_args=launch_config.terminal_launch_args,
+                ),
             )
-        except Exception as exc:
+        except BaseException as exc:
+            if isinstance(exc, asyncio.CancelledError):
+                await _rollback_codex_managed_startup(
+                    session_id=session_id,
+                    bridge_dir=bridge_dir,
+                    startup_generation=_startup_generation,
+                    resource_registry=resource_registry,
+                    publish_event=publish_event,
+                    app_server=app_server,
+                    event_client=event_client,
+                    subagent_router=_codex_router,
+                    turn_router=_codex_turn_router,
+                )
+                raise
             if not is_unreadable_thread_error(exc):
-                # The app-server started above must not outlive a refused resume:
-                # without this close, every retry stacked another live codex
-                # process (and only the newest stayed tracked for teardown).
-                with contextlib.suppress(Exception):
-                    await app_server.close()
-                _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+                await _rollback_codex_managed_startup(
+                    session_id=session_id,
+                    bridge_dir=bridge_dir,
+                    startup_generation=_startup_generation,
+                    resource_registry=resource_registry,
+                    publish_event=publish_event,
+                    app_server=app_server,
+                    event_client=event_client,
+                    subagent_router=_codex_router,
+                    turn_router=_codex_turn_router,
+                )
                 raise
             # Codex cannot load this thread's rollout, so no retry can resume
             # it. Start a fresh thread on the same app-server instead of
@@ -4290,15 +4466,22 @@ async def _auto_create_codex_terminal(
             # Connect the listener BEFORE launching the TUI so it observes the
             # ``thread/started`` the TUI emits on startup (the client buffers
             # notifications, so there is no created-before-listening race).
-            await event_client.connect()
-        except Exception:
-            # connect() may have half-opened the ws before the initialize
-            # handshake failed, so close the listener too — not just the
-            # app-server.
-            with contextlib.suppress(Exception):
-                await event_client.close()
-            await app_server.close()
-            _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+            await _startup_deadline.run(
+                "connecting the app-server event client",
+                event_client.connect,
+            )
+        except BaseException:
+            await _rollback_codex_managed_startup(
+                session_id=session_id,
+                bridge_dir=bridge_dir,
+                startup_generation=_startup_generation,
+                resource_registry=resource_registry,
+                publish_event=publish_event,
+                app_server=app_server,
+                event_client=event_client,
+                subagent_router=_codex_router,
+                turn_router=_codex_turn_router,
+            )
             raise
 
     # Register the Codex TUI as a streamable terminal resource attached to
@@ -4321,6 +4504,8 @@ async def _auto_create_codex_terminal(
     # setup (arg build + config resolve) shares the terminal launch's teardown
     # below: a raise here must still close them and drop the
     # ``_AUTO_CODEX_APP_SERVERS`` entry, or the failure leaks the app-server.
+    terminal_instance: TerminalInstance | None = None
+    terminal_resource_published = False
     try:
         codex_remote_args = build_codex_remote_args(
             codex_args=tuple(launch_config.terminal_launch_args or ()),
@@ -4374,38 +4559,47 @@ async def _auto_create_codex_terminal(
         codex_launch_args = resolve_harness_args(
             "codex-native", tuple(codex_remote_args), cfg=_codex_harness_cfg
         )
-        terminal_view = await resource_registry.launch_auxiliary_terminal(
-            session_id=session_id,
-            terminal_name="codex",
-            session_key="main",
-            resource_role=CODEX_NATIVE_TERMINAL_ROLE,
-            parent_os_env=agent_os_env,
-            spec=TerminalEnvSpec(
-                os_env=OSEnvSpec(
-                    type="caller_process",
-                    cwd=workspace,
-                    sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
+        terminal_view = await _startup_deadline.run(
+            "launching the Codex terminal",
+            lambda: resource_registry.launch_auxiliary_terminal(
+                session_id=session_id,
+                terminal_name="codex",
+                session_key="main",
+                resource_role=CODEX_NATIVE_TERMINAL_ROLE,
+                parent_os_env=agent_os_env,
+                spec=TerminalEnvSpec(
+                    os_env=OSEnvSpec(
+                        type="caller_process",
+                        cwd=workspace,
+                        sandbox=(agent_os_env.sandbox if agent_os_env is not None else None),
+                    ),
+                    command=codex_command,
+                    args=codex_launch_args,
+                    env=codex_terminal_env(app_server),
+                    # Match the local ``omnigent codex`` terminal scrollback.
+                    scrollback=100_000,
+                    # Enable tmux passthrough so the Codex TUI's escape sequences
+                    # reach the web xterm.
+                    tmux_allow_passthrough=True,
+                    # Start the TUI at creation rather than on first attach,
+                    # mirroring claude-native. Deferring to attach (the local CLI
+                    # default) means the full-screen TUI cold-starts the instant
+                    # the web UI attaches over the runner tunnel; that initial
+                    # render burst starves the tunnel ping/pong and the host
+                    # recycles the unresponsive runner (the "runner
+                    # death on terminal attach" class). Starting now lets the TUI settle
+                    # in the detached tmux pane (no tunnel traffic) and create its
+                    # thread before anyone attaches.
+                    tmux_start_on_attach=False,
                 ),
-                command=codex_command,
-                args=codex_launch_args,
-                env=codex_terminal_env(app_server),
-                # Match the local ``omnigent codex`` terminal scrollback.
-                scrollback=100_000,
-                # Enable tmux passthrough so the Codex TUI's escape sequences
-                # reach the web xterm.
-                tmux_allow_passthrough=True,
-                # Start the TUI at creation rather than on first attach,
-                # mirroring claude-native. Deferring to attach (the local CLI
-                # default) means the full-screen TUI cold-starts the instant
-                # the web UI attaches over the runner tunnel; that initial
-                # render burst starves the tunnel ping/pong and the host
-                # recycles the unresponsive runner (the "runner
-                # death on terminal attach" class). Starting now lets the TUI settle
-                # in the detached tmux pane (no tunnel traffic) and create its
-                # thread before anyone attaches.
-                tmux_start_on_attach=False,
             ),
         )
+        terminal_registry = resource_registry.terminal_registry
+        if terminal_registry is None:
+            raise RuntimeError("Terminal registry disappeared after Codex terminal launch")
+        terminal_instance = terminal_registry.get(session_id, "codex", "main")
+        if terminal_instance is None:
+            raise RuntimeError("Codex terminal launch returned without a registered instance")
         publish_event(
             session_id,
             {
@@ -4413,10 +4607,21 @@ async def _auto_create_codex_terminal(
                 "resource": session_resource_view_to_dict(terminal_view),
             },
         )
-    except Exception:
-        await event_client.close()
-        await app_server.close()
-        _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+        terminal_resource_published = True
+    except BaseException:
+        await _rollback_codex_managed_startup(
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            startup_generation=_startup_generation,
+            resource_registry=resource_registry,
+            publish_event=publish_event,
+            app_server=app_server,
+            event_client=event_client,
+            terminal_instance=terminal_instance,
+            terminal_resource_published=terminal_resource_published,
+            subagent_router=_codex_router,
+            turn_router=_codex_turn_router,
+        )
         raise
 
     # Adopt the thread the fresh TUI creates and run the forwarder in the
@@ -4432,6 +4637,12 @@ async def _auto_create_codex_terminal(
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
                 login_required=_codex_launch.login_required,
+                startup_deadline=_startup_deadline,
+                startup_generation=_startup_generation,
+                app_server=app_server,
+                resource_registry=resource_registry,
+                publish_event=publish_event,
+                terminal_instance=terminal_instance,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4441,6 +4652,11 @@ async def _auto_create_codex_terminal(
                 bridge_dir=bridge_dir,
                 codex_ws_url=codex_ws_url,
                 thread_id=launch_config.external_session_id,
+                startup_generation=_startup_generation,
+                app_server=app_server,
+                resource_registry=resource_registry,
+                publish_event=publish_event,
+                terminal_instance=terminal_instance,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4449,22 +4665,46 @@ async def _auto_create_codex_terminal(
     )
     _register_auto_forwarder_task(session_id, _forwarder_task)
 
-    # A prompt a previous launch blocked for routing but never got to replay
-    # exists nowhere else: the block consumed it and the marker stops the hook
-    # from ever asking again. Drain it once this launch's thread is live.
-    _recover_pending_turn_replay(
-        session_id,
-        bridge_dir=bridge_dir,
-        server_client=server_client,
-    )
+    try:
+        # A prompt a previous launch blocked for routing but never got to replay
+        # exists nowhere else: the block consumed it and the marker stops the hook
+        # from ever asking again. Drain it once this launch's thread is live.
+        _recover_pending_turn_replay(
+            session_id,
+            bridge_dir=bridge_dir,
+            server_client=server_client,
+        )
 
-    # Start the relay now (into codex's serve-mcp bridge dir) so tool_relay.json
-    # is on disk and the relay recorded before codex connects on its first turn:
-    # the first-turn `_ensure_comment_relay_started` then fast-paths, avoiding
-    # the ~30s stall (see its docstring for the lazy-bridge / await_notify=False
-    # rationale).
-    if ensure_comment_relay is not None:
-        await ensure_comment_relay(session_id, explicit_bridge_dir=bridge_dir, await_notify=False)
+        # Start the relay now (into codex's serve-mcp bridge dir) so
+        # tool_relay.json is on disk before codex connects on its first turn.
+        if ensure_comment_relay is not None:
+            await _startup_deadline.run(
+                "starting the native tool relay",
+                lambda: ensure_comment_relay(
+                    session_id,
+                    explicit_bridge_dir=bridge_dir,
+                    await_notify=False,
+                ),
+            )
+    except BaseException:
+        # Ownership has transferred to the forwarder, but it may not have run
+        # yet. Cancel it and also perform identity-safe rollback here so a task
+        # cancelled before its first instruction cannot leak the launch.
+        await _cancel_auto_forwarder_task(session_id)
+        await _rollback_codex_managed_startup(
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            startup_generation=_startup_generation,
+            resource_registry=resource_registry,
+            publish_event=publish_event,
+            app_server=app_server,
+            event_client=event_client,
+            terminal_instance=terminal_instance,
+            terminal_resource_published=True,
+            subagent_router=_codex_router,
+            turn_router=_codex_turn_router,
+        )
+        raise
 
     _logger.info(
         "Auto-created codex terminal + forwarder for session %s",
@@ -4483,6 +4723,12 @@ async def _codex_discover_thread_and_forward(
     event_client: CodexAppServerClient,
     routing_summary: str,
     login_required: bool = False,
+    startup_deadline: _CodexManagedStartupDeadline,
+    startup_generation: str,
+    app_server: CodexNativeAppServer,
+    resource_registry: SessionResourceRegistry,
+    publish_event: Callable[[str, _JsonObject], None],
+    terminal_instance: TerminalInstance,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4519,6 +4765,13 @@ async def _codex_discover_thread_and_forward(
         the thread-start timeout), while thread discovery keeps listening
         so an interactive sign-in from the terminal still recovers the
         session.
+    :param startup_deadline: Absolute budget shared with app-server, client,
+        and terminal startup.
+    :param app_server: Exact app-server generation owned by this forwarder.
+    :param resource_registry: Registry used to retract this launch's terminal.
+    :param publish_event: Session event publisher used for terminal deletion.
+    :param terminal_instance: Exact tmux terminal generation owned by this
+        forwarder.
     :param subagent_router: Router this terminal launch started, torn down
         in the ``finally``. Passed so a late teardown cannot close the
         endpoint a re-created terminal has since installed.
@@ -4564,6 +4817,7 @@ async def _codex_discover_thread_and_forward(
             "(`omnigent setup`), then send the message again.",
         )
 
+    bridge_published = False
     try:
         try:
             if login_required:
@@ -4571,7 +4825,10 @@ async def _codex_discover_thread_and_forward(
                 # so this wait only serves a possible interactive sign-in.
                 thread_id = await wait_for_thread_started(event_client, timeout=None)
             else:
-                thread_id = await wait_for_thread_started(event_client)
+                thread_id = await wait_for_thread_started(
+                    event_client,
+                    timeout=startup_deadline.remaining("waiting for thread/started"),
+                )
         except (TimeoutError, RuntimeError) as exc:
             # Expected failure modes of wait_for_thread_started: the TUI exited
             # at startup, or the event stream ended before a thread was
@@ -4611,6 +4868,7 @@ async def _codex_discover_thread_and_forward(
                 cwd=workspace,
             ),
         )
+        bridge_published = True
 
         server_url = _required_runner_env("RUNNER_SERVER_URL")
         auth_factory = _make_auth_token_factory()
@@ -4669,21 +4927,20 @@ async def _codex_discover_thread_and_forward(
             auth=_RunnerDatabricksAuth(auth_factory),
         )
     finally:
-        # Tear down the listener and the per-session app-server whenever
-        # forwarding ends — discovery failed, the app-server connection dropped
-        # (``supervise_forwarder`` returned), or the task was cancelled on
-        # session teardown. ``supervise_forwarder`` also closes ``event_client``
-        # in its own ``finally``; ``close()`` is idempotent. The app-server
-        # subprocess is ours to stop, else it orphans one process per session.
-        # Pop first so the dict never holds a closed reference.
-        leftover_app_server = _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
-        with contextlib.suppress(Exception):
-            await event_client.close()
-        if leftover_app_server is not None:
-            with contextlib.suppress(Exception):
-                await leftover_app_server.close()
-        await _shutdown_session_router_async(session_id, subagent_router)
-        await _shutdown_session_turn_router_async(session_id, turn_router)
+        await _rollback_codex_managed_startup(
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            startup_generation=startup_generation,
+            resource_registry=resource_registry,
+            publish_event=publish_event,
+            app_server=app_server,
+            event_client=event_client,
+            terminal_instance=terminal_instance,
+            terminal_resource_published=True,
+            subagent_router=subagent_router,
+            turn_router=turn_router,
+            clear_bridge=not bridge_published,
+        )
 
 
 async def _codex_forward_known_thread(
@@ -4692,6 +4949,11 @@ async def _codex_forward_known_thread(
     bridge_dir: Path,
     codex_ws_url: str,
     thread_id: str,
+    startup_generation: str,
+    app_server: CodexNativeAppServer,
+    resource_registry: SessionResourceRegistry,
+    publish_event: Callable[[str, _JsonObject], None],
+    terminal_instance: TerminalInstance,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4704,6 +4966,11 @@ async def _codex_forward_known_thread(
         ``"ws://127.0.0.1:9876"``.
     :param thread_id: Existing Codex app-server thread id, e.g.
         ``"thread_abc123"``.
+    :param app_server: Exact app-server generation owned by this forwarder.
+    :param resource_registry: Registry used to retract this launch's terminal.
+    :param publish_event: Session event publisher used for terminal deletion.
+    :param terminal_instance: Exact tmux terminal generation owned by this
+        forwarder.
     :param subagent_router: Router this terminal launch started, torn down
         in the ``finally``. Passed so a late teardown cannot close the
         endpoint a re-created terminal has since installed.
@@ -4733,12 +5000,19 @@ async def _codex_forward_known_thread(
             auth=_RunnerDatabricksAuth(auth_factory),
         )
     finally:
-        leftover_app_server = _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
-        if leftover_app_server is not None:
-            with contextlib.suppress(Exception):
-                await leftover_app_server.close()
-        await _shutdown_session_router_async(session_id, subagent_router)
-        await _shutdown_session_turn_router_async(session_id, turn_router)
+        await _rollback_codex_managed_startup(
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            startup_generation=startup_generation,
+            resource_registry=resource_registry,
+            publish_event=publish_event,
+            app_server=app_server,
+            terminal_instance=terminal_instance,
+            terminal_resource_published=True,
+            subagent_router=subagent_router,
+            turn_router=turn_router,
+            clear_bridge=False,
+        )
 
 
 async def _run_antigravity_reader(

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -1487,11 +1487,16 @@ class SessionResourceRegistry:
         self,
         session_id: str,
         terminal_id: str,
+        *,
+        expected: TerminalInstance | None = None,
     ) -> bool:
         """Close a terminal resource by id.
 
         :param session_id: Session/conversation identifier.
         :param terminal_id: Opaque terminal resource id.
+        :param expected: When given, close only if this exact terminal instance
+            still owns the resource id. This protects a replacement generation
+            from delayed cleanup belonging to its predecessor.
         :returns: ``True`` if a terminal was closed.
         """
         if self._terminal_registry is None:
@@ -1505,6 +1510,7 @@ class SessionResourceRegistry:
                     session_id,
                     entry.terminal_name,
                     entry.session_key,
+                    expected=expected,
                 )
                 if closed:
                     with self._lock:

--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -43,6 +43,7 @@ import base64
 import contextlib
 import json
 import logging
+import os
 import re
 import shutil
 from collections.abc import Callable
@@ -551,6 +552,11 @@ async def bridge_tmux_control_to_websocket(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            # launchd commonly gives the host ``TERM=dumb``. tmux records the
+            # attaching control client's TERM as ``#{client_termname}``, and
+            # Codex uses that capability signal even though the pane itself has
+            # a rich TERM. Never let a browser attach downgrade the live TUI.
+            env={**os.environ, "TERM": "xterm-256color"},
             # Raise the stdout StreamReader buffer above the 64 KiB default so a
             # single ``read`` can pull a whole output burst (see
             # _CONTROL_STDOUT_BUFFER_LIMIT).

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -48,6 +48,28 @@ from tests.runner.conftest import (
 from tests.runner.helpers import NullServerClient
 
 
+class _CodexResourceRegistryGenerationSupport:
+    """Supply exact terminal identity to managed-startup unit-test fakes."""
+
+    _terminal_instance = object()
+
+    @property
+    def terminal_registry(self) -> _CodexResourceRegistryGenerationSupport:
+        return self
+
+    def get(self, _session_id: str, _terminal_name: str, _session_key: str) -> object:
+        return self._terminal_instance
+
+    async def close_terminal(
+        self,
+        _session_id: str,
+        _terminal_id: str,
+        *,
+        expected: object | None = None,
+    ) -> bool:
+        return expected is self._terminal_instance
+
+
 @pytest.mark.asyncio
 async def test_create_session_threads_cursor_bridge_dir_without_dead_guard_env(
     tmp_path: Path,
@@ -480,7 +502,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
 
     launched_specs: list[Any] = []
 
-    class _FakeResourceRegistry:
+    class _FakeResourceRegistry(_CodexResourceRegistryGenerationSupport):
         """Resource registry that records the launched terminal spec."""
 
         async def launch_auxiliary_terminal(
@@ -620,6 +642,15 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     del forward_calls[0]["subagent_router"]
     assert "turn_router" in forward_calls[0]
     del forward_calls[0]["turn_router"]
+    for ownership_key in (
+        "app_server",
+        "resource_registry",
+        "publish_event",
+        "terminal_instance",
+        "startup_generation",
+    ):
+        assert ownership_key in forward_calls[0]
+        del forward_calls[0][ownership_key]
     assert forward_calls == [
         {
             "session_id": session_id,
@@ -797,7 +828,7 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
 
     launched_specs: list[Any] = []
 
-    class _FakeResourceRegistry:
+    class _FakeResourceRegistry(_CodexResourceRegistryGenerationSupport):
         """Resource registry that records the launched terminal spec."""
 
         async def launch_auxiliary_terminal(
@@ -1068,7 +1099,7 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
 
     launched_specs: list[Any] = []
 
-    class _FakeResourceRegistry:
+    class _FakeResourceRegistry(_CodexResourceRegistryGenerationSupport):
         """Resource registry that records the launched terminal spec."""
 
         async def launch_auxiliary_terminal(
@@ -1323,7 +1354,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
 
     launch_captured: dict[str, Any] = {}
 
-    class _FakeResourceRegistry:
+    class _FakeResourceRegistry(_CodexResourceRegistryGenerationSupport):
         """Resource registry that records the launched terminal spec."""
 
         async def launch_auxiliary_terminal(
@@ -1519,7 +1550,7 @@ async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
         async def close(self) -> None:
             """:returns: None."""
 
-    class _FakeResourceRegistry:
+    class _FakeResourceRegistry(_CodexResourceRegistryGenerationSupport):
         """Resource registry returning a fixed terminal view."""
 
         async def launch_auxiliary_terminal(
@@ -3026,6 +3057,304 @@ async def test_codex_session_needs_runner_terminal_false_without_client() -> Non
     )
 
 
+class _CloseOnlyResourceRegistry:
+    """Minimal facade recording generation-safe terminal cleanup in forwarder tests."""
+
+    def __init__(self) -> None:
+        self.expected: object | None = None
+
+    async def close_terminal(
+        self,
+        _session_id: str,
+        _terminal_id: str,
+        *,
+        expected: object | None = None,
+    ) -> bool:
+        self.expected = expected
+        return True
+
+
+class _TransactionAppServer:
+    """Small app-server double for managed-startup transaction wiring tests."""
+
+    codex_path = "/opt/codex/bin/codex"
+    codex_cli_version: tuple[int, int, int] | None = (0, 145, 0)
+
+    def __init__(self, tmp_path: Path, *, start_error: BaseException | None = None) -> None:
+        self.env: dict[str, str] = {}
+        self.codex_home = tmp_path / "unconfigured-codex-home"
+        self.config_overrides: list[str] = []
+        self.listen_url: str | None = None
+        self.readiness_timeout_seconds = 10.0
+        self.start_error = start_error
+        self.closed = False
+
+    async def start(self) -> None:
+        if self.start_error is not None:
+            raise self.start_error
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _patch_minimal_codex_auto_create_transaction(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    session_id: str,
+    app_server: _TransactionAppServer,
+    external_session_id: str | None,
+) -> tuple[Path, object, object, list[object]]:
+    """Patch non-transactional launch details so tests isolate ownership."""
+    import omnigent.codex_native as codex_native_mod
+    import omnigent.codex_native_app_server as codex_app_mod
+    import omnigent.codex_native_process_registry as process_registry_mod
+    import omnigent.inner.codex_executor as codex_executor_mod
+    import omnigent.runner.native.orchestration as orchestration_mod
+    from omnigent.runner.native.orchestration import _CodexNativeLaunchConfig
+
+    bridge_root = tmp_path / "codex-bridge"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", bridge_root)
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    async def _launch_config(**_kwargs: object) -> _CodexNativeLaunchConfig:
+        return _CodexNativeLaunchConfig(
+            workspace=tmp_path / "workspace",
+            policy_server_url="http://ap.example",
+            terminal_launch_args=None,
+            model_override=None,
+            external_session_id=external_session_id,
+            fork_source_id=None,
+            fork_source_external_id=None,
+            fork_carry_history=False,
+            bypass_sandbox=False,
+        )
+
+    monkeypatch.setattr(orchestration_mod, "_codex_native_launch_config", _launch_config)
+    monkeypatch.setattr(
+        codex_app_mod,
+        "resolve_native_codex_launch",
+        lambda *, model, spec=None: codex_app_mod.NativeCodexLaunch(
+            config_overrides=[],
+            model=model or "gpt-test",
+            profile=None,
+            summary="test route",
+        ),
+    )
+    monkeypatch.setattr(codex_executor_mod, "_find_codex_cli", lambda: app_server.codex_path)
+    monkeypatch.setattr(codex_executor_mod, "populate_codex_skills_from_bundle", lambda *_a: None)
+    monkeypatch.setattr(codex_executor_mod, "codex_extended_catalog_env", lambda _enabled: {})
+    monkeypatch.setattr(
+        process_registry_mod,
+        "reap_codex_native_processes_for_state_dir",
+        lambda _bridge_dir: [],
+    )
+
+    def _build_app_server(**kwargs: object) -> _TransactionAppServer:
+        app_server.codex_home = cast(Path, kwargs["codex_home"])
+        return app_server
+
+    monkeypatch.setattr(codex_app_mod, "build_codex_native_server", _build_app_server)
+
+    router = object()
+    turn_router = object()
+    shutdown: list[object] = []
+    monkeypatch.setattr(
+        orchestration_mod,
+        "_start_subagent_router_for_native_session",
+        lambda *_args, **_kwargs: (tmp_path / "router", router),
+    )
+    monkeypatch.setattr(
+        orchestration_mod,
+        "_start_turn_router_for_native_session",
+        lambda *_args, **_kwargs: turn_router,
+    )
+
+    async def _shutdown_router(_session_id: str, handle: object | None = None) -> None:
+        if handle is not None:
+            shutdown.append(handle)
+
+    monkeypatch.setattr(orchestration_mod, "_shutdown_session_router_async", _shutdown_router)
+    monkeypatch.setattr(orchestration_mod, "_shutdown_session_turn_router_async", _shutdown_router)
+
+    async def _ensure_resume_rollout(*_args: object, **_kwargs: object) -> Path:
+        return tmp_path / "rollout.jsonl"
+
+    monkeypatch.setattr(
+        codex_native_mod,
+        "_ensure_local_codex_resume_rollout",
+        _ensure_resume_rollout,
+    )
+    return codex_native_bridge.bridge_dir_for_bridge_id(session_id), router, turn_router, shutdown
+
+
+@pytest.mark.asyncio
+async def test_codex_managed_startup_deadline_preserves_inner_timeout() -> None:
+    """A fast operation-owned timeout is not mislabeled as budget exhaustion."""
+    from omnigent.runner.native.orchestration import _CodexManagedStartupDeadline
+
+    async def _inner_timeout() -> None:
+        raise TimeoutError("event client handshake timed out")
+
+    deadline = _CodexManagedStartupDeadline.start(timeout_seconds=1.0)
+    with pytest.raises(TimeoutError, match="event client handshake timed out") as exc_info:
+        await deadline.run("connecting event client", _inner_timeout)
+
+    assert "managed startup exceeded" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_codex_managed_startup_deadline_names_expired_stage() -> None:
+    """Budget expiry is bounded and names the gate operators should inspect."""
+    from omnigent.runner.native.orchestration import _CodexManagedStartupDeadline
+
+    deadline = _CodexManagedStartupDeadline.start(timeout_seconds=0.01)
+    with pytest.raises(TimeoutError, match="while launching terminal"):
+        await deadline.run("launching terminal", lambda: asyncio.sleep(1.0))
+
+
+@pytest.mark.asyncio
+async def test_auto_create_codex_app_server_failure_rolls_back_both_routers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Router ownership is armed before app-server startup can fail."""
+    import omnigent.runner.native.orchestration as orchestration_mod
+
+    session_id = "8034a1baf8514dd1ae413a2b7da8378f"
+    app_server = _TransactionAppServer(
+        tmp_path,
+        start_error=RuntimeError("app-server readiness failed"),
+    )
+    bridge_dir, router, turn_router, shutdown = _patch_minimal_codex_auto_create_transaction(
+        monkeypatch,
+        tmp_path,
+        session_id=session_id,
+        app_server=app_server,
+        external_session_id=None,
+    )
+
+    with pytest.raises(RuntimeError, match="app-server readiness failed"):
+        await _auto_create_codex_terminal(
+            session_id,
+            SessionResourceRegistry(),
+            lambda *_args: None,
+            server_client=None,
+        )
+
+    assert app_server.closed is True
+    assert shutdown == [router, turn_router]
+    assert session_id not in orchestration_mod._AUTO_CODEX_APP_SERVERS
+    assert codex_native_bridge.read_bridge_state(bridge_dir) is None
+
+
+@pytest.mark.asyncio
+async def test_auto_create_codex_terminal_cancellation_rolls_back_resume_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled terminal launch retracts resume state and all live owners."""
+    import omnigent.codex_native_app_server as codex_app_mod
+    import omnigent.runner.native.orchestration as orchestration_mod
+
+    session_id = "610d28bd105d4a789aee9367838d6846"
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936d"
+    app_server = _TransactionAppServer(tmp_path)
+    bridge_dir, router, turn_router, shutdown = _patch_minimal_codex_auto_create_transaction(
+        monkeypatch,
+        tmp_path,
+        session_id=session_id,
+        app_server=app_server,
+        external_session_id=thread_id,
+    )
+
+    class _EventClient:
+        instance: _EventClient | None = None
+
+        def __init__(self, **_kwargs: object) -> None:
+            self.closed = False
+            type(self).instance = self
+
+        async def close(self) -> None:
+            self.closed = True
+
+    async def _preload(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    class _CancelledTerminalRegistry:
+        async def launch_auxiliary_terminal(self, **_kwargs: object) -> SessionResourceView:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _EventClient)
+    monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _preload)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _auto_create_codex_terminal(
+            session_id,
+            _CancelledTerminalRegistry(),  # type: ignore[arg-type]
+            lambda *_args: None,
+            server_client=cast(Any, object()),
+        )
+
+    assert _EventClient.instance is not None and _EventClient.instance.closed is True
+    assert app_server.closed is True
+    assert shutdown == [router, turn_router]
+    assert session_id not in orchestration_mod._AUTO_CODEX_APP_SERVERS
+    assert codex_native_bridge.read_bridge_state(bridge_dir) is None
+
+
+@pytest.mark.asyncio
+async def test_codex_startup_rollback_does_not_remove_successor_app_server(
+    tmp_path: Path,
+) -> None:
+    """Delayed cleanup closes its own server without popping a new generation."""
+    from omnigent.runner.native.orchestration import (
+        _AUTO_CODEX_APP_SERVERS,
+        _rollback_codex_managed_startup,
+    )
+
+    class _AppServer:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    session_id = "3d49242924bc4b91b21f9e165a8fc861"
+    old_server = _AppServer()
+    successor = _AppServer()
+    codex_native_bridge.write_bridge_startup_generation(tmp_path, "successor-generation")
+    codex_native_bridge.write_bridge_state(
+        tmp_path,
+        codex_native_bridge.CodexNativeBridgeState(
+            session_id=session_id,
+            socket_path="ws://127.0.0.1:2",
+            thread_id="successor-thread",
+            codex_home=str(tmp_path / "successor-home"),
+        ),
+    )
+    _AUTO_CODEX_APP_SERVERS[session_id] = successor  # type: ignore[assignment]
+    try:
+        await _rollback_codex_managed_startup(
+            session_id=session_id,
+            bridge_dir=tmp_path,
+            startup_generation="old-generation",
+            resource_registry=_CloseOnlyResourceRegistry(),  # type: ignore[arg-type]
+            publish_event=lambda *_args: None,
+            app_server=old_server,  # type: ignore[arg-type]
+        )
+
+        assert old_server.closed is True
+        assert successor.closed is False
+        assert _AUTO_CODEX_APP_SERVERS[session_id] is successor
+        successor_state = codex_native_bridge.read_bridge_state(tmp_path)
+        assert successor_state is not None
+        assert successor_state.thread_id == "successor-thread"
+    finally:
+        _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+
 @pytest.mark.asyncio
 async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -3041,6 +3370,7 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
         _AUTO_CODEX_APP_SERVERS,
         _codex_discover_thread_and_forward,
     )
+    from omnigent.runner.native.orchestration import _CodexManagedStartupDeadline
 
     closed = {"client": False, "app_server": False}
 
@@ -3052,7 +3382,11 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
         async def close(self) -> None:
             closed["app_server"] = True
 
-    async def _raise_no_thread(*_args: object, **_kwargs: object) -> str:
+    observed_timeout: float | None = None
+
+    async def _raise_no_thread(*_args: object, **kwargs: object) -> str:
+        nonlocal observed_timeout
+        observed_timeout = cast(float, kwargs["timeout"])
         raise TimeoutError("no thread/started observed")
 
     # The helper lazily imports wait_for_thread_started from the forwarder
@@ -3060,7 +3394,13 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
     monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _raise_no_thread)
 
     session_id = "2053b47e49239a8c24e3cd30cdb21c8e"
-    _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    app_server = _AppServer()
+    resource_registry = _CloseOnlyResourceRegistry()
+    terminal_instance = object()
+    published: list[dict[str, object]] = []
+    startup_generation = "discovery-failure-generation"
+    codex_native_bridge.write_bridge_startup_generation(tmp_path, startup_generation)
+    _AUTO_CODEX_APP_SERVERS[session_id] = app_server
     try:
         await _codex_discover_thread_and_forward(
             session_id=session_id,
@@ -3070,6 +3410,12 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
             workspace=str(tmp_path / "workspace"),
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
+            startup_deadline=_CodexManagedStartupDeadline.start(),
+            startup_generation=startup_generation,
+            app_server=app_server,  # type: ignore[arg-type]
+            resource_registry=resource_registry,  # type: ignore[arg-type]
+            publish_event=lambda _session_id, event: published.append(event),
+            terminal_instance=terminal_instance,  # type: ignore[arg-type]
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -3079,6 +3425,10 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
     assert closed["client"] is True
     assert closed["app_server"] is True
     assert session_id not in _AUTO_CODEX_APP_SERVERS
+    assert resource_registry.expected is terminal_instance
+    assert published[-1]["type"] == "session.resource.deleted"
+    assert observed_timeout is not None
+    assert 30.0 < observed_timeout <= 180.0
 
 
 @pytest.mark.asyncio
@@ -3109,6 +3459,7 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
         _AUTO_CODEX_APP_SERVERS,
         _codex_discover_thread_and_forward,
     )
+    from omnigent.runner.native.orchestration import _CodexManagedStartupDeadline
 
     class _Client:
         async def close(self) -> None:
@@ -3124,7 +3475,12 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
     monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _raise)
 
     session_id = "5cb1fea582a3bd8aad3619ca820af75b"
-    _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    app_server = _AppServer()
+    resource_registry = _CloseOnlyResourceRegistry()
+    terminal_instance = object()
+    startup_generation = "startup-error-generation"
+    codex_native_bridge.write_bridge_startup_generation(tmp_path, startup_generation)
+    _AUTO_CODEX_APP_SERVERS[session_id] = app_server
     try:
         await _codex_discover_thread_and_forward(
             session_id=session_id,
@@ -3134,6 +3490,12 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
             workspace=str(tmp_path / "workspace"),
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
+            startup_deadline=_CodexManagedStartupDeadline.start(),
+            startup_generation=startup_generation,
+            app_server=app_server,  # type: ignore[arg-type]
+            resource_registry=resource_registry,  # type: ignore[arg-type]
+            publish_event=lambda *_args: None,
+            terminal_instance=terminal_instance,  # type: ignore[arg-type]
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -3166,6 +3528,7 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
         _AUTO_CODEX_APP_SERVERS,
         _codex_discover_thread_and_forward,
     )
+    from omnigent.runner.native.orchestration import _CodexManagedStartupDeadline
 
     thread_id = "019e96aa-abcd-7343-8d3b-6f914d60936b"
     workspace = tmp_path / "selected-workspace"
@@ -3190,7 +3553,12 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
 
     session_id = "9f1f7f7bd7f24f80a621d9a3ba3fbc10"
-    _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    app_server = _AppServer()
+    resource_registry = _CloseOnlyResourceRegistry()
+    terminal_instance = object()
+    startup_generation = "successful-discovery-generation"
+    codex_native_bridge.write_bridge_startup_generation(tmp_path, startup_generation)
+    _AUTO_CODEX_APP_SERVERS[session_id] = app_server
     try:
         await _codex_discover_thread_and_forward(
             session_id=session_id,
@@ -3200,6 +3568,12 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
             workspace=str(workspace),
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
+            startup_deadline=_CodexManagedStartupDeadline.start(),
+            startup_generation=startup_generation,
+            app_server=app_server,  # type: ignore[arg-type]
+            resource_registry=resource_registry,  # type: ignore[arg-type]
+            publish_event=lambda *_args: None,
+            terminal_instance=terminal_instance,  # type: ignore[arg-type]
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -3487,7 +3861,7 @@ async def test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog(
         """
         del kwargs
 
-    class _FakeResourceRegistry:
+    class _FakeResourceRegistry(_CodexResourceRegistryGenerationSupport):
         """Resource registry that accepts the terminal launch."""
 
         async def launch_auxiliary_terminal(

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -926,6 +926,27 @@ async def test_delete_terminal_closes_and_returns_confirmation(
 
 
 @pytest.mark.asyncio
+async def test_close_terminal_expected_instance_preserves_successor(tmp_path: Path) -> None:
+    """The resource facade forwards generation identity to terminal cleanup."""
+    session_id = "conv_expected_terminal_generation"
+    superseded = _make_instance("codex", "main", tmp_path / "old")
+    successor = _make_instance("codex", "main", tmp_path / "new")
+    terminal_registry = TerminalRegistry()
+    _seed_registry(terminal_registry, session_id, [successor])
+    resources = SessionResourceRegistry(terminal_registry=terminal_registry)
+
+    closed = await resources.close_terminal(
+        session_id,
+        terminal_resource_id("codex", "main"),
+        expected=superseded,
+    )
+
+    assert closed is False
+    assert terminal_registry.get(session_id, "codex", "main") is successor
+    assert successor.running is True
+
+
+@pytest.mark.asyncio
 async def test_delete_terminal_returns_404_for_unknown(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -239,6 +239,49 @@ async def _kill_and_join(sock: Path, task: asyncio.Task[None]) -> None:
 
 @pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
 @pytest.mark.asyncio
+async def test_control_attach_never_advertises_launchd_term_dumb(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The persistent browser control client advertises a capable terminal."""
+    sock, target = await _new_private_tmux("sleep 30")
+    tmux = shutil.which("tmux")
+    assert tmux
+    monkeypatch.setenv("TERM", "dumb")
+    ws = _FakeWebSocket(inbound=[])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws,
+            socket_path=str(sock),
+            tmux_target=target,
+            read_only=False,
+        )
+    )
+    try:
+        client_terms: list[str] = []
+        for _ in range(50):
+            proc = await asyncio.create_subprocess_exec(
+                tmux,
+                "-S",
+                str(sock),
+                "list-clients",
+                "-F",
+                "#{client_termname}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _stderr = await proc.communicate()
+            client_terms = stdout.decode().splitlines()
+            if client_terms:
+                break
+            await asyncio.sleep(0.05)
+
+        assert client_terms == ["xterm-256color"]
+    finally:
+        await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
 async def test_control_bridge_outer_cancellation_joins_child_tasks() -> None:
     """Cancelling the route cannot leave bridge reader/sender tasks detached."""
     sock, target = await _new_private_tmux("sleep 30")

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -11255,37 +11255,72 @@ def test_resolve_native_codex_launch_databricks_provider_sets_summary(
     assert launch.summary == "Databricks ucode profile 'my-profile'"
 
 
+class _FakeManagedStartupClosable:
+    """Minimal app-server/client cleanup target for discovery helper tests."""
+
+    async def close(self) -> None:
+        """Accept rollback cleanup."""
+
+
+class _FakeManagedStartupRegistry:
+    """Minimal terminal registry facade for discovery helper tests."""
+
+    async def close_terminal(
+        self,
+        _session_id: str,
+        _terminal_id: str,
+        *,
+        expected: object,
+    ) -> bool:
+        """Confirm identity-scoped terminal cleanup."""
+        return expected is not None
+
+
 def test_codex_discover_thread_and_forward_writes_routing_summary_on_timeout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A startup timeout records the launch routing summary in the bridge error (#2745)."""
     from omnigent import codex_native_forwarder as _fwd
-    from omnigent.codex_native_bridge import read_bridge_startup_error
+    from omnigent.codex_native_bridge import (
+        read_bridge_startup_error,
+        write_bridge_startup_generation,
+    )
     from omnigent.runner.native import orchestration as native_orch
 
     bridge_dir = tmp_path / "bridge"
     bridge_dir.mkdir()
 
-    async def _timeout(_client: object) -> str:
+    async def _timeout(
+        _client: object,
+        *,
+        timeout: float | None = 30.0,
+    ) -> str:
+        assert timeout is not None
         raise TimeoutError("no thread event")
 
     monkeypatch.setattr(_fwd, "wait_for_thread_started", _timeout)
 
-    class _FakeClient:
-        async def close(self) -> None:
-            return None
+    startup_generation = "routing-summary-timeout-generation"
+    write_bridge_startup_generation(bridge_dir, startup_generation)
 
-    asyncio.run(
-        native_orch._codex_discover_thread_and_forward(
+    async def _run_discovery() -> None:
+        await native_orch._codex_discover_thread_and_forward(
             session_id="conv_test",
             bridge_dir=bridge_dir,
             codex_ws_url="ws://127.0.0.1:9999",
             codex_home=tmp_path / "codex-home",
             workspace=str(tmp_path / "workspace"),
-            event_client=_FakeClient(),
+            event_client=_FakeManagedStartupClosable(),  # type: ignore[arg-type]
             routing_summary="Codex CLI login (no provider configured) -- SENTINEL",
+            startup_deadline=native_orch._CodexManagedStartupDeadline.start(),
+            startup_generation=startup_generation,
+            app_server=_FakeManagedStartupClosable(),  # type: ignore[arg-type]
+            resource_registry=_FakeManagedStartupRegistry(),  # type: ignore[arg-type]
+            publish_event=lambda *_args: None,
+            terminal_instance=object(),  # type: ignore[arg-type]
         )
-    )
+
+    asyncio.run(_run_discovery())
 
     err = read_bridge_startup_error(bridge_dir)
     assert err is not None
@@ -11308,7 +11343,10 @@ def test_codex_discover_thread_login_required_records_error_before_waiting(
     thread-start timeout (the "Codex TUI never started a thread" hang).
     """
     from omnigent import codex_native_forwarder as _fwd
-    from omnigent.codex_native_bridge import read_bridge_startup_error
+    from omnigent.codex_native_bridge import (
+        read_bridge_startup_error,
+        write_bridge_startup_generation,
+    )
     from omnigent.runner.native import orchestration as native_orch
 
     bridge_dir = tmp_path / "bridge"
@@ -11325,22 +11363,28 @@ def test_codex_discover_thread_login_required_records_error_before_waiting(
 
     monkeypatch.setattr(_fwd, "wait_for_thread_started", _wait)
 
-    class _FakeClient:
-        async def close(self) -> None:
-            return None
+    startup_generation = "login-required-failure-generation"
+    write_bridge_startup_generation(bridge_dir, startup_generation)
 
-    asyncio.run(
-        native_orch._codex_discover_thread_and_forward(
+    async def _run_discovery() -> None:
+        await native_orch._codex_discover_thread_and_forward(
             session_id="conv_test",
             bridge_dir=bridge_dir,
             codex_ws_url="ws://127.0.0.1:9999",
             codex_home=tmp_path / "codex-home",
             workspace=str(tmp_path / "workspace"),
-            event_client=_FakeClient(),
+            event_client=_FakeManagedStartupClosable(),  # type: ignore[arg-type]
             routing_summary="Codex CLI login (no provider configured) -- SENTINEL",
             login_required=True,
+            startup_deadline=native_orch._CodexManagedStartupDeadline.start(),
+            startup_generation=startup_generation,
+            app_server=_FakeManagedStartupClosable(),  # type: ignore[arg-type]
+            resource_registry=_FakeManagedStartupRegistry(),  # type: ignore[arg-type]
+            publish_event=lambda *_args: None,
+            terminal_instance=object(),  # type: ignore[arg-type]
         )
-    )
+
+    asyncio.run(_run_discovery())
 
     assert error_at_wait_time and error_at_wait_time[0] is not None
     recorded = error_at_wait_time[0]
@@ -11365,6 +11409,7 @@ def test_codex_discover_thread_login_required_clears_error_on_thread_start(
     from omnigent.codex_native_bridge import (
         read_bridge_startup_error,
         read_bridge_state,
+        write_bridge_startup_generation,
     )
     from omnigent.runner.native import orchestration as native_orch
 
@@ -11381,22 +11426,28 @@ def test_codex_discover_thread_login_required_clears_error_on_thread_start(
     monkeypatch.setattr(_fwd, "supervise_forwarder", _forward)
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:1")
 
-    class _FakeClient:
-        async def close(self) -> None:
-            return None
+    startup_generation = "login-required-success-generation"
+    write_bridge_startup_generation(bridge_dir, startup_generation)
 
-    asyncio.run(
-        native_orch._codex_discover_thread_and_forward(
+    async def _run_discovery() -> None:
+        await native_orch._codex_discover_thread_and_forward(
             session_id="conv_test",
             bridge_dir=bridge_dir,
             codex_ws_url="ws://127.0.0.1:9999",
             codex_home=tmp_path / "codex-home",
             workspace=str(tmp_path / "workspace"),
-            event_client=_FakeClient(),
+            event_client=_FakeManagedStartupClosable(),  # type: ignore[arg-type]
             routing_summary="Codex CLI login (no provider configured)",
             login_required=True,
+            startup_deadline=native_orch._CodexManagedStartupDeadline.start(),
+            startup_generation=startup_generation,
+            app_server=_FakeManagedStartupClosable(),  # type: ignore[arg-type]
+            resource_registry=_FakeManagedStartupRegistry(),  # type: ignore[arg-type]
+            publish_event=lambda *_args: None,
+            terminal_instance=object(),  # type: ignore[arg-type]
         )
-    )
+
+    asyncio.run(_run_discovery())
 
     assert read_bridge_startup_error(bridge_dir) is None
     state = read_bridge_state(bridge_dir)

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -844,6 +844,44 @@ def _test_app_server(
     )
 
 
+async def test_app_server_readiness_honors_managed_instance_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed readiness can exceed the local app-server timeout boundary."""
+    from omnigent import codex_native_app_server
+
+    attempts = 0
+
+    class _RetryingClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def connect(self) -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise OSError("not listening yet")
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(codex_native_app_server, "CodexAppServerClient", _RetryingClient)
+    monkeypatch.setattr(codex_native_app_server, "_CONNECT_TIMEOUT_SECONDS", 0.0)
+    monkeypatch.setattr(codex_native_app_server, "_CONNECT_RETRY_DELAY_SECONDS", 0.0)
+    server = _test_app_server(
+        tmp_path,
+        tmp_path / "codex-home",
+        tmp_path / "bridge",
+        tmp_path,
+    )
+    server.readiness_timeout_seconds = 1.0
+
+    await server._wait_until_ready()
+
+    assert attempts == 3
+
+
 async def test_start_upserts_mcp_server_config_across_relaunches(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -13,6 +13,7 @@ from omnigent.codex_native_bridge import (
     CodexNativeBridgeState,
     cancel_pending_mcp_startup,
     clear_active_turn_id_if_matches,
+    clear_bridge_runtime_state,
     clear_bridge_state,
     codex_home_for_bridge_dir,
     codex_mcp_config_overrides,
@@ -29,6 +30,7 @@ from omnigent.codex_native_bridge import (
     update_active_turn_id,
     update_mcp_server_startup,
     write_bridge_startup_error,
+    write_bridge_startup_generation,
     write_bridge_state,
     write_codex_config_model,
     write_policy_hook_config,
@@ -355,12 +357,29 @@ def test_bridge_startup_error_round_trips_and_is_cleared(bridge_dir: Path) -> No
     drops it before each launch so stale failures don't linger (issue #59).
     """
     assert read_bridge_startup_error(bridge_dir) is None
-
     write_bridge_startup_error(bridge_dir, "thread never started (TimeoutError)")
     assert read_bridge_startup_error(bridge_dir) == "thread never started (TimeoutError)"
 
     clear_bridge_state(bridge_dir)
     assert read_bridge_startup_error(bridge_dir) is None
+
+
+def test_clear_bridge_runtime_state_preserves_startup_error(bridge_dir: Path) -> None:
+    """Rollback removes stale live pointers without erasing its diagnosis."""
+    _seed_active_turn(bridge_dir, None)
+    update_mcp_server_startup(bridge_dir, "slow-mcp", status="starting")
+    write_bridge_startup_error(bridge_dir, "thread startup exceeded its managed deadline")
+    write_bridge_startup_generation(bridge_dir, "current-generation")
+
+    cleared = clear_bridge_runtime_state(
+        bridge_dir,
+        expected_generation="current-generation",
+    )
+
+    assert cleared is True
+    assert read_bridge_state(bridge_dir) is None
+    assert read_mcp_startup(bridge_dir) == {}
+    assert read_bridge_startup_error(bridge_dir) == "thread startup exceeded its managed deadline"
 
 
 def test_mcp_startup_updates_round_trip(bridge_dir: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #6456.

This supersedes the timeout portion of #2325; its plugin-cache work shipped in #3401.

## Summary

- Give managed Codex startup one 180-second monotonic budget across app-server readiness, resume preload, event connection, terminal launch, native relay startup, thread discovery, and bridge observation.
- Treat launch as a transaction: on failure or cancellation, retract the exact terminal/app-server/bridge generation, close event clients and routers, emit terminal deletion, and preserve the stage-specific startup error for the user.
- Prevent a browser tmux control attach inherited from launchd from advertising `TERM=dumb` and downgrading the live Codex TUI.

ELI5: startup used to be several timers and several owners handing resources to one another. A slow cold start could expire one timer halfway through and leave pieces behind, so the next retry collided with stale state. This makes startup one stopwatch and one cleanup receipt.

```mermaid
flowchart LR
  A[Create session] --> B[App server]
  B --> C[Preload or event client]
  C --> D[Codex terminal]
  D --> E[thread/started]
  E --> F[Bridge ready]
  G[One 180s deadline] --- B
  G --- C
  G --- D
  G --- E
  B -. failure .-> H[Generation-scoped rollback]
  C -. failure .-> H
  D -. failure .-> H
  E -. failure .-> H
```

## Test Plan

- `uv run --no-sync pre-commit run --all-files` — passed, including Ruff, Pyrefly, web/editor/extension type checks, Android/iOS formatting, generated bundles, lock normalization, and repository hygiene hooks.
- Focused managed-startup/rollback node set — 16 passed. Covers deadline classification, managed app-server readiness beyond the old boundary, router/app-server rollback, cancellation, successor generation safety, terminal identity safety, bridge-error retention, discovery cleanup, and real-tmux TERM behavior.
- `OMNIGENT_CONFIG_HOME=/tmp/omnigent-test-config-empty .venv/bin/pytest -q tests/runner/test_app_sessions_native_terminals_runtime.py -k 'auto_create_codex_terminal'` — 9 passed, 38 deselected.
- Changed-file `py_compile` and Ruff checks — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression suite uses a real tmux control client to prove the browser attach advertises `xterm-256color`, and failure-injection tests prove each startup owner is released without deleting a successor generation.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused failure-injection tests cover startup, cancellation, and delayed-predecessor cleanup. The existing Codex auto-create subset verifies resume, fork, workspace, relay, and model-catalog behavior remains intact.

## Changelog

Codex-native sessions now tolerate cold managed starts and clean up failed launch generations without poisoning retries.
