### PR TITLE
Add direct session import by ID

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -55,6 +55,7 @@ from omnigent.host.frames import (
     HostHarnessReadinessFrame,
     HostHelloFrame,
     HostImportedLocalSession,
+    HostImportLocalByIdFrame,
     HostImportLocalDoneFrame,
     HostImportLocalFrame,
     HostImportLocalSessionFrame,
@@ -2137,13 +2138,16 @@ class HostProcess:
         )
 
     async def _handle_import_local(
-        self, ws: websockets.asyncio.client.ClientConnection, frame: HostImportLocalFrame
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        frame: HostImportLocalFrame | HostImportLocalByIdFrame,
     ) -> None:
-        """Stream the host's recent local transcripts, one frame per session.
+        """Stream requested local transcripts, one frame per session.
 
-        The host owns the session files (``~/.claude`` etc.). It enumerates the
-        targets ("all" merges every harness into one global recency order, top
-        ``limit`` total), then reads + normalizes each and sends it immediately
+        The host owns the session files (``~/.claude`` etc.). An exact session
+        id is loaded directly; otherwise it enumerates the targets ("all"
+        merges every harness into one global recency order, top ``limit``
+        total). It reads + normalizes each and sends it immediately
         (``host.import_local_session``) so a large batch never rides in one frame
         and the server persists as each arrives. A terminal ``host.import_local_done``
         closes the stream. Sessions that fail to load are skipped; a single-harness
@@ -2157,6 +2161,8 @@ class HostProcess:
             )
             from omnigent.session_import.models import ImportSource, SessionImportNotFoundError
 
+            if isinstance(frame, HostImportLocalByIdFrame):
+                return [(frame.source, frame.session_id)], None
             if frame.source == "all":
                 return list(list_recent_sessions_across_harnesses(limit=frame.limit)), None
             source = cast(ImportSource, frame.source)
@@ -3947,7 +3953,7 @@ class HostProcess:
                     error=f"model options resolution crashed for {frame.harness!r}",
                 )
             await ws.send(encode_host_frame(options_result))
-        elif isinstance(frame, HostImportLocalFrame):
+        elif isinstance(frame, (HostImportLocalFrame, HostImportLocalByIdFrame)):
             # Streams one host.import_local_session per session (reads run off the
             # event loop inside), then a terminal host.import_local_done.
             await self._handle_import_local(ws, frame)

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -75,6 +75,7 @@ class HostFrameKind(str, Enum):
     MODEL_OPTIONS = "host.model_options"
     MODEL_OPTIONS_RESULT = "host.model_options_result"
     IMPORT_LOCAL = "host.import_local"
+    IMPORT_LOCAL_BY_ID = "host.import_local_by_id"
     IMPORT_LOCAL_SESSION = "host.import_local_session"
     IMPORT_LOCAL_DONE = "host.import_local_done"
 
@@ -911,6 +912,20 @@ class HostImportLocalFrame:
 
 
 @dataclass
