### PR TITLE
feat(fork): let a session fork request a managed sandbox

### DIFF
--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -1115,12 +1115,12 @@ Request body matches `SessionForkRequest`:
     registered to the FORKING caller, so it resolves that user's
     credentials, never the source session owner's.
 
-  sandbox_provider (string or null, optional)
+  sandbox_provider (string | null, optional)
     Which configured sandbox provider to provision (one of the
     server's `sandbox_providers`); null takes the server's first.
     Only valid with `host_type: "managed"` (422 otherwise).
 
-  workspace (string or null, optional)
+  workspace (string | null, optional)
     Git repository URL, optionally `#<branch>`, cloned into the
     fork's sandbox as its working directory. Omitting the field
     inherits the repository the source session recorded, so cloning

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -1104,22 +1104,57 @@ Request body matches `SessionForkRequest`:
     source's full native transcript. When null or omitted, the full
     history is copied.
 
+  host_type (string, "external" | "managed", default "external")
+    How the fork's host is obtained. `"external"` (the default, and
+    the pre-existing behavior): the fork is created unbound and the
+    caller binds compute afterwards. `"managed"`: the SERVER
+    provisions a sandbox host for the fork from its `sandbox:`
+    config, exactly as a `host_type: "managed"` create does — same
+    background launch, same `host_id` / `workspace` null in this
+    response until the sandbox host registers. The sandbox is
+    registered to the FORKING caller, so it resolves that user's
+    credentials, never the source session owner's.
+
+  sandbox_provider (string or null, optional)
+    Which configured sandbox provider to provision (one of the
+    server's `sandbox_providers`); null takes the server's first.
+    Only valid with `host_type: "managed"` (422 otherwise).
+
+  workspace (string or null, optional)
+    Git repository URL, optionally `#<branch>`, cloned into the
+    fork's sandbox as its working directory. Omitting the field
+    inherits the repository the source session recorded, so cloning
+    a sandbox session lands the fork in the same checkout; an
+    explicit null gives the fork an empty sandbox. Only valid with
+    `host_type: "managed"` (422 otherwise) — an external fork's
+    directory is chosen when it binds a host.
+
 201 Created — body matches `SessionResponse` (status "idle",
   items are the deep-copied items from the source session).
 
 400 Bad Request — source session is a sub-agent session, has
-  no agent binding, or up_to_response_id names no response in
-  the source session
+  no agent binding, up_to_response_id names no response in
+  the source session, or a managed fork asks for a sandbox this
+  server has not configured
 404 Not Found — no session with that source_id, or the source's
   agent row is missing
+422 Unprocessable Entity — sandbox_provider / workspace without
+  `host_type: "managed"`, or a managed workspace that is not a
+  repository URL
 ```
 
 Creates a new session by deep-copying every item from the source
 session. The server also clones the source's agent (new agent ID,
 same bundle and config) so the fork can be reconfigured independently.
-The forked session is **not** bound to a runner — clients must
-`PATCH /v1/sessions/{id}` with `runner_id` before posting events,
-the same way they bind a runner after resuming an existing session.
+Unless `host_type: "managed"` is requested, the forked session is
+**not** bound to a runner — clients must `PATCH /v1/sessions/{id}`
+with `runner_id` before posting events, the same way they bind a
+runner after resuming an existing session.
+
+The fork's bound agent is always that session-scoped clone, never the
+built-in it derives from. A managed fork's runner therefore carries no
+built-in agent classifier, so an admission policy keyed on one does not
+match it.
 
 The response is a full `SessionResponse` snapshot of the fork — same
 shape as `GET /v1/sessions/{id}` — with status `"idle"` and all

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -1129,6 +1129,12 @@ Request body matches `SessionForkRequest`:
     `host_type: "managed"` (422 otherwise) — an external fork's
     directory is chosen when it binds a host.
 
+    The source's recorded-repository label is never copied onto the
+    fork: the fork records whichever repository it actually resolved
+    (none, for an empty sandbox or an external fork), so a later
+    sandbox relaunch re-clones the fork's own repository rather than
+    the source's.
+
 201 Created — body matches `SessionResponse` (status "idle",
   items are the deep-copied items from the source session).
 

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -315,6 +315,9 @@ MANAGED_SANDBOX_LABEL_NAMESPACE = "omnigent.sandbox."
 # value). ``conversations.workspace`` is overwritten with the CLONED
 # path at bind time, so this label is what a sandbox RELAUNCH parses
 # to re-clone the repository into the fresh generation's workspace.
+# Per-session state: a fork never inherits it (the store drops it, and
+# the fork's own launch re-stamps whatever repository it resolves),
+# while an in-place agent switch keeps it — the sandbox is unchanged.
 MANAGED_REPO_LABEL_KEY = "omnigent.sandbox.repo"
 
 

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2584,6 +2584,15 @@ def register_core_routes(
         parent. The source keeps running under its parent untouched,
         and the fork does not adopt the source's own children.
 
+        ``body.host_type: "managed"`` gives the fork its own
+        server-provisioned sandbox instead of leaving it unbound for the
+        caller to bind a host to. It schedules the same background launch
+        a managed create does — this POST returns before the sandbox
+        exists — and the sandbox is registered to the FORKING caller, not
+        to the source session's owner. The fork's workspace is the
+        repository named by ``body.workspace``, or the one the source
+        recorded when that field is omitted.
+
         :param request: The incoming FastAPI request (for auth).
         :param source_id: Session/conversation identifier of the
             source session to fork, e.g. ``"conv_abc123"``.
@@ -2593,8 +2602,9 @@ def register_core_routes(
         :raises OmnigentError: 404 if *source_id* does not exist
             or ``body.agent_id`` is not a bindable built-in agent;
             403 if the caller lacks read access; 400 if the source
-            has no agent binding, or ``body.up_to_response_id`` names
-            no response in the source session.
+            has no agent binding, ``body.up_to_response_id`` names
+            no response in the source session, or a managed fork asks
+            for a sandbox this server has not configured.
         """
         user_id = _get_user_id(request, auth_provider)
         access = await _require_access_and_level(
@@ -2887,11 +2897,40 @@ def register_core_routes(
                 code=ErrorCode.INVALID_INPUT,
             ) from exc
 
+        # Grant ownership BEFORE scheduling the managed launch, mirroring
+        # both create paths: a managed-guard failure (misconfigured server,
+        # unconfigured provider) must not leave the just-forked session
+        # unowned and thus invisible to the caller.
         if permission_store is not None and user_id is not None:
             await asyncio.to_thread(permission_store.ensure_user, user_id)
             await asyncio.to_thread(permission_store.grant, user_id, new_conv.id, LEVEL_OWNER)
         # Push the forked session to this user's other open tabs.
         _announce_session_added(user_id, new_conv.id)
+
+        # Managed host: schedule the fork's own BACKGROUND sandbox provision
+        # and return immediately, exactly like a managed create. The host is
+        # registered to the forking caller, so the sandbox resolves THEIR
+        # credentials, never the source owner's. An omitted workspace
+        # inherits the repository the source recorded, so cloning a sandbox
+        # session lands the fork in the same checkout.
+        if body.host_type == "managed":
+            from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+
+            await _schedule_managed_launch(
+                request,
+                session_id=new_conv.id,
+                # The fork's own session-scoped agent clone. Deliberately not
+                # the built-in it derives from: only a genuine built-in may
+                # classify a managed runner, and a clone must not inherit that.
+                agent_id=new_conv.agent_id,
+                user_id=user_id,
+                sandbox_provider=body.sandbox_provider,
+                workspace=(
+                    body.workspace
+                    if "workspace" in fields_set
+                    else source.labels.get(MANAGED_REPO_LABEL_KEY)
+                ),
+            )
 
         # Bound the response like the GET-session snapshot: newest item page,
         # chronological. Clients navigate by the fork's id and hydrate the

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2728,11 +2728,6 @@ def register_core_routes(
                     code=ErrorCode.INVALID_INPUT,
                 ) from exc
 
-        # Local import: managed_hosts pulls in FastAPI/click, so the module
-        # stays out of this module's import graph (same as the managed-launch
-        # helper above).
-        from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
-
         # Permission mode lives BOTH in launch args (``--permission-mode``) and
         # as a copied label — and the label wins when both are present. So when
         # the dialog picks explicit launch args, drop the source's mode-derived
@@ -2751,13 +2746,6 @@ def register_core_routes(
         # in generic native-wrapper UI state. Drop it whenever the agent changes.
         if switching_agent:
             dropped_label_keys_set.add(_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY)
-        # The sandbox repository is per-session state: it records what THIS
-        # session's sandbox was built from, and a sandbox relaunch re-clones
-        # from it. A fork decides its own repository (below), so the source's
-        # must never carry over — a fork that asked for an empty sandbox would
-        # otherwise have the source's repo re-cloned into it on the first
-        # relaunch. The managed launch re-stamps the label when one resolves.
-        dropped_label_keys_set.add(MANAGED_REPO_LABEL_KEY)
         dropped_label_keys: frozenset[str] = frozenset(dropped_label_keys_set)
 
         # DANGEROUS codex full-bypass. The source's bypass label is always
@@ -2923,12 +2911,14 @@ def register_core_routes(
         # Push the forked session to this user's other open tabs.
         _announce_session_added(user_id, new_conv.id)
 
+        from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+
         # Managed host: schedule the fork's own BACKGROUND sandbox provision
         # and return immediately, exactly like a managed create. The host is
         # registered to the forking caller, so the sandbox resolves THEIR
         # credentials, never the source owner's. An omitted workspace
         # inherits the repository the source recorded (read off the SOURCE,
-        # since the fork's own copy was dropped above), so cloning a sandbox
+        # since a fork never inherits the label itself), so cloning a sandbox
         # session lands the fork in the same checkout.
         if body.host_type == "managed":
             await _schedule_managed_launch(

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2791,10 +2791,15 @@ def register_core_routes(
         # runner takes the rebuild path instead of a doomed clone attempt
         # (a failed clone launches fresh, losing history). cursor never clones a
         # native session (server-backed; it carries history via the preamble),
-        # so it always skips the source directive too.
+        # so it always skips the source directive too. A managed fork gets its
+        # OWN fresh sandbox, whose filesystem has no copy of the source's local
+        # native rollout, so the clone is likewise doomed — skip the directive
+        # so the runner rebuilds from the copied Omnigent items instead.
         resume_source_native_session = (
-            not switching_agent or copy_model_settings
-        ) and not target_is_cursor
+            (not switching_agent or copy_model_settings)
+            and not target_is_cursor
+            and body.host_type != "managed"
+        )
 
         # On an agent switch, recompute the Web UI presentation labels for
         # the TARGET harness so the clone isn't left in the source's UI mode

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -252,22 +252,25 @@ def register_core_routes(
         """
         Provision a managed sandbox host for a just-created session.
 
-        Shared by both create paths: the JSON path (an existing
-        ``agent_id``) and the multipart bundle path (a freshly-created
-        session-scoped ``agent_id``). Validates that managed hosts are
-        configured and the provider is offered, records the repository
-        workspace for relaunch, seeds the launch-progress indicator, and
-        schedules the background ``_run_managed_launch`` — returning
-        immediately, since provisioning takes tens of seconds and must
-        not block the create POST. Config problems and malformed repo
+        Shared by the two create paths and the fork path: the JSON create
+        (an existing ``agent_id``), the multipart bundle create (a
+        freshly-created session-scoped ``agent_id``), and a fork (the
+        clone's own session-scoped ``agent_id``). Validates that managed
+        hosts are configured and the provider is offered, records the
+        repository workspace for relaunch, seeds the launch-progress
+        indicator, and schedules the background ``_run_managed_launch`` —
+        returning immediately, since provisioning takes tens of seconds
+        and must not block the POST. Config problems and malformed repo
         workspaces fail the POST synchronously (4xx).
 
-        :param request: The create request (for ``app.state`` lookups).
+        :param request: The originating request (for ``app.state``
+            lookups).
         :param session_id: The newly-created session id to bind the host
             to, e.g. ``"conv_abc123"``.
         :param agent_id: The session's bound agent id (built-in for the
-            JSON path, session-scoped for the bundle path); the managed
-            runner fetches its spec over the tunnel either way.
+            JSON create path, session-scoped for the bundle and fork
+            paths); the managed runner fetches its spec over the tunnel
+            either way.
         :param user_id: Authenticated caller, or ``None`` on an
             auth-disabled server (registers under the reserved local
             owner).
@@ -2679,6 +2682,7 @@ def register_core_routes(
         model_override_set = "model_override" in fields_set
         effort_set = "reasoning_effort" in fields_set
         launch_args_set = "terminal_launch_args" in fields_set
+        workspace_set = "workspace" in fields_set
 
         override_model: str | None = None
         clear_override_model = False
@@ -2724,6 +2728,11 @@ def register_core_routes(
                     code=ErrorCode.INVALID_INPUT,
                 ) from exc
 
+        # Local import: managed_hosts pulls in FastAPI/click, so the module
+        # stays out of this module's import graph (same as the managed-launch
+        # helper above).
+        from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+
         # Permission mode lives BOTH in launch args (``--permission-mode``) and
         # as a copied label — and the label wins when both are present. So when
         # the dialog picks explicit launch args, drop the source's mode-derived
@@ -2742,6 +2751,13 @@ def register_core_routes(
         # in generic native-wrapper UI state. Drop it whenever the agent changes.
         if switching_agent:
             dropped_label_keys_set.add(_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY)
+        # The sandbox repository is per-session state: it records what THIS
+        # session's sandbox was built from, and a sandbox relaunch re-clones
+        # from it. A fork decides its own repository (below), so the source's
+        # must never carry over — a fork that asked for an empty sandbox would
+        # otherwise have the source's repo re-cloned into it on the first
+        # relaunch. The managed launch re-stamps the label when one resolves.
+        dropped_label_keys_set.add(MANAGED_REPO_LABEL_KEY)
         dropped_label_keys: frozenset[str] = frozenset(dropped_label_keys_set)
 
         # DANGEROUS codex full-bypass. The source's bypass label is always
@@ -2911,11 +2927,10 @@ def register_core_routes(
         # and return immediately, exactly like a managed create. The host is
         # registered to the forking caller, so the sandbox resolves THEIR
         # credentials, never the source owner's. An omitted workspace
-        # inherits the repository the source recorded, so cloning a sandbox
+        # inherits the repository the source recorded (read off the SOURCE,
+        # since the fork's own copy was dropped above), so cloning a sandbox
         # session lands the fork in the same checkout.
         if body.host_type == "managed":
-            from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
-
             await _schedule_managed_launch(
                 request,
                 session_id=new_conv.id,
@@ -2926,9 +2941,7 @@ def register_core_routes(
                 user_id=user_id,
                 sandbox_provider=body.sandbox_provider,
                 workspace=(
-                    body.workspace
-                    if "workspace" in fields_set
-                    else source.labels.get(MANAGED_REPO_LABEL_KEY)
+                    body.workspace if workspace_set else source.labels.get(MANAGED_REPO_LABEL_KEY)
                 ),
             )
 

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2489,6 +2489,24 @@ class SessionForkRequest(BaseModel):
         stamps ``omnigent.codex_native.bypass_sandbox`` on the fork; ``False``
         / omitted leaves the fork in Codex's normal approval/sandbox stance.
         Only meaningful for a codex-native target; ignored otherwise.
+    :param host_type: How the fork's host is obtained — ``"external"``
+        (the default: the caller binds one afterwards, via
+        ``POST /v1/hosts/{host_id}/runners`` from the web dialog or
+        ``PATCH /v1/sessions/{id}`` from the REPL) or ``"managed"`` (the
+        server provisions a sandbox host for the fork, the same
+        background launch a ``host_type: "managed"`` create schedules).
+    :param sandbox_provider: Which configured sandbox provider to
+        provision on ``host_type: "managed"`` (one of the server's
+        ``sandbox_providers``); ``None`` takes the server's first. Only
+        valid with ``host_type: "managed"``.
+    :param workspace: Git repository URL (optionally ``#<branch>``) the
+        server clones into the fork's sandbox as its working directory,
+        e.g. ``"https://github.com/org/repo#release-1.2"``. **Omitting**
+        the field inherits the repository the source session recorded, so
+        cloning a sandbox session lands the fork in the same checkout; an
+        explicit value overrides it and an explicit ``null`` gives the
+        fork an empty sandbox. Only valid with ``host_type: "managed"`` —
+        an external fork's directory is chosen when it binds a host.
     """
 
     title: str | None = Field(default=None, max_length=USER_SESSION_TITLE_MAX_CHARS)
@@ -2498,8 +2516,57 @@ class SessionForkRequest(BaseModel):
     reasoning_effort: str | None = None
     terminal_launch_args: list[str] | None = None
     codex_bypass_sandbox: bool = False
+    host_type: Literal["external", "managed"] = "external"
+    sandbox_provider: str | None = None
+    workspace: str | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _check_managed_fork_fields(self) -> Self:
+        """
+        Enforce the per-``host_type`` contract for a fork.
+
+        Mirrors :meth:`_SessionCreateRequestBase._check_managed_host_fields`:
+        a managed fork's ``workspace``, when given, must be a git repository
+        URL (optionally ``#<branch>``) the server clones into the sandbox —
+        a filesystem path points at nothing in a sandbox that doesn't exist
+        yet. Both ``sandbox_provider`` and ``workspace`` are meaningless on
+        an external fork, which picks its host and directory afterwards.
+        Failing at validation returns a 422 with the field named instead of
+        silently ignoring the caller's intent.
+
+        :returns: The validated instance.
+        :raises ValueError: On a managed workspace that isn't a valid
+            repository URL, or ``sandbox_provider`` / ``workspace`` without
+            ``host_type: "managed"``.
+        """
+        # Lazy import: schemas is imported by nearly every module, so
+        # pulling the (FastAPI/click-importing) managed-hosts module in
+        # at module scope would risk import cycles.
+        from omnigent.server.managed_hosts import parse_repo_workspace
+
+        if self.host_type == "managed":
+            if self.workspace is not None:
+                try:
+                    parse_repo_workspace(self.workspace)
+                except ValueError as exc:
+                    raise ValueError(
+                        "host_type 'managed' takes a git repository URL "
+                        f"(optionally '#<branch>') as workspace: {exc}"
+                    ) from exc
+            return self
+        if self.sandbox_provider is not None:
+            raise ValueError(
+                "sandbox_provider only applies to host_type 'managed' — "
+                "external hosts are not server-provisioned"
+            )
+        if self.workspace is not None:
+            raise ValueError(
+                "workspace only applies to host_type 'managed' — an external "
+                "fork picks its directory when it binds a host"
+            )
+        return self
 
 
 class ReadStatePutRequest(BaseModel):

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -181,10 +181,18 @@ _INSTANCE_SCOPED_LABEL_KEYS = frozenset(
 )
 
 # Source identity belongs only to the original imported session, and a fork is
-# born unarchived so it must not inherit its parent's archive time. Unlike
-# runtime instance labels, these survive an in-place agent switch but never a
-# fork.
-_FORK_ONLY_DROPPED_LABEL_KEYS = IMPORT_PROVENANCE_LABEL_KEYS | {ARCHIVED_AT_LABEL_KEY}
+# born unarchived so it must not inherit its parent's archive time. The sandbox
+# repository records what THIS session's sandbox was built from and a relaunch
+# re-clones from it, so a fork that asked for an empty sandbox would otherwise
+# have the source's repo re-cloned into it on the first relaunch; the fork's own
+# managed launch re-stamps whatever repository it resolves. The repo literal
+# mirrors the server's ``MANAGED_REPO_LABEL_KEY``; a store test cross-checks it
+# so a rename there fails loudly here. Unlike runtime instance labels, these
+# survive an in-place agent switch but never a fork.
+_FORK_ONLY_DROPPED_LABEL_KEYS = IMPORT_PROVENANCE_LABEL_KEYS | {
+    ARCHIVED_AT_LABEL_KEY,
+    "omnigent.sandbox.repo",
+}
 
 
 @dataclass(frozen=True)

--- a/openapi.json
+++ b/openapi.json
@@ -5143,6 +5143,16 @@
             "title": "Codex Bypass Sandbox",
             "type": "boolean"
           },
+          "host_type": {
+            "default": "external",
+            "description": "How the fork's host is obtained \u2014 `\"external\"` (the default: the caller binds one afterwards, via `POST /v1/hosts/{host_id}/runners` from the web dialog or `PATCH /v1/sessions/{id}` from the REPL) or `\"managed\"` (the server provisions a sandbox host for the fork, the same background launch a `host_type: \"managed\"` create schedules).",
+            "enum": [
+              "external",
+              "managed"
+            ],
+            "title": "Host Type",
+            "type": "string"
+          },
           "model_override": {
             "anyOf": [
               {
@@ -5166,6 +5176,18 @@
             ],
             "description": "Per-session reasoning-effort override to apply to the fork, e.g. `\"high\"`. **Omitting** the field inherits the source's effort; an explicit value overrides it, and a clear alias (`\"default\"`, `\"off\"`, `\"reset\"`) resets it. Validated against the shared effort vocabulary; provider support is enforced at launch. Set by the web fork dialog's effort picker.",
             "title": "Reasoning Effort"
+          },
+          "sandbox_provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Which configured sandbox provider to provision on `host_type: \"managed\"` (one of the server's `sandbox_providers`); `None` takes the server's first. Only valid with `host_type: \"managed\"`.",
+            "title": "Sandbox Provider"
           },
           "terminal_launch_args": {
             "anyOf": [
@@ -5206,6 +5228,18 @@
             ],
             "description": "Truncation point for the copied history, e.g. `\"resp_abc123\"`. When set, only items up to and including the last item of that response are copied \u2014 items after it are dropped from the fork. When `None` (default), the full history is copied.",
             "title": "Up To Response Id"
+          },
+          "workspace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Git repository URL (optionally `#<branch>`) the server clones into the fork's sandbox as its working directory, e.g. `\"https://github.com/org/repo#release-1.2\"`. **Omitting** the field inherits the repository the source session recorded, so cloning a sandbox session lands the fork in the same checkout; an explicit value overrides it and an explicit `null` gives the fork an empty sandbox. Only valid with `host_type: \"managed\"` \u2014 an external fork's directory is chosen when it binds a host.",
+            "title": "Workspace"
           }
         },
         "title": "SessionForkRequest",
