### PR TITLE
Gate direct session imports on host capability

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -42,6 +42,7 @@ from omnigent.host import HOST_FATAL_EXIT_CODE
 from omnigent.host.daemon_lifecycle import DaemonLifecycleLock
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    IMPORT_LOCAL_BY_ID_CAPABILITY,
     WORKSPACE_MISSING_ERROR_CODE,
     HostConnectionErrorFrame,
     HostCreateDirFrame,
@@ -3770,6 +3771,7 @@ class HostProcess:
             frame_protocol_version=1,
             name=self._identity.name,
             runners=self._alive_runner_ids(),
+            capabilities=[IMPORT_LOCAL_BY_ID_CAPABILITY],
             configured_harnesses=self._configured_harnesses,
             gateway_inference=self._gateway_inference,
             telemetry_opt_out=_tel_opt_out,

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -38,6 +38,9 @@ HARNESS_NOT_CONFIGURED_ERROR_CODE = "harness_not_configured"
 # daemon (producer) and server (consumer) so both can handle it structurally.
 WORKSPACE_MISSING_ERROR_CODE = "workspace_missing"
 
+# Host supports loading one local harness transcript without enumerating history.
+IMPORT_LOCAL_BY_ID_CAPABILITY = "import_local_by_id"
+
 
 class HostFrameKind(str, Enum):
     """All host frame kinds; the value is the JSON wire string."""
@@ -95,6 +98,8 @@ class HostHelloFrame:
     :param runners: Runner IDs currently alive on this host.
         Enables state reconciliation on reconnect — the server
         diffs this against sessions in the DB.
+    :param capabilities: Additive host features the server may use. An empty
+        list means the host predates capability negotiation.
     :param configured_harnesses: Per-harness readiness on this
         machine, e.g. ``{"claude-sdk": True, "codex": False}``
         (see ``omnigent.onboarding.harness_readiness``). Keys
@@ -115,6 +120,7 @@ class HostHelloFrame:
     frame_protocol_version: int
     name: str
     runners: list[str] = field(default_factory=list)
+    capabilities: list[str] = field(default_factory=list)
     configured_harnesses: dict[str, HarnessAvailability] | None = None
     gateway_inference: dict[str, bool] | None = None
     telemetry_opt_out: bool = False
@@ -1045,6 +1051,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "frame_protocol_version": frame.frame_protocol_version,
                 "name": frame.name,
                 "runners": list(frame.runners),
+                "capabilities": list(frame.capabilities),
                 "configured_harnesses": frame.configured_harnesses,
                 "gateway_inference": frame.gateway_inference,
                 "telemetry_opt_out": frame.telemetry_opt_out,
@@ -1554,6 +1561,7 @@ def _decode_host_hello(msg: _JsonObject) -> HostHelloFrame:
         frame_protocol_version=_required_int(msg, "frame_protocol_version"),
         name=_required_str(msg, "name"),
         runners=_optional_str_list(msg, "runners"),
+        capabilities=_optional_str_list(msg, "capabilities"),
         configured_harnesses=_optional_str_availability_map(msg, "configured_harnesses"),
         gateway_inference=optional_str_bool_map(msg, "gateway_inference"),
         telemetry_opt_out=bool(msg.get("telemetry_opt_out", False)),

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -18,7 +18,12 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.host.frames import HostImportLocalByIdFrame, HostImportLocalFrame, encode_host_frame
+from omnigent.host.frames import (
+    IMPORT_LOCAL_BY_ID_CAPABILITY,
+    HostImportLocalByIdFrame,
+    HostImportLocalFrame,
+    encode_host_frame,
+)
 from omnigent.native_coding_agents import native_coding_agent_for_harness
 from omnigent.server.auth import LEVEL_OWNER, AuthProvider
 from omnigent.server.host_registry import HostConnection, HostRegistry
