### PR TITLE
fix(slack): give id-less (SDK) harnesses a message boundary signal

### DIFF
--- a/integrations/slack/DESIGN.md
+++ b/integrations/slack/DESIGN.md
@@ -122,6 +122,13 @@ generator already running".
   only), the newest server message is recovered as a last resort — guarded so it
   can't resurrect a prior turn's message (baseline compare) or re-post an answer
   an earlier sealed segment already showed (`already_delivered`).
+- **Paragraph-break boundary, id-bearing or id-less.** A new assistant message
+  inside a turn gets a paragraph break so back-to-back messages don't run
+  together. An id-bearing harness (claude-native) is authoritative: a
+  `message_id` change IS the boundary. The in-process harness (claude-sdk)
+  never sets one, so `_AnswerReply` falls back to `mark_message_end()` —
+  raised when the server commits a message (`response.output_item.done`) —
+  consulted only when both the current and prior `message_id` are `None`.
 
 ## Elicitations (tool approvals & questions): pure-push
 

--- a/integrations/slack/src/omnigent_slack/service.py
+++ b/integrations/slack/src/omnigent_slack/service.py
@@ -885,6 +885,10 @@ class SlackOmnigentService:
 
         item_text = extract_assistant_text(event)
         if item_text:
+            # ``response.output_item.done`` for an assistant message: it committed.
+            # For an id-less harness (claude-sdk) that is the only signal the
+            # message ended, so the next delta gets a break instead of running on.
+            reply.mark_message_end()
             reply.set_final(item_text)
 
         event_error = extract_error_text(event)

--- a/integrations/slack/src/omnigent_slack/streaming.py
+++ b/integrations/slack/src/omnigent_slack/streaming.py
@@ -226,10 +226,12 @@ class _AnswerReply:
         # stable id, and emit several per turn (narration between tool calls). The
         # deltas arrive back to back, so without a boundary the last sentence of one
         # message butts directly against the first of the next ("…once more.The
-        # credentials…"). We insert a paragraph break when the id changes. ``None``
-        # (ordinary in-process streaming, where deltas already group by the active
-        # response) never triggers one — the behavior there is unchanged.
+        # credentials…"). We insert a paragraph break when the id changes.
         self._last_message_id: str | None = None
+        # Whether an assistant message committed since the last delta. The boundary
+        # signal for an id-LESS stream: in-process/SDK harnesses (claude-sdk) leave
+        # ``message_id`` None for every message, so the id above never changes.
+        self._message_ended = False
         # Text put on screen in each sealed segment this turn. Unlike
         # ``_streamed``/``_final`` (which reset at each seal), this survives
         # interruptions, so the no-delta fallback can tell whether the server's
@@ -256,24 +258,31 @@ class _AnswerReply:
     def streamed_len(self) -> int:
         return len(self._streamed)
 
+    def mark_message_end(self) -> None:
+        """Record that the assistant message being streamed just committed.
+
+        The boundary signal for a harness whose deltas carry no ``message_id``:
+        claude-sdk and the other in-process harnesses put every message of a turn
+        in one id-less bucket, so nothing else marks the seam. The next delta
+        opens a new message and gets the paragraph break an id change would have
+        given it. One-shot — repeated calls with no delta between them still yield
+        at most one break, and a call before anything streamed yields none.
+        """
+        self._message_ended = True
+
     async def add_delta(self, delta: str, message_id: str | None = None) -> None:
         # Append the delta; the SDK buffers and only flushes to Slack once the
         # buffer fills. Clear the placeholder only on the flush that actually
         # puts content on screen — never while still buffering — so there's no
         # empty gap.
         #
-        # A change in ``message_id`` (native terminal harnesses tag each assistant
-        # message item) marks a new message: insert a paragraph break so
+        # A new assistant message starts here → insert a paragraph break so
         # back-to-back messages don't run together ("…once more.The credentials…").