+class HostImportLocalByIdFrame:
+    """Server → host: read one known local transcript without listing.
+
+    :param request_id: Unique id for correlating the result.
+    :param source: Harness namespace containing the session.
+    :param session_id: Exact harness-native session id to load.
+    """
+
+    request_id: str
+    source: str
+    session_id: str
+
+
+@dataclass
 class HostImportLocalSessionFrame:
     """Host → server: one normalized local session, streamed as it's read.
 
@@ -980,6 +995,7 @@ HostFrame = (
     | HostModelOptionsFrame
     | HostModelOptionsResultFrame
     | HostImportLocalFrame
+    | HostImportLocalByIdFrame
     | HostImportLocalSessionFrame
     | HostImportLocalDoneFrame
 )
@@ -1353,6 +1369,15 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "limit": frame.limit,
             }
         )
+    if isinstance(frame, HostImportLocalByIdFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.IMPORT_LOCAL_BY_ID.value,
+                "request_id": frame.request_id,
+                "source": frame.source,
+                "session_id": frame.session_id,
+            }
+        )
     if isinstance(frame, HostImportLocalSessionFrame):
         s = frame.session
         return _encode_payload(
@@ -1509,6 +1534,8 @@ def _decode_known_host_frame(
             return _decode_model_options_result(msg)
         case HostFrameKind.IMPORT_LOCAL:
             return _decode_import_local(msg)
+        case HostFrameKind.IMPORT_LOCAL_BY_ID:
+            return _decode_import_local_by_id(msg)
         case HostFrameKind.IMPORT_LOCAL_SESSION:
             return _decode_import_local_session(msg)
         case HostFrameKind.IMPORT_LOCAL_DONE:
@@ -2041,6 +2068,15 @@ def _decode_import_local(msg: _JsonObject) -> HostImportLocalFrame:
         request_id=_required_str(msg, "request_id"),
         source=_required_str(msg, "source"),
         limit=_required_int(msg, "limit"),
+    )
+
+
+def _decode_import_local_by_id(msg: _JsonObject) -> HostImportLocalByIdFrame:
+    """Decode a host.import_local_by_id frame."""
+    return HostImportLocalByIdFrame(
+        request_id=_required_str(msg, "request_id"),
+        source=_required_str(msg, "source"),
+        session_id=_required_str(msg, "session_id"),
     )
 
 

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -13,12 +13,12 @@ from typing import Any, Literal, cast, get_args
 
 from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.host.frames import HostImportLocalFrame, encode_host_frame
+from omnigent.host.frames import HostImportLocalByIdFrame, HostImportLocalFrame, encode_host_frame
 from omnigent.native_coding_agents import native_coding_agent_for_harness
 from omnigent.server.auth import LEVEL_OWNER, AuthProvider
 from omnigent.server.host_registry import HostConnection, HostRegistry
@@ -98,11 +98,13 @@ class ImportSessionResponse(BaseModel):
 
 
 class LocalImportRequest(BaseModel):
-    """Request to import the caller's recent local harness sessions from a host.
+    """Request to import local harness sessions from a host.
 
     Unlike ``/imports`` (the CLI posts already-normalized items), the server
     asks the chosen host to read + normalize its own transcripts over the
-    tunnel — the transcripts live on the caller's machine, not the server.
+    tunnel — the transcripts live on the caller's machine, not the server. A
+    supplied ``session_id`` loads that exact session without enumerating local
+    history.
     """
 
     host_id: str
@@ -110,6 +112,25 @@ class LocalImportRequest(BaseModel):
     # the host in one batch (each imported session keeps its own source).
     source: ImportSource | Literal["all"]
     limit: int = Field(default=10, ge=1, le=100)
+    session_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+    @field_validator("session_id")
+    @classmethod
+    def strip_session_id(cls, value: str | None) -> str | None:
+        """Reject an exact session id that is only whitespace."""
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            raise ValueError("session_id must not be blank")
+        return value
+
+    @model_validator(mode="after")
+    def exact_import_needs_harness(self) -> LocalImportRequest:
+        """An id is only meaningful within one harness namespace."""
+        if self.session_id is not None and self.source == "all":
+            raise ValueError("an exact session import requires a specific harness")
+        return self
 
 
 class ImportedSessionRef(BaseModel):
@@ -190,11 +211,12 @@ async def _stream_local_sessions_from_host(
     host_conn: HostConnection,
     source: str,
     limit: int,
+    session_id: str | None = None,
     stats: dict[str, int] | None = None,
 ) -> AsyncIterator[dict[str, Any]]:
-    """Yield the host's recent local sessions one at a time as they stream in.
+    """Yield requested local sessions one at a time as they stream in.
 
-    Sends a ``host.import_local`` frame and drains the per-request queue the
+    Sends a recent or exact import frame and drains the per-request queue the
     tunnel fills: each ``host.import_local_session`` frame yields one session
     dict (``{total, external_session_id, workspace, items, title, source}``); the
     terminal ``host.import_local_done`` ends the stream. The caller persists each