@@ -465,6 +470,15 @@ def create_imports_router(
             # an offline host: WRONG_REPLICA (400) so the client re-addresses
             # keyless, CONFLICT (409) only when the row is genuinely stale.
             raise host_absent_error(host)
+        if (
+            body.session_id is not None
+            and IMPORT_LOCAL_BY_ID_CAPABILITY not in host_conn.hello.capabilities
+        ):
+            raise OmnigentError(
+                f"host '{host_conn.host_id}' does not support importing by session ID; "
+                "update and restart the host, then try again",
+                code=ErrorCode.CONFLICT,
+            )
         return user_id, host_conn
 
     async def _import_local_core(

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -599,12 +599,24 @@ def load_codex_session(
     codex_home: Path | None = None,
 ) -> LocalSessionImport:
     """Load one Codex session from its local rollout JSONL file."""
-    configured_home = os.environ.get("CODEX_HOME")
-    home = codex_home or (Path(configured_home).expanduser() if configured_home else None)
-    home = home or Path.home() / ".codex"
-    rollout_path = _find_codex_rollout(home, session_id) or _find_archived_codex_rollout(
-        home, session_id
-    )
+    default_home = Path.home() / ".codex"
+    if codex_home is not None:
+        homes = (codex_home,)
+    else:
+        configured_home = os.environ.get("CODEX_HOME")
+        configured = Path(configured_home).expanduser() if configured_home else default_home
+        homes = (configured,) if configured == default_home else (configured, default_home)
+
+    home = homes[0]
+    rollout_path: Path | None = None
+    for candidate_home in homes:
+        candidate = _find_codex_rollout(
+            candidate_home, session_id
+        ) or _find_archived_codex_rollout(candidate_home, session_id)
+        if candidate is not None:
+            home = candidate_home
+            rollout_path = candidate
+            break
     if rollout_path is None:
         raise SessionImportNotFoundError(f"Codex session {session_id!r} was not found")
 

--- a/tests/e2e_ui/sessions/test_import_sessions.py
+++ b/tests/e2e_ui/sessions/test_import_sessions.py
@@ -119,7 +119,10 @@ def test_settings_import_panel_imports_one_session_by_id(
     page.get_by_role("option", name="Session by ID").click()
     page.get_by_test_id("import-source-select").click()
     page.get_by_role("option", name="Codex").click()
-    page.get_by_test_id("import-session-id").fill("session-exact")
+    session_id_input = page.get_by_test_id("import-session-id")
+    session_id_input.fill("  session-exact  ")
+    session_id_input.blur()
+    expect(session_id_input).to_have_value("session-exact")
     page.get_by_test_id("import-submit").click()
 
     expect(page.get_by_test_id("import-result")).to_contain_text("Imported 1", timeout=30_000)

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -30,6 +30,7 @@ from omnigent.host.connect import (
 )
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    IMPORT_LOCAL_BY_ID_CAPABILITY,
     HostConnectionErrorFrame,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
@@ -1341,6 +1342,7 @@ async def test_hello_advertises_installed_version() -> None:
     hello = decode_host_frame(tunnel.sent[0])
     assert isinstance(hello, HostHelloFrame)
     assert hello.version == VERSION
+    assert hello.capabilities == [IMPORT_LOCAL_BY_ID_CAPABILITY]
     # Guard against the old hard-coded literal creeping back.
     assert hello.version != "0.1.0"
 

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -8,6 +8,7 @@ import pytest
 
 from omnigent.host.frames import (
     HARNESS_NOT_CONFIGURED_ERROR_CODE,
+    IMPORT_LOCAL_BY_ID_CAPABILITY,
     HostConnectionErrorFrame,
     HostCreateDirFrame,
     HostCreateDirResultFrame,
@@ -229,6 +230,7 @@ def test_hello_frame_round_trip() -> None:
         frame_protocol_version=1,
         name="corey-laptop",
         runners=["runner_token_aaa", "runner_token_bbb"],
+        capabilities=[IMPORT_LOCAL_BY_ID_CAPABILITY],
     )
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
@@ -236,6 +238,7 @@ def test_hello_frame_round_trip() -> None:
     assert decoded.frame_protocol_version == 1
     assert decoded.name == "corey-laptop"
     assert decoded.runners == ["runner_token_aaa", "runner_token_bbb"]
+    assert decoded.capabilities == [IMPORT_LOCAL_BY_ID_CAPABILITY]
 
 
 def test_hello_frame_empty_runners() -> None:
@@ -252,6 +255,7 @@ def test_hello_frame_empty_runners() -> None:
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
     assert decoded.runners == []
+    assert decoded.capabilities == []
 
 
 def test_launch_runner_frame_round_trip() -> None:

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.host.frames import HostHelloFrame
 from omnigent.server.host_registry import HostRegistry
 from omnigent.server.routes.imports import (
     LocalImportRequest,
@@ -615,3 +616,26 @@ async def test_import_local_offline_host_is_conflict(db_uri: str) -> None:
         )
     assert res.status_code == 409
     assert res.json()["error"]["code"] == ErrorCode.CONFLICT
+
+
+async def test_import_local_by_id_rejects_host_without_capability(db_uri: str) -> None:
+    """An older host fails before the streaming response or tunnel request starts."""
+    host_id = "host_0123456789abcdef0123456789abcdef"
+    HostStore(db_uri).upsert_on_connect(host_id, "laptop", "alice@example.com")
+    registry = HostRegistry()
+    conn = registry.register(
+        host_id,
+        SimpleNamespace(),  # type: ignore[arg-type]
+        HostHelloFrame(version="0.1.0-test", frame_protocol_version=1, name="laptop"),
+        owner=None,
+    )
+
+    async with _host_import_client(db_uri, registry) as client:
+        res = await client.post(
+            "/v1/imports/local/stream",
+            json={"host_id": host_id, "source": "codex", "session_id": "session-exact"},
+        )
+
+    assert res.status_code == 409
+    assert "update and restart the host" in res.json()["error"]["message"]
+    assert conn.outbound_queue.empty()

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -686,6 +686,22 @@ def _write_codex_threads_db(
         con.close()
 
 
+def test_load_codex_session_falls_back_to_default_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An inherited isolated CODEX_HOME does not hide the user's normal transcripts."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    user_home = tmp_path / "user"
+    _write_codex_rollout(user_home / ".codex", session_id, first_message="from default home")
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "isolated-codex-home"))
+    monkeypatch.setattr("pathlib.Path.home", lambda: user_home)
+
+    imported = load_codex_session(session_id)
+
+    assert imported.title == "from default home"
+
+
 def test_load_codex_session_uses_custom_thread_title(tmp_path: Path) -> None:
     """A renamed Codex thread (title != first message) carries its custom name."""
     session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"

--- a/web/src/shell/ImportSessionsPanel.test.tsx
+++ b/web/src/shell/ImportSessionsPanel.test.tsx
@@ -125,6 +125,8 @@ describe("ImportSessionsPanel", () => {
     const idInput = screen.getByTestId("import-session-id");
     expect(screen.getByTestId("import-submit")).toBeDisabled();
     fireEvent.change(idInput, { target: { value: "  session-exact  " } });
+    fireEvent.blur(idInput);
+    expect(idInput).toHaveValue("session-exact");
     fireEvent.click(screen.getByTestId("import-submit"));
 
     await waitFor(() =>

--- a/web/src/shell/ImportSessionsPanel.tsx
+++ b/web/src/shell/ImportSessionsPanel.tsx
@@ -80,6 +80,7 @@ export function ImportSessionsPanel() {
     if (hostId === null) return;
     const exactSessionId = sessionId.trim();
     if (mode === "session" && exactSessionId.length === 0) return;
+    if (mode === "session") setSessionId(exactSessionId);
     setSubmitting(true);
     setError(null);
     setResult(null);
@@ -199,6 +200,7 @@ export function ImportSessionsPanel() {
             autoComplete="off"
             placeholder="Enter a session ID"
             onChange={(event) => setSessionId(event.target.value)}
+            onBlur={() => setSessionId((value) => value.trim())}
             onKeyDown={(event) => {
               if (event.key === "Enter") void handleImport();
             }}


### PR DESCRIPTION
## Related issue

Related to #4462

## Summary

- Advertise additive host capabilities in `host.hello` and gate direct session-ID imports on `import_local_by_id`.
- Return an immediate 409 with an update/restart instruction when a new server is paired with an older host, instead of waiting 60 seconds for an unknown frame.
- Trim pasted session IDs and let Codex imports fall back from an isolated `CODEX_HOME` to the user's normal `~/.codex` history.

ELI5: the server asks whether the host understands direct imports before sending one. If it does not, the UI gets a useful error immediately.

```text
host.hello capabilities -> server checks import_local_by_id -> send exact-import frame
                                                      \-> 409 update-host error
```

## Test Plan

- Focused host frame, tunnel, import route, and transcript tests: 53 passed.
- `npm --prefix web test`: 6,785 passed, 3 expected failures, 1 skipped.
- `npm --prefix web run lint`
- `npm --prefix web run build`
- `uv run pytest tests/e2e_ui/sessions/test_import_sessions.py -q`: 3 passed.
- `.venv/bin/pre-commit run --all-files`

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

![Direct session import by harness and ID](https://github.com/marktai/omnigent/releases/download/mt--direct-session-import-demo/direct-session-import.png)

## Type of change

- [x] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The route regression test verifies an older host gets a 409 before any tunnel frame is queued. Frame and host tests cover capability negotiation; UI and transcript tests cover trimming and Codex-home fallback.

## Changelog

Direct session imports fail immediately with an update instruction on older hosts, accept IDs with surrounding whitespace, and find Codex sessions in the normal user history.
