### PR TITLE
feat(sandbox): allow pod-only Kubernetes environment values

### DIFF
--- a/deploy/kubernetes/overlays/sandbox-runners/README.md
+++ b/deploy/kubernetes/overlays/sandbox-runners/README.md
@@ -209,13 +209,125 @@ writing nothing to disk — use HTTPS repository URLs. Details by provider match
 | `secret_name` | Harness-creds Secret projected into every Pod via `envFrom`. |
 | `service_account` | ServiceAccount the runner Pods run as (powerless). |
 | `image` | Optional runner image override (defaults to the official multi-arch amd64/arm64 host image). |
-| `env` | Optional list of SERVER env-var names to inject as literal Pod env (prefer `secret_name` for credentials). |
+| `env` | Optional list of SERVER env-var names to inject as literal host-container env. Each name must be set on the server; credential-looking and launcher-reserved names are rejected. If omitted, `OMNIGENT_KUBERNETES_SANDBOX_ENV` supplies the list; `[]` disables that fallback. |
+| `env_values` | Optional mapping of non-secret names to string values for the host container only, without reading or changing the server environment. Defaults to no values. Names must not overlap `env` or its environment-variable fallback. See [Pod-only literal environment](#pod-only-literal-environment-env_values). |
 | `node_selector` | Optional extra node labels, merged with a default `kubernetes.io/arch: amd64` — set that key to `arm64` to schedule runners on arm64 nodes. |
 | `resources` | Optional `requests` / `limits` (`cpu` / `memory`) override. |
 | `pod_ready_timeout_s` | Optional override for how long to wait for a runner Pod to reach `Running` (schedule + image pull + init container) before failing the launch — default 90s. Raise it for deployments whose host image regularly takes longer to pull. Also settable via env: `OMNIGENT_K8S_POD_READY_TIMEOUT_S` (this key takes precedence when both are set). |
 | `in_cluster` | Optional cluster-config source: `true` (in-cluster SA only), `false` (kubeconfig only), omit (try in-cluster, then kubeconfig). |
 | `kubeconfig` | Optional kubeconfig path for the out-of-cluster fallback (env: `OMNIGENT_KUBERNETES_KUBECONFIG`). |
 | `pvc_mounts` | Optional pre-created PersistentVolumeClaims mounted into every runner Pod — see [Persistent storage mounts](#persistent-storage-mounts-pvc_mounts). |
+
+## Pod-only literal environment (`env_values`)
+
+Use `sandbox.kubernetes.env_values` when a value belongs in the runner Pod but
+not in the server process. Both `kubernetes` and `agent_sandbox` use the same
+block. For example, point the host at a CA bundle mounted only in its container:
+
+```yaml
+sandbox:
+  provider: kubernetes  # or agent_sandbox
+  server_url: http://omnigent.omnigent.svc.cluster.local
+  kubernetes:
+    env: []  # optional: disable the SERVER env-name fallback
+    env_values:
+      SSL_CERT_FILE: /mnt/ca/ca.crt
+    secret_mounts:
+      - secret_name: runner-ca
+        mount_path: /mnt/ca
+```
+
+Create `runner-ca` in the runner namespace with a `ca.crt` key containing a
+valid PEM CA bundle. Do **not** export this Pod-only `SSL_CERT_FILE` path on the
+server: the file need not exist there, and parsing or launching a sandbox never
+copies `env_values` into server `os.environ`.
+
+The mapping must have names matching `[A-Za-z_][A-Za-z0-9_]*` and string values.
+Quote YAML numbers and booleans (`"123"`, `"true"`); empty strings and whitespace
+are preserved. `null`, non-string values, malformed names, and NUL characters
+are rejected. Omitting `env_values` or using `{}` preserves existing defaults.
+Omnigent does not expand values; Kubernetes applies its normal `env.value`
+expansion rules (use `$$` to escape a dollar sign).
+
+These are **not secrets**: values appear in the Pod spec and etcd. The existing
+credential-name protection also applies here: names with an underscore-delimited
+`TOKEN`, `KEY`, `SECRET`, `PASSWORD`, `CREDENTIAL`, or `CREDENTIALS` segment
+(case-insensitive) are rejected. This is a name guard, not secret-content
+detection; keep all credentials in `secret_name` or Secret file mounts.
+`HOME`, `IS_SANDBOX`, `OMNIGENT_HOST_ID`, `OMNIGENT_HOST_NAME`, and
+`OMNIGENT_HOST_TOKEN` remain launcher-reserved.
+
+A name cannot appear in both `env` and `env_values`, even with the same value
+or when the server variable is unset. Explicit-list overlap fails at config
+parse time; overlap with `OMNIGENT_KUBERNETES_SANDBOX_ENV` fails at launch.
+The existing name-only `env` setting still reads values from the server and
+fails if a requested variable is missing.
+
+Like existing `env` passthrough, these values go to the **host container**, not
+the workspace-preparation init container. PVC and Secret file mounts are also
+host-only, so forwarding a Pod-only CA path into init would point it at an
+unmounted file. The existing exception is `OMNIGENT_CONFIG_HOME`: both containers
+receive it so init writes `sandbox.host_config` where the host reads it. When
+`host_config` is set, that directory must resolve under `/home/omnigent`.
+This setting does not change the separate host-to-runner environment
+passthrough rules or supply a CA bundle for init's optional repository clone.
+
+### Live-cluster happy-path test
+
+Use a **disposable** server built from this checkout with the `kubernetes`
+extra, the overlay's runner RBAC, a usable host image, and at least one
+registered agent. The server URL must be reachable from both the test machine
+and runner Pods (separate external test and internal `sandbox.server_url`
+URLs are fine). The `agent_sandbox` variant also needs the agent-sandbox
+controller/CRD. The test caller needs `kubectl` access to list/get runner Pods
+and `pods/exec`; this is not an additional permission for the server.
+
+Create a test CA Secret containing public certificates only:
+
+```sh
+kubectl create secret generic omnigent-e2e-ca -n omnigent-sandboxes \
+  --from-file=ca.crt=/etc/ssl/certs/ca-certificates.crt
+```
+
+Configure the disposable server's `sandbox.kubernetes` block as follows (keep
+the namespace, service account, image, and other required deployment settings):
+
+```yaml
+env: []
+env_values:
+  SSL_CERT_FILE: /mnt/omnigent-e2e-ca/ca.crt
+  OMNIGENT_CONFIG_HOME: /home/omnigent/e2e-config
+  POD_ENV_VALUES_MARKER: "  pod-only literal  "
+  POD_ENV_VALUES_EMPTY: ""
+secret_mounts:
+  - secret_name: omnigent-e2e-ca
+    mount_path: /mnt/omnigent-e2e-ca
+```
+
+Do not mount this CA path or set these variables on the server. Restart it to
+load the config. Use a single-user test server (or a test proxy supplying the
+required identity); no LLM credentials or LLM call are needed for this
+host-startup test. On Linux/macOS, from the checkout:
+
+```sh
+uv sync --extra all --extra kubernetes --group dev
+export OMNIGENT_E2E_KUBERNETES_SERVER=http://localhost:8080
+# For a second disposable server configured with provider: agent_sandbox:
+export OMNIGENT_E2E_AGENT_SANDBOX_SERVER=http://localhost:8081
+(uv run --no-sync pytest -o addopts= \
+  tests/e2e/integrations/deploy/kubernetes/test_managed_env_values.py \
+  -q -rs > /tmp/omnigent-env-values-e2e.log 2>&1) &
+```
+
+Only configured provider rows run; unset URLs skip explicitly. Optional
+`OMNIGENT_E2E_KUBECTL` selects a command/context (for example,
+`kubectl --context test-cluster`), `OMNIGENT_E2E_KUBERNETES_NAMESPACE` overrides
+the runner namespace, and `OMNIGENT_E2E_AGENT_ID` selects the registered agent.
+The test creates and deletes its own managed session, waits for an online
+host, inspects the real Pod's host/init environment and mounts, then executes
+Python in the host container to assert exact values and load the mounted CA
+with `ssl.create_default_context()`. Inspect
+`/tmp/omnigent-env-values-e2e.log` for results.
 
 ## Self-reclaiming sandboxes (`provider: agent_sandbox`)
 

--- a/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
+++ b/deploy/kubernetes/overlays/sandbox-runners/sandbox-config.yaml
@@ -39,7 +39,12 @@ data:
         service_account: omnigent-runner
         # ── all optional below ──
         # image: ghcr.io/your-org/omnigent-host:latest  # default: official multi-arch (amd64/arm64) host image
-        # env: [PROXY_URL]           # SERVER env vars injected as literal Pod env (prefer secret_name for creds)
+        # env: [PROXY_URL]           # SERVER env vars injected into the host container (non-secret names only)
+        # env_values:               # Pod-only non-secret strings; never set in the server environment
+        #   SSL_CERT_FILE: /mnt/ca/ca.crt  # requires a CA bundle mounted in the host container
+        # secret_mounts:
+        #   - secret_name: runner-ca # pre-created Secret containing a ca.crt key
+        #     mount_path: /mnt/ca
         # node_selector:             # extra node labels; default kubernetes.io/arch: amd64, override to arm64 to run there
         #   disktype: ssd
         # resources:                 # runner Pod sizing (defaults: 0.5-2 cpu / 1-4Gi)

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -244,6 +244,8 @@ _RESERVED_ENV_NAMES: frozenset[str] = frozenset(
     {"HOME", "IS_SANDBOX", HOST_ID_ENV_VAR, HOST_NAME_ENV_VAR, HOST_TOKEN_ENV_VAR}
 )
 
+_ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
 # PID-1 reaper, run as the host container's entrypoint. It spawns its argv
 # (``omnigent host …``) as a child, forwards SIGTERM/SIGINT for prompt graceful
 # shutdown, and loops os.wait() to reap every child — including runner processes
@@ -343,6 +345,41 @@ def _env_name_is_sensitive(name: str) -> bool:
     """
     segments = {seg.upper() for seg in name.split("_") if seg}
     return bool(segments & _SENSITIVE_KEY_SEGMENTS)
+
+
+def validate_env_values(values: object, *, env: Sequence[str] = ()) -> dict[str, str]:
+    """Validate Pod-only literals without resolving or modifying the server environment."""
+    field = "sandbox.kubernetes.env_values"
+    if not isinstance(values, Mapping):
+        raise ValueError(f"{field} must be a mapping of environment variable names to strings")
+    validated: dict[str, str] = {}
+    for name, value in values.items():
+        if not isinstance(name, str) or not _ENV_NAME_RE.fullmatch(name):
+            raise ValueError(
+                f"{field} has an invalid environment variable name: {name!r} "
+                "(expected [A-Za-z_][A-Za-z0-9_]*)"
+            )
+        if name in _RESERVED_ENV_NAMES:
+            raise ValueError(f"{field} names {name!r}, which is reserved by the sandbox launcher")
+        if _env_name_is_sensitive(name):
+            raise ValueError(
+                f"{field} names {name!r}, which looks like a credential; "
+                "use the Secret named by sandbox.kubernetes.secret_name instead "
+                "(literal values are stored in the Pod spec and etcd)"
+            )
+        if not isinstance(value, str):
+            raise ValueError(f"{field}[{name!r}] must be a string (quote YAML numbers/booleans)")
+        if "\0" in value:
+            raise ValueError(f"{field}[{name!r}] must not contain NUL characters")
+        validated[name] = value
+    overlap = sorted(set(env) & validated.keys())
+    if overlap:
+        raise ValueError(
+            f"{field} overlaps sandbox.kubernetes.env / "
+            f"{SANDBOX_ENV_PASSTHROUGH_ENV_VAR}: {', '.join(overlap)}; "
+            "each name must have only one source"
+        )
+    return validated
 
 
 def _validate_k8s_name_env(
@@ -667,8 +704,10 @@ def build_job_manifest(
         via ``secretKeyRef``.
     :param harness_secret: Name of the harness-credentials Secret projected via
         ``envFrom``, or ``None`` for none.
-    :param env_literals: Literal name → value env entries (the resolved
-        server-env passthrough). Secrets ride *harness_secret*, not this map.
+    :param env_literals: Literal name → value env entries (resolved server-env
+        passthrough plus Pod-only ``env_values``). These go to the host only,
+        except ``OMNIGENT_CONFIG_HOME``, which is shared with init.
+        Secrets ride *harness_secret*, not this map.
     :param node_selector: Extra node selector labels, or ``None``. Merged with
         a default ``kubernetes.io/arch: amd64``; an operator-supplied
         ``kubernetes.io/arch`` entry overrides the default.
@@ -1108,6 +1147,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         image: str | None = None,
         namespace: str | None = None,
         env: Sequence[str] | None = None,
+        env_values: Mapping[str, str] | None = None,
         secret_name: str | None = None,
         node_selector: dict[str, str] | None = None,
         service_account: str | None = None,
@@ -1131,6 +1171,11 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         self._image_ref = image
         self._namespace = namespace
         self._env_names = tuple(env) if env is not None else None
+        self._env_values = (
+            validate_env_values(env_values, env=self._env_names or ())
+            if env_values is not None
+            else {}
+        )
         self._secret_name = secret_name
         self._node_selector = dict(node_selector) if node_selector is not None else None
         self._service_account = service_account
@@ -1281,14 +1326,16 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
 
         Explicit constructor names win; otherwise
         :data:`SANDBOX_ENV_PASSTHROUGH_ENV_VAR` (comma-separated) applies. Values
-        come from the server's own environment — a configured name that is unset
-        there fails loud (silently launching without it would surface much later
-        as an opaque failure inside the sandbox).
+        for those names come from the server's own environment — a configured
+        name that is unset there fails loud. ``env_values`` supplies separate
+        Pod-only literals without reading or changing the server environment.
+        A name in both sources is an error, even if its server value is unset.
 
         :returns: Name → value mapping for literal Pod ``env``.
         :raises click.ClickException: When a configured name is unset in the
             server environment, names a reserved variable, or looks like a
-            credential (use ``sandbox.kubernetes.secret_name`` for those).
+            credential (use ``sandbox.kubernetes.secret_name`` for those), or
+            overlaps ``env_values``.
         """
         if self._env_names is not None:
             names: Sequence[str] = self._env_names
@@ -1298,7 +1345,10 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                 for name in os.environ.get(SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "").split(",")
                 if name.strip()
             ]
