### PR TITLE
Allow multiple browser soft tabs

### DIFF
--- a/tests/e2e_ui/browser/test_browser_tab.py
+++ b/tests/e2e_ui/browser/test_browser_tab.py
@@ -130,3 +130,48 @@ def test_no_browser_tab_in_plain_browser(
     # absent (not merely hidden) in a non-Electron shell.
     expect(rail.get_by_role("tab", name=re.compile("Agents"))).to_be_visible()
     expect(rail.get_by_role("tab", name=re.compile("Browser"))).to_have_count(0)
+
+
+def test_multiple_browser_soft_tabs(page: Page, seeded_session: tuple[str, str]) -> None:
+    """User-created browser tabs select independent views and close individually."""
+    base_url, session_id = seeded_session
+    page.add_init_script(_ELECTRON_SHELL_INIT_SCRIPT)
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_placeholder("Send a message…")).to_be_visible()
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+
+    for ordinal in (1, 2):
+        rail.get_by_role("button", name="Open new", exact=True).click()
+        page.get_by_role("menuitem", name="Browser", exact=True).click()
+        expect(rail.get_by_role("tab", name=f"Browser {ordinal}", exact=True)).to_have_attribute(
+            "aria-selected", "true"
+        )
+
+    second_view = rail.locator("[data-browser-pane-conversation]").get_attribute(
+        "data-browser-pane-conversation"
+    )
+    rail.get_by_role("tab", name="Browser 1", exact=True).click()
+    first_view = rail.locator("[data-browser-pane-conversation]").get_attribute(
+        "data-browser-pane-conversation"
+    )
+    assert first_view != second_view
+    assert first_view != session_id
+    rail.get_by_role("tab", name="Browser 2", exact=True).click()
+    expect(rail.locator("[data-browser-pane-conversation]")).to_have_attribute(
+        "data-browser-pane-conversation", second_view
+    )
+
+    page.reload()
+    expect(rail.get_by_role("tab", name="Browser 2", exact=True)).to_have_attribute(
+        "aria-selected", "true"
+    )
+    rail.get_by_role("button", name="Close Browser 2", exact=True).click()
+    expect(rail.get_by_role("tab", name="Browser 2", exact=True)).to_have_count(0)
+    expect(rail.get_by_role("tab", name="Browser 1", exact=True)).to_have_attribute(
+        "aria-selected", "true"
+    )
+    rail.get_by_role("button", name="Close Browser 1", exact=True).click()
+    expect(rail.get_by_role("tab", name="Browser", exact=True)).to_have_attribute(
+        "aria-selected", "true"
+    )

--- a/web/electron/src/browserIpc.js
+++ b/web/electron/src/browserIpc.js
@@ -381,7 +381,13 @@ function registerBrowserIpc({ ipcMain, isPinnedOriginSender, getRegistryForEvent
     const g = gateRegistry(event);
     if (g.error) return { exists: false };
     const { conversationId } = args ?? {};
-    return { exists: typeof conversationId === "string" && g.registry.has(conversationId) };
+    const entry = typeof conversationId === "string" ? g.registry.get(conversationId) : null;
+    if (!entry) return { exists: false };
+    return {
+      exists: true,
+      url: entry.view.webContents.getURL(),
+      ...readNavState(entry.view.webContents),
+    };
   });
 
   // Destroy the conversation's view (explicit close — unmount only detaches).

--- a/web/electron/test/browserIpc.test.js
+++ b/web/electron/test/browserIpc.test.js
@@ -67,6 +67,7 @@ function makeWebContents({ canBack = false, canForward = false } = {}) {
     reload: () => calls.push("reload"),
     isDevToolsOpened: () => devtoolsOpen,
     isDestroyed: () => false,
+    getURL: () => "https://example.com/restored",
     getZoomFactor: () => 1,
     executeJavaScript: (js) => {
       calls.push(`executeJavaScript:${String(js).slice(0, 40)}`);
@@ -144,6 +145,24 @@ function setup({ pinned = true, conversationId = "conv_1", webContents } = {}) {
   });
   return { ipcMain, registry, wc, sent, event };
 }
