### PR TITLE
ci(security): audit uv.lock independently of author trust

### DIFF
--- a/.github/scripts/security-scan/audit-uv-lock.sh
+++ b/.github/scripts/security-scan/audit-uv-lock.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+audit_dir=$(mktemp -d)
+trap 'rm -rf "$audit_dir"' EXIT
+
+# Export both compatible resolution sets; the antigravity extra conflicts with
+# protobuf constraints in the default set. Editable workspace packages are not
+# third-party dependencies and cannot be consumed by pip-audit.
+uv export --frozen --format requirements-txt \
+  --all-extras --no-extra antigravity --all-groups > "$audit_dir/full.txt"
+grep -v '^-e ' "$audit_dir/full.txt" > "$audit_dir/audit.txt"
+
+uv export --frozen --format requirements-txt \
+  --extra antigravity --extra all --no-default-groups > "$audit_dir/antigravity-full.txt"
+grep -v '^-e ' "$audit_dir/antigravity-full.txt" > "$audit_dir/antigravity-audit.txt"
+
+uvx pip-audit --requirement "$audit_dir/audit.txt" \
+  --no-deps --disable-pip --vulnerability-service osv
+uvx pip-audit --requirement "$audit_dir/antigravity-audit.txt" \
+  --no-deps --disable-pip --vulnerability-service osv

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,33 @@
+name: Dependency Audit
+
+on:
+  schedule:
+    - cron: "37 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-audit-main
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Python dependency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      UV_INDEX_URL: https://pypi.org/simple
+    steps:
+      - name: Check out main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v3
+
+      - name: Audit uv.lock
+        run: bash .github/scripts/security-scan/audit-uv-lock.sh

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,10 +15,9 @@ name: Security Scan
 # / uv sync / test). Detectors run fail-fast -- the first finding fails the job,
 # so a clean PR must pass every one.
 #
-# Trust tiers (should-scan.sh): trusted (OWNER/MEMBER/COLLABORATOR, or an author
-# in the MAINTAINERS list -- covers maintainers with private org membership) and
-# non-PR events aren't scanned; returning contributors are; first-timers are held
-# by GitHub's native fork-approval gate first.
+# Trust tiers (should-scan.sh) apply only to the static diff detectors. The
+# dependency audit runs whenever uv.lock changes, regardless of author or
+# skip-security-scan waiver.
 
 on:
   pull_request:
@@ -86,16 +85,28 @@ jobs:
           fi
           bash .github/scripts/security-scan/should-scan.sh
 
