### PR TITLE
fix(sandboxes): avoid host rule for public microsandbox servers

### DIFF
--- a/deploy/microsandbox/README.md
+++ b/deploy/microsandbox/README.md
@@ -72,7 +72,7 @@ sandbox:
 | `all` | Everything, including private LANs. |
 
 Under `host` mode, VMs run untrusted agent code on the same machine as the server, so guest-to-host access is always scoped to a TCP port allowlist.
-Managed VMs allow the `server_url` port plus any `host_ports` entries.
+Managed VMs allow the `server_url` port when it uses `host.microsandbox.internal`, plus any explicit `host_ports` entries.
 List the ports of host-local services agents legitimately need - e.g. `host_ports: [8317]` for a local LLM gateway the sandbox env points at via `http://host.microsandbox.internal:8317`.
 Everything else on the host stays unreachable.
 CLI-bootstrap VMs allow only the local `--server` port; public server URLs add no host rule.

--- a/omnigent/onboarding/sandboxes/microsandbox.py
+++ b/omnigent/onboarding/sandboxes/microsandbox.py
@@ -99,7 +99,8 @@ configured host ports; ``public-only`` drops all host rules (use it when
 ``server_url`` is a genuinely public URL); ``all`` opens LAN/private egress
 too."""
 
-_HOST_GATEWAY_NAME = "host.microsandbox.internal"
+HOST_GATEWAY_NAME: str = "host.microsandbox.internal"
+"""Stable guest hostname for the machine running microsandbox."""
 
 # Resources for the VM. Matches the Modal / Daytona / boxlite launchers:
 # 2 vCPU / 4 GiB is enough for a host running one interactive session.
@@ -161,7 +162,7 @@ except OSError:
 def _host_ports_for_server_url(server_url: str) -> tuple[int, ...]:
     """Return the host-gateway port needed to reach a local server URL."""
     split = urlsplit(server_url.strip())
-    if (split.hostname or "").lower() != _HOST_GATEWAY_NAME:
+    if (split.hostname or "").lower() != HOST_GATEWAY_NAME:
         return ()
     try:
         port = split.port

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -2218,19 +2218,21 @@ def _resolve_microsandbox_host_ports(raw: dict[str, object], server_url: str) ->
 
     Managed VMs run untrusted agent code on the SAME machine as the server,
     so their default ``host`` network mode is scoped to explicit ports rather
-    than the whole host: the port of *server_url* (the dial-back path) plus
-    any operator-listed ``sandbox.microsandbox.host_ports`` (e.g. a local LLM
-    gateway). Only the launcher's managed path receives this list - the CLI
-    bootstrap constructs the launcher without one and keeps full host access
-    (a locally self-hosted server's port isn't known at creation time).
+    than the whole host: the port of *server_url* when it targets the host
+    gateway, plus any operator-listed ``sandbox.microsandbox.host_ports``
+    (e.g. a local LLM gateway). Public server URLs need only public egress and
+    do not implicitly expose the same port on the host machine.
 
     :param raw: The raw ``sandbox`` mapping.
     :param server_url: The validated ``sandbox.server_url`` value.
-    :returns: De-duplicated port list, always containing the server port.
+    :returns: De-duplicated host port list, containing the server port only
+        when the URL targets ``host.microsandbox.internal``.
     :raises ValueError: When ``host_ports`` is present but not a list of
         integers in 1-65535, or the server URL carries no resolvable port.
     """
     from urllib.parse import urlsplit
+
+    from omnigent.onboarding.sandboxes.microsandbox import HOST_GATEWAY_NAME
 
     split = urlsplit(server_url.strip())
     server_port = split.port
@@ -2244,7 +2246,7 @@ def _resolve_microsandbox_host_ports(raw: dict[str, object], server_url: str) ->
             "non-zero port for the microsandbox provider (an explicit :port, "
             "or an http/https scheme)"
         )
-    ports = [server_port]
+    ports = [server_port] if (split.hostname or "").lower() == HOST_GATEWAY_NAME else []
     section = _parse_provider_section(raw, "microsandbox")
     extra = section.get("host_ports") if section is not None else None
     if extra is not None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -1464,10 +1464,10 @@ def test_parse_microsandbox_without_section_defaults(
     assert fake.host_ports == [8799]
 
 
-def test_parse_microsandbox_derives_scheme_default_port(
+def test_parse_microsandbox_public_server_does_not_open_host_port(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A server_url without an explicit port scopes host access by scheme."""
+    """A public server URL needs no corresponding host-machine rule."""
     cfg = parse_sandbox_config(
         {"provider": "microsandbox", "server_url": "https://omnigent.example.com"}
     )
@@ -1476,7 +1476,25 @@ def test_parse_microsandbox_derives_scheme_default_port(
     fake = FakeSandboxLauncher()
     install_fake_microsandbox_launcher(monkeypatch, fake)
     assert cfg.launcher_factory() is fake
-    assert fake.host_ports == [443]
+    assert fake.host_ports == []
+
+
+def test_parse_microsandbox_public_server_keeps_explicit_host_ports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operators can still expose named host-local services explicitly."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "microsandbox",
+            "server_url": "https://omnigent.example.com",
+            "microsandbox": {"host_ports": [8317]},
+        }
+    )
+    assert cfg is not None
+    fake = FakeSandboxLauncher()
+    install_fake_microsandbox_launcher(monkeypatch, fake)
+    assert cfg.default.launcher_factory() is fake
+    assert fake.host_ports == [8317]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related issue

Follow-up to #2875 and [Polly's blocking review](https://github.com/omnigent-ai/omnigent/pull/2875#issuecomment-5557138039).

## Summary

- Add the managed `server_url` port to the guest-to-host allowlist only when the URL targets `host.microsandbox.internal`.
- Keep operator-configured `sandbox.microsandbox.host_ports` available for public-server deployments.
- Correct the managed-network documentation that still described the old CLI behavior.

## Test Plan

- `.venv/bin/python -m pytest -q tests/server/test_managed_hosts.py -k microsandbox` — 13 passed.
- `.venv/bin/python -m pytest -q tests/onboarding/sandboxes/test_microsandbox.py tests/onboarding/sandboxes/test_registry.py` — 73 passed.
- `.venv/bin/pre-commit run --files $(git diff --name-only origin/main...)` — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Public `https://omnigent.example.com` now resolves to an empty implicit host allowlist, while `http://host.microsandbox.internal:8799` still resolves to `[8799]` and explicit `host_ports: [8317]` remains `[8317]`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage exercises local server URLs, public server URLs, and explicit host-port overrides through the full managed-sandbox config parser and launcher factory.

## Changelog

Managed microsandbox VMs no longer expose a host-machine port merely because a public server URL uses the same port.
