### PR TITLE
Keep Codex Working status across server restarts

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -9662,8 +9662,8 @@ async def _get_session_snapshot(
 
     Centralizes the create/get response building so both endpoints
     return identical projections. The lifecycle ``status`` is
-    derived from the relay-fed ``_session_status_cache`` (the tasks
-    table has been removed).
+    derived from the relay-fed ``_session_status_cache``, falling back to
+    the persisted relay status after a server recycle (the tasks table is gone).
 
     :param conv_store: The conversation store to read from.
     :param session_id: Session/conversation identifier,
@@ -9755,7 +9755,10 @@ async def _get_session_snapshot(
             ),
         )
 
-    status = _session_status_from_cache(session_id)
+    # A server recycle clears this cache while the persisted relay status survives.
+    # Prefer it because native injection can finish before an external harness turn,
+    # making the runner's generic active-turn probe report a false ``idle``.
+    status = _session_status_from_cache(session_id, conv.live_status)
     if status == "idle":
         # Cache miss (or truly idle): either the server restarted, or the
         # relay has not yet published the first ``"running"`` event for a

--- a/tests/e2e_ui/chat/test_codex_working_indicator_restart.py
+++ b/tests/e2e_ui/chat/test_codex_working_indicator_restart.py
@@ -1,0 +1,77 @@
+"""E2E coverage for native Codex status recovery after a server restart."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.codex_parity.helpers import (
+    ev_assistant_message,
+    ev_completed,
+    ev_function_call,
+    ev_response_created,
+)
+from tests.e2e_ui.conftest import MockedCodexNativeSession
+from tests.e2e_ui.messages.test_message_render_parity import _select_view_mode, _send
+
+_PROMPT = "Keep working while the Omnigent server restarts."
+_RESPONSES = [
+    [
+        ev_response_created("resp-restart-tool"),
+        ev_function_call(
+            "call_restart_sleep",
+            "exec_command",
+            json.dumps({"cmd": "sleep 90"}),
+        ),
+        ev_completed("resp-restart-tool"),
+    ],
+    [
+        ev_response_created("resp-restart-finished"),
+        ev_assistant_message("msg-restart-finished", "Restart work finished."),
+        ev_completed("resp-restart-finished"),
+    ],
+]
+_TIMEOUT_MS = 180_000
+
+
+@pytest.mark.parametrize(
+    "mocked_native_codex_session",
+    [_RESPONSES],
+    indirect=True,
+    ids=["server-restart"],
+)
+@pytest.mark.timeout(300)
+def test_codex_working_indicator_survives_server_restart(
+    page: Page,
+    mocked_native_codex_session: MockedCodexNativeSession,
+) -> None:
+    """A fresh server snapshot keeps Working visible for an existing Codex turn."""
+    session = mocked_native_codex_session
+    page.goto(f"{session.base_url}/c/{session.session_id}")
+    _select_view_mode(page, "Chat")
+    _send(page, _PROMPT)
+
+    working = page.locator('[data-testid="working-indicator"]')
+    expect(working).to_be_visible(timeout=_TIMEOUT_MS)
+    requests = session.sidecar.requests(min_count=1, timeout_ms=30_000)
+    assert any(_PROMPT in str(request["body"]["input"]) for request in requests)
+    sleep_call = page.locator('button[title="sleep 90"]').first
+    expect(sleep_call.locator(".animate-spin")).to_be_visible(timeout=_TIMEOUT_MS)
+
+    # Recycle the server process only. The runner, Codex app-server, and its
+    # long-running shell call survive, matching a production App restart.
+    session.restart_server()
+    snapshot = httpx.get(
+        f"{session.base_url}/v1/sessions/{session.session_id}",
+        timeout=30.0,
+    )
+    snapshot.raise_for_status()
+    assert snapshot.json()["status"] == "running"
+    assert snapshot.json()["runner_online"] is True
+
+    # Hydrate from the new process rather than relying on pre-restart UI state.
+    page.reload()
+    expect(working).to_be_visible(timeout=_TIMEOUT_MS)

--- a/tests/e2e_ui/conftest.py
+++ b/tests/e2e_ui/conftest.py
@@ -45,7 +45,7 @@ import sys
 import tarfile
 import textwrap
 import time
-from collections.abc import Generator, Iterator
+from collections.abc import Callable, Generator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -2792,6 +2792,7 @@ class MockedCodexNativeSession:
     base_url: str
     session_id: str
     sidecar: CodexResponsesSidecar
+    restart_server: Callable[[], None]
 
 
 def _write_mock_codex_provider_config(
@@ -2929,50 +2930,52 @@ def mocked_native_codex_session(
         "RUNNER_SERVER_URL": base_url,
     }
 
+    server_command = [
+        sys.executable,
+        "-c",
+        "import omnigent.server.presence as _p; _p._LEAVE_GRACE_S = 1.0; "
+        + "from omnigent.cli import main; main()",
+        "server",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--database-uri",
+        f"sqlite:///{db_path}",
+        "--artifact-location",
+        str(artifact_dir),
+        "--agent",
+        str(agent_yaml_path),
+    ]
+
     log_handle = open(log_path, "w")  # noqa: SIM115
     runner_log_handle = open(runner_log_path, "w")  # noqa: SIM115
     proc: subprocess.Popen[bytes] | None = None
     runner_proc: subprocess.Popen[bytes] | None = None
     session_id: str | None = None
-    try:
-        proc = subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                "import omnigent.server.presence as _p; _p._LEAVE_GRACE_S = 1.0; "
-                + "from omnigent.cli import main; main()",
-                "server",
-                "--host",
-                "127.0.0.1",
-                "--port",
-                str(port),
-                "--database-uri",
-                f"sqlite:///{db_path}",
-                "--artifact-location",
-                str(artifact_dir),
-                "--agent",
-                str(agent_yaml_path),
-            ],
+
+    def _spawn_server() -> subprocess.Popen[bytes]:
+        """Start one server generation against the fixture's durable store."""
+        return subprocess.Popen(
+            server_command,
             env=server_env,
             stdout=log_handle,
             stderr=subprocess.STDOUT,
         )
