### PR TITLE
feat(ChatPage): Add keep-chat-pinned-to-bottom toggle and scroll position restore

### DIFF
--- a/tests/e2e_ui/chat/test_bottom_lock_scroll_restore.py
+++ b/tests/e2e_ui/chat/test_bottom_lock_scroll_restore.py
@@ -1,0 +1,152 @@
+"""E2E: the bottom-lock preference and per-session scroll restore.
+
+``Keep chat pinned to bottom`` (Settings -> Appearance) gates whether the
+transcript jumps to and follows the response on send. When it is off, the
+``use-stick-to-bottom`` lock is released, so a reader parked mid-history keeps
+their position — including when they send. Independently, each conversation's
+reading position is captured when the user navigates away and restored when
+they come back, anchored to the user message at the top of the viewport.
+
+Neither behavior is observable in jsdom (no layout, no compositor), so this
+drives two real sessions against the mock LLM: build a scrollable transcript,
+park mid-history, leave and return, and assert the viewport lands back on the
+same region; then, with the toggle off, send mid-history and assert the
+viewport does not move.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import configure_mock_llm
+
+_COMPOSER = "Send a message…"
+_SEND = "Send"
+_USER = '[data-testid="message-bubble"][data-role="user"]'
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_WORKING = '[data-testid="working-indicator"]'
+
+# Small viewport so a handful of turns make the transcript scrollable.
+_VIEWPORT = {"width": 1280, "height": 480}
+
+# Mock reply long enough that six turns overflow a 480px viewport.
+_REPLY = (
+    "A measured reply with enough prose to occupy real vertical space in the "
+    "transcript column, so that a handful of turns produces a genuine scroll "
+    "range rather than a transcript that always fits the viewport."
+)
+
+# Tag the transcript's scroll element (tallest scrollable descendant of the
+# log region — the same shape the other transcript tests use) and return its
+# geometry.
+_TAG_SCROLLER = """
+() => {
+  const log = document.querySelector('[role="log"]');
+  let best = null;
+  log.querySelectorAll('*').forEach((el) => {
+    if (el.scrollHeight > el.clientHeight + 4) {
+      if (!best || el.scrollHeight > best.scrollHeight) best = el;
+    }
+  });
+  const el = best || log;
+  el.setAttribute('data-pw-scroller', '1');
+  return {
+    scrollTop: el.scrollTop,
+    maxScrollTop: el.scrollHeight - el.clientHeight,
+  };
+}
+"""
+
+_READ_SCROLLER = """
+() => {
+  const el = document.querySelector('[data-pw-scroller]');
+  return {
+    scrollTop: el.scrollTop,
+    maxScrollTop: el.scrollHeight - el.clientHeight,
+  };
+}
+"""
+
+_PARK = "el => { el.scrollTop = el.scrollHeight / 2; }"
+
+
+def _build_turns(page: Page, count: int) -> None:
+    """Send *count* turns, waiting for each to settle before the next."""
+    for i in range(count):
+        page.get_by_placeholder(_COMPOSER).fill(f"next turn {i}")
+        page.get_by_role("button", name=_SEND, exact=True).click()
+        expect(page.locator(_USER)).to_have_count(i + 1, timeout=30_000)
+        expect(page.locator(_ASSISTANT)).to_have_count(i + 1, timeout=60_000)
+        expect(page.locator(_WORKING)).to_have_count(0, timeout=30_000)
+
+
+def test_scroll_position_restored_after_leaving_and_returning(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """Returning to a session restores the reader's viewport, not the bottom."""
+    base_url, session_a, session_b = seeded_session_pair
+    configure_mock_llm(mock_llm_server_url, [{"text": _REPLY}] * 6, key="default")
+
+    page.set_viewport_size(_VIEWPORT)
+    page.goto(f"{base_url}/c/{session_a}")
+    _build_turns(page, 6)
+
+    # Escape the bottom lock and park mid-history.
+    geometry = page.evaluate(_TAG_SCROLLER)
+    assert geometry["maxScrollTop"] > 100, "transcript did not build a scroll range"
+    page.locator("[data-pw-scroller]").evaluate(_PARK)
+    parked = page.evaluate(_READ_SCROLLER)
+    assert parked["scrollTop"] < parked["maxScrollTop"] - 50
+
+    # Leave for another session, then come back.
+    page.goto(f"{base_url}/c/{session_b}")
+    page.goto(f"{base_url}/c/{session_a}")
+    expect(page.locator(_USER)).to_have_count(6, timeout=30_000)
+    expect(page.locator(_ASSISTANT)).to_have_count(6, timeout=30_000)
+
+    restored = page.evaluate(_READ_SCROLLER)
+    # Restored to the parked region, NOT jumped to the bottom. The anchor is a
+    # user message, so the exact pixel can differ from the parked scrollTop —
+    # a bounded drift is the contract.
+    assert restored["scrollTop"] < restored["maxScrollTop"] - 50
+    assert abs(restored["scrollTop"] - parked["scrollTop"]) <= 200
+
+
+def test_send_with_bottom_lock_off_keeps_reader_position(
+    page: Page,
+    seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """With the toggle off, sending from mid-history does not yank to the bottom."""
+    base_url, session_id = seeded_session
+    token = f"lock-off-{uuid.uuid4().hex[:8]}"
+    configure_mock_llm(mock_llm_server_url, [{"text": _REPLY}] * 6, key="default")
+    configure_mock_llm(mock_llm_server_url, [{"text": f"ack {token}"}], key="default", match=token)
+
+    # The preference is read on boot; seed it before the SPA loads.
+    page.add_init_script("window.localStorage.setItem('omnigent:bottom-lock', 'false')")
+    page.set_viewport_size(_VIEWPORT)
+    page.goto(f"{base_url}/c/{session_id}")
+    _build_turns(page, 6)
+
+    geometry = page.evaluate(_TAG_SCROLLER)
+    assert geometry["maxScrollTop"] > 100, "transcript did not build a scroll range"
+    page.locator("[data-pw-scroller]").evaluate(_PARK)
+    parked = page.evaluate(_READ_SCROLLER)
+
+    # Send from mid-history: the user bubble must appear and the assistant must
+    # reply, while the viewport stays parked (bottom lock off).
+    page.get_by_placeholder(_COMPOSER).fill(f"say {token}")
+    page.get_by_role("button", name=_SEND, exact=True).click()
+    expect(page.locator(_USER)).to_have_count(7, timeout=30_000)
+    expect(page.locator(_ASSISTANT).last).to_contain_text(token, timeout=60_000)
+
+    after = page.evaluate(_READ_SCROLLER)
+    assert after["maxScrollTop"] >= parked["maxScrollTop"], "transcript shrank unexpectedly"
+    # Not yanked to the bottom: still parked (within the drift the appended
+    # turn's own height allows), far from the new maximum.
+    assert after["scrollTop"] < after["maxScrollTop"] - 200

--- a/tests/e2e_ui/chat/test_bottom_lock_scroll_restore.py
+++ b/tests/e2e_ui/chat/test_bottom_lock_scroll_restore.py
@@ -108,6 +108,9 @@ def test_scroll_position_restored_after_leaving_and_returning(
     expect(page.locator(_USER)).to_have_count(6, timeout=30_000)
     expect(page.locator(_ASSISTANT)).to_have_count(6, timeout=30_000)
 
+    # The transcript remounts on return, so the previously tagged element is
+    # gone — re-tag the fresh scroller, then read the restored offset.
+    page.evaluate(_TAG_SCROLLER)
     restored = page.evaluate(_READ_SCROLLER)
     # Restored to the parked region, NOT jumped to the bottom. The anchor is a
     # user message, so the exact pixel can differ from the parked scrollTop —

--- a/tests/e2e_ui/chat/test_bottom_lock_scroll_restore.py
+++ b/tests/e2e_ui/chat/test_bottom_lock_scroll_restore.py
@@ -102,9 +102,11 @@ def test_scroll_position_restored_after_leaving_and_returning(
     parked = page.evaluate(_READ_SCROLLER)
     assert parked["scrollTop"] < parked["maxScrollTop"] - 50
 
-    # Leave for another session, then come back.
-    page.goto(f"{base_url}/c/{session_b}")
-    page.goto(f"{base_url}/c/{session_a}")
+    # Leave for another session, then come back — via the sidebar, the way a
+    # user does: a full page.goto reload would tear down the SPA and skip the
+    # capture-on-switch effect this feature relies on.
+    page.locator(f'a[href="/c/{session_b}"]').click()
+    page.locator(f'a[href="/c/{session_a}"]').click()
     expect(page.locator(_USER)).to_have_count(6, timeout=30_000)
     expect(page.locator(_ASSISTANT)).to_have_count(6, timeout=30_000)
 

--- a/web/src/components/chat/Transcript.tsx
+++ b/web/src/components/chat/Transcript.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -26,14 +26,22 @@ import { ChatPlanAccordion } from "@/shell/ChatPlanAccordion";
 import { RunnerStartingIndicator, McpStartupIndicator } from "@/pages/ChatIndicators";
 import { CHAT_COLUMN_WIDTH } from "@/pages/chatLayout";
 import {
+  DEFAULT_BOTTOM_LOCK_ENABLED,
+  readBottomLockEnabled,
+  subscribeBottomLockEnabled,
+} from "@/lib/bottomLockPreferences";
+import {
   type ConversationScroller,
+  BottomLockController,
   BubbleView,
+  ConversationScrollPosition,
   ConversationScrollRefBridge,
   HistoryAutoLoader,
   HistoryLoadingIndicator,
   JumpToTopButton,
   KeepBottomOnViewportResize,
   LatestTurnSpacer,
+  ReleaseBottomLockOnResponseEnd,
   ScrollToBottomOnSend,
   UserMessageNavConnected,
   WorkingIndicator,
@@ -113,6 +121,12 @@ function TranscriptImpl({
   const subagentRoutingOverride = useChatStore((s) => s.subagentRoutingOverride);
   const mcpStartupActive = useChatStore((s) => s.mcpStartup !== null);
   const hasTasks = useChatStore((s) => s.todos.length > 0);
+  const status = useChatStore((s) => s.status);
+  const bottomLockEnabled = useSyncExternalStore(
+    subscribeBottomLockEnabled,
+    readBottomLockEnabled,
+    () => DEFAULT_BOTTOM_LOCK_ENABLED,
+  );
 
   // Build bubbles once per blocks/activeResponse change. Per-surface reuse
   // cache so a streaming append rebuilds only the active bubble, reusing the
@@ -242,8 +256,10 @@ function TranscriptImpl({
             )}
           >
             {/* Scroll helpers — must live inside StickToBottom to access context. */}
-            <ScrollToBottomOnSend nonce={sendScrollNonce} />
-            <KeepBottomOnViewportResize />
+            <BottomLockController enabled={bottomLockEnabled} />
+            <ScrollToBottomOnSend nonce={sendScrollNonce} enabled={bottomLockEnabled} />
+            <ReleaseBottomLockOnResponseEnd status={status} enabled={bottomLockEnabled} />
+            {bottomLockEnabled && <KeepBottomOnViewportResize />}
             <ConversationScrollRefBridge onScroller={setScroller} />
             <HistoryAutoLoader scrollElement={scroller?.el ?? null} />
             {bubbles.length === 0 && !showWorkingIndicator && !mcpStartupActive ? (
@@ -320,6 +336,11 @@ function TranscriptImpl({
         {/* Constant-height scrollbar. Sibling of Conversation so it escapes the
         chat-scroll-fade mask. */}
         <TranscriptScrollbar scroller={scroller} topInset={hasTasks ? 12 : undefined} />
+        <ConversationScrollPosition
+          conversationId={conversationId}
+          scroller={scroller}
+          followBottomOnFallback={bottomLockEnabled}
+        />
         {/* Hover the top edge to reveal a pill that loads all older history. */}
         <JumpToTopButton
           containerEl={containerEl}

--- a/web/src/components/chat/Transcript.tsx
+++ b/web/src/components/chat/Transcript.tsx
@@ -337,7 +337,7 @@ function TranscriptImpl({
         chat-scroll-fade mask. */}
         <TranscriptScrollbar scroller={scroller} topInset={hasTasks ? 12 : undefined} />
         <ConversationScrollPosition
-          conversationId={conversationId}
+          conversationId={conversationKey ?? null}
           scroller={scroller}
           followBottomOnFallback={bottomLockEnabled}
         />

--- a/web/src/components/chat/chatBubbleParts.tsx
+++ b/web/src/components/chat/chatBubbleParts.tsx
@@ -1174,9 +1174,15 @@ export function ConversationScrollPosition({
       if (saved.wasAtBottom && followBottomOnFallbackRef.current) finishAtBottom();
       else restore();
     } else {
-      el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
-      if (followBottomOnFallbackRef.current) followConversationBottom(el);
-      else {
+      // No saved position. With the lock on, StickToBottom owns initial
+      // positioning (its own settle parks one pixel short of the maximum) —
+      // writing here would override that park by a pixel and shift the whole
+      // transcript. Only the lock-off path pins explicitly, because the
+      // released library never will.
+      if (followBottomOnFallbackRef.current) {
+        followConversationBottom(el);
+      } else {
+        el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
         takeConversationScrollControl(el);
         releaseBottomLock();
       }

--- a/web/src/components/chat/chatBubbleParts.tsx
+++ b/web/src/components/chat/chatBubbleParts.tsx
@@ -56,6 +56,23 @@ import { getCurrentAuthorId } from "@/lib/identity";
 import { retrySession } from "@/lib/sessionsApi";
 import { useChatStore, type PendingUserMessage } from "@/store/chatStore";
 import { useStickToBottomContext } from "use-stick-to-bottom";
+import {
+  getConversationScrollPosition,
+  getConversationScrollRestoreTarget,
+  isConversationScrollPositionRestored,
+  registerActiveConversationScroller,
+  restoreConversationScrollPosition,
+  saveConversationScrollPosition,
+} from "@/lib/conversationScrollPositions";
+import {
+  beginConversationScrollRestore,
+  conversationScrollMode,
+  followConversationBottom,
+  isConversationFollowingBottom,
+  isCurrentConversationScrollRestore,
+  markConversationScrollRestoring,
+  takeConversationScrollControl,
+} from "@/lib/conversationScrollState";
 import { UserMessageNav } from "@/components/UserMessageNav";
 import { isSessionScopedDecision, showsRoutingDecisionChip } from "@/lib/routingDecision";
 import { useWorkingLabelTick } from "@/hooks/useWorkingLabelTick";
@@ -905,18 +922,24 @@ export function UserMessageNavConnected(props: React.ComponentProps<typeof UserM
   );
 }
 
-/**
- * Forces the conversation back to the bottom when this client submits a new
- * message.
- */
-export function ScrollToBottomOnSend({ nonce }: { nonce: number }) {
-  const { scrollToBottom } = useStickToBottomContext();
+/** Optionally jumps to and follows the response after a local send. */
+export function ScrollToBottomOnSend({ nonce, enabled }: { nonce: number; enabled: boolean }) {
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef?: React.RefObject<HTMLElement>;
+  };
+  const scrollRef = ctx.scrollRef;
+  const scrollToBottom = ctx.scrollToBottom;
 
   useLayoutEffect(() => {
-    if (nonce === 0) return;
+    if (!enabled || nonce === 0) return;
+    const el = scrollRef?.current;
+    if (el) followConversationBottom(el);
     scrollToBottom("instant");
-    requestAnimationFrame(() => scrollToBottom("instant"));
-  }, [nonce, scrollToBottom]);
+    const frame = requestAnimationFrame(() => {
+      if (!el || isConversationFollowingBottom(el)) scrollToBottom("instant");
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [enabled, nonce, scrollRef, scrollToBottom]);
 
   return null;
 }
@@ -971,6 +994,255 @@ export function KeepBottomOnViewportResize() {
       if (frame !== null) cancelAnimationFrame(frame);
     };
   }, [scrollRef, scrollToBottom, state]);
+
+  return null;
+}
+
+export function BottomLockController({ enabled }: { enabled: boolean }) {
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef?: React.RefObject<HTMLElement>;
+    contentRef?: React.RefObject<HTMLElement>;
+    state: { isAtBottom: boolean; escapedFromLock: boolean };
+    stopScroll: () => void;
+  };
+  const scrollRef = ctx.scrollRef;
+  const contentRef = ctx.contentRef;
+  const state = ctx.state;
+  const stopScroll = ctx.stopScroll;
+
+  useLayoutEffect(() => {
+    if (enabled) return;
+    const scrollElement = scrollRef?.current;
+    const release = () => {
+      stopScroll();
+      state.isAtBottom = false;
+      state.escapedFromLock = true;
+    };
+    release();
+    if (!scrollElement) return;
+
+    scrollElement.addEventListener("scroll", release, { passive: true });
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => release());
+    const contentElement = contentRef?.current;
+    if (contentElement) observer?.observe(contentElement);
+    return () => {
+      scrollElement.removeEventListener("scroll", release);
+      observer?.disconnect();
+    };
+  }, [contentRef, enabled, scrollRef, state, stopScroll]);
+
+  return null;
+}
+
+/**
+ * Preserves each transcript's reading position while switching sessions.
+ *
+ * Session hydration temporarily unmounts the conversation, and StickToBottom
+ * initializes every mount at the end. A user-message anchor and its viewport
+ * offset restore the same visible turn even when transcript height changes.
+ */
+export function ConversationScrollPosition({
+  conversationId,
+  scroller,
+  followBottomOnFallback,
+}: {
+  conversationId: string | null;
+  scroller: ConversationScroller | null;
+  followBottomOnFallback: boolean;
+}) {
+  const scrollElement = scroller?.el ?? null;
+  const scrollState = scroller?.state ?? null;
+  const stopScroll = scroller?.stopScroll ?? null;
+  const followBottomOnFallbackRef = useRef(followBottomOnFallback);
+  useLayoutEffect(() => {
+    followBottomOnFallbackRef.current = followBottomOnFallback;
+  }, [followBottomOnFallback]);
+  useLayoutEffect(() => {
+    const el = scrollElement;
+    if (!el || !conversationId || !scrollState || !stopScroll) return;
+    const unregister = registerActiveConversationScroller(conversationId, el);
+    const saved = getConversationScrollPosition(conversationId);
+    const generation = saved === undefined ? 0 : beginConversationScrollRestore(el);
+    let frame = 0;
+    let restoring = saved !== undefined;
+    let userIntentSeen = false;
+
+    const releaseBottomLock = () => {
+      stopScroll();
+      scrollState.isAtBottom = false;
+      scrollState.escapedFromLock = true;
+    };
+    const persist = () => saveConversationScrollPosition(conversationId, el);
+    const onScroll = () => {
+      if (userIntentSeen && !restoring && conversationScrollMode(el) === "user-controlled")
+        persist();
+    };
+    const takeUserControl = () => {
+      userIntentSeen = true;
+      takeConversationScrollControl(el);
+      restoring = false;
+      cancelAnimationFrame(frame);
+      releaseBottomLock();
+    };
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.isContentEditable ||
+        target?.matches('input, textarea, select, button, a, [role="button"]')
+      )
+        return;
+      if (["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key)) {
+        takeUserControl();
+      }
+    };
+
+    const onPointerDown = (event: PointerEvent) => {
+      // A pointerdown on the scroll root itself is a native scrollbar drag.
+      if (event.target === el) takeUserControl();
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    for (const event of ["wheel", "touchmove"] as const) {
+      el.addEventListener(event, takeUserControl, { passive: true });
+    }
+    el.addEventListener("pointerdown", onPointerDown, { passive: true });
+    window.addEventListener("keydown", onKeyDown, true);
+
+    if (saved) {
+      releaseBottomLock();
+      const deadline = performance.now() + 7_000;
+      let quietSince = performance.now();
+      let lastScrollHeight = el.scrollHeight;
+      let largestScrollHeight = lastScrollHeight;
+
+      const finishAtBottom = () => {
+        if (!isCurrentConversationScrollRestore(el, generation)) return;
+        el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+        restoring = false;
+        if (followBottomOnFallbackRef.current) {
+          followConversationBottom(el);
+          scrollState.isAtBottom = true;
+          scrollState.escapedFromLock = false;
+        } else {
+          takeConversationScrollControl(el);
+          releaseBottomLock();
+        }
+      };
+
+      const restore = () => {
+        if (!isCurrentConversationScrollRestore(el, generation)) return;
+        const now = performance.now();
+        const scrollHeight = el.scrollHeight;
+        if (scrollHeight !== lastScrollHeight) quietSince = now;
+        largestScrollHeight = Math.max(largestScrollHeight, scrollHeight);
+        const target = getConversationScrollRestoreTarget(el, saved);
+
+        if (target.kind === "restore") {
+          if (!markConversationScrollRestoring(el, generation)) return;
+          restoreConversationScrollPosition(el, saved);
+          const settled =
+            isConversationScrollPositionRestored(el, saved) && now - quietSince >= 150;
+          if (settled) {
+            restoring = false;
+            takeConversationScrollControl(el);
+            releaseBottomLock();
+            persist();
+            return;
+          }
+        } else {
+          // Anchor not yet loaded (history is paginated). Stay at the
+          // currently rendered bottom rather than sitting at scrollTop=0,
+          // so a running session doesn't flash to the top while waiting.
+          if (!markConversationScrollRestoring(el, generation)) return;
+          el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+          // A shrinking document can make the old location permanently invalid.
+          // Once that shrink settles, bottom is the only valid fallback.
+          const shrank = scrollHeight < largestScrollHeight;
+          if (shrank && now - quietSince >= 150) {
+            finishAtBottom();
+            return;
+          }
+        }
+
+        lastScrollHeight = scrollHeight;
+        if (now >= deadline) {
+          finishAtBottom();
+          return;
+        }
+        frame = requestAnimationFrame(restore);
+      };
+      if (saved.wasAtBottom && followBottomOnFallbackRef.current) finishAtBottom();
+      else restore();
+    } else {
+      el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      if (followBottomOnFallbackRef.current) followConversationBottom(el);
+      else {
+        takeConversationScrollControl(el);
+        releaseBottomLock();
+      }
+    }
+
+    return () => {
+      cancelAnimationFrame(frame);
+      unregister();
+      el.removeEventListener("scroll", onScroll);
+      for (const event of ["wheel", "touchmove"] as const) {
+        el.removeEventListener(event, takeUserControl);
+      }
+      el.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [conversationId, scrollElement, scrollState, stopScroll]);
+
+  return null;
+}
+
+/** Prevent completion-time resizes from moving readers when bottom locking is disabled. */
+export function ReleaseBottomLockOnResponseEnd({
+  status,
+  enabled,
+}: {
+  status: "idle" | "streaming";
+  enabled: boolean;
+}) {
+  const ctx = useStickToBottomContext() as ReturnType<typeof useStickToBottomContext> & {
+    scrollRef?: React.RefObject<HTMLElement>;
+    state: { isAtBottom: boolean; escapedFromLock: boolean };
+    stopScroll: () => void;
+  };
+  const previousStatusRef = useRef(status);
+  const scrollRef = ctx.scrollRef;
+  const state = ctx.state;
+  const stopScroll = ctx.stopScroll;
+
+  useLayoutEffect(() => {
+    const previousStatus = previousStatusRef.current;
+    previousStatusRef.current = status;
+    if (enabled || previousStatus !== "streaming" || status !== "idle") return;
+    const scrollElement = scrollRef?.current;
+    if (!scrollElement || !isConversationFollowingBottom(scrollElement)) return;
+    const scrollTop = scrollElement.scrollTop;
+    const physicallyAtBottom =
+      scrollElement.scrollHeight - scrollElement.clientHeight - scrollTop <= 1;
+    if (physicallyAtBottom) return;
+    const preserve = () => {
+      if (!isConversationFollowingBottom(scrollElement)) return;
+      stopScroll();
+      state.isAtBottom = false;
+      state.escapedFromLock = true;
+      scrollElement.scrollTop = scrollTop;
+    };
+    preserve();
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      preserve();
+      secondFrame = requestAnimationFrame(preserve);
+    });
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
+  }, [enabled, scrollRef, state, status, stopScroll]);
 
   return null;
 }

--- a/web/src/lib/bottomLockPreferences.test.ts
+++ b/web/src/lib/bottomLockPreferences.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readBottomLockEnabled,
+  subscribeBottomLockEnabled,
+  writeBottomLockEnabled,
+} from "./bottomLockPreferences";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("bottom lock preferences", () => {
+  it("defaults to enabled and stores only the disabled override", () => {
+    expect(readBottomLockEnabled()).toBe(true);
+
+    writeBottomLockEnabled(false);
+    expect(readBottomLockEnabled()).toBe(false);
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("false");
+
+    writeBottomLockEnabled(true);
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBeNull();
+  });
+
+  it("notifies mounted chat views when the setting changes", () => {
+    const onChange = vi.fn();
+    const unsubscribe = subscribeBottomLockEnabled(onChange);
+
+    writeBottomLockEnabled(false);
+    expect(onChange).toHaveBeenCalledOnce();
+
+    unsubscribe();
+    writeBottomLockEnabled(true);
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/lib/bottomLockPreferences.ts
+++ b/web/src/lib/bottomLockPreferences.ts
@@ -1,0 +1,38 @@
+export const DEFAULT_BOTTOM_LOCK_ENABLED = true;
+export const BOTTOM_LOCK_STORAGE_KEY = "omnigent:bottom-lock";
+
+const CHANGE_EVENT = "omnigent:bottom-lock-change";
+
+export function readBottomLockEnabled(): boolean {
+  if (typeof window === "undefined") return DEFAULT_BOTTOM_LOCK_ENABLED;
+  try {
+    const stored = window.localStorage.getItem(BOTTOM_LOCK_STORAGE_KEY);
+    return stored === null ? DEFAULT_BOTTOM_LOCK_ENABLED : stored === "true";
+  } catch {
+    return DEFAULT_BOTTOM_LOCK_ENABLED;
+  }
+}
+
+export function writeBottomLockEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (enabled === DEFAULT_BOTTOM_LOCK_ENABLED) {
+      window.localStorage.removeItem(BOTTOM_LOCK_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(BOTTOM_LOCK_STORAGE_KEY, String(enabled));
+    }
+  } catch {
+    // localStorage access errors are non-fatal.
+  }
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function subscribeBottomLockEnabled(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(CHANGE_EVENT, onChange);
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}

--- a/web/src/lib/conversationScrollPositions.test.ts
+++ b/web/src/lib/conversationScrollPositions.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  captureActiveConversationScroll,
+  getConversationScrollPosition,
+  isConversationScrollPositionRestored,
+  registerActiveConversationScroller,
+  restoreConversationScrollPosition,
+  saveConversationScrollPosition,
+} from "./conversationScrollPositions";
+
+function scroller(scrollTop: number): HTMLElement {
+  const element = document.createElement("div");
+  Object.defineProperties(element, {
+    scrollTop: { configurable: true, value: scrollTop, writable: true },
+    scrollHeight: { configurable: true, value: 2400 },
+    clientHeight: { configurable: true, value: 800 },
+  });
+  return element;
+}
+
+describe("conversation scroll positions", () => {
+  it("captures the rendered session at the switch boundary", () => {
+    const element = scroller(640);
+    const unregister = registerActiveConversationScroller("conv-outgoing", element);
+
+    captureActiveConversationScroll("conv-outgoing");
+
+    expect(getConversationScrollPosition("conv-outgoing")).toEqual({
+      scrollTop: 640,
+      wasAtBottom: false,
+    });
+    unregister();
+  });
+
+  it("does not associate shared DOM with a store session that has not rendered", () => {
+    const element = scroller(640);
+    const unregister = registerActiveConversationScroller("conv-rendered", element);
+
+    captureActiveConversationScroll("conv-store-leading");
+
+    expect(getConversationScrollPosition("conv-store-leading")).toBeUndefined();
+    unregister();
+  });
+
+  it("restores a user-message anchor after transcript height changes", () => {
+    const element = scroller(640);
+    const message = document.createElement("div");
+    message.dataset.role = "user";
+    message.dataset.userMessageId = "message-1";
+    element.append(message);
+    Object.defineProperty(message, "offsetTop", { configurable: true, value: 560 });
+    saveConversationScrollPosition("conv-anchored", element);
+
+    element.scrollTop = 1600;
+    Object.defineProperty(message, "offsetTop", { configurable: true, value: 1060 });
+    const saved = getConversationScrollPosition("conv-anchored");
+    expect(saved).toBeDefined();
+
+    restoreConversationScrollPosition(element, saved!);
+
+    expect(element.scrollTop).toBe(1140);
+  });
+
+  it("does not write a temporary fallback while the saved anchor is missing", () => {
+    const element = scroller(0);
+    const position = {
+      scrollTop: 5000,
+      anchorMessageId: "message-delayed",
+      anchorOffset: -80,
+    };
+
+    expect(restoreConversationScrollPosition(element, position)).toBe(false);
+
+    expect(element.scrollTop).toBe(0);
+  });
+
+  it("reports that restoration must retry until its anchor renders", () => {
+    const element = scroller(1600);
+    const position = {
+      scrollTop: 640,
+      anchorMessageId: "message-delayed",
+      anchorOffset: -80,
+    };
+
+    expect(restoreConversationScrollPosition(element, position)).toBe(false);
+
+    const message = document.createElement("div");
+    message.dataset.role = "user";
+    message.dataset.userMessageId = "message-delayed";
+    Object.defineProperty(message, "offsetTop", { configurable: true, value: 1060 });
+    element.append(message);
+
+    expect(restoreConversationScrollPosition(element, position)).toBe(true);
+    expect(element.scrollTop).toBe(1140);
+  });
+
+  it("does not settle when the saved position is beyond the current scroll range", () => {
+    // Content hasn't fully rendered: scrollHeight is small, so maxScrollTop = 0.
+    const element = document.createElement("div");
+    Object.defineProperties(element, {
+      scrollTop: { configurable: true, value: 0, writable: true },
+      scrollHeight: { configurable: true, value: 400 },
+      clientHeight: { configurable: true, value: 800 },
+    });
+    // Saved position was at the bottom of a fully-rendered transcript.
+    const position = { scrollTop: 5000 };
+
+    // The target is clamped to 0 (maxScrollTop = 0), scrollTop matches, but
+    // the restore must NOT consider itself settled — content will grow.
+    expect(isConversationScrollPositionRestored(element, position)).toBe(false);
+  });
+
+  it("does not settle when an anchored position is beyond the current scroll range", () => {
+    const element = document.createElement("div");
+    const message = document.createElement("div");
+    message.dataset.role = "user";
+    message.dataset.userMessageId = "msg-bottom";
+    Object.defineProperty(message, "offsetTop", { configurable: true, value: 4800 });
+    element.append(message);
+    Object.defineProperties(element, {
+      scrollTop: { configurable: true, value: 0, writable: true },
+      scrollHeight: { configurable: true, value: 400 },
+      clientHeight: { configurable: true, value: 800 },
+    });
+    // Saved at scrollTop=5000 with an anchor near the bottom.
+    const position = { scrollTop: 5000, anchorMessageId: "msg-bottom", anchorOffset: -200 };
+
+    // Anchor is found, but anchorTarget (5000) > maxScrollTop (0).
+    expect(isConversationScrollPositionRestored(element, position)).toBe(false);
+  });
+
+  it("settles once content grows enough to hold the saved position", () => {
+    const element = document.createElement("div");
+    Object.defineProperties(element, {
+      scrollTop: { configurable: true, value: 5000, writable: true },
+      scrollHeight: { configurable: true, value: 5800 },
+      clientHeight: { configurable: true, value: 800 },
+    });
+    const position = { scrollTop: 5000 };
+
+    // maxScrollTop = 5000, saved scrollTop = 5000, scrollTop matches.
+    expect(isConversationScrollPositionRestored(element, position)).toBe(true);
+  });
+});

--- a/web/src/lib/conversationScrollPositions.ts
+++ b/web/src/lib/conversationScrollPositions.ts
@@ -1,0 +1,171 @@
+export interface ConversationScrollPosition {
+  scrollTop: number;
+  anchorMessageId?: string;
+  anchorOffset?: number;
+  wasAtBottom?: boolean;
+}
+
+interface ActiveConversationScroller {
+  conversationId: string;
+  element: HTMLElement;
+}
+
+const STORAGE_KEY = "omnigent:conversation-scroll-positions:v2";
+
+function loadPositions(): Map<string, ConversationScrollPosition> {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as Record<
+      string,
+      ConversationScrollPosition
+    >;
+    return new Map(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, ConversationScrollPosition] =>
+          typeof entry[1]?.scrollTop === "number",
+      ),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+function persistPositions(positions: Map<string, ConversationScrollPosition>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(positions)));
+  } catch {
+    // Scroll restoration remains available in memory when storage is unavailable.
+  }
+}
+
+const positions = loadPositions();
+let activeScroller: ActiveConversationScroller | null = null;
+
+function naturalTop(element: HTMLElement): number {
+  let top = 0;
+  let current: HTMLElement | null = element;
+  while (current) {
+    top += current.offsetTop;
+    current = current.offsetParent as HTMLElement | null;
+  }
+  return top;
+}
+
+function readElementPosition(element: HTMLElement): ConversationScrollPosition {
+  const wasAtBottom = element.scrollHeight - element.clientHeight - element.scrollTop <= 1;
+  const messages = Array.from(
+    element.querySelectorAll<HTMLElement>('[data-role="user"][data-user-message-id]'),
+  );
+  const viewportTop = naturalTop(element) + element.scrollTop;
+  let anchor: HTMLElement | undefined;
+  let anchorTop = Number.NEGATIVE_INFINITY;
+  for (const message of messages) {
+    const top = naturalTop(message);
+    if (top <= viewportTop + 1 && top > anchorTop) {
+      anchor = message;
+      anchorTop = top;
+    }
+  }
+  if (!anchor && messages.length > 0) {
+    anchor = messages.reduce((nearest, message) =>
+      naturalTop(message) < naturalTop(nearest) ? message : nearest,
+    );
+    anchorTop = naturalTop(anchor);
+  }
+  return anchor
+    ? {
+        scrollTop: element.scrollTop,
+        anchorMessageId: anchor.dataset.userMessageId,
+        anchorOffset: anchorTop - viewportTop,
+        wasAtBottom,
+      }
+    : { scrollTop: element.scrollTop, wasAtBottom };
+}
+
+export function saveConversationScrollPosition(conversationId: string, element: HTMLElement): void {
+  const position = readElementPosition(element);
+  positions.set(conversationId, position);
+  persistPositions(positions);
+}
+
+export function getConversationScrollPosition(
+  conversationId: string,
+): ConversationScrollPosition | undefined {
+  return positions.get(conversationId);
+}
+
+export type ConversationScrollRestoreTarget =
+  | { kind: "waiting"; reason: "anchor-missing" | "target-unreachable" }
+  | { kind: "restore"; top: number };
+
+/**
+ * Returns a target only when the saved location exists in the current layout.
+ * An incomplete transcript must not be replaced with a clamped pixel fallback:
+ * that fallback is a temporary location and visibly jumps when layout catches up.
+ */
+export function getConversationScrollRestoreTarget(
+  element: HTMLElement,
+  position: ConversationScrollPosition,
+): ConversationScrollRestoreTarget {
+  const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight);
+  if (position.anchorMessageId !== undefined) {
+    const anchor = Array.from(
+      element.querySelectorAll<HTMLElement>('[data-role="user"][data-user-message-id]'),
+    ).find((message) => message.dataset.userMessageId === position.anchorMessageId);
+    if (!anchor || position.anchorOffset === undefined) {
+      return { kind: "waiting", reason: "anchor-missing" };
+    }
+    const top = naturalTop(anchor) - naturalTop(element) - position.anchorOffset;
+    return top >= 0 && top <= maxScrollTop + 1
+      ? { kind: "restore", top }
+      : { kind: "waiting", reason: "target-unreachable" };
+  }
+
+  const top = Math.max(0, position.scrollTop);
+  return top <= maxScrollTop + 1
+    ? { kind: "restore", top }
+    : { kind: "waiting", reason: "target-unreachable" };
+}
+
+export function restoreConversationScrollPosition(
+  element: HTMLElement,
+  position: ConversationScrollPosition,
+): boolean {
+  const target = getConversationScrollRestoreTarget(element, position);
+  if (target.kind === "waiting") return false;
+  element.scrollTop = target.top;
+  return true;
+}
+
+export function isConversationScrollPositionRestored(
+  element: HTMLElement,
+  position: ConversationScrollPosition,
+): boolean {
+  const target = getConversationScrollRestoreTarget(element, position);
+  return target.kind === "restore" && Math.abs(element.scrollTop - target.top) <= 1;
+}
+
+export function registerActiveConversationScroller(
+  conversationId: string,
+  element: HTMLElement,
+): () => void {
+  const registration = { conversationId, element };
+  activeScroller = registration;
+  return () => {
+    if (activeScroller === registration) {
+      activeScroller = null;
+    }
+  };
+}
+
+/**
+ * Capture immediately before chatStore changes its active conversation.
+ *
+ * The expected id prevents a URL/store render race from saving the shared DOM
+ * element under a session whose messages have not rendered yet.
+ */
+export function captureActiveConversationScroll(expectedConversationId: string | null): void {
+  if (!activeScroller || activeScroller.conversationId !== expectedConversationId) {
+    return;
+  }
+  saveConversationScrollPosition(activeScroller.conversationId, activeScroller.element);
+}

--- a/web/src/lib/conversationScrollState.ts
+++ b/web/src/lib/conversationScrollState.ts
@@ -1,0 +1,63 @@
+export type ConversationScrollMode =
+  "following-bottom" | "restore-pending" | "restoring" | "user-controlled";
+
+interface ConversationScrollState {
+  mode: ConversationScrollMode;
+  generation: number;
+}
+
+const states = new WeakMap<HTMLElement, ConversationScrollState>();
+
+function stateFor(element: HTMLElement): ConversationScrollState {
+  let state = states.get(element);
+  if (!state) {
+    state = { mode: "following-bottom", generation: 0 };
+    states.set(element, state);
+  }
+  return state;
+}
+
+export function conversationScrollMode(element: HTMLElement): ConversationScrollMode {
+  return stateFor(element).mode;
+}
+
+export function beginConversationScrollRestore(element: HTMLElement): number {
+  const state = stateFor(element);
+  state.generation += 1;
+  state.mode = "restore-pending";
+  return state.generation;
+}
+
+export function markConversationScrollRestoring(element: HTMLElement, generation: number): boolean {
+  const state = stateFor(element);
+  if (state.generation !== generation || state.mode === "user-controlled") return false;
+  state.mode = "restoring";
+  return true;
+}
+
+export function isCurrentConversationScrollRestore(
+  element: HTMLElement,
+  generation: number,
+): boolean {
+  const state = stateFor(element);
+  return (
+    state.generation === generation &&
+    (state.mode === "restore-pending" || state.mode === "restoring")
+  );
+}
+
+export function takeConversationScrollControl(element: HTMLElement): void {
+  const state = stateFor(element);
+  state.generation += 1;
+  state.mode = "user-controlled";
+}
+
+export function followConversationBottom(element: HTMLElement): void {
+  const state = stateFor(element);
+  state.generation += 1;
+  state.mode = "following-bottom";
+}
+
+export function isConversationFollowingBottom(element: HTMLElement): boolean {
+  return stateFor(element).mode === "following-bottom";
+}

--- a/web/src/pages/ChatPage.historyLoad.test.tsx
+++ b/web/src/pages/ChatPage.historyLoad.test.tsx
@@ -3,11 +3,15 @@ import { Profiler, useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserMessageBlock } from "@/lib/blocks";
 import { useChatStore } from "@/store/chatStore";
+import { captureActiveConversationScroll } from "@/lib/conversationScrollPositions";
 import {
+  BottomLockController,
+  ConversationScrollPosition,
   HistoryAutoLoader,
   JumpToTopButton,
   KeepBottomOnViewportResize,
   LatestTurnSpacer,
+  ReleaseBottomLockOnResponseEnd,
 } from "./ChatPage";
 
 const stickContext = vi.hoisted(() => ({
@@ -68,6 +72,151 @@ function setScrollMetrics(
     get: () => metrics.clientHeight ?? 0,
   });
 }
+
+describe("BottomLockController", () => {
+  afterEach(() => {
+    cleanup();
+    stickContext.scrollRef.current = null;
+    stickContext.stopScroll = undefined;
+  });
+
+  it("releases the lock initially and whenever reaching the bottom re-arms it", () => {
+    const scrollRoot = document.createElement("div");
+    stickContext.scrollRef.current = scrollRoot;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+    const stopScroll = vi.fn();
+    stickContext.stopScroll = stopScroll;
+
+    render(<BottomLockController enabled={false} />);
+    expect(stopScroll).toHaveBeenCalledOnce();
+    expect(stickContext.state).toEqual({ isAtBottom: false, escapedFromLock: true });
+
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+    fireEvent.scroll(scrollRoot);
+    expect(stopScroll).toHaveBeenCalledTimes(2);
+    expect(stickContext.state).toEqual({ isAtBottom: false, escapedFromLock: true });
+  });
+});
+
+describe("ConversationScrollPosition", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    stickContext.scrollRef.current = null;
+    stickContext.scrollToBottom.mockReset();
+    stickContext.stopScroll = undefined;
+  });
+
+  it("restores a session's non-bottom transcript position after remount", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((_callback: FrameRequestCallback) => {
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    const metrics = { scrollTop: 0, scrollHeight: 2400, clientHeight: 800 };
+    const scrollRoot = document.createElement("div");
+    setScrollMetrics(scrollRoot, metrics);
+    stickContext.scrollRef.current = scrollRoot;
+    const stopScroll = vi.fn();
+    stickContext.stopScroll = stopScroll;
+    const scroller = { el: scrollRoot, state: stickContext.state, stopScroll };
+
+    const view = render(
+      <ConversationScrollPosition
+        conversationId="conv-scroll-restore"
+        scroller={scroller}
+        followBottomOnFallback
+      />,
+    );
+    // New-session init parks at the bottom; the reader then scrolls up to 640.
+    metrics.scrollTop = 640;
+    // Switching away captures the reading position ahead of the store switch
+    // (ChatPage's urlConvId effect), so the init scroll can't lose it.
+    captureActiveConversationScroll("conv-scroll-restore");
+    view.rerender(
+      <ConversationScrollPosition
+        conversationId="conv-other-session"
+        scroller={scroller}
+        followBottomOnFallback
+      />,
+    );
+    metrics.scrollTop = 300;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+
+    view.rerender(
+      <ConversationScrollPosition
+        conversationId="conv-scroll-restore"
+        scroller={scroller}
+        followBottomOnFallback
+      />,
+    );
+
+    expect(metrics.scrollTop).toBe(640);
+    expect(stopScroll).toHaveBeenCalledOnce();
+    expect(stickContext.state).toEqual({ isAtBottom: false, escapedFromLock: true });
+  });
+});
+
+describe("ReleaseBottomLockOnResponseEnd", () => {
+  it("keeps the reader's position when streaming settles", () => {
+    const scrollRoot = document.createElement("div");
+    const metrics = { scrollTop: 640, scrollHeight: 2400, clientHeight: 800 };
+    setScrollMetrics(scrollRoot, metrics);
+    stickContext.scrollRef.current = scrollRoot;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+    const stopScroll = vi.fn();
+    stickContext.stopScroll = stopScroll;
+
+    const { rerender } = render(
+      <ReleaseBottomLockOnResponseEnd status="streaming" enabled={false} />,
+    );
+    rerender(<ReleaseBottomLockOnResponseEnd status="idle" enabled={false} />);
+
+    expect(stopScroll).toHaveBeenCalledOnce();
+    expect(stickContext.state).toEqual({ isAtBottom: false, escapedFromLock: true });
+    expect(metrics.scrollTop).toBe(640);
+  });
+
+  it("keeps the normal bottom lock when the reader is already at the end", () => {
+    const scrollRoot = document.createElement("div");
+    setScrollMetrics(scrollRoot, { scrollTop: 1600, scrollHeight: 2400, clientHeight: 800 });
+    stickContext.scrollRef.current = scrollRoot;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+    const stopScroll = vi.fn();
+    stickContext.stopScroll = stopScroll;
+
+    const { rerender } = render(
+      <ReleaseBottomLockOnResponseEnd status="streaming" enabled={false} />,
+    );
+    rerender(<ReleaseBottomLockOnResponseEnd status="idle" enabled={false} />);
+
+    expect(stopScroll).not.toHaveBeenCalled();
+    expect(stickContext.state).toEqual({ isAtBottom: true, escapedFromLock: false });
+  });
+
+  it("allows completion to follow the response when bottom locking is enabled", () => {
+    const scrollRoot = document.createElement("div");
+    setScrollMetrics(scrollRoot, { scrollTop: 640, scrollHeight: 2400, clientHeight: 800 });
+    stickContext.scrollRef.current = scrollRoot;
+    stickContext.state.isAtBottom = true;
+    stickContext.state.escapedFromLock = false;
+    const stopScroll = vi.fn();
+    stickContext.stopScroll = stopScroll;
+
+    const { rerender } = render(<ReleaseBottomLockOnResponseEnd status="streaming" enabled />);
+    rerender(<ReleaseBottomLockOnResponseEnd status="idle" enabled />);
+
+    expect(stopScroll).not.toHaveBeenCalled();
+    expect(stickContext.state).toEqual({ isAtBottom: true, escapedFromLock: false });
+  });
+});
 
 describe("KeepBottomOnViewportResize", () => {
   let resize: (() => void) | null;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1572,20 +1572,14 @@ const MainAgentSurface = memo(function MainAgentSurfaceImpl({
   const prepareSendScroll = useCallback(() => {
     const current = scroller;
     if (!current) return;
-    const { el, state, stopScroll } = current;
-    if (!bottomLockEnabled) {
-      takeConversationScrollControl(el);
-      stopScroll();
-      state.isAtBottom = false;
-      state.escapedFromLock = true;
-      return;
-    }
-    const atBottom = el.scrollHeight - el.clientHeight - el.scrollTop <= 1;
-    if (atBottom) {
+    // Lock on: sending follows the response (jump to the latest message),
+    // matching the preference's description and the library's contract.
+    if (bottomLockEnabled) {
       setSendScrollNonce((n) => n + 1);
       return;
     }
-    // Sending does not imply "follow" while the reader is looking at history.
+    // Lock off: sending must not yank a reader parked in history.
+    const { el, state, stopScroll } = current;
     takeConversationScrollControl(el);
     stopScroll();
     state.isAtBottom = false;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -33,6 +33,13 @@ import {
 } from "@/components/KeyboardShortcut";
 import { useNavigate, useParams } from "@/lib/routing";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
+import { captureActiveConversationScroll } from "@/lib/conversationScrollPositions";
+import { takeConversationScrollControl } from "@/lib/conversationScrollState";
+import {
+  DEFAULT_BOTTOM_LOCK_ENABLED,
+  readBottomLockEnabled,
+  subscribeBottomLockEnabled,
+} from "@/lib/bottomLockPreferences";
 import { Button } from "@/components/ui/button";
 import { useAppName } from "@/lib/branding";
 import { cn } from "@/lib/utils";
@@ -103,13 +110,16 @@ export type { MentionItem, MentionState };
 // keep working. SessionSharedContext and computeIsWorking are also imported
 // back below for ChatPage's own use.
 export {
+  BottomLockController,
   BubbleView,
+  ConversationScrollPosition,
   ConversationScrollRefBridge,
   HistoryAutoLoader,
   HistoryLoadingIndicator,
   JumpToTopButton,
   KeepBottomOnViewportResize,
   LatestTurnSpacer,
+  ReleaseBottomLockOnResponseEnd,
   ScrollToBottomOnSend,
   SessionSharedContext,
   UserMessageNavConnected,
@@ -431,6 +441,7 @@ export function ChatPage() {
   // intentionally don't await it here. The store's `loadingConversation` flag
   // drives the loading UI below; `conversationLoadError` drives the error UI.
   useEffect(() => {
+    captureActiveConversationScroll(useChatStore.getState().conversationId);
     void useChatStore.getState().switchTo(urlConvId ?? null);
   }, [urlConvId]);
 
@@ -1552,12 +1563,39 @@ const MainAgentSurface = memo(function MainAgentSurfaceImpl({
     };
   }, [scroller]);
   const [sendScrollNonce, setSendScrollNonce] = useState(0);
+  const bottomLockEnabled = useSyncExternalStore(
+    subscribeBottomLockEnabled,
+    readBottomLockEnabled,
+    () => DEFAULT_BOTTOM_LOCK_ENABLED,
+  );
+  const prepareSendScroll = useCallback(() => {
+    const current = scroller;
+    if (!current) return;
+    const { el, state, stopScroll } = current;
+    if (!bottomLockEnabled) {
+      takeConversationScrollControl(el);
+      stopScroll();
+      state.isAtBottom = false;
+      state.escapedFromLock = true;
+      return;
+    }
+    const atBottom = el.scrollHeight - el.clientHeight - el.scrollTop <= 1;
+    if (atBottom) {
+      setSendScrollNonce((n) => n + 1);
+      return;
+    }
+    // Sending does not imply "follow" while the reader is looking at history.
+    takeConversationScrollControl(el);
+    stopScroll();
+    state.isAtBottom = false;
+    state.escapedFromLock = true;
+  }, [bottomLockEnabled, scroller]);
   const handleSend = useCallback(
     (text: string, files?: File[]) => {
-      setSendScrollNonce((n) => n + 1);
+      prepareSendScroll();
       onSend(text, files);
     },
-    [onSend],
+    [onSend, prepareSendScroll],
   );
   // Wrap the slash-command sender the same way (scroll to bottom on send).
   // Gated off for native-wrapper sessions (claude-native / codex-native):
@@ -1579,11 +1617,11 @@ const MainAgentSurface = memo(function MainAgentSurfaceImpl({
     () =>
       onSendSlashCommand && !isNativeWrapper
         ? (name: string, args: string) => {
-            setSendScrollNonce((n) => n + 1);
+            prepareSendScroll();
             onSendSlashCommand(name, args);
           }
         : undefined,
-    [onSendSlashCommand, isNativeWrapper],
+    [onSendSlashCommand, isNativeWrapper, prepareSendScroll],
   );
 
   // Synchronous bottom re-pin for the composer's growth, called in the same

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -543,6 +543,16 @@ describe("SettingsPage", () => {
     expect(localStorage.getItem("omnigent:ui-font-family")).toBeNull();
   });
 
+  it("keeps automatic bottom locking on by default", () => {
+    renderPage("/settings/appearance");
+    const toggle = screen.getByTestId("bottom-lock-toggle");
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(localStorage.getItem("omnigent:bottom-lock")).toBe("false");
+  });
+
   it("resets every appearance preference back to product defaults", () => {
     localStorage.clear();
     renderPage("/settings/appearance");
@@ -557,6 +567,7 @@ describe("SettingsPage", () => {
     fireEvent.click(screen.getByTestId("transcript-view-default-terminal"));
     fireEvent.click(screen.getByTestId("workspace-panel-default-collapsed"));
     fireEvent.click(screen.getByTestId("hide-unconfigured-harnesses-toggle"));
+    fireEvent.click(screen.getByTestId("bottom-lock-toggle"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.click(screen.getByTestId("ui-font-size-inc"));
     fireEvent.change(screen.getByTestId("ui-font-family-input") as HTMLInputElement, {
@@ -613,6 +624,9 @@ describe("SettingsPage", () => {
       "aria-checked",
       "false",
     );
+
+    // Bottom lock is back on (the product default).
+    expect(screen.getByTestId("bottom-lock-toggle")).toHaveAttribute("aria-checked", "true");
   });
 
   it("lets you clear and retype the font size without clamping mid-edit", () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -172,6 +172,12 @@ import {
   writeTranscriptViewDefault,
   type TranscriptViewDefault,
 } from "@/lib/transcriptViewPreferences";
+import {
+  BOTTOM_LOCK_STORAGE_KEY,
+  DEFAULT_BOTTOM_LOCK_ENABLED,
+  readBottomLockEnabled,
+  writeBottomLockEnabled,
+} from "@/lib/bottomLockPreferences";
 import { readDefaultBaseBranch, writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readAlwaysSteer, writeAlwaysSteer } from "@/lib/alwaysSteerPreferences";
 import {
@@ -754,6 +760,34 @@ function HideUnconfiguredHarnessesControl() {
   );
 }
 
+function BottomLockControl() {
+  const [enabled, setEnabled] = useState(() => readBottomLockEnabled());
+  const labelId = useId();
+  const toggle = useCallback((next: boolean) => {
+    setEnabled(next);
+    writeBottomLockEnabled(next);
+  }, []);
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex flex-col">
+        <span id={labelId} className="text-ui font-medium">
+          Keep chat pinned to bottom
+        </span>
+        <span className="text-sm text-muted-foreground">
+          Jump to the latest message when you send, then follow new response content automatically.
+        </span>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        checked={enabled}
+        onCheckedChange={toggle}
+        data-testid="bottom-lock-toggle"
+        className="mt-0.5 shrink-0"
+      />
+    </div>
+  );
+}
+
 function AppearanceSection() {
   // Embedded: the host owns light/dark, so the Mode picker would be a no-op —
   // replace it with a note (plus a link to the host's own theme settings when
@@ -785,6 +819,8 @@ function AppearanceSection() {
 
     writeHideUnconfiguredHarnesses(DEFAULT_HIDE_UNCONFIGURED_HARNESSES);
 
+    writeBottomLockEnabled(DEFAULT_BOTTOM_LOCK_ENABLED);
+
     applyDesktopUiFontSize(UI_FONT_SIZE_DEFAULT);
     applyUiFontFamily(UI_FONT_FAMILY_DEFAULT);
 
@@ -810,6 +846,7 @@ function AppearanceSection() {
           "omnigent:default-transcript-view",
           "omnigent:default-workspace-panel",
           "omnigent:hide-unconfigured-harnesses",
+          BOTTOM_LOCK_STORAGE_KEY,
         ]) {
           window.localStorage.removeItem(key);
         }
@@ -894,6 +931,8 @@ function AppearanceSection() {
         <WorkspacePanelDefaultControl />
 
         <HideUnconfiguredHarnessesControl />
+
+        <BottomLockControl />
 
         <UiFontSizeControl />
 


### PR DESCRIPTION
## Related issue

Closes #6665. Supersedes #5249 — its head branch (`chat-pinned-bottom-scroll-restore`) was deleted after the draft was closed, so it could not be reopened; this PR re-proposes the feature rebased onto current `main`.

## Summary

Two appearance preferences for the chat transcript:

1. **Keep chat pinned to bottom** (opt-out toggle, **enabled by default** to preserve existing behavior): When enabled, sending a message jumps to the latest content and follows the streaming response. When disabled, the `use-stick-to-bottom` library's implicit bottom lock is released so readers can scroll freely without being yanked back — including on completion-time resizes.

2. **Restore last view position across session switches**: Each conversation's scroll position is captured ahead of the store switch (`captureActiveConversationScroll` in the `urlConvId` effect) and restored on return, anchored to the user message that was at the top of the viewport so it survives transcript height changes during hydration. A generation-guarded `requestAnimationFrame` loop re-targets until the transcript height settles (150ms quiet window, 7s deadline). Wheel, touch, pointer, **and keyboard** input take over immediately — matching the takeover semantics #6643 added for the files-panel restore.

This is useful for people whose habit is to send a message while reading the AI response and stay focused.

### How it works

**Bottom lock toggle** — `BottomLockController` releases the library's bottom lock (sets `escapedFromLock = true` on every scroll/content resize) when the toggle is off. `ScrollToBottomOnSend` only jumps to the bottom on send when the toggle is on, and re-arms following via `followConversationBottom`. `ReleaseBottomLockOnResponseEnd` preserves the reader's scroll position through final response layout resizes when the toggle is off. `KeepBottomOnViewportResize` (only mounted when on) keeps bottom-locked readers pinned during composer height changes.

**Scroll position restore** — `ConversationScrollPosition` registers the active scroller per conversation; ChatPage captures the reading position just before the store switches conversations, then restores it on mount via an rAF loop that re-targets the anchored user-message position until layout settles. Restores are mode-guarded (`conversationScrollState`) so a user gesture during the loop wins. Sessions with no saved position initialize at the bottom.

### Files

- `web/src/lib/bottomLockPreferences.ts` — localStorage toggle (read/write/subscribe via custom events)
- `web/src/lib/conversationScrollPositions.ts` — per-conversation scroll save/restore with user-message anchoring + restore-target resolution
- `web/src/lib/conversationScrollState.ts` — per-element scroll ownership state machine (following-bottom / restore-pending / restoring / user-controlled)
- `web/src/components/chat/chatBubbleParts.tsx` — `BottomLockController`, `ScrollToBottomOnSend` (now gated), `ReleaseBottomLockOnResponseEnd`, `ConversationScrollPosition`
- `web/src/components/chat/Transcript.tsx` — mounts the controllers inside/outside the StickToBottom subtree
- `web/src/pages/ChatPage.tsx` — bottom-lock-aware send scroll (`prepareSendScroll`) + capture-on-switch
- `web/src/pages/SettingsPage.tsx` — "Keep chat pinned to bottom" Switch in Appearance, included in reset-to-defaults

## Test Plan

- `npx tsc -b --noEmit` — passes (zero type errors)
- `npx vitest run src/pages/ChatPage.historyLoad.test.tsx src/lib/conversationScrollPositions.test.ts src/lib/bottomLockPreferences.test.ts src/pages/SettingsPage.test.tsx` — 116 tests pass
- `npx vitest run src/pages/ChatPage.*` — 548 tests pass (no regressions)
- Full web suite: green except pre-existing `NewChatDialog` failures (reproduce on pristine `main`)

## Demo

<img width="878" height="60" alt="image" src="https://github.com/user-attachments/assets/19b5973a-0df8-475a-a200-0a3ef73fb080" />


https://github.com/user-attachments/assets/0b85dcc6-34e7-4734-99e0-54ae6ff24488



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the preference modules (`bottomLockPreferences.test.ts`, `conversationScrollPositions.test.ts`), the four scroll controllers (`ChatPage.historyLoad.test.tsx`), the Settings toggle default, and the reset-to-defaults path (`SettingsPage.test.tsx`). Manual verification: toggle off → scroll mid-transcript → switch sessions and back restores the position; sending while reading history does not yank the view; streaming does not re-pin.

## Changelog

Keep chat pinned to bottom is now an opt-out appearance preference (on by default), and each conversation remembers its scroll position when you switch away and back.
