### PR TITLE
fix(cursor): deliver transcript before parent completion

### DIFF
--- a/omnigent/cursor_native_forwarder.py
+++ b/omnigent/cursor_native_forwarder.py
@@ -929,6 +929,12 @@ async def forward_cursor_store_to_session(
     ) as client:
         while True:
             try:
+                # Snapshot completion before reading its transcript. A turn
+                # finishing during this poll must wait for the next read.
+                total_turn_ends = await asyncio.to_thread(
+                    cursor_native_status.count_turn_ends, bridge_dir
+                )
+                retrying_items = False
                 if store_path is None or not store_path.exists():
                     # On cold resume the runner pre-seeds the bridge state with
                     # the known store path (see ``preseed_resume_state``), so we
@@ -1102,6 +1108,7 @@ async def forward_cursor_store_to_session(
                                                 item.rowid,
                                                 failed_attempts,
                                             )
+                                            retrying_items = True
                                             break  # retry this item before any after it
                                         _logger.error(
                                             "cursor forwarder dropping item after %s "
@@ -1125,6 +1132,7 @@ async def forward_cursor_store_to_session(
                                             item.rowid,
                                             exc_info=True,
                                         )
+                                        retrying_items = True
                                         break
                             # Reached on a successful post, an ambiguous-delivery
                             # skip, a quarantine, or a non-posted sentinel row:
@@ -1171,10 +1179,7 @@ async def forward_cursor_store_to_session(
                 # supervisor restart never re-wakes the parent for a turn it
                 # already reported. Best-effort: a failed post leaves the count
                 # unadvanced so the next poll retries.
-                total_turn_ends = await asyncio.to_thread(
-                    cursor_native_status.count_turn_ends, bridge_dir
-                )
-                if total_turn_ends > await asyncio.to_thread(
+                if not retrying_items and total_turn_ends > await asyncio.to_thread(
                     cursor_native_status.read_posted_count, bridge_dir
                 ):
                     await _post_external_session_status(

--- a/tests/test_cursor_native_status.py
+++ b/tests/test_cursor_native_status.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 from pathlib import Path
 
+import httpx
 import pytest
 
 from omnigent import cursor_native_forwarder as fwd
@@ -228,3 +230,78 @@ async def test_idle_restart_safe_does_not_rewake(tmp_path: Path, monkeypatch) ->
         await asyncio.gather(task, return_exceptions=True)
     assert recorder.statuses == []
     assert status.read_posted_count(bridge) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("race", ["finishes_after_read", "rejected_item", "connection_error"])
+async def test_completion_waits_for_final_reply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, race: str
+) -> None:
+    """The parent's completion must follow delivery of the child's final reply."""
+    bridge = tmp_path / "bridge"
+    store = tmp_path / "store.db"
+    with sqlite3.connect(store) as db:
+        db.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+
+    def finish_turn() -> None:
+        reply = {"role": "assistant", "content": [{"type": "text", "text": "pwd: /workspace"}]}
+        with sqlite3.connect(store) as db:
+            db.execute("INSERT INTO blobs VALUES (?, ?)", ("reply", json.dumps(reply)))
+        status.record_turn_end(bridge)
+
+    if race != "finishes_after_read":
+        finish_turn()
+    read_items = fwd._read_new_items
+    first_read = True
+
+    def read_then_finish(*args):
+        nonlocal first_read
+        items = read_items(*args)
+        if first_read and race == "finishes_after_read":
+            finish_turn()
+        first_read = False
+        return items
+
+    delivered: list[str] = []
+    attempts = 0
+
+    async def post_item(client, *, session_id, item):
+        nonlocal attempts
+        attempts += 1
+        if race == "rejected_item" and attempts == 1:
+            response = httpx.Response(503, request=httpx.Request("POST", "http://test/events"))
+            response.raise_for_status()
+        if race == "connection_error" and attempts == 1:
+            raise httpx.ConnectError("connection refused")
+        delivered.append(item.item_data["content"][0]["text"])
+
+    async def post_status(client, *, session_id, status):
+        delivered.append(status)
+
+    async def ignore_patch(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(fwd, "_discover_store", lambda *args: store)
+    monkeypatch.setattr(fwd, "_read_new_items", read_then_finish)
+    monkeypatch.setattr(fwd, "_read_last_used_model", lambda path: None)
+    monkeypatch.setattr(fwd, "_patch_external_session_id", ignore_patch)
+    monkeypatch.setattr(fwd, "_post_conversation_item", post_item)
+    monkeypatch.setattr(fwd, "_post_external_session_status", post_status)
+    task = asyncio.create_task(
+        fwd.forward_cursor_store_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="child",
+            bridge_dir=bridge,
+            agent_name="cursor-native-ui",
+            workspace=str(tmp_path),
+            launch_epoch_ms=1000,
+            poll_interval_s=0.001,
+        )
+    )
+    try:
+        await _wait_until(lambda: status.read_posted_count(bridge) == 1)
+        assert delivered == ["pwd: /workspace", "idle"]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)


### PR DESCRIPTION
## Related issue

Refs #5677. Fixes a reproduced empty-output delivery race; the original Cursor CLI tool-use report still needs live verification.

## Summary

Cursor can finish a turn between the forwarder's transcript read and stop-marker read. The parent then receives completion before the final reply is mirrored and sees an empty output. A rejected or unreachable transcript POST has the same effect because completion currently proceeds while the item waits for retry.

Read completion markers before the transcript and defer completion while transcript items are awaiting retry. Existing bounded rejection handling and approval behavior stay intact.

ELI5: deliver the child's answer before telling its parent that the answer is ready.

```text
Read stop markers -> read transcript -> deliver items -> notify parent
                                          |
                                     retry needed
                                          |
                                     next poll
```

## Test Plan

- All three new cases fail on unchanged `main`: completion after a transcript snapshot, HTTP 503 on the final reply, and a connection failure on the final reply.
- `python -m pytest tests/test_cursor_native_status.py tests/test_cursor_native_forwarder.py tests/test_cursor_native_permissions.py -q`: 134 passed.
- `python -m pre_commit run`: formatting, lint, and file checks passed. Pyrefly reports the same 101 errors as unchanged `main` in this environment, with no added errors.
- For live confirmation, send a Cursor child a prompt to run `pwd` and report its output. Confirm that the parent receives the final reply before completion, including after a transient transcript POST failure.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable, no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regressions run the real forwarder loop and SQLite transcript reader with controlled completion timing and mocked HTTP delivery. An authenticated Cursor CLI was unavailable, so this does not claim to resolve every tool execution or approval failure in the report.

## Changelog

Cursor subagents wait for pending transcript delivery before notifying their parent that a turn is complete.
