### PR TITLE
feat(cli): add offline AgentSpec validation with JSON diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,13 @@ The same file can declare sub-agents and reviewers. For a fuller example, see
 Polly at [`examples/polly/`](https://github.com/omnigent-ai/omnigent/tree/main/examples/polly/), and the
 [Agent YAML spec](https://github.com/omnigent-ai/omnigent/blob/main/docs/AGENT_YAML_SPEC.md) for the full schema.
 
+For **Agent Image Spec v1** bundles (`config.yaml` with `spec_version: 1`),
+`omnigent validate path/to/bundle --offline --json` checks supported static
+content without executing code or contacting services. See
+[offline validation](docs/OFFLINE_VALIDATION.md) for its supported subset,
+skipped runtime checks and exit codes. The standalone YAML format shown above
+is not yet supported by offline validation.
+
 ---
 
 ## Telemetry

--- a/docs/OFFLINE_VALIDATION.md
+++ b/docs/OFFLINE_VALIDATION.md
@@ -5,9 +5,12 @@ starting agents, importing bundle-local Python or policy handlers, resolving
 credentials, expanding environment variables, contacting services, or changing
 the input. It also bypasses normal CLI state migration, diagnostic logs, update
 checks, and community-plugin loading. Operator-required CLI wrappers still apply.
-For this command, the working directory and supplied bundle roots are removed
-from dependency lookup before package initialization, so a bundle-local
-`yaml.py` or `hashlib.py` cannot replace an installed dependency.
+For this command, the working directory, supplied bundle roots and their
+descendant import paths are removed from dependency lookup before package
+initialization, so a bundle-local `yaml.py` or `hashlib.py` cannot replace an
+installed dependency. Only the running interpreter's identified standard-library
+and dependency installation paths are exempt, including an active project-local
+virtualenv; merely naming a directory `site-packages` does not make it trusted.
 
 This is an independently useful **static preflight**, not proof that an agent
 can run. It does not validate deployment readiness or execute workflows.
@@ -44,7 +47,8 @@ the current directory; offline mode is always enabled, so `--offline` is
 optional. Without `--json`, output is human-readable and still lists skipped
 checks. Runtime root flags such as `--profiling`, `--debug`, and
 `--log-to-stderr` are not supported for `validate`; they are rejected instead
-of activating their startup effects. `validate --help` exits `0`.
+of activating their startup effects, including before a root `--` separator.
+`omnigent -- validate ...` is supported. `validate --help` exits `0`.
 
 ## Supported scope
 

--- a/docs/OFFLINE_VALIDATION.md
+++ b/docs/OFFLINE_VALIDATION.md
@@ -1,0 +1,162 @@
+# Offline agent-image validation
+
+`omnigent validate` checks a supported local agent image as data, without
+starting agents, importing bundle-local Python or policy handlers, resolving
+credentials, expanding environment variables, contacting services, or changing
+the input. It also bypasses normal CLI state migration, diagnostic logs, update
+checks, and community-plugin loading. Operator-required CLI wrappers still apply.
+For this command, the working directory and supplied bundle roots are removed
+from dependency lookup before package initialization, so a bundle-local
+`yaml.py` or `hashlib.py` cannot replace an installed dependency.
+
+This is an independently useful **static preflight**, not proof that an agent
+can run. It does not validate deployment readiness or execute workflows.
+
+## Try it
+
+Save this as `my-agent/config.yaml`:
+
+```yaml
+spec_version: 1
+name: example
+instructions: You are a helpful assistant.
+executor:
+  config:
+    harness: claude-sdk
+  auth:
+    type: api_key
+    api_key: ${MY_API_KEY}
+```
+
+On a supported Omnigent installation (Linux or macOS):
+
+```bash
+omnigent validate my-agent --offline --json
+omnigent validate my-agent/config.yaml --json
+```
+
+Both commands return the same JSON and exit `0`; `MY_API_KEY` need not exist.
+Change `spec_version` to `2` and the result becomes `invalid`, with exit `1`.
+Pass a nonexistent path or an unknown CLI option to get exit `2`.
+
+`omni` and `python -m omnigent` use the same entry point. The path defaults to
+the current directory; offline mode is always enabled, so `--offline` is
+optional. Without `--json`, output is human-readable and still lists skipped
+checks. Runtime root flags such as `--profiling`, `--debug`, and
+`--log-to-stderr` are not supported for `validate`; they are rejected instead
+of activating their startup effects. `validate --help` exits `0`.
+
+## Supported scope
+
+The schema remains the existing
+[Agent Image Spec](../omnigent/spec/AGENTSPEC.md), not a separate YAML format.
+Inputs are a directory containing `config.yaml`, or a `.yaml`/`.yml` file
+containing `spec_version: 1`. An explicit file uses its parent directory as its
+asset root, just as `config.yaml` does.
+
+| Area | Offline checks |
+| --- | --- |
+| Config | Version, names, descriptions, boolean capability flags, sharing policy, interaction modalities and compaction; existing parser and static validator rules apply. |
+| Executor | `type`, `model`, `reasoning_effort`, `profile`, `connection`, `auth`, `timeout`, `max_iterations`, `context_window`; `config` supports `harness` and `profile`. Harness names come only from shipped metadata, not community plugins. |
+| LLM | `model`, `profile`, `connection`, `request_timeout`, `retry`. Additional provider-specific options are outside this initial scope. |
+| Tools | Declared sub-agent references, timeout/retry, bare configurable builtin names, HTTP/stdio inline MCP declarations and `tools/mcp/*.yaml` declarations; required fields, transport conflicts and name collisions. |
+| Local code | Names of `tools/python/*.py` and `tools/typescript/*.ts` are checked for collisions. Their contents are not read, parsed, imported or executed. |
+| Sub-agents | Recursive `agents/<directory>/config.yaml` images. Missing or invalid children are errors, never pruned. Declared names, not directory names, are used for references. |
+| Skills | Existing skill-directory and namespace layout, required frontmatter, name/description rules, `user-invocable` boolean and bundled-skill filter references. Other frontmatter fields are outside this scope. Skill body prose is opaque data. |
+| Instructions | Inline text or contained files; the existing `AGENTS.md`, `CLAUDE.md`, `.cursorrules` fallback order applies. Single-line `.md`, `.txt`, `.rst` references must exist. Absolute, parent-traversing, home-relative and linked paths are rejected, not expanded. |
+| Policies | Existing `guardrails` function-policy declarations, dotted reference syntax, label definitions, conditions, writable labels and positive ask timeouts. Each policy must declare exactly one of `function` or `handler`. Factory arguments and config must be mappings but their handler-specific semantics are not checked. |
+| Opaque data | `params`, instruction text, skill bodies, and policy argument/config values are data, not programs or templates. |
+
+Policy condition keys and writable labels must be declared in the same agent.
+Condition values must belong to a label's declared `values` when present.
+The ignored function-policy `on` selector and unknown policy fields are rejected
+rather than giving a misleading impression of enforcement. Policy handlers,
+including built-in ones, are never resolved: missing modules, factory signatures,
+registry authorization and actual policy decisions remain runtime checks.
+
+Unsupported content fails with exit `1`, not a successful partial result.
+Examples include the standalone `name`/`prompt` YAML format without
+`spec_version`, `os_env`, `terminals`, workflow declarations, provider-specific
+LLM options, configured builtin mappings, and non-MCP inline tool declarations.
+These need additional data-only adapters before offline support can be added.
+Do not convert a standalone YAML by merely adding `spec_version`: its tool and
+executor conventions differ.
+
+Unknown static fields and shapes that the runtime parser would silently discard
+or coerce are rejected. This deliberately makes the supported offline subset
+stricter than runtime parsing. Environment references in string-valued connection,
+auth, header and environment mappings are kept literal. Optional Hindsight tool
+names are reserved for deterministic collision checks regardless of installation.
+MCP files and skill frontmatter retain the runtime's YAML 1.1 scalar semantics;
+quote string values such as `"on"` and `"yes"` in those assets. Config files
+retain the existing config loader's narrower boolean rules.
+
+Other files outside the agent-image discovery layout are not inspected. Tarballs,
+remote URLs, UNC paths and stdin are not supported inputs. YAML must be a single
+document, with string mapping keys and no duplicates, aliases, merge keys or
+custom object tags. Symlinks, reparse points and special files on checked paths
+are rejected. Limits are 1 MiB per read file, 1,000 read files/discovered directory
+entries, 32 levels of YAML/agent nesting and 50,000 YAML nodes per document.
+Use a stable local directory; concurrent filesystem replacement is not supported.
+
+## Output and exit codes
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | All supported static checks passed (or help was requested). Runtime checks remain skipped. |
+| `1` | Invalid or unsupported content, missing required assets, unreadable bundle content, or input limits exceeded. |
+| `2` | Invalid invocation: unknown/extra arguments, nonexistent or unsupported top-level path, remote/archive input, unsafe top-level link, or required wrapper missing. |
+
+With `--json`, stdout contains one JSON object, including for invocation errors.
+Stderr is empty for these expected outcomes. For example, an invalid version
+produces this diagnostic in the envelope:
+
+```json
+{
+  "code": "INVALID_SPEC",
+  "column": null,
+  "field": "spec_version",
+  "file": "config.yaml",
+  "line": null,
+  "message": "Only AgentSpec version 1 is supported.",
+  "severity": "error"
+}
+```
+
+The complete envelope has `schema_version: 1`, `mode: "offline"`, `status`
+(`valid`, `invalid`, or `invalid_invocation`), `exit_code`, `diagnostics`, and
+`skipped_checks`. Skipped check IDs are `HOST_AUTH`, `LIVE_SERVICES`, `CODE`,
+and `PLUGINS`; each includes an explanation. Consumers should use version,
+status, exit code and diagnostic codes rather than parse message text.
+
+Diagnostics sort by bundle-relative file, field, line, column and code; JSON
+object keys are sorted. There are no timestamps, durations or absolute host
+paths. YAML syntax errors carry 1-based coordinates when available. Other
+diagnostics identify safe field groups or numeric policy indexes. Parser
+exceptions and validator messages can contain secrets, so neither raw messages
+nor authored names/values are echoed or logged. This trades some error detail
+for non-disclosure; nested validator errors may identify the sub-agent group
+rather than its authored name. Bundle-relative filenames are visible.
+
+Structural parsing stops at the first error, in deterministic discovery order;
+once parsing succeeds, static validator errors are reported together. An
+`unsupported` diagnostic always makes the overall result invalid.
+
+## Contributor tests
+
+In the repository's supported Linux/macOS development environment:
+
+```bash
+uv run --no-sync pytest tests/spec/test_offline.py tests/cli/test_cli_validate.py \
+  tests/spec/test_parser.py tests/spec/test_policy_parser.py \
+  tests/spec/test_validator.py tests/spec/test_policy_validator.py \
+  tests/spec/test_load.py tests/cli/test_cli.py tests/cli/test_cli_invocation.py \
+  tests/tools/builtins/test_registry_unified.py tests/test_harness_plugins.py -q
+uv run --no-sync pytest -o addopts= tests/e2e/test_offline_validate_e2e.py -q
+```
+
+The e2e is intentionally credential-free: it runs the real module CLI in a fresh
+process, validates an image containing child agents, skills, MCP declarations,
+tool code and a policy factory, rejects runtime imports and network/process
+attempts with tripwires, compares repeated JSON output and checks unchanged
+input bytes. It does not require `--llm-api-key`, a running server or a live LLM.

--- a/omnigent/__init__.py
+++ b/omnigent/__init__.py
@@ -1,5 +1,9 @@
 """Omnigent: A declarative agent authoring and runtime framework."""
 
+from omnigent.entrypoint import isolate_offline_imports as _isolate_offline_imports
+
+_isolate_offline_imports(package_init=True)
+
 # Some libraries we transitively depend on call ``hashlib.md5()``
 # without ``usedforsecurity=False`` for non-security content hashes.
 # On FIPS-enabled OpenSSL builds the bare md5 constructor raises
@@ -10,7 +14,7 @@
 # the fix before any dependency import touches it. The flag is the
 # standard Python 3.9+ opt-out for non-security md5 calls and is a
 # harmless no-op on non-FIPS hosts.
-import hashlib as _fips_safe_hashlib
+import hashlib as _fips_safe_hashlib  # noqa: E402
 
 _fips_safe_orig_md5 = _fips_safe_hashlib.md5
 

--- a/omnigent/__main__.py
+++ b/omnigent/__main__.py
@@ -1,6 +1,6 @@
 """Allow running Omnigent as ``python -m omnigent``."""
 
-from omnigent.cli import main
+from omnigent.entrypoint import main
 
 if __name__ == "__main__":
     main()

--- a/omnigent/builtin_catalog.py
+++ b/omnigent/builtin_catalog.py
@@ -1,0 +1,38 @@
+"""Data-only builtin tool catalog shared by validation and runtime dispatch."""
+
+BUILTIN_FACTORIES: dict[str, str] = {
+    "web_search": "omnigent.tools.builtins.web_search:WebSearchTool",
+    "nimble_research": "omnigent.tools.builtins.nimble_research:NimbleResearchTool",
+    "nimble_extract": "omnigent.tools.builtins.nimble_extract:NimbleExtractTool",
+    "upload_file": "omnigent.tools.builtins:_create_upload_file",
+    "list_files": "omnigent.tools.builtins:_create_list_files",
+    "download_file": "omnigent.tools.builtins:_create_download_file",
+    "search_conversations": "omnigent.tools.builtins:_create_search_conversations",
+    "export_agent": "omnigent.tools.builtins:_create_export_agent",
+}
+
+FRAMEWORK_TOOL_NAMES = frozenset(
+    {
+        "web_fetch",
+        "list_comments",
+        "update_comment",
+        "sys_list_models",
+        "sys_advise_models",
+        "browser_navigate",
+        "browser_snapshot",
+        "browser_click",
+        "browser_type",
+        "browser_screenshot",
+    }
+)
+
+HINDSIGHT_FACTORIES: dict[str, str] = {
+    "hindsight_retain": "omnigent.tools.builtins:_create_hindsight_retain",
+    "hindsight_recall": "omnigent.tools.builtins:_create_hindsight_recall",
+    "hindsight_reflect": "omnigent.tools.builtins:_create_hindsight_reflect",
+}
+
+# Offline results must not depend on optional packages installed on this host.
+STATIC_BUILTIN_NAMES = (
+    frozenset(BUILTIN_FACTORIES) | FRAMEWORK_TOOL_NAMES | frozenset(HINDSIGHT_FACTORIES)
+)

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -45,10 +45,17 @@ from omnigent.cli_config import (
     _run_configure_harnesses_interactive,
     _warn_missing_harness_dependencies,
 )
-from omnigent.cli_invocation import WRAPPER_COMMAND_ENV, cli_invocation
+from omnigent.cli_invocation import REQUIRE_WRAPPER_ENV as REQUIRE_WRAPPER_ENV
+from omnigent.cli_invocation import (
+    WRAPPER_BYPASS_ENV,
+    WRAPPER_COMMAND_ENV,
+    cli_invocation,
+    wrapper_required,
+)
 from omnigent.cli_native import register_native_commands as _register_native_commands
 from omnigent.cli_sandbox import lakebox as _lakebox_alias_group
 from omnigent.cli_sandbox import sandbox as _sandbox_group
+from omnigent.cli_validate import validate_command
 from omnigent.config import (
     _merge_effective_config,
     global_config_path,
@@ -93,7 +100,6 @@ from omnigent.process_logging import (
     LOG_LEVEL_ENV_VAR,
     LOG_TO_STDERR_ENV_VAR,
     data_dir,
-    env_truthy,
     process_log_dir_reference,
 )
 from omnigent.server_url import ServerUrl
@@ -2024,6 +2030,9 @@ def cli() -> None:
     """Omnigent CLI."""
 
 
+cli.add_command(validate_command)
+
+
 # Names of every subcommand the click group owns. Used by
 # :func:`main` to reject the removed top-level ad-hoc chat path
 # before click reports an opaque "no such command" error.
@@ -2070,6 +2079,7 @@ _CLICK_SUBCOMMANDS: frozenset[str] = frozenset(
         "update",
         "upgrade",
         "usage",
+        "validate",
         "version",
     }
 )
@@ -2095,6 +2105,7 @@ def _should_skip_update_check(argv: list[str]) -> bool:
         "-h",
         "--version",
         "version",
+        "validate",
         "update",
         "upgrade",
         "pane-split",
@@ -2126,10 +2137,6 @@ def _warn_deprecated_harness_path_env_vars() -> None:
         )
 
 
-REQUIRE_WRAPPER_ENV = "OMNIGENT_REQUIRE_WRAPPER"
-WRAPPER_BYPASS_ENV = "OMNIGENT_WRAPPER_BYPASS"
-
-
 def _wrapper_guard_error(env: Mapping[str, str], prog: str) -> str | None:
     """Return the block message when a naked ``omni`` call is refused, else ``None``.
 
@@ -2138,9 +2145,7 @@ def _wrapper_guard_error(env: Mapping[str, str], prog: str) -> str | None:
     ``OMNIGENT_WRAPPER_BYPASS`` around its own invocation to pass through, and
     ``OMNIGENT_WRAPPER_COMMAND`` names the command to suggest instead.
     """
-    if not env_truthy(env.get(REQUIRE_WRAPPER_ENV)):
-        return None
-    if env_truthy(env.get(WRAPPER_BYPASS_ENV)):
+    if not wrapper_required(env):
         return None
     redirect = (env.get(WRAPPER_COMMAND_ENV) or "").strip()
     if redirect:
@@ -2184,6 +2189,13 @@ def main() -> None:
     so unhandled exceptions are captured even when the user didn't
     enable ``--log`` or ``--debug-events``.
     """
+    from omnigent.entrypoint import offline_arguments
+
+    offline_args = offline_arguments(sys.argv[1:])
+    if offline_args is not None:
+        validate_command.main(args=offline_args, prog_name="omnigent validate")
+        return
+
     # Friendly crash handler: replaces Python's raw traceback with a
     # calm, branded crash screen + a one-tap path to file a GitHub issue
     # (browser opens the repo's pre-filled bug-report template with the

--- a/omnigent/cli_invocation.py
+++ b/omnigent/cli_invocation.py
@@ -17,6 +17,15 @@ from collections.abc import Mapping
 
 DEFAULT_CLI_NAME = "omnigent"
 WRAPPER_COMMAND_ENV = "OMNIGENT_WRAPPER_COMMAND"
+REQUIRE_WRAPPER_ENV = "OMNIGENT_REQUIRE_WRAPPER"
+WRAPPER_BYPASS_ENV = "OMNIGENT_WRAPPER_BYPASS"
+
+
+def wrapper_required(env: Mapping[str, str]) -> bool:
+    """Whether the operator's wrapper gate currently refuses a naked invocation."""
+    from omnigent.process_logging import env_truthy
+
+    return env_truthy(env.get(REQUIRE_WRAPPER_ENV)) and not env_truthy(env.get(WRAPPER_BYPASS_ENV))
 
 
 def cli_invocation(*, name: str = DEFAULT_CLI_NAME, env: Mapping[str, str] | None = None) -> str:

--- a/omnigent/cli_validate.py
+++ b/omnigent/cli_validate.py
@@ -1,0 +1,84 @@
+"""Offline validation CLI; deliberately independent of omnigent.cli."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+import click
+
+from omnigent.cli_invocation import wrapper_required
+from omnigent.spec.offline import (
+    SKIPPED_CHECKS,
+    Diagnostic,
+    OfflineResult,
+    invocation_error,
+    validate_path,
+)
+
+
+def _emit(result: OfflineResult, *, json_output: bool) -> None:
+    if json_output:
+        click.echo(json.dumps(result.to_dict(), sort_keys=True, indent=2, ensure_ascii=True))
+        return
+    if result.exit_code == 0:
+        click.echo("Supported offline checks passed; runtime readiness is not verified.")
+    for diagnostic in result.diagnostics:
+        location = f"{diagnostic.file}:{diagnostic.field}".strip(":")
+        click.echo(f"{diagnostic.code} {location}: {diagnostic.message}")
+    for code, reason in SKIPPED_CHECKS:
+        click.echo(f"SKIPPED {code}: {reason}")
+
+
+class _ValidationCommand(click.Command):
+    def main(
+        self,
+        args: Sequence[str] | None = None,
+        prog_name: str | None = None,
+        complete_var: str | None = None,
+        standalone_mode: bool = True,
+        **extra: Any,  # type: ignore[explicit-any]  # Click context keyword arguments
+    ) -> Any:  # type: ignore[explicit-any]  # Click callback return value
+        argv = list(args) if args is not None else sys.argv[1:]
+        before_separator = argv[: argv.index("--")] if "--" in argv else argv
+        try:
+            code = super().main(
+                args=argv,
+                prog_name=prog_name,
+                complete_var=complete_var,
+                standalone_mode=False,
+                **extra,
+            )
+        except click.UsageError:
+            # Click's messages echo unknown options and extra arguments verbatim.
+            _emit(invocation_error(), json_output="--json" in before_separator)
+            code = 2
+        if standalone_mode:
+            raise SystemExit(code or 0)
+        return code
+
+
+@click.command("validate", cls=_ValidationCommand)
+@click.argument("path", required=False, default=".")
+@click.option("--offline", is_flag=True, default=True, help="Use data-only checks (the default).")
+@click.option("--json", "json_output", is_flag=True, help="Emit versioned JSON, including errors.")
+@click.pass_context
+def validate_command(ctx: click.Context, path: str, offline: bool, json_output: bool) -> None:
+    """Validate a local AgentSpec v1 bundle or YAML without running agent code."""
+    del offline  # There is intentionally no online mode.
+    if wrapper_required(os.environ):
+        result = OfflineResult(
+            [
+                Diagnostic(
+                    "WRAPPER_REQUIRED", "This installation requires its configured CLI wrapper."
+                )
+            ],
+            2,
+        )
+    else:
+        result = validate_path(path)
+    _emit(result, json_output=json_output)
+    ctx.exit(result.exit_code)

--- a/omnigent/entrypoint.py
+++ b/omnigent/entrypoint.py
@@ -1,0 +1,71 @@
+"""Lightweight console dispatch before runtime imports or CLI startup effects."""
+
+from __future__ import annotations
+
+import sys
+
+
+def offline_arguments(argv: list[str]) -> list[str] | None:
+    """Recognize validate, rejecting runtime root flags rather than running them."""
+    index = 0
+    while index < len(argv) and argv[index] in {"--debug", "--log-to-stderr", "--profiling"}:
+        index += 1
+    if index < len(argv) and argv[index] == "validate":
+        return [*argv[:index], *argv[index + 1 :]]
+    return None
+
+
+def isolate_offline_imports(*, package_init: bool = False) -> None:
+    """Keep the working directory and input bundle out of dependency lookup.
+
+    Called before package initialization too: ``python -m omnigent`` otherwise
+    allows a bundle's ``hashlib.py``/``yaml.py`` to shadow trusted dependencies.
+    Only lexical path operations are used, never filesystem or remote probing.
+    """
+    args = offline_arguments(sys.argv[1:])
+    if args is None:
+        return
+    import os
+
+    if package_init:
+        program = os.path.basename(sys.argv[0]).lower()
+        module_cli = (
+            program == "-m"
+            and "-m" in sys.orig_argv
+            and sys.orig_argv[sys.orig_argv.index("-m") + 1 :] == ["omnigent", *sys.argv[1:]]
+        )
+        if not module_cli and program not in {"omnigent", "omni", "omnigent.exe", "omni.exe"}:
+            return
+    sys.dont_write_bytecode = True
+    roots = {os.path.normcase(os.getcwd())}
+    for arg in args:
+        if not arg or arg.startswith(("-", "~", "//", "\\\\")) or "://" in arg:
+            continue
+        try:
+            path = os.path.normcase(os.path.abspath(arg))
+        except (OSError, ValueError):
+            continue  # The command reports invalid arguments; this only limits imports.
+        roots.add(path)
+        if path.endswith((".yaml", ".yml")):
+            roots.add(os.path.dirname(path))
+    trusted_paths = []
+    for entry in sys.path:
+        path = os.path.normcase(os.path.abspath(entry))
+        # A project's .venv is a trusted interpreter dependency path, not the
+        # project import root; retain nested installation paths.
+        if path not in roots:
+            trusted_paths.append(entry)
+    sys.path[:] = trusted_paths
+
+
+def main() -> None:
+    args = offline_arguments(sys.argv[1:])
+    if args is not None:
+        isolate_offline_imports()
+        from omnigent.cli_validate import validate_command
+
+        validate_command.main(args=args, prog_name="omnigent validate")
+    else:
+        from omnigent.cli import main as runtime_main
+
+        runtime_main()

--- a/omnigent/entrypoint.py
+++ b/omnigent/entrypoint.py
@@ -10,8 +10,9 @@ def offline_arguments(argv: list[str]) -> list[str] | None:
     index = 0
     while index < len(argv) and argv[index] in {"--debug", "--log-to-stderr", "--profiling"}:
         index += 1
-    if index < len(argv) and argv[index] == "validate":
-        return [*argv[:index], *argv[index + 1 :]]
+    command_index = index + 1 if index < len(argv) and argv[index] == "--" else index
+    if command_index < len(argv) and argv[command_index] == "validate":
+        return [*argv[:index], *argv[command_index + 1 :]]
     return None
 
 
@@ -48,14 +49,53 @@ def isolate_offline_imports(*, package_init: bool = False) -> None:
         roots.add(path)
         if path.endswith((".yaml", ".yml")):
             roots.add(os.path.dirname(path))
-    trusted_paths = []
-    for entry in sys.path:
-        path = os.path.normcase(os.path.abspath(entry))
-        # A project's .venv is a trusted interpreter dependency path, not the
-        # project import root; retain nested installation paths.
-        if path not in roots:
-            trusted_paths.append(entry)
-    sys.path[:] = trusted_paths
+
+    def normalized(path: str) -> str:
+        return os.path.normcase(os.path.abspath(path))
+
+    # Bootstrap metadata discovery from the running interpreter's stdlib, never
+    # a bundle's sysconfig.py. Do not trust a path merely named "site-packages".
+    stdlib = getattr(sys, "_stdlib_dir", None) or os.path.dirname(os.__file__)
+    trusted = {
+        normalized(stdlib),
+        normalized(os.path.join(stdlib, "lib-dynload")),
+        normalized(
+            os.path.join(
+                os.path.dirname(stdlib),
+                f"python{sys.version_info.major}{sys.version_info.minor}.zip",
+            )
+        ),
+    }
+    if os.name == "nt":
+        trusted.add(normalized(os.path.join(sys.base_exec_prefix, "DLLs")))
+    original_paths = [(entry, normalized(entry)) for entry in sys.path]
+
+    def filtered_paths() -> list[str]:
+        return [
+            entry
+            for entry, path in original_paths
+            if path in trusted
+            or not any(
+                path == root or path.startswith(root.rstrip(os.sep) + os.sep) for root in roots
+            )
+        ]
+
+    sys.path[:] = filtered_paths()
+    import sysconfig
+
+    trusted.update(
+        normalized(sysconfig.get_path(name))
+        for name in ("stdlib", "platstdlib", "purelib", "platlib")
+    )
+    extension_path = sysconfig.get_config_var("DESTSHARED")
+    if isinstance(extension_path, str):
+        trusted.add(normalized(extension_path))
+    site = sys.modules.get("site")
+    if site is not None:
+        trusted.update(normalized(path) for path in site.getsitepackages())
+        if site.ENABLE_USER_SITE and site.USER_SITE:
+            trusted.add(normalized(site.USER_SITE))
+    sys.path[:] = filtered_paths()
 
 
 def main() -> None:

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -868,6 +868,11 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
 _state: HarnessPluginState | None = None
 
 
+def builtin_harness_spellings() -> frozenset[str]:
+    """Return shipped harness names and aliases without loading plugins."""
+    return _BUILTIN_CONTRIBUTION.valid_harnesses | frozenset(_BUILTIN_CONTRIBUTION.aliases)
+
+
 def _entry_points() -> tuple[importlib.metadata.EntryPoint, ...]:
     discovered = importlib.metadata.entry_points()
     if hasattr(discovered, "select"):

--- a/omnigent/spec/__init__.py
+++ b/omnigent/spec/__init__.py
@@ -7,15 +7,6 @@ import shutil
 from pathlib import Path
 
 from omnigent.errors import ErrorCode, OmnigentError
-
-# Omnigent compat: imported surgically from a dedicated module so
-# the integration's tech debt is removable in one shot. See
-# omnigent/spec/_omnigent_compat.py.
-from omnigent.spec._omnigent_compat import (
-    diagnose_yaml_rejection,
-    is_omnigent_yaml,
-    load_omnigent_yaml,
-)
 from omnigent.spec.parser import expand_env_vars, parse, parse_default_policies, parse_server_llm
 from omnigent.spec.tar_utils import ExtractionError, extract_safe
 from omnigent.spec.types import (
@@ -88,6 +79,36 @@ __all__ = [
     "parse_server_llm",
     "validate",
 ]
+
+
+def is_omnigent_yaml(path: Path) -> bool:
+    """Keep format detection available without importing compatibility code eagerly."""
+    from omnigent.spec._omnigent_compat import is_omnigent_yaml as detect
+
+    return detect(path)
+
+
+def diagnose_yaml_rejection(path: Path) -> str:
+    """Lazily diagnose the standalone YAML format."""
+    from omnigent.spec._omnigent_compat import diagnose_yaml_rejection as diagnose
+
+    return diagnose(path)
+
+
+def load_omnigent_yaml(
+    path: Path,
+    *,
+    enforce_handler_allowlist: bool = False,
+    prune_invalid_sub_agents: bool = False,
+) -> AgentSpec:
+    """Preserve the existing standalone loader export, loading runtime code on use."""
+    from omnigent.spec._omnigent_compat import load_omnigent_yaml as load_yaml
+
+    return load_yaml(
+        path,
+        enforce_handler_allowlist=enforce_handler_allowlist,
+        prune_invalid_sub_agents=prune_invalid_sub_agents,
+    )
 
 
 def materialize_bundle(source: Path, dest: Path) -> Path:

--- a/omnigent/spec/offline.py
+++ b/omnigent/spec/offline.py
@@ -1,0 +1,451 @@
+"""Read-only, data-only validation of local AgentSpec v1 images."""
+
+from __future__ import annotations
+
+import errno
+import os
+import re
+import stat
+from collections.abc import Hashable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PureWindowsPath
+from typing import Any
+
+import yaml
+
+from omnigent.errors import OmnigentError
+from omnigent.spec import offline_scope as scope
+from omnigent.spec.parser import (
+    _CONTEXT_FILE_PRIORITY,
+    _FRONTMATTER_RE,
+    _SKILL_NAMESPACE_MAX_DEPTH,
+    _ConfigYamlLoader,
+    _parse_http_mcp_server,
+    _parse_stdio_mcp_server,
+    parse_config,
+    parse_skill_text,
+)
+from omnigent.spec.types import AgentSpec, LocalToolInfo, SkillSpec
+from omnigent.spec.validator import ValidationError, validate
+
+MAX_FILE_BYTES = 1024 * 1024
+MAX_FILES = 1000
+MAX_DEPTH = 32
+MAX_YAML_NODES = 50000
+
+SKIPPED_CHECKS = (
+    (
+        "HOST_AUTH",
+        "Host readiness, credentials, environment expansion and provider auth are not checked.",
+    ),
+    ("LIVE_SERVICES", "MCP, model and network availability are not checked."),
+    (
+        "CODE",
+        "Tool implementations and policy handlers/arguments are not imported, "
+        "resolved or executed.",
+    ),
+    ("PLUGINS", "Community harness plugins and optional-package availability are not checked."),
+)
+
+_STATIC_FIELDS = {
+    "spec_version": "Only AgentSpec version 1 is supported.",
+    "executor": "Executor configuration violates AgentSpec rules.",
+    "llm": "Model configuration violates AgentSpec rules.",
+    "interaction": "Interaction modalities violate AgentSpec rules.",
+    "skills": "Skill names or descriptions violate AgentSpec rules.",
+    "mcp_servers": "MCP declarations contain invalid fields or colliding names.",
+    "local_tools": "Local tool declarations contain invalid fields or colliding names.",
+    "tools": "A tool references an undeclared sub-agent.",
+    "sub_agents": "A sub-agent's metadata or references violate AgentSpec rules.",
+    "name": "Agent names must be legal, non-reserved and unique across the bundle.",
+    "compaction": "Compaction settings violate AgentSpec rules.",
+}
+
+
+def _static_diagnostic(error: ValidationError, filename: str) -> Diagnostic:
+    # Nested validator paths embed authored names. Only expose a fixed field
+    # group, not the original path or message (either can contain credentials).
+    group = next(
+        (
+            name
+            for name in _STATIC_FIELDS
+            if error.path == name or error.path.startswith((name + ".", name + "["))
+        ),
+        "",
+    )
+    return Diagnostic(
+        "INVALID_SPEC",
+        _STATIC_FIELDS.get(group, "Agent metadata or references violate AgentSpec rules."),
+        filename,
+        group,
+    )
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    code: str
+    message: str
+    file: str = ""
+    field: str = ""
+    line: int | None = None
+    column: int | None = None
+    severity: str = "error"
+
+
+@dataclass
+class OfflineResult:
+    """Version 1 result envelope, with no timings, paths to the host, or input values."""
+
+    diagnostics: list[Diagnostic] = field(default_factory=list)
+    exit_code: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        ordered = sorted(
+            self.diagnostics,
+            key=lambda item: (item.file, item.field, item.line or 0, item.column or 0, item.code),
+        )
+        return {
+            "schema_version": 1,
+            "mode": "offline",
+            "status": {0: "valid", 1: "invalid", 2: "invalid_invocation"}[self.exit_code],
+            "exit_code": self.exit_code,
+            "diagnostics": [asdict(item) for item in ordered],
+            "skipped_checks": [
+                {"code": code, "reason": reason} for code, reason in SKIPPED_CHECKS
+            ],
+        }
+
+
+def invocation_error() -> OfflineResult:
+    return OfflineResult(
+        [
+            Diagnostic(
+                "INVALID_INVOCATION", "Expected one readable local YAML file or bundle directory."
+            )
+        ],
+        exit_code=2,
+    )
+
+
+class _OfflineYamlLoader(_ConfigYamlLoader):
+    """Keep the config loader's scalar semantics; reject ambiguous/unbounded YAML."""
+
+    def __init__(self, stream: str) -> None:
+        super().__init__(stream)
+        self._nodes = 0
+        self._depth = 0
+
+    def compose_node(self, parent: yaml.Node | None, index: int) -> yaml.Node | None:
+        self._nodes += 1
+        self._depth += 1
+        try:
+            if self.check_event(yaml.AliasEvent):
+                raise scope.ContentError(
+                    "UNSUPPORTED_YAML", "", "YAML aliases are outside the offline scope."
+                )
+            if self._nodes > MAX_YAML_NODES or self._depth > MAX_DEPTH:
+                raise scope.ContentError(
+                    "INPUT_LIMIT", "", "YAML exceeds the offline complexity limit."
+                )
+            return super().compose_node(parent, index)
+        finally:
+            self._depth -= 1
+
+    def construct_mapping(self, node: yaml.MappingNode, deep: bool = False) -> dict[Hashable, Any]:  # type: ignore[explicit-any]  # SafeLoader override contract
+        if not isinstance(node, yaml.MappingNode):
+            raise scope.ContentError("INVALID_YAML", "", "Expected a YAML mapping.")
+        result: dict[Hashable, Any] = {}  # type: ignore[explicit-any]  # decoded YAML values
+        for key_node, value_node in node.value:
+            if key_node.tag != "tag:yaml.org,2002:str":
+                raise scope.ContentError(
+                    "UNSUPPORTED_YAML", "", "YAML mapping keys must be strings."
+                )
+            key = key_node.value
+            if key in result:
+                raise scope.ContentError("DUPLICATE_KEY", "", "Duplicate YAML mapping key.")
+            result[key] = self.construct_object(value_node, deep=deep)
+        return result
+
+    def flatten_mapping(self, node: yaml.MappingNode) -> None:
+        if any(key.tag == "tag:yaml.org,2002:merge" for key, _ in node.value):
+            raise scope.ContentError(
+                "UNSUPPORTED_YAML", "", "YAML merges are outside the offline scope."
+            )
+        super().flatten_mapping(node)
+
+
+class _OfflineAssetYamlLoader(_OfflineYamlLoader):
+    # MCP files and skill frontmatter use SafeLoader's YAML 1.1 scalar rules,
+    # unlike config.yaml. Keep that distinction without changing runtime parsing.
+    yaml_implicit_resolvers = yaml.SafeLoader.yaml_implicit_resolvers
+
+
+def _load_yaml(text: str, *, asset: bool = False) -> object:
+    return yaml.load(text, Loader=_OfflineAssetYamlLoader if asset else _OfflineYamlLoader)
+
+
+def _is_link(info: os.stat_result) -> bool:
+    return stat.S_ISLNK(info.st_mode) or bool(
+        getattr(info, "st_file_attributes", 0) & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    )
+
+
+def _check_path(path: Path) -> os.stat_result:
+    # Reject ancestors too: a regular file reached through a directory symlink
+    # could otherwise read outside the bundle or traverse a UNC target.
+    for component in (*reversed(path.parents), path):
+        info = component.lstat()
+        if _is_link(info):
+            raise scope.ContentError(
+                "UNSAFE_PATH", "", "Symlinks and reparse points are not supported."
+            )
+    return info
+
+
+class _Reader:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.current = ""
+        self.files = 0
+        self.entry_count = 0
+
+    def read(self, path: Path) -> str:
+        self.current = path.relative_to(self.root).as_posix()
+        self.files += 1
+        if self.files > MAX_FILES:
+            raise scope.ContentError("INPUT_LIMIT", "", "Bundle exceeds the offline file limit.")
+        info = _check_path(path)
+        if not stat.S_ISREG(info.st_mode):
+            raise scope.ContentError("UNSAFE_PATH", "", "Expected a regular local file.")
+        # Nonblocking/no-follow also prevents the final component being swapped
+        # to a FIFO or symlink between lstat and open on supported POSIX hosts.
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as stream:
+            if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+                raise scope.ContentError("UNSAFE_PATH", "", "Expected a regular local file.")
+            content = stream.read(MAX_FILE_BYTES + 1)
+        if len(content) > MAX_FILE_BYTES:
+            raise scope.ContentError("INPUT_LIMIT", "", "File exceeds the offline size limit.")
+        return content.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+    def entries(self, directory: Path) -> list[Path]:
+        self.current = directory.relative_to(self.root).as_posix()
+        try:
+            info = _check_path(directory)
+        except FileNotFoundError:
+            return []
+        if not stat.S_ISDIR(info.st_mode):
+            raise scope.ContentError("UNSAFE_PATH", "", "Expected a bundle directory.")
+        entries = []
+        with os.scandir(directory) as iterator:
+            for entry in iterator:
+                self.entry_count += 1
+                if self.entry_count > MAX_FILES:
+                    raise scope.ContentError(
+                        "INPUT_LIMIT", "", "Directory exceeds the offline entry limit."
+                    )
+                entries.append(Path(entry.path))
+        entries.sort(key=lambda entry: entry.name)
+        for entry in entries:
+            self.current = entry.relative_to(self.root).as_posix()
+            info = _check_path(entry)
+            if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+                raise scope.ContentError(
+                    "UNSAFE_PATH", "", "Only regular files and directories are supported."
+                )
+        return entries
+
+    def instructions(self, root: Path, raw: dict[str, object]) -> str | None:
+        value = raw.get("instructions", raw.get("prompt"))
+        if isinstance(value, str):
+            # Preserve inline prose; make common explicit filename references
+            # strict instead of silently turning a missing file into instructions.
+            if not value or "\n" in value:
+                return value
+            windows = PureWindowsPath(value)
+            if value.startswith(("/", "\\", "~")) or windows.drive or ".." in windows.parts:
+                raise scope.ContentError(
+                    "UNSAFE_REFERENCE",
+                    "instructions",
+                    "Instruction paths must stay inside the bundle.",
+                )
+            candidate = root / value
+            looks_like_file = Path(value).suffix.lower() in {".md", ".txt", ".rst"}
+            try:
+                info = _check_path(candidate)
+            except (FileNotFoundError, NotADirectoryError):
+                if looks_like_file:
+                    raise scope.ContentError(
+                        "MISSING_REFERENCE", "instructions", "Instruction file was not found."
+                    ) from None
+                return value
+            except OSError as exc:
+                if not looks_like_file and exc.errno in {errno.ENAMETOOLONG, errno.EINVAL}:
+                    return value
+                raise
+            if stat.S_ISDIR(info.st_mode) and not looks_like_file:
+                return value
+            return self.read(candidate)
+        for name in _CONTEXT_FILE_PRIORITY:
+            candidate = root / name
+            try:
+                _check_path(candidate)
+            except FileNotFoundError:
+                continue
+            return self.read(candidate)
+        return None
+
+    def skills(self, directory: Path, depth: int = 0) -> list[SkillSpec]:
+        result = []
+        for entry in self.entries(directory):
+            if not entry.is_dir() or entry.name.startswith("."):
+                continue
+            path = entry / "SKILL.md"
+            try:
+                _check_path(path)
+            except FileNotFoundError:
+                if depth < _SKILL_NAMESPACE_MAX_DEPTH:
+                    result.extend(self.skills(entry, depth + 1))
+                    continue
+                raise scope.ContentError(
+                    "MISSING_REFERENCE", "skills", "Skill directory is missing SKILL.md."
+                ) from None
+            text = self.read(path)
+            match = _FRONTMATTER_RE.match(text)
+            if match is None:
+                raise scope.ContentError(
+                    "INVALID_SKILL", "skills", "SKILL.md requires YAML frontmatter."
+                )
+            metadata = scope.mapping(
+                _load_yaml(match.group(1), asset=True),
+                "skills",
+                {"name", "description", "user-invocable"},
+            )
+            scope.require(
+                isinstance(metadata.get("name"), str)
+                and isinstance(metadata.get("description"), str),
+                "skills",
+                "Skill name and description must be strings.",
+            )
+            scope.scalar_fields(metadata, "skills", {"user-invocable"}, bool)
+            result.append(parse_skill_text(text, path))
+        return result
+
+    def agent(self, path: Path, depth: int = 0) -> AgentSpec:
+        if depth > MAX_DEPTH:
+            raise scope.ContentError(
+                "INPUT_LIMIT", "agents", "Agent nesting exceeds the offline limit."
+            )
+        raw = scope.config(_load_yaml(self.read(path)))
+        spec = parse_config(raw, expand_env=False)
+        root = path.parent
+        spec.instructions = self.instructions(root, raw)
+        spec.skills = self.skills(root / "skills")
+        if isinstance(spec.skills_filter, list):
+            scope.require(
+                set(spec.skills_filter) <= {skill.name for skill in spec.skills},
+                "skills",
+                "Skill filter references must name bundled skills.",
+            )
+        for config_path in self.entries(root / "tools" / "mcp"):
+            if config_path.suffix == ".yml":
+                raise scope.ContentError(
+                    "UNSUPPORTED_FORMAT",
+                    "tools.mcp",
+                    "Bundled MCP declarations require the .yaml extension.",
+                )
+            if config_path.suffix != ".yaml":
+                continue
+            data = scope.mcp(
+                _load_yaml(self.read(config_path), asset=True), "tools.mcp", inline=False
+            )
+            parser = (
+                _parse_http_mcp_server if data["transport"] == "http" else _parse_stdio_mcp_server
+            )
+            spec.mcp_servers.append(parser(data["name"], data, config_path, expand_env=False))
+        for language, extension in (("python", ".py"), ("typescript", ".ts")):
+            for tool in self.entries(root / "tools" / language):
+                if tool.suffix == extension:
+                    scope.require(
+                        tool.is_file(), "local_tools", "Tool declarations must be files."
+                    )
+                    spec.local_tools.append(
+                        LocalToolInfo(tool.stem, str(tool.relative_to(root)), language)
+                    )
+        for child in self.entries(root / "agents"):
+            scope.require(
+                child.is_dir(), "agents", "Sub-agent entries must be directories with config.yaml."
+            )
+            sub_spec = self.agent(child / "config.yaml", depth + 1)
+            sub_spec.source_rel_dir = child.name
+            spec.sub_agents.append(sub_spec)
+        return spec
+
+
+def validate_path(value: str) -> OfflineResult:
+    """Validate local data only; never call spec.load or the standalone YAML loader."""
+    if (
+        not value
+        or value.startswith(("\\\\", "//", "~"))
+        or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*://", value)
+    ):
+        return invocation_error()
+    try:
+        source = Path(os.path.abspath(value))
+        info = _check_path(source)
+    except scope.ContentError as exc:
+        return OfflineResult([Diagnostic(exc.code, str(exc))], 2)
+    except (OSError, ValueError):
+        return invocation_error()
+    if stat.S_ISDIR(info.st_mode):
+        root, config_path = source, source / "config.yaml"
+    elif stat.S_ISREG(info.st_mode) and source.suffix.lower() in {".yaml", ".yml"}:
+        root, config_path = source.parent, source
+    else:
+        return invocation_error()
+    reader = _Reader(root)
+    try:
+        spec = reader.agent(config_path)
+        errors = validate(spec, offline=True).errors
+    except scope.ContentError as exc:
+        return OfflineResult([Diagnostic(exc.code, str(exc), reader.current, exc.field)], 1)
+    except yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        return OfflineResult(
+            [
+                Diagnostic(
+                    "INVALID_YAML",
+                    "Invalid YAML document.",
+                    reader.current,
+                    line=mark.line + 1 if mark is not None else None,
+                    column=mark.column + 1 if mark is not None else None,
+                )
+            ],
+            1,
+        )
+    except OSError:
+        return OfflineResult(
+            [
+                Diagnostic(
+                    "UNREADABLE_INPUT", "A required bundle file could not be read.", reader.current
+                )
+            ],
+            1,
+        )
+    except (OmnigentError, ValueError, TypeError, OverflowError, RecursionError):
+        # Parser errors can include complete credentials or policy arguments.
+        # Expected content failures are deliberately not logged or interpolated.
+        return OfflineResult(
+            [
+                Diagnostic(
+                    "INVALID_SPEC", "Content violates the AgentSpec parser rules.", reader.current
+                )
+            ],
+            1,
+        )
+    # Validator messages and paths may contain authored names and values too.
+    return OfflineResult(
+        [_static_diagnostic(error, config_path.name) for error in errors],
+        1 if errors else 0,
+    )

--- a/omnigent/spec/offline.py
+++ b/omnigent/spec/offline.py
@@ -338,7 +338,7 @@ class _Reader:
                 "INPUT_LIMIT", "agents", "Agent nesting exceeds the offline limit."
             )
         raw = scope.config(_load_yaml(self.read(path)))