-        # Only between messages, never before the first, and never for id-less
-        # in-process streaming (its id stays None, so this branch never fires).
-        if (
-            message_id is not None
-            and self._last_message_id is not None
-            and message_id != self._last_message_id
-            and self._streamed
-            and not self._streamed.endswith("\n")
-        ):
+        # Only between messages, never before the first, never after a newline.
+        starts_new_message = self._starts_new_message(message_id)
+        self._last_message_id = message_id
+        self._message_ended = False
+        if starts_new_message and self._streamed and not self._streamed.endswith("\n"):
             self._streamed += "\n\n"
             # Honor the separator's flush too: if the 2-char append is the one
             # that crosses the SDK buffer threshold (and the following delta only
@@ -281,10 +290,21 @@ class _AnswerReply:
             # placeholder now rather than leaving it up until the next flush.
             if await self._reply.append("\n\n"):
                 await self._clear_ack()
-        self._last_message_id = message_id
         self._streamed += delta
         if await self._reply.append(delta):
             await self._clear_ack()
+
+    def _starts_new_message(self, message_id: str | None) -> bool:
+        # Which boundary signal to trust. An id-bearing stream is authoritative —
+        # the id changing IS the new message, and an unchanged id IS the same one
+        # continuing. An id-less stream has only the committed-message event.
+        if message_id is None and self._last_message_id is None:
+            return self._message_ended
+        return (
+            message_id is not None
+            and self._last_message_id is not None
+            and message_id != self._last_message_id
+        )
 
     async def flush_if_buffered(self) -> None:
         """Force buffered-but-unflushed text onto the screen NOW.

--- a/integrations/slack/src/omnigent_slack/streaming.py
+++ b/integrations/slack/src/omnigent_slack/streaming.py
@@ -229,7 +229,7 @@ class _AnswerReply:
         # credentials…"). We insert a paragraph break when the id changes.
         self._last_message_id: str | None = None
         # Whether an assistant message committed since the last delta. The boundary
-        # signal for an id-LESS stream: in-process/SDK harnesses (claude-sdk) leave
+        # signal for an id-LESS stream: the in-process harness (claude-sdk) leaves
         # ``message_id`` None for every message, so the id above never changes.
         self._message_ended = False
         # Text put on screen in each sealed segment this turn. Unlike
@@ -262,11 +262,10 @@ class _AnswerReply:
         """Record that the assistant message being streamed just committed.
 
         The boundary signal for a harness whose deltas carry no ``message_id``:
