### PR TITLE
fix(codex): accept string compaction window IDs

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -6297,7 +6297,8 @@ def _read_compacted_history(rollout_path: Path) -> dict[str, object] | None:
     """Read the last ``Compacted`` entry from a rollout JSONL.
 
     Codex appends a ``{type: "compacted", payload: {replacement_history: [...],
-    window_id: N}}`` entry after compaction. Returns a dict with
+    window_id: ID}}`` rollout entry after compaction. Current Codex writes a
+    UUID string at this ``payload.window_id`` location. Returns a dict with
     ``replacement_history`` and ``window_id`` for persistence, or ``None``.
 
     :param rollout_path: Path to the rollout JSONL.

--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -470,6 +470,10 @@ class CompactionData(BaseModel):
         e.g. ``"openai/gpt-4o"``.
     :param token_count: Approximate token count of the summary
         text, for budget tracking, e.g. ``342``.
+    :param window_id: Opaque vendor compaction-window identifier. Current
+        Codex writes a UUID string to ``payload.window_id`` on its
+        ``type == "compacted"`` rollout JSONL record; older Codex rollouts
+        used integer counters there.
     """
 
     summary: str
@@ -477,7 +481,7 @@ class CompactionData(BaseModel):
     model: str | None = None
     token_count: int
     compacted_messages: list[dict[str, Any]] | None = None
-    window_id: int | None = None
+    window_id: int | str | None = None
 
     @field_validator("compacted_messages")
     @classmethod

--- a/openapi.json
+++ b/openapi.json
@@ -1056,9 +1056,13 @@
                 "type": "integer"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
+            "description": "Opaque vendor compaction-window identifier. Current Codex writes a UUID string to `payload.window_id` on its `type == \"compacted\"` rollout JSONL record; older Codex rollouts used integer counters there.",
             "title": "Window Id"
           }
         },

--- a/tests/entities/test_conversation_extended.py
+++ b/tests/entities/test_conversation_extended.py
@@ -106,6 +106,19 @@ def test_compaction_data_valid() -> None:
     assert cd.token_count == 342
 
 
+@pytest.mark.parametrize("window_id", [2, "01a070e2-2665-7d62-9b74-973decf239b7"])
+def test_compaction_data_accepts_vendor_window_id(window_id: int | str) -> None:
+    cd = CompactionData(
+        summary="Compacted",
+        last_item_id="msg_abc123",
+        model="system.ai.gpt-5-6-sol",
+        token_count=0,
+        window_id=window_id,
+    )
+
+    assert cd.window_id == window_id
+
+
 def test_compaction_data_missing_field() -> None:
     with pytest.raises(ValidationError, match="last_item_id"):
         CompactionData(summary="s", model="m", token_count=1)  # type: ignore[call-arg]

--- a/tests/server/integration/test_sessions_compact.py
+++ b/tests/server/integration/test_sessions_compact.py
@@ -405,6 +405,7 @@ async def test_compaction_snapshot_persists_without_base64_payloads(
                 "last_item_id": "msg_boundary_abc123",
                 "model": "unknown",
                 "token_count": 0,
+                "window_id": "01a070e2-2665-7d62-9b74-973decf239b7",
                 "compacted_messages": [
                     {
                         "type": "message",
@@ -445,6 +446,7 @@ async def test_compaction_snapshot_persists_without_base64_payloads(
     )
 
     item = compaction_items[0]
+    assert item["window_id"] == "01a070e2-2665-7d62-9b74-973decf239b7"
     # to_api_dict spreads CompactionData onto the top level, so serialising the
     # whole item leaves nowhere for a stray copy of the payload to hide.
     item_json = json.dumps(item)

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -11071,7 +11071,7 @@ def test_rollout_records_includes_compacted_entry_from_compaction_item() -> None
                     "encrypted_content": "gAAAA_encrypted",
                 },
             ],
-            "window_id": 2,
+            "window_id": "01a070e2-2665-7d62-9b74-973decf239b7",
             "response_id": "compact_1",
         },
         {
@@ -11106,7 +11106,7 @@ def test_rollout_records_includes_compacted_entry_from_compaction_item() -> None
     compacted_records = [r for r in records if r["type"] == "compacted"]
     assert len(compacted_records) == 1
     cp = compacted_records[0]["payload"]
-    assert cp["window_id"] == 2
+    assert cp["window_id"] == "01a070e2-2665-7d62-9b74-973decf239b7"
     assert len(cp["replacement_history"]) == 2
     assert cp["replacement_history"][1]["encrypted_content"] == "gAAAA_encrypted"
     # Post-compaction message should still be present

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1663,8 +1663,42 @@ async def test_reasoning_delta_skips_empty_non_opening_delta() -> None:
 
 
 @pytest.mark.asyncio
-async def test_persist_codex_compaction_item_posts_event() -> None:
-    """Compaction event is posted with last_item_id and Codex summary."""
+async def test_persist_codex_compaction_item_posts_uuid_window_id(tmp_path: Path) -> None:
+    """Codex's UUID window id is posted with the compaction checkpoint."""
+    import json as _json
+
+    codex_home = codex_home_for_bridge_dir(tmp_path)
+    rollout = codex_home / "sessions" / "2026" / "09" / "05" / "rollout-thread_1.jsonl"
+    rollout.parent.mkdir(parents=True)
+    rollout.write_text(
+        _json.dumps(
+            {
+                "type": "compacted",
+                "payload": {
+                    "replacement_history": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "hi"}],
+                        }
+                    ],
+                    "window_id": "01a070e2-2665-7d62-9b74-973decf239b7",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_codex",
+            socket_path="ws://127.0.0.1:9999",
+            thread_id="thread_1",
+            codex_home=str(codex_home),
+            cwd="/tmp/workspace",
+        ),
+    )
     get_resp = MagicMock()
     get_resp.json.return_value = {"data": [{"id": "item_codex"}]}
     get_resp.raise_for_status = MagicMock()