-        spec = parse_config(raw, expand_env=False)
+        spec = parse_config(raw, expand_env=False, default_container_runtime="docker")
         root = path.parent
         spec.instructions = self.instructions(root, raw)
         spec.skills = self.skills(root / "skills")

--- a/omnigent/spec/offline_scope.py
+++ b/omnigent/spec/offline_scope.py
@@ -1,0 +1,351 @@
+"""Strict admission checks for the supported subset of the existing AgentSpec.
+
+The runtime parser owns conversion and semantic validation. These guards reject
+fields/shapes it would silently discard or coerce, before calling its helpers.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import fields
+from typing import Any, TypeAlias
+
+from omnigent.builtin_catalog import BUILTIN_FACTORIES, HINDSIGHT_FACTORIES
+from omnigent.spec.parser import _TOOLS_CONFIG_KEYS
+from omnigent.spec.types import RetryPolicy
+
+YamlMapping: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]  # decoded YAML boundary
+
+# web_fetch is configured by ToolManager rather than a catalog factory.
+_ENABLABLE_BUILTINS = frozenset(BUILTIN_FACTORIES) | frozenset(HINDSIGHT_FACTORIES) | {"web_fetch"}
+
+
+class ContentError(ValueError):
+    """A safe diagnostic: messages and field paths never contain authored values."""
+
+    def __init__(self, code: str, field: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.field = field
+
+
+def require(condition: bool, field: str, message: str) -> None:
+    if not condition:
+        raise ContentError("INVALID_SHAPE", field, message)
+
+
+def mapping(value: object, field: str, allowed: set[str] | None = None) -> YamlMapping:
+    if not isinstance(value, dict):
+        raise ContentError("INVALID_SHAPE", field, "Expected a mapping.")
+    require(all(isinstance(key, str) for key in value), field, "Expected string mapping keys.")
+    if allowed is not None and value.keys() - allowed:
+        raise ContentError(
+            "UNSUPPORTED_FIELD", field, "A field is unknown or outside the offline scope."
+        )
+    return value
+
+
+def strings(value: object, field: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ContentError("INVALID_SHAPE", field, "Expected a list of strings.")
+    return value
+
+
+def string_map(value: object, field: str) -> None:
+    data = mapping(value, field)
+    require(all(isinstance(item, str) for item in data.values()), field, "Expected string values.")
+
+
+def scalar_fields(data: YamlMapping, field: str, names: set[str], kind: type) -> None:
+    for name in sorted(names & data.keys()):
+        value = data[name]
+        require(type(value) is kind, f"{field}.{name}".lstrip("."), f"Expected {kind.__name__}.")
+
+
+def retry(value: object, field: str) -> None:
+    data = mapping(value, field, {item.name for item in fields(RetryPolicy)})
+    for name, item in data.items():
+        if name == "retryable_status_codes":
+            require(
+                isinstance(item, list) and all(type(code) is int for code in item),
+                field,
+                "Expected integer status codes.",
+            )
+        elif name == "jitter":
+            require(type(item) is bool, field, "Expected a boolean jitter flag.")
+        elif name == "timeout_per_request_s" and item is None:
+            continue
+        else:
+            require(
+                type(item) in (int, float) and (isinstance(item, int) or math.isfinite(item)),
+                field,
+                "Expected finite retry numbers.",
+            )
+            if name == "max_retries":
+                require(type(item) is int, field, "Expected an integer retry count.")
+
+
+def mcp(value: object, field: str, *, inline: bool) -> YamlMapping:
+    common = {"description", "url", "headers", "command", "args", "env"}
+    allowed = common | (
+        {"type", "tools", "auth"} if inline else {"name", "transport", "timeout", "retry"}
+    )
+    data = mapping(value, field, allowed)
+    scalar_fields(data, field, {"name", "description", "url", "command", "type", "transport"}, str)
+    if inline:
+        require(
+            data.get("type") == "mcp", field, "Only inline MCP tool declarations are supported."
+        )
+        transport = "stdio" if "command" in data else "http"
+    else:
+        require(
+            isinstance(data.get("name"), str) and bool(data["name"]),
+            field,
+            "MCP name is required.",
+        )
+        transport = data.get("transport")
+    require(transport in ("http", "stdio"), field, "Expected an HTTP or stdio transport.")
+    required = "url" if transport == "http" else "command"
+    require(bool(data.get(required)), field, "The MCP transport endpoint is required.")
+    disallowed = {"command", "args", "env"} if transport == "http" else {"url", "headers", "auth"}
+    require(not (data.keys() & disallowed), field, "MCP fields conflict with the transport.")
+    for name in ("headers", "env"):
+        if name in data:
+            string_map(data[name], f"{field}.{name}")
+    for name in ("args", "tools"):
+        if name in data:
+            strings(data[name], f"{field}.{name}")
+    if "auth" in data:
+        auth = mapping(data["auth"], f"{field}.auth", {"type", "profile"})
+        require(
+            auth.get("type") == "databricks"
+            and isinstance(auth.get("profile"), str)
+            and bool(auth["profile"]),
+            f"{field}.auth",
+            "MCP auth requires a Databricks profile declaration.",
+        )
+    if "retry" in data:
+        retry(data["retry"], f"{field}.retry")
+    scalar_fields(data, field, {"timeout"}, int)
+    return data
+
+
+def guardrails(value: object) -> None:
+    data = mapping(value, "guardrails", {"labels", "policies", "ask_timeout"})
+    labels = mapping(data.get("labels", {}), "guardrails.labels")
+    for index, label in enumerate(labels.values()):
+        field = f"guardrails.labels[{index}]"
+        if isinstance(label, dict):
+            entry = mapping(label, field, {"initial", "values"})
+            if "values" in entry:
+                require(
+                    isinstance(entry["values"], list)
+                    and all(type(v) in (str, int, float, bool) for v in entry["values"]),
+                    field,
+                    "Expected scalar label values.",
+                )
+            require(
+                type(entry.get("initial")) in (str, int, float, bool, type(None)),
+                field,
+                "Expected a scalar initial label.",
+            )
+        else:
+            require(
+                type(label) in (str, int, float, bool, type(None)),
+                field,
+                "Expected a scalar label or label definition.",
+            )
+    policies = mapping(data.get("policies", {}), "guardrails.policies")
+    for index, value in enumerate(policies.values()):
+        field = f"guardrails.policies[{index}]"
+        policy = mapping(
+            value,
+            field,
+            {"type", "function", "handler", "condition", "set_labels", "config", "ask_timeout"},
+        )
+        require(policy.get("type") == "function", field, "Expected a function policy.")
+        require(
+            ("function" in policy) != ("handler" in policy),
+            field,
+            "Declare exactly one function or handler reference.",
+        )
+        reference = policy.get("function", policy.get("handler"))
+        if isinstance(reference, dict):
+            function = mapping(reference, f"{field}.function", {"path", "arguments"})
+            reference = function.get("path")
+            if "arguments" in function:
+                mapping(function["arguments"], f"{field}.function.arguments")
+        require(
+            isinstance(reference, str)
+            and re.fullmatch(r"(?:[A-Za-z_]\w*\.)+[A-Za-z_]\w*", reference) is not None,
+            f"{field}.function",
+            "Expected a dotted Python reference; it will not be imported.",
+        )
+        if "config" in policy:
+            mapping(policy["config"], f"{field}.config")
+        if "set_labels" in policy:
+            writable = strings(policy["set_labels"], f"{field}.set_labels")
+            require(
+                set(writable) <= labels.keys(),
+                f"{field}.set_labels",
+                "Writable labels must be declared in this agent.",
+            )
+        if "condition" in policy:
+            condition = mapping(policy["condition"], f"{field}.condition")
+            require(
+                condition.keys() <= labels.keys(),
+                f"{field}.condition",
+                "Condition labels must be declared in this agent.",
+            )
+            for key, expected in condition.items():
+                choices = expected if isinstance(expected, list) else [expected]
+                require(
+                    all(type(item) in (str, int, float, bool) for item in choices),
+                    f"{field}.condition",
+                    "Expected scalar condition values.",
+                )
+                label = labels[key]
+                if isinstance(label, dict) and isinstance(label.get("values"), list):
+                    require(
+                        {str(item) for item in choices} <= {str(item) for item in label["values"]},
+                        f"{field}.condition",
+                        "Condition values must belong to the declared label values.",
+                    )
+        scalar_fields(policy, field, {"ask_timeout"}, int)
+    scalar_fields(data, "guardrails", {"ask_timeout"}, int)
+
+
+def config(value: object) -> YamlMapping:
+    data = mapping(value, "")
+    if "spec_version" not in data:
+        raise ContentError(
+            "UNSUPPORTED_FORMAT", "", "Offline validation requires a spec_version: 1 agent image."
+        )
+    mapping(
+        data,
+        "",
+        {
+            "spec_version",
+            "name",
+            "description",
+            "instructions",
+            "prompt",
+            "llm",
+            "interaction",
+            "tools",
+            "executor",
+            "compaction",
+            "guardrails",
+            "params",
+            "async",
+            "timers",
+            "spawn",
+            "agent_session_sharing",
+            "skills",
+        },
+    )
+    scalar_fields(data, "", {"spec_version"}, int)
+    scalar_fields(data, "", {"async", "timers", "spawn"}, bool)
+    scalar_fields(
+        data, "", {"name", "description", "instructions", "prompt", "agent_session_sharing"}, str
+    )
+    if "params" in data:
+        mapping(data["params"], "params")
+    if "skills" in data and data["skills"] != "*":
+        strings(data["skills"], "skills")
+    if "llm" in data:
+        llm = mapping(
+            data["llm"], "llm", {"model", "profile", "connection", "request_timeout", "retry"}
+        )
+        scalar_fields(llm, "llm", {"model", "profile"}, str)
+        scalar_fields(llm, "llm", {"request_timeout"}, int)
+        if "connection" in llm:
+            string_map(llm["connection"], "llm.connection")
+        if "retry" in llm:
+            retry(llm["retry"], "llm.retry")
+    if "executor" in data:
+        executor = mapping(
+            data["executor"],
+            "executor",
+            {
+                "type",
+                "model",
+                "reasoning_effort",
+                "profile",
+                "config",
+                "connection",
+                "auth",
+                "timeout",
+                "max_iterations",
+                "context_window",
+            },
+        )
+        scalar_fields(executor, "executor", {"type", "model", "reasoning_effort", "profile"}, str)
+        scalar_fields(executor, "executor", {"timeout", "max_iterations", "context_window"}, int)
+        if "config" in executor:
+            mapping(executor["config"], "executor.config", {"harness", "profile"})
+            string_map(executor["config"], "executor.config")
+        if "connection" in executor:
+            string_map(executor["connection"], "executor.connection")
+        if "auth" in executor:
+            auth = mapping(executor["auth"], "executor.auth")
+            variants = {
+                "api_key": {"type", "api_key", "base_url"},
+                "databricks": {"type", "profile"},
+                "provider": {"type", "name"},
+            }
+            require(isinstance(auth.get("type"), str), "executor.auth", "Auth type is required.")
+            allowed = variants.get(auth["type"])
+            require(allowed is not None, "executor.auth", "Unsupported auth type.")
+            mapping(auth, "executor.auth", allowed)
+            string_map(auth, "executor.auth")
+    if "interaction" in data:
+        interaction = mapping(data["interaction"], "interaction", {"conversational", "modalities"})
+        scalar_fields(interaction, "interaction", {"conversational"}, bool)
+        if "modalities" in interaction:
+            modalities = mapping(
+                interaction["modalities"], "interaction.modalities", {"input", "output"}
+            )
+            for value in modalities.values():
+                strings(value, "interaction.modalities")
+    if "compaction" in data:
+        compaction = mapping(
+            data["compaction"], "compaction", {"trigger_threshold", "recent_window"}
+        )
+        scalar_fields(compaction, "compaction", {"recent_window"}, int)
+        if "trigger_threshold" in compaction:
+            threshold = compaction["trigger_threshold"]
+            require(
+                type(threshold) in (int, float)
+                and (isinstance(threshold, int) or math.isfinite(threshold)),
+                "compaction.trigger_threshold",
+                "Expected a finite threshold.",
+            )
+    if "tools" in data:
+        tools = mapping(data["tools"], "tools")
+        for index, (name, value) in enumerate(tools.items()):
+            if name == "agents":
+                strings(value, "tools.agents")
+            elif name == "timeout":
+                require(type(value) is int, "tools.timeout", "Expected an integer timeout.")
+            elif name == "retry":
+                retry(value, "tools.retry")
+            elif name == "builtins":
+                names = strings(value, "tools.builtins")
+                require(
+                    set(names) <= _ENABLABLE_BUILTINS,
+                    "tools.builtins",
+                    "Unknown or non-configurable builtin tool.",
+                )
+            elif name in _TOOLS_CONFIG_KEYS:
+                raise ContentError(
+                    "UNSUPPORTED_FIELD",
+                    "tools",
+                    "This reserved tools field is outside the offline scope.",
+                )
+            else:
+                mcp(value, f"tools[{index}]", inline=True)
+    if "guardrails" in data:
+        guardrails(data["guardrails"])
+    return data

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -203,12 +203,15 @@ def parse_config(
     raw: dict[str, Any],  # type: ignore[explicit-any]  # heterogeneous decoded YAML
     *,
     expand_env: bool = True,
+    default_container_runtime: Literal["docker", "podman"] | None = None,
 ) -> AgentSpec:
     """Parse config fields without discovering assets or resolving instructions.
 
     Callers handling untrusted data must validate its shape first and disable
     environment expansion. OS-environment configuration has separate credential
     resolution rules; offline callers must exclude that block.
