### PR TITLE
Make managed sandbox cleanup durable after deletion

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1320,6 +1320,9 @@ class SqlHost(OmnigentBase):
         active host generation and awaiting successful provider termination.
         A fresh generation may be registered in ``sandbox_id`` while this
         cleanup remains pending.
+    :param deleted_at: Logical deletion timestamp for a managed host whose
+        provider sandbox cleanup is still pending. The row is physically
+        removed after every recorded sandbox id terminates successfully.
     :param configured_harnesses: JSON-encoded per-harness readiness map
         reported in the host's last ``host.hello`` frame, e.g.
         ``'{"claude-sdk": true, "codex": false}'``. ``NULL`` when the
@@ -1354,6 +1357,7 @@ class SqlHost(OmnigentBase):
     sandbox_provider: Mapped[str | None] = mapped_column(String(32), nullable=True)
     sandbox_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
     terminating_sandbox_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    deleted_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # Opaque; never SQL-filtered — stored compressed (CompressedText).
     configured_harnesses: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
 

--- a/omnigent/db/migrations/versions/gc1b2c3d4e5f_add_hosts_deleted_at.py
+++ b/omnigent/db/migrations/versions/gc1b2c3d4e5f_add_hosts_deleted_at.py
@@ -1,0 +1,34 @@
+"""Add logical deletion tombstones to managed hosts.
+
+Revision ID: gc1b2c3d4e5f
+Revises: gb1b2c3d4e5f
+Create Date: 2026-09-05 00:00:00.000000
+
+Managed host rows remain as internal tombstones while provider sandbox
+termination is pending. This keeps cleanup retryable without exposing the
+logically deleted host to users.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "gc1b2c3d4e5f"
+down_revision: str | None = "gb1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the logical deletion timestamp."""
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.add_column(sa.Column("deleted_at", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove the logical deletion timestamp."""
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.drop_column("deleted_at")

--- a/omnigent/server/identity_migration.py
+++ b/omnigent/server/identity_migration.py
@@ -37,9 +37,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import cast
 
-from sqlalchemy import Engine, select, update
+from sqlalchemy import Engine, and_, select, text, update
 from sqlalchemy.engine import CursorResult
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 
 from omnigent.db.db_models import (
     SqlAccountToken,
@@ -52,6 +52,36 @@ from omnigent.db.db_models import (
 )
 from omnigent.db.query_context import query_name_scope
 from omnigent.server.auth import _RESERVED_USERS
+
+
+def _lock_host_collisions_and_check_tombstones(
+    session: Session,
+    old_id: str,
+    new_id: str,
+) -> bool:
+    """Lock same-name host collisions and detect cleanup tombstones."""
+    old_host = aliased(SqlHost)
+    new_host = aliased(SqlHost)
+    collisions = session.execute(
+        select(old_host, new_host)
+        .join(
+            new_host,
+            and_(
+                new_host.workspace_id == old_host.workspace_id,
+                new_host.user_id == new_id,
+                new_host.name == old_host.name,
+            ),
+        )
+        .where(
+            old_host.workspace_id == current_workspace_id(),
+            old_host.user_id == old_id,
+        )
+        .with_for_update()
+    ).all()
+    return any(
+        old_row.deleted_at is not None or new_row.deleted_at is not None
+        for old_row, new_row in collisions
+    )
 
 
 @dataclass
@@ -159,6 +189,8 @@ def remap_identities(
         query_name_scope("omnigent.identity_migration.remap_identities"),
         Session(engine) as session,
     ):
+        if engine.dialect.name == "sqlite":
+            session.execute(text("BEGIN IMMEDIATE"))
         for old_id, new_id in mapping.items():
             if old_id == new_id:
                 continue
@@ -173,6 +205,12 @@ def remap_identities(
                 if not force:
                     report.refused.append(f"{old_id} -> {new_id}")
                     continue
+
+            if _lock_host_collisions_and_check_tombstones(session, old_id, new_id):
+                report.refused.append(f"{old_id} -> {new_id}")
+                continue
+
+            if new_user is not None:
                 # Merge: the surviving (new) row gains admin if either had it.
                 new_user.is_admin = new_user.is_admin or old_user.is_admin
                 report._bump("users")  # merged

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -3560,7 +3560,7 @@ async def resume_managed_host(
                     )
                     if terminated and current.terminating_sandbox_id == sandbox_id:
                         await asyncio.to_thread(
-                            host_store.mark_terminating_sandbox_terminated,
+                            host_store.mark_sandbox_terminated,
                             host.host_id,
                             sandbox_id=sandbox_id,
                         )
@@ -3599,12 +3599,11 @@ async def terminate_managed_host(
     """
     Terminate a managed host's sandbox and delete its host row.
 
-    The latest row is locked and deleted before provider termination. This
-    serializes full teardown with generation replacement: either teardown takes
-    the newly registered generation, or replacement observes the missing row
-    and cleans up its unregistered sandbox. Deleting the row also removes the
-    host from the picker and revokes its launch token. Provider termination
-    remains best-effort and never blocks database teardown.
+    The latest row is locked and logically deleted before provider termination.
+    This removes the host from user-visible reads, revokes its token, and
+    serializes teardown with generation replacement. Recorded sandbox ids remain
+    on the tombstone until termination succeeds, allowing the reaper to retry
+    transient provider failures.
 
     :param host: The managed host to tear down. Active and pending sandbox ids
         are both terminated when present.
@@ -3613,19 +3612,25 @@ async def terminate_managed_host(
         the launcher for the provider-side terminate), or ``None``
         when managed hosts are no longer configured.
     """
-    deleted = await asyncio.to_thread(host_store.delete_host, host.host_id)
-    if deleted is None:
+    tombstone = await asyncio.to_thread(host_store.delete_host, host.host_id)
+    if tombstone is None:
         return
-    launcher = _launcher_for_teardown(deleted, config)
-    sandbox_ids = dict.fromkeys((deleted.sandbox_id, deleted.terminating_sandbox_id))
+    launcher = _launcher_for_teardown(tombstone, config)
+    sandbox_ids = dict.fromkeys((tombstone.sandbox_id, tombstone.terminating_sandbox_id))
     for sandbox_id in sandbox_ids:
         if sandbox_id is not None:
-            await _terminate_sandbox_best_effort(
+            terminated = await _terminate_sandbox_best_effort(
                 launcher,
                 sandbox_id,
-                host_id=deleted.host_id,
-                provider=deleted.sandbox_provider,
+                host_id=tombstone.host_id,
+                provider=tombstone.sandbox_provider,
             )
+            if terminated:
+                await asyncio.to_thread(
+                    host_store.mark_sandbox_terminated,
+                    tombstone.host_id,
+                    sandbox_id=sandbox_id,
+                )
 
 
 async def _terminate_sandbox_best_effort(

--- a/omnigent/server/managed_sandbox_reaper.py
+++ b/omnigent/server/managed_sandbox_reaper.py
@@ -165,6 +165,17 @@ class ManagedSandboxReaper:
             with launcher.reaper_identity(workspace_id):
                 for candidate in candidates:
                     try:
+                        if candidate.deleted_at is not None:
+                            sandbox_id = candidate.terminating_sandbox_id or candidate.sandbox_id
+                            if sandbox_id is None:
+                                continue
+                            launcher.terminate(sandbox_id)
+                            if self._host_store.mark_sandbox_terminated(
+                                candidate.host_id,
+                                sandbox_id=sandbox_id,
+                            ):
+                                reaped += 1
+                            continue
                         sandbox_id = candidate.terminating_sandbox_id
                         if sandbox_id is None:
                             if not self._is_reap_candidate(candidate, cutoff=cutoff, now=now):
@@ -185,7 +196,7 @@ class ManagedSandboxReaper:
                             )
                             continue
                         launcher.terminate(sandbox_id)
-                        if self._host_store.mark_terminating_sandbox_terminated(
+                        if self._host_store.mark_sandbox_terminated(
                             candidate.host_id,
                             sandbox_id=sandbox_id,
                         ):
@@ -200,7 +211,11 @@ class ManagedSandboxReaper:
     @staticmethod
     def _is_reap_candidate(host: Host, *, cutoff: int, now: int) -> bool:
         return host.sandbox_provider is not None and (
-            host.terminating_sandbox_id is not None
+            (
+                host.deleted_at is not None
+                and (host.sandbox_id is not None or host.terminating_sandbox_id is not None)
+            )
+            or host.terminating_sandbox_id is not None
             or (
                 host.sandbox_id is not None
                 and not host_is_live(host, now=now)

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -77,6 +77,8 @@ class Host:
     :param terminating_sandbox_id: Provider-assigned id detached from the
         active generation and awaiting provider termination. A newly launched
         generation may coexist in ``sandbox_id`` while this cleanup retries.
+    :param deleted_at: Logical deletion timestamp. A managed host with pending
+        provider cleanup keeps an internal tombstone row until cleanup succeeds.
     :param configured_harnesses: Per-harness readiness reported in the
         host's last ``host.hello`` frame, e.g.
         ``{"claude-sdk": True, "codex": False}``. ``None`` when the
@@ -94,6 +96,7 @@ class Host:
     sandbox_id: str | None = None
     configured_harnesses: dict[str, HarnessAvailability] | None = None
     terminating_sandbox_id: str | None = None
+    deleted_at: int | None = None
 
 
 def host_is_live(host: Host, now: int | None = None) -> bool:
@@ -162,6 +165,7 @@ def _row_to_host(row: SqlHost) -> Host:
         sandbox_provider=row.sandbox_provider,
         sandbox_id=row.sandbox_id,
         terminating_sandbox_id=row.terminating_sandbox_id,
+        deleted_at=row.deleted_at,
         configured_harnesses=_parse_configured_harnesses(row.configured_harnesses),
     )
 
@@ -279,6 +283,7 @@ class HostStore:
                             SqlHost.token_expires_at.is_not(None),
                             SqlHost.token_expires_at >= now,
                             SqlHost.sandbox_id.is_not(None),
+                            SqlHost.deleted_at.is_(None),
                         )
                         .values(
                             name=name,
@@ -298,6 +303,8 @@ class HostStore:
             # Primary lookup: by (workspace_id, host_id) — the new PK.
             row = session.get(SqlHost, (current_workspace_id(), host_id))
             if row is not None:
+                if row.deleted_at is not None:
+                    raise ValueError("host has been deleted")
                 # W2-class boundary: a different user must not claim another
                 # user's host_id. Raise the same IntegrityError the old UNIQUE
                 # constraint produced so the tunnel handler rejects the hijack.
@@ -337,6 +344,7 @@ class HostStore:
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.user_id == user_id,
                     SqlHost.name == name,
+                    SqlHost.deleted_at.is_(None),
                 )
             ).scalar_one_or_none()
             if existing_by_name is not None:
@@ -502,7 +510,9 @@ class HostStore:
         """
         existing = session.execute(
             select(SqlHost).where(
-                SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
+                SqlHost.workspace_id == current_workspace_id(),
+                SqlHost.host_id == host_id,
+                SqlHost.deleted_at.is_(None),
             )
         ).scalar_one_or_none()
         if existing is None:
@@ -514,6 +524,7 @@ class HostStore:
             .where(
                 SqlHost.workspace_id == current_workspace_id(),
                 SqlHost.host_id == host_id,
+                SqlHost.deleted_at.is_(None),
             )
             .values(
                 user_id=user_id,
@@ -548,7 +559,9 @@ class HostStore:
         with self._session("set_host_offline") as session:
             row = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
+                    SqlHost.workspace_id == current_workspace_id(),
+                    SqlHost.host_id == host_id,
+                    SqlHost.deleted_at.is_(None),
                 )
             ).scalar_one_or_none()
             if row is not None:
@@ -571,6 +584,7 @@ class HostStore:
                 .where(
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id == host_id,
+                    SqlHost.deleted_at.is_(None),
                 )
                 .values(
                     configured_harnesses=json.dumps(configured_harnesses),
@@ -602,6 +616,7 @@ class HostStore:
                 .where(
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id == host_id,
+                    SqlHost.deleted_at.is_(None),
                 )
                 .values(updated_at=now_epoch())
             )
@@ -652,6 +667,7 @@ class HostStore:
                 select(SqlHost.host_id, SqlHost.status, SqlHost.updated_at).where(
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id.in_(unique_ids),
+                    SqlHost.deleted_at.is_(None),
                 )
             ).all()
         online_code = encode_host_status("online")
