### PR TITLE
fix(logging): make process log setup non-blocking on unwritable directories

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -4307,7 +4307,10 @@ def server(
     click.echo(f"Starting omnigent server on {host}:{port}")
     click.echo(f"  database:  {_display_db_uri(db_uri)}")
     click.echo(f"  artifacts: {art_loc}")
-    click.echo(f"  log:       {_display_path(server_log_path)}")
+    log_display = (
+        _display_path(server_log_path) if server_log_path is not None else "(unavailable)"
+    )
+    click.echo(f"  log:       {log_display}")
 
     # Warn loudly when the SPA bundle is absent: the server still boots
     # but serves an API-only JSON landing at "/", so the operator hits

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4123,7 +4123,10 @@ def run_host_process(
     # file is printed when each runner launches). The host process's
     # own diagnostics go to the host destination.
     print(f"Session logs: {display_log_path(_runner_log_dir())}/")
-    print(f"This host's log: {display_log_path(host_log_path)}")
+    host_log_display = (
+        display_log_path(host_log_path) if host_log_path is not None else "(unavailable)"
+    )
+    print(f"This host's log: {host_log_display}")
     from omnigent.cli_diagnostics import current_cli_log_path
 
     _cli_log = current_cli_log_path()

--- a/omnigent/process_logging.py
+++ b/omnigent/process_logging.py
@@ -477,36 +477,59 @@ def configure_process_logging(
     root: bool = True,
     force: bool = False,
     debug_log_send: Callable[[list[dict[str, object]]], None] | None = None,
-) -> Path:
+) -> Path | None:
     """Configure Python logging for one process destination.
 
-    The returned file always receives logs. Stderr receives logs only when
-    requested and an interactive terminal stream is available. When provided,
-    ``debug_log_send`` receives prepared debug-log batches on a daemon thread;
-    otherwise the environment-gated ZeroBus sender remains the default.
+    File logging is best-effort: if the log directory cannot be created or the
+    log file cannot be opened (e.g. a read-only filesystem), the process
+    continues with stderr-only logging rather than crashing. The return value
+    is ``None`` in that case.
+
+    Stderr receives logs only when requested and an interactive terminal stream
+    is available. When provided, ``debug_log_send`` receives prepared debug-log
+    batches on a daemon thread; otherwise the environment-gated ZeroBus sender
+    remains the default.
     """
     global _current_process_log_path
 
     resolved_level = effective_log_level() if level is None else level
-    path = Path(log_path).expanduser() if log_path is not None else _process_log_file_from_env()
-    if path is None:
-        path = create_process_log_path(destination)
-        # A process that dies before its first record would leave this
-        # freshly created file empty forever (crash-at-birth hosts littered
-        # dozens a day); sweep it on exit. Self-allocated paths only — a
-        # parent-published or explicit path is the caller's to manage.
-        atexit.register(_unlink_if_empty, path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    _current_process_log_path = path
+    resolved_path = (
+        Path(log_path).expanduser() if log_path is not None else _process_log_file_from_env()
+    )
+    path: Path | None = resolved_path
+    try:
+        if path is None:
+            path = create_process_log_path(destination)
+            # A process that dies before its first record would leave this
+            # freshly created file empty forever (crash-at-birth hosts littered
+            # dozens a day); sweep it on exit. Self-allocated paths only — a
+            # parent-published or explicit path is the caller's to manage.
+            atexit.register(_unlink_if_empty, path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _current_process_log_path = path
+    except OSError as exc:
+        sys.stderr.write(
+            f"omnigent: warning: could not create log file for {destination!r}"
+            f" ({exc}); continuing without file logging\n"
+        )
+        path = None
 
     formatter = RedactingLogFormatter(use_colors=False)
     handlers: list[logging.Handler] = []
 
-    file_handler = _ProcessLogFileHandler(path, encoding="utf-8")
-    file_handler.setLevel(resolved_level)
-    file_handler.setFormatter(formatter)
-    file_handler._omnigent_process_log_path = str(path)
-    handlers.append(file_handler)
+    if path is not None:
+        try:
+            file_handler = _ProcessLogFileHandler(path, encoding="utf-8")
+            file_handler.setLevel(resolved_level)
+            file_handler.setFormatter(formatter)
+            file_handler._omnigent_process_log_path = str(path)
+            handlers.append(file_handler)
+        except OSError as exc:
+            sys.stderr.write(
+                f"omnigent: warning: could not open log file {path}"
+                f" ({exc}); continuing without file logging\n"
+            )
+            path = None
 
     mirror = should_log_to_stderr() if log_to_stderr is None else log_to_stderr
     if mirror:
@@ -552,7 +575,7 @@ def configure_process_logging(
     )
 
     logging.captureWarnings(True)
-    return path
+    return path  # None when file logging could not be set up
 
 
 def _debug_sink_target_loggers(logger_names: Sequence[str], *, root: bool) -> list[logging.Logger]:

--- a/tests/test_process_logging.py
+++ b/tests/test_process_logging.py
@@ -396,6 +396,43 @@ def test_configure_process_logging_forwards_custom_debug_log_send(
             handler.close()
 
 
+def test_configure_process_logging_is_non_blocking_when_log_dir_is_unwritable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A read-only log directory must not crash the process.
+
+    If the filesystem or the log directory is unwritable, logging setup falls
+    through to stderr-only and returns ``None`` instead of raising.
+    """
+    monkeypatch.setattr("omnigent.process_logging._current_process_log_path", None)
+    monkeypatch.delenv(PROCESS_LOG_FILE_ENV_VAR, raising=False)
+    read_only = tmp_path / "ro"
+    read_only.mkdir()
+    read_only.chmod(0o555)
+    monkeypatch.setenv(DATA_DIR_ENV_VAR, str(read_only))
+
+    logger_name = "omnigent.test_configure_noblocking"
+    result = configure_process_logging(
+        "runner",
+        logger_names=(logger_name,),
+        root=False,
+    )
+    try:
+        assert result is None
+        assert current_process_log_path() is None
+        captured = capsys.readouterr()
+        assert "warning" in captured.err
+        assert "runner" in captured.err
+    finally:
+        read_only.chmod(0o755)
+        logger = logging.getLogger(logger_name)
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+
+
 def test_unlink_if_empty_sweeps_only_empty_files(tmp_path: Path) -> None:
     """The exit sweep removes an empty log, keeps a written one, tolerates absence."""
     empty = tmp_path / "empty.log"


### PR DESCRIPTION
## Summary

- `configure_process_logging()` raised `OSError` and crashed the process when the log directory was read-only or otherwise unwritable (e.g. a managed-sandbox runner whose data dir sits on a read-only filesystem — the failure mode that surfaced in the OMNI-6389 CI runner).
- Log directory creation and file-handler instantiation are now wrapped in `try/except OSError`: on failure a one-line warning goes to stderr and the process continues with stderr-only (or no-handler) logging.
- Return type widens to `Path | None`; two display callsites in `cli.py` and `host/connect.py` that dereference the return value are updated to handle `None`.

## Test Plan

- `tests/test_process_logging.py::test_configure_process_logging_is_non_blocking_when_log_dir_is_unwritable` — new test that points `OMNIGENT_DATA_DIR` at a `chmod 555` directory and asserts the function returns `None`, `current_process_log_path()` is `None`, and a `warning` mentioning `runner` appeared on stderr.
- All existing `test_process_logging` tests continue to pass.
- Manual: set `OMNIGENT_DATA_DIR` to a read-only path and start the runner or server — the process comes up with a warning on stderr instead of crashing.

## Demo

N/A — non-visual change.

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests added/updated