### PR TITLE
fix(codex): finish client cleanup after reader disconnects

### DIFF
--- a/omnigent/codex_native_app_server.py
+++ b/omnigent/codex_native_app_server.py
@@ -23,6 +23,7 @@ import tomlkit
 import websockets
 from cachetools import TTLCache
 from websockets.asyncio.client import ClientConnection
+from websockets.exceptions import ConnectionClosed
 
 from omnigent import model_catalog
 from omnigent.json_types import JsonObject as _JsonObject
@@ -603,18 +604,22 @@ class CodexAppServerClient:
 
         :returns: None.
         """
-        if self._reader_task is not None:
-            self._reader_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._reader_task
-        for future in self._pending_requests.values():
-            if not future.done():
-                future.cancel()
-        self._pending_requests.clear()
-        if self._ws is not None:
-            await self._ws.close()
-        self._ws = None
-        self._reader_task = None
+        try:
+            if self._reader_task is not None:
+                self._reader_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, ConnectionClosed):
+                    await self._reader_task
+        finally:
+            for future in self._pending_requests.values():
+                if not future.done():
+                    future.cancel()
+            self._pending_requests.clear()
+            try:
+                if self._ws is not None:
+                    await self._ws.close()
+            finally:
+                self._ws = None
+                self._reader_task = None
 
     async def request(self, method: str, params: CodexParams) -> CodexMessage:
         """

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import stat
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
+from websockets.asyncio.client import ClientConnection
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 try:
     import tomllib
@@ -19,6 +23,7 @@ except ImportError:  # pragma: no cover - Python < 3.11
 from omnigent.codex_native_app_server import (
     _FRAMEWORK_APPROVED_TOOLS,
     _POLICY_HOOK_TIMEOUT_SECONDS,
+    CodexAppServerClient,
     CodexNativeAppServer,
     _build_native_codex_app_server_argv,
     _codex_policy_hooks_settings,
@@ -38,6 +43,79 @@ from omnigent.inner.codex_executor import (
     _populate_codex_home_config,
     _provider_codex_config_overrides,
 )
+
+
+@pytest.mark.parametrize(
+    "reader_error", [ConnectionClosedError(None, None), ConnectionClosedOK(None, None)]
+)
+async def test_client_close_cleans_up_after_reader_disconnect(reader_error: Exception) -> None:
+    client = CodexAppServerClient(ws_url="ws://127.0.0.1:12345")
+    websocket = AsyncMock(spec=ClientConnection)
+    client._ws = cast(ClientConnection, websocket)
+
+    async def fail_reader() -> None:
+        raise reader_error
+
+    reader = asyncio.create_task(fail_reader())
+    client._reader_task = reader
+    pending = asyncio.get_running_loop().create_future()
+    client._pending_requests[1] = pending
+    await asyncio.sleep(0)
+    assert reader.done()
+
+    await client.close()
+
+    assert pending.cancelled()
+    assert client._pending_requests == {}
+    assert client._reader_task is None
+    assert client._ws is None
+    websocket.close.assert_awaited_once()
+    await client.close()
+    websocket.close.assert_awaited_once()
+
+
+async def test_client_close_preserves_reader_bug_after_cleanup() -> None:
+    client = CodexAppServerClient(ws_url="ws://127.0.0.1:12345")
+    websocket = AsyncMock(spec=ClientConnection)
+    client._ws = cast(ClientConnection, websocket)
+
+    async def fail_reader() -> None:
+        raise ValueError("invalid event payload")
+
+    reader = asyncio.create_task(fail_reader())
+    client._reader_task = reader
+    pending = asyncio.get_running_loop().create_future()
+    client._pending_requests[1] = pending
+    await asyncio.sleep(0)
+
+    with pytest.raises(ValueError, match="invalid event payload"):
+        await client.close()
+
+    assert pending.cancelled()
+    assert client._pending_requests == {}
+    assert client._reader_task is None
+    assert client._ws is None
+    websocket.close.assert_awaited_once()
+
+
+async def test_client_close_clears_state_when_websocket_close_fails() -> None:
+    client = CodexAppServerClient(ws_url="ws://127.0.0.1:12345")
+    websocket = AsyncMock(spec=ClientConnection)
+    websocket.close.side_effect = ValueError("close failed")
+    client._ws = cast(ClientConnection, websocket)
+    reader = asyncio.create_task(asyncio.sleep(60))
+    client._reader_task = reader
+    pending = asyncio.get_running_loop().create_future()
+    client._pending_requests[1] = pending
+
+    with pytest.raises(ValueError, match="close failed"):
+        await client.close()
+
+    assert reader.cancelled()
+    assert pending.cancelled()
+    assert client._pending_requests == {}
+    assert client._reader_task is None
+    assert client._ws is None
 
 
 async def test_discover_codex_model_options_strips_secrets_and_stops_process(


### PR DESCRIPTION
## Related issue

Closes #6472

## Summary

- A completed websocket reader can raise again during `close()`, interrupting request cancellation and socket cleanup.
- Finish cleanup in `finally` blocks and treat reader disconnects as expected during shutdown. Unexpected reader/socket-close failures still propagate after cleanup.
- ELI5: a broken connection should not prevent us from putting its resources away. This does not add reconnection.

`reader failure → cancel pending requests → close socket → clear references`

## Test Plan

- Red: all four new cleanup cases fail against the unchanged implementation.
- Green: `.venv/bin/python -m pytest tests/test_codex_native_app_server.py -q` — **80 passed**.
- `PYTHONPATH="$PWD:$PWD/sdks/python-client:$PWD/sdks/ui" .venv/bin/pre-commit run --files omnigent/codex_native_app_server.py tests/test_codex_native_app_server.py` — passed, including pyrefly.
- To reproduce narrowly, run `.venv/bin/python -m pytest tests/test_codex_native_app_server.py -k test_client_close -q`. The tests inject completed reader disconnects, unexpected reader failures, and socket-close failure without a live service.

## Demo

N/A — backend-only change; reproducible synthetic evidence is in Test Plan.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests check pending-future cancellation, socket closure, cleared client state, repeat-close safety, and preservation of unexpected exceptions. No provider-backed session or live network test was run.

## Changelog

Codex connection cleanup completes even when its websocket reader has already disconnected.