+      - name: Fetch changed files
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr diff "$PR" --repo "$REPO" --name-only > "$GITHUB_WORKSPACE/changed.txt"
+          echo "Changed files:"; cat "$GITHUB_WORKSPACE/changed.txt"
+          if grep -qxF 'uv.lock' "$GITHUB_WORKSPACE/changed.txt"; then
+            echo "uv_lock=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "uv_lock=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fetch PR diff
         if: ${{ steps.gate.outputs.scan == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-        run: |
-          gh pr diff "$PR" --repo "$REPO" > "$GITHUB_WORKSPACE/pr.diff"
-          gh pr diff "$PR" --repo "$REPO" --name-only > "$GITHUB_WORKSPACE/changed.txt"
-          echo "Changed files:"; cat "$GITHUB_WORKSPACE/changed.txt"
+        run: gh pr diff "$PR" --repo "$REPO" > "$GITHUB_WORKSPACE/pr.diff"
 
       - name: Secret scan (added lines)
         if: ${{ steps.gate.outputs.scan == 'true' }}
@@ -115,8 +126,8 @@ jobs:
           CHANGED_FILES: ${{ github.workspace }}/changed.txt
         run: bash .github/scripts/security-scan/sensitive-paths.sh
 
-      - name: Check out PR head for static analysis
-        if: ${{ steps.gate.outputs.scan == 'true' }}
+      - name: Check out PR head
+        if: ${{ steps.gate.outputs.scan == 'true' || steps.changes.outputs.uv_lock == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # untrusted: only statically scanned
@@ -131,46 +142,18 @@ jobs:
         run: python3 "$GITHUB_WORKSPACE/.github/scripts/security-scan/lint-workflow-misuse.py"
 
       - name: Install uv
-        if: ${{ steps.gate.outputs.scan == 'true' }}
+        if: ${{ steps.gate.outputs.scan == 'true' || steps.changes.outputs.uv_lock == 'true' }}
         uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v3
 
       - name: OSV advisory scan (uv.lock)
+        id: advisory
         # Checks every package version pinned in the PR's uv.lock against the
         # OSV advisory database, which covers known-malicious, typosquatted,
-        # and CVE-flagged versions. Only fires when uv.lock is in the changeset
-        # to avoid blocking PRs when main's baseline lockfile already has open
-        # advisories on main.
-        if: ${{ steps.gate.outputs.scan == 'true' }}
+        # and CVE-flagged versions. Author trust and the static-scan waiver do
+        # not bypass dependency auditing.
+        if: ${{ steps.changes.outputs.uv_lock == 'true' }}
         working-directory: pr
-        run: |
-          if ! grep -qxF 'uv.lock' "$GITHUB_WORKSPACE/changed.txt"; then
-            echo "uv.lock not changed; skipping OSV scan."
-            exit 0
-          fi
-          # Drop editable local packages (the project itself + sdks/*) before
-          # auditing. pip-audit can't hash an editable path requirement and
-          # errors out when one is present, so without this filter any PR that
-          # actually changes uv.lock fails here. We only want to audit
-          # third-party pinned packages anyway — OSV has no advisories for
-          # local source. Filtering all `-e` lines (rather than naming each
-          # workspace member) keeps this correct if members are added later.
-          # The project declares mutually exclusive extras (antigravity's
-          # protobuf>=7 conflicts with cwsandbox/modal/databricks and the lint
-          # group), so --all-extras alone exits 2 before pip-audit ever runs,
-          # blocking every gated downstream job for untrusted uv.lock PRs.
-          # Audit the full compatible resolution sets instead: everything
-          # except antigravity (with every dependency group, since
-          # default-groups is empty), then antigravity plus the `all` extra
-          # (which selects the locked databricks-sdk fork). Together they
-          # cover every registry package/version tuple in uv.lock.
-          uv export --frozen --format requirements-txt \
-            --all-extras --no-extra antigravity --all-groups > /tmp/uv-req-full.txt
-          grep -v '^-e ' /tmp/uv-req-full.txt > /tmp/uv-req.txt
-          uv export --frozen --format requirements-txt \
-            --extra antigravity --extra all --no-default-groups > /tmp/uv-req-antigravity.txt
-          grep -v '^-e ' /tmp/uv-req-antigravity.txt > /tmp/uv-req-ag.txt
-          uvx pip-audit --requirement /tmp/uv-req.txt --no-deps
-          uvx pip-audit --requirement /tmp/uv-req-ag.txt --no-deps
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/security-scan/audit-uv-lock.sh"
 
       - name: Semgrep (changed files, local rules)
         if: ${{ steps.gate.outputs.scan == 'true' }}
@@ -201,7 +184,7 @@ jobs:
       # itself the maintainer gate (see should-scan.sh). Applying it re-runs this
       # scan via the labeled trigger above.
       - name: Explain the maintainer waiver (on failure)
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.advisory.outcome != 'failure' }}
         run: |
           MSG="A maintainer can skip the Security Scan by applying the 'skip-security-scan' label (this requires Triage permission, so a fork author cannot self-waive). Applying the label re-runs this scan automatically."
           echo "::error::$MSG"

--- a/tests/scripts/test_dependency_audit.py
+++ b/tests/scripts/test_dependency_audit.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AUDIT_SCRIPT = REPO_ROOT / ".github/scripts/security-scan/audit-uv-lock.sh"
+PR_WORKFLOW = REPO_ROOT / ".github/workflows/security-scan.yml"
+SCHEDULED_WORKFLOW = REPO_ROOT / ".github/workflows/dependency-audit.yml"
+
+
+def _step(workflow: str, name: str) -> str:
+    marker = f"      - name: {name}\n"
+    start = workflow.index(marker)
+    end = workflow.find("\n      - name: ", start + len(marker))
+    return workflow[start:] if end == -1 else workflow[start:end]
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source)
+    path.chmod(0o755)
+
+
+def test_audit_exports_both_resolutions_and_filters_editables(tmp_path: Path) -> None:
+    calls = tmp_path / "calls"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "uv",
+        "#!/bin/sh\n"
+        'printf "uv %s\\n" "$*" >> "$AUDIT_CALLS"\n'
+        "printf '%s\\n' '-e .' 'safe-package==1.0'\n",
+    )
+    _write_executable(
+        bin_dir / "uvx",
+        "#!/bin/sh\n"
+        'printf "uvx %s\\n" "$*" >> "$AUDIT_CALLS"\n'
+        'requirements=""\n'
+        'while [ "$#" -gt 0 ]; do\n'
+        '  if [ "$1" = "--requirement" ]; then requirements="$2"; break; fi\n'
+        "  shift\n"
+        "done\n"
+        'grep -q "^-e " "$requirements" && exit 91\n'
+        'grep -q "^safe-package==1.0$" "$requirements"\n',
+    )
+    env = os.environ.copy()
+    env["AUDIT_CALLS"] = str(calls)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    subprocess.run(["bash", str(AUDIT_SCRIPT)], cwd=tmp_path, env=env, check=True)
+
+    recorded = calls.read_text().splitlines()
+    assert len([line for line in recorded if line.startswith("uv export ")]) == 2
+    assert len([line for line in recorded if line.startswith("uvx pip-audit ")]) == 2
+    assert all(
+        "--no-deps --disable-pip --vulnerability-service osv" in line
+        for line in recorded
+        if line.startswith("uvx pip-audit ")
+    )
+    assert any("--no-extra antigravity --all-groups" in line for line in recorded)
+    assert any("--extra antigravity --extra all --no-default-groups" in line for line in recorded)
+
+
+def test_audit_propagates_pip_audit_failure(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "uv",
+        "#!/bin/sh\nprintf '%s\\n' 'vulnerable-package==1.0'\n",
+    )
+    _write_executable(bin_dir / "uvx", "#!/bin/sh\nexit 1\n")
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+
+    result = subprocess.run(["bash", str(AUDIT_SCRIPT)], cwd=tmp_path, env=env)
+
+    assert result.returncode == 1
+
+
+def test_pr_audit_is_independent_of_author_trust() -> None:
+    workflow = PR_WORKFLOW.read_text()
+
+    assert "if:" not in _step(workflow, "Fetch changed files")
+    assert "steps.changes.outputs.uv_lock == 'true'" in _step(workflow, "Check out PR head")
+    assert "steps.changes.outputs.uv_lock == 'true'" in _step(workflow, "Install uv")
+    advisory = _step(workflow, "OSV advisory scan (uv.lock)")
+    assert "if: ${{ steps.changes.outputs.uv_lock == 'true' }}" in advisory
+    assert "steps.gate.outputs.scan" not in advisory
+    assert "steps.advisory.outcome != 'failure'" in _step(
+        workflow, "Explain the maintainer waiver (on failure)"
+    )
+
+
+def test_main_has_a_scheduled_dependency_audit() -> None:
+    workflow = SCHEDULED_WORKFLOW.read_text()
+
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "ref: main" in _step(workflow, "Check out main")
+    assert "bash .github/scripts/security-scan/audit-uv-lock.sh" in workflow