-        runner_proc = subprocess.Popen(
-            [sys.executable, "-m", "omnigent.runner._entry"],
-            env=runner_env,
-            stdout=runner_log_handle,
-            stderr=subprocess.STDOUT,
-        )
 
+    def _wait_until_ready(
+        server_process: subprocess.Popen[bytes],
+        runner_process: subprocess.Popen[bytes],
+    ) -> None:
+        """Wait until both the server generation and surviving runner are ready."""
         deadline = time.monotonic() + _HEALTH_TIMEOUT_S
-        ready = False
         last_error = "not polled yet"
         while time.monotonic() < deadline:
-            if proc.poll() is not None:
-                last_error = f"process exited early with code {proc.returncode}"
+            if server_process.poll() is not None:
+                last_error = f"process exited early with code {server_process.returncode}"
                 break
-            if runner_proc.poll() is not None:
-                last_error = f"runner exited early with code {runner_proc.returncode}"
+            if runner_process.poll() is not None:
+                last_error = f"runner exited early with code {runner_process.returncode}"
                 break
             try:
                 resp = httpx.get(f"{base_url}/health", timeout=2)
@@ -2982,8 +2985,7 @@ def mocked_native_codex_session(
                         timeout=2,
                     )
                     if status_resp.status_code == 200 and status_resp.json()["online"] is True:
-                        ready = True
-                        break
+                        return
                     last_error = (
                         f"runner status HTTP {status_resp.status_code}: {status_resp.text[:200]}"
                     )
@@ -2992,20 +2994,48 @@ def mocked_native_codex_session(
             except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException) as exc:
                 last_error = f"{type(exc).__name__}: {exc}"
             time.sleep(_HEALTH_POLL_INTERVAL_S)
+        raise RuntimeError(
+            f"mocked Codex e2e server did not become healthy within "
+            f"{_HEALTH_TIMEOUT_S:.0f}s on {base_url} "
+            f"(last_error={last_error}).\n"
+            f"Server log at {log_path}:\n"
+            f"{log_path.read_text()[-3000:] if log_path.exists() else ''}\n"
+            f"Runner log at {runner_log_path}:\n"
+            f"{runner_log_path.read_text()[-3000:] if runner_log_path.exists() else ''}"
+        )
 
-        if not ready:
-            raise RuntimeError(
-                f"mocked Codex e2e server did not become healthy within "
-                f"{_HEALTH_TIMEOUT_S:.0f}s on {base_url} "
-                f"(last_error={last_error}).\n"
-                f"Server log at {log_path}:\n"
-                f"{log_path.read_text()[-3000:] if log_path.exists() else ''}\n"
-                f"Runner log at {runner_log_path}:\n"
-                f"{runner_log_path.read_text()[-3000:] if runner_log_path.exists() else ''}"
-            )
+    try:
+        proc = _spawn_server()
+        runner_proc = subprocess.Popen(
+            [sys.executable, "-m", "omnigent.runner._entry"],
+            env=runner_env,
+            stdout=runner_log_handle,
+            stderr=subprocess.STDOUT,
+        )
+        _wait_until_ready(proc, runner_proc)
 
         session_id = _create_native_codex_session(base_url, runner_id, model=model)