@@ -678,6 +694,7 @@ class HostStore:
                 .filter(
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.user_id == user_id,
+                    SqlHost.deleted_at.is_(None),
                 )
                 .order_by(SqlHost.updated_at.desc())
                 .all()
@@ -723,6 +740,7 @@ class HostStore:
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.sandbox_provider.is_not(None),
                     or_(
+                        SqlHost.deleted_at.is_not(None),
                         SqlHost.terminating_sandbox_id.is_not(None),
                         and_(
                             SqlHost.terminating_sandbox_id.is_(None),
@@ -747,7 +765,9 @@ class HostStore:
         with self._session("select_host_by_id") as session:
             row = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
+                    SqlHost.workspace_id == current_workspace_id(),
+                    SqlHost.host_id == host_id,
+                    SqlHost.deleted_at.is_(None),
                 )
             ).scalar_one_or_none()
             if row is None:
@@ -835,6 +855,8 @@ class HostStore:
             ).scalar_one_or_none()
             if existing is None:
                 return None
+            if existing.deleted_at is not None:
+                return None
             if existing.user_id != user_id:
                 raise ValueError(
                     f"host {host_id!r} is registered to a different user; "
@@ -886,6 +908,7 @@ class HostStore:
                         SqlHost.sandbox_id == sandbox_id,
                         SqlHost.updated_at == expected_updated_at,
                         SqlHost.sandbox_provider.is_not(None),
+                        SqlHost.deleted_at.is_(None),
                         or_(
                             SqlHost.terminating_sandbox_id.is_(None),
                             SqlHost.terminating_sandbox_id != sandbox_id,
@@ -930,6 +953,7 @@ class HostStore:
                 select(SqlHost).where(
                     SqlHost.workspace_id == current_workspace_id(),
                     SqlHost.host_id == host_id,
+                    SqlHost.deleted_at.is_(None),
                 )
             ).scalar_one_or_none()
             # token_expires_at is written together with token_hash, so a
@@ -946,19 +970,16 @@ class HostStore:
 
     def delete_host(self, host_id: str) -> Host | None:
         """
-        Atomically take and delete a host row.
+        Logically delete a host and retain pending sandbox cleanup.
 
-        Managed-host teardown: removes the host from the picker AND
-        revokes its launch token in one operation (the row IS the
-        credential). Explicitly nulls ``conversations.host_id`` for any
-        sessions still bound to this host — the DB no longer cascades
-        this via FK. No-op when the row does not exist — deletion is
-        invoked from best-effort cleanup paths that may race. The row lock
-        serializes deletion with managed-host generation replacement, and the
-        returned snapshot lets teardown target the generation actually removed.
+        The row is immediately hidden, its credential is revoked, and bound
+        sessions are detached. Managed hosts with recorded sandbox ids remain
+        as internal tombstones until provider cleanup succeeds; rows without
+        cleanup work are physically deleted immediately. The row lock serializes
+        deletion with managed-host generation replacement.
 
         :param host_id: Host identifier, e.g. ``"host_a1b2c3d4..."``.
-        :returns: The deleted host snapshot, or ``None`` when already absent.
+        :returns: The latest host snapshot, or ``None`` when already absent.
         """
         with self._lifecycle_session("delete_host") as session:
             row = session.execute(
@@ -980,13 +1001,21 @@ class HostStore:
                 )
                 .values(host_id=None)
             )
