### PR TITLE
fix(triage): pass a boolean to reusable intake

### DIFF
--- a/.github/triage_v2/tests/test_bundle_configuration.py
+++ b/.github/triage_v2/tests/test_bundle_configuration.py
@@ -68,6 +68,11 @@ def test_v2_owns_intake_when_enabled_and_manual_dispatch_is_dry_by_default() -> 
         "apply: ${{ github.event_name != 'workflow_dispatch' || inputs.apply_labels }}"
     )
     assert apply_expression in prioritize
+    assert (
+        "post_duplicate_comments: ${{ github.event_name == 'workflow_dispatch' "
+        "&& inputs.post_comment }}" in prioritize
+    )
+    assert "post_duplicate_comments: ${{ inputs.post_comment }}" not in prioritize
     assert "--intake --maintainers .github/MAINTAINER" in reusable
     assert "mode=dry_run" in reusable
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -796,5 +796,5 @@ jobs:
       intake: ${{ github.event_name == 'workflow_dispatch' || github.event.action == 'opened' }}
       apply: ${{ github.event_name != 'workflow_dispatch' || inputs.apply_labels }}
       manual_dispatch: ${{ github.event_name == 'workflow_dispatch' }}
-      post_duplicate_comments: ${{ inputs.post_comment }}
+      post_duplicate_comments: ${{ github.event_name == 'workflow_dispatch' && inputs.post_comment }}
     secrets: inherit


### PR DESCRIPTION
## Related issue

Related to #6434

## Summary

New issues were not being assigned because the `issues` event passed an absent `inputs.post_comment` value to a reusable workflow input declared as a boolean. GitHub rejected the reusable workflow call before any V2 intake steps ran, leaving only the intentionally skipped legacy job.

This change makes the value explicitly boolean for every event: manual dispatches preserve the requested value, while normal issue events pass `false`.

## Test Plan

- `uv run --frozen --project .github/triage_v2 pytest -q .github/triage_v2/tests/test_bundle_configuration.py .github/triage_v2/tests/test_intake.py .github/triage_v2/tests/test_event.py`
- `uvx pre-commit run --files .github/workflows/issue-triage.yml .github/triage_v2/tests/test_bundle_configuration.py`
- Parsed both triage workflow YAML files with PyYAML.
- After merge: edit #6434 to exercise the `issues` event, then manually run intake in apply mode to backfill its owner.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The failing run for #6434 had an empty log archive and only the skipped legacy job; manual-dispatch V2 runs succeeded because their boolean input existed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The configuration test now rejects the untyped caller expression and requires a boolean expression for issue events.
