### PR TITLE
fix(security): redact stack traces from client errors

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6072,7 +6072,11 @@ def _native_terminal_start_error_payload(exc: BaseException, runtime_name: str) 
     from omnigent.claude_native_bridge import ClaudeNativeHookInterpreterMismatchError
 
     if isinstance(exc, ClaudeNativeHookInterpreterMismatchError):
-        message = str(exc)
+        message = (
+            "Claude Code is Windows-native, but Omnigent is running under WSL. "
+            "Install @anthropic-ai/claude-code from WSL so a WSL-native `claude` "
+            "binary wins PATH resolution, then retry."
+        )
     elif IS_WINDOWS:
         # Native terminals are tmux/PTY-based and disabled on Windows by design.
         # Give the client an actionable message instead of a log pointer.

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6062,12 +6062,14 @@ def _native_terminal_start_error_payload(exc: BaseException, runtime_name: str) 
         JSON error responses. Known actionable configuration errors surface
         their safe message directly; other causes point to the runner log.
     """
+    error_id = f"err_{uuid.uuid4().hex}"
     _logger.warning(
-        "Native %s terminal start failed: %s",
+        "Native %s terminal start failed; error_id=%s: %s",
         runtime_name,
+        error_id,
         exc,
         exc_info=exc,
-        extra={"session_id": runner_primary_session_id()},
+        extra={"session_id": runner_primary_session_id(), "error_id": error_id},
     )
     from omnigent.claude_native_bridge import ClaudeNativeHookInterpreterMismatchError
 
@@ -6091,7 +6093,11 @@ def _native_terminal_start_error_payload(exc: BaseException, runtime_name: str) 
             f"Native {runtime_name} terminal failed to start; "
             f"see the runner log for details: {log_reference}"
         )
-    return {"code": _NATIVE_TERMINAL_START_FAILED_CODE, "message": message}
+    return {
+        "code": _NATIVE_TERMINAL_START_FAILED_CODE,
+        "error_id": error_id,
+        "message": f"{message} Error ID: {error_id}.",
+    }
 
 
 def _publish_native_terminal_start_error(

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -596,13 +596,13 @@ def create_imports_router(
         try:
             async for ref in _import_local_core(body, user_id, host_conn, counts):
                 sessions.append(ref)
-        except OmnigentError:
+        except OmnigentError as exc:
             error_id, message = _record_local_import_failure()
             return JSONResponse(
-                status_code=500,
+                status_code=exc.http_status,
                 content={
                     "error": {
-                        "code": ErrorCode.INTERNAL_ERROR,
+                        "code": exc.code,
                         "error_id": error_id,
                         "message": message,
                     }

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import secrets
 import threading
 from collections.abc import AsyncIterator
@@ -39,9 +40,14 @@ from omnigent.stores.host_store import HostStore
 from omnigent.stores.permission_store import PermissionStore
 from omnigent.stores.project_store import ProjectStore
 
+_logger = logging.getLogger(__name__)
+
 # Upper bound on items in one imported session, shared by the CLI-normalized
 # ``/imports`` body and the host-streamed ``/imports/local`` path.
 _MAX_IMPORT_ITEMS = 100_000
+_LOCAL_IMPORT_STREAM_ERROR_MESSAGE = (
+    "The local session import stopped unexpectedly. Retry the import or contact an administrator."
+)
 
 
 class ImportItemInput(BaseModel):
@@ -617,10 +623,11 @@ def create_imports_router(
                     yield _import_event_line(
                         {"event": "session", "session_id": ref.session_id, "title": ref.title}
                     )
-            except OmnigentError as exc:
+            except OmnigentError:
                 # The read dropped/stalled mid-stream. The 200 + partial body is
                 # already sent, so report the failure inline rather than raising.
-                error_message = str(exc)
+                _logger.exception("Local session import stream failed")
+                error_message = _LOCAL_IMPORT_STREAM_ERROR_MESSAGE
             if error_message is not None:
                 yield _import_event_line({"event": "error", "message": error_message})
             yield _import_event_line(

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -617,7 +617,7 @@ def create_imports_router(
 
         async def _events() -> AsyncIterator[bytes]:
             counts: dict[str, int] = {}
-            error_message: str | None = None
+            error_id: str | None = None
             try:
                 async for ref in _import_local_core(body, user_id, host_conn, counts):
                     yield _import_event_line(
@@ -626,10 +626,20 @@ def create_imports_router(
             except OmnigentError:
                 # The read dropped/stalled mid-stream. The 200 + partial body is
                 # already sent, so report the failure inline rather than raising.
-                _logger.exception("Local session import stream failed")
-                error_message = _LOCAL_IMPORT_STREAM_ERROR_MESSAGE
-            if error_message is not None:
-                yield _import_event_line({"event": "error", "message": error_message})
+                error_id = f"err_{secrets.token_hex(16)}"
+                _logger.exception(
+                    "Local session import stream failed; error_id=%s",
+                    error_id,
+                    extra={"error_id": error_id},
+                )
+            if error_id is not None:
+                yield _import_event_line(
+                    {
+                        "event": "error",
+                        "error_id": error_id,
+                        "message": f"{_LOCAL_IMPORT_STREAM_ERROR_MESSAGE} Error ID: {error_id}.",
+                    }
+                )
             yield _import_event_line(
                 {
                     "event": "done",

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast, get_args
 
 from fastapi import APIRouter, Depends, Request, Response
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from omnigent.db.utils import builtin_agent_id
@@ -48,6 +48,17 @@ _MAX_IMPORT_ITEMS = 100_000
 _LOCAL_IMPORT_STREAM_ERROR_MESSAGE = (
     "The local session import stopped unexpectedly. Retry the import or contact an administrator."
 )
+
+
+def _record_local_import_failure() -> tuple[str, str]:
+    """Log the active import exception and return its safe client correlation data."""
+    error_id = f"err_{secrets.token_hex(16)}"
+    _logger.exception(
+        "Local session import failed; error_id=%s",
+        error_id,
+        extra={"error_id": error_id},
+    )
+    return error_id, f"{_LOCAL_IMPORT_STREAM_ERROR_MESSAGE} Error ID: {error_id}."
 
 
 class ImportItemInput(BaseModel):
@@ -565,7 +576,7 @@ def create_imports_router(
     async def import_local_sessions(
         body: LocalImportRequest,
         request: Request,
-    ) -> LocalImportResponse:
+    ) -> LocalImportResponse | JSONResponse:
         """Import local transcripts from a chosen host.
 
         The transcripts live on the caller's machine, so the read happens on
