### PR TITLE
feat(runner): emit harness_started debug event on spawn

### DIFF
--- a/omnigent/runtime/harnesses/process_manager.py
+++ b/omnigent/runtime/harnesses/process_manager.py
@@ -39,6 +39,7 @@ from typing import Any
 import httpx
 
 from omnigent._platform import IS_WINDOWS
+from omnigent.debug_logging import debug_event
 from omnigent.harness_plugins import missing_install_packages
 from omnigent.inner import _proc
 from omnigent.inner._subprocess_lifecycle import close_subprocess_transport
@@ -564,6 +565,9 @@ class HarnessProcessManager:
         # Pre-allocate the instance dir path so it stays stable
         # across re-entrant ``start()`` calls (idempotent boot).
         self._instance_dir = self._tmp_parent / f"ap-{uuid.uuid4().hex}"
+        # Monotonic clock at ``start()``; the harness_started event reports each
+        # spawn's readiness latency relative to it (harness boot vs manager boot).
+        self._started_at: float | None = None
         self._entries: dict[str, _SubprocessEntry] = {}
         # Per-conversation in-flight harness response_id. The runner's
         # ``proxy_stream`` populates it via :meth:`mark_in_flight` when
@@ -679,6 +683,7 @@ class HarnessProcessManager:
             name="harness-process-manager-idle-reaper",
         )
         self._started = True
+        self._started_at = time.monotonic()
         _logger.info(
             "HarnessProcessManager started; instance_dir=%s",
             self._instance_dir,
@@ -1232,9 +1237,32 @@ class HarnessProcessManager:
             "--parent-pid",
             str(parent_pid),
         ]
+        spawn_started_at = time.monotonic()
         process = await self._spawn_harness_process(runner_argv, effective_env)
         try:
             await _wait_for_bind(process, endpoint, harness, conversation_id)
+            # The harness process has bound its socket and is ready to serve —
+            # the observable "harness started" edge. Report the spawn->ready
+            # latency; on a cold runner the first spawn's manager-relative
+            # latency is the runner_start -> harness_started interval.
+            _now = time.monotonic()
+            _logger.info(
+                "harness started for conversation %s (harness=%s)",
+                conversation_id,
+                harness,
+                extra=debug_event(
+                    "harness_started",
+                    session_id=conversation_id,
+                    harness=harness,
+                    pid=process.pid,
+                    spawn_ms=int((_now - spawn_started_at) * 1000),
+                    since_manager_start_ms=(
+                        int((_now - self._started_at) * 1000)
+                        if self._started_at is not None
+                        else None
+                    ),
+                ),
+            )
 
             # ``base_url`` is required for relative-URL routing; the
             # actual host portion is irrelevant under uds transport,

--- a/tests/runtime/harnesses/test_process_manager.py
+++ b/tests/runtime/harnesses/test_process_manager.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import os
 import shutil
 import signal
@@ -264,6 +265,35 @@ async def test_get_client_spawns_and_serves(
         # the contract; verify the round-trip works.
         cid_resp = await client.get("/conversation-id")
         assert cid_resp.json() == {"conversation_id": "conv_a"}
+    finally:
+        await manager.shutdown()
+
+
+async def test_get_client_emits_harness_started_event(
+    manager: HarnessProcessManager,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A successful spawn emits one ``harness_started`` debug event.
+
+    This is the observable "harness bound and ready" edge used to measure
+    startup latency; the row carries the spawn->ready time and, for the
+    first spawn on a cold runner, the manager-start-relative time.
+    """
+    await manager.start()
+    try:
+        with caplog.at_level(logging.INFO, logger="omnigent.runtime.harnesses.process_manager"):
+            await manager.get_client("conv_a", _TEST_HARNESS_NAME)
+        started = [
+            r for r in caplog.records if getattr(r, "event_name", None) == "harness_started"
+        ]
+        assert len(started) == 1
+        record = started[0]
+        assert record.session_id == "conv_a"
+        attrs = record.attributes
+        assert attrs["harness"] == _TEST_HARNESS_NAME
+        assert isinstance(attrs["pid"], int)
+        assert attrs["spawn_ms"] >= 0
+        assert attrs["since_manager_start_ms"] >= 0
     finally:
         await manager.shutdown()
 


### PR DESCRIPTION
## Related issue

N/A — internal observability change (no user-facing behavior); no tracking issue.

## Summary

- Emit a `harness_started` semantic debug event when a harness subprocess binds its socket and is ready to serve (in `HarnessProcessManager._spawn_entry`, right after `_wait_for_bind`).
- The row carries `session_id` (conversation id), `harness`, `pid`, `spawn_ms` (spawn -> ready), and `since_manager_start_ms` (relative to `HarnessProcessManager.start()`; on a cold runner the first spawn's value is the `runner_start -> harness_started` interval).
- Today a successful spawn logs nothing — only failures (`_native_terminal_start_error_payload`, zygote-unavailable) are recorded — so harness-start latency is not queryable. This closes that gap without changing any behavior.

## Test Plan

- `uv run pytest tests/runtime/harnesses/test_process_manager.py` — 42 passed (includes the new `test_get_client_emits_harness_started_event`, which spawns the real fixture harness and asserts exactly one `harness_started` record with the expected `session_id`/`harness`/`pid`/`spawn_ms`/`since_manager_start_ms`).
- `uv run ruff check` / `ruff format --check` / `uv run pre-commit run --files ...` — all pass.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change (adds a log event only)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran the full `test_process_manager.py` module (42 passed, real subprocess spawns) to confirm the new event fires on the ready edge and no lifecycle behavior regressed. The event is pure instrumentation (one INFO log on the existing success path), so no integration/E2E coverage is warranted.