+
+it("restores the URL and history state for the requested browser tab only", () => {
+  const viewId = "browser-tab:conv_1:tab-two";
+  const { ipcMain, event } = setup({
+    conversationId: viewId,
+    webContents: makeWebContents({ canBack: true }),
+  });
+  assert.deepEqual(ipcMain.invoke("omnigent:browser-has-view", event, { conversationId: viewId }), {
+    exists: true,
+    url: "https://example.com/restored",
+    canGoBack: true,
+    canGoForward: false,
+  });
+  assert.deepEqual(
+    ipcMain.invoke("omnigent:browser-has-view", event, { conversationId: "conv_1" }),
+    { exists: false },
+  );
+});
 
 describe("browserIpc — trust gate", () => {
   it("registers every browser-* channel", () => {

--- a/web/electron/test/browserViewRegistry.test.js
+++ b/web/electron/test/browserViewRegistry.test.js
@@ -52,6 +52,21 @@ describe("browserViewRegistry — first-navigate activation signal", () => {
     ctx = makeRegistry();
   });
 
+  it("keeps the agent view and two user tabs independent through switch and close", () => {
+    const ids = ["conv_1", "browser-tab:conv_1:first", "browser-tab:conv_1:second"];
+    for (const id of ids) ctx.registry.openOrNavigate(id, "https://example.com");
+    const views = ids.map((id) => ctx.registry.get(id).view);
+    assert.equal(new Set(views).size, 3);
+    ctx.registry.setActive(ids[1]);
+    ctx.registry.setActive(ids[2]);
+    assert.deepEqual(ctx.detached, [views[1]]);
+    ctx.registry.close(ids[1]);
+    assert.equal(ctx.registry.get(ids[1]), null);
+    assert.equal(ctx.registry.get(ids[0]).view, views[0]);
+    assert.equal(ctx.registry.get(ids[2]).view, views[2]);
+    assert.equal(ctx.registry.activeConversationId(), ids[2]);
+  });
+
   it("emits browser-view-created on first openOrNavigate for a fresh conversation", () => {
     const r = ctx.registry.openOrNavigate("conv_1", "https://example.com");
     assert.equal(r.ok, true);

--- a/web/src/components/BrowserPane/BrowserPane.test.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserPane } from "./BrowserPane";
 
@@ -58,6 +58,46 @@ afterEach(() => {
 });
 
 describe("BrowserPane cold-start (no view yet)", () => {
+  it("does not claim that the agent navigates user-created tabs", () => {
+    render(<BrowserPane conversationId="browser-tab:conv_a:two" agentBrowser={false} />);
+    expect(screen.getByText("Enter a URL above to get started.")).toBeInTheDocument();
+    expect(screen.queryByText(/the agent will open pages here too/)).toBeNull();
+  });
+
+  it("restores a tab's URL and navigation state from its existing native view", async () => {
+    const bridge = installBridge({
+      browserHasView: vi.fn().mockResolvedValue({
+        exists: true,
+        url: "https://example.com/tab-two",
+        canGoBack: true,
+        canGoForward: false,
+      }),
+    });
+    render(<BrowserPane conversationId="browser-tab:conv_a:two" />);
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Address bar" })).toHaveValue(
+        "https://example.com/tab-two",
+      ),
+    );
+    expect(screen.getByRole("button", { name: "Go back" })).toBeEnabled();
+    expect(bridge.browserSetActive).toHaveBeenCalledWith("browser-tab:conv_a:two");
+    cleanup();
+    expect(bridge.browserSetActive).toHaveBeenLastCalledWith(null);
+  });
+
+  it("reports native view-cap failures instead of silently leaving a blank tab", async () => {
+    installBridge({
+      browserOpenOrNavigate: vi
+        .fn()
+        .mockResolvedValue({ ok: false, error: "browser view cap reached — close one" }),
+    });
+    render(<BrowserPane conversationId="browser-tab:conv_a:two" />);
+    const address = screen.getByRole("textbox", { name: "Address bar" });
+    fireEvent.change(address, { target: { value: "example.com" } });
+    fireEvent.keyDown(address, { key: "Enter" });
+    expect(await screen.findByRole("alert")).toHaveTextContent("browser view cap reached");
+  });
+
   it("renders the URL bar in the empty state so the first page is reachable", async () => {
     render(<BrowserPane conversationId="conv_a" />);
 

--- a/web/src/components/BrowserPane/BrowserPane.test.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.test.tsx
@@ -96,6 +96,7 @@ describe("BrowserPane cold-start (no view yet)", () => {
     fireEvent.change(address, { target: { value: "example.com" } });
     fireEvent.keyDown(address, { key: "Enter" });
     expect(await screen.findByRole("alert")).toHaveTextContent("browser view cap reached");
+    expect(address).toHaveValue("example.com");
   });
 
   it("renders the URL bar in the empty state so the first page is reachable", async () => {
@@ -172,7 +173,7 @@ describe("BrowserPane design-mode toggle", () => {
     expect(screen.getByRole("button", { name: /enter design mode/i })).toBeDisabled();
   });
 
-  it("calls enable then disable IPC as it toggles, once a view is active", async () => {
+  it("calls enable then disable IPC as it toggles, and disables on unmount", async () => {
     let fireCreated: ((p: { conversationId: string }) => void) | undefined;
     const bridge = installBridge({
       onBrowserViewCreated: vi.fn((cb: (p: { conversationId: string }) => void) => {
@@ -181,7 +182,7 @@ describe("BrowserPane design-mode toggle", () => {
       }),
     });
 
-    render(<BrowserPane conversationId="conv_dm3" />);
+    const { unmount } = render(<BrowserPane conversationId="conv_dm3" />);
     await screen.findByRole("textbox", { name: /address bar/i });
 
     // Activate a view so the toggle is enabled.
@@ -207,6 +208,12 @@ describe("BrowserPane design-mode toggle", () => {
       "aria-pressed",
       "false",
     );
+    screen.getByRole("button", { name: /enter design mode/i }).click();
+    await waitFor(() => {
+      expect(bridge.browserEnableDesignMode).toHaveBeenCalledTimes(2);
+    });
+    unmount();
+    expect(bridge.browserDisableDesignMode).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/web/src/components/BrowserPane/BrowserPane.test.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.test.tsx
@@ -80,7 +80,9 @@ describe("BrowserPane cold-start (no view yet)", () => {
       ),
     );
     expect(screen.getByRole("button", { name: "Go back" })).toBeEnabled();
-    expect(bridge.browserSetActive).toHaveBeenCalledWith("browser-tab:conv_a:two");
+    await waitFor(() =>
+      expect(bridge.browserSetActive).toHaveBeenCalledWith("browser-tab:conv_a:two"),
+    );
     cleanup();
     expect(bridge.browserSetActive).toHaveBeenLastCalledWith(null);
   });

--- a/web/src/components/BrowserPane/BrowserPane.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.tsx
@@ -83,7 +83,12 @@ interface BrowserPaneBridge {
       canGoForward: boolean;
     }) => void,
   ) => () => void;
-  browserHasView?: (conversationId: string) => Promise<{ exists: boolean }>;
+  browserHasView?: (conversationId: string) => Promise<{
+    exists: boolean;
+    url?: string;
+    canGoBack?: boolean;
+    canGoForward?: boolean;
+  }>;
 }
 
 function getBridge(): BrowserPaneBridge | null {
@@ -93,8 +98,9 @@ function getBridge(): BrowserPaneBridge | null {
 }
 
 export interface BrowserPaneProps {
-  /** Conversation whose WebContentsView this pane hosts. */
+  /** Native view key: the session ID or a session-scoped browser tab ID. */
   conversationId: string;
+  agentBrowser?: boolean;
   /** Extra classes for the measuring placeholder wrapper. */
   className?: string;
 }
@@ -103,7 +109,7 @@ export interface BrowserPaneProps {
  * Keeps the agent relay alive for a conversation and, once a native browser
  * view is attached, keeps that view positioned over a measuring placeholder.
  */
-export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
+export function BrowserPane({ conversationId, className, agentBrowser = true }: BrowserPaneProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const lastBoundsRef = useRef<Bounds | null>(null);
   const browserSupported = supportsBrowser();
@@ -115,6 +121,7 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
   // edits the input (urlEditingRef gates the stomp); canGoBack/Forward drive
   // the arrow buttons.
   const [currentUrl, setCurrentUrl] = useState("");
+  const [navigationError, setNavigationError] = useState<string | null>(null);
   // Ref (not state): read synchronously in the url-changed listener; a
   // stale-closure state read would race.
   const urlEditingRef = useRef(false);
@@ -137,7 +144,12 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
 
     // (2) Re-show an already-created view when the pane remounts.
     void bridge.browserHasView?.(conversationId).then((r) => {
-      if (!cancelled && r?.exists) setViewActive(true);
+      if (!cancelled && r?.exists) {
+        setViewActive(true);
+        if (!urlEditingRef.current && r.url) setCurrentUrl(r.url);
+        setCanGoBack(!!r.canGoBack);
+        setCanGoForward(!!r.canGoForward);
+      }
     });
 
     // (1) A view was just created for this conversation (first navigate).
@@ -196,7 +208,13 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
     if (!raw) return;
     const navUrl = normalizeTypedUrl(raw);
     setCurrentUrl(navUrl);
-    void bridge.browserOpenOrNavigate(conversationId, navUrl, undefined, { force: true });
+    setNavigationError(null);
+    void bridge
+      .browserOpenOrNavigate(conversationId, navUrl, undefined, { force: true })
+      .then((result) => {
+        if (!result.ok) setNavigationError(result.error ?? "Unable to open this page.");
+      })
+      .catch(() => setNavigationError("Unable to open this page."));
   }, [conversationId, currentUrl]);
 
   const handleBack = useCallback(() => {
@@ -469,6 +487,11 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
           <SquareDashedMousePointerIcon className="size-4" />
         </button>
       </div>
+      {navigationError && (
+        <div role="alert" className="px-2 py-1 text-destructive text-xs">
+          {navigationError}
+        </div>
+      )}
       {viewActive ? (
         /* Measuring region — the native WebContentsView paints over this.
            flex-1 min-h-0 so it fills everything BELOW the toolbar; its rect
@@ -477,7 +500,8 @@ export function BrowserPane({ conversationId, className }: BrowserPaneProps) {
         <div ref={containerRef} className="min-h-0 min-w-0 flex-1" />
       ) : (
         <div className="flex min-h-0 flex-1 items-center justify-center bg-card px-6 py-8 text-center text-muted-foreground text-ui">
-          Enter a URL above to get started — the agent will open pages here too.
+          Enter a URL above to get started
+          {agentBrowser ? " — the agent will open pages here too." : "."}
         </div>
       )}
     </div>

--- a/web/src/components/BrowserPane/BrowserPane.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.tsx
@@ -207,12 +207,12 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
     const raw = currentUrl.trim();
     if (!raw) return;
     const navUrl = normalizeTypedUrl(raw);
-    setCurrentUrl(navUrl);
     setNavigationError(null);
     void bridge
       .browserOpenOrNavigate(conversationId, navUrl, undefined, { force: true })
       .then((result) => {
-        if (!result.ok) setNavigationError(result.error ?? "Unable to open this page.");
+        if (result.ok) setCurrentUrl(navUrl);
+        else setNavigationError(result.error ?? "Unable to open this page.");
       })
       .catch(() => setNavigationError("Unable to open this page."));
   }, [conversationId, currentUrl]);
@@ -323,6 +323,7 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
     return () => {
       cancelled = true;
       lastBoundsRef.current = null;
+      if (designMode) void getBridge()?.browserDisableDesignMode?.(conversationId);
       // Detach whatever is currently active (this pane owned it). The view
       // survives in the registry; only an explicit close destroys it.
       try {
@@ -331,7 +332,7 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
         /* swallow — window may be tearing down */
       }
     };
-  }, [conversationId, browserSupported, viewActive, syncBounds]);
+  }, [conversationId, browserSupported, designMode, viewActive, syncBounds]);
 
   // Reconcile bounds every frame while shown (cheap: same-rect setBounds is a
   // no-op + we dedupe via lastBoundsRef). Catches position-only shifts that

--- a/web/src/components/BrowserPane/BrowserPane.tsx
+++ b/web/src/components/BrowserPane/BrowserPane.tsx
@@ -130,6 +130,7 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
   // Design-mode toggle: on, the main process injects the in-page picker; submit
   // routing lives in AppShell. This flag only drives the button + enable/disable IPC.
   const [designMode, setDesignMode] = useState(false);
+  const designModeRef = useRef(false);
 
   // Feed `viewActive` from three signals so the placeholder mounts exactly when
   // a view exists: (1) browser-view-created — first navigate (often detached,
@@ -251,9 +252,11 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
     const bridge = getBridge();
     if (!bridge) return;
     if (designMode) {
+      designModeRef.current = false;
       void bridge.browserDisableDesignMode?.(conversationId);
       setDesignMode(false);
     } else {
+      designModeRef.current = true;
       void bridge.browserEnableDesignMode?.(conversationId);
       setDesignMode(true);
     }
@@ -262,7 +265,10 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
   // If the view goes away (closed) while design mode is on, drop the pressed
   // state so the button doesn't lie — the injected picker died with the view.
   useEffect(() => {
-    if (!viewActive && designMode) setDesignMode(false);
+    if (!viewActive && designMode) {
+      designModeRef.current = false;
+      setDesignMode(false);
+    }
   }, [viewActive, designMode]);
 
   // Measure the placeholder and push bounds to the main process. These are
@@ -323,7 +329,7 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
     return () => {
       cancelled = true;
       lastBoundsRef.current = null;
-      if (designMode) void getBridge()?.browserDisableDesignMode?.(conversationId);
+      if (designModeRef.current) void getBridge()?.browserDisableDesignMode?.(conversationId);
       // Detach whatever is currently active (this pane owned it). The view
       // survives in the registry; only an explicit close destroys it.
       try {
@@ -332,7 +338,7 @@ export function BrowserPane({ conversationId, className, agentBrowser = true }: 
         /* swallow — window may be tearing down */
       }
     };
-  }, [conversationId, browserSupported, designMode, viewActive, syncBounds]);
+  }, [conversationId, browserSupported, viewActive, syncBounds]);
 
   // Reconcile bounds every frame while shown (cheap: same-rect setBounds is a
   // no-op + we dedupe via lastBoundsRef). Catches position-only shifts that

--- a/web/src/hooks/useBrowserTabs.test.tsx
+++ b/web/src/hooks/useBrowserTabs.test.tsx
@@ -1,0 +1,99 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { emitBrowserActionRequest } from "@/lib/browserActionBus";
+import { readSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
+import { browserViewId, useBrowserTabs } from "./useBrowserTabs";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  Reflect.deleteProperty(window, "omnigentDesktop");
+});
+
+describe("browser soft tabs", () => {
+  it("persists a pending close even if the workspace unmounts", async () => {
+    let finishClose!: (value: { ok: boolean }) => void;
+    const browserClose = vi.fn(
+      () =>
+        new Promise<{ ok: boolean }>((resolve) => {
+          finishClose = resolve;
+        }),
+    );
+    Object.assign(window, { omnigentDesktop: { browserClose } });
+    const { result, unmount } = renderHook(() => useBrowserTabs("session-a"));
+    act(() => result.current.add());
+    const pendingClose = result.current.close(result.current.selected!);
+    unmount();
+    await act(async () => {
+      finishClose({ ok: true });
+      await pendingClose;
+    });
+    expect(readSessionWorkspaceState("session-a").openBrowsers).toEqual([]);
+  });
+
+  it("creates independent views and restores the selection on remount", () => {
+    const first = renderHook(() => useBrowserTabs("session-a"));
+    expect(first.result.current.viewId).toBe("session-a");
+    act(() => first.result.current.add());
+    const firstId = first.result.current.selected!;
+    act(() => first.result.current.add());
+    const secondId = first.result.current.selected!;
+    expect(secondId).not.toBe(firstId);
+    expect(first.result.current.tabs).toEqual([firstId, secondId]);
+    expect(browserViewId("session-a", firstId)).not.toBe(browserViewId("session-b", firstId));
+    first.unmount();
+    const restored = renderHook(() => useBrowserTabs("session-a"));
+    expect(restored.result.current.selected).toBe(secondId);
+    expect(restored.result.current.tabs).toEqual([firstId, secondId]);
+    const other = renderHook(() => useBrowserTabs("session-b"));
+    expect(other.result.current.tabs).toEqual([]);
+  });
+
+  it("closes only the target view and selects a neighbor, then the default", async () => {
+    const browserClose = vi.fn().mockResolvedValue({ ok: true });
+    Object.assign(window, { omnigentDesktop: { browserClose } });
+    const { result } = renderHook(() => useBrowserTabs("session-a"));
+    act(() => result.current.add());
+    const firstId = result.current.selected!;
+    act(() => result.current.add());
+    const secondId = result.current.selected!;
+    await act(() => result.current.close(secondId));
+    expect(browserClose).toHaveBeenCalledWith(browserViewId("session-a", secondId));
+    expect(result.current.selected).toBe(firstId);
+    await act(() => result.current.close(firstId));
+    expect(result.current.viewId).toBe("session-a");
+    expect(readSessionWorkspaceState("session-a").openBrowsers).toEqual([]);
+  });
+
+  it("keeps the selection when closing a background tab or a close fails", async () => {
+    const browserClose = vi.fn().mockResolvedValue({ ok: true });
+    Object.assign(window, { omnigentDesktop: { browserClose } });
+    const { result } = renderHook(() => useBrowserTabs("session-a"));
+    act(() => result.current.add());
+    const firstId = result.current.selected!;
+    act(() => result.current.add());
+    const secondId = result.current.selected!;
+    await act(() => result.current.close(firstId));
+    expect(result.current.selected).toBe(secondId);
+    browserClose.mockRejectedValueOnce(new Error("disconnected"));
+    await act(() => result.current.close(secondId));
+    expect(result.current.tabs).toEqual([secondId]);
+  });
+
+  it("surfaces only the owning session's default browser for agent navigation", () => {
+    const { result } = renderHook(() => useBrowserTabs("session-a"));
+    act(() => result.current.add());
+    const selected = result.current.selected;
+    const event = {
+      type: "browser_action_request" as const,
+      actionId: "navigate-1",
+      action: "navigate",
+      args: {},
+    };
+    act(() => emitBrowserActionRequest(event, "session-b"));
+    expect(result.current.selected).toBe(selected);
+    act(() => emitBrowserActionRequest(event, "session-a"));
+    expect(result.current.selected).toBeNull();
+    expect(result.current.tabs).toEqual([selected]);
+  });
+});

--- a/web/src/hooks/useBrowserTabs.test.tsx
+++ b/web/src/hooks/useBrowserTabs.test.tsx
@@ -31,6 +31,42 @@ describe("browser soft tabs", () => {
     expect(readSessionWorkspaceState("session-a").openBrowsers).toEqual([]);
   });
 
+  it("does not clobber a tab added after remount while a close resolves", async () => {
+    let finishClose!: (value: { ok: boolean }) => void;
+    const browserClose = vi.fn(
+      () =>
+        new Promise<{ ok: boolean }>((resolve) => {
+          finishClose = resolve;
+        }),
+    );
+    Object.assign(window, { omnigentDesktop: { browserClose } });
+
+    const first = renderHook(() => useBrowserTabs("session-a"));
+    act(() => first.result.current.add());
+    const firstId = first.result.current.selected!;
+    act(() => first.result.current.add());
+    const secondId = first.result.current.selected!;
+    const pendingClose = first.result.current.close(firstId);
+    first.unmount();
+
+    const second = renderHook(() => useBrowserTabs("session-a"));
+    act(() => second.result.current.add());
+    const thirdId = second.result.current.selected!;
+
+    await act(async () => {
+      finishClose({ ok: true });
+      await pendingClose;
+    });
+    second.unmount();
+    const reopened = renderHook(() => useBrowserTabs("session-a"));
+    expect(reopened.result.current.tabs).toEqual([secondId, thirdId]);
+    expect(reopened.result.current.selected).toBe(thirdId);
+    expect(readSessionWorkspaceState("session-a")).toEqual({
+      openBrowsers: [secondId, thirdId],
+      selectedBrowserId: thirdId,
+    });
+  });
+
   it("creates independent views and restores the selection on remount", () => {
     const first = renderHook(() => useBrowserTabs("session-a"));
     expect(first.result.current.viewId).toBe("session-a");
@@ -76,7 +112,11 @@ describe("browser soft tabs", () => {
     await act(() => result.current.close(firstId));
     expect(result.current.selected).toBe(secondId);
     browserClose.mockRejectedValueOnce(new Error("disconnected"));
-    await act(() => result.current.close(secondId));
+    let closed = true;
+    await act(async () => {
+      closed = await result.current.close(secondId);
+    });
+    expect(closed).toBe(false);
     expect(result.current.tabs).toEqual([secondId]);
   });
 

--- a/web/src/hooks/useBrowserTabs.ts
+++ b/web/src/hooks/useBrowserTabs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { onBrowserActionRequest } from "@/lib/browserActionBus";
 import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 
@@ -8,19 +8,25 @@ export function browserViewId(conversationId: string, tabId: string | null): str
     : `browser-tab:${encodeURIComponent(conversationId)}:${tabId}`;
 }
 
+interface BrowserTabsState {
+  tabs: string[];
+  selected: string | null;
+}
+
+function readBrowserTabsState(conversationId: string): BrowserTabsState {
+  const saved = readSessionWorkspaceState(conversationId);
+  const tabs = saved.openBrowsers ?? [];
+  return {
+    tabs,
+    selected: tabs.includes(saved.selectedBrowserId ?? "") ? saved.selectedBrowserId! : null,
+  };
+}
+
 export function useBrowserTabs(conversationId: string) {
-  const [state, setState] = useState(() => {
-    const saved = readSessionWorkspaceState(conversationId);
-    const tabs = saved.openBrowsers ?? [];
-    return {
-      tabs,
-      selected: tabs.includes(saved.selectedBrowserId ?? "") ? saved.selectedBrowserId! : null,
-    };
-  });
-  const stateRef = useRef(state);
+  const [state, setState] = useState(() => readBrowserTabsState(conversationId));
   const update = useCallback(
-    (next: typeof state) => {
-      stateRef.current = next;
+    (mutate: (current: BrowserTabsState) => BrowserTabsState) => {
+      const next = mutate(readBrowserTabsState(conversationId));
       writeSessionWorkspaceState(conversationId, {
         openBrowsers: next.tabs,
         selectedBrowserId: next.selected,
@@ -31,14 +37,14 @@ export function useBrowserTabs(conversationId: string) {
   );
 
   const select = (selected: string | null) => {
-    update({ ...stateRef.current, selected });
+    update((current) => ({ ...current, selected }));
   };
 
   useEffect(
     () =>
       onBrowserActionRequest((event, sourceConversationId) => {
         if (sourceConversationId === conversationId && event.action === "navigate") {
-          update({ ...stateRef.current, selected: null });
+          update((current) => ({ ...current, selected: null }));
         }
       }),
     [conversationId, update],
@@ -46,11 +52,10 @@ export function useBrowserTabs(conversationId: string) {
 
   const add = () => {
     const selected = crypto.randomUUID();
-    const tabs = [...stateRef.current.tabs, selected];
-    update({ tabs, selected });
+    update((current) => ({ tabs: [...current.tabs, selected], selected }));
   };
 
-  const close = async (tabId: string) => {
+  const close = async (tabId: string): Promise<boolean> => {
     const desktop = (
       window as unknown as {
         omnigentDesktop?: {
@@ -61,14 +66,16 @@ export function useBrowserTabs(conversationId: string) {
     const result = await desktop
       ?.browserClose?.(browserViewId(conversationId, tabId))
       .catch(() => ({ ok: false }));
-    if (result && !result.ok) return;
-    const previous = stateRef.current;
-    const tabs = previous.tabs.filter((id) => id !== tabId);
-    const selected =
-      previous.selected === tabId
-        ? (tabs[Math.max(0, previous.tabs.indexOf(tabId) - 1)] ?? null)
-        : previous.selected;
-    update({ tabs, selected });
+    if (result && !result.ok) return false;
+    update((previous) => {
+      const index = previous.tabs.indexOf(tabId);
+      if (index === -1) return previous;
+      const tabs = previous.tabs.filter((id) => id !== tabId);
+      const selected =
+        previous.selected === tabId ? (tabs[Math.max(0, index - 1)] ?? null) : previous.selected;
+      return { tabs, selected };
+    });
+    return true;
   };
 
   return { ...state, add, close, select, viewId: browserViewId(conversationId, state.selected) };

--- a/web/src/hooks/useBrowserTabs.ts
+++ b/web/src/hooks/useBrowserTabs.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { onBrowserActionRequest } from "@/lib/browserActionBus";
+import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
+
+export function browserViewId(conversationId: string, tabId: string | null): string {
+  return tabId === null
+    ? conversationId
+    : `browser-tab:${encodeURIComponent(conversationId)}:${tabId}`;
+}
+
+export function useBrowserTabs(conversationId: string) {
+  const [state, setState] = useState(() => {
+    const saved = readSessionWorkspaceState(conversationId);
+    const tabs = saved.openBrowsers ?? [];
+    return {
+      tabs,
+      selected: tabs.includes(saved.selectedBrowserId ?? "") ? saved.selectedBrowserId! : null,
+    };
+  });
+  const stateRef = useRef(state);
+  const update = useCallback(
+    (next: typeof state) => {
+      stateRef.current = next;
+      writeSessionWorkspaceState(conversationId, {
+        openBrowsers: next.tabs,
+        selectedBrowserId: next.selected,
+      });
+      setState(next);
+    },
+    [conversationId],
+  );
+
+  const select = (selected: string | null) => {
+    update({ ...stateRef.current, selected });
+  };
+
+  useEffect(
+    () =>
+      onBrowserActionRequest((event, sourceConversationId) => {
+        if (sourceConversationId === conversationId && event.action === "navigate") {
+          update({ ...stateRef.current, selected: null });
+        }
+      }),
+    [conversationId, update],
+  );
+
+  const add = () => {
+    const selected = crypto.randomUUID();
+    const tabs = [...stateRef.current.tabs, selected];
+    update({ tabs, selected });
+  };
+
+  const close = async (tabId: string) => {
+    const desktop = (
+      window as unknown as {
+        omnigentDesktop?: {
+          browserClose?: (viewId: string) => Promise<{ ok: boolean }>;
+        };
+      }
+    ).omnigentDesktop;
+    const result = await desktop
+      ?.browserClose?.(browserViewId(conversationId, tabId))
+      .catch(() => ({ ok: false }));
+    if (result && !result.ok) return;
+    const previous = stateRef.current;
+    const tabs = previous.tabs.filter((id) => id !== tabId);
+    const selected =
+      previous.selected === tabId
+        ? (tabs[Math.max(0, previous.tabs.indexOf(tabId) - 1)] ?? null)
+        : previous.selected;
+    update({ tabs, selected });
+  };
+
+  return { ...state, add, close, select, viewId: browserViewId(conversationId, state.selected) };
+}

--- a/web/src/lib/sessionWorkspaceState.test.ts
+++ b/web/src/lib/sessionWorkspaceState.test.ts
@@ -75,6 +75,14 @@ describe("sessionWorkspaceState", () => {
     expect(stored).toEqual(Array.from({ length: 20 }, (_, i) => `terminal:t${i + 5}`));
   });
 
+  it("caps the persisted browser tabs at 20, keeping the most recent", () => {
+    const browsers = Array.from({ length: 25 }, (_, i) => `browser:b${i}`);
+    writeSessionWorkspaceState("conv_browsers", { openBrowsers: browsers });
+
+    const stored = readSessionWorkspaceState("conv_browsers").openBrowsers;
+    expect(stored).toEqual(Array.from({ length: 20 }, (_, i) => `browser:b${i + 5}`));
+  });
+
   it("prunes the least-recently-touched session past the cap (numeric ids)", () => {
     // Seed exactly MAX_SESSIONS sessions with purely numeric ids ("1".."100").
     // Numeric-string keys are the case a plain object store gets wrong: V8

--- a/web/src/lib/sessionWorkspaceState.ts
+++ b/web/src/lib/sessionWorkspaceState.ts
@@ -25,6 +25,8 @@ export interface SessionWorkspaceState {
   openTerminals?: string[];
   /** The active shell tab (null = a file/scope view is active). */
   selectedTerminalKey?: string | null;
+  openBrowsers?: string[];
+  selectedBrowserId?: string | null;
 }
 
 const STORAGE_KEY = "omnigent:session-workspace-state";
@@ -80,6 +82,18 @@ function sanitize(entry: unknown): SessionWorkspaceState {
   }
   if (record.selectedTerminalKey === null || typeof record.selectedTerminalKey === "string") {
     state.selectedTerminalKey = record.selectedTerminalKey;
+  }
+  if (Array.isArray(record.openBrowsers)) {
+    state.openBrowsers = [
+      ...new Set(
+        record.openBrowsers.filter(
+          (value): value is string => typeof value === "string" && value.length > 0,
+        ),
+      ),
+    ];
+  }
+  if (record.selectedBrowserId === null || typeof record.selectedBrowserId === "string") {
+    state.selectedBrowserId = record.selectedBrowserId;
   }
   return state;
 }

--- a/web/src/lib/sessionWorkspaceState.ts
+++ b/web/src/lib/sessionWorkspaceState.ts
@@ -150,6 +150,11 @@ export function writeSessionWorkspaceState(
   if (next.openTerminals && next.openTerminals.length > MAX_OPEN_FILES) {
     next.openTerminals = next.openTerminals.slice(-MAX_OPEN_FILES);
   }
+  // Same bound for browser tabs. Native view creation enforces its own lower
+  // runtime cap; this keeps the persisted rail from growing without bound.
+  if (next.openBrowsers && next.openBrowsers.length > MAX_OPEN_FILES) {
+    next.openBrowsers = next.openBrowsers.slice(-MAX_OPEN_FILES);
+  }
   // Drop any existing entry and re-append so the most-recently-touched session
   // moves to the end; pruning then evicts from the front (oldest-touched).
   if (existingIdx >= 0) store.splice(existingIdx, 1);

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -816,12 +816,13 @@ export function AppShell() {
   // Browser-capable shells only; no-op elsewhere (the bus never fires without a relay).
   useEffect(() => {
     if (!supportsBrowser()) return;
-    return onBrowserActionRequest((evt) => {
-      if (evt.action !== "navigate") return;
+    return onBrowserActionRequest((evt, sourceConversationId) => {
+      if (evt.action !== "navigate" || sourceConversationId !== conversationId) return;
+      if (conversationId) writeSessionWorkspaceState(conversationId, { selectedBrowserId: null });
       setRightRailTab("browser");
       setRightPanelOpen(true);
     });
-  }, []);
+  }, [conversationId]);
 
   // Design-mode submit routing. Lives here (with the hoisted relay) because the
   // in-page popup posts back via preload IPC delivered to the always-mounted
@@ -2049,6 +2050,7 @@ export function AppShell() {
               push panels below sit outside the group. */}
                 {conversationId && workspacePanelVisible && (
                   <WorkspacePanel
+                    key={conversationId}
                     conversationId={conversationId}
                     width={inlinePanelWidth}
                     inert={inlinePanelWidth === 0}

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -817,10 +817,12 @@ export function AppShell() {
   useEffect(() => {
     if (!supportsBrowser()) return;
     return onBrowserActionRequest((evt, sourceConversationId) => {
-      if (evt.action !== "navigate" || sourceConversationId !== conversationId) return;
-      if (conversationId) writeSessionWorkspaceState(conversationId, { selectedBrowserId: null });
-      setRightRailTab("browser");
-      setRightPanelOpen(true);
+      if (evt.action !== "navigate" || !sourceConversationId) return;
+      writeSessionWorkspaceState(sourceConversationId, { selectedBrowserId: null });
+      if (sourceConversationId === conversationId) {
+        setRightRailTab("browser");
+        setRightPanelOpen(true);
+      }
     });
   }, [conversationId]);
 

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -2052,7 +2052,6 @@ export function AppShell() {
               push panels below sit outside the group. */}
                 {conversationId && workspacePanelVisible && (
                   <WorkspacePanel
-                    key={conversationId}
                     conversationId={conversationId}
                     width={inlinePanelWidth}
                     inert={inlinePanelWidth === 0}

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useSessionAgent } from "@/hooks/useAgents";
 import type { SessionLiveness } from "@/hooks/useSessionLiveness";
@@ -50,6 +51,7 @@ vi.mock("@/hooks/useTerminals", async (importOriginal) => ({
 vi.mock("@/hooks/useAgents", () => ({
   useSessionAgent: vi.fn(() => ({ data: undefined })),
 }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
 
 const useTerminalsMock = vi.mocked(useTerminals);
 const useCreateTerminalMock = vi.mocked(useCreateTerminal);
@@ -59,6 +61,7 @@ afterEach(() => {
   cleanup();
   localStorage.clear();
   vi.clearAllMocks();
+  Reflect.deleteProperty(window, "omnigentDesktop");
   useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
   useCreateTerminalMock.mockReturnValue({
     mutate: vi.fn(),
@@ -742,5 +745,22 @@ describe("WorkspacePanel browser tab", () => {
     expect(screen.getByTestId("browser-pane-stub")).toBeInTheDocument();
     // And the file scope views are not mounted in that branch.
     expect(screen.queryByTestId("files-panel-stub")).toBeNull();
+  });
+
+  it("shows an error when a native browser close fails", async () => {
+    renderWorkspace({ showBrowserTab: true, rightRailTab: "browser" });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Browser" }));
+
+    Object.assign(window, {
+      omnigentDesktop: { browserClose: vi.fn().mockRejectedValue(new Error("disconnected")) },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Close Browser 1" }));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Couldn't close browser tab. Try again."),
+    );
   });
 });

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -57,6 +57,7 @@ const useSessionAgentMock = vi.mocked(useSessionAgent);
 
 afterEach(() => {
   cleanup();
+  localStorage.clear();
   vi.clearAllMocks();
   useTerminalsMock.mockReturnValue({ terminals: [], isLoading: false, error: null });
   useCreateTerminalMock.mockReturnValue({
@@ -384,9 +385,6 @@ describe("WorkspacePanel shell tabs", () => {
 });
 
 describe('WorkspacePanel "+" new-tab menu', () => {
-  // The "+" gates purely on shell access — the agent's declared terminals.
-  // (The embedded browser is one view per conversation, reached via its own
-  // pinned tab, so it isn't offered here.)
   const declaresShell = () =>
     useSessionAgentMock.mockReturnValue({ data: { terminals: ["zsh"] } } as unknown as ReturnType<
       typeof useSessionAgent
@@ -394,7 +392,7 @@ describe('WorkspacePanel "+" new-tab menu', () => {
 
   it("is hidden when the agent has no terminal access", () => {
     // No declared terminals (default mock: data undefined) → nothing to open.
-    renderWorkspace({ showBrowserTab: true });
+    renderWorkspace({ showBrowserTab: false });
     expect(screen.queryByRole("button", { name: "Open new" })).toBeNull();
   });
 
@@ -702,6 +700,32 @@ describe("WorkspacePanel tab-strip layout (regression)", () => {
 });
 
 describe("WorkspacePanel browser tab", () => {
+  it("offers browsers without shell access and creates multiple closable tabs", async () => {
+    renderWorkspace({ showBrowserTab: true, rightRailTab: "browser" });
+    const openBrowser = async () => {
+      fireEvent.pointerDown(screen.getByRole("button", { name: "Open new" }), {
+        button: 0,
+        ctrlKey: false,
+      });
+      fireEvent.click(await screen.findByRole("menuitem", { name: "Browser" }));
+    };
+    await openBrowser();
+    const firstView = screen.getByTestId("browser-pane-stub").textContent;
+    await openBrowser();
+    expect(screen.getAllByRole("tab", { name: /^Browser \d/ })).toHaveLength(2);
+    expect(screen.getByTestId("browser-pane-stub").textContent).not.toBe(firstView);
+    fireEvent.click(screen.getByRole("tab", { name: "Browser 1" }));
+    expect(screen.getByTestId("browser-pane-stub")).toHaveTextContent(firstView!);
+    fireEvent.click(screen.getByRole("button", { name: "Close Browser 1" }));
+    await waitFor(() =>
+      expect(screen.getAllByRole("tab", { name: /^Browser \d/ })).toHaveLength(1),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Close Browser 1" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-pane-stub")).toHaveTextContent("conv_ws"),
+    );
+  });
+
   it("renders the Browser tab only when showBrowserTab is set", () => {
     renderWorkspace({ showBrowserTab: true });
     expect(screen.getByRole("tab", { name: /browser/i })).toBeInTheDocument();

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -11,6 +11,7 @@ import {
   TerminalIcon,
   XIcon,
 } from "lucide-react";
+import { toast } from "sonner";
 import {
   type CSSProperties,
   type ReactElement,
@@ -711,6 +712,10 @@ function WorkspacePanelImpl({
   onShellCreateFailed,
 }: WorkspacePanelProps) {
   const browsers = useBrowserTabs(conversationId);
+  const closeBrowserTab = async (tabId: string) => {
+    const closed = await browsers.close(tabId);
+    if (!closed) toast.error("Couldn't close browser tab. Try again.");
+  };
   const activeBrowserRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     activeBrowserRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
@@ -947,7 +952,7 @@ function WorkspacePanelImpl({
                       onAuxClick={(event) => {
                         if (event.button === 1) {
                           event.preventDefault();
-                          void browsers.close(tabId);
+                          void closeBrowserTab(tabId);
                         }
                       }}
                       onClick={() => {
@@ -962,7 +967,7 @@ function WorkspacePanelImpl({
                       type="button"
                       aria-label={`Close Browser ${index + 1}`}
                       className="flex size-4 items-center justify-center rounded hover:bg-muted"
-                      onClick={() => void browsers.close(tabId)}
+                      onClick={() => void closeBrowserTab(tabId)}
                     >
                       <XIcon className="size-3" />
                     </button>

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -37,6 +37,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { BrowserPane } from "@/components/BrowserPane/BrowserPane";
+import { useBrowserTabs } from "@/hooks/useBrowserTabs";
 import { useSessionAgent } from "@/hooks/useAgents";
 import type { SessionLiveness } from "@/hooks/useSessionLiveness";
 import { terminalTabKey, useCreateTerminal, useTerminals } from "@/hooks/useTerminals";
@@ -119,6 +120,7 @@ function shellConnectState(liveness: SessionLiveness | undefined): ShellConnectS
 function NewTabMenu({
   conversationId,
   onOpenTerminal,
+  onOpenBrowser,
   onCreateStart,
   onCreateError,
   triggerClassName,
@@ -127,6 +129,7 @@ function NewTabMenu({
   conversationId: string;
   /** Open a freshly-created terminal as a rail tab by its tab key. */
   onOpenTerminal: (key: string) => void;
+  onOpenBrowser?: () => void;
   /** Called when a shell create is initiated (before the POST resolves), so
    *  the shell can be focused as soon as its tab appears in the list. */
   onCreateStart?: () => void;
@@ -152,9 +155,7 @@ function NewTabMenu({
   // declare a non-empty ``terminals:`` block.
   const declaredTerminals = agent?.terminals ?? [];
   const canOpenShell = declaredTerminals.length > 0;
-  // Nothing to offer → no "+" button at all. (The embedded browser is one view
-  // per conversation, reached via its own pinned tab, so it's not offered here.)
-  if (!canOpenShell) return null;
+  if (!canOpenShell && !onOpenBrowser) return null;
 
   // The default launched by the primary segment: the remembered pick when it
   // is still a declared type, else the first declared name. Non-null here since
@@ -241,50 +242,57 @@ function NewTabMenu({
             paint over the dropdown (#3980). Only this rail menu needs it. */}
         <SuppressBrowserView />
         <DropdownMenuLabel>Open new</DropdownMenuLabel>
-        {multipleShells ? (
-          // Several types → a single "Shell (default)" row that launches the
-          // default on click and reveals a flyout of the OTHER types on hover.
-          // The sub-trigger's built-in chevron is hidden ([&>svg:last-child]) to
-          // keep the row clean. The click handler guards on ``shellDisabled``
-          // itself because Radix runs a sub-trigger's onClick before its own
-          // disabled check — without the guard an offline session would still
-          // fire a create.
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger
-              disabled={shellDisabled}
-              onClick={() => {
-                if (!shellDisabled) launchShell(defaultShell);
-              }}
-              className="cursor-pointer [&>svg:last-child]:hidden"
-            >
-              {shellItemContent}
-            </DropdownMenuSubTrigger>
-            {/* min-w-0 drops the default 96px floor so the box hugs the shell
-                name (e.g. "bash") instead of padding it out. */}
-            <DropdownMenuSubContent className="min-w-0">
-              <DropdownMenuLabel>Other shells</DropdownMenuLabel>
-              {otherShells.map((name) => (
-                <DropdownMenuItem
-                  key={name}
-                  onSelect={() => pickShell(name)}
-                  disabled={shellDisabled}
-                  className="cursor-pointer"
-                >
-                  {name}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-        ) : (
-          // Single type → a plain launch item.
-          <DropdownMenuItem
-            onSelect={() => launchShell(defaultShell)}
-            disabled={shellDisabled}
-            className="cursor-pointer"
-          >
-            {shellItemContent}
+        {onOpenBrowser && (
+          <DropdownMenuItem onSelect={onOpenBrowser} className="cursor-pointer">
+            <GlobeIcon className="size-4" />
+            Browser
           </DropdownMenuItem>
         )}
+        {canOpenShell &&
+          (multipleShells ? (
+            // Several types → a single "Shell (default)" row that launches the
+            // default on click and reveals a flyout of the OTHER types on hover.
+            // The sub-trigger's built-in chevron is hidden ([&>svg:last-child]) to
+            // keep the row clean. The click handler guards on ``shellDisabled``
+            // itself because Radix runs a sub-trigger's onClick before its own
+            // disabled check — without the guard an offline session would still
+            // fire a create.
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                disabled={shellDisabled}
+                onClick={() => {
+                  if (!shellDisabled) launchShell(defaultShell);
+                }}
+                className="cursor-pointer [&>svg:last-child]:hidden"
+              >
+                {shellItemContent}
+              </DropdownMenuSubTrigger>
+              {/* min-w-0 drops the default 96px floor so the box hugs the shell
+                  name (e.g. "bash") instead of padding it out. */}
+              <DropdownMenuSubContent className="min-w-0">
+                <DropdownMenuLabel>Other shells</DropdownMenuLabel>
+                {otherShells.map((name) => (
+                  <DropdownMenuItem
+                    key={name}
+                    onSelect={() => pickShell(name)}
+                    disabled={shellDisabled}
+                    className="cursor-pointer"
+                  >
+                    {name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          ) : (
+            // Single type → a plain launch item.
+            <DropdownMenuItem
+              onSelect={() => launchShell(defaultShell)}
+              disabled={shellDisabled}
+              className="cursor-pointer"
+            >
+              {shellItemContent}
+            </DropdownMenuItem>
+          ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -702,6 +710,19 @@ function WorkspacePanelImpl({
   onShellCreateStart,
   onShellCreateFailed,
 }: WorkspacePanelProps) {
+  const browsers = useBrowserTabs(conversationId);
+  const activeBrowserRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    activeBrowserRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [browsers.selected, rightRailTab]);
+  const browserSelected =
+    rightRailTab === "browser" && selectedFilePath === null && selectedTerminalKey === null;
+  const addBrowser = showBrowserTab
+    ? () => {
+        browsers.add();
+        onRightRailTabChange("browser");
+      }
+    : undefined;
   // Memoized so FileViewer's Escape-to-close effect doesn't re-subscribe its
   // window keydown listener on every render — an inline arrow would change
   // identity each render and thrash the effect's add/remove cycle.
@@ -790,11 +811,15 @@ function WorkspacePanelImpl({
           // the fallback nav view, so its nav tab must highlight, not "__tab__".
           value={
             selectedFilePath !== null ||
+            (browserSelected && browsers.selected !== null) ||
             (selectedTerminalKey !== null && openTerminals.includes(selectedTerminalKey))
               ? "__tab__"
               : rightRailTab
           }
-          onValueChange={(v) => onRightRailTabChange(v as RightRailTab)}
+          onValueChange={(value) => {
+            if (value === "browser") browsers.select(null);
+            onRightRailTabChange(value as RightRailTab);
+          }}
           componentId="chat.right_rail.tabs"
         >
           <TabsList variant="pill" className="gap-1">
@@ -876,7 +901,9 @@ function WorkspacePanelImpl({
                 Pinned (outside the scrolling file-tabs region), so it stays put
                 at every rail width while the tabs scroll past it. */}
         <div aria-hidden className="mx-[8px] h-[14px] w-px shrink-0 self-center bg-border-strong" />
-        {(openFiles.length > 0 || openTerminals.length > 0) && (
+        {(openFiles.length > 0 ||
+          openTerminals.length > 0 ||
+          (showBrowserTab && browsers.tabs.length > 0)) && (
           <>
             {/* Open-tabs region (file tabs + shell tabs) — the horizontal
                 scroller. It sizes to its content and shrinks+scrolls only when
@@ -900,6 +927,47 @@ function WorkspacePanelImpl({
                 onSelect={openTerminalTab}
                 onClose={onCloseTerminal}
               />
+              {showBrowserTab &&
+                browsers.tabs.map((tabId, index) => (
+                  <div
+                    key={tabId}
+                    ref={browserSelected && browsers.selected === tabId ? activeBrowserRef : null}
+                    className={cn(
+                      "flex h-[24px] shrink-0 items-center gap-[6px] rounded-md px-2 text-ui font-medium leading-5 transition-colors",
+                      browserSelected && browsers.selected === tabId
+                        ? "bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] text-foreground"
+                        : "text-muted-foreground hover:bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] hover:text-foreground",
+                    )}
+                  >
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={browserSelected && browsers.selected === tabId}
+                      className="flex items-center gap-1"
+                      onAuxClick={(event) => {
+                        if (event.button === 1) {
+                          event.preventDefault();
+                          void browsers.close(tabId);
+                        }
+                      }}
+                      onClick={() => {
+                        browsers.select(tabId);
+                        onRightRailTabChange("browser");
+                      }}
+                    >
+                      <GlobeIcon className="size-4" />
+                      Browser {index + 1}
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Close Browser ${index + 1}`}
+                      className="flex size-4 items-center justify-center rounded hover:bg-muted"
+                      onClick={() => void browsers.close(tabId)}
+                    >
+                      <XIcon className="size-3" />
+                    </button>
+                  </div>
+                ))}
             </div>
             {/* "+" trails the last tab but sits OUTSIDE the scroller, so it
                 stays pinned (never scrolls under / overlaps the tabs) when they
@@ -907,6 +975,7 @@ function WorkspacePanelImpl({
                 same gap the scroller's gap-0.5 gives between tabs. */}
             <NewTabMenu
               conversationId={conversationId}
+              onOpenBrowser={addBrowser}
               onCreateError={onShellCreateFailed}
               onOpenTerminal={openTerminalTab}
               onCreateStart={onShellCreateStart}
@@ -919,15 +988,18 @@ function WorkspacePanelImpl({
             after the nav tabs (next to Shells); once tabs exist it moves into
             the open-tabs region to trail the last tab (see above). Self-gates
             to nothing when the agent has no terminal access. */}
-        {openFiles.length === 0 && openTerminals.length === 0 && (
-          <NewTabMenu
-            conversationId={conversationId}
-            onOpenTerminal={openTerminalTab}
-            onCreateStart={onShellCreateStart}
-            onCreateError={onShellCreateFailed}
-            liveness={liveness}
-          />
-        )}
+        {openFiles.length === 0 &&
+          openTerminals.length === 0 &&
+          (!showBrowserTab || browsers.tabs.length === 0) && (
+            <NewTabMenu
+              conversationId={conversationId}
+              onOpenBrowser={addBrowser}
+              onOpenTerminal={openTerminalTab}
+              onCreateStart={onShellCreateStart}
+              onCreateError={onShellCreateFailed}
+              liveness={liveness}
+            />
+          )}
         {/* Maximize/minimize toggle, pinned to the rightmost edge via ml-auto,
             which absorbs the free space before it. When open tabs exist their
             ≥500px flex-1 region absorbs the space instead, so the button still
@@ -981,7 +1053,12 @@ function WorkspacePanelImpl({
         ) : rightRailTab === "browser" && showBrowserTab ? (
           // Embedded browser (Electron only) — BrowserPane self-gates and
           // measures this rail slot to position the native view over it.
-          <BrowserPane conversationId={conversationId} className="min-h-0 flex-1" />
+          <BrowserPane
+            key={browsers.viewId}
+            conversationId={browsers.viewId}
+            agentBrowser={browsers.selected === null}
+            className="min-h-0 flex-1"
+          />
         ) : rightRailTab === "github" && showGithubTab ? (
           <GithubPanel conversationId={conversationId} />
         ) : rightRailTab === "subagents" && rootSessionId ? (


### PR DESCRIPTION
## Related issue

Linear: OMNI-3746

## Summary

- Adds independent, closable browser soft tabs from **+ → Browser** while preserving the pinned agent browser as the default.
- Persists each session's browser-tab inventory and selection, and restores each native view's URL/history state when switching.
- ELI5: each browser pill now gets its own native view key instead of every pill sharing the session's single browser.

```text
Workspace + menu → browser tab key → independent Electron WebContentsView
                              └── persisted selection per session
```

## Test Plan

- `cd web && npm test -- --run src/hooks/useBrowserTabs.test.tsx src/shell/WorkspacePanel.test.tsx src/shell/AppShell.test.tsx src/components/BrowserPane/BrowserPane.test.tsx src/lib/sessionWorkspaceState.test.ts` — 185/185 passed after rebasing onto current `main`.
- `cd web/electron && node --test test/browserIpc.test.js test/browserViewRegistry.test.js` — 60/60 passed after rebasing.
- `git diff --check upstream/main...HEAD` — passed.
- `cd web && npm run type-check` — blocked by the reused install missing `fake-indexeddb/auto` for two unchanged extension-service tests; changed-surface Vitest suites compile and pass.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Light and dark theme verification at standard width:

<img width="1200" height="520" alt="browser-tabs-light-dark" src="https://github.com/user-attachments/assets/e1925f5c-c0b6-49cd-9eb7-0b078f23a32a" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered tab creation, independent navigation/state, session restoration, close behavior, narrow overflow, and light/dark themes. The added E2E regression runs in GitHub CI; local automation used the Electron bridge stub rather than native WebContentsView painting.

## Changelog

You can open multiple independent browser tabs in a session.

