### PR TITLE
fix(claude): normalize tools-changed transport failures

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -47,10 +47,11 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from http import HTTPStatus
+from http.client import HTTPException
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from urllib import error, request
+from urllib import request
 
 from omnigent._platform import stable_user_id
 from omnigent.claude_model_vocabulary import MODEL_VOCABULARY_ENV_VARS
@@ -3809,8 +3810,8 @@ def post_tools_changed(
     :param timeout_s: Seconds to wait for the bridge HTTP control
         endpoint to publish itself, e.g. ``30.0``.
     :returns: None.
-    :raises RuntimeError: If the bridge server is not ready or
-        rejects the notification.
+    :raises RuntimeError: If the bridge server is not ready, cannot
+        be reached, or rejects the notification.
     """
     server = _wait_for_server_info(bridge_dir, timeout_s=timeout_s)
     token = server.get("token")
@@ -3830,7 +3831,7 @@ def post_tools_changed(
         with request.urlopen(req, timeout=_TOOLS_CHANGED_POST_TIMEOUT_S) as resp:
             if resp.status >= 400:
                 raise RuntimeError(f"tools-changed POST failed with HTTP {resp.status}")
-    except error.URLError as exc:
+    except (OSError, HTTPException) as exc:
         raise RuntimeError(f"failed to notify Claude tool list change: {exc}") from exc
 
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -14,10 +14,13 @@ import tempfile
 import threading
 import time
 from collections.abc import Iterator
+from http.client import BadStatusLine, RemoteDisconnected
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, TextIO
+from unittest.mock import Mock
+from urllib.error import URLError
 
 import pytest
 
@@ -4605,6 +4608,48 @@ def test_inject_slash_command_raises_when_tmux_target_never_published(
             command="/effort high",
             timeout_s=0.0,
         )
+
+
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        URLError("bridge unavailable"),
+        ConnectionResetError("connection reset"),
+        RemoteDisconnected("bridge disconnected"),
+        TimeoutError("notification timed out"),
+        BadStatusLine("invalid response"),
+    ],
+)
+def test_post_tools_changed_normalizes_transport_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, transport_error: Exception
+) -> None:
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_wait_for_server_info",
+        Mock(return_value={"url": "http://127.0.0.1:12345", "token": "test-token"}),
+    )
+    monkeypatch.setattr(claude_native_bridge.request, "urlopen", Mock(side_effect=transport_error))
+
+    with pytest.raises(RuntimeError, match="failed to notify Claude tool list change") as caught:
+        post_tools_changed(tmp_path)
+
+    assert caught.value.__cause__ is transport_error
+
+
+def test_post_tools_changed_preserves_programming_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_wait_for_server_info",
+        Mock(return_value={"url": "http://127.0.0.1:12345", "token": "test-token"}),
+    )
+    monkeypatch.setattr(
+        claude_native_bridge.request, "urlopen", Mock(side_effect=ValueError("bug"))
+    )
+
+    with pytest.raises(ValueError, match="bug"):
+        post_tools_changed(tmp_path)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #6473

## Summary

- Claude bridge notification failures such as connection resets and timeouts bypass the runner's existing `RuntimeError` handler.
- Normalize OS/network and HTTP-protocol failures in `post_tools_changed()` to its existing `RuntimeError` contract, preserving their causes. Unrelated programming errors remain visible.
- ELI5: a best-effort notification should report a broken connection in the form its caller already knows how to handle. No retries or blanket exception suppression are added.

`transport failure → RuntimeError with cause → existing best-effort caller handler`

## Test Plan

- Red: four new transport cases fail against the unchanged implementation; existing `URLError` behavior and propagation of programming errors already pass.
- Green: `.venv/bin/python -m pytest tests/test_claude_native_bridge.py -q` — **299 passed**, including the existing live local relay test.
- `PYTHONPATH="$PWD:$PWD/sdks/python-client:$PWD/sdks/ui" .venv/bin/pre-commit run --files omnigent/claude_native_bridge.py tests/test_claude_native_bridge.py` — passed, including pyrefly.
- To reproduce narrowly, run `.venv/bin/python -m pytest tests/test_claude_native_bridge.py -k test_post_tools_changed -q`. This injects URL errors, connection resets, remote disconnects, timeouts, and malformed HTTP responses; each must produce a `RuntimeError` whose cause is the original exception.

## Demo

N/A — backend-only change; reproducible synthetic evidence is in Test Plan.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Five synthetic transport cases and one programming-error case cover the helper's exception boundary. The full bridge suite includes existing successful notification/relay coverage. No provider-backed manual session was run.

## Changelog

Claude tool-list notifications handle connection resets and other transport failures through the existing best-effort failure path.