-        resolved: dict[str, str] = {}
+        try:
+            resolved = validate_env_values(self._env_values, env=names)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
         for name in names:
             if name in _RESERVED_ENV_NAMES:
                 raise click.ClickException(

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1342,6 +1342,7 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
                 {
                     "image",
                     "env",
+                    "env_values",
                     "namespace",
                     "secret_name",
                     "service_account",
@@ -1359,10 +1360,12 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
         pvc_mounts = _parse_kubernetes_pvc_mounts(raw)
         secret_mounts = _parse_kubernetes_secret_mounts(raw)
         _reject_overlapping_kubernetes_mounts(pvc_mounts, secret_mounts)
+        env = _parse_provider_env(raw, "kubernetes")
         launcher_factory = _kubernetes_launcher_factory(
             agent_sandbox=provider == "agent_sandbox",
             image=_parse_provider_image(raw, "kubernetes"),
-            env=_parse_provider_env(raw, "kubernetes"),
+            env=env,
+            env_values=_parse_kubernetes_env_values(raw, env),
             namespace=_parse_provider_string(raw, "kubernetes", "namespace"),
             secret_name=_parse_provider_string(raw, "kubernetes", "secret_name"),
             service_account=_parse_provider_string(raw, "kubernetes", "service_account"),
@@ -2343,6 +2346,18 @@ def _validate_kubernetes_identifiers(
             )
 
 
+def _parse_kubernetes_env_values(
+    raw: dict[str, object], env: list[str] | None
+) -> dict[str, str] | None:
+    """Parse non-secret Pod-only literals, preserving empty strings and whitespace."""
+    section = _parse_provider_section(raw, "kubernetes")
+    if section is None or "env_values" not in section:
+        return None
+    from omnigent.onboarding.sandboxes.kubernetes import validate_env_values
+
+    return validate_env_values(section["env_values"], env=env or ())
+
+
 def _parse_kubernetes_resources(raw: dict[str, object]) -> dict[str, object] | None:
     """
     Extract and validate the optional ``sandbox.kubernetes.resources`` block.
@@ -2637,6 +2652,7 @@ def _kubernetes_launcher_factory(
     agent_sandbox: bool = False,
     image: str | None,
     env: list[str] | None,
+    env_values: dict[str, str] | None,
     namespace: str | None,
     secret_name: str | None,
     service_account: str | None,
@@ -2660,6 +2676,7 @@ def _kubernetes_launcher_factory(
     :param env: Names of server-process environment variables injected into
         every Pod as literal ``env``, or ``None``. Prefer *secret_name* for
         credentials.
+    :param env_values: Non-secret Pod-only literal values, or ``None``.
     :param namespace: Namespace to create Pods in, or ``None`` for the default.
     :param secret_name: Pre-created Secret projected into every Pod via
         ``envFrom`` (harness credentials), or ``None``.
@@ -2700,6 +2717,7 @@ def _kubernetes_launcher_factory(
         return launcher_cls(
             image=image,
             env=env,
+            env_values=env_values,
             namespace=namespace,
             secret_name=secret_name,
             service_account=service_account,

--- a/tests/e2e/integrations/deploy/kubernetes/test_managed_env_values.py
+++ b/tests/e2e/integrations/deploy/kubernetes/test_managed_env_values.py
@@ -1,0 +1,129 @@
+"""Exercise Pod-only env_values through a live managed-session launch.
+
+Requires a disposable deployed server from this checkout, a real cluster, and
+kubectl access to its runner Pods (including exec). Set
+OMNIGENT_E2E_KUBERNETES_SERVER and/or OMNIGENT_E2E_AGENT_SANDBOX_SERVER to opt in.
+See deploy/kubernetes/overlays/sandbox-runners/README.md for the server config
+and CA Secret setup. No LLM call is needed: the feature runs at host startup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+
+import httpx
+import pytest
+
+from tests.e2e.integrations.deploy.kubernetes.e2e_managed_host_config import (
+    HOST_CONTAINER,
+    create_managed_session,
+    pick_agent,
+    runner_pod_for_host,
+    wait_host_online,
+)
+
+_EXPECTED_ENV = {
+    "SSL_CERT_FILE": "/mnt/omnigent-e2e-ca/ca.crt",
+    "OMNIGENT_CONFIG_HOME": "/home/omnigent/e2e-config",
+    "POD_ENV_VALUES_MARKER": "  pod-only literal  ",
+    "POD_ENV_VALUES_EMPTY": "",
+}
+
+
+@pytest.mark.parametrize("provider", ["kubernetes", "agent_sandbox"])
+@pytest.mark.timeout(600)
+def test_managed_env_values_reaches_live_host(provider: str) -> None:
+    server_var = f"OMNIGENT_E2E_{provider.upper()}_SERVER"
+    base = os.environ.get(server_var, "").rstrip("/")
+    if not base:
+        pytest.skip(f"set {server_var} to a disposable server configured for env_values")
+    kubectl = os.environ.get("OMNIGENT_E2E_KUBECTL", "kubectl")
+    kubectl_args = shlex.split(kubectl)
+    if not kubectl_args or shutil.which(kubectl_args[0]) is None:
+        pytest.fail("kubectl must be on PATH when the live-cluster test is enabled")
+    namespace = os.environ.get("OMNIGENT_E2E_KUBERNETES_NAMESPACE", "omnigent-sandboxes")
+
+    info = httpx.get(f"{base}/v1/info", timeout=10.0)
+    info.raise_for_status()
+    assert info.json()["managed_sandboxes_enabled"]
+    assert info.json()["sandbox_provider"] == provider
+    agent_id = pick_agent(base, os.environ.get("OMNIGENT_E2E_AGENT_ID"))
+    session_id = create_managed_session(base, agent_id)
+    try:
+        host_id = wait_host_online(base, session_id, timeout_s=300.0)
+        host = httpx.get(f"{base}/v1/hosts/{host_id}", timeout=10.0)
+        host.raise_for_status()
+        assert host.json()["status"] == "online"
+        pod = runner_pod_for_host(kubectl, namespace, host_id)
+        manifest = json.loads(
+            subprocess.run(
+                [*kubectl_args, "get", "-n", namespace, pod, "-o", "json"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            ).stdout
+        )
+        spec = manifest["spec"]
+        container = next(c for c in spec["containers"] if c["name"] == HOST_CONTAINER)
+        for name, value in _EXPECTED_ENV.items():
+            assert {"name": name, "value": value} in container["env"]
+        init = next(c for c in spec["initContainers"] if c["name"] == "workspace-prep")
+        init_names = {entry["name"] for entry in init["env"]}
+        assert init_names.isdisjoint(set(_EXPECTED_ENV) - {"OMNIGENT_CONFIG_HOME"})
+        assert {
+            "name": "OMNIGENT_CONFIG_HOME",
+            "value": _EXPECTED_ENV["OMNIGENT_CONFIG_HOME"],
+        } in init["env"]
+        assert any(
+            mount["mountPath"] == "/mnt/omnigent-e2e-ca" for mount in container["volumeMounts"]
+        )
+        assert all(
+            mount["mountPath"] != "/mnt/omnigent-e2e-ca" for mount in init["volumeMounts"]
+        )
+        # Inspect the real container environment and load its mounted CA bundle,
+        # not just the API object's intended environment.
+        probe = """
+import json, os, ssl, sys
+from pathlib import Path
+
+expected = json.loads(sys.argv[1])
+actual = {name: os.environ.get(name) for name in expected}
+assert actual == expected, actual
+cert = Path(os.environ["SSL_CERT_FILE"])
+assert cert.is_file(), cert
+assert ssl.get_default_verify_paths().cafile == str(cert)
+context = ssl.create_default_context()
+assert context.cert_store_stats()["x509_ca"] > 0
+print("env_values: real host environment and CA loading passed")
+"""
+        result = subprocess.run(
+            [
+                *kubectl_args,
+                "exec",
+                "-n",
+                namespace,
+                pod,
+                "-c",
+                HOST_CONTAINER,
+                "--",
+                "python3",
+                "-c",
+                probe,
+                json.dumps(_EXPECTED_ENV),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        assert "real host environment and CA loading passed" in result.stdout
+        health = httpx.get(f"{base}/health", timeout=10.0)
+        health.raise_for_status()
+    finally:
+        cleanup = httpx.delete(f"{base}/v1/sessions/{session_id}", timeout=60.0)
+        cleanup.raise_for_status()

--- a/tests/e2e/integrations/deploy/kubernetes/test_managed_env_values.py
+++ b/tests/e2e/integrations/deploy/kubernetes/test_managed_env_values.py
@@ -82,9 +82,7 @@ def test_managed_env_values_reaches_live_host(provider: str) -> None:
         assert any(
             mount["mountPath"] == "/mnt/omnigent-e2e-ca" for mount in container["volumeMounts"]
         )
-        assert all(
-            mount["mountPath"] != "/mnt/omnigent-e2e-ca" for mount in init["volumeMounts"]
-        )
+        assert all(mount["mountPath"] != "/mnt/omnigent-e2e-ca" for mount in init["volumeMounts"])
         # Inspect the real container environment and load its mounted CA bundle,
         # not just the API object's intended environment.
         probe = """

--- a/tests/onboarding/sandboxes/test_agent_sandbox.py
+++ b/tests/onboarding/sandboxes/test_agent_sandbox.py
@@ -211,8 +211,7 @@ def test_start_host_carries_env_values_into_the_sandbox_manifest(
     fake_clients: tuple[_FakeCore, _FakeCustom], monkeypatch: pytest.MonkeyPatch
 ) -> None:
     core, custom = fake_clients
-    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
-    before = dict(os.environ)
+    monkeypatch.setattr(os, "environ", {"UNRELATED_CONFIG": "unchanged"})
     values = {
         "SSL_CERT_FILE": "/mnt/ca/ca.crt",
         "OMNIGENT_CONFIG_HOME": "/home/omnigent/custom-config",
@@ -242,7 +241,7 @@ def test_start_host_carries_env_values_into_the_sandbox_manifest(
         {"name": "HOME", "value": k8s._HOME_DIR},
         {"name": "OMNIGENT_CONFIG_HOME", "value": values["OMNIGENT_CONFIG_HOME"]},
     ]
-    assert dict(os.environ) == before
+    assert os.environ == {"UNRELATED_CONFIG": "unchanged"}
 
 
 def test_sandbox_manifest_expiry_suspends_rather_than_destroys() -> None:

--- a/tests/onboarding/sandboxes/test_agent_sandbox.py
+++ b/tests/onboarding/sandboxes/test_agent_sandbox.py
@@ -12,6 +12,7 @@ an optional dependency, so a fake package with a recording
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import types
 from datetime import UTC, datetime
@@ -75,6 +76,7 @@ class _FakeCore:
 
     def __init__(self) -> None:
         self.calls: list[str] = []
+        self.created_secrets: list[dict[str, object]] = []
         self.deleted_secrets: list[str] = []
         self.deleted_pods: list[str] = []
         self.read_pod_error: Exception | None = None
@@ -85,8 +87,13 @@ class _FakeCore:
         if self.read_pod_error is not None:
             raise self.read_pod_error
         return SimpleNamespace(
-            metadata=SimpleNamespace(name=name, deletion_timestamp=self.pod_deletion_timestamp)
+            metadata=SimpleNamespace(name=name, deletion_timestamp=self.pod_deletion_timestamp),
+            status=SimpleNamespace(phase="Running"),
         )
+
+    def create_namespaced_secret(self, namespace, body, _request_timeout=None):
+        self.calls.append("create_secret")
+        self.created_secrets.append(body)
 
     def delete_namespaced_secret(self, name, namespace, _request_timeout=None):
         self.calls.append("delete_secret")
@@ -198,6 +205,44 @@ def test_sandbox_manifest_carries_the_pod_template_verbatim() -> None:
     assert pod_spec["automountServiceAccountToken"] is False
     assert pod_spec["securityContext"]["runAsNonRoot"] is True
     assert pod_spec["restartPolicy"] == "OnFailure"
+
+
+def test_start_host_carries_env_values_into_the_sandbox_manifest(
+    fake_clients: tuple[_FakeCore, _FakeCustom], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core, custom = fake_clients
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    before = dict(os.environ)
+    values = {
+        "SSL_CERT_FILE": "/mnt/ca/ca.crt",
+        "OMNIGENT_CONFIG_HOME": "/home/omnigent/custom-config",
+        "EMPTY": "",
+    }
+    launcher = AgentSandboxLauncher(
+        in_cluster=True, namespace="omnigent-sandboxes", env=(), env_values=values
+    )
+    launcher.start_host(
+        _SANDBOX_ID,
+        token="test-launch-token",
+        host_id="host_abcdef",
+        host_name="managed-abcdef",
+        server_url="http://srv.example.com",
+        host_config={"providers": {"litellm": {"kind": "gateway"}}},
+    )
+    assert core.created_secrets
+    assert len(custom.created) == 1
+    manifest = custom.created[0]
+    assert manifest["kind"] == "Sandbox"
+    spec = manifest["spec"]["podTemplate"]["spec"]
+    host_env = spec["containers"][0]["env"]
+    for name, value in values.items():
+        assert {"name": name, "value": value} in host_env
+    assert len({entry["name"] for entry in host_env}) == len(host_env)
+    assert spec["initContainers"][0]["env"] == [
+        {"name": "HOME", "value": k8s._HOME_DIR},
+        {"name": "OMNIGENT_CONFIG_HOME", "value": values["OMNIGENT_CONFIG_HOME"]},
+    ]
+    assert dict(os.environ) == before
 
 
 def test_sandbox_manifest_expiry_suspends_rather_than_destroys() -> None:

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -869,8 +869,7 @@ def test_launch_host_threads_env_values_into_host_but_only_config_home_into_init
 ) -> None:
     core, batch = fake_clients
     _setup_pod_discovery(core)
-    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
-    before = dict(os.environ)
+    monkeypatch.setattr(os, "environ", {"UNRELATED_CONFIG": "unchanged"})
     values = {
         "SSL_CERT_FILE": "/mnt/ca/ca.crt",
         "OMNIGENT_CONFIG_HOME": "/home/omnigent/custom-config",
@@ -906,7 +905,7 @@ def test_launch_host_threads_env_values_into_host_but_only_config_home_into_init
     assert has_init_token is (repo_url is not None)
     assert any(m["mountPath"] == "/mnt/ca" for m in spec["containers"][0]["volumeMounts"])
     assert all(m["mountPath"] != "/mnt/ca" for m in init["volumeMounts"])
-    assert dict(os.environ) == before
+    assert os.environ == {"UNRELATED_CONFIG": "unchanged"}
 
 
 @pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 import types
 from types import SimpleNamespace
@@ -24,6 +25,7 @@ from omnigent.host.identity import (
     HOST_NAME_ENV_VAR,
     HOST_TOKEN_ENV_VAR,
 )
+from omnigent.onboarding.sandboxes.agent_sandbox import AgentSandboxLauncher
 from omnigent.onboarding.sandboxes.base import (
     render_host_config_write_command,
 )
@@ -519,6 +521,101 @@ def test_resolve_sandbox_env_rejects_reserved_and_credential_and_missing(
         KubernetesSandboxLauncher(env=["DEFINITELY_UNSET_VAR_XYZ"])._resolve_sandbox_env()
 
 
+@pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])
+def test_env_values_are_copied_and_do_not_modify_server_environment(
+    launcher_cls: type[KubernetesSandboxLauncher], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setenv("PLAIN_CONFIG", "from-server")
+    before = dict(os.environ)
+    values = {"SSL_CERT_FILE": "/mnt/ca/ca.crt", "EMPTY": "", "TEXT": "  literal\ntext  "}
+    launcher = launcher_cls(env=["PLAIN_CONFIG"], env_values=values)
+    values["SSL_CERT_FILE"] = "/changed-after-construction"
+    resolved = launcher._resolve_sandbox_env()
+    assert resolved == {
+        "SSL_CERT_FILE": "/mnt/ca/ca.crt",
+        "EMPTY": "",
+        "TEXT": "  literal\ntext  ",
+        "PLAIN_CONFIG": "from-server",
+    }
+    resolved["SSL_CERT_FILE"] = "/changed-after-resolution"
+    assert launcher._resolve_sandbox_env()["SSL_CERT_FILE"] == "/mnt/ca/ca.crt"
+    assert dict(os.environ) == before
+
+
+@pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])
+@pytest.mark.parametrize(
+    "name",
+    [
+        *sorted(k8s._RESERVED_ENV_NAMES),
+        "OPENAI_API_KEY",
+        "git_TOKEN",
+        "my_password",
+        "MY_SECRET",
+        "CREDENTIAL",
+        "SOME_CREDENTIALS",
+    ],
+)
+def test_env_values_rejects_reserved_and_credential_names(
+    launcher_cls: type[KubernetesSandboxLauncher], name: str
+) -> None:
+    with pytest.raises(ValueError, match="reserved|credential") as exc:
+        launcher_cls(env_values={name: "not-for-errors"})
+    assert "not-for-errors" not in str(exc.value)
+
+
+@pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])
+@pytest.mark.parametrize("values", [[], {"BAD-NAME": "x"}, {"PLAIN_CONFIG": 1}])
+def test_launcher_validates_env_values_without_the_parser(
+    launcher_cls: type[KubernetesSandboxLauncher], values: object
+) -> None:
+    with pytest.raises(ValueError, match="sandbox.kubernetes.env_values"):
+        launcher_cls(env_values=values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])
+def test_env_values_rejects_explicit_overlap(
+    launcher_cls: type[KubernetesSandboxLauncher],
+) -> None:
+    with pytest.raises(ValueError, match="overlaps"):
+        launcher_cls(env=["SSL_CERT_FILE"], env_values={"SSL_CERT_FILE": "/mnt/ca/ca.crt"})
+
+
+@pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])
+@pytest.mark.parametrize("server_value", [None, "/mnt/ca/ca.crt"])
+def test_env_values_rejects_env_fallback_overlap_even_if_unset_or_equal(
+    launcher_cls: type[KubernetesSandboxLauncher],
+    server_value: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    if server_value is not None:
+        monkeypatch.setenv("SSL_CERT_FILE", server_value)
+    launcher = launcher_cls(env_values={"SSL_CERT_FILE": "/mnt/ca/ca.crt"})
+    monkeypatch.setenv(k8s.SANDBOX_ENV_PASSTHROUGH_ENV_VAR, " SSL_CERT_FILE ,")
+    with pytest.raises(click.ClickException, match=r"overlaps.*SSL_CERT_FILE"):
+        launcher._resolve_sandbox_env()
+
+
+@pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])
+def test_env_values_preserves_name_only_fallback_and_explicit_empty_env(
+    launcher_cls: type[KubernetesSandboxLauncher], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(k8s.SANDBOX_ENV_PASSTHROUGH_ENV_VAR, raising=False)
+    assert launcher_cls()._resolve_sandbox_env() == {}
+    assert launcher_cls(env_values={})._resolve_sandbox_env() == {}
+    monkeypatch.setenv(k8s.SANDBOX_ENV_PASSTHROUGH_ENV_VAR, "PLAIN_CONFIG")
+    monkeypatch.setenv("PLAIN_CONFIG", "from-server")
+    assert launcher_cls()._resolve_sandbox_env() == {"PLAIN_CONFIG": "from-server"}
+    assert launcher_cls(env_values={})._resolve_sandbox_env() == {"PLAIN_CONFIG": "from-server"}
+    assert launcher_cls(env=[])._resolve_sandbox_env() == {}
+    launcher = launcher_cls(env=[], env_values={"PLAIN_CONFIG": "pod-only"})
+    assert launcher._resolve_sandbox_env() == {"PLAIN_CONFIG": "pod-only"}
+    monkeypatch.delenv("PLAIN_CONFIG")
+    with pytest.raises(click.ClickException, match="not set"):
+        launcher_cls(env_values={"SSL_CERT_FILE": "/mnt/ca/ca.crt"})._resolve_sandbox_env()
+
+
 def test_env_var_name_override_is_validated(monkeypatch: pytest.MonkeyPatch) -> None:
     """An env-var namespace override that isn't a valid RFC 1123 name fails fast."""
     monkeypatch.setenv(k8s.NAMESPACE_ENV_VAR, "Not_A_Valid_NS")
@@ -764,6 +861,66 @@ def test_launch_host_creates_secret_then_job_and_returns_workspace(
     assert batch.created_jobs[0]["metadata"]["name"] == "omnigent-job-1"
     # Nothing torn down on success.
     assert batch.deleted_jobs == []
+
+
+@pytest.mark.parametrize("repo_url", [None, "https://github.com/org/repo.git"])
+def test_launch_host_threads_env_values_into_host_but_only_config_home_into_init(
+    fake_clients: tuple[_FakeCore, _FakeBatch],
+    monkeypatch: pytest.MonkeyPatch,
+    repo_url: str | None,
+) -> None:
+    core, batch = fake_clients
+    _setup_pod_discovery(core)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    before = dict(os.environ)
+    values = {
+        "SSL_CERT_FILE": "/mnt/ca/ca.crt",
+        "OMNIGENT_CONFIG_HOME": "/home/omnigent/custom-config",
+        "EMPTY": "",
+    }
+    launcher = KubernetesSandboxLauncher(
+        in_cluster=True,
+        namespace="omnigent-sandboxes",
+        env=(),
+        env_values=values,
+        secret_mounts=[{"secret_name": "runner-ca", "mount_path": "/mnt/ca"}],
+    )
+    launcher.start_host(
+        "omnigent-job-1",
+        token=_TOKEN,
+        host_id="host_1",
+        host_name="managed-1",
+        server_url="http://srv.example.com",
+        repo_url=repo_url,
+        repo_name="repo" if repo_url else None,
+        host_config=_HOST_CONFIG,
+    )
+    spec = _pod_spec(batch.created_jobs[0])
+    host_env = spec["containers"][0]["env"]
+    for name, value in values.items():
+        assert {"name": name, "value": value} in host_env
+    assert len({entry["name"] for entry in host_env}) == len(host_env)
+    init = spec["initContainers"][0]
+    init_env = init["env"]
+    assert {"name": "OMNIGENT_CONFIG_HOME", "value": values["OMNIGENT_CONFIG_HOME"]} in init_env
+    assert all(entry["name"] not in ("SSL_CERT_FILE", "EMPTY") for entry in init_env)
+    has_init_token = any(entry["name"] == HOST_TOKEN_ENV_VAR for entry in init_env)
+    assert has_init_token is (repo_url is not None)
+    assert any(m["mountPath"] == "/mnt/ca" for m in spec["containers"][0]["volumeMounts"])
+    assert all(m["mountPath"] != "/mnt/ca" for m in init["volumeMounts"])
+    assert dict(os.environ) == before
+
+
+@pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])
+def test_env_values_config_home_still_requires_shared_init_volume(
+    launcher_cls: type[KubernetesSandboxLauncher],
+) -> None:
+    launcher = launcher_cls(env=(), env_values={"OMNIGENT_CONFIG_HOME": "/tmp/not-shared"})
+    with pytest.raises(ValueError, match=r"OMNIGENT_CONFIG_HOME.*must resolve under"):
+        build_job_manifest(
+            **{**_MANIFEST_KW, "env_literals": launcher._resolve_sandbox_env()},
+            host_config=_HOST_CONFIG,
+        )
 
 
 def test_launch_host_threads_pvc_mounts_into_the_job(

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -525,9 +525,7 @@ def test_resolve_sandbox_env_rejects_reserved_and_credential_and_missing(
 def test_env_values_are_copied_and_do_not_modify_server_environment(
     launcher_cls: type[KubernetesSandboxLauncher], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
-    monkeypatch.setenv("PLAIN_CONFIG", "from-server")
-    before = dict(os.environ)
+    monkeypatch.setattr(os, "environ", {"PLAIN_CONFIG": "from-server"})
     values = {"SSL_CERT_FILE": "/mnt/ca/ca.crt", "EMPTY": "", "TEXT": "  literal\ntext  "}
     launcher = launcher_cls(env=["PLAIN_CONFIG"], env_values=values)
     values["SSL_CERT_FILE"] = "/changed-after-construction"
@@ -540,7 +538,7 @@ def test_env_values_are_copied_and_do_not_modify_server_environment(
     }
     resolved["SSL_CERT_FILE"] = "/changed-after-resolution"
     assert launcher._resolve_sandbox_env()["SSL_CERT_FILE"] == "/mnt/ca/ca.crt"
-    assert dict(os.environ) == before
+    assert os.environ == {"PLAIN_CONFIG": "from-server"}
 
 
 @pytest.mark.parametrize("launcher_cls", [KubernetesSandboxLauncher, AgentSandboxLauncher])

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -559,7 +559,7 @@ def test_env_values_are_copied_and_do_not_modify_server_environment(
 def test_env_values_rejects_reserved_and_credential_names(
     launcher_cls: type[KubernetesSandboxLauncher], name: str
 ) -> None:
-    with pytest.raises(ValueError, match="reserved|credential") as exc:
+    with pytest.raises(ValueError, match=r"reserved|credential") as exc:
         launcher_cls(env_values={name: "not-for-errors"})
     assert "not-for-errors" not in str(exc.value)
 
@@ -569,7 +569,7 @@ def test_env_values_rejects_reserved_and_credential_names(
 def test_launcher_validates_env_values_without_the_parser(
     launcher_cls: type[KubernetesSandboxLauncher], values: object
 ) -> None:
-    with pytest.raises(ValueError, match="sandbox.kubernetes.env_values"):
+    with pytest.raises(ValueError, match=r"sandbox\.kubernetes\.env_values"):
         launcher_cls(env_values=values)  # type: ignore[arg-type]
 
 

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -208,6 +208,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.idle_pause_after_s: int | None = None
         self.cluster: str | None = None
         # Kubernetes ctor wiring (captured by install_fake_kubernetes_launcher).
+        self.env_values: dict[str, str] | None = None
         self.namespace: str | None = None
         self.secret_name: str | None = None
         self.service_account: str | None = None
@@ -553,7 +554,7 @@ def install_fake_kubernetes_launcher(
     """
     Substitute the fake for ``KubernetesSandboxLauncher`` at its public seam.
 
-    The managed flow constructs ``KubernetesSandboxLauncher(image=…, env=…,
+    The managed flow constructs ``KubernetesSandboxLauncher(image=…, env=…, env_values=…,
     namespace=…, secret_name=…, service_account=…, node_selector=…,
     kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…, secret_mounts=…,
     pod_ready_timeout_s=…, runtime_class=…)``; the shim records those constructor args on the
@@ -568,6 +569,7 @@ def install_fake_kubernetes_launcher(
         *,
         image: str | None = None,
         env: list[str] | None = None,
+        env_values: dict[str, str] | None = None,
         namespace: str | None = None,
         secret_name: str | None = None,
         service_account: str | None = None,
@@ -583,6 +585,7 @@ def install_fake_kubernetes_launcher(
         """Stand-in constructor recording the construction wiring."""
         fake.image = image
         fake.env = env
+        fake.env_values = env_values
         fake.namespace = namespace
         fake.secret_name = secret_name
         fake.service_account = service_account

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -818,12 +818,10 @@ def test_parse_kubernetes_without_section_defaults(monkeypatch: pytest.MonkeyPat
 def test_parse_kubernetes_env_values_are_pod_only(
     provider: str, server_cert: str | None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    if server_cert is None:
-        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
-    else:
-        monkeypatch.setenv("SSL_CERT_FILE", server_cert)
-    monkeypatch.setenv("PLAIN_CONFIG", "from-server")
-    before = dict(os.environ)
+    expected_env = {"PLAIN_CONFIG": "from-server"}
+    if server_cert is not None:
+        expected_env["SSL_CERT_FILE"] = server_cert
+    monkeypatch.setattr(os, "environ", expected_env.copy())
     values = {
         "SSL_CERT_FILE": "/mnt/ca/ca.crt",
         "EMPTY": "",
@@ -842,7 +840,7 @@ def test_parse_kubernetes_env_values_are_pod_only(
     assert isinstance(launcher, KubernetesSandboxLauncher)
     assert launcher.provider == provider
     assert launcher._resolve_sandbox_env() == {**values, "PLAIN_CONFIG": "from-server"}
-    assert dict(os.environ) == before
+    assert os.environ == expected_env
 
 
 @pytest.mark.parametrize("provider", ["kubernetes", "agent_sandbox"])

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import os
 import re
 import sys
 import types
@@ -27,6 +28,7 @@ from omnigent.onboarding.sandboxes.base import (
 )
 from omnigent.onboarding.sandboxes.blaxel import managed_token_ttl_s as blaxel_managed_token_ttl_s
 from omnigent.onboarding.sandboxes.e2b import managed_token_ttl_s as e2b_managed_token_ttl_s
+from omnigent.onboarding.sandboxes.kubernetes import KubernetesSandboxLauncher
 from omnigent.onboarding.sandboxes.registry import (
     COMMUNITY_MODULE_PREFIX,
     SandboxProviderContribution,
@@ -755,6 +757,7 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
             "kubernetes": {
                 "image": "ghcr.io/me/omnigent-host:latest",
                 "env": ["OPENAI_API_KEY", "GIT_TOKEN"],
+                "env_values": {"SSL_CERT_FILE": "/mnt/ca/ca.crt"},
                 "namespace": "omnigent-sandboxes",
                 "secret_name": "omnigent-creds",
                 "service_account": "omnigent-runner",
@@ -777,6 +780,7 @@ def test_parse_valid_kubernetes_config_builds_parameterized_factory(
     assert cfg.launcher_factory() is fake
     assert fake.image == "ghcr.io/me/omnigent-host:latest"
     assert fake.env == ["OPENAI_API_KEY", "GIT_TOKEN"]
+    assert fake.env_values == {"SSL_CERT_FILE": "/mnt/ca/ca.crt"}
     assert fake.namespace == "omnigent-sandboxes"
     assert fake.secret_name == "omnigent-creds"
     assert fake.service_account == "omnigent-runner"
@@ -800,12 +804,140 @@ def test_parse_kubernetes_without_section_defaults(monkeypatch: pytest.MonkeyPat
     fake = FakeSandboxLauncher()
     install_fake_kubernetes_launcher(monkeypatch, fake)
     assert cfg.launcher_factory() is fake
+    assert fake.env_values is None
     assert fake.namespace is None
     assert fake.secret_name is None
     assert fake.in_cluster is None
     assert fake.resources is None
     assert fake.pvc_mounts is None
     assert fake.pod_ready_timeout_s is None
+
+
+@pytest.mark.parametrize("provider", ["kubernetes", "agent_sandbox"])
+@pytest.mark.parametrize("server_cert", [None, "/server-only/ca.crt"])
+def test_parse_kubernetes_env_values_are_pod_only(
+    provider: str, server_cert: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if server_cert is None:
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    else:
+        monkeypatch.setenv("SSL_CERT_FILE", server_cert)
+    monkeypatch.setenv("PLAIN_CONFIG", "from-server")
+    before = dict(os.environ)
+    values = {
+        "SSL_CERT_FILE": "/mnt/ca/ca.crt",
+        "EMPTY": "",
+        "TEXT": "  spaces\nand unicode: \u00e9  ",
+        "MONKEY": "not a credential name",
+    }
+    cfg = parse_sandbox_config(
+        {
+            "provider": provider,
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {"env": ["PLAIN_CONFIG"], "env_values": values},
+        }
+    )
+    assert cfg is not None
+    launcher = cfg.default.launcher_factory()
+    assert isinstance(launcher, KubernetesSandboxLauncher)
+    assert launcher.provider == provider
+    assert launcher._resolve_sandbox_env() == {**values, "PLAIN_CONFIG": "from-server"}
+    assert dict(os.environ) == before
+
+
+@pytest.mark.parametrize("provider", ["kubernetes", "agent_sandbox"])
+@pytest.mark.parametrize(
+    ("values", "message"),
+    [
+        (None, "must be a mapping"),
+        ([], "must be a mapping"),
+        ("SSL_CERT_FILE=/mnt/ca/ca.crt", "must be a mapping"),
+        (True, "must be a mapping"),
+        ({1: "value"}, "invalid environment variable name"),
+        ({"": "value"}, "invalid environment variable name"),
+        ({" SSL_CERT_FILE": "value"}, "invalid environment variable name"),
+        ({"BAD-NAME": "value"}, "invalid environment variable name"),
+        ({"NAME=VALUE": "value"}, "invalid environment variable name"),
+        ({"1NAME": "value"}, "invalid environment variable name"),
+        ({"NAME\n": "value"}, "invalid environment variable name"),
+        ({"caf\u00e9": "value"}, "invalid environment variable name"),
+        ({"SSL_CERT_FILE": None}, "must be a string"),
+        ({"SSL_CERT_FILE": False}, "must be a string"),
+        ({"SSL_CERT_FILE": 42}, "must be a string"),
+        ({"SSL_CERT_FILE": 1.5}, "must be a string"),
+        ({"SSL_CERT_FILE": ["/mnt/ca"]}, "must be a string"),
+        ({"SSL_CERT_FILE": {"value": "/mnt/ca"}}, "must be a string"),
+        ({"SSL_CERT_FILE": "/mnt/\0ca"}, "NUL"),
+        ({"HOME": "not-for-errors"}, "reserved"),
+        ({"OMNIGENT_HOST_TOKEN": "not-for-errors"}, "reserved"),
+        ({"OPENAI_API_KEY": "not-for-errors"}, "credential"),
+        ({"GIT_TOKEN": "not-for-errors"}, "credential"),
+        ({"my_password": "not-for-errors"}, "credential"),
+    ],
+)
+def test_parse_kubernetes_env_values_rejects_invalid(
+    provider: str, values: object, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message) as exc:
+        parse_sandbox_config(
+            {
+                "provider": provider,
+                "server_url": "http://s.svc.cluster.local",
+                "kubernetes": {"env_values": values},
+            }
+        )
+    assert "sandbox.kubernetes.env_values" in str(exc.value)
+    assert "not-for-errors" not in str(exc.value)
+
+
+@pytest.mark.parametrize("provider", ["kubernetes", "agent_sandbox"])
+def test_parse_kubernetes_env_remains_name_only(provider: str) -> None:
+    with pytest.raises(ValueError, match=r"sandbox\.kubernetes\.env.*must be a list"):
+        parse_sandbox_config(
+            {
+                "provider": provider,
+                "server_url": "http://s.svc.cluster.local",
+                "kubernetes": {"env": {"SSL_CERT_FILE": "/mnt/ca/ca.crt"}},
+            }
+        )
+
+
+@pytest.mark.parametrize("provider", ["kubernetes", "agent_sandbox"])
+def test_parse_kubernetes_env_values_rejects_overlap(
+    provider: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    with pytest.raises(ValueError, match=r"env_values overlaps.*env.*SSL_CERT_FILE"):
+        parse_sandbox_config(
+            {
+                "provider": provider,
+                "server_url": "http://s.svc.cluster.local",
+                "kubernetes": {
+                    "env": [" SSL_CERT_FILE "],
+                    "env_values": {"SSL_CERT_FILE": "/mnt/ca/ca.crt"},
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize("provider", ["kubernetes", "agent_sandbox"])
+@pytest.mark.parametrize("section", [{}, {"env_values": {}}])
+def test_parse_kubernetes_env_values_defaults_preserve_env_fallback(
+    provider: str, section: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMNIGENT_KUBERNETES_SANDBOX_ENV", "PLAIN_CONFIG")
+    monkeypatch.setenv("PLAIN_CONFIG", "from-server")
+    cfg = parse_sandbox_config(
+        {
+            "provider": provider,
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": section,
+        }
+    )
+    assert cfg is not None
+    launcher = cfg.default.launcher_factory()
+    assert isinstance(launcher, KubernetesSandboxLauncher)
+    assert launcher._resolve_sandbox_env() == {"PLAIN_CONFIG": "from-server"}
 
 
 def test_parse_host_config_threads_verbatim_without_resolving_secrets(


### PR DESCRIPTION
## Related issue

Part of #6318 (option C only).

## Summary

Add `sandbox.kubernetes.env_values` for non-secret, Pod-only strings. This lets
operators configure a host-container CA path without exporting a path that does
not exist in the server process.

- Wire the mapping through both `kubernetes` and `agent_sandbox`.
- Preserve existing name-only `env` behavior and reserved/credential-name guards.
- Reject invalid values and overlapping sources; never mutate server `os.environ`.

In plain terms: the server can describe the Pod's environment without adopting it.

```text
server config -> validation -> sandbox launcher -> host-container env
                         server os.environ stays unchanged
```

As with existing passthrough, values are host-only except for the existing
`OMNIGENT_CONFIG_HOME` sharing with the workspace-preparation init container.
Per-agent credentials, admission policies, and sandbox fallback are out of scope.

## Test Plan

[Linux fork CI passed for commit `d3ee79e`](https://github.com/santhoshravindran7/omnigent/actions/runs/33992782251),
including the configured pre-commit hooks (Ruff and Pyrefly) and the selected
behavioral suites:

```text
tests/onboarding/sandboxes/test_kubernetes.py
tests/onboarding/sandboxes/test_agent_sandbox.py
tests/server/test_managed_hosts.py
tests/e2e/integrations/deploy/kubernetes/test_managed_env_values.py
```

Regression cases cover unchanged defaults, missing server values, preserved
literal strings, invalid names/types, reserved and credential-like names,
overlap, and manifest propagation for both providers.
Environment-isolation tests use controlled synthetic mappings rather than
copying the runner's environment.

The live-cluster rows are opt-in and have not been exercised against a real
cluster. The deployment README documents the disposable-server/CA-Secret setup.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable -- no behavioral change

```yaml
sandbox:
  provider: kubernetes
  server_url: http://omnigent.omnigent.svc.cluster.local
  kubernetes:
    env: []
    env_values:
      SSL_CERT_FILE: /mnt/ca/ca.crt
    secret_mounts:
      - secret_name: runner-ca
        mount_path: /mnt/ca
```

The server does not need `/mnt/ca/ca.crt`; the runner's Secret must provide it.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Implementation and automated review used GitHub Copilot CLI. Human review is
pending. This draft does not claim maintainer approval of the approach or a
successful live Kubernetes deployment.

## Changelog

Configure non-secret environment values for Kubernetes sandbox hosts without
setting them on the Omnigent server.
