### PR TITLE
fix(codex-native): resume on a gateway-spelled model override

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3889,18 +3889,24 @@ async def _auto_create_codex_terminal(
     ):
         from dataclasses import replace as _dataclass_replace
 
+        from omnigent.codex_model_vocabulary import codex_reachable_model_slug
         from omnigent.codex_native_app_server import (
             codex_launch_catalog,
             codex_launch_catalog_is_stale,
         )
-        from omnigent.model_catalog_store import catalog_contains, default_row
+        from omnigent.model_catalog_store import default_row
 
         # Read staleness BEFORE the fetch — the fetch kicks the background
         # re-probe, which could land between the two reads.
         _codex_catalog_was_stale = await codex_launch_catalog_is_stale(codex_path=_codex_cli_path)
         _codex_catalog = await codex_launch_catalog(codex_path=_codex_cli_path)
         if launch_config.model_override and _codex_catalog:
-            if not catalog_contains(_codex_catalog, launch_config.model_override):
+            # Match by codex's vocabulary, not string equality: a persisted
+            # override carries the gateway spelling (``databricks-gpt-5-6-sol``)
+            # while the catalog lists codex's own slug (``gpt-5.6-sol``). The
+            # launch itself translates between the two, so the raw check refused
+            # a model this host serves.
+            if codex_reachable_model_slug(launch_config.model_override, _codex_catalog) is None:
                 raise click.ClickException(
                     f"the requested model {launch_config.model_override!r} is not in "
                     "this host's current model list — it may have changed since the "

--- a/tests/e2e/omnigent/test_model_flows_live.py
+++ b/tests/e2e/omnigent/test_model_flows_live.py
@@ -728,6 +728,128 @@ def test_row18_cold_resume_honors_the_persisted_model_override(
         )
 
 
+@pytest.mark.timeout(900)
+def test_row18b_codex_cold_resume_honors_a_gateway_spelled_override(
+    rig: ModelFlowsRig,
+    shaped_host: Callable[[str], str],
+    tmp_path: Path,
+) -> None:
+    """
+    A codex resume honors an override stored in the gateway spelling.
+
+    The realistic bite is a databricks-profile session whose persisted
+    ``/model`` is a gateway id (``databricks-gpt-5-6-sol``) while the catalog
+    lists codex's own slug (``gpt-5.6-sol``). The launch translates between the
+    two, so the relaunch must fold the spellings rather than refuse the model
+    as "not in this host's current model list" (a raw string-equality check
+    did, failing the whole cold resume).
+    """
+    from omnigent.codex_model_vocabulary import codex_reachable_model_slug, comparable_model_id
+    from omnigent.model_catalog_store import catalog_contains
+
+    harness = "codex-native"
+    ready = _COLD_RESUME_HARNESSES[harness][2]
+    require_clis("codex")
+    host_id = shaped_host("codex-databricks")
+
+    def _rows() -> list[dict[str, Any]] | None:
+        try:
+            payload = host_model_options(rig.base_url, host_id, harness)
+        except httpx.HTTPError:
+            return None
+        return payload.get("models") or None
+
+    rows = wait_for(_rows, timeout=180.0, what="the boot-warmed codex-databricks catalog")
+    # A non-default codex-slug row, respelled the gateway way. Only meaningful
+    # when the catalog spells it as a codex slug and the raw check misses it.
+    slug = next(
+        (
+            str(r["id"])
+            for r in rows
+            if r.get("id") and not r.get("isDefault") and not r.get("hidden")
+        ),
+        None,
+    )
+    if slug is None:
+        pytest.skip(f"this catalog offers no non-default row to respell: {rows}")
+    override = "databricks-" + slug.replace(".", "-")
+    if catalog_contains(rows, override) or codex_reachable_model_slug(override, rows) is None:
+        pytest.skip(
+            f"the gateway respelling {override!r} does not exercise the fold "
+            f"against this catalog: {rows}"
+        )
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "README.md").write_text("# gateway-spelled cold resume\n")
+    pane = PaneWatcher()
+    pane.arm()
+    session_id = rest_create_session(
+        rig.base_url,
+        agent_name=CODEX_NATIVE_AGENT_NAME,
+        host_id=host_id,
+        workspace=workspace,
+        terminal_launch_args=bypass_args(harness),
+    )
+    rest_post_user_message(rig.base_url, session_id, "Reply with exactly: ok. Nothing else.")
+    pane.wait_for_pane()
+    pane.wait_for_text(ready)
+    dismiss_blocking_dialogs(pane)
+
+    def _replies(at_least: int) -> Callable[[], int | None]:
+        def _count() -> int | None:
+            snapshot = session_snapshot(rig.base_url, session_id)
+            assert snapshot.get("status") != "failed", (
+                f"session {session_id} failed: "
+                f"{snapshot.get('last_task_error') or snapshot.get('error')}"
+            )
+            count = assistant_message_count(snapshot)
+            return count if count >= at_least else None
+
+        return _count
+
+    def _folds_to_override() -> str | None:
+        reported = session_snapshot(rig.base_url, session_id).get("llm_model")
+        if isinstance(reported, str) and comparable_model_id(reported) == comparable_model_id(
+            override
+        ):
+            return reported
+        return None
+
+    wait_for(_replies(1), timeout=150.0, what="the first reply")
+
+    # Persist the GATEWAY spelling, the way a databricks route / API client
+    # does; the live switch folds it to codex's slug and the pane reports that.
+    rest_patch_session(rig.base_url, session_id, model_override=override)
+    rest_post_user_message(rig.base_url, session_id, "Reply with exactly: switched. Nothing else.")
+    wait_for(_replies(2), timeout=150.0, what="the reply on the switched model")
+    wait_for(_folds_to_override, timeout=60.0, what=f"the pane to fold to {override!r}")
+
+    # The pane exits; the next message is the resume. Pre-fix, the relaunch's
+    # raw catalog check refused the gateway-spelled override and the session
+    # failed here.
+    kill_pane(pane)
+    resumed = PaneWatcher()
+    resumed.arm()
+    rest_post_user_message(rig.base_url, session_id, "Reply with exactly: back. Nothing else.")
+    wait_for(_replies(3), timeout=240.0, what="the reply after the cold resume")
+
+    snapshot = session_snapshot(rig.base_url, session_id)
+    assert snapshot.get("model_override") == override, (
+        f"the resume rewrote the persisted pick: {snapshot.get('model_override')!r}"
+    )
+    reported = snapshot.get("llm_model")
+    assert isinstance(reported, str) and comparable_model_id(reported) == comparable_model_id(
+        override
+    ), f"the resumed pane runs {reported!r}, not the folded {override!r} (session {session_id})"
+    resumed.wait_for_pane()
+    resumed.wait_for_text(ready)
+    pinned = codex_config_copy_model(session_id)
+    assert pinned is not None and comparable_model_id(pinned) == comparable_model_id(override), (
+        f"the relaunch pinned {pinned!r} in the config copy, not a fold of {override!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Stale catalog: a Default launch must not run yesterday's default
 # ---------------------------------------------------------------------------

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -3555,3 +3555,208 @@ async def test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog(
             await task
         # The background re-probe healed the store for the next launch.
         assert model_catalog_store.read_catalog("codex-native", fingerprint) == refreshed
+
+
+@pytest.mark.asyncio
+async def test_auto_create_codex_terminal_accepts_gateway_spelled_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A persisted override in the gateway spelling still resolves the catalog.
+
+    The override is stored as the servable id ``databricks-gpt-5-6-sol`` while
+    the catalog lists codex's own slug ``gpt-5.6-sol``. The launch translates
+    between the two, so the pre-launch check must match by codex's vocabulary,
+    not string equality — a raw membership test refuses a model this host serves.
+    """
+    import omnigent.codex_native_app_server as codex_app_mod
+    from omnigent import model_catalog_store
+    from omnigent.runner import app as runner_app_mod
+    from tests.runner.conftest import REAL_CODEX_LAUNCH_CATALOG
+
+    session_id = "5b0c7e2a9d1f4c3b8e6a7d5f4c3b2a1e"
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60937f"
+    override = "databricks-gpt-5-6-sol"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    monkeypatch.setattr(
+        codex_app_mod,
+        "resolve_native_codex_launch",
+        lambda *, model, spec=None: codex_app_mod.NativeCodexLaunch(
+            config_overrides=[], model=model, profile=None
+        ),
+    )
+    monkeypatch.setattr(codex_app_mod, "codex_launch_catalog", REAL_CODEX_LAUNCH_CATALOG)
+
+    async def _fake_probe(*, codex_path: str | None = None) -> list[dict[str, object]]:
+        """Stand in for the real codex probe; unused on a store hit."""
+        del codex_path
+        return [{"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "isDefault": True}]
+
+    monkeypatch.setattr(codex_app_mod, "probe_codex_model_options", _fake_probe)
+    fingerprint = codex_app_mod.codex_catalog_fingerprint(
+        codex_app_mod.resolve_native_codex_launch(model=None)
+    )
+    # A fresh catalog carrying codex's own slug, not the gateway spelling.
+    model_catalog_store.write_catalog(
+        "codex-native",
+        fingerprint,
+        [{"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "isDefault": True}],
+    )
+
+    class _SnapshotServerClient:
+        """Server client returning a resume snapshot with the gateway override."""
+
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            """
+            Return the session snapshot / item history the helper reads.
+
+            :param url: Request path.
+            :param kwargs: Request keyword arguments.
+            :returns: HTTP 200 response.
+            """
+            del kwargs
+            if url == f"/v1/sessions/{session_id}/items":
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {
+                                "id": "b1649a5cbfec3f92bec12275c14f4b61",
+                                "response_id": "codex_turn_1",
+                                "type": "message",
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "remember this"}],
+                            }
+                        ],
+                        "has_more": False,
+                    },
+                    request=httpx.Request("GET", url),
+                )
+            return httpx.Response(
+                200,
+                json={"model_override": override, "external_session_id": thread_id},
+                request=httpx.Request("GET", url),
+            )
+
+    class _FakeCodexAppServer:
+        """Minimal app-server object used by ``codex_terminal_env``."""
+
+        codex_path = "/opt/codex/bin/codex"
+        codex_cli_version: tuple[int, int, int] | None = (0, 145, 0)
+
+        def __init__(self) -> None:
+            """Initialize the fake app-server state."""
+            self.env = {"OPENAI_API_KEY": "sk-test"}
+            self.codex_home = tmp_path / "unconfigured-codex-home"
+            self.listen_url: str | None = None
+            self.started = False
+            self.config_overrides: list[str] = []
+
+        async def start(self) -> None:
+            """Mark the fake app-server started."""
+            self.started = True
+
+        async def close(self) -> None:
+            """No-op close."""
+
+    app_server = _FakeCodexAppServer()
+    build_calls: list[dict[str, Any]] = []
+
+    def _fake_build_codex_native_server(**kwargs: Any) -> _FakeCodexAppServer:
+        """
+        Capture app-server construction.
+
+        :param kwargs: Keyword arguments passed by the runner helper.
+        :returns: Fake app-server.
+        """
+        build_calls.append(kwargs)
+        app_server.codex_home = kwargs["codex_home"]
+        return app_server
+
+    class _UnexpectedDiscoveryClient:
+        """App-server client that must not connect on a known-thread resume."""
+
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            """
+            :param ws_url: App-server WebSocket URL.
+            :param client_name: JSON-RPC client name.
+            """
+            self.ws_url = ws_url
+            self.client_name = client_name
+
+        async def connect(self) -> None:
+            """Fail if the resume path tries to discover a fresh thread."""
+            raise AssertionError("resume path must not connect discovery client")
+
+        async def close(self) -> None:
+            """No-op close."""
+
+    async def _fake_preload_thread(
+        transport: str,
+        loaded_thread_id: str,
+        *,
+        terminal_launch_args: list[str] | None = None,
+    ) -> None:
+        """Accept preloading of the known Codex thread."""
+        del transport, loaded_thread_id, terminal_launch_args
+
+    async def _fake_forward_known_thread(**kwargs: Any) -> None:
+        """Accept the known-thread forwarder invocation."""
+        del kwargs
+
+    class _FakeResourceRegistry:
+        """Resource registry that accepts the terminal launch."""
+
+        async def launch_auxiliary_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            """Accept the terminal launch request."""
+            del terminal_name, session_key, spec, resource_role, parent_os_env
+            return SessionResourceView(
+                id="terminal_codex_main",
+                type="terminal",
+                session_id=session_id,
+                name="Codex",
+            )
+
+    monkeypatch.setattr(
+        codex_app_mod, "build_codex_native_server", _fake_build_codex_native_server
+    )
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
+    monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
+
+    agent_spec = AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "codex-native"}),
+    )
+    try:
+        await _auto_create_codex_terminal(
+            session_id,
+            _FakeResourceRegistry(),  # type: ignore[arg-type]
+            lambda _sid, _evt: None,
+            agent_spec=agent_spec,
+            server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
+        )
+        await asyncio.sleep(0)
+    finally:
+        runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+    # The gateway-spelled override was accepted (not refused) and passed
+    # through to the launch, which translates it to codex's slug downstream.
+    assert build_calls, "a servable override was refused as unknown"
+    assert build_calls[0]["model"] == override


### PR DESCRIPTION
## Related issue

No public issue is linked. This is a bug fix; happy to attach one if a maintainer wants it tracked.

Closes #

## Summary

- A codex-native session whose persisted `/model` override is stored in the **gateway spelling** (`databricks-gpt-5-6-sol`) failed to relaunch with `"the requested model 'databricks-gpt-5-6-sol' is not in this host's current model list"`, even though the host serves the model — codex's catalog lists it under codex's own slug (`gpt-5.6-sol`).
- The launch path already translates between the two spellings (`codex_spawn_model`), but the pre-launch validation compared with a raw string-equality check (`catalog_contains`), so it refused the override *before* the translation ran.
- Fix: validate with `codex_reachable_model_slug`, which folds the gateway and codex spellings to one comparable id. The hard failure now fires only for a model genuinely absent from the catalog.

**ELI5:** the model exists — we were just spelling its name two different ways and rejecting our own spelling. The in-pane `/model` picker persists codex's slug (so it never hit this), but an override that arrives in the gateway spelling — from `--model`, smart routing, or a resumed import — did.

```
persisted override        catalog rows            comparable fold
databricks-gpt-5-6-sol    id: gpt-5.6-sol   -->   gpt-5-6-sol  == gpt-5-6-sol  MATCH
   (raw ==)  ---------------------------------->  no match     -> false refusal (bug)
```

This is the codex twin of the claude fix in #5167. The vocabulary helper has existed since #4074; this check was just never wired to it. The refusal was introduced by #5022.

## Test Plan

- **Unit regression** `test_auto_create_codex_terminal_accepts_gateway_spelled_override`: seeds a fresh catalog listing `gpt-5.6-sol` + a persisted override of `databricks-gpt-5-6-sol`, drives the real `_auto_create_codex_terminal`, and asserts it launches (not refused) and passes the override through. **Fails on the pre-fix `catalog_contains` check** (raising the exact `ClickException`) and **passes on the fix**.
- **Live E2E** `test_row18b_codex_cold_resume_honors_a_gateway_spelled_override` (`tests/e2e/omnigent`, opt-in `OMNIGENT_E2E_MODEL_FLOWS=1`, codex-databricks shape): real server + host + codex TUI, persists `databricks-gpt-5-6-terra`, kills the pane, resumes.
  - **Post-fix: PASSED** — the resumed pane runs the folded model (`gpt-5.6-terra`), the persisted gateway spelling survives, and the config copy pins the fold.
  - **Pre-fix: FAILED** at the cold-resume step; the runner log shows `Native Codex terminal start failed: the requested model 'databricks-gpt-5-6-terra' is not in this host's current model list …` — the exact reported error.
  - Skips without a `kind:databricks` provider, so it's inert in CI.
- Live-catalog check against this box's real probed codex catalog: old `catalog_contains("databricks-gpt-5-6-sol")` → False; new `codex_reachable_model_slug(...)` → `gpt-5.6-sol`.
- `uv run pytest ...::test_auto_create_codex_terminal_accepts_gateway_spelled_override ...::test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog tests/test_codex_model_vocabulary.py` → 33 passed.
- `uv run ruff check` / `ruff format --check` on all changed files → clean; `pre-commit` on changed files → passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit test drives the real `_auto_create_codex_terminal` (real snapshot read, real catalog store; only the codex subprocess/socket faked) — a true regression test that fails on the prior `catalog_contains` check and passes on the fix. The live E2E was run both ways on a real codex-databricks host: green on the fix, and red on pre-fix code with the exact `ClickException` in the runner log. Manual verification = those live runs (a `kind:databricks` provider was added to a local config for the run and removed afterward; no repo files or credentials touched).

## Changelog

A codex session pinned to a model in the gateway spelling (e.g. `databricks-gpt-5-6-sol`) now resumes instead of failing with "not in this host's current model list".

This pull request and its description were written by Isaac.
