### PR TITLE
ci: isolate trusted cache-producing checkouts

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -10,7 +10,7 @@ name: E2E UI Tests
 # Triggers:
 #   pull_request        ALL PRs (same-repo + fork). Draft PRs skip.
 #   schedule            09:00 UTC daily, alongside nightly.yml.
-#   workflow_dispatch   manual run. Input `branch` selects a non-main ref.
+#   workflow_dispatch   manual run on the selected workflow ref.
 
 on:
   pull_request:
@@ -22,19 +22,13 @@ on:
   schedule:
     - cron: "0 9 * * *"
   workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to run UI tests against"
-        required: false
-        default: "main"
 
 permissions:
   contents: read
 
 concurrency:
-  # PRs key by number, dispatch by branch (so re-runs cancel); push /
-  # schedule key by SHA so each merge to `main` gets its own run.
-  group: e2e-ui-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}
+  # PRs key by number, dispatch by ref (so re-runs cancel), and schedule by SHA.
+  group: e2e-ui-${{ github.workflow }}-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.ref) || github.sha }}
   cancel-in-progress: true
 
 env:
@@ -106,8 +100,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
@@ -160,8 +152,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ name: E2E Tests
 #
 # Triggers:
 #   schedule            09:00 UTC daily (alongside nightly.yml).
-#   workflow_dispatch   manual run. Inputs: `branch` (non-main ref) and
+#   workflow_dispatch   manual run on the selected workflow ref. Input:
 #                       `parallelism` (pytest `-n` worker count).
 #   pull_request        PR gate for ALL PRs -- same-repo AND fork. This suite
 #                       runs entirely against the in-process mock LLM (no
@@ -26,10 +26,6 @@ on:
     paths-ignore: ['web/**', 'tests/e2e_ui/**', 'CHANGELOG.md']
   workflow_dispatch:
     inputs:
-      branch:
-        description: "Branch to run e2e tests against"
-        required: false
-        default: "main"
       parallelism:
         description: "Number of pytest workers per shard (-n flag). Default 2 keeps per-shard concurrency low so the 4 shards * 2 workers = 8 concurrent gateway calls stays below the nightly's pain point (20 concurrent triggered 429s)."
         required: false
@@ -39,7 +35,7 @@ concurrency:
   # PRs key by number, dispatch by branch (so re-runs cancel); schedule keys
   # by SHA so each merge to `main` gets its own run. Label events append the
   # label name so they get an isolated slot and never cancel a code-push run.
-  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name || 'run' }}
+  group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.ref) || github.sha }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name || 'run' }}
   cancel-in-progress: true
 
 permissions:
@@ -116,12 +112,9 @@ jobs:
 
     steps:
       - name: Checkout
+        # The default is the PR merge commit for pull_request and the workflow
+        # ref for schedule/dispatch, keeping checked-out code in its cache scope.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          # PRs (same-repo and fork) test the merge result (refs/pull/N/merge --
-          # absent when the PR conflicts, so a conflicted PR fails checkout by
-          # design). Schedule / dispatch fall back to the branch / ref.
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.event.inputs.branch || github.ref }}
 
       # Steps below are shared verbatim with server-compat.yml's backcompat-e2e
       # job via the composite action, so the two never drift. server_version

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,8 +34,8 @@ env:
   CLAUDE_CODE: ""
 
 concurrency:
-  # Key by PR number so re-syncs cancel; push/dispatch key by SHA/branch.
-  group: integration-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.inputs.branch || github.sha }}
+  # Key by PR number so re-syncs cancel, dispatch by ref, and schedule by SHA.
+  group: integration-${{ github.workflow }}-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.ref) || github.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -92,8 +92,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
 
       # Shared verbatim with server-compat.yml's backcompat-integration job via
       # the composite action, so the two never drift. server_version is omitted

--- a/.github/workflows/server-compat.yml
+++ b/.github/workflows/server-compat.yml
@@ -99,7 +99,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
           fetch-depth: 0
       - name: Run compat smoke (Config 1)
         uses: ./.github/actions/compat-smoke-run
@@ -116,7 +115,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
           fetch-depth: 0
       - name: Run compat smoke (Config 2)
         uses: ./.github/actions/compat-smoke-run
@@ -133,7 +131,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
           fetch-depth: 0
       - name: Run UI compat smoke (Config A)
         uses: ./.github/actions/compat-smoke-ui-run
@@ -150,7 +147,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
           fetch-depth: 0
       - name: Run UI compat smoke (Config B)
         uses: ./.github/actions/compat-smoke-ui-run


### PR DESCRIPTION
## Related issue

N/A — resolves CodeQL cache-poisoning alerts #192, #193, #194, #196, #197, #198, #199, #200, #201, and #243.

## Summary

- Remove explicit checkout refs from E2E, UI E2E, integration, and compatibility jobs. `actions/checkout` already selects the PR merge commit for `pull_request` and the workflow ref for scheduled/manual runs.
- Replace the E2E and UI E2E independent `branch` inputs with GitHub's native workflow-dispatch ref, keeping executed code and GitHub's cache scope on the same ref.
- Align dispatch concurrency keys with the native workflow ref while preserving PR merge-result testing, full-history compatibility checkouts, and cache performance.

**ELI5:** A run must not say “I belong to main” while executing code selected through a separate ref expression, because that code could write a cache later trusted by main. Letting GitHub select the checkout keeps code and cache in the same security boundary.

```text
Before: default-branch run ── custom ref expression ──> other code ──> main cache
After:  workflow ref       ── default checkout       ──> same code  ──> same-ref cache
```

## Test Plan

- `pre-commit run check-yaml --files .github/workflows/e2e.yml .github/workflows/e2e-ui.yml .github/workflows/integration.yml .github/workflows/server-compat.yml`
- `pre-commit run trailing-whitespace --files .github/workflows/e2e.yml .github/workflows/e2e-ui.yml .github/workflows/integration.yml .github/workflows/server-compat.yml`
- `pre-commit run end-of-file-fixer --files .github/workflows/e2e.yml .github/workflows/e2e-ui.yml .github/workflows/integration.yml .github/workflows/server-compat.yml`
- `git diff --check`
- Verified no workflow references `github.event.inputs.branch`.
- CodeQL Actions analysis confirms the cache-poisoning alerts are resolved.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The workflow diff and CodeQL Actions result provide the non-visual evidence.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified the checkout/ref expressions and parsed all affected workflow files through the repository's YAML pre-commit check. GitHub Actions and CodeQL provide runtime validation.