### PR TITLE
fix(sessions): correct stale status in sys_session_get_info

### DIFF
--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -4514,11 +4514,10 @@ async def _session_get_info_via_rest(
     reasoning effort, effective model,
     parent linkage, workspace / git branch, persisted last-activity time,
     and the outstanding approval prompts (the prompts themselves plus a
-    count). Runner connectivity
-    is resolved best-effort via
-    ``GET /v1/runners/{id}/status`` (``runner_online`` is ``None`` when
-    the lookup fails or no runner is bound); host readiness is likewise
-    best-effort via ``GET /v1/hosts/{id}``. The full transcript is
+    count). Runner connectivity comes from the authorized session snapshot,
+    including liveness persisted by other server replicas. Missing liveness
+    remains unknown; host readiness is best-effort via ``GET /v1/hosts/{id}``.
+    The full transcript is
     intentionally omitted — that is what ``sys_session_get_history`` returns.
 
     Maps a 404 to ``session_not_found`` and 401/403 to ``access_denied``
@@ -4539,7 +4538,7 @@ async def _session_get_info_via_rest(
     try:
         resp = await server_client.get(
             f"/v1/sessions/{raw_target}",
-            params={"include_items": "false", "include_liveness": "false"},
+            params={"include_items": "false", "include_liveness": "true"},
             timeout=30.0,
         )
     except Exception as exc:  # noqa: BLE001
@@ -4553,17 +4552,33 @@ async def _session_get_info_via_rest(
     snap: _JsonObject = resp.json()
     pending_value = snap.get("pending_elicitations")
     pending = pending_value if isinstance(pending_value, list) else []
-    snap_agent_name = _optional_string(snap.get("agent_name"))
-    snap_runner_id = _optional_string(snap.get("runner_id"))
-    snap_host_id = _optional_string(snap.get("host_id"))
-    runner_online, configured_harnesses = await asyncio.gather(
-        _runner_online_or_none(snap_runner_id, server_client),
-        _host_harnesses_or_none(snap_host_id, server_client),
+    closed = is_session_closed(
+        _string_mapping(snap.get("labels")), _optional_string(snap.get("title"))
     )
+    snap_agent_name = _optional_string(snap.get("agent_name"))
+    snap_host_id = _optional_string(snap.get("host_id"))
+    snapshot_online = snap.get("runner_online")
+    runner_online = snapshot_online if isinstance(snapshot_online, bool) else None
+    configured_harnesses = await _host_harnesses_or_none(snap_host_id, server_client)
+    status = snap.get("status")
+    status_reason: str | None = None
+    # An unclean runner death can leave the server's cached status unchanged.
+    # Reconcile this read without persisting a failure during a reconnect gap.
+    if closed:
+        status_reason = "Session is closed."
+        if status in ("running", "waiting"):
+            status = "idle"
+    elif runner_online is False and status in ("running", "waiting"):
+        status = "failed"
+        status_reason = "Runner is offline; current execution cannot be confirmed."
+    if closed or runner_online is False:
+        pending = []
     return json.dumps(
         {
             "session_id": snap.get("id"),
-            "status": snap.get("status"),
+            "status": status,
+            "status_reason": status_reason,
+            "closed": closed,
             # Persisted conversation activity is distinct from lifecycle
             # status: repeated polls with an unchanged value let an
             # orchestrator detect a running session that is not advancing.

--- a/omnigent/tools/builtins/spawn.py
+++ b/omnigent/tools/builtins/spawn.py
@@ -667,8 +667,8 @@ class SysSessionGetInfoTool(Tool):
     session is described.
 
     Runner-dispatched: the runner proxies ``GET /v1/sessions/{id}``
-    (plus best-effort runner status and host readiness lookups) and projects
-    the result. Returns
+    with session liveness (plus a best-effort host readiness lookup) and
+    projects the result. Returns
     ``session_not_found`` when the id is unknown and ``access_denied``
     when the server refuses the read.
     """
@@ -687,9 +687,12 @@ class SysSessionGetInfoTool(Tool):
             "host + configured harness readiness, reasoning effort, model, "
             "parent session, workspace, "
             "persisted last-activity time, and outstanding approval "
-            "prompts. Global read — any "
+            "prompts. Includes closed and status_reason: an offline runner "
+            "changes an active status to failed, and closed sessions cannot "
+            "report running or waiting. Unknown connectivity preserves the "
+            "reported status. Global read, any "
             "session you can access. Pass session_id to target another "
-            "session; omit it to describe your own. Metadata only — "
+            "session; omit it to describe your own. Metadata only, "
             "use sys_session_get_history for the conversation transcript."
         )
 

--- a/tests/runner/test_runner_dispatch.py
+++ b/tests/runner/test_runner_dispatch.py
@@ -7943,15 +7943,14 @@ async def test_sys_session_share_public_allows_public_grant() -> None:
 async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() -> None:
     """
     ``sys_session_get_info`` projects ``GET /v1/sessions/{id}`` metadata
-    and folds in live runner connectivity from ``GET
-    /v1/runners/{id}/status`` and host harness readiness from ``GET
-    /v1/hosts/{id}``.
+    including session liveness and host harness readiness from
+    ``GET /v1/hosts/{id}``.
 
     Proves the full runner-dispatch path: read the session snapshot,
     derive the effective model (a per-session ``model_override`` wins
     over the spec's ``llm_model``), count pending approval prompts, and
     attach ``runner_online``. If the projection regressed (dropped a
-    field, skipped the runner-status call, or picked the wrong model),
+    field, skipped session liveness, or picked the wrong model),
     the asserted values would differ. The transcript is intentionally
     absent — get_info is metadata-only (``sys_session_get_history`` returns
     items).
@@ -7961,7 +7960,7 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     async def _server_handler(request: httpx.Request) -> httpx.Response:
         if request.method == "GET" and request.url.path == "/v1/sessions/conv_target":
             assert request.url.params["include_items"] == "false"
-            assert request.url.params["include_liveness"] == "false"
+            assert request.url.params["include_liveness"] == "true"
             return httpx.Response(
                 200,
                 json={
@@ -7973,6 +7972,7 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
                     "updated_at": 84,
                     "title": "auth flow",
                     "runner_id": "runner_1",
+                    "runner_online": True,
                     "host_id": "host_1",
                     "reasoning_effort": "high",
                     "parent_session_id": "conv_parent",
@@ -7984,8 +7984,6 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
                     "pending_elicitations": [{"id": "el_1"}, {"id": "el_2"}],
                 },
             )
-        if request.method == "GET" and request.url.path == "/v1/runners/runner_1/status":
-            return httpx.Response(200, json={"runner_id": "runner_1", "online": True})
         if request.method == "GET" and request.url.path == "/v1/hosts/host_1":
             return httpx.Response(
                 200,
@@ -8012,8 +8010,7 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     assert info["agent_id"] == "ag_xyz"
     assert info["agent_name"] == "researcher"
     assert info["runner_id"] == "runner_1"
-    # Live connectivity folded in from the runners status endpoint —
-    # None here would mean the best-effort status call was skipped.
+    # Session liveness includes runners connected to another replica.
     assert info["runner_online"] is True
     assert info["host_id"] == "host_1"
     assert info["configured_harnesses"] == {
@@ -8033,6 +8030,121 @@ async def test_sys_session_get_info_projects_metadata_and_runner_connectivity() 
     assert info["pending_elicitations"] == [{"id": "el_1"}, {"id": "el_2"}]
     # Metadata-only: the full transcript is never embedded.
     assert "items" not in info
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stored_status,online,closed_marker,expected_status",
+    [
+        ("running", False, None, "failed"),
+        ("waiting", False, None, "failed"),
+        ("running", True, "label", "idle"),
+        ("running", False, "label", "idle"),
+        ("waiting", None, "label", "idle"),
+        ("running", True, "title", "idle"),
+        ("failed", False, "label", "failed"),
+    ],
+)
+async def test_sys_session_get_info_reconciles_inactive_sessions(
+    stored_status: str,
+    online: bool | None,
+    closed_marker: str | None,
+    expected_status: str,
+) -> None:
+    """Stale cached status and prompts must not imply a dead child is executing."""
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/sessions/child":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "child",
+                    "status": stored_status,
+                    "runner_id": "runner_1",
+                    "runner_online": online,
+                    "title": "worker:task:closed:child" if closed_marker == "title" else "task",
+                    "labels": {"omnigent.closed": "true"} if closed_marker == "label" else {},
+                    "pending_elicitations": [{"id": "stale_approval"}],
+                },
+            )
+        assert request.url.path == "/v1/runners/runner_1/status"
+        return httpx.Response(200, json={"online": online})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        info = json.loads(
+            await execute_tool(
+                tool_name="sys_session_get_info",
+                arguments='{"session_id": "child"}',
+                server_client=client,
+                conversation_id="parent",
+            )
+        )
+
+    assert info["status"] == expected_status
+    assert info["closed"] is (closed_marker is not None)
+    assert info["runner_online"] is online
+    assert info["status_reason"]
+    assert info["pending_elicitations"] == []
+    assert info["pending_elicitation_count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stored_status,snapshot_online,expected_online",
+    [
+        ("running", True, True),
+        ("waiting", True, True),
+        ("idle", False, False),
+        ("failed", False, False),
+        ("running", None, None),
+        ("running", "false", None),
+        ("running", [], None),
+    ],
+)
+async def test_sys_session_get_info_preserves_status_without_confirmed_interruption(
+    stored_status: str, snapshot_online: object, expected_online: bool | None
+) -> None:
+    from omnigent.runner.tool_dispatch import execute_tool
+
+    requested_paths: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        if request.url.path == "/v1/sessions/child":
+            return httpx.Response(
+                200,
+                json={
+                    "id": "child",
+                    "status": stored_status,
+                    "runner_id": "runner_1",
+                    "runner_online": snapshot_online,
+                    "pending_elicitations": [{"id": "approval"}],
+                },
+            )
+        assert request.url.path == "/v1/runners/runner_1/status"
+        # A different replica or a shared session's runner can be hidden here.
+        return httpx.Response(200, json={"online": False})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://server"
+    ) as client:
+        info = json.loads(
+            await execute_tool(
+                tool_name="sys_session_get_info",
+                arguments='{"session_id": "child"}',
+                server_client=client,
+                conversation_id="parent",
+            )
+        )
+
+    assert info["status"] == stored_status
+    assert info["runner_online"] is expected_online
+    assert requested_paths == ["/v1/sessions/child"]
+    if expected_online is not False:
+        assert info["pending_elicitations"] == [{"id": "approval"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Refs #4838. Addresses its independent stale-status invariant in `sys_session_get_info`. Automatic adoption and resumption of interrupted children remain open.

## Summary

After an unclean runner death or `sys_session_close`, `sys_session_get_info` can keep reporting cached `running` status and stale approval prompts. Reconcile the tool response with the session's liveness and closed markers, and return `closed` plus an explanatory `status_reason`.

Use the authorized session snapshot's liveness instead of the runner-status endpoint, which can report offline for a runner connected to another replica or hidden from a shared-session reader. Confirmed offline active sessions report `failed`; closed active sessions report `idle` with `closed: true`. Existing terminal states and unknown connectivity preserve their status. This is a read-time projection, so reconnecting does not require clearing a newly persisted failure.

ELI5: check whether the worker is reachable and the task is still open before repeating an old "working" sign.

```text
Session snapshot with liveness
  -> closed?           report closed, clear active status and stale prompts
  -> offline + active? report failed with a reason, clear stale prompts
  -> otherwise         preserve status
```

## Test Plan

- All 14 added regression cases fail on unchanged `main`.
- Session-tool tests plus the existing server tests for strict liveness, single-session liveness, and fresh runner stamps on other replicas: 79 passed.
- Reproduce with:
  ```bash
  python -m pytest tests/runner/test_runner_dispatch.py tests/tools/builtins/test_spawn.py tests/server/test_app.py -k 'sys_session or SysSession or health_batch_reports_strict_runner_and_host_liveness or health_single_session_reports_both_liveness_fields or health_derives_runner_online_from_fresh_row_stamp' -q
  ```
- `python -m pre_commit run`: formatting, lint, and file checks passed. Pyrefly reports the same 101 errors as unchanged `main` in this environment, with no added errors.
- Manual confirmation: poll an interrupted child after session liveness becomes offline. Expect `failed` and an offline explanation. Close an active child and poll again. Expect `closed: true`, an inactive status, and zero pending approval prompts. A live child on another replica should continue reporting `running`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable, no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests exercise the public tool dispatcher with controlled server snapshots, including legacy closed titles, unknown liveness, and live runners that the runner-status endpoint would hide. Existing server tests validate the liveness source across replicas. This does not change the REST snapshot's status, runner recovery policy, or resume interrupted native CLI turns.

## Changelog

Session info no longer reports closed or confirmed offline children as running, and explains why their status changed.
