### PR TITLE
feat(extensions): support host-provided frames

### DIFF
--- a/web/src/embed.tsx
+++ b/web/src/embed.tsx
@@ -63,7 +63,12 @@ import { QueueFlushProvider } from "./hooks/QueueFlushProvider";
 import { ExtensionProvider } from "./extensions/ExtensionProvider";
 import { SessionUpdatesProvider } from "./hooks/SessionUpdatesProvider";
 
-export type { OmnigentHostConfig } from "./lib/host";
+export type {
+  OmnigentExtensionFramePostMessage,
+  OmnigentExtensionFrameProps,
+  OmnigentExtensionFrameReady,
+  OmnigentHostConfig,
+} from "./lib/host";
 export type { RoutingApi } from "./lib/routing";
 
 // Re-export the host-config setter so the host can install transport config

--- a/web/src/extensions/ExtensionViewHost.test.tsx
+++ b/web/src/extensions/ExtensionViewHost.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setOmnigentHostConfig, type OmnigentExtensionFrameProps } from "@/lib/host";
 import { EXTENSION_RPC_SOURCE, EXTENSION_RPC_VERSION } from "./rpc/protocol";
 import type { ExtensionCatalogItem, ExtensionPage } from "./types";
 
@@ -55,12 +56,20 @@ const refresh = vi.fn(async () => [extension]);
 
 beforeEach(() => {
   vi.stubGlobal("MessageChannel", FakeMessageChannel);
+  FakeMessageChannel.latest = null;
   loadBundleMock.mockReset().mockResolvedValue({ extension, script: "", styles: "" });
-  buildDocumentMock.mockReset().mockReturnValue({ srcDoc: "<html></html>", identity });
+  buildDocumentMock.mockReset().mockReturnValue({
+    srcDoc: "<html></html>",
+    htmlContent: '<div id="root"></div>',
+    contentSecurityPolicy: "default-src 'none'",
+    identity,
+  });
   refresh.mockClear();
+  setOmnigentHostConfig({});
 });
 
 afterEach(() => {
+  setOmnigentHostConfig({});
   vi.useRealTimers();
   vi.unstubAllGlobals();
 });
@@ -82,6 +91,40 @@ describe("ExtensionViewHost", () => {
       } as MessageEvent<unknown>);
     });
     await waitFor(() => expect(screen.queryByRole("status")).toBeNull());