-        claude-sdk and the other in-process harnesses put every message of a turn
-        in one id-less bucket, so nothing else marks the seam. The next delta
-        opens a new message and gets the paragraph break an id change would have
-        given it. One-shot — repeated calls with no delta between them still yield
-        at most one break, and a call before anything streamed yields none.
+        the in-process harness (claude-sdk) puts every message of a turn in one
+        id-less bucket, so nothing else marks the boundary. The next delta opens
+        a new message and gets the paragraph break an id change would have given
+        it.
         """
         self._message_ended = True
 

--- a/integrations/slack/tests/test_sdk_message_boundary.py
+++ b/integrations/slack/tests/test_sdk_message_boundary.py
@@ -1,0 +1,167 @@
+"""SDK-harness message boundaries in the streamed Slack reply.
+
+An in-process/scaffold harness (claude-sdk) streams every assistant message of
+a turn as id-less ``response.output_text.delta`` events — unlike native
+terminal harnesses, whose deltas carry a per-message ``message_id`` and already
+get a paragraph break on id change. For the id-less shape the server publishes
+the harness-agnostic boundary signal instead: after buffered narration is
+persisted at a text→tool boundary (and at turn end), the committed segment is
+published as ``response.output_item.done`` with the assistant ``message`` item.
+The web UI and the TUI consume that event per segment and render the segments
+separately; the Slack reply must not run them together into one paragraph
+("…drafted the spec.Now waiting…").
+
+The SSE body below encodes the wire shape captured from a real claude-sdk turn
+against a live server (narration → Glob tool call → narration): an id-less
+``running`` edge, id-less deltas, the committed ``message`` item published
+between the two delta groups, the tool-call items, and the id-less ``idle``
+that ends an in-process turn.
+
+Vertical drive, like the rest of this suite: the REAL service and the REAL
+``OmnigentClient`` (real httpx) run a full @-mention turn against
+:class:`FakeOmnigentServer`, and the assertions read exactly what a Slack user
+would see via :class:`RecordingSlackClient`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import respx
+from fakes import FakeOmnigentServer, RecordingSlackClient, sse_delta, sse_status
+from omnigent_slack.models import UserConfig
+from omnigent_slack.omnigent import OmnigentClientPool
+from omnigent_slack.service import SlackOmnigentService
+from omnigent_slack.store import SQLiteStore
+
+_SERVER = "http://omnigent.test"
+
+# Two narration segments from consecutive assistant messages of ONE turn. The
+# first ends and the second starts with sentence text, so a missing separator
+# produces the telltale mid-punctuation run-on ("…the spec.Now waiting…").
+_SEG_A = "Dispatched the sub-agents and drafted the spec."
+_SEG_B = "Now waiting on the cross-vendor technical review of the spec."
+
+
+def _sse_item_done(item: dict[str, Any]) -> str:
+    """One ``response.output_item.done`` SSE frame carrying *item*."""
+    return f"data: {json.dumps({'type': 'response.output_item.done', 'item': item})}\n\n"
+
+
+def _assistant_message_item(text: str) -> dict[str, Any]:
+    """The committed assistant message the relay publishes after each flush."""
+    return {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": text}],
+    }
+
+
+# The captured claude-sdk wire shape: id-less running edge; id-less deltas; the
+# committed message item published between the delta groups (the boundary
+# signal); the tool-call items; a second committed message; then completion and
+# the id-less idle that ends an in-process turn.
+_SDK_TURN_SSE_BODY = (
+    sse_status("running")
+    + sse_delta(_SEG_A)
+    + _sse_item_done(_assistant_message_item(_SEG_A))
+    + _sse_item_done(
+        {
+            "type": "function_call",
+            "name": "Glob",
+            "call_id": "call_1",
+            "arguments": json.dumps({"pattern": "*.md"}),
+            "status": "completed",
+        }
+    )
+    + _sse_item_done({"type": "function_call_output", "call_id": "call_1", "output": ""})
+    + sse_delta(_SEG_B)
+    + _sse_item_done(_assistant_message_item(_SEG_B))
+    + 'data: {"type":"response.completed","response":{"status":"completed"}}\n\n'
+    + sse_status("idle")
+)
+
+
+class _NoopSetup:
+    """SetupFlow stand-in for turns where the user is already configured."""
+
+    async def prompt_unconfigured(self, *args: object, **kwargs: object) -> None:
+        raise AssertionError("configured user should not be prompted to set up")
+
+    async def prompt_relogin(self, *args: object, **kwargs: object) -> bool:
+        return True
+
+
+async def _wait_for_turns(service: SlackOmnigentService, timeout: float = 10.0) -> None:
+    """Await the spawned turn tasks (event-driven; timeout only bounds a hang)."""
+    tasks = list(service._turn_tasks)
+    if not tasks:
+        return
+    await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=timeout)
+
+
+@respx.mock
+async def test_sdk_harness_turn_separates_back_to_back_messages(tmp_path: Path) -> None:
+    """Back-to-back assistant messages of an id-less (SDK-harness) turn must be
+    separated in the Slack reply, not concatenated into one run-on paragraph."""
+    server = FakeOmnigentServer(_SERVER)
+    server.harness = "claude-sdk"
+    server.sse_body = _SDK_TURN_SSE_BODY
+    server.install(respx.mock)
+
+    store = SQLiteStore(tmp_path / "store.sqlite3")
+    await store.initialize()
+    await store.upsert_user_config(
+        "T1",
+        "U1",
+        UserConfig(
+            agent_id="ag_1",
+            agent_name="debby",
+            workspace="/home/bot/work",
+            host_id="h1",
+        ),
+    )
+    pool = OmnigentClientPool()
+    service = SlackOmnigentService(store=store, pool=pool, setup=_NoopSetup(), server_url=_SERVER)
+    client = RecordingSlackClient()
+
+    try:
+        await service.handle_app_mention(
+            body={"team_id": "T1", "event_id": "Ev1"},
+            event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> run the task"},
+            client=client,
+            context={"bot_user_id": "B1"},
+        )
+        await _wait_for_turns(service)
+    finally:
+        await service.shutdown()
+        await pool.aclose_all()
+
+    # What the Slack user reads: every streamed message this turn delivered,
+    # in order. Separate Slack messages are themselves a visual break, so a
+    # fix that seals into a new message also passes.
+    assert client.streams, "turn delivered no streamed reply"
+    delivered = "\n\n".join(stream.text for stream in client.streams)
+
+    # Both narration segments reached the user, in order.
+    idx_a = delivered.find(_SEG_A)
+    idx_b = delivered.find(_SEG_B)
+    assert idx_a != -1, f"first message never reached Slack: {delivered!r}"
+    assert idx_b != -1, f"second message never reached Slack: {delivered!r}"
+    assert idx_a < idx_b, f"messages out of order: {delivered!r}"
+
+    # THE regression: with no boundary for id-less streams the two messages
+    # butt against each other mid-punctuation ("…the spec.Now waiting…").
+    assert _SEG_A + _SEG_B not in delivered, (
+        f"distinct assistant messages ran together with no separator: {delivered!r}"
+    )
+    # And the separation is a real line break (the same paragraph break a
+    # message_id change already produces for native harnesses).
+    between = delivered[idx_a + len(_SEG_A) : idx_b]
+    assert "\n" in between, (
+        "expected a paragraph break between back-to-back assistant messages, "
+        f"got {between!r} in {delivered!r}"
+    )

