### PR TITLE
fix(web): keep composer popovers below the session header

### DIFF
--- a/web/src/components/FileMentionMenu.tsx
+++ b/web/src/components/FileMentionMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { FileTextIcon, FolderIcon, PlusIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
+import { COMPOSER_POPOVER_MAX_H, COMPOSER_POPOVER_Z } from "@/pages/chatLayout";
 
 interface FileMentionMenuProps {
   /** Directory currently being browsed ("" = workspace root). */
@@ -45,7 +46,9 @@ export function FileMentionMenu({
   if (entries.length === 0 && !loading) return null;
 
   return (
-    <div className="absolute bottom-full left-0 z-10 mb-2 flex items-end gap-2">
+    <div
+      className={cn("absolute bottom-full left-0 mb-2 flex items-end gap-2", COMPOSER_POPOVER_Z)}
+    >
       <div className="w-80 max-w-[calc(100vw-2rem)] shrink-0 overflow-hidden rounded-[12px] border border-border bg-popover p-2 shadow-menu">
         <div className="flex items-center justify-between gap-2 px-1.5 py-1 text-sm font-medium text-muted-foreground">
           <span className="truncate">{currentDir ? `/${currentDir}` : "Workspace"}</span>
@@ -54,7 +57,11 @@ export function FileMentionMenu({
         {entries.length === 0 && loading ? (
           <div className="px-1.5 py-1 text-ui text-muted-foreground">Loading…</div>
         ) : (
-          <div ref={listRef} role="listbox" className="max-h-80 overflow-y-auto">
+          <div
+            ref={listRef}
+            role="listbox"
+            className={cn(COMPOSER_POPOVER_MAX_H, "overflow-y-auto")}
+          >
             {entries.map((entry, i) => {
               const isDir = entry.type === "directory";
               return (

--- a/web/src/components/SlashCommandMenu.tsx
+++ b/web/src/components/SlashCommandMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { CommandIcon, WandSparklesIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { COMPOSER_POPOVER_MAX_H, COMPOSER_POPOVER_Z } from "@/pages/chatLayout";
 
 /**
  * Built-in slash commands the web UI recognises directly. Each entry
@@ -200,9 +201,11 @@ export function SlashCommandMenu({
   );
 
   return (
-    <div className="absolute bottom-full left-0 z-10 mb-2 flex items-end gap-2">
+    <div
+      className={cn("absolute bottom-full left-0 mb-2 flex items-end gap-2", COMPOSER_POPOVER_Z)}
+    >
       <div className="w-64 shrink-0 overflow-hidden rounded-[12px] border border-border bg-popover p-2 shadow-menu">
-        <div ref={listRef} className="max-h-80 overflow-y-auto">
+        <div ref={listRef} className={cn(COMPOSER_POPOVER_MAX_H, "overflow-y-auto")}>
           {builtinRows.length > 0 && sectionHeader("Commands")}
           {builtinRows.map((row) => (
             <MenuRowButton
@@ -229,7 +232,10 @@ export function SlashCommandMenu({
       {active && (
         <div
           data-testid="slash-menu-detail"
-          className="hidden max-h-80 w-80 shrink-0 overflow-y-auto rounded-[12px] border border-border bg-popover p-2 shadow-menu md:block"
+          className={cn(
+            "hidden w-80 shrink-0 overflow-y-auto rounded-[12px] border border-border bg-popover p-2 shadow-menu md:block",
+            COMPOSER_POPOVER_MAX_H,
+          )}
         >
           <p className="font-mono text-sm font-medium text-foreground">{active.name}</p>
           <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -376,6 +376,7 @@ describe("Composer slash-command menu", () => {
     // Built-ins are inserted first, so "/compact" tops the list and is the
     // default highlight — the crux of the fix (was -1 / nothing selected).
     expect(activeRow()?.textContent).toContain("/compact");
+    expect(activeRow()?.closest(".absolute")).toHaveClass("z-20");
   });
 
   it("Tab completes the highlighted skill into the textarea", () => {
@@ -611,7 +612,7 @@ describe("Composer slash-command submit routing", () => {
     const output = screen.getByTestId("composer-command-output");
     expect(output).toHaveTextContent("/help — Show available slash commands");
     expect(output).toHaveTextContent("/deslop — Remove AI slop");
-    expect(output).toHaveClass("absolute", "max-h-64", "overflow-y-auto");
+    expect(output).toHaveClass("absolute", "z-20", "overflow-y-auto");
     expect(ta.value).toBe("");
     expect(output.parentElement).toHaveAttribute("data-composer-card");
   });

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -599,6 +599,23 @@ describe("Composer slash-command submit routing", () => {
     expect(onSend).toHaveBeenCalledWith("/not-a-real-skill", undefined);
   });
 
+  it("floats /help output above the composer in a capped scroll panel", () => {
+    // Long skill blurbs used to dump into the composer card and grow it
+    // under the ChatHeader overlay. The listing must float, stay capped,
+    // and scroll leftovers instead of stretching the card.
+    render(<Composer {...composerProps({ onSendSlashCommand: vi.fn() })} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "/help" } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    const output = screen.getByTestId("composer-command-output");
+    expect(output).toHaveTextContent("/help — Show available slash commands");
+    expect(output).toHaveTextContent("/deslop — Remove AI slop");
+    expect(output).toHaveClass("absolute", "max-h-64", "overflow-y-auto");
+    expect(ta.value).toBe("");
+    expect(output.parentElement).toHaveAttribute("data-composer-card");
+  });
+
   it("treats /effort as plaintext when effort controls are hidden", () => {
     const onSend = vi.fn();
     const onSendSlashCommand = vi.fn();

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -617,6 +617,21 @@ describe("Composer slash-command submit routing", () => {
     expect(output.parentElement).toHaveAttribute("data-composer-card");
   });
 
+  it("floats the bare /model hint in the popover band and clears the draft", () => {
+    // Same band as /help — the "/model" draft must not linger in the
+    // textarea under the floating usage hint (matches /help and /context).
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    // Trailing space closes the slash menu so Enter submits (see /model tests).
+    fireEvent.change(ta, { target: { value: "/model " } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    const output = screen.getByTestId("composer-command-output");
+    expect(output).toHaveTextContent("Usage: /model <name> · /model default to reset");
+    expect(output).toHaveClass("absolute", "z-20");
+    expect(ta.value).toBe("");
+  });
+
   it("treats /effort as plaintext when effort controls are hidden", () => {
     const onSend = vi.fn();
     const onSendSlashCommand = vi.fn();

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -226,7 +226,7 @@ import { GoalControl, GoalStatusPill, useGoalState, type Goal } from "@/componen
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { ConnectionIndicator } from "./ChatIndicators";
-import { CHAT_COLUMN_WIDTH } from "./chatLayout";
+import { CHAT_COLUMN_WIDTH, COMPOSER_POPOVER_MAX_H, COMPOSER_POPOVER_Z } from "./chatLayout";
 import { Transcript } from "@/components/chat/Transcript";
 
 /** Server-info as consumers see it: the probe's result, or "loading". */
@@ -2437,7 +2437,8 @@ export function BackgroundTaskPill() {
             style={box ? { width: box.width, height: box.height } : undefined}
             className={cn(
               "absolute bottom-0 left-0 overflow-hidden rounded-2xl bg-card text-sm shadow-sm ring-1 ring-border transition-[width,height,box-shadow] duration-200 ease-out",
-              showCard && "z-10 shadow-menu",
+              showCard &&
+                cn(COMPOSER_POPOVER_Z, COMPOSER_POPOVER_MAX_H, "overflow-y-auto shadow-menu"),
             )}
           >
             <div
@@ -3461,13 +3462,17 @@ function ComposerImpl({
             commands={slashCommands}
           />
         )}
-        {/* Float command output so a long /help listing cannot grow the card
-            up into the ChatHeader overlay (absolute z-30, unpainted). */}
+        {/* /help, /context, and command errors share the composer popover
+            band so they cannot grow into the ChatHeader overlay. */}
         {commandError !== null && (
           <div
             data-testid="composer-command-output"
             role="status"
-            className="absolute inset-x-0 bottom-full z-20 mb-2 max-h-64 overflow-y-auto overscroll-contain rounded-[12px] border border-border bg-popover px-3 py-2 shadow-menu"
+            className={cn(
+              "absolute inset-x-0 bottom-full mb-2 overflow-y-auto overscroll-contain rounded-[12px] border border-border bg-popover px-3 py-2 shadow-menu",
+              COMPOSER_POPOVER_Z,
+              COMPOSER_POPOVER_MAX_H,
+            )}
           >
             <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-muted-foreground">
               {commandError}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2978,6 +2978,8 @@ function ComposerImpl({
           const current = sessionModelOverride
             ? `${sessionModelOverride} (override)`
             : (llmModel ?? "agent default");
+          dirtyRef.current = true;
+          setValue("");
           setCommandError(`Model: ${current}\nUsage: /model <name> · /model default to reset`);
           return true;
         }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3025,11 +3025,15 @@ function ComposerImpl({
           lines.push("No usage data yet — send a message first.");
         }
         lines.push(`Items in context: ${blocks.length}`);
+        dirtyRef.current = true;
+        setValue("");
         setCommandError(lines.join("\n"));
         return true;
       }
       case "/help": {
         const lines = Object.entries(slashCommands).map(([name, desc]) => `${name} — ${desc}`);
+        dirtyRef.current = true;
+        setValue("");
         setCommandError(lines.join("\n"));
         return true;
       }
@@ -3457,6 +3461,19 @@ function ComposerImpl({
             commands={slashCommands}
           />
         )}
+        {/* Float command output so a long /help listing cannot grow the card
+            up into the ChatHeader overlay (absolute z-30, unpainted). */}
+        {commandError !== null && (
+          <div
+            data-testid="composer-command-output"
+            role="status"
+            className="absolute inset-x-0 bottom-full z-20 mb-2 max-h-64 overflow-y-auto overscroll-contain rounded-[12px] border border-border bg-popover px-3 py-2 shadow-menu"
+          >
+            <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-muted-foreground">
+              {commandError}
+            </p>
+          </div>
+        )}
         {/* "@"-file-mention browser — native coding-agent sessions only.
             Also shown (as a loading row) while the listing is still fetching,
             so "@" isn't silently dead during runner cold-boot or a drill-in. */}
@@ -3662,12 +3679,6 @@ function ComposerImpl({
                 </button>
               </span>
             ))}
-          </div>
-        )}
-        {/* Inline slash-command feedback: errors and /help output */}
-        {commandError !== null && (
-          <div className="px-4 pb-2 text-sm text-muted-foreground whitespace-pre-wrap">
-            {commandError}
           </div>
         )}
         <div className="flex items-center justify-between gap-2 px-2 pb-2">

--- a/web/src/pages/chatLayout.ts
+++ b/web/src/pages/chatLayout.ts
@@ -8,5 +8,10 @@ export const CHAT_COLUMN_WIDTH =
  */
 export const COMPOSER_POPOVER_Z = "z-20";
 
-/** 16rem, or whatever still fits under the header + composer on a short window. */
-export const COMPOSER_POPOVER_MAX_H = "max-h-[min(16rem,calc(100svh-14rem))]";
+/**
+ * Cap at the `max-h-64` step of the spacing scale; on short windows shrink to
+ * what fits above the composer card: viewport minus the header band
+ * (`--omnigent-header-height`) minus the card + gap (~10.5rem).
+ */
+export const COMPOSER_POPOVER_MAX_H =
+  "max-h-[min(--spacing(64),calc(100svh_-_var(--omnigent-header-height)_-_10.5rem))]";

--- a/web/src/pages/chatLayout.ts
+++ b/web/src/pages/chatLayout.ts
@@ -1,2 +1,12 @@
 export const CHAT_COLUMN_WIDTH =
   "max-w-3xl min-[1921px]:max-w-4xl min-[2561px]:max-w-[clamp(64rem,40vw,100rem)]";
+
+/**
+ * Composer popovers grow upward (`bottom-full`) toward ChatHeader
+ * (`absolute z-30`, no paint). Stay in this band so they stack above the
+ * transcript but never enter the header box.
+ */
+export const COMPOSER_POPOVER_Z = "z-20";
+
+/** 16rem, or whatever still fits under the header + composer on a short window. */
+export const COMPOSER_POPOVER_MAX_H = "max-h-[min(16rem,calc(100svh-14rem))]";


### PR DESCRIPTION
## Related issue

Closes #6552

Found while running `/help` in a session with a long skill list.

## Summary

Composer popovers grow upward from the input toward a transparent ChatHeader (`z-30`, no paint). A long `/help` listing used to expand the composer card itself, so the title and header icons painted on top of the text. The same path exists for the slash menu, `@` mentions, and the background-task card.

Those surfaces now share one popover band (`z-20`) and scroll leftovers inside the panel. The height cap is expressed with tokens the app already owns: `--spacing(64)` (the `max-h-64` step of the spacing scale) for the preferred size, and `--omnigent-header-height` for the header band it must clear, so the cap adapts if either token changes. Bare `/model` now clears the draft before showing its usage hint, matching `/help` and `/context`.

One review note turned out to be a false positive: Tailwind 4 (locked 4.3.1) normalizes operator spacing inside `calc()`, so the repo-wide no-space form (`calc(100vw-2rem)` and this PR's `100svh` math) compiles to valid CSS with spaces inserted. Confirmed against the compiler and the production build output; nothing needed changing there.

## Test Plan

- `cd web && pnpm vitest run src/pages/ChatPage.composer.test.tsx -t "floats"` (plus `-t "highlights the first match"`)
- `pnpm type-check` and `pnpm lint` clean; `pre-commit run --files` passes on the changed files; `pnpm build` emits `max-height: min(calc(var(--spacing) * 64), calc(100svh - var(--omnigent-header-height) - 10.5rem))`
- Open a session with several skills
  - type `/` : slash menu stays above the composer and below the header
  - type `/help` and press Enter : listing is a short scrollable box, title and header icons stay readable
  - type `/model ` and press Enter : usage hint floats in the same band and the draft clears (unit-tested; same band as `/help`)
  - type `@` on a native session : mention list stays in the same band
  - hover an expanded background-task pill if one is running : card does not cover the header
  - leftover rows scroll inside each panel

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

### Before

The listing sat under the session title and header actions:

<img src="https://raw.githubusercontent.com/anxkhn/omnigent/pr-assets/web-help-overlay/pr-assets/before-header-icons-overlap.png" alt="Before: header icons overlapping the /help listing" width="720" />

### After

https://github.com/user-attachments/assets/9edaee73-effd-4a65-9731-b322ba5655d4

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests assert `/help` renders in a capped `z-20` panel, that the slash menu uses the same band, and that bare `/model` clears its draft while showing the usage hint. The `/model` draft-clearing change itself is covered by the unit test; the band behaviour was verified manually earlier with `/help` in a Copilot session with a long skill list, where the title and header icons stay readable. The five pre-existing `localStorage` failures in the "Composer send shortcut" block reproduce on the clean branch and are unrelated to this PR.

## Changelog

Composer popovers stay below the session header, and bare `/model` no longer leaves its draft in the composer

## Issues

Resolves [OMNI-6341](https://linear.app/omnigent/issue/OMNI-6341/bug-composer-help-listing-and-other-popovers-paint-under-the-session)
