### PR TITLE
feat(github): split the GitHub panel into Summary and Changes tabs

### DIFF
--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -57,8 +57,11 @@ _DEFAULT_GH_TIMEOUT_SECONDS = 15.0
 
 # Fields requested from ``gh pr view``. Always pass ``--json`` — bare
 # ``gh pr view`` opens an interactive/pager view and misbehaves in a
-# non-interactive subprocess.
-_PR_VIEW_FIELDS = "number,title,state,url,isDraft,author,baseRefName,headRefName,statusCheckRollup"
+# non-interactive subprocess. ``body`` + ``comments`` feed the Summary tab;
+# both are accepted by ``gh pr list`` too, so the fork-fallback path shares them.
+_PR_VIEW_FIELDS = (
+    "number,title,state,url,isDraft,author,baseRefName,headRefName,statusCheckRollup,body,comments"
+)
 
 
 def _gh_timeout_seconds() -> float:
@@ -197,6 +200,41 @@ def _summarize_checks(rollup: Any) -> dict[str, Any]:
     }
 
 
+# Cap the comments list so a very chatty PR can't bloat the payload; ``gh``
+# returns them oldest-first, so the cap keeps the earliest ``_MAX_COMMENTS``.
+_MAX_COMMENTS = 100
+
+
+def _shape_comments(raw: Any) -> list[dict[str, Any]]:
+    """Shape ``gh``'s PR ``comments`` into the Summary tab's comment list.
+
+    Keeps the top-level conversation comments GitHub shows by default: a
+    minimized/collapsed comment is dropped (mirroring the PR page). Each entry
+    is ``{author, body, created_at, url}``; the list is capped at
+    ``_MAX_COMMENTS``.
+    """
+    shaped: list[dict[str, Any]] = []
+    if not isinstance(raw, list):
+        return shaped
+    for comment in raw:
+        if not isinstance(comment, dict):
+            continue
+        if comment.get("isMinimized"):
+            continue
+        author = comment.get("author")
+        shaped.append(
+            {
+                "author": author.get("login") if isinstance(author, dict) else None,
+                "body": str(comment.get("body") or ""),
+                "created_at": comment.get("createdAt") or None,
+                "url": comment.get("url") or None,
+            }
+        )
+        if len(shaped) >= _MAX_COMMENTS:
+            break
+    return shaped
+
+
 def _current_branch(root: str) -> str | None:
     """Return the workspace's current branch name, or ``None`` (detached / not a repo)."""
     rc, out, _ = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
@@ -329,6 +367,7 @@ def github_info(root: str) -> dict[str, Any]:
     data = _pr_view_json(root, _PR_VIEW_FIELDS)
     if data is not None:
         author = data.get("author")
+        body = data.get("body")
         pr = {
             "number": data.get("number"),
             "title": data.get("title"),
@@ -339,6 +378,10 @@ def github_info(root: str) -> dict[str, Any]:
             "base_ref": data.get("baseRefName"),
             "head_ref": data.get("headRefName"),
             "checks": _summarize_checks(data.get("statusCheckRollup")),
+            # PR description + conversation comments feed the Summary tab; an
+            # empty body is null so the UI shows its "no description" state.
+            "body": body if isinstance(body, str) and body.strip() else None,
+            "comments": _shape_comments(data.get("comments")),
         }
     payload["pr"] = pr
 

--- a/tests/e2e_ui/github/test_github_tab.py
+++ b/tests/e2e_ui/github/test_github_tab.py
@@ -61,6 +61,16 @@ _INFO = {
                 {"name": "e2e", "bucket": "failing", "url": None},
             ],
         },
+        # The Summary tab renders the description (markdown) and comments.
+        "body": "## Summary\n\nAdds the GitHub tab to the workspace rail.",
+        "comments": [
+            {
+                "author": "octocat",
+                "body": "Nice work!",
+                "created_at": "2026-09-05T07:32:02Z",
+                "url": "https://example.com/pr/4242#c1",
+            }
+        ],
     },
 }
 
@@ -129,11 +139,11 @@ def _stub_github(page: Page) -> None:
     )
 
 
