### PR TITLE
chore(ci): add dhruv0811 as owner of the sandbox area

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -322,6 +322,7 @@
         "omnigent/sandbox/"
       ],
       "owners": [
+        "dhruv0811",
         "fanzeyi",
         "dbczumar"
       ]


### PR DESCRIPTION
## Related issue

N/A — `Test / CI` change (no issue required per the PR template).

## Summary

- Add `dhruv0811` as the **first** owner of the `sandbox` area in `.github/areas.json`, ahead of the existing owners `fanzeyi` and `dbczumar`.
- The `sandbox` area is the OS sandbox (bwrap/seatbelt isolation + egress controls, `omnigent/sandbox/`). This file is the single source of truth feeding both PR reviewer assignment (`.github/workflows/auto-assign-reviewer.js`) and issue triage.

## Test Plan

- `node --test .github/workflows/areas.test.js` — all `areas.json` integrity checks pass (every owner in `.github/MAINTAINER`, valid `comp:*` label, 2+ owners, path resolution).
- `pre-commit run --files .github/areas.json` — passed (trailing whitespace, end-of-file, model-id, merge-conflict, case-conflict checks).
- Validated JSON parses (`python3 -c "import json; json.load(open('.github/areas.json'))"`).

## Demo

N/A — non-visual change (CI config / ownership map).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`areas.test.js` already validates every invariant this change could break (owner is a real maintainer, label exists, 2+ owners, paths resolve). Ran it locally after the edit — green. No new test needed for a single ownership-list addition.

<!-- Changelog section deleted per template: not a user-facing change (CI / reviewer-routing config). -->

This pull request and its description were written by Isaac.
