### PR TITLE
fix(web): preserve assistant single line breaks

### DIFF
--- a/tests/e2e_ui/messages/test_assistant_line_breaks.py
+++ b/tests/e2e_ui/messages/test_assistant_line_breaks.py
@@ -1,0 +1,52 @@
+"""E2E: meaningful single newlines in assistant output remain visible."""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_AGENT_NAME = "hello_world"
+_LINES = (
+    "Current task: complete",
+    "Next task: review the draft",
+    "Final task: publish after approval",
+)
+
+
+def test_assistant_single_newlines_render_as_line_breaks(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A persisted three-line assistant message renders as three visual lines."""
+    base_url, session_id = seeded_session
+    message = "\n".join(_LINES)
+    response = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_assistant_message",
+            "data": {"agent": _AGENT_NAME, "text": message},
+        },
+        timeout=10.0,
+    )
+    response.raise_for_status()
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    section = page.get_by_test_id("assistant-text-section").filter(has_text=_LINES[0])
+    expect(section).to_have_count(1, timeout=30_000)
+    expect(section).to_have_text(message)
+    expect(section.locator("br")).to_have_count(len(_LINES) - 1)
+
+    line_tops = section.locator("p").evaluate(
+        """paragraph => {
+            const range = document.createRange();
+            return Array.from(paragraph.childNodes)
+              .filter(node => node.nodeType === Node.TEXT_NODE && node.textContent.trim())
+              .map(node => {
+                range.selectNodeContents(node);
+                return Math.round(range.getBoundingClientRect().top);
+              });
+        }"""
+    )
+    assert line_tops == sorted(set(line_tops))
+    assert len(line_tops) == len(_LINES)

--- a/web/src/components/blocks/BlockRenderer.test.tsx
+++ b/web/src/components/blocks/BlockRenderer.test.tsx
@@ -325,6 +325,19 @@ describe("BlockRenderer dispatch", () => {
     expect(sections[1]!.contains(strong)).toBe(true);
   });
 
+  it("keeps single newlines in assistant text as visible line breaks", () => {
+    const { container } = renderMarkdownText(
+      [
+        "This series: complete",
+        "Other series: continue GTR03",
+        "Other series: continue IMP01",
+        "git add -- files && git commit",
+      ].join("\n"),
+    );
+
+    expect(container.querySelectorAll("br")).toHaveLength(3);
+  });
+
   it("does not add adjacent-text spacing across tool items", () => {
     // Rendered as a live turn ("running") so the whole trace stays
     // expanded — a settled turn would fold "Before tool." behind the

--- a/web/src/components/blocks/BlockRenderer.tsx
+++ b/web/src/components/blocks/BlockRenderer.tsx
@@ -757,7 +757,7 @@ function renderItem(
           data-testid="assistant-text-section"
           className={cn("min-w-0", followsText && "mt-2")}
         >
-          <FilePathAwareMessageResponse>{item.text}</FilePathAwareMessageResponse>
+          <FilePathAwareMessageResponse breaks>{item.text}</FilePathAwareMessageResponse>
         </div>
       );
     case "reasoning":

--- a/web/src/components/blocks/ChatMarkdown.tsx
+++ b/web/src/components/blocks/ChatMarkdown.tsx
@@ -334,9 +334,9 @@ function PlainTextFallback({ text }: { text: string }) {
  * block rendering too, stripping `<pre>` and collapsing whitespace.
  *
  * When `breaks` is set, single newlines render as `<br>` (remark-breaks)
- * instead of collapsing to spaces per CommonMark. Used for user bubbles,
- * where people type multi-line messages without blank-line paragraph
- * separators and expect their line breaks preserved. NOTE: Streamdown's
+ * instead of collapsing to spaces per CommonMark. Used for chat bubbles,
+ * where user input and CLI output can contain meaningful line breaks without
+ * blank-line paragraph separators. NOTE: Streamdown's
  * `remarkPlugins` prop *replaces* its defaults rather than merging, so we
  * extend `defaultRemarkPlugins` (which carries remark-gfm) — passing
  * `[remarkBreaks]` alone would silently drop GFM tables / strikethrough.


### PR DESCRIPTION
## Related issue

Closes #6618

## Summary

- Preserve meaningful single newlines in assistant text by enabling the existing `breaks` path on `FilePathAwareMessageResponse`.
- Keep Streamdown's default GitHub-flavored Markdown plugins while adding `remark-breaks`, and cover the persisted-session render path in Chromium.

ELI5: the transcript already contains separate lines; this change tells the chat renderer to display those line endings instead of treating them like ordinary spaces.

```mermaid
flowchart LR
  A[Assistant text with single newlines] --> B[Existing Markdown breaks option]
  B --> C[Visible line breaks in chat]
```

## Test Plan

Base: `upstream/main` at `440b9f3a7dc8548d4dfddcae9a3076478351bf2f`.

- `node node_modules/vitest/vitest.mjs run src/components/blocks/BlockRenderer.test.tsx` — 73 passed.
- `node node_modules/typescript/bin/tsc -b` — passed.
- Production Vite build — passed.
- `pytest tests/e2e_ui/messages/test_assistant_line_breaks.py -q --ui-skip-build` with the local Windows fixture-startup adapter — 1 passed; the test persists an assistant event and checks both `<br>` count and distinct line positions.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

A reviewed synthetic before/after fixture is already hosted on the dedicated evidence branch and remains unchanged by this refresh:

![Assistant single-line breaks before and after](https://raw.githubusercontent.com/pandalaohe/omnigent/a994ebbd15e5593bc4177e4052b95a8a0a4a2045/.github/pr-evidence/2026-09-06/assistant-linebreaks-demo.png)

The refreshed Chromium fixture persists three synthetic assistant lines and asserts two `<br>` elements and three distinct line positions.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests exercise the real persisted-session renderer. The exact patch applied cleanly on `440b9f3`. A local startup adapter treats loopback mock-server `ConnectTimeout` as transient on Windows; this adapter is excluded from the product patch.

## Changelog

Assistant messages preserve meaningful single line breaks in chat.

## Issues

Resolves [OMNI-6421](https://linear.app/omnigent/issue/OMNI-6421/bug-assistant-chat-output-collapses-meaningful-single-newlines)