@@ -1676,7 +1710,11 @@ async def test_persist_codex_compaction_item_posts_event() -> None:
     post_resp.raise_for_status = MagicMock()
     client.post = AsyncMock(return_value=post_resp)
 
-    await _persist_codex_compaction_item(client, session_id="conv_codex")
+    await _persist_codex_compaction_item(
+        client,
+        session_id="conv_codex",
+        bridge_dir=tmp_path,
+    )
 
     client.post.assert_called_once()
     _url, kwargs = client.post.call_args
@@ -1684,8 +1722,8 @@ async def test_persist_codex_compaction_item_posts_event() -> None:
     assert body["type"] == "compaction"
     assert body["data"]["last_item_id"] == "item_codex"
     assert "Codex" in body["data"]["summary"]
-    # Codex can't read post-compaction state, so no compacted_messages
-    assert "compacted_messages" not in body["data"]
+    assert body["data"]["window_id"] == "01a070e2-2665-7d62-9b74-973decf239b7"
+    assert body["data"]["compacted_messages"][0]["role"] == "user"
 
 
 @pytest.mark.asyncio
@@ -1711,8 +1749,10 @@ async def test_persist_codex_compaction_item_empty_items_fallback() -> None:
     assert "compacted_messages" not in body["data"]
 
 
+@pytest.mark.parametrize("window_id", [2, "01a070e2-2665-7d62-9b74-973decf239b7"])
 def test_read_compacted_history_extracts_replacement_history_and_window_id(
     tmp_path: Path,
+    window_id: int | str,
 ) -> None:
     """_read_compacted_history returns replacement_history and window_id."""
     import json as _json
@@ -1737,7 +1777,7 @@ def test_read_compacted_history_extracts_replacement_history_and_window_id(
                             "encrypted_content": "gAAAA_test_token",
                         },
                     ],
-                    "window_id": 2,
+                    "window_id": window_id,
                 },
             }
         ),
@@ -1747,7 +1787,7 @@ def test_read_compacted_history_extracts_replacement_history_and_window_id(
     result = fwd._read_compacted_history(rollout)
 
     assert result is not None
-    assert result["window_id"] == 2
+    assert result["window_id"] == window_id
     assert len(result["replacement_history"]) == 2
     assert result["replacement_history"][0]["type"] == "message"
     assert result["replacement_history"][0]["role"] == "user"


### PR DESCRIPTION
## Related issue

N/A — discovered while reproducing a Codex session that failed after compaction and rehydration.

## Summary

- Accept both legacy integer and current UUID-string Codex compaction `window_id` values.
- Document the Codex source as `payload.window_id` on its `type == \"compacted\"` rollout JSONL record.
- Keep the forwarder’s existing single-request behavior: it sends Codex’s UUID with the compaction checkpoint, and the updated server persists both together.
- Cover entity validation, API persistence, forwarder transport, rollout reconstruction, and the generated OpenAPI schema.

**ELI5:** Codex changed a compaction marker from a number to a UUID. Omnigent rejected the new shape, which discarded the entire checkpoint needed after restart, resume, or fork. The server now accepts either representation on the first request.

```text
legacy integer ─┐
                ├─> updated server accepts and persists compaction
current UUID ───┘
```

## Test Plan

- `PYTHONPATH="$PWD" .venv/bin/python -m pytest -q tests/entities/test_conversation_extended.py::test_compaction_data_accepts_vendor_window_id tests/server/integration/test_sessions_compact.py::test_compaction_snapshot_persists_without_base64_payloads tests/test_codex_native.py::test_rollout_records_includes_compacted_entry_from_compaction_item tests/test_codex_native_forwarder.py::test_persist_codex_compaction_item_posts_uuid_window_id tests/test_codex_native_forwarder.py::test_read_compacted_history_extracts_replacement_history_and_window_id tests/server/test_openapi_drift.py::test_openapi_json_matches_generator_output` — 8 passed.
- `SKIP=pyrefly .venv/bin/pre-commit run --files <changed files>` — all applicable formatting, lint, and hygiene hooks passed.
- Real Codex `0.147.0` A/B cold-resume replay against one frozen 7.17 MB rollout:
  - Remove only its two UUID `compacted` records: the first turn fails at `258400/258400` with `contextWindowExceeded` and “Codex ran out of room in the model's context window.”
  - Preserve those records: the same prompt succeeds with `REPLAY_OK` at 113,845 input tokens.
- Real Omnigent/Codex lifecycle verification:
  - Current server rejects the real UUID compaction event with HTTP 400 and stores no checkpoint.
  - Updated server returns HTTP 202, retains the UUID, reconstructs with the compaction boundary after restart, and completes the follow-up turn.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

```json
{"kind":"paired_assertion","no_checkpoint_error":{"codexErrorInfo":"contextWindowExceeded","message":"Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying."},"passed":true,"with_checkpoint_text":"REPLAY_OK"}
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests cover historical integer IDs, current UUID-string IDs, server persistence, forwarder transport, and rollout reconstruction. Manual real-Codex A/B replay verifies the production symptom and confirms that retaining UUID compaction checkpoints prevents it after cold resume.

## Changelog

Codex sessions retain their compaction history across restarts, resumes, and forks.

