### PR TITLE
fix(web): keep archived rows pinned during the archive round-trip

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -1,7 +1,7 @@
 name: E2E UI Tests
 
 # Runs the Playwright UI suite against a freshly built web SPA, split across
-# a 5-shard matrix. The whole suite (including the native Claude/Codex/Cursor
+# a 4-shard matrix. The whole suite (including the native Claude/Codex/Cursor
 # render-parity tests) runs against the in-process mock LLM and needs NO
 # secrets, so it runs on ALL PRs -- same-repo AND fork -- directly, like ci.yml.
 # (The native_*_mock_session fixtures use the real gateway only when LLM_API_KEY
@@ -80,7 +80,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
-          NUM_SHARDS: "5"
+          NUM_SHARDS: "4"
         run: bash .github/scripts/ci/e2e-shard-matrix.sh
 
   # Build the Codex-parity sidecar ONCE and publish the binary. The
@@ -144,9 +144,7 @@ jobs:
     strategy:
       # One red shard shouldn't cancel siblings -- we want every shard's signal.
       fail-fast: false
-      # Matches NUM_SHARDS so all shards run concurrently (no serialized tail);
-      # the suite is in-process mock LLM, so there's no gateway rate-limit cap.
-      max-parallel: 5
+      max-parallel: 4
       # Shards from `setup`; [] when skipped. Shard check names live in
       # merge-ready/required.sh -- keep in sync with NUM_SHARDS above.
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -1,7 +1,7 @@
 name: E2E UI Tests
 
 # Runs the Playwright UI suite against a freshly built web SPA, split across
-# a 4-shard matrix. The whole suite (including the native Claude/Codex/Cursor
+# a 5-shard matrix. The whole suite (including the native Claude/Codex/Cursor
 # render-parity tests) runs against the in-process mock LLM and needs NO
 # secrets, so it runs on ALL PRs -- same-repo AND fork -- directly, like ci.yml.
 # (The native_*_mock_session fixtures use the real gateway only when LLM_API_KEY
@@ -80,7 +80,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
-          NUM_SHARDS: "4"
+          NUM_SHARDS: "5"
         run: bash .github/scripts/ci/e2e-shard-matrix.sh
 
   # Build the Codex-parity sidecar ONCE and publish the binary. The
@@ -144,7 +144,9 @@ jobs:
     strategy:
       # One red shard shouldn't cancel siblings -- we want every shard's signal.
       fail-fast: false
-      max-parallel: 4
+      # Matches NUM_SHARDS so all shards run concurrently (no serialized tail);
+      # the suite is in-process mock LLM, so there's no gateway rate-limit cap.
+      max-parallel: 5
       # Shards from `setup`; [] when skipped. Shard check names live in
       # merge-ready/required.sh -- keep in sync with NUM_SHARDS above.
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}

--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -5,12 +5,19 @@
 // covered separately in sessionListCache.test.ts; here we mock the socket
 // and assert exactly which ids reach `setWatched`.
 
-import { act, cleanup, render } from "@testing-library/react";
+import { act, cleanup, render, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useNavigate } from "react-router-dom";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
+import {
+  clearRecentlyCreated,
+  clearSessionTombstones,
+  useArchiveConversation,
+  type Conversation,
+  type ConversationsPage,
+} from "@/hooks/useConversations";
 import type { ConversationsInfiniteData } from "@/lib/sessionListCache";
 
 // Mock the socket transport so setWatched is observable and start/stop are
