### PR TITLE
feat: add user preference sync foundation

### DIFF
--- a/deploy/databricks/src/app.py
+++ b/deploy/databricks/src/app.py
@@ -170,6 +170,7 @@ try:
     from omnigent.runtime.caps import RuntimeCaps
     from omnigent.server.app import create_app
     from omnigent.server.auth import create_auth_provider, warn_if_single_user_exposed
+    from omnigent.server.user_preferences_store import SqlAlchemyUserPreferencesStore
 
     # OTel: the Databricks Apps platform auto-injects
     # OTEL_EXPORTER_OTLP_ENDPOINT when `telemetry_export_destinations`
@@ -238,6 +239,7 @@ try:
     project_store = SqlAlchemyProjectStore(DB_URI)
     host_store = HostStore(DB_URI)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(DB_URI)
+    user_preferences_store = SqlAlchemyUserPreferencesStore(DB_URI)
 
     agent_cache = AgentCache(artifact_store=artifact_store, cache_dir=CACHE_DIR)
 
@@ -278,6 +280,7 @@ try:
         project_store=project_store,
         host_store=host_store,
         scheduled_task_store=scheduled_task_store,
+        user_preferences_store=user_preferences_store,
         auth_provider=auth_provider,
     )
 

--- a/deploy/docker/entrypoint.py
+++ b/deploy/docker/entrypoint.py
@@ -362,6 +362,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     from omnigent.runtime.agent_cache import AgentCache
     from omnigent.runtime.caps import RuntimeCaps
     from omnigent.server.managed_hosts import parse_sandbox_config
