### PR TITLE
ci: clean up expired UI preview apps hourly

### DIFF
--- a/.github/scripts/ui-preview/reconcile.py
+++ b/.github/scripts/ui-preview/reconcile.py
@@ -1,0 +1,196 @@
+"""Delete PR previews when their PR is merged or their app is older than its TTL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import urlencode
+
+APP_PATTERN = re.compile(r"omnigent-ui-preview-pr-([1-9][0-9]*)\Z")
+TERMINAL_DEPLOYMENTS = {"SUCCEEDED", "FAILED", "CANCELLED"}
+
+
+def timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp has no timezone")
+    return parsed
+
+
+def candidate_reason(app: dict, pr: dict, repo: str, cutoff: datetime) -> str | None:
+    """Return a retention reason, or None for a lifecycle-expired preview."""
+    match = APP_PATTERN.fullmatch(app.get("name", ""))
+    if not match:
+        return "not a per-PR preview"
+    number = int(match[1])
+    expected_url = f"https://github.com/{repo}/pull/{number}"
+    if app.get("description") != expected_url or pr.get("html_url") != expected_url:
+        return "PR URL does not match the app description"
+    if pr.get("number") != number or pr.get("state") not in {"open", "closed"}:
+        return "PR identity or state is unconfirmed"
+    try:
+        created_at = timestamp(app["create_time"])
+    except (KeyError, TypeError, ValueError, AttributeError):
+        return "missing or invalid app creation timestamp"
+    if pr.get("merged") is not True and created_at >= cutoff:
+        return "PR is unmerged and app has not exceeded its TTL"
+    if not app.get("id") or not app.get("creator"):
+        return "missing app identity"
+    expected_source = f"/Workspace/Users/{app['creator']}/apps/{app['name']}"
+    if app.get("default_source_code_path") != expected_source:
+        return "source path does not match the preview convention"
+    if app.get("resources"):
+        return "app has attached resources; manual investigation required"
+    if app.get("compute_status", {}).get("state") not in {"ACTIVE", "STOPPED", "ERROR"}:
+        return "compute is transitioning or its state is unknown"
+    if app.get("pending_deployment") or app.get("pending_update"):
+        return "app has a pending deployment or update"
+    return None
+
+
+class Client:
+    def __init__(self, repo: str, profile: str | None = None):
+        self.repo = repo
+        self.profile_args = ["--profile", profile] if profile else []
+
+    @staticmethod
+    def run(args: list[str]):
+        result = subprocess.run(args, capture_output=True, text=True, timeout=60, check=False)
+        if result.returncode:
+            # CLI diagnostics can contain credentials or server response bodies.
+            raise RuntimeError(f"{args[0]} command failed (exit {result.returncode})")
+        return json.loads(result.stdout) if result.stdout.strip() else None
+
+    def apps(self, *args: str):
+        return self.run(["databricks", "apps", *args, *self.profile_args, "--output", "json"])
+
+    def pr(self, number: int) -> dict:
+        return self.run(["gh", "api", f"repos/{self.repo}/pulls/{number}"])
+
+    def busy_reason(self, app: dict, pr: dict) -> str | None:
+        deployments = self.apps("list-deployments", app["name"])
+        if not isinstance(deployments, list):
+            return "deployment history is unavailable"
+        if any(d.get("status", {}).get("state") not in TERMINAL_DEPLOYMENTS for d in deployments):
+            return "deployment is in progress or its state is unknown"
+        branch = pr.get("head", {}).get("ref")
+        if not branch:
+            return "PR head branch is unavailable"
+        query = urlencode({"branch": branch, "per_page": 100})
+        pages = self.run(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{self.repo}/actions/workflows/ui-preview.yml/runs?{query}",
+            ]
+        )
+        if not isinstance(pages, list) or not pages:
+            return "preview workflow history is unavailable"
+        for page in pages:
+            if not isinstance(page.get("workflow_runs"), list):
+                return "preview workflow history is unavailable"
+            if any(run.get("status") != "completed" for run in page["workflow_runs"]):
+                return "preview workflow is still in progress"
+        return None
+
+
+def inspect(client: Client, name: str, cutoff: datetime) -> tuple[dict, dict, str | None]:
+    match = APP_PATTERN.fullmatch(name)
+    if not match:
+        raise ValueError("not a per-PR preview name")
+    app = client.apps("get", name)
+    if app.get("name") != name:
+        raise ValueError("app response name does not match request")
+    pr = client.pr(int(match[1]))
+    reason = candidate_reason(app, pr, client.repo, cutoff)
+    if reason is None:
+        reason = client.busy_reason(app, pr)
+    return app, pr, reason
+
+
+def reconcile(client: Client, names: list[str], *, cutoff: datetime, apply: bool) -> list[dict]:
+    report = []
+    for name in names:
+        row = {"app": name, "action": "retain"}
+        try:
+            app, pr, reason = inspect(client, name, cutoff)
+            row.update(
+                pr=pr["html_url"],
+                author=pr.get("user", {}).get("login"),
+                closed_at=pr.get("closed_at"),
+                merged=pr.get("merged") is True,
+                app_created_at=app.get("create_time"),
+                compute_state=app.get("compute_status", {}).get("state"),
+            )
+            if reason is not None:
+                row["reason"] = reason
+            elif not apply:
+                row.update(action="candidate", reason="PR merged or app exceeded TTL")
+            else:
+                fresh_app, _, reason = inspect(client, name, cutoff)
+                identity = ("id", "create_time", "update_time", "default_source_code_path")
+                if reason is not None:
+                    row["reason"] = f"recheck: {reason}"
+                elif any(fresh_app.get(key) != app.get(key) for key in identity):
+                    row["reason"] = "app changed during review"
+                else:
+                    client.apps("delete", name, "--auto-approve")
+                    row.update(
+                        action="deleted", reason="PR merged or app exceeded TTL; source preserved"
+                    )
+        except (
+            RuntimeError,
+            ValueError,
+            TypeError,
+            KeyError,
+            AttributeError,
+            OSError,
+            subprocess.TimeoutExpired,
+        ) as exc:
+            row.update(action="error", reason=f"lookup/delete failed ({type(exc).__name__})")
+        report.append(row)
+        print(json.dumps(row), flush=True)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="omnigent-ai/omnigent")
+    parser.add_argument("--profile")
+    parser.add_argument("--ttl-hours", type=int, default=24)
+    parser.add_argument(
+        "--app", action="append", default=[], help="Limit cleanup to this exact app"
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Delete all matching expired previews"
+    )
+    parser.add_argument("--report", type=Path, help="Write the JSON report to this file")
+    args = parser.parse_args()
+    if args.ttl_hours < 1:
+        parser.error("--ttl-hours must be at least 1")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", args.repo):
+        parser.error("--repo must be owner/repository")
+    if any(not APP_PATTERN.fullmatch(name) for name in args.app):
+        parser.error("--app must be an exact omnigent-ui-preview-pr-<number> name")
+    client = Client(args.repo, args.profile)
+    names = list(dict.fromkeys(args.app))
+    if not names:
+        apps = client.apps("list")
+        if not isinstance(apps, list):
+            raise ValueError("unexpected app inventory response")
+        names = [app["name"] for app in apps if APP_PATTERN.fullmatch(app.get("name", ""))]
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=args.ttl_hours)
+    report = reconcile(client, names, cutoff=cutoff, apply=args.apply)
+    if args.report:
+        args.report.write_text(json.dumps(report, indent=2) + "\n")
+    return int(any(row["action"] == "error" for row in report))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/ui-preview/test_reconcile.py
+++ b/.github/scripts/ui-preview/test_reconcile.py
@@ -1,0 +1,395 @@
+import copy
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from reconcile import Client, candidate_reason, main, reconcile
+
+REPO = "example/project"
+NAME = "omnigent-ui-preview-pr-123"
+OLD = "2026-01-01T00:00:00Z"
+CUTOFF = datetime(2026, 2, 1, tzinfo=timezone.utc)
+RECENT = "2026-02-01T23:00:00Z"
+NON_PREVIEWS = (
+    "omnigent-repro",
+    "omnigent-ui-preview-dev",
+    "customer-app",
+    NAME + "-backup",
+    "other-" + NAME,
+    "omnigent-ui-preview-pr-0123",
+    "omnigent-ui-preview-pr-0",
+    "omnigent-ui-preview-pr-123\n",
+    "",
+)
+
+
+def app(number=123):
+    name = f"omnigent-ui-preview-pr-{number}"
+    return {
+        "id": f"preview-id-{number}",
+        "name": name,
+        "description": f"https://github.com/{REPO}/pull/{number}",
+        "creator": "ci-principal",
+        "create_time": OLD,
+        "update_time": OLD,
+        "default_source_code_path": f"/Workspace/Users/ci-principal/apps/{name}",
+        "compute_status": {"state": "ACTIVE"},
+    }
+
+
+def pr(number=123):
+    return {
+        "number": number,
+        "state": "closed",
+        "merged": False,
+        "html_url": f"https://github.com/{REPO}/pull/{number}",
+        "closed_at": OLD,
+        "labels": [],
+        "user": {"login": "test-bot"},
+        "head": {"ref": "test-branch"},
+    }
+
+
+class FakeClient:
+    repo = REPO
+
+    def __init__(self):
+        self.app = app()
+        self.inventory = [self.app]
+        self.pull = pr()
+        self.deletes = []
+        self.gets = 0
+        self.requested_names = []
+        self.before_second_get = lambda: None
+        self.busy = None
+
+    def apps(self, *args):
+        if args[0] == "list":
+            return copy.deepcopy(self.inventory)
+        if args[0] == "get":
+            self.gets += 1
+            self.requested_names.append(args[1])
+            if self.gets == 2:
+                self.before_second_get()
+            return copy.deepcopy(next(item for item in self.inventory if item["name"] == args[1]))
+        if args[0] == "delete":
+            self.deletes.append(args[1])
+            return None
+        raise AssertionError(args)
+
+    def pr(self, number):
+        return copy.deepcopy(self.pull if number == 123 else pr(number))
+
+    def busy_reason(self, _app, _pr):
+        return self.busy
+
+
+class ReconcileTest(unittest.TestCase):
+    def run_reconcile(self, client, *, apply=False):
+        with redirect_stdout(io.StringIO()):
+            return reconcile(client, [NAME], cutoff=CUTOFF, apply=apply)[0]
+
+    def test_dry_run_never_deletes(self):
+        client = FakeClient()
+        row = self.run_reconcile(client)
+        self.assertEqual(row["action"], "candidate")
+        self.assertEqual(client.deletes, [])
+
+    def test_apply_rechecks_then_deletes(self):
+        client = FakeClient()
+        row = self.run_reconcile(client, apply=True)
+        self.assertEqual(row["action"], "deleted")
+        self.assertEqual(client.gets, 2)
+        self.assertEqual(client.deletes, [NAME])
+
+    def test_new_app_is_retained_if_merge_is_unconfirmed_on_recheck(self):
+        client = FakeClient()
+        client.app.update(create_time=RECENT)
+        client.pull.update(merged=True)
+        client.before_second_get = lambda: client.pull.update(merged=False)
+        row = self.run_reconcile(client, apply=True)
+        self.assertEqual(row["action"], "retain")
+        self.assertEqual(client.deletes, [])
+
+    def test_old_app_still_expires_when_pr_reopens(self):
+        client = FakeClient()
+        client.before_second_get = lambda: client.pull.update(state="open")
+        self.assertEqual(self.run_reconcile(client, apply=True)["action"], "deleted")
+        self.assertEqual(client.deletes, [NAME])
+
+    def test_recreated_or_modified_app_is_retained(self):
+        for change in (
+            {"id": "replacement"},
+            {"create_time": "2026-01-02T00:00:00Z"},
+            {"update_time": "2026-01-02T00:00:00Z"},
+        ):
+            with self.subTest(change=change):
+                client = FakeClient()
+                client.before_second_get = lambda change=change, client=client: client.app.update(
+                    change
+                )
+                row = self.run_reconcile(client, apply=True)
+                self.assertEqual(row["reason"], "app changed during review")
+                self.assertEqual(client.deletes, [])
+
+    def test_pending_workflow_or_deployment_is_retained(self):
+        client = FakeClient()
+        client.busy = "preview workflow is still in progress"
+        row = self.run_reconcile(client, apply=True)
+        self.assertEqual(row["action"], "retain")
+        self.assertEqual(client.deletes, [])
+
+    def test_activity_starting_during_recheck_retains_app(self):
+        client = FakeClient()
+        client.before_second_get = lambda: setattr(client, "busy", "deployment started")
+        self.assertEqual(self.run_reconcile(client, apply=True)["action"], "retain")
+        self.assertEqual(client.deletes, [])
+
+    def test_lookup_errors_never_delete_or_expose_error_body(self):
+        client = FakeClient()
+        with patch.object(client, "pr", side_effect=RuntimeError("secret token")):
+            row = self.run_reconcile(client, apply=True)
+        self.assertEqual(row["action"], "error")
+        self.assertNotIn("secret", str(row))
+        self.assertEqual(client.deletes, [])
+
+    def test_non_preview_apps_are_excluded(self):
+        for name in NON_PREVIEWS:
+            with self.subTest(name=name):
+                item = app() | {"name": name}
+                self.assertIsNotNone(candidate_reason(item, pr(), REPO, CUTOFF))
+
+    def test_invalid_provenance_or_external_resources_are_retained(self):
+        changes = [
+            {"description": "https://github.com/other/project/pull/123"},
+            {"id": None},
+            {"creator": None},
+            {"default_source_code_path": "/Workspace/Users/ci-principal"},
+            {"resources": [{"name": "persistent-database"}]},
+            {"compute_status": {"state": "STARTING"}},
+            {"compute_status": {}},
+            {"pending_deployment": {"deployment_id": "pending"}},
+            {"pending_update": {"update_id": "pending"}},
+        ]
+        for change in changes:
+            with self.subTest(change=change):
+                self.assertIsNotNone(candidate_reason(app() | change, pr(), REPO, CUTOFF))
+
+    def test_invalid_pr_identity_or_state_is_retained(self):
+        for change in (
+            {"state": None},
+            {"state": "unknown"},
+            {"number": 124},
+            {"html_url": "https://github.com/other/project/pull/123"},
+        ):
+            with self.subTest(change=change):
+                self.assertIsNotNone(candidate_reason(app(), pr() | change, REPO, CUTOFF))
+
+    def test_merged_pr_expires_even_for_a_fresh_app(self):
+        self.assertIsNone(
+            candidate_reason(
+                app() | {"create_time": RECENT}, pr() | {"merged": True}, REPO, CUTOFF
+            )
+        )
+
+    def test_old_apps_expire_for_open_and_closed_unmerged_prs(self):
+        for state in ("open", "closed"):
+            with self.subTest(state=state):
+                self.assertIsNone(candidate_reason(app(), pr() | {"state": state}, REPO, CUTOFF))
+
+    def test_unmerged_apps_are_retained_until_strictly_older_than_ttl(self):
+        for state in ("open", "closed"):
+            for created_at in (RECENT, "2026-02-01T00:00:00Z"):
+                with self.subTest(state=state, created_at=created_at):
+                    self.assertIsNotNone(
+                        candidate_reason(
+                            app() | {"create_time": created_at},
+                            pr() | {"state": state},
+                            REPO,
+                            CUTOFF,
+                        )
+                    )
+        self.assertIsNone(
+            candidate_reason(
+                app() | {"create_time": "2026-01-31T23:59:59.999999Z"}, pr(), REPO, CUTOFF
+            )
+        )
+
+    def test_age_uses_app_creation_not_pr_age_or_latest_deployment(self):
+        old_pr = pr() | {"created_at": OLD, "closed_at": OLD}
+        self.assertIsNotNone(
+            candidate_reason(app() | {"create_time": RECENT}, old_pr, REPO, CUTOFF)
+        )
+        recent_pr = pr() | {"created_at": RECENT, "closed_at": RECENT}
+        redeployed_app = app() | {
+            "update_time": RECENT,
+            "active_deployment": {"create_time": RECENT},
+        }
+        self.assertIsNone(candidate_reason(redeployed_app, recent_pr, REPO, CUTOFF))
+
+    def test_invalid_or_missing_creation_timestamp_is_retained(self):
+        for merged in (True, False):
+            for created_at in (None, "invalid", "2026-01-01T00:00:00", 0):
+                with self.subTest(merged=merged, created_at=created_at):
+                    self.assertIsNotNone(
+                        candidate_reason(
+                            app() | {"create_time": created_at},
+                            pr() | {"merged": merged},
+                            REPO,
+                            CUTOFF,
+                        )
+                    )
+        item = app()
+        del item["create_time"]
+        self.assertIsNotNone(candidate_reason(item, pr(), REPO, CUTOFF))
+
+    def test_cli_apply_discovers_all_ui_previews_and_excludes_other_apps(self):
+        client = FakeClient()
+        client.inventory.extend([app(124), *(app() | {"name": name} for name in NON_PREVIEWS)])
+        with (
+            patch("sys.argv", ["reconcile.py", "--repo", REPO, "--apply"]),
+            patch("reconcile.Client", return_value=client),
+            patch("reconcile.datetime", wraps=datetime) as clock,
+            redirect_stdout(io.StringIO()),
+        ):
+            clock.now.return_value = CUTOFF + timedelta(hours=24)
+            self.assertEqual(main(), 0)
+        self.assertEqual(client.deletes, [NAME, "omnigent-ui-preview-pr-124"])
+        self.assertEqual(set(client.requested_names), {NAME, "omnigent-ui-preview-pr-124"})
+        self.assertEqual(client.gets, 4)
+
+    def test_cli_matching_name_without_preview_provenance_is_retained(self):
+        client = FakeClient()
+        client.app.update(description="A different app with a preview-like name")
+        with (
+            patch("sys.argv", ["reconcile.py", "--repo", REPO, "--apply"]),
+            patch("reconcile.Client", return_value=client),
+            redirect_stdout(io.StringIO()),
+        ):
+            self.assertEqual(main(), 0)
+        self.assertEqual(client.deletes, [])
+
+    def test_cli_explicit_scope_and_report(self):
+        client = FakeClient()
+        client.inventory.append(app(124))
+        with tempfile.TemporaryDirectory() as directory:
+            report_path = Path(directory) / "report.json"
+            with (
+                patch(
+                    "sys.argv",
+                    ["reconcile.py", "--app", NAME, "--apply", "--report", str(report_path)],
+                ),
+                patch("reconcile.Client", return_value=client),
+                redirect_stdout(io.StringIO()),
+            ):
+                self.assertEqual(main(), 0)
+            report = json.loads(report_path.read_text())
+        self.assertEqual(client.deletes, [NAME])
+        self.assertEqual(len(report), 1)
+        self.assertEqual(report[0]["action"], "deleted")
+        self.assertEqual(report[0]["app_created_at"], OLD)
+
+    def test_cli_returns_failure_for_lookup_errors(self):
+        client = FakeClient()
+        with (
+            patch("sys.argv", ["reconcile.py", "--apply"]),
+            patch("reconcile.Client", return_value=client),
+            patch.object(client, "pr", side_effect=RuntimeError("lookup failed")),
+            redirect_stdout(io.StringIO()),
+        ):
+            self.assertEqual(main(), 1)
+        self.assertEqual(client.deletes, [])
+
+    def test_cli_defaults_to_dry_run(self):
+        client = FakeClient()
+        with (
+            patch("sys.argv", ["reconcile.py", "--repo", REPO]),
+            patch("reconcile.Client", return_value=client),
+            redirect_stdout(io.StringIO()),
+        ):
+            self.assertEqual(main(), 0)
+        self.assertEqual(client.deletes, [])
+
+    def test_cli_rejects_invalid_ttl_and_non_preview_targets(self):
+        for args in (["--ttl-hours", "0"], ["--app", "omnigent-repro"]):
+            with self.subTest(args=args), patch("sys.argv", ["reconcile.py", *args]):
+                with (
+                    patch("sys.stderr", new=io.StringIO()),
+                    self.assertRaises(SystemExit) as error,
+                ):
+                    main()
+                self.assertEqual(error.exception.code, 2)
+
+
+class ClientTest(unittest.TestCase):
+    def test_all_deployments_must_have_known_terminal_states(self):
+        for state in ("IN_PROGRESS", "CANCELING", "UNKNOWN", None):
+            with self.subTest(state=state):
+                client = Client(REPO)
+                with patch.object(client, "apps", return_value=[{"status": {"state": state}}]):
+                    self.assertIsNotNone(client.busy_reason(app(), pr()))
+
+    def test_active_workflow_on_later_page_blocks_cleanup(self):
+        client = Client(REPO)
+        pages = [
+            {"workflow_runs": [{"status": "completed"}]},
+            {"workflow_runs": [{"status": "queued"}]},
+        ]
+        with (
+            patch.object(client, "apps", return_value=[]),
+            patch.object(client, "run", return_value=pages) as run,
+        ):
+            self.assertEqual(
+                client.busy_reason(app(), pr()), "preview workflow is still in progress"
+            )
+        self.assertIn("--paginate", run.call_args.args[0])
+        self.assertIn("--slurp", run.call_args.args[0])
+
+    def test_missing_workflow_results_block_cleanup(self):
+        client = Client(REPO)
+        for pages in (None, [], [{}], [{"workflow_runs": None}]):
+            with (
+                self.subTest(pages=pages),
+                patch.object(client, "apps", return_value=[]),
+                patch.object(client, "run", return_value=pages),
+            ):
+                self.assertIsNotNone(client.busy_reason(app(), pr()))
+
+    def test_terminal_deployments_and_completed_workflows_allow_review(self):
+        client = Client(REPO)
+        deployments = [
+            {"status": {"state": state}} for state in ("SUCCEEDED", "FAILED", "CANCELLED")
+        ]
+        with (
+            patch.object(client, "apps", return_value=deployments),
+            patch.object(client, "run", return_value=[{"workflow_runs": []}]),
+        ):
+            self.assertIsNone(client.busy_reason(app(), pr()))
+
+    def test_delete_always_includes_explicit_app_name_and_profile(self):
+        client = Client(REPO, "test-workspace")
+        with patch.object(client, "run") as run:
+            client.apps("delete", NAME, "--auto-approve")
+        self.assertEqual(
+            run.call_args.args[0],
+            [
+                "databricks",
+                "apps",
+                "delete",
+                NAME,
+                "--auto-approve",
+                "--profile",
+                "test-workspace",
+                "--output",
+                "json",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -16,6 +16,64 @@ when a PR changes the frontend (`web/`).
 3. A comment with the preview URL is posted on the PR and updated on each push.
 4. The app is deleted automatically when the PR is closed.
 
+## Hourly preview cleanup
+
+The **UI Preview Cleanup** workflow runs hourly at minute 43 and automatically
+deletes PR-preview apps when **the PR is merged OR the app is more than 24 hours
+old**, including apps for open PRs. Age is measured from the app's `create_time`,
+not the PR's age or the app's latest deployment. Merged PRs have no grace period.
+This is a lifecycle policy, not an inference that nobody is currently using the
+preview: local sessions/artifacts are ephemeral and are lost on deletion.
+
+Apps must match `omnigent-ui-preview-pr-<N>` and the exact PR URL in their
+description, have the expected per-app source directory, and have no attached
+resources. Unknown states, API errors, pending updates, in-progress deployments,
+and unfinished preview workflows retain the app until a later hourly run.
+Shared apps such as `omnigent-repro` and `omnigent-ui-preview-dev` are excluded.
+The existing immediate close-event cleanup is unchanged.
+
+The workflow uses the same Databricks secrets as UI Preview and starts scheduling
+after merge to the default branch. Each run uploads `preview-cleanup-report` for
+14 days. Manual dispatch also deletes by default; check **dry_run** to preview
+the selection, and optionally enter a PR number to limit the run to one app.
+No per-app approval or reviewer-activity confirmation is required.
+
+To preview the selection locally (requires authenticated `gh` and Databricks CLIs):
+
+```bash
+python .github/scripts/ui-preview/reconcile.py --profile YOUR_PROFILE
+```
+
+If `DATABRICKS_HOST` points elsewhere, unset it for this command so it cannot
+override the selected profile. The app creator identifies the deploying identity,
+not necessarily Otto; the report includes the linked PR's author. These apps have
+no dedicated Otto tag. For human-authored PRs, inspect who applied `ui-preview`
+in the PR timeline to attribute an Otto-triggered deployment.
+
+To apply the same policy locally to all PR previews:
+
+```bash
+python .github/scripts/ui-preview/reconcile.py --profile YOUR_PROFILE --apply
+```
+
+Use `--app omnigent-ui-preview-pr-123` to limit either mode to one app. The script
+rechecks app identity, PR state, and deployment activity immediately before
+deletion. Targeted workflow runs share the deployment's per-PR concurrency group;
+there is no atomic cross-service check-and-delete for the full sweep.
+
+The reconciler preserves workspace source directories and does not delete
+Lakebase/UC resources or modify PR comments. Stopping alone does not free an app
+slot. After deletion, check that `databricks apps get` reports the exact app
+missing, and rerun the previously blocked deployment. For an open PR whose
+preview expired, pushing a new commit while `ui-preview` remains applied
+recreates the app with a fresh 24-hour TTL.
+
+Test the safety checks without external access:
+
+```bash
+python -m unittest discover -s .github/scripts/ui-preview -p 'test_*.py' -v
+```
+
 ## Fork PR safety
 
 `ui-preview.yml` runs its build/deploy on `pull_request_target`, so the label is

--- a/.github/workflows/ui-preview-cleanup-test.yml
+++ b/.github/workflows/ui-preview-cleanup-test.yml
@@ -1,0 +1,27 @@
+name: UI Preview Cleanup Tests
+
+on:
+  pull_request:
+    paths:
+      - .github/scripts/ui-preview/**
+      - .github/workflows/ui-preview-cleanup*.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/scripts/ui-preview/**
+      - .github/workflows/ui-preview-cleanup*.yml
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+      - run: python -m unittest discover -s .github/scripts/ui-preview -p 'test_*.py' -v

--- a/.github/workflows/ui-preview-cleanup.yml
+++ b/.github/workflows/ui-preview-cleanup.yml
@@ -1,0 +1,71 @@
+name: UI Preview Cleanup
+
+on:
+  schedule:
+    - cron: '43 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Limit to one PR number (blank processes all PR previews)'
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report matching apps without deleting them'
+        type: boolean
+        default: false
+
+permissions: {}
+
+concurrency:
+  # A targeted cleanup shares the deployment workflow's per-PR lock.
+  group: ${{ inputs.pr_number && format('UI Preview-{0}', inputs.pr_number) || 'ui-preview-cleanup' }}
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+      - name: Install Databricks CLI
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/2260866f83a41a2df55e1cfe7ffe038b78325bf6/install.sh | sh
+      - name: Reconcile previews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
+          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+          DATABRICKS_AUTH_TYPE: oauth-m2m
+          PR_NUMBER: ${{ inputs.pr_number }}
+          APPLY: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+        run: |
+          set -euo pipefail
+          args=(--repo "$REPO" --report preview-cleanup-report.json)
+          if [[ -n "$PR_NUMBER" ]]; then
+            [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || { echo 'Invalid PR number'; exit 1; }
+            args+=(--app "omnigent-ui-preview-pr-$PR_NUMBER")
+          fi
+          if [[ "$APPLY" == true ]]; then
+            args+=(--apply)
+          fi
+          python .github/scripts/ui-preview/reconcile.py "${args[@]}"
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-cleanup-report
+          path: preview-cleanup-report.json
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## Related issue

N/A — Test / CI maintenance for ephemeral preview infrastructure.

## Summary

Old PR previews consume the Databricks workspace app quota and block new deployments.

- Run cleanup hourly at minute 43 using the existing preview workspace credentials. Delete only verified `omnigent-ui-preview-pr-<number>` apps when their PR is merged **or the app is older than 24 hours**, including open PRs.
- Require the matching repository/PR URL and expected source path; exclude shared apps, lookalike names, attached resources, and pending deployments. Recheck identity and activity immediately before deletion; preserve workspace source directories.
- Add a manual dry-run option, JSON audit artifacts, 27 unit tests, and a dedicated test workflow. Existing close-event cleanup remains unchanged.

ELI5: temporary PR previews get a one-day lifetime, and merged PRs no longer need a preview. Other apps are left alone.

```text
Hourly inventory
  -> exact UI PR-preview name + verified PR metadata
  -> PR merged OR app create_time older than 24 hours
  -> no attached resources / active deployment; recheck identity
  -> delete that app only + record result
```

## Test Plan

- `python -m unittest discover -s .github/scripts/ui-preview -p 'test_*.py' -v` — 27 tests pass on current main, covering merged/old/new previews, the exact TTL boundary, inventory exclusions, dry-run/apply, provenance checks, activity checks, API errors, and identity changes.
- Scoped pre-commit checks pass for all five changed files; workflow YAML and embedded shell syntax also pass.
- After merge: Actions → UI Preview Cleanup → Run workflow → check `dry_run`; inspect `preview-cleanup-report` and confirm it contains only eligible per-PR UI previews. Scheduled runs automatically apply the policy.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — infrastructure-only change; test evidence and verification steps above.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No live app deletion was performed for validation. Unit tests use fake API clients. Full sweeps recheck state but cannot atomically lock across GitHub and Databricks; targeted dispatches share the preview deployment's per-PR concurrency group. Deletion intentionally discards ephemeral local sessions/artifacts and is not a claim that a preview is unused.

## Changelog

N/A — CI maintenance.