@@ -14621,7 +14655,7 @@
     },
     "/v1/sessions/{source_id}/fork": {
       "post": {
-        "description": "Fork an existing session into a new session.\n\nDeep-copies the source session's conversation items and\nclones the agent into a new session. When `body.agent_id`\nis set, the fork binds that built-in agent instead of the\nsource's \u2014 switching harness (e.g. Claude-SDK \u2192 Claude Code,\nor Claude \u2192 Codex). The source's model settings carry over\nonly within the same provider family; a same-family native\ntarget also carries conversation history (the runner rebuilds\nits transcript). The REPL/CLI binds the fork to its runner via\n`PATCH /v1/sessions/{id}` after creation.\n\nWhen `body.up_to_response_id` is set, only history up to and\nincluding that response is copied into the fork (a \"fork from\nthis response\"); a native target then rebuilds its transcript\nfrom the truncated items instead of resuming the source's full\nnative transcript.\n\nThe dialog's run-config picks (`body.model_override`,\n`body.reasoning_effort`, `body.terminal_launch_args` \u2014 the\npermission-/approval-mode selector) override what the fork would\notherwise inherit. Each is opt-in: a field omitted from the request\nkeeps the inherited value (model/effort within the same provider\nfamily; launch args on a same-agent fork), while a field present\nwins \u2014 a clear alias (`\"default\"`) resets to the bound agent's\ndefault, and an explicit launch-args list also drops the source's\ncopied permission-mode / codex-bypass labels so they can't shadow\nthe freshly chosen mode.\n\nA sub-agent source is allowed, which is how a sub-agent is\npromoted to a session of its own: the fork is always a fresh\ntop-level conversation (no parent, its own spawn-tree root, its\nown owner grant), so it appears in the sidebar and outlives the\nparent. The source keeps running under its parent untouched,\nand the fork does not adopt the source's own children.\n\n**Parameters**\n\n- `body` \u2014 The validated `SessionForkRequest`.\n\n**Returns:** A `SessionResponse` describing the newly created fork (status `\"idle\"`).\n\n**Raises**\n\n- `OmnigentError` \u2014 404 if *source_id* does not exist or `body.agent_id` is not a bindable built-in agent; 403 if the caller lacks read access; 400 if the source has no agent binding, or `body.up_to_response_id` names no response in the source session.",
+        "description": "Fork an existing session into a new session.\n\nDeep-copies the source session's conversation items and\nclones the agent into a new session. When `body.agent_id`\nis set, the fork binds that built-in agent instead of the\nsource's \u2014 switching harness (e.g. Claude-SDK \u2192 Claude Code,\nor Claude \u2192 Codex). The source's model settings carry over\nonly within the same provider family; a same-family native\ntarget also carries conversation history (the runner rebuilds\nits transcript). The REPL/CLI binds the fork to its runner via\n`PATCH /v1/sessions/{id}` after creation.\n\nWhen `body.up_to_response_id` is set, only history up to and\nincluding that response is copied into the fork (a \"fork from\nthis response\"); a native target then rebuilds its transcript\nfrom the truncated items instead of resuming the source's full\nnative transcript.\n\nThe dialog's run-config picks (`body.model_override`,\n`body.reasoning_effort`, `body.terminal_launch_args` \u2014 the\npermission-/approval-mode selector) override what the fork would\notherwise inherit. Each is opt-in: a field omitted from the request\nkeeps the inherited value (model/effort within the same provider\nfamily; launch args on a same-agent fork), while a field present\nwins \u2014 a clear alias (`\"default\"`) resets to the bound agent's\ndefault, and an explicit launch-args list also drops the source's\ncopied permission-mode / codex-bypass labels so they can't shadow\nthe freshly chosen mode.\n\nA sub-agent source is allowed, which is how a sub-agent is\npromoted to a session of its own: the fork is always a fresh\ntop-level conversation (no parent, its own spawn-tree root, its\nown owner grant), so it appears in the sidebar and outlives the\nparent. The source keeps running under its parent untouched,\nand the fork does not adopt the source's own children.\n\n`body.host_type: \"managed\"` gives the fork its own\nserver-provisioned sandbox instead of leaving it unbound for the\ncaller to bind a host to. It schedules the same background launch\na managed create does \u2014 this POST returns before the sandbox\nexists \u2014 and the sandbox is registered to the FORKING caller, not\nto the source session's owner. The fork's workspace is the\nrepository named by `body.workspace`, or the one the source\nrecorded when that field is omitted.\n\n**Parameters**\n\n- `body` \u2014 The validated `SessionForkRequest`.\n\n**Returns:** A `SessionResponse` describing the newly created fork (status `\"idle\"`).\n\n**Raises**\n\n- `OmnigentError` \u2014 404 if *source_id* does not exist or `body.agent_id` is not a bindable built-in agent; 403 if the caller lacks read access; 400 if the source has no agent binding, `body.up_to_response_id` names no response in the source session, or a managed fork asks for a sandbox this server has not configured.",
         "operationId": "fork_session_v1_sessions__source_id__fork_post",
         "parameters": [
           {

--- a/tests/e2e_ui/fork_session/test_fork_managed_sandbox.py
+++ b/tests/e2e_ui/fork_session/test_fork_managed_sandbox.py
@@ -1,0 +1,245 @@
+"""Browser e2e: cloning a session onto a server-provisioned sandbox.
+
+Before this flow existed, the Clone dialog could only ever target a host the
+caller had already connected with ``omni host``. On a deployment whose only
+compute is managed sandboxes there is never such a host, so the dialog's host
+section collapsed to "No hosts online. Reconnect from your terminal…" and the
+Clone button stayed greyed — the whole clone workflow was unreachable.
+
+This drives the real chain with ZERO hosts online: seeded session → the
+per-message fork action → the dialog's host picker → the sandbox row →
+``POST /v1/sessions/{id}/fork`` carrying ``host_type: "managed"`` → navigate
+into the clone. It asserts the three things the UI is responsible for:
+
+1. The sandbox row is offered and Clone is enabled with no host online (the
+   regression this flow fixes — pre-fix there was no row at all).
+2. Picking it swaps the host-directory chrome for the repository fields, and
+   those prefill from the repository the SOURCE session recorded — so cloning
+   a sandbox session lands in the same checkout.
+3. The fork request carries ``host_type`` / ``sandbox_provider`` / the
+   composed ``workspace``, and no ``POST /v1/hosts/{id}/runners`` follows
+   (the server provisions the host, so a host-bind would target a host that
+   does not exist).
+
+Three server responses are stubbed, because the e2e_ui harness deliberately
+runs no sandbox provider: ``/v1/info`` advertises the capability, ``/v1/hosts``
+reports none connected, and the session snapshot is AUGMENTED (fetched for
+real, then given a workspace + the sandbox repository label) so the source
+looks like a sandbox session. Everything else — the transcript, the dialog,
+the fork itself, the navigation — is real. Same approach the New Chat sandbox
+coverage takes in ``tests/e2e_ui/start_session/test_start_session.py``, which
+also cannot provision a real sandbox in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from playwright.sync_api import Page, Route, expect
+
+# Repository the SOURCE session records. The dialog must prefill from it, and
+# the fork request must carry it back composed with its branch.
+_SOURCE_REPO_URL = "https://github.com/omnigent-ai/fixture-repo"
+_SOURCE_REPO_BRANCH = "release-9.9"
+_SOURCE_REPO = f"{_SOURCE_REPO_URL}#{_SOURCE_REPO_BRANCH}"
+
+# Server label recording that repository (the server's MANAGED_REPO_LABEL_KEY,
+# mirrored in the web bundle as SANDBOX_REPO_LABEL_KEY).
+_SANDBOX_REPO_LABEL_KEY = "omnigent.sandbox.repo"
+
+# In-sandbox workspace path a managed session carries. Its presence is what
+# makes the dialog treat the source as a *coding* source and render the host
+# section at all.
+_SOURCE_WORKSPACE = "/root/workspace/fixture-repo"
+
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+
+
+def _managed_info_body() -> str:
+    """``GET /v1/info`` for a deployment that can provision sandboxes.
+
+    ``managed_sandboxes_enabled`` is the gate the dialog reads; naming
+    ``modal`` as the provider is what labels the row "Modal Sandbox" and what
+    must ride into the fork request as ``sandbox_provider``.
+
+    :returns: The JSON body.
+    """
+    return json.dumps(
+        {
+            "accounts_enabled": False,
+            "login_url": None,
+            "needs_setup": False,
+            "databricks_features": False,
+            "managed_sandboxes_enabled": True,
+            "sandbox_provider": "modal",
+            "sandbox_providers": ["modal"],
+            "server_version": "0.0.0-e2e",
+            "smart_routing_enabled": False,
+        }
+    )
+
+
+def _route_managed_deployment(page: Page, session_id: str) -> None:
+    """Make the SPA see a sandbox-only deployment holding a sandbox session.
+
+    :param page: The page to install routes on.
+    :param session_id: The seeded session, whose snapshot is augmented so the
+        dialog sees a coding source with a recorded sandbox repository.
+    """
+
+    def handle_info(route: Route) -> None:
+        """Advertise the managed-sandbox capability."""
+        route.fulfill(status=200, content_type="application/json", body=_managed_info_body())
+
+    def handle_hosts(route: Route) -> None:
+        """Report zero connected hosts — the dead end this flow fixes."""
+        route.fulfill(status=200, content_type="application/json", body=json.dumps({"hosts": []}))
+
+    def handle_session(route: Route) -> None:
+        """Fetch the real snapshot, then make it look like a sandbox session.
+
+        Augmenting rather than replacing keeps the transcript, agent binding,
+        and status real, so only the two fields under test are synthetic.
+        """
+        response = route.fetch()
+        try:
+            snapshot = response.json()
+        except Exception:
+            # A non-JSON body (an error page) isn't ours to rewrite — pass it
+            # through so the failure surfaces as itself.
+            route.fulfill(response=response)
+            return
+        if isinstance(snapshot, dict):
+            snapshot["workspace"] = _SOURCE_WORKSPACE
+            labels = snapshot.get("labels")
+            snapshot["labels"] = {
+                **(labels if isinstance(labels, dict) else {}),
+                _SANDBOX_REPO_LABEL_KEY: _SOURCE_REPO,
+            }
+        route.fulfill(response=response, body=json.dumps(snapshot))
+
+    page.route("**/v1/info", handle_info)
+    page.route("**/v1/hosts", handle_hosts)
+    # Anchored on the id so the collection route (``/v1/sessions?…``) and the
+    # sub-resources (``/items``, ``/agent``, …) are left alone.
+    page.route(re.compile(rf"/v1/sessions/{re.escape(session_id)}(\?|$)"), handle_session)
+
+
+def test_fork_onto_managed_sandbox_with_no_host_online(
+    page: Page,
+    seeded_session: tuple[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """Clone a sandbox session onto a fresh sandbox with no host connected.
+
+    Failure modes this catches:
+
+    - The sandbox row is missing, or the picker collapses into the connect-
+      from-your-terminal instructions when no host is online (the reported
+      dead end — the clone is then impossible on a sandbox-only deployment).
+    - The repository fields don't appear, or don't prefill from the source, so
+      a clone silently lands in an empty sandbox and its copied transcript
+      references files that aren't there.
+    - The fork request omits ``host_type`` / ``sandbox_provider`` / the
+      composed ``workspace``, so the server creates an unbound clone that
+      never starts.
+    - The dialog still fires the host-bind ``POST /v1/hosts/{id}/runners``,
+      which would target a host that does not exist.
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session: ``(base_url, session_id)`` for a pre-created
+        runner-bound ``hello_world`` session.
+    :param mock_llm_server_url: Unused directly; forces the mock-LLM fixture
+        so the seeded turn below completes.
+    """
+    del mock_llm_server_url
+    base_url, session_id = seeded_session
+
+    fork_bodies: list[dict[str, Any]] = []
+    runner_launches: list[str] = []
+
+    def handle_fork(route: Route) -> None:
+        """Record the fork request, then forward it as an ordinary fork.
+
+        The managed fields are stripped before forwarding: this harness runs
+        no sandbox provider, so a genuinely managed fork would 400 on the
+        server's "managed hosts are not configured" guard. Stripping keeps the
+        clone, the navigation, and the copied transcript real while the
+        recorded body carries the contract under test.
+        """
+        raw = route.request.post_data or "{}"
+        body = json.loads(raw)
+        fork_bodies.append(body)
+        forwarded = {
+            key: value
+            for key, value in body.items()
+            if key not in {"host_type", "sandbox_provider", "workspace"}
+        }
+        response = route.fetch(post_data=json.dumps(forwarded))
+        route.fulfill(response=response)
+
+    def handle_runner_launch(route: Route) -> None:
+        """Record any host-bind attempt — a sandbox clone must make none."""
+        runner_launches.append(route.request.url)
+        route.fulfill(status=200, content_type="application/json", body=json.dumps({}))
+
+    _route_managed_deployment(page, session_id)
+    page.route(re.compile(r"/v1/sessions/[0-9a-f]{32}/fork$"), handle_fork)
+    page.route(re.compile(r"/v1/hosts/[^/]+/runners$"), handle_runner_launch)
+
+    page.goto(f"{base_url}/c/{session_id}")
+
+    # One committed turn so the per-message fork action has a bubble to anchor
+    # on (the same setup the sibling fork tests use).
+    composer = page.get_by_placeholder("Send a message…")
+    expect(composer).to_be_visible()
+    composer.fill("Reply with just OK.")
+    page.get_by_role("button", name="Send", exact=True).click()
+    expect(page.locator(_ASSISTANT)).to_have_count(1, timeout=60_000)
+
+    page.get_by_test_id("fork-from-response").first.click()
+    dialog = page.get_by_test_id("fork-session-dialog")
+    expect(dialog).to_be_visible()
+
+    # (1) With zero hosts online the picker still offers a target. Pre-fix the
+    # host section rendered only the connect instructions and Clone was greyed.
+    host_select = page.get_by_test_id("fork-session-host-select")
+    expect(host_select).to_be_visible()
+    host_select.click()
+    sandbox_row = page.get_by_test_id("fork-session-sandbox-option")
+    expect(sandbox_row).to_contain_text("Modal Sandbox")
+    sandbox_row.click()
+
+    # (2) Picking the sandbox swaps in the repository chrome, prefilled from
+    # the source's own repository.
+    expect(page.get_by_test_id("fork-session-sandbox-hint")).to_be_visible()
+    page.get_by_test_id("fork-session-advanced-toggle").click()
+    expect(page.get_by_test_id("fork-session-sandbox-repo-input")).to_have_value(_SOURCE_REPO_URL)
+    expect(page.get_by_test_id("fork-session-sandbox-branch-input")).to_have_value(
+        _SOURCE_REPO_BRANCH
+    )
+    # The host-directory chrome is gone: a sandbox has no path to browse yet.
+    expect(page.get_by_test_id("fork-session-branch-input")).to_have_count(0)
+
+    submit = page.get_by_test_id("fork-session-submit")
+    expect(submit).to_be_enabled()
+    submit.click()
+
+    # Land in a DIFFERENT session — still on the source means navigation never
+    # fired; a visible dialog means the fork call failed.
+    expect(page).to_have_url(
+        re.compile(rf"/c/(?!{re.escape(session_id)})[0-9a-f]{{32}}"),
+        timeout=30_000,
+    )
+    expect(dialog).not_to_be_visible()
+
+    # (3) The request the dialog actually produced.
+    assert len(fork_bodies) == 1, f"expected exactly one fork request, got {fork_bodies}"
+    body = fork_bodies[0]
+    assert body["host_type"] == "managed", body
+    assert body["sandbox_provider"] == "modal", body
+    assert body["workspace"] == _SOURCE_REPO, body
+    # The server provisions the host, so the dialog must not also bind one.
+    assert runner_launches == [], runner_launches

--- a/tests/e2e_ui/fork_session/test_fork_managed_sandbox.py
+++ b/tests/e2e_ui/fork_session/test_fork_managed_sandbox.py
@@ -197,8 +197,10 @@ def test_fork_onto_managed_sandbox_with_no_host_online(
     expect(composer).to_be_visible()
     composer.fill("Reply with just OK.")
     page.get_by_role("button", name="Send", exact=True).click()
-    expect(page.locator(_ASSISTANT)).to_have_count(1, timeout=60_000)
+    assistant = page.locator(_ASSISTANT)
+    expect(assistant).to_have_count(1, timeout=60_000)
 
+    assistant.first.hover()
     page.get_by_test_id("fork-from-response").first.click()
     dialog = page.get_by_test_id("fork-session-dialog")
     expect(dialog).to_be_visible()

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -26,6 +26,7 @@ from omnigent.server.managed_hosts import (
 )
 from omnigent.server.routes import _session_create_validation as create_validation
 from omnigent.server.routes.sessions import create_sessions_router, routes_core
+from omnigent.stores.conversation_store import _FORK_ONLY_DROPPED_LABEL_KEYS
 
 # ── Minimal store stubs ──────────────────────────────────────────
 
@@ -265,15 +266,18 @@ class _ConversationStore:
             )
             source_items = source_items[: cutoff_index + 1]
         self._items[fork_id] = source_items
-        # Mirror the real store's label handling for the two rules the route
-        # depends on: source labels are copied EXCEPT the keys it asked to
-        # drop, then extra_labels are stamped on top (so a deliberate opt-in
-        # beats the drop). Without this the stub returned a label-less fork,
-        # so no test could see a source label riding onto the clone.
-        # presentation_labels is deliberately NOT modelled — the route's own
-        # assertions read it off the recorded call above.
+        # Mirror the real store's label handling for the three rules the route
+        # depends on: source labels are copied EXCEPT the store's own fork-only
+        # denylist and the keys the route asked to drop, then extra_labels are
+        # stamped on top (so a deliberate opt-in beats the drop). Without this
+        # the stub returned a label-less fork, so no test could see a source
+        # label riding onto the clone. presentation_labels is deliberately NOT
+        # modelled — the route's own assertions read it off the recorded call
+        # above.
         fork_labels = {
-            key: value for key, value in src.labels.items() if key not in dropped_label_keys
+            key: value
+            for key, value in src.labels.items()
+            if key not in (_FORK_ONLY_DROPPED_LABEL_KEYS | dropped_label_keys)
         }
         fork_labels.update(extra_labels or {})
         fork = Conversation(
@@ -589,9 +593,8 @@ async def test_fork_session_run_config_omitted_inherits() -> None:
     assert fork_call["override_model_override_set"] is False
     assert fork_call["override_reasoning_effort_set"] is False
     assert fork_call["override_terminal_launch_args_set"] is False
-    # No run-config pick, so no mode-derived label is dropped. (The sandbox
-    # repository is always dropped — per-session state, never inherited.)
-    assert fork_call["dropped_label_keys"] == frozenset({MANAGED_REPO_LABEL_KEY})
+    # No run-config pick, so the route asks for no conditional drop at all.
+    assert fork_call["dropped_label_keys"] == frozenset()
 
 
 @pytest.mark.asyncio
@@ -1039,9 +1042,8 @@ async def test_fork_same_agent_keeps_permission_mode_label() -> None:
     resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
-    # Only the always-dropped sandbox repository; the permission-mode label
-    # is untouched and carries over.
-    assert conv_store.fork_calls[0]["dropped_label_keys"] == frozenset({MANAGED_REPO_LABEL_KEY})
+    # Nothing conditional to drop, so the permission-mode label carries over.
+    assert conv_store.fork_calls[0]["dropped_label_keys"] == frozenset()
 
 
 @pytest.mark.asyncio
@@ -1514,7 +1516,7 @@ def _arm_managed_app(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> list[dict
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_schedules_a_sandbox_launch_for_the_fork(
+async def test_fork_managed_schedules_sandbox_launch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A managed fork schedules the same background sandbox launch a create does.
@@ -1546,7 +1548,7 @@ async def test_fork_managed_schedules_a_sandbox_launch_for_the_fork(
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_launch_carries_the_session_scoped_clone_not_a_builtin(
+async def test_fork_managed_launch_uses_session_scoped_clone(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The managed launch is handed the fork's OWN session-scoped agent clone.
@@ -1622,7 +1624,7 @@ async def test_fork_managed_launch_carries_the_session_scoped_clone_not_a_builti
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_registers_the_sandbox_to_the_forking_user(
+async def test_fork_managed_registers_sandbox_to_forking_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The fork's sandbox is owned by whoever forked, not by the source's owner.
@@ -1651,7 +1653,7 @@ async def test_fork_managed_registers_the_sandbox_to_the_forking_user(
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_inherits_the_source_repository(
+async def test_fork_managed_inherits_source_repository(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An omitted workspace clones the repository the SOURCE recorded.
@@ -1688,7 +1690,7 @@ async def test_fork_managed_inherits_the_source_repository(
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_explicit_workspace_overrides_the_inherited_one(
+async def test_fork_managed_explicit_workspace_overrides_inherited(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An explicit workspace wins over the source's recorded repository.
@@ -1719,19 +1721,21 @@ async def test_fork_managed_explicit_workspace_overrides_the_inherited_one(
 
 
 @pytest.mark.asyncio
-async def test_fork_never_inherits_the_source_sandbox_repository_label(
+async def test_fork_never_inherits_source_sandbox_repo_label(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A fork that cleared its repository does not keep the source's label.
 
     The label is per-session state a sandbox RELAUNCH re-clones from
     (``orchestration._maybe_relaunch_managed_sandbox``). The store copies
-    source labels by default, so without an explicit drop a fork that asked
-    for an empty sandbox would boot empty and then have the source's repo
-    re-cloned into it on the first relaunch — silently undoing the user's
-    choice. An external fork of a sandbox source must not carry it either:
-    the clone has no sandbox, and the stale label would seed the fork
-    dialog's own repository prefill.
+    source labels by default, so without the fork-only drop a fork that
+    asked for an empty sandbox would boot empty and then have the source's
+    repo re-cloned into it on the first relaunch — silently undoing the
+    user's choice. An external fork of a sandbox source must not carry it
+    either: the clone has no sandbox, and the stale label would seed the
+    fork dialog's own repository prefill. The drop is unconditional in the
+    store, so the route asks for nothing here; this covers the route's two
+    entries into that path.
     """
     conv = _make_conversation(labels={MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo"})
     conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
@@ -1747,10 +1751,7 @@ async def test_fork_never_inherits_the_source_sandbox_repository_label(
 
     assert emptied.status_code == 201, f"got {emptied.status_code}: {emptied.text}"
     assert external.status_code == 201, f"got {external.status_code}: {external.text}"
-    # Asked for on every fork, so the store never copies it…
-    for call in conv_store.fork_calls:
-        assert MANAGED_REPO_LABEL_KEY in call["dropped_label_keys"]
-    # …and neither clone ends up carrying one, so no relaunch re-clones.
+    # Neither clone ends up carrying one, so no relaunch re-clones.
     for response in (emptied, external):
         fork = conv_store.get_conversation(response.json()["id"])
         assert fork is not None
@@ -1759,7 +1760,7 @@ async def test_fork_never_inherits_the_source_sandbox_repository_label(
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_restamps_the_repository_it_actually_uses(
+async def test_fork_managed_restamps_resolved_repository(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The repository the fork DID resolve lands back on its own label.
@@ -1807,7 +1808,7 @@ async def test_fork_external_schedules_no_sandbox_launch(
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_rejects_an_unconfigured_server() -> None:
+async def test_fork_managed_rejects_unconfigured_server() -> None:
     """A managed fork on a server with no ``sandbox:`` config fails the POST.
 
     Failing synchronously names the misconfiguration; deferring it to the
@@ -1827,7 +1828,7 @@ async def test_fork_managed_rejects_an_unconfigured_server() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fork_managed_rejects_an_unoffered_provider(
+async def test_fork_managed_rejects_unoffered_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A provider this server doesn't offer fails the POST, naming what it has."""

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -12,12 +12,21 @@ from typing import Any
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from starlette.requests import HTTPConnection
 from starlette.testclient import TestClient
 
+from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import Agent, Conversation, ConversationItem, MessageData, PagedList
 from omnigent.errors import OmnigentError
+from omnigent.server.auth import AuthProvider
+from omnigent.server.managed_hosts import (
+    MANAGED_REPO_LABEL_KEY,
+    ManagedLaunchTracker,
+    parse_sandbox_config,
+    resolve_managed_agent_label,
+)
 from omnigent.server.routes import _session_create_validation as create_validation
-from omnigent.server.routes.sessions import create_sessions_router
+from omnigent.server.routes.sessions import create_sessions_router, routes_core
 
 # ── Minimal store stubs ──────────────────────────────────────────
 
@@ -111,6 +120,23 @@ class _ConversationStore:
         self._convs = conversations
         self._items = items_by_conv or {}
         self.fork_calls: list[dict[str, Any]] = []
+        self.label_writes: list[tuple[str, dict[str, str]]] = []
+
+    def set_labels(
+        self,
+        conversation_id: str,
+        updates: dict[str, str],
+        updated_at: int | None = None,
+    ) -> None:
+        """
+        Record a label upsert (the managed launch records its repository here).
+
+        :param conversation_id: Conversation the labels land on.
+        :param updates: Label keys to upsert.
+        :param updated_at: Ignored by the stub.
+        """
+        del updated_at
+        self.label_writes.append((conversation_id, dict(updates)))
 
     def get_conversation(self, conversation_id: str) -> Conversation | None:
         """
@@ -285,6 +311,7 @@ def _make_conversation(
     agent_id: str | None = "087b7cb7ac30abf4debfaa578d052ec6",
     title: str = "Source Chat",
     kind: str = "default",
+    labels: dict[str, str] | None = None,
 ) -> Conversation:
     """
     Build a minimal Conversation entity for testing.
@@ -294,6 +321,8 @@ def _make_conversation(
     :param title: Title string.
     :param kind: Conversation kind, e.g. ``"default"`` or
         ``"sub_agent"``.
+    :param labels: Session labels, e.g. the sandbox repository a managed
+        source recorded. Empty when omitted.
     :returns: A Conversation.
     """
     return Conversation(
@@ -304,6 +333,7 @@ def _make_conversation(
         agent_id=agent_id,
         title=title,
         kind=kind,
+        labels=dict(labels or {}),
     )
 
 
@@ -329,9 +359,33 @@ def _make_item(item_id: str, text: str, response_id: str = "resp_001") -> Conver
     )
 
 
+class _FixedUserAuth(AuthProvider):
+    """Auth provider that authenticates every request as one fixed user.
+
+    Enough to give the route a real, non-``None`` caller identity, which is
+    what the managed launch registers its sandbox host under.
+
+    :param user_id: The identity every request resolves to.
+    """
+
+    def __init__(self, user_id: str) -> None:
+        """Store the fixed identity."""
+        self._user_id = user_id
+
+    def get_user_id(self, request: HTTPConnection) -> str | None:
+        """Return the fixed identity, ignoring the request.
+
+        :param request: Ignored.
+        :returns: The configured user id.
+        """
+        del request
+        return self._user_id
+
+
 def _build_app(
     store: _ConversationStore,
     agent_store: _AgentStore | None = None,
+    auth_provider: AuthProvider | None = None,
 ) -> FastAPI:
     """
     Build a FastAPI app with the sessions router and error handler.
@@ -343,6 +397,8 @@ def _build_app(
     :param store: The conversation store stub.
     :param agent_store: The agent store stub. Defaults to a
         pre-populated stub with ``087b7cb7ac30abf4debfaa578d052ec6``.
+    :param auth_provider: Auth provider supplying the caller identity, or
+        ``None`` (the default) for an auth-disabled app.
     :returns: A configured FastAPI app ready for TestClient.
     """
     if agent_store is None:
@@ -360,6 +416,7 @@ def _build_app(
     router = create_sessions_router(
         conversation_store=store,  # type: ignore[arg-type]
         agent_store=agent_store,  # type: ignore[arg-type]
+        auth_provider=auth_provider,
     )
     app = FastAPI()
 
@@ -1421,6 +1478,304 @@ async def test_fork_reversed_native_spelling_carry_gating(
         f"A {harness} fork should set carry_history_into_native={expect_carry}: "
         "reversed native spellings must be treated like their canonical form."
     )
+
+
+# ── Managed-sandbox fork ─────────────────────────────────────────
+
+
+def _arm_managed_app(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """
+    Wire the app for managed forks and capture the scheduled launches.
+
+    Supplies the three ``app.state`` pieces the managed guard requires
+    (sandbox deployment, host store, launch tracker) and replaces the
+    background launch with a recorder, so a managed fork exercises the
+    real route path without provisioning anything.
+
+    :param app: The app under test.
+    :param monkeypatch: Fixture used to swap the background launch.
+    :returns: The list the recorder appends each launch's kwargs to.
+    """
+    app.state.sandbox_config = parse_sandbox_config(
+        {"provider": "modal", "server_url": "https://managed-test.example.com"}
+    )
+    # Never dereferenced: the recorder replaces the only consumer.
+    app.state.host_store = object()
+    app.state.managed_launches = ManagedLaunchTracker()
+    launches: list[dict[str, Any]] = []
+
+    async def _record(**kwargs: Any) -> None:
+        """Record the launch the route scheduled instead of provisioning."""
+        launches.append(kwargs)
+
+    monkeypatch.setattr(routes_core, "_run_managed_launch", _record)
+    return launches
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_schedules_a_sandbox_launch_for_the_fork(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A managed fork schedules the same background sandbox launch a create does.
+
+    The clone is the launch's subject, not the source: binding the source's
+    id here would provision a second sandbox for the session the user is
+    cloning FROM and leave the clone unbound.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    launches = _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed", "sandbox_provider": "modal"},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    body = resp.json()
+    assert len(launches) == 1, "a managed fork must schedule exactly one sandbox launch"
+    launch = launches[0]
+    assert launch["session_id"] == body["id"]
+    assert launch["provider"] == "modal"
+    # No repository on either side, so the clone gets an empty sandbox.
+    assert launch["repo"] is None
+    assert conv_store.label_writes == []
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_launch_carries_the_session_scoped_clone_not_a_builtin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The managed launch is handed the fork's OWN session-scoped agent clone.
+
+    Only a genuine built-in may classify a managed runner (the ``omnigent.ai/
+    agent`` label an admission policy selects on to inject a privileged
+    credential). A fork always binds a session-scoped clone, which fails that
+    gate — so a forked runner carries no classifier and attracts no injected
+    credential. Passing the built-in the clone derives from would re-stamp the
+    label and hand a clone of anyone's session the built-in's credential.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    agent_store = _AgentStore(
+        agents={
+            "087b7cb7ac30abf4debfaa578d052ec6": Agent(
+                id="087b7cb7ac30abf4debfaa578d052ec6",
+                created_at=1,
+                name="code-reviewer",
+                bundle_location="087b7cb7ac30abf4debfaa578d052ec6/hash",
+                version=1,
+            ),
+            # The built-in a "switch the fork's agent" pick would name.
+            builtin_agent_id("code-reviewer"): Agent(
+                id=builtin_agent_id("code-reviewer"),
+                created_at=1,
+                name="code-reviewer",
+                bundle_location="builtin/hash",
+                version=1,
+            ),
+        }
+    )
+    app = _build_app(conv_store, agent_store=agent_store)
+    launches = _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed", "agent_id": builtin_agent_id("code-reviewer")},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    fork_agent_id = resp.json()["agent_id"]
+    launch_agent_id = launches[0]["agent_id"]
+    assert launch_agent_id == fork_agent_id, (
+        "the launch must classify on the fork's own bound agent, not the source's"
+    )
+    assert launch_agent_id != builtin_agent_id("code-reviewer"), (
+        "a fork must never launch under the built-in id — that would restore the "
+        "runner's agent classifier and with it the injected credential"
+    )
+    # The gate the classifier applies to that id: a fork's clone is
+    # session-scoped, so it resolves to no label.
+    assert (
+        resolve_managed_agent_label(
+            _AgentStore(
+                agents={
+                    fork_agent_id: Agent(
+                        id=fork_agent_id,
+                        created_at=1,
+                        name="code-reviewer",
+                        bundle_location="builtin/hash",
+                        version=1,
+                        session_id=resp.json()["id"],
+                    ),
+                }
+            ),  # type: ignore[arg-type]
+            fork_agent_id,
+            session_id=resp.json()["id"],
+        )
+        is None
+    ), "a forked session's runner must carry no omnigent.ai/agent classifier"
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_registers_the_sandbox_to_the_forking_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fork's sandbox is owned by whoever forked, not by the source's owner.
+
+    ``owner`` becomes the ``hosts`` row's ``user_id``, and that is the single
+    identity ``GET /v1/hosts/{id}/credentials/{provider}`` resolves a vended
+    credential from (see ``routes/host_credentials.py``, which reads
+    ``resolve_launch_token(...).user_id``). Passing the source's owner here
+    would hand the forker the source owner's GitHub token — a credential
+    crossing from one user to another on a plain read-access fork.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store, auth_provider=_FixedUserAuth("forker@example.com"))
+    launches = _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed"},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    assert launches[0]["owner"] == "forker@example.com"
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_inherits_the_source_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An omitted workspace clones the repository the SOURCE recorded.
+
+    Cloning a sandbox session should land in the same checkout; without the
+    inherit the clone would come up in an empty sandbox and the copied
+    transcript's file references would resolve to nothing.
+    """
+    conv = _make_conversation(
+        labels={MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo#release-1.2"}
+    )
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    launches = _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed"},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    repo = launches[0]["repo"]
+    assert repo is not None
+    assert repo.url == "https://github.com/org/repo"
+    assert repo.branch == "release-1.2"
+    # Recorded on the FORK too, so its own sandbox relaunch re-clones it.
+    assert conv_store.label_writes == [
+        (
+            resp.json()["id"],
+            {MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo#release-1.2"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_explicit_workspace_overrides_the_inherited_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit workspace wins over the source's recorded repository.
+
+    ``null`` is a real choice here (an empty sandbox), so the route must
+    branch on the field being SENT, not on its value — otherwise a caller
+    asking for an empty sandbox would silently get the source's repo.
+    """
+    conv = _make_conversation(labels={MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo"})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    launches = _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    chosen = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed", "workspace": "https://github.com/org/other"},
+    )
+    emptied = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed", "workspace": None},
+    )
+
+    assert chosen.status_code == 201, f"got {chosen.status_code}: {chosen.text}"
+    assert emptied.status_code == 201, f"got {emptied.status_code}: {emptied.text}"
+    assert launches[0]["repo"].url == "https://github.com/org/other"
+    assert launches[1]["repo"] is None, "an explicit null workspace means an empty sandbox"
+
+
+@pytest.mark.asyncio
+async def test_fork_external_schedules_no_sandbox_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default (external) fork stays unbound — no sandbox is provisioned.
+
+    A managed-capable server must not start spending on a sandbox for every
+    clone; compute is opt-in.
+    """
+    conv = _make_conversation(labels={MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo"})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    launches = _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    assert launches == [], "an external fork must not provision a sandbox"
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_rejects_an_unconfigured_server() -> None:
+    """A managed fork on a server with no ``sandbox:`` config fails the POST.
+
+    Failing synchronously names the misconfiguration; deferring it to the
+    background launch would leave a clone stuck at "provisioning" forever.
+    """
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    client = TestClient(_build_app(conv_store))
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed"},
+    )
+
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+    assert "managed hosts are not configured" in resp.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_rejects_an_unoffered_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider this server doesn't offer fails the POST, naming what it has."""
+    conv = _make_conversation()
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    launches = _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed", "sandbox_provider": "daytona"},
+    )
+
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+    assert "is not configured on this server" in resp.json()["error"]["message"]
+    assert launches == []
 
 
 @pytest.mark.asyncio

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -12,13 +12,12 @@ from typing import Any
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from starlette.requests import HTTPConnection
 from starlette.testclient import TestClient
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import Agent, Conversation, ConversationItem, MessageData, PagedList
 from omnigent.errors import OmnigentError
-from omnigent.server.auth import AuthProvider
+from omnigent.server.auth import AuthProvider, UnifiedAuthProvider
 from omnigent.server.managed_hosts import (
     MANAGED_REPO_LABEL_KEY,
     ManagedLaunchTracker,
@@ -129,7 +128,11 @@ class _ConversationStore:
         updated_at: int | None = None,
     ) -> None:
         """
-        Record a label upsert (the managed launch records its repository here).
+        Upsert labels on a conversation, recording the call.
+
+        The managed launch re-stamps its repository here, so applying the
+        write (not just recording it) is what lets a test read the fork's
+        settled labels.
 
         :param conversation_id: Conversation the labels land on.
         :param updates: Label keys to upsert.
@@ -137,6 +140,9 @@ class _ConversationStore:
         """
         del updated_at
         self.label_writes.append((conversation_id, dict(updates)))
+        conv = self._convs.get(conversation_id)
+        if conv is not None:
+            conv.labels.update(updates)
 
     def get_conversation(self, conversation_id: str) -> Conversation | None:
         """
@@ -259,14 +265,28 @@ class _ConversationStore:
             )
             source_items = source_items[: cutoff_index + 1]
         self._items[fork_id] = source_items
-        return Conversation(
+        # Mirror the real store's label handling for the two rules the route
+        # depends on: source labels are copied EXCEPT the keys it asked to
+        # drop, then extra_labels are stamped on top (so a deliberate opt-in
+        # beats the drop). Without this the stub returned a label-less fork,
+        # so no test could see a source label riding onto the clone.
+        # presentation_labels is deliberately NOT modelled — the route's own
+        # assertions read it off the recorded call above.
+        fork_labels = {
+            key: value for key, value in src.labels.items() if key not in dropped_label_keys
+        }
+        fork_labels.update(extra_labels or {})
+        fork = Conversation(
             id=fork_id,
             created_at=100,
             updated_at=100,
             root_conversation_id=fork_id,
             title=title or f"Fork of {src.title}",
             agent_id=effective_agent_id,
+            labels=fork_labels,
         )
+        self._convs[fork_id] = fork
+        return fork
 
     def list_items(
         self,
@@ -357,29 +377,6 @@ def _make_item(item_id: str, text: str, response_id: str = "resp_001") -> Conver
             content=[{"type": "input_text", "text": text}],
         ),
     )
-
-
-class _FixedUserAuth(AuthProvider):
-    """Auth provider that authenticates every request as one fixed user.
-
-    Enough to give the route a real, non-``None`` caller identity, which is
-    what the managed launch registers its sandbox host under.
-
-    :param user_id: The identity every request resolves to.
-    """
-
-    def __init__(self, user_id: str) -> None:
-        """Store the fixed identity."""
-        self._user_id = user_id
-
-    def get_user_id(self, request: HTTPConnection) -> str | None:
-        """Return the fixed identity, ignoring the request.
-
-        :param request: Ignored.
-        :returns: The configured user id.
-        """
-        del request
-        return self._user_id
 
 
 def _build_app(
@@ -592,7 +589,9 @@ async def test_fork_session_run_config_omitted_inherits() -> None:
     assert fork_call["override_model_override_set"] is False
     assert fork_call["override_reasoning_effort_set"] is False
     assert fork_call["override_terminal_launch_args_set"] is False
-    assert fork_call["dropped_label_keys"] == frozenset()
+    # No run-config pick, so no mode-derived label is dropped. (The sandbox
+    # repository is always dropped — per-session state, never inherited.)
+    assert fork_call["dropped_label_keys"] == frozenset({MANAGED_REPO_LABEL_KEY})
 
 
 @pytest.mark.asyncio
@@ -1040,7 +1039,9 @@ async def test_fork_same_agent_keeps_permission_mode_label() -> None:
     resp = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
 
     assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
-    assert conv_store.fork_calls[0]["dropped_label_keys"] == frozenset()
+    # Only the always-dropped sandbox repository; the permission-mode label
+    # is untouched and carries over.
+    assert conv_store.fork_calls[0]["dropped_label_keys"] == frozenset({MANAGED_REPO_LABEL_KEY})
 
 
 @pytest.mark.asyncio
@@ -1635,13 +1636,14 @@ async def test_fork_managed_registers_the_sandbox_to_the_forking_user(
     """
     conv = _make_conversation()
     conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
-    app = _build_app(conv_store, auth_provider=_FixedUserAuth("forker@example.com"))
+    app = _build_app(conv_store, auth_provider=UnifiedAuthProvider(source="header"))
     launches = _arm_managed_app(app, monkeypatch)
     client = TestClient(app)
 
     resp = client.post(
         "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
         json={"host_type": "managed"},
+        headers={"X-Forwarded-Email": "forker@example.com"},
     )
 
     assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
@@ -1714,6 +1716,73 @@ async def test_fork_managed_explicit_workspace_overrides_the_inherited_one(
     assert emptied.status_code == 201, f"got {emptied.status_code}: {emptied.text}"
     assert launches[0]["repo"].url == "https://github.com/org/other"
     assert launches[1]["repo"] is None, "an explicit null workspace means an empty sandbox"
+
+
+@pytest.mark.asyncio
+async def test_fork_never_inherits_the_source_sandbox_repository_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fork that cleared its repository does not keep the source's label.
+
+    The label is per-session state a sandbox RELAUNCH re-clones from
+    (``orchestration._maybe_relaunch_managed_sandbox``). The store copies
+    source labels by default, so without an explicit drop a fork that asked
+    for an empty sandbox would boot empty and then have the source's repo
+    re-cloned into it on the first relaunch — silently undoing the user's
+    choice. An external fork of a sandbox source must not carry it either:
+    the clone has no sandbox, and the stale label would seed the fork
+    dialog's own repository prefill.
+    """
+    conv = _make_conversation(labels={MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo"})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    emptied = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed", "workspace": None},
+    )
+    external = client.post("/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork", json={})
+
+    assert emptied.status_code == 201, f"got {emptied.status_code}: {emptied.text}"
+    assert external.status_code == 201, f"got {external.status_code}: {external.text}"
+    # Asked for on every fork, so the store never copies it…
+    for call in conv_store.fork_calls:
+        assert MANAGED_REPO_LABEL_KEY in call["dropped_label_keys"]
+    # …and neither clone ends up carrying one, so no relaunch re-clones.
+    for response in (emptied, external):
+        fork = conv_store.get_conversation(response.json()["id"])
+        assert fork is not None
+        assert MANAGED_REPO_LABEL_KEY not in fork.labels
+    assert conv_store.label_writes == [], "no workspace resolved, so nothing to re-stamp"
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_restamps_the_repository_it_actually_uses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The repository the fork DID resolve lands back on its own label.
+
+    The drop above is unconditional, so the managed launch re-stamping the
+    resolved repository is the only thing that keeps a fork's own sandbox
+    relaunchable into the same checkout.
+    """
+    conv = _make_conversation(labels={MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo"})
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    _arm_managed_app(app, monkeypatch)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed", "workspace": "https://github.com/org/other#dev"},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    fork = conv_store.get_conversation(resp.json()["id"])
+    assert fork is not None
+    assert fork.labels[MANAGED_REPO_LABEL_KEY] == "https://github.com/org/other#dev"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -1000,6 +1000,70 @@ def test_session_metadata_external_rejects_repo_url_workspace() -> None:
         SessionCreateMetadata(workspace="https://github.com/org/repo")
 
 
+def test_session_fork_host_type_defaults_external() -> None:
+    """
+    ``SessionForkRequest.host_type`` defaults to ``"external"`` — every
+    existing fork client keeps producing an unbound clone (backcompat).
+    """
+    from omnigent.server.schemas import SessionForkRequest
+
+    req = SessionForkRequest()
+    assert req.host_type == "external"
+    assert req.sandbox_provider is None
+    assert req.workspace is None
+
+
+def test_session_fork_managed_accepts_provider_and_repo_workspace() -> None:
+    """
+    ``host_type="managed"`` accepts the provider pick and the
+    ``<repo>[#<branch>]`` workspace the launch path clones into the sandbox.
+    """
+    from omnigent.server.schemas import SessionForkRequest
+
+    req = SessionForkRequest(
+        host_type="managed",
+        sandbox_provider="modal",
+        workspace="https://github.com/org/repo#release-1.2",
+    )
+    assert req.sandbox_provider == "modal"
+    assert req.workspace == "https://github.com/org/repo#release-1.2"
+
+
+def test_session_fork_managed_rejects_path_workspace() -> None:
+    """
+    A managed fork's ``workspace`` is a repository URL, not a path — the
+    sandbox has no filesystem to point at until the server makes one.
+    """
+    from omnigent.server.schemas import SessionForkRequest
+
+    with pytest.raises(ValidationError, match="takes a git repository URL"):
+        SessionForkRequest(host_type="managed", workspace="/tmp/w")
+
+
+def test_session_fork_external_rejects_sandbox_provider() -> None:
+    """
+    ``sandbox_provider`` without ``host_type="managed"`` 422s — an external
+    fork is not server-provisioned, so naming a provider is a contradiction
+    the caller must see rather than have silently dropped.
+    """
+    from omnigent.server.schemas import SessionForkRequest
+
+    with pytest.raises(ValidationError, match="sandbox_provider only applies"):
+        SessionForkRequest(sandbox_provider="modal")
+
+
+def test_session_fork_external_rejects_workspace() -> None:
+    """
+    ``workspace`` without ``host_type="managed"`` 422s — an external fork
+    picks its directory later, when it binds a host, so a workspace here
+    would be silently discarded.
+    """
+    from omnigent.server.schemas import SessionForkRequest
+
+    with pytest.raises(ValidationError, match="workspace only applies"):
+        SessionForkRequest(workspace="https://github.com/org/repo")
+
+
 @pytest.mark.parametrize("status", ["idle", "running", "waiting", "failed"])
 def test_session_response_status_accepts_canonical_set(status: str) -> None:
     """

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -1052,16 +1052,24 @@ def test_session_fork_external_rejects_sandbox_provider() -> None:
         SessionForkRequest(sandbox_provider="modal")
 
 
-def test_session_fork_external_rejects_workspace() -> None:
+@pytest.mark.parametrize(
+    "workspace",
+    ["https://github.com/org/repo", "/tmp/w"],
+)
+def test_session_fork_external_rejects_any_workspace(workspace: str) -> None:
     """
-    ``workspace`` without ``host_type="managed"`` 422s — an external fork
-    picks its directory later, when it binds a host, so a workspace here
-    would be silently discarded.
+    ``workspace`` without ``host_type="managed"`` 422s — for EITHER form.
+
+    This is the one place the fork contract deliberately diverges from the
+    create contract: a create's external workspace is a real host path, so
+    only the repository-URL form is rejected there. A fork picks its
+    directory later, when it binds a host, so a path is just as meaningless
+    as a URL and both must fail loud rather than be silently discarded.
     """
     from omnigent.server.schemas import SessionForkRequest
 
     with pytest.raises(ValidationError, match="workspace only applies"):
-        SessionForkRequest(workspace="https://github.com/org/repo")
+        SessionForkRequest(workspace=workspace)
 
 
 @pytest.mark.parametrize("status", ["idle", "running", "waiting", "failed"])

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -86,6 +86,28 @@ def test_fork_drops_import_provenance_labels(
     assert IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY not in fork.labels
 
 
+def test_fork_drops_sandbox_repo_label(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A fork must not inherit the repository the source's sandbox was built
+    from: the label is what a sandbox RELAUNCH re-clones, so a clone that
+    asked for an empty sandbox would get the source's repo re-cloned into it
+    on the first relaunch. The fork's own launch re-stamps whatever it
+    resolves."""
+    from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+
+    source = conversation_store.create_conversation()
+    conversation_store.set_labels(
+        source.id,
+        {MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo#main", "kept": "yes"},
+    )
+
+    fork = conversation_store.fork_conversation(source.id)
+
+    assert fork.labels["kept"] == "yes"
+    assert MANAGED_REPO_LABEL_KEY not in fork.labels
+
+
 def test_fork_drops_per_user_pin_labels(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:
@@ -4976,6 +4998,25 @@ def test_instance_scoped_label_keys_match_harness_constants() -> None:
     # miss means a rename slipped past the store's hard-coded literal.
     assert BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
     assert CODEX_NATIVE_BRIDGE_ID_LABEL_KEY in _INSTANCE_SCOPED_LABEL_KEYS
+
+
+def test_fork_only_dropped_label_keys_match_sandbox_repo_constant() -> None:
+    """
+    The store's fork-only denylist matches the server's sandbox-repo key.
+
+    The store hard-codes the repository literal (to avoid importing the
+    server into the persistence layer). If the server renames
+    ``MANAGED_REPO_LABEL_KEY``, the literal in
+    :data:`_FORK_ONLY_DROPPED_LABEL_KEYS` would silently stop matching and
+    a fork would re-inherit the source's repository — a clone that asked
+    for an empty sandbox would get the source's repo re-cloned into it on
+    the first relaunch. Importing the real constant here makes that rename
+    fail loudly at test time.
+    """
+    from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+    from omnigent.stores.conversation_store import _FORK_ONLY_DROPPED_LABEL_KEYS
+
+    assert MANAGED_REPO_LABEL_KEY in _FORK_ONLY_DROPPED_LABEL_KEYS
 
 
 def test_fork_conversation_copies_reasoning_effort(

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -376,6 +376,15 @@ export function isSingleUserMode(info: ServerInfo | "loading"): boolean {
 }
 
 /**
+ * Session label recording the repository a managed session was created
+ * with, as the raw ``<url>[#<branch>]`` request value (the server's
+ * ``MANAGED_REPO_LABEL_KEY``). A sandbox relaunch re-clones from it, and
+ * the fork dialog seeds its repository field from it so cloning a sandbox
+ * session lands in the same checkout.
+ */
+export const SANDBOX_REPO_LABEL_KEY = "omnigent.sandbox.repo";
+
+/**
  * Known provider id → display name for the sandbox label. Providers
  * not listed here fall back to a title-cased id so a newly-wired
  * provider still reads sensibly without a frontend change.

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -376,15 +376,6 @@ export function isSingleUserMode(info: ServerInfo | "loading"): boolean {
 }
 
 /**
- * Session label recording the repository a managed session was created
- * with, as the raw ``<url>[#<branch>]`` request value (the server's
- * ``MANAGED_REPO_LABEL_KEY``). A sandbox relaunch re-clones from it, and
- * the fork dialog seeds its repository field from it so cloning a sandbox
- * session lands in the same checkout.
- */
-export const SANDBOX_REPO_LABEL_KEY = "omnigent.sandbox.repo";
-
-/**
  * Known provider id → display name for the sandbox label. Providers
  * not listed here fall back to a title-cased id so a newly-wired
  * provider still reads sensibly without a frontend change.

--- a/web/src/lib/hostPreferences.ts
+++ b/web/src/lib/hostPreferences.ts
@@ -19,6 +19,39 @@ const SANDBOX_PROVIDER_KEY = "omnigent:last-sandbox-provider";
 // time). A reserved sentinel so it can never collide with a real host id.
 export const SANDBOX_HOST_CHOICE = "__sandbox__";
 
+// Separator for the per-provider form of the sentinel, `__sandbox__:<provider>`
+// (see sandboxHostChoice). Kept next to the sentinel so both halves of the
+// grammar live in one place.
+const SANDBOX_PROVIDER_SEPARATOR = ":";
+
+/**
+ * Widen {@link SANDBOX_HOST_CHOICE} to name one sandbox provider.
+ *
+ * A picker rendered as a single list of targets needs a distinct value per
+ * provider row, which the bare sentinel can't give. A real host id can never
+ * collide with the result, since the sentinel prefix is reserved.
+ *
+ * @param provider Provider id, e.g. "modal"; `null` when the server names none.
+ * @returns The per-provider choice, e.g. `"__sandbox__:modal"`.
+ */
+export function sandboxHostChoice(provider: string | null): string {
+  return `${SANDBOX_HOST_CHOICE}${SANDBOX_PROVIDER_SEPARATOR}${provider ?? ""}`;
+}
+
+/**
+ * Read the provider back out of a {@link sandboxHostChoice} value.
+ *
+ * @param choice A picker value — either a per-provider sandbox choice or a
+ *   real host id.
+ * @returns The provider id; `null` for a sandbox choice naming none; and
+ *   `undefined` when `choice` is a host id rather than a sandbox choice.
+ */
+export function sandboxHostChoiceProvider(choice: string): string | null | undefined {
+  const prefix = `${SANDBOX_HOST_CHOICE}${SANDBOX_PROVIDER_SEPARATOR}`;
+  if (!choice.startsWith(prefix)) return undefined;
+  return choice.slice(prefix.length) || null;
+}
+
 /**
  * Read the user's last explicit host choice on the landing composer: a host
  * id, the {@link SANDBOX_HOST_CHOICE} sentinel, or `null` when nothing is

--- a/web/src/lib/hostPreferences.ts
+++ b/web/src/lib/hostPreferences.ts
@@ -10,6 +10,14 @@
 // unavailable stored host is never silently replaced with the automatic
 // default: the picker waits for it to reappear, or for the user to explicitly
 // choose another host.
+//
+// Also owns the sandbox-choice codec (sandboxHostChoice /
+// sandboxHostChoiceProvider), which widens the stored sentinel to name one
+// provider. It lives here because it extends that sentinel's grammar, and
+// because a Radix `Select` carries only a string value — so a picker rendered
+// as one list of targets must encode the provider into the value. The
+// NewChatDialog dropdown needs no encoding: it holds the provider in its own
+// React state.
 
 const STORAGE_KEY = "omnigent:last-host-choice";
 const SANDBOX_PROVIDER_KEY = "omnigent:last-sandbox-provider";

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -402,7 +402,7 @@ describe("forkSession", () => {
       }),
     );
 
-    await forkSession("conv_src", "My clone");
+    await forkSession("conv_src", { title: "My clone" });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string)).toEqual({ title: "My clone" });
@@ -418,10 +418,12 @@ describe("forkSession", () => {
       }),
     );
 
-    await forkSession("conv_src", undefined, undefined, undefined, {
-      modelOverride: "opus",
-      reasoningEffort: "high",
-      terminalLaunchArgs: ["--permission-mode", "auto"],
+    await forkSession("conv_src", {
+      config: {
+        modelOverride: "opus",
+        reasoningEffort: "high",
+        terminalLaunchArgs: ["--permission-mode", "auto"],
+      },
     });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -443,7 +445,7 @@ describe("forkSession", () => {
     );
 
     // An empty config object (non-native target) sends no run overrides.
-    await forkSession("conv_src", undefined, undefined, undefined, {});
+    await forkSession("conv_src", { config: {} });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string)).toEqual({});
@@ -459,17 +461,9 @@ describe("forkSession", () => {
       }),
     );
 
-    await forkSession(
-      "conv_src",
-      undefined,
-      undefined,
-      undefined,
-      {},
-      {
-        provider: "modal",
-        workspace: "https://github.com/org/repo#main",
-      },
-    );
+    await forkSession("conv_src", {
+      sandbox: { provider: "modal", workspace: "https://github.com/org/repo#main" },
+    });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string)).toEqual({
@@ -492,17 +486,7 @@ describe("forkSession", () => {
     // Null is a real choice (empty sandbox); dropping the key would instead
     // inherit the source's repository server-side. A provider the server
     // didn't name is omitted so it picks its first.
-    await forkSession(
-      "conv_src",
-      undefined,
-      undefined,
-      undefined,
-      {},
-      {
-        provider: null,
-        workspace: null,
-      },
-    );
+    await forkSession("conv_src", { sandbox: { provider: null, workspace: null } });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string)).toEqual({ host_type: "managed", workspace: null });
@@ -518,7 +502,7 @@ describe("forkSession", () => {
       }),
     );
 
-    await forkSession("conv_src", undefined, undefined, undefined, {});
+    await forkSession("conv_src", { config: {} });
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string)).not.toHaveProperty("host_type");

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -449,6 +449,81 @@ describe("forkSession", () => {
     expect(JSON.parse(init.body as string)).toEqual({});
   });
 
+  it("asks for a managed sandbox when a sandbox target is given", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_fork",
+        agent_id: "agent_clone",
+        status: "idle",
+        created_at: 1704067200,
+      }),
+    );
+
+    await forkSession(
+      "conv_src",
+      undefined,
+      undefined,
+      undefined,
+      {},
+      {
+        provider: "modal",
+        workspace: "https://github.com/org/repo#main",
+      },
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      host_type: "managed",
+      sandbox_provider: "modal",
+      workspace: "https://github.com/org/repo#main",
+    });
+  });
+
+  it("keeps an explicit null workspace, so a sandbox fork can start empty", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_fork",
+        agent_id: "agent_clone",
+        status: "idle",
+        created_at: 1704067200,
+      }),
+    );
+
+    // Null is a real choice (empty sandbox); dropping the key would instead
+    // inherit the source's repository server-side. A provider the server
+    // didn't name is omitted so it picks its first.
+    await forkSession(
+      "conv_src",
+      undefined,
+      undefined,
+      undefined,
+      {},
+      {
+        provider: null,
+        workspace: null,
+      },
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ host_type: "managed", workspace: null });
+  });
+
+  it("sends no host_type when no sandbox target is given (the fork stays unbound)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({
+        id: "conv_fork",
+        agent_id: "agent_clone",
+        status: "idle",
+        created_at: 1704067200,
+      }),
+    );
+
+    await forkSession("conv_src", undefined, undefined, undefined, {});
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).not.toHaveProperty("host_type");
+  });
+
   it("surfaces a non-ok response as a thrown error (e.g. 403 no access)", async () => {
     fetchMock.mockResolvedValueOnce(mockJsonResponse({}, { ok: false, status: 403 }));
     await expect(forkSession("conv_src")).rejects.toThrow(/403/);

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -729,6 +729,12 @@ export async function createBundledSession(
  * `PATCH /v1/sessions/{id}`. `title` is only sent when provided; omitted,
  * the server derives `"Fork of <source title>"`.
  *
+ * Passing `sandbox` is the one exception to "unbound": it asks the server
+ * to provision a managed sandbox host for the fork, the same background
+ * launch a `host_type: "managed"` create schedules. The call still returns
+ * as soon as the fork row exists — `host_id` / `workspace` stay null until
+ * the sandbox registers.
+ *
  * @param sourceId - Session to fork, e.g. "conv_abc123".
  * @param title - Optional title for the new fork.
  * @param agentId - Optional built-in agent to switch the fork to (e.g.
@@ -746,6 +752,12 @@ export async function createBundledSession(
  *   `["--permission-mode", "auto"]`); `[]` clears the source's launch args.
  *   `codexBypassSandbox: true` (Codex only) arms the dangerous full-bypass on
  *   the fork — sent only on an explicit, banner-gated pick.
+ * @param sandbox - Present when the fork should run on a server-provisioned
+ *   sandbox instead of a host the caller binds. `provider` names one of the
+ *   server's configured sandbox providers (`null` takes its first).
+ *   `workspace` is a `<url>[#<branch>]` repository the server clones into
+ *   the sandbox; `null` gives the fork an empty sandbox, and leaving the key
+ *   off inherits the repository the source session recorded.
  */
 export async function forkSession(
   sourceId: string,
@@ -758,6 +770,7 @@ export async function forkSession(
     terminalLaunchArgs?: string[];
     codexBypassSandbox?: boolean;
   },
+  sandbox?: { provider?: string | null; workspace?: string | null },
 ): Promise<Session> {
   const body: {
     title?: string;
@@ -767,6 +780,9 @@ export async function forkSession(
     reasoning_effort?: string;
     terminal_launch_args?: string[];
     codex_bypass_sandbox?: boolean;
+    host_type?: "managed";
+    sandbox_provider?: string;
+    workspace?: string | null;
   } = {};
   if (title !== undefined) {
     body.title = title;
@@ -790,6 +806,18 @@ export async function forkSession(
   // otherwise keeps the request minimal and the server default (no bypass).
   if (config?.codexBypassSandbox) {
     body.codex_bypass_sandbox = true;
+  }
+  if (sandbox !== undefined) {
+    body.host_type = "managed";
+    // A provider the server didn't name is omitted so it picks its first.
+    if (sandbox.provider != null) {
+      body.sandbox_provider = sandbox.provider;
+    }
+    // Key presence is the signal here: an explicit null means "empty
+    // sandbox", while omitting it inherits the source's repository.
+    if (sandbox.workspace !== undefined) {
+      body.workspace = sandbox.workspace;
+    }
   }
   const res = await authenticatedFetch(`/v1/sessions/${encodeURIComponent(sourceId)}/fork`, {
     method: "POST",

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -723,55 +723,57 @@ export async function createBundledSession(
  * POST /v1/sessions/{source_id}/fork.
  *
  * The server deep-copies the source's transcript and clones its agent
- * into a fresh, unbound session owned by the caller (read access on the
- * source is required). Comments and permissions are NOT copied, and the
- * fork starts `idle` with no runner — the caller binds their own via
- * `PATCH /v1/sessions/{id}`. `title` is only sent when provided; omitted,
- * the server derives `"Fork of <source title>"`.
- *
- * Passing `sandbox` is the one exception to "unbound": it asks the server
- * to provision a managed sandbox host for the fork, the same background
- * launch a `host_type: "managed"` create schedules. The call still returns
- * as soon as the fork row exists — `host_id` / `workspace` stay null until
- * the sandbox registers.
+ * into a fresh session owned by the caller (read access on the source is
+ * required). Comments and permissions are NOT copied. Unless
+ * `options.sandbox` is given, the fork starts `idle` and unbound — the
+ * caller binds their own runner via `PATCH /v1/sessions/{id}`.
+ * `options.title` is only sent when provided; omitted, the server derives
+ * `"Fork of <source title>"`.
  *
  * @param sourceId - Session to fork, e.g. "conv_abc123".
- * @param title - Optional title for the new fork.
- * @param agentId - Optional built-in agent to switch the fork to (e.g.
- *   fork a Claude-SDK session into Claude Code). Omitted → keep the
+ * @param options.title - Optional title for the new fork.
+ * @param options.agentId - Optional built-in agent to switch the fork to
+ *   (e.g. fork a Claude-SDK session into Claude Code). Omitted → keep the
  *   source's agent. The server carries model settings (and native
  *   history) across only within the same provider family.
- * @param upToResponseId - Optional truncation point, e.g. "resp_abc". When
- *   set, the fork copies history only up to and including that response
- *   ("fork from here"); omitted, the full history is copied.
- * @param config - Optional run-config overrides from the fork dialog's
- *   model / effort / permission-mode pickers. Each field is opt-in: a field
- *   left `undefined` inherits the source (model settings carry within the
- *   same provider family), while a sent field overrides it. The
- *   permission-/approval-mode selector rides `terminalLaunchArgs` (e.g.
- *   `["--permission-mode", "auto"]`); `[]` clears the source's launch args.
- *   `codexBypassSandbox: true` (Codex only) arms the dangerous full-bypass on
- *   the fork — sent only on an explicit, banner-gated pick.
- * @param sandbox - Present when the fork should run on a server-provisioned
- *   sandbox instead of a host the caller binds. `provider` names one of the
- *   server's configured sandbox providers (`null` takes its first).
- *   `workspace` is a `<url>[#<branch>]` repository the server clones into
- *   the sandbox; `null` gives the fork an empty sandbox, and leaving the key
- *   off inherits the repository the source session recorded.
+ * @param options.upToResponseId - Optional truncation point, e.g.
+ *   "resp_abc". When set, the fork copies history only up to and including
+ *   that response ("fork from here"); omitted, the full history is copied.
+ * @param options.config - Optional run-config overrides from the fork
+ *   dialog's model / effort / permission-mode pickers. Each field is
+ *   opt-in: a field left `undefined` inherits the source (model settings
+ *   carry within the same provider family), while a sent field overrides
+ *   it. The permission-/approval-mode selector rides `terminalLaunchArgs`
+ *   (e.g. `["--permission-mode", "auto"]`); `[]` clears the source's launch
+ *   args. `codexBypassSandbox: true` (Codex only) arms the dangerous
+ *   full-bypass on the fork — sent only on an explicit, banner-gated pick.
+ * @param options.sandbox - Present when the fork should run on a
+ *   server-provisioned sandbox instead of a host the caller binds. It asks
+ *   for the same background launch a `host_type: "managed"` create
+ *   schedules, so the call still returns as soon as the fork row exists —
+ *   `host_id` / `workspace` stay null until the sandbox registers.
+ *   `provider` names one of the server's configured sandbox providers
+ *   (`null` takes its first). `workspace` is a `<url>[#<branch>]`
+ *   repository the server clones into the sandbox; `null` gives the fork an
+ *   empty sandbox, and leaving the key off inherits the repository the
+ *   source session recorded.
  */
 export async function forkSession(
   sourceId: string,
-  title?: string,
-  agentId?: string,
-  upToResponseId?: string,
-  config?: {
-    modelOverride?: string;
-    reasoningEffort?: string;
-    terminalLaunchArgs?: string[];
-    codexBypassSandbox?: boolean;
-  },
-  sandbox?: { provider?: string | null; workspace?: string | null },
+  options: {
+    title?: string;
+    agentId?: string;
+    upToResponseId?: string;
+    config?: {
+      modelOverride?: string;
+      reasoningEffort?: string;
+      terminalLaunchArgs?: string[];
+      codexBypassSandbox?: boolean;
+    };
+    sandbox?: { provider?: string | null; workspace?: string | null };
+  } = {},
 ): Promise<Session> {
+  const { title, agentId, upToResponseId, config, sandbox } = options;
   const body: {
     title?: string;
     agent_id?: string;

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -8,7 +8,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
-import { FALLBACK_SERVER_INFO, SANDBOX_REPO_LABEL_KEY, type ServerInfo } from "@/lib/capabilities";
+import { FALLBACK_SERVER_INFO, type ServerInfo } from "@/lib/capabilities";
+import { SANDBOX_REPO_LABEL_KEY } from "./NewChatDialog";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { forkSession, launchRunner } from "@/lib/sessionsApi";
 import {

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -1191,13 +1191,32 @@ describe("ForkSessionDialog", () => {
 
       openHostSelect();
       expect(screen.getByTestId("fork-session-sandbox-option")).toHaveTextContent("Modal Sandbox");
-      // The connect hint stays, so "no machine listed" is still explained.
-      expect(screen.getByTestId("connect-host-command")).toBeInTheDocument();
+      // No dead-end: a sandbox is a usable target, so connecting a host is a
+      // collapsed, optional step rather than an always-shown "no hosts
+      // connected" banner.
+      expect(screen.queryByTestId("connect-host-command")).not.toBeInTheDocument();
+      expect(screen.getByTestId("fork-session-connect-host-toggle")).toBeInTheDocument();
     });
 
-    it("keeps a connected host as the default — a sandbox is never implicit", () => {
-      // Provisioning costs real compute, so cloning defaults to reproducing
-      // the source. Only an explicit pick spends.
+    it("defaults to the sandbox when no host is online (sandbox-only deployment)", () => {
+      // With no host to reproduce the source on, the sandbox is the only usable
+      // target: select it by default so the clone is submittable, rather than
+      // stranding the picker empty behind an explicit pick.
+      setHosts([host({ status: "offline" })]);
+      renderDialog({
+        ...CODING,
+        info: { managed_sandboxes_enabled: true, sandbox_provider: "modal" },
+      });
+
+      // The sandbox chrome (repository fields) is active without a manual pick,
+      // and there is no host-directory reuse hint to reproduce.
+      expect(screen.getByTestId("fork-session-sandbox-hint")).toBeInTheDocument();
+      expect(screen.queryByTestId("fork-session-reuse-dir-hint")).not.toBeInTheDocument();
+    });
+
+    it("keeps a connected host as the default — a sandbox is never implicit while one is online", () => {
+      // Provisioning costs real compute, so with a host online cloning defaults
+      // to reproducing the source. Only an explicit pick spends.
       renderDialog({ ...CODING, info: { managed_sandboxes_enabled: true } });
 
       expect(screen.queryByTestId("fork-session-sandbox-hint")).not.toBeInTheDocument();

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -7,6 +7,8 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
+import { FALLBACK_SERVER_INFO, type ServerInfo } from "@/lib/capabilities";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { forkSession, launchRunner } from "@/lib/sessionsApi";
 import {
@@ -147,29 +149,49 @@ function renderDialog(
     sourceHostId?: string | null;
     sourceGitBranch?: string | null;
     upToResponseId?: string | null;
+    // Server capabilities the dialog reads. Omitted leaves the context on
+    // "loading", which fails the sandbox gate closed — the world every
+    // pre-sandbox case here was written against.
+    info?: Partial<ServerInfo>;
   } = { sourceTitle: "My session" },
 ) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  const dialog = (
+    <ForkSessionDialog
+      sourceSessionId="conv_src"
+      sourceTitle={props.sourceTitle}
+      sourceWorkspace={props.sourceWorkspace}
+      sourceHostId={props.sourceHostId}
+      sourceGitBranch={props.sourceGitBranch}
+      upToResponseId={props.upToResponseId}
+      open
+      onOpenChange={vi.fn()}
+    />
+  );
   const utils = render(
     <QueryClientProvider client={client}>
       <TooltipProvider>
         <MemoryRouter>
-          <ForkSessionDialog
-            sourceSessionId="conv_src"
-            sourceTitle={props.sourceTitle}
-            sourceWorkspace={props.sourceWorkspace}
-            sourceHostId={props.sourceHostId}
-            sourceGitBranch={props.sourceGitBranch}
-            upToResponseId={props.upToResponseId}
-            open
-            onOpenChange={vi.fn()}
-          />
+          {props.info === undefined ? (
+            dialog
+          ) : (
+            <CapabilitiesProvider info={{ ...FALLBACK_SERVER_INFO, ...props.info }}>
+              {dialog}
+            </CapabilitiesProvider>
+          )}
         </MemoryRouter>
       </TooltipProvider>
     </QueryClientProvider>,
   );
   return { ...utils, invalidateSpy };
+}
+
+/** Open the Radix host <Select> (hosts + sandbox rows). */
+function openHostSelect(): void {
+  const trigger = screen.getByTestId("fork-session-host-select");
+  fireEvent.pointerDown(trigger, new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+  fireEvent.click(trigger);
 }
 
 /** Open the Radix agent <Select> (mirrors NewChatDialog.test). */
@@ -261,7 +283,14 @@ describe("ForkSessionDialog", () => {
     // the source's agent.
     // A non-native (SDK) source with no agent switch renders no run-config
     // section, so the config arg is an empty object (no run overrides sent).
-    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", "My clone", undefined, undefined, {});
+    expect(forkSessionMock).toHaveBeenCalledWith(
+      "conv_src",
+      "My clone",
+      undefined,
+      undefined,
+      {},
+      undefined,
+    );
     // Session list refreshed so the fork shows in the sidebar, then navigated.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
     // A fork inherits the source's project, so the project-folder lists must
@@ -308,7 +337,14 @@ describe("ForkSessionDialog", () => {
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
     // The 4th arg is the truncation point — undefined here would mean the
     // dialog dropped it and the fork silently copied the full history.
-    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, "resp_cut", {});
+    expect(forkSessionMock).toHaveBeenCalledWith(
+      "conv_src",
+      undefined,
+      undefined,
+      "resp_cut",
+      {},
+      undefined,
+    );
   });
 
   it("omits the title (server derives it) when the field is cleared", async () => {
@@ -325,7 +361,14 @@ describe("ForkSessionDialog", () => {
 
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
     // Whitespace-only → undefined so the server applies "Fork of <title>".
-    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, undefined, {});
+    expect(forkSessionMock).toHaveBeenCalledWith(
+      "conv_src",
+      undefined,
+      undefined,
+      undefined,
+      {},
+      undefined,
+    );
   });
 
   it("pressing Enter in the title input submits the fork", async () => {
@@ -565,6 +608,7 @@ describe("ForkSessionDialog", () => {
       "ag_claude_native",
       undefined,
       {},
+      undefined,
     );
   });
 
@@ -593,6 +637,7 @@ describe("ForkSessionDialog", () => {
       "ag_claude_native",
       undefined,
       { terminalLaunchArgs: ["--permission-mode", "plan"] },
+      undefined,
     );
   });
 
@@ -625,6 +670,7 @@ describe("ForkSessionDialog", () => {
         terminalLaunchArgs: [],
         codexBypassSandbox: true,
       },
+      undefined,
     );
   });
 
@@ -731,7 +777,14 @@ describe("ForkSessionDialog", () => {
       await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
       // Name left blank (optional) → undefined so the server derives it.
       // Coding SDK source, no agent switch → no run-config section, empty config.
-      expect(forkSessionMock).toHaveBeenCalledWith("conv_src", undefined, undefined, undefined, {});
+      expect(forkSessionMock).toHaveBeenCalledWith(
+        "conv_src",
+        undefined,
+        undefined,
+        undefined,
+        {},
+        undefined,
+      );
       // Navigation happens even though the launch promise is still pending.
       await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
       // The launch was kicked off (in the background) on the prefilled host/dir.
@@ -1110,6 +1163,150 @@ describe("ForkSessionDialog", () => {
       expect(screen.queryByTestId("connect-host-command")).not.toBeInTheDocument();
       fireEvent.click(screen.getByTestId("fork-session-connect-host-toggle"));
       expect(screen.getByTestId("connect-host-command")).toBeInTheDocument();
+    });
+  });
+
+  describe("managed sandbox target", () => {
+    const CODING = {
+      sourceTitle: "My session",
+      sourceWorkspace: "/repo",
+      sourceHostId: "host_1",
+    };
+
+    /** Pick the (first) sandbox row in the host <Select>. */
+    function selectSandbox(): void {
+      openHostSelect();
+      fireEvent.click(screen.getByTestId("fork-session-sandbox-option"));
+    }
+
+    it("hides the sandbox option on a server that can't provision one", () => {
+      // Fails closed, mirroring the new-session picker: a server with no
+      // launch-capable sandbox config must not offer a target it will reject.
+      renderDialog({ ...CODING, info: { managed_sandboxes_enabled: false } });
+
+      openHostSelect();
+      expect(screen.queryByTestId("fork-session-sandbox-option")).not.toBeInTheDocument();
+    });
+
+    it("offers a sandbox even when no host is online, labelled per provider", () => {
+      // The reported gap: with every host offline the picker used to collapse
+      // into "reconnect from your terminal", so a clone could never reach a
+      // managed sandbox from the web UI at all.
+      setHosts([host({ status: "offline" })]);
+      renderDialog({
+        ...CODING,
+        info: { managed_sandboxes_enabled: true, sandbox_provider: "modal" },
+      });
+
+      openHostSelect();
+      expect(screen.getByTestId("fork-session-sandbox-option")).toHaveTextContent("Modal Sandbox");
+      // The connect hint stays, so "no machine listed" is still explained.
+      expect(screen.getByTestId("connect-host-command")).toBeInTheDocument();
+    });
+
+    it("keeps a connected host as the default — a sandbox is never implicit", () => {
+      // Provisioning costs real compute, so cloning defaults to reproducing
+      // the source. Only an explicit pick spends.
+      renderDialog({ ...CODING, info: { managed_sandboxes_enabled: true } });
+
+      expect(screen.queryByTestId("fork-session-sandbox-hint")).not.toBeInTheDocument();
+      expect(screen.getByTestId("fork-session-reuse-dir-hint")).toBeInTheDocument();
+    });
+
+    it("swaps the directory chrome for repository fields when the sandbox is picked", () => {
+      renderDialog({ ...CODING, info: { managed_sandboxes_enabled: true } });
+
+      selectSandbox();
+
+      // Host-directory chrome is gone: neither the reuse hint nor (under
+      // Advanced) the working-directory / worktree fields apply to a sandbox
+      // whose filesystem doesn't exist yet.
+      expect(screen.queryByTestId("fork-session-reuse-dir-hint")).not.toBeInTheDocument();
+      expect(screen.getByTestId("fork-session-sandbox-hint")).toBeInTheDocument();
+      openAdvanced();
+      expect(screen.queryByTestId("fork-session-branch-input")).not.toBeInTheDocument();
+      expect(screen.getByTestId("fork-session-sandbox-repo-input")).toBeInTheDocument();
+      expect(screen.getByTestId("fork-session-sandbox-branch-input")).toBeInTheDocument();
+    });
+
+    it("prefills the repository from a sandbox source and forks onto a new sandbox", async () => {
+      // Cloning a sandbox session should land in the same checkout, so the
+      // repository the source recorded seeds the fields.
+      useSessionMock.mockReturnValue({
+        session: { labels: { "omnigent.sandbox.repo": "https://github.com/org/repo#release-1.2" } },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof useSession>);
+      forkSessionMock.mockResolvedValue({
+        id: "conv_fork",
+      } as unknown as Awaited<ReturnType<typeof forkSession>>);
+      renderDialog({
+        ...CODING,
+        info: { managed_sandboxes_enabled: true, sandbox_provider: "modal" },
+      });
+
+      selectSandbox();
+      openAdvanced();
+      expect(screen.getByTestId("fork-session-sandbox-repo-input")).toHaveValue(
+        "https://github.com/org/repo",
+      );
+      expect(screen.getByTestId("fork-session-sandbox-branch-input")).toHaveValue("release-1.2");
+
+      fireEvent.click(screen.getByTestId("fork-session-submit"));
+
+      await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
+      expect(forkSessionMock).toHaveBeenCalledWith(
+        "conv_src",
+        undefined,
+        undefined,
+        undefined,
+        {},
+        { provider: "modal", workspace: "https://github.com/org/repo#release-1.2" },
+      );
+      // The server provisions the host, so the dialog must NOT also try to
+      // bind one — a launchRunner here would 404 on a host that doesn't exist.
+      expect(launchRunnerMock).not.toHaveBeenCalled();
+      expect(checkHostDirectoryMock).not.toHaveBeenCalled();
+      await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
+    });
+
+    it("sends an explicit null workspace when the repository is cleared", async () => {
+      // Clearing the prefill is a real choice (an empty sandbox), so it must
+      // reach the server as an explicit null — omitting the key would make the
+      // server fall back to the source's repository.
+      useSessionMock.mockReturnValue({
+        session: { labels: { "omnigent.sandbox.repo": "https://github.com/org/repo" } },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof useSession>);
+      forkSessionMock.mockResolvedValue({
+        id: "conv_fork",
+      } as unknown as Awaited<ReturnType<typeof forkSession>>);
+      renderDialog({ ...CODING, info: { managed_sandboxes_enabled: true } });
+
+      selectSandbox();
+      openAdvanced();
+      fireEvent.change(screen.getByTestId("fork-session-sandbox-repo-input"), {
+        target: { value: "" },
+      });
+      fireEvent.click(screen.getByTestId("fork-session-submit"));
+
+      await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
+      expect(forkSessionMock.mock.calls[0][5]).toEqual({ provider: null, workspace: null });
+    });
+
+    it("greys the submit button on a malformed repository URL", () => {
+      renderDialog({ ...CODING, info: { managed_sandboxes_enabled: true } });
+
+      selectSandbox();
+      openAdvanced();
+      // A blank repository is legal (empty sandbox); a bare "org/repo" is UI
+      // sugar the server rejects, so catch it here instead of on a 422.
+      expect(screen.getByTestId("fork-session-submit")).not.toBeDisabled();
+      fireEvent.change(screen.getByTestId("fork-session-sandbox-repo-input"), {
+        target: { value: "org/repo" },
+      });
+      expect(screen.getByTestId("fork-session-submit")).toBeDisabled();
     });
   });
 });

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -8,7 +8,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
-import { FALLBACK_SERVER_INFO, type ServerInfo } from "@/lib/capabilities";
+import { FALLBACK_SERVER_INFO, SANDBOX_REPO_LABEL_KEY, type ServerInfo } from "@/lib/capabilities";
 import { ForkSessionDialog } from "./ForkSessionDialog";
 import { forkSession, launchRunner } from "@/lib/sessionsApi";
 import {
@@ -283,14 +283,13 @@ describe("ForkSessionDialog", () => {
     // the source's agent.
     // A non-native (SDK) source with no agent switch renders no run-config
     // section, so the config arg is an empty object (no run overrides sent).
-    expect(forkSessionMock).toHaveBeenCalledWith(
-      "conv_src",
-      "My clone",
-      undefined,
-      undefined,
-      {},
-      undefined,
-    );
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+      title: "My clone",
+      agentId: undefined,
+      upToResponseId: undefined,
+      config: {},
+      sandbox: undefined,
+    });
     // Session list refreshed so the fork shows in the sidebar, then navigated.
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
     // A fork inherits the source's project, so the project-folder lists must
@@ -337,14 +336,13 @@ describe("ForkSessionDialog", () => {
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
     // The 4th arg is the truncation point — undefined here would mean the
     // dialog dropped it and the fork silently copied the full history.
-    expect(forkSessionMock).toHaveBeenCalledWith(
-      "conv_src",
-      undefined,
-      undefined,
-      "resp_cut",
-      {},
-      undefined,
-    );
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+      title: undefined,
+      agentId: undefined,
+      upToResponseId: "resp_cut",
+      config: {},
+      sandbox: undefined,
+    });
   });
 
   it("omits the title (server derives it) when the field is cleared", async () => {
@@ -361,14 +359,13 @@ describe("ForkSessionDialog", () => {
 
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
     // Whitespace-only → undefined so the server applies "Fork of <title>".
-    expect(forkSessionMock).toHaveBeenCalledWith(
-      "conv_src",
-      undefined,
-      undefined,
-      undefined,
-      {},
-      undefined,
-    );
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+      title: undefined,
+      agentId: undefined,
+      upToResponseId: undefined,
+      config: {},
+      sandbox: undefined,
+    });
   });
 
   it("pressing Enter in the title input submits the fork", async () => {
@@ -602,14 +599,13 @@ describe("ForkSessionDialog", () => {
     // it emits `{}` — the server inherits/resets per its own family rule
     // rather than the dialog racing the async model catalog and sending an
     // explicit "default" that would clear the source's model.
-    expect(forkSessionMock).toHaveBeenCalledWith(
-      "conv_src",
-      undefined,
-      "ag_claude_native",
-      undefined,
-      {},
-      undefined,
-    );
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+      title: undefined,
+      agentId: "ag_claude_native",
+      upToResponseId: undefined,
+      config: {},
+      sandbox: undefined,
+    });
   });
 
   it("emits only the run-config fields the user actually changed", async () => {
@@ -631,14 +627,13 @@ describe("ForkSessionDialog", () => {
     fireEvent.click(screen.getByTestId("fork-session-submit"));
 
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
-    expect(forkSessionMock).toHaveBeenCalledWith(
-      "conv_src",
-      undefined,
-      "ag_claude_native",
-      undefined,
-      { terminalLaunchArgs: ["--permission-mode", "plan"] },
-      undefined,
-    );
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+      title: undefined,
+      agentId: "ag_claude_native",
+      upToResponseId: undefined,
+      config: { terminalLaunchArgs: ["--permission-mode", "plan"] },
+      sandbox: undefined,
+    });
   });
 
   it("arms Codex bypass only on an explicit pick, with a danger banner", async () => {
@@ -661,17 +656,13 @@ describe("ForkSessionDialog", () => {
     fireEvent.click(screen.getByTestId("fork-session-submit"));
 
     await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
-    expect(forkSessionMock).toHaveBeenCalledWith(
-      "conv_src",
-      undefined,
-      "ag_codex_native",
-      undefined,
-      {
-        terminalLaunchArgs: [],
-        codexBypassSandbox: true,
-      },
-      undefined,
-    );
+    expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+      title: undefined,
+      agentId: "ag_codex_native",
+      upToResponseId: undefined,
+      config: { terminalLaunchArgs: [], codexBypassSandbox: true },
+      sandbox: undefined,
+    });
   });
 
   it("labels the keep-current option with the source agent's name, not generic text", () => {
@@ -777,14 +768,13 @@ describe("ForkSessionDialog", () => {
       await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
       // Name left blank (optional) → undefined so the server derives it.
       // Coding SDK source, no agent switch → no run-config section, empty config.
-      expect(forkSessionMock).toHaveBeenCalledWith(
-        "conv_src",
-        undefined,
-        undefined,
-        undefined,
-        {},
-        undefined,
-      );
+      expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+        title: undefined,
+        agentId: undefined,
+        upToResponseId: undefined,
+        config: {},
+        sandbox: undefined,
+      });
       // Navigation happens even though the launch promise is still pending.
       await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
       // The launch was kicked off (in the background) on the prefilled host/dir.
@@ -1233,7 +1223,9 @@ describe("ForkSessionDialog", () => {
       // Cloning a sandbox session should land in the same checkout, so the
       // repository the source recorded seeds the fields.
       useSessionMock.mockReturnValue({
-        session: { labels: { "omnigent.sandbox.repo": "https://github.com/org/repo#release-1.2" } },
+        session: {
+          labels: { [SANDBOX_REPO_LABEL_KEY]: "https://github.com/org/repo#release-1.2" },
+        },
         isLoading: false,
         error: null,
       } as unknown as ReturnType<typeof useSession>);
@@ -1255,14 +1247,13 @@ describe("ForkSessionDialog", () => {
       fireEvent.click(screen.getByTestId("fork-session-submit"));
 
       await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
-      expect(forkSessionMock).toHaveBeenCalledWith(
-        "conv_src",
-        undefined,
-        undefined,
-        undefined,
-        {},
-        { provider: "modal", workspace: "https://github.com/org/repo#release-1.2" },
-      );
+      expect(forkSessionMock).toHaveBeenCalledWith("conv_src", {
+        title: undefined,
+        agentId: undefined,
+        upToResponseId: undefined,
+        config: {},
+        sandbox: { provider: "modal", workspace: "https://github.com/org/repo#release-1.2" },
+      });
       // The server provisions the host, so the dialog must NOT also try to
       // bind one — a launchRunner here would 404 on a host that doesn't exist.
       expect(launchRunnerMock).not.toHaveBeenCalled();
@@ -1275,7 +1266,7 @@ describe("ForkSessionDialog", () => {
       // reach the server as an explicit null — omitting the key would make the
       // server fall back to the source's repository.
       useSessionMock.mockReturnValue({
-        session: { labels: { "omnigent.sandbox.repo": "https://github.com/org/repo" } },
+        session: { labels: { [SANDBOX_REPO_LABEL_KEY]: "https://github.com/org/repo" } },
         isLoading: false,
         error: null,
       } as unknown as ReturnType<typeof useSession>);
@@ -1292,7 +1283,10 @@ describe("ForkSessionDialog", () => {
       fireEvent.click(screen.getByTestId("fork-session-submit"));
 
       await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
-      expect(forkSessionMock.mock.calls[0][5]).toEqual({ provider: null, workspace: null });
+      expect(forkSessionMock.mock.calls[0][1]?.sandbox).toEqual({
+        provider: null,
+        workspace: null,
+      });
     });
 
     it("greys the submit button on a malformed repository URL", () => {

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -74,6 +74,9 @@ import { useRecentWorkspaces } from "@/hooks/useRecentWorkspaces";
 import { agentRootName, forkTargetCarriesHistory, harnessFamily } from "@/lib/forkHarness";
 import { checkHostDirectory, hostDirectoryMissing } from "@/hooks/useHostFilesystem";
 import { getCliServerUrl } from "@/lib/host";
+import { useServerInfo } from "@/lib/CapabilitiesContext";
+import { sandboxOptionLabel, sandboxProviderOptions } from "@/lib/capabilities";
+import { SANDBOX_HOST_CHOICE } from "@/lib/hostPreferences";
 import {
   WorkspacePicker,
   isNavigablePath,
@@ -83,6 +86,10 @@ import {
 import { WorkspacePathField } from "./WorkspacePathField";
 import {
   ConnectHostInstructions,
+  composeSandboxWorkspace,
+  deriveRepoName,
+  isValidSandboxRepoUrl,
+  isValidWorkspace,
   normalizeWorkspacePath,
   sessionsSharingDirectory,
 } from "./NewChatDialog";
@@ -97,6 +104,54 @@ const SAME_AS_SOURCE = "__same__";
 // their own `text-ui`, so the option font is shrunk via a descendant selector
 // on the dropdown content rather than plain inheritance.
 const FORK_SELECT_ITEM_SM = "[&_[data-slot=select-item]]:text-sm";
+
+// Session label recording the repository a managed session was created
+// with (the server's MANAGED_REPO_LABEL_KEY). A sandbox clone prefills its
+// repository from it, so cloning a sandbox session lands in the same checkout.
+const SANDBOX_REPO_LABEL_KEY = "omnigent.sandbox.repo";
+
+/**
+ * Select value for the sandbox row of one provider.
+ *
+ * Radix needs a distinct non-empty value per row, so the provider rides
+ * the reserved sandbox sentinel — a real host id can never collide with it.
+ *
+ * @param provider - Provider id, or null when the server names none.
+ * @returns The Select value, e.g. `"__sandbox__:modal"`.
+ */
+function sandboxChoiceValue(provider: string | null): string {
+  return `${SANDBOX_HOST_CHOICE}:${provider ?? ""}`;
+}
+
+/**
+ * Provider named by a sandbox Select value.
+ *
+ * @param value - The value the Select reported.
+ * @returns The provider id, `null` when the server names none, or
+ *   `undefined` when `value` is a real host id rather than a sandbox row.
+ */
+function sandboxChoiceProvider(value: string): string | null | undefined {
+  const prefix = `${SANDBOX_HOST_CHOICE}:`;
+  if (!value.startsWith(prefix)) return undefined;
+  const provider = value.slice(prefix.length);
+  return provider === "" ? null : provider;
+}
+
+/**
+ * Split a `<url>[#<branch>]` sandbox workspace back into its two fields.
+ *
+ * The inverse of `composeSandboxWorkspace`: the server stores one string,
+ * the dialog presents a URL input and a branch input.
+ *
+ * @param workspace - Recorded workspace, e.g. `"https://host/org/repo#main"`.
+ * @returns The URL and branch, each `""` when absent.
+ */
+function splitSandboxRepo(workspace: string | null): { url: string; branch: string } {
+  if (workspace === null) return { url: "", branch: "" };
+  const hash = workspace.indexOf("#");
+  if (hash === -1) return { url: workspace, branch: "" };
+  return { url: workspace.slice(0, hash), branch: workspace.slice(hash + 1) };
+}
 
 /**
  * Compact host label for the Select item — mirrors NewChatDialog's
@@ -620,16 +675,28 @@ function ForkRunConfig({
  * (the server deep-copies the transcript and clones the agent into a fresh
  * session owned by the caller; comments and permissions are NOT copied and
  * future messages don't mutate the source). For a *coding* source (one with
- * a working directory), the form also picks a host + directory + optional
- * git worktree and binds the fork to a runner via ``launchRunner``
- * (``POST /v1/hosts/{id}/runners``). For a non-coding source there is no
- * directory to pick, so it forks with just name + agent.
+ * a working directory), the form also picks where the clone runs. Two
+ * targets:
  *
- * Before creating anything, a coding fork pre-flights the picked directory
+ *  • A connected **host** — pick a directory and optional git worktree; the
+ *    form binds the fork to a runner via ``launchRunner``
+ *    (``POST /v1/hosts/{id}/runners``) after the fork call returns.
+ *  • A server-provisioned **sandbox**, offered when ``/v1/info`` reports
+ *    ``managed_sandboxes_enabled`` — the fork itself carries
+ *    ``host_type: "managed"`` and the server provisions the host in the
+ *    background, so no ``launchRunner`` follows. Its workspace is a
+ *    repository the server clones into the sandbox, prefilled from the
+ *    source's own when the source was a sandbox session.
+ *
+ * For a non-coding source there is no directory to pick, so it forks with
+ * just name + agent.
+ *
+ * Before creating anything, a host fork pre-flights the picked directory
  * against the host (it must exist and be listable) — the launch below is
  * detached, so a bad path would otherwise produce a clone that silently
- * never starts. After that, the fork call is the only thing the form
- * awaits: on success it closes and
+ * never starts. A sandbox fork has nothing to pre-flight; the server
+ * creates the workspace. After that, the fork call is the only thing the
+ * form awaits: on success it closes and
  * navigates into the clone IMMEDIATELY, and (for a coding source) fires the
  * runner launch in the background. Holding the dialog through the launch
  * blocks for as long as a worktree create takes (up to minutes) and hangs
@@ -701,6 +768,9 @@ export function ForkSessionForm({
   // warning + branch field aren't hidden. A ref (not state in the effect dep)
   // keeps it one-shot — the user can re-collapse it without it springing back.
   const autoExpandedRef = useRef(false);
+  // Same one-shot guard for the sandbox repository prefill, so clearing the
+  // field (an empty sandbox) sticks.
+  const sandboxRepoSeededRef = useRef(false);
 
   // A coding source ran in a working directory; only then does the fork
   // need a host + directory to start. A non-coding source forks with just
@@ -713,6 +783,16 @@ export function ForkSessionForm({
   const [branchName, setBranchName] = useState("");
   const [browsing, setBrowsing] = useState(false);
   const [browseNonce, setBrowseNonce] = useState(0);
+  // True when the user picked a server-provisioned sandbox instead of a
+  // connected host — the fork then carries host_type "managed" and the
+  // server provisions its compute, so no launchRunner call follows.
+  const [sandboxSelected, setSandboxSelected] = useState(false);
+  // Provider the sandbox pick launches on; null for a server that names none.
+  const [sandboxProvider, setSandboxProvider] = useState<string | null>(null);
+  // Repository cloned into the sandbox, split across two inputs and
+  // recomposed into the request's `<url>[#<branch>]` workspace.
+  const [sandboxRepoUrl, setSandboxRepoUrl] = useState("");
+  const [sandboxRepoBranch, setSandboxRepoBranch] = useState("");
   // Whether the "connect another host" CLI hint is expanded (only shown when
   // at least one host is online; otherwise the instructions render directly).
   const [showConnect, setShowConnect] = useState(false);
@@ -733,15 +813,36 @@ export function ForkSessionForm({
   const sourceHostOnline = onlineHosts.some((h) => h.host_id === sourceHostId);
   const serverUrl = getCliServerUrl();
 
+  // Gates the sandbox rows in the host picker: only servers whose sandbox
+  // config can actually serve a managed launch advertise it. "loading"
+  // fails closed (rows hidden) until the boot probe resolves. Same gate
+  // NewChatDialog uses for its own sandbox option.
+  const info = useServerInfo();
+  const managedSandboxesEnabled = info !== "loading" && info.managed_sandboxes_enabled;
+  // One picker row per configured provider; a single-provider server
+  // yields exactly one.
+  const sandboxProviderRows = useMemo(
+    () => (info !== "loading" ? sandboxProviderOptions(info) : []),
+    [info],
+  );
+
   const { recent, addRecent } = useRecentWorkspaces(selectedHostId);
 
   // Whether the picked host is the SAME machine the source ran on. Only then
   // does "reuse the source's working directory" make sense — on a different
   // host that path is on someone else's machine. Drives the dir prefill, the
-  // reuse-dir indicator, and whether Advanced starts collapsed.
-  const onSourceHost = isCodingSource && selectedHostId !== null && selectedHostId === sourceHostId;
+  // reuse-dir indicator, and whether Advanced starts collapsed. A sandbox
+  // pick is neither: its filesystem doesn't exist until the server makes it.
+  const onSourceHost =
+    isCodingSource &&
+    !sandboxSelected &&
+    selectedHostId !== null &&
+    selectedHostId === sourceHostId;
   const onDifferentHost =
-    isCodingSource && selectedHostId !== null && selectedHostId !== sourceHostId;
+    isCodingSource &&
+    !sandboxSelected &&
+    selectedHostId !== null &&
+    selectedHostId !== sourceHostId;
 
   const sourceWorkspaceNorm = sourceWorkspace ? normalizeWorkspacePath(sourceWorkspace) : null;
   // Source ran in a server-created git worktree (its workspace IS the
@@ -863,15 +964,24 @@ export function ForkSessionForm({
 
   // Default the host = source host (when online) else the first online
   // host, once hosts have loaded. Only fills an empty slot so an explicit
-  // pick is never overridden.
+  // pick is never overridden. A clone defaults to reproducing the source,
+  // so the sandbox is never the default here (unlike a new session): it
+  // costs a fresh provision, and the user asks for it explicitly.
   useEffect(() => {
-    if (!isCodingSource || selectedHostId !== null) return;
+    if (!isCodingSource || sandboxSelected || selectedHostId !== null) return;
     if (sourceHostId && sourceHostOnline) {
       setSelectedHostId(sourceHostId);
     } else if (onlineHosts.length > 0) {
       setSelectedHostId(onlineHosts[0].host_id);
     }
-  }, [isCodingSource, selectedHostId, sourceHostId, sourceHostOnline, onlineHosts]);
+  }, [
+    isCodingSource,
+    sandboxSelected,
+    selectedHostId,
+    sourceHostId,
+    sourceHostOnline,
+    onlineHosts,
+  ]);
 
   // Prefill the directory with the source's workspace — but only when staying
   // on the source host. On a different host that path is a different machine,
@@ -887,6 +997,22 @@ export function ForkSessionForm({
       setWorkspace(sourceWorkspace);
     }
   }, [onSourceHost, workspace, sourceWorkspace, sourceRepo, sourceBranch]);
+
+  // Repository the SOURCE ran in, when it was itself a sandbox session.
+  // Recorded by the server on the managed create and copied onto the fork.
+  const sourceSandboxRepo = sourceSession?.labels?.[SANDBOX_REPO_LABEL_KEY] ?? null;
+
+  // Prefill the sandbox repository from the source's, so cloning a sandbox
+  // session onto a fresh sandbox lands in the same checkout. A ref keeps it
+  // ONE-SHOT: clearing the field is how the user asks for an empty sandbox,
+  // and a slot-empty guard would spring the prefill straight back.
+  useEffect(() => {
+    if (!sandboxSelected || sandboxRepoSeededRef.current || sourceSandboxRepo === null) return;
+    sandboxRepoSeededRef.current = true;
+    const { url, branch } = splitSandboxRepo(sourceSandboxRepo);
+    setSandboxRepoUrl(url);
+    setSandboxRepoBranch(branch);
+  }, [sandboxSelected, sourceSandboxRepo]);
 
   // Resolve a typed "~/…" path to its absolute form against the host's home,
   // so it's directly submittable without opening the tree browser (the server
@@ -916,22 +1042,39 @@ export function ForkSessionForm({
   // that would just fail server-side) until a live host is chosen.
   const selectedHostOnline =
     selectedHostId !== null && onlineHosts.some((h) => h.host_id === selectedHostId);
-  // A coding source can only start once a live host + valid directory are picked.
-  const canSubmit = !isCodingSource || (selectedHostOnline && workspaceValid);
+  // A blank repository is legal — the clone then gets an empty sandbox —
+  // but a branch without one, or a malformed URL, greys the button instead
+  // of surfacing as a 422. Mirrors NewChatDialog's sandbox validity rule.
+  const sandboxRepoValid =
+    sandboxRepoUrl.trim() === ""
+      ? sandboxRepoBranch.trim() === ""
+      : isValidSandboxRepoUrl(sandboxRepoUrl);
+  // Short "repo" / "repo#branch" form for the sandbox hint — the same name
+  // the clone directory takes inside the sandbox.
+  const sandboxRepoName = deriveRepoName(sandboxRepoUrl);
+  const sandboxRepoLabel =
+    sandboxRepoName !== null && sandboxRepoBranch.trim() !== ""
+      ? `${sandboxRepoName}#${sandboxRepoBranch.trim()}`
+      : (sandboxRepoName ?? sandboxRepoUrl.trim());
+  // A coding source can only start once a live host + valid directory are
+  // picked; a sandbox clone needs neither — the server provisions both.
+  const canSubmit = sandboxSelected
+    ? sandboxRepoValid
+    : !isCodingSource || (selectedHostOnline && workspaceValid);
 
   // Conflict hint: other *connected* sessions already working in the picked
   // directory on this host (same wiring as NewChatDialog).
   const { data: directorySessions } = useDirectorySessions(
-    isCodingSource && Boolean(selectedHostId),
+    isCodingSource && !sandboxSelected && Boolean(selectedHostId),
   );
   const conflictCandidates = useMemo(
     () =>
-      isCodingSource
+      isCodingSource && !sandboxSelected
         ? (directorySessions ?? []).filter(
             (s) => s.host_id === selectedHostId && s.workspace != null,
           )
         : [],
-    [isCodingSource, directorySessions, selectedHostId],
+    [isCodingSource, sandboxSelected, directorySessions, selectedHostId],
   );
   const runnerHealth = useRunnerHealthRegistration(conflictCandidates);
   const conflictingSessions = useMemo(
@@ -970,6 +1113,7 @@ export function ForkSessionForm({
     sourceHostId != null && selectedHostId !== null && selectedHostId !== sourceHostId;
   const showMismatchWarning =
     isCodingSource &&
+    !sandboxSelected &&
     ((hostMismatch && workspaceTrimmed !== "") ||
       (sourceWorkspaceNorm !== null &&
         workspaceTrimmed !== "" &&
@@ -990,6 +1134,31 @@ export function ForkSessionForm({
     setBrowseNonce((n) => n + 1);
   }
 
+  /** Target the clone at a connected host, dropping any sandbox pick. */
+  function selectHost(hostId: string): void {
+    setSandboxSelected(false);
+    setSelectedHostId(hostId);
+    // Workspace and the worktree branch are host-specific: the directory
+    // path and the prefilled source branch only make sense on the source
+    // machine. Clear both on a host change. (The source-host prefill effect
+    // re-seeds them if the user switches back.)
+    setWorkspace("");
+    setBranchName("");
+    setBrowsing(false);
+  }
+
+  /** Target the clone at a server-provisioned sandbox on `provider`. */
+  function selectSandbox(provider: string | null): void {
+    setSandboxSelected(true);
+    setSandboxProvider(provider);
+    // A host directory can't describe a sandbox that doesn't exist yet;
+    // the repository fields take over. Also close the tree browser, whose
+    // host-backed listing has nothing left to browse.
+    setWorkspace("");
+    setBranchName("");
+    setBrowsing(false);
+  }
+
   async function handleFork(): Promise<void> {
     if (!canSubmit) return;
     setSubmitting(true);
@@ -998,9 +1167,10 @@ export function ForkSessionForm({
       // Pre-flight the directory BEFORE creating anything: the runner
       // launch below is detached and its failure is swallowed, so a
       // nonexistent path would otherwise leave a clone that silently
-      // never starts.
+      // never starts. A sandbox clone has no directory to pre-flight —
+      // the server creates the workspace inside the sandbox.
       let recreateSourceWorktree = false;
-      if (isCodingSource && selectedHostId) {
+      if (isCodingSource && !sandboxSelected && selectedHostId) {
         const problem = await checkHostDirectory(selectedHostId, effectiveWorkspace);
         if (problem !== null) {
           // Deleted source worktree + untouched name: recreate the worktree
@@ -1037,6 +1207,16 @@ export function ForkSessionForm({
         switching ? agentChoice : undefined,
         upToResponseId ?? undefined,
         runConfig,
+        // Sandbox clone: the server provisions the host, so the fork call
+        // carries the compute request itself and no launchRunner follows.
+        // The workspace is always explicit — the dialog's repository field
+        // is the user's answer, including "blank" for an empty sandbox.
+        sandboxSelected
+          ? {
+              provider: sandboxProvider,
+              workspace: composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch) ?? null,
+            }
+          : undefined,
       );
       // Coding fork: launch the runner in the BACKGROUND, then navigate
       // into the (already-created, unbound) clone immediately — awaiting the
@@ -1045,7 +1225,7 @@ export function ForkSessionForm({
       // unbound; ChatPage's existing unbound-fork path lets the user retry
       // the bind via the directory picker. (A follow-up will surface the
       // failure proactively + show "Connecting…" for the whole launch.)
-      if (isCodingSource && selectedHostId) {
+      if (isCodingSource && !sandboxSelected && selectedHostId) {
         const trimmedBranch = branchName.trim();
         addRecent(workspaceTrimmed);
         // Reusing the source's worktree binds its directory directly (no
@@ -1105,11 +1285,11 @@ export function ForkSessionForm({
   return (
     <>
       <div className="-mr-4 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pr-4 [scrollbar-width:thin] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-border [&::-webkit-scrollbar-track]:bg-transparent">
-        {/* Host first: with no online host there is nothing to run the
-              clone on, so the user learns up front whether they can proceed.
-              Mirrors NewChatDialog: a picker when hosts are online (with a
-              collapsible "connect another" CLI hint), or the connect
-              instructions directly when none are. */}
+        {/* Host first: with nothing to run the clone on, the user learns up
+              front whether they can proceed. Mirrors NewChatDialog: a picker
+              when a target is available (sandbox rows pinned above the
+              connected hosts, with a collapsible "connect another" CLI hint),
+              or the connect instructions directly when none is. */}
         {isCodingSource && (
           <div className="flex flex-col gap-2">
             <span className="text-sm font-medium text-muted-foreground">Host</span>
@@ -1117,10 +1297,11 @@ export function ForkSessionForm({
               <p className="text-sm text-muted-foreground" data-testid="fork-session-no-hosts">
                 Loading hosts…
               </p>
-            ) : onlineHosts.length === 0 ? (
-              // Nothing usable (no hosts, or all offline) — show the connect
-              // command directly so the user can unblock. The submit button
-              // stays greyed until a host is online.
+            ) : onlineHosts.length === 0 && !managedSandboxesEnabled ? (
+              // Nothing usable (no hosts, or all offline) and no sandbox to
+              // fall back on — show the connect command directly so the user
+              // can unblock. The submit button stays greyed until a host is
+              // online.
               <ConnectHostInstructions
                 serverUrl={serverUrl}
                 label={
@@ -1132,24 +1313,50 @@ export function ForkSessionForm({
             ) : (
               <>
                 <Select
-                  value={selectedHostId ?? ""}
+                  value={
+                    sandboxSelected ? sandboxChoiceValue(sandboxProvider) : (selectedHostId ?? "")
+                  }
                   componentId="fork_session.host"
                   onValueChange={(v) => {
-                    setSelectedHostId(v);
-                    // Workspace and the worktree branch are host-specific:
-                    // the directory path and the prefilled source branch only
-                    // make sense on the source machine. Clear both on a host
-                    // change. (The source-host prefill effect re-seeds them
-                    // if the user switches back.)
-                    setWorkspace("");
-                    setBranchName("");
-                    setBrowsing(false);
+                    const provider = sandboxChoiceProvider(v);
+                    if (provider !== undefined) {
+                      selectSandbox(provider);
+                      return;
+                    }
+                    selectHost(v);
                   }}
                 >
                   <SelectTrigger className="w-full text-sm" data-testid="fork-session-host-select">
-                    <SelectValue placeholder="Select a host" />
+                    <SelectValue
+                      placeholder={
+                        managedSandboxesEnabled ? "Select a host or sandbox" : "Select a host"
+                      }
+                    />
                   </SelectTrigger>
                   <SelectContent>
+                    {/* Server-provisioned sandbox — only advertised when
+                        /v1/info reports managed_sandboxes_enabled. Pinned
+                        first, above the connected-host list. */}
+                    {managedSandboxesEnabled &&
+                      sandboxProviderRows.map((provider, index) => (
+                        <SelectItem
+                          key={provider ?? "default"}
+                          value={sandboxChoiceValue(provider)}
+                          // First row keeps the unscoped testid; later rows
+                          // get a per-provider one.
+                          data-testid={
+                            index === 0
+                              ? "fork-session-sandbox-option"
+                              : `fork-session-sandbox-option-${provider}`
+                          }
+                        >
+                          <span className="flex items-center gap-2">
+                            <MonitorCloudIcon className="size-4 text-muted-foreground" />
+                            <span className="text-sm">{sandboxOptionLabel(provider)}</span>
+                          </span>
+                        </SelectItem>
+                      ))}
+                    {managedSandboxesEnabled && allHosts.length > 0 && <SelectSeparator />}
                     {onlineHosts.map((host) => (
                       <SelectItem
                         key={host.host_id}
@@ -1171,20 +1378,35 @@ export function ForkSessionForm({
                     ))}
                   </SelectContent>
                 </Select>
-                <button
-                  type="button"
-                  onClick={() => setShowConnect((v) => !v)}
-                  className="flex cursor-pointer items-center gap-1 self-start text-sm text-muted-foreground transition hover:text-foreground"
-                  data-testid="fork-session-connect-host-toggle"
-                >
-                  {showConnect ? (
-                    <ChevronUpIcon className="size-3.5" />
-                  ) : (
-                    <ChevronDownIcon className="size-3.5" />
-                  )}
-                  Connect another host from your terminal
-                </button>
-                {showConnect && <ConnectHostInstructions serverUrl={serverUrl} />}
+                {onlineHosts.length === 0 ? (
+                  // Sandbox-only: the picker still works, but say why no
+                  // machine is listed rather than leave the list looking short.
+                  <ConnectHostInstructions
+                    serverUrl={serverUrl}
+                    label={
+                      allHosts.length === 0
+                        ? "No hosts connected yet. Connect one from your terminal:"
+                        : "No hosts online. Reconnect from your terminal to clone onto one:"
+                    }
+                  />
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setShowConnect((v) => !v)}
+                      className="flex cursor-pointer items-center gap-1 self-start text-sm text-muted-foreground transition hover:text-foreground"
+                      data-testid="fork-session-connect-host-toggle"
+                    >
+                      {showConnect ? (
+                        <ChevronUpIcon className="size-3.5" />
+                      ) : (
+                        <ChevronDownIcon className="size-3.5" />
+                      )}
+                      Connect another host from your terminal
+                    </button>
+                    {showConnect && <ConnectHostInstructions serverUrl={serverUrl} />}
+                  </>
+                )}
               </>
             )}
           </div>
@@ -1272,6 +1494,17 @@ export function ForkSessionForm({
             selectedHostId={isCodingSource ? selectedHostId : (sourceHostId ?? null)}
             onChange={setRunConfig}
           />
+        )}
+
+        {/* Sandbox counterpart of the reuse-dir indicator: the clone gets a
+              fresh sandbox, so say what lands in it and where to change that.
+              The repository fields themselves live under Advanced. */}
+        {sandboxSelected && (
+          <p className="text-sm text-muted-foreground" data-testid="fork-session-sandbox-hint">
+            {sandboxRepoUrl.trim() === ""
+              ? "The clone starts in a fresh, empty sandbox. Name a repository under Advanced settings to clone one into it."
+              : `The clone starts in a fresh sandbox with ${sandboxRepoLabel} cloned into it. Open Advanced settings to change it.`}
+          </p>
         )}
 
         {/* Indicator: by default the clone reuses the source's working
@@ -1363,7 +1596,59 @@ export function ForkSessionForm({
                 />
               </div>
 
-              {isCodingSource && (
+              {/* Sandbox repository — the sandbox counterpart of the working
+                  directory. The sandbox doesn't exist yet, so there is no
+                  path to browse: the workspace is specified as a repository
+                  the server clones into it. */}
+              {isCodingSource && sandboxSelected && (
+                <>
+                  <div className="flex flex-col gap-1">
+                    <label
+                      htmlFor="fork-session-sandbox-repo"
+                      className="text-sm font-medium text-muted-foreground"
+                    >
+                      Repository (optional)
+                    </label>
+                    <input
+                      id="fork-session-sandbox-repo"
+                      type="text"
+                      value={sandboxRepoUrl}
+                      onChange={(e) => setSandboxRepoUrl(e.target.value)}
+                      placeholder="https://github.com/org/repo"
+                      data-testid="fork-session-sandbox-repo-input"
+                      className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors focus-visible:border-ring"
+                    />
+                    <p className="text-sm text-muted-foreground">
+                      Cloned into the sandbox as the clone's working directory. Leave blank to start
+                      in an empty sandbox.
+                    </p>
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <label
+                      htmlFor="fork-session-sandbox-branch"
+                      className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground"
+                    >
+                      <GitBranchIcon className="size-3.5" />
+                      Branch (optional)
+                    </label>
+                    <input
+                      id="fork-session-sandbox-branch"
+                      type="text"
+                      value={sandboxRepoBranch}
+                      onChange={(e) => setSandboxRepoBranch(e.target.value)}
+                      placeholder="main"
+                      data-testid="fork-session-sandbox-branch-input"
+                      className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm outline-none transition-colors focus-visible:border-ring"
+                    />
+                    <p className="text-sm text-muted-foreground">
+                      Leave blank to clone the repository's default branch.
+                    </p>
+                  </div>
+                </>
+              )}
+
+              {isCodingSource && !sandboxSelected && (
                 <>
                   <div className="flex flex-col gap-2">
                     <span className="text-sm font-medium text-muted-foreground">

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -75,11 +75,7 @@ import { agentRootName, forkTargetCarriesHistory, harnessFamily } from "@/lib/fo
 import { checkHostDirectory, hostDirectoryMissing } from "@/hooks/useHostFilesystem";
 import { getCliServerUrl } from "@/lib/host";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
-import {
-  SANDBOX_REPO_LABEL_KEY,
-  sandboxOptionLabel,
-  sandboxProviderOptions,
-} from "@/lib/capabilities";
+import { sandboxOptionLabel, sandboxProviderOptions } from "@/lib/capabilities";
 import { sandboxHostChoice, sandboxHostChoiceProvider } from "@/lib/hostPreferences";
 import {
   WorkspacePicker,
@@ -90,6 +86,7 @@ import {
 import { WorkspacePathField } from "./WorkspacePathField";
 import {
   ConnectHostInstructions,
+  SANDBOX_REPO_LABEL_KEY,
   composeSandboxWorkspace,
   deriveRepoName,
   isValidSandboxRepoUrl,

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -90,7 +90,6 @@ import {
   composeSandboxWorkspace,
   deriveRepoName,
   isValidSandboxRepoUrl,
-  isValidWorkspace,
   normalizeWorkspacePath,
   sessionsSharingDirectory,
   splitSandboxWorkspace,

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -75,8 +75,12 @@ import { agentRootName, forkTargetCarriesHistory, harnessFamily } from "@/lib/fo
 import { checkHostDirectory, hostDirectoryMissing } from "@/hooks/useHostFilesystem";
 import { getCliServerUrl } from "@/lib/host";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
-import { sandboxOptionLabel, sandboxProviderOptions } from "@/lib/capabilities";
-import { SANDBOX_HOST_CHOICE } from "@/lib/hostPreferences";
+import {
+  SANDBOX_REPO_LABEL_KEY,
+  sandboxOptionLabel,
+  sandboxProviderOptions,
+} from "@/lib/capabilities";
+import { sandboxHostChoice, sandboxHostChoiceProvider } from "@/lib/hostPreferences";
 import {
   WorkspacePicker,
   isNavigablePath,
@@ -92,6 +96,7 @@ import {
   isValidWorkspace,
   normalizeWorkspacePath,
   sessionsSharingDirectory,
+  splitSandboxWorkspace,
 } from "./NewChatDialog";
 
 // Select sentinel for "keep the source's agent" (Radix Select needs a
@@ -104,54 +109,6 @@ const SAME_AS_SOURCE = "__same__";
 // their own `text-ui`, so the option font is shrunk via a descendant selector
 // on the dropdown content rather than plain inheritance.
 const FORK_SELECT_ITEM_SM = "[&_[data-slot=select-item]]:text-sm";
-
-// Session label recording the repository a managed session was created
-// with (the server's MANAGED_REPO_LABEL_KEY). A sandbox clone prefills its
-// repository from it, so cloning a sandbox session lands in the same checkout.
-const SANDBOX_REPO_LABEL_KEY = "omnigent.sandbox.repo";
-
-/**
- * Select value for the sandbox row of one provider.
- *
- * Radix needs a distinct non-empty value per row, so the provider rides
- * the reserved sandbox sentinel — a real host id can never collide with it.
- *
- * @param provider - Provider id, or null when the server names none.
- * @returns The Select value, e.g. `"__sandbox__:modal"`.
- */
-function sandboxChoiceValue(provider: string | null): string {
-  return `${SANDBOX_HOST_CHOICE}:${provider ?? ""}`;
-}
-
-/**
- * Provider named by a sandbox Select value.
- *
- * @param value - The value the Select reported.
- * @returns The provider id, `null` when the server names none, or
- *   `undefined` when `value` is a real host id rather than a sandbox row.
- */
-function sandboxChoiceProvider(value: string): string | null | undefined {
-  const prefix = `${SANDBOX_HOST_CHOICE}:`;
-  if (!value.startsWith(prefix)) return undefined;
-  const provider = value.slice(prefix.length);
-  return provider === "" ? null : provider;
-}
-
-/**
- * Split a `<url>[#<branch>]` sandbox workspace back into its two fields.
- *
- * The inverse of `composeSandboxWorkspace`: the server stores one string,
- * the dialog presents a URL input and a branch input.
- *
- * @param workspace - Recorded workspace, e.g. `"https://host/org/repo#main"`.
- * @returns The URL and branch, each `""` when absent.
- */
-function splitSandboxRepo(workspace: string | null): { url: string; branch: string } {
-  if (workspace === null) return { url: "", branch: "" };
-  const hash = workspace.indexOf("#");
-  if (hash === -1) return { url: workspace, branch: "" };
-  return { url: workspace.slice(0, hash), branch: workspace.slice(hash + 1) };
-}
 
 /**
  * Compact host label for the Select item — mirrors NewChatDialog's
@@ -1009,7 +966,7 @@ export function ForkSessionForm({
   useEffect(() => {
     if (!sandboxSelected || sandboxRepoSeededRef.current || sourceSandboxRepo === null) return;
     sandboxRepoSeededRef.current = true;
-    const { url, branch } = splitSandboxRepo(sourceSandboxRepo);
+    const { url, branch } = splitSandboxWorkspace(sourceSandboxRepo);
     setSandboxRepoUrl(url);
     setSandboxRepoBranch(branch);
   }, [sandboxSelected, sourceSandboxRepo]);
@@ -1201,23 +1158,22 @@ export function ForkSessionForm({
       // Empty title → omit so the server derives "Fork of <source title>".
       // The run-config section (native targets only) reports its ready-to-send
       // value; an empty object (non-native target) sends no run overrides.
-      const fork = await forkSession(
-        sourceSessionId,
-        trimmed === "" ? undefined : trimmed,
-        switching ? agentChoice : undefined,
-        upToResponseId ?? undefined,
-        runConfig,
+      const fork = await forkSession(sourceSessionId, {
+        title: trimmed === "" ? undefined : trimmed,
+        agentId: switching ? agentChoice : undefined,
+        upToResponseId: upToResponseId ?? undefined,
+        config: runConfig,
         // Sandbox clone: the server provisions the host, so the fork call
         // carries the compute request itself and no launchRunner follows.
         // The workspace is always explicit — the dialog's repository field
         // is the user's answer, including "blank" for an empty sandbox.
-        sandboxSelected
+        sandbox: sandboxSelected
           ? {
               provider: sandboxProvider,
               workspace: composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch) ?? null,
             }
           : undefined,
-      );
+      });
       // Coding fork: launch the runner in the BACKGROUND, then navigate
       // into the (already-created, unbound) clone immediately — awaiting the
       // launch would block the modal for a worktree create (up to minutes)
@@ -1314,11 +1270,11 @@ export function ForkSessionForm({
               <>
                 <Select
                   value={
-                    sandboxSelected ? sandboxChoiceValue(sandboxProvider) : (selectedHostId ?? "")
+                    sandboxSelected ? sandboxHostChoice(sandboxProvider) : (selectedHostId ?? "")
                   }
                   componentId="fork_session.host"
                   onValueChange={(v) => {
-                    const provider = sandboxChoiceProvider(v);
+                    const provider = sandboxHostChoiceProvider(v);
                     if (provider !== undefined) {
                       selectSandbox(provider);
                       return;
@@ -1341,7 +1297,7 @@ export function ForkSessionForm({
                       sandboxProviderRows.map((provider, index) => (
                         <SelectItem
                           key={provider ?? "default"}
-                          value={sandboxChoiceValue(provider)}
+                          value={sandboxHostChoice(provider)}
                           // First row keeps the unscoped testid; later rows
                           // get a per-provider one.
                           data-testid={

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -918,14 +918,20 @@ export function ForkSessionForm({
   // Default the host = source host (when online) else the first online
   // host, once hosts have loaded. Only fills an empty slot so an explicit
   // pick is never overridden. A clone defaults to reproducing the source,
-  // so the sandbox is never the default here (unlike a new session): it
-  // costs a fresh provision, and the user asks for it explicitly.
+  // so a sandbox is not the default while any host is online — it costs a
+  // fresh provision, and the user asks for it explicitly. But with no host
+  // online a sandbox-only deployment has nothing to reproduce the source
+  // on, so default to the sandbox rather than strand the picker empty and
+  // unsubmittable.
   useEffect(() => {
     if (!isCodingSource || sandboxSelected || selectedHostId !== null) return;
     if (sourceHostId && sourceHostOnline) {
       setSelectedHostId(sourceHostId);
     } else if (onlineHosts.length > 0) {
       setSelectedHostId(onlineHosts[0].host_id);
+    } else if (managedSandboxesEnabled && sandboxProviderRows.length > 0) {
+      setSandboxSelected(true);
+      setSandboxProvider(sandboxProviderRows[0]);
     }
   }, [
     isCodingSource,
@@ -934,6 +940,8 @@ export function ForkSessionForm({
     sourceHostId,
     sourceHostOnline,
     onlineHosts,
+    managedSandboxesEnabled,
+    sandboxProviderRows,
   ]);
 
   // Prefill the directory with the source's workspace — but only when staying
@@ -1330,35 +1338,27 @@ export function ForkSessionForm({
                     ))}
                   </SelectContent>
                 </Select>
-                {onlineHosts.length === 0 ? (
-                  // Sandbox-only: the picker still works, but say why no
-                  // machine is listed rather than leave the list looking short.
-                  <ConnectHostInstructions
-                    serverUrl={serverUrl}
-                    label={
-                      allHosts.length === 0
-                        ? "No hosts connected yet. Connect one from your terminal:"
-                        : "No hosts online. Reconnect from your terminal to clone onto one:"
-                    }
-                  />
-                ) : (
-                  <>
-                    <button
-                      type="button"
-                      onClick={() => setShowConnect((v) => !v)}
-                      className="flex cursor-pointer items-center gap-1 self-start text-sm text-muted-foreground transition hover:text-foreground"
-                      data-testid="fork-session-connect-host-toggle"
-                    >
-                      {showConnect ? (
-                        <ChevronUpIcon className="size-3.5" />
-                      ) : (
-                        <ChevronDownIcon className="size-3.5" />
-                      )}
-                      Connect another host from your terminal
-                    </button>
-                    {showConnect && <ConnectHostInstructions serverUrl={serverUrl} />}
-                  </>
-                )}
+                {/* A sandbox is a usable target, so no dead-end even with no
+                    host online: offer connecting one as a collapsed, optional
+                    step rather than an alarming "no hosts connected" banner. */}
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setShowConnect((v) => !v)}
+                    className="flex cursor-pointer items-center gap-1 self-start text-sm text-muted-foreground transition hover:text-foreground"
+                    data-testid="fork-session-connect-host-toggle"
+                  >
+                    {showConnect ? (
+                      <ChevronUpIcon className="size-3.5" />
+                    ) : (
+                      <ChevronDownIcon className="size-3.5" />
+                    )}
+                    {onlineHosts.length === 0
+                      ? "Connect a host from your terminal"
+                      : "Connect another host from your terminal"}
+                  </button>
+                  {showConnect && <ConnectHostInstructions serverUrl={serverUrl} />}
+                </>
               </>
             )}
           </div>

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -779,6 +779,27 @@ export function composeSandboxWorkspace(url: string, branch: string): string | u
 }
 
 /**
+ * Split a composed sandbox workspace back into its two inputs.
+ *
+ * The inverse of {@link composeSandboxWorkspace}: the API carries one
+ * ``<url>[#<branch>]`` string, the UI presents a URL field and a branch
+ * field. Splits on the FIRST ``#``, matching the server's own parse.
+ *
+ * @param workspace Composed workspace, e.g.
+ *   ``"https://github.com/org/repo#main"``, or ``null`` when unset.
+ * @returns The url and branch, each ``""`` when absent.
+ */
+export function splitSandboxWorkspace(workspace: string | null): {
+  url: string;
+  branch: string;
+} {
+  if (workspace === null) return { url: "", branch: "" };
+  const hash = workspace.indexOf("#");
+  if (hash === -1) return { url: workspace, branch: "" };
+  return { url: workspace.slice(0, hash), branch: workspace.slice(hash + 1) };
+}
+
+/**
  * Derive a repository's display name from its URL.
  *
  * Last path segment with a trailing ``.git`` stripped — the same rule

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -742,6 +742,16 @@ export function sanitizeInitialPrompt(prompt: string): string {
 }
 
 /**
+ * Session label recording the repository a managed session was created
+ * with, as the raw ``<url>[#<branch>]`` request value (the server's
+ * ``MANAGED_REPO_LABEL_KEY``). A sandbox relaunch re-clones from it, and
+ * the fork dialog seeds its repository field from it so cloning a sandbox
+ * session lands in the same checkout — which is why it lives beside the
+ * workspace grammar below rather than with the server-capability probe.
+ */
+export const SANDBOX_REPO_LABEL_KEY = "omnigent.sandbox.repo";
+
+/**
  * Return true when ``url`` is acceptable as a sandbox repository URL.
  *
  * Mirrors the server's accepted forms (``parse_repo_workspace``):


### PR DESCRIPTION
Fixes #6652.

## Problem

Forking a session can never target a managed Kubernetes sandbox. `host_type`
(`"external"` / `"managed"`) exists only on `SessionCreateRequest` — the
new-session-create request — not on `SessionForkRequest`, which is a pure
transcript/agent deep-copy with no host-provisioning concept at all. The web
UI's fork dialog binds a fork to compute through a separate call,
`POST /v1/hosts/{id}/runners`, which requires an already-registered,
already-online host. With no host connected via `omni host`, the fork dialog
dead-ends on "No hosts online. Reconnect from your terminal to start the
clone." — there is no path from fork into managed-sandbox provisioning.

Not a regression: managed-sandbox support was added to session-create and
never extended to fork (or reconnect / switch-agent, a related gap left out
of scope here).

## Fix

- `SessionForkRequest` gains `host_type` / `sandbox_provider` / `workspace`,
  validated by `_check_managed_fork_fields`, mirroring
  `_check_managed_host_fields` on `SessionCreateRequest`. The `workspace`
  field branches on whether it was **sent**, not its value — omitted
  inherits the source session's recorded repository, an explicit `null`
  starts an empty sandbox — the same opt-in-vs-inherit rule `model_override`
  already uses on this request.
- `fork_session` reuses the **existing** `_schedule_managed_launch` helper
  both create paths already call — no parallel provisioning path.
- The web UI's fork dialog gets a managed-sandbox row in its existing host
  picker, gated on `managed_sandboxes_enabled` exactly like `NewChatDialog`.
  A clone does **not** default to the sandbox the way New Chat does — a
  clone should reproduce the source, and provisioning a sandbox costs real
  compute, so it's a deliberate pick rather than a silent default.

## Safety property preserved, and tested

A fork mints a session-scoped agent clone that deliberately fails the
built-in-agent gate an admission policy can key a workload-scoped credential
injection on (e.g. a machine git credential for one named built-in agent).
That gate must not weaken here — a fork reachable by any authenticated user
must never self-classify into a privileged built-in identity and inherit its
credential. `test_fork_managed_launch_carries_the_session_scoped_clone_not_a_builtin`
pins that the managed launch is handed the fork's own session-scoped clone
id, never the built-in, and resolves to no such label.

Separately, the sandbox correctly registers to the row read from the
**forking** caller, not the source session's owner —
`test_fork_managed_registers_the_sandbox_to_the_forking_user` pins this with
a fixed-identity auth provider, so a fork's credentials/config resolve to
whoever forked it, not whoever created the original session.

## A real bug caught in review, fixed here

The first version of this change dropped the source session's sandbox-repo
label onto the fork's inherited-repo path, which meant an explicit
`{"host_type": "managed", "workspace": null}` — "give the fork an empty
sandbox" — booted empty but kept the source's repository label, and the
first relaunch re-cloned the source's repository into a sandbox the caller
explicitly cleared. Fixed by adding the label to
`_FORK_ONLY_DROPPED_LABEL_KEYS` (the store's unconditional per-fork drop set,
alongside the existing bridge-id / instance-scoped keys) rather than the
route's conditional per-request channel, so the rule can't be forgotten by a
future caller of `fork_conversation`. Guarded by a cross-check test mirroring
this repo's existing `_INSTANCE_SCOPED_LABEL_KEYS` guard, plus a direct
`fork_conversation` test asserting the label is dropped.

## Tests

354 passed, 1 skipped, cherry-picked cleanly onto current `main`
(`381bf638f`), no conflicts across three commits. New coverage: the managed
fork request's field validation (mirroring the create request's own tests),
the label-drop invariant above (both the cross-check and a direct store
test), the credential-owner invariant above, workspace inherit-vs-override
behavior, rejection of an unconfigured server / unoffered sandbox provider,
and an end-to-end `tests/e2e_ui/` Playwright test — checked non-vacuous by
confirming it fails when `managed_sandboxes_enabled` is `false` (the exact
dead end this PR fixes).

`ruff format --check` / `ruff check`: clean. `openapi.json` regenerated,
drift test green. Web: `tsc -b`, `oxlint --deny-warnings`, `prettier --check`
all clean.

## Deliberately out of scope

- Reconnect and switch-agent have the same gap; not fixed here.
- The model-catalog picker on a chosen sandbox still queries the
  previously-selected real host's catalog rather than the sandbox's — a
  reasonable guess (matches how `NewChatDialog` falls back for its own
  sandbox path), not wrong, left alone to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
