### PR TITLE
More session navigation optimizations

### DIFF
--- a/web/src/components/chat/Transcript.tsx
+++ b/web/src/components/chat/Transcript.tsx
@@ -1,13 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useStickToBottomContext } from "use-stick-to-bottom";
@@ -186,10 +177,9 @@ function TranscriptImpl({
     }
     return ids;
   }, [blocks]);
-  // Defer one coherent display model. Every bubble-derived surface changes in
-  // the same commit, so the rail/spacer/indicators can never describe the new
-  // conversation while the virtual rows still show the previous one.
-  const nextDisplaySnapshot = useMemo(
+  // Keep every bubble-derived surface on one coherent model so the
+  // rail/spacer/indicators always describe the rows being rendered.
+  const display = useMemo(
     () => ({
       conversationId,
       bubbles,
@@ -219,8 +209,6 @@ function TranscriptImpl({
       showsWorking,
     ],
   );
-  const display = useDeferredValue(nextDisplaySnapshot);
-  const isSwitchPending = display.conversationId !== conversationId;
   const [nativeFindConversationId, setNativeFindConversationId] = useState<string | null>(null);
   useEffect(() => setNativeFindConversationId(null), [conversationId]);
   useEffect(() => {
@@ -314,13 +302,6 @@ function TranscriptImpl({
   }, [nav]);
 
   const showWorkingIndicator = shouldShowWorkingIndicator(display.showsWorking, display.bubbles);
-  useLayoutEffect(() => {
-    const content = scroller?.el.firstElementChild;
-    if (!(content instanceof HTMLElement)) return;
-    content.toggleAttribute("inert", isSwitchPending);
-    return () => content.removeAttribute("inert");
-  }, [isSwitchPending, scroller]);
-
   return (
     <>
       {/* Task tracker pinned above the thread. Sibling of the viewport (not an
@@ -336,7 +317,6 @@ function TranscriptImpl({
         <Conversation className={cn(!display.hasTasks && "chat-scroll-fade", "flex-1")}>
           <ConversationContent
             scrollClassName="transcript-hide-native-scrollbar"
-            aria-hidden={isSwitchPending || undefined}
             className={cn(
               "chat-conversation-content mx-auto w-full gap-4 px-4 pb-6",
               display.hasTasks ? "pt-4" : "pt-20",

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -225,6 +225,44 @@ describe("useUnseenTick", () => {
   });
 });
 
+describe("useConversationReadState", () => {
+  it("does not re-render a row whose read state did not change", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([
+      { id: "conv-1", viewer_last_seen: 1_000 },
+      { id: "conv-2", viewer_last_seen: 1_000 },
+    ]);
+    let conv1Renders = 0;
+    let conv2Renders = 0;
+    const conv1 = renderHook(() => {
+      conv1Renders += 1;
+      return mod.useConversationReadState("conv-1", 2_000, "idle");
+    });
+    const conv2 = renderHook(() => {
+      conv2Renders += 1;
+      return mod.useConversationReadState("conv-2", 2_000, "idle");
+    });
+    const conv2Before = conv2Renders;
+
+    act(() => mod.markConversationSeen("conv-1", 2_000));
+
+    expect(conv1.result.current.unseen).toBe(false);
+    expect(conv1Renders).toBeGreaterThan(1);
+    expect(conv2.result.current.unseen).toBe(true);
+    expect(conv2Renders).toBe(conv2Before);
+  });
+
+  it("reports the explicit-unread bit independently of automatic unseen state", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 1_000 }]);
+    const { result } = renderHook(() => mod.useConversationReadState("conv-1", 2_000, "running"));
+
+    act(() => mod.markConversationUnread("conv-1", 2_000));
+
+    expect(result.current).toEqual({ unseen: false, explicitlyUnread: true });
+  });
+});
+
 describe("useMarkConversationSeen", () => {
   it("marks the active thread seen on mount when focused (after seed)", async () => {
     const mod = await loadFresh();

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -301,6 +301,28 @@ export function useUnseenTick(): number {
   );
 }
 
+export function useConversationReadState(
+  conversationId: string,
+  updatedAt: number,
+  status: string | undefined,
+): { unseen: boolean; explicitlyUnread: boolean } {
+  const read = () =>
+    (isConversationUnseen(conversationId, updatedAt, status) ? 1 : 0) |
+    (isExplicitlyUnread(conversationId) ? 2 : 0);
+  const state = useSyncExternalStore(
+    (onChange) => {
+      subscribers.add(onChange);
+      return () => subscribers.delete(onChange);
+    },
+    read,
+    read,
+  );
+  return {
+    unseen: (state & 1) !== 0,
+    explicitlyUnread: (state & 2) !== 0,
+  };
+}
+
 /**
  * A conversation is "unseen" only when (a) the agent has finished
  * a turn — status is "idle" or "failed", not "running" — and

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -139,7 +139,7 @@ function RootApp({ initialInfo }: { initialInfo: ServerInfo }) {
           <ThemeProvider>
             <TooltipProvider>
               <ImageLightboxProvider>
-                <BrowserRouter>
+                <BrowserRouter future={{ v7_startTransition: true }}>
                   <SessionUpdatesProvider>
                     <RunnerHealthProvider>
                       <QueueFlushProvider>

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4245,6 +4245,11 @@ export function NewChatLandingScreen() {
     // form submit) and Enter-key sends alike. After the guard so guarded no-ops
     // don't emit, matching the disabled Start button.
     trackClick("new_chat.start_session", "button");
+    // BrowserRouter may defer its React update even though history already
+    // changed. Remember the submit location so a late create cannot redirect
+    // after the user has navigated elsewhere while this component is still
+    // mounted in the outgoing transition tree.
+    const createLocation = window.location.href;
     // Remember the repo/branch for next time (seeds the picker on the next
     // visit). Only when a repo is actually set — a no-repo session leaves the
     // remembered repo untouched rather than clearing it.
@@ -4671,7 +4676,9 @@ export function NewChatLandingScreen() {
       // session; jumping them into this one now would hijack that. The
       // session is created either way and its first message stays held
       // for whenever they open it.
-      if (onScreenRef.current) navigate(`/c/${data.id}`);
+      if (onScreenRef.current && window.location.href === createLocation) {
+        navigate(`/c/${data.id}`);
+      }
     } catch {
       returnDraftToUser();
       setCreateError("Couldn't reach the server. Check your connection and try again.");

--- a/web/src/shell/Sidebar.selectionActiveHighlight.test.tsx
+++ b/web/src/shell/Sidebar.selectionActiveHighlight.test.tsx
@@ -8,10 +8,12 @@ import type * as SessionsApiModule from "@/lib/sessionsApi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { forwardRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
 import type { Session } from "@/lib/types";
+import { type OmnigentLinkProps, reactRouterRouting, RoutingProvider } from "@/lib/routing";
 
 vi.mock("@/hooks/useConversations", () => ({
   useConversations: vi.fn(),
@@ -102,16 +104,38 @@ function snapshot(id: string, parentSessionId: string | null): Session {
   } as unknown as Session;
 }
 
-function renderAt(initialEntry: string) {
+function renderAt(initialEntry: string, holdRoute = false) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const StaticLink = forwardRef<HTMLAnchorElement, OmnigentLinkProps>(
+    ({ componentId: _componentId, onClick, to, ...props }, ref) => (
+      <a
+        ref={ref}
+        href={String(to)}
+        {...props}
+        onClick={(event) => {
+          onClick?.(event);
+          event.preventDefault();
+        }}
+      />
+    ),
+  );
+  const routes = (
+    <Routes>
+      <Route path="/" element={<Sidebar open onClose={vi.fn()} />} />
+      <Route path="/c/:conversationId" element={<Sidebar open onClose={vi.fn()} />} />
+    </Routes>
+  );
   return render(
     <QueryClientProvider client={qc}>
       <TooltipProvider>
         <MemoryRouter initialEntries={[initialEntry]}>
-          <Routes>
-            <Route path="/" element={<Sidebar open onClose={vi.fn()} />} />
-            <Route path="/c/:conversationId" element={<Sidebar open onClose={vi.fn()} />} />
-          </Routes>
+          {holdRoute ? (
+            <RoutingProvider value={{ ...reactRouterRouting, Link: StaticLink }}>
+              {routes}
+            </RoutingProvider>
+          ) : (
+            routes
+          )}
         </MemoryRouter>
       </TooltipProvider>
     </QueryClientProvider>,
@@ -131,6 +155,19 @@ function rowFor(id: string): HTMLElement {
 }
 
 describe("sidebar active highlight in selection mode", () => {
+  it("highlights a clicked session before route state catches up", async () => {
+    mockConversations([topLevelConv("conv_active"), topLevelConv("conv_other")]);
+    getSessionSlimMock.mockImplementation((id: string) => Promise.resolve(snapshot(id, null)));
+
+    renderAt("/c/conv_active", true);
+    await waitFor(() => expect(rowFor("conv_active")).toHaveClass("bg-[var(--sidebar-active)]"));
+
+    fireEvent.click(rowFor("conv_other"));
+
+    expect(rowFor("conv_other")).toHaveClass("bg-[var(--sidebar-active)]");
+    expect(rowFor("conv_active")).not.toHaveClass("bg-[var(--sidebar-active)]");
+  });
+
   it("drops the active-session highlight once selection mode is on", async () => {
     mockConversations([topLevelConv("conv_active"), topLevelConv("conv_other")]);
     getSessionSlimMock.mockImplementation((id: string) => Promise.resolve(snapshot(id, null)));

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -245,6 +245,9 @@ const HostsByIdContext = createContext<ReadonlyMap<string, Host>>(new Map());
 const IsMobileContext = createContext<boolean>(false);
 const ViewerIdContext = createContext<string | null>(null);
 const ServerInfoContext = createContext<ReturnType<typeof useServerInfo>>("loading");
+const RowActivationContext = createContext<
+  (id: string, event: MouseEvent<HTMLAnchorElement>) => void
+>(() => {});
 // Rows report an in-progress inline-rename edit here so ConversationList can
 // hold the sort order for the edit's whole duration — the pointer often
 // leaves the list while typing, and a reorder then would shuffle rows around
@@ -267,6 +270,7 @@ function SidebarRowDataProvider({
   isMobile,
   viewerId,
   serverInfo,
+  onActivate,
   children,
 }: {
   projectNamesById: Map<string, string>;
@@ -275,6 +279,7 @@ function SidebarRowDataProvider({
   isMobile: boolean;
   viewerId: string | null;
   serverInfo: ReturnType<typeof useServerInfo>;
+  onActivate: (id: string, event: MouseEvent<HTMLAnchorElement>) => void;
   children: ReactNode;
 }) {
   return (
@@ -283,7 +288,11 @@ function SidebarRowDataProvider({
         <HostsByIdContext.Provider value={hostsById}>
           <IsMobileContext.Provider value={isMobile}>
             <ViewerIdContext.Provider value={viewerId}>
-              <ServerInfoContext.Provider value={serverInfo}>{children}</ServerInfoContext.Provider>
+              <ServerInfoContext.Provider value={serverInfo}>
+                <RowActivationContext.Provider value={onActivate}>
+                  {children}
+                </RowActivationContext.Provider>
+              </ServerInfoContext.Provider>
             </ViewerIdContext.Provider>
           </IsMobileContext.Provider>
         </HostsByIdContext.Provider>
@@ -1635,6 +1644,14 @@ function ConversationList({
   // parent walk loads — a top-level session resolves to itself.
   const activeRootSessionId = useActiveRootSessionId(activeId ?? null);
   const resolvedActiveId = activeRootSessionId ?? activeId ?? null;
+  const [optimisticActiveId, setOptimisticActiveId] = useState<string | null>(null);
+  useEffect(() => setOptimisticActiveId(null), [activeId]);
+  const activateRow = useCallback((id: string, event: MouseEvent<HTMLAnchorElement>) => {
+    if (event.defaultPrevented || event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    setOptimisticActiveId(id);
+  }, []);
+  const displayedActiveId = optimisticActiveId ?? resolvedActiveId;
   const [activeOverride, setActiveOverride] = useState<ActiveChatOverride | null>(null);
   useEffect(() => {
     setActiveOverride((prev) => computeNextActiveOverride(activeId, allConversations, prev));
@@ -2112,6 +2129,7 @@ function ConversationList({
       isMobile={isMobile}
       viewerId={viewerId}
       serverInfo={serverInfo}
+      onActivate={activateRow}
     >
       <DndContext
         sensors={sensors}
@@ -2168,7 +2186,7 @@ function ConversationList({
                     <ConversationSection
                       title="Pinned"
                       conversations={sections.pinned}
-                      activeConversationId={resolvedActiveId}
+                      activeConversationId={displayedActiveId}
                       pinnedConversationIds={pinnedConversationIds}
                       collapsed={effectiveCollapsedSections.includes("Pinned")}
                       onToggleCollapsed={() => effectiveToggleSectionCollapsed("Pinned")}
@@ -2227,7 +2245,7 @@ function ConversationList({
                       projectId={group.id}
                       icon={group.icon}
                       windowConversations={group.conversations}
-                      activeConversationId={resolvedActiveId}
+                      activeConversationId={displayedActiveId}
                       expanded={expandedProjects.includes(group.name)}
                       active={newSessionProjectName === group.name}
                       // Best-effort marker from the globally-loaded window: a
@@ -2268,7 +2286,7 @@ function ConversationList({
                     <ConversationSection
                       title="Sessions"
                       conversations={sections.sessions}
-                      activeConversationId={resolvedActiveId}
+                      activeConversationId={displayedActiveId}
                       emptyMessage={SIDEBAR_FILTER_EMPTY[activeTab]}
                       pinnedConversationIds={pinnedConversationIds}
                       collapsed={effectiveCollapsedSections.includes("Chats")}
@@ -3516,6 +3534,7 @@ function ConversationRowImpl({
   // portal), and a passive effect would leave a post-paint frame where churn
   // could reorder — and blur — the just-mounted input before the hold lands.
   const reportRowEditing = useContext(RowEditHoldContext);
+  const activateRow = useContext(RowActivationContext);
   useLayoutEffect(() => {
     if (!isEditing) return;
     reportRowEditing(conversation.id, true);
@@ -3857,6 +3876,7 @@ function ConversationRowImpl({
           onToggleSelected(conversation.id, e.shiftKey);
           return;
         }
+        activateRow(conversation.id, e);
         onClick(e);
       }}
       onDoubleClick={(e) => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -157,9 +157,8 @@ import { getSessionState, type SessionState } from "@/hooks/useSessionState";
 import { useChatStore } from "@/store/chatStore";
 import {
   isConversationUnseen,
-  isExplicitlyUnread,
   markConversationUnread,
-  useUnseenTick,
+  useConversationReadState,
 } from "@/hooks/useUnseenConversations";
 import { cn } from "@/lib/utils";
 import { useOmnigentAnalytics } from "@/lib/analytics";
@@ -3608,10 +3607,13 @@ function ConversationRowImpl({
   const isProvisionalLabel =
     pendingTitle === null && conversation.title == null && optimisticTitle !== undefined;
   const hasDraft = useHasSessionDraft(conversation.id);
-  // Recompute unseen state the moment the last-seen map changes (e.g. the
-  // user picks "Mark as unread" on this row) rather than waiting for the
-  // next conversations poll.
-  useUnseenTick();
+  // A write for another conversation leaves this primitive snapshot unchanged,
+  // so useSyncExternalStore skips the heavy row render.
+  const readState = useConversationReadState(
+    conversation.id,
+    conversation.updated_at,
+    conversation.status,
+  );
   // The dot shows when the conversation is content-unseen AND either the
   // row isn't the one you're viewing OR you explicitly marked it unread.
   // `isConversationUnseen` still gates on status, so a *running* turn never
@@ -3619,9 +3621,7 @@ function ConversationRowImpl({
   // invisible until the turn finishes (then the dot lights like any unseen
   // row). The explicit override only lifts the active-row suppression, so
   // flagging the thread you're currently viewing surfaces the dot at once.
-  const hasUnseenMessages =
-    isConversationUnseen(conversation.id, conversation.updated_at, conversation.status) &&
-    (!isActive || isExplicitlyUnread(conversation.id));
+  const hasUnseenMessages = readState.unseen && (!isActive || readState.explicitlyUnread);
   // "Mark as unread" is offered on any row not already showing the dot.
   const canMarkUnread = !hasUnseenMessages;
   // Badge precedence: a pending approval ("Needs response") outranks the


### PR DESCRIPTION
## Related issue

Follow-up to #6522.

## Summary

- Keep read-state updates local to the conversation row whose unread state changed instead of re-rendering every visible sidebar row.
- Highlight the clicked session optimistically and schedule the route update as a React transition, so immediate sidebar feedback is no longer coupled to the heavier page switch.

ELI5: the row you click lights up first; the conversation can finish switching immediately afterward.

```text
session click ──► active row highlight (urgent)
             └─► route + conversation update (transition)
```

## Test Plan

- `pnpm --filter web test src/hooks/useUnseenConversations.test.ts src/shell/Sidebar.selectionActiveHighlight.test.tsx src/shell/Sidebar.subagentHighlight.test.tsx src/shell/Sidebar.test.tsx` — 125 tests passed.
- `pnpm --filter web run type-check` — passed.
- `pnpm --filter web run lint` — passed.
- `pnpm --filter web run format:check` — passed.

## Demo

The final visual styling is unchanged; the observable change is that the active-row feedback paints before route work settles. The regression test holds routing in place and verifies the clicked row highlights immediately.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused hook test proves unrelated rows no longer re-render on read-state writes. The sidebar test proves active highlighting occurs before route state catches up.

## Changelog

Session rows now highlight immediately while conversation navigation finishes in the background.