### PR TITLE
fix(kubernetes): re-stamp the agent classifier when a runner wakes

### DIFF
--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -3149,6 +3149,7 @@ async def resume_managed_host(
     *,
     force: bool = False,
     on_stage: Callable[[str], None] | None = None,
+    agent_name: str | None = None,
 ) -> None:
     """
     Wake a dormant managed host so a session bound to it can run again.
@@ -3184,6 +3185,10 @@ async def resume_managed_host(
         exactly like a fresh launch (:func:`_arm_and_start_host`) — without it a
         wake shows a single frozen ``"provisioning"`` band for its whole
         duration. ``None`` disables progress reporting.
+    :param agent_name: Built-in agent classifier to re-stamp on the woken
+        runner, or ``None`` to leave it unstamped. A wake rebuilds the runner
+        from scratch, so the classifier is not carried over by the resume: the
+        caller re-derives it through the same built-in gate a launch uses.
     :raises HTTPException: 502 when the resume or host restart fails.
     """
     if config is None:
@@ -3245,6 +3250,7 @@ async def resume_managed_host(
                 repo_name=None,
                 host_config=entry.host_config,
                 on_stage=on_stage,
+                agent_name=agent_name,
             )
             await _wait_for_host_online(host_store, host.host_id)
         except Exception as exc:

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -3586,6 +3586,13 @@ def _kick_managed_wake_impl(
     # session page when the wake fires (the composer let them send into a
     # host_asleep session).
     _publish_sandbox_status(session_id, "provisioning")
+    wake_agent_store = getattr(app_state, "agent_store", None)
+    if wake_agent_store is None:
+        _logger.warning(
+            "session %s: wake has no agent store; woken runner stays unclassified",
+            session_id,
+            extra={"session_id": session_id},
+        )
     wake_task = asyncio.create_task(
         _run_managed_wake(
             session_id=session_id,
@@ -3596,6 +3603,8 @@ def _kick_managed_wake_impl(
             host_store=host_store,
             host_registry=getattr(app_state, "host_registry", None),
             tunnel_registry=getattr(app_state, "tunnel_registry", None),
+            agent_store=wake_agent_store,
+            agent_id=conv.agent_id,
         )
     )
     _managed_launch_tasks.add(wake_task)
@@ -3612,6 +3621,8 @@ async def _run_managed_wake(
     host_store: HostStore,
     host_registry: HostRegistry | None,
     tunnel_registry: TunnelRegistry | None,
+    agent_store: AgentStore | None = None,
+    agent_id: str | None = None,
 ) -> None:
     """
     Wake a dormant resumable managed host in the background, settling the
@@ -3640,8 +3651,16 @@ async def _run_managed_wake(
         frame. ``None`` in minimal test wirings.
     :param tunnel_registry: Runner-tunnel registry used to await the launched
         runner's connection. ``None`` in minimal test wirings.
+    :param agent_store: Store the runner's agent classifier is resolved from,
+        or ``None`` (a stripped test wiring) to leave the runner unclassified.
+    :param agent_id: Agent the session is bound to, resolved through the
+        built-in gate into the woken runner Pod's ``omnigent.ai/agent``
+        classifier, or ``None`` to leave it unstamped.
     """
-    from omnigent.server.managed_hosts import resume_managed_host
+    from omnigent.server.managed_hosts import (
+        resolve_managed_agent_label,
+        resume_managed_host,
+    )
     from omnigent.server.routes import sessions as _facade
 
     host_id = conv.host_id
@@ -3665,8 +3684,25 @@ async def _run_managed_wake(
     try:
         # Wake the same sandbox in place; resume_managed_host is single-flight
         # per host and a no-op if it's already online.
+        # Re-derived here rather than by the caller, matching the launch path:
+        # the read runs on the task that already owns the single-flight claim,
+        # and it is never read back from a stored label — so there is nothing to
+        # keep in sync, or to forge.
+        agent_name: str | None = None
+        if agent_store is not None and agent_id is not None:
+            agent_name = await asyncio.to_thread(
+                resolve_managed_agent_label,
+                agent_store,
+                agent_id,
+                session_id=session_id,
+            )
         await resume_managed_host(
-            host_id, host_store, sandbox_config, force=True, on_stage=_on_stage
+            host_id,
+            host_store,
+            sandbox_config,
+            force=True,
+            on_stage=_on_stage,
+            agent_name=agent_name,
         )
         _publish_sandbox_status(session_id, "connecting")
         refreshed = await asyncio.to_thread(conversation_store.get_conversation, session_id)

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -2618,6 +2618,85 @@ async def test_resume_managed_host_forwards_on_stage(db_uri: str) -> None:
     assert "starting" in stages
 
 
+async def test_resume_threads_agent_name_to_classifying_start_host(db_uri: str) -> None:
+    """
+    A wake re-stamps the runner's classifier.
+
+    The resume rebuilds the runner from scratch under the same sandbox id, so a
+    classifier the first launch stamped is NOT carried over by the provider. If
+    the wake omits it, the woken runner comes back unclassified, the admission
+    policy that selects on the label stops matching, and the runner silently
+    loses the credential the label exists to attract.
+    """
+    host_store = HostStore(db_uri)
+
+    def _register(invocation: HostStartInvocation) -> None:
+        host_store.upsert_on_connect(
+            host_id=invocation.host_id, name=invocation.host_name, user_id=_OWNER
+        )
+
+    fake = _ClassifyingFakeSandboxLauncher(on_host_start=_register, can_resume=True)
+    config = _injected_config(fake)
+    first = await launch_managed_host(
+        config=config, owner=_OWNER, host_store=host_store, agent_name="code-reviewer"
+    )
+    host_store.set_offline(first.host_id)
+
+    await resume_managed_host(first.host_id, host_store, config, agent_name="code-reviewer")
+
+    assert fake.resumed == ["sb-fake-1"]
+    assert fake.agent_names == ["code-reviewer", "code-reviewer"]
+
+
+async def test_resume_never_passes_agent_name_to_a_non_classifying_launcher(
+    db_uri: str,
+) -> None:
+    """
+    The wake gates on the capability, not on the value.
+
+    An exec-model launcher has no ``agent_name`` keyword, so a wake that reached
+    it with one would raise ``TypeError`` and 502. The wake succeeding proves the
+    keyword was omitted.
+    """
+    host_store = HostStore(db_uri)
+
+    def _register(invocation: HostStartInvocation) -> None:
+        host_store.upsert_on_connect(
+            host_id=invocation.host_id, name=invocation.host_name, user_id=_OWNER
+        )
+
+    fake = _IsloFakeLauncher(on_host_start=_register, can_resume=True)
+    config = _injected_config(fake)
+    first = await launch_managed_host(config=config, owner=_OWNER, host_store=host_store)
+    host_store.set_offline(first.host_id)
+
+    await resume_managed_host(first.host_id, host_store, config, agent_name="code-reviewer")
+
+    assert fake.resumed == ["sb-fake-1"]
+    assert host_store.get_host(first.host_id) is not None
+
+
+async def test_resume_without_a_classifier_leaves_the_woken_runner_unstamped(
+    db_uri: str,
+) -> None:
+    """No resolved name means the classifying launcher is told nothing to stamp."""
+    host_store = HostStore(db_uri)
+
+    def _register(invocation: HostStartInvocation) -> None:
+        host_store.upsert_on_connect(
+            host_id=invocation.host_id, name=invocation.host_name, user_id=_OWNER
+        )
+
+    fake = _ClassifyingFakeSandboxLauncher(on_host_start=_register, can_resume=True)
+    config = _injected_config(fake)
+    first = await launch_managed_host(config=config, owner=_OWNER, host_store=host_store)
+    host_store.set_offline(first.host_id)
+
+    await resume_managed_host(first.host_id, host_store, config)
+
+    assert fake.agent_names == [None, None]
+
+
 async def test_resume_managed_host_force_wakes_fresh_online_row(db_uri: str) -> None:
     """A local missing-tunnel wake can bypass stale cross-replica DB freshness."""
     host_store = HostStore(db_uri)
@@ -3552,6 +3631,138 @@ async def test_run_managed_launch_omits_the_classifier_for_a_session_scoped_impo
         repo=None,
         tracker=ManagedLaunchTracker(),
         conversation_store=SimpleNamespace(),
+        host_store=SimpleNamespace(),
+        host_registry=None,
+        tunnel_registry=None,
+        agent_store=_StubAgentStore({impostor.id: impostor}),
+        agent_id=impostor.id,
+    )
+    assert captured["agent_name"] is None
+
+
+async def test_kick_managed_wake_defers_the_classifier_to_the_wake_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The wake hands the agent store and the bound agent id to the wake task rather
+    than resolving the classifier itself, matching the relaunch path: the
+    claim-to-task region stays synchronous and only the winning caller pays for
+    the read.
+    """
+    from omnigent.server.routes._sessions import orchestration
+
+    captured: dict[str, object] = {}
+
+    async def _capture(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(orchestration, "_run_managed_wake", _capture)
+
+    builtin = Agent(
+        id=builtin_agent_id("code-reviewer"),
+        created_at=now_epoch(),
+        name="code-reviewer",
+        bundle_location="bundle/loc",
+        session_id=None,
+    )
+
+    reads: list[str] = []
+
+    class _RecordingStore(_StubAgentStore):
+        def get(self, agent_id: str) -> Agent | None:
+            reads.append(agent_id)
+            return super().get(agent_id)
+
+    store = _RecordingStore({builtin.id: builtin})
+    conv = SimpleNamespace(labels={}, host_id="host_1", agent_id=builtin.id)
+    before = set(orchestration._managed_launch_tasks)
+    orchestration._kick_managed_wake_impl(
+        session_id="conv_1",
+        conv=conv,
+        sandbox_config=SimpleNamespace(),
+        tracker=ManagedLaunchTracker(),
+        conversation_store=SimpleNamespace(),
+        host_store=SimpleNamespace(),
+        app_state=SimpleNamespace(agent_store=store),
+    )
+    scheduled = set(orchestration._managed_launch_tasks) - before
+    assert scheduled, "the claim was taken but no task was scheduled to settle it"
+    await asyncio.gather(*scheduled)
+    assert reads == [], "the kick must not read the agent store; the wake task does"
+    assert captured["agent_store"] is store
+    assert captured["agent_id"] == builtin.id
+
+
+async def test_run_managed_wake_re_stamps_the_woken_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The wake task resolves the bound agent through the built-in gate and forwards
+    the name into the resume, so the rebuilt runner carries its classifier again.
+    """
+    from omnigent.server.routes._sessions import orchestration
+
+    captured: dict[str, object] = {}
+
+    async def _resume(*args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("omnigent.server.managed_hosts.resume_managed_host", _resume)
+
+    builtin = Agent(
+        id=builtin_agent_id("code-reviewer"),
+        created_at=now_epoch(),
+        name="code-reviewer",
+        bundle_location="bundle/loc",
+        session_id=None,
+    )
+    conv = SimpleNamespace(labels={}, host_id="host_1", agent_id=builtin.id)
+    await orchestration._run_managed_wake(
+        session_id="conv_1",
+        conv=conv,
+        sandbox_config=SimpleNamespace(),
+        tracker=ManagedLaunchTracker(),
+        conversation_store=SimpleNamespace(get_conversation=lambda _sid: None),
+        host_store=SimpleNamespace(),
+        host_registry=None,
+        tunnel_registry=None,
+        agent_store=_StubAgentStore({builtin.id: builtin}),
+        agent_id=builtin.id,
+    )
+    assert captured["agent_name"] == "code-reviewer"
+
+
+async def test_run_managed_wake_omits_the_classifier_for_a_session_scoped_impostor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A session-scoped agent named after a built-in resolves to no classifier on
+    the wake path too, so a wake cannot be used to obtain a label the initial
+    launch would have refused.
+    """
+    from omnigent.server.routes._sessions import orchestration
+
+    captured: dict[str, object] = {}
+
+    async def _resume(*args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("omnigent.server.managed_hosts.resume_managed_host", _resume)
+
+    impostor = Agent(
+        id="9f2c1b7e4a5d4c8fa1b2c3d4e5f60718",
+        created_at=now_epoch(),
+        name="code-reviewer",
+        bundle_location="bundle/loc",
+        session_id="conv_1",
+    )
+    conv = SimpleNamespace(labels={}, host_id="host_1", agent_id=impostor.id)
+    await orchestration._run_managed_wake(
+        session_id="conv_1",
+        conv=conv,
+        sandbox_config=SimpleNamespace(),
+        tracker=ManagedLaunchTracker(),
+        conversation_store=SimpleNamespace(get_conversation=lambda _sid: None),
         host_store=SimpleNamespace(),
         host_registry=None,
         tunnel_registry=None,


### PR DESCRIPTION
Fixes #6463

## What

`resume_managed_host` never passed `agent_name`, so a woken managed runner
came back with no `omnigent.ai/agent` label.

A wake rebuilds the runner from scratch under the same sandbox id. The
provider does not carry the label across that rebuild, and the label is
deliberately not persisted — `resolve_managed_agent_label` re-derives it on
every launch through the built-in gate, precisely so there is no stored
classifier to keep in sync or to forge. The launch and relaunch paths call
it; the wake path did not.

## Why it matters

The label is what an admission policy selects on to inject a privileged
credential. When a woken runner loses it, the policy stops matching and the
runner silently loses the credential — no error at the wake, no error at
admission. The failure surfaces far from its cause, as an agent that cannot
read the repository it was reading before it went dormant.

Observed on a Kubernetes deployment: a dormant session woke, its Pod came
back with `omnigent.ai/role=sandbox-host` and no `omnigent.ai/agent`, and the
Kyverno policy keyed on that label skipped the Pod entirely — so the Pod got
neither the credential volume nor its git configuration.

## The fix

Resolve the classifier on the wake task and forward it into the resume,
mirroring `_run_managed_launch` exactly:

- `resume_managed_host` takes `agent_name` and passes it to
  `_start_sandbox_host`, which already gates on
  `classifies_runner_by_agent` — so a non-classifying launcher never
  receives the keyword and is unaffected.
- `_run_managed_wake` resolves the name through `resolve_managed_agent_label`
  on the task that already owns the single-flight claim, so the request path
  keeps no `await` between claiming and spawning and a losing concurrent
  message pays nothing for the read.
- `_kick_managed_wake_impl` hands the store and the bound agent id to the
  task and reads the store not at all, matching `_kick_managed_relaunch`.

No schema change and no new stored state: a wake re-derives the classifier
the same way a launch does, so a session-scoped impostor cannot use a wake to
obtain a label the initial launch would have refused.

## Tests

Six added to `tests/server/test_managed_hosts.py`:

| Test | Asserts |
|---|---|
| `test_resume_threads_agent_name_to_classifying_start_host` | a wake re-stamps the classifier |
| `test_resume_never_passes_agent_name_to_a_non_classifying_launcher` | the capability gate holds on the wake path |
| `test_resume_without_a_classifier_leaves_the_woken_runner_unstamped` | no name resolved → nothing stamped |
| `test_kick_managed_wake_defers_the_classifier_to_the_wake_task` | the kick forwards the store and never reads it |
| `test_run_managed_wake_re_stamps_the_woken_runner` | the wake task resolves and forwards the name |
| `test_run_managed_wake_omits_the_classifier_for_a_session_scoped_impostor` | a wake cannot obtain a label a launch would refuse |

Each of the three parts of the fix was mutation-tested independently; every
mutation kills exactly one of the new tests.

```
264 passed        tests/server/test_managed_hosts.py
All checks passed ruff check
3 files already formatted   ruff format --check
0 errors          pyrefly check (changed modules)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
