### PR TITLE
fix: keep Claude synthetic errors out of session model metadata

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -58,6 +58,7 @@ from omnigent.claude_native_message_display_hook import MESSAGE_DELTAS_FILE
 from omnigent.claude_native_status import CONTEXT_RAW_FILE
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.kiro_native_bridge import bridge_root as kiro_bridge_root
+from omnigent.model_metadata import concrete_reported_model
 
 if TYPE_CHECKING:
     import httpx
@@ -5537,10 +5538,7 @@ def _model_from_transcript_entry(entry: _JsonObject) -> str | None:
     message = entry.get("message")
     if not isinstance(message, dict) or message.get("role") != "assistant":
         return None
-    model = message.get("model")
-    if isinstance(model, str) and model:
-        return model
-    return None
+    return concrete_reported_model(message.get("model"))
 
 
 def _custom_title_from_transcript_entry(entry: _JsonObject) -> str | None:

--- a/omnigent/claude_native_forwarder.py
+++ b/omnigent/claude_native_forwarder.py
@@ -48,6 +48,7 @@ from omnigent.claude_native_bridge import (
 from omnigent.claude_native_message_display_hook import MESSAGE_DELTAS_FILE
 from omnigent.claude_native_status import sync_raw_status_context
 from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.model_metadata import concrete_reported_model
 from omnigent.reasoning_effort import CLAUDE_EFFORTS, EFFORT_CLEAR_VALUES
 
 _FORWARDER_STATE_FILE = "transcript_forwarder.json"
@@ -4511,6 +4512,7 @@ async def _post_model_change_if_new(
         fresh observation," and a previously-observed-but-unposted model
         is still reconciled (retried) here.
     """
+    model = concrete_reported_model(model)
     if model is not None:
         dedupe.observed_model = model
     if dedupe.observed_model is None or dedupe.observed_model == dedupe.posted_model:

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -57,6 +57,7 @@ from omnigent.inner.hook_scripts import subagent_router
 from omnigent.json_types import JsonObject as _JsonObject
 from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
 from omnigent.llms.adapters._content import parse_data_uri as _parse_replay_data_uri
+from omnigent.model_metadata import concrete_reported_model
 from omnigent.reasoning_effort import CLAUDE_EFFORTS, validate_effort
 from omnigent.spec.types import RetryPolicy
 
@@ -2958,8 +2959,8 @@ class ClaudeSDKExecutor(Executor):
                         assistant_msg = cast(_AssistantMessageObj, message)
                         # Capture the concrete model the SDK used (the resolved
                         # config ``model`` is None when the spec pins none).
-                        _am_model = getattr(assistant_msg, "model", None)
-                        if isinstance(_am_model, str) and _am_model:
+                        _am_model = concrete_reported_model(getattr(assistant_msg, "model", None))
+                        if _am_model is not None:
                             observed_model = _am_model
                         if got_stream_events:
                             # StreamEvents already emitted text. Emit the

--- a/omnigent/model_metadata.py
+++ b/omnigent/model_metadata.py
@@ -6,6 +6,14 @@ from dataclasses import dataclass
 from enum import Enum
 
 
+def concrete_reported_model(value: object) -> str | None:
+    """Keep model reports verbatim, excluding Claude Code's local-error marker."""
+    if not isinstance(value, str):
+        return None
+    model = value.strip()
+    return model if model and model != "<synthetic>" else None
+
+
 class ModelIntent(str, Enum):
     """Stable purpose requested by a model-selection caller."""
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -66,6 +66,7 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_plugins import (
     NativeCodingAgent,
 )
+from omnigent.model_metadata import concrete_reported_model
 from omnigent.native_coding_agents import (
     native_coding_agent_for_harness,
     native_coding_agent_for_wrapper_label,
@@ -2214,8 +2215,8 @@ async def _persist_external_model_change(
             "external_model_change requires data.model to be a non-empty string",
             code=ErrorCode.INVALID_INPUT,
         )
-    model = raw_model.strip()
-    if conv.reported_model == model:
+    model = concrete_reported_model(raw_model)
+    if model is None or conv.reported_model == model:
         return
     await asyncio.to_thread(
         conversation_store.update_conversation,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -56,6 +56,7 @@ from omnigent.host.frames import (
     WORKSPACE_MISSING_ERROR_CODE as _WORKSPACE_MISSING_ERROR_CODE,
 )
 from omnigent.llms.context_window import resolve_effective_context_window
+from omnigent.model_metadata import concrete_reported_model
 from omnigent.native_coding_agents import (
     native_coding_agent_for_agent_name,
     native_coding_agent_for_harness,
@@ -1374,9 +1375,9 @@ async def _persist_relay_reported_model(
     if not isinstance(usage_obj, dict):
         return
     raw_model = usage_obj.get("model")
-    if not isinstance(raw_model, str) or not raw_model.strip():
+    model = concrete_reported_model(raw_model)
+    if model is None:
         return
-    model = raw_model.strip()
     conv = await asyncio.to_thread(conversation_store.get_conversation, session_id)
     if conv is None or conv.reported_model == model:
         return
@@ -9825,8 +9826,8 @@ async def _get_session_snapshot(
     # a verbatim ``reported_model``, it supersedes the spec-derived value on
     # the wire's ``llm_model`` field (the web renders and highlights only
     # from this).
-    if conv.reported_model:
-        llm_model = conv.reported_model
+    if reported_model := concrete_reported_model(conv.reported_model):
+        llm_model = reported_model
     # Skills are runner-owned: the bound runner discovers them against its
     # own filesystem (bundled skills + host skills under the session's
     # workspace and ``~/.claude/skills/``) — the host where the harness

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -4319,7 +4319,12 @@ async def test_context_tokens_emitted_when_turn_ends_without_result_message() ->
 
 
 @pytest.mark.asyncio
-async def test_assistant_message_model_flows_to_turn_usage() -> None:
+@pytest.mark.parametrize("synthetic_error", [False, True])
+@pytest.mark.parametrize("observed", [True, False])
+async def test_assistant_message_model_flows_to_turn_usage(
+    synthetic_error: bool,
+    observed: bool,
+) -> None:
     """The SDK's assistant-message model is forwarded in ``TurnComplete.usage``.
 
     When the agent spec pins no model (a delegating supervisor on the gateway),
@@ -4354,7 +4359,7 @@ async def test_assistant_message_model_flows_to_turn_usage() -> None:
         total_cost_usd=0.0,
         duration_ms=1,
         duration_api_ms=1,
-        is_error=False,
+        is_error=synthetic_error,
         num_turns=1,
         usage={"input_tokens": 100, "output_tokens": 50},
     )
@@ -4366,7 +4371,10 @@ async def test_assistant_message_model_flows_to_turn_usage() -> None:
         StreamEvent = SDKStreamEvent
         ResultMessage = SDKResultMessage
         ClaudeAgentOptions = SDKClaudeAgentOptions
-        messages = [assistant, sdk_result]
+        messages = [assistant] if observed else []
+        if synthetic_error:
+            messages.append(_AsstMsg(content=[], model="<synthetic>"))
+        messages.append(sdk_result)
 
         class ClaudeSDKClient:
             def __init__(self, options: object) -> None:
@@ -4385,7 +4393,7 @@ async def test_assistant_message_model_flows_to_turn_usage() -> None:
             async def disconnect(self) -> None:
                 return None
 
-    executor = ClaudeSDKExecutor()
+    executor = ClaudeSDKExecutor(model=None if observed else "configured-model")
     with patch("omnigent.inner.claude_sdk_executor._ensure_sdk", return_value=_FakeSDK):
         events = [
             e
@@ -4396,14 +4404,12 @@ async def test_assistant_message_model_flows_to_turn_usage() -> None:
             )
         ]
 
-    turn = next(e for e in events if isinstance(e, TurnComplete))
+    terminal_type = ExecutorError if synthetic_error else TurnComplete
+    turn = next(e for e in events if isinstance(e, terminal_type))
     assert turn.usage is not None
-    # No model is configured (no cfg.model / override), so a non-None model here
-    # can only be the one captured from the AssistantMessage.
-    assert turn.usage["model"] == "claude-opus-4-8", (
-        f"usage model {turn.usage.get('model')!r} != 'claude-opus-4-8' — the "
-        "assistant-message model was not captured/forwarded."
-    )
+    # Synthetic errors preserve the last real report, or the configured fallback.
+    expected_model = "claude-opus-4-8" if observed else "configured-model"
+    assert turn.usage["model"] == expected_model
 
 
 @pytest.mark.asyncio

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -6832,6 +6832,52 @@ async def test_post_external_model_change_publishes_session_model(
     assert snapshot["model_override"] is None
 
 
+@pytest.mark.parametrize("sentinel", ["<synthetic>", " <synthetic> "])
+async def test_external_synthetic_model_preserves_report(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    sentinel: str,
+) -> None:
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    response = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "external_model_change", "data": {"model": "gateway-claude-model"}},
+    )
+    assert response.status_code == 202
+    published: list[object] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda *args: published.append(args),
+    )
+    response = await client.post(
+        f"/v1/sessions/{sid}/events",
+        json={"type": "external_model_change", "data": {"model": sentinel}},
+    )
+    assert response.status_code == 202
+    assert published == []
+    snapshot = (await client.get(f"/v1/sessions/{sid}")).json()
+    assert snapshot["llm_model"] == "gateway-claude-model"
+    assert snapshot["model_override"] is None
+
+
+@pytest.mark.parametrize("sentinel", ["<synthetic>", " <synthetic> "])
+async def test_snapshot_ignores_legacy_synthetic_model(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    sentinel: str,
+) -> None:
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    sid = session["id"]
+    original = (await client.get(f"/v1/sessions/{sid}")).json()
+    SqlAlchemyConversationStore(db_uri).update_conversation(sid, reported_model=sentinel)
+    snapshot = (await client.get(f"/v1/sessions/{sid}")).json()
+    assert snapshot["llm_model"] == original["llm_model"]
+    assert snapshot["llm_model"] != sentinel
+
+
 async def test_post_external_model_change_dedupes_when_unchanged(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -4605,8 +4605,10 @@ async def test_relay_skips_malformed_resource_created_from_runner() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("terminal_type", ["response.completed", "response.failed"])
+@pytest.mark.parametrize("reported_model", ["claude-opus-4-8", "<synthetic>"])
 async def test_relay_persists_harness_reported_model(
     terminal_type: str,
+    reported_model: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """SDK terminal usage records the concrete model on the session snapshot."""
@@ -4631,7 +4633,7 @@ async def test_relay_persists_harness_reported_model(
                             "input_tokens": 0,
                             "output_tokens": 0,
                             "total_tokens": 0,
-                            "model": "claude-opus-4-8",
+                            "model": reported_model,
                         },
                     },
                 }
@@ -4642,15 +4644,20 @@ async def test_relay_persists_harness_reported_model(
 
     await _relay_runner_stream(session_id, client, store)  # type: ignore[arg-type]
 
-    assert store.get_conversation(session_id).reported_model == "claude-opus-4-8"  # type: ignore[union-attr]
+    expected = None if reported_model == "<synthetic>" else reported_model
+    assert store.get_conversation(session_id).reported_model == expected  # type: ignore[union-attr]
     model_events = [event for event in published if event.get("type") == "session.model"]
-    assert model_events == [
-        {
-            "type": "session.model",
-            "conversation_id": session_id,
-            "model": "claude-opus-4-8",
-        }
-    ]
+    assert model_events == (
+        []
+        if expected is None
+        else [
+            {
+                "type": "session.model",
+                "conversation_id": session_id,
+                "model": "claude-opus-4-8",
+            }
+        ]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -5771,6 +5771,37 @@ def test_read_transcript_items_from_offset_returns_latest_model(
     assert result.latest_model == "claude-opus-4-7"
 
 
+@pytest.mark.parametrize("initial_model", [None, "gateway-claude-model"])
+def test_transcript_synthetic_error_preserves_model(
+    tmp_path: Path, initial_model: str | None
+) -> None:
+    transcript_path = tmp_path / "session.jsonl"
+    models = [initial_model, "<synthetic>"] if initial_model else ["<synthetic>"]
+    transcript_path.write_text(
+        "".join(
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "uuid": f"a{index}",
+                    "message": {
+                        "role": "assistant",
+                        "model": model,
+                        "content": [{"type": "text", "text": "API Error: 429"}],
+                    },
+                }
+            )
+            + "\n"
+            for index, model in enumerate(models)
+        ),
+        encoding="utf-8",
+    )
+    result = read_transcript_items_from_offset(
+        transcript_path, 0, start_line=0, agent_name="claude-native-ui"
+    )
+    assert result.latest_model == initial_model
+    assert result.items  # Error messages remain visible; only model metadata is ignored.
+
+
 def test_read_transcript_items_surfaces_custom_title_without_an_item(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -3662,9 +3662,12 @@ async def test_model_reports_keep_generation_and_context_marker(tmp_path: Path) 
     transport = httpx.MockTransport(_handle_request)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         for model in (
+            "<synthetic>",
             "databricks-claude-opus-4-8",
+            "<synthetic>",
             "databricks-claude-opus-4-9",
             "databricks-claude-opus-4-9[1m]",
+            " <synthetic> ",
         ):
             await forwarder._post_model_change_if_new(
                 client, session_id="conv_abc", dedupe=dedupe, model=model
@@ -3675,6 +3678,7 @@ async def test_model_reports_keep_generation_and_context_marker(tmp_path: Path) 
         "databricks-claude-opus-4-9",
         "databricks-claude-opus-4-9[1m]",
     ]
+    assert dedupe.observed_model == "databricks-claude-opus-4-9[1m]"
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_metadata.py
+++ b/tests/test_model_metadata.py
@@ -1,0 +1,16 @@
+"""Validation of runtime-reported model names."""
+
+import pytest
+
+from omnigent.model_metadata import concrete_reported_model
+
+
+@pytest.mark.parametrize("value", [None, 42, "", " ", "<synthetic>", " <synthetic> "])
+def test_non_model_reports_are_ignored(value: object) -> None:
+    assert concrete_reported_model(value) is None
+
+
+@pytest.mark.parametrize("value", ["custom-model", "provider/model[1m]", "opus", "<custom>"])
+def test_concrete_model_reports_keep_their_spelling(value: str) -> None:
+    assert concrete_reported_model(value) == value
+    assert concrete_reported_model(f" {value} ") == value


### PR DESCRIPTION
## Related issue

Closes #6466

## Summary

Claude Code uses `<synthetic>` on locally generated error messages. Omnigent was treating that message marker as an actual model, so an API failure could replace the composer's model label and survive reloads.

The observed failure is in **native Claude Code**, not just the SDK. ELI5: an error-message label was accidentally saved as the model's name.

```text
Claude error message.model
  → native transcript → external_model_change ┐
  → SDK assistant message → terminal usage    ├→ reported_model → snapshot / live model label
                                              ┘
```

Reject the marker at both producers and server ingestion paths, preserve the last real observation, and ignore legacy persisted markers in snapshots. Keep ordinary model spellings and the actual error messages unchanged. No frontend changes and no changes to rate-limit handling.

## Test Plan

- Added failing-before-fix regressions for native transcript parsing, model-report persistence/broadcast, and SDK model usage.
- Cover synthetic-only transcripts, real-model then error sequences, configured SDK fallback, failed and successful relay events, native report deduplication, and legacy snapshot recovery.
- `.venv/bin/python -m pytest tests/test_model_metadata.py tests/test_claude_native_bridge.py tests/test_claude_native_forwarder.py tests/inner/test_claude_sdk_executor.py tests/server/routes/test_session_resources.py tests/server/routes/test_sessions_snapshot.py -q` — **815 passed, 1 existing xfailed**.
- Sessions API integration subset: `pytest tests/server/integration/test_sessions_endpoints.py -k 'synthetic or external_model_change' -q` — 8 passed.
- All applicable staged pre-commit hooks passed, including Pyrefly. The isolated worktree uses explicit PYTHONPATH entries for its editable SDK packages because the reused virtualenv points at the original checkout.
- Human check after deploying both server and host: open a native Claude session, observe its real model, then trigger a controlled API error. The error should remain visible without changing the model to `<synthetic>`, including after refresh. Previously affected sessions should stop displaying the marker on refresh; a fresh real report restores the observed model.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — backend metadata fix. Deterministic regression evidence is in Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

API and transcript tests use deterministic error fixtures; no live rate-limit exhaustion or production mutation was performed. Browser verification was not available. The 429 itself is a separate upstream limit, not fixed here.

## Changelog

Claude Code errors no longer replace the session's model label with `<synthetic>`.
