### PR TITLE
feat(slack): support host_type=managed sandbox sessions

### DIFF
--- a/integrations/slack/src/omnigent_slack/events.py
+++ b/integrations/slack/src/omnigent_slack/events.py
@@ -4,9 +4,17 @@ import json
 import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 _logger = logging.getLogger(__name__)
+
+# How a session gets its host, in the server's own ``host_type`` vocabulary.
+# ``external``: the session runs on a host the caller registered with
+# ``omni host`` and keeps online. ``managed``: the server provisions a sandbox
+# from its ``sandbox:`` config, chooses the host and workspace itself, and binds
+# the session to it — so the bot must not send a host id or a workspace path,
+# and must not launch a runner.
+HostType = Literal["external", "managed"]
 
 
 class OmnigentError(RuntimeError):

--- a/integrations/slack/src/omnigent_slack/models.py
+++ b/integrations/slack/src/omnigent_slack/models.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from omnigent_slack.events import HostType
+
 
 def event_is_dm(event: dict[str, object]) -> bool:
     """Whether a Slack event arrived via a 1:1 DM rather than a channel.
@@ -59,6 +61,10 @@ class UserConfig:
 
     The Omnigent server is operator-fixed (``OMNIGENT_SERVER_URL``), so it
     is not part of a user's config.
+
+    ``host_type`` picks between the two ways a session gets a host. It is
+    ``"managed"`` when the user chose a server-provisioned sandbox, and then
+    ``host_id`` and ``workspace`` are empty — the server chooses both.
     """
 
     agent_id: str
@@ -66,16 +72,23 @@ class UserConfig:
     workspace: str
     host_id: str | None = None
     host_name: str | None = None
+    host_type: HostType = "external"
 
 
 @dataclass(frozen=True, slots=True)
 class SessionRecord:
-    """A Slack thread's Omnigent session and where it runs."""
+    """A Slack thread's Omnigent session and where it runs.
+
+    ``host_type`` is recorded per session, not just per user: it decides whether
+    a later turn on this thread may launch a runner, and it must survive both a
+    bot restart and the user changing their setup mid-thread.
+    """
 
     session_id: str
     owner_user_id: str | None
     host_id: str | None
     workspace: str | None
+    host_type: HostType = "external"
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,3 +103,4 @@ class SlackTurn:
     owner_user_id: str
     workspace: str | None = None
     host_id: str | None = None
+    host_type: HostType = "external"

--- a/integrations/slack/src/omnigent_slack/omnigent.py
+++ b/integrations/slack/src/omnigent_slack/omnigent.py
@@ -19,6 +19,7 @@ from omnigent_slack.events import (
     ElicitationOption,
     ElicitationQuestion,
     ElicitationRequest,
+    HostType,
     OmnigentError,
     OutputFile,
     SessionActivity,
@@ -49,6 +50,7 @@ __all__ = [
     "ElicitationQuestion",
     "ElicitationRequest",
     "HarnessNotConfiguredError",
+    "HostType",
     "HostUnavailableError",
     "OmnigentClient",
     "OmnigentClientPool",
@@ -184,10 +186,19 @@ def _is_auth_redirect(location: str) -> bool:
 
 @dataclass(frozen=True, slots=True)
 class ValidatedServer:
-    """Outcome of probing an Omnigent server during Slack setup."""
+    """Outcome of probing an Omnigent server during Slack setup.
+
+    ``managed_hosts`` is whether the server can provision a sandbox for a
+    session itself, so setup can offer that instead of dead-ending a user who
+    runs no host of their own. ``managed_host_provider`` names the backing
+    provider (e.g. ``"modal"``) for the menu label, and is ``None`` when the
+    server doesn't name one.
+    """
 
     agents: list[dict[str, Any]]
     online_hosts: list[dict[str, Any]]
+    managed_hosts: bool = False
+    managed_host_provider: str | None = None
 
 
 class ClientAuth:
@@ -354,23 +365,59 @@ class OmnigentClient:
         # Setup-time probe. Confirms the server is reachable (``/health``) and
         # that unauthenticated access works — ``list_agents`` hits an
         # auth-gated endpoint, so a server with auth enabled raises
-        # ``AuthRequiredError`` here. Returns the agents and online hosts that
-        # populate the setup select menus.
+        # ``AuthRequiredError`` here. Returns the agents, online hosts, and
+        # managed-sandbox support that populate the setup select menus.
         await self.check_health()
         agents = await self.list_agents()
         hosts = await self.list_hosts()
         online_hosts = [host for host in hosts if _is_host_online(host)]
-        return ValidatedServer(agents=agents, online_hosts=online_hosts)
+        managed_hosts, provider = await self.managed_host_support()
+        return ValidatedServer(
+            agents=agents,
+            online_hosts=online_hosts,
+            managed_hosts=managed_hosts,
+            managed_host_provider=provider,
+        )
 
-    async def create_session(self, agent_id: str, title: str) -> str:
+    async def managed_host_support(self) -> tuple[bool, str | None]:
+        """Whether the server provisions managed sandboxes, and which provider.
+
+        Reads ``managed_sandboxes_enabled`` / ``sandbox_provider`` off the
+        unauthenticated ``GET /v1/info`` — the same gate the web UI's
+        new-session sandbox option uses, so a server whose ``sandbox:`` config
+        is missing or can't actually launch never advertises the option.
+        Best-effort: an unreadable probe reports "not supported", so setup
+        offers a managed session only when the create would be accepted.
+        """
+        info = await self._get_json("/v1/info")
+        if info is None:
+            self._logger.info("Omnigent server info unavailable; managed sandboxes not offered")
+            return False, None
+        enabled = info.get("managed_sandboxes_enabled") is True
+        provider = info.get("sandbox_provider")
+        self._logger.debug("Omnigent managed sandboxes enabled=%s provider=%s", enabled, provider)
+        return enabled, provider if isinstance(provider, str) and provider else None
+
+    async def create_session(
+        self,
+        agent_id: str,
+        title: str,
+        *,
+        host_type: HostType = "external",
+    ) -> str:
         # Don't log the title — it embeds the user's message text; log only the
         # agent id (everywhere else we log lengths, not content).
-        self._logger.info("Creating Omnigent session agent_id=%s", agent_id)
-        response = await self._request(
-            "POST",
-            "/v1/sessions",
-            json={"agent_id": agent_id, "title": title},
+        self._logger.info(
+            "Creating Omnigent session agent_id=%s host_type=%s", agent_id, host_type
         )
+        body: dict[str, Any] = {"agent_id": agent_id, "title": title}
+        if host_type == "managed":
+            # The server picks the sandbox's host and workspace, and rejects a
+            # caller-supplied ``host_id``/path with a 422 — so send only the
+            # switch. The key is omitted for an external session so that request
+            # stays byte-identical to what the server has always received.
+            body["host_type"] = host_type
+        response = await self._request("POST", "/v1/sessions", json=body)
         await _raise_for_status(response)
         payload = response.json()
         session_id = _extract_session_id(payload)
@@ -611,6 +658,7 @@ class OmnigentClient:
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: HostType = "external",
         idle_grace_seconds: float = 600.0,
     ) -> AsyncIterator[dict[str, Any]]:
         try:
@@ -618,6 +666,16 @@ class OmnigentClient:
                 yield event
             return
         except RunnerUnavailableError:
+            if host_type == "managed":
+                # The server owns a managed session's sandbox and rebinds its
+                # runner itself; there is no host of ours to launch on, and the
+                # session has no workspace path to launch in.
+                self._logger.info(
+                    "Managed session reported no runner; leaving the relaunch to "
+                    "the server session_id=%s",
+                    session_id,
+                )
+                raise
             # No runner bound to the session — launch one and retry the turn once.
             if not workspace:
                 raise

--- a/integrations/slack/src/omnigent_slack/service.py
+++ b/integrations/slack/src/omnigent_slack/service.py
@@ -461,6 +461,10 @@ class SlackOmnigentService:
                         owner_user_id=record.owner_user_id or requester,
                         workspace=record.workspace,
                         host_id=record.host_id,
+                        # From the SESSION, not the user's current config: a
+                        # thread keeps running where it was created even if the
+                        # user re-runs setup and switches host type.
+                        host_type=record.host_type,
                     )
                 )
                 spawned = True