-def test_github_tab_shows_pr_checks_and_file_tree(
+def test_github_tab_shows_summary_checks_and_file_tree(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """The GitHub tab renders the PR, its CI pills, and the compacted file tree."""
+    """The GitHub tab lands on Summary; Changes shows the compacted file tree."""
     base_url, session_id = seeded_session
     _stub_github(page)
     page.goto(f"{base_url}/c/{session_id}")
@@ -142,7 +152,7 @@ def test_github_tab_shows_pr_checks_and_file_tree(
     rail = page.get_by_role("complementary", name="Workspace")
     rail.get_by_role("tab", name="GitHub").click()
 
-    # PR header: title + number.
+    # PR header (shared across both inner tabs): title + number.
     expect(rail.get_by_text("Add the GitHub tab")).to_be_visible(timeout=30_000)
     expect(rail.get_by_text(f"#{_PR_NUMBER}")).to_be_visible()
 
@@ -151,9 +161,15 @@ def test_github_tab_shows_pr_checks_and_file_tree(
     expect(rail.get_by_text(re.compile(r"3\s*passed"))).to_be_visible()
     expect(rail.get_by_text(re.compile(r"1\s*failed"))).to_be_visible()
 
-    # Sidebar file tree: the src → app single-child chain compacts into one
-    # "src/app" folder row (exact match — the diff section header carries the
-    # full path and would match a substring).
+    # Summary is the default tab: the PR description + a comment render there.
+    expect(rail.get_by_text(re.compile(r"Adds the GitHub tab"))).to_be_visible()
+    expect(rail.get_by_text("Nice work!")).to_be_visible()
+
+    # Switching to Changes reveals the sidebar file tree. Scope to the inner
+    # "Pull request" tablist — the rail's own tab bar also has a "Changes" tab.
+    # The src → app single-child chain compacts into one "src/app" folder row
+    # (exact — the diff section header carries the full path and would substring).
+    rail.get_by_role("tablist", name="Pull request").get_by_role("tab", name="Changes").click()
     expect(rail.get_by_role("button", name="src/app", exact=True)).to_be_visible()
     expect(rail.get_by_role("button", name=re.compile(r"main\.py")).first).to_be_visible()
 

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -405,6 +405,123 @@ def test_summarize_checks_empty() -> None:
     }
 
 
+def test_github_info_includes_body_and_comments(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The PR carries its description and its shaped conversation comments.
+
+    ``body`` feeds the Summary tab's description; ``comments`` its list. A
+    minimized/collapsed comment is dropped (as GitHub hides it), and each entry
+    is flattened to ``{author, body, created_at, url}``.
+    """
+    view = {
+        "number": 8,
+        "title": "t",
+        "state": "OPEN",
+        "url": "u",
+        "isDraft": False,
+        "author": {"login": "a"},
+        "baseRefName": "main",
+        "headRefName": "feature",
+        "statusCheckRollup": [],
+        "body": "## Summary\nDoes things.",
+        "comments": [
+            {
+                "author": {"login": "reviewer"},
+                "body": "nice",
+                "createdAt": "2026-09-05T07:32:02Z",
+                "url": "https://example.com/c/1",
+                "isMinimized": False,
+            },
+            {
+                "author": {"login": "spammer"},
+                "body": "hidden",
+                "createdAt": "2026-09-05T08:00:00Z",
+                "url": "https://example.com/c/2",
+                "isMinimized": True,
+            },
+        ],
+    }
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        head = tuple(argv[:2])
+        if head == ("auth", "status"):
+            return (0, "", "")
+        if head == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "o/r"}), "")
+        if head == ("pr", "view"):
+            return (0, json.dumps(view), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"]["body"] == "## Summary\nDoes things."
+    # The minimized comment is dropped; the survivor is flattened to snake_case.
+    assert info["pr"]["comments"] == [
+        {
+            "author": "reviewer",
+            "body": "nice",
+            "created_at": "2026-09-05T07:32:02Z",
+            "url": "https://example.com/c/1",
+        }
+    ]
+
+
+def test_github_info_empty_body_is_null(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A blank PR body becomes null so the UI shows its 'no description' state."""
+    view = {
+        "number": 8,
+        "title": "t",
+        "state": "OPEN",
+        "url": "u",
+        "isDraft": False,
+        "author": {"login": "a"},
+        "baseRefName": "main",
+        "headRefName": "feature",
+        "statusCheckRollup": [],
+        "body": "   ",
+        "comments": [],
+    }
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        head = tuple(argv[:2])
+        if head == ("auth", "status"):
+            return (0, "", "")
+        if head == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "o/r"}), "")
+        if head == ("pr", "view"):
+            return (0, json.dumps(view), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"]["body"] is None
+    assert info["pr"]["comments"] == []
+
+
+def test_shape_comments_filters_minimized_and_caps() -> None:
+    """Minimized comments drop out and the list caps at ``_MAX_COMMENTS``."""
+    raw: list[dict[str, object]] = [
+        {"author": {"login": "min"}, "body": "x", "isMinimized": True},
+    ]
+    raw += [
+        {"author": {"login": f"u{i}"}, "body": f"c{i}", "createdAt": "t", "url": None}
+        for i in range(github_resource._MAX_COMMENTS + 5)
+    ]
+    shaped = github_resource._shape_comments(raw)
+    assert len(shaped) == github_resource._MAX_COMMENTS
+    assert all(c["author"] != "min" for c in shaped)
+    # A missing author flattens to None; a non-list input is an empty list.
+    assert github_resource._shape_comments([{"body": "hi"}]) == [
+        {"author": None, "body": "hi", "created_at": None, "url": None}
+    ]
+    assert github_resource._shape_comments(None) == []
+
+
 def test_gh_scrubs_env_tokens_in_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
     # In a sandbox the panel's gh must authenticate as the connected owner via
     # hosts.yml, never an ambient GH_TOKEN/GITHUB_TOKEN (gh ranks those above

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -43,6 +43,19 @@ export interface GithubChecks {
   runs: GithubCheckRun[];
 }
 
+/** One top-level PR conversation comment (from `gh pr view --json comments`).
+ *  Minimized/collapsed comments are dropped by the runner, matching GitHub. */
+export interface GithubComment {
+  /** Commenter's GitHub login, or null when unknown. */
+  author: string | null;
+  /** Comment body (GitHub-flavored markdown). */
+  body: string;
+  /** ISO-8601 creation time, or null. */
+  created_at: string | null;
+  /** Link to the comment on GitHub, or null. */
+  url: string | null;
+}
+
 export interface GithubPr {
   number: number;
   title: string;
@@ -54,6 +67,11 @@ export interface GithubPr {
   base_ref: string | null;
   head_ref: string | null;
   checks: GithubChecks;
+  /** PR description (GitHub-flavored markdown); null when empty. Optional: a
+   *  host predating the Summary tab omits it, so treat undefined as none. */
+  body?: string | null;
+  /** Top-level PR comments GitHub shows by default; absent from an older host. */
+  comments?: GithubComment[];
 }
 
 export interface GithubRepo {

--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -54,6 +54,13 @@ vi.mock("@pierre/diffs/react", () => ({
 vi.mock("@/components/theme/useResolvedThemeMode", () => ({
   useResolvedThemeMode: () => "light",
 }));
+// The Summary tab renders markdown via MessageResponse (Streamdown); stub it to
+// a passthrough so tests assert the text without the real renderer.
+vi.mock("@/components/ai-elements/message", () => ({
+  MessageResponse: ({ children }: { children: string }) => (
+    <div data-testid="markdown">{children}</div>
+  ),
+}));
 
 import { GithubPanel, deriveGithubPanelState } from "./GithubPanel";
 import { RunnerOfflineError } from "@/hooks/useWorkspaceChangedFiles";
@@ -82,6 +89,15 @@ function renderPanel() {
       <GithubPanel conversationId="conv_1" />
     </QueryClientProvider>,
   );
+}
+
+/** Render, then switch to the Changes tab — Summary is the default, so the
+ *  diff view (and its toolbar) only exists after activating Changes. Radix
+ *  tabs select on pointer-down, so mouseDown (not click) flips the tab. */
+function renderChanges() {
+  const r = renderPanel();
+  fireEvent.mouseDown(screen.getByRole("tab", { name: "Changes" }));
+  return r;
 }
 
 let scrollIntoView: ReturnType<typeof vi.fn>;
@@ -176,14 +192,49 @@ describe("GithubPanel", () => {
     expect(screen.queryByText(/pending/)).toBeNull();
   });
 
-  it("stacks a diff section per changed file", async () => {
+  it("lands on the Summary tab, showing the PR description and comments", async () => {
+    state.info!.data!.pr!.body = "## Overview\nThis PR does the thing.";
+    state.info!.data!.pr!.comments = [
+      {
+        author: "octocat",
+        body: "Looks good to me!",
+        created_at: "2026-09-05T07:32:02Z",
+        url: "https://example.com/pr/6000#c1",
+      },
+    ];
     renderPanel();
+    // Summary is the default — the diff sections aren't mounted yet.
+    expect(screen.queryByTestId("diff")).toBeNull();
+    expect(await screen.findByText(/This PR does the thing\./)).toBeInTheDocument();
+    expect(screen.getByText("Comments (1)")).toBeInTheDocument();
+    expect(screen.getByText("octocat")).toBeInTheDocument();
+    expect(screen.getByText("Looks good to me!")).toBeInTheDocument();
+  });
+
+  it("shows Summary empty states when the PR has no body or comments", () => {
+    // The default fixture carries neither a body nor comments.
+    renderPanel();
+    expect(screen.getByText("No description provided.")).toBeInTheDocument();
+    expect(screen.getByText("No comments yet.")).toBeInTheDocument();
+    expect(screen.queryByTestId("diff")).toBeNull();
+  });
+
+  it("reveals the stacked diff after switching to the Changes tab", async () => {
+    renderPanel();
+    expect(screen.queryByTestId("diff")).toBeNull();
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Changes" }));
+    const diffs = await screen.findAllByTestId("diff");
+    expect(diffs.map((d) => d.getAttribute("data-path"))).toEqual(["hello.py", "src/app.ts"]);
+  });
+
+  it("stacks a diff section per changed file", async () => {
+    renderChanges();
     const diffs = await screen.findAllByTestId("diff");
     expect(diffs.map((d) => d.getAttribute("data-path"))).toEqual(["hello.py", "src/app.ts"]);
   });
 
   it("jumps to a file's section when its sidebar row is clicked", async () => {
-    renderPanel();
+    renderChanges();
     await screen.findAllByTestId("diff");
     // Both the sidebar row and the section header are buttons matching the
     // name; the sidebar row (which scrolls) is first in the DOM.
@@ -193,7 +244,7 @@ describe("GithubPanel", () => {
   });
 
   it("collapses a file's diff when its section header is clicked", async () => {
-    renderPanel();
+    renderChanges();
     expect(await screen.findAllByTestId("diff")).toHaveLength(2);
     // The section header carries aria-expanded; the sidebar row doesn't.
     const header = screen.getByRole("button", { name: /app\.ts/, expanded: true });
@@ -204,7 +255,7 @@ describe("GithubPanel", () => {
   });
 
   it("collapses and expands every diff from the toolbar", async () => {
-    renderPanel();
+    renderChanges();
     expect(await screen.findAllByTestId("diff")).toHaveLength(2);
     fireEvent.click(screen.getByRole("button", { name: "Collapse all diffs" }));
     expect(screen.queryAllByTestId("diff")).toHaveLength(0);
@@ -214,7 +265,7 @@ describe("GithubPanel", () => {
   });
 
   it("hides and shows the file sidebar from the toolbar", async () => {
-    renderPanel();
+    renderChanges();
     await screen.findAllByTestId("diff");
     // hello.py appears as a sidebar jump row and as a section header.
     expect(screen.getAllByRole("button", { name: /hello\.py/ })).toHaveLength(2);
@@ -226,7 +277,7 @@ describe("GithubPanel", () => {
   });
 
   it("toggles the diff layout between unified and split", async () => {
-    renderPanel();
+    renderChanges();
     await screen.findAllByTestId("diff");
     // Defaults to unified, so the toggle offers split; clicking flips its label.
     fireEvent.click(screen.getByRole("button", { name: "Switch to split view" }));
@@ -246,7 +297,7 @@ describe("GithubPanel", () => {
       error: null,
       isFetching: false,
     };
-    renderPanel();
+    renderChanges();
     // The lone omnigent → runner chain collapses to a single "omnigent/runner"
     // folder row (exact name; the diff section headers carry the full path).
     expect(await screen.findByRole("button", { name: "omnigent/runner" })).toBeInTheDocument();
@@ -265,7 +316,7 @@ describe("GithubPanel", () => {
       error: null,
       isFetching: false,
     };
-    renderPanel();
+    renderChanges();
     const folder = await screen.findByRole("button", { name: "omnigent/runner" });
     // Before collapse: the sidebar leaf + the diff section header both match.
     expect(screen.getAllByRole("button", { name: /app\.py/ })).toHaveLength(2);
@@ -284,7 +335,7 @@ describe("GithubPanel", () => {
     state.parsedFiles = [
       { name: "omnigent/new_name.py", prevName: "omnigent/old_name.py", type: "rename-pure" },
     ];
-    renderPanel();
+    renderChanges();
     // No diff body for a 100%-similarity rename — a note instead.
     expect(await screen.findByText("File renamed without changes.")).toBeInTheDocument();
     expect(screen.queryByTestId("diff")).toBeNull();

--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -180,11 +180,12 @@ afterEach(() => {
 });
 
 describe("GithubPanel", () => {
-  it("shows the PR header with title and CI check pills", async () => {
+  it("shows the PR title in the header and CI check pills on the Summary tab", async () => {
     renderPanel();
+    // Title + number live in the shared header (both tabs).
     expect(await screen.findByText("chore: dummy PR")).toBeInTheDocument();
     expect(screen.getByText("#6000")).toBeInTheDocument();
-    // CI checks are on their own line as labeled pills (not a diffstat). A
+    // CI checks render on the Summary tab (the default) as labeled pills. A
     // zero bucket (pending) renders no pill.
     expect(screen.getByText("Checks")).toBeInTheDocument();
     expect(screen.getByText(/66\s*passed/)).toBeInTheDocument();
@@ -225,6 +226,8 @@ describe("GithubPanel", () => {
     fireEvent.mouseDown(screen.getByRole("tab", { name: "Changes" }));
     const diffs = await screen.findAllByTestId("diff");
     expect(diffs.map((d) => d.getAttribute("data-path"))).toEqual(["hello.py", "src/app.ts"]);
+    // Checks live on the Summary tab, so they're gone once Changes is active.
+    expect(screen.queryByText("Checks")).toBeNull();
   });
 
   it("stacks a diff section per changed file", async () => {

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -958,7 +958,7 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
             Changes tab on their own line, so they don't crowd the tabs. gap-0 +
             flex-none keep the two labels close and content-sized (the default
             flex-1 equalizes and spreads them). */}
-          <TabsList variant="line" aria-label="Pull request" className="mt-1.5 h-auto gap-0 p-0">
+          <TabsList variant="line" aria-label="Pull request" className="h-auto gap-0 p-0">
             <TabsTrigger value="summary" className="flex-none">
               Summary
             </TabsTrigger>

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -65,6 +65,7 @@ import {
   useGithubPrDiff,
   type GithubChangedFile,
   type GithubCheckRun,
+  type GithubChecks,
   type GithubComment,
   type GithubInfo,
 } from "@/hooks/useGithub";
@@ -432,16 +433,50 @@ function GithubCommentCard({ comment }: { comment: GithubComment }) {
   );
 }
 
-/** The Summary tab body: the PR description followed by its comments. */
+/** The Summary tab body: CI checks, the PR description, then its comments. */
 function GithubSummaryTab({
+  checks,
   body,
   comments,
 }: {
+  checks: GithubChecks;
   body: string | null | undefined;
   comments: GithubComment[];
 }) {
   return (
     <div className="space-y-4 p-3">
+      {/* CI status checks (from the PR's statusCheckRollup) as pills; hover a
+          pill to see the job names in that bucket. */}
+      {checks.total > 0 && (
+        <section className="space-y-1.5">
+          <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+            Checks
+          </h3>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <CheckPill
+              label="passed"
+              count={checks.passing}
+              runs={checks.runs.filter((r) => r.bucket === "passing")}
+              icon={<CircleCheckIcon className="size-2.5 text-green-600 dark:text-green-400" />}
+              className="border-green-500/25 bg-green-500/10 text-green-700 dark:text-green-400"
+            />
+            <CheckPill
+              label="pending"
+              count={checks.pending}
+              runs={checks.runs.filter((r) => r.bucket === "pending")}
+              icon={<CircleDotIcon className="size-2.5 text-amber-600 dark:text-amber-400" />}
+              className="border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+            />
+            <CheckPill
+              label="failed"
+              count={checks.failing}
+              runs={checks.runs.filter((r) => r.bucket === "failing")}
+              icon={<CircleXIcon className="size-2.5 text-red-600 dark:text-red-400" />}
+              className="border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-400"
+            />
+          </div>
+        </section>
+      )}
       <section className="space-y-1.5">
         <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
           Description
@@ -881,8 +916,6 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
   const pr = data.pr!;
   const checks = pr.checks;
   const comments = pr.comments ?? [];
-  // The diff controls only make sense on the Changes tab and only with files.
-  const showChangesControls = activeTab === "changes" && files.length > 0;
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -917,59 +950,36 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
               <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
             </a>
           </div>
-          {/* CI status checks (from the PR's statusCheckRollup), on their own
-            line as pills; hover a pill to see the job names in that bucket. */}
-          {checks.total > 0 && (
-            <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-muted-foreground">
-              <span className="text-ui font-medium">Checks</span>
-              <CheckPill
-                label="passed"
-                count={checks.passing}
-                runs={checks.runs.filter((r) => r.bucket === "passing")}
-                icon={<CircleCheckIcon className="size-2.5 text-green-600 dark:text-green-400" />}
-                className="border-green-500/25 bg-green-500/10 text-green-700 dark:text-green-400"
-              />
-              <CheckPill
-                label="pending"
-                count={checks.pending}
-                runs={checks.runs.filter((r) => r.bucket === "pending")}
-                icon={<CircleDotIcon className="size-2.5 text-amber-600 dark:text-amber-400" />}
-                className="border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-400"
-              />
-              <CheckPill
-                label="failed"
-                count={checks.failing}
-                runs={checks.runs.filter((r) => r.bucket === "failing")}
-                icon={<CircleXIcon className="size-2.5 text-red-600 dark:text-red-400" />}
-                className="border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-400"
-              />
-            </div>
-          )}
-          {/* Tab bar (Summary | Changes). The diff controls — file-list toggle
-            (left of the tabs), layout + expand/collapse-all (right) — belong to
-            the Changes view, so they show only there and only with files. */}
-          <div className="mt-1.5 flex w-full items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-1">
-              {showChangesControls && (
-                <IconButton
-                  label={sidebarCollapsed ? "Show file list" : "Hide file list"}
-                  onClick={() => setSidebarCollapsed((v) => !v)}
-                  className="size-5 text-muted-foreground"
-                >
-                  {sidebarCollapsed ? (
-                    <PanelLeftOpenIcon className="size-3.5" />
-                  ) : (
-                    <PanelLeftCloseIcon className="size-3.5" />
-                  )}
-                </IconButton>
-              )}
-              <TabsList variant="line" aria-label="Pull request" className="h-auto gap-3 p-0">
-                <TabsTrigger value="summary">Summary</TabsTrigger>
-                <TabsTrigger value="changes">Changes</TabsTrigger>
-              </TabsList>
-            </div>
-            {showChangesControls && (
-              <div className="flex shrink-0 items-center gap-0.5">
+          {/* Tab bar (Summary | Changes). The diff controls live inside the
+            Changes tab on their own line, so they don't crowd the tabs. */}
+          <TabsList variant="line" aria-label="Pull request" className="mt-1.5 h-auto gap-3 p-0">
+            <TabsTrigger value="summary">Summary</TabsTrigger>
+            <TabsTrigger value="changes">Changes</TabsTrigger>
+          </TabsList>
+        </div>
+
+        {/* Summary: CI checks + the PR description + its conversation comments. */}
+        <TabsContent value="summary" className="min-h-0 flex-1 overflow-y-auto">
+          <GithubSummaryTab checks={checks} body={pr.body} comments={comments} />
+        </TabsContent>
+
+        {/* Changes: a controls row, then the sidebar (jump-to-file) + one scroll
+            of all files' diffs. */}
+        <TabsContent value="changes" className="flex min-h-0 flex-1 flex-col">
+          {files.length > 0 && (
+            <div className="flex w-full shrink-0 items-center justify-between gap-2 border-b border-border px-2 py-1">
+              <IconButton
+                label={sidebarCollapsed ? "Show file list" : "Hide file list"}
+                onClick={() => setSidebarCollapsed((v) => !v)}
+                className="size-5 text-muted-foreground"
+              >
+                {sidebarCollapsed ? (
+                  <PanelLeftOpenIcon className="size-3.5" />
+                ) : (
+                  <PanelLeftCloseIcon className="size-3.5" />
+                )}
+              </IconButton>
+              <div className="flex items-center gap-0.5">
                 <IconButton
                   label={diffStyle === "split" ? "Switch to unified view" : "Switch to split view"}
                   onClick={toggleDiffStyle}
@@ -993,17 +1003,8 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
                   )}
                 </IconButton>
               </div>
-            )}
-          </div>
-        </div>
-
-        {/* Summary: the PR description + its conversation comments. */}
-        <TabsContent value="summary" className="min-h-0 flex-1 overflow-y-auto">
-          <GithubSummaryTab body={pr.body} comments={comments} />
-        </TabsContent>
-
-        {/* Changes: sidebar (jump-to-file) + one scroll of all files' diffs. */}
-        <TabsContent value="changes" className="flex min-h-0 flex-1 flex-col">
+            </div>
+          )}
           <div ref={bodyRef as React.RefObject<HTMLDivElement>} className="flex min-h-0 flex-1">
             {!sidebarCollapsed && (
               <div

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -930,7 +930,7 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
             Padding lives on the title block (not the outer container) so the
             tabs align to the gutter and the underline row spans full width. */}
         <div className="shrink-0 border-b border-border pb-0.5">
-          <div className="px-2 pt-2">
+          <div className="px-3 pt-2">
             <span className="block min-w-0 truncate text-xs text-muted-foreground">
               {data.repo?.name_with_owner ?? "GitHub"}
               {data.branch && (
@@ -959,10 +959,10 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
             flex-none keep the two labels close and content-sized (the default
             flex-1 equalizes and spreads them). */}
           <TabsList variant="line" aria-label="Pull request" className="h-auto gap-0 p-0">
-            <TabsTrigger value="summary" className="flex-none leading-none">
+            <TabsTrigger value="summary" className="flex-none px-3 leading-none">
               Summary
             </TabsTrigger>
-            <TabsTrigger value="changes" className="flex-none leading-none">
+            <TabsTrigger value="changes" className="flex-none px-3 leading-none">
               Changes
             </TabsTrigger>
           </TabsList>

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -927,10 +927,9 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
       >
         {/* Header: repo + PR metadata + the Summary/Changes tabs. Refreshes on
             its own — via the git-activity SSE signal and the panel's CI poll.
-            Padding lives on the title block (not the outer container) so the tabs
-            align to the gutter; pb-2 leaves room for the active tab's underline
-            (anchored 5px below the trigger) to sit just above the border. */}
-        <div className="shrink-0 border-b border-border pb-2">
+            Padding lives on the title block (not the outer container) so the
+            tabs align to the gutter and the underline row spans full width. */}
+        <div className="shrink-0 border-b border-border pb-0.5">
           <div className="px-2 pt-2">
             <span className="block min-w-0 truncate text-xs text-muted-foreground">
               {data.repo?.name_with_owner ?? "GitHub"}
@@ -956,15 +955,10 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
             </div>
           </div>
           {/* Tab bar (Summary | Changes); the diff controls live inside the
-            Changes tab on their own line, so they don't crowd the tabs. Each
-            trigger owns its px-1.5, so pl-0.5 nudges the list right to align
-            "Summary" with the title gutter; gap-0 + flex-none keep the two
-            labels close and content-sized (the default flex-1 equalizes them). */}
-          <TabsList
-            variant="line"
-            aria-label="Pull request"
-            className="mt-1.5 h-auto gap-0 p-0 pl-0.5"
-          >
+            Changes tab on their own line, so they don't crowd the tabs. gap-0 +
+            flex-none keep the two labels close and content-sized (the default
+            flex-1 equalizes and spreads them). */}
+          <TabsList variant="line" aria-label="Pull request" className="mt-1.5 h-auto gap-0 p-0">
             <TabsTrigger value="summary" className="flex-none">
               Summary
             </TabsTrigger>

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -959,10 +959,10 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
             flex-none keep the two labels close and content-sized (the default
             flex-1 equalizes and spreads them). */}
           <TabsList variant="line" aria-label="Pull request" className="h-auto gap-0 p-0">
-            <TabsTrigger value="summary" className="flex-none">
+            <TabsTrigger value="summary" className="flex-none leading-none">
               Summary
             </TabsTrigger>
-            <TabsTrigger value="changes" className="flex-none">
+            <TabsTrigger value="changes" className="flex-none leading-none">
               Changes
             </TabsTrigger>
           </TabsList>

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -50,11 +50,14 @@ import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { MessageResponse } from "@/components/ai-elements/message";
 import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { useResizableColumn } from "@/hooks/useResizableColumn";
 import { RunnerOfflineError } from "@/hooks/useWorkspaceChangedFiles";
 import { readFileViewPreferences, writeFileViewPreferences } from "@/lib/fileViewPreferences";
+import { absoluteTime, relativeTime } from "@/lib/relativeTime";
 import {
   fetchGithubFileContents,
   useGithubChangedFiles,
@@ -62,6 +65,7 @@ import {
   useGithubPrDiff,
   type GithubChangedFile,
   type GithubCheckRun,
+  type GithubComment,
   type GithubInfo,
 } from "@/hooks/useGithub";
 
@@ -383,6 +387,91 @@ function CheckPill({
   );
 }
 
+// ── Summary tab ──────────────────────────────────────────────────────────
+// The PR's description and its conversation comments (from `gh pr view`), both
+// rendered as GitHub-flavored markdown via the shared MessageResponse.
+
+/** One comment card: an author + relative-time header over the markdown body. */
+function GithubCommentCard({ comment }: { comment: GithubComment }) {
+  const ts = comment.created_at ? Date.parse(comment.created_at) : NaN;
+  const rel = relativeTime(ts);
+  const initial = comment.author?.[0]?.toUpperCase() ?? "?";
+  return (
+    <li className="rounded-lg border border-border bg-muted/20 p-3">
+      <div className="mb-1.5 flex items-center gap-2 text-xs">
+        <span
+          aria-hidden
+          className="inline-flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground"
+        >
+          {initial}
+        </span>
+        <span className="min-w-0 truncate font-medium text-foreground">
+          {comment.author ?? "unknown"}
+        </span>
+        {rel && (
+          <span className="shrink-0 text-muted-foreground/70" title={absoluteTime(ts)}>
+            {rel}
+          </span>
+        )}
+        {comment.url && (
+          <a
+            href={comment.url}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open comment on GitHub"
+            className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <ExternalLinkIcon className="size-3" />
+          </a>
+        )}
+      </div>
+      <div className="text-ui break-words">
+        <MessageResponse>{comment.body}</MessageResponse>
+      </div>
+    </li>
+  );
+}
+
+/** The Summary tab body: the PR description followed by its comments. */
+function GithubSummaryTab({
+  body,
+  comments,
+}: {
+  body: string | null | undefined;
+  comments: GithubComment[];
+}) {
+  return (
+    <div className="space-y-4 p-3">
+      <section className="space-y-1.5">
+        <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Description
+        </h3>
+        {body ? (
+          <div className="text-ui break-words">
+            <MessageResponse>{body}</MessageResponse>
+          </div>
+        ) : (
+          <p className="text-ui text-muted-foreground italic">No description provided.</p>
+        )}
+      </section>
+      <section className="space-y-2">
+        <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          {comments.length > 0 ? `Comments (${comments.length})` : "Comments"}
+        </h3>
+        {comments.length === 0 ? (
+          <p className="text-ui text-muted-foreground">No comments yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {comments.map((c, i) => (
+              <GithubCommentCard key={c.url ?? `${c.author}-${i}`} comment={c} />
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
 // ── Sidebar file tree ────────────────────────────────────────────────────
 // The changed files group into a folder tree. A single-child directory chain
 // collapses into one row (VS Code "compact folders"): a lone change under
@@ -550,6 +639,10 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
   const hasPr = !!info.data?.pr;
   const changes = useGithubChangedFiles(conversationId, hasPr);
   const prDiff = useGithubPrDiff(conversationId, hasPr);
+
+  // Summary (PR body + comments) vs Changes (the stacked diff). Summary is the
+  // landing tab — like GitHub's PR page opening on the Conversation view.
+  const [activeTab, setActiveTab] = useState<"summary" | "changes">("summary");
 
   const themeType = useResolvedThemeMode();
   // Diff layout is the app-global FileViewer preference (unified/split); seed
@@ -787,13 +880,20 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
   const data = info.data!;
   const pr = data.pr!;
   const checks = pr.checks;
+  const comments = pr.comments ?? [];
+  // The diff controls only make sense on the Changes tab and only with files.
+  const showChangesControls = activeTab === "changes" && files.length > 0;
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="flex h-full min-h-0 flex-col">
-        {/* Header: repo + PR metadata. Refreshes on its own — via the
-            git-activity SSE signal and the panel's own CI poll — so there's no
-            manual Refresh control. */}
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v === "changes" ? "changes" : "summary")}
+        componentId="github.panel.tabs"
+        className="flex h-full min-h-0 flex-col gap-0"
+      >
+        {/* Header: repo + PR metadata + the Summary/Changes tabs. Refreshes on
+            its own — via the git-activity SSE signal and the panel's CI poll. */}
         <div className="shrink-0 border-b border-border p-2">
           <span className="block min-w-0 truncate text-xs text-muted-foreground">
             {data.repo?.name_with_owner ?? "GitHub"}
@@ -845,22 +945,31 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
               />
             </div>
           )}
-          {/* Controls bar: hide the file list (left); toggle layout + expand/
-            collapse every diff (right). */}
-          {files.length > 0 && (
-            <div className="mt-1.5 flex w-full items-center justify-between">
-              <IconButton
-                label={sidebarCollapsed ? "Show file list" : "Hide file list"}
-                onClick={() => setSidebarCollapsed((v) => !v)}
-                className="size-5 text-muted-foreground"
-              >
-                {sidebarCollapsed ? (
-                  <PanelLeftOpenIcon className="size-3.5" />
-                ) : (
-                  <PanelLeftCloseIcon className="size-3.5" />
-                )}
-              </IconButton>
-              <div className="flex items-center gap-0.5">
+          {/* Tab bar (Summary | Changes). The diff controls — file-list toggle
+            (left of the tabs), layout + expand/collapse-all (right) — belong to
+            the Changes view, so they show only there and only with files. */}
+          <div className="mt-1.5 flex w-full items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1">
+              {showChangesControls && (
+                <IconButton
+                  label={sidebarCollapsed ? "Show file list" : "Hide file list"}
+                  onClick={() => setSidebarCollapsed((v) => !v)}
+                  className="size-5 text-muted-foreground"
+                >
+                  {sidebarCollapsed ? (
+                    <PanelLeftOpenIcon className="size-3.5" />
+                  ) : (
+                    <PanelLeftCloseIcon className="size-3.5" />
+                  )}
+                </IconButton>
+              )}
+              <TabsList variant="line" aria-label="Pull request" className="h-auto gap-3 p-0">
+                <TabsTrigger value="summary">Summary</TabsTrigger>
+                <TabsTrigger value="changes">Changes</TabsTrigger>
+              </TabsList>
+            </div>
+            {showChangesControls && (
+              <div className="flex shrink-0 items-center gap-0.5">
                 <IconButton
                   label={diffStyle === "split" ? "Switch to unified view" : "Switch to split view"}
                   onClick={toggleDiffStyle}
@@ -884,78 +993,85 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
                   )}
                 </IconButton>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
 
-        {/* Body: sidebar (jump-to-file) + one scroll of all files' diffs. */}
-        <div ref={bodyRef as React.RefObject<HTMLDivElement>} className="flex min-h-0 flex-1">
-          {!sidebarCollapsed && (
-            <div
-              style={{ width: `${sidebarWidth}px` }}
-              className="relative shrink-0 overflow-y-auto border-r border-border pb-1"
-            >
-              {/* Drag the right edge to resize the file list. */}
+        {/* Summary: the PR description + its conversation comments. */}
+        <TabsContent value="summary" className="min-h-0 flex-1 overflow-y-auto">
+          <GithubSummaryTab body={pr.body} comments={comments} />
+        </TabsContent>
+
+        {/* Changes: sidebar (jump-to-file) + one scroll of all files' diffs. */}
+        <TabsContent value="changes" className="flex min-h-0 flex-1 flex-col">
+          <div ref={bodyRef as React.RefObject<HTMLDivElement>} className="flex min-h-0 flex-1">
+            {!sidebarCollapsed && (
               <div
-                {...sidebarHandleProps}
-                aria-label="Resize file list"
-                className="absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50"
-              />
-              {changes.isLoading ? (
-                <div className="flex items-center justify-center p-4 text-muted-foreground">
-                  <Loader2Icon className="size-4 animate-spin" />
-                </div>
-              ) : changes.error ? (
-                <p className="px-2 py-1 text-ui text-muted-foreground">
-                  {changes.error instanceof RunnerOfflineError
-                    ? "Runner offline."
-                    : (changes.error as Error).message}
-                </p>
-              ) : files.length === 0 ? (
-                <p className="px-2 py-1 text-ui text-muted-foreground">No changes vs base.</p>
+                style={{ width: `${sidebarWidth}px` }}
+                className="relative shrink-0 overflow-y-auto border-r border-border pb-1"
+              >
+                {/* Drag the right edge to resize the file list. */}
+                <div
+                  {...sidebarHandleProps}
+                  aria-label="Resize file list"
+                  className="absolute inset-y-0 right-0 z-10 w-1 cursor-col-resize transition-colors hover:bg-primary/30 active:bg-primary/50"
+                />
+                {changes.isLoading ? (
+                  <div className="flex items-center justify-center p-4 text-muted-foreground">
+                    <Loader2Icon className="size-4 animate-spin" />
+                  </div>
+                ) : changes.error ? (
+                  <p className="px-2 py-1 text-ui text-muted-foreground">
+                    {changes.error instanceof RunnerOfflineError
+                      ? "Runner offline."
+                      : (changes.error as Error).message}
+                  </p>
+                ) : files.length === 0 ? (
+                  <p className="px-2 py-1 text-ui text-muted-foreground">No changes vs base.</p>
+                ) : (
+                  fileTree.map((node) => (
+                    <SidebarNode
+                      key={node.type === "file" ? node.file.path : node.path}
+                      node={node}
+                      depth={0}
+                      activePath={activePath}
+                      onSelectFile={jumpTo}
+                      collapsedDirs={collapsedDirs}
+                      onToggleDir={toggleDir}
+                    />
+                  ))
+                )}
+              </div>
+            )}
+            <div ref={scrollRef} onScroll={onScroll} className="min-w-0 flex-1 overflow-y-auto">
+              {files.length === 0 || prDiff.isLoading ? (
+                <PanelMessage>
+                  {changes.isLoading || prDiff.isLoading ? (
+                    <>
+                      <Loader2Icon className="size-5 animate-spin" />
+                      Loading changes…
+                    </>
+                  ) : (
+                    "No changes vs base."
+                  )}
+                </PanelMessage>
               ) : (
-                fileTree.map((node) => (
-                  <SidebarNode
-                    key={node.type === "file" ? node.file.path : node.path}
-                    node={node}
-                    depth={0}
-                    activePath={activePath}
-                    onSelectFile={jumpTo}
-                    collapsedDirs={collapsedDirs}
-                    onToggleDir={toggleDir}
+                files.map((file) => (
+                  <GithubFileSection
+                    key={file.path}
+                    file={file}
+                    fileDiff={filesByPath.get(file.path)}
+                    options={diffOptions}
+                    registerRef={registerRef}
+                    collapsed={collapsedPaths.has(file.path)}
+                    onToggleCollapsed={() => toggleOne(file.path)}
                   />
                 ))
               )}
             </div>
-          )}
-          <div ref={scrollRef} onScroll={onScroll} className="min-w-0 flex-1 overflow-y-auto">
-            {files.length === 0 || prDiff.isLoading ? (
-              <PanelMessage>
-                {changes.isLoading || prDiff.isLoading ? (
-                  <>
-                    <Loader2Icon className="size-5 animate-spin" />
-                    Loading changes…
-                  </>
-                ) : (
-                  "No changes vs base."
-                )}
-              </PanelMessage>
-            ) : (
-              files.map((file) => (
-                <GithubFileSection
-                  key={file.path}
-                  file={file}
-                  fileDiff={filesByPath.get(file.path)}
-                  options={diffOptions}
-                  registerRef={registerRef}
-                  collapsed={collapsedPaths.has(file.path)}
-                  onToggleCollapsed={() => toggleOne(file.path)}
-                />
-              ))
-            )}
           </div>
-        </div>
-      </div>
+        </TabsContent>
+      </Tabs>
     </TooltipProvider>
   );
 }

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -941,7 +941,7 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
                 </>
               )}
             </span>
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
               <a
                 href={pr.url}
                 target="_blank"

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -926,35 +926,51 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
         className="flex h-full min-h-0 flex-col gap-0"
       >
         {/* Header: repo + PR metadata + the Summary/Changes tabs. Refreshes on
-            its own — via the git-activity SSE signal and the panel's CI poll. */}
-        <div className="shrink-0 border-b border-border p-2">
-          <span className="block min-w-0 truncate text-xs text-muted-foreground">
-            {data.repo?.name_with_owner ?? "GitHub"}
-            {data.branch && (
-              <>
-                {" · "}
-                <span className="font-mono">{data.branch}</span>
-                {baseRef && <span className="text-muted-foreground"> → {baseRef}</span>}
-              </>
-            )}
-          </span>
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <a
-              href={pr.url}
-              target="_blank"
-              rel="noreferrer"
-              className="group inline-flex min-w-0 items-center gap-1 text-ui font-medium hover:underline"
-            >
-              <span className="truncate">{pr.title}</span>
-              <span className="shrink-0 text-muted-foreground">#{pr.number}</span>
-              <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
-            </a>
+            its own — via the git-activity SSE signal and the panel's CI poll.
+            Padding lives on the title block (not the outer container) so the tabs
+            align to the gutter; pb-2 leaves room for the active tab's underline
+            (anchored 5px below the trigger) to sit just above the border. */}
+        <div className="shrink-0 border-b border-border pb-2">
+          <div className="px-2 pt-2">
+            <span className="block min-w-0 truncate text-xs text-muted-foreground">
+              {data.repo?.name_with_owner ?? "GitHub"}
+              {data.branch && (
+                <>
+                  {" · "}
+                  <span className="font-mono">{data.branch}</span>
+                  {baseRef && <span className="text-muted-foreground"> → {baseRef}</span>}
+                </>
+              )}
+            </span>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <a
+                href={pr.url}
+                target="_blank"
+                rel="noreferrer"
+                className="group inline-flex min-w-0 items-center gap-1 text-ui font-medium hover:underline"
+              >
+                <span className="truncate">{pr.title}</span>
+                <span className="shrink-0 text-muted-foreground">#{pr.number}</span>
+                <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
+              </a>
+            </div>
           </div>
-          {/* Tab bar (Summary | Changes). The diff controls live inside the
-            Changes tab on their own line, so they don't crowd the tabs. */}
-          <TabsList variant="line" aria-label="Pull request" className="mt-1.5 h-auto gap-3 p-0">
-            <TabsTrigger value="summary">Summary</TabsTrigger>
-            <TabsTrigger value="changes">Changes</TabsTrigger>
+          {/* Tab bar (Summary | Changes); the diff controls live inside the
+            Changes tab on their own line, so they don't crowd the tabs. Each
+            trigger owns its px-1.5, so pl-0.5 nudges the list right to align
+            "Summary" with the title gutter; gap-0 + flex-none keep the two
+            labels close and content-sized (the default flex-1 equalizes them). */}
+          <TabsList
+            variant="line"
+            aria-label="Pull request"
+            className="mt-1.5 h-auto gap-0 p-0 pl-0.5"
+          >
+            <TabsTrigger value="summary" className="flex-none">
+              Summary
+            </TabsTrigger>
+            <TabsTrigger value="changes" className="flex-none">
+              Changes
+            </TabsTrigger>
           </TabsList>
         </div>
 

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -444,7 +444,9 @@ function GithubSummaryTab({
   comments: GithubComment[];
 }) {
   return (
-    <div className="space-y-4 p-3">
+    // Extra bottom padding so the last comment can scroll clear of the very
+    // bottom edge, where it's awkward to read.
+    <div className="space-y-4 p-3 pb-16">
       {/* CI status checks (from the PR's statusCheckRollup) as pills; hover a
           pill to see the job names in that bucket. */}
       {checks.total > 0 && (
@@ -959,10 +961,10 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
             flex-none keep the two labels close and content-sized (the default
             flex-1 equalizes and spreads them). */}
           <TabsList variant="line" aria-label="Pull request" className="h-auto gap-0 p-0">
-            <TabsTrigger value="summary" className="flex-none px-3 leading-none">
+            <TabsTrigger value="summary" className="flex-none border-0 px-3 leading-none">
               Summary
             </TabsTrigger>
-            <TabsTrigger value="changes" className="flex-none px-3 leading-none">
+            <TabsTrigger value="changes" className="flex-none border-0 px-3 leading-none">
               Changes
             </TabsTrigger>
           </TabsList>


### PR DESCRIPTION
## Related issue

N/A — feature requested directly; no tracking issue.

## Summary

- Splits the read-only **GitHub** rail tab into two inner tabs: **Summary** (the landing tab, matching GitHub's PR page) and **Changes**.
- **Summary** shows the PR description and its conversation comments, both rendered as sanitized GitHub-flavored markdown via the shared `MessageResponse`. **Changes** keeps the existing file tree + stacked diff, with its toolbar controls (file-list toggle, split/unified, expand/collapse-all) scoped to that tab.
- The runner's PR resource (`gh pr view`) now also requests `body` and `comments`; comments are flattened to `{author, body, created_at, url}`, minimized/collapsed ones are dropped (as GitHub hides them), and the list is capped at 100.

**ELI5:** the GitHub panel used to jump straight to the file diff. Now it opens on a "Summary" page (the PR write-up and the back-and-forth comments), and the diff moves one click away under a "Changes" tab — just like the real PR page on GitHub.

```
Shared header:  acme/app · feat/x -> main
                <PR title>  #123  (open on GitHub)
                Checks  103 passed  1 failed
                [ Summary ] Changes          (Changes only: file-list | layout | expand/collapse)
Summary tab                     Changes tab
  Description (markdown)          sidebar file tree | stacked per-file diffs
  Comments (N)                    (unchanged)
```

## Test Plan

- Backend: `pytest tests/runner/test_github_resource.py` -> 21 passed (adds coverage for `body`/`comments` shaping, minimized-comment filtering, the `_MAX_COMMENTS` cap, and empty-body -> null). Verified empirically that both `gh pr view` and the fork-fallback `gh pr list --head` accept `body,comments` in `--json`.
- Frontend: `vitest` on `GithubPanel.test.tsx` (21) + `useGithub.turnEnd` + `AppShell.githubTabVisibility` -> all green. New tests cover the Summary default, description/comment rendering, empty states, and revealing the diff after switching to Changes.
- `tsc -b`, `oxlint`, `prettier`, and `ruff check`/`ruff format` all clean.
- E2E `tests/e2e_ui/github/test_github_tab.py` updated for the new default tab and the inner-tab switch (runs in CI/Docker).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change


https://github.com/user-attachments/assets/aa29dc93-9c8c-4e4c-b539-db0c694e9e4e



## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Backend shaping and the frontend tab behavior (default tab, Summary rendering, empty states, tab switch) are covered by unit tests; the e2e was updated for the new layout. Live in-app manual verification (and a screenshot) is still pending — see Demo.

## Changelog

The GitHub PR panel now opens on a Summary tab showing the PR description and comments, with the file diff moved under a Changes tab.

---

This pull request and its description were written by Isaac.