--- a/integrations/slack/tests/test_service.py
+++ b/integrations/slack/tests/test_service.py
@@ -780,7 +780,7 @@ async def test_back_to_back_messages_get_paragraph_break(tmp_path: Path) -> None
 
 
 def _message_done(text: str) -> dict[str, Any]:
-    """A ``response.output_item.done`` committing one assistant message."""
+    # A ``response.output_item.done`` committing one assistant message.
     return {
         "type": "response.output_item.done",
         "item": {
@@ -792,7 +792,7 @@ def _message_done(text: str) -> dict[str, Any]:
 
 
 def _tool_call_done(call_id: str) -> dict[str, Any]:
-    """A ``response.output_item.done`` committing one completed tool call."""
+    # A ``response.output_item.done`` committing one completed tool call.
     return {
         "type": "response.output_item.done",
         "item": {
@@ -808,8 +808,7 @@ def _tool_call_done(call_id: str) -> dict[str, Any]:
 class SdkMultiMessageClient(FakeOmnigentClient):
     """The claude-sdk shape: every delta is id-LESS (one bucket per turn), and the
     server commits each narration segment at its tool-call boundary as a
-    ``response.output_item.done``. The tool call's own item-done sits between the
-    two messages and is not a message boundary.
+    ``response.output_item.done``.
     """
 
     async def run_turn(
@@ -856,14 +855,14 @@ async def test_sdk_harness_messages_get_paragraph_break(tmp_path: Path) -> None:
     assert (
         slack.streamed_text == "Let me poll once more.\n\nThe credentials agent is taking longer."
     )
-    # The tool call's item-done is not a message and adds no second break.
+    # The tool call's own commit is not a message and adds no second break.
     assert slack.streamed_text.count("\n\n") == 1
 
 
 class NativeItemDoneClient(FakeOmnigentClient):
     """The claude-native shape with its committed-message events interleaved:
     id-tagged deltas plus a ``response.output_item.done`` per message, including
-    one that lands mid-message. The ``message_id`` stays authoritative.
+    one that lands mid-message.
     """
 
     async def run_turn(
@@ -899,9 +898,9 @@ class NativeItemDoneClient(FakeOmnigentClient):
         yield {"type": "session.status", "status": "idle", "response_id": "resp_1"}
 
 
-async def test_native_boundary_unchanged_by_item_done(tmp_path: Path) -> None:
+async def test_native_boundary_unchanged_by_commits(tmp_path: Path) -> None:
     # The id-bearing (claude-native) path is untouched: the same two messages land
-    # with the same single break as without any item-done event, and the late
+    # with the same single break as without any commit event, and the late
     # commit that arrives mid-message does not split it.
     store = await _store(tmp_path)
     slack = FakeSlackClient()
@@ -926,7 +925,7 @@ async def test_native_boundary_unchanged_by_item_done(tmp_path: Path) -> None:
 
 class LeadingItemDoneClient(FakeOmnigentClient):
     """Commits a message before any delta reaches the reply — the turn's first
-    item-done arrives with nothing on screen yet.
+    commit arrives with nothing on screen yet.
     """
 
     async def run_turn(
@@ -945,7 +944,7 @@ class LeadingItemDoneClient(FakeOmnigentClient):
         yield {"type": "session.status", "status": "idle"}
 
 
-async def test_item_done_before_any_delta_adds_no_leading_break(tmp_path: Path) -> None:
+async def test_commit_before_any_delta_adds_no_leading_break(tmp_path: Path) -> None:
     # A break goes only BETWEEN messages: a commit with nothing streamed yet must
     # not push the turn's first words down behind a blank line.
     store = await _store(tmp_path)
@@ -989,7 +988,7 @@ class RepeatedItemDoneClient(FakeOmnigentClient):
         yield {"type": "session.status", "status": "idle"}
 
 
-async def test_repeated_item_done_adds_a_single_break(tmp_path: Path) -> None:
+async def test_repeated_commit_adds_a_single_break(tmp_path: Path) -> None:
     # Back-to-back commits are one boundary, not two — no stacked blank lines.
     store = await _store(tmp_path)
     slack = FakeSlackClient()

--- a/integrations/slack/tests/test_service.py
+++ b/integrations/slack/tests/test_service.py
@@ -779,6 +779,288 @@ async def test_back_to_back_messages_get_paragraph_break(tmp_path: Path) -> None
     )
 
 
+def _message_done(text: str) -> dict[str, Any]:
+    """A ``response.output_item.done`` committing one assistant message."""
+    return {
+        "type": "response.output_item.done",
+        "item": {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": text}],
+        },
+    }
+
+
+def _tool_call_done(call_id: str) -> dict[str, Any]:
+    """A ``response.output_item.done`` committing one completed tool call."""
+    return {
+        "type": "response.output_item.done",
+        "item": {
+            "type": "function_call",
+            "status": "completed",
+            "name": "poll_agent",
+            "arguments": "{}",
+            "call_id": call_id,
+        },
+    }
+
+
+class SdkMultiMessageClient(FakeOmnigentClient):
+    """The claude-sdk shape: every delta is id-LESS (one bucket per turn), and the
+    server commits each narration segment at its tool-call boundary as a
+    ``response.output_item.done``. The tool call's own item-done sits between the
+    two messages and is not a message boundary.
+    """
+
+    async def run_turn(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        workspace: str | None = None,
+        host_id: str | None = None,
+        host_type: str = "external",
+    ) -> AsyncIterator[dict[str, Any]]:
+        self.turns.append((session_id, text))
+        yield {"type": "session.status", "status": "running"}
+        yield {"type": "response.output_text.delta", "delta": "Let me poll once more."}
+        yield _message_done("Let me poll once more.")
+        yield _tool_call_done("call_1")
+        yield {
+            "type": "response.output_text.delta",
+            "delta": "The credentials agent is taking longer.",
+        }
+        yield _message_done("The credentials agent is taking longer.")
+        yield {"type": "session.status", "status": "idle"}
+
+
+async def test_sdk_harness_messages_get_paragraph_break(tmp_path: Path) -> None:
+    # Regression: an SDK harness never tags a delta with a message_id, so the
+    # committed-message event is the only boundary. Without it the two narration
+    # segments concatenate ("…once more.The credentials…").
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = SdkMultiMessageClient(final_text="")
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> status?"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    assert (
+        slack.streamed_text == "Let me poll once more.\n\nThe credentials agent is taking longer."
+    )
+    # The tool call's item-done is not a message and adds no second break.
+    assert slack.streamed_text.count("\n\n") == 1
+
+
+class NativeItemDoneClient(FakeOmnigentClient):
+    """The claude-native shape with its committed-message events interleaved:
+    id-tagged deltas plus a ``response.output_item.done`` per message, including
+    one that lands mid-message. The ``message_id`` stays authoritative.
+    """
+
+    async def run_turn(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        workspace: str | None = None,
+        host_id: str | None = None,
+        host_type: str = "external",
+    ) -> AsyncIterator[dict[str, Any]]:
+        self.turns.append((session_id, text))
+        yield {"type": "session.status", "status": "running", "response_id": "resp_1"}
+        yield {
+            "type": "response.output_text.delta",
+            "delta": "Let me poll once more.",
+            "message_id": "msg_a",
+        }
+        yield _message_done("Let me poll once more.")
+        yield {
+            "type": "response.output_text.delta",
+            "delta": "The credentials agent",
+            "message_id": "msg_b",
+        }
+        # A late commit for the PREVIOUS message, mid-way through this one.
+        yield _message_done("Let me poll once more.")
+        yield {
+            "type": "response.output_text.delta",
+            "delta": " is taking longer.",
+            "message_id": "msg_b",
+        }
+        yield _message_done("The credentials agent is taking longer.")
+        yield {"type": "session.status", "status": "idle", "response_id": "resp_1"}
+
+
+async def test_native_boundary_unchanged_by_item_done(tmp_path: Path) -> None:
+    # The id-bearing (claude-native) path is untouched: the same two messages land
+    # with the same single break as without any item-done event, and the late
+    # commit that arrives mid-message does not split it.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = NativeItemDoneClient(final_text="")
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> status?"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    assert (
+        slack.streamed_text == "Let me poll once more.\n\nThe credentials agent is taking longer."
+    )
+    assert slack.streamed_text.count("\n\n") == 1
+
+
+class LeadingItemDoneClient(FakeOmnigentClient):
+    """Commits a message before any delta reaches the reply — the turn's first
+    item-done arrives with nothing on screen yet.
+    """
+
+    async def run_turn(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        workspace: str | None = None,
+        host_id: str | None = None,
+        host_type: str = "external",
+    ) -> AsyncIterator[dict[str, Any]]:
+        self.turns.append((session_id, text))
+        yield {"type": "session.status", "status": "running"}
+        yield _message_done("A message the deltas never carried.")
+        yield {"type": "response.output_text.delta", "delta": "Here is the answer."}
+        yield {"type": "session.status", "status": "idle"}
+
+
+async def test_item_done_before_any_delta_adds_no_leading_break(tmp_path: Path) -> None:
+    # A break goes only BETWEEN messages: a commit with nothing streamed yet must
+    # not push the turn's first words down behind a blank line.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = LeadingItemDoneClient(final_text="")
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> status?"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    assert slack.streamed_text == "Here is the answer."
+
+
+class RepeatedItemDoneClient(FakeOmnigentClient):
+    """Commits twice with no delta in between (an item that carried no new visible
+    text), then narrates again.
+    """
+
+    async def run_turn(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        workspace: str | None = None,
+        host_id: str | None = None,
+        host_type: str = "external",
+    ) -> AsyncIterator[dict[str, Any]]:
+        self.turns.append((session_id, text))
+        yield {"type": "session.status", "status": "running"}
+        yield {"type": "response.output_text.delta", "delta": "First thought."}
+        yield _message_done("First thought.")
+        yield _message_done("First thought.")
+        yield {"type": "response.output_text.delta", "delta": "Second thought."}
+        yield {"type": "session.status", "status": "idle"}
+
+
+async def test_repeated_item_done_adds_a_single_break(tmp_path: Path) -> None:
+    # Back-to-back commits are one boundary, not two — no stacked blank lines.
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = RepeatedItemDoneClient(final_text="")
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> status?"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    assert slack.streamed_text == "First thought.\n\nSecond thought."
+
+
+_SDK_NARRATION = (
+    "Dispatched the sub-agents before drafting the spec.",
+    "Now waiting on the cross-vendor technical review of the spec before finalizing.",
+    "Good — this is a real, fresh run in progress.",
+)
+
+
+class SdkNarrationClient(FakeOmnigentClient):
+    """A multi-agent orchestrator on an SDK harness, narrating across several of
+    its own loop iterations: id-less deltas, one committed message per iteration.
+    """
+
+    async def run_turn(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        workspace: str | None = None,
+        host_id: str | None = None,
+        host_type: str = "external",
+    ) -> AsyncIterator[dict[str, Any]]:
+        self.turns.append((session_id, text))
+        yield {"type": "session.status", "status": "running"}
+        for line in _SDK_NARRATION:
+            yield {"type": "response.output_text.delta", "delta": line}
+            yield _message_done(line)
+        yield {"type": "session.status", "status": "idle"}
+
+
+async def test_sdk_narration_reads_as_separate_blocks(tmp_path: Path) -> None:
+    # The reported symptom: several of the orchestrator's own turns ran together
+    # with no separator ("…before drafting the spec.Now waiting on…").
+    store = await _store(tmp_path)
+    slack = FakeSlackClient()
+    omnigent = SdkNarrationClient(final_text="")
+    service, _pool, _setup = _service(store, omnigent)
+    await _configure_user(store, "T1", "U1")
+
+    await service.handle_app_mention(
+        body={"team_id": "T1", "event_id": "Ev1"},
+        event={"channel": "C1", "ts": "100.1", "user": "U1", "text": "<@B1> status?"},
+        client=slack,
+        context={"bot_user_id": "B1"},
+    )
+    await _wait_for_stream_stop(slack)
+    await service.shutdown()
+
+    assert slack.streamed_text == "\n\n".join(_SDK_NARRATION)
+    # Every adjacent pair is separated — no sentence butts against the next.
+    assert slack.streamed_text.count("\n\n") == len(_SDK_NARRATION) - 1
+
+
 async def test_long_answer_streams_in_full(tmp_path: Path) -> None:
     # A long answer is streamed and finalized without any splitting/msg_too_long
     # handling — Slack owns chunking for streams.


### PR DESCRIPTION
Fixes #6648.

## Problem

The Slack integration inserts a paragraph break between back-to-back assistant messages only when `message_id` changes (`_AnswerReply._starts_new_message`). That works for terminal-backed harnesses (claude-native), which tag each message with a stable id. It fails for the in-process harness (claude-sdk): every delta in a turn carries `message_id=None`, so the id never changes and no break is ever inserted. Two narration segments concatenate directly — "…once more.The credentials…" — reading in Slack as one garbled sentence instead of two.

`_flush_relay_text`'s docstring in `omnigent/server/routes/_sessions/helpers.py` documents `response.output_item.done` as the harness-agnostic signal a message just committed, already consumed per-segment by the web UI and TUI. The Slack integration never consumed it.

## Fix

- `_AnswerReply.mark_message_end()` — a one-shot flag set when the caller sees a `response.output_item.done` committing an assistant message.
- `_starts_new_message` now falls back to that flag only when both the current and prior `message_id` are `None` — an id-bearing stream still decides purely on the id changing, so the claude-native path is untouched.
- `service.py` calls `mark_message_end()` right before the existing `set_final(item_text)`, gated on the event actually carrying assistant text.
- `DESIGN.md` gets a fifth bullet under `_AnswerReply` / `_LiveReply` invariants recording the new boundary rule and its precedence against `message_id`.

No server-side change — this is a client-side gap in `integrations/slack/`, consuming an event shape the server already emits.

## Tests

348 passing on this branch (cherry-picked cleanly onto current `main`, no conflicts; the Sei fork's superset carries 369, the 21-test difference being unrelated managed-sandbox coverage not present upstream). New coverage: an SDK-harness two-message turn gets the same single paragraph break as the id-bearing case, the id-bearing path is provably unchanged by the presence of commit events (including a late commit landing mid-message), a leading commit before any delta adds no break, and repeated commits with no delta between them add at most one break.

`ruff format --check` / `ruff check`: clean.

## Deliberately out of scope

- No change to `_flush_relay_text` or any other server-side code — the commit signal already exists; this only makes the Slack client consume it.
- The web UI's and TUI's own consumption of the same event is unaffected — this PR touches only `integrations/slack/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Issues

Resolves [OMNI-6443](https://linear.app/omnigent/issue/OMNI-6443/bug-slack-claude-sdk-sdk-harness-turns-run-distinct-assistant-messages)
