### PR TITLE
feat(web): add a Send messages keyboard shortcut setting

### DIFF
--- a/web/src/components/KeyboardShortcutsDialog.tsx
+++ b/web/src/components/KeyboardShortcutsDialog.tsx
@@ -29,6 +29,7 @@ import {
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import { readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
+import { readSendMessageShortcut } from "@/lib/sendMessagePreferences";
 import { hasCommandModifier } from "@/lib/hotkeys";
 import { isNativeShell } from "@/lib/nativeBridge";
 
@@ -159,7 +160,7 @@ export function KeyboardShortcutsList() {
   const preventsKeyboardSubmit = isMobileViewport || isCoarsePointer;
   const groups = shortcutGroupsFor(
     isNativeShell(),
-    readSubmitWithModEnter(),
+    readSubmitWithModEnter() || readSendMessageShortcut() === "command-enter",
     preventsKeyboardSubmit,
   );
   return (

--- a/web/src/lib/sendMessagePreferences.test.ts
+++ b/web/src/lib/sendMessagePreferences.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  isSendMessageShortcut,
+  readSendMessageShortcut,
+  writeSendMessageShortcut,
+} from "./sendMessagePreferences";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("send message shortcut preference", () => {
+  it("defaults to Enter", () => {
+    expect(readSendMessageShortcut()).toBe("enter");
+    expect(
+      isSendMessageShortcut({ key: "Enter", shiftKey: false, metaKey: false, ctrlKey: false }),
+    ).toBe(true);
+  });
+
+  it("requires Command or Ctrl when configured", () => {
+    writeSendMessageShortcut("command-enter");
+
+    expect(
+      isSendMessageShortcut({ key: "Enter", shiftKey: false, metaKey: false, ctrlKey: false }),
+    ).toBe(false);
+    expect(
+      isSendMessageShortcut({ key: "Enter", shiftKey: false, metaKey: true, ctrlKey: false }),
+    ).toBe(true);
+    expect(
+      isSendMessageShortcut({ key: "Enter", shiftKey: false, metaKey: false, ctrlKey: true }),
+    ).toBe(true);
+    expect(
+      isSendMessageShortcut({ key: "Enter", shiftKey: true, metaKey: true, ctrlKey: false }),
+    ).toBe(false);
+  });
+});

--- a/web/src/lib/sendMessagePreferences.ts
+++ b/web/src/lib/sendMessagePreferences.ts
@@ -1,0 +1,41 @@
+export type SendMessageShortcut = "enter" | "command-enter";
+
+export const DEFAULT_SEND_MESSAGE_SHORTCUT: SendMessageShortcut = "enter";
+const STORAGE_KEY = "omnigent:send-message-shortcut";
+
+export function readSendMessageShortcut(): SendMessageShortcut {
+  if (typeof window === "undefined") return DEFAULT_SEND_MESSAGE_SHORTCUT;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "command-enter"
+      ? "command-enter"
+      : DEFAULT_SEND_MESSAGE_SHORTCUT;
+  } catch {
+    return DEFAULT_SEND_MESSAGE_SHORTCUT;
+  }
+}
+
+export function writeSendMessageShortcut(shortcut: SendMessageShortcut): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (shortcut === DEFAULT_SEND_MESSAGE_SHORTCUT) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, shortcut);
+    }
+  } catch {
+    // localStorage access errors are non-fatal.
+  }
+}
+
+export function isSendMessageShortcut(event: {
+  key: string;
+  shiftKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+}): boolean {
+  if (event.key !== "Enter" || event.shiftKey) return false;
+  if (readSendMessageShortcut() === "command-enter") {
+    return event.metaKey || event.ctrlKey;
+  }
+  return true;
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -58,6 +58,7 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
 import type { ElicitationBlock } from "@/lib/blocks";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Composer, isSubagentRoutingEligible, shouldQueueSend } from "./ChatPage";