@@ -494,6 +498,7 @@ class SlackOmnigentService:
                     owner_user_id=requester,
                     workspace=config.workspace,
                     host_id=config.host_id,
+                    host_type=config.host_type,
                 )
             )
             spawned = True
@@ -651,10 +656,23 @@ class SlackOmnigentService:
             return None
 
         try:
-            session_id = await omnigent.create_session(turn.agent_id, turn.title)
-            runner_id = await omnigent.launch_runner(
-                session_id, workspace=turn.workspace or "", host_id=turn.host_id
+            session_id = await omnigent.create_session(
+                turn.agent_id, turn.title, host_type=turn.host_type
             )
+            runner_id: str | None = None
+            if turn.host_type == "managed":
+                # The server provisions this session's sandbox in the background,
+                # so there is no host to launch a runner on — and none is needed:
+                # the server holds the first message until the launch settles.
+                self._logger.info(
+                    "Managed session; the server provisions its host thread=%s session_id=%s",
+                    turn.key.display(),
+                    session_id,
+                )
+            else:
+                runner_id = await omnigent.launch_runner(
+                    session_id, workspace=turn.workspace or "", host_id=turn.host_id
+                )
         except AuthRequiredError as exc:
             # Expired/lost token: DM a re-login button rather than a plain notice.
             self._logger.info(
@@ -693,6 +711,7 @@ class SlackOmnigentService:
             owner_user_id=turn.owner_user_id,
             host_id=turn.host_id,
             workspace=turn.workspace,
+            host_type=turn.host_type,
         )
         self._logger.info(
             "Mapped Slack thread to new Omnigent session thread=%s session_id=%s runner_id=%s",
@@ -749,7 +768,11 @@ class SlackOmnigentService:
             # idle windows (a timeout must NOT cancel it — that would end the
             # generator); we re-await it next window.
             events = omnigent.run_turn(
-                session_id, turn.text, workspace=turn.workspace, host_id=turn.host_id
+                session_id,
+                turn.text,
+                workspace=turn.workspace,
+                host_id=turn.host_id,
+                host_type=turn.host_type,
             ).__aiter__()
             pending: asyncio.Task[dict[str, Any]] | None = None
             try:

--- a/integrations/slack/src/omnigent_slack/setup.py
+++ b/integrations/slack/src/omnigent_slack/setup.py
@@ -42,6 +42,12 @@ HOST_ACTION = "host_select"
 WORKSPACE_BLOCK = "workspace_block"
 WORKSPACE_ACTION = "workspace_input"
 
+# ``value`` of the host menu's managed-sandbox entry. Not a host id: the server
+# provisions the host when the session is created, so this marks "let the server
+# choose one" rather than naming a machine. Prefixed and underscored so it can
+# never collide with a real host id.
+MANAGED_HOST_VALUE = "__omnigent_managed__"
+
 # Slack caps a static_select at 100 options; both agents and hosts are far
 # below that in practice, but truncate defensively so a huge server never
 # produces an invalid view payload.
@@ -370,16 +376,23 @@ class SetupFlow:
             # routing through the login-framed errors branch.
             await ack(response_action="update", view=no_agents_modal(server_url))
             return
-        if not validated.online_hosts:
-            # A session needs a host to run on, so setup can't finish without
-            # one. Swap the modal for the same guidance a turn shows when no
-            # host is reachable, telling the user how to bring one online.
+        if not validated.online_hosts and not validated.managed_hosts:
+            # Nothing can run a session: the user has no host of their own online
+            # and the server provisions none. Swap the modal for the same
+            # guidance a turn shows when no host is reachable, telling the user
+            # how to bring one online. A server WITH managed sandboxes never
+            # reaches here — the picker offers one instead of dead-ending.
             await ack(response_action="update", view=no_host_modal(server_url))
             return
         # Default the workspace to the host's home directory (where runners
         # actually run), not the bot process's cwd. Fall back to the bot's cwd
-        # only if the host can't be probed.
-        workspace_default = await self._resolve_default_workspace(omnigent, validated.online_hosts)
+        # only if the host can't be probed. With no host to probe, leave it
+        # blank — the bot's cwd names nothing a managed sandbox can use.
+        workspace_default = (
+            await self._resolve_default_workspace(omnigent, validated.online_hosts)
+            if validated.online_hosts
+            else None
+        )
         await ack(
             response_action="update",
             view=select_modal(server_url, validated, workspace_default=workspace_default),
@@ -661,14 +674,9 @@ class SetupFlow:
             )
             return
 
-        workspace = _input_value(view, WORKSPACE_BLOCK, WORKSPACE_ACTION).strip()
-        if not workspace.startswith("/"):
-            await ack(
-                response_action="errors",
-                errors={WORKSPACE_BLOCK: "Enter an absolute workspace path (starting with /)."},
-            )
-            return
-
+        # The host choice is read BEFORE the workspace, because it decides what a
+        # valid workspace is: a managed sandbox is created by the server with its
+        # own working directory, so there is no path for the user to supply.
         host_option = _selected_option(view, HOST_BLOCK, HOST_ACTION)
         if host_option is None:
             await ack(
@@ -676,8 +684,25 @@ class SetupFlow:
                 errors={HOST_BLOCK: "Select a host to run your sessions on."},
             )
             return
-        host_id = str(host_option.get("value"))
+        host_value = str(host_option.get("value"))
+        managed = host_value == MANAGED_HOST_VALUE
+        host_id = None if managed else host_value
         host_name = _option_text(host_option)
+
+        # A managed sandbox's working directory is created by the server inside
+        # it, so the path field does not apply and is not stored. An external
+        # host still needs an absolute path to start its runner in.
+        workspace = ""
+        if not managed:
+            workspace = _input_value(view, WORKSPACE_BLOCK, WORKSPACE_ACTION).strip()
+            if not workspace.startswith("/"):
+                await ack(
+                    response_action="errors",
+                    errors={
+                        WORKSPACE_BLOCK: "Enter an absolute workspace path (starting with /)."
+                    },
+                )
+                return
 
         config = UserConfig(
             agent_id=str(agent_option.get("value")),
@@ -685,6 +710,7 @@ class SetupFlow:
             workspace=workspace,
             host_id=host_id,
             host_name=host_name,
+            host_type="managed" if managed else "external",
         )
 
         team_id = str((body.get("team") or {}).get("id") or body.get("team_id") or "")
@@ -700,15 +726,19 @@ class SetupFlow:
         await self._store.upsert_user_config(team_id, user_id, config)
         await ack()
         self._logger.info(
-            "Saved Omnigent setup team=%s user=%s server=%s agent=%s host=%s",
+            "Saved Omnigent setup team=%s user=%s server=%s agent=%s host_type=%s host=%s",
             team_id,
             user_id,
             server_url,
             config.agent_id,
+            config.host_type,
             host_id,
         )
 
-        host_line = f" on host *{host_name}*" if host_name else ""
+        if managed:
+            host_line = " in a sandbox this server runs for you"
+        else:
+            host_line = f" on host *{host_name}*" if host_name else ""
         await self._dm_user(
             client,
             user_id,
@@ -966,7 +996,7 @@ def select_modal(
             },
         },
     ]
-    host_options = _host_options(validated.online_hosts)
+    host_options = _host_options(validated)
     blocks.append(
         {
             "type": "input",
@@ -980,20 +1010,35 @@ def select_modal(
             },
         }
     )
+    workspace_element: dict[str, Any] = {
+        "type": "plain_text_input",
+        "action_id": WORKSPACE_ACTION,
+        "placeholder": {"type": "plain_text", "text": "/absolute/path/on/the/host"},
+    }
+    # A path only means something on a host the user runs. Seed it from that host
+    # when there is one; with only a managed sandbox on offer, start blank rather
+    # than suggest a directory that exists nowhere the session can reach.
+    workspace_initial = workspace_default or (
+        default_workspace() if validated.online_hosts else ""
+    )
+    if workspace_initial:
+        workspace_element["initial_value"] = workspace_initial
     blocks.append(
         {
             "type": "input",
             "block_id": WORKSPACE_BLOCK,
+            # Optional in Slack's own required-field check, because a managed
+            # sandbox brings its own workspace. The submit handler still demands
+            # an absolute path whenever a real host is chosen.
+            "optional": True,
             "label": {"type": "plain_text", "text": "Workspace path"},
-            "element": {
-                "type": "plain_text_input",
-                "action_id": WORKSPACE_ACTION,
-                "initial_value": workspace_default or default_workspace(),
-                "placeholder": {"type": "plain_text", "text": "/absolute/path/on/the/host"},
-            },
+            "element": workspace_element,
             "hint": {
                 "type": "plain_text",
-                "text": "Absolute directory on the host where each session's runner starts.",
+                "text": (
+                    "Absolute directory on the host where each session's runner "
+                    "starts. Ignored for a managed sandbox."
+                ),
             },
         }
     )
@@ -1018,15 +1063,35 @@ def _agent_options(agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return options
 
 
-def _host_options(hosts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _host_options(validated: ValidatedServer) -> list[dict[str, Any]]:
+    """Host menu entries: the managed sandbox first, then the user's own hosts.
+
+    The managed entry is listed first so a user with nothing online still sees a
+    usable choice at the top of the menu, and is omitted entirely when the server
+    can't provision one — an option that would only 422 is worse than no option.
+    """
     options: list[dict[str, Any]] = []
-    for host in hosts[:_MAX_SELECT_OPTIONS]:
+    if validated.managed_hosts:
+        options.append(
+            _option(
+                truncate_option(managed_host_label(validated.managed_host_provider)),
+                MANAGED_HOST_VALUE,
+            )
+        )
+    # The managed entry counts against Slack's option cap, so the host slice
+    # shrinks by what is already in the menu.
+    for host in validated.online_hosts[: _MAX_SELECT_OPTIONS - len(options)]:
         host_id = host_id_of(host)
         if host_id is None:
             continue
         name = host.get("name") or host_id
         options.append(_option(truncate_option(str(name)), host_id))
     return options
+
+
+def managed_host_label(provider: str | None) -> str:
+    """Menu label for the server-provisioned sandbox, named by its provider."""
+    return f"Managed sandbox ({provider})" if provider else "Managed sandbox"
 
 
 def _option(text: str, value: str) -> dict[str, Any]:

--- a/integrations/slack/src/omnigent_slack/store.py
+++ b/integrations/slack/src/omnigent_slack/store.py
@@ -2,10 +2,33 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Any
 
 import aiosqlite
 
+from omnigent_slack.events import HostType
 from omnigent_slack.models import SessionRecord, ThreadKey, UserConfig
+
+# Columns added to a table after it was first created, as
+# ``(table, column, definition)``. ``CREATE TABLE IF NOT EXISTS`` leaves an
+# existing table alone, so a database written by an earlier build keeps the old
+# shape and every query naming a newer column fails. ``initialize`` adds each
+# missing one in place. A definition must carry a default, since SQLite requires
+# one to add a NOT NULL column to a populated table.
+_ADDED_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("thread_sessions", "host_type", "TEXT NOT NULL DEFAULT 'external'"),
+    ("user_configs", "host_type", "TEXT NOT NULL DEFAULT 'external'"),
+)
+
+
+def _host_type(value: Any) -> HostType:
+    """Narrow a stored ``host_type`` to the literal, defaulting to external.
+
+    A row written before the column existed reads as its ``'external'``
+    default, and anything unrecognized would be a hand-edited database. Both
+    land on ``"external"`` — the behavior every pre-existing row had.
+    """
+    return "managed" if value == "managed" else "external"
 
 
 class SQLiteStore:
@@ -27,6 +50,7 @@ class SQLiteStore:
                     owner_user_id TEXT,
                     host_id TEXT,
                     workspace TEXT,
+                    host_type TEXT NOT NULL DEFAULT 'external',
                     created_at INTEGER NOT NULL,
                     updated_at INTEGER NOT NULL,
                     PRIMARY KEY (team_id, channel_id, thread_ts)
@@ -51,19 +75,38 @@ class SQLiteStore:
                     workspace TEXT,
                     host_id TEXT,
                     host_name TEXT,
+                    host_type TEXT NOT NULL DEFAULT 'external',
                     created_at INTEGER NOT NULL,
                     updated_at INTEGER NOT NULL,
                     PRIMARY KEY (team_id, user_id)
                 )
                 """
             )
+            await self._add_missing_columns(db)
             await db.commit()
+
+    @staticmethod
+    async def _add_missing_columns(db: aiosqlite.Connection) -> None:
+        """Bring an older database's tables up to the current column set.
+
+        SQLite has no ``ADD COLUMN IF NOT EXISTS``, so read each table's live
+        columns and add only what :data:`_ADDED_COLUMNS` says is missing. That
+        keeps ``initialize`` idempotent on a fresh file and on one written
+        before the column existed.
+        """
+        for table, column, definition in _ADDED_COLUMNS:
+            cursor = await db.execute(f"PRAGMA table_info({table})")
+            rows = await cursor.fetchall()
+            await cursor.close()
+            if any(row[1] == column for row in rows):
+                continue
+            await db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
 
     async def get_session(self, key: ThreadKey) -> SessionRecord | None:
         async with aiosqlite.connect(self._path) as db:
             cursor = await db.execute(
                 """
-                SELECT omnigent_session_id, owner_user_id, host_id, workspace
+                SELECT omnigent_session_id, owner_user_id, host_id, workspace, host_type
                 FROM thread_sessions
                 WHERE team_id = ? AND channel_id = ? AND thread_ts = ?
                 """,
@@ -78,6 +121,7 @@ class SQLiteStore:
             owner_user_id=str(row[1]) if row[1] is not None else None,
             host_id=str(row[2]) if row[2] is not None else None,
             workspace=str(row[3]) if row[3] is not None else None,
+            host_type=_host_type(row[4]),
         )
 
     async def upsert_session(
@@ -89,6 +133,7 @@ class SQLiteStore:
         owner_user_id: str | None = None,
         host_id: str | None = None,
         workspace: str | None = None,
+        host_type: HostType = "external",
     ) -> None:
         now = int(time.time())
         async with aiosqlite.connect(self._path) as db:
@@ -96,16 +141,17 @@ class SQLiteStore:
                 """
                 INSERT INTO thread_sessions (
                     team_id, channel_id, thread_ts, omnigent_session_id,
-                    title, owner_user_id, host_id, workspace,
+                    title, owner_user_id, host_id, workspace, host_type,
                     created_at, updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(team_id, channel_id, thread_ts) DO UPDATE SET
                     omnigent_session_id = excluded.omnigent_session_id,
                     title = excluded.title,
                     owner_user_id = excluded.owner_user_id,
                     host_id = excluded.host_id,
                     workspace = excluded.workspace,
+                    host_type = excluded.host_type,
                     updated_at = excluded.updated_at
                 """,
                 (
@@ -117,6 +163,7 @@ class SQLiteStore:
                     owner_user_id,
                     host_id,
                     workspace,
+                    host_type,
                     now,
                     now,
                 ),
@@ -127,7 +174,7 @@ class SQLiteStore:
         async with aiosqlite.connect(self._path) as db:
             cursor = await db.execute(
                 """
-                SELECT agent_id, agent_name, workspace, host_id, host_name
+                SELECT agent_id, agent_name, workspace, host_id, host_name, host_type
                 FROM user_configs
                 WHERE team_id = ? AND user_id = ?
                 """,
@@ -143,6 +190,7 @@ class SQLiteStore:
             workspace=str(row[2]) if row[2] is not None else "",
             host_id=str(row[3]) if row[3] is not None else None,
             host_name=str(row[4]) if row[4] is not None else None,
+            host_type=_host_type(row[5]),
         )
 
     async def upsert_user_config(self, team_id: str, user_id: str, config: UserConfig) -> None:
@@ -151,16 +199,17 @@ class SQLiteStore:
             await db.execute(
                 """
                 INSERT INTO user_configs (
-                    team_id, user_id, agent_id, agent_name,
-                    workspace, host_id, host_name, created_at, updated_at
+                    team_id, user_id, agent_id, agent_name, workspace,
+                    host_id, host_name, host_type, created_at, updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(team_id, user_id) DO UPDATE SET
                     agent_id = excluded.agent_id,
                     agent_name = excluded.agent_name,
                     workspace = excluded.workspace,
                     host_id = excluded.host_id,
                     host_name = excluded.host_name,
+                    host_type = excluded.host_type,
                     updated_at = excluded.updated_at
                 """,
                 (
@@ -171,6 +220,7 @@ class SQLiteStore:
                     config.workspace,
                     config.host_id,
                     config.host_name,
+                    config.host_type,
                     now,
                     now,
                 ),

--- a/integrations/slack/tests/fakes.py
+++ b/integrations/slack/tests/fakes.py
@@ -215,6 +215,7 @@ OMNIGENT_ENDPOINTS: list[tuple[str, str, bool]] = [
     # Setup / validation.
     ("GET", "/health", True),
     ("GET", "/v1/me", True),
+    ("GET", "/v1/info", True),
     ("GET", "/v1/agents", True),
     ("GET", "/v1/hosts", True),
     ("GET", "/v1/hosts/{host_id}/filesystem", True),
@@ -247,6 +248,9 @@ OMNIGENT_RESPONSE_FIELDS: dict[str, tuple[str, ...]] = {
     "SessionResponse": ("harness", "agent_name"),
     # GET /v1/agents → PaginatedList (list_agents reads .data).
     "PaginatedList": ("data",),
+    # GET /v1/info → ServerInfoResponse (managed_host_support gates the setup
+    # menu's managed-sandbox option on these two).
+    "ServerInfoResponse": ("managed_sandboxes_enabled", "sandbox_provider"),
 }
 
 
@@ -293,6 +297,10 @@ class FakeOmnigentServer:
         self.hosts: list[dict[str, Any]] = [
             {"host_id": "h1", "name": "Host One", "status": "online"}
         ]
+        # Managed-sandbox capability reported by GET /v1/info — the gate that
+        # decides whether setup offers a server-provisioned host at all.
+        self.managed_sandboxes_enabled = False
+        self.sandbox_provider: str | None = None
         self.session_id = "conv_1"
         self.runner_id = "runner_1"
         self.harness = "claude-native"
@@ -366,6 +374,20 @@ class FakeOmnigentServer:
             return httpx.Response(401, json={"login_url": "/login"})
 
         respx_mock.get(b + "/v1/me").mock(side_effect=_me)
+
+        # Capability probe (unauthed): whether the server provisions managed
+        # sandboxes, and which provider labels the setup menu entry.
+        def _info(request: httpx.Request) -> httpx.Response:
+            self._record(request)
+            return httpx.Response(
+                200,
+                json={
+                    "managed_sandboxes_enabled": self.managed_sandboxes_enabled,
+                    "sandbox_provider": self.sandbox_provider,
+                },
+            )
+
+        respx_mock.get(b + "/v1/info").mock(side_effect=_info)
 
         def _device_authorize(request: httpx.Request) -> httpx.Response:
             self._record(request)

--- a/integrations/slack/tests/test_integration.py
+++ b/integrations/slack/tests/test_integration.py
@@ -60,6 +60,19 @@ async def _configure_user(
     )
 
 
+async def _configure_managed_user(store: SQLiteStore, team_id: str, user_id: str) -> None:
+    """Configure a user whose sessions run in a server-provisioned sandbox.
+
+    No host id and no workspace: the server chooses both when the session is
+    created.
+    """
+    await store.upsert_user_config(
+        team_id,
+        user_id,
+        UserConfig(agent_id="ag_1", agent_name="debby", workspace="", host_type="managed"),
+    )
+
+
 # Generous ceiling for the waits below. These are event-driven (they await the
 # actual turn task), so a healthy run returns near-instantly and never spends
 # this budget; it only bounds a genuine hang. Kept well above any real turn so a
@@ -217,6 +230,53 @@ async def test_app_mention_runs_full_turn_and_streams_answer(tmp_path: Path) -> 
     assert f"/v1/sessions/{server.session_id}/stream" in server.paths("GET")
 
     # Slack side: the SSE answer streamed into the reply.
+    assert "Here is the answer." in client.streamed_text
+
+
+# ── Scenario 3b: managed session → create + submit, never a runner launch ──────
+
+
+@respx.mock
+async def test_managed_session_turn_never_posts_a_runner_launch(tmp_path: Path) -> None:
+    """A managed session's host is provisioned by the server, so the turn goes
+    create → submit → stream with NO ``POST /v1/hosts/{id}/runners`` in between —
+    and the create carries ``host_type`` without a host id or workspace."""
+    server = FakeOmnigentServer(_SERVER)
+    server.managed_sandboxes_enabled = True
+    server.sandbox_provider = "modal"
+    server.install(respx.mock)
+
+    store = await _store(tmp_path)
+    await _configure_managed_user(store, "T1", "U1")
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> review this"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_stream_stop(client, service)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # Server side: the create asks the server to provision the host, and sends
+    # neither a host id nor a workspace (both are a 422 for a managed session).
+    create = server.assert_request(
+        "POST", "/v1/sessions", json_contains={"agent_id": "ag_1", "host_type": "managed"}
+    )
+    assert "host_id" not in create[3]
+    assert "workspace" not in create[3]
+    # No runner launch anywhere, and no host listing to pick one from.
+    assert not any(path.endswith("/runners") for path in server.paths("POST"))
+    assert "/v1/hosts" not in server.paths("GET")
+    # The turn still submitted and streamed — the server queues the first message
+    # until its sandbox launch settles.
+    server.assert_request("POST", f"/v1/sessions/{server.session_id}/events")
     assert "Here is the answer." in client.streamed_text
 
 

--- a/integrations/slack/tests/test_omnigent.py
+++ b/integrations/slack/tests/test_omnigent.py
@@ -153,6 +153,59 @@ async def test_client_create_and_submit_request_shapes() -> None:
 
 
 @respx.mock
+async def test_create_session_managed_asks_the_server_to_provision_a_host() -> None:
+    # A managed session sends ONLY the host_type switch: the server picks the
+    # sandbox's host and workspace, and 422s a caller that supplies either.
+    create = respx.post("http://omnigent.test/v1/sessions").mock(
+        return_value=httpx.Response(201, json={"id": "conv_m"})
+    )
+    client = OmnigentClient("http://omnigent.test")
+
+    try:
+        session_id = await client.create_session("ag_1", "Slack C/1", host_type="managed")
+    finally:
+        await client.aclose()
+
+    assert session_id == "conv_m"
+    assert create.calls.last.request.read() == (
+        b'{"agent_id":"ag_1","title":"Slack C/1","host_type":"managed"}'
+    )
+
+
+@respx.mock
+async def test_managed_host_support_reads_the_server_capability_probe() -> None:
+    info = respx.get("http://omnigent.test/v1/info").mock(
+        return_value=httpx.Response(
+            200, json={"managed_sandboxes_enabled": True, "sandbox_provider": "modal"}
+        )
+    )
+    client = OmnigentClient("http://omnigent.test")
+
+    try:
+        supported = await client.managed_host_support()
+    finally:
+        await client.aclose()
+
+    assert supported == (True, "modal")
+    assert info.calls.call_count == 1
+
+
+@respx.mock
+async def test_managed_host_support_reports_unsupported_when_probe_fails() -> None:
+    # An unreadable /v1/info must NOT advertise managed sandboxes: setup would
+    # then offer an option the server rejects with a 422 at first message.
+    respx.get("http://omnigent.test/v1/info").mock(return_value=httpx.Response(500))
+    client = OmnigentClient("http://omnigent.test")
+
+    try:
+        supported = await client.managed_host_support()
+    finally:
+        await client.aclose()
+
+    assert supported == (False, None)
+
+
+@respx.mock
 async def test_check_health_probes_health_endpoint() -> None:
     health = respx.get("http://omnigent.test/health").mock(
         return_value=httpx.Response(200, json={"status": "ok"})
@@ -187,6 +240,11 @@ async def test_validate_returns_agents_and_online_hosts() -> None:
             },
         )
     )
+    respx.get("http://omnigent.test/v1/info").mock(
+        return_value=httpx.Response(
+            200, json={"managed_sandboxes_enabled": False, "sandbox_provider": None}
+        )
+    )
     client = OmnigentClient("http://omnigent.test")
 
     try:
@@ -196,6 +254,8 @@ async def test_validate_returns_agents_and_online_hosts() -> None:
 
     assert [a["id"] for a in validated.agents] == ["ag_1"]
     assert [h["host_id"] for h in validated.online_hosts] == ["h_on"]
+    assert validated.managed_hosts is False
+    assert validated.managed_host_provider is None
 
 
 @respx.mock
@@ -814,6 +874,83 @@ async def test_client_raises_runner_unavailable() -> None:
         await client.aclose()
 
     assert raised is True
+
+
+@respx.mock
+async def test_run_turn_relaunches_a_runner_only_for_an_external_session() -> None:
+    # A session whose runner died reports 503 runner_unavailable on submit. For
+    # an EXTERNAL host the client launches a fresh runner and retries the turn.
+    respx.post("http://omnigent.test/v1/sessions/conv_1/events").mock(
+        side_effect=[
+            httpx.Response(503, json={"error": {"code": "runner_unavailable"}}),
+            httpx.Response(202, json={}),
+        ]
+    )
+    respx.get("http://omnigent.test/v1/sessions/conv_1/stream").mock(
+        return_value=httpx.Response(
+            200,
+            text=(
+                'data: {"type":"response.output_text.delta","delta":"back"}\n\n'
+                'data: {"type":"session.status","status":"idle","response_id":"r1"}\n\n'
+            ),
+        )
+    )
+    launch = respx.post("http://omnigent.test/v1/hosts/host_1/runners").mock(
+        return_value=httpx.Response(200, json={"runner_id": "runner_2"})
+    )
+    respx.get("http://omnigent.test/v1/runners/runner_2/status").mock(
+        return_value=httpx.Response(200, json={"online": True})
+    )
+    client = OmnigentClient("http://omnigent.test")
+
+    try:
+        deltas = [
+            event.get("delta")
+            async for event in client.run_turn(
+                "conv_1", "go", workspace="/home/u", host_id="host_1"
+            )
+            if event.get("type") == "response.output_text.delta"
+        ]
+    finally:
+        await client.aclose()
+
+    assert deltas == ["back"]
+    assert launch.called
+
+
+@respx.mock
+async def test_run_turn_never_launches_a_runner_for_a_managed_session() -> None:
+    # The server owns a managed session's sandbox and rebinds its runner itself.
+    # There is no host of ours to launch on, so the client must surface the
+    # failure rather than POST a runner onto a host it doesn't own.
+    respx.post("http://omnigent.test/v1/sessions/conv_m/events").mock(
+        return_value=httpx.Response(503, json={"error": {"code": "runner_unavailable"}})
+    )
+    respx.get("http://omnigent.test/v1/sessions/conv_m/stream").mock(
+        return_value=httpx.Response(200, text="")
+    )
+    hosts = respx.get("http://omnigent.test/v1/hosts").mock(
+        return_value=httpx.Response(200, json={"hosts": [{"host_id": "h1", "status": "online"}]})
+    )
+    launch = respx.post(url__regex=r"http://omnigent\.test/v1/hosts/[^/]+/runners").mock(
+        return_value=httpx.Response(200, json={"runner_id": "runner_2"})
+    )
+    client = OmnigentClient("http://omnigent.test")
+
+    try:
+        raised = False
+        try:
+            async for _event in client.run_turn("conv_m", "go", host_type="managed"):
+                pass
+        except RunnerUnavailableError:
+            raised = True
+    finally:
+        await client.aclose()
+
+    assert raised is True
+    # No runner launch, and no host was even shopped for one.
+    assert not launch.called
+    assert not hosts.called
 
 
 @respx.mock

--- a/integrations/slack/tests/test_service.py
+++ b/integrations/slack/tests/test_service.py
@@ -10,6 +10,7 @@ from omnigent_slack.models import ThreadKey, UserConfig
 from omnigent_slack.omnigent import (
     AuthRequiredError,
     HarnessNotConfiguredError,
+    HostType,
     HostUnavailableError,
     OmnigentError,
     ServerUnreachableError,
@@ -232,6 +233,10 @@ class FakeSlackClient:
 class FakeOmnigentClient:
     def __init__(self, final_text: str = "hello final") -> None:
         self.created: list[tuple[str, str]] = []
+        # host_type each create_session / run_turn was asked for, so a test can
+        # prove a managed session never reaches the runner-launch path.
+        self.created_host_types: list[str] = []
+        self.turn_host_types: list[str] = []
         self.bound: list[str] = []
         self.launched: list[tuple[str, str, str | None]] = []
         self.turns: list[tuple[str, str]] = []
@@ -272,8 +277,11 @@ class FakeOmnigentClient:
 
         return SessionInfo(harness=self.info_harness, agent_name=self.info_agent_name)
 
-    async def create_session(self, agent_id: str, title: str) -> str:
+    async def create_session(
+        self, agent_id: str, title: str, *, host_type: str = "external"
+    ) -> str:
         self.created.append((agent_id, title))
+        self.created_host_types.append(host_type)
         return self.next_session_id
 
     async def launch_runner(
@@ -290,8 +298,10 @@ class FakeOmnigentClient:
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
+        self.turn_host_types.append(host_type)
         yield {"type": "response.output_text.delta", "delta": "hel"}
         yield {"type": "response.output_text.delta", "delta": "lo"}
         yield {
@@ -416,6 +426,7 @@ async def _configure_user(
     agent_id: str = "ag_1",
     workspace: str = "/tmp/workspace",
     host_id: str | None = None,
+    host_type: HostType = "external",
 ) -> None:
     await store.upsert_user_config(
         team_id,
@@ -425,6 +436,7 @@ async def _configure_user(
             agent_name="Helper",
             workspace=workspace,
             host_id=host_id,
+            host_type=host_type,
         ),
     )
 
@@ -487,6 +499,63 @@ async def test_app_mention_creates_session_and_posts_response(tmp_path: Path) ->
     # stop(); the ack was still live then and is deleted only afterwards, so the
     # thread is never empty while waiting for content.
     assert stream.ack_live_when_visible is True
+
+
+async def test_managed_session_skips_the_runner_launch(tmp_path: Path) -> None:
+    # A managed session has no host to launch a runner on when it is created —
+    # the server provisions the sandbox in the background and queues the first
+    # message until the launch settles. Creating one must go straight to the turn.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = FakeOmnigentClient()
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1", workspace="", host_type="managed")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> hello"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    stream = await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    # The create asked for a managed host and NO runner was launched.
+    assert omnigent.created_host_types == ["managed"]
+    assert omnigent.launched == []
+    # The turn still ran and answered, and it knows it is managed — so a lost
+    # runner mid-turn won't be "fixed" by launching one on someone else's host.
+    assert omnigent.turns == [("conv_1", "hello")]
+    assert omnigent.turn_host_types == ["managed"]
+    assert stream.text == "hello final"
+    # The session is recorded as managed, so a follow-up after a restart still
+    # knows not to launch a runner for this thread.
+    record = await store.get_session(ThreadKey("T1", "C1", "100.1"))
+    assert record is not None
+    assert record.host_type == "managed"
+    assert record.host_id is None
+
+
+async def test_external_session_still_launches_a_runner(tmp_path: Path) -> None:
+    # The default path is unchanged: an external host gets its runner launched
+    # in the caller's workspace before the turn starts.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = FakeOmnigentClient()
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1", workspace="/tmp/ws", host_id="h1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> hello"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    assert omnigent.created_host_types == ["external"]
+    assert omnigent.launched == [("conv_1", "/tmp/ws", "h1")]
 
 
 async def test_failed_handle_unclaims_event_so_it_can_retry(tmp_path: Path) -> None:
@@ -648,6 +717,7 @@ class StreamingClient(FakeOmnigentClient):
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
         for i in range(0, len(self.final_text), 500):
@@ -680,6 +750,7 @@ class NoDeltaIdleClient(FakeOmnigentClient):
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
         yield {"type": "session.status", "status": "running"}
@@ -735,6 +806,7 @@ class MultiMessageClient(FakeOmnigentClient):
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
         yield {"type": "session.status", "status": "running", "response_id": "resp_1"}
@@ -822,6 +894,7 @@ async def test_turn_error_posts_separate_reply_and_keeps_answer(tmp_path: Path) 
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             yield {
@@ -881,6 +954,7 @@ async def test_turn_error_without_answer_finalizes_with_generic_message(tmp_path
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             yield {
@@ -923,6 +997,7 @@ async def test_exhausted_reconnect_shows_non_alarming_text(tmp_path: Path) -> No
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             raise StreamInterruptedError("stream dropped mid-turn")
@@ -1025,6 +1100,7 @@ async def test_stream_closed_then_error_continues_and_posts_failure(tmp_path: Pa
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             yield {"type": "response.output_text.delta", "delta": "part one "}
@@ -1270,6 +1346,7 @@ async def test_second_message_while_local_stream_active_is_deflected(tmp_path: P
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             await release.wait()  # hold the first turn streaming locally
@@ -1688,7 +1765,9 @@ async def test_turn_runs_against_the_fixed_operator_server(tmp_path: Path) -> No
 
 
 class ServerUnreachableClient(FakeOmnigentClient):
-    async def create_session(self, agent_id: str, title: str) -> str:
+    async def create_session(
+        self, agent_id: str, title: str, *, host_type: str = "external"
+    ) -> str:
         raise ServerUnreachableError("boom")
 
 
@@ -1700,12 +1779,16 @@ class HostUnavailableClient(FakeOmnigentClient):
 
 
 class AuthRequiredClient(FakeOmnigentClient):
-    async def create_session(self, agent_id: str, title: str) -> str:
+    async def create_session(
+        self, agent_id: str, title: str, *, host_type: str = "external"
+    ) -> str:
         raise AuthRequiredError("401")
 
 
 class ServerErrorClient(FakeOmnigentClient):
-    async def create_session(self, agent_id: str, title: str) -> str:
+    async def create_session(
+        self, agent_id: str, title: str, *, host_type: str = "external"
+    ) -> str:
         # Mirrors a 500 from POST /v1/sessions: a bare OmnigentError, NOT one of
         # the specifically-handled subclasses.
         raise OmnigentError("Omnigent request failed with 500: internal_error")
@@ -1804,6 +1887,7 @@ async def test_auth_required_mid_stream_prompts_relogin(tmp_path: Path) -> None:
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             raise AuthRequiredError("401 mid-stream")
@@ -2041,6 +2125,7 @@ class ApprovalClient(FakeOmnigentClient):
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
         yield {"type": "response.output_text.delta", "delta": "work"}
@@ -2074,6 +2159,7 @@ class PreambleThenCommittedAnswerClient(FakeOmnigentClient):
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
         # Preamble: streamed as a delta AND committed as an item.
@@ -2239,6 +2325,7 @@ async def test_idle_stream_flushes_buffered_text_before_turn_end(
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             # A short burst that won't fill the SDK buffer, then go quiet.
@@ -2543,6 +2630,7 @@ async def test_denied_approval_does_not_resurrect_prior_answer(tmp_path: Path) -
             *,
             workspace: str | None = None,
             host_id: str | None = None,
+            host_type: str = "external",
         ) -> AsyncIterator[dict[str, Any]]:
             self.turns.append((session_id, text))
             # Only a gated tool call, no answer text. Park until the deny is
@@ -2797,6 +2885,7 @@ class PreambleThenSilentAfterElicitationClient(FakeOmnigentClient):
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
         yield {"type": "response.output_text.delta", "delta": "Before deleting, let me look."}
@@ -2896,6 +2985,7 @@ class EventScriptClient(FakeOmnigentClient):
         *,
         workspace: str | None = None,
         host_id: str | None = None,
+        host_type: str = "external",
     ) -> AsyncIterator[dict[str, Any]]:
         self.turns.append((session_id, text))
         for event in self._events:

--- a/integrations/slack/tests/test_setup.py
+++ b/integrations/slack/tests/test_setup.py
@@ -10,6 +10,7 @@ from omnigent_slack.setup import (
     AGENT_BLOCK,
     CALLBACK_SETUP_INFO,
     HOST_BLOCK,
+    MANAGED_HOST_VALUE,
     WORKSPACE_BLOCK,
     SetupFlow,
     connecting_modal,
@@ -88,6 +89,24 @@ class SlackResponseSetupClient(FakeSetupClient):
         return SlackResponseLike({"channel": SlackResponseLike({"id": "D123"})})
 
 
+def _mock_info(*, managed: bool = False, provider: str | None = None) -> None:
+    """Mock ``GET /v1/info``, the managed-sandbox capability probe ``validate`` reads.
+
+    Every setup path that validates the server hits this, so each respx test that
+    drives ``_begin_setup`` past ``/health`` declares it. Defaults to a server
+    with no managed sandboxes — the pre-existing behavior.
+    """
+    respx.get(_SERVER + "/v1/info").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "managed_sandboxes_enabled": managed,
+                "sandbox_provider": provider,
+            },
+        )
+    )
+
+
 async def _store(tmp_path: Path) -> SQLiteStore:
     store = SQLiteStore(tmp_path / "store.sqlite3")
     await store.initialize()
@@ -123,6 +142,55 @@ def test_select_modal_lists_agents_and_hosts() -> None:
     assert workspace_el["initial_value"]
 
 
+def test_select_modal_offers_the_managed_sandbox_alongside_real_hosts() -> None:
+    from omnigent_slack.omnigent import ValidatedServer
+
+    view = select_modal(
+        _SERVER,
+        ValidatedServer(
+            agents=[{"id": "ag_1", "name": "Helper"}],
+            online_hosts=[{"host_id": "h1", "name": "Host One"}],
+            managed_hosts=True,
+            managed_host_provider="modal",
+        ),
+    )
+    blocks = {b["block_id"]: b for b in view["blocks"] if "block_id" in b}
+    host_opts = blocks[HOST_BLOCK]["element"]["options"]
+    # The managed sandbox leads the menu, so a user with nothing online sees a
+    # usable choice first; their own hosts follow.
+    assert [o["value"] for o in host_opts] == [MANAGED_HOST_VALUE, "h1"]
+    assert "modal" in host_opts[0]["text"]["text"]
+    # The workspace field stops being required — a managed sandbox has no path.
+    assert blocks[WORKSPACE_BLOCK]["optional"] is True
+
+
+def test_select_modal_omits_managed_option_when_server_provisions_none() -> None:
+    from omnigent_slack.omnigent import ValidatedServer
+
+    view = select_modal(
+        _SERVER,
+        ValidatedServer(
+            agents=[{"id": "ag_1", "name": "Helper"}],
+            online_hosts=[{"host_id": "h1", "name": "Host One"}],
+        ),
+    )
+    blocks = {b["block_id"]: b for b in view["blocks"] if "block_id" in b}
+    assert [o["value"] for o in blocks[HOST_BLOCK]["element"]["options"]] == ["h1"]
+
+
+def test_select_modal_leaves_workspace_blank_with_no_host_to_seed_it_from() -> None:
+    # With only a managed sandbox on offer there is no host home to probe, and
+    # the bot's own cwd names nothing the session can reach — so no default.
+    from omnigent_slack.omnigent import ValidatedServer
+
+    view = select_modal(
+        _SERVER,
+        ValidatedServer(agents=[{"id": "ag_1"}], online_hosts=[], managed_hosts=True),
+    )
+    blocks = {b["block_id"]: b for b in view["blocks"] if "block_id" in b}
+    assert "initial_value" not in blocks[WORKSPACE_BLOCK]["element"]
+
+
 def _last_update(client: FakeSetupClient) -> dict[str, Any]:
     assert client.updated_views, "expected a views_update"
     return client.updated_views[-1]["view"]
@@ -147,6 +215,7 @@ async def test_setup_advances_to_select_modal_with_host_home_workspace(
             json={"data": [{"name": ".bashrc", "path": "/home/bob/.bashrc", "type": "file"}]},
         )
     )
+    _mock_info()
     pool = OmnigentClientPool()
     flow = _flow(await _store(tmp_path), pool)
     client = FakeSetupClient()
@@ -165,6 +234,8 @@ async def test_setup_advances_to_select_modal_with_host_home_workspace(
 
 @respx.mock
 async def test_setup_shows_no_host_guidance_when_no_online_host(tmp_path: Path) -> None:
+    # No online host of the user's own AND no managed sandboxes on the server:
+    # nothing can run a session, so the guidance screen is still the right end.
     respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
     respx.get(_SERVER + "/v1/agents").mock(
         return_value=httpx.Response(200, json={"data": [{"id": "ag_1", "name": "Helper"}]})
@@ -172,6 +243,7 @@ async def test_setup_shows_no_host_guidance_when_no_online_host(tmp_path: Path) 
     respx.get(_SERVER + "/v1/hosts").mock(
         return_value=httpx.Response(200, json={"hosts": [{"host_id": "h", "status": "offline"}]})
     )
+    _mock_info(managed=False)
     pool = OmnigentClientPool()
     flow = _flow(await _store(tmp_path), pool)
     client = FakeSetupClient()
@@ -190,6 +262,37 @@ async def test_setup_shows_no_host_guidance_when_no_online_host(tmp_path: Path) 
 
 
 @respx.mock
+async def test_setup_offers_managed_sandbox_instead_of_dead_end(tmp_path: Path) -> None:
+    # The reported failure: a user with no host of their own was hard-stopped and
+    # told to run `omni host` on their own machine. With managed sandboxes on the
+    # server, setup must reach the picker instead, offering the sandbox.
+    respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
+    respx.get(_SERVER + "/v1/agents").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "ag_1", "name": "Helper"}]})
+    )
+    respx.get(_SERVER + "/v1/hosts").mock(
+        return_value=httpx.Response(200, json={"hosts": [{"host_id": "h", "status": "offline"}]})
+    )
+    _mock_info(managed=True, provider="modal")
+    pool = OmnigentClientPool()
+    flow = _flow(await _store(tmp_path), pool)
+    client = FakeSetupClient()
+
+    try:
+        await flow._begin_setup(client, team_id="T1", user_id="U1", view_id="V1")
+    finally:
+        await pool.aclose_all()
+
+    view = _last_update(client)
+    assert view["callback_id"] == "omnigent_setup_select"
+    blocks = {b["block_id"]: b for b in view["blocks"] if "block_id" in b}
+    # The sandbox is the only host on offer, and no `omni host` guidance is shown.
+    host_opts = blocks[HOST_BLOCK]["element"]["options"]
+    assert [o["value"] for o in host_opts] == [MANAGED_HOST_VALUE]
+    assert "omni host --server" not in str(view)
+
+
+@respx.mock
 async def test_setup_shows_no_agents_guidance_when_server_has_no_agents(tmp_path: Path) -> None:
     respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
     respx.get(_SERVER + "/v1/agents").mock(return_value=httpx.Response(200, json={"data": []}))
@@ -198,6 +301,7 @@ async def test_setup_shows_no_agents_guidance_when_server_has_no_agents(tmp_path
             200, json={"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]}
         )
     )
+    _mock_info()
     pool = OmnigentClientPool()
     flow = _flow(await _store(tmp_path), pool)
     client = FakeSetupClient()
@@ -250,6 +354,7 @@ async def test_setup_shows_login_in_modal_and_advances_on_approval(tmp_path: Pat
             200, json={"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
         )
     )
+    _mock_info()
     authorize_route = respx.post(_SERVER + "/oauth/device/authorize").mock(
         return_value=httpx.Response(
             200,
@@ -517,6 +622,7 @@ async def test_post_enrollment_advance_uses_freshly_stored_token(tmp_path: Path)
             json={"data": [{"name": ".bashrc", "path": "/home/bob/.bashrc", "type": "file"}]},
         )
     )
+    _mock_info()
 
     def _url(team_id: str, user_id: str, email: str, team_name: str = "") -> str:
         return "https://bot/callback"
@@ -674,6 +780,99 @@ async def test_select_submit_persists_config(tmp_path: Path) -> None:
     assert client.posts and "set up" in client.posts[0]["text"].lower()
 
 
+async def test_select_submit_persists_managed_choice_without_a_workspace(tmp_path: Path) -> None:
+    # Picking the managed sandbox stores host_type="managed" with no host id and
+    # no workspace — the server chooses both. The stale path left in the (now
+    # optional) workspace box must not be persisted or block the submit.
+    store = await _store(tmp_path)
+    pool = OmnigentClientPool()
+    flow = _flow(store, pool)
+    ack = FakeAck()
+    client = FakeSetupClient()
+
+    view = {
+        "state": {
+            "values": {
+                AGENT_BLOCK: {
+                    "agent_select": {
+                        "selected_option": {
+                            "text": {"type": "plain_text", "text": "Helper"},
+                            "value": "ag_1",
+                        }
+                    }
+                },
+                HOST_BLOCK: {
+                    "host_select": {
+                        "selected_option": {
+                            "text": {"type": "plain_text", "text": "Managed sandbox (modal)"},
+                            "value": MANAGED_HOST_VALUE,
+                        }
+                    }
+                },
+                WORKSPACE_BLOCK: {"workspace_input": {"value": "/left/over/path"}},
+            }
+        },
+    }
+    body = {"team": {"id": "T1"}, "user": {"id": "U1"}}
+
+    try:
+        await flow._handle_select_submit(ack, body, view, client)
+    finally:
+        await pool.aclose_all()
+
+    assert ack.calls == [{}]  # saved, not an inline error
+    config = await store.get_user_config("T1", "U1")
+    assert config is not None
+    assert config.host_type == "managed"
+    assert config.host_id is None
+    assert config.workspace == ""
+    assert client.posts and "sandbox" in client.posts[0]["text"].lower()
+
+
+async def test_select_submit_still_requires_a_path_for_a_real_host(tmp_path: Path) -> None:
+    # Making the workspace input optional is for the managed sandbox only — an
+    # external host still can't start a runner without an absolute path.
+    store = await _store(tmp_path)
+    pool = OmnigentClientPool()
+    flow = _flow(store, pool)
+    ack = FakeAck()
+    client = FakeSetupClient()
+
+    view = {
+        "state": {
+            "values": {
+                AGENT_BLOCK: {
+                    "agent_select": {
+                        "selected_option": {
+                            "text": {"type": "plain_text", "text": "Helper"},
+                            "value": "ag_1",
+                        }
+                    }
+                },
+                HOST_BLOCK: {
+                    "host_select": {
+                        "selected_option": {
+                            "text": {"type": "plain_text", "text": "Host One"},
+                            "value": "h1",
+                        }
+                    }
+                },
+                WORKSPACE_BLOCK: {"workspace_input": {"value": ""}},
+            }
+        },
+    }
+    body = {"team": {"id": "T1"}, "user": {"id": "U1"}}
+
+    try:
+        await flow._handle_select_submit(ack, body, view, client)
+    finally:
+        await pool.aclose_all()
+
+    assert ack.calls[0]["response_action"] == "errors"
+    assert WORKSPACE_BLOCK in ack.calls[0]["errors"]
+    assert await store.get_user_config("T1", "U1") is None
+
+
 async def test_select_submit_requires_a_host(tmp_path: Path) -> None:
     store = await _store(tmp_path)
     pool = OmnigentClientPool()
@@ -804,6 +1003,7 @@ async def test_setup_settles_modal_before_first_update(tmp_path: Path, monkeypat
     respx.get(_SERVER + "/v1/hosts/h1/filesystem").mock(
         return_value=httpx.Response(200, json={"data": []})
     )
+    _mock_info()
 
     events: list[str] = []
 

--- a/integrations/slack/tests/test_store.py
+++ b/integrations/slack/tests/test_store.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import aiosqlite
 from omnigent_slack.models import ThreadKey, UserConfig
 from omnigent_slack.store import SQLiteStore
 
@@ -56,6 +57,70 @@ async def test_store_user_config_round_trip(tmp_path: Path) -> None:
     assert await store.get_user_config("T1", "U1") == updated
     # A different user in the same workspace is isolated.
     assert await store.get_user_config("T1", "U2") is None
+
+
+async def test_store_round_trips_managed_host_type(tmp_path: Path) -> None:
+    # A managed session carries no host id and no workspace path — the server
+    # chooses both — so host_type is the only record of where it runs.
+    store = SQLiteStore(tmp_path / "store.sqlite3")
+    await store.initialize()
+
+    config = UserConfig(agent_id="ag_1", agent_name="Helper", workspace="", host_type="managed")
+    await store.upsert_user_config("T1", "U1", config)
+    assert await store.get_user_config("T1", "U1") == config
+
+    key = ThreadKey(team_id="T1", channel_id="C1", thread_ts="100.1")
+    await store.upsert_session(key, "conv_1", "t", owner_user_id="U1", host_type="managed")
+    record = await store.get_session(key)
+    assert record is not None
+    assert record.host_type == "managed"
+    assert record.host_id is None
+
+    # Switching a user back to their own host is recorded as external again.
+    await store.upsert_user_config(
+        "T1", "U1", UserConfig("ag_1", "Helper", "/home/me", host_id="h1")
+    )
+    reread = await store.get_user_config("T1", "U1")
+    assert reread is not None and reread.host_type == "external"
+
+
+async def test_store_adds_host_type_to_a_pre_existing_database(tmp_path: Path) -> None:
+    # A store written before host_type existed keeps the old table shape, and
+    # every query naming the column would fail. initialize() must add it in place
+    # and read existing rows as "external" — the behavior they were saved with.
+    path = tmp_path / "store.sqlite3"
+    async with aiosqlite.connect(path) as db:
+        await db.execute(
+            """
+            CREATE TABLE user_configs (
+                team_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                agent_name TEXT NOT NULL,
+                workspace TEXT,
+                host_id TEXT,
+                host_name TEXT,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (team_id, user_id)
+            )
+            """
+        )
+        await db.execute(
+            "INSERT INTO user_configs VALUES ('T1','U1','ag_1','Helper','/ws','h1','H',1,1)"
+        )
+        await db.commit()
+
+    store = SQLiteStore(path)
+    await store.initialize()
+
+    config = await store.get_user_config("T1", "U1")
+    assert config is not None
+    assert config.host_type == "external"
+    assert config.host_id == "h1"
+    # Idempotent: a second initialize on the upgraded file must not fail.
+    await store.initialize()
+    assert await store.get_user_config("T1", "U1") == config
 
 
 async def test_store_claim_event_dedupes(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #6601.

## Problem

The Slack integration only ever creates `host_type="external"` sessions, requiring the caller to already own an online host — either a pinned `host_id` or `omni host --server <url>` kept running in a foreground terminal (closing it drops the host immediately). No code path requests `host_type="managed"`, even though the server has supported it all along.

This is a correctness gap, not just onboarding friction: host↔session is effectively 1:1 (a managed host is a singleton sandbox), and neither a saved `host_id` nor `_select_random_online_host()` checks whether a host already has a runner bound — only whether it's online. `launch_runner()`'s own comment calls a 409 "host offline / **connection replaced**" — landing a new session on an already-busy host risks replacing that session's live connection, not just failing cleanly.

## Fix

- `create_session`/`run_turn` accept `host_type`, sent only when managed (external request body stays byte-identical).
- `launch_runner` is skipped for managed sessions — the server provisions host + runner in the background and queues the first message until ready (documented behavior in `SessionCreateRequest.host_type`'s docstring), so no client-side polling.
- Setup flow offers a managed-sandbox option in the host picker, gated on a `GET /v1/info` capability probe so it's never offered against a server that would 422 it — replacing the old hard-fail to "run `omni host` yourself" when the caller has no online host.
- `host_type` is read from the session record on follow-up turns, not the user's live config, so re-running setup mid-thread can't retarget an active session.
- SQLite store gets an additive migration (`PRAGMA table_info` + `ALTER TABLE`) for the new column — this file has no formal migration framework, verified idempotent against both a fresh and an already-upgraded database.

## Tests

361 passing on this branch (cherry-picked cleanly onto current `main`, no conflicts). New coverage: byte-exact managed request body, the `/v1/info` probe (enabled + unreadable→false), `run_turn` skipping relaunch for managed but not external, the setup-flow fallback end-to-end, the migration test (hand-built pre-existing schema → `initialize()` → column lands, run twice for idempotency), and an integration test asserting **no** `POST /v1/hosts/*/runners` or `GET /v1/hosts` call happens for a managed session. Both new guards mutation-checked (flipped, confirmed the intended tests catch it).

`ruff format --check` / `ruff check`: clean.

## Deliberately out of scope

- No "running in a managed sandbox" location line in the session summary yet (workspace is empty for managed) — cosmetic, worth a follow-up if people ask where it's running.
- Managed-launch progress events currently fall through the dispatcher harmlessly (not rendered) — also a follow-up, not a correctness issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)