### PR TITLE
fix(host): prepare harness setup hints off the event loop

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -1596,12 +1596,14 @@ class HostProcess:
         if frame.harness is not None and not await asyncio.to_thread(
             harness_is_configured, frame.harness
         ):
+            # Remediation may probe the CLI too, so keep it off the loop.
+            setup_hint = await asyncio.to_thread(harness_setup_hint, frame.harness)
             return HostLaunchRunnerResultFrame(
                 request_id=frame.request_id,
                 status="failed",
                 error=(
                     f"harness {frame.harness!r} is not configured on host "
-                    f"{self._identity.name!r} — {harness_setup_hint(frame.harness)}"
+                    f"{self._identity.name!r} — {setup_hint}"
                 ),
                 error_code=HARNESS_NOT_CONFIGURED_ERROR_CODE,
             )

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5114,6 +5114,54 @@ async def test_launch_harness_probe_runs_off_the_event_loop(
     )
 
 
+async def test_launch_setup_hint_does_not_block_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A slow remediation probe must leave the host loop free to handle frames."""
+    host = _make_host_process()
+    loop = asyncio.get_running_loop()
+    loop_thread_id = threading.get_ident()
+    hint_started = asyncio.Event()
+    release_hint = threading.Event()
+    hint = "upgrade the harness CLI, then log in"
+
+    def _slow_hint(harness: str) -> str:
+        assert harness == "cursor-native"
+        loop.call_soon_threadsafe(hint_started.set)
+        assert threading.get_ident() != loop_thread_id
+        assert release_hint.wait(timeout=5), "event loop did not release the hint probe"
+        return hint
+
+    monkeypatch.setattr("omnigent.host.connect.harness_is_configured", lambda harness: False)
+    monkeypatch.setattr("omnigent.host.connect.harness_setup_hint", _slow_hint)
+    launch = asyncio.create_task(
+        host._handle_launch(
+            HostLaunchRunnerFrame(
+                request_id="req_hint_probe",
+                binding_token="token_abc",
+                workspace=str(tmp_path),
+                harness="cursor-native",
+            )
+        )
+    )
+    try:
+        await asyncio.wait_for(hint_started.wait(), timeout=2)
+        assert not launch.done()
+    finally:
+        release_hint.set()
+        result = await launch
+
+    assert result.request_id == "req_hint_probe"
+    assert result.status == "failed"
+    assert result.error_code == HARNESS_NOT_CONFIGURED_ERROR_CODE
+    assert hint in (result.error or "")
+    assert "cursor-native" in (result.error or "")
+    assert "test-laptop" in (result.error or "")
+    assert result.runner_id is None
+    assert host._runners == {}
+
+
 async def test_fatal_upgrade_error_surfaces_server_refusal_body() -> None:
     """A refusal that carries a body (what ``_refuse_upgrade`` sends, e.g. the
     server's malformed-host-id 400) is surfaced verbatim — the client passes the


### PR DESCRIPTION
## Related issue

Closes #6452

## Summary

Run `harness_setup_hint()` through `asyncio.to_thread()` after a failed readiness check. If remediation probes a slow CLI, the host event loop can continue processing frames while the launch waits for its error message. The refusal code and hint text are preserved.

Scope clarification: at base `293b5aa7`, main's hint formatter does not itself probe CLI versions. The pending #6449 change adds that probe. This PR protects the shared async caller independently, without changing readiness APIs or the formatter.

## Test Plan

- Added a blocked-hint regression that verifies worker-thread execution, event-loop progress before the hint completes, and the structured refusal without spawning a runner. It fails with the original inline call and passes with this change.
- `python -m pytest tests/host/test_connect.py tests/onboarding/test_harness_install.py -q -k 'not model_options'`: **293 passed**.
- The model-options tests have **5 failures and 6 passes on unchanged main** in this environment. The same five failures appeared during the broader modified-tree runs.
- Staged `pre-commit run`: formatting, lint, and applicable hygiene checks passed. Pyrefly reports **101 identical diagnostics on both unchanged main and this branch**, including missing optional dependencies and SDK import resolution errors in the existing local environment. No new type-check diagnostics.

## Demo

N/A for visual media. The blocked-hint regression above provides non-visual evidence.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable: no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression injects a blocking hint implementation at the async caller boundary. Existing tests exercise the real formatter and configured, unconfigured, and legacy no-harness launch paths. This does not claim a live CLI hang reproduction on current main.

## Changelog

Keep the host responsive while preparing setup guidance for a harness that cannot launch.