+    ``default_container_runtime`` supplies an explicit sandbox fallback without
+    consulting the host environment; ``None`` preserves runtime defaults.
     """
     if not isinstance(raw, dict):
         raise OmnigentError(
@@ -228,7 +231,9 @@ def parse_config(
     raw_tools = raw.get("tools")
     llm = _parse_llm(raw_llm, expand_env=expand_env)
     interaction = _parse_interaction(raw.get("interaction"))
-    tools_config = _parse_tools_config(raw_tools, expand_env=expand_env)
+    tools_config = _parse_tools_config(
+        raw_tools, expand_env=expand_env, default_container_runtime=default_container_runtime
+    )
     executor = _parse_executor(raw_executor, expand_env=expand_env)
     # ── Consolidate llm: → executor ────────────────────────────────
     # ``executor.model`` and ``executor.connection`` are the primary
@@ -443,6 +448,7 @@ def _parse_tools_config(
     raw: dict[str, object] | None,
     *,
     expand_env: bool = True,
+    default_container_runtime: Literal["docker", "podman"] | None = None,
 ) -> ToolsConfig:
     """
     Parse the ``tools:`` block from config.yaml into a
@@ -456,11 +462,17 @@ def _parse_tools_config(
         when *raw* is ``None``.
     """
     if raw is None:
-        return ToolsConfig()
+        return ToolsConfig(
+            sandbox=_parse_sandbox_config(
+                None, default_container_runtime=default_container_runtime
+            )
+        )
     timeout = _parse_int_field(raw["timeout"], "tools.timeout") if "timeout" in raw else 60
     retry = _parse_retry(raw.get("retry"))
     builtins = _parse_builtin_tools(raw.get("builtins", []), expand_env=expand_env)
-    sandbox = _parse_sandbox_config(raw.get("sandbox"))
+    sandbox = _parse_sandbox_config(
+        raw.get("sandbox"), default_container_runtime=default_container_runtime
+    )
     raw_agents = raw.get("agents", [])
     if not isinstance(raw_agents, list):
         raise OmnigentError(
@@ -478,6 +490,8 @@ def _parse_tools_config(
 
 def _parse_sandbox_config(
     raw: object,
+    *,
+    default_container_runtime: Literal["docker", "podman"] | None = None,
 ) -> SandboxConfig:
     """
     Parse the ``tools.sandbox`` block from config.yaml.
@@ -493,16 +507,18 @@ def _parse_sandbox_config(
 
     :param raw: The raw ``sandbox`` value from the ``tools``
         block. ``None`` means not specified (use defaults).
+    :param default_container_runtime: Explicit fallback for data-only callers;
+        ``None`` retains the environment-based runtime default.
     :returns: A :class:`SandboxConfig`.
     """
     if raw is None or not isinstance(raw, dict):
-        return SandboxConfig()
+        return SandboxConfig(container_runtime=default_container_runtime)
     raw_image = raw.get("container_image") or raw.get("docker_image")
     image = str(raw_image) if raw_image is not None else None
     raw_runtime = raw.get("container_runtime")
     runtime: Literal["docker", "podman"] | None
     if "container_runtime" not in raw:
-        runtime = None
+        runtime = default_container_runtime
     elif raw_runtime == "docker":
         runtime = "docker"
     elif raw_runtime == "podman":

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Literal, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
 import yaml
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator
@@ -185,6 +185,31 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         raise FileNotFoundError(f"config.yaml not found in {root}")
 
     raw = yaml.load(config_path.read_text(), Loader=_ConfigYamlLoader)
+    spec = parse_config(raw, expand_env=expand_env)
+    raw_instructions = raw.get("instructions")
+    if raw_instructions is None:
+        raw_instructions = raw.get("prompt")
+    spec.instructions = _resolve_instructions(root, raw_instructions)
+    spec.skills = _discover_skills(root / "skills")
+    spec.mcp_servers = (
+        _discover_mcp_servers(root / "tools" / "mcp", expand_env=expand_env) + spec.mcp_servers
+    )
+    spec.local_tools = _discover_local_tools(root / "tools")
+    spec.sub_agents = _discover_sub_agents(root / "agents", expand_env=expand_env)
+    return spec
+
+
+def parse_config(
+    raw: dict[str, Any],  # type: ignore[explicit-any]  # heterogeneous decoded YAML
+    *,
+    expand_env: bool = True,
+) -> AgentSpec:
+    """Parse config fields without discovering assets or resolving instructions.
+
+    Callers handling untrusted data must validate its shape first and disable
+    environment expansion. OS-environment configuration has separate credential
+    resolution rules; offline callers must exclude that block.
+    """
     if not isinstance(raw, dict):
         raise OmnigentError(
             f"config.yaml must be a YAML mapping, got {type(raw).__name__}",
@@ -279,18 +304,8 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
     # anonymous read.
     agent_session_sharing = _parse_share_policy(raw.get("agent_session_sharing"))
 
-    # Honor ``prompt:`` as the legacy alias for ``instructions:`` (per
-    # ``_OMNIGENT_SYSTEM_PROMPT_KEYS``); ``instructions:`` wins if both set.
-    raw_instructions = raw.get("instructions")
-    if raw_instructions is None:
-        raw_instructions = raw.get("prompt")
-    instructions = _resolve_instructions(root, raw_instructions)
-    skills = _discover_skills(root / "skills")
     skills_filter = _parse_skills_filter(raw.get("skills"))
-    mcp_servers = _discover_mcp_servers(root / "tools" / "mcp", expand_env=expand_env)
-    mcp_servers = mcp_servers + _parse_inline_mcp_servers(raw_tools, expand_env=expand_env)
-    local_tools = _discover_local_tools(root / "tools")
-    sub_agents = _discover_sub_agents(root / "agents", expand_env=expand_env)
+    mcp_servers = _parse_inline_mcp_servers(raw_tools, expand_env=expand_env)
 
     return AgentSpec(
         spec_version=spec_version,
@@ -303,12 +318,8 @@ def parse(root: Path, *, expand_env: bool = True) -> AgentSpec:
         compaction=compaction,
         guardrails=guardrails,
         params=params,
-        instructions=instructions,
-        skills=skills,
         skills_filter=skills_filter,
         mcp_servers=mcp_servers,
-        local_tools=local_tools,
-        sub_agents=sub_agents,
         async_enabled=async_enabled,
         os_env=os_env,
         terminals=terminals,
@@ -2469,6 +2480,11 @@ def _parse_skill(skill_md: Path) -> SkillSpec:
             f"SKILL.md could not be read: {skill_md}: {exc}",
             code=ErrorCode.INVALID_INPUT,
         ) from exc
+    return parse_skill_text(text, skill_md)
+
+
+def parse_skill_text(text: str, skill_md: Path) -> SkillSpec:
+    """Parse already-read skill text; the path records provenance only."""
     match = _FRONTMATTER_RE.match(text)
     if not match:
         raise OmnigentError(

--- a/omnigent/spec/validator.py
+++ b/omnigent/spec/validator.py
@@ -75,24 +75,26 @@ class ValidationResult:
         self.errors.append(ValidationError(path=path, message=message))
 
 
-def validate(spec: AgentSpec) -> ValidationResult:
+def validate(spec: AgentSpec, *, offline: bool = False) -> ValidationResult:
     """
     Validate an :class:`AgentSpec` against AGENTSPEC.md rules.
 
     :param spec: The parsed agent spec to validate.
+    :param offline: Use only shipped harness/tool metadata, without importing
+        runtime tools or discovering community plugins.
     :returns: A :class:`ValidationResult`; check ``.valid`` to see
         if the spec passes all checks.
     """
     result = ValidationResult()
     _validate_spec_version(spec, result)
-    _validate_executor_type(spec, result)
+    _validate_executor_type(spec, result, offline=offline)
     _validate_llm(spec, result)
     _validate_reasoning_effort(spec, result)
     _validate_interaction(spec, result)
     _validate_skills(spec, result)
     _validate_mcp_servers(spec, result)
-    _validate_local_tools(spec, result)
-    _validate_sub_agents(spec, result)
+    _validate_local_tools(spec, result, offline=offline)
+    _validate_sub_agents(spec, result, offline=offline)
     _validate_compaction(spec, result)
     _validate_os_env(spec, result)
     return result
@@ -109,26 +111,18 @@ def _validate_spec_version(spec: AgentSpec, result: ValidationResult) -> None:
         result.add("spec_version", f"must be 1, got {spec.spec_version}")
 
 
-# Omnigent compat: imported surgically from a dedicated module so
-# the integration's tech debt is removable in one shot. See
-# omnigent/spec/_omnigent_compat.py. Placed after the module's
-# internal helpers (rather than with the top-of-file imports) so the
-# integration's footprint is reviewable as one contiguous block.
-from omnigent.spec._omnigent_compat import (  # noqa: E402
-    OMNIGENT_EXECUTOR_TYPE,
-    validate_omnigent_executor,
-)
-
 _VALID_EXECUTOR_TYPES = {
     "claude_sdk",
     "agents_sdk",
-    OMNIGENT_EXECUTOR_TYPE,
+    "omnigent",
 }
 
 
 def _validate_executor_type(
     spec: AgentSpec,
     result: ValidationResult,
+    *,
+    offline: bool = False,
 ) -> None:
     """
     Validate that all spec fields are valid for the declared executor type.
@@ -152,7 +146,19 @@ def _validate_executor_type(
         _validate_claude_sdk_executor(spec, result)
     elif etype == "agents_sdk":
         _validate_agents_sdk_executor(spec, result)
-    elif etype == OMNIGENT_EXECUTOR_TYPE:
+    elif offline:
+        from omnigent.harness_plugins import builtin_harness_spellings
+
+        harness = spec.executor.config.get("harness")
+        if harness not in builtin_harness_spellings() and not (
+            isinstance(harness, str) and harness.startswith("acp:") and harness[4:]
+        ):
+            result.add("executor.config.harness", "must name a shipped harness")
+        if spec.compaction is not None:
+            result.add("compaction", "not supported when executor.type is 'omnigent'")
+    else:
+        from omnigent.spec._omnigent_compat import validate_omnigent_executor
+
         validate_omnigent_executor(spec, result)
 
 
@@ -349,7 +355,9 @@ def _validate_mcp_servers(spec: AgentSpec, result: ValidationResult) -> None:
             )
 
 
-def _validate_local_tools(spec: AgentSpec, result: ValidationResult) -> None:
+def _validate_local_tools(
+    spec: AgentSpec, result: ValidationResult, *, offline: bool = False
+) -> None:
     """
     Validate local tool name uniqueness across all tool sources
     (MCP servers and local tools), and reject collisions with
@@ -361,14 +369,21 @@ def _validate_local_tools(spec: AgentSpec, result: ValidationResult) -> None:
     # Lazy import to avoid pulling the tools package during
     # spec load (the validator runs from ``omnigent.spec``,
     # which is a lower layer than ``omnigent.tools``).
-    from omnigent.tools.builtins import BUILTIN_NAMES
+    if offline:
+        from omnigent.builtin_catalog import STATIC_BUILTIN_NAMES
+
+        builtin_names = STATIC_BUILTIN_NAMES
+    else:
+        from omnigent.tools.builtins import BUILTIN_NAMES
+
+        builtin_names = BUILTIN_NAMES
 
     # Collect everything the agent declares and cross-check
     # against the reserved builtin name-space. The same set is
     # also used for duplicate-name detection across sources.
     all_tool_names: set[str] = set()
     for i, mcp in enumerate(spec.mcp_servers):
-        if mcp.name in BUILTIN_NAMES:
+        if mcp.name in builtin_names:
             result.add(
                 f"mcp_servers[{i}].name",
                 f"tool name {mcp.name!r} collides with a reserved "
@@ -376,7 +391,7 @@ def _validate_local_tools(spec: AgentSpec, result: ValidationResult) -> None:
             )
         all_tool_names.add(mcp.name)
     for i, tool in enumerate(spec.local_tools):
-        if tool.name in BUILTIN_NAMES:
+        if tool.name in builtin_names:
             result.add(
                 f"local_tools[{i}].name",
                 f"tool name {tool.name!r} collides with a reserved "
@@ -429,6 +444,8 @@ def _validate_local_tools(spec: AgentSpec, result: ValidationResult) -> None:
 def _validate_sub_agents(
     spec: AgentSpec,
     result: ValidationResult,
+    *,
+    offline: bool = False,
 ) -> None:
     """
     Validate sub-agent declarations.
@@ -456,7 +473,7 @@ def _validate_sub_agents(
     # Validate each sub-agent independently — its own executor.type
     # determines which fields are required/invalid.
     for sa in spec.sub_agents:
-        sa_result = validate(sa)
+        sa_result = validate(sa, offline=offline)
         for err in sa_result.errors:
             sa_name = sa.name or "unnamed"
             result.add(

--- a/omnigent/tools/builtins/__init__.py
+++ b/omnigent/tools/builtins/__init__.py
@@ -21,7 +21,14 @@ Public API:
 from __future__ import annotations
 
 from collections.abc import Callable
+from functools import partial
+from importlib import import_module
 
+from omnigent.builtin_catalog import (
+    BUILTIN_FACTORIES,
+    FRAMEWORK_TOOL_NAMES,
+    HINDSIGHT_FACTORIES,
+)
 from omnigent.spec.types import SkillSpec
 from omnigent.tools.base import Tool
 from omnigent.tools.builtins.advise_models import SysAdviseModelsTool
@@ -247,62 +254,23 @@ def _create_hindsight_reflect(config: dict[str, str]) -> Tool:
 # the spec declares a ``terminals:`` block — not via this
 # registry. One-shot shell commands now use ``sys_os_shell``
 # instead.
+def _catalog_factory(path: str, config: dict[str, str]) -> Tool:
+    """Resolve a shipped factory only when a tool is instantiated."""
+    module, name = path.split(":")
+    return getattr(import_module(module), name)(config=config)
+
+
 _BUILTIN_REGISTRY: dict[str, _BuiltinFactory | None] = {
-    # User-enablable tools (factory present).
-    "web_search": lambda config: WebSearchTool(config=config),
-    "nimble_research": lambda config: NimbleResearchTool(config=config),
-    "nimble_extract": lambda config: NimbleExtractTool(config=config),
-    "upload_file": _create_upload_file,
-    "list_files": _create_list_files,
-    "download_file": _create_download_file,
-    "search_conversations": _create_search_conversations,
-    "export_agent": _create_export_agent,
-    # Framework-owned: need runtime context. ``web_fetch`` is
-    # constructed by ToolManager before reaching this registry.
-    # ``list_comments`` and ``update_comment`` are auto-registered by
-    # ``ToolManager._register_comment_tools`` — they are reserved
-    # here so user specs cannot shadow them. (Policy ASKs are
-    # surfaced as MCP-shape elicitations on the SSE stream — not
-    # via the tool registry — see omnigent/runtime/policies/approval.py.)
-    "web_fetch": None,
-    "list_comments": None,
-    "update_comment": None,
-    # ``sys_list_models`` is auto-registered by
-    # ``ToolManager._register_sub_agent_tools`` with the dispatch grant
-    # and intercepted by name in the runner's tool dispatch — reserved
-    # here so user specs cannot shadow it.
-    "sys_list_models": None,
-    # ``sys_advise_models`` is auto-registered alongside ``sys_list_models``
-    # when ``RuntimeCaps.routing_client`` is configured. Intercepted by
-    # name in the runner's tool dispatch — reserved here so user specs
-    # cannot shadow it.
-    "sys_advise_models": None,
-    # ``browser_*`` embedded-browser tools are framework-owned: always
-    # auto-registered by ``ToolManager._register_browser_tools`` (the
-    # single source of truth for registration), so any agent can drive
-    # the desktop app's browser without the spec opting in. Reserved
-    # here with ``None`` — exactly like ``list_comments`` /
-    # ``update_comment`` — so user specs cannot shadow the names and
-    # ``get_builtin_tool`` returns ``None`` for them (they are not
-    # instantiated via this registry). Execution is runner-dispatched
-    # (``_BROWSER_TOOLS`` in omnigent/runner/tool_dispatch.py).
-    "browser_navigate": None,
-    "browser_snapshot": None,
-    "browser_click": None,
-    "browser_type": None,
-    "browser_screenshot": None,
+    name: partial(_catalog_factory, path) for name, path in BUILTIN_FACTORIES.items()
 }
+_BUILTIN_REGISTRY.update(dict.fromkeys(FRAMEWORK_TOOL_NAMES))
 
 # Hindsight long-term memory (optional ``hindsight`` extra). Registered only
 # when ``hindsight-client`` is installed, so the tools are absent from the
 # builtin list on installs without the extra.
 if _hindsight_available():
     _BUILTIN_REGISTRY.update(
-        {
-            "hindsight_retain": _create_hindsight_retain,
-            "hindsight_recall": _create_hindsight_recall,
-            "hindsight_reflect": _create_hindsight_reflect,
-        }
+        {name: partial(_catalog_factory, path) for name, path in HINDSIGHT_FACTORIES.items()}
     )
 
 # Canonical set of every reserved builtin name. Derived from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -390,8 +390,8 @@ dev = [
 # absorption. `omni` is installed as a short alias — both resolve to
 # the same entry point. (No former-name aliases: only `omnigent` and
 # `omni` ship, internal and OSS alike.)
-omnigent = "omnigent.cli:main"
-omni = "omnigent.cli:main"
+omnigent = "omnigent.entrypoint:main"
+omni = "omnigent.entrypoint:main"
 
 [tool.uv]
 # Keep plain `uv sync` aligned with the published base package. Repository

--- a/tests/cli/test_cli_validate.py
+++ b/tests/cli/test_cli_validate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+import sysconfig
 import types
 from pathlib import Path
 
@@ -77,7 +78,16 @@ def test_help() -> None:
 
 
 @pytest.mark.parametrize(
-    "argv", [["version"], ["run", "agent.yaml"], ["--help"], ["host"], ["--version", "validate"]]
+    "argv",
+    [
+        ["version"],
+        ["run", "agent.yaml"],
+        ["--help"],
+        ["host"],
+        ["--version", "validate"],
+        ["--", "version"],
+        ["--profiling", "--", "version"],
+    ],
 )
 def test_other_entrypoint_commands_are_delegated_unchanged(
     argv: list[str], monkeypatch: pytest.MonkeyPatch
@@ -91,9 +101,19 @@ def test_other_entrypoint_commands_are_delegated_unchanged(
     assert called == [["omnigent", *argv]]
 
 
-def test_root_runtime_flags_do_not_trigger_startup() -> None:
-    args = offline_arguments(["--profiling", "validate", "--json"])
-    assert args == ["--profiling", "--json"]
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        ["--profiling"],
+        ["--profiling", "--"],
+        ["--debug", "--"],
+        ["--log-to-stderr", "--"],
+        ["--debug", "--log-to-stderr", "--profiling", "--"],
+    ],
+)
+def test_root_runtime_flags_do_not_trigger_startup(prefix: list[str]) -> None:
+    args = offline_arguments([*prefix, "validate", "--json"])
+    assert args == [flag for flag in prefix if flag != "--"] + ["--json"]
     result = CliRunner().invoke(validate_command, args)
     assert result.exit_code == 2
     assert json.loads(result.stdout)["status"] == "invalid_invocation"
@@ -121,7 +141,23 @@ def test_import_isolation_preserves_project_virtualenv(
     monkeypatch.setattr(sys, "argv", ["omnigent", "validate", "--json"])
     monkeypatch.setattr(sys, "dont_write_bytecode", False)
     site_packages = str(tmp_path / ".venv" / "lib" / "site-packages")
-    monkeypatch.setattr(sys, "path", ["", str(tmp_path), site_packages])
+    child = str(tmp_path / "tools" / "python")
+    fake_site_packages = str(tmp_path / "fake-venv" / "lib" / "site-packages")
+    original_get_path = sysconfig.get_path
+    monkeypatch.setattr(
+        sysconfig,
+        "get_path",
+        lambda name: site_packages if name in {"purelib", "platlib"} else original_get_path(name),
+    )
+    monkeypatch.setattr(sys, "path", ["", str(tmp_path), child, fake_site_packages, site_packages])
     isolate_offline_imports(package_init=True)
     assert sys.path == [site_packages]
     assert sys.dont_write_bytecode
+
+
+def test_root_separator_is_removed_but_command_separator_is_preserved() -> None:
+    assert offline_arguments(["--", "validate", "bundle", "--json"]) == ["bundle", "--json"]
+    assert offline_arguments(["--", "validate", "--", "--literal.yaml"]) == [
+        "--",
+        "--literal.yaml",
+    ]

--- a/tests/cli/test_cli_validate.py
+++ b/tests/cli/test_cli_validate.py
@@ -1,0 +1,127 @@
+"""The offline command's public output, exit codes and lightweight dispatch."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import tomllib
+from click.testing import CliRunner
+
+from omnigent.cli_validate import validate_command
+from omnigent.entrypoint import isolate_offline_imports, main, offline_arguments
+from omnigent.spec.offline import validate_path
+
+
+def test_json_output_is_deterministic_and_matches_library(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("spec_version: 1\nexecutor: {type: agents_sdk}\n", encoding="utf-8")
+    runner = CliRunner()
+    args = [str(path), "--offline", "--json"]
+    first = runner.invoke(validate_command, args)
+    second = runner.invoke(validate_command, args)
+    assert first.exit_code == second.exit_code == 0, first.output
+    assert first.output == second.output
+    assert first.stderr == ""
+    assert json.loads(first.stdout) == validate_path(str(path)).to_dict()
+
+
+@pytest.mark.parametrize(
+    "args", [["--unknown=private-value", "--json"], ["one", "private-value", "--json"]]
+)
+def test_json_usage_errors_are_sanitized(args: list[str]) -> None:
+    result = CliRunner().invoke(validate_command, args)
+    assert result.exit_code == 2
+    assert result.stderr == ""
+    assert "private-value" not in result.output
+    assert json.loads(result.stdout)["status"] == "invalid_invocation"
+
+
+def test_invalid_content_exit_and_json(tmp_path: Path) -> None:
+    path = tmp_path / "config.yaml"
+    path.write_text("spec_version: 4", encoding="utf-8")
+    result = CliRunner().invoke(validate_command, [str(path), "--json"])
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["status"] == "invalid"
+
+
+def test_default_path_offline_and_text_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "config.yaml").write_text(
+        "spec_version: 1\nexecutor: {type: agents_sdk}", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(validate_command, [])
+    assert result.exit_code == 0, result.output
+    assert "runtime readiness is not verified" in result.output
+    assert "SKIPPED CODE" in result.output
+
+
+def test_wrapper_gate_still_applies(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OMNIGENT_REQUIRE_WRAPPER", "1")
+    monkeypatch.delenv("OMNIGENT_WRAPPER_BYPASS", raising=False)
+    result = CliRunner().invoke(validate_command, [str(tmp_path), "--json"])
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["diagnostics"][0]["code"] == "WRAPPER_REQUIRED"
+
+
+def test_help() -> None:
+    result = CliRunner().invoke(validate_command, ["--help"])
+    assert result.exit_code == 0
+    assert "--offline" in result.output
+    assert "--json" in result.output
+
+
+@pytest.mark.parametrize(
+    "argv", [["version"], ["run", "agent.yaml"], ["--help"], ["host"], ["--version", "validate"]]
+)
+def test_other_entrypoint_commands_are_delegated_unchanged(
+    argv: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = []
+    runtime = types.ModuleType("omnigent.cli")
+    runtime.main = lambda: called.append(sys.argv.copy())
+    monkeypatch.setitem(sys.modules, "omnigent.cli", runtime)
+    monkeypatch.setattr(sys, "argv", ["omnigent", *argv])
+    main()
+    assert called == [["omnigent", *argv]]
+
+
+def test_root_runtime_flags_do_not_trigger_startup() -> None:
+    args = offline_arguments(["--profiling", "validate", "--json"])
+    assert args == ["--profiling", "--json"]
+    result = CliRunner().invoke(validate_command, args)
+    assert result.exit_code == 2
+    assert json.loads(result.stdout)["status"] == "invalid_invocation"
+
+
+def test_console_aliases_use_the_lightweight_entrypoint() -> None:
+    project = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    scripts = tomllib.loads(project.read_text(encoding="utf-8"))["project"]["scripts"]
+    assert scripts["omnigent"] == scripts["omni"] == "omnigent.entrypoint:main"
+
+
+def test_library_import_is_not_mistaken_for_the_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["consumer.py", "validate", "--json"])
+    before = sys.path.copy()
+    bytecode = sys.dont_write_bytecode
+    isolate_offline_imports(package_init=True)
+    assert sys.path == before
+    assert sys.dont_write_bytecode == bytecode
+
+
+def test_import_isolation_preserves_project_virtualenv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["omnigent", "validate", "--json"])
+    monkeypatch.setattr(sys, "dont_write_bytecode", False)
+    site_packages = str(tmp_path / ".venv" / "lib" / "site-packages")
+    monkeypatch.setattr(sys, "path", ["", str(tmp_path), site_packages])
+    isolate_offline_imports(package_init=True)
+    assert sys.path == [site_packages]
+    assert sys.dont_write_bytecode

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -2,6 +2,14 @@
 
 These tests start a real `omnigent` server subprocess, upload real agent bundles, and call real LLM APIs. They are **excluded from the default `pytest` run** via `addopts = --ignore=tests/e2e` in `pyproject.toml`. To exercise them you must opt in with `--llm-api-key` (and optionally `--profile`).
 
+The credential-free CLI exception is `test_offline_validate_e2e.py`. It runs the
+real module entry point with network/process and runtime-import tripwires, not a
+server or LLM. Run it explicitly without credentials:
+
+```bash
+uv run --no-sync pytest -o addopts= tests/e2e/test_offline_validate_e2e.py -q
+```
+
 ## ALWAYS RUN INTEGRATION + UNIT TESTS IN THE BACKGROUND
 
 The e2e suite takes 5–10 minutes even fully parallel; the unit suite takes 5–7 minutes parallel. **Never block your terminal (or an interactive Claude Code session) on a foreground run** — kick them off backgrounded and monitor:

--- a/tests/e2e/test_offline_validate_e2e.py
+++ b/tests/e2e/test_offline_validate_e2e.py
@@ -1,0 +1,143 @@
+"""Credential-free CLI e2e: no server, agent, provider or harness is started."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_GUARDED_ENTRYPOINT = r"""
+import importlib.abc
+import runpy
+import sys
+
+def audit(event, args):
+    if event.startswith(("socket.",
+                         "subprocess.", "os.system", "os.exec", "os.spawn",
+                         "os.posix_spawn", "os.fork")):
+        raise AssertionError("Offline CLI attempted network/process activity")
+
+class BlockRuntime(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.startswith(("offline_bundle_trap", "omnigent.inner.loader",
+                                "omnigent.runtime", "omnigent.policies",
+                                "omnigent.tools.builtins", "omnigent.cli_config",
+                                "omnigent.spec._omnigent_compat")):
+            raise AssertionError("Offline CLI imported runtime or bundle code")
+
+sys.addaudithook(audit)
+sys.meta_path.insert(0, BlockRuntime())
+sys.argv[0] = "omnigent"
+runpy.run_module("omnigent", run_name="__main__")
+"""
+
+
+def test_offline_bundle_cli_happy_path(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "config.yaml").write_text(
+        """spec_version: 1
+name: orchestrator
+instructions: prompt.md
+executor:
+  config: {harness: claude-sdk}
+  auth: {type: api_key, api_key: "${OFFLINE_E2E_SECRET}"}
+tools:
+  agents: [worker]
+  search:
+    type: mcp
+    url: https://example.invalid/mcp
+    headers: {Authorization: "${OFFLINE_E2E_SECRET}"}
+guardrails:
+  labels: {access: {initial: yes, values: [yes, no]}}
+  policies:
+    gate:
+      type: function
+      handler:
+        path: offline_bundle_trap.factory
+        arguments: {token: "${OFFLINE_E2E_SECRET}"}
+      condition: {access: yes}
+      set_labels: [access]
+""",
+        encoding="utf-8",
+    )
+    (bundle / "prompt.md").write_text("Delegate to worker when appropriate.", encoding="utf-8")
+    child = bundle / "agents" / "worker-directory"
+    child.mkdir(parents=True)
+    (child / "config.yaml").write_text(
+        "spec_version: 1\nname: worker\nexecutor: {type: agents_sdk}\n",
+        encoding="utf-8",
+    )
+    skill = bundle / "skills" / "summarize"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: summarize\ndescription: Summarize text.\n---\nBe concise.\n",
+        encoding="utf-8",
+    )
+    mcp = bundle / "tools" / "mcp"
+    mcp.mkdir(parents=True)
+    (mcp / "local.yaml").write_text(
+        "name: local\ntransport: stdio\ncommand: never-start-this-command\n"
+        "env: {TOKEN: '${OFFLINE_E2E_SECRET}'}\n",
+        encoding="utf-8",
+    )
+    code = "raise AssertionError('Bundle code must never be imported')\n"
+    (bundle / "offline_bundle_trap.py").write_text(code, encoding="utf-8")
+    for dependency in ("yaml", "pydantic", "click", "hashlib"):
+        (bundle / f"{dependency}.py").write_text(code, encoding="utf-8")
+    python_tools = bundle / "tools" / "python"
+    python_tools.mkdir()
+    (python_tools / "untrusted.py").write_text(code, encoding="utf-8")
+    before = {p.relative_to(bundle): p.read_bytes() for p in bundle.rglob("*") if p.is_file()}
+    repo = Path(__file__).resolve().parents[2]
+    secret = "offline-e2e-secret-not-a-real-credential"
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(repo),
+        "PYTHONDONTWRITEBYTECODE": "",
+        "OMNIGENT_WRAPPER_BYPASS": "1",
+        "OMNIGENT_DATA_DIR": str(tmp_path / "must-not-be-created"),
+        "OFFLINE_E2E_SECRET": secret,
+    }
+    outputs = []
+    for arguments in ([str(bundle), "--offline", "--json"], ["config.yaml", "--json"]):
+        result = subprocess.run(
+            [sys.executable, "-c", _GUARDED_ENTRYPOINT, "validate", *arguments],
+            cwd=bundle,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert result.stderr == ""
+        assert secret not in result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["schema_version"] == 1
+        assert payload["status"] == "valid"
+        assert payload["diagnostics"] == []
+        assert {check["code"] for check in payload["skipped_checks"]} == {
+            "HOST_AUTH",
+            "LIVE_SERVICES",
+            "CODE",
+            "PLUGINS",
+        }
+        outputs.append(result.stdout)
+    assert outputs[0] == outputs[1]
+    module_result = subprocess.run(
+        [sys.executable, "-m", "omnigent", "validate", "--offline", "--json"],
+        cwd=bundle,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert module_result.returncode == 0, module_result.stdout + module_result.stderr
+    assert module_result.stdout == outputs[0]
+    assert module_result.stderr == ""
+    assert not (tmp_path / "must-not-be-created").exists()
+    assert before == {
+        p.relative_to(bundle): p.read_bytes() for p in bundle.rglob("*") if p.is_file()
+    }

--- a/tests/e2e/test_offline_validate_e2e.py
+++ b/tests/e2e/test_offline_validate_e2e.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _GUARDED_ENTRYPOINT = r"""
 import importlib.abc
 import runpy
@@ -21,7 +23,8 @@ def audit(event, args):
 
 class BlockRuntime(importlib.abc.MetaPathFinder):
     def find_spec(self, fullname, path=None, target=None):
-        if fullname.startswith(("offline_bundle_trap", "omnigent.inner.loader",
+        if fullname == "omnigent.cli" or fullname.startswith((
+                                "offline_bundle_trap", "omnigent.inner.loader",
                                 "omnigent.runtime", "omnigent.policies",
                                 "omnigent.tools.builtins", "omnigent.cli_config",
                                 "omnigent.spec._omnigent_compat")):
@@ -34,7 +37,137 @@ runpy.run_module("omnigent", run_name="__main__")
 """
 
 
-def test_offline_bundle_cli_happy_path(tmp_path: Path) -> None:
+@pytest.fixture
+def offline_bundle(tmp_path: Path) -> Path:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "config.yaml").write_text(
+        "spec_version: 1\nexecutor: {type: agents_sdk}\n", encoding="utf-8"
+    )
+    return bundle
+
+
+@pytest.fixture
+def offline_cli_env(tmp_path: Path) -> dict[str, str]:
+    process_env = {
+        name: os.environ[name]
+        for name in (
+            "PATH",
+            "SYSTEMROOT",
+            "WINDIR",
+            "HOME",
+            "USERPROFILE",
+            "APPDATA",
+            "LOCALAPPDATA",
+            "TEMP",
+            "TMP",
+            "LANG",
+            "LC_ALL",
+        )
+        if name in os.environ
+    }
+    return {
+        **process_env,
+        "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+        "PYTHONDONTWRITEBYTECODE": "",
+        "OMNIGENT_WRAPPER_BYPASS": "1",
+        "OMNIGENT_DATA_DIR": str(tmp_path / "must-not-be-created"),
+        "OMNIGENT_CONTAINER_RUNTIME": "invalid-host-runtime",
+    }
+
+
+@pytest.mark.parametrize("input_form", ["directory", "file"])
+def test_offline_cli_rejects_descendant_dependency_shadowing(
+    tmp_path: Path, offline_bundle: Path, offline_cli_env: dict[str, str], input_form: str
+) -> None:
+    caller = tmp_path / "caller"
+    caller.mkdir()
+    import_roots = [
+        offline_bundle / "tools" / "python",
+        offline_bundle / "fake-venv" / "lib" / "site-packages",
+    ]
+    for root in import_roots:
+        root.mkdir(parents=True)
+        for name in ("yaml", "click", "hashlib", "sysconfig"):
+            (root / f"{name}.py").write_text(
+                "raise AssertionError('Imported bundle descendant as a dependency')\n",
+                encoding="utf-8",
+            )
+    before = {
+        p.relative_to(offline_bundle): p.read_bytes()
+        for p in offline_bundle.rglob("*")
+        if p.is_file()
+    }
+    offline_cli_env["PYTHONPATH"] = os.pathsep.join(
+        [offline_cli_env["PYTHONPATH"], *(str(root) for root in import_roots)]
+    )
+    source = offline_bundle if input_form == "directory" else offline_bundle / "config.yaml"
+    result = subprocess.run(
+        [sys.executable, "-m", "omnigent", "validate", str(source), "--offline", "--json"],
+        cwd=caller,
+        env=offline_cli_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr == ""
+    assert json.loads(result.stdout)["status"] == "valid"
+    assert not (tmp_path / "must-not-be-created").exists()
+    assert before == {
+        p.relative_to(offline_bundle): p.read_bytes()
+        for p in offline_bundle.rglob("*")
+        if p.is_file()
+    }
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected_exit"),
+    [
+        (["--"], 0),
+        (["--profiling", "--"], 2),
+        (["--debug", "--"], 2),
+        (["--log-to-stderr", "--"], 2),
+        (["--debug", "--profiling", "--log-to-stderr", "--"], 2),
+    ],
+)
+def test_offline_cli_root_separator_cannot_enter_runtime(
+    tmp_path: Path,
+    offline_bundle: Path,
+    offline_cli_env: dict[str, str],
+    prefix: list[str],
+    expected_exit: int,
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _GUARDED_ENTRYPOINT,
+            *prefix,
+            "validate",
+            str(offline_bundle),
+            "--offline",
+            "--json",
+        ],
+        cwd=offline_bundle,
+        env=offline_cli_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == expected_exit, result.stdout + result.stderr
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["exit_code"] == expected_exit
+    assert payload["status"] == ("valid" if expected_exit == 0 else "invalid_invocation")
+    if expected_exit:
+        assert payload["diagnostics"][0]["code"] == "INVALID_INVOCATION"
+        assert str(offline_bundle) not in result.stdout
+    assert not (tmp_path / "must-not-be-created").exists()
+    assert list(offline_bundle.iterdir()) == [offline_bundle / "config.yaml"]
+
+
+def test_offline_bundle_cli_happy_path(tmp_path: Path, offline_cli_env: dict[str, str]) -> None:
     bundle = tmp_path / "bundle"
     bundle.mkdir()
     (bundle / "config.yaml").write_text(
@@ -91,14 +224,9 @@ guardrails:
     python_tools.mkdir()
     (python_tools / "untrusted.py").write_text(code, encoding="utf-8")
     before = {p.relative_to(bundle): p.read_bytes() for p in bundle.rglob("*") if p.is_file()}
-    repo = Path(__file__).resolve().parents[2]
     secret = "offline-e2e-secret-not-a-real-credential"
     env = {
-        **os.environ,
-        "PYTHONPATH": str(repo),
-        "PYTHONDONTWRITEBYTECODE": "",
-        "OMNIGENT_WRAPPER_BYPASS": "1",
-        "OMNIGENT_DATA_DIR": str(tmp_path / "must-not-be-created"),
+        **offline_cli_env,
         "OFFLINE_E2E_SECRET": secret,
     }
     outputs = []

--- a/tests/spec/test_offline.py
+++ b/tests/spec/test_offline.py
@@ -1,0 +1,380 @@
+"""Data-only AgentSpec validation, including hostile and unsupported inputs."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import socket
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from omnigent.spec.offline import MAX_FILE_BYTES, MAX_FILES, _Reader, validate_path
+from omnigent.spec.offline_scope import ContentError
+from omnigent.spec.parser import parse, parse_config
+from omnigent.spec.validator import validate
+
+BASE = "spec_version: 1\nname: example\nexecutor:\n  config:\n    harness: claude-sdk\n"
+SECRET = "offline-test-secret-not-a-real-credential"
+
+
+def write_config(root: Path, text: str = BASE) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "config.yaml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_bundle_and_explicit_config_have_the_same_report(tmp_path: Path) -> None:
+    path = write_config(tmp_path)
+    directory = validate_path(str(tmp_path)).to_dict()
+    explicit = validate_path(str(path)).to_dict()
+    assert directory == explicit
+    assert directory == {
+        "schema_version": 1,
+        "mode": "offline",
+        "status": "valid",
+        "exit_code": 0,
+        "diagnostics": [],
+        "skipped_checks": [
+            {
+                "code": "HOST_AUTH",
+                "reason": "Host readiness, credentials, environment expansion "
+                "and provider auth are not checked.",
+            },
+            {
+                "code": "LIVE_SERVICES",
+                "reason": "MCP, model and network availability are not checked.",
+            },
+            {
+                "code": "CODE",
+                "reason": "Tool implementations and policy handlers/arguments are not imported, "
+                "resolved or executed.",
+            },
+            {
+                "code": "PLUGINS",
+                "reason": "Community harness plugins and optional-package availability "
+                "are not checked.",
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize("extension", [".yaml", ".yml"])
+def test_explicit_v1_yaml_filename(tmp_path: Path, extension: str) -> None:
+    path = tmp_path / f"agent{extension}"
+    path.write_text(BASE, encoding="utf-8")
+    assert validate_path(str(path)).exit_code == 0
+
+
+@pytest.mark.parametrize(
+    ("text", "code"),
+    [
+        ("", "INVALID_SHAPE"),
+        ("[]", "INVALID_SHAPE"),
+        ("name: old-format\nprompt: hello\npolicies: {}", "UNSUPPORTED_FORMAT"),
+        ("spec_version: 2", "INVALID_SPEC"),
+        ("spec_version: false", "INVALID_SHAPE"),
+        ("spec_version: 1\nname: [one]", "INVALID_SHAPE"),
+        (BASE + "unknown: ignored-by-runtime", "UNSUPPORTED_FIELD"),
+        (BASE + "os_env: {cwd: /tmp}", "UNSUPPORTED_FIELD"),
+        (BASE + "terminals: {}", "UNSUPPORTED_FIELD"),
+        (BASE + "llm: []", "INVALID_SHAPE"),
+        (BASE + "llm: {model: a, misspelled: true}", "UNSUPPORTED_FIELD"),
+        (BASE + "interaction: {modalities: false}", "INVALID_SHAPE"),
+        (BASE + "tools: {missing: {type: mcp}}", "INVALID_SHAPE"),
+        (BASE + "tools: {missing: {type: function, callable: local.run}}", "UNSUPPORTED_FIELD"),
+        (BASE + "tools: {builtins: [not_a_builtin]}", "INVALID_SHAPE"),
+        (BASE + "tools: {builtins: [browser_navigate]}", "INVALID_SHAPE"),
+        (BASE + "tools: {sandbox: {type: mcp, command: silently-discarded}}", "UNSUPPORTED_FIELD"),
+        (BASE + "tools: {builtins: [{name: web_search, api_key: secret}]}", "INVALID_SHAPE"),
+        (BASE + "tools: {agents: [missing]}", "INVALID_SPEC"),
+        (BASE + "skills: [missing]", "INVALID_SHAPE"),
+        (BASE + "params: &p {again: *p}", "UNSUPPORTED_YAML"),
+        (BASE + "params: {<<: {value: 1}}", "UNSUPPORTED_YAML"),
+        (BASE + "params: {key: first, key: second}", "DUPLICATE_KEY"),
+        (BASE + "params: !!python/object/apply:os.system ['echo forbidden']", "INVALID_YAML"),
+        (BASE + "params: [\n", "INVALID_YAML"),
+        (BASE + "---\nsecond: document", "INVALID_YAML"),
+    ],
+)
+def test_rejects_invalid_or_unvalidated_content(tmp_path: Path, text: str, code: str) -> None:
+    path = write_config(tmp_path, text)
+    result = validate_path(str(path))
+    assert result.exit_code == 1
+    assert result.diagnostics[0].code == code
+    assert result.to_dict()["status"] == "invalid"
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        "type: function\n      function: local.handler\n      typo: deny",
+        "type: function\n      function: local.handler\n      on: [response]",
+        "type: function\n      function: local.handler\n      on: [not_a_phase]",
+        "type: function\n      function: local.handler\n      handler: other.handler",
+        "type: function\n      function: invalid-path",
+        "type: function\n      function: {path: local.handler, arguments: []}",
+        "type: function\n      function: {path: local.handler, typo: true}",
+        "type: function\n      function: local.handler\n      set_labels: [missing]",
+        "type: function\n      function: local.handler\n      condition: {missing: yes}",
+        "type: function\n      function: local.handler\n      condition: {access: bad}",
+        "type: prompt\n      prompt: Never disclose data",
+    ],
+)
+def test_strict_policy_declarations(tmp_path: Path, policy: str) -> None:
+    path = write_config(
+        tmp_path,
+        BASE + "guardrails:\n  labels:\n    access: {values: [yes, no]}\n"
+        f"  policies:\n    gate:\n      {policy}\n",
+    )
+    assert validate_path(str(path)).exit_code == 1
+
+
+def test_policy_factories_tools_and_credentials_are_only_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def forbidden(*args: object, **kwargs: object) -> None:
+        pytest.fail("Offline validation attempted a runtime operation")
+
+    path = write_config(
+        tmp_path,
+        BASE
+        + """tools:
+  local_mcp:
+    type: mcp
+    command: never-run-me
+    args: [--start-agent]
+    env: {TOKEN: "${OFFLINE_SECRET}"}
+guardrails:
+  labels:
+    access: {initial: yes, values: [yes, no]}
+  policies:
+    gate:
+      type: function
+      handler:
+        path: offline_bundle_trap.factory
+        arguments: {api_key: "${OFFLINE_SECRET}"}
+      config: {token: "${OFFLINE_SECRET}"}
+      condition: {access: yes}
+      set_labels: [access]
+""",
+    )
+    trap = "raise AssertionError('Bundle-local code was imported')\n"
+    (tmp_path / "offline_bundle_trap.py").write_text(trap, encoding="utf-8")
+    tools = tmp_path / "tools" / "python"
+    tools.mkdir(parents=True)
+    (tools / "tool.py").write_text(trap, encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setenv("OFFLINE_SECRET", SECRET)
+    from omnigent.spec import parser
+
+    monkeypatch.setattr(parser, "expand_env_vars", forbidden)
+    monkeypatch.setattr(importlib, "import_module", forbidden)
+    monkeypatch.setattr(socket, "create_connection", forbidden)
+    monkeypatch.setattr(socket, "getaddrinfo", forbidden)
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
+    monkeypatch.setattr(subprocess, "Popen", forbidden)
+    monkeypatch.setattr(os, "system", forbidden)
+    before = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    result = validate_path(str(path))
+    after = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    assert result.exit_code == 0, result.to_dict()
+    assert before == after
+    assert SECRET not in str(result.to_dict())
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        f"spec_version: '{SECRET}'",
+        BASE + f"guardrails: {{labels: {{private: {{initial: '{SECRET}', values: [public]}}}}}}",
+        BASE + f"params: {{'{SECRET}': [}}",
+        BASE + f"tools: {{agents: ['{SECRET}']}}",
+        BASE + f"params: {{'{SECRET}': 1, '{SECRET}': 2}}",
+        BASE + f"guardrails: {{policies: {{'{SECRET}': {{type: function, on: [response]}}}}}}",
+    ],
+)
+def test_diagnostics_never_disclose_values(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, text: str
+) -> None:
+    path = write_config(tmp_path, text)
+    result = validate_path(str(path))
+    assert result.exit_code == 1
+    assert SECRET not in str(result.to_dict())
+    assert SECRET not in caplog.text
+
+
+def test_missing_subagent_is_not_pruned(tmp_path: Path) -> None:
+    write_config(tmp_path)
+    (tmp_path / "agents" / "incomplete").mkdir(parents=True)
+    result = validate_path(str(tmp_path))
+    assert result.exit_code == 1
+    assert result.diagnostics[0].file == "agents/incomplete/config.yaml"
+
+
+def test_invalid_child_and_duplicate_names_fail(tmp_path: Path) -> None:
+    write_config(tmp_path)
+    write_config(tmp_path / "agents" / "first")
+    write_config(tmp_path / "agents" / "second")
+    assert validate_path(str(tmp_path)).exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "instruction", ["missing.md", "../secret.txt", "/secret.txt", "C:\\secret.txt"]
+)
+def test_strict_instruction_references(tmp_path: Path, instruction: str) -> None:
+    path = write_config(tmp_path, BASE + f"instructions: '{instruction}'\n")
+    assert validate_path(str(path)).exit_code == 1
+
+
+def test_file_and_yaml_complexity_limits(tmp_path: Path) -> None:
+    path = write_config(tmp_path, BASE + "#" * MAX_FILE_BYTES)
+    assert validate_path(str(path)).diagnostics[0].code == "INPUT_LIMIT"
+    path.write_text(BASE + "params: " + "[" * 40 + "0" + "]" * 40, encoding="utf-8")
+    assert validate_path(str(path)).diagnostics[0].code == "INPUT_LIMIT"
+
+
+@pytest.mark.parametrize(
+    "value", ["https://example.invalid/agent.yaml", "\\\\server\\bundle", "//server/bundle", ""]
+)
+def test_remote_inputs_do_not_touch_the_filesystem(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def forbidden(*args: object, **kwargs: object) -> None:
+        pytest.fail("Remote validation input touched the filesystem")
+
+    monkeypatch.setattr(Path, "lstat", forbidden)
+    assert validate_path(value).exit_code == 2
+
+
+def test_missing_and_unsupported_input(tmp_path: Path) -> None:
+    assert validate_path(str(tmp_path / "missing.yaml")).exit_code == 2
+    path = tmp_path / "bundle.tar.gz"
+    path.write_bytes(b"not an archive")
+    assert validate_path(str(path)).exit_code == 2
+    assert validate_path(str(tmp_path)).exit_code == 1
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="POSIX symlink/FIFO safety; native Windows unsupported"
+)
+def test_symlinks_and_special_files_are_not_read(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    write_config(bundle, BASE + "instructions: prompt.md\n")
+    target = tmp_path / "outside.md"
+    target.write_text(SECRET, encoding="utf-8")
+    (bundle / "prompt.md").symlink_to(target)
+    result = validate_path(str(bundle))
+    assert result.exit_code == 1
+    assert SECRET not in str(result.to_dict())
+    (bundle / "prompt.md").unlink()
+    os.mkfifo(bundle / "prompt.md")
+    assert validate_path(str(bundle)).exit_code == 1
+    alias = tmp_path / "alias"
+    alias.symlink_to(bundle, target_is_directory=True)
+    assert validate_path(str(alias)).exit_code == 2
+
+
+def test_shared_config_parser_preserves_normal_bundle_parsing(tmp_path: Path) -> None:
+    write_config(tmp_path, BASE + "instructions: prompt.md\n")
+    (tmp_path / "prompt.md").write_text("Hello from instructions.", encoding="utf-8")
+    spec = parse(tmp_path, expand_env=False)
+    assert spec.instructions == "Hello from instructions."
+    assert spec.executor.config["harness"] == "claude-sdk"
+    assert validate(spec, offline=True).valid
+    assert (
+        parse_config({"spec_version": 1, "executor": {"type": "agents_sdk"}}).instructions is None
+    )
+
+
+def test_long_single_line_prose_remains_inline(tmp_path: Path) -> None:
+    path = write_config(tmp_path, BASE + "instructions: " + "You are a helpful assistant. " * 40)
+    assert validate_path(str(path)).exit_code == 0
+
+
+def test_empty_inline_instructions_are_not_a_directory_reference(tmp_path: Path) -> None:
+    path = write_config(tmp_path, BASE + "instructions: ''\n")
+    assert validate_path(str(path)).exit_code == 0
+
+
+def test_diagnostics_ignore_directory_creation_order(tmp_path: Path) -> None:
+    results = []
+    for name, children in (("one", ("b", "A")), ("two", ("A", "b"))):
+        root = tmp_path / name
+        write_config(root)
+        for child in children:
+            write_config(root / "agents" / child, BASE + "guardrails: {labels: []}")
+        result = validate_path(str(root))
+        assert result.exit_code == 1
+        assert result.diagnostics[0].file == "agents/A/config.yaml"
+        results.append(result.to_dict())
+    assert results[0] == results[1]
+
+
+@pytest.mark.parametrize("name", ["on", "yes", "true"])
+def test_mcp_scalar_coercion_cannot_hide_collisions(tmp_path: Path, name: str) -> None:
+    write_config(tmp_path)
+    mcp = tmp_path / "tools" / "mcp"
+    mcp.mkdir(parents=True)
+    (mcp / "server.yaml").write_text(
+        f"name: {name}\ntransport: http\nurl: https://example.invalid/mcp\n", encoding="utf-8"
+    )
+    assert validate_path(str(tmp_path)).exit_code == 1
+    (mcp / "server.yaml").write_text(
+        f"name: '{name}'\ntransport: http\nurl: https://example.invalid/mcp\n", encoding="utf-8"
+    )
+    assert validate_path(str(tmp_path)).exit_code == 0
+    assert parse(tmp_path, expand_env=False).mcp_servers[0].name == name
+
+
+def test_directory_limit_bounds_enumeration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = []
+
+    class Entries:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def __iter__(self):
+            for index in range(MAX_FILES * 10):
+                calls.append(index)
+                yield types.SimpleNamespace(path=str(tmp_path / str(index)))
+
+    monkeypatch.setattr(os, "scandir", lambda path: Entries())
+    with pytest.raises(ContentError, match="entry limit"):
+        _Reader(tmp_path).entries(tmp_path)
+    assert len(calls) == MAX_FILES + 1
+
+
+def test_legacy_spec_exports_are_lazy_and_forward_arguments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import omnigent.spec as spec_module
+
+    compat = types.ModuleType("omnigent.spec._omnigent_compat")
+    compat.is_omnigent_yaml = Mock(return_value=True)
+    compat.diagnose_yaml_rejection = Mock(return_value="reason")
+    sentinel = parse_config({"spec_version": 1})
+    compat.load_omnigent_yaml = Mock(return_value=sentinel)
+    monkeypatch.setitem(sys.modules, compat.__name__, compat)
+    path = tmp_path / "legacy.yaml"
+    assert spec_module.is_omnigent_yaml(path)
+    assert spec_module.diagnose_yaml_rejection(path) == "reason"
+    assert (
+        spec_module.load_omnigent_yaml(
+            path, enforce_handler_allowlist=True, prune_invalid_sub_agents=True
+        )
+        is sentinel
+    )
+    compat.load_omnigent_yaml.assert_called_once_with(
+        path, enforce_handler_allowlist=True, prune_invalid_sub_agents=True
+    )

--- a/tests/spec/test_offline.py
+++ b/tests/spec/test_offline.py
@@ -64,6 +64,38 @@ def test_bundle_and_explicit_config_have_the_same_report(tmp_path: Path) -> None
     }
 
 
+@pytest.mark.parametrize("tools", ["", "tools: {}\n", "tools: {agents: [worker]}\n"])
+def test_offline_output_does_not_depend_on_container_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tools: str
+) -> None:
+    path = write_config(tmp_path, BASE + tools)
+    write_config(
+        tmp_path / "agents" / "worker",
+        "spec_version: 1\nname: worker\nexecutor: {type: agents_sdk}\n",
+    )
+    monkeypatch.delenv("OMNIGENT_CONTAINER_RUNTIME", raising=False)
+    expected = validate_path(str(path)).to_dict()
+    assert expected["status"] == "valid"
+    for value in ("docker", "podman", "", "invalid-host-runtime"):
+        monkeypatch.setenv("OMNIGENT_CONTAINER_RUNTIME", value)
+        assert validate_path(str(path)).to_dict() == expected
+        assert os.environ["OMNIGENT_CONTAINER_RUNTIME"] == value
+
+
+def test_offline_validation_does_not_read_container_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = write_config(tmp_path)
+    original_get = os.environ.get
+
+    def guarded_get(key: str, default: object = None) -> object:
+        assert key != "OMNIGENT_CONTAINER_RUNTIME", "Offline parsing read the runtime environment"
+        return original_get(key, default)
+
+    monkeypatch.setattr(os.environ, "get", guarded_get)
+    assert validate_path(str(path)).exit_code == 0
+
+
 @pytest.mark.parametrize("extension", [".yaml", ".yml"])
 def test_explicit_v1_yaml_filename(tmp_path: Path, extension: str) -> None:
     path = tmp_path / f"agent{extension}"

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 import yaml
 
 from omnigent.errors import OmnigentError
-from omnigent.spec.parser import _parse_skill, discover_host_skills, parse
+from omnigent.spec.parser import _parse_skill, discover_host_skills, parse, parse_config
 from omnigent.spec.types import ApiKeyAuth, DatabricksAuth, ProviderAuth, SharePolicy
 
 
@@ -1571,6 +1572,42 @@ def test_parse_tools_sandbox_null_runtime_rejected(tmp_path: Path) -> None:
     (tmp_path / "config.yaml").write_text(yaml.dump(config))
     with pytest.raises(ValueError, match="container_runtime"):
         parse(tmp_path)
+
+
+@pytest.mark.parametrize("tools", [None, {}, {"sandbox": {"container_image": "python:3.12-slim"}}])
+def test_parse_config_container_runtime_default_is_explicit(
+    monkeypatch: pytest.MonkeyPatch, tools: dict[str, object] | None
+) -> None:
+    raw = {"spec_version": 1, "tools": tools}
+    monkeypatch.setenv("OMNIGENT_CONTAINER_RUNTIME", "podman")
+    assert parse_config(raw, expand_env=False).tools.sandbox.container_runtime == "podman"
+    assert (
+        parse_config(
+            raw, expand_env=False, default_container_runtime="docker"
+        ).tools.sandbox.container_runtime
+        == "docker"
+    )
+    monkeypatch.setenv("OMNIGENT_CONTAINER_RUNTIME", "invalid-host-runtime")
+    with pytest.raises(ValueError, match="container_runtime"):
+        parse_config(raw, expand_env=False)
+    assert (
+        parse_config(
+            raw, expand_env=False, default_container_runtime="docker"
+        ).tools.sandbox.container_runtime
+        == "docker"
+    )
+    assert os.environ["OMNIGENT_CONTAINER_RUNTIME"] == "invalid-host-runtime"
+
+
+def test_parse_config_yaml_runtime_beats_explicit_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OMNIGENT_CONTAINER_RUNTIME", "invalid-host-runtime")
+    raw = {"spec_version": 1, "tools": {"sandbox": {"container_runtime": "podman"}}}
+    assert (
+        parse_config(
+            raw, expand_env=False, default_container_runtime="docker"
+        ).tools.sandbox.container_runtime
+        == "podman"
+    )
 
 
 def test_parse_inline_mcp_skips_non_mcp_type_entries(tmp_path: Path) -> None:


### PR DESCRIPTION
## Related issue

Part of #5672. This implements a bounded, independently useful static preflight,
not the issue's full workflow/deployment-readiness proposal.

## Summary

`omnigent validate <path> --offline --json` checks supported AgentSpec v1 images
as data, without executing bundle code or policy handlers, expanding credentials,
starting agents, or probing services. It reports deterministic versioned
diagnostics and explicitly skipped runtime checks. Unsupported content is an
error, not a successful partial validation.

ELI5: check the package's declared structure before attempting to run it; a
successful result is not a promise that its credentials or services work.

```text
local v1 image -> data-only parsing -> static checks -> text / JSON + exit code
                                                    |
                              runtime checks explicitly marked skipped
```

A lightweight entry point and lazy import boundaries keep offline validation
separate from normal runtime startup. Existing parsers, static validators, and
shipped builtin/harness metadata are reused. Normal CLI invocations still take
the runtime path.

## Test Plan

[Linux fork run 33993617858](https://github.com/santhoshravindran7/omnigent/actions/runs/33993617858)
passed against commit `9b64fb2d6225c9b5b40c531328b0894e96280339`: configured
pre-commit hooks (including the full type check) and **840 tests, with no skips**.
The selected suites cover offline parsing/CLI/e2e behavior and existing parser,
policy, validator, loader, CLI invocation, builtin registry, and harness-plugin
behavior, using the normal repository fixtures.

The eight new credential-free e2e cases invoke the actual module CLI in fresh
processes. They cover a complete supported image, descendant dependency-shadowing
traps, root argument separators and prohibited startup flags, alongside
network/process/runtime-import tripwires, repeatable JSON and unchanged input
bytes. No live model or server is invoked. Static parser regressions also verify
that host container-runtime settings do not change the offline verdict.

Reproduction commands and the full supported subset are in
`docs/OFFLINE_VALIDATION.md`. The fork-only orchestration workflow is not included
in this feature diff; upstream PR checks are separate.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

On a supported installation, save the following as `my-agent/config.yaml`:

```yaml
spec_version: 1
name: example
instructions: You are a helpful assistant.
executor:
  config:
    harness: claude-sdk
  auth:
    type: api_key
    api_key: ${MY_API_KEY}
```

Run `omnigent validate my-agent --offline --json` without setting `MY_API_KEY`.
The expected result is `status: "valid"` and exit `0`, with runtime checks
listed as skipped. Change `spec_version` to `2` for exit `1`; pass a nonexistent
path for an `invalid_invocation` result and exit `2`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The first version accepts AgentSpec v1 image directories and explicit v1 YAML
files. Legacy standalone YAML, `os_env`, `terminals`, remote/archive inputs, and
other unsupported fields fail explicitly. It does not validate live
authentication, provider readiness, handler semantics, community plugins, or
cross-harness workflows. Concurrent filesystem replacement is not supported.

GitHub Copilot CLI generated the implementation and performed automated review
and validation. Human self-review remains outstanding, so this is a draft.
No maintainer approval or live-deployment success is implied.

The upstream Security Scan needs maintainer triage: it flags
`tests/spec/test_offline.py` for a secret-named source and network sink in one
file. That test uses a dummy credential and replaces socket/network, subprocess
and handler operations with `pytest.fail` tripwires; it verifies that validation
does not call them or disclose the dummy value. The scan has not been waived or
weakened. Maintainer approval is also outstanding.

## Changelog

`omnigent validate --offline --json` checks supported AgentSpec v1 images without running their code or contacting services.