@@ -91,6 +98,10 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  // Tombstones and the recently-created keep-alive are module-level state;
+  // clear them so an archive in one test can't suppress rows in the next.
+  clearSessionTombstones();
+  clearRecentlyCreated();
 });
 
 describe("SessionUpdatesProvider watch-set", () => {
@@ -309,6 +320,73 @@ describe("SessionUpdatesProvider fingerprint pruning", () => {
     // got reverted, and unbounding the map. First sight must re-fire.
     act(() => handler({ type: "changed", items: [wireItem("conv_b", 1, 1_000)] }));
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ["comments", "conv_b"] });
+  });
+});
+
+describe("SessionUpdatesProvider archive tombstone", () => {
+  it("a stale changed frame carrying archived:false cannot resurrect an archiving row", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ...conv("conv_a"), archived: true, updated_at: 10 }),
+      }),
+    );
+    try {
+      const client = new QueryClient();
+      seedConversations(client, ["conv_a", "conv_b"]);
+      client.setQueryData<ConversationsInfiniteData>(["conversations", "", true], {
+        pages: [
+          {
+            data: [{ ...conv("conv_c"), archived: true }],
+            first_id: "conv_c",
+            last_id: "conv_c",
+            has_more: false,
+          },
+        ],
+        pageParams: [undefined],
+      });
+      renderProvider(client, ["/"]);
+      const handler = frameHandler();
+
+      // Drive the real archive mutation: onMutate tombstones the id and the
+      // optimistic overlay drops the row from this non-archived list.
+      const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      );
+      const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+      result.current.mutate({ id: "conv_a", archived: true });
+      await waitFor(() => {
+        const data = client.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+        expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_b"]);
+      });
+
+      // A pre-commit changed frame still carries archived:false for the row.
+      // The tombstone pins archived:true: the row stays out of the non-archived
+      // list but still merges (title applied, into the include-archived list).
+      act(() =>
+        handler({
+          type: "changed",
+          items: [{ ...conv("conv_a"), archived: false, title: "Late edit" }],
+        }),
+      );
+      const data = client.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+      expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_b"]);
+      const archivedData = client.getQueryData<ConversationsInfiniteData>([
+        "conversations",
+        "",
+        true,
+      ]);
+      expect(archivedData!.pages[0].data.map((c) => c.id)).toEqual(["conv_a", "conv_c"]);
+      expect(archivedData!.pages[0].data[0]).toMatchObject({
+        title: "Late edit",
+        archived: true,
+      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -20,7 +20,11 @@ import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { getCurrentUserId } from "@/lib/identity";
 import { useActiveConversationId } from "@/hooks/useActiveConversationId";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
-import { isSessionDeleting, markRecentlyCreated } from "@/hooks/useConversations";
+import {
+  isSessionArchiving,
+  isSessionDeleting,
+  markRecentlyCreated,
+} from "@/hooks/useConversations";
 import {
   type ConversationsInfiniteData,
   type SessionListWireItem,
@@ -65,7 +69,17 @@ function applyItemsToCache(
   // Frames are full rows with explicit nulls; convert null → undefined so a
   // cleared field overlays the cache in the same shape GET /v1/sessions
   // produces (absent), without tripping the permission_level === null sentinel.
-  const itemsById = new Map(items.map((item) => [item.id, nullsToUndefined(item)]));
+  // Frames for a session with an optimistic delete in flight are dropped.
+  // For an optimistic archive the frame still merges with `archived` pinned
+  // to true, so a stale pre-commit frame can't resurrect or hide the row.
+  const itemsById = new Map<string, SessionListWireItem>();
+  for (const item of items) {
+    if (isSessionDeleting(item.id)) continue;
+    itemsById.set(
+      item.id,
+      nullsToUndefined(isSessionArchiving(item.id) ? { ...item, archived: true } : item),
+    );
+  }
   const foundAnywhere = new Set<string>();
   let needsRefetch = false;
   const entries = queryClient.getQueriesData<ConversationsInfiniteData>({

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -2,7 +2,7 @@
 // query-invalidation contract of the stop mutation hook.
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConversationsInfiniteData } from "@/lib/sessionListCache";
@@ -29,7 +29,7 @@ import {
   useStopSession,
   useTogglePinnedConversation,
   fetchPinnedConversations,
-  unmarkSessionsDeleting,
+  clearSessionTombstones,
   markRecentlyCreated,
   clearRecentlyCreated,
   PINNED_CONVERSATIONS_KEY,
@@ -60,10 +60,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  // Optimistic delete hides ids from every list fetch until the delete
-  // settles, in module-level state that would otherwise leak into the next
-  // test (which reuses the same ids against a fresh cache).
-  unmarkSessionsDeleting();
+  // Tombstones are module-level state that would leak into the next test.
+  clearSessionTombstones();
   // Same for the recently-created keep-alive.
   clearRecentlyCreated();
 });
@@ -2367,6 +2365,15 @@ describe("useMoveToProject", () => {
 });
 
 describe("useArchiveConversation", () => {
+  // A list page the search index keeps serving while it lags the PATCH.
+  const staleListPage = {
+    object: "list",
+    data: [{ id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 5 }],
+    first_id: "conv_a",
+    last_id: "conv_a",
+    has_more: false,
+  };
+
   it("PATCHes archived, overlays the flag optimistically, and doesn't race the reindex", async () => {
     fetchMock.mockResolvedValueOnce(
       mockResponse({
@@ -2474,6 +2481,561 @@ describe("useArchiveConversation", () => {
       .pages[0].data;
     expect(rows[0].archived).toBe(false);
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
+  });
+
+  it("keeps the row out when a stale sidebar-list refetch lands mid-archive", async () => {
+    // Hold the PATCH open so the refetch lands while the server (and the
+    // search index behind it) still lists the session with archived:false.
+    let settlePatch = (_res: Response) => {};
+    const pendingPatch = new Promise<Response>((resolve) => {
+      settlePatch = resolve;
+    });
+    fetchMock.mockImplementationOnce(() => pendingPatch);
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_a" }), conversation({ id: "conv_other" })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    // An active observer on the sidebar's own key, so the refetch below runs
+    // the real queryFn (the seeded data is fresh, so mounting fetches nothing).
+    renderHook(() => useConversations("", false), { wrapper });
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+    result.current.mutate({ id: "conv_a", archived: true });
+    // The optimistic overlay drops the row from the default list immediately.
+    await waitFor(() => {
+      const data = queryClient.getQueryData<ConversationsInfiniteData>([
+        "conversations",
+        "",
+        false,
+      ]);
+      expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_other"]);
+    });
+
+    // A stale refetch of the sidebar list lands mid-archive (debounced WS
+    // invalidation or reconcile poll). The tombstone drops the row, as the
+    // server would have, and cursors re-anchor on the survivor.
+    const stalePage = {
+      object: "list",
+      data: [
+        { id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 5 },
+        { id: "conv_other", object: "conversation", title: "B", created_at: 0, updated_at: 4 },
+      ],
+      first_id: "conv_a",
+      last_id: "conv_other",
+      has_more: false,
+    };
+    fetchMock.mockResolvedValueOnce(mockResponse(stalePage));
+    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", false] }));
+    const page = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+      .pages[0];
+    expect(page.data.map((c) => c.id)).toEqual(["conv_other"]);
+    expect([page.first_id, page.last_id]).toEqual(["conv_other", "conv_other"]);
+
+    // The same stale page on an include-archived list keeps the row visible
+    // (the Archived tab), pinned archived:true.
+    fetchMock.mockResolvedValueOnce(mockResponse(stalePage));
+    const archivedList = renderHook(() => useConversations("", true), { wrapper });
+    await waitFor(() => expect(archivedList.result.current.data).toBeDefined());
+    const archivedRow = archivedList.result.current.data!.pages[0].data.find(
+      (c) => c.id === "conv_a",
+    );
+    expect(archivedRow?.archived).toBe(true);
+
+    settlePatch(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("cancels in-flight conversations AND project-sessions fetches on archive", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a" })]),
+    );
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+    result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Parity with rename/delete: a stale project-folder fetch resolving after
+    // the overlay would resurrect the row in its folder.
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
+  });
+
+  it("clears the tombstone on unarchive so the returning row is never suppressed", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a", archived: false })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    renderHook(() => useConversations("", true), { wrapper });
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+    const cachedRow = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === "conv_a");
+
+    // Archive succeeds; the tombstone pins the row archived:true for the
+    // grace window, so a stale refetch can't show it active again.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    await result.current.mutateAsync({ id: "conv_a", archived: true });
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
+    expect(cachedRow()?.archived).toBe(true);
+
+    // Unarchive clears the tombstone, so the SAME stale page now comes back
+    // with the flag the server sent — the returning row is never suppressed.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 11 }),
+    );
+    await result.current.mutateAsync({ id: "conv_a", archived: false });
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
+    expect(cachedRow()?.archived).toBeFalsy();
+  });
+
+  it("keeps the tombstone when a session is re-archived inside the first archive's grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      // Stream connected → no safety poll would fire while time is advanced.
+      vi.mocked(useSessionUpdatesConnected).mockReturnValue(true);
+      const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+      queryClient.setQueryData(
+        ["conversations", "", true],
+        infinitePage([conversation({ id: "conv_a" })]),
+      );
+      const wrapper = ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children);
+      renderHook(() => useConversations("", true), { wrapper });
+      const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+      );
+      await result.current.mutateAsync({ id: "conv_a", archived: true });
+      // Half the grace window passes, then an unarchive (clears the tombstone
+      // and its pending expiry)…
+      vi.advanceTimersByTime(30_000);
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 11 }),
+      );
+      await result.current.mutateAsync({ id: "conv_a", archived: false });
+      // …and a second archive re-arms both.
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
+      );
+      await result.current.mutateAsync({ id: "conv_a", archived: true });
+
+      // Past the FIRST archive's original expiry: its timer was cleared by the
+      // unarchive, so it must not clear the second archive's live tombstone.
+      vi.advanceTimersByTime(31_000);
+      fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+      await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
+      const row = queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === "conv_a");
+      expect(row?.archived).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-arms the tombstone when an unarchive fails inside the grace window", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a", archived: false })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    renderHook(() => useConversations("", true), { wrapper });
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+    // Archive succeeds — the tombstone is armed for the grace window.
+    const toasts: string[] = [];
+    window.addEventListener("omnigent:toast", (e) => {
+      toasts.push(String((e as CustomEvent<{ content: unknown }>).detail.content));
+    });
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // The unarchive fails: onMutate cleared the tombstone and onError must
+    // re-arm it — the session is still archived server-side, so a stale
+    // refetch must keep the row flagged archived.
+    fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    result.current.mutate({ id: "conv_a", archived: false });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(toasts).toEqual(["Couldn't unarchive the session."]);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        object: "list",
+        data: [{ id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 5 }],
+        first_id: "conv_a",
+        last_id: "conv_a",
+        has_more: false,
+      }),
+    );
+    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
+    const row = queryClient
+      .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+      .pages[0].data.find((c) => c.id === "conv_a");
+    expect(row?.archived).toBe(true);
+  });
+
+  it("a failed unarchive after a newer archive neither rolls back nor toasts", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a", archived: false })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    renderHook(() => useConversations("", true), { wrapper });
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
+    const unarchive = renderHook(() => useArchiveConversation(), { wrapper });
+    const toasts: string[] = [];
+    window.addEventListener("omnigent:toast", (e) => {
+      toasts.push(String((e as CustomEvent<{ content: unknown }>).detail.content));
+    });
+    const cachedRow = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === "conv_a");
+
+    // Archive succeeds; the row is pinned archived for the grace window.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
+
+    // An unarchive starts (PATCH held open)…
+    let settleUnarchive = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settleUnarchive = resolve;
+        }),
+    );
+    unarchive.result.current.mutate({ id: "conv_a", archived: false });
+    await waitFor(() => expect(cachedRow()?.archived).toBe(false));
+
+    // …then a NEWER archive succeeds and owns the tombstone again.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
+    );
+    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
+
+    // The unarchive's PATCH fails last: the newer archive owns what the user
+    // sees, so no snapshot rollback and no failure toast.
+    settleUnarchive(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    await waitFor(() => expect(unarchive.result.current.isError).toBe(true));
+    expect(cachedRow()?.archived).toBe(true);
+    expect(toasts).toEqual([]);
+  });
+
+  it("delete inside the archive grace window takes over the tombstone (no stranded pin)", async () => {
+    vi.useFakeTimers();
+    try {
+      // Stream connected → no safety poll would fire while time is advanced.
+      vi.mocked(useSessionUpdatesConnected).mockReturnValue(true);
+      const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+      queryClient.setQueryData(
+        ["conversations", "", true],
+        infinitePage([conversation({ id: "conv_a" })]),
+      );
+      const wrapper = ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client: queryClient }, children);
+      renderHook(() => useConversations("", true), { wrapper });
+      const archive = renderHook(() => useArchiveConversation(), { wrapper });
+      const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
+
+      fetchMock.mockResolvedValueOnce(
+        mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+      );
+      await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
+
+      // Delete while the archive pin is still in its grace window: the delete
+      // tombstone replaces the archive entry, including its pending expiry.
+      fetchMock.mockResolvedValueOnce(mockResponse({}));
+      fetchMock.mockResolvedValueOnce(mockResponse({ id: "conv_a", deleted: true }));
+      await del.result.current.mutateAsync({ id: "conv_a" });
+
+      // Past the grace window both tombstones are gone, so a stale page comes
+      // back exactly as the server sent it — no pin left behind.
+      vi.advanceTimersByTime(61_000);
+      fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+      await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
+      const row = queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === "conv_a");
+      expect(row?.archived).toBeFalsy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a failed delete inside the archive grace window re-arms the archive pin", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a", archived: false })]),
+    );
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_a" })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    renderHook(() => useConversations("", true), { wrapper });
+    renderHook(() => useConversations("", false), { wrapper });
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
+    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
+
+    // The delete fails (stop ok, DELETE 500): onError releases the delete
+    // tombstone and re-arms the archive pin it replaced, so the rollback
+    // refetch's stale page stays pinned archived:true (off the default page).
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    del.result.current.mutate({ id: "conv_a" });
+    await waitFor(() => expect(del.result.current.isError).toBe(true));
+    // updated_at:5 only arrives via the stale refetch, proving it landed.
+    await waitFor(() => {
+      const row = queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === "conv_a");
+      expect(row).toMatchObject({ archived: true, updated_at: 5 });
+    });
+    const defaultIds = queryClient
+      .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+      .pages[0].data.map((c) => c.id);
+    expect(defaultIds).toEqual([]);
+  });
+
+  it("a failed bulk archive keeps a row a newer delete owns out of the restored lists", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_a" }), conversation({ id: "conv_b" })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const bulk = renderHook(() => useBulkArchiveConversations(), { wrapper });
+    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
+    const defaultIds = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+        .pages[0].data.map((c) => c.id);
+
+    // Bulk archive of conv_a: PATCH held open; the overlay drops the row.
+    let settleArchive = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settleArchive = resolve;
+        }),
+    );
+    bulk.result.current.mutate({ ids: ["conv_a"], archived: true });
+    await waitFor(() => expect(defaultIds()).toEqual(["conv_b"]));
+
+    // A newer delete takes over conv_a's tombstone and succeeds.
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    fetchMock.mockResolvedValueOnce(mockResponse({ id: "conv_a", deleted: true }));
+    await del.result.current.mutateAsync({ id: "conv_a" });
+
+    // The bulk archive's PATCH finally fails: rolling its snapshot back must
+    // not resurrect the row the delete owns.
+    settleArchive(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    await waitFor(() => expect(bulk.result.current.isError).toBe(true));
+    expect(defaultIds()).toEqual(["conv_b"]);
+  });
+
+  it("a failed bulk unarchive keeps a newer archive's pin on a succeeded id", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([
+        conversation({ id: "conv_a", archived: true }),
+        conversation({ id: "conv_b", archived: true }),
+      ]),
+    );
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_c" })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const bulk = renderHook(() => useBulkArchiveConversations(), { wrapper });
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
+    const archivedRow = (id: string) =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === id);
+
+    // Bulk UNarchive of both: PATCHes held open; the overlay flags them active.
+    const settlers: ((res: Response) => void)[] = [];
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          settlers.push(resolve);
+        }),
+    );
+    bulk.result.current.mutate({ ids: ["conv_a", "conv_b"], archived: false });
+    await waitFor(() => expect(archivedRow("conv_a")?.archived).toBe(false));
+
+    // A newer single archive of conv_a succeeds and owns its tombstone.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
+    );
+    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
+
+    // The bulk settles: conv_a's PATCH ok, conv_b's fails. The rollback must
+    // not strip the archive pin the newer mutation owns; conv_b rolls back.
+    settlers[0](
+      mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 13 }),
+    );
+    settlers[1](mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    await waitFor(() => expect(bulk.result.current.isError).toBe(true));
+    expect(archivedRow("conv_a")?.archived).toBe(true);
+    expect(archivedRow("conv_b")?.archived).toBe(true);
+    const defaultIds = queryClient
+      .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+      .pages[0].data.map((c) => c.id);
+    expect(defaultIds).toEqual(["conv_c"]);
+  });
+
+  it("a failed delete keeps a newer archive's pin through the snapshot rollback", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a", archived: false })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
+    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
+    const archivedRow = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === "conv_a");
+
+    // Delete starts: the row is spliced out; the DELETE is held open.
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    let settleDelete = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settleDelete = resolve;
+        }),
+    );
+    del.result.current.mutate({ id: "conv_a" });
+    await waitFor(() => expect(archivedRow()).toBeUndefined());
+
+    // A newer archive takes over the id's tombstone and succeeds.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
+
+    // The delete fails: its snapshot rollback restores the row archived:false
+    // — the live archive tombstone must re-pin it (no refetch involved).
+    settleDelete(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    await waitFor(() => expect(del.result.current.isError).toBe(true));
+    expect(archivedRow()?.archived).toBe(true);
+  });
+
+  it("a superseded archive's late failure cannot release the newer tombstone", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a", archived: false })]),
+    );
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_a" })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    renderHook(() => useConversations("", true), { wrapper });
+    renderHook(() => useConversations("", false), { wrapper });
+    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+
+    const archivedRow = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((c) => c.id === "conv_a");
+    const defaultIds = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+        .pages[0].data.map((c) => c.id);
+
+    // Archive #1: PATCH held open; the overlay drops the row from the
+    // default list immediately. A separate hook instance, so its isError
+    // reflects #1 even after later mutations run on the other instance.
+    let settleFirst = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settleFirst = resolve;
+        }),
+    );
+    const first = renderHook(() => useArchiveConversation(), { wrapper });
+    first.result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(defaultIds()).toEqual([]));
+
+    // Unarchive, then archive #2 — both settle while #1 is still in flight,
+    // so #2 owns the live tombstone.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 11 }),
+    );
+    await result.current.mutateAsync({ id: "conv_a", archived: false });
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
+    );
+    await result.current.mutateAsync({ id: "conv_a", archived: true });
+
+    // Archive #1's PATCH finally fails: its onError must neither release the
+    // tombstone archive #2 owns nor roll the caches back to its own stale
+    // snapshot — the rows stay exactly as archive #2 painted them.
+    settleFirst(mockResponse({ error: "late" }, { ok: false, status: 500 }));
+    await waitFor(() => expect(first.result.current.isError).toBe(true));
+    expect(archivedRow()?.archived).toBe(true);
+    expect(defaultIds()).toEqual([]);
+
+    // A stale refetch of either list still finds the server mid-commit: the
+    // live tombstone pins the row archived:true on the include-archived page
+    // and drops it from the default page.
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    await act(() => queryClient.refetchQueries({ queryKey: ["conversations"] }));
+    expect(archivedRow()?.archived).toBe(true);
+    expect(defaultIds()).toEqual([]);
   });
 });
 

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -2550,6 +2550,61 @@ describe("useArchiveConversation", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 
+  it("keeps pagination alive when archive tombstones empty a fetched page", async () => {
+    let settlePatch = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settlePatch = resolve;
+        }),
+    );
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const seeded = infinitePage([conversation({ id: "conv_a" })]);
+    seeded.pages[0].has_more = true;
+    queryClient.setQueryData(["conversations", "", false], seeded);
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    const list = renderHook(() => useConversations("", false), { wrapper });
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
+
+    archive.result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(list.result.current.data!.pages[0].data).toEqual([]));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    fetchMock.mockResolvedValueOnce(mockResponse({ ...staleListPage, has_more: true }));
+    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", false] }));
+
+    const page = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+      .pages[0];
+    expect(page.data).toEqual([]);
+    expect(page.last_id).toBe("conv_a");
+    expect(list.result.current.hasNextPage).toBe(true);
+
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        data: [
+          {
+            id: "conv_other",
+            object: "conversation",
+            title: "Older",
+            created_at: 0,
+            updated_at: 4,
+          },
+        ],
+        first_id: "conv_other",
+        last_id: "conv_other",
+        has_more: false,
+      }),
+    );
+    await act(() => list.result.current.fetchNextPage());
+    expect(fetchMock.mock.calls[2][0]).toContain("after=conv_a");
+
+    settlePatch(
+      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
+    );
+    await waitFor(() => expect(archive.result.current.isSuccess).toBe(true));
+  });
+
   it("cancels in-flight conversations AND project-sessions fetches on archive", async () => {
     fetchMock.mockResolvedValueOnce(
       mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
@@ -2774,8 +2829,8 @@ describe("useArchiveConversation", () => {
       );
       await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
 
-      // Delete while the archive pin is still in its grace window: the delete
-      // tombstone replaces the archive entry, including its pending expiry.
+      // Delete while the archive pin is still in its grace window: the
+      // independent delete tombstone takes visibility precedence.
       fetchMock.mockResolvedValueOnce(mockResponse({}));
       fetchMock.mockResolvedValueOnce(mockResponse({ id: "conv_a", deleted: true }));
       await del.result.current.mutateAsync({ id: "conv_a" });
@@ -2855,9 +2910,8 @@ describe("useArchiveConversation", () => {
     );
     await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
 
-    // The delete fails (stop ok, DELETE 500): onError releases the delete
-    // tombstone and re-arms the archive pin it replaced, so the rollback
-    // refetch's stale page stays pinned archived:true (off the default page).
+    // The delete fails (stop ok, DELETE 500): onError releases only the delete
+    // tombstone, so the independent archive pin survives the rollback.
     fetchMock.mockResolvedValueOnce(mockResponse({}));
     fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
     fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -2794,6 +2794,45 @@ describe("useArchiveConversation", () => {
     }
   });
 
+  it("a failed archive cannot release an active delete tombstone", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_a" })]),
+    );
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+    renderHook(() => useConversations("", false), { wrapper });
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
+    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
+    const defaultIds = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+        .pages[0].data.map((c) => c.id);
+
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    let settleDelete = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settleDelete = resolve;
+        }),
+    );
+    del.result.current.mutate({ id: "conv_a" });
+    await waitFor(() => expect(defaultIds()).toEqual([]));
+
+    fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
+    archive.result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(archive.result.current.isError).toBe(true));
+
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", false] }));
+    expect(defaultIds()).toEqual([]);
+
+    settleDelete(mockResponse({ id: "conv_a", deleted: true }));
+    await waitFor(() => expect(del.result.current.isSuccess).toBe(true));
+  });
+
   it("a failed delete inside the archive grace window re-arms the archive pin", async () => {
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     queryClient.setQueryData(

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -254,65 +254,110 @@ export interface ConversationsPage {
   has_more: boolean;
 }
 
-// ── Deleting-session tombstones ───────────────────────────────────────
+// ── Hidden-session tombstones (delete / archive in flight) ──────────
 //
-// Delete paints optimistically: the row leaves the sidebar the moment the
-// user confirms, long before the server finishes tearing the session down
-// (stop, runner resources, worktree, managed sandbox — seconds). Until
-// that lands, `GET /v1/sessions` still returns the session, and on the
-// search-indexed deployment it keeps returning it for a while after. Any
-// list fetch in that window — the reconcile poll, the refetch a WS frame
-// schedules, expanding a project folder — would repaint the row the user
-// just deleted.
-//
-// Ids recorded here are filtered out of every list fetch until the delete
-// settles: dropped immediately when it fails (the row comes back), or
-// after a grace window once it succeeds (the server's async reindex).
-const deletingSessionIds = new Set<string>();
+// Deleting ids are dropped from fetches/frames; archiving ids are pinned
+// `archived: true`. Each entry records its owning mutation generation, so
+// a superseded settle can neither release nor expire it.
+const sessionTombstones = new Map<
+  string,
+  { kind: "delete" | "archive"; gen: number; timer?: ReturnType<typeof setTimeout> }
+>();
+let tombstoneGen = 0;
 
-/** Grace window for the server's async delete reindex. */
+/** Grace window for the server's async list-index catch-up. */
 const DELETED_TOMBSTONE_MS = 60_000;
 
-/** Hide these sessions from every list fetch (optimistic delete). */
-export function markSessionsDeleting(ids: Iterable<string>): void {
-  for (const id of ids) deletingSessionIds.add(id);
+/** Tombstone the sessions for an in-flight delete/archive; returns the owning generation. */
+function markSessionTombstones(ids: Iterable<string>, kind: "delete" | "archive"): number {
+  const gen = ++tombstoneGen;
+  for (const id of ids) {
+    const prev = sessionTombstones.get(id);
+    if (prev?.timer !== undefined) clearTimeout(prev.timer);
+    sessionTombstones.set(id, { kind, gen });
+  }
+  return gen;
+}
+
+/** Release tombstones the caller still owns (`gen` matches) — the mutation failed or was undone. */
+function releaseSessionTombstones(ids: Iterable<string>, gen: number): void {
+  for (const id of ids) {
+    const entry = sessionTombstones.get(id);
+    if (entry === undefined || entry.gen !== gen) continue;
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    sessionTombstones.delete(id);
+  }
+}
+
+/** Clear archive tombstones outright — an explicit unarchive brings the row back. */
+function releaseArchiveTombstones(ids: Iterable<string>): void {
+  for (const id of ids) {
+    const entry = sessionTombstones.get(id);
+    if (entry?.kind !== "archive") continue;
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    sessionTombstones.delete(id);
+  }
+}
+
+/** Hold settled tombstones through the reindex grace window, then release them. */
+function expireSessionTombstones(ids: Iterable<string>, gen: number): void {
+  for (const id of ids) {
+    const entry = sessionTombstones.get(id);
+    if (entry === undefined || entry.gen !== gen) continue;
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    entry.timer = setTimeout(() => {
+      if (sessionTombstones.get(id) === entry) sessionTombstones.delete(id);
+    }, DELETED_TOMBSTONE_MS);
+  }
+}
+
+/** Re-arm archive tombstones a failed unarchive/delete cleared, with a fresh grace window. */
+function rearmArchiveTombstones(ids: readonly string[]): void {
+  const rearm = ids.filter((id) => sessionTombstones.get(id) === undefined);
+  if (rearm.length > 0) expireSessionTombstones(rearm, markSessionTombstones(rearm, "archive"));
+}
+
+/** Wipe every tombstone — exported for test cleanup. */
+export function clearSessionTombstones(): void {
+  for (const entry of sessionTombstones.values()) {
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+  }
+  sessionTombstones.clear();
 }
 
 /** Whether a session has an optimistic delete in flight (tombstoned). */
 export function isSessionDeleting(id: string): boolean {
-  return deletingSessionIds.has(id);
+  return sessionTombstones.get(id)?.kind === "delete";
+}
+
+/** Whether a session has an optimistic archive in flight (tombstoned). */
+export function isSessionArchiving(id: string): boolean {
+  return sessionTombstones.get(id)?.kind === "archive";
 }
 
 /**
- * Stop hiding sessions — their delete failed, so the rows return.
- * Omit `ids` to release every tombstone at once.
+ * Apply tombstones to a freshly fetched page: drop deleting sessions; pin
+ * archiving sessions to `archived: true` (or drop them when `dropArchiving`
+ * — lists that never show archived rows). Cursors follow the survivors.
  */
-export function unmarkSessionsDeleting(ids?: Iterable<string>): void {
-  if (ids === undefined) {
-    deletingSessionIds.clear();
-    return;
+function applySessionTombstones(page: ConversationsPage, dropArchiving = false): ConversationsPage {
+  if (sessionTombstones.size === 0) return page;
+  let changed = false;
+  const data: Conversation[] = [];
+  for (const conv of page.data) {
+    const tombstone = sessionTombstones.get(conv.id);
+    if (tombstone?.kind === "delete" || (dropArchiving && tombstone !== undefined)) {
+      changed = true;
+      continue;
+    }
+    if (tombstone?.kind === "archive" && conv.archived !== true) {
+      changed = true;
+      data.push({ ...conv, archived: true });
+      continue;
+    }
+    data.push(conv);
   }
-  for (const id of ids) deletingSessionIds.delete(id);
-}
-
-/** Release confirmed-delete tombstones once the server has caught up. */
-function expireSessionsDeleting(ids: string[]): void {
-  setTimeout(() => unmarkSessionsDeleting(ids), DELETED_TOMBSTONE_MS);
-}
-
-/**
- * Drop rows for sessions with a delete in flight from a freshly fetched
- * page, recomputing the page cursors from the survivors so pagination
- * never anchors on an id the server is about to forget (mirrors
- * `removeIdsFromPages`).
- *
- * @param page - A page as returned by `GET /v1/sessions`.
- * @returns The page, or a filtered copy when it held a deleting session.
- */
-function withoutDeletingSessions(page: ConversationsPage): ConversationsPage {
-  if (deletingSessionIds.size === 0) return page;
-  const data = page.data.filter((conv) => !deletingSessionIds.has(conv.id));
-  if (data.length === page.data.length) return page;
+  if (!changed) return page;
   return {
     ...page,
     data,
@@ -330,7 +375,7 @@ export { markRecentlyCreated, clearRecentlyCreated } from "@/lib/sessionListCach
  * Prepend recently-created rows the first page doesn't yet include (the index
  * hasn't caught up). Only the unfiltered, unsearched first page — a create sorts
  * newest-first. Once the fetch returns the row itself, the keep-alive is dropped.
- * Applied before `withoutDeletingSessions`, so a create-then-delete stays gone.
+ * Applied before `applySessionTombstones`, so a create-then-delete stays gone.
  */
 function withRecentlyCreated(
   page: ConversationsPage,
@@ -468,7 +513,8 @@ async function fetchConversationsPage({
   // falling back to the modal. host_id is fixed for a session's life, so this
   // can't seed a stale value; a hostless row clears any prior mapping.
   for (const row of page.data) setSessionHost(row.id, row.host_id);
-  return withoutDeletingSessions(
+  // Non-archived queries exclude archived rows server-side — drop, don't pin.
+  return applySessionTombstones(
     withRecentlyCreated(
       page,
       after,
@@ -478,6 +524,7 @@ async function fetchConversationsPage({
       queryClient,
       visibility,
     ),
+    !includeArchived && visibility !== "archived",
   );
 }
 
@@ -782,34 +829,56 @@ function dropFromPinnedCache(queryClient: QueryClient, ids: Iterable<string>): v
   );
 }
 
+/**
+ * Paint an archive/unarchive before the server confirms it: tombstone the
+ * ids (an unarchive clears it), cancel in-flight list refetches, then overlay
+ * the flag into every cached list. Mirrors `paintConversationsDeleted`.
+ */
+async function paintConversationsArchived(
+  queryClient: QueryClient,
+  ids: readonly string[],
+  archived: boolean,
+): Promise<{ snapshot: ArchiveListsSnapshot; gen: number; restoreArchiving: string[] }> {
+  const restoreArchiving = ids.filter((id) => isSessionArchiving(id));
+  await Promise.all([
+    queryClient.cancelQueries({ queryKey: ["conversations"] }),
+    queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
+  ]);
+  // Unarchive marks nothing but still gets a gen, so gen-guarded release/expire are no-ops.
+  const gen = markSessionTombstones(archived ? ids : [], "archive");
+  if (!archived) releaseArchiveTombstones(ids);
+  const snapshot = snapshotArchiveLists(queryClient);
+  for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);
+  if (archived) dropFromPinnedCache(queryClient, ids);
+  return { snapshot, gen, restoreArchiving };
+}
+
 export function useArchiveConversation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, archived }: { id: string; archived: boolean }) =>
       archiveConversation(id, archived),
-    onMutate: async ({ id, archived }) => {
-      // Cancel any in-flight list refetch so it can't resolve after this
-      // overlay and clobber the flag with the stale search-indexed state.
-      await queryClient.cancelQueries({ queryKey: ["conversations"] });
-      const snapshot = snapshotArchiveLists(queryClient);
-      overlayArchivedIntoCaches(queryClient, id, archived);
-      // Drop an archived pin from the backfill cache too (mirrors delete).
-      if (archived) dropFromPinnedCache(queryClient, [id]);
-      return { snapshot };
-    },
-    onError: (_err, { archived }, context) => {
+    onMutate: ({ id, archived }) => paintConversationsArchived(queryClient, [id], archived),
+    onError: (_err, { id, archived }, context) => {
+      // A newer mutation owns the id — leave its tombstone and overlay alone.
+      const live = sessionTombstones.get(id);
+      if (context && live !== undefined && live.gen !== context.gen) return;
+      if (archived && context) releaseSessionTombstones([id], context.gen);
+      if (context) rearmArchiveTombstones(context.restoreArchiving);
       // Roll back to exactly the pre-archive caches, synchronously — so the
       // row (and any dropped pin) returns at once, rather than waiting on a
       // search-indexed refetch that lags the write.
-      if (context?.snapshot) restoreArchiveLists(queryClient, context.snapshot);
+      if (context) restoreArchiveLists(queryClient, context.snapshot);
+      if (context) reapplyLiveTombstones(queryClient);
       showToast(
         archived
           ? "Couldn't archive the session — it's back in the sidebar."
           : "Couldn't unarchive the session.",
       );
     },
-    onSuccess: (updated) => {
+    onSuccess: (updated, { archived }, context) => {
       markConversationSeen(updated.id, updated.updated_at);
+      if (archived && context) expireSessionTombstones([updated.id], context.gen);
       // Archiving/unarchiving the last (or first) non-archived member of a
       // project removes/restores it from the server's project list, and adds
       // or drops it from that project folder's own paginated list. These read
@@ -854,6 +923,18 @@ function removeConversationsFromLists(queryClient: QueryClient, ids: Set<string>
   );
 }
 
+/** Re-apply every live tombstone's optimistic state after a wholesale snapshot restore. */
+function reapplyLiveTombstones(queryClient: QueryClient): void {
+  const deleted = new Set<string>();
+  const archived = new Set<string>();
+  for (const [id, entry] of sessionTombstones)
+    if (entry.kind === "delete") deleted.add(id);
+    else archived.add(id);
+  for (const id of archived) overlayArchivedIntoCaches(queryClient, id, true);
+  if (archived.size > 0) dropFromPinnedCache(queryClient, archived);
+  if (deleted.size > 0) removeConversationsFromLists(queryClient, deleted);
+}
+
 /** Every cached list touched by an optimistic delete, as it was before. */
 interface DeletedListsSnapshot {
   lists: [readonly unknown[], ConversationsInfiniteData | undefined][];
@@ -874,12 +955,13 @@ interface DeletedListsSnapshot {
 async function paintConversationsDeleted(
   queryClient: QueryClient,
   ids: readonly string[],
-): Promise<DeletedListsSnapshot> {
-  markSessionsDeleting(ids);
+): Promise<{ snapshot: DeletedListsSnapshot; gen: number; restoreArchiving: string[] }> {
+  const restoreArchiving = ids.filter((id) => isSessionArchiving(id));
   await Promise.all([
     queryClient.cancelQueries({ queryKey: ["conversations"] }),
     queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
   ]);
+  const gen = markSessionTombstones(ids, "delete");
   const snapshot: DeletedListsSnapshot = {
     lists: [
       ...queryClient.getQueriesData<ConversationsInfiniteData>({ queryKey: ["conversations"] }),
@@ -888,34 +970,33 @@ async function paintConversationsDeleted(
     pinned: queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY),
   };
   removeConversationsFromLists(queryClient, new Set(ids));
-  return snapshot;
+  return { snapshot, gen, restoreArchiving };
 }
 
 /**
  * Put optimistically-removed rows back after a failed delete.
  *
  * Restores the snapshot wholesale (the same rollback shape
- * `useMoveToProject` uses) rather than re-deriving positions, then
- * re-splices whatever DID delete — a bulk delete can fail for only part
- * of its selection. The lists are invalidated afterwards so the server
- * reconciles the window the snapshot froze over.
+ * `useMoveToProject` uses), then re-applies live tombstones so ids a newer
+ * mutation owns keep that mutation's state (and ids that DID delete in a
+ * partial bulk failure stay gone). The lists are invalidated afterwards so
+ * the server reconciles the window the snapshot froze over.
  *
  * @param queryClient - The app QueryClient.
- * @param snapshot - Cache state captured by `paintConversationsDeleted`.
+ * @param paint - Tombstone + cache state captured by `paintConversationsDeleted`.
  * @param failedIds - Conversation ids whose delete failed (rows return).
- * @param deletedIds - Conversation ids that did delete (rows stay gone).
  */
 function restoreDeletedConversations(
   queryClient: QueryClient,
-  snapshot: DeletedListsSnapshot | undefined,
+  paint: { snapshot: DeletedListsSnapshot; gen: number; restoreArchiving: string[] } | undefined,
   failedIds: readonly string[],
-  deletedIds: readonly string[] = [],
 ): void {
-  unmarkSessionsDeleting(failedIds);
-  if (snapshot) {
-    for (const [key, data] of snapshot.lists) queryClient.setQueryData(key, data);
-    queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, snapshot.pinned);
-    if (deletedIds.length > 0) removeConversationsFromLists(queryClient, new Set(deletedIds));
+  if (paint !== undefined) {
+    releaseSessionTombstones(failedIds, paint.gen);
+    rearmArchiveTombstones(paint.restoreArchiving.filter((id) => failedIds.includes(id)));
+    for (const [key, data] of paint.snapshot.lists) queryClient.setQueryData(key, data);
+    queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, paint.snapshot.pinned);
+    reapplyLiveTombstones(queryClient);
   }
   void queryClient.invalidateQueries({ queryKey: ["conversations"] });
   void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
@@ -931,12 +1012,16 @@ function restoreDeletedConversations(
  * @param queryClient - The app QueryClient.
  * @param ids - Conversation ids the server confirmed deleted.
  */
-function finalizeDeletedConversations(queryClient: QueryClient, ids: readonly string[]): void {
+function finalizeDeletedConversations(
+  queryClient: QueryClient,
+  ids: readonly string[],
+  gen: number,
+): void {
   for (const id of ids) {
     queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
     queryClient.removeQueries({ queryKey: ["session", id] });
   }
-  expireSessionsDeleting([...ids]);
+  expireSessionTombstones(ids, gen);
   // Deleting the last member of a project empties it, so refresh the
   // project list to drop the now-empty folder. Unlike the conversations
   // list, /v1/sessions/projects reads the DB directly (no search-index
@@ -982,7 +1067,7 @@ function deleteFailedToast(label: string | null | undefined, err: unknown): stri
  * round-trip — server-side teardown (runner resources, worktree, managed
  * sandbox) can take seconds, which is what made delete feel slower than
  * archive. The session is tombstoned for that window so a concurrent list
- * fetch can't repaint the row (see `withoutDeletingSessions`); `onError`
+ * fetch can't repaint the row (see `applySessionTombstones`); `onError`
  * drops the tombstone and refetches, restoring the row. Callers (the
  * sidebar row) are responsible for navigating away from `/c/{id}` if the
  * deleted conversation is the active one.
@@ -1002,11 +1087,11 @@ export function useStopAndDeleteConversation() {
       // Snapshot the label before the row leaves the cache — a failure
       // toast fired later can no longer look it up.
       const row = findCachedConversationRow(queryClient, id);
-      const snapshot = await paintConversationsDeleted(queryClient, [id]);
-      return { label: row ? conversationDisplayLabel(row) : null, snapshot };
+      const paint = await paintConversationsDeleted(queryClient, [id]);
+      return { label: row ? conversationDisplayLabel(row) : null, paint };
     },
     onError: (err, { id }, context) => {
-      restoreDeletedConversations(queryClient, context?.snapshot, [id]);
+      restoreDeletedConversations(queryClient, context?.paint, [id]);
       // The row is back in the sidebar but nothing else marks it as failed
       // (the row unmounted when it was spliced out, taking any in-row error
       // state with it), so the toast is the only failure signal. Keep it
@@ -1015,8 +1100,8 @@ export function useStopAndDeleteConversation() {
       // only hint for what to do next.
       showToast(deleteFailedToast(context?.label, err), { duration: 0 });
     },
-    onSuccess: (_data, { id }) => {
-      finalizeDeletedConversations(queryClient, [id]);
+    onSuccess: (_data, { id }, context) => {
+      if (context !== undefined) finalizeDeletedConversations(queryClient, [id], context.paint.gen);
     },
   });
 }
@@ -1119,25 +1204,26 @@ export function useBulkArchiveConversations() {
         .filter((r): r is PromiseFulfilledResult<Conversation> => r.status === "fulfilled")
         .map((r) => r.value);
     },
-    onMutate: async ({ ids, archived }) => {
-      await queryClient.cancelQueries({ queryKey: ["conversations"] });
-      const snapshot = snapshotArchiveLists(queryClient);
-      for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);
-      if (archived) dropFromPinnedCache(queryClient, ids);
-      return { snapshot };
-    },
+    onMutate: ({ ids, archived }) => paintConversationsArchived(queryClient, ids, archived),
     onError: (err, { ids, archived }, context) => {
-      // Partial failure: restore the pre-archive caches, then RE-apply the
-      // overlay for the ids that DID archive so they stay hidden — only the
-      // failed ids return. Restoring from the snapshot rather than refetching
-      // ["conversations"] is what stops the search-index lag from resurrecting
-      // the successful archives (the exact regression this reconcile guards).
-      if (!context?.snapshot) return;
-      restoreArchiveLists(queryClient, context.snapshot);
+      if (!context) return;
       const failed = new Set(err instanceof BulkConversationMutationError ? err.failed : ids);
       const succeeded = ids.filter((id) => !failed.has(id));
-      for (const id of succeeded) overlayArchivedIntoCaches(queryClient, id, archived);
-      if (archived) dropFromPinnedCache(queryClient, succeeded);
+      if (archived) {
+        releaseSessionTombstones(failed, context.gen);
+        expireSessionTombstones(succeeded, context.gen);
+      }
+      rearmArchiveTombstones(context.restoreArchiving.filter((id) => failed.has(id)));
+      restoreArchiveLists(queryClient, context.snapshot);
+      reapplyLiveTombstones(queryClient);
+      // Succeeded unarchives own no tombstone — re-apply their flag by hand.
+      if (!archived) {
+        for (const id of succeeded.filter((sid) => !sessionTombstones.has(sid)))
+          overlayArchivedIntoCaches(queryClient, id, false);
+      }
+    },
+    onSuccess: (_data, { ids, archived }, context) => {
+      if (archived && context !== undefined) expireSessionTombstones(ids, context.gen);
     },
     onSettled: () => {
       // Project caches read the DB directly (no search-index lag), so unlike
@@ -1200,17 +1286,19 @@ export function useBulkDeleteConversations() {
       return { succeeded, failed };
     },
     onMutate: ({ ids }) => paintConversationsDeleted(queryClient, ids),
-    onSuccess: (_data, { ids }) => {
-      finalizeDeletedConversations(queryClient, ids);
+    onSuccess: (_data, { ids }, context) => {
+      if (context !== undefined) finalizeDeletedConversations(queryClient, ids, context.gen);
     },
-    onError: (error, { ids }, snapshot) => {
+    onError: (error, { ids }, context) => {
       // Partial failure: the sessions that did delete stay gone; the rest
       // come back. A non-bulk error (nothing reported) restores everything.
       const bulk = error instanceof BulkConversationMutationError ? error : null;
       const failed = bulk ? bulk.failed : [...ids];
       const succeeded = bulk ? bulk.succeeded : [];
-      restoreDeletedConversations(queryClient, snapshot, failed, succeeded);
-      if (succeeded.length > 0) finalizeDeletedConversations(queryClient, succeeded);
+      restoreDeletedConversations(queryClient, context, failed);
+      if (succeeded.length > 0 && context !== undefined) {
+        finalizeDeletedConversations(queryClient, succeeded, context.gen);
+      }
       showToast(
         failed.length === 1
           ? "Couldn't delete 1 session — it's back in the sidebar."
@@ -1342,7 +1430,7 @@ export async function fetchPinnedConversations(): Promise<PinnedConversationsRes
   });
   const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  const rows = withoutDeletingSessions((await res.json()) as ConversationsPage).data;
+  const rows = applySessionTombstones((await res.json()) as ConversationsPage, true).data;
   const conversations = rows.filter((c) => c.labels?.[PINNED_LABEL_KEY] != null);
   // Honored iff the server returned nothing, or everything it returned is
   // actually pinned. An old server returns unfiltered rows (none pinned), so a
@@ -1954,7 +2042,7 @@ async function fetchProjectSessionsPage(
   if (after) params.set("after", after);
   const res = await authenticatedFetch(`/v1/sessions?${params.toString()}`);
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return withoutDeletingSessions((await res.json()) as ConversationsPage);
+  return applySessionTombstones((await res.json()) as ConversationsPage, true);
 }
 
 /**

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -255,84 +255,101 @@ export interface ConversationsPage {
 }
 
 // ── Hidden-session tombstones (delete / archive in flight) ──────────
-//
-// Deleting ids are dropped from fetches/frames; archiving ids are pinned
-// `archived: true`. Each entry records its owning mutation generation, so
-// a superseded settle can neither release nor expire it.
-const sessionTombstones = new Map<
-  string,
-  { kind: "delete" | "archive"; gen: number; timer?: ReturnType<typeof setTimeout> }
->();
+interface SessionTombstone {
+  gen: number;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+// Delete and archive lifecycles are independent, so archive cannot release
+// the stronger delete tombstone.
+const deletingSessionTombstones = new Map<string, SessionTombstone>();
+const archivingSessionTombstones = new Map<string, SessionTombstone>();
 let tombstoneGen = 0;
 
 /** Grace window for the server's async list-index catch-up. */
 const DELETED_TOMBSTONE_MS = 60_000;
 
-/** Tombstone the sessions for an in-flight delete/archive; returns the owning generation. */
-function markSessionTombstones(ids: Iterable<string>, kind: "delete" | "archive"): number {
+/** Replace entries in one tombstone lifecycle; returns the owning generation. */
+function markSessionTombstones<T extends SessionTombstone>(
+  tombstones: Map<string, T>,
+  ids: Iterable<string>,
+  makeEntry: (gen: number) => T,
+): number {
   const gen = ++tombstoneGen;
   for (const id of ids) {
-    const prev = sessionTombstones.get(id);
+    const prev = tombstones.get(id);
     if (prev?.timer !== undefined) clearTimeout(prev.timer);
-    sessionTombstones.set(id, { kind, gen });
+    tombstones.set(id, makeEntry(gen));
   }
   return gen;
 }
 
 /** Release tombstones the caller still owns (`gen` matches) — the mutation failed or was undone. */
-function releaseSessionTombstones(ids: Iterable<string>, gen: number): void {
+function releaseSessionTombstones<T extends SessionTombstone>(
+  tombstones: Map<string, T>,
+  ids: Iterable<string>,
+  gen: number,
+): void {
   for (const id of ids) {
-    const entry = sessionTombstones.get(id);
+    const entry = tombstones.get(id);
     if (entry === undefined || entry.gen !== gen) continue;
     if (entry.timer !== undefined) clearTimeout(entry.timer);
-    sessionTombstones.delete(id);
-  }
-}
-
-/** Clear archive tombstones outright — an explicit unarchive brings the row back. */
-function releaseArchiveTombstones(ids: Iterable<string>): void {
-  for (const id of ids) {
-    const entry = sessionTombstones.get(id);
-    if (entry?.kind !== "archive") continue;
-    if (entry.timer !== undefined) clearTimeout(entry.timer);
-    sessionTombstones.delete(id);
+    tombstones.delete(id);
   }
 }
 
 /** Hold settled tombstones through the reindex grace window, then release them. */
-function expireSessionTombstones(ids: Iterable<string>, gen: number): void {
+function expireSessionTombstones<T extends SessionTombstone>(
+  tombstones: Map<string, T>,
+  ids: Iterable<string>,
+  gen: number,
+): void {
   for (const id of ids) {
-    const entry = sessionTombstones.get(id);
+    const entry = tombstones.get(id);
     if (entry === undefined || entry.gen !== gen) continue;
     if (entry.timer !== undefined) clearTimeout(entry.timer);
     entry.timer = setTimeout(() => {
-      if (sessionTombstones.get(id) === entry) sessionTombstones.delete(id);
+      if (tombstones.get(id) === entry) tombstones.delete(id);
     }, DELETED_TOMBSTONE_MS);
   }
 }
 
 /** Re-arm archive tombstones a failed unarchive/delete cleared, with a fresh grace window. */
 function rearmArchiveTombstones(ids: readonly string[]): void {
-  const rearm = ids.filter((id) => sessionTombstones.get(id) === undefined);
-  if (rearm.length > 0) expireSessionTombstones(rearm, markSessionTombstones(rearm, "archive"));
+  const rearm = ids.filter((id) => archivingSessionTombstones.get(id) === undefined);
+  if (rearm.length === 0) return;
+  const gen = markSessionTombstones(archivingSessionTombstones, rearm, (entryGen) => ({
+    gen: entryGen,
+  }));
+  expireSessionTombstones(archivingSessionTombstones, rearm, gen);
+}
+
+function clearArchivingSessionTombstones(ids: Iterable<string>): void {
+  for (const id of ids) {
+    const entry = archivingSessionTombstones.get(id);
+    if (entry?.timer !== undefined) clearTimeout(entry.timer);
+    archivingSessionTombstones.delete(id);
+  }
 }
 
 /** Wipe every tombstone — exported for test cleanup. */
 export function clearSessionTombstones(): void {
-  for (const entry of sessionTombstones.values()) {
-    if (entry.timer !== undefined) clearTimeout(entry.timer);
+  for (const tombstones of [deletingSessionTombstones, archivingSessionTombstones]) {
+    for (const entry of tombstones.values()) {
+      if (entry.timer !== undefined) clearTimeout(entry.timer);
+    }
+    tombstones.clear();
   }
-  sessionTombstones.clear();
 }
 
 /** Whether a session has an optimistic delete in flight (tombstoned). */
 export function isSessionDeleting(id: string): boolean {
-  return sessionTombstones.get(id)?.kind === "delete";
+  return deletingSessionTombstones.has(id);
 }
 
 /** Whether a session has an optimistic archive in flight (tombstoned). */
 export function isSessionArchiving(id: string): boolean {
-  return sessionTombstones.get(id)?.kind === "archive";
+  return archivingSessionTombstones.has(id);
 }
 
 /**
@@ -341,16 +358,16 @@ export function isSessionArchiving(id: string): boolean {
  * — lists that never show archived rows). Cursors follow the survivors.
  */
 function applySessionTombstones(page: ConversationsPage, dropArchiving = false): ConversationsPage {
-  if (sessionTombstones.size === 0) return page;
+  if (deletingSessionTombstones.size === 0 && archivingSessionTombstones.size === 0) return page;
   let changed = false;
   const data: Conversation[] = [];
   for (const conv of page.data) {
-    const tombstone = sessionTombstones.get(conv.id);
-    if (tombstone?.kind === "delete" || (dropArchiving && tombstone !== undefined)) {
+    const archiving = isSessionArchiving(conv.id);
+    if (isSessionDeleting(conv.id) || (dropArchiving && archiving)) {
       changed = true;
       continue;
     }
-    if (tombstone?.kind === "archive" && conv.archived !== true) {
+    if (archiving && conv.archived !== true) {
       changed = true;
       data.push({ ...conv, archived: true });
       continue;
@@ -844,9 +861,12 @@ async function paintConversationsArchived(
     queryClient.cancelQueries({ queryKey: ["conversations"] }),
     queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
   ]);
-  // Unarchive marks nothing but still gets a gen, so gen-guarded release/expire are no-ops.
-  const gen = markSessionTombstones(archived ? ids : [], "archive");
-  if (!archived) releaseArchiveTombstones(ids);
+  const gen = markSessionTombstones(
+    archivingSessionTombstones,
+    archived ? ids : [],
+    (entryGen) => ({ gen: entryGen }),
+  );
+  if (!archived) clearArchivingSessionTombstones(ids);
   const snapshot = snapshotArchiveLists(queryClient);
   for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);
   if (archived) dropFromPinnedCache(queryClient, ids);
@@ -861,9 +881,11 @@ export function useArchiveConversation() {
     onMutate: ({ id, archived }) => paintConversationsArchived(queryClient, [id], archived),
     onError: (_err, { id, archived }, context) => {
       // A newer mutation owns the id — leave its tombstone and overlay alone.
-      const live = sessionTombstones.get(id);
+      const live = archivingSessionTombstones.get(id);
       if (context && live !== undefined && live.gen !== context.gen) return;
-      if (archived && context) releaseSessionTombstones([id], context.gen);
+      if (archived && context) {
+        releaseSessionTombstones(archivingSessionTombstones, [id], context.gen);
+      }
       if (context) rearmArchiveTombstones(context.restoreArchiving);
       // Roll back to exactly the pre-archive caches, synchronously — so the
       // row (and any dropped pin) returns at once, rather than waiting on a
@@ -878,7 +900,9 @@ export function useArchiveConversation() {
     },
     onSuccess: (updated, { archived }, context) => {
       markConversationSeen(updated.id, updated.updated_at);
-      if (archived && context) expireSessionTombstones([updated.id], context.gen);
+      if (archived && context) {
+        expireSessionTombstones(archivingSessionTombstones, [updated.id], context.gen);
+      }
       // Archiving/unarchiving the last (or first) non-archived member of a
       // project removes/restores it from the server's project list, and adds
       // or drops it from that project folder's own paginated list. These read
@@ -925,14 +949,12 @@ function removeConversationsFromLists(queryClient: QueryClient, ids: Set<string>
 
 /** Re-apply every live tombstone's optimistic state after a wholesale snapshot restore. */
 function reapplyLiveTombstones(queryClient: QueryClient): void {
-  const deleted = new Set<string>();
-  const archived = new Set<string>();
-  for (const [id, entry] of sessionTombstones)
-    if (entry.kind === "delete") deleted.add(id);
-    else archived.add(id);
+  const archived = new Set(archivingSessionTombstones.keys());
   for (const id of archived) overlayArchivedIntoCaches(queryClient, id, true);
   if (archived.size > 0) dropFromPinnedCache(queryClient, archived);
-  if (deleted.size > 0) removeConversationsFromLists(queryClient, deleted);
+  if (deletingSessionTombstones.size > 0) {
+    removeConversationsFromLists(queryClient, new Set(deletingSessionTombstones.keys()));
+  }
 }
 
 /** Every cached list touched by an optimistic delete, as it was before. */
@@ -955,13 +977,14 @@ interface DeletedListsSnapshot {
 async function paintConversationsDeleted(
   queryClient: QueryClient,
   ids: readonly string[],
-): Promise<{ snapshot: DeletedListsSnapshot; gen: number; restoreArchiving: string[] }> {
-  const restoreArchiving = ids.filter((id) => isSessionArchiving(id));
+): Promise<{ snapshot: DeletedListsSnapshot; gen: number }> {
   await Promise.all([
     queryClient.cancelQueries({ queryKey: ["conversations"] }),
     queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
   ]);
-  const gen = markSessionTombstones(ids, "delete");
+  const gen = markSessionTombstones(deletingSessionTombstones, ids, (entryGen) => ({
+    gen: entryGen,
+  }));
   const snapshot: DeletedListsSnapshot = {
     lists: [
       ...queryClient.getQueriesData<ConversationsInfiniteData>({ queryKey: ["conversations"] }),
@@ -970,7 +993,7 @@ async function paintConversationsDeleted(
     pinned: queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY),
   };
   removeConversationsFromLists(queryClient, new Set(ids));
-  return { snapshot, gen, restoreArchiving };
+  return { snapshot, gen };
 }
 
 /**
@@ -988,12 +1011,11 @@ async function paintConversationsDeleted(
  */
 function restoreDeletedConversations(
   queryClient: QueryClient,
-  paint: { snapshot: DeletedListsSnapshot; gen: number; restoreArchiving: string[] } | undefined,
+  paint: { snapshot: DeletedListsSnapshot; gen: number } | undefined,
   failedIds: readonly string[],
 ): void {
   if (paint !== undefined) {
-    releaseSessionTombstones(failedIds, paint.gen);
-    rearmArchiveTombstones(paint.restoreArchiving.filter((id) => failedIds.includes(id)));
+    releaseSessionTombstones(deletingSessionTombstones, failedIds, paint.gen);
     for (const [key, data] of paint.snapshot.lists) queryClient.setQueryData(key, data);
     queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, paint.snapshot.pinned);
     reapplyLiveTombstones(queryClient);
@@ -1021,7 +1043,8 @@ function finalizeDeletedConversations(
     queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
     queryClient.removeQueries({ queryKey: ["session", id] });
   }
-  expireSessionTombstones(ids, gen);
+  clearArchivingSessionTombstones(ids);
+  expireSessionTombstones(deletingSessionTombstones, ids, gen);
   // Deleting the last member of a project empties it, so refresh the
   // project list to drop the now-empty folder. Unlike the conversations
   // list, /v1/sessions/projects reads the DB directly (no search-index
@@ -1210,20 +1233,22 @@ export function useBulkArchiveConversations() {
       const failed = new Set(err instanceof BulkConversationMutationError ? err.failed : ids);
       const succeeded = ids.filter((id) => !failed.has(id));
       if (archived) {
-        releaseSessionTombstones(failed, context.gen);
-        expireSessionTombstones(succeeded, context.gen);
+        releaseSessionTombstones(archivingSessionTombstones, failed, context.gen);
+        expireSessionTombstones(archivingSessionTombstones, succeeded, context.gen);
       }
       rearmArchiveTombstones(context.restoreArchiving.filter((id) => failed.has(id)));
       restoreArchiveLists(queryClient, context.snapshot);
       reapplyLiveTombstones(queryClient);
       // Succeeded unarchives own no tombstone — re-apply their flag by hand.
       if (!archived) {
-        for (const id of succeeded.filter((sid) => !sessionTombstones.has(sid)))
+        for (const id of succeeded.filter((sid) => !archivingSessionTombstones.has(sid)))
           overlayArchivedIntoCaches(queryClient, id, false);
       }
     },
     onSuccess: (_data, { ids, archived }, context) => {
-      if (archived && context !== undefined) expireSessionTombstones(ids, context.gen);
+      if (archived && context !== undefined) {
+        expireSessionTombstones(archivingSessionTombstones, ids, context.gen);
+      }
     },
     onSettled: () => {
       // Project caches read the DB directly (no search-index lag), so unlike

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -360,11 +360,17 @@ export function isSessionArchiving(id: string): boolean {
 function applySessionTombstones(page: ConversationsPage, dropArchiving = false): ConversationsPage {
   if (deletingSessionTombstones.size === 0 && archivingSessionTombstones.size === 0) return page;
   let changed = false;
+  let lastArchivingId: string | null = null;
   const data: Conversation[] = [];
   for (const conv of page.data) {
     const archiving = isSessionArchiving(conv.id);
-    if (isSessionDeleting(conv.id) || (dropArchiving && archiving)) {
+    if (isSessionDeleting(conv.id)) {
       changed = true;
+      continue;
+    }
+    if (dropArchiving && archiving) {
+      changed = true;
+      lastArchivingId = conv.id;
       continue;
     }
     if (archiving && conv.archived !== true) {
@@ -379,7 +385,8 @@ function applySessionTombstones(page: ConversationsPage, dropArchiving = false):
     ...page,
     data,
     first_id: data[0]?.id ?? null,
-    last_id: data[data.length - 1]?.id ?? null,
+    // Archived rows remain valid server cursors; deleted rows do not.
+    last_id: data[data.length - 1]?.id ?? lastArchivingId,
   };
 }
 
@@ -866,6 +873,8 @@ async function paintConversationsArchived(
     archived ? ids : [],
     (entryGen) => ({ gen: entryGen }),
   );
+  // Unarchive must not retain a true pin; overlapping rollbacks reconcile
+  // through the server refresh path rather than pinning archived:false.
   if (!archived) clearArchivingSessionTombstones(ids);
   const snapshot = snapshotArchiveLists(queryClient);
   for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -345,8 +345,8 @@ export function clearRecentlyCreated(): void {
  * refetch (which lags the search index). A new row sorts newest-first, so page 0
  * is its home. Skips: search lists (membership unknown), archived/wrong-project
  * rows, sub-agent children (`parent_session_id` — they live off the sidebar),
- * and ids the caller excludes via `skip` (e.g. an optimistic delete in flight).
- * `candidates` should already exclude rows the list holds.
+ * and ids the caller excludes via `skip` (e.g. an optimistic delete or
+ * archive in flight). `candidates` should already exclude rows the list holds.
  */
 export function insertNewRowsIntoPages(
   data: ConversationsInfiniteData | undefined,
@@ -519,13 +519,10 @@ export function overlayTitleIntoCaches(
  *
  * Patched in place rather than invalidated, for the same reason rename/delete
  * are: GET /v1/sessions may be served from a search index that lags the PATCH,
- * so an immediate refetch races the reindex and bounces the row back. The
- * server-confirmed state converges via the WS stream and the reconcile poll.
- *
- * ponytail: a reconcile poll firing inside the reindex-lag window (before the
- * index reflects the archive) can briefly bounce the row back; it self-heals on
- * the next poll. Add a fetch-time flag override (like `withoutDeletingSessions`)
- * if metrics show the bounce.
+ * so an immediate refetch races the reindex and bounces the row back. List
+ * fetches and push deltas landing inside that lag window are pinned to
+ * `archived: true` by the tombstone the archive mutations set (see
+ * `markSessionTombstones` in useConversations).
  */
 export function overlayArchivedIntoCaches(
   queryClient: QueryClient,


### PR DESCRIPTION
## Related issue

Closes #6442

## Summary

Archiving sessions in quick succession made the just-archived rows pop back into the sidebar until the next refresh. The archive mutation painted optimistically but, unlike delete, never tombstoned the id — so a stale full-page refetch (the debounced `["conversations"]` invalidation a WS frame schedules), an in-flight `["project-sessions"]` fetch, or a pre-commit WS `changed` frame carrying `archived:false` resurrected the row.

The fix extends the existing mechanism into two independent, generation-tagged maps (`deletingSessionTombstones` / `archivingSessionTombstones`) with three shared lifecycle helpers — `markSessionTombstones` / `releaseSessionTombstones` / `expireSessionTombstones` — and the existing consumer API (`isSessionDeleting` / `isSessionArchiving`). Keeping the lifecycles separate makes delete the stronger state without letting archive settlement release delete protection:

- **Deleting ids are dropped** from list fetches and WS frames, as before. **Archiving ids are pinned to `archived: true`** on archived views (include-archived / `visibility="archived"` pages) and **dropped on non-archived pages**, exactly as the server would have excluded the row — so the row stays visible in the Archived tab while the default sidebar drops it with cursors re-anchored on the survivors (`applySessionTombstones`, formerly `withoutDeletingSessions`). Pinned/project-folder fetches always drop.
- **Delete and archive lifecycles are independent**: delete takes read/visibility precedence, a failed operation releases only its own map entry, and a confirmed delete clears any obsolete archive pin.
- **Generations make settle callbacks safe under overlap**: `paintConversationsArchived` returns the gen it marked; `onError`/`onSuccess` release/expire only if the entry's gen still matches, so with archive→unarchive→archive in flight, the first archive's late failure can't release the newer tombstone. When a *live* entry belongs to a newer mutation, a superseded failure skips its rollback and toast entirely — the newer mutation owns what the user sees. A failed unarchive re-arms the tombstone it cleared — only for ids no newer mutation has claimed.
- **Snapshot restores re-apply live tombstones**: every failure rollback (single/bulk archive, delete) is followed by `reapplyLiveTombstones`, which re-pins or re-splices whatever the two live maps still own (including the pinned backfill cache) — so a newer mutation's optimistic state survives an older mutation's rollback.
- WS `changed` frames for archiving ids still merge (title, status, elicitation counts) with `archived` pinned to true, so a legitimate update from another client isn't lost for the grace window, but a stale `archived:false` frame can neither resurrect the row in the default list nor hide it from archived views.
- Archive `onMutate` now also cancels `["project-sessions"]` queries, for parity with rename and delete.

ELI5: when you archive a chat, the app already keeps a short-lived "this one is leaving" sticky note for delete; archive never wrote one. Any list refresh or live update arriving while the server was still catching up saw the chat as active and put it back. Now archive writes its own note — "this one is archived" — and every refresh or live update re-stamps the flag instead of dropping the row, so the Archived tab still shows it while the main list keeps it out. Each note is numbered, so an older operation that finishes late can't peel off a newer operation's note.

The race, before the fix:

```
user            archive hook            WS / list fetch           cache
 |  archive A     |                        |                        |
 |--------------->| onMutate: overlay      |                        |
 |                | archived:true (row     |                        |
 |                | leaves list)           |                        |
 |                |  PATCH in flight ----->| server not yet         |
 |                |                        | committed              |
 |                |                        | stale read:            |
 |                |                        | A archived:false       |
 |                |                        |----------------------->| row pops back
 |                |  PATCH commits ------->|                        |
 |                |                        | next refresh fixes it  |
```

## Test Plan

From `web/` (Node 22, pnpm 11):

```
npx -y pnpm@11.15.1 install --frozen-lockfile
npx -y pnpm@11.15.1 vitest run src/hooks/useConversations.test.ts src/hooks/SessionUpdatesProvider.test.tsx src/lib/sessionListCache.test.ts
npx -y pnpm@11.15.1 run lint
npx -y pnpm@11.15.1 run type-check
npx -y pnpm@11.15.1 run format:check
pre-commit run --files web/src/hooks/useConversations.ts web/src/hooks/useConversations.test.ts web/src/hooks/SessionUpdatesProvider.tsx web/src/hooks/SessionUpdatesProvider.test.tsx web/src/lib/sessionListCache.ts
```

All pass (147 tests in the three touched files, 131 of them pre-existing). Mutation check: with the three source files checked out from `upstream/main`, each new/changed test fails on its behavioral assertion; with the fix restored, all pass.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Deterministic reproduction of the race (vitest): `useConversations.test.ts` › "keeps the row out when a stale sidebar-list refetch lands mid-archive" holds the archive PATCH open, then lands a refetch of the sidebar's own query key that still returns the session with `archived:false` — the row is dropped from the non-archived page (cursors re-anchored on the survivor) and pinned `archived:true` in an include-archived list. `SessionUpdatesProvider.test.tsx` › "a stale changed frame carrying archived:false cannot resurrect an archiving row" drives the real `useArchiveConversation` mutation, then feeds a pre-commit `changed` frame through the provider's frame handler — the row is not re-inserted into the default list, and the frame's other fields merge into the include-archived list with the flag pinned.

Also covered: an archive-filtered empty page retains a valid archived-row cursor so `fetchNextPage` reaches older sessions; unarchive clears the tombstone; re-archiving inside the grace window survives the first archive's expiry timer; a failed unarchive re-arms the tombstone; delete and archive failures release only their independent entries; superseded mutations preserve newer optimistic state; partial bulk failures preserve successful work; and `["project-sessions"]` cancellation parity.

Performance evidence: tombstones use two module-level `Map`s (no React state/subscriptions, no extra renders); checks are O(1) `Map` lookups on paths that already iterate rows. One expiry timer per id per active lifecycle. No new queries, invalidations, or dependencies — the tests drive the same fetch/WS paths the app already had, and the full pre-existing suite passes unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Sixteen new tests (plus one strengthened assertion) extend the existing colocated suites (`useConversations.test.ts`, `SessionUpdatesProvider.test.tsx`); each was verified RED against the behavior it covers and GREEN with the fix. The existing browser archive journey also passes with Chromium. No manual verification — the race reproductions are deterministic in unit tests.

## Changelog

Sessions no longer pop back into the sidebar right after you archive them

## Follow-ups

- `web/src/hooks/useConversations.ts` (`useDeleteProject`) — archives every project member via `archiveAndUnfileConversation` without tombstoning the ids; the same mid-flight list refetch can briefly resurrect member rows. Suggested fix: wrap the bulk archive loop with the shared tombstone lifecycle, mirroring `useBulkArchiveConversations`.
- `web/src/hooks/useConversations.ts` (`useLeaveSession`) — splices the left session out of caches without a tombstone; a WS-scheduled list refetch before the server records the revoke can repaint the row. Suggested fix: same shared tombstone lifecycle as delete.
- `web/src/hooks/useConversations.ts` (`useArchiveConversation` unarchive) — two overlapping unarchives where the older one's PATCH fails last re-arms a tombstone the newer unarchive already cleared. Suggested fix: generation-tag unarchive clears as well as marks.
