### PR TITLE
fix(web): let keyboard/AT scrolling settle the file-panel scroll restore

### DIFF
--- a/web/src/shell/useScrollRestore.test.tsx
+++ b/web/src/shell/useScrollRestore.test.tsx
@@ -147,6 +147,20 @@ describe("useScrollRestore", () => {
     expect(getSavedScrollTop("view:wheel")).toBe(12);
   });
 
+  it("stops fighting a keyboard / assistive-tech scroll during a pending restore", async () => {
+    // Keyboard scrolling (PageDown/arrows/Space) and AT scroll-into-view fire
+    // keydown, not wheel/pointer — the restore must yield to them too, or it
+    // snaps the reader back for the whole budget.
+    saveScrollTop("view:keydown", 300);
+    const { el } = mount("view:keydown");
+
+    fireEvent.keyDown(el, { key: "PageDown" });
+    el.scrollTop = 42;
+    fireEvent.scroll(el);
+
+    expect(getSavedScrollTop("view:keydown")).toBe(42);
+  });
+
   it("saves again once the restore has settled", async () => {
     saveScrollTop("view:settle", 90);
     const { el } = mount("view:settle");

--- a/web/src/shell/useScrollRestore.ts
+++ b/web/src/shell/useScrollRestore.ts
@@ -27,8 +27,14 @@ export function saveScrollTop(key: string, scrollTop: number): void {
  */
 export const SCROLL_RESTORE_BUDGET_MS = 1500;
 
-/** Pointer/touch/wheel input that means the user has taken over scrolling. */
-const USER_SCROLL_EVENTS = ["wheel", "touchstart", "pointerdown"] as const;
+/**
+ * Input that means the reader has taken over scrolling, so the restore must
+ * stop re-asserting the saved offset and never fight them. Includes `keydown`
+ * for keyboard and assistive-tech scrolling (PageDown/arrows/Space/Home/End),
+ * not just pointer/touch/wheel — otherwise a keyboard scroll within the restore
+ * budget would be snapped back each frame.
+ */
+const USER_SCROLL_EVENTS = ["wheel", "touchstart", "pointerdown", "keydown"] as const;
 
 /** The slice of a Monaco code editor the scroll restore needs. */
 interface ScrollableEditor {


### PR DESCRIPTION
## Related issue

N/A — accessibility fix / follow-up to #6518.

## Summary

Follow-up to #6518 (workspace file-tree virtualization), addressing the one blocking accessibility note from that PR's final review.

`useScrollRestore` re-asserts the saved `scrollTop` on every animation frame for the full 1.5s restore budget, and only `wheel` / `touchstart` / `pointerdown` counted as a "user took over" signal that settles it. So a **keyboard** scroll (PageDown, arrows, Space, Home/End) or a screen-reader scroll-into-view within that window — right after a mount, conversation switch, or key change — got snapped back each frame. It's an accessibility regression, and it affects **every** consumer of the shared hook (the Files panel and the file-viewer surfaces), not just the tree.

Fix: add `keydown` to the takeover set, so a keyboard/assistive-tech scroll settles the restore exactly like a pointer gesture already does. The save-suppression behavior (keeping `pendingRef` non-null so measurement-driven scrolls can't overwrite the saved offset) is unchanged — this only adds keyboard to what counts as the reader taking over.

> Not re-adding the old reachability early-exit (`maxScroll >= target`) instead: it settled on the first frame, before a virtualized tree finishes measuring its row heights, which is what let a measurement-driven scroll overwrite the saved offset in the first place (the regression #6518 fixed). `keydown` takeover is orthogonal and doesn't reopen that.

## Test Plan

- `tsc -b`, `oxlint`, `prettier` — clean.
- `vitest run src/shell/useScrollRestore.test.tsx` — 11/11, including a new keyboard-takeover regression test (verified it fails without `keydown` in the takeover set and passes with it).

Manual: in the Files panel or a file viewer, switch conversations and immediately press PageDown/arrows — the view should scroll and stay where you put it, not snap back.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Behavior-only, keyboard/AT interaction; no intended visual change. See Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added a unit test asserting a `keydown` during a pending restore settles it (so a subsequent scroll is persisted rather than fought). Confirmed it fails on the pre-fix takeover set and passes after adding `keydown`.

## Changelog

Keyboard and screen-reader scrolling in the file panel and file viewer is no longer snapped back right after switching conversations