@@ -582,8 +593,21 @@ def create_imports_router(
         user_id, host_conn = _resolve_import_target(request, body)
         counts: dict[str, int] = {}
         sessions: list[ImportedSessionRef] = []
-        async for ref in _import_local_core(body, user_id, host_conn, counts):
-            sessions.append(ref)
+        try:
+            async for ref in _import_local_core(body, user_id, host_conn, counts):
+                sessions.append(ref)
+        except OmnigentError:
+            error_id, message = _record_local_import_failure()
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": {
+                        "code": ErrorCode.INTERNAL_ERROR,
+                        "error_id": error_id,
+                        "message": message,
+                    }
+                },
+            )
         return LocalImportResponse(
             imported=counts.get("imported", 0),
             already_imported=counts.get("already_imported", 0),
@@ -617,7 +641,7 @@ def create_imports_router(
 
         async def _events() -> AsyncIterator[bytes]:
             counts: dict[str, int] = {}
-            error_id: str | None = None
+            error: tuple[str, str] | None = None
             try:
                 async for ref in _import_local_core(body, user_id, host_conn, counts):
                     yield _import_event_line(
@@ -626,18 +650,14 @@ def create_imports_router(
             except OmnigentError:
                 # The read dropped/stalled mid-stream. The 200 + partial body is
                 # already sent, so report the failure inline rather than raising.
-                error_id = f"err_{secrets.token_hex(16)}"
-                _logger.exception(
-                    "Local session import stream failed; error_id=%s",
-                    error_id,
-                    extra={"error_id": error_id},
-                )
-            if error_id is not None:
+                error = _record_local_import_failure()
+            if error is not None:
+                error_id, message = error
                 yield _import_event_line(
                     {
                         "event": "error",
                         "error_id": error_id,
-                        "message": f"{_LOCAL_IMPORT_STREAM_ERROR_MESSAGE} Error ID: {error_id}.",
+                        "message": message,
                     }
                 )
             yield _import_event_line(

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -544,12 +544,20 @@ def test_native_terminal_start_failure_names_the_readable_runner_log(
             f"expected the goose terminal start to fail, got {ensure_resp.status_code}: "
             f"{ensure_resp.text}"
         )
-        message = ensure_resp.json()["error"]["message"]
+        error = ensure_resp.json()["error"]
+        message = error["message"]
         assert "Native Goose terminal failed to start" in message, message
+
+        # The server normalizes runner errors to code + message, so recover the
+        # runner's correlation ID from that preserved public message.
+        error_id_match = re.search(r" Error ID: (err_[0-9a-f]{32})\.$", message)
+        assert error_id_match is not None, f"message has no error ID: {message!r}"
+        error_id = error_id_match.group(1)
+        error_id_suffix = error_id_match.group(0)
 
         # The daemon runs with HOME=tmp_path, so the runner's home-relative
         # path resolves back under the test's temp dir.
-        named_path = message.rsplit(": ", 1)[-1]
+        named_path = message.removesuffix(error_id_suffix).rsplit(": ", 1)[-1]
         assert named_path.endswith(".log"), f"message names no log file: {message!r}"
         runner_log = tmp_path / named_path[2:] if named_path.startswith("~/") else Path(named_path)
         assert runner_log.exists(), (
@@ -557,7 +565,9 @@ def test_native_terminal_start_failure_names_the_readable_runner_log(
         )
         # The message stays free of the raw cause; the named log carries it.
         assert "requires the 'goose' CLI" not in message
-        assert "requires the 'goose' CLI" in runner_log.read_text()
+        runner_log_text = runner_log.read_text()
+        assert "requires the 'goose' CLI" in runner_log_text
+        assert error_id in runner_log_text
 
     finally:
         host_proc.send_signal(signal.SIGTERM)

--- a/tests/runner/test_app_sessions_native_terminal_routing.py
+++ b/tests/runner/test_app_sessions_native_terminal_routing.py
@@ -263,12 +263,17 @@ async def test_create_session_terminal_ensure_failure_returns_json_without_live_
     # the reader can find the cause. The raw ImportError text ("requires the
     # 'claude' CLI") must not appear in the HTTP body — only in that log.
     body = resp.json()
-    assert body["error"]["code"] == "native_terminal_start_failed"
-    assert body["error"]["message"] == (
+    error = body["error"]
+    error_id = error["error_id"]
+    assert error["code"] == "native_terminal_start_failed"
+    assert error_id.startswith("err_")
+    assert len(error_id) == 36
+    int(error_id.removeprefix("err_"), 16)
+    assert error["message"] == (
         "Native Claude terminal failed to start; "
-        f"see the runner log for details: {pinned_runner_log}"
+        f"see the runner log for details: {pinned_runner_log} Error ID: {error_id}."
     )
-    assert "requires the 'claude' CLI" not in body["error"]["message"]
+    assert "requires the 'claude' CLI" not in error["message"]
 
 
 @dataclass

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -2163,11 +2163,17 @@ def test_publish_native_terminal_start_error_emits_failed_status_only(
         )
 
     # Client-safe payload pointing at the runner log — no raw exception text.
+    error_id = error["error_id"]
+    assert error_id.startswith("err_")
+    assert len(error_id) == 36
+    int(error_id.removeprefix("err_"), 16)
     assert error == {
         "code": "native_terminal_start_failed",
+        "error_id": error_id,
         "message": (
             "Native Codex terminal failed to start; "
-            f"see the runner log for details: {pinned_runner_log}"
+            f"see the runner log for details: {pinned_runner_log} "
+            f"Error ID: {error_id}."
         ),
     }
     # The raw cause must NOT leak into the surfaced message, but MUST be
@@ -2175,6 +2181,7 @@ def test_publish_native_terminal_start_error_emits_failed_status_only(
     # text back in the payload) or the server-side log was dropped.
     assert "requires the 'codex' CLI" not in error["message"]
     assert "requires the 'codex' CLI on PATH." in caplog.text
+    assert error_id in caplog.text
     assert [p.event for p in published] == [
         {
             "type": "session.status",
@@ -2205,16 +2212,22 @@ def test_publish_native_terminal_start_error_redacts_mismatch_path(
             ),
         )
 
+    error_id = error["error_id"]
+    assert error_id.startswith("err_")
+    assert len(error_id) == 36
+    int(error_id.removeprefix("err_"), 16)
     assert error == {
         "code": "native_terminal_start_failed",
+        "error_id": error_id,
         "message": (
             "Claude Code is Windows-native, but Omnigent is running under WSL. "
             "Install @anthropic-ai/claude-code from WSL so a WSL-native `claude` "
-            "binary wins PATH resolution, then retry."
+            f"binary wins PATH resolution, then retry. Error ID: {error_id}."
         ),
     }
     assert sensitive_path not in error["message"]
     assert sensitive_path in caplog.text
+    assert error_id in caplog.text
     assert published[0].event["error"] == error
 
 

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -2185,6 +2185,39 @@ def test_publish_native_terminal_start_error_emits_failed_status_only(
     assert all(p.session_id == "415c9954e2fe4b9276083a4d2c66f689" for p in published)
 
 
+def test_publish_native_terminal_start_error_redacts_mismatch_path(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The actionable WSL mismatch response omits the rejected executable path."""
+    published: list[_PublishedEvent] = []
+    sensitive_path = "/mnt/c/Users/private/AppData/Roaming/npm/claude.cmd"
+
+    def _capture(session_id: str, event: dict[str, Any]) -> None:
+        published.append(_PublishedEvent(session_id=session_id, event=event))
+
+    with caplog.at_level(logging.WARNING):
+        error = _publish_native_terminal_start_error(
+            _capture,
+            "415c9954e2fe4b9276083a4d2c66f690",
+            "Claude",
+            ClaudeNativeHookInterpreterMismatchError(
+                f"Claude Code executable {sensitive_path!r} is Windows-native"
+            ),
+        )
+
+    assert error == {
+        "code": "native_terminal_start_failed",
+        "message": (
+            "Claude Code is Windows-native, but Omnigent is running under WSL. "
+            "Install @anthropic-ai/claude-code from WSL so a WSL-native `claude` "
+            "binary wins PATH resolution, then retry."
+        ),
+    }
+    assert sensitive_path not in error["message"]
+    assert sensitive_path in caplog.text
+    assert published[0].event["error"] == error
+
+
 def test_terminal_lookup_miss_log_explains_stopped_registered_terminal(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -600,15 +600,22 @@ async def test_local_import_stream_redacts_host_error(
             )
 
     events = [json.loads(line) for line in response.text.splitlines() if line.strip()]
-    assert events[0] == {
+    error_event = events[0]
+    error_id = error_event["error_id"]
+    assert error_id.startswith("err_")
+    assert len(error_id) == 36
+    int(error_id.removeprefix("err_"), 16)
+    assert error_event == {
         "event": "error",
+        "error_id": error_id,
         "message": (
             "The local session import stopped unexpectedly. "
-            "Retry the import or contact an administrator."
+            f"Retry the import or contact an administrator. Error ID: {error_id}."
         ),
     }
     assert sensitive_detail not in response.text
     assert sensitive_detail in caplog.text
+    assert error_id in caplog.text
 
 
 def _host_import_client(db_uri: str, host_registry: HostRegistry) -> httpx.AsyncClient:

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -555,12 +555,14 @@ async def test_local_import_stream_emits_ndjson_session_then_done(
         assert conversation_store.get_conversation(e["session_id"]) is not None
 
 
-async def test_local_import_stream_redacts_host_error(
+@pytest.mark.parametrize("stream", [False, True], ids=["buffered", "stream"])
+async def test_local_import_endpoints_redact_host_error(
     db_uri: str,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    stream: bool,
 ) -> None:
-    """A mid-stream host failure keeps exception details out of the NDJSON body."""
+    """Host failures retain diagnostics in logs but not either API response."""
     from omnigent.server.routes import imports as imports_module
 
     sensitive_detail = "host read failed at /private/transcripts/session.json\nTraceback: secret"
@@ -591,7 +593,7 @@ async def test_local_import_stream_redacts_host_error(
     with caplog.at_level(logging.ERROR, logger=imports_module.__name__):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post(
-                "/v1/imports/local/stream",
+                f"/v1/imports/local{'/stream' if stream else ''}",
                 json={
                     "host_id": "host_0123456789abcdef0123456789abcdef",
                     "source": "claude",
@@ -599,20 +601,23 @@ async def test_local_import_stream_redacts_host_error(
                 },
             )
 
-    events = [json.loads(line) for line in response.text.splitlines() if line.strip()]
-    error_event = events[0]
-    error_id = error_event["error_id"]
+    if stream:
+        events = [json.loads(line) for line in response.text.splitlines() if line.strip()]
+        error_payload = events[0]
+        assert error_payload["event"] == "error"
+    else:
+        assert response.status_code == 500
+        error_payload = response.json()["error"]
+        assert error_payload["code"] == ErrorCode.INTERNAL_ERROR
+
+    error_id = error_payload["error_id"]
     assert error_id.startswith("err_")
     assert len(error_id) == 36
     int(error_id.removeprefix("err_"), 16)
-    assert error_event == {
-        "event": "error",
-        "error_id": error_id,
-        "message": (
-            "The local session import stopped unexpectedly. "
-            f"Retry the import or contact an administrator. Error ID: {error_id}."
-        ),
-    }
+    assert error_payload["message"] == (
+        "The local session import stopped unexpectedly. "
+        f"Retry the import or contact an administrator. Error ID: {error_id}."
+    )
     assert sensitive_detail not in response.text
     assert sensitive_detail in caplog.text
     assert error_id in caplog.text

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -569,7 +569,7 @@ async def test_local_import_endpoints_redact_host_error(
 
     async def _fake_stream(**_kwargs: object):
         yield {}
-        raise OmnigentError(sensitive_detail, code=ErrorCode.INTERNAL_ERROR)
+        raise OmnigentError(sensitive_detail, code=ErrorCode.CONFLICT)
 
     monkeypatch.setattr(imports_module, "_stream_local_sessions_from_host", _fake_stream)
 
@@ -606,9 +606,9 @@ async def test_local_import_endpoints_redact_host_error(
         error_payload = events[0]
         assert error_payload["event"] == "error"
     else:
-        assert response.status_code == 500
+        assert response.status_code == 409
         error_payload = response.json()["error"]
-        assert error_payload["code"] == ErrorCode.INTERNAL_ERROR
+        assert error_payload["code"] == ErrorCode.CONFLICT
 
     error_id = error_payload["error_id"]
     assert error_id.startswith("err_")

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from types import SimpleNamespace
 
 import httpx
@@ -552,6 +553,62 @@ async def test_local_import_stream_emits_ndjson_session_then_done(
     # Each streamed session was actually persisted.
     for e in session_events:
         assert conversation_store.get_conversation(e["session_id"]) is not None
+
+
+async def test_local_import_stream_redacts_host_error(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A mid-stream host failure keeps exception details out of the NDJSON body."""
+    from omnigent.server.routes import imports as imports_module
+
+    sensitive_detail = "host read failed at /private/transcripts/session.json\nTraceback: secret"
+
+    async def _fake_stream(**_kwargs: object):
+        yield {}
+        raise OmnigentError(sensitive_detail, code=ErrorCode.INTERNAL_ERROR)
+
+    monkeypatch.setattr(imports_module, "_stream_local_sessions_from_host", _fake_stream)
+
+    host_conn = SimpleNamespace(
+        host_id="host_0123456789abcdef0123456789abcdef", pending_import_local={}
+    )
+    app = FastAPI()
+    app.include_router(
+        imports_module.create_imports_router(
+            SqlAlchemyConversationStore(db_uri),
+            SqlAlchemyAgentStore(db_uri),
+            host_registry=SimpleNamespace(get=lambda _host_id: host_conn),  # type: ignore[arg-type]
+            host_store=SimpleNamespace(  # type: ignore[arg-type]
+                get_host=lambda _host_id: SimpleNamespace(user_id=None)
+            ),
+        ),
+        prefix="/v1",
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    with caplog.at_level(logging.ERROR, logger=imports_module.__name__):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/v1/imports/local/stream",
+                json={
+                    "host_id": "host_0123456789abcdef0123456789abcdef",
+                    "source": "claude",
+                    "limit": 5,
+                },
+            )
+
+    events = [json.loads(line) for line in response.text.splitlines() if line.strip()]
+    assert events[0] == {
+        "event": "error",
+        "message": (
+            "The local session import stopped unexpectedly. "
+            "Retry the import or contact an administrator."
+        ),
+    }
+    assert sensitive_detail not in response.text
+    assert sensitive_detail in caplog.text
 
 
 def _host_import_client(db_uri: str, host_registry: HostRegistry) -> httpx.AsyncClient:


### PR DESCRIPTION
## Related issue

Resolves CodeQL alerts [#264](https://github.com/omnigent-ai/omnigent/security/code-scanning/264) and [#275](https://github.com/omnigent-ai/omnigent/security/code-scanning/275).

## Summary

- Replace buffered and streamed local-import exception text with generic client-safe errors while retaining full exceptions in server logs.
- Keep actionable WSL/Windows Claude guidance but omit the rejected executable path from runner responses and session events.
- Add an opaque error ID to every safe client message and structured runner payload, recording the same ID with the detailed operator log.
- Update unit and E2E assertions to validate the safe message, log path, and matching correlation ID independently.

**ELI5:** Errors can contain local file paths and stack details. Operators still get those details in logs, while clients receive safe guidance plus an error ID that identifies the matching log entry.

## Test Plan

- `uv run --frozen pytest -q tests/server/routes/test_imports.py -k 'local_import'` — 5 passed
- `uv run --frozen pytest -q tests/runner/test_app_sessions_native_terminals_autocreate.py -k 'publish_native_terminal_start_error'` — 2 passed
- `uv run --frozen pytest -q tests/runner/test_app_sessions_native_terminal_routing.py::test_create_session_terminal_ensure_failure_returns_json_without_live_error` — 1 passed
- `pre-commit run --files omnigent/server/routes/imports.py omnigent/runner/native/orchestration.py tests/server/routes/test_imports.py tests/runner/test_app_sessions_native_terminals_autocreate.py tests/runner/test_app_sessions_native_terminal_routing.py tests/e2e/test_host_e2e.py`
- `git diff --check`
- CI's Goose-absent E2E shard validates the real runner-log correlation path.
- CodeQL Python analysis should close both stack-trace exposure alerts.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The focused route and event-payload regressions provide non-visual evidence.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — focused regressions cover the buffered API, streaming API, direct runner response, proxied server response, and native terminal event paths.