-            session.execute(
-                sql_delete(SqlHost).where(
-                    SqlHost.workspace_id == current_workspace_id(),
-                    SqlHost.host_id == host_id,
+            if row.sandbox_provider is None or (
+                row.sandbox_id is None and row.terminating_sandbox_id is None
+            ):
+                session.execute(
+                    sql_delete(SqlHost).where(
+                        SqlHost.workspace_id == current_workspace_id(),
+                        SqlHost.host_id == host_id,
+                    )
                 )
-            )
-            return deleted
+                return deleted
+            row.token_hash = None
+            row.token_expires_at = None
+            row.status = encode_host_status("offline")
+            row.deleted_at = row.deleted_at or now_epoch()
+            return _row_to_host(row)
 
     def detach_stale_managed_sandbox(
         self,
@@ -1018,6 +1047,7 @@ class HostStore:
                         SqlHost.sandbox_id == sandbox_id,
                         SqlHost.updated_at == expected_updated_at,
                         SqlHost.sandbox_provider.is_not(None),
+                        SqlHost.deleted_at.is_(None),
                         SqlHost.terminating_sandbox_id.is_(None),
                     )
                     .values(
@@ -1031,32 +1061,48 @@ class HostStore:
             )
             return result.rowcount == 1
 
-    def mark_terminating_sandbox_terminated(
+    def mark_sandbox_terminated(
         self,
         host_id: str,
         *,
         sandbox_id: str,
     ) -> bool:
-        """Clear one successfully terminated pending sandbox id.
+        """Clear one terminated sandbox id and remove an empty tombstone.
+
+        Active ids may be cleared only after the host is logically deleted.
+        Otherwise, the id must already be detached into the pending slot.
 
         :param host_id: Durable managed host identifier.
-        :param sandbox_id: Exact pending provider id that was terminated.
-        :returns: ``True`` when that pending id was cleared.
+        :param sandbox_id: Exact provider id that was terminated.
+        :returns: ``True`` when that recorded id was cleared.
         """
-        with self._session("mark_terminating_sandbox_terminated") as session:
-            result = cast(
-                CursorResult[tuple[object]],
-                session.execute(
-                    update(SqlHost)
-                    .where(
-                        SqlHost.workspace_id == current_workspace_id(),
-                        SqlHost.host_id == host_id,
-                        SqlHost.terminating_sandbox_id == sandbox_id,
-                    )
-                    .values(terminating_sandbox_id=None)
-                ),
-            )
-            return result.rowcount == 1
+        with self._lifecycle_session("mark_sandbox_terminated") as session:
+            row = session.execute(
+                select(SqlHost)
+                .where(
+                    SqlHost.workspace_id == current_workspace_id(),
+                    SqlHost.host_id == host_id,
+                )
+                .with_for_update()
+            ).scalar_one_or_none()
+            if row is None:
+                return False
+
+            if row.deleted_at is None:
+                if row.terminating_sandbox_id != sandbox_id:
+                    return False
+                row.terminating_sandbox_id = None
+                return True
+
+            if sandbox_id not in {row.sandbox_id, row.terminating_sandbox_id}:
+                return False
+            if row.sandbox_id == sandbox_id:
+                row.sandbox_id = None
+            if row.terminating_sandbox_id == sandbox_id:
+                row.terminating_sandbox_id = None
+            if row.sandbox_id is None and row.terminating_sandbox_id is None:
+                session.delete(row)
+            return True
 
     def revoke_launch_token(self, host_id: str) -> None:
         """
@@ -1075,7 +1121,9 @@ class HostStore:
         with self._session("revoke_launch_token") as session:
             row = session.execute(
                 select(SqlHost).where(
-                    SqlHost.workspace_id == current_workspace_id(), SqlHost.host_id == host_id
+                    SqlHost.workspace_id == current_workspace_id(),
+                    SqlHost.host_id == host_id,
+                    SqlHost.deleted_at.is_(None),
                 )
             ).scalar_one_or_none()
             if row is None:

--- a/tests/db/test_migration_connections.py
+++ b/tests/db/test_migration_connections.py
@@ -34,7 +34,7 @@ def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
 def test_single_alembic_head() -> None:
     script = ScriptDirectory.from_config(_build_alembic_config("sqlite://"))
     heads = script.get_heads()
-    assert heads == ["gb1b2c3d4e5f"], f"expected a single head, got {heads!r}"
+    assert heads == ["gc1b2c3d4e5f"], f"expected a single head, got {heads!r}"
 
 
 def test_upgrade_creates_table_downgrade_drops_it(tmp_path: Path) -> None:

--- a/tests/db/test_migration_managed_sandbox_deleted_at.py
+++ b/tests/db/test_migration_managed_sandbox_deleted_at.py
@@ -1,0 +1,47 @@
+"""Tests for the managed sandbox logical-deletion migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+
+from omnigent.db.utils import _build_alembic_config, clear_engine_cache
+
+
+def _migrate(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as connection:
+        config.attributes["connection"] = connection
+        command.upgrade(config, revision)
+
+
+def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
+    config = _build_alembic_config(uri)
+    with engine.begin() as connection:
+        config.attributes["connection"] = connection
+        command.downgrade(config, revision)
+
+
+def test_upgrade_adds_hosts_deleted_at_and_downgrade_removes_it(tmp_path: Path) -> None:
+    uri = f"sqlite:///{tmp_path / 'managed-sandbox-deleted-at.db'}"
+    engine = sa.create_engine(uri)
+
+    _migrate(uri, engine, "gb1b2c3d4e5f")
+    assert "deleted_at" not in {
+        column["name"] for column in sa.inspect(engine).get_columns("hosts")
+    }
+
+    _migrate(uri, engine, "gc1b2c3d4e5f")
+    columns = {column["name"]: column for column in sa.inspect(engine).get_columns("hosts")}
+    assert columns["deleted_at"]["nullable"] is True
+    assert isinstance(columns["deleted_at"]["type"], sa.Integer)
+
+    _downgrade(uri, engine, "gb1b2c3d4e5f")
+    assert "deleted_at" not in {
+        column["name"] for column in sa.inspect(engine).get_columns("hosts")
+    }
+
+    engine.dispose()
+    clear_engine_cache()

--- a/tests/e2e_ui/sessions/test_initial_prompt_session_switch.py
+++ b/tests/e2e_ui/sessions/test_initial_prompt_session_switch.py
@@ -46,11 +46,13 @@ import threading
 from collections.abc import Coroutine
 from typing import Any
 
+import httpx
 from playwright.async_api import Route, async_playwright
 
 # Unique sentinels so each POST body is unambiguously identifiable.
 _PROMPT = "sentinel-initprompt-7b3e initial prompt bound to session A"
 _FOLLOWUP = "sentinel-followup-2d9a live send into session B"
+_SESSION_B_TITLE = "e2e-initial-prompt-destination"
 
 _EVENTS_RE = re.compile(r"/v1/sessions/([^/]+)/events$")
 # Bare create endpoint: ``/v1/sessions`` with an optional query, but NOT
@@ -113,6 +115,12 @@ def test_initial_prompt_stays_bound_to_origin_session_after_switch(
     A→B switch commit.
     """
     base_url, session_a, session_b = seeded_session_pair
+    response = httpx.patch(
+        f"{base_url}/v1/sessions/{session_b}",
+        json={"title": _SESSION_B_TITLE},
+        timeout=10.0,
+    )
+    response.raise_for_status()
     _run_in_fresh_loop(_drive_initial_prompt_switch(base_url, session_a, session_b))
 
 
@@ -250,6 +258,11 @@ async def _drive_initial_prompt_switch(base_url: str, session_a: str, session_b:
             # client-side navigation that preserves the JS module state.
             await page.locator(f'a[href="/c/{session_b}"]').click()
             await page.wait_for_url(re.compile(rf"/c/{re.escape(session_b)}"))
+            await (
+                page.locator("header.chat-header")
+                .get_by_text(_SESSION_B_TITLE, exact=True)
+                .wait_for(state="visible", timeout=15_000)
+            )
 
             # Drive a real follow-up send into B. It MUST land in B, and it
             # acts as a barrier: once it is observed the A→B switch commit

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -1730,7 +1730,7 @@ async def test_delete_reaped_managed_session_removes_durable_host(
         sandbox_id="sb-reaped-delete",
         expected_updated_at=host.updated_at,
     )
-    assert env.host_store.mark_terminating_sandbox_terminated(
+    assert env.host_store.mark_sandbox_terminated(
         host.host_id,
         sandbox_id="sb-reaped-delete",
     )

--- a/tests/server/test_identity_migration.py
+++ b/tests/server/test_identity_migration.py
@@ -179,6 +179,91 @@ def test_remap_repoints_comments_policies_tokens_hosts(db_uri: str) -> None:
         assert host_owners == ["alice@example.com"]
 
 
+def test_remap_refuses_host_name_collision_with_tombstone(db_uri: str) -> None:
+    account_store = SqlAlchemyAccountStore(db_uri)
+    for user_id in (
+        "alice",
+        "alice@example.com",
+        "bob",
+        "bob@example.com",
+    ):
+        account_store.create_user_with_password(user_id, hash_password("password123"))
+    engine = get_or_create_engine(db_uri)
+    hosts = [
+        SqlHost(
+            user_id="alice",
+            name="old-tombstone",
+            host_id="07d47e6d61e34c79a4fab73c1a1b8790",
+            status=encode_host_status("offline"),
+            created_at=1,
+            updated_at=1,
+            sandbox_provider="modal",
+            sandbox_id="old-tombstone-sandbox",
+            deleted_at=1,
+        ),
+        SqlHost(
+            user_id="alice@example.com",
+            name="old-tombstone",
+            host_id="5a719585ea684939a0dc82fd321b8348",
+            status=encode_host_status("online"),
+            created_at=1,
+            updated_at=1,
+            sandbox_provider="modal",
+            sandbox_id="new-live-sandbox",
+        ),
+        SqlHost(
+            user_id="bob",
+            name="new-tombstone",
+            host_id="dfe6c207feec41cbaf6b91fafbf7a334",
+            status=encode_host_status("online"),
+            created_at=1,
+            updated_at=1,
+            sandbox_provider="modal",
+            sandbox_id="old-live-sandbox",
+        ),
+        SqlHost(
+            user_id="bob@example.com",
+            name="new-tombstone",
+            host_id="a017ff8f65044b01a68be30a7b4f75cc",
+            status=encode_host_status("offline"),
+            created_at=1,
+            updated_at=1,
+            sandbox_provider="modal",
+            sandbox_id="new-tombstone-sandbox",
+            deleted_at=1,
+        ),
+    ]
+    expected_hosts = {
+        host.host_id: (host.user_id, host.sandbox_id, host.deleted_at) for host in hosts
+    }
+    with Session(engine) as session:
+        session.add_all(hosts)
+        session.commit()
+
+    report = remap_identities(
+        engine,
+        {
+            "alice": "alice@example.com",
+            "bob": "bob@example.com",
+        },
+        dry_run=False,
+        force=True,
+    )
+
+    assert report.refused == [
+        "alice -> alice@example.com",
+        "bob -> bob@example.com",
+    ]
+    for user_id in ("alice", "alice@example.com", "bob", "bob@example.com"):
+        assert account_store.get_user(user_id) is not None
+    with Session(engine) as session:
+        persisted = {
+            host.host_id: (host.user_id, host.sandbox_id, host.deleted_at)
+            for host in session.execute(select(SqlHost)).scalars()
+        }
+    assert persisted == expected_hosts
+
+
 def test_dry_run_mutates_nothing_but_reports(db_uri: str) -> None:
     """A dry run reports would-change counts but leaves the DB untouched."""
     account_store = SqlAlchemyAccountStore(db_uri)

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -3407,15 +3407,15 @@ async def test_terminate_managed_host_deletes_row_before_provider_call(
     assert fake.terminated == ["sb-delete-first"]
 
 
-async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
+async def test_terminate_managed_host_retries_tombstone_after_terminate_fails(
     db_uri: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    Best-effort contract: a provider termination failure neither
-    propagates nor blocks the row deletion (the provider's lifetime
-    cap reaps the sandbox; the credential must die now).
+    A provider failure does not block logical deletion, and the persisted
+    sandbox id is retried by the existing reaper.
     """
     fake = FakeSandboxLauncher()
+    original_terminate = fake.terminate
 
     def _explode(sandbox_id: str) -> None:
         """Simulate a provider API failure during termination."""
@@ -3439,15 +3439,83 @@ async def test_terminate_managed_host_deletes_row_even_when_terminate_fails(
     assert (
         host_store.resolve_launch_token("057e7fa3f1cdb40c0ec393a3d42affc7", "tok-term-2") is None
     )
+    tombstones = host_store.list_stale_managed_sandbox_hosts(now_epoch())
+    assert len(tombstones) == 1
+    assert tombstones[0].deleted_at is not None
+    assert tombstones[0].sandbox_id == "sb-term-2"
+
+    monkeypatch.setattr(fake, "terminate", original_terminate)
+    reaper = ManagedSandboxReaper(
+        host_store=host_store,
+        sandbox_config=_injected_config(fake),
+    )
+    assert await reaper.sweep_once() == 1
+    assert fake.terminated == ["sb-term-2"]
+    assert host_store.list_stale_managed_sandbox_hosts(now_epoch()) == []
+
+
+async def test_terminate_managed_host_retains_only_failed_generation(
+    db_uri: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = FakeSandboxLauncher()
+    original_terminate = fake.terminate
+    host_store = HostStore(db_uri)
+    host_id = "9e50e018919e494886b984df0bbec12b"
+    original = host_store.register_managed_host(
+        host_id=host_id,
+        name="managed-term-partial",
+        user_id=_OWNER,
+        token="tok-term-old-partial",
+        provider="modal",
+        sandbox_id="sb-term-old-partial",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert host_store.detach_stale_managed_sandbox(
+        host_id,
+        sandbox_id="sb-term-old-partial",
+        expected_updated_at=original.updated_at,
+    )
+    host = host_store.replace_managed_host_sandbox(
+        host_id=host_id,
+        user_id=_OWNER,
+        token="tok-term-new-partial",
+        provider="modal",
+        sandbox_id="sb-term-new-partial",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert host is not None
+    attempts: list[str] = []
+
+    def _terminate(sandbox_id: str) -> None:
+        attempts.append(sandbox_id)
+        if sandbox_id == "sb-term-new-partial":
+            raise click.ClickException("provider unavailable")
+        original_terminate(sandbox_id)
+
+    monkeypatch.setattr(fake, "terminate", _terminate)
+    await terminate_managed_host(host, host_store, _injected_config(fake))
+
+    assert attempts == ["sb-term-new-partial", "sb-term-old-partial"]
+    tombstones = host_store.list_stale_managed_sandbox_hosts(now_epoch())
+    assert len(tombstones) == 1
+    assert tombstones[0].sandbox_id == "sb-term-new-partial"
+    assert tombstones[0].terminating_sandbox_id is None
+
+    monkeypatch.setattr(fake, "terminate", original_terminate)
+    reaper = ManagedSandboxReaper(
+        host_store=host_store,
+        sandbox_config=_injected_config(fake),
+    )
+    assert await reaper.sweep_once() == 1
+    assert fake.terminated == ["sb-term-old-partial", "sb-term-new-partial"]
+    assert host_store.list_stale_managed_sandbox_hosts(now_epoch()) == []
 
 
 async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> None:
     """
-    A config change between launch and teardown (current launcher's
-    provider ≠ the provider recorded on the row) must NOT aim the new
-    provider's terminate at a stale sandbox id — the sandbox is left
-    to its lifetime cap, but the row still dies (token revoked, no
-    picker ghost). Also covers config=None (section removed).
+    A config change between launch and teardown must not aim the new provider's
+    terminate at a stale sandbox id. The host becomes invisible and its cleanup
+    tombstone remains available if that provider is configured again later.
     """
     fake = FakeSandboxLauncher()  # provider "modal"
     host_store = HostStore(db_uri)
@@ -3470,7 +3538,7 @@ async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> 
         host_store.resolve_launch_token("487212fd2b157b6ab6a6d6d3ef06ce5b", "tok-term-3") is None
     )
 
-    # config=None behaves the same: row deleted, nothing terminated.
+    # config=None behaves the same: host hidden, cleanup retained.
     host2 = host_store.register_managed_host(
         host_id="b114bf90a8fd155ce6007c3bb262aa79",
         name="managed-term4",

--- a/tests/server/test_managed_sandbox_reaper.py
+++ b/tests/server/test_managed_sandbox_reaper.py
@@ -89,7 +89,8 @@ class _FakeHostStore:
             for host in self.hosts[workspace_id].values()
             if host.sandbox_provider is not None
             and (
-                host.terminating_sandbox_id is not None
+                host.deleted_at is not None
+                or host.terminating_sandbox_id is not None
                 or (host.sandbox_id is not None and host.updated_at <= older_than_epoch)
             )
         ]
@@ -111,6 +112,7 @@ class _FakeHostStore:
             self.refresh_on_detach.remove(host_id)
         if (
             host is None
+            or host.deleted_at is not None
             or host.sandbox_id != sandbox_id
             or host.updated_at != expected_updated_at
             or host.terminating_sandbox_id is not None
@@ -125,7 +127,7 @@ class _FakeHostStore:
         self.detached.append((workspace_id, host_id, sandbox_id))
         return True
 
-    def mark_terminating_sandbox_terminated(
+    def mark_sandbox_terminated(
         self,
         host_id: str,
         *,
@@ -133,12 +135,30 @@ class _FakeHostStore:
     ) -> bool:
         workspace_id = current_workspace_id()
         host = self.hosts[workspace_id].get(host_id)
-        if host is None or host.terminating_sandbox_id != sandbox_id:
+        if host is None:
             return False
-        self.hosts[workspace_id][host_id] = replace(
+        if host.deleted_at is None:
+            if host.terminating_sandbox_id != sandbox_id:
+                return False
+            self.hosts[workspace_id][host_id] = replace(
+                host,
+                terminating_sandbox_id=None,
+            )
+            self.cleared.append((workspace_id, host_id, sandbox_id))
+            return True
+        if sandbox_id not in {host.sandbox_id, host.terminating_sandbox_id}:
+            return False
+        updated = replace(
             host,
-            terminating_sandbox_id=None,
+            sandbox_id=None if host.sandbox_id == sandbox_id else host.sandbox_id,
+            terminating_sandbox_id=(
+                None if host.terminating_sandbox_id == sandbox_id else host.terminating_sandbox_id
+            ),
         )
+        if updated.sandbox_id is None and updated.terminating_sandbox_id is None:
+            del self.hosts[workspace_id][host_id]
+        else:
+            self.hosts[workspace_id][host_id] = updated
         self.cleared.append((workspace_id, host_id, sandbox_id))
         return True
 
@@ -151,6 +171,7 @@ def _host(
     updated_at: int,
     status: str = "offline",
     terminating_sandbox_id: str | None = None,
+    deleted_at: int | None = None,
 ) -> Host:
     return Host(
         host_id=host_id,
@@ -162,6 +183,7 @@ def _host(
         sandbox_provider=provider,
         sandbox_id=sandbox_id,
         terminating_sandbox_id=terminating_sandbox_id,
+        deleted_at=deleted_at,
     )
 
 
@@ -290,6 +312,37 @@ async def test_provider_failure_does_not_stop_other_sandboxes() -> None:
     assert hosts.hosts[7]["host_modal"].terminating_sandbox_id == "sb-modal"
     assert hosts.hosts[7]["host_e2b"].sandbox_id is None
     assert e2b.terminated == ["sb-e2b"]
+
+
+async def test_deleted_host_cleanup_retries_without_offline_age() -> None:
+    now = 4_000_000
+    modal = _RecordingLauncher("modal", fail=True)
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_deleted",
+                    provider="modal",
+                    sandbox_id="sb-deleted",
+                    updated_at=now,
+                    status="online",
+                    deleted_at=now,
+                )
+            ]
+        }
+    )
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal]),
+    )
+
+    assert await reaper.sweep_once(now=now) == 0
+    assert hosts.hosts[7]["host_deleted"].sandbox_id == "sb-deleted"
+
+    modal.fail = False
+    assert await reaper.sweep_once(now=now) == 1
+    assert modal.terminated == ["sb-deleted"]
+    assert "host_deleted" not in hosts.hosts[7]
 
 
 async def test_provider_identity_failure_does_not_stop_other_sandboxes() -> None:

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -827,11 +827,10 @@ def test_managed_columns_survive_connect(db_uri: str) -> None:
     )
 
 
-def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
+def test_delete_host_hides_row_and_retains_cleanup_tombstone(db_uri: str) -> None:
     """
-    ``delete_host`` removes the host from the picker AND revokes its
-    launch token in one operation (the row IS the credential); a
-    second delete is a safe no-op for racing cleanup paths.
+    Logical deletion removes the host from user-visible reads and revokes its
+    token while retaining the sandbox id until cleanup succeeds.
     """
     store = HostStore(db_uri)
     store.register_managed_host(
@@ -853,11 +852,58 @@ def test_delete_host_removes_row_and_revokes_token(db_uri: str) -> None:
         is None
     )
     assert store.list_hosts("alice@example.com") == []
-    # Second delete is a no-op, not an error.
-    assert store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566") is None
+    retry = store.delete_host("dcf4eb5fc0b04985ec45f79cfda95566")
+    assert retry is not None
+    assert retry.deleted_at is not None
+    assert retry.sandbox_id == "sb-m5"
+
+    cleanup = store.list_stale_managed_sandbox_hosts(now_epoch())
+    assert [host.host_id for host in cleanup] == ["dcf4eb5fc0b04985ec45f79cfda95566"]
+    assert cleanup[0].deleted_at == retry.deleted_at
+    assert store.mark_sandbox_terminated(
+        "dcf4eb5fc0b04985ec45f79cfda95566",
+        sandbox_id="sb-m5",
+    )
+    assert store.list_stale_managed_sandbox_hosts(now_epoch()) == []
+
+    engine = get_or_create_engine(db_uri)
+    with Session(engine) as session:
+        assert session.get(SqlHost, (0, "dcf4eb5fc0b04985ec45f79cfda95566")) is None
 
 
-def test_replace_managed_host_sandbox_cannot_recreate_deleted_host(db_uri: str) -> None:
+def test_stale_completion_removes_host_deleted_after_detach(db_uri: str) -> None:
+    store = HostStore(db_uri)
+    host_id = "405a78021f6648e5ae887350047f76b5"
+    original = store.register_managed_host(
+        host_id=host_id,
+        name="managed-detach-delete-complete",
+        user_id="alice@example.com",
+        token="detach-delete-token",
+        provider="modal",
+        sandbox_id="detach-delete-sandbox",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert store.detach_stale_managed_sandbox(
+        host_id,
+        sandbox_id="detach-delete-sandbox",
+        expected_updated_at=original.updated_at,
+    )
+    deleted = store.delete_host(host_id)
+    assert deleted is not None
+    assert deleted.deleted_at is not None
+    assert deleted.terminating_sandbox_id == "detach-delete-sandbox"
+
+    assert store.mark_sandbox_terminated(
+        host_id,
+        sandbox_id="detach-delete-sandbox",
+    )
+
+    engine = get_or_create_engine(db_uri)
+    with Session(engine) as session:
+        assert session.get(SqlHost, (0, host_id)) is None
+
+
+def test_replace_managed_host_sandbox_cannot_recreate_missing_host(db_uri: str) -> None:
     store = HostStore(db_uri)
 
     assert (
@@ -872,6 +918,38 @@ def test_replace_managed_host_sandbox_cannot_recreate_deleted_host(db_uri: str) 
         is None
     )
     assert store.resolve_launch_token("c48e6fda4172492aa60ec299e5ce01d3", "too-late-token") is None
+
+
+def test_replace_managed_host_sandbox_cannot_revive_deleted_tombstone(db_uri: str) -> None:
+    store = HostStore(db_uri)
+    host_id = "be41c27f5a6746db8178096b13685b44"
+    store.register_managed_host(
+        host_id=host_id,
+        name="managed-deleted-replace",
+        user_id="alice@example.com",
+        token="original-token",
+        provider="modal",
+        sandbox_id="original-sandbox",
+        token_expires_at=now_epoch() + 3600,
+    )
+    assert store.delete_host(host_id) is not None
+
+    assert (
+        store.replace_managed_host_sandbox(
+            host_id=host_id,
+            user_id="alice@example.com",
+            token="replacement-token",
+            provider="modal",
+            sandbox_id="replacement-sandbox",
+            token_expires_at=now_epoch() + 3600,
+        )
+        is None
+    )
+    tombstones = store.list_stale_managed_sandbox_hosts(now_epoch())
+    assert [(host.host_id, host.sandbox_id) for host in tombstones] == [
+        (host_id, "original-sandbox")
+    ]
+    assert store.resolve_launch_token(host_id, "replacement-token") is None
 
 
 def test_delete_host_serializes_with_sandbox_replacement(db_uri: str) -> None:
@@ -1036,14 +1114,14 @@ def test_managed_sandbox_reaper_queries_and_compare_clear_span_workspaces(
         assert store.resolve_launch_token(host_11, "token-11") is None
         assert store.list_managed_sandbox_workspace_ids() == [11, 22]
         assert (
-            store.mark_terminating_sandbox_terminated(
+            store.mark_sandbox_terminated(
                 host_11,
                 sandbox_id="sb-other",
             )
             is False
         )
         assert (
-            store.mark_terminating_sandbox_terminated(
+            store.mark_sandbox_terminated(
                 host_11,
                 sandbox_id="sb-11",
             )


### PR DESCRIPTION
## Related issue

N/A — follow-up to #6358, which is merged. This branch is rebased onto current `main`.

## Summary

- Add a nullable `hosts.deleted_at` tombstone so deleting a managed host immediately hides it, detaches its sessions, and revokes its launch token without discarding sandbox IDs that still need provider cleanup.
- Clear each recorded active or pending sandbox ID only after provider termination succeeds; delete the tombstone after the final ID is cleared.
- Use one state-aware sandbox completion operation so a stale reaper candidate that is deleted during provider termination removes its now-empty tombstone, while a live host can clear only its detached pending sandbox ID.
- Make the existing managed sandbox reaper retry tombstones immediately, without waiting for the ordinary offline-age threshold.
- Refuse identity migration when a same-name host collision contains a cleanup tombstone, locking all colliding host rows before any mapping mutation so concurrent deletion cannot invalidate the check.

**ELI5:** deleting a session now keeps a hidden cleanup receipt until every recorded sandbox is actually gone. A transient provider error leaves the receipt for the next reaper sweep instead of leaking the sandbox forever.

```text
session deletion
      |
      v
lock host row -> detach sessions -> revoke token -> set deleted_at
      |
      v
terminate recorded sandbox IDs
      |
      +-- success -> clear exact ID -> no IDs remain -> delete row
      |
      +-- failure -> keep ID on tombstone -> reaper retries later
```

## Test Plan

- `.venv/bin/pytest -q tests/stores/test_host_store.py tests/server/test_managed_sandbox_reaper.py tests/server/test_managed_hosts.py tests/db/test_migration_managed_sandbox_deleted_at.py` (`337 passed`)
- `.venv/bin/pytest -q tests/db/test_migration_managed_sandbox_deleted_at.py tests/db/test_migration_managed_sandbox_reaper.py tests/db/test_migrations_sqlite_safe.py tests/server/integration/test_host_tunnel_route.py tests/server/test_identity_migration.py` (`40 passed`)
- `.venv/bin/pytest -q tests/server/test_identity_migration.py tests/server/test_managed_sandbox_reaper.py tests/stores/test_host_store.py tests/server/integration/test_host_session_binding.py tests/db/test_migration_managed_sandbox_deleted_at.py` (`90 passed` after rebasing and review fixes)
- `.venv/bin/pre-commit run --files omnigent/server/identity_migration.py omnigent/server/managed_hosts.py omnigent/server/managed_sandbox_reaper.py omnigent/stores/host_store.py tests/server/integration/test_host_session_binding.py tests/server/test_identity_migration.py tests/server/test_managed_sandbox_reaper.py tests/stores/test_host_store.py` (all applicable hooks passed)

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes logical deletion visibility, launch-token revocation, relaunch rejection, active-plus-pending cleanup, partial provider failure, reaper retry, stale-candidate deletion during completion, final physical deletion, tombstone-safe identity migration collisions, and migration round trips.

## Changelog

Deleted managed sessions now retry transient sandbox cleanup failures instead of leaking provider compute.