@@ -204,9 +226,16 @@ async def _stream_local_sessions_from_host(
         the host reports a read failure.
     """
     request_id = secrets.token_hex(8)
-    frame = encode_host_frame(
-        HostImportLocalFrame(request_id=request_id, source=source, limit=limit)
+    request_frame = (
+        HostImportLocalByIdFrame(
+            request_id=request_id,
+            source=source,
+            session_id=session_id,
+        )
+        if session_id is not None
+        else HostImportLocalFrame(request_id=request_id, source=source, limit=limit)
     )
+    frame = encode_host_frame(request_frame)
     queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
     host_conn.pending_import_local[request_id] = queue
     try:
@@ -444,7 +473,7 @@ def create_imports_router(
         host_conn: HostConnection,
         counts: dict[str, int],
     ) -> AsyncIterator[ImportedSessionRef]:
-        """Import the host's recent sessions, one at a time.
+        """Import the host's requested sessions, one at a time.
 
         Yields one ref per newly imported session and tracks the running tally in
         ``counts`` (``imported`` / ``already_imported`` / ``failed``). Persists
@@ -467,6 +496,7 @@ def create_imports_router(
             host_conn=host_conn,
             source=body.source,
             limit=body.limit,
+            session_id=body.session_id,
             stats=stats,
         ):
             external_session_id = session.get("external_session_id")
@@ -530,12 +560,12 @@ def create_imports_router(
         body: LocalImportRequest,
         request: Request,
     ) -> LocalImportResponse:
-        """Import the caller's recent local transcripts from a chosen host.
+        """Import local transcripts from a chosen host.
 
         The transcripts live on the caller's machine, so the read happens on
         the connected host over its tunnel — the server can't see them. The
-        host enumerates + normalizes the most recent sessions; the server
-        imports those not already imported.
+        host loads an exact id or enumerates recent sessions, then normalizes
+        them; the server imports those not already imported.
 
         Buffered form: returns the whole batch's tally in one JSON body. For a
         live per-session list use ``POST /v1/imports/local/stream``. Not atomic:
@@ -566,7 +596,7 @@ def create_imports_router(
         body: LocalImportRequest,
         request: Request,
     ) -> StreamingResponse:
-        """Stream the caller's recent local transcripts from a chosen host.
+        """Stream local transcripts from a chosen host.
 
         Same import as the buffered ``POST /v1/imports/local``, but responds with
         NDJSON: one ``{"event": "session", ...}`` line per newly imported session

--- a/openapi.json
+++ b/openapi.json
@@ -2852,7 +2852,7 @@
         "type": "object"
       },
       "LocalImportRequest": {
-        "description": "Request to import the caller's recent local harness sessions from a host.\n\nUnlike `/imports` (the CLI posts already-normalized items), the server\nasks the chosen host to read + normalize its own transcripts over the\ntunnel \u2014 the transcripts live on the caller's machine, not the server.",
+        "description": "Request to import local harness sessions from a host.\n\nUnlike `/imports` (the CLI posts already-normalized items), the server\nasks the chosen host to read + normalize its own transcripts over the\ntunnel \u2014 the transcripts live on the caller's machine, not the server. A\nsupplied `session_id` loads that exact session without enumerating local\nhistory.",
         "properties": {
           "host_id": {
             "title": "Host Id",
@@ -2865,6 +2865,19 @@
             "minimum": 1.0,
             "title": "Limit",
             "type": "integer"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
           },
           "source": {
             "anyOf": [
@@ -9714,7 +9727,7 @@
     },
     "/v1/imports/local": {
       "post": {
-        "description": "Import the caller's recent local transcripts from a chosen host.\n\nThe transcripts live on the caller's machine, so the read happens on\nthe connected host over its tunnel \u2014 the server can't see them. The\nhost enumerates + normalizes the most recent sessions; the server\nimports those not already imported.\n\nBuffered form: returns the whole batch's tally in one JSON body. For a\nlive per-session list use `POST /v1/imports/local/stream`. Not atomic:\neach session is persisted as its frame arrives, so if the host drops\nmid-stream this raises after the sessions read so far are already\ncommitted; a retry is idempotent (they come back as already-imported).",
+        "description": "Import local transcripts from a chosen host.\n\nThe transcripts live on the caller's machine, so the read happens on\nthe connected host over its tunnel \u2014 the server can't see them. The\nhost loads an exact id or enumerates recent sessions, then normalizes\nthem; the server imports those not already imported.\n\nBuffered form: returns the whole batch's tally in one JSON body. For a\nlive per-session list use `POST /v1/imports/local/stream`. Not atomic:\neach session is persisted as its frame arrives, so if the host drops\nmid-stream this raises after the sessions read so far are already\ncommitted; a retry is idempotent (they come back as already-imported).",
         "operationId": "import_local_sessions_v1_imports_local_post",
         "requestBody": {
           "content": {
@@ -9756,7 +9769,7 @@
     },
     "/v1/imports/local/stream": {
       "post": {
-        "description": "Stream the caller's recent local transcripts from a chosen host.\n\nSame import as the buffered `POST /v1/imports/local`, but responds with\nNDJSON: one `{\"event\": \"session\", ...}` line per newly imported session\nas its frame lands, so the caller lists sessions as they arrive rather\nthan waiting out the whole batch; a terminal `{\"event\": \"done\", ...}`\ncarries the tally. A mid-stream host failure emits `{\"event\": \"error\", ...}` before `done` \u2014 the sessions read so far are already committed\nand a retry is idempotent. Request validation still fails ahead of the\nstream with the usual HTTP error.",
+        "description": "Stream local transcripts from a chosen host.\n\nSame import as the buffered `POST /v1/imports/local`, but responds with\nNDJSON: one `{\"event\": \"session\", ...}` line per newly imported session\nas its frame lands, so the caller lists sessions as they arrive rather\nthan waiting out the whole batch; a terminal `{\"event\": \"done\", ...}`\ncarries the tally. A mid-stream host failure emits `{\"event\": \"error\", ...}` before `done` \u2014 the sessions read so far are already committed\nand a retry is idempotent. Request validation still fails ahead of the\nstream with the usual HTTP error.",
         "operationId": "import_local_sessions_stream_v1_imports_local_stream_post",
         "requestBody": {
           "content": {

--- a/tests/e2e_ui/sessions/test_import_sessions.py
+++ b/tests/e2e_ui/sessions/test_import_sessions.py
@@ -93,6 +93,44 @@ def test_settings_import_panel_imports_and_links_sessions(
     assert captured["post"] == {"host_id": _HOST_ID, "source": "all", "limit": 25}
 
 
+def test_settings_import_panel_imports_one_session_by_id(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Settings can import an exact harness session without showing a session list."""
+    captured: dict[str, object] = {}
+
+    def _handle_import(route: Route) -> None:
+        captured["post"] = route.request.post_data_json
+        _fulfill_ndjson(
+            route,
+            [
+                {"event": "session", "session_id": "conv_exact", "title": "Exact import"},
+                {"event": "done", "imported": 1, "already_imported": 0, "failed": 0},
+            ],
+        )
+
+    page.route("**/v1/hosts", lambda r: _fulfill_json(r, _HOSTS_BODY))
+    page.route("**/v1/imports/local/stream", _handle_import)
+    page.goto(f"{live_server}/settings/import")
+
+    expect(page.get_by_test_id("import-sessions-panel")).to_be_visible(timeout=30_000)
+    page.get_by_test_id("import-mode-select").click()
+    page.get_by_role("option", name="Session by ID").click()
+    page.get_by_test_id("import-source-select").click()
+    page.get_by_role("option", name="Codex").click()
+    page.get_by_test_id("import-session-id").fill("session-exact")
+    page.get_by_test_id("import-submit").click()
+
+    expect(page.get_by_test_id("import-result")).to_contain_text("Imported 1", timeout=30_000)
+    assert captured["post"] == {
+        "host_id": _HOST_ID,
+        "source": "codex",
+        "limit": 25,
+        "session_id": "session-exact",
+    }
+
+
 def test_empty_landing_import_button_opens_settings(
     page: Page,
     live_server: str,

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -37,6 +37,7 @@ from omnigent.host.frames import (
     HostDetectCredentialsResultFrame,
     HostHarnessReadinessFrame,
     HostHelloFrame,
+    HostImportLocalByIdFrame,
     HostImportLocalFrame,
     HostInstallHarnessFrame,
     HostInstallHarnessResultFrame,
@@ -5421,6 +5422,63 @@ async def test_handle_import_local_all_streams_a_frame_per_session(
         (f.session.external_session_id, f.session.source, f.session.title) for f in session_frames
     } == {("c1", "claude", "claude title"), ("x1", "codex", "codex title")}
     assert all(f.total == 2 for f in session_frames)
+    assert len(done_frames) == 1 and done_frames[0].status == "ok"
+
+
+async def test_handle_import_local_exact_id_does_not_list_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exact harness/id request loads that transcript without enumeration."""
+    from omnigent.host.frames import HostImportLocalDoneFrame, HostImportLocalSessionFrame
+
+    host = _make_host_process()
+
+    def _unexpected_list(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("exact import must not enumerate local sessions")
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        assert (source, session_id) == ("codex", "session-exact")
+        item = SimpleNamespace(
+            type="message",
+            response_id="r1",
+            data=SimpleNamespace(model_dump=lambda **_kw: {"role": "user"}),
+        )
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=[item],
+            title="Exact session",
+            source=source,
+        )
+
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_sessions_across_harnesses", _unexpected_list
+    )
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_local_session_ids", _unexpected_list
+    )
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            sent.append(text)
+
+    await host._handle_import_local(
+        _FakeWs(),  # type: ignore[arg-type]
+        HostImportLocalByIdFrame(
+            request_id="req_exact",
+            source="codex",
+            session_id="session-exact",
+        ),
+    )
+
+    frames = [decode_host_frame(text) for text in sent]
+    session_frames = [f for f in frames if isinstance(f, HostImportLocalSessionFrame)]
+    done_frames = [f for f in frames if isinstance(f, HostImportLocalDoneFrame)]
+    assert [f.session.external_session_id for f in session_frames] == ["session-exact"]
+    assert session_frames[0].total == 1
     assert len(done_frames) == 1 and done_frames[0].status == "ok"
 
 

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -20,6 +20,7 @@ from omnigent.host.frames import (
     HostHarnessReadinessFrame,
     HostHelloFrame,
     HostImportedLocalSession,
+    HostImportLocalByIdFrame,
     HostImportLocalDoneFrame,
     HostImportLocalFrame,
     HostImportLocalSessionFrame,
@@ -56,6 +57,21 @@ def test_import_local_frames_round_trip() -> None:
         encode_host_frame(HostImportLocalFrame(request_id="req_imp", source="claude", limit=3))
     )
     assert request == HostImportLocalFrame(request_id="req_imp", source="claude", limit=3)
+
+    exact_request = decode_host_frame(
+        encode_host_frame(
+            HostImportLocalByIdFrame(
+                request_id="req_exact",
+                source="codex",
+                session_id="0198d07d-session",
+            )
+        )
+    )
+    assert exact_request == HostImportLocalByIdFrame(
+        request_id="req_exact",
+        source="codex",
+        session_id="0198d07d-session",
+    )
 
     session = decode_host_frame(
         encode_host_frame(

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -14,7 +14,11 @@ from fastapi.responses import JSONResponse
 from omnigent.db.utils import builtin_agent_id
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.host_registry import HostRegistry
-from omnigent.server.routes.imports import _stream_local_sessions_from_host, create_imports_router
+from omnigent.server.routes.imports import (
+    LocalImportRequest,
+    _stream_local_sessions_from_host,
+    create_imports_router,
+)
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 from omnigent.stores.host_store import HostStore
@@ -227,6 +231,15 @@ def test_imported_session_ref_allows_null_title() -> None:
     assert ImportedSessionRef(session_id="conv_y", title=None).title is None
 
 
+def test_exact_local_import_requires_one_harness_and_trims_id() -> None:
+    """An exact id is normalized and cannot be paired with the all selector."""
+    request = LocalImportRequest(host_id="h1", source="claude", session_id="  exact-id  ")
+    assert request.session_id == "exact-id"
+
+    with pytest.raises(ValueError, match="requires a specific harness"):
+        LocalImportRequest(host_id="h1", source="all", session_id="exact-id")
+
+
 async def test_stream_local_sessions_yields_each_then_stops_on_done() -> None:
     """The streaming consumer yields one session per frame, then cleans up on done.
 
@@ -273,6 +286,37 @@ async def test_stream_local_sessions_yields_each_then_stops_on_done() -> None:
     assert [s["external_session_id"] for s in got] == ["c1", "c2"]
     # The per-request queue is removed once the stream ends.
     assert conn.pending_import_local == {}
+
+
+async def test_stream_local_sessions_sends_exact_session_id() -> None:
+    """The server carries an exact id through the host tunnel request."""
+    from omnigent.host.frames import HostImportLocalByIdFrame, decode_host_frame
+
+    conn = SimpleNamespace(host_id="h1", pending_import_local={})
+    sent: list[HostImportLocalByIdFrame] = []
+
+    class _Reg:
+        def send_text(self, host_conn: object, frame: str) -> None:
+            decoded = decode_host_frame(frame)
+            assert isinstance(decoded, HostImportLocalByIdFrame)
+            sent.append(decoded)
+            (queue,) = conn.pending_import_local.values()
+            queue.put_nowait(("done", {"status": "ok", "error": None}))
+
+    got = [
+        session
+        async for session in _stream_local_sessions_from_host(
+            host_registry=_Reg(),  # type: ignore[arg-type]
+            host_conn=conn,  # type: ignore[arg-type]
+            source="codex",
+            limit=10,
+            session_id="session-exact",
+        )
+    ]
+
+    assert got == []
+    assert sent[0].source == "codex"
+    assert sent[0].session_id == "session-exact"
 
 
 async def test_stream_local_sessions_surfaces_host_failed_count() -> None:

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -1040,6 +1040,34 @@ describe("importLocalSessions", () => {
     expect(seen).toEqual(["c1"]);
   });
 
+  it("sends an exact session ID with its harness", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockNdjsonResponse([
+        JSON.stringify({ event: "session", session_id: "c1", title: "Exact" }),
+        JSON.stringify({ event: "done", imported: 1, already_imported: 0, failed: 0 }),
+      ]),
+    );
+
+    await importLocalSessions("host_1", "codex", 25, undefined, "session-exact");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      host_id: "host_1",
+      source: "codex",
+      limit: 25,
+      session_id: "session-exact",
+    });
+  });
+
+  it("does not fall back to a server that cannot distinguish an exact import", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({}, { ok: false, status: 404 }));
+
+    await expect(
+      importLocalSessions("host_1", "codex", 25, undefined, "session-exact"),
+    ).rejects.toThrow("Direct session import is not supported");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to the buffered endpoint when the stream endpoint 404s", async () => {
     // Old server: the streaming endpoint is absent, so the client retries the
     // buffered one and delivers every session through onSession at once.

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -516,10 +516,11 @@ export interface LocalImportResult {
 }
 
 /**
- * Import the caller's most recent local transcripts from a chosen host. The
+ * Import local transcripts from a chosen host. The
  * host reads + normalizes its own transcripts over the tunnel (they live on
  * that machine, not the server); already-imported sessions are skipped.
- * `source` is a specific harness or "all" for every harness at once.
+ * Passing `sessionId` loads that exact session from `source` without listing
+ * local history. Otherwise, `source` may be "all" for every harness at once.
  *
  * Prefers the streaming endpoint `POST /v1/imports/local/stream` (NDJSON):
  * `onSession` fires for each newly imported session as its frame lands, so
@@ -536,15 +537,20 @@ export async function importLocalSessions(
   source: ImportSourceSelector,
   limit: number,
   onSession?: (session: ImportedSessionRef) => void,
+  sessionId?: string,
 ): Promise<LocalImportResult> {
+  const body = { host_id: hostId, source, limit, session_id: sessionId };
   const res = await authenticatedFetch("/v1/imports/local/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
-    body: JSON.stringify({ host_id: hostId, source, limit }),
+    body: JSON.stringify(body),
   });
   // Older server without the streaming endpoint: fall back to the buffered
   // import so a newer client still works against it.
   if (res.status === 404) {
+    if (sessionId !== undefined) {
+      throw new Error("Direct session import is not supported by this server.");
+    }
     return importLocalSessionsBuffered(hostId, source, limit, onSession);
   }
   if (!res.ok) throw await apiErrorFromResponse(res);

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2288,7 +2288,7 @@ function ImportSection() {
   return (
     <Section
       title="Import sessions"
-      description="Pull your recent local chats from a machine you're running into Omnigent. Sessions already imported are skipped."
+      description="Pull local chats from a machine you're running into Omnigent. Sessions already imported are skipped."
     >
       <ImportSessionsPanel />
     </Section>

--- a/web/src/shell/ImportSessionsPanel.test.tsx
+++ b/web/src/shell/ImportSessionsPanel.test.tsx
@@ -101,4 +101,40 @@ describe("ImportSessionsPanel", () => {
     // A null title renders the placeholder rather than crashing.
     expect(screen.getByTestId("import-result-link-c2")).toHaveTextContent("Untitled session");
   });
+
+  it("imports one session by harness and ID without listing sessions", async () => {
+    useHostsMock.mockReturnValue({
+      data: [{ host_id: "host_1", name: "mac-laptop", owner: "alice", status: "online" }],
+    } as unknown as ReturnType<typeof useHosts>);
+    importLocalSessionsMock.mockImplementation(async (_host, _source, _limit, onSession) => {
+      onSession?.({ id: "c1", title: "Exact session" });
+      return {
+        imported: 1,
+        alreadyImported: 0,
+        failed: 0,
+        sessions: [{ id: "c1", title: "Exact session" }],
+      };
+    });
+
+    renderPanel();
+    fireEvent.change(screen.getAllByRole("combobox")[1], {
+      target: { value: "session" },
+    });
+
+    expect(screen.queryByTestId("import-limit-select")).toBeNull();
+    const idInput = screen.getByTestId("import-session-id");
+    expect(screen.getByTestId("import-submit")).toBeDisabled();
+    fireEvent.change(idInput, { target: { value: "  session-exact  " } });
+    fireEvent.click(screen.getByTestId("import-submit"));
+
+    await waitFor(() =>
+      expect(importLocalSessionsMock).toHaveBeenCalledWith(
+        "host_1",
+        "claude",
+        25,
+        expect.any(Function),
+        "session-exact",
+      ),
+    );
+  });
 });

--- a/web/src/shell/ImportSessionsPanel.tsx
+++ b/web/src/shell/ImportSessionsPanel.tsx
@@ -4,6 +4,7 @@ import { useHosts } from "@/hooks/useHosts";
 import { Link } from "@/lib/routing";
 import { HostLabel } from "./HostLabel";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -32,13 +33,13 @@ const SOURCES: { value: ImportSourceSelector; label: string }[] = [
 ];
 
 const LIMITS = [25, 50, 100];
+type ImportMode = "recent" | "session";
 
 /**
  * Inline (non-modal) import UI for the Settings "Import sessions" section.
- * Batch-imports the caller's recent local transcripts for a chosen harness via
- * `POST /v1/imports/local` — the chosen host reads + normalizes its own
- * transcripts over the tunnel — then refreshes the sidebar. Already-imported
- * sessions are skipped server-side; the result links each newly imported session.
+ * Imports recent transcripts or one known harness session through the chosen
+ * host, then refreshes the sidebar. Already-imported sessions are skipped
+ * server-side; the result links each newly imported session.
  */
 export function ImportSessionsPanel() {
   const queryClient = useQueryClient();
@@ -47,6 +48,8 @@ export function ImportSessionsPanel() {
   const [hostId, setHostId] = useState<string | null>(null);
   const [source, setSource] = useState<ImportSourceSelector>("all");
   const [limit, setLimit] = useState(25);
+  const [mode, setMode] = useState<ImportMode>("recent");
+  const [sessionId, setSessionId] = useState("");
   const [submitting, setSubmitting] = useState(false);
   // Sessions appended as their frames stream in, so the list fills live rather
   // than appearing all at once when the import finishes.
@@ -75,14 +78,18 @@ export function ImportSessionsPanel() {
 
   async function handleImport(): Promise<void> {
     if (hostId === null) return;
+    const exactSessionId = sessionId.trim();
+    if (mode === "session" && exactSessionId.length === 0) return;
     setSubmitting(true);
     setError(null);
     setResult(null);
     setStreamed([]);
     try {
-      const res = await importLocalSessions(hostId, source, limit, (s) => {
-        setStreamed((prev) => [...prev, s]);
-      });
+      const onSession = (s: ImportedSessionRef) => setStreamed((prev) => [...prev, s]);
+      const res =
+        mode === "session"
+          ? await importLocalSessions(hostId, source, limit, onSession, exactSessionId)
+          : await importLocalSessions(hostId, source, limit, onSession);
       setResult(res);
       // Newly imported sessions land in the sidebar list.
       await queryClient.invalidateQueries({ queryKey: ["conversations"] });
@@ -126,13 +133,33 @@ export function ImportSessionsPanel() {
       </div>
 
       <div className="flex flex-col gap-2">
+        <span className="text-sm font-medium text-muted-foreground">Import</span>
+        <Select
+          value={mode}
+          onValueChange={(value) => {
+            const nextMode = value as ImportMode;
+            setMode(nextMode);
+            if (nextMode === "session" && source === "all") setSource("claude");
+          }}
+        >
+          <SelectTrigger className="w-full text-sm" data-testid="import-mode-select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="recent">Recent sessions</SelectItem>
+            <SelectItem value="session">Session by ID</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-2">
         <span className="text-sm font-medium text-muted-foreground">Harness</span>
         <Select value={source} onValueChange={(v) => setSource(v as ImportSourceSelector)}>
           <SelectTrigger className="w-full text-sm" data-testid="import-source-select">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {SOURCES.map((s) => (
+            {SOURCES.filter((s) => mode === "recent" || s.value !== "all").map((s) => (
               <SelectItem key={s.value} value={s.value} data-testid={`import-source-${s.value}`}>
                 {s.label}
               </SelectItem>
@@ -141,29 +168,49 @@ export function ImportSessionsPanel() {
         </Select>
       </div>
 
-      <div className="flex flex-col gap-2">
-        <span className="text-sm font-medium text-muted-foreground">
-          How many recent sessions{source === "all" ? " (across all harnesses)" : ""}
-        </span>
-        <Select value={String(limit)} onValueChange={(v) => setLimit(Number(v))}>
-          <SelectTrigger className="w-full text-sm" data-testid="import-limit-select">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {LIMITS.map((n) => (
-              <SelectItem key={n} value={String(n)}>
-                Last {n}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      {mode === "recent" ? (
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-muted-foreground">
+            How many recent sessions{source === "all" ? " (across all harnesses)" : ""}
+          </span>
+          <Select value={String(limit)} onValueChange={(v) => setLimit(Number(v))}>
+            <SelectTrigger className="w-full text-sm" data-testid="import-limit-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {LIMITS.map((n) => (
+                <SelectItem key={n} value={String(n)}>
+                  Last {n}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <label htmlFor="import-session-id" className="text-sm font-medium text-muted-foreground">
+            Session ID
+          </label>
+          <Input
+            id="import-session-id"
+            data-testid="import-session-id"
+            value={sessionId}
+            maxLength={128}
+            autoComplete="off"
+            placeholder="Enter a session ID"
+            onChange={(event) => setSessionId(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void handleImport();
+            }}
+          />
+        </div>
+      )}
 
       <div>
         <Button
           data-testid="import-submit"
           loading={submitting}
-          disabled={hostId === null}
+          disabled={hostId === null || (mode === "session" && sessionId.trim().length === 0)}
           onClick={() => void handleImport()}
         >
           Import


### PR DESCRIPTION
## Related issue

Related to #4462

## Summary

- Add a direct import mode that accepts one harness and its native session ID.
- Load that transcript directly on the selected host without enumerating or displaying local sessions.
- Keep recent-session import unchanged. Exact imports use a distinct host frame so an older host cannot accidentally import recent sessions.

ELI5: paste the ID of a Claude Code or Codex chat, choose where it came from, and Omnigent imports only that chat.

```text
Web UI (host + harness + ID) -> server exact-import frame -> host load_local_session -> streamed Omnigent session
```

This does not add session browsing or listing.

## Test Plan

- Focused host frame, tunnel, and import route tests: 19 passed.
- `cd web && npm test`: 6,767 passed, 3 expected failures, 1 skipped.
- `cd web && npm run lint`
- `cd web && npm run type-check`
- `cd web && npm run build`
- Import Playwright suite: 3 passed, including direct import by harness and ID.
- `.venv/bin/pre-commit run --all-files`

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable - no behavioral change

![Direct session import by harness and ID](https://github.com/marktai/omnigent/releases/download/mt--direct-session-import-demo/direct-session-import.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The E2E test verifies that direct mode submits one harness and session ID without a session-list request. Host and server tests verify direct loading and frame transport.

## Changelog

Import a Claude Code or Codex session directly by harness and session ID.