-        yield MockedCodexNativeSession(base_url=base_url, session_id=session_id, sidecar=sidecar)
+
+        def _restart_server() -> None:
+            """Recycle only the server, preserving the runner and Codex turn."""
+            nonlocal proc
+            assert proc is not None
+            assert runner_proc is not None
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+            proc = _spawn_server()
+            _wait_until_ready(proc, runner_proc)
+
+        yield MockedCodexNativeSession(
+            base_url=base_url,
+            session_id=session_id,
+            sidecar=sidecar,
+            restart_server=_restart_server,
+        )
     finally:
         if session_id is not None:
             with contextlib.suppress(httpx.HTTPError):

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -657,6 +657,67 @@ async def test_session_snapshot_queries_runner_on_cache_miss(
 
 
 @pytest.mark.asyncio
+async def test_session_snapshot_uses_persisted_status_after_server_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recycled server keeps a native turn running from its durable status.
+
+    Native harness injection returns before the external turn completes, so the
+    runner's generic session endpoint can report ``idle`` while Codex is still
+    working. After a server restart clears the in-memory status cache, the
+    conversation row is the surviving relay truth and must win over that probe.
+    """
+    from omnigent.server.routes import sessions as _mod
+
+    session_id = "bef42153ba7a4f2cb35350dc23b27c93"
+    _mod._session_status_cache.pop(session_id, None)
+    _mod._runner_skills_cache.pop(session_id, None)
+
+    class _SkillsResponse:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, list[Any]]:
+            return {"skills": []}
+
+    class _IdleRunnerClient:
+        def __init__(self) -> None:
+            self.get_calls: list[str] = []
+
+        async def get(self, url: str, timeout: float = 5.0) -> Any:
+            self.get_calls.append(url)
+            if url.endswith("/skills"):
+                return _SkillsResponse()
+            raise AssertionError("persisted running status must avoid the idle runner probe")
+
+    runner_client = _IdleRunnerClient()
+    monkeypatch.setattr("omnigent.runtime.get_runner_client", lambda: runner_client)
+    monkeypatch.setattr("omnigent.runtime.get_runner_router", lambda: None)
+    conv = Conversation(
+        id=session_id,
+        created_at=1,
+        updated_at=1,
+        root_conversation_id=session_id,
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
+        live_status="running",
+    )
+
+    try:
+        snapshot = await _get_session_snapshot(
+            _ConversationStore([], conversations={session_id: conv}),  # type: ignore[arg-type]
+            session_id,
+        )
+        await _drain_runner_skills(session_id)
+    finally:
+        _mod._session_status_cache.pop(session_id, None)
+        _mod._runner_skills_cache.pop(session_id, None)
+
+    assert snapshot.status == "running"
+    status_calls = [url for url in runner_client.get_calls if not url.endswith("/skills")]
+    assert status_calls == []
+
+
+@pytest.mark.asyncio
 async def test_session_snapshot_defaults_idle_when_runner_unreachable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #6668

## Summary

- Preserve an active session's persisted relay status when a server recycle clears the process-local cache, instead of replacing it with the native runner's already-finished injection-task status.
- Add a native Codex browser E2E that holds a real tool call open, restarts only the Omnigent server, reloads the chat, and verifies the Working indicator remains visible.
- Refactor the mocked Codex fixture so tests can recycle its server while preserving the runner, Codex app-server, database, and turn.

ELI5: Omnigent remembered “Codex is working” in the database, but after restarting it asked a short-lived delivery task instead. That task had finished, so the UI was incorrectly told Codex was idle. The snapshot now uses the durable answer first.

```mermaid
flowchart LR
  A[Codex turn running] --> B[Server restarts]
  B --> C[In-memory status cache is empty]
  C --> D[Read persisted live_status]
  D --> E[Snapshot remains running]
  E --> F[Web UI keeps Working visible]
```

## Test Plan

- `.venv/bin/python -m pytest tests/server/routes/test_sessions_snapshot.py -q` — 49 passed.
- `.venv/bin/pre-commit run --all-files` — all hooks passed.
- `.venv/bin/python -m pytest tests/e2e_ui/chat/test_codex_working_indicator_restart.py -q -rs` — collected successfully; skipped locally because Cargo/the prebuilt Codex parity sidecar is unavailable. The E2E CI job supplies that sidecar and executes the journey.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression E2E performs the production sequence end-to-end: long-running native Codex shell call → server process restart → surviving runner reconnect → browser reload → `status=running` and Working indicator visible.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused server test pins durable-status precedence over a false-idle runner probe. The browser E2E covers the real native Codex process and tunnel-reconnect lifecycle.

## Changelog

The Working indicator now stays visible when an active Codex session survives an Omnigent server restart.