+  });
+
+  it("starts the handshake when a host-provided frame reports readiness", async () => {
+    let frameProps: OmnigentExtensionFrameProps | null = null;
+    const ExtensionFrame = (props: OmnigentExtensionFrameProps) => {
+      frameProps = props;
+      return <div title={props.title} />;
+    };
+    const postMessage = vi.fn();
+    setOmnigentHostConfig({ extensionFrame: ExtensionFrame });
+
+    render(<ExtensionViewHost extension={extension} page={page} refresh={refresh} />);
+
+    expect((await screen.findByTitle("Dashboard")).tagName).toBe("DIV");
+    expect(frameProps).toMatchObject({
+      htmlContent: '<div id="root"></div>',
+      contentSecurityPolicy: "default-src 'none'",
+      nonce: "nonce",
+    });
+
+    act(() => frameProps?.onReady({ nonce: "stale", postMessage }));
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(FakeMessageChannel.latest).toBeNull();
+
+    act(() => frameProps?.onReady({ nonce: "nonce", postMessage }));
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...identity,
+        source: EXTENSION_RPC_SOURCE,
+        type: "init",
+      }),
+      [FakeMessageChannel.latest!.port2],
+    );
   });
 
   it("rejects an incompatible extension SDK explicitly", async () => {

--- a/web/src/extensions/ExtensionViewHost.tsx
+++ b/web/src/extensions/ExtensionViewHost.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  getOmnigentHostConfig,
+  type OmnigentExtensionFramePostMessage,
+  type OmnigentExtensionFrameReady,
+} from "@/lib/host";
 import type { ExtensionCatalogItem, ExtensionPage } from "./types";
 import { buildExtensionDocument, createExtensionNonce, loadExtensionBundle } from "./rpc/host";
 import {
@@ -31,6 +36,8 @@ interface PendingRequest {
 
 interface DocumentState {
   srcDoc: string;
+  htmlContent: string;
+  contentSecurityPolicy: string;
   identity: ExtensionIdentity;
 }
 
@@ -48,6 +55,9 @@ export function ExtensionViewHost({
   events?: Readonly<Record<string, unknown>>;
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const framePostMessageRef = useRef<OmnigentExtensionFramePostMessage | null>(null);
+  const activeFrameNonceRef = useRef<string | null>(null);
+  const readyFrameNonceRef = useRef<string | null>(null);
   const portRef = useRef<MessagePort | null>(null);
   const identityRef = useRef<ExtensionIdentity | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -82,6 +92,9 @@ export function ExtensionViewHost({
     }
     portRef.current = null;
     identityRef.current = null;
+    framePostMessageRef.current = null;
+    activeFrameNonceRef.current = null;
+    readyFrameNonceRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -108,6 +121,7 @@ export function ExtensionViewHost({
       .then((bundle) => {
         if (cancelled) return;
         const nextDocument = buildExtensionDocument(bundle, page, createExtensionNonce());
+        activeFrameNonceRef.current = nextDocument.identity.nonce;
         setFrameDocument(nextDocument);
         setStatus("activating");
         timeoutRef.current = setTimeout(() => {
@@ -143,8 +157,18 @@ export function ExtensionViewHost({
     }
   }, [events, status]);
 
-  const handleLoad = useCallback(() => {
-    if (!frameDocument || !iframeRef.current?.contentWindow) return;
+  const startHandshake = useCallback(() => {
+    if (!frameDocument || readyFrameNonceRef.current !== activeFrameNonceRef.current) return;
+    const contentWindow = iframeRef.current?.contentWindow;
+    const postMessage =
+      framePostMessageRef.current ??
+      (contentWindow
+        ? // A srcdoc frame has opaque origin "null"; the mount nonce and
+          // transferred port are the boundary, so targetOrigin must be "*".
+          (message: unknown, transfer?: Transferable[]) =>
+            contentWindow.postMessage(message, "*", transfer ?? [])
+        : null);
+    if (!postMessage) return;
     if (handshakeDoneRef.current) {
       closeRuntime();
       setError("Extension frame reloaded during activation");
@@ -269,10 +293,23 @@ export function ExtensionViewHost({
       type: "init",
       capabilities: Object.keys(methodsRef.current).sort(),
     };
-    // A srcdoc frame has opaque origin "null"; the per-mount nonce and the
-    // transferred port are the spoofing boundary, so targetOrigin must be "*".
-    iframeRef.current.contentWindow.postMessage(init, "*", [channel.port2]);
+    postMessage(init, [channel.port2]);
   }, [closeRuntime, frameDocument]);
+
+  const handleFrameReady = useCallback(
+    ({ nonce, postMessage }: OmnigentExtensionFrameReady) => {
+      if (nonce !== activeFrameNonceRef.current) return;
+      readyFrameNonceRef.current = nonce;
+      framePostMessageRef.current = postMessage;
+      startHandshake();
+    },
+    [startHandshake],
+  );
+
+  const handleDefaultFrameLoad = useCallback(() => {
+    readyFrameNonceRef.current = frameDocument?.identity.nonce ?? null;
+    startHandshake();
+  }, [frameDocument?.identity.nonce, startHandshake]);
 
   if (status === "error") {
     return (
@@ -295,20 +332,34 @@ export function ExtensionViewHost({
     );
   }
 
+  const ExtensionFrame = getOmnigentHostConfig().extensionFrame;
+  const frameClassName = "min-h-0 w-full flex-1 border-0 bg-background";
+
   return (
     <div className="extension-view-host relative flex h-full min-h-0 w-full flex-col overflow-hidden pt-14 md:pt-12">
-      {frameDocument && (
-        <iframe
-          key={frameDocument.identity.nonce}
-          ref={iframeRef}
-          title={page.title}
-          sandbox="allow-scripts"
-          allow=""
-          srcDoc={frameDocument.srcDoc}
-          onLoad={handleLoad}
-          className="min-h-0 w-full flex-1 border-0 bg-background"
-        />
-      )}
+      {frameDocument &&
+        (ExtensionFrame ? (
+          <ExtensionFrame
+            key={frameDocument.identity.nonce}
+            title={page.title}
+            htmlContent={frameDocument.htmlContent}
+            contentSecurityPolicy={frameDocument.contentSecurityPolicy}
+            nonce={frameDocument.identity.nonce}
+            className={frameClassName}
+            onReady={handleFrameReady}
+          />
+        ) : (
+          <iframe
+            key={frameDocument.identity.nonce}
+            ref={iframeRef}
+            title={page.title}
+            sandbox="allow-scripts"
+            allow=""
+            srcDoc={frameDocument.srcDoc}
+            onLoad={handleDefaultFrameLoad}
+            className={frameClassName}
+          />
+        ))}
       {status !== "ready" && (
         <div className="extension-view-status absolute inset-x-0 bottom-0 top-14 flex items-center justify-center bg-background md:top-12">
           <Spinner className="size-5 text-muted-foreground" aria-label="Loading extension" />

--- a/web/src/extensions/rpc/host.test.ts
+++ b/web/src/extensions/rpc/host.test.ts
@@ -73,7 +73,7 @@ describe("loadExtensionBundle", () => {
 
 describe("buildExtensionDocument", () => {
   it("builds an opaque-origin document with no network egress", () => {
-    const { srcDoc, identity } = buildExtensionDocument(
+    const { contentSecurityPolicy, htmlContent, srcDoc, identity } = buildExtensionDocument(
       { extension, script: "globalThis.ok=true;</script>", styles: "body{color:red}</style>" },
       page,
       "nonce123",
@@ -96,6 +96,11 @@ describe("buildExtensionDocument", () => {
     expect(srcDoc).toContain("atob(");
     expect(srcDoc).not.toContain("globalThis.ok=true;</script>");
     expect(srcDoc).not.toContain("body{color:red}</style>");
+    expect(contentSecurityPolicy).toContain("default-src 'none'");
+    expect(contentSecurityPolicy).toContain("connect-src 'none'");
+    expect(htmlContent).toContain('<div id="root"></div>');
+    expect(htmlContent).toContain('nonce="nonce123"');
+    expect(srcDoc).toContain(`<body>${htmlContent}</body>`);
   });
 });
 

--- a/web/src/extensions/rpc/host.ts
+++ b/web/src/extensions/rpc/host.ts
@@ -8,6 +8,13 @@ export interface LoadedExtensionBundle {
   styles: string;
 }
 
+export interface ExtensionDocument {
+  srcDoc: string;
+  htmlContent: string;
+  contentSecurityPolicy: string;
+  identity: ExtensionIdentity;
+}
+
 export function createExtensionNonce(): string {
   const bytes = new Uint8Array(24);
   crypto.getRandomValues(bytes);
@@ -67,7 +74,7 @@ export function buildExtensionDocument(
   bundle: LoadedExtensionBundle,
   page: ExtensionPage,
   nonce: string,
-): { srcDoc: string; identity: ExtensionIdentity } {
+): ExtensionDocument {
   const identity: ExtensionIdentity = {
     extensionId: bundle.extension.id,
     pageId: page.id,
@@ -90,8 +97,11 @@ export function buildExtensionDocument(
     "base-uri 'none'",
     "webrtc 'none'",
   ].join("; ");
+  const htmlContent = `<div id="root"></div><script nonce="${nonce}">${bootstrap}</script>`;
   return {
     identity,
-    srcDoc: `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}"><meta name="viewport" content="width=device-width,initial-scale=1"></head><body><div id="root"></div><script nonce="${nonce}">${bootstrap}</script></body></html>`,
+    htmlContent,
+    contentSecurityPolicy: csp,
+    srcDoc: `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${csp}"><meta name="viewport" content="width=device-width,initial-scale=1"></head><body>${htmlContent}</body></html>`,
   };
 }

--- a/web/src/lib/host.ts
+++ b/web/src/lib/host.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ComponentType, ReactNode } from "react";
 
 /**
  * Embed host integration seam.
@@ -22,6 +22,32 @@ import type { ReactNode } from "react";
 export interface UserSuggestion {
   userId: string;
   displayName?: string;
+}
+
+export type OmnigentExtensionFramePostMessage = (
+  message: unknown,
+  transfer?: Transferable[],
+) => void;
+
+export interface OmnigentExtensionFrameReady {
+  nonce: string;
+  postMessage: OmnigentExtensionFramePostMessage;
+}
+
+/**
+ * Contract for a host-controlled extension frame. Implementations must isolate
+ * extension scripts, enforce the supplied CSP, validate the loaded frame's
+ * source and origin, and keep the returned sender bound to that exact frame.
+ */
+export interface OmnigentExtensionFrameProps {
+  title: string;
+  /** Body markup to inject into the isolated document. */
+  htmlContent: string;
+  contentSecurityPolicy: string;
+  nonce: string;
+  className?: string;
+  /** Called with the same nonce after the frame can receive init and its port. */
+  onReady: (ready: OmnigentExtensionFrameReady) => void;
 }
 
 /**
@@ -165,6 +191,8 @@ export interface OmnigentHostConfig {
      */
     databricksGitCredentials?: ReactNode;
   };
+  /** Host-provided frame used to render extensions outside the host document. */
+  extensionFrame?: ComponentType<OmnigentExtensionFrameProps>;
 }
 
 let hostConfig: OmnigentHostConfig = {};


### PR DESCRIPTION
## Related issue

Closes #6615

## Summary

- Add an optional host-provided extension frame component for embedded deployments that need a security boundary other than the default `srcdoc` iframe.
- Keep extension loading, RPC lifecycle, CSP generation, and the standalone sandboxed iframe behavior in Omnigent.
- Bind frame readiness to the current mount nonce so stale callbacks cannot receive the extension `MessagePort`.

**ELI5:** Omnigent still prepares and controls the extension runtime; an embed host may now provide the isolated window that displays it.

```text
extension bundle
      |
      v
body HTML + CSP + nonce
      |
      +--> default sandboxed srcdoc iframe
      |
      +--> optional host-provided isolated frame
                         |
                         v
              validated ready sender
                         |
                         v
                 init + MessagePort
```

## Test Plan

- `pnpm --dir web exec vitest run src/extensions/ExtensionViewHost.test.tsx src/extensions/rpc/host.test.ts`
- `pnpm --dir web type-check`
- `pnpm --dir web lint`
- `pnpm --dir web build:embed`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The new component test exercises the host frame path, verifies the generated CSP/body/nonce contract, rejects a stale nonce, and confirms the current frame receives the init message and transferred port. Existing tests continue to cover the default sandboxed `srcdoc` path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The host-specific frame implementation remains outside OSS; this PR tests the public handoff contract and preserves the existing standalone frame behavior.

## Changelog

Embedded hosts can provide an isolated frame for web extensions while reusing Omnigent's extension runtime and RPC infrastructure.