### PR DESCRIPTION
## Related issue

N/A — Test / CI change.

## Summary

- Audit every PR that changes `uv.lock`, regardless of author trust or the `skip-security-scan` static-analysis waiver.
- Share one hardened audit script between PR checks and a daily main-branch audit. The script disables pip resolution for uv's hashed export and explicitly queries OSV.
- Add regression tests for workflow routing, both compatible resolution exports, editable-package filtering, and audit failure propagation.

ELI5: author trust answers “do we need to inspect this contributor's code?”, while a dependency advisory answers “is this pinned version vulnerable?” Those are separate questions, so the second check no longer inherits the first check's bypass.

```text
PR changes uv.lock ──> shared OSV audit <── daily main schedule
                              |
                     fails on live advisory

PR author trust ──> static diff scanners only
```

## Test Plan

- `.venv/bin/python -m pytest -q tests/scripts/test_dependency_audit.py` — 4 passed.
- `.venv/bin/pre-commit run --files .github/workflows/security-scan.yml .github/workflows/dependency-audit.yml .github/scripts/security-scan/audit-uv-lock.sh tests/scripts/test_dependency_audit.py` — passed.
- Live negative control against current main: the shared script reached OSV and exited 1 with 24 known vulnerabilities across `cryptography`, `gitpython`, `h2`, and `mlflow`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The live run verifies the extracted script bypasses pip resolution, reaches OSV, and turns the known vulnerable main lockfile into a failing audit. The unit tests exercise the control flow without network access.
