### PR TITLE
Increase inline code punctuation spacing

### DIFF
--- a/tests/e2e_ui/messages/test_inline_code_spacing.py
+++ b/tests/e2e_ui/messages/test_inline_code_spacing.py
@@ -1,0 +1,32 @@
+"""E2E: inline code keeps punctuation runs visually separated."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+_COMPOSER = "Message the agent"
+_USER_BUBBLE = '[data-testid="message-bubble"][data-role="user"]'
+_COMMAND = "abc--def abc...def"
+
+
+def test_inline_code_adds_tracking_for_punctuation_runs(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Inline code retains spacing around adjacent hyphens and periods."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+
+    composer = page.get_by_label(_COMPOSER)
+    expect(composer).to_be_enabled(timeout=30_000)
+    composer.fill(f"Run `{_COMMAND}`")
+    page.get_by_role("button", name="Send", exact=True).click()
+
+    bubble = page.locator(_USER_BUBBLE).last
+    code = bubble.locator('code[data-streamdown="inline-code"]')
+    expect(code).to_be_visible(timeout=30_000)
+    expect(code).to_have_text(_COMMAND)
+
+    letter_spacing = code.evaluate("el => getComputedStyle(el).letterSpacing")
+    assert letter_spacing.endswith("px")
+    assert float(letter_spacing.removesuffix("px")) > 0

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1007,11 +1007,14 @@ aside[aria-label="Workspace"][data-maximized] {
  *
  * The bg override pulls inline-code chips off the page-default `bg-muted`
  * (which is only ~4% darker than the background) onto the dedicated
- * --code-bg token (~7% light / ~12% dark step from page). Reference:
+ * --code-bg token (~7% light / ~12% dark step from page). A small tracking
+ * step keeps punctuation runs distinct at the fractional rendered size.
+ * Reference:
  * Claude Code's inline chips — stronger contrast does the differentiation
  * work without needing a foreground tint or extra border. */
 [data-streamdown="inline-code"] {
   font-size: 0.875em;
+  letter-spacing: 0.025em;
   background-color: var(--code-bg);
 }
 [data-streamdown="code-block-body"] {

--- a/web/src/index.css.test.ts
+++ b/web/src/index.css.test.ts
@@ -174,6 +174,17 @@ describe("index.css app-shell viewport lock", () => {
   });
 });
 
+describe("index.css inline code rule", () => {
+  const rule = cssBlocks
+    .map(([block]) => block)
+    .find((block) => selectorOf(block) === '[data-streamdown="inline-code"]');
+
+  it("keeps punctuation runs visually separated", () => {
+    expect(rule, "the inline-code rule is gone from index.css").toBeDefined();
+    expect(rule).toMatch(/letter-spacing\s*:\s*0\.025em/);
+  });
+});
+
 const allWidthNativeLayoutRules = [
   ["iOS keyboard viewport", "[data-ios-native].app-shell", "--omnigent-viewport-height"],
   ["native chat header", ".chat-header", "--omnigent-safe-top"],


### PR DESCRIPTION
## Related issue

Closes #6468

## Summary

- Add slight tracking to Streamdown inline-code chips so spaces, double hyphens, and period runs stay distinct at the fractional 11.375px rendered size.
- Cover the CSS contract and rendered inline-code path, including punctuation attached directly to adjacent characters.

## Test Plan

- `cd web && ./node_modules/.bin/vitest run src/index.css.test.ts src/shell/CliCommandBlock.test.tsx`
- `cd web && npm run lint`
- `cd web && npm run type-check`
- `cd web && npm run build`
- `.venv/bin/pytest tests/e2e_ui/messages/test_inline_code_spacing.py -v --ui-skip-build`

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The added tracking creates a visible gap around punctuation runs without changing the font or text content:

![Before and after inline-code punctuation spacing](https://github.com/marktai/omnigent/releases/download/issue6468-demo/omnigent-inline-code-spacing.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Compared the old and updated inline-code elements in Chromium at DPR 2. The rendered tracking changes from `normal` to `0.284375px` at the affected font size.

## Changelog

Inline code keeps punctuation runs and surrounding spaces visually distinct.
