### PR TITLE
fix(web): show the real project icon in the pinned session flyout

### DIFF
--- a/web/src/shell/Sidebar.rowActions.test.tsx
+++ b/web/src/shell/Sidebar.rowActions.test.tsx
@@ -792,8 +792,9 @@ describe("quick-archive owner gate", () => {
 describe("pinned row project flyout", () => {
   // Pinning lifts a session out of its project folder into the flat "Pinned"
   // section, so the folder no longer conveys which project it came from. The
-  // hover flyout restores that cue: title + folder icon + project name. It
-  // opens on focus/hover — fire focus on the row link and await the portal.
+  // hover flyout restores that cue: title + project icon (the project's chosen
+  // emoji, or a folder fallback) + project name. It opens on focus/hover — fire
+  // focus on the row link and await the portal.
 
   it("shows the project name in the flyout for a pinned, project-owned row", async () => {
     // Seed the pin so the row lifts into the always-expanded Pinned section
@@ -823,6 +824,46 @@ describe("pinned row project flyout", () => {
     expect(within(flyout).getByTestId("pinned-project-flyout-branch")).toHaveTextContent(
       "fix/sidebar-row-height",
     );
+  });
+
+  it("shows the project's real emoji icon in the flyout when the project has one", async () => {
+    // The flyout mirrors the folder/picker: a first-class project that carries a
+    // chosen emoji surfaces that glyph next to its name, not the generic folder.
+    // The icon is keyed off the row's first-class `project_id`, so seed one that
+    // resolves into the mocked projects list (id `p_<name>`).
+    mocks.projects = ["Moonshot"];
+    mocks.projectIcons = { Moonshot: "🚀" };
+    mocks.pinnedStore.set(["conv_1"]);
+    mockConversations([{ ...CONV, project_id: "p_Moonshot" }]);
+    renderSidebar();
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+
+    fireEvent.focus(screen.getByRole("link", { name: /My Session/ }));
+    const flyout = await screen.findByTestId("pinned-project-flyout");
+    expect(within(flyout).getByText("Moonshot")).toBeInTheDocument();
+    // The emoji renders via ProjectRowIcon (data-testid project-icon), replacing
+    // the folder svg the fallback would otherwise draw.
+    const icon = within(flyout).getByTestId("project-icon");
+    expect(icon).toHaveTextContent("🚀");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(within(flyout).queryByRole("img", { hidden: true })).toBeNull();
+  });
+
+  it("falls back to the folder icon in the flyout for a project with no emoji", async () => {
+    // A label-only project (no first-class id/icon) has no glyph to surface, so
+    // the flyout keeps the folder icon — proving the emoji path is opt-in.
+    mocks.pinnedStore.set(["conv_1"]);
+    mockConversations([{ ...CONV, labels: { omni_project: "Moonshot" } }]);
+    renderSidebar();
+    expect(screen.getByText("Pinned")).toBeInTheDocument();
+
+    fireEvent.focus(screen.getByRole("link", { name: /My Session/ }));
+    const flyout = await screen.findByTestId("pinned-project-flyout");
+    expect(within(flyout).getByText("Moonshot")).toBeInTheDocument();
+    // No emoji span; the project line leads with the folder svg fallback.
+    expect(within(flyout).queryByTestId("project-icon")).toBeNull();
+    const projectLine = within(flyout).getByText("Moonshot").closest("p")!;
+    expect(projectLine.querySelector("svg")).not.toBeNull();
   });
 
   it("renders no project flyout for a pinned row with no project", () => {

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -235,6 +235,10 @@ const DROP_TARGET_HIGHLIGHT = SIDEBAR_ACTIVE_HIGHLIGHT;
 // ``useProjects()`` subscription. Keeps row renders O(1) and avoids spinning up
 // a query observer per row (which would also re-run on every project mutation).
 const ProjectNamesContext = createContext<Map<string, string>>(new Map());
+// Maps a first-class project id → its chosen emoji icon (only projects that
+// have one), sharing the same list-level lookup as the names map so a row can
+// surface the real project glyph in the pinned flyout without its own query.
+const ProjectIconsContext = createContext<Map<string, string>>(new Map());
 const HostsByIdContext = createContext<ReadonlyMap<string, Host>>(new Map());
 // Row-invariant values resolved once at the list owner and shared, so a row
 // doesn't run `useIsMobileViewport` (a matchMedia-on-every-render store) or
@@ -259,6 +263,7 @@ function useStableCallback<A extends unknown[], R>(fn: (...args: A) => R): (...a
 
 function SidebarRowDataProvider({
   projectNamesById,
+  projectIconsById,
   hostsById,
   isMobile,
   viewerId,
@@ -266,6 +271,7 @@ function SidebarRowDataProvider({
   children,
 }: {
   projectNamesById: Map<string, string>;
+  projectIconsById: Map<string, string>;
   hostsById: ReadonlyMap<string, Host>;
   isMobile: boolean;
   viewerId: string | null;
@@ -274,13 +280,15 @@ function SidebarRowDataProvider({
 }) {
   return (
     <ProjectNamesContext.Provider value={projectNamesById}>
-      <HostsByIdContext.Provider value={hostsById}>
-        <IsMobileContext.Provider value={isMobile}>
-          <ViewerIdContext.Provider value={viewerId}>
-            <ServerInfoContext.Provider value={serverInfo}>{children}</ServerInfoContext.Provider>
-          </ViewerIdContext.Provider>
-        </IsMobileContext.Provider>
-      </HostsByIdContext.Provider>
+      <ProjectIconsContext.Provider value={projectIconsById}>
+        <HostsByIdContext.Provider value={hostsById}>
+          <IsMobileContext.Provider value={isMobile}>
+            <ViewerIdContext.Provider value={viewerId}>
+              <ServerInfoContext.Provider value={serverInfo}>{children}</ServerInfoContext.Provider>
+            </ViewerIdContext.Provider>
+          </IsMobileContext.Provider>
+        </HostsByIdContext.Provider>
+      </ProjectIconsContext.Provider>
     </ProjectNamesContext.Provider>
   );
 }
@@ -1608,6 +1616,16 @@ function ConversationList({
     return map;
   }, [projects]);
 
+  // id → emoji icon for rows that want to show the real project glyph (e.g. the
+  // pinned flyout); built alongside the names map and shared the same way.
+  const projectIconsById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects) {
+      if (p.id !== null && p.icon) map.set(p.id, p.icon);
+    }
+    return map;
+  }, [projects]);
+
   // Freeze the active chat's sort key while you're inside it so an
   // updated_at bump from sending a message doesn't reorder the row
   // out from under you. Snapshot is dropped on navigate-away so the
@@ -2090,6 +2108,7 @@ function ConversationList({
   return (
     <SidebarRowDataProvider
       projectNamesById={projectNamesById}
+      projectIconsById={projectIconsById}
       hostsById={hostsById}
       isMobile={isMobile}
       viewerId={viewerId}
@@ -3560,6 +3579,13 @@ function ConversationRowImpl({
   // routes the row through the plain ContextMenu/link path and restores the
   // native `title` tooltip.
   const projectFlyoutName = !isMobile && isPinned ? currentProject : null;
+  // First-class projects can carry a chosen emoji; label-only projects have
+  // none, so the flyout falls back to the folder glyph for those.
+  const projectIconsById = useContext(ProjectIconsContext);
+  const projectFlyoutIcon =
+    conversation.project_id != null
+      ? (projectIconsById.get(conversation.project_id) ?? null)
+      : null;
 
   // The title the user just committed. The rename's cache write reaches this
   // row as a prop from the list above, which re-renders a tick after the row's
@@ -3893,6 +3919,7 @@ function ConversationRowImpl({
             <PinnedProjectFlyoutContent
               title={conversation.title ?? conversation.id}
               projectName={projectFlyoutName}
+              projectIcon={projectFlyoutIcon}
               gitBranch={gitBranch}
             />
           </HoverCard>
@@ -3921,6 +3948,7 @@ function ConversationRowImpl({
           <PinnedProjectFlyoutContent
             title={conversation.title ?? conversation.id}
             projectName={projectFlyoutName}
+            projectIcon={projectFlyoutIcon}
             gitBranch={gitBranch}
           />
         </HoverCard>
@@ -4346,10 +4374,12 @@ const ConversationRow = memo(ConversationRowImpl, (prev, next) => {
 function PinnedProjectFlyoutContent({
   title,
   projectName,
+  projectIcon,
   gitBranch,
 }: {
   title: string;
   projectName: string;
+  projectIcon: string | null;
   gitBranch: string | null;
 }) {
   return (
@@ -4365,7 +4395,7 @@ function PinnedProjectFlyoutContent({
           the DOM. */}
       <p className="sidebar-compact-text line-clamp-3 font-medium">{title}</p>
       <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
-        <FolderIcon className="size-3.5 shrink-0" />
+        <ProjectRowIcon icon={projectIcon} />
         <span className="truncate">{projectName}</span>
       </p>
       {gitBranch && (


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- The pinned-session hover flyout in the sidebar always drew the generic folder glyph next to the project name, even when the project had a chosen emoji icon.
- This was inconsistent with the sidebar folder header, project picker, and header breadcrumb, which all surface the project's real emoji.
- Now the flyout threads the project's emoji through a list-level `ProjectIconsContext` (built alongside the existing names map, so rows don't each subscribe to `useProjects`) and renders it via the shared `ProjectRowIcon`, which falls back to the folder icon when a project has no emoji.

## Test Plan

- `cd web && npm test` (vitest) — added two cases to `Sidebar.rowActions.test.tsx`: one asserts the project's real emoji renders in the flyout, one asserts the folder-icon fallback for a project with no emoji. All 50 tests in the file pass.
- `cd web && npm run build` — passes (tsc + vite).
- Manual: give a project a custom emoji, start and **pin** a session in it, hover the pinned row → the flyout shows the emoji. Repeat with an icon-less project → folder icon still shown.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Small icon swap inside an existing hover flyout; covered by unit tests asserting the rendered glyph. Screen recording can be added if desired.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added vitest coverage for both the emoji and folder-fallback paths of the pinned-project flyout. Manually verified in the running app by pinning a session in a project with a custom emoji (flyout shows the emoji) and one without (flyout shows the folder icon).

## Changelog

The pinned-session hover flyout now shows the project's real icon instead of always a folder icon.

This pull request and its description were written by Isaac.