+    from omnigent.server.user_preferences_store import SqlAlchemyUserPreferencesStore
     from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
     from omnigent.stores.comment_store.sqlalchemy_store import (
         SqlAlchemyCommentStore,
@@ -391,6 +392,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
     policy_store = SqlAlchemyPolicyStore(database_url)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(database_url)
     project_store = SqlAlchemyProjectStore(database_url)
+    user_preferences_store = SqlAlchemyUserPreferencesStore(database_url)
     # Fail startup loud on a malformed `sandbox:` section (an operator
     # typo should not surface as a runtime 502 on the first managed
     # session); the startup catch-all below logs it.
@@ -479,6 +481,7 @@ def build_app(resolved_config: _ResolvedConfig | None = None) -> _BuiltApp:
         project_store=project_store,
         auth_provider=auth_provider,
         account_store=account_store,
+        user_preferences_store=user_preferences_store,
         # Non-secret auth settings from the config file (admins are the
         # canonical, declarative roster; allowed_domains gates OIDC). Both
         # union with their runtime-editable files under <data_dir>.

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4072,6 +4072,7 @@ def server(
         SESSION_TITLE_INSTRUCTIONS_KEY,
         config_str_list,
     )
+    from omnigent.server.user_preferences_store import SqlAlchemyUserPreferencesStore
     from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
     from omnigent.stores.comment_store.sqlalchemy_store import SqlAlchemyCommentStore
     from omnigent.stores.conversation_store.sqlalchemy_store import (
@@ -4125,6 +4126,7 @@ def server(
     permission_store = SqlAlchemyPermissionStore(db_uri)
     scheduled_task_store = SqlAlchemyScheduledTaskStore(db_uri)
     project_store = SqlAlchemyProjectStore(db_uri)
+    user_preferences_store = SqlAlchemyUserPreferencesStore(db_uri)
     artifact_store = _create_artifact_store(art_loc)
 
     # Initialize the runtime with store references so workflow code
@@ -4294,6 +4296,7 @@ def server(
         auth_provider=auth_provider,
         host_store=host_store,
         account_store=account_store,
+        user_preferences_store=user_preferences_store,
         policy_modules=cfg.get("policy_modules"),
         debug_router_modules=config_str_list(cfg.get("debug_router_modules")),
         admins=config_str_list(cfg.get("admins")),

--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -375,6 +375,10 @@ class SqlUser(OmnigentBase):
     :param last_login_at: Unix epoch seconds of the most recent
         successful ``/auth/login`` (accounts mode). ``NULL`` until
         the first login.
+    :param preferences: Versioned JSON envelope for cross-device user
+        preferences. ``NULL`` means the user has never initialized synced
+        preferences; an envelope with empty ``settings`` means they explicitly
+        initialized and are using all defaults.
     """
 
     __tablename__ = "users"
@@ -392,6 +396,9 @@ class SqlUser(OmnigentBase):
     password_hash: Mapped[str | None] = mapped_column(String(256), nullable=True)
     created_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     last_login_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # Opaque JSON, never SQL-filtered. Compression keeps shortcut/button
+    # payloads compact without leaking persistence details into API callers.
+    preferences: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
 
 
 class SqlAccountToken(OmnigentBase):

--- a/omnigent/db/migrations/versions/c7e4d9a1b2f6_add_user_preferences.py
+++ b/omnigent/db/migrations/versions/c7e4d9a1b2f6_add_user_preferences.py
@@ -1,0 +1,36 @@
+"""add cross-device user preferences
+
+Revision ID: c7e4d9a1b2f6
+Revises: gb1b2c3d4e5f
+Create Date: 2026-09-06 00:00:00.000000
+
+The ORM maps this opaque JSON column through ``CompressedText``. Its database
+representation is therefore binary (BLOB/BYTEA), while callers continue to
+read and write normal JSON text.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c7e4d9a1b2f6"
+down_revision: str | None = "gb1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the optional compressed preferences envelope."""
+    op.add_column(
+        "users",
+        sa.Column("preferences", sa.LargeBinary(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove synced user preferences."""
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("preferences")

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -14,10 +14,10 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
-from fastapi import FastAPI, Query, Request
+from fastapi import Depends, FastAPI, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlalchemy.exc import StatementError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.gzip import GZipMiddleware
@@ -60,7 +60,7 @@ from omnigent.runtime import (
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.harnesses.process_manager import HarnessProcessManager
 from omnigent.server import managed_host_keepalive, session_live_state, shutdown_state
-from omnigent.server.auth import AuthProvider, SharingMode
+from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider, SharingMode
 from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
     RunnerBackgroundTitleGenerator,
@@ -78,6 +78,8 @@ from omnigent.server.performance_metrics import (
     set_request_session_id_for_access_log,
     set_request_user_agent_for_access_log,
 )
+from omnigent.server.routes._auth_helpers import require_user
+from omnigent.server.routes._content_type import require_json_content_type
 from omnigent.server.routes.builtin_agents import create_builtin_agents_router
 from omnigent.server.routes.comments import create_comments_router
 from omnigent.server.routes.default_policies import create_default_policies_router
@@ -104,6 +106,19 @@ from omnigent.server.routes.terminal_attach import create_terminal_attach_router
 from omnigent.server.routes.usage import create_usage_router
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 from omnigent.server.scheduled import ScheduledTaskScheduler
+from omnigent.server.schemas import (
+    CurrentUserResponse,
+    UserPreferenceNamespace,
+    UserPreferenceNamespacePatchRequest,
+    UserPreferencesEnvelope,
+)
+from omnigent.server.user_preferences_store import (
+    USER_PREFERENCE_NAMESPACES,
+    USER_PREFERENCES_MAX_BYTES,
+    SqlAlchemyUserPreferencesStore,
+    UserPreferencesUserNotFoundError,
+    UserPreferencesValidationError,
+)
 from omnigent.server.ws_origin import WebSocketOriginMiddleware
 from omnigent.stores import (
     AgentStore,
@@ -1075,6 +1090,7 @@ def create_app(
     auth_provider: AuthProvider | None = None,
     host_store: HostStore | None = None,
     account_store: Any | None = None,  # SqlAlchemyAccountStore — accounts mode only
+    user_preferences_store: SqlAlchemyUserPreferencesStore | None = None,
     extra_routers: list[tuple[Any, str, list[str]]] | None = None,
     policy_modules: list[str] | None = None,
     debug_router_modules: list[str] | None = None,
@@ -1133,6 +1149,9 @@ def create_app(
     :param host_store: Store for host registrations. ``None``
         disables host connectivity features (list hosts, launch
         runners on remote hosts).
+    :param user_preferences_store: Store for authenticated, cross-device user
+        preferences. ``None`` leaves ``/v1/me.preferences`` unset and makes
+        preference mutation endpoints unavailable.
     :param policy_modules: Additional dotted module paths to
         scan for ``POLICY_REGISTRY`` lists at startup, e.g.
         ``["myorg.policies.safety"]``. Sourced from the server
@@ -2494,8 +2513,12 @@ def create_app(
             headers={"X-Content-Type-Options": "nosniff"},
         )
 
-    @app.get("/v1/me", response_model=None)  # Union return type (dict | JSONResponse)
-    async def me(request: Request) -> dict[str, str | bool | None] | JSONResponse:
+    @app.get(
+        "/v1/me",
+        response_model=CurrentUserResponse,
+        response_model_exclude_unset=True,
+    )
+    async def me(request: Request, http_response: Response) -> dict[str, Any] | JSONResponse:
         """Return the current user's identity.
 
         Reads the user from the auth provider (same logic that
@@ -2525,7 +2548,9 @@ def create_app(
             return JSONResponse(
                 status_code=401,
                 content={"user_id": None, "login_url": login_url},
+                headers={"Cache-Control": "private, no-store"},
             )
+        http_response.headers["Cache-Control"] = "private, no-store"
         # Mirror the admin check the auth routes use
         # (``permission_store.is_admin(caller) or admin_list.is_admin(caller)``)
         # so the SPA's admin chrome never under-reports relative to what the
@@ -2536,7 +2561,216 @@ def create_app(
             (permission_store is not None and permission_store.is_admin(user_id))
             or admin_list.is_admin(user_id)
         )
-        return {"user_id": user_id, "is_admin": is_admin}
+        preferences = None
+        preferences_owner: str | None = None
+        if auth_provider is None:
+            preferences_owner = RESERVED_USER_LOCAL
+        elif user_id is not None:
+            preferences_owner = user_id
+        if user_preferences_store is not None and preferences_owner is not None:
+            preferences = await asyncio.to_thread(
+                user_preferences_store.get,
+                preferences_owner,
+            )
+        response: dict[str, Any] = {
+            "user_id": user_id,
+            "is_admin": is_admin,
+        }
+        # Preserve the response contract for create_app consumers that have not
+        # adopted preferences persistence.
+        if user_preferences_store is not None:
+            response["preferences"] = preferences
+        return response
+
+    def _preferences_store() -> SqlAlchemyUserPreferencesStore:
+        if user_preferences_store is None:
+            raise StarletteHTTPException(
+                status_code=503,
+                detail="Synced user preferences are unavailable",
+            )
+        return user_preferences_store
+
+    def _preferences_owner(request: Request) -> tuple[str, bool]:
+        owner = require_user(request, auth_provider) or RESERVED_USER_LOCAL
+        from omnigent.server.auth import UnifiedAuthProvider
+
+        accounts_mode = (
+            isinstance(auth_provider, UnifiedAuthProvider) and auth_provider._source == "accounts"
+        )
+        # Accounts are created only by the account lifecycle. The store checks
+        # the user row inside its write transaction, so a stale cookie cannot
+        # recreate an account deleted concurrently with this request.
+        return owner, not accounts_mode
+
+    _preferences_http_max_bytes = USER_PREFERENCES_MAX_BYTES + 4096
+
+    async def _read_preferences_body(request: Request, model: type[BaseModel]) -> BaseModel:
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                if int(content_length) > _preferences_http_max_bytes:
+                    raise StarletteHTTPException(
+                        status_code=413,
+                        detail="Preferences body too large",
+                    )
+            except ValueError as exc:
+                raise StarletteHTTPException(
+                    status_code=400,
+                    detail="Invalid Content-Length",
+                ) from exc
+        body = bytearray()
+        async for chunk in request.stream():
+            body.extend(chunk)
+            if len(body) > _preferences_http_max_bytes:
+                raise StarletteHTTPException(status_code=413, detail="Preferences body too large")
+        try:
+            return model.model_validate_json(bytes(body))
+        except ValidationError as exc:
+            raise StarletteHTTPException(
+                status_code=422,
+                detail="Invalid preferences payload",
+            ) from exc
+
+    _preference_write_hits: dict[str, list[float]] = {}
+    _preference_last_rate_cleanup = 0.0
+
+    _preferences_envelope_request_schema: dict[str, Any] = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["version", "settings"],
+        "properties": {
+            "version": {"type": "integer", "const": 1},
+            "settings": {
+                "type": "object",
+                "propertyNames": {"enum": sorted(USER_PREFERENCE_NAMESPACES)},
+                "additionalProperties": {},
+            },
+        },
+    }
+    _preferences_patch_request_schema: dict[str, Any] = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["value"],
+        "properties": {"value": {}},
+    }
+    _preferences_error_responses: dict[int | str, dict[str, Any]] = {
+        400: {"description": "Invalid Content-Length header"},
+        401: {"description": "Authentication required or account deleted"},
+        413: {"description": "Request body exceeds the preferences limit"},
+        415: {"description": "Request body is not application/json"},
+        422: {"description": "Invalid preferences payload or namespace"},
+        429: {"description": "Per-user write rate exceeded"},
+        503: {"description": "Preferences persistence is unavailable"},
+    }
+
+    def _check_preference_write_rate(owner: str) -> None:
+        nonlocal _preference_last_rate_cleanup
+        now = time.monotonic()
+        cutoff = now - 60.0
+        hits = [hit for hit in _preference_write_hits.get(owner, ()) if hit > cutoff]
+        if len(hits) >= 120:
+            _preference_write_hits[owner] = hits
+            raise StarletteHTTPException(
+                status_code=429,
+                detail="Too many preference updates",
+                headers={"Retry-After": "60"},
+            )
+        if owner not in _preference_write_hits and len(_preference_write_hits) >= 10_000:
+            # Throttle the full-map cleanup so rotating new identities cannot
+            # turn a bounded-memory guard into repeated O(n) work.
+            if now - _preference_last_rate_cleanup >= 1.0:
+                _preference_last_rate_cleanup = now
+                expired = [
+                    key
+                    for key, key_hits in _preference_write_hits.items()
+                    if not key_hits or key_hits[-1] <= cutoff
+                ]
+                for key in expired:
+                    _preference_write_hits.pop(key, None)
+            if len(_preference_write_hits) >= 10_000:
+                raise StarletteHTTPException(
+                    status_code=429,
+                    detail="Too many preference updates",
+                    headers={"Retry-After": "60"},
+                )
+        hits.append(now)
+        _preference_write_hits[owner] = hits
+
+    @app.put(
+        "/v1/me/preferences",
+        response_model=UserPreferencesEnvelope,
+        dependencies=[Depends(require_json_content_type)],
+        responses=_preferences_error_responses,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {"application/json": {"schema": _preferences_envelope_request_schema}},
+            }
+        },
+    )
+    async def initialize_user_preferences(
+        request: Request,
+    ) -> UserPreferencesEnvelope:
+        """Initialize the caller's full preference envelope exactly once."""
+        store = _preferences_store()
+        owner, create_if_missing = _preferences_owner(request)
+        _check_preference_write_rate(owner)
+        body = await _read_preferences_body(request, UserPreferencesEnvelope)
+        assert isinstance(body, UserPreferencesEnvelope)
+        try:
+            persisted = await asyncio.to_thread(
+                store.initialize,
+                owner,
+                body.model_dump(mode="python"),
+                create_if_missing=create_if_missing,
+            )
+        except UserPreferencesUserNotFoundError as exc:
+            raise StarletteHTTPException(
+                status_code=401,
+                detail="Account no longer exists",
+            ) from exc
+        except UserPreferencesValidationError as exc:
+            raise StarletteHTTPException(status_code=422, detail=str(exc)) from exc
+        return UserPreferencesEnvelope.model_validate(persisted)
+
+    @app.patch(
+        "/v1/me/preferences/{namespace}",
+        response_model=UserPreferencesEnvelope,
+        dependencies=[Depends(require_json_content_type)],
+        responses=_preferences_error_responses,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {"application/json": {"schema": _preferences_patch_request_schema}},
+            }
+        },
+    )
+    async def patch_user_preferences_namespace(
+        namespace: UserPreferenceNamespace,
+        request: Request,
+    ) -> UserPreferencesEnvelope:
+        """Atomically merge or remove one namespace for the current user."""
+        store = _preferences_store()
+        owner, create_if_missing = _preferences_owner(request)
+        _check_preference_write_rate(owner)
+        body = await _read_preferences_body(request, UserPreferenceNamespacePatchRequest)
+        assert isinstance(body, UserPreferenceNamespacePatchRequest)
+        try:
+            persisted = await asyncio.to_thread(
+                store.patch_namespace,
+                owner,
+                namespace,
+                body.value,
+                create_if_missing=create_if_missing,
+            )
+        except UserPreferencesUserNotFoundError as exc:
+            raise StarletteHTTPException(
+                status_code=401,
+                detail="Account no longer exists",
+            ) from exc
+        except UserPreferencesValidationError as exc:
+            raise StarletteHTTPException(status_code=422, detail=str(exc)) from exc
+        return UserPreferencesEnvelope.model_validate(persisted)
 
     app.include_router(
         create_sessions_router(

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -18,6 +18,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    JsonValue,
     SerializerFunctionWrapHandler,
     Strict,
     field_validator,
@@ -30,6 +31,7 @@ from omnigent.entities import (
     USER_SESSION_TITLE_MAX_CHARS,
     ConversationItem,
 )
+from omnigent.server.user_preferences_store import validate_preferences_envelope
 
 # ── Shared ──────────────────────────────────────────────────────
 
@@ -58,6 +60,46 @@ class PaginatedList(BaseModel):
     first_id: str | None = None
     last_id: str | None = None
     has_more: bool = False
+
+
+UserPreferenceNamespace = Literal[
+    "keyboard_shortcuts",
+    "mobile_assistant",
+    "session_navigation",
+    "context_indicator",
+    "usage_context",
+    "agent_badges",
+]
+
+
+class UserPreferencesEnvelope(BaseModel):
+    """Versioned, allowlisted cross-device preference payload."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    version: Literal[1]
+    settings: dict[UserPreferenceNamespace, JsonValue]
+
+    @model_validator(mode="after")
+    def _validate_persisted_contract(self) -> Self:
+        validate_preferences_envelope(self.model_dump(mode="python"))
+        return self
+
+
+class UserPreferenceNamespacePatchRequest(BaseModel):
+    """Atomic partial update for one preference namespace."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    value: JsonValue | None
+
+
+class CurrentUserResponse(BaseModel):
+    """Authenticated identity and optional synchronized preferences."""
+
+    user_id: str | None
+    is_admin: bool
+    preferences: UserPreferencesEnvelope | None = None
 
 
 # ── Agents ──────────────────────────────────────────────────────

--- a/omnigent/server/user_preferences_store.py
+++ b/omnigent/server/user_preferences_store.py
@@ -1,0 +1,248 @@
+"""Persistence for versioned, user-scoped web preferences.
+
+The server stores one small JSON envelope on the authenticated user's row.
+Namespace updates run in a single database transaction, so concurrent clients
+cannot observe a partially-written preference set. The store owns structural
+and size validation as a defence-in-depth boundary for non-HTTP callers.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from copy import deepcopy
+from typing import Any, TypeAlias, cast
+
+from sqlalchemy.exc import IntegrityError
+
+from omnigent.db.db_models import SqlUser, current_workspace_id
+from omnigent.db.utils import get_or_create_engine, make_named_managed_session_maker
+
+USER_PREFERENCE_VERSION = 1
+USER_PREFERENCES_MAX_BYTES = 64 * 1024
+USER_PREFERENCE_NAMESPACES = frozenset(
+    {
+        "keyboard_shortcuts",
+        "mobile_assistant",
+        "session_navigation",
+        "context_indicator",
+        "usage_context",
+        "agent_badges",
+    }
+)
+
+PreferencesEnvelope: TypeAlias = dict[str, Any]
+
+
+class UserPreferencesValidationError(ValueError):
+    """A preferences payload violates the persisted envelope contract."""
+
+
+class UserPreferencesUserNotFoundError(LookupError):
+    """The authenticated account no longer has a backing user row."""
+
+
+def _validate_json(value: Any, *, depth: int = 0) -> None:
+    """Reject non-JSON values and pathological nesting before serialization."""
+    if depth > 32:
+        raise UserPreferencesValidationError("preferences nesting exceeds 32 levels")
+    if value is None or isinstance(value, (str, bool)):
+        return
+    if isinstance(value, int) and not isinstance(value, bool):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise UserPreferencesValidationError("preferences numbers must be finite")
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_json(item, depth=depth + 1)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise UserPreferencesValidationError("preferences object keys must be strings")
+            _validate_json(item, depth=depth + 1)
+        return
+    raise UserPreferencesValidationError(
+        f"preferences values must be JSON-compatible, got {type(value).__name__}"
+    )
+
+
+def validate_preferences_envelope(envelope: Any) -> PreferencesEnvelope:
+    """Validate and copy a version-1 preferences envelope.
+
+    ``settings`` is deliberately namespaced and allowlisted. Namespace values
+    remain client-versioned JSON (for example, ``context_indicator`` is a
+    string while shortcut settings are objects); the server still guarantees
+    JSON-only content, bounded nesting, and a 64 KiB serialized cap.
+    """
+    if not isinstance(envelope, dict) or set(envelope) != {"version", "settings"}:
+        raise UserPreferencesValidationError(
+            "preferences must contain exactly 'version' and 'settings'"
+        )
+    if type(envelope["version"]) is not int or envelope["version"] != USER_PREFERENCE_VERSION:
+        raise UserPreferencesValidationError("preferences version must be 1")
+    settings = envelope["settings"]
+    if not isinstance(settings, dict):
+        raise UserPreferencesValidationError("preferences settings must be an object")
+    unknown = set(settings) - USER_PREFERENCE_NAMESPACES
+    if unknown:
+        raise UserPreferencesValidationError(
+            f"unsupported preferences namespace: {sorted(unknown)[0]}"
+        )
+    for value in settings.values():
+        _validate_json(value)
+
+    copied: PreferencesEnvelope = {
+        "version": USER_PREFERENCE_VERSION,
+        "settings": deepcopy(settings),
+    }
+    try:
+        serialized = json.dumps(
+            copied,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise UserPreferencesValidationError("preferences strings must be valid UTF-8") from exc
+    if len(serialized) > USER_PREFERENCES_MAX_BYTES:
+        raise UserPreferencesValidationError("preferences exceed the 64 KiB limit")
+    return copied
+
+
+def _serialize(envelope: PreferencesEnvelope) -> str:
+    validated = validate_preferences_envelope(envelope)
+    return json.dumps(
+        validated,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _deserialize(raw: str) -> PreferencesEnvelope:
+    try:
+        value = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise UserPreferencesValidationError("stored preferences are invalid JSON") from exc
+    return validate_preferences_envelope(value)
+
+
+class SqlAlchemyUserPreferencesStore:
+    """SQLAlchemy repository for current-user preferences."""
+
+    def __init__(self, storage_location: str) -> None:
+        self._engine = get_or_create_engine(storage_location)
+        # BEGIN IMMEDIATE closes SQLite's read-then-write race. Other dialects
+        # pair the transaction with SELECT FOR UPDATE below.
+        self._read_session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.user_preferences_store",
+        )
+        self._write_session = make_named_managed_session_maker(
+            self._engine,
+            query_name_prefix="omnigent.user_preferences_store",
+            immediate=True,
+        )
+
+    def get(self, user_id: str) -> PreferencesEnvelope | None:
+        """Return the user's envelope, preserving NULL as uninitialized."""
+        with self._read_session("get") as session:
+            row = session.get(SqlUser, (current_workspace_id(), user_id))
+            if row is None or row.preferences is None:
+                return None
+            return _deserialize(row.preferences)
+
+    def initialize(
+        self,
+        user_id: str,
+        envelope: PreferencesEnvelope,
+        *,
+        create_if_missing: bool = True,
+    ) -> PreferencesEnvelope:
+        """Set the full envelope only when this user is still uninitialized.
+
+        Repeated/racing first-device migrations are idempotent: once any
+        client wins, later calls receive the already-persisted value instead
+        of overwriting it with stale localStorage.
+        """
+        encoded = _serialize(envelope)
+        for attempt in range(2):
+            try:
+                with self._write_session("initialize") as session:
+                    row = session.get(
+                        SqlUser,
+                        (current_workspace_id(), user_id),
+                        with_for_update=self._engine.dialect.name != "sqlite",
+                    )
+                    if row is None:
+                        if not create_if_missing:
+                            raise UserPreferencesUserNotFoundError(user_id)
+                        row = SqlUser(id=user_id, is_admin=False, preferences=encoded)
+                        session.add(row)
+                        # SELECT FOR UPDATE cannot lock a missing PostgreSQL row.
+                        # Flush now so a racing first writer is handled below.
+                        session.flush()
+                        return _deserialize(encoded)
+                    if row.preferences is None:
+                        row.preferences = encoded
+                        return _deserialize(encoded)
+                    return _deserialize(row.preferences)
+            except IntegrityError:
+                if attempt == 1:
+                    raise
+        raise AssertionError("unreachable")
+
+    def patch_namespace(
+        self,
+        user_id: str,
+        namespace: str,
+        value: Any | None,
+        *,
+        create_if_missing: bool = True,
+    ) -> PreferencesEnvelope:
+        """Atomically shallow-merge one namespace, or delete it with NULL."""
+        if namespace not in USER_PREFERENCE_NAMESPACES:
+            raise UserPreferencesValidationError(f"unsupported preferences namespace: {namespace}")
+        if value is not None:
+            _validate_json(value)
+
+        for attempt in range(2):
+            try:
+                with self._write_session("patch_namespace") as session:
+                    row = session.get(
+                        SqlUser,
+                        (current_workspace_id(), user_id),
+                        with_for_update=self._engine.dialect.name != "sqlite",
+                    )
+                    if row is None:
+                        if not create_if_missing:
+                            raise UserPreferencesUserNotFoundError(user_id)
+                        row = SqlUser(id=user_id, is_admin=False)
+                        session.add(row)
+                        session.flush()
+                    current = (
+                        _deserialize(row.preferences)
+                        if row.preferences is not None
+                        else {"version": USER_PREFERENCE_VERSION, "settings": {}}
+                    )
+                    settings = cast(dict[str, Any], current["settings"])
+                    if value is None:
+                        settings.pop(namespace, None)
+                    else:
+                        existing = settings.get(namespace)
+                        if isinstance(existing, dict) and isinstance(value, dict):
+                            settings[namespace] = {**existing, **deepcopy(value)}
+                        else:
+                            settings[namespace] = deepcopy(value)
+                    encoded = _serialize(current)
+                    row.preferences = encoded
+                    return _deserialize(encoded)
+            except IntegrityError:
+                if attempt == 1:
+                    raise
+        raise AssertionError("unreachable")

--- a/openapi.json
+++ b/openapi.json
@@ -1474,6 +1474,42 @@
         "title": "CreatedEvent",
         "type": "object"
       },
+      "CurrentUserResponse": {
+        "description": "Authenticated identity and optional synchronized preferences.",
+        "properties": {
+          "is_admin": {
+            "title": "Is Admin",
+            "type": "boolean"
+          },
+          "preferences": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserPreferencesEnvelope"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "user_id",
+          "is_admin"
+        ],
+        "title": "CurrentUserResponse",
+        "type": "object"
+      },
       "DailyCost": {
         "description": "One day's LLM spend for the daily timeline chart.",
         "properties": {
@@ -2819,6 +2855,7 @@
         "title": "IncompleteEvent",
         "type": "object"
       },
+      "JsonValue": {},
       "LaunchRunnerRequest": {
         "description": "Request body for `POST /v1/hosts/{host_id}/runners`.",
         "properties": {
@@ -8452,6 +8489,41 @@
         "title": "UsageReport",
         "type": "object"
       },
+      "UserPreferencesEnvelope": {
+        "additionalProperties": false,
+        "description": "Versioned, allowlisted cross-device preference payload.",
+        "properties": {
+          "settings": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "propertyNames": {
+              "enum": [
+                "keyboard_shortcuts",
+                "mobile_assistant",
+                "session_navigation",
+                "context_indicator",
+                "usage_context",
+                "agent_badges"
+              ]
+            },
+            "title": "Settings",
+            "type": "object"
+          },
+          "version": {
+            "const": 1,
+            "format": "int64",
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "version",
+          "settings"
+        ],
+        "title": "UserPreferencesEnvelope",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -9868,7 +9940,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentUserResponse"
+                }
               }
             },
             "description": "Successful Response"
@@ -9878,6 +9952,157 @@
         "tags": [
           "system"
         ]
+      }
+    },
+    "/v1/me/preferences": {
+      "put": {
+        "description": "Initialize the caller's full preference envelope exactly once.",
+        "operationId": "initialize_user_preferences_v1_me_preferences_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "settings": {
+                    "additionalProperties": {},
+                    "propertyNames": {
+                      "enum": [
+                        "agent_badges",
+                        "context_indicator",
+                        "keyboard_shortcuts",
+                        "mobile_assistant",
+                        "session_navigation",
+                        "usage_context"
+                      ]
+                    },
+                    "type": "object"
+                  },
+                  "version": {
+                    "const": 1,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "version",
+                  "settings"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserPreferencesEnvelope"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid Content-Length header"
+          },
+          "401": {
+            "description": "Authentication required or account deleted"
+          },
+          "413": {
+            "description": "Request body exceeds the preferences limit"
+          },
+          "415": {
+            "description": "Request body is not application/json"
+          },
+          "422": {
+            "description": "Invalid preferences payload or namespace"
+          },
+          "429": {
+            "description": "Per-user write rate exceeded"
+          },
+          "503": {
+            "description": "Preferences persistence is unavailable"
+          }
+        },
+        "summary": "Initialize User Preferences"
+      }
+    },
+    "/v1/me/preferences/{namespace}": {
+      "patch": {
+        "description": "Atomically merge or remove one namespace for the current user.",
+        "operationId": "patch_user_preferences_namespace_v1_me_preferences__namespace__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "enum": [
+                "keyboard_shortcuts",
+                "mobile_assistant",
+                "session_navigation",
+                "context_indicator",
+                "usage_context",
+                "agent_badges"
+              ],
+              "title": "Namespace",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "value": {}
+                },
+                "required": [
+                  "value"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserPreferencesEnvelope"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Invalid Content-Length header"
+          },
+          "401": {
+            "description": "Authentication required or account deleted"
+          },
+          "413": {
+            "description": "Request body exceeds the preferences limit"
+          },
+          "415": {
+            "description": "Request body is not application/json"
+          },
+          "422": {
+            "description": "Invalid preferences payload or namespace"
+          },
+          "429": {
+            "description": "Per-user write rate exceeded"
+          },
+          "503": {
+            "description": "Preferences persistence is unavailable"
+          }
+        },
+        "summary": "Patch User Preferences Namespace"
       }
     },
     "/v1/policies": {

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2314,6 +2314,12 @@ def test_server_command_reads_tunnel_token_and_does_not_spawn_runner(
     assert captured["create_app_kwargs"]["server_config"] == {
         "session_title_instructions": "Prefix titles with the current date."
     }
+    from omnigent.server.user_preferences_store import SqlAlchemyUserPreferencesStore
+
+    assert isinstance(
+        captured["create_app_kwargs"]["user_preferences_store"],
+        SqlAlchemyUserPreferencesStore,
+    )
 
 
 def test_server_explicit_config_overrides_omnigent_config_env(

--- a/tests/db/test_migration_connections.py
+++ b/tests/db/test_migration_connections.py
@@ -34,7 +34,7 @@ def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
 def test_single_alembic_head() -> None:
     script = ScriptDirectory.from_config(_build_alembic_config("sqlite://"))
     heads = script.get_heads()
-    assert heads == ["gb1b2c3d4e5f"], f"expected a single head, got {heads!r}"
+    assert heads == ["c7e4d9a1b2f6"], f"expected a single head, got {heads!r}"
 
 
 def test_upgrade_creates_table_downgrade_drops_it(tmp_path: Path) -> None:

--- a/tests/db/test_migration_user_preferences.py
+++ b/tests/db/test_migration_user_preferences.py
@@ -1,0 +1,81 @@
+"""Tests for the cross-device user preferences migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.orm import Session
+
+from omnigent.db.db_models import SqlUser
+from omnigent.db.utils import _build_alembic_config
+
+_PREVIOUS_HEAD = "gb1b2c3d4e5f"
+_PREFERENCES_REVISION = "c7e4d9a1b2f6"
+
+
+def test_users_preferences_column_is_nullable_binary(db_uri: str) -> None:
+    """The head schema carries an optional compressed preferences column."""
+    engine = sa.create_engine(db_uri)
+    try:
+        columns = {column["name"]: column for column in sa.inspect(engine).get_columns("users")}
+    finally:
+        engine.dispose()
+
+    assert columns["preferences"]["nullable"] is True
+    assert isinstance(columns["preferences"]["type"], sa.LargeBinary)
+
+
+def test_preferences_migration_round_trips_and_preserves_null_semantics(tmp_path: Path) -> None:
+    """Upgrade and downgrade preserve users while NULL remains uninitialized."""
+    uri = f"sqlite:///{tmp_path / 'preferences-migration.db'}"
+    config = _build_alembic_config(uri)
+    command.upgrade(config, _PREVIOUS_HEAD)
+
+    engine = sa.create_engine(uri)
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                "INSERT INTO users (workspace_id, id, is_admin) "
+                "VALUES (0, 'alice@example.com', false)"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config, _PREFERENCES_REVISION)
+    engine = sa.create_engine(uri)
+    with Session(engine) as session:
+        alice = session.get(SqlUser, (0, "alice@example.com"))
+        assert alice is not None
+        assert alice.preferences is None
+        alice.preferences = '{"settings":{},"version":1}'
+        session.commit()
+
+    with engine.connect() as connection:
+        stored = connection.scalar(
+            sa.text("SELECT preferences FROM users WHERE id = 'alice@example.com'")
+        )
+    assert isinstance(stored, bytes)
+    assert stored != b'{"settings":{},"version":1}'
+    engine.dispose()
+
+    command.downgrade(config, _PREVIOUS_HEAD)
+    engine = sa.create_engine(uri)
+    assert "preferences" not in {
+        column["name"] for column in sa.inspect(engine).get_columns("users")
+    }
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text("SELECT id FROM users")) == "alice@example.com"
+    engine.dispose()
+
+    command.upgrade(config, _PREFERENCES_REVISION)
+    engine = sa.create_engine(uri)
+    with engine.connect() as connection:
+        assert (
+            connection.scalar(
+                sa.text("SELECT preferences FROM users WHERE id = 'alice@example.com'")
+            )
+            is None
+        )
+    engine.dispose()

--- a/tests/deploy/test_databricks_app_lakebase_cold_start.py
+++ b/tests/deploy/test_databricks_app_lakebase_cold_start.py
@@ -60,6 +60,7 @@ _BOOT_STORE_CLASSES = (
     "omnigent.stores.policy_store.sqlalchemy_store.SqlAlchemyPolicyStore",
     "omnigent.stores.project_store.sqlalchemy_store.SqlAlchemyProjectStore",
     "omnigent.stores.scheduled_task_store.sqlalchemy_store.SqlAlchemyScheduledTaskStore",
+    "omnigent.server.user_preferences_store.SqlAlchemyUserPreferencesStore",
 )
 
 

--- a/tests/deploy/test_databricks_web_ui.py
+++ b/tests/deploy/test_databricks_web_ui.py
@@ -13,6 +13,7 @@ server reads it at import time, so it is checked in a subprocess.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import io
 import os
@@ -95,6 +96,34 @@ def test_app_py_extracts_web_ui_before_importing_server() -> None:
     assert 'archive = here / "web-ui.tar.gz"' in source
     assert "from web_ui_archive import extract_web_ui_archive" in source
     assert 'loose = here / "web-ui"' in source
+
+
+def test_app_wires_the_user_preferences_store() -> None:
+    """Keep cross-device settings available on the hosted workspace path."""
+    tree = ast.parse(_APP_PY.read_text())
+    assignments = {
+        target.id: node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    preference_store = assignments.get("user_preferences_store")
+    assert isinstance(preference_store, ast.Call)
+    assert isinstance(preference_store.func, ast.Name)
+    assert preference_store.func.id == "SqlAlchemyUserPreferencesStore"
+
+    create_app_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "create_app"
+    ]
+    assert len(create_app_calls) == 1
+    wired = {keyword.arg: keyword.value for keyword in create_app_calls[0].keywords}
+    assert isinstance(wired.get("user_preferences_store"), ast.Name)
+    assert wired["user_preferences_store"].id == "user_preferences_store"
 
 
 def test_app_extractor_extracts_normal_archive(tmp_path: Path) -> None:

--- a/tests/deploy/test_docker_entrypoint_import.py
+++ b/tests/deploy/test_docker_entrypoint_import.py
@@ -11,7 +11,9 @@ blow up if called during import).
 
 from __future__ import annotations
 
+import ast
 import importlib
+import inspect
 import sys
 from pathlib import Path
 from typing import NoReturn
@@ -83,6 +85,24 @@ def test_entrypoint_imports_without_side_effects(
     # build_app()/main() rather than being imported or executed at module import.
     for module_name in _BOOT_MODULES:
         assert module_name not in sys.modules
+
+
+def test_docker_entrypoint_wires_the_user_preferences_store() -> None:
+    """Keep cross-device settings available on the actual container path."""
+    from deploy.docker.entrypoint import build_app
+
+    tree = ast.parse(inspect.getsource(build_app))
+    create_app_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "create_app"
+    ]
+
+    assert len(create_app_calls) == 1
+    wired_keywords = {keyword.arg for keyword in create_app_calls[0].keywords}
+    assert "user_preferences_store" in wired_keywords
 
 
 # ── artifact-store resolution + selection ────────────────────────────────

--- a/tests/e2e/test_user_preferences_api_e2e.py
+++ b/tests/e2e/test_user_preferences_api_e2e.py
@@ -1,0 +1,100 @@
+"""End-to-end user-preferences API coverage against a real server process."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _wait_until_healthy(base_url: str, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stdout, stderr = process.communicate()
+            raise AssertionError(
+                f"server exited with {process.returncode}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        try:
+            if httpx.get(f"{base_url}/health", timeout=1).status_code == 200:
+                return
+        except httpx.HTTPError:
+            pass
+        time.sleep(0.1)
+    raise AssertionError("server did not become healthy within 30 seconds")
+
+
+def test_preferences_follow_an_authenticated_user_across_clients(tmp_path: Path) -> None:
+    """A real CLI server persists one user's settings across HTTP clients."""
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "OMNIGENT_AUTH_ENABLED": "1",
+            "OMNIGENT_AUTH_PROVIDER": "header",
+            "OMNIGENT_AUTH_HEADER": "X-Test-User",
+            "OMNIGENT_CONFIG": str(config_path),
+            "OMNIGENT_DATA_DIR": str(tmp_path / "data"),
+            "OMNIGENT_SKIP_WEB_UI": "true",
+        }
+    )
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "omnigent",
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--database-uri",
+            f"sqlite:///{tmp_path / 'preferences-e2e.db'}",
+            "--artifact-location",
+            str(tmp_path / "artifacts"),
+            "--no-open",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        _wait_until_healthy(base_url, process)
+        headers = {"X-Test-User": "alice@example.com"}
+        with httpx.Client(base_url=base_url, headers=headers) as first_client:
+            initialized = first_client.put(
+                "/v1/me/preferences",
+                json={
+                    "version": 1,
+                    "settings": {"keyboard_shortcuts": {"enabled": False}},
+                },
+            )
+            assert initialized.status_code == 200
+
+        with httpx.Client(base_url=base_url, headers=headers) as second_client:
+            me = second_client.get("/v1/me")
+            assert me.status_code == 200
+            assert me.json()["preferences"] == initialized.json()
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)

--- a/tests/server/test_user_preferences.py
+++ b/tests/server/test_user_preferences.py
@@ -1,0 +1,344 @@
+"""User-scoped, cross-device preferences API tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from starlette.requests import HTTPConnection
+
+from omnigent.runtime.agent_cache import AgentCache
+from omnigent.server.app import create_app
+from omnigent.server.auth import AuthProvider, UnifiedAuthProvider
+from omnigent.server.user_preferences_store import (
+    SqlAlchemyUserPreferencesStore,
+    UserPreferencesUserNotFoundError,
+    UserPreferencesValidationError,
+    validate_preferences_envelope,
+)
+from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
+from omnigent.stores.artifact_store.local import LocalArtifactStore
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+from omnigent.stores.file_store.sqlalchemy_store import SqlAlchemyFileStore
+
+
+class _HeaderAuthProvider(AuthProvider):
+    """Resolve a test identity from ``X-Test-User``."""
+
+    def get_user_id(self, request: HTTPConnection) -> str | None:
+        return request.headers.get("x-test-user")
+
+
+class _AccountsAuthProvider(UnifiedAuthProvider):
+    """Expose test-header identity while exercising accounts-mode guards."""
+
+    def __init__(self) -> None:
+        super().__init__(source="header", local_single_user=False)
+
+    def get_user_id(self, request: HTTPConnection) -> str | None:
+        return request.headers.get("x-test-user")
+
+
+def _preferences_app(db_uri: str, tmp_path: Path) -> FastAPI:
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts-preferences"))
+    return create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache-preferences",
+        ),
+        auth_provider=_HeaderAuthProvider(),
+        user_preferences_store=SqlAlchemyUserPreferencesStore(db_uri),
+    )
+
+
+def _deleted_account_app(db_uri: str, tmp_path: Path) -> FastAPI:
+    artifact_store = LocalArtifactStore(str(tmp_path / "artifacts-deleted-account"))
+    auth_provider = _AccountsAuthProvider()
+    app = create_app(
+        agent_store=SqlAlchemyAgentStore(db_uri),
+        file_store=SqlAlchemyFileStore(db_uri),
+        conversation_store=SqlAlchemyConversationStore(db_uri),
+        artifact_store=artifact_store,
+        agent_cache=AgentCache(
+            artifact_store=artifact_store,
+            cache_dir=tmp_path / "cache-deleted-account",
+        ),
+        auth_provider=auth_provider,
+        user_preferences_store=SqlAlchemyUserPreferencesStore(db_uri),
+    )
+    # create_app only mounts accounts-only auth routes when accounts mode is
+    # active at construction. Switch after construction so this focused test
+    # exercises the preferences guard without bootstrapping a real account.
+    auth_provider._source = "accounts"
+    return app
+
+
+def test_store_preserves_uninitialized_vs_initialized_defaults(db_uri: str) -> None:
+    """NULL and an explicit empty settings envelope have different meaning."""
+    store = SqlAlchemyUserPreferencesStore(db_uri)
+    assert store.get("alice@example.com") is None
+
+    empty = {"version": 1, "settings": {}}
+    assert store.initialize("alice@example.com", empty) == empty
+    assert store.get("alice@example.com") == empty
+
+    # First-device migration is idempotent and cannot overwrite an already
+    # initialized account with stale localStorage from another device.
+    stale = {"version": 1, "settings": {"usage_context": {"visible": False}}}
+    assert store.initialize("alice@example.com", stale) == empty
+
+
+def test_store_merges_one_namespace_and_keeps_users_isolated(db_uri: str) -> None:
+    store = SqlAlchemyUserPreferencesStore(db_uri)
+    first = store.patch_namespace(
+        "alice@example.com",
+        "keyboard_shortcuts",
+        {"enabled": True, "actions": {"archive": "Alt+W"}},
+    )
+    assert first["settings"]["keyboard_shortcuts"]["enabled"] is True
+
+    merged = store.patch_namespace(
+        "alice@example.com",
+        "keyboard_shortcuts",
+        {"enabled": False},
+    )
+    assert merged["settings"]["keyboard_shortcuts"] == {
+        "enabled": False,
+        "actions": {"archive": "Alt+W"},
+    }
+    assert store.get("bob@example.com") is None
+
+    removed = store.patch_namespace("alice@example.com", "keyboard_shortcuts", None)
+    assert removed == {"version": 1, "settings": {}}
+
+    compact = store.patch_namespace("alice@example.com", "context_indicator", "compact")
+    assert compact["settings"]["context_indicator"] == "compact"
+
+
+def test_store_can_refuse_to_recreate_a_deleted_account(db_uri: str) -> None:
+    """Accounts-mode routes fail closed when a JWT outlives its user row."""
+    store = SqlAlchemyUserPreferencesStore(db_uri)
+    with pytest.raises(UserPreferencesUserNotFoundError):
+        store.initialize(
+            "deleted@example.com",
+            {"version": 1, "settings": {}},
+            create_if_missing=False,
+        )
+    with pytest.raises(UserPreferencesUserNotFoundError):
+        store.patch_namespace(
+            "deleted@example.com",
+            "usage_context",
+            {"version": 1},
+            create_if_missing=False,
+        )
+    assert store.get("deleted@example.com") is None
+
+
+def test_store_rejects_an_unpaired_unicode_surrogate_as_a_validation_error() -> None:
+    with pytest.raises(UserPreferencesValidationError, match="valid UTF-8"):
+        validate_preferences_envelope({"version": 1, "settings": {"usage_context": "\ud800"}})
+
+
+@pytest.mark.asyncio
+async def test_preferences_api_initializes_merges_and_returns_from_me(
+    db_uri: str,
+    runtime_init: None,
+    tmp_path: Path,
+) -> None:
+    app = _preferences_app(db_uri, tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"x-test-user": "alice@example.com"}
+
+        initial_me = await client.get("/v1/me", headers=headers)
+        assert initial_me.status_code == 200
+        assert initial_me.headers["cache-control"] == "private, no-store"
+        assert initial_me.json() == {
+            "user_id": "alice@example.com",
+            "is_admin": False,
+            "preferences": None,
+        }
+
+        initialized = await client.put(
+            "/v1/me/preferences",
+            headers=headers,
+            json={
+                "version": 1,
+                "settings": {"session_navigation": {"activeHours": 12}},
+            },
+        )
+        assert initialized.status_code == 200
+
+        # Once initialized, PUT is idempotent and cannot replace the first
+        # device's value with stale state from a second device.
+        repeated = await client.put(
+            "/v1/me/preferences",
+            headers=headers,
+            json={"version": 1, "settings": {}},
+        )
+        assert repeated.json() == initialized.json()
+
+        patched = await client.patch(
+            "/v1/me/preferences/session_navigation",
+            headers=headers,
+            json={"value": {"showMobileTitle": True}},
+        )
+        assert patched.status_code == 200
+        assert patched.json()["settings"]["session_navigation"] == {
+            "activeHours": 12,
+            "showMobileTitle": True,
+        }
+
+        patched = await client.patch(
+            "/v1/me/preferences/agent_badges",
+            headers=headers,
+            json={
+                "value": {
+                    "version": 1,
+                    "enabled": False,
+                    "entries": {
+                        "agent-a": {
+                            "label": "A",
+                            "borderColor": "#123456",
+                            "textColor": "#abcdef",
+                        }
+                    },
+                }
+            },
+        )
+        assert patched.status_code == 200
+        assert patched.json()["settings"]["agent_badges"]["enabled"] is False
+        assert "agent-a" in patched.json()["settings"]["agent_badges"]["entries"]
+
+        synced_me = await client.get("/v1/me", headers=headers)
+        assert synced_me.json()["preferences"] == patched.json()
+
+
+@pytest.mark.asyncio
+async def test_preferences_api_isolates_users_and_rejects_invalid_payloads(
+    db_uri: str,
+    runtime_init: None,
+    tmp_path: Path,
+) -> None:
+    app = _preferences_app(db_uri, tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        alice = {"x-test-user": "alice@example.com"}
+        bob = {"x-test-user": "bob@example.com"}
+        payload = {
+            "version": 1,
+            "settings": {"mobile_assistant": {"enabled": True}},
+        }
+        assert (
+            await client.put("/v1/me/preferences", headers=alice, json=payload)
+        ).status_code == 200
+
+        bob_me = await client.get("/v1/me", headers=bob)
+        assert bob_me.status_code == 200
+        assert bob_me.json()["preferences"] is None
+
+        unauthorized = await client.patch(
+            "/v1/me/preferences/mobile_assistant",
+            json={"value": {"enabled": False}},
+        )
+        assert unauthorized.status_code == 401
+
+        unknown = await client.patch(
+            "/v1/me/preferences/not_allowed",
+            headers=alice,
+            json={"value": {}},
+        )
+        assert unknown.status_code == 422
+
+        oversized = await client.put(
+            "/v1/me/preferences",
+            headers=alice,
+            json={
+                "version": 1,
+                "settings": {"usage_context": {"padding": "x" * (64 * 1024)}},
+            },
+        )
+        assert oversized.status_code == 422
+
+        raw_oversized = await client.put(
+            "/v1/me/preferences",
+            headers={**alice, "content-type": "application/json"},
+            content=b'{"version":1,"settings":{"usage_context":{"padding":"'
+            + (b"x" * (1024 * 1024))
+            + b'"}}}',
+        )
+        assert raw_oversized.status_code == 413
+
+        extra = await client.put(
+            "/v1/me/preferences",
+            headers=alice,
+            json={"version": 1, "settings": {}, "unexpected": True},
+        )
+        assert extra.status_code == 422
+
+        invalid_unicode = await client.patch(
+            "/v1/me/preferences/usage_context",
+            headers={**alice, "content-type": "application/json"},
+            content=b'{"value":"\\ud800"}',
+        )
+        assert invalid_unicode.status_code == 422
+
+        wrong_media_type = await client.put(
+            "/v1/me/preferences",
+            headers={**alice, "content-type": "text/plain"},
+            content=b'{"version":1,"settings":{}}',
+        )
+        assert wrong_media_type.status_code == 415
+
+
+@pytest.mark.asyncio
+async def test_preferences_api_does_not_recreate_a_deleted_account(
+    db_uri: str,
+    runtime_init: None,
+    tmp_path: Path,
+) -> None:
+    app = _deleted_account_app(db_uri, tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.patch(
+            "/v1/me/preferences/usage_context",
+            headers={"x-test-user": "deleted@example.com"},
+            json={"value": {"visible": True}},
+        )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Account no longer exists"
+    assert SqlAlchemyUserPreferencesStore(db_uri).get("deleted@example.com") is None
+
+
+@pytest.mark.asyncio
+async def test_preferences_api_rate_limits_writes_per_user(
+    db_uri: str,
+    runtime_init: None,
+    tmp_path: Path,
+) -> None:
+    app = _preferences_app(db_uri, tmp_path)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"x-test-user": "rate-limited@example.com"}
+        for index in range(120):
+            response = await client.patch(
+                "/v1/me/preferences/usage_context",
+                headers=headers,
+                json={"value": {"counter": index}},
+            )
+            assert response.status_code == 200
+
+        limited = await client.patch(
+            "/v1/me/preferences/usage_context",
+            headers=headers,
+            json={"value": {"counter": 120}},
+        )
+        assert limited.status_code == 429
+        assert limited.headers["retry-after"] == "60"

--- a/web/src/lib/identity.test.ts
+++ b/web/src/lib/identity.test.ts
@@ -32,6 +32,72 @@ afterEach(() => {
 });
 
 describe("resolveIdentity", () => {
+  it("does not hydrate a preference initialization body after the Host connection changes", async () => {
+    let finishBody!: (body: unknown) => void;
+    const json = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          finishBody = resolve;
+        }),
+    );
+    const serverA = vi
+      .fn()
+      .mockResolvedValueOnce(mockJsonResponse({ user_id: "alice", preferences: null }))
+      .mockResolvedValueOnce({ ok: true, status: 200, json });
+    const serverB = vi.fn();
+    const { setOmnigentHostConfig } = await import("./host");
+    setOmnigentHostConfig({ serverIdentity: "server-a", fetcher: serverA });
+    const { resolveIdentity } = await import("./identity");
+    const pending = resolveIdentity();
+    await vi.waitFor(() => expect(json).toHaveBeenCalledOnce());
+    setOmnigentHostConfig({ serverIdentity: "server-b", fetcher: serverB });
+    finishBody({ version: 1, settings: { context_indicator: "compact" } });
+    expect(await pending).toBeNull();
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBeNull();
+    expect(serverB).not.toHaveBeenCalled();
+  });
+  it("discards a body decoded after switching Servers before a new identity lookup", async () => {
+    let finishBody!: (body: unknown) => void;
+    const json = vi.fn(
+      () =>
+        new Promise<unknown>((resolve) => {
+          finishBody = resolve;
+        }),
+    );
+    const serverA = vi.fn().mockResolvedValue({ ok: true, status: 200, json });
+    const serverB = vi.fn().mockResolvedValue(mockJsonResponse({ version: 1, settings: {} }));
+    const { setOmnigentHostConfig } = await import("./host");
+    setOmnigentHostConfig({ serverIdentity: "server-a", fetcher: serverA });
+    const { resolveIdentity } = await import("./identity");
+    const pending = resolveIdentity();
+    await vi.waitFor(() => expect(json).toHaveBeenCalledOnce());
+    setOmnigentHostConfig({ serverIdentity: "server-b", fetcher: serverB });
+    finishBody({ user_id: "alice", preferences: null });
+    expect(await pending).toBeNull();
+    expect(serverB).not.toHaveBeenCalled();
+  });
+
+  it("never sends queued preferences to a newly selected Server before identity resolves", async () => {
+    vi.useFakeTimers();
+    const serverA = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        user_id: "alice",
+        preferences: { version: 1, settings: {} },
+      }),
+    );
+    const serverB = vi.fn().mockResolvedValue(mockJsonResponse({ version: 1, settings: {} }));
+    const { setOmnigentHostConfig } = await import("./host");
+    setOmnigentHostConfig({ serverIdentity: "server-a", fetcher: serverA });
+    const { resolveIdentity } = await import("./identity");
+    const { queueUserPreferencePatch, resetUserPreferencesSyncForTests } =
+      await import("./userPreferencesSync");
+    await resolveIdentity();
+    queueUserPreferencePatch("context_indicator", "compact");
+    setOmnigentHostConfig({ serverIdentity: "server-b", fetcher: serverB });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(serverB).not.toHaveBeenCalled();
+    resetUserPreferencesSyncForTests();
+  });
   it("calls GET /v1/me and caches the user id", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({ user_id: "alice@example.com" }));
     const { resolveIdentity, getCurrentUserId } = await import("./identity");

--- a/web/src/lib/identity.test.ts
+++ b/web/src/lib/identity.test.ts
@@ -21,11 +21,13 @@ const fetchMock = vi.fn();
 
 beforeEach(() => {
   fetchMock.mockReset();
+  localStorage.clear();
   vi.stubGlobal("fetch", fetchMock);
   vi.resetModules();
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -40,6 +42,21 @@ describe("resolveIdentity", () => {
     expect(getCurrentUserId()).toBe("alice@example.com");
     expect(fetchMock).toHaveBeenCalledOnce();
     expect(fetchMock.mock.calls[0][0]).toBe("/v1/me");
+  });
+
+  it("hydrates server preferences during identity discovery", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        user_id: "alice@example.com",
+        preferences: { version: 1, settings: { context_indicator: "compact" } },
+      }),
+    );
+    const { resolveIdentity } = await import("./identity");
+
+    await resolveIdentity();
+
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBe("compact");
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("returns the cached value on subsequent calls without re-fetching", async () => {
@@ -77,6 +94,62 @@ describe("resolveIdentity", () => {
     expect(await a).toBe("carol");
     expect(await b).toBe("carol");
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes the cached identity after the embedded Server connection changes", async () => {
+    vi.useFakeTimers();
+    const serverA = vi
+      .fn()
+      .mockResolvedValue(
+        mockJsonResponse({ user_id: "alice", preferences: { version: 1, settings: {} } }),
+      );
+    const serverB = vi
+      .fn()
+      .mockResolvedValue(
+        mockJsonResponse({ user_id: "bob", preferences: { version: 1, settings: {} } }),
+      );
+    const { setOmnigentHostConfig } = await import("./host");
+    setOmnigentHostConfig({ serverIdentity: "server-a", fetcher: serverA });
+    const { resolveIdentity, getCurrentUserId } = await import("./identity");
+    const { queueUserPreferencePatch } = await import("./userPreferencesSync");
+
+    expect(await resolveIdentity()).toBe("alice");
+    queueUserPreferencePatch("context_indicator", "compact");
+    setOmnigentHostConfig({ serverIdentity: "server-b", fetcher: serverB });
+
+    expect(await resolveIdentity()).toBe("bob");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getCurrentUserId()).toBe("bob");
+    expect(serverA).toHaveBeenCalledOnce();
+    expect(serverB).toHaveBeenCalledOnce();
+  });
+
+  it("discards a delayed identity response from the previous Server", async () => {
+    let resolveServerA!: (response: Response) => void;
+    const serverA = vi.fn().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveServerA = resolve;
+      }),
+    );
+    const serverB = vi
+      .fn()
+      .mockResolvedValue(
+        mockJsonResponse({ user_id: "bob", preferences: { version: 1, settings: {} } }),
+      );
+    const { setOmnigentHostConfig } = await import("./host");
+    setOmnigentHostConfig({ serverIdentity: "server-a", fetcher: serverA });
+    const { resolveIdentity, getCurrentUserId } = await import("./identity");
+
+    const staleResolution = resolveIdentity();
+    setOmnigentHostConfig({ serverIdentity: "server-b", fetcher: serverB });
+    const currentResolution = resolveIdentity();
+    resolveServerA(mockJsonResponse({ user_id: "alice", preferences: null }));
+
+    expect(await staleResolution).toBeNull();
+    expect(await currentResolution).toBe("bob");
+    expect(getCurrentUserId()).toBe("bob");
+    expect(serverA).toHaveBeenCalledOnce();
+    expect(serverB).toHaveBeenCalledOnce();
   });
 
   it("returns null when the server responds with user_id: null", async () => {
@@ -223,6 +296,8 @@ describe("authenticatedFetch", () => {
       }));
       vi.doMock("./host", () => ({
         getOmnigentHostConfig: vi.fn(() => ({ fetcher: () => fetch })),
+        getOmnigentHostGeneration: vi.fn(() => 0),
+        getOmnigentServerIdentity: vi.fn(() => "server"),
         hostFetch: fetchMock,
         isDatabricksWorkspace: vi.fn(() => true),
       }));
@@ -255,6 +330,8 @@ describe("authenticatedFetch", () => {
       }));
       vi.doMock("./host", () => ({
         getOmnigentHostConfig: vi.fn(() => ({})),
+        getOmnigentHostGeneration: vi.fn(() => 0),
+        getOmnigentServerIdentity: vi.fn(() => "server"),
         hostFetch: fetchMock,
         isDatabricksWorkspace: vi.fn(() => true),
       }));
@@ -281,6 +358,8 @@ describe("authenticatedFetch", () => {
       }));
       vi.doMock("./host", () => ({
         getOmnigentHostConfig: vi.fn(() => ({ fetcher: () => fetch })),
+        getOmnigentHostGeneration: vi.fn(() => 0),
+        getOmnigentServerIdentity: vi.fn(() => "server"),
         hostFetch: fetchMock,
         isDatabricksWorkspace: vi.fn(() => true),
       }));
@@ -331,6 +410,8 @@ describe("authenticatedFetch", () => {
       }));
       vi.doMock("./host", () => ({
         getOmnigentHostConfig: vi.fn(() => ({ fetcher: () => fetch })),
+        getOmnigentHostGeneration: vi.fn(() => 0),
+        getOmnigentServerIdentity: vi.fn(() => "server"),
         hostFetch: fetchMock,
         isDatabricksWorkspace: vi.fn(() => true),
       }));

--- a/web/src/lib/identity.ts
+++ b/web/src/lib/identity.ts
@@ -16,7 +16,13 @@
  */
 
 import { getCachedServerInfo } from "./capabilities";
-import { getOmnigentHostConfig, hostFetch, isDatabricksWorkspace } from "./host";
+import {
+  getOmnigentHostConfig,
+  getOmnigentHostGeneration,
+  getOmnigentServerIdentity,
+  hostFetch,
+  isDatabricksWorkspace,
+} from "./host";
 import {
   clearHostKeyless,
   getSessionHost,
@@ -24,6 +30,10 @@ import {
   markHostKeyless,
   modalHostId,
 } from "@/lib/sessionHost";
+import {
+  deactivateUserPreferencesSync,
+  initializeUserPreferencesSync,
+} from "./userPreferencesSync";
 
 // Single-user sentinel from `GET /v1/me` (server's RESERVED_USER_LOCAL);
 // not a real actor, so never used as an author label.
@@ -246,6 +256,7 @@ function isBodyHostKeyedRequest(url: string, body: BodyInit | null | undefined):
 let currentIsAdmin = false;
 let identityResolved = false;
 let identityPromise: Promise<string | null> | null = null;
+let identityConnectionId: string | null = null;
 // Cache the server-provided login URL on the first /v1/me probe so
 // later session-expiry redirects in authenticatedFetch hit the right
 // path per provider — "/login" for accounts, "/auth/login" for OIDC.
@@ -259,6 +270,14 @@ let serverLoginUrl: string | null = null;
 // navigations. Boot also reads this to skip mounting the app when the
 // session is already on its way out (see `isLoginRedirectPending`).
 let loginRedirectPending = false;
+
+function currentIdentityConnectionId(): string {
+  return `${getOmnigentServerIdentity() ?? "__default__"}:${getOmnigentHostGeneration()}`;
+}
+
+function identityMatchesCurrentConnection(): boolean {
+  return identityConnectionId === currentIdentityConnectionId();
+}
 
 /**
  * Hand the browser to `loginUrl`, at most once per document.
@@ -313,11 +332,25 @@ function isOnLoginPath(): boolean {
  * redirects the browser to the login page.
  */
 export async function resolveIdentity(): Promise<string | null> {
+  const stablePreferenceServerId = getOmnigentServerIdentity() ?? "__default__";
+  const preferenceConnectionId = currentIdentityConnectionId();
+  if (identityConnectionId !== preferenceConnectionId) {
+    identityConnectionId = preferenceConnectionId;
+    identityResolved = false;
+    identityPromise = null;
+    currentUserId = null;
+    currentIsAdmin = false;
+    serverLoginUrl = null;
+    deactivateUserPreferencesSync();
+  }
   if (identityResolved) return currentUserId;
   if (identityPromise) return identityPromise;
   identityPromise = (async () => {
     try {
       const res = await hostFetch("/v1/me");
+      if (preferenceConnectionId !== currentIdentityConnectionId()) {
+        return null;
+      }
       if (res.status === 401) {
         // OIDC / accounts mode: server requires authentication.
         // Redirect to the login URL provided in the response body —
@@ -328,6 +361,7 @@ export async function resolveIdentity(): Promise<string | null> {
             user_id: null;
             login_url?: string;
           };
+          if (identityConnectionId !== preferenceConnectionId) return null;
           if (data.login_url) {
             serverLoginUrl = data.login_url;
             if (!isOnLoginPath()) {
@@ -343,22 +377,38 @@ export async function resolveIdentity(): Promise<string | null> {
         const data = (await res.json()) as {
           user_id: string | null;
           is_admin?: boolean;
+          preferences?: unknown | null;
         };
+        if (identityConnectionId !== preferenceConnectionId) return null;
         currentUserId = data.user_id;
         currentIsAdmin = data.is_admin ?? false;
+        await initializeUserPreferencesSync(
+          data.preferences,
+          authenticatedFetch,
+          data.user_id,
+          stablePreferenceServerId,
+          preferenceConnectionId,
+        );
       }
     } catch {
       // Server unreachable — leave as null.
     }
-    identityResolved = true;
-    return currentUserId;
+    const connectionIsCurrent =
+      identityConnectionId === preferenceConnectionId &&
+      preferenceConnectionId === currentIdentityConnectionId();
+    if (connectionIsCurrent) identityResolved = true;
+    else if (identityConnectionId === preferenceConnectionId) {
+      currentUserId = null;
+      currentIsAdmin = false;
+    }
+    return connectionIsCurrent ? currentUserId : null;
   })();
   return identityPromise;
 }
 
 /** Return the cached user ID (null before resolveIdentity completes). */
 export function getCurrentUserId(): string | null {
-  return currentUserId;
+  return identityMatchesCurrentConnection() ? currentUserId : null;
 }
 
 /**
@@ -367,7 +417,7 @@ export function getCurrentUserId(): string | null {
  * AND OIDC. Returns false before `resolveIdentity` completes.
  */
 export function getCurrentIsAdmin(): boolean {
-  return currentIsAdmin;
+  return identityMatchesCurrentConnection() && currentIsAdmin;
 }
 
 /**
@@ -376,10 +426,11 @@ export function getCurrentIsAdmin(): boolean {
  * resolves and for the `"local"` sentinel, so those stay unlabeled.
  */
 export function getCurrentAuthorId(): string | null {
-  if (currentUserId === null || currentUserId === RESERVED_USER_LOCAL) {
+  const userId = getCurrentUserId();
+  if (userId === null || userId === RESERVED_USER_LOCAL) {
     return null;
   }
-  return currentUserId;
+  return userId;
 }
 
 /**
@@ -414,7 +465,12 @@ export async function authenticatedFetch(
   init?: RequestInit,
 ): Promise<Response> {
   const headers = new Headers(init?.headers);
-  if (currentUserId && currentUserId !== RESERVED_USER_LOCAL && !headers.has("X-Forwarded-Email")) {
+  if (
+    identityMatchesCurrentConnection() &&
+    currentUserId &&
+    currentUserId !== RESERVED_USER_LOCAL &&
+    !headers.has("X-Forwarded-Email")
+  ) {
     headers.set("X-Forwarded-Email", currentUserId);
   }
   // Pin host- and session-scoped requests to the replica holding that host's

--- a/web/src/lib/identity.ts
+++ b/web/src/lib/identity.ts
@@ -361,7 +361,11 @@ export async function resolveIdentity(): Promise<string | null> {
             user_id: null;
             login_url?: string;
           };
-          if (identityConnectionId !== preferenceConnectionId) return null;
+          if (
+            identityConnectionId !== preferenceConnectionId ||
+            preferenceConnectionId !== currentIdentityConnectionId()
+          )
+            return null;
           if (data.login_url) {
             serverLoginUrl = data.login_url;
             if (!isOnLoginPath()) {
@@ -379,7 +383,11 @@ export async function resolveIdentity(): Promise<string | null> {
           is_admin?: boolean;
           preferences?: unknown | null;
         };
-        if (identityConnectionId !== preferenceConnectionId) return null;
+        if (
+          identityConnectionId !== preferenceConnectionId ||
+          preferenceConnectionId !== currentIdentityConnectionId()
+        )
+          return null;
         currentUserId = data.user_id;
         currentIsAdmin = data.is_admin ?? false;
         await initializeUserPreferencesSync(
@@ -388,6 +396,7 @@ export async function resolveIdentity(): Promise<string | null> {
           data.user_id,
           stablePreferenceServerId,
           preferenceConnectionId,
+          () => preferenceConnectionId === currentIdentityConnectionId(),
         );
       }
     } catch {

--- a/web/src/lib/userPreferencesSync.test.ts
+++ b/web/src/lib/userPreferencesSync.test.ts
@@ -1,0 +1,480 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  collectLocalUserPreferences,
+  initializeUserPreferencesSync,
+  queueUserPreferencePatch,
+  refreshUserPreferencesFromServer,
+  resetUserPreferencesSyncForTests,
+} from "./userPreferencesSync";
+
+beforeEach(() => {
+  localStorage.clear();
+  resetUserPreferencesSyncForTests();
+  vi.useRealTimers();
+});
+
+describe("user preference synchronization", () => {
+  it("does nothing when an older Server omits the preferences field", async () => {
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    const fetcher = vi.fn();
+    await initializeUserPreferencesSync(undefined, fetcher);
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBe("compact");
+    expect(localStorage.getItem("omnigent:user-preferences-owner")).toBe("__default__:__local__");
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("does not seed a new Server from an older Server's local preferences", async () => {
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    await initializeUserPreferencesSync(undefined, vi.fn(), "alice", "server-a");
+    const serverB = vi.fn().mockResolvedValue(Response.json({ version: 1, settings: {} }));
+
+    await initializeUserPreferencesSync(null, serverB, "alice", "server-b");
+
+    expect(serverB).toHaveBeenCalledWith(
+      "/v1/me/preferences",
+      expect.objectContaining({ body: JSON.stringify({ version: 1, settings: {} }) }),
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBeNull();
+    expect(localStorage.getItem("omnigent:user-preferences-owner")).toBe("server-b:alice");
+  });
+
+  it("downgrades an unrecognized preferences envelope to device-only behavior", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn();
+    await initializeUserPreferencesSync({ version: 2, settings: {} }, fetcher, "alice", "server-a");
+
+    queueUserPreferencePatch("context_indicator", "compact");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(localStorage.getItem("omnigent:user-preferences-owner")).toBe("server-a:alice");
+  });
+
+  it("collects and hydrates the Agent badge namespace", async () => {
+    const badgePreferences = {
+      version: 1,
+      enabled: false,
+      entries: {
+        "agent-a": { label: "A", borderColor: "#123456", textColor: "#abcdef" },
+      },
+    };
+    localStorage.setItem("omnigent:agent-badge-preferences", JSON.stringify(badgePreferences));
+    expect(collectLocalUserPreferences().settings.agent_badges).toEqual(badgePreferences);
+
+    await initializeUserPreferencesSync(
+      {
+        version: 1,
+        settings: { agent_badges: { ...badgePreferences, enabled: true } },
+      },
+      vi.fn(),
+    );
+
+    expect(JSON.parse(localStorage.getItem("omnigent:agent-badge-preferences") ?? "null")).toEqual({
+      ...badgePreferences,
+      enabled: true,
+    });
+  });
+
+  it("cancels queued sync when switching to an older Server", async () => {
+    vi.useFakeTimers();
+    const currentServer = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, currentServer, "alice");
+    queueUserPreferencePatch("context_indicator", "compact");
+
+    const oldServer = vi.fn();
+    await initializeUserPreferencesSync(undefined, oldServer, "alice");
+    await vi.advanceTimersByTimeAsync(500);
+    queueUserPreferencePatch("context_indicator", "compact");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(currentServer).not.toHaveBeenCalled();
+    expect(oldServer).not.toHaveBeenCalled();
+  });
+
+  it("uploads existing local preferences exactly when the user has no server value", async () => {
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(Response.json({ version: 1, settings: { context_indicator: "compact" } }));
+    await initializeUserPreferencesSync(null, fetcher, "alice");
+    expect(fetcher).toHaveBeenCalledWith(
+      "/v1/me/preferences",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify(collectLocalUserPreferences()),
+      }),
+    );
+    expect(localStorage.getItem("omnigent:user-preferences-owner")).toBe("__default__:alice");
+  });
+
+  it("does not seed a new account from another user's local cache", async () => {
+    localStorage.setItem("omnigent:user-preferences-owner", "__default__:alice");
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    const fetcher = vi.fn().mockResolvedValue(Response.json({ version: 1, settings: {} }));
+    await initializeUserPreferencesSync(null, fetcher, "bob");
+    expect(fetcher).toHaveBeenCalledWith(
+      "/v1/me/preferences",
+      expect.objectContaining({
+        body: JSON.stringify({ version: 1, settings: {} }),
+      }),
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBeNull();
+    expect(localStorage.getItem("omnigent:user-preferences-owner")).toBe("__default__:bob");
+  });
+
+  it("clears another scope's local values even when initialization fails", async () => {
+    localStorage.setItem("omnigent:user-preferences-owner", "server-a:alice");
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+
+    await initializeUserPreferencesSync(null, fetcher, "alice", "server-b");
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "/v1/me/preferences",
+      expect.objectContaining({
+        body: JSON.stringify({ version: 1, settings: {} }),
+      }),
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBeNull();
+    expect(localStorage.getItem("omnigent:user-preferences-owner")).toBe("server-b:alice");
+  });
+
+  it("hydrates the persisted winner after a racing first-device initialization", async () => {
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(Response.json({ version: 1, settings: { context_indicator: null } }));
+    await initializeUserPreferencesSync(null, fetcher, "alice");
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBeNull();
+  });
+
+  it("lets the server win while retaining device-only assistant position", async () => {
+    localStorage.setItem(
+      "omnigent:mobile-assistant-preferences",
+      JSON.stringify({ version: 2, enabled: true, buttons: [], position: { x: 0.2, y: 0.8 } }),
+    );
+    const fetcher = vi.fn();
+    await initializeUserPreferencesSync(
+      {
+        version: 1,
+        settings: {
+          context_indicator: "compact",
+          mobile_assistant: { version: 2, enabled: false, buttons: [{ id: "one" }] },
+        },
+      },
+      fetcher,
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBe("compact");
+    expect(JSON.parse(localStorage.getItem("omnigent:mobile-assistant-preferences")!)).toEqual({
+      version: 2,
+      enabled: false,
+      buttons: [{ id: "one" }],
+      position: { x: 0.2, y: 0.8 },
+    });
+    expect(JSON.parse(localStorage.getItem("omnigent:mobile-assistant-device-state")!)).toEqual({
+      position: { x: 0.2, y: 0.8 },
+    });
+  });
+
+  it("retains device-only assistant placement when the user has no assistant namespace", async () => {
+    localStorage.setItem(
+      "omnigent:mobile-assistant-preferences",
+      JSON.stringify({
+        version: 2,
+        enabled: true,
+        buttons: [],
+        dock: { edge: "right", offset: 0.4 },
+      }),
+    );
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, vi.fn(), "alice");
+    expect(localStorage.getItem("omnigent:mobile-assistant-preferences")).toBeNull();
+    expect(JSON.parse(localStorage.getItem("omnigent:mobile-assistant-device-state")!)).toEqual({
+      dock: { edge: "right", offset: 0.4 },
+    });
+  });
+
+  it("ignores device-only assistant placement received from the Server", async () => {
+    await initializeUserPreferencesSync(
+      {
+        version: 1,
+        settings: {
+          mobile_assistant: {
+            version: 2,
+            enabled: true,
+            buttons: [],
+            dock: { edge: "left", offset: 0.25 },
+            position: { x: 0.1, y: 0.2 },
+          },
+        },
+      },
+      vi.fn(),
+    );
+
+    expect(JSON.parse(localStorage.getItem("omnigent:mobile-assistant-preferences")!)).toEqual({
+      version: 2,
+      enabled: true,
+      buttons: [],
+    });
+    expect(localStorage.getItem("omnigent:mobile-assistant-device-state")).toBeNull();
+  });
+
+  it("keeps the latest local assistant placement across later hydration", async () => {
+    localStorage.setItem(
+      "omnigent:mobile-assistant-preferences",
+      JSON.stringify({ version: 2, enabled: true, buttons: [], position: { x: 0.2, y: 0.8 } }),
+    );
+    const serverEnvelope = {
+      version: 1 as const,
+      settings: { mobile_assistant: { version: 2, enabled: false, buttons: [] } },
+    };
+    await initializeUserPreferencesSync(serverEnvelope, vi.fn(), "alice");
+    localStorage.setItem(
+      "omnigent:mobile-assistant-preferences",
+      JSON.stringify({ version: 2, enabled: false, buttons: [], position: { x: 0.6, y: 0.4 } }),
+    );
+
+    await initializeUserPreferencesSync(serverEnvelope, vi.fn(), "alice");
+
+    expect(JSON.parse(localStorage.getItem("omnigent:mobile-assistant-preferences")!)).toEqual({
+      version: 2,
+      enabled: false,
+      buttons: [],
+      position: { x: 0.6, y: 0.4 },
+    });
+    expect(JSON.parse(localStorage.getItem("omnigent:mobile-assistant-device-state")!)).toEqual({
+      position: { x: 0.6, y: 0.4 },
+    });
+  });
+
+  it("debounces independent namespace patches", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, fetcher);
+    queueUserPreferencePatch("usage_context", { version: 1, showCodexRateLimits: false });
+    queueUserPreferencePatch("usage_context", { version: 1, showCodexRateLimits: true });
+    await vi.advanceTimersByTimeAsync(251);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith(
+      "/v1/me/preferences/usage_context",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ value: { version: 1, showCodexRateLimits: true } }),
+      }),
+    );
+  });
+
+  it("serializes overlapping patches so the latest value is persisted last", async () => {
+    vi.useFakeTimers();
+    let resolveFirst!: (response: Response) => void;
+    let resolveSecond!: (response: Response) => void;
+    const fetcher = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, fetcher, "alice");
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    queueUserPreferencePatch("context_indicator", "compact");
+    await vi.advanceTimersByTimeAsync(251);
+
+    localStorage.removeItem("omnigent:context-indicator-mode");
+    queueUserPreferencePatch("context_indicator", null);
+    await vi.advanceTimersByTimeAsync(251);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    resolveFirst(new Response(null, { status: 200 }));
+    await vi.runOnlyPendingTimersAsync();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls.map((call) => (call[1] as RequestInit).body)).toEqual([
+      JSON.stringify({ value: "compact" }),
+      JSON.stringify({ value: null }),
+    ]);
+    expect(localStorage.getItem("omnigent:user-preferences-dirty")).not.toBeNull();
+
+    resolveSecond(new Response(null, { status: 200 }));
+    await Promise.resolve();
+    expect(localStorage.getItem("omnigent:user-preferences-dirty")).toBeNull();
+  });
+
+  it("retries an unacknowledged patch and clears its durable dirty marker", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, fetcher, "alice");
+    localStorage.setItem(
+      "omnigent:usage-context-preferences",
+      JSON.stringify({ version: 1, showCodexRateLimits: true }),
+    );
+    queueUserPreferencePatch("usage_context", {
+      version: 1,
+      showCodexRateLimits: true,
+    });
+    await vi.advanceTimersByTimeAsync(251);
+    await vi.runOnlyPendingTimersAsync();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem("omnigent:user-preferences-dirty")).toBeNull();
+  });
+
+  it("cancels a pending account patch when the resolved user changes", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, fetcher, "alice");
+    queueUserPreferencePatch("context_indicator", "compact");
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, fetcher, "bob");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending writes when the same owner switches servers", async () => {
+    vi.useFakeTimers();
+    const serverA = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    const serverB = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, serverA, "alice", "server-a");
+    queueUserPreferencePatch("context_indicator", "compact");
+
+    await initializeUserPreferencesSync({ version: 1, settings: {} }, serverB, "alice", "server-b");
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(serverA).not.toHaveBeenCalled();
+    expect(serverB).not.toHaveBeenCalled();
+  });
+
+  it("retains an offline edit across A to B to A using the stable Server id", async () => {
+    vi.useFakeTimers();
+    const serverAFirst = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    const serverB = vi.fn();
+    const serverAReturn = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    await initializeUserPreferencesSync(
+      { version: 1, settings: {} },
+      serverAFirst,
+      "alice",
+      "server-a",
+      "server-a:connection-1",
+    );
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    queueUserPreferencePatch("context_indicator", "compact");
+    await vi.advanceTimersByTimeAsync(251);
+    expect(serverAFirst).toHaveBeenCalledTimes(1);
+
+    await initializeUserPreferencesSync(
+      { version: 1, settings: {} },
+      serverB,
+      "alice",
+      "server-b",
+      "server-b:connection-1",
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBeNull();
+    await initializeUserPreferencesSync(
+      { version: 1, settings: {} },
+      serverAReturn,
+      "alice",
+      "server-a",
+      "server-a:connection-2",
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBe("compact");
+    await vi.advanceTimersByTimeAsync(251);
+
+    expect(serverB).not.toHaveBeenCalled();
+    expect(serverAReturn).toHaveBeenCalledWith(
+      "/v1/me/preferences/context_indicator",
+      expect.objectContaining({ body: JSON.stringify({ value: "compact" }) }),
+    );
+    expect(localStorage.getItem("omnigent:user-preferences-dirty")).toBeNull();
+  });
+
+  it("recovers an offline edit after a reload on the same stable Server", async () => {
+    vi.useFakeTimers();
+    const beforeReload = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    await initializeUserPreferencesSync(
+      { version: 1, settings: {} },
+      beforeReload,
+      "alice",
+      "server-a",
+      "server-a:connection-1",
+    );
+    localStorage.setItem("omnigent:context-indicator-mode", "compact");
+    queueUserPreferencePatch("context_indicator", "compact");
+    await vi.advanceTimersByTimeAsync(251);
+
+    resetUserPreferencesSyncForTests();
+    const afterReload = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    await initializeUserPreferencesSync(
+      { version: 1, settings: {} },
+      afterReload,
+      "alice",
+      "server-a",
+      "server-a:connection-2",
+    );
+    await vi.advanceTimersByTimeAsync(251);
+
+    expect(afterReload).toHaveBeenCalledWith(
+      "/v1/me/preferences/context_indicator",
+      expect.objectContaining({ body: JSON.stringify({ value: "compact" }) }),
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBe("compact");
+    expect(localStorage.getItem("omnigent:user-preferences-dirty-values")).toBeNull();
+  });
+
+  it("ignores a delayed foreground refresh from the previous server", async () => {
+    let resolveA!: (response: Response) => void;
+    const serverA = vi.fn().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveA = resolve;
+      }),
+    );
+    const serverB = vi.fn();
+    await initializeUserPreferencesSync(
+      { version: 1, settings: { context_indicator: "compact" } },
+      serverA,
+      "alice",
+      "server-a",
+    );
+    const refresh = refreshUserPreferencesFromServer();
+    await initializeUserPreferencesSync(
+      { version: 1, settings: { context_indicator: "compact" } },
+      serverB,
+      "alice",
+      "server-b",
+    );
+
+    resolveA(
+      Response.json({
+        user_id: "alice",
+        preferences: { version: 1, settings: { context_indicator: null } },
+      }),
+    );
+    await refresh;
+
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBe("compact");
+  });
+
+  it("refreshes server settings when a long-lived client returns to the foreground", async () => {
+    const fetcher = vi.fn().mockResolvedValue(
+      Response.json({
+        user_id: "alice",
+        preferences: { version: 1, settings: {} },
+      }),
+    );
+    await initializeUserPreferencesSync(
+      { version: 1, settings: { context_indicator: "compact" } },
+      fetcher,
+      "alice",
+    );
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBe("compact");
+
+    await refreshUserPreferencesFromServer();
+
+    expect(fetcher).toHaveBeenCalledWith("/v1/me", { cache: "no-store" });
+    expect(localStorage.getItem("omnigent:context-indicator-mode")).toBeNull();
+  });
+});

--- a/web/src/lib/userPreferencesSync.ts
+++ b/web/src/lib/userPreferencesSync.ts
@@ -53,6 +53,11 @@ let activeOwnerId: string | null = null;
 let activeServerId = "__default__";
 let activeConnectionId = "__default__";
 let syncGeneration = 0;
+let preferenceConnectionIsCurrent = () => true;
+
+function isCurrentPreferenceGeneration(generation: number): boolean {
+  return generation === syncGeneration && preferenceConnectionIsCurrent();
+}
 let refreshListenersInstalled = false;
 let lastFocusRefreshAt = 0;
 const pendingTimers = new Map<UserPreferenceNamespace, number>();
@@ -256,15 +261,15 @@ function hydrateServerEnvelope(envelope: UserPreferencesEnvelope): void {
 export async function refreshUserPreferencesFromServer(): Promise<void> {
   const fetcher = preferenceFetcher;
   const generation = syncGeneration;
-  if (!serverSupportsPreferences || fetcher === null) return;
+  if (!serverSupportsPreferences || fetcher === null || !preferenceConnectionIsCurrent()) return;
   try {
     const response = await fetcher("/v1/me", { cache: "no-store" });
-    if (generation !== syncGeneration) return;
+    if (!isCurrentPreferenceGeneration(generation)) return;
     if (!response.ok) return;
     const data = (await response.json()) as { user_id?: unknown; preferences?: unknown };
     const responseOwner = typeof data.user_id === "string" ? data.user_id : null;
     if (
-      generation !== syncGeneration ||
+      !isCurrentPreferenceGeneration(generation) ||
       responseOwner !== activeOwnerId ||
       !isEnvelope(data.preferences)
     )
@@ -325,6 +330,7 @@ export async function initializeUserPreferencesSync(
   ownerId: string | null = null,
   serverId = "__default__",
   connectionId = serverId,
+  isCurrentConnection: () => boolean = () => true,
 ): Promise<void> {
   if (
     activeOwnerId !== ownerId ||
@@ -337,6 +343,7 @@ export async function initializeUserPreferencesSync(
   activeServerId = serverId;
   activeConnectionId = connectionId;
   preferenceFetcher = fetcher;
+  preferenceConnectionIsCurrent = isCurrentConnection;
   if (serverValue === undefined) {
     // A native client can switch from a newer Server to an older one without
     // reloading the SPA. Cancel writes queued for the previous Server and
@@ -372,11 +379,11 @@ export async function initializeUserPreferencesSync(
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(initialEnvelope),
       });
-      if (generation !== syncGeneration) return;
+      if (!isCurrentPreferenceGeneration(generation)) return;
       if (response.ok) {
         window.localStorage.setItem(USER_PREFERENCES_SCOPE_KEY, preferenceScope);
         const persisted = (await response.json().catch(() => null)) as unknown;
-        if (generation !== syncGeneration) return;
+        if (!isCurrentPreferenceGeneration(generation)) return;
         // A concurrent first device may have initialized the account first.
         // Hydrate the winning server envelope immediately instead of waiting
         // for a reload while showing stale device settings.
@@ -409,7 +416,7 @@ function schedulePatch(
     namespace,
     window.setTimeout(() => {
       pendingTimers.delete(namespace);
-      if (generation !== syncGeneration) return;
+      if (!isCurrentPreferenceGeneration(generation)) return;
       if (inFlightPatches.has(namespace)) {
         patchesAfterFlight.set(namespace, { syncValue, serialized, delayMs: 0, attempt });
         return;
@@ -426,7 +433,7 @@ function schedulePatch(
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ value: syncValue }),
           });
-          if (generation !== syncGeneration) return;
+          if (!isCurrentPreferenceGeneration(generation)) return;
           if (!response?.ok) throw new Error("preference patch failed");
           lastAcknowledged.set(namespace, serialized);
           const current = latestNamespaceValue(namespace);
@@ -443,7 +450,7 @@ function schedulePatch(
             });
           }
         } catch {
-          if (generation === syncGeneration) {
+          if (isCurrentPreferenceGeneration(generation)) {
             const current = latestNamespaceValue(namespace);
             const currentSerialized = serializedNamespaceValue(namespace, current);
             if (currentSerialized !== serialized) {
@@ -465,7 +472,7 @@ function schedulePatch(
           }
         } finally {
           if (inFlightPatches.get(namespace) === generation) inFlightPatches.delete(namespace);
-          if (generation === syncGeneration) {
+          if (isCurrentPreferenceGeneration(generation)) {
             const next = patchesAfterFlight.get(namespace);
             if (next) {
               patchesAfterFlight.delete(namespace);
@@ -486,6 +493,7 @@ export function queueUserPreferencePatch(
     typeof window === "undefined" ||
     applyingServerPreferences ||
     !serverSupportsPreferences ||
+    !preferenceConnectionIsCurrent() ||
     preferenceFetcher === null
   ) {
     return;
@@ -520,6 +528,7 @@ export function resetUserPreferencesSyncForTests(): void {
   activeServerId = "__default__";
   activeConnectionId = "__default__";
   syncGeneration = 0;
+  preferenceConnectionIsCurrent = () => true;
   lastFocusRefreshAt = 0;
   if (refreshListenersInstalled) {
     window.removeEventListener("focus", refreshOnFocus);

--- a/web/src/lib/userPreferencesSync.ts
+++ b/web/src/lib/userPreferencesSync.ts
@@ -1,0 +1,529 @@
+export type UserPreferenceNamespace =
+  | "keyboard_shortcuts"
+  | "mobile_assistant"
+  | "session_navigation"
+  | "context_indicator"
+  | "usage_context"
+  | "agent_badges";
+
+export interface UserPreferencesEnvelope {
+  version: 1;
+  settings: Partial<Record<UserPreferenceNamespace, unknown>>;
+}
+
+type PreferenceFetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+const CATEGORY_CONFIG: Record<UserPreferenceNamespace, { storageKey: string; eventName: string }> =
+  {
+    keyboard_shortcuts: {
+      storageKey: "omnigent:keyboard-shortcut-preferences",
+      eventName: "omnigent:keyboard-shortcuts-changed",
+    },
+    mobile_assistant: {
+      storageKey: "omnigent:mobile-assistant-preferences",
+      eventName: "omnigent:mobile-assistant-changed",
+    },
+    session_navigation: {
+      storageKey: "omnigent:session-navigation",
+      eventName: "omnigent:session-navigation-changed",
+    },
+    context_indicator: {
+      storageKey: "omnigent:context-indicator-mode",
+      eventName: "omnigent:context-indicator-mode-changed",
+    },
+    usage_context: {
+      storageKey: "omnigent:usage-context-preferences",
+      eventName: "omnigent:usage-context-preferences-changed",
+    },
+    agent_badges: {
+      storageKey: "omnigent:agent-badge-preferences",
+      eventName: "omnigent:agent-badge-preferences-changed",
+    },
+  };
+
+const USER_PREFERENCES_SCOPE_KEY = "omnigent:user-preferences-owner";
+const USER_PREFERENCES_DIRTY_KEY = "omnigent:user-preferences-dirty";
+const USER_PREFERENCES_DIRTY_VALUES_KEY = "omnigent:user-preferences-dirty-values";
+const MOBILE_ASSISTANT_DEVICE_STORAGE_KEY = "omnigent:mobile-assistant-device-state";
+
+let preferenceFetcher: PreferenceFetcher | null = null;
+let serverSupportsPreferences = false;
+let applyingServerPreferences = false;
+let activeOwnerId: string | null = null;
+let activeServerId = "__default__";
+let activeConnectionId = "__default__";
+let syncGeneration = 0;
+let refreshListenersInstalled = false;
+let lastFocusRefreshAt = 0;
+const pendingTimers = new Map<UserPreferenceNamespace, number>();
+const lastAcknowledged = new Map<UserPreferenceNamespace, string>();
+interface PendingPatch {
+  syncValue: unknown | null;
+  serialized: string;
+  delayMs: number;
+  attempt: number;
+}
+const patchesAfterFlight = new Map<UserPreferenceNamespace, PendingPatch>();
+const inFlightPatches = new Map<UserPreferenceNamespace, number>();
+
+function dirtyOwnerKey(): string {
+  return `${activeServerId}:${activeOwnerId ?? "__local__"}`;
+}
+
+function readDirtyNamespaces(): Set<UserPreferenceNamespace> {
+  const parsed = safeParse(window.localStorage.getItem(USER_PREFERENCES_DIRTY_KEY));
+  if (!parsed || typeof parsed !== "object") return new Set();
+  const values = (parsed as Record<string, unknown>)[dirtyOwnerKey()];
+  if (!Array.isArray(values)) return new Set();
+  return new Set(
+    values.filter((value): value is UserPreferenceNamespace => value in CATEGORY_CONFIG),
+  );
+}
+
+function writeDirtyNamespaces(values: Set<UserPreferenceNamespace>): void {
+  const parsed = safeParse(window.localStorage.getItem(USER_PREFERENCES_DIRTY_KEY));
+  const all =
+    parsed && typeof parsed === "object" ? { ...(parsed as Record<string, unknown>) } : {};
+  if (values.size === 0) Reflect.deleteProperty(all, dirtyOwnerKey());
+  else all[dirtyOwnerKey()] = [...values];
+  if (Object.keys(all).length === 0) window.localStorage.removeItem(USER_PREFERENCES_DIRTY_KEY);
+  else window.localStorage.setItem(USER_PREFERENCES_DIRTY_KEY, JSON.stringify(all));
+}
+
+function readDirtyValue(namespace: UserPreferenceNamespace): { found: boolean; value: unknown } {
+  const parsed = safeParse(window.localStorage.getItem(USER_PREFERENCES_DIRTY_VALUES_KEY));
+  if (!parsed || typeof parsed !== "object") return { found: false, value: null };
+  const ownerValues = (parsed as Record<string, unknown>)[dirtyOwnerKey()];
+  if (!ownerValues || typeof ownerValues !== "object" || Array.isArray(ownerValues)) {
+    return { found: false, value: null };
+  }
+  if (!Object.hasOwn(ownerValues, namespace)) {
+    return { found: false, value: null };
+  }
+  return { found: true, value: (ownerValues as Record<string, unknown>)[namespace] };
+}
+
+function writeDirtyValue(namespace: UserPreferenceNamespace, value: unknown, remove = false): void {
+  const parsed = safeParse(window.localStorage.getItem(USER_PREFERENCES_DIRTY_VALUES_KEY));
+  const all =
+    parsed && typeof parsed === "object" ? { ...(parsed as Record<string, unknown>) } : {};
+  const current = all[dirtyOwnerKey()];
+  const ownerValues =
+    current && typeof current === "object" && !Array.isArray(current)
+      ? { ...(current as Record<string, unknown>) }
+      : {};
+  if (remove) Reflect.deleteProperty(ownerValues, namespace);
+  else ownerValues[namespace] = value;
+  if (Object.keys(ownerValues).length === 0) Reflect.deleteProperty(all, dirtyOwnerKey());
+  else all[dirtyOwnerKey()] = ownerValues;
+  if (Object.keys(all).length === 0)
+    window.localStorage.removeItem(USER_PREFERENCES_DIRTY_VALUES_KEY);
+  else window.localStorage.setItem(USER_PREFERENCES_DIRTY_VALUES_KEY, JSON.stringify(all));
+}
+
+function markDirty(namespace: UserPreferenceNamespace, value: unknown): void {
+  const dirty = readDirtyNamespaces();
+  dirty.add(namespace);
+  writeDirtyNamespaces(dirty);
+  writeDirtyValue(namespace, value);
+}
+
+function clearDirty(namespace: UserPreferenceNamespace): void {
+  const dirty = readDirtyNamespaces();
+  dirty.delete(namespace);
+  writeDirtyNamespaces(dirty);
+  writeDirtyValue(namespace, null, true);
+}
+
+function safeParse(raw: string | null): unknown | null {
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function mobileSyncValue(value: unknown): unknown | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as { version?: unknown; enabled?: unknown; buttons?: unknown };
+  if (raw.version !== 2 || typeof raw.enabled !== "boolean" || !Array.isArray(raw.buttons)) {
+    return null;
+  }
+  return { version: 2, enabled: raw.enabled, buttons: raw.buttons };
+}
+
+function mobileDeviceState(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const raw = value as { position?: unknown; dock?: unknown };
+  return {
+    ...(raw.position !== undefined ? { position: raw.position } : {}),
+    ...(raw.dock !== undefined ? { dock: raw.dock } : {}),
+  };
+}
+
+function localNamespaceValue(namespace: UserPreferenceNamespace): unknown | null {
+  if (typeof window === "undefined") return null;
+  const { storageKey } = CATEGORY_CONFIG[namespace];
+  const raw = window.localStorage.getItem(storageKey);
+  if (namespace === "context_indicator") return raw === "compact" ? "compact" : null;
+  const parsed = safeParse(raw);
+  return namespace === "mobile_assistant" ? mobileSyncValue(parsed) : parsed;
+}
+
+export function collectLocalUserPreferences(): UserPreferencesEnvelope {
+  const settings: UserPreferencesEnvelope["settings"] = {};
+  (Object.keys(CATEGORY_CONFIG) as UserPreferenceNamespace[]).forEach((namespace) => {
+    const value = localNamespaceValue(namespace);
+    if (value !== null) settings[namespace] = value;
+  });
+  return { version: 1, settings };
+}
+
+function applyNamespace(namespace: UserPreferenceNamespace, value: unknown | null): void {
+  const { storageKey, eventName } = CATEGORY_CONFIG[namespace];
+  let storedValue = value;
+  if (namespace === "mobile_assistant") {
+    const local = safeParse(window.localStorage.getItem(storageKey));
+    const savedDeviceState = safeParse(
+      window.localStorage.getItem(MOBILE_ASSISTANT_DEVICE_STORAGE_KEY),
+    );
+    const deviceState = {
+      ...mobileDeviceState(savedDeviceState),
+      ...mobileDeviceState(local),
+    };
+    if (Object.keys(deviceState).length > 0) {
+      window.localStorage.setItem(MOBILE_ASSISTANT_DEVICE_STORAGE_KEY, JSON.stringify(deviceState));
+    }
+    const syncValue = mobileSyncValue(value);
+    storedValue = syncValue === null ? null : { ...(syncValue as object), ...deviceState };
+  }
+  if (storedValue === null) window.localStorage.removeItem(storageKey);
+  else if (namespace === "context_indicator" && storedValue === "compact") {
+    window.localStorage.setItem(storageKey, "compact");
+  } else {
+    window.localStorage.setItem(storageKey, JSON.stringify(storedValue));
+  }
+  window.dispatchEvent(new Event(eventName));
+}
+
+function isEnvelope(value: unknown): value is UserPreferencesEnvelope {
+  if (!value || typeof value !== "object") return false;
+  const raw = value as { version?: unknown; settings?: unknown };
+  return raw.version === 1 && !!raw.settings && typeof raw.settings === "object";
+}
+
+function serializedNamespaceValue(
+  namespace: UserPreferenceNamespace,
+  value: unknown | null,
+): string {
+  return JSON.stringify(namespace === "mobile_assistant" ? mobileSyncValue(value) : value);
+}
+
+function latestNamespaceValue(namespace: UserPreferenceNamespace): unknown | null {
+  const dirty = readDirtyValue(namespace);
+  return dirty.found ? dirty.value : localNamespaceValue(namespace);
+}
+
+function hydrateServerEnvelope(envelope: UserPreferencesEnvelope): void {
+  const dirty = readDirtyNamespaces();
+  const pendingDirty: UserPreferenceNamespace[] = [];
+  applyingServerPreferences = true;
+  try {
+    for (const namespace of Object.keys(CATEGORY_CONFIG) as UserPreferenceNamespace[]) {
+      const serverNamespace = envelope.settings[namespace] ?? null;
+      if (dirty.has(namespace)) {
+        const retained = readDirtyValue(namespace);
+        if (retained.found) applyNamespace(namespace, retained.value);
+        pendingDirty.push(namespace);
+      } else {
+        applyNamespace(namespace, serverNamespace);
+        lastAcknowledged.set(namespace, serializedNamespaceValue(namespace, serverNamespace));
+      }
+    }
+  } finally {
+    applyingServerPreferences = false;
+  }
+  for (const namespace of pendingDirty) {
+    const retained = readDirtyValue(namespace);
+    queueUserPreferencePatch(
+      namespace,
+      retained.found ? retained.value : localNamespaceValue(namespace),
+    );
+  }
+}
+
+export async function refreshUserPreferencesFromServer(): Promise<void> {
+  const fetcher = preferenceFetcher;
+  const generation = syncGeneration;
+  if (!serverSupportsPreferences || fetcher === null) return;
+  try {
+    const response = await fetcher("/v1/me", { cache: "no-store" });
+    if (generation !== syncGeneration) return;
+    if (!response.ok) return;
+    const data = (await response.json()) as { user_id?: unknown; preferences?: unknown };
+    const responseOwner = typeof data.user_id === "string" ? data.user_id : null;
+    if (
+      generation !== syncGeneration ||
+      responseOwner !== activeOwnerId ||
+      !isEnvelope(data.preferences)
+    )
+      return;
+    hydrateServerEnvelope(data.preferences);
+  } catch {
+    // The durable dirty map retains offline edits for the next focus/reload.
+  }
+}
+
+function refreshOnFocus(): void {
+  const now = Date.now();
+  if (now - lastFocusRefreshAt < 5000) return;
+  lastFocusRefreshAt = now;
+  void refreshUserPreferencesFromServer();
+}
+
+function refreshOnVisibility(): void {
+  if (document.visibilityState === "visible") refreshOnFocus();
+}
+
+function installRefreshListeners(): void {
+  if (refreshListenersInstalled) return;
+  window.addEventListener("focus", refreshOnFocus);
+  document.addEventListener("visibilitychange", refreshOnVisibility);
+  refreshListenersInstalled = true;
+}
+
+function cancelPreferenceActivity(): void {
+  for (const timer of pendingTimers.values()) window.clearTimeout(timer);
+  pendingTimers.clear();
+  patchesAfterFlight.clear();
+  inFlightPatches.clear();
+  lastAcknowledged.clear();
+  syncGeneration += 1;
+}
+
+function downgradeToDeviceOnlyScope(): void {
+  cancelPreferenceActivity();
+  serverSupportsPreferences = false;
+  const preferenceScope = dirtyOwnerKey();
+  const previousScope = window.localStorage.getItem(USER_PREFERENCES_SCOPE_KEY);
+  if (previousScope !== null && previousScope !== preferenceScope) {
+    hydrateServerEnvelope({ version: 1, settings: {} });
+  }
+  window.localStorage.setItem(USER_PREFERENCES_SCOPE_KEY, preferenceScope);
+}
+
+export function deactivateUserPreferencesSync(): void {
+  cancelPreferenceActivity();
+  serverSupportsPreferences = false;
+  preferenceFetcher = null;
+}
+
+export async function initializeUserPreferencesSync(
+  serverValue: unknown | null | undefined,
+  fetcher: PreferenceFetcher,
+  ownerId: string | null = null,
+  serverId = "__default__",
+  connectionId = serverId,
+): Promise<void> {
+  if (
+    activeOwnerId !== ownerId ||
+    activeServerId !== serverId ||
+    activeConnectionId !== connectionId
+  ) {
+    cancelPreferenceActivity();
+  }
+  activeOwnerId = ownerId;
+  activeServerId = serverId;
+  activeConnectionId = connectionId;
+  preferenceFetcher = fetcher;
+  if (serverValue === undefined) {
+    // A native client can switch from a newer Server to an older one without
+    // reloading the SPA. Cancel writes queued for the previous Server and
+    // return to device-only behavior until capability is observed again.
+    downgradeToDeviceOnlyScope();
+    return;
+  }
+  if (serverValue !== null && !isEnvelope(serverValue)) {
+    downgradeToDeviceOnlyScope();
+    return;
+  }
+  serverSupportsPreferences = true;
+  installRefreshListeners();
+  if (serverValue === null) {
+    const generation = syncGeneration;
+    try {
+      const preferenceScope = dirtyOwnerKey();
+      const previousScope = window.localStorage.getItem(USER_PREFERENCES_SCOPE_KEY);
+      // A browser profile can use more than one account or embedded Server.
+      // Never seed a new scope from another scope's origin-wide localStorage,
+      // and clear it before the network call so a failed PUT cannot expose the
+      // previous user's values to the newly resolved identity.
+      const scopeChanged = previousScope !== null && previousScope !== preferenceScope;
+      if (scopeChanged) {
+        hydrateServerEnvelope({ version: 1, settings: {} });
+        window.localStorage.setItem(USER_PREFERENCES_SCOPE_KEY, preferenceScope);
+      }
+      const initialEnvelope = scopeChanged
+        ? { version: 1 as const, settings: {} }
+        : collectLocalUserPreferences();
+      const response = await fetcher("/v1/me/preferences", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(initialEnvelope),
+      });
+      if (generation !== syncGeneration) return;
+      if (response.ok) {
+        window.localStorage.setItem(USER_PREFERENCES_SCOPE_KEY, preferenceScope);
+        const persisted = (await response.json().catch(() => null)) as unknown;
+        if (generation !== syncGeneration) return;
+        // A concurrent first device may have initialized the account first.
+        // Hydrate the winning server envelope immediately instead of waiting
+        // for a reload while showing stale device settings.
+        if (isEnvelope(persisted)) {
+          hydrateServerEnvelope(persisted);
+        }
+      }
+    } catch {
+      // Offline cache remains authoritative until the next successful boot.
+    }
+    return;
+  }
+  if (!isEnvelope(serverValue)) return;
+  window.localStorage.setItem(USER_PREFERENCES_SCOPE_KEY, dirtyOwnerKey());
+  hydrateServerEnvelope(serverValue);
+}
+
+function schedulePatch(
+  namespace: UserPreferenceNamespace,
+  syncValue: unknown | null,
+  serialized: string,
+  delayMs: number,
+  attempt: number,
+): void {
+  const generation = syncGeneration;
+  const fetcher = preferenceFetcher;
+  const existing = pendingTimers.get(namespace);
+  if (existing !== undefined) window.clearTimeout(existing);
+  pendingTimers.set(
+    namespace,
+    window.setTimeout(() => {
+      pendingTimers.delete(namespace);
+      if (generation !== syncGeneration) return;
+      if (inFlightPatches.has(namespace)) {
+        patchesAfterFlight.set(namespace, { syncValue, serialized, delayMs: 0, attempt });
+        return;
+      }
+      if (lastAcknowledged.get(namespace) === serialized && !readDirtyNamespaces().has(namespace)) {
+        return;
+      }
+      if (fetcher === null) return;
+      inFlightPatches.set(namespace, generation);
+      void (async () => {
+        try {
+          const response = await fetcher(`/v1/me/preferences/${namespace}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ value: syncValue }),
+          });
+          if (generation !== syncGeneration) return;
+          if (!response?.ok) throw new Error("preference patch failed");
+          lastAcknowledged.set(namespace, serialized);
+          const current = latestNamespaceValue(namespace);
+          const currentSerialized = serializedNamespaceValue(namespace, current);
+          if (currentSerialized === serialized) {
+            clearDirty(namespace);
+          } else {
+            markDirty(namespace, current);
+            patchesAfterFlight.set(namespace, {
+              syncValue: current,
+              serialized: currentSerialized,
+              delayMs: 0,
+              attempt: 0,
+            });
+          }
+        } catch {
+          if (generation === syncGeneration) {
+            const current = latestNamespaceValue(namespace);
+            const currentSerialized = serializedNamespaceValue(namespace, current);
+            if (currentSerialized !== serialized) {
+              markDirty(namespace, current);
+              patchesAfterFlight.set(namespace, {
+                syncValue: current,
+                serialized: currentSerialized,
+                delayMs: 0,
+                attempt: 0,
+              });
+            } else if (attempt < 3 && !patchesAfterFlight.has(namespace)) {
+              patchesAfterFlight.set(namespace, {
+                syncValue,
+                serialized,
+                delayMs: 1000 * 2 ** attempt,
+                attempt: attempt + 1,
+              });
+            }
+          }
+        } finally {
+          if (inFlightPatches.get(namespace) === generation) inFlightPatches.delete(namespace);
+          if (generation === syncGeneration) {
+            const next = patchesAfterFlight.get(namespace);
+            if (next) {
+              patchesAfterFlight.delete(namespace);
+              schedulePatch(namespace, next.syncValue, next.serialized, next.delayMs, next.attempt);
+            }
+          }
+        }
+      })();
+    }, delayMs),
+  );
+}
+
+export function queueUserPreferencePatch(
+  namespace: UserPreferenceNamespace,
+  value: unknown | null,
+): void {
+  if (
+    typeof window === "undefined" ||
+    applyingServerPreferences ||
+    !serverSupportsPreferences ||
+    preferenceFetcher === null
+  ) {
+    return;
+  }
+  const syncValue = namespace === "mobile_assistant" ? mobileSyncValue(value) : value;
+  const serialized = JSON.stringify(syncValue);
+  if (lastAcknowledged.get(namespace) === serialized && !readDirtyNamespaces().has(namespace))
+    return;
+  markDirty(namespace, syncValue);
+  schedulePatch(namespace, syncValue, serialized, 250, 0);
+}
+
+export function syncAllUserPreferencesFromLocal(): void {
+  const envelope = collectLocalUserPreferences();
+  for (const namespace of Object.keys(CATEGORY_CONFIG) as UserPreferenceNamespace[]) {
+    queueUserPreferencePatch(namespace, envelope.settings[namespace] ?? null);
+    window.dispatchEvent(new Event(CATEGORY_CONFIG[namespace].eventName));
+  }
+}
+
+/** Test-only reset for module-scoped boot/debounce state. */
+export function resetUserPreferencesSyncForTests(): void {
+  for (const timer of pendingTimers.values()) window.clearTimeout(timer);
+  pendingTimers.clear();
+  patchesAfterFlight.clear();
+  inFlightPatches.clear();
+  lastAcknowledged.clear();
+  preferenceFetcher = null;
+  serverSupportsPreferences = false;
+  applyingServerPreferences = false;
+  activeOwnerId = null;
+  activeServerId = "__default__";
+  activeConnectionId = "__default__";
+  syncGeneration = 0;
+  lastFocusRefreshAt = 0;
+  if (refreshListenersInstalled) {
+    window.removeEventListener("focus", refreshOnFocus);
+    document.removeEventListener("visibilitychange", refreshOnVisibility);
+    refreshListenersInstalled = false;
+  }
+}


### PR DESCRIPTION
## Related issue

Part of #6621

## Summary

- Add a compressed, nullable preferences envelope to each user, with once-only initialization and atomic namespace patches through `/v1/me`.
- Enforce authenticated ownership, deleted-account protection, allowlisted/versioned JSON, a 64 KiB persisted limit, a bounded request body, and per-user write throttling.
- Wire the store through `omnigent server`, Docker, and Databricks Apps, and add a capability-detected web sync client that isolates offline work by Server and user. Setting-specific UI consumers will follow separately.
- Bind identity and pending writes to the active host generation, serialize namespace patches so the latest edit wins, preserve mobile position/dock as current-device state, and fail closed for older or unrecognized preference envelopes.

ELI5: the Server now provides one small, private settings record for each user, and the web client has a safe way to read, initialize, and update parts of it without older Servers breaking.

```text
GET /v1/me
    |
    +-- preferences omitted -> older Server, keep device-only behavior
    +-- preferences null    -> PUT local envelope exactly once
    +-- preferences object  -> hydrate local cache
                                |
local setting owner -> queued namespace PATCH -> per-user Server row
```

## Test Plan

- Final focused `pytest` store/API, migration, CLI, Docker, and Databricks wiring matrix: 29 passed.
- Real `omnigent server` subprocess with two authenticated HTTP clients: 1 passed.
- `vitest` identity and preference sync suites, including host-switch races before identity resolution, delayed response bodies, and overlapping writes: 51 passed.
- Ruff, Pyrefly, Prettier, Oxlint, TypeScript, generated OpenAPI, and Vite production build passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The real-process E2E starts `omnigent server`, initializes preferences as one authenticated user, creates a second HTTP client, and verifies that `GET /v1/me` returns the same persisted envelope.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage exercises the store, HTTP contract, account-deletion guard, size and rate limits, all three production entrypoints, migration round trips, identity initialization, offline retries, Server switching, ordered patches, and device-local mobile placement. Three broader Databricks web-UI harness tests retain their existing Windows-only POSIX PATH/bash failures; the new Databricks wiring test passes. This PR adds no visible setting controls, so there is no visual demo.

## Changelog

Authenticated clients can now persist a versioned, per-user preferences envelope on the Server.