+import { writeSendMessageShortcut } from "@/lib/sendMessagePreferences";
 import type { Session } from "@/lib/types";
 import type { QueuedMessage } from "@/store/chatStore";
 import {
@@ -366,6 +367,21 @@ describe("Composer slash-command menu", () => {
     cleanup();
     vi.restoreAllMocks();
     setOmnigentHostConfig({});
+    localStorage.clear();
+  });
+
+  it("requires Command or Ctrl+Enter when configured", () => {
+    writeSendMessageShortcut("command-enter");
+    const onSend = vi.fn();
+    render(<Composer {...composerProps({ onSend })} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "hello there" } });
+
+    fireEvent.keyDown(ta, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(ta, { key: "Enter", metaKey: true });
+    expect(onSend).toHaveBeenCalledWith("hello there", undefined);
   });
 
   it("highlights the first match as soon as the menu opens", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -81,6 +81,7 @@ import {
 } from "@/lib/nativeCodingAgents";
 import { readAlwaysSteer } from "@/lib/alwaysSteerPreferences";
 import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
+import { readSendMessageShortcut } from "@/lib/sendMessagePreferences";
 import {
   buildMentionPreamble,
   detectMentionAt,
@@ -2532,7 +2533,9 @@ function ComposerImpl({
   onViewportShrinkPinScroll,
 }: ComposerProps) {
   const [value, setValue] = useState("");
-  const [submitWithModEnter] = useState(() => readSubmitWithModEnter());
+  const [submitWithModEnter] = useState(
+    () => readSubmitWithModEnter() || readSendMessageShortcut() === "command-enter",
+  );
   const [files, setFiles] = useState<File[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [commandError, setCommandError] = useState<string | null>(null);

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -275,6 +275,17 @@ function installUpdateBridge(config: UpdateConfig = DEFAULT_UPDATE_CONFIG) {
 }
 
 describe("SettingsPage", () => {
+  it("configures the send-message keyboard shortcut", () => {
+    renderPage("/settings/shortcuts");
+    const select = screen.getByTestId("send-message-shortcut-select");
+
+    expect(select).toHaveValue("enter");
+    fireEvent.change(select, { target: { value: "command-enter" } });
+    expect(select).toHaveValue("command-enter");
+    expect(localStorage.getItem("omnigent:send-message-shortcut")).toBe("command-enter");
+    expect(screen.getByText("Command/Ctrl + Enter")).toBeInTheDocument();
+  });
+
   it("renders composer shortcut guidance as two accessible lines", () => {
     renderPage("/settings/general");
     const toggle = screen.getByTestId("composer-submit-with-mod-enter-toggle");

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -172,6 +172,11 @@ import {
   writeTranscriptViewDefault,
   type TranscriptViewDefault,
 } from "@/lib/transcriptViewPreferences";
+import {
+  readSendMessageShortcut,
+  type SendMessageShortcut,
+  writeSendMessageShortcut,
+} from "@/lib/sendMessagePreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readAlwaysSteer, writeAlwaysSteer } from "@/lib/alwaysSteerPreferences";
 import {
@@ -1755,8 +1760,42 @@ function StepperButton({
 }
 
 function ShortcutsSection() {
+  const [sendShortcut, setSendShortcut] = useState<SendMessageShortcut>(readSendMessageShortcut);
+  const labelId = useId();
+
+  const updateSendShortcut = (value: SendMessageShortcut) => {
+    setSendShortcut(value);
+    writeSendMessageShortcut(value);
+  };
+
   return (
     <Section title="Keyboard shortcuts" description="Speed up common actions with the keyboard.">
+      <div className="flex items-start justify-between gap-6 border-b border-border pb-6">
+        <div className="flex flex-col">
+          <span id={labelId} className="text-sm font-medium">
+            Send messages
+          </span>
+          <span className="text-sm text-muted-foreground">
+            Choose whether Enter sends immediately or inserts a new line.
+          </span>
+        </div>
+        <Select
+          value={sendShortcut}
+          onValueChange={(value) => updateSendShortcut(value as SendMessageShortcut)}
+        >
+          <SelectTrigger
+            aria-labelledby={labelId}
+            data-testid="send-message-shortcut-select"
+            className="w-48 shrink-0"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="enter">Enter</SelectItem>
+            <SelectItem value="command-enter">Command/Ctrl + Enter</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
       <KeyboardShortcutsList />
     </Section>
   );

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -15,6 +15,7 @@ import type { AvailableAgent } from "@/hooks/useAvailableAgents";
 import { useAvailableAgents } from "@/hooks/useAvailableAgents";
 import { NewChatLandingScreen, resetLandingDraft, sanitizeInitialPrompt } from "./NewChatDialog";
 import { writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
+import { writeSendMessageShortcut } from "@/lib/sendMessagePreferences";
 
 // The landing screen drives the real Web-start flow end to end: the host and
 // first agent auto-select, the working directory seeds from the host's most-
@@ -493,6 +494,29 @@ describe("NewChatLandingScreen create flow", () => {
     // this through and created an unintended empty session.
     expect(authenticatedFetch).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("uses Command+Enter to create a session when configured", async () => {
+    writeSendMessageShortcut("command-enter");
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+    renderLanding();
+    await waitForWorkspaceSeed();
+    const input = screen.getByTestId("new-chat-landing-input");
+    fireEvent.change(input, { target: { value: "start a session" } });
+
+    // Plain Enter must not CREATE a session. (The landing page also fires
+    // unrelated mount-time fetches, so assert on the create endpoint
+    // specifically rather than on all authenticated fetches.)
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(authenticatedFetch).not.toHaveBeenCalledWith("/v1/sessions", expect.anything());
+
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+    await waitFor(() =>
+      expect(authenticatedFetch).toHaveBeenCalledWith("/v1/sessions", expect.anything()),
+    );
   });
 
   it("does not create a session when Enter confirms active IME composition", async () => {

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -70,6 +70,7 @@ import { authenticatedFetch } from "@/lib/identity";
 import { fetchGithubBranches, fetchGithubRepos, type GithubRepo } from "@/lib/githubIntegration";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
+import { readSendMessageShortcut } from "@/lib/sendMessagePreferences";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
 import { recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -2209,7 +2210,9 @@ export function NewChatLandingScreen() {
   const isMobileViewport = useIsMobileViewport();
   const isCoarsePointer = useIsCoarsePointer();
   const preventsKeyboardSubmit = isMobileViewport || isCoarsePointer;
-  const [submitWithModEnter] = useState(() => readSubmitWithModEnter());
+  const [submitWithModEnter] = useState(
+    () => readSubmitWithModEnter() || readSendMessageShortcut() === "command-enter",
+  );
   // Single send-telemetry point (see handleCreate). Emitting there rather than
   // via the Start button's componentId covers Enter-key sends too, which never
   // submit the form and would otherwise bypass the Button entirely.


### PR DESCRIPTION
## Related issue

N/A — new setting, no tracking issue yet. Happy to file one if maintainers prefer issues for features.

## Summary

- Adds a **"Send messages"** select to *Settings → Keyboard shortcuts*: choose whether **Enter** or **Command/Ctrl+Enter** sends composer messages; the other combination inserts a newline.
- All composer entry points honor the setting: the in-chat composer, the new-session landing screen, and the shortcut cheat-sheet (dialog + Settings embed), so the displayed keys always match actual behavior.
- It composes with the existing *"Submit with Cmd/Ctrl+Enter on desktop"* preference — either one opts in — and mobile behavior is unchanged (Enter inserts a newline; Send stays an explicit tap).

**ELI5:** Before, pressing Enter always sent the message. Now you can tell omnigent "only send when I hold Cmd/Ctrl", and every text box that starts a session or chats agrees on that rule.

```text
Settings ──▶ "Send messages: Enter | Command/Ctrl+Enter"   (localStorage)
                        │
     ┌──────────────────┼──────────────────────┐
     ▼                  ▼                      ▼
Chat composer     New-session landing     Shortcut cheat-sheet
(reads both prefs)  (reads both prefs)     (shows effective keys)
```

## Test Plan

- `pnpm --dir web exec vitest run src/lib/sendMessagePreferences.test.ts src/pages/SettingsPage.test.tsx src/pages/ChatPage.composer.test.tsx src/shell/NewChatDialog.flow.test.tsx src/components/KeyboardShortcutsDialog.test.tsx` — 309 passed, including the new tests: Settings select round-trip; composer requires Cmd/Ctrl+Enter when configured (plain Enter no-op); landing flow creates a session on Cmd+Enter and not on plain Enter (asserted against the create endpoint specifically).
- `pnpm --dir web lint` — passed.
- `pnpm --dir web type-check` — passed.
- `pnpm --dir web format:check` — passed.
- Manually verified in day-to-day use on the author's deployment (this is how the landing-screen gap was spotted).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Behavioral evidence is in the Test Plan (unit + flow tests); happy to attach a short screen recording if reviewers would like one.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The setting is covered by unit tests (preference lib, Settings select), composer tests (both submit paths), and a landing-flow test (session creation gated on the configured shortcut). Manual verification: the setting has been in daily use on the author's self-hosted deployment; the landing screen initially ignored it, which this PR's landing changes prevent (and test).

## Changelog

You can now choose whether pressing Enter or Command/Ctrl+Enter sends chat messages, from Settings → Keyboard shortcuts.
