### PR TITLE
test: add portable managed-server black-box contract

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -481,6 +481,7 @@ timeout_method = "thread"
 # both relative paths here keeps the test suite self-contained.
 pythonpath = [".", "sdks/python-client", "sdks/ui"]
 markers = [
+    "managed_black_box: portable server contract runnable against local OSS or a live managed deployment.",
     "live: end-to-end tests requiring real LLM API key (run with --llm-api-key)",
     "live_app: end-to-end tests requiring a deployed Databricks App server",
     "databricks: requires the `databricks` extra (psycopg / databricks-sdk). Deselected on the standard lanes via -m 'not databricks'; runs only in the Pytest (databricks) lane, which installs the extra. Use for tests that build a postgresql+psycopg engine or call the Databricks SDK.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,7 +317,7 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--omnigent-managed-agent",
-        default="databricks_coding_agent",
+        default="codex-native-ui",
         help="Built-in agent name used for managed black-box sessions.",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,6 +292,34 @@ def pytest_addoption(parser):
             "configured with the credentials/profile the test needs."
         ),
     )
+    parser.addoption(
+        "--omnigent-server-kind",
+        choices=("local", "managed"),
+        default="local",
+        help="Server adapter used by portable black-box E2E contracts.",
+    )
+    parser.addoption(
+        "--omnigent-token-env",
+        default="OMNIGENT_E2E_TOKEN",
+        help="Environment variable containing the managed-server bearer token.",
+    )
+    parser.addoption("--omnigent-org-id", default=None)
+    parser.addoption(
+        "--omnigent-org-routing",
+        choices=("header", "query"),
+        default="header",
+        help="Send the managed workspace/org id in a header or the ?o= query.",
+    )
+    parser.addoption(
+        "--omnigent-traffic-id",
+        default=None,
+        help="Optional x-databricks-traffic-id (for example a LiteSwap route).",
+    )
+    parser.addoption(
+        "--omnigent-managed-agent",
+        default="databricks_coding_agent",
+        help="Built-in agent name used for managed black-box sessions.",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -32,6 +32,33 @@ grep -E "passed in [0-9]|failed in [0-9]" /tmp/e2e.log | tail -1
 
 This applies to **both** the unit suite (`uv run --no-sync pytest -n 8 --dist=loadfile`) and the e2e suite. Inside Claude Code, use `Bash(run_in_background=true)` plus a separate `Bash` polling loop with `until grep -q ...` to wait for the terminal marker — that pattern frees the assistant to continue with other work and surfaces the summary as a single notification.
 
+## Managed-server black-box contract
+
+`test_managed_server_contract.py` is the portable API contract for a local OSS
+server or a live managed deployment. Managed runs need an existing deployment,
+a bearer token, workspace/org routing, and the name of an agent available in the
+managed catalog:
+
+```bash
+export OMNIGENT_E2E_TOKEN=<workspace-bearer-token>
+OMNIGENT_DISABLE_TEST_GUARDRAILS=1 uv run --no-sync pytest \
+  -o addopts= tests/e2e/test_managed_server_contract.py \
+  -m managed_black_box \
+  --omnigent-server-kind managed \
+  --omnigent-server-url https://<workspace-host>/api/2.0/omnigent \
+  --omnigent-token-env OMNIGENT_E2E_TOKEN \
+  --omnigent-org-id <workspace-org-id> \
+  --omnigent-org-routing header \
+  --omnigent-traffic-id testenv://liteswap/<swap-id> \
+  --omnigent-managed-agent codex-native-ui \
+  --timeout=600 -v
+```
+
+Use `--omnigent-org-routing query` when the deployment expects `?o=` instead
+of `X-Databricks-Org-Id`. The managed auth adapter learns each session's host,
+adds the slice key to session-scoped requests, and retries a `wrong_replica`
+response without the key when the host has been demoted to keyless routing.
+
 ## Prerequisites
 
 ### LLM credentials — pick ONE

--- a/tests/e2e/_managed_server.py
+++ b/tests/e2e/_managed_server.py
@@ -56,8 +56,6 @@ class ManagedServerConfig:
 class ManagedServerAuth(httpx.Auth):
     """Inject managed routing headers and retry wrong-replica responses."""
 
-    requires_response_body = True
-
     def __init__(self, config: ManagedServerConfig) -> None:
         self._config = config
         self._session_hosts: dict[str, str] = {}
@@ -117,6 +115,7 @@ class ManagedServerAuth(httpx.Auth):
         if response.status_code != 400:
             return False
         try:
+            response.read()
             body = response.json()
         except ValueError:
             return False

--- a/tests/e2e/_managed_server.py
+++ b/tests/e2e/_managed_server.py
@@ -1,0 +1,136 @@
+"""Managed-server transport helpers for black-box E2E tests."""
+
+from __future__ import annotations
+
+import os
+import re
+import threading
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Literal
+
+import httpx
+import pytest
+
+_ORG_HEADER = "X-Databricks-Org-Id"
+_SLICE_HEADER = "X-Databricks-Omnigent-Slice-Key"
+_TRAFFIC_HEADER = "x-databricks-traffic-id"
+_SESSION_PATH = re.compile(r"/v1/sessions/([^/]+)(?:/|$)")
+
+
+@dataclass(frozen=True)
+class ManagedServerConfig:
+    """Connection settings for a managed Omnigent deployment."""
+
+    base_url: str
+    token: str
+    org_id: str | None
+    org_routing: Literal["header", "query"]
+    traffic_id: str | None
+    agent_name: str
+
+    @classmethod
+    def from_pytest(cls, config: pytest.Config) -> ManagedServerConfig:
+        """Build configuration from non-secret CLI options and a token env var."""
+        base_url = config.getoption("--omnigent-server-url")
+        if not base_url:
+            raise pytest.UsageError("managed mode requires --omnigent-server-url")
+
+        token_env = config.getoption("--omnigent-token-env")
+        token = os.environ.get(token_env)
+        if not token:
+            raise pytest.UsageError(
+                f"managed mode requires a bearer token in environment variable {token_env!r}"
+            )
+
+        return cls(
+            base_url=base_url.rstrip("/"),
+            token=token,
+            org_id=config.getoption("--omnigent-org-id"),
+            org_routing=config.getoption("--omnigent-org-routing"),
+            traffic_id=config.getoption("--omnigent-traffic-id"),
+            agent_name=config.getoption("--omnigent-managed-agent"),
+        )
+
+
+class ManagedServerAuth(httpx.Auth):
+    """Inject managed routing headers and retry wrong-replica responses."""
+
+    requires_response_body = True
+
+    def __init__(self, config: ManagedServerConfig) -> None:
+        self._config = config
+        self._session_hosts: dict[str, str] = {}
+        self._keyless_hosts: set[str] = set()
+        self._lock = threading.Lock()
+
+    def remember_session_host(self, session_id: str, host_id: str) -> None:
+        """Associate a session with the host that owns its runner tunnel."""
+        with self._lock:
+            self._session_hosts[session_id] = host_id
+
+    def is_host_keyless(self, host_id: str) -> bool:
+        """Return whether a successful retry proved that *host_id* routes keyless."""
+        with self._lock:
+            return host_id in self._keyless_hosts
+
+    def sync_auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Apply auth/routing and yield at most one keyless retry."""
+        request.headers["Authorization"] = f"Bearer {self._config.token}"
+        if self._config.traffic_id:
+            request.headers[_TRAFFIC_HEADER] = self._config.traffic_id
+        if self._config.org_id:
+            if self._config.org_routing == "header":
+                request.headers[_ORG_HEADER] = self._config.org_id
+            else:
+                request.url = request.url.copy_merge_params({"o": self._config.org_id})
+
+        host_id = self._host_for_request(request)
+        stamped_slice_key = False
+        if host_id and not self.is_host_keyless(host_id):
+            request.headers[_SLICE_HEADER] = host_id
+            stamped_slice_key = True
+
+        response = yield request
+        if stamped_slice_key and self._is_wrong_replica(response):
+            request.headers.pop(_SLICE_HEADER, None)
+            response = yield request
+            if host_id and response.is_success:
+                with self._lock:
+                    self._keyless_hosts.add(host_id)
+        elif host_id and not stamped_slice_key and self._is_wrong_replica(response):
+            with self._lock:
+                self._keyless_hosts.discard(host_id)
+
+    def _host_for_request(self, request: httpx.Request) -> str | None:
+        match = _SESSION_PATH.search(request.url.path)
+        if match is None:
+            return None
+        session_id = match.group(1)
+        with self._lock:
+            return self._session_hosts.get(session_id)
+
+    @staticmethod
+    def _is_wrong_replica(response: httpx.Response) -> bool:
+        if response.status_code != 400:
+            return False
+        try:
+            body = response.json()
+        except ValueError:
+            return False
+        if not isinstance(body, dict):
+            return False
+        error = body.get("error")
+        return isinstance(error, dict) and error.get("code") == "wrong_replica"
+
+
+def managed_client(
+    config: ManagedServerConfig,
+    auth: ManagedServerAuth,
+    *,
+    timeout: float = 300,
+) -> httpx.Client:
+    """Create a client sharing the managed routing state in *auth*."""
+    return httpx.Client(base_url=config.base_url, auth=auth, timeout=timeout)

--- a/tests/e2e/test_managed_server_auth.py
+++ b/tests/e2e/test_managed_server_auth.py
@@ -1,0 +1,155 @@
+"""Tests for managed black-box E2E request routing."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+
+from tests.e2e._managed_server import ManagedServerAuth, ManagedServerConfig
+
+
+def _config(*, org_routing: Literal["header", "query"] = "header") -> ManagedServerConfig:
+    return ManagedServerConfig(
+        base_url="https://workspace.example/api/2.0/omnigent",
+        token="secret-token",
+        org_id="12345",
+        org_routing=org_routing,
+        traffic_id="testenv://liteswap/contract",
+        agent_name="databricks_coding_agent",
+    )
+
+
+def test_injects_auth_org_and_liteswap_headers() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    auth = ManagedServerAuth(_config())
+    with httpx.Client(
+        base_url=_config().base_url,
+        auth=auth,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        client.get("/v1/agents")
+
+    assert seen[0].headers["Authorization"] == "Bearer secret-token"
+    assert seen[0].headers["X-Databricks-Org-Id"] == "12345"
+    assert seen[0].headers["x-databricks-traffic-id"] == "testenv://liteswap/contract"
+
+
+def test_supports_org_query_routing() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    config = _config(org_routing="query")
+    with httpx.Client(
+        base_url=config.base_url,
+        auth=ManagedServerAuth(config),
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        client.get("/v1/agents", params={"limit": 10})
+
+    assert seen[0].url.params["limit"] == "10"
+    assert seen[0].url.params["o"] == "12345"
+    assert "X-Databricks-Org-Id" not in seen[0].headers
+
+
+def test_managed_create_is_unkeyed_then_session_calls_use_host() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={})
+
+    config = _config()
+    auth = ManagedServerAuth(config)
+    with httpx.Client(
+        base_url=config.base_url,
+        auth=auth,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        client.post("/v1/sessions", json={"host_type": "managed"})
+        auth.remember_session_host("conv_1", "host_1")
+        client.get("/v1/sessions/conv_1/items")
+
+    assert "X-Databricks-Omnigent-Slice-Key" not in seen[0].headers
+    assert seen[1].headers["X-Databricks-Omnigent-Slice-Key"] == "host_1"
+
+
+def test_wrong_replica_retries_once_and_sticks_to_keyless() -> None:
+    seen_headers: list[httpx.Headers] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(request.headers.copy())
+        if len(seen_headers) == 1:
+            return httpx.Response(
+                400,
+                json={"error": {"code": "wrong_replica", "message": "retry"}},
+            )
+        return httpx.Response(200, json={"data": []})
+
+    config = _config()
+    auth = ManagedServerAuth(config)
+    auth.remember_session_host("conv_1", "host_1")
+    with httpx.Client(
+        base_url=config.base_url,
+        auth=auth,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        assert client.get("/v1/sessions/conv_1/items").status_code == 200
+        assert client.get("/v1/sessions/conv_1/permissions").status_code == 200
+
+    assert seen_headers[0]["X-Databricks-Omnigent-Slice-Key"] == "host_1"
+    assert "X-Databricks-Omnigent-Slice-Key" not in seen_headers[1]
+    assert "X-Databricks-Omnigent-Slice-Key" not in seen_headers[2]
+    assert auth.is_host_keyless("host_1")
+
+
+def test_failed_keyless_retry_does_not_demote_host() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(400, json={"error": {"code": "wrong_replica"}})
+        return httpx.Response(503, json={"error": {"code": "runner_unavailable"}})
+
+    config = _config()
+    auth = ManagedServerAuth(config)
+    auth.remember_session_host("conv_1", "host_1")
+    with httpx.Client(
+        base_url=config.base_url,
+        auth=auth,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        assert client.get("/v1/sessions/conv_1/items").status_code == 503
+
+    assert not auth.is_host_keyless("host_1")
+
+
+def test_non_object_error_body_does_not_trigger_retry() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(400, json={"error": "wrong_replica"})
+
+    config = _config()
+    auth = ManagedServerAuth(config)
+    auth.remember_session_host("conv_1", "host_1")
+    with httpx.Client(
+        base_url=config.base_url,
+        auth=auth,
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        assert client.get("/v1/sessions/conv_1/items").status_code == 400
+
+    assert calls == 1

--- a/tests/e2e/test_managed_server_auth.py
+++ b/tests/e2e/test_managed_server_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Literal
 
 import httpx
@@ -16,7 +17,7 @@ def _config(*, org_routing: Literal["header", "query"] = "header") -> ManagedSer
         org_id="12345",
         org_routing=org_routing,
         traffic_id="testenv://liteswap/contract",
-        agent_name="databricks_coding_agent",
+        agent_name="codex-native-ui",
     )
 
 
@@ -58,6 +59,30 @@ def test_supports_org_query_routing() -> None:
     assert seen[0].url.params["limit"] == "10"
     assert seen[0].url.params["o"] == "12345"
     assert "X-Databricks-Org-Id" not in seen[0].headers
+
+
+def test_successful_stream_is_not_preconsumed_by_auth() -> None:
+    class RecordingStream(httpx.SyncByteStream):
+        iterated = False
+
+        def __iter__(self) -> Iterator[bytes]:
+            self.iterated = True
+            yield b'data: {"type":"ready"}\n\n'
+
+    stream = RecordingStream()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream)
+
+    config = _config()
+    with httpx.Client(
+        base_url=config.base_url,
+        auth=ManagedServerAuth(config),
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        with client.stream("GET", "/v1/sessions/conv_1/stream") as response:
+            assert not stream.iterated
+            assert response.read().startswith(b"data:")
 
 
 def test_managed_create_is_unkeyed_then_session_calls_use_host() -> None:

--- a/tests/e2e/test_managed_server_contract.py
+++ b/tests/e2e/test_managed_server_contract.py
@@ -1,0 +1,215 @@
+"""Portable OSS behavioral contract for local and managed servers."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.runner.identity import OMNIGENT_INTERNAL_WS_ORIGIN
+from tests.e2e._managed_server import (
+    ManagedServerAuth,
+    ManagedServerConfig,
+    managed_client,
+)
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+
+
+def _iter_sse(response: httpx.Response) -> Iterator[dict[str, Any]]:
+    buffer = ""
+    for chunk in response.iter_text():
+        buffer += chunk
+        while "\n\n" in buffer:
+            frame, _, buffer = buffer.partition("\n\n")
+            data_line = next(
+                (line for line in frame.splitlines() if line.startswith("data:")), None
+            )
+            if data_line is None:
+                continue
+            payload = data_line.removeprefix("data:").strip()
+            if payload == "[DONE]":
+                return
+            try:
+                event = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                yield event
+
+
+def _lookup_agent_id(client: httpx.Client, name: str) -> str:
+    response = client.get("/v1/agents", params={"limit": 100})
+    response.raise_for_status()
+    agents = response.json().get("data", [])
+    for agent in agents:
+        if agent.get("name") == name:
+            return str(agent["id"])
+    raise AssertionError(
+        f"managed agent {name!r} not found; available agents: "
+        f"{[agent.get('name') for agent in agents]}"
+    )
+
+
+def _wait_for_managed_runner(
+    client: httpx.Client,
+    auth: ManagedServerAuth,
+    session_id: str,
+    *,
+    timeout: float = 300,
+) -> None:
+    deadline = time.monotonic() + timeout
+    last_snapshot: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        response = client.get(f"/v1/sessions/{session_id}")
+        response.raise_for_status()
+        last_snapshot = response.json()
+        host_id = last_snapshot.get("host_id")
+        if isinstance(host_id, str) and host_id:
+            auth.remember_session_host(session_id, host_id)
+        sandbox = last_snapshot.get("sandbox_status")
+        if isinstance(sandbox, dict) and sandbox.get("stage") == "failed":
+            raise AssertionError(f"managed sandbox launch failed: {sandbox.get('error')}")
+        if host_id and last_snapshot.get("runner_id") and last_snapshot.get("runner_online"):
+            return
+        time.sleep(1)
+    raise AssertionError(
+        f"managed runner was not ready within {timeout}s; last snapshot: {last_snapshot}"
+    )
+
+
+def _run_streamed_turn(
+    client: httpx.Client,
+    poster: httpx.Client,
+    session_id: str,
+    prompt: str,
+) -> tuple[list[str], str]:
+    event_types: list[str] = []
+    text_chunks: list[str] = []
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        with client.stream("GET", f"/v1/sessions/{session_id}/stream", timeout=300) as stream:
+            stream.raise_for_status()
+            send_future = None
+            for event in _iter_sse(stream):
+                if send_future is None:
+                    send_future = executor.submit(
+                        send_user_message_to_session,
+                        poster,
+                        session_id=session_id,
+                        content=prompt,
+                    )
+                event_type = event.get("type")
+                if isinstance(event_type, str):
+                    event_types.append(event_type)
+                if event_type == "response.output_text.delta":
+                    delta = event.get("delta")
+                    if isinstance(delta, str):
+                        text_chunks.append(delta)
+                if event_type in {"response.completed", "response.failed"}:
+                    break
+            assert send_future is not None, "session stream ended before its first SSE frame"
+            response_id = send_future.result(timeout=300)
+    assert "response.completed" in event_types, f"turn did not complete; saw {event_types}"
+    return event_types, response_id
+
+
+def _wait_until_idle(client: httpx.Client, session_id: str, timeout: float = 60) -> None:
+    deadline = time.monotonic() + timeout
+    last_status = None
+    while time.monotonic() < deadline:
+        response = client.get(f"/v1/sessions/{session_id}")
+        response.raise_for_status()
+        last_status = response.json().get("status")
+        if last_status == "idle":
+            return
+        if last_status == "failed":
+            break
+        time.sleep(0.25)
+    raise AssertionError(f"session did not settle to idle; last status was {last_status!r}")
+
+
+@pytest.mark.managed_black_box
+def test_core_session_contract(request: pytest.FixtureRequest) -> None:
+    """Create → turn → stream → items → permissions works in either server mode."""
+    server_kind: str = request.config.getoption("--omnigent-server-kind")
+    suffix = uuid.uuid4().hex[:8]
+    prompt = f"Reply briefly to this managed contract probe ({suffix})."
+
+    with ExitStack() as stack:
+        if server_kind == "managed":
+            config = ManagedServerConfig.from_pytest(request.config)
+            auth = ManagedServerAuth(config)
+            client = stack.enter_context(managed_client(config, auth))
+            poster = stack.enter_context(managed_client(config, auth))
+            agent_id = _lookup_agent_id(client, config.agent_name)
+            created = client.post(
+                "/v1/sessions",
+                json={"agent_id": agent_id, "host_type": "managed"},
+            )
+            created.raise_for_status()
+            session_id = str(created.json()["id"])
+            _wait_for_managed_runner(client, auth, session_id)
+        else:
+            client = request.getfixturevalue("http_client")
+            live_server: str = request.getfixturevalue("live_server")
+            runner_id: str = request.getfixturevalue("live_runner_id")
+            mock_url: str | None = request.getfixturevalue("mock_llm_server_url")
+            model = f"managed-contract-{suffix}"
+            reset_mock_llm(mock_url)
+            configure_mock_llm(mock_url, [{"text": f"contract-ok-{suffix}"}], key=model)
+            agent_name = register_inline_agent(
+                client,
+                name=f"managed-contract-{suffix}",
+                harness="openai-agents",
+                model=model,
+                profile="",
+                prompt="You are a terse test assistant.",
+                mock_llm_base_url=f"{mock_url}/v1" if mock_url else None,
+            )
+            session_id = create_runner_bound_session(
+                client, agent_name=agent_name, runner_id=runner_id
+            )
+            poster = stack.enter_context(
+                httpx.Client(
+                    base_url=live_server,
+                    timeout=300,
+                    headers={"Origin": OMNIGENT_INTERNAL_WS_ORIGIN},
+                )
+            )
+
+        try:
+            event_types, _ = _run_streamed_turn(client, poster, session_id, prompt)
+            assert event_types
+            _wait_until_idle(client, session_id)
+
+            items_response = client.get(
+                f"/v1/sessions/{session_id}/items", params={"limit": 100, "order": "asc"}
+            )
+            items_response.raise_for_status()
+            items = items_response.json().get("data", [])
+            assert any(
+                item.get("type") == "message" and item.get("role") == "user" for item in items
+            )
+            assert any(
+                item.get("type") == "message" and item.get("role") == "assistant" for item in items
+            )
+
+            permissions_response = client.get(f"/v1/sessions/{session_id}/permissions")
+            permissions_response.raise_for_status()
+            permissions = permissions_response.json()
+            assert isinstance(permissions.get("permissions"), list)
+        finally:
+            deleted = client.delete(f"/v1/sessions/{session_id}")
+            deleted.raise_for_status()

--- a/tests/e2e/test_managed_server_contract.py
+++ b/tests/e2e/test_managed_server_contract.py
@@ -101,15 +101,13 @@ def _run_streamed_turn(
     with ThreadPoolExecutor(max_workers=1) as executor:
         with client.stream("GET", f"/v1/sessions/{session_id}/stream", timeout=300) as stream:
             stream.raise_for_status()
-            send_future = None
+            send_future = executor.submit(
+                send_user_message_to_session,
+                poster,
+                session_id=session_id,
+                content=prompt,
+            )
             for event in _iter_sse(stream):
-                if send_future is None:
-                    send_future = executor.submit(
-                        send_user_message_to_session,
-                        poster,
-                        session_id=session_id,
-                        content=prompt,
-                    )
                 event_type = event.get("type")
                 if isinstance(event_type, str):
                     event_types.append(event_type)
@@ -119,7 +117,6 @@ def _run_streamed_turn(
                         text_chunks.append(delta)
                 if event_type in {"response.completed", "response.failed"}:
                     break
-            assert send_future is not None, "session stream ended before its first SSE frame"
             response_id = send_future.result(timeout=300)
     assert "response.completed" in event_types, f"turn did not complete; saw {event_types}"
     return event_types, response_id

--- a/tests/e2e/test_managed_server_contract.py
+++ b/tests/e2e/test_managed_server_contract.py
@@ -24,7 +24,6 @@ from tests.e2e.conftest import (
     create_runner_bound_session,
     register_inline_agent,
     reset_mock_llm,
-    send_user_message_to_session,
 )
 
 
@@ -102,7 +101,7 @@ def _run_streamed_turn(
         with client.stream("GET", f"/v1/sessions/{session_id}/stream", timeout=300) as stream:
             stream.raise_for_status()
             send_future = executor.submit(
-                send_user_message_to_session,
+                _send_user_message,
                 poster,
                 session_id=session_id,
                 content=prompt,
@@ -120,6 +119,31 @@ def _run_streamed_turn(
             response_id = send_future.result(timeout=300)
     assert "response.completed" in event_types, f"turn did not complete; saw {event_types}"
     return event_types, response_id
+
+
+def _send_user_message(
+    client: httpx.Client,
+    *,
+    session_id: str,
+    content: str,
+) -> str:
+    response = client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": [{"type": "input_text", "text": content}],
+            },
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+    queued_id = payload.get("item_id") or payload.get("pending_id")
+    assert payload.get("queued") is True and isinstance(queued_id, str), (
+        f"events endpoint did not queue a turn for session {session_id!r}: {payload}"
+    )
+    return queued_id
 
 
 def _wait_until_idle(client: httpx.Client, session_id: str, timeout: float = 60) -> None:


### PR DESCRIPTION
## Related issue

Tracking: https://linear.app/omnigent/issue/OMNI-3230/run-oss-e2e-tests-against-the-managed-server

## Summary

- Add a portable black-box contract for session create → turn/SSE stream → items → permissions that runs against either a local OSS server or a live managed server.
- Add a managed `httpx.Auth` adapter for bearer auth, `X-Databricks-Org-Id`/`?o=` routing, LiteSwap traffic routing, host slice keys, wrong-replica retry, and keyless demotion.
- Expose the managed connection parameters as pytest options and document the managed invocation.

ELI5: the same behavioral checklist can now point at the server started by the OSS test suite or at a hosted managed server; only the connection and routing adapter changes.

```text
managed_black_box contract
        |
        +-- local fixtures -------------------+
        |                                     |
        +-- managed auth + routing adapter ---+--> /v1 session lifecycle
```

## Test Plan

- `uv run --no-sync pytest tests/e2e/test_managed_server_auth.py -q` — 7 passed
- `uv run --no-sync pytest -o addopts= tests/e2e/test_managed_server_contract.py -m managed_black_box --omnigent-server-kind local --timeout=600 -v` — 1 passed
- `uv run --no-sync pre-commit run --files pyproject.toml tests/conftest.py tests/e2e/AGENTS.md tests/e2e/_managed_server.py tests/e2e/test_managed_server_auth.py tests/e2e/test_managed_server_contract.py` — passed
- The managed form was exercised against `testenv://liteswap/moon-mas-lakebox` before the branch refresh — 1 passed in 174.76s.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The managed adapter has focused mock-transport coverage. The portable contract passed against both a local OSS server and a live managed LiteSwap; the live run was completed before rebasing the unchanged contract commits onto current `main`.
