### PR TITLE
feat(github): deterministic PR resolution + per-workspace account selection for the session GitHub panel

### DIFF
--- a/omnigent/config.py
+++ b/omnigent/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TypeAlias
 
@@ -93,9 +94,99 @@ def load_effective_config() -> _Config:
     return _merge_effective_config(load_global_config(), load_local_config())
 
 
+def save_global_config(
+    settings: Mapping[str, object],
+    *,
+    deep_merge_keys: tuple[str, ...] = (),
+    path: Path | None = None,
+) -> None:
+    """Merge *settings* into the user-level config and write it back atomically.
+
+    A reusable, runtime-safe writer (the runner and host reader persist GitHub
+    account preferences through it), mirroring the merge semantics of the CLI's
+    ``_save_global_config`` minus its harness-scalar normalization. Every key in
+    *settings* replaces its existing value wholesale, except keys in
+    *deep_merge_keys*, whose mapping value is merged one level deep into the
+    existing mapping for that key.
+
+    :param settings: Key/value pairs to set.
+    :param deep_merge_keys: Keys whose mapping value is merged one level deep
+        rather than replacing the existing mapping.
+    :param path: Config path override (defaults to :func:`global_config_path`).
+    """
+    resolved = path or global_config_path()
+    cfg = load_global_config(resolved)
+    for key, value in settings.items():
+        if key in deep_merge_keys and isinstance(value, Mapping):
+            existing = cfg.get(key)
+            merged = dict(existing) if isinstance(existing, Mapping) else {}
+            merged.update(value)
+            cfg[key] = merged
+        else:
+            cfg[key] = value
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic replace so a crash mid-write can't truncate the user's config.
+    tmp = resolved.with_name(resolved.name + ".tmp")
+    with tmp.open("w") as config_file:
+        yaml.safe_dump(cfg, config_file, default_flow_style=False, sort_keys=True)
+    os.replace(tmp, resolved)
+
+
+def _github_accounts(cfg: _Config) -> dict[str, object]:
+    """Return the ``github.accounts`` mapping from *cfg* (empty when absent)."""
+    github = cfg.get("github")
+    if not isinstance(github, Mapping):
+        return {}
+    accounts = github.get("accounts")
+    return dict(accounts) if isinstance(accounts, Mapping) else {}
+
+
+def github_account_preference(workspace_key: str, path: Path | None = None) -> str | None:
+    """Return the preferred ``gh`` login for a workspace, or ``None``.
+
+    :param workspace_key: Stable per-workspace key (the main worktree path), used
+        verbatim — a filesystem path, so not case-folded.
+    :param path: Config path override (defaults to :func:`global_config_path`).
+    """
+    accounts = _github_accounts(load_global_config(path))
+    value = accounts.get(workspace_key)
+    return value if isinstance(value, str) and value else None
+
+
+def set_github_account_preference(
+    workspace_key: str,
+    login: str | None,
+    path: Path | None = None,
+) -> None:
+    """Persist (or clear, when *login* is falsy) the preferred login for a workspace.
+
+    Stored under ``github.accounts`` keyed by the workspace's main worktree path,
+    so the choice is shared across a repo's linked worktrees (which share one
+    ``.git``) while separate clones stay distinct.
+
+    :param workspace_key: Stable per-workspace key (the main worktree path).
+    :param login: GitHub login to prefer, or ``None``/empty to clear the entry.
+    :param path: Config path override (defaults to :func:`global_config_path`).
+    """
+    resolved = path or global_config_path()
+    github = load_global_config(resolved).get("github")
+    github_block = dict(github) if isinstance(github, Mapping) else {}
+    accounts = _github_accounts({"github": github_block})
+    key = workspace_key
+    if login:
+        accounts[key] = login
+    else:
+        accounts.pop(key, None)
+    github_block["accounts"] = accounts
+    save_global_config({"github": github_block}, path=resolved)
+
+
 __all__ = [
+    "github_account_preference",
     "global_config_path",
     "load_effective_config",
     "load_global_config",
     "load_local_config",
+    "save_global_config",
+    "set_github_account_preference",
 ]

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -51,6 +51,7 @@ from omnigent.host.frames import (
     HostDetectCredentialsResultFrame,
     HostFsRequestFrame,
     HostFsResultFrame,
+    HostFsWriteFrame,
     HostHarnessReadinessFrame,
     HostHelloFrame,
     HostImportedLocalSession,
@@ -2992,6 +2993,79 @@ class HostProcess:
             return r.github_pr_diff()
         raise ValueError(f"unknown fs op: {op!r}")
 
+    def _handle_fs_write(self, frame: HostFsWriteFrame) -> HostFsResultFrame:
+        """Serve a workspace-mutating op from the host (runner-offline fallback).
+
+        Mirrors :meth:`_handle_fs_request` but for the small set of writes the
+        host can serve — currently the GitHub account/base preference, which
+        touches the host's ``~/.omnigent/config.yaml`` and runs ``gh``/``git`` in
+        the workspace. Called inside a worker thread by the dispatcher.
+
+        :param frame: The write frame (op + workspace + params).
+        :returns: A result frame with the refreshed payload, or an error frame.
+        """
+        try:
+            expanded = os.path.expanduser(frame.workspace)
+        except (TypeError, ValueError) as exc:
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=400,
+                error_code="invalid_workspace",
+                error=f"workspace path expansion failed: {exc}",
+            )
+        if not os.path.isdir(expanded):
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=404,
+                error_code="not_found",
+                error="workspace directory does not exist on host",
+            )
+        try:
+            payload = self._dispatch_fs_write_op(expanded, frame.op, frame.params or {})
+        except ValueError as exc:
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=400,
+                error_code="invalid_request",
+                error=str(exc),
+            )
+        except Exception as exc:
+            _logger.exception("host fs_write op %r failed", frame.op)
+            return HostFsResultFrame(
+                request_id=frame.request_id,
+                status="error",
+                error_status=500,
+                error_code="fs_write_failed",
+                error=str(exc),
+            )
+        return HostFsResultFrame(request_id=frame.request_id, status="ok", payload=payload)
+
+    @staticmethod
+    def _dispatch_fs_write_op(
+        workspace: str,
+        op: str,
+        params: dict[str, object],
+    ) -> dict[str, object]:
+        """Route a write op to its handler. Writes call ``github_resource``
+        directly (not the read-only ``WorkspaceReader``).
+
+        :raises ValueError: On an unknown op.
+        """
+        from typing import cast
+
+        from omnigent.runner import github_resource
+
+        if op == "github_set_preference":
+            return github_resource.set_github_preference(
+                workspace,
+                account=cast("str | None", params.get("account")),
+                remote=cast("str | None", params.get("remote")),
+            )
+        raise ValueError(f"unknown fs write op: {op!r}")
+
     async def _handle_create_worktree(
         self,
         frame: HostCreateWorktreeFrame,
@@ -4038,6 +4112,10 @@ class HostProcess:
             # off the event loop and reply when it completes.
             fs_result = await asyncio.to_thread(self._handle_fs_request, frame)
             await ws.send(encode_host_frame(fs_result))
+        elif isinstance(frame, HostFsWriteFrame):
+            # gh/git writes can block; run off the event loop and reply back.
+            fs_write_result = await asyncio.to_thread(self._handle_fs_write, frame)
+            await ws.send(encode_host_frame(fs_write_result))
         elif isinstance(frame, HostModelOptionsFrame):
             # Every dispatched frame already runs on its own task (see
             # _start_frame_task), so a cold harness probe here cannot stall

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -72,6 +72,7 @@ class HostFrameKind(str, Enum):
     DETECT_CREDENTIALS_RESULT = "host.detect_credentials_result"
     FS_REQUEST = "host.fs_request"
     FS_RESULT = "host.fs_result"
+    FS_WRITE_REQUEST = "host.fs_write_request"
     MODEL_OPTIONS = "host.model_options"
     MODEL_OPTIONS_RESULT = "host.model_options_result"
     IMPORT_LOCAL = "host.import_local"
@@ -822,10 +823,37 @@ class HostFsRequestFrame:
 
 
 @dataclass
-class HostFsResultFrame:
-    """Host → server: outcome of a workspace filesystem request.
+class HostFsWriteFrame:
+    """Server → host: a workspace-mutating operation, served host-side.
 
-    :param request_id: Correlates to the :class:`HostFsRequestFrame`.
+    The read counterpart (:class:`HostFsRequestFrame`) is read-only by design;
+    this carries the small set of writes the host can serve when the session's
+    runner is offline — currently the GitHub account/base preference
+    (``op="github_set_preference"``). The host runs the mutation against
+    ``workspace`` and replies with the same :class:`HostFsResultFrame` a read
+    would, so the result transport and correlation are shared.
+
+    :param request_id: Correlates the result, e.g. ``"req_fsw_1"``.
+    :param op: Write op name — currently ``"github_set_preference"``.
+    :param workspace: Absolute path to the session's workspace on the host.
+    :param session_id: Session id, for parity with the read frame.
+    :param params: Operation-specific arguments, e.g.
+        ``{"account": "octocat", "remote": "origin"}``.
+    """
+
+    request_id: str
+    op: str
+    workspace: str
+    session_id: str
+    params: _JsonObject = field(default_factory=dict)
+
+
+@dataclass
+class HostFsResultFrame:
+    """Host → server: outcome of a workspace filesystem request (read or write).
+
+    :param request_id: Correlates to the :class:`HostFsRequestFrame` or
+        :class:`HostFsWriteFrame`.
     :param status: ``"ok"`` when ``payload`` carries the runner-shaped
         result, or ``"error"`` when the read failed.
     :param payload: The runner-shaped JSON result on success, ``None`` on
@@ -992,6 +1020,7 @@ HostFrame = (
     | HostDetectCredentialsResultFrame
     | HostFsRequestFrame
     | HostFsResultFrame
+    | HostFsWriteFrame
     | HostModelOptionsFrame
     | HostModelOptionsResultFrame
     | HostImportLocalFrame
@@ -1329,6 +1358,17 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "params": frame.params,
             }
         )
+    if isinstance(frame, HostFsWriteFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.FS_WRITE_REQUEST.value,
+                "request_id": frame.request_id,
+                "op": frame.op,
+                "workspace": frame.workspace,
+                "session_id": frame.session_id,
+                "params": frame.params,
+            }
+        )
     if isinstance(frame, HostFsResultFrame):
         return _encode_payload(
             {
@@ -1528,6 +1568,8 @@ def _decode_known_host_frame(
             return _decode_fs_request(msg)
         case HostFrameKind.FS_RESULT:
             return _decode_fs_result(msg)
+        case HostFrameKind.FS_WRITE_REQUEST:
+            return _decode_fs_write_request(msg)
         case HostFrameKind.MODEL_OPTIONS:
             return _decode_model_options(msg)
         case HostFrameKind.MODEL_OPTIONS_RESULT:
@@ -2003,6 +2045,24 @@ def _decode_fs_request(msg: _JsonObject) -> HostFsRequestFrame:
     if not isinstance(params, dict):
         raise ValueError("frame field must be a JSON object: 'params'")
     return HostFsRequestFrame(
+        request_id=_required_str(msg, "request_id"),
+        op=_required_str(msg, "op"),
+        workspace=_required_str(msg, "workspace"),
+        session_id=_required_str(msg, "session_id"),
+        params=params,
+    )
+
+
+def _decode_fs_write_request(msg: _JsonObject) -> HostFsWriteFrame:
+    """Decode a host.fs_write_request frame.
+
+    :param msg: Decoded frame object.
+    :returns: Typed host.fs_write_request frame.
+    """
+    params = msg.get("params", {})
+    if not isinstance(params, dict):
+        raise ValueError("frame field must be a JSON object: 'params'")
+    return HostFsWriteFrame(
         request_id=_required_str(msg, "request_id"),
         op=_required_str(msg, "op"),
         workspace=_required_str(msg, "workspace"),

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -10085,6 +10085,27 @@ def create_runner_app(
         )
         return JSONResponse(status_code=200, content=result)
 
+    @app.post("/v1/sessions/{session_id}/resources/github/preferences")
+    async def set_github_preference_route(
+        session_id: str,
+        request: Request,
+    ) -> JSONResponse:
+        # Apply the panel's account / remote selection (gh repo set-default +
+        # a per-repo account preference), then return the refreshed info payload.
+        import asyncio as _asyncio
+
+        from omnigent.runner.github_resource import set_github_preference
+
+        body = await request.json()
+        root = await _github_workspace_root(session_id)
+        info = await _asyncio.to_thread(
+            set_github_preference,
+            root,
+            account=body.get("account"),
+            remote=body.get("remote"),
+        )
+        return JSONResponse(status_code=200, content=info)
+
     @app.get(
         "/v1/sessions/{session_id}/resources/environments"
         "/{environment_id}/filesystem/{relative_path:path}"

--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -24,14 +24,23 @@ Design notes:
 - Only the on-demand per-file expand-context reader (:func:`github_file_diff`)
   still uses ``git show`` for full before/after content — a unified-diff blob
   can't drive the viewer's context expansion.
-- The branch→PR lookup resolves in one ``gh`` call, picked by whether the pushed
-  ref (``branch.<name>.merge``) was renamed from the local branch — the mark of
-  a fork / triangular push (Databricks prefixes it with ``<user>/``). Renamed →
-  ``gh pr list --head <pushed-ref>``, which matches the head ref name alone and
-  so finds a fork head a bare ``gh pr view`` misses. Not renamed → a bare ``gh pr
-  view``, which is correct and more precise for same-repo branches and returns
-  nothing for a base branch like ``master`` (``gh pr list --head master`` would
-  wrongly match a stranger's PR whose head merely shares the name).
+- The branch→PR lookup is a ``gh pr view --json`` (``--json`` avoids the
+  interactive pager and the Projects-classic mis-parse of a bare view), backed by
+  a commit-identity fallback for when the remote branch name is decoupled from the
+  checkout. Fork / triangular PRs resolve once the two coordinates they turn on
+  are set explicitly: the base repo (``gh repo set-default``, which ``gh`` stores
+  in ``.git/config`` as ``remote.<name>.gh-resolved``) and the head owner (the
+  authenticated account). The panel surfaces an account + remote selector so the
+  user pins both; a per-repo account preference (``~/.omnigent/config.yaml``) is
+  applied by running each ``gh`` call as the chosen account —
+  ``GH_TOKEN=$(gh auth token --user <login>)`` — outside a sandbox (inside one we
+  keep the single broker identity).
+- When a stacking tool (git-stack, ``git pp``) pushes under a remote branch name
+  that differs from the local checkout and leaves no upstream tracking, ``gh``'s
+  branch-name lookup misses. The pushed commit is the invariant that still links
+  the checkout to its PR, so the fallback asks GitHub which PR a pushed commit
+  belongs to (``repos/{owner}/{repo}/commits/{sha}/pulls``), querying the repo it
+  was pushed to (the fork for a fork PR) — see :func:`_resolve_pr_via_commit`.
 - ``available: false`` payloads let the tab render a message ("gh not installed",
   "not a git repo") instead of surfacing an error.
 """
@@ -41,11 +50,13 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
 from typing import Any
 
+from omnigent import config as _config
 from omnigent.runtime.filesystem_registry import _git_timeout_seconds
 
 _logger = logging.getLogger(__name__)
@@ -131,17 +142,165 @@ def _in_sandbox() -> bool:
     return (os.environ.get("IS_SANDBOX") or "").strip() == "1"
 
 
-def _gh(argv: list[str], *, cwd: str) -> tuple[int | None, str, str]:
+def _gh(argv: list[str], *, cwd: str, token: str | None = None) -> tuple[int | None, str, str]:
     # In a managed sandbox the panel must authenticate as the connected owner via
     # the per-user hosts.yml that configure_host_gh writes — never an ambient
     # GH_TOKEN/GITHUB_TOKEN, which gh ranks ABOVE hosts.yml. Scrub them so a stray
     # token in the sandbox/runner env (e.g. a gh-MCP passthrough) can't silently
     # make the panel act as a shared identity. Outside a sandbox (local dev) the
     # env is inherited untouched, so the developer's own gh auth still works.
+    #
+    # ``token`` deliberately re-adds GH_TOKEN to run this one call as a chosen
+    # account (the account selector). It's only ever set outside a sandbox — see
+    # _account_token_for — so it never overrides the sandbox's broker identity.
     env: dict[str, str] | None = None
     if _in_sandbox():
         env = {k: v for k, v in os.environ.items() if k not in ("GH_TOKEN", "GITHUB_TOKEN")}
+    if token:
+        env = dict(os.environ) if env is None else env
+        env["GH_TOKEN"] = token
+        env.pop("GITHUB_TOKEN", None)
     return _run(["gh", *argv], cwd=cwd, timeout=_gh_timeout_seconds(), env=env)
+
+
+# ── Account selection ────────────────────────────────────────────────────────
+# The panel offers ONE selector — the account (head owner) — since fork/triangular
+# PRs resolve by pushed-commit identity and the base repo is auto-resolved from the
+# PR. A per-workspace account preference runs every ``gh`` call as the chosen login;
+# a sandbox has a single identity so the account override no-ops there.
+
+
+def _owner_repo_from_url(url: str | None) -> str | None:
+    """Derive ``owner/repo`` from a git remote URL, or ``None``.
+
+    Handles HTTPS/SSH/scp-style GitHub URLs, stripping any ``.git`` suffix.
+    """
+    if not url:
+        return None
+    candidate = url.strip()
+    scp = re.match(r"^[\w.\-]+@[\w.\-]+:(?P<path>.+)$", candidate)
+    if scp:
+        path = scp.group("path")
+    else:
+        scheme = re.match(r"^\w+://(?:[^@/]+@)?[\w.\-]+/(?P<path>.+)$", candidate)
+        if not scheme:
+            return None
+        path = scheme.group("path")
+    parts = path.removesuffix(".git").strip("/").split("/")
+    if len(parts) < 2 or not parts[-1] or not parts[-2]:
+        return None
+    return f"{parts[-2]}/{parts[-1]}"
+
+
+def _owner_repo_from_pr_url(url: str | None) -> str | None:
+    """Derive the base ``owner/repo`` from a PR's HTML URL, or ``None``.
+
+    A PR lives on its base repo, so ``https://host/<owner>/<repo>/pull/<n>`` names
+    it in the first two path segments — lets us skip a separate ``gh repo view``
+    once a PR resolves.
+    """
+    if not url:
+        return None
+    match = re.match(r"^https?://[^/]+/([^/]+)/([^/]+)/pull/\d+", url.strip())
+    return f"{match.group(1)}/{match.group(2)}" if match else None
+
+
+def _list_accounts(root: str) -> tuple[bool, list[dict[str, Any]]]:
+    """Return ``(authenticated, accounts)`` from ``gh auth status --json hosts``.
+
+    ``accounts`` is ``[{login, active, state, host}]``; ``authenticated`` is true
+    when at least one account validates (``state == "success"``). Falls back to a
+    plain ``gh auth status`` for the boolean on an older ``gh`` without ``--json``.
+    """
+    _, out, _ = _gh(["auth", "status", "--json", "hosts"], cwd=root)
+    try:
+        data = json.loads(out)
+    except ValueError:
+        data = None
+    hosts = data.get("hosts") if isinstance(data, dict) else None
+    if isinstance(hosts, dict):
+        accounts: list[dict[str, Any]] = []
+        for host, entries in hosts.items():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict) or not entry.get("login"):
+                    continue
+                accounts.append(
+                    {
+                        "login": entry.get("login"),
+                        "active": bool(entry.get("active")),
+                        "state": entry.get("state"),
+                        "host": entry.get("host") or host,
+                    }
+                )
+        return any(a.get("state") == "success" for a in accounts), accounts
+    # Older gh (no --json hosts): fall back to the plain status exit code.
+    rc, _, _ = _gh(["auth", "status"], cwd=root)
+    return rc == 0, []
+
+
+def _resolved_base_nwo(root: str) -> str | None:
+    """Return the gh-resolved base repo ``owner/repo`` for the checkout, or ``None``.
+
+    Reads ``gh repo set-default --view`` — a local git-config read (no network),
+    the same base ``gh`` itself resolves PRs against. ``None`` when no default is
+    set (``--view`` exits non-zero) or the output isn't an ``owner/repo``.
+    """
+    rc, out, _ = _gh(["repo", "set-default", "--view"], cwd=root)
+    if rc != 0:
+        return None
+    value = out.strip()
+    if value and "/" in value and " " not in value:
+        return value
+    return None
+
+
+def _workspace_key(root: str) -> str | None:
+    """Return the stable per-workspace key for the account preference, or ``None``.
+
+    The account preference is keyed by the **main worktree path** — the first
+    entry of ``git worktree list`` — so a checkout and all its linked worktrees
+    (which share one ``.git``) resolve to the same key, while separate clones stay
+    distinct. Purely local (no network, no auth), so it's available before any
+    ``gh`` call — the constraint that rules out keying on the resolved base repo.
+    """
+    rc, out, _ = _git(["worktree", "list", "--porcelain"], cwd=root)
+    if rc != 0:
+        return None
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            path = line[len("worktree ") :].strip()
+            return path or None
+    return None
+
+
+def _gh_auth_token(root: str, login: str) -> str | None:
+    """Return *login*'s GitHub token via ``gh auth token --user`` (never logged)."""
+    rc, out, _ = _gh(["auth", "token", "--user", login, "-h", "github.com"], cwd=root)
+    if rc != 0:
+        return None
+    return out.strip() or None
+
+
+def _account_token_for(root: str, workspace_key: str | None = None) -> str | None:
+    """Return the GH_TOKEN to run ``gh`` as this workspace's preferred account.
+
+    ``None`` (use ``gh``'s active auth) inside a sandbox (single broker identity),
+    when the workspace key can't be resolved, or when it has no stored preference.
+
+    :param root: Absolute workspace path.
+    :param workspace_key: Precomputed key to skip a repeat resolution.
+    """
+    if _in_sandbox():
+        return None
+    key = workspace_key if workspace_key is not None else _workspace_key(root)
+    if not key:
+        return None
+    login = _config.github_account_preference(key)
+    if not login:
+        return None
+    return _gh_auth_token(root, login)
 
 
 # Cap the per-check list so a pathological rollup can't bloat the payload; the
@@ -235,75 +394,145 @@ def _shape_comments(raw: Any) -> list[dict[str, Any]]:
     return shaped
 
 
-def _current_branch(root: str) -> str | None:
-    """Return the workspace's current branch name, or ``None`` (detached / not a repo)."""
-    rc, out, _ = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
+def _head_commit_shas(root: str) -> list[str]:
+    """Candidate commit SHAs to resolve the PR by identity, most-pushed first.
+
+    ``@{push}`` is the exact ref the branch was pushed to — the pushed tip even
+    when a stacking tool renamed the remote branch. ``HEAD`` is the local tip,
+    which equals the pushed tip right after such a push when no upstream tracking
+    was configured. Order-preserving and deduped; empty on a detached HEAD.
+    """
+    shas: list[str] = []
+    for rev in ("@{push}", "HEAD"):
+        rc, out, _ = _git(["rev-parse", "--verify", "--quiet", rev], cwd=root)
+        sha = out.strip()
+        if rc == 0 and sha and sha not in shas:
+            shas.append(sha)
+    return shas
+
+
+def _remote_nwo(root: str, remote: str) -> str | None:
+    """``owner/repo`` for a named git remote, or ``None``."""
+    rc, url, _ = _git(["remote", "get-url", remote], cwd=root)
     if rc != 0:
         return None
-    return out.strip() or None
+    return _owner_repo_from_url(url.strip())
 
 
-def _pushed_head_ref(root: str, branch: str) -> str | None:
-    """Return ``branch``'s pushed head ref name, or ``None``.
+def _commit_lookup_repo(root: str) -> str | None:
+    """The repo the branch was pushed to — where its commit (and PR) live.
 
-    Reads the configured upstream (``branch.<name>.merge``), whose value is the
-    ref that was actually pushed — which may carry a ``<user>/`` prefix under a
-    fork / triangular push flow and so differ from the local branch name.
-    ``None`` with no upstream configured.
+    The branch's tracking remote (``branch.<name>.remote``), else ``origin``. One
+    repo suffices: ``commits/{sha}/pulls`` resolves the PR across the fork network
+    (it reports the PR's own base repo, whatever that is), and a commit that
+    wasn't pushed to this repo won't be in the base repo either — so querying more
+    repos for the same commit is redundant.
     """
-    rc, out, _ = _git(["config", f"branch.{branch}.merge"], cwd=root)
-    if rc != 0 or not out.strip():
+    rc, br, _ = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=root)
+    branch = br.strip()
+    if rc == 0 and branch and branch != "HEAD":
+        rc, remote, _ = _git(["config", f"branch.{branch}.remote"], cwd=root)
+        remote = remote.strip()
+        if rc == 0 and remote and remote != ".":
+            nwo = _remote_nwo(root, remote)
+            if nwo:
+                return nwo
+    return _remote_nwo(root, "origin")
+
+
+def _resolve_pr_via_commit(root: str, *, token: str | None = None) -> tuple[int, str] | None:
+    """Resolve ``(PR number, base owner/repo)`` by pushed-commit identity, or ``None``.
+
+    Branch-name-independent: asks GitHub which PR a pushed commit belongs to
+    (``repos/{owner}/{repo}/commits/{sha}/pulls``), so it finds the PR even when a
+    stacking tool (git-stack, ``git pp``) pushed under a remote branch name that
+    differs from the checkout, or a fork PR whose head ``gh`` can't name. The
+    commit lives in the repo it was pushed to (the fork for a fork PR), and the
+    response names the PR's own base repo — returned so the caller fetches the PR
+    from the right place regardless of the local ``gh repo set-default``.
+
+    Only **open** PRs are accepted. For a commit already on the default branch
+    (master/main, or any merged tip) the endpoint returns the *merged* PR that
+    introduced it, which is a false positive — never the branch's own outgoing
+    PR — so a closed/merged row is skipped rather than surfaced.
+    """
+    shas = _head_commit_shas(root)
+    repo = _commit_lookup_repo(root)
+    if not shas or not repo:
         return None
-    return out.strip().removeprefix("refs/heads/") or None
-
-
-def _pr_view_json(root: str, fields: str) -> dict[str, Any] | None:
-    """Return the branch's PR as a ``gh``-JSON object for ``fields``, or ``None``.
-
-    Resolves the PR in a single ``gh`` call, choosing the query from a cheap git
-    signal: whether the pushed ref (``branch.<name>.merge``) was *renamed* from
-    the local branch name. A fork / triangular push renames it (Databricks pushes
-    carry a ``<user>/`` prefix), and only then does a bare ``gh pr view`` miss the
-    PR — its head-repo-owner guess looks in the wrong place. There we resolve by
-    the pushed ref with ``gh pr list --head`` (``--json`` takes the same fields,
-    and a row shares the shape of a ``gh pr view`` object, so it parses
-    identically; ``--state all`` keeps merged/closed PRs visible).
-
-    Otherwise a bare ``gh pr view`` is correct and *more precise*: it resolves
-    same-repo and standard-fork PRs, and returns nothing for a base branch like
-    ``master``. Using ``gh pr list --head`` there would be wrong — it matches on
-    the head ref name alone, so on ``master`` it returns a stranger's unrelated
-    PR whose head merely happens to be named ``master``.
-    """
-    branch = _current_branch(root)
-    pushed_ref = _pushed_head_ref(root, branch) if branch is not None else None
-    if pushed_ref is not None and pushed_ref != branch:
-        rc, out, _ = _gh(
-            [
-                "pr",
-                "list",
-                "--head",
-                pushed_ref,
-                "--state",
-                "all",
-                "--limit",
-                "1",
-                "--json",
-                fields,
-            ],
-            cwd=root,
-        )
+    for sha in shas:
+        rc, out, _ = _gh(["api", f"repos/{repo}/commits/{sha}/pulls"], cwd=root, token=token)
         if rc != 0:
-            return None
+            continue
         try:
             rows = json.loads(out)
         except ValueError:
-            return None
-        if isinstance(rows, list) and rows and isinstance(rows[0], dict):
-            return rows[0]
-        return None
+            continue
+        if not isinstance(rows, list) or not rows:
+            continue
 
-    rc, out, _ = _gh(["pr", "view", "--json", fields], cwd=root)
+        def _is_open(row: Any) -> bool:
+            return isinstance(row, dict) and str(row.get("state", "")).lower() == "open"
+
+        # Accept only an OPEN PR. On the default branch (and any branch whose tip
+        # is already merged) this endpoint returns the *merged* PR that introduced
+        # the commit — a false positive, since it's not the branch's own outgoing
+        # PR. A genuine fallback hit (a fork / renamed branch gh can't name) is
+        # always open, so a closed row is never the PR we want; skip it rather
+        # than falling back to the first row.
+        chosen = next((r for r in rows if _is_open(r)), None)
+        if chosen is None:
+            continue
+        number = chosen.get("number")
+        base = chosen.get("base")
+        base_repo = base.get("repo") if isinstance(base, dict) else None
+        base_full = base_repo.get("full_name") if isinstance(base_repo, dict) else None
+        if isinstance(number, int) and isinstance(base_full, str) and "/" in base_full:
+            return number, base_full
+    return None
+
+
+def _pr_view_json(root: str, fields: str, *, token: str | None = None) -> dict[str, Any] | None:
+    """Return the branch's PR as a ``gh``-JSON object for ``fields``, or ``None``.
+
+    Two-step, so a decoupled remote branch name never hides the PR:
+
+    1. ``gh pr view --json`` — resolves the current branch's PR against the
+       gh-resolved base as the authenticated account. Fast, and covers same-repo
+       branches and any push that set upstream tracking (plain ``push -u``, and
+       ``git pp``, which pushes ``-u``). ``--json`` also avoids the interactive
+       pager and the Projects-classic mis-parse of a bare ``gh pr view``.
+    2. Commit-identity fallback — when a stacking tool (git-stack, ``git pp``)
+       pushed under a remote branch name that differs from the checkout, or a
+       fork PR whose head ``gh`` can't name, the branch-name lookup misses. The
+       pushed commit still maps to the PR (:func:`_resolve_pr_via_commit`), which
+       also yields the PR's base repo so the full object is fetched with an
+       explicit ``-R``. This subsumes the old ``branch.<name>.merge`` head guess.
+
+    :param token: Optional GH_TOKEN to run the calls as the selected account.
+    """
+    rc, out, _ = _gh(["pr", "view", "--json", fields], cwd=root, token=token)
+    if rc == 0:
+        try:
+            data = json.loads(out)
+        except ValueError:
+            data = None
+        if isinstance(data, dict):
+            return data
+
+    resolved = _resolve_pr_via_commit(root, token=token)
+    if resolved is None:
+        return None
+    number, base_repo = resolved
+    # First-run convenience: point gh's default at the PR's real base so the
+    # agent's own `gh` in the terminal targets it too. Only when unset, so a
+    # manual `gh repo set-default` is never overridden; best-effort — resolution
+    # itself doesn't need it (the explicit ``-R`` below carries the base).
+    if not _resolved_base_nwo(root):
+        _gh(["repo", "set-default", base_repo], cwd=root, token=token)
+    rc, out, _ = _gh(
+        ["pr", "view", str(number), "-R", base_repo, "--json", fields], cwd=root, token=token
+    )
     if rc != 0:
         return None
     try:
@@ -325,7 +554,15 @@ def github_info(root: str) -> dict[str, Any]:
     :returns: A ``session.github.info`` object. ``available`` is false only when
         this isn't a git repo (``reason: not_a_git_repo``). ``gh_available`` /
         ``authenticated`` report whether the ``gh`` CLI is present and signed in;
-        ``repo`` / ``pr`` / ``base_ref`` are null without it.
+        ``repo`` / ``pr`` / ``base_ref`` are null without it. ``accounts`` /
+        ``selected_account`` are populated only when the repo can't be reached (to
+        drive the account selector), so the happy path stays fast.
+
+    Ordering is a fast-path optimization: resolve the PR first, and only fall to
+    the ``gh repo view`` reachability probe (and, if that fails, the ``gh auth
+    status`` account enumeration) when there's no PR. A resolved PR already tells
+    us the repo and that we're authenticated, so those extra network calls are
+    skipped whenever a PR exists.
     """
     payload: dict[str, Any] = {"object": "session.github.info"}
 
@@ -349,26 +586,18 @@ def github_info(root: str) -> dict[str, Any]:
         return payload
     payload["gh_available"] = True
 
-    auth_rc, _, _ = _gh(["auth", "status"], cwd=root)
-    authenticated = auth_rc == 0
-    payload["authenticated"] = authenticated
-    if not authenticated:
-        return payload
+    # Run the API-touching calls as the workspace's preferred account (local dev);
+    # resolving the token is local (config read + keyring), so it's always cheap.
+    token = _account_token_for(root)
 
-    rc, out, _ = _gh(["repo", "view", "--json", "nameWithOwner"], cwd=root)
-    if rc == 0:
-        try:
-            data = json.loads(out)
-            payload["repo"] = {"name_with_owner": data.get("nameWithOwner")}
-        except (ValueError, AttributeError):
-            pass
-
-    pr: dict[str, Any] | None = None
-    data = _pr_view_json(root, _PR_VIEW_FIELDS)
+    # Resolve the PR first. A hit tells us the repo (from the PR URL) and that
+    # we're authenticated, so we skip the separate `gh repo view` and the account
+    # enumeration entirely — the common case makes the fewest network calls.
+    data = _pr_view_json(root, _PR_VIEW_FIELDS, token=token)
     if data is not None:
         author = data.get("author")
         body = data.get("body")
-        pr = {
+        payload["pr"] = {
             "number": data.get("number"),
             "title": data.get("title"),
             "state": data.get("state"),
@@ -383,11 +612,64 @@ def github_info(root: str) -> dict[str, Any]:
             "body": body if isinstance(body, str) and body.strip() else None,
             "comments": _shape_comments(data.get("comments")),
         }
-    payload["pr"] = pr
+        payload["authenticated"] = True
+        payload["base_ref"] = data.get("baseRefName")
+        payload["repo"] = {"name_with_owner": _owner_repo_from_pr_url(data.get("url"))}
+        return payload
 
-    # A pure PR view: the base is the PR's base branch, else null (no PR).
-    payload["base_ref"] = pr.get("base_ref") if pr else None
+    # No PR. Probe repo reachability to tell "no PR yet" from "can't reach repo".
+    rc, out, _ = _gh(["repo", "view", "--json", "nameWithOwner"], cwd=root, token=token)
+    if rc == 0:
+        try:
+            nwo = json.loads(out).get("nameWithOwner")
+        except (ValueError, AttributeError):
+            nwo = None
+        if nwo:
+            payload["authenticated"] = True
+            payload["repo"] = {"name_with_owner": nwo}
+            return payload  # -> no-pr
+
+    # Repo unreachable / not signed in — enumerate accounts so the panel can offer
+    # the account selector (the only state where it's shown).
+    authenticated, accounts = _list_accounts(root)
+    payload["authenticated"] = authenticated
+    payload["accounts"] = accounts
+    workspace_key = _workspace_key(root)
+    pref_login = _config.github_account_preference(workspace_key) if workspace_key else None
+    active_login = next((a["login"] for a in accounts if a.get("active")), None)
+    payload["selected_account"] = pref_login or active_login
     return payload
+
+
+def set_github_preference(
+    root: str,
+    *,
+    account: str | None = None,
+    remote: str | None = None,
+) -> dict[str, Any]:
+    """Apply an account and/or remote selection, then return refreshed info.
+
+    The account preference is keyed per workspace (the main worktree path, shared
+    across a repo's worktrees) and persisted to the user config via
+    :func:`omnigent.config.set_github_account_preference`; an empty ``account``
+    clears the entry, falling back to ``gh``'s active account. The remote is
+    ``gh repo set-default`` (persisted by ``gh`` in ``.git/config``) — the
+    normal-case base is auto-resolved, so this is only an escape hatch.
+
+    :param root: Absolute workspace path.
+    :param account: GitHub login to prefer for this workspace, or ``None`` to
+        leave it unchanged (empty string clears it).
+    :param remote: Git remote name or ``owner/repo`` to set as the base repo, or
+        ``None`` to leave the base unchanged.
+    :returns: The refreshed :func:`github_info` payload.
+    """
+    if remote:
+        _gh(["repo", "set-default", remote], cwd=root)
+    if account is not None:
+        key = _workspace_key(root)
+        if key:
+            _config.set_github_account_preference(key, account or None)
+    return github_info(root)
 
 
 def resolve_base_ref(root: str, base: str | None) -> str | None:
@@ -443,14 +725,15 @@ _GH_STATUS_MAP = {
 }
 
 
-def _pr_number(root: str) -> int | None:
+def _pr_number(root: str, *, token: str | None = None) -> int | None:
     """Return the PR number for the workspace's branch, or ``None``.
 
     :param root: Absolute workspace path.
+    :param token: Optional GH_TOKEN to run ``gh`` as the selected account.
     :returns: The associated PR's number, or ``None`` when no PR resolves (none
         for the branch, ``gh`` missing, or not authenticated).
     """
-    data = _pr_view_json(root, "number")
+    data = _pr_view_json(root, "number", token=token)
     if data is None:
         return None
     number = data.get("number")
@@ -469,7 +752,8 @@ def github_changed_files(root: str) -> dict[str, Any]:
         / ``status`` / ``lines_added`` / ``lines_removed``.
     """
     empty: dict[str, Any] = {"object": "list", "data": [], "has_more": False}
-    number = _pr_number(root)
+    token = _account_token_for(root)
+    number = _pr_number(root, token=token)
     if number is None:
         return empty
     # ``{owner}`` / ``{repo}`` are filled by ``gh`` from the repo; ``--paginate``
@@ -477,6 +761,7 @@ def github_changed_files(root: str) -> dict[str, Any]:
     rc, out, _ = _gh(
         ["api", "--paginate", f"repos/{{owner}}/{{repo}}/pulls/{number}/files?per_page=100"],
         cwd=root,
+        token=token,
     )
     if rc != 0:
         return empty
@@ -555,8 +840,9 @@ def github_pr_diff(root: str) -> dict[str, Any]:
         (empty when there's no PR / no changes).
     """
     empty: dict[str, Any] = {"object": "session.github.pr_diff", "patch": ""}
-    number = _pr_number(root)
+    token = _account_token_for(root)
+    number = _pr_number(root, token=token)
     if number is None:
         return empty
-    rc, out, _ = _gh(["pr", "diff", str(number)], cwd=root)
+    rc, out, _ = _gh(["pr", "diff", str(number)], cwd=root, token=token)
     return {"object": "session.github.pr_diff", "patch": out if rc == 0 else ""}

--- a/omnigent/server/routes/_host_filesystem.py
+++ b/omnigent/server/routes/_host_filesystem.py
@@ -19,7 +19,7 @@ import logging
 import secrets
 from typing import Any
 
-from omnigent.host.frames import HostFsRequestFrame, encode_host_frame
+from omnigent.host.frames import HostFsRequestFrame, HostFsWriteFrame, encode_host_frame
 from omnigent.server.host_registry import HostConnection, HostRegistry
 
 _logger = logging.getLogger(__name__)
@@ -129,6 +129,81 @@ async def read_workspace_from_host(
     status = result.get("error_status")
     code = result.get("error_code") or "fs_read_failed"
     message = result.get("error") or "host filesystem read failed"
+    if not isinstance(status, int):
+        status = 500
+    raise HostFsError(status, str(code), str(message))
+
+
+async def write_workspace_from_host(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    op: str,
+    workspace: str,
+    session_id: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Send a ``host.fs_write_request`` frame and await its result.
+
+    The write counterpart of :func:`read_workspace_from_host` — for the small set
+    of host-servable writes (currently ``"github_set_preference"``) so a
+    preference change works when the session's runner is offline. Shares the
+    result frame, the ``pending_fs_requests`` correlation map, and the error
+    mapping with reads.
+
+    :param op: Write op name — currently ``"github_set_preference"``.
+    :param params: Operation-specific arguments, e.g. ``{"account": ...}``.
+    :returns: The refreshed payload on success.
+    :raises HostFsError: When the host reports a failure (reproduces the runner's
+        response).
+    :raises HostFsUnavailableError: On connection loss or timeout.
+    """
+    request_id = secrets.token_hex(8)
+    frame = encode_host_frame(
+        HostFsWriteFrame(
+            request_id=request_id,
+            op=op,
+            workspace=workspace,
+            session_id=session_id,
+            params=params,
+        )
+    )
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+    host_conn.pending_fs_requests[request_id] = future
+    try:
+        try:
+            host_registry.send_text(host_conn, frame)
+        except ConnectionError as exc:
+            raise HostFsUnavailableError(
+                f"host '{host_conn.host_id}' connection lost during fs write"
+            ) from exc
+        try:
+            result = await asyncio.wait_for(future, timeout=_FS_TIMEOUT_S)
+        except asyncio.TimeoutError as exc:
+            _logger.warning(
+                "host '%s' did not answer fs write op %r within %.0fs",
+                host_conn.host_id,
+                op,
+                _FS_TIMEOUT_S,
+            )
+            raise HostFsUnavailableError(
+                f"host '{host_conn.host_id}' did not respond to fs write within "
+                f"{_FS_TIMEOUT_S:.0f}s (it may be running an older version)"
+            ) from exc
+    finally:
+        host_conn.pending_fs_requests.pop(request_id, None)
+
+    if result.get("status") == "ok":
+        payload = result.get("payload")
+        if not isinstance(payload, dict):
+            raise HostFsUnavailableError(
+                f"host '{host_conn.host_id}' returned an incomplete fs write result"
+            )
+        return payload
+
+    status = result.get("error_status")
+    code = result.get("error_code") or "fs_write_failed"
+    message = result.get("error") or "host filesystem write failed"
     if not isinstance(status, int):
         status = 500
     raise HostFsError(status, str(code), str(message))

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -772,6 +772,53 @@ def register_resources_routes(
             # runner proxy, which wraps non-200/404 responses as a 502.
             raise HTTPException(status_code=502, detail=exc.message) from exc
 
+    async def _write_workspace_via_host(
+        session_id: str,
+        conversation: Conversation,
+        op: str,
+        host_params: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Serve a workspace-mutating op over the session's host tunnel.
+
+        The write counterpart of :func:`_read_workspace_via_host`, for when the
+        runner is offline but the host holding the workspace is connected.
+
+        :param op: Host-side write op — currently ``"github_set_preference"``.
+        :param host_params: Op-specific args for the host writer.
+        :returns: The refreshed payload, or ``None`` when no host is bound /
+            connected / reachable (caller re-raises the runner-offline error).
+        :raises HTTPException: On host-reported failures, reproducing the runner's
+            status.
+        """
+        from omnigent.server.routes._host_filesystem import (
+            HostFsError,
+            HostFsUnavailableError,
+            write_workspace_from_host,
+        )
+
+        if host_registry is None:
+            return None
+        if not conversation.host_id or not conversation.workspace:
+            return None
+        host_conn = host_registry.get(conversation.host_id)
+        if host_conn is None:
+            return None
+        try:
+            return await write_workspace_from_host(
+                host_registry=host_registry,
+                host_conn=host_conn,
+                op=op,
+                workspace=conversation.workspace,
+                session_id=session_id,
+                params=host_params,
+            )
+        except HostFsUnavailableError:
+            return None
+        except HostFsError as exc:
+            if exc.status == 400:
+                raise HTTPException(status_code=400, detail=exc.message) from exc
+            raise HTTPException(status_code=502, detail=exc.message) from exc
+
     async def _proxy_post_to_runner(
         session_id: str,
         path: str,
@@ -2566,6 +2613,56 @@ def register_resources_routes(
             host_params={},
             runner_path=f"/v1/sessions/{session_id}/resources/github/changes",
         )
+
+    @router.post(
+        "/sessions/{session_id}/resources/github/preferences",
+        response_model=None,
+    )
+    async def set_session_github_preference(
+        request: Request,
+        session_id: str,
+    ) -> dict[str, Any]:
+        """
+        Apply the GitHub panel's account (and optional base) selection.
+
+        Persists the choice — a per-workspace account preference in the user
+        config, and ``gh repo set-default`` when a base is given — then returns the
+        refreshed ``session.github.info``. Served by the runner when it's online,
+        else by the host over its tunnel (both run the same
+        :func:`github_resource.set_github_preference` against the local config +
+        workspace), so a preference change works with the runner asleep.
+
+        :param request: The incoming FastAPI request (JSON body + auth).
+        :param session_id: Session/conversation identifier.
+        :returns: The refreshed ``session.github.info`` object.
+        """
+        conv = await _validate_session(session_id, request, LEVEL_EDIT)
+        body = await request.json()
+        params = {"account": body.get("account"), "remote": body.get("remote")}
+        try:
+            status, result = await _proxy_post_to_runner(
+                session_id,
+                f"/v1/sessions/{session_id}/resources/github/preferences",
+                params,
+                conv,
+            )
+        except OmnigentError as exc:
+            # Runner asleep — serve the write from the host if it's connected.
+            if exc.code != ErrorCode.RUNNER_UNAVAILABLE:
+                raise
+            payload = await _write_workspace_via_host(
+                session_id, conv, op="github_set_preference", host_params=params
+            )
+            if payload is None:
+                raise
+            return payload
+        if status >= 400:
+            error = result.get("error", {})
+            raise OmnigentError(
+                error.get("message", f"GitHub preference update failed (HTTP {status})"),
+                code=error.get("code", ErrorCode.INTERNAL_ERROR),
+            )
+        return result
 
     # Generic single-resource lookup — registered AFTER typed
     # collections so "environments", "terminals", "files" are not

--- a/openapi.json
+++ b/openapi.json
@@ -14100,6 +14100,48 @@
         ]
       }
     },
+    "/v1/sessions/{session_id}/resources/github/preferences": {
+      "post": {
+        "description": "Apply the GitHub panel's account (and optional base) selection.\n\nPersists the choice \u2014 a per-workspace account preference in the user\nconfig, and `gh repo set-default` when a base is given \u2014 then returns the\nrefreshed `session.github.info`. Served by the runner when it's online,\nelse by the host over its tunnel (both run the same\n`github_resource.set_github_preference` against the local config +\nworkspace), so a preference change works with the runner asleep.\n\n**Returns:** The refreshed `session.github.info` object.",
+        "operationId": "set_session_github_preference_v1_sessions__session_id__resources_github_preferences_post",
+        "parameters": [
+          {
+            "description": "Session/conversation identifier.",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Set Session Github Preference",
+        "tags": [
+          "session_resources"
+        ]
+      }
+    },
     "/v1/sessions/{session_id}/resources/terminals": {
       "get": {
         "description": "Return only terminal resources for a session.\n\nThe runner endpoint's pagination params (`limit` / `after` /\n`before` / `order`) are forwarded from the incoming query\nstring \u2014 without this, a client-requested `order=asc` (the web\nterminal tabs rely on creation order to keep the session's own\nterminal first) would be silently dropped and the runner's\n`desc` default would apply.\n\n**Returns:** `PaginatedList` of terminal resources.",

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5726,3 +5726,31 @@ async def test_handle_import_local_reports_unreadable_sessions_as_failed(
     assert [f.session.external_session_id for f in session_frames] == ["good"]
     assert len(done_frames) == 1
     assert done_frames[0].status == "ok" and done_frames[0].failed == 1
+
+
+async def test_dispatch_fs_write_op_routes_github_set_preference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The write dispatcher forwards to github_resource.set_github_preference."""
+    from omnigent.runner import github_resource
+
+    seen: dict[str, object] = {}
+
+    def fake_set(root, *, account=None, remote=None):
+        seen.update({"root": root, "account": account, "remote": remote})
+        return {"object": "session.github.info", "ok": True}
+
+    monkeypatch.setattr(github_resource, "set_github_preference", fake_set)
+    out = HostProcess._dispatch_fs_write_op(
+        "/ws/omnigent",
+        "github_set_preference",
+        {"account": "octocat", "remote": "origin"},
+    )
+    assert out == {"object": "session.github.info", "ok": True}
+    assert seen == {"root": "/ws/omnigent", "account": "octocat", "remote": "origin"}
+
+
+async def test_dispatch_fs_write_op_unknown_op_raises() -> None:
+    """An unknown write op fails loud rather than silently no-op'ing."""
+    with pytest.raises(ValueError, match="unknown fs write op"):
+        HostProcess._dispatch_fs_write_op("/ws", "bogus", {})

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -17,6 +17,7 @@ from omnigent.host.frames import (
     HostDetectCredentialsResultFrame,
     HostFsRequestFrame,
     HostFsResultFrame,
+    HostFsWriteFrame,
     HostHarnessReadinessFrame,
     HostHelloFrame,
     HostImportedLocalSession,
@@ -1611,6 +1612,34 @@ def test_fs_request_non_object_params_raises() -> None:
         decode_host_frame(
             '{"kind": "host.fs_request", "request_id": "r", "op": "changes", '
             '"workspace": "/w", "session_id": "s", "params": []}'
+        )
+
+
+def test_fs_write_round_trip() -> None:
+    """A host.fs_write_request round-trips op, workspace, session, and params.
+
+    The write frame carries the GitHub preference selection to the host when the
+    runner is offline; a dropped ``params`` would apply an empty selection.
+    """
+    original = HostFsWriteFrame(
+        request_id="req_fsw_1",
+        op="github_set_preference",
+        workspace="/Users/corey/project",
+        session_id="conv_abc123",
+        params={"account": "octocat", "remote": "origin"},
+    )
+    decoded = decode_host_frame(encode_host_frame(original))
+    assert isinstance(decoded, HostFsWriteFrame)
+    assert decoded == original
+
+
+def test_fs_write_non_object_params_raises() -> None:
+    """A non-object ``params`` on a write frame is rejected, like the read frame."""
+    with pytest.raises(ValueError, match="must be a JSON object: 'params'"):
+        decode_host_frame(
+            '{"kind": "host.fs_write_request", "request_id": "r", '
+            '"op": "github_set_preference", "workspace": "/w", "session_id": "s", '
+            '"params": []}'
         )
 
 

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -3,8 +3,8 @@
 :func:`github_file_diff` (the on-demand expand-context reader) runs ``git show``
 against a real temp repo. The PR-backed :func:`github_changed_files` /
 :func:`github_pr_diff` shell out to ``gh``, stubbed here via :func:`_stub_gh`.
-:func:`github_info`'s availability fallbacks and its check-summary reducer need
-neither ``gh`` nor the network.
+:func:`github_info`'s availability fallbacks, its account enumeration, and its
+check-summary reducer need neither ``gh`` nor the network.
 """
 
 from __future__ import annotations
@@ -37,7 +37,9 @@ def _stub_gh(
         the ``(returncode, stdout, stderr)`` it should return.
     """
 
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
         for prefix, value in responses.items():
             if tuple(argv[: len(prefix)]) == prefix:
                 return value
@@ -59,15 +61,6 @@ def _git_env() -> dict[str, str]:
 
 def _run(argv: list[str], cwd: Path) -> None:
     subprocess.run(argv, cwd=cwd, check=True, capture_output=True, env=_git_env())
-
-
-def _set_pushed_ref(repo: Path, head_ref: str) -> None:
-    """Give the ``feature`` branch an upstream whose pushed ref is ``head_ref``.
-
-    Mirrors a fork / triangular push, where the pushed ref (``branch.feature.merge``)
-    differs from the local branch name.
-    """
-    _run(["git", "config", "branch.feature.merge", f"refs/heads/{head_ref}"], repo)
 
 
 @pytest.fixture
@@ -119,14 +112,13 @@ def test_github_info_not_a_git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     assert info["reason"] == "not_a_git_repo"
 
 
-def test_github_info_pr_via_pr_list_head(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The PR resolves in one ``gh pr list --head`` call keyed by the pushed ref.
+def test_github_info_pr_via_pr_view(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The PR resolves in one bare ``gh pr view --json`` — fork heads included.
 
-    In a fork / triangular flow the pushed ref (``alice/feature``, from
-    ``branch.<n>.merge``) differs from the checkout's ``feature``; ``--head``
-    matches on the ref name alone, finding a PR a bare ``gh pr view`` would miss.
+    With the base repo and account pinned, ``gh`` resolves the current branch's
+    PR itself (fork / triangular ``alice/feature`` head and all), so there's no
+    head-ref heuristic and never a ``gh pr list`` call.
     """
-    _set_pushed_ref(repo, "alice/feature")
     pr = {
         "number": 42,
         "title": "Add thing",
@@ -140,15 +132,17 @@ def test_github_info_pr_via_pr_list_head(repo: Path, monkeypatch: pytest.MonkeyP
     }
     calls: list[tuple[str, ...]] = []
 
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
         calls.append(tuple(argv))
         head = tuple(argv[:2])
         if head == ("auth", "status"):
             return (0, "", "")
         if head == ("repo", "view"):
             return (0, json.dumps({"nameWithOwner": "acme/repo"}), "")
-        if head == ("pr", "list"):
-            return (0, json.dumps([pr]), "")
+        if head == ("pr", "view"):
+            return (0, json.dumps(pr), "")
         return (1, "", "no stub")
 
     monkeypatch.setattr(github_resource, "_gh", fake_gh)
@@ -159,69 +153,16 @@ def test_github_info_pr_via_pr_list_head(repo: Path, monkeypatch: pytest.MonkeyP
     assert info["pr"]["head_ref"] == "alice/feature"
     assert info["pr"]["is_draft"] is True
     assert info["base_ref"] == "main"
-    # One resolve call: gh pr list --head <pushed ref> --state all, no gh pr view.
-    list_calls = [c for c in calls if c[:2] == ("pr", "list")]
-    assert len(list_calls) == 1
-    args = list_calls[0]
-    assert args[args.index("--head") + 1] == "alice/feature"
-    assert args[args.index("--state") + 1] == "all"
-    assert not any(c[:2] == ("pr", "view") for c in calls)
-
-
-def test_github_info_pr_no_upstream_uses_pr_view(
-    repo: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """With no upstream to name the head, fall back to a bare ``gh pr view``."""
-    # The fixture's `feature` branch has no configured upstream.
-    view = {
-        "number": 5,
-        "title": "t",
-        "state": "OPEN",
-        "url": "u",
-        "isDraft": False,
-        "author": {"login": "a"},
-        "baseRefName": "main",
-        "headRefName": "feature",
-        "statusCheckRollup": [],
-    }
-    calls: list[tuple[str, ...]] = []
-
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
-        calls.append(tuple(argv))
-        head = tuple(argv[:2])
-        if head == ("auth", "status"):
-            return (0, "", "")
-        if head == ("repo", "view"):
-            return (0, json.dumps({"nameWithOwner": "o/r"}), "")
-        if head == ("pr", "view"):
-            return (0, json.dumps(view), "")
-        return (1, "", "no stub")
-
-    monkeypatch.setattr(github_resource, "_gh", fake_gh)
-    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
-
-    info = github_info(str(repo))
-    assert info["pr"]["number"] == 5
-    # No upstream → bare gh pr view, never gh pr list.
     assert any(c[:2] == ("pr", "view") for c in calls)
     assert not any(c[:2] == ("pr", "list") for c in calls)
 
 
-def test_github_info_pushed_ref_matches_branch_uses_pr_view_not_list(
-    repo: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A branch pushed under its own name resolves via bare ``gh pr view``, not list.
+def test_github_info_no_pr(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A branch with no PR yields ``pr``/``base_ref`` null (bare ``gh pr view`` empty)."""
 
-    Regression: on a base branch like ``master`` the pushed ref equals the local
-    name, so a bare ``gh pr view`` (which correctly finds no PR) must be used.
-    ``gh pr list --head`` matches the ref name alone and would return a
-    stranger's unrelated PR whose head merely shares the name — a false positive.
-    """
-    _set_pushed_ref(repo, "feature")  # pushed ref == local branch name
-    calls: list[tuple[str, ...]] = []
-
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
-        calls.append(tuple(argv))
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
         head = tuple(argv[:2])
         if head == ("auth", "status"):
             return (0, "", "")
@@ -229,9 +170,6 @@ def test_github_info_pushed_ref_matches_branch_uses_pr_view_not_list(
             return (0, json.dumps({"nameWithOwner": "o/r"}), "")
         if head == ("pr", "view"):
             return (1, "", "no pull requests found for branch")
-        if head == ("pr", "list"):
-            # A stranger's PR sharing the ref name — must never be consulted here.
-            return (0, json.dumps([{"number": 999, "headRefName": "feature"}]), "")
         return (1, "", "no stub")
 
     monkeypatch.setattr(github_resource, "_gh", fake_gh)
@@ -240,23 +178,311 @@ def test_github_info_pushed_ref_matches_branch_uses_pr_view_not_list(
     info = github_info(str(repo))
     assert info["pr"] is None
     assert info["base_ref"] is None
-    assert not any(c[:2] == ("pr", "list") for c in calls)
 
 
-def test_github_changed_files_via_pr_list_head(
+def test_github_info_pr_via_commit_fork_fallback(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The changed-files list resolves the PR number via ``gh pr list --head`` too.
-
-    Exercises the second call site (:func:`_pr_number`): ``gh pr list --head``
-    supplies the number, then the files fetch runs.
+    """A fork PR (``git pp`` to a fork, renamed remote branch): ``gh pr view`` misses
+    on the branch name, but the pushed commit resolves the PR from the FORK repo,
+    and the PR is then fetched from its own base repo.
     """
-    _set_pushed_ref(repo, "alice/feature")
+    # origin is the fork the branch was pushed to; the PR's base is upstream.
+    _run(["git", "remote", "add", "origin", "git@github.com:daniellok-db/repo.git"], repo)
+    pr = {
+        "number": 77,
+        "title": "Renamed head",
+        "state": "OPEN",
+        "url": "https://github.com/acme/repo/pull/77",
+        "isDraft": False,
+        "author": {"login": "daniellok-db"},
+        "baseRefName": "main",
+        "headRefName": "daniellok-db/feature",
+        "statusCheckRollup": [],
+    }
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        if list(argv[:4]) == ["auth", "status", "--json", "hosts"]:
+            me = {"login": "daniellok-db", "active": True, "state": "success"}
+            return (0, json.dumps({"hosts": {"github.com": [me]}}), "")
+        if tuple(argv[:2]) == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "acme/repo"}), "")
+        # Current-branch lookup misses (gh can't name the renamed fork head).
+        if tuple(argv[:2]) == ("pr", "view") and argv[2] == "--json":
+            return (1, "", 'no pull requests found for branch "daniellok-db:feature"')
+        # The commit lives in the fork, so only the fork's commits/pulls matches.
+        if argv[0] == "api" and "repos/daniellok-db/repo/commits/" in argv[1]:
+            row = {"number": 77, "state": "open", "base": {"repo": {"full_name": "acme/repo"}}}
+            return (0, json.dumps([row]), "")
+        # The full object is fetched from the PR's base repo via explicit -R.
+        if tuple(argv[:2]) == ("pr", "view") and "-R" in argv:
+            assert argv[argv.index("-R") + 1] == "acme/repo"
+            assert argv[2] == "77"
+            return (0, json.dumps(pr), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"]["number"] == 77
+    assert info["pr"]["head_ref"] == "daniellok-db/feature"
+    assert info["base_ref"] == "main"
+    # Resolved via the FORK's commits/{sha}/pulls, never a base-repo branch list.
+    assert any(c[0] == "api" and "daniellok-db/repo/commits/" in c[1] for c in calls)
+
+
+def test_github_info_no_false_positive_on_default_branch(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On master, the commit fallback must NOT surface the merged PR that
+    introduced the tip: gh pr view finds nothing and the fallback returns a
+    closed row, so github_info reports no PR."""
+    _run(["git", "remote", "add", "origin", "git@github.com:daniellok-db/repo.git"], repo)
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        if list(argv[:4]) == ["auth", "status", "--json", "hosts"]:
+            me = {"login": "daniellok-db", "active": True, "state": "success"}
+            return (0, json.dumps({"hosts": {"github.com": [me]}}), "")
+        if tuple(argv[:2]) == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "acme/repo"}), "")
+        if tuple(argv[:2]) == ("pr", "view"):  # no open PR for master
+            return (1, "", 'no pull requests found for branch "daniellok-db:feature"')
+        if argv[0] == "api" and "/commits/" in argv[1]:
+            # commits/{master-tip}/pulls → the MERGED PR that introduced the tip.
+            row = {
+                "number": 20050,
+                "state": "closed",
+                "base": {"ref": "feature", "repo": {"full_name": "acme/repo"}},
+            }
+            return (0, json.dumps([row]), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"] is None
+    assert info["base_ref"] is None
+    # It did consult the commit endpoint (so this proves the closed row was
+    # rejected, not that the fallback was skipped) but never fetched the PR body.
+    assert any(c[0] == "api" and "/commits/" in c[1] for c in calls)
+    assert not any(tuple(c[:2]) == ("pr", "view") and "-R" in c for c in calls)
+
+
+def test_resolve_pr_via_commit_prefers_open(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When one commit maps to several PRs (a stack), the open one is chosen, and
+    the PR's own base repo is returned alongside the number."""
+    monkeypatch.setattr(github_resource, "_commit_lookup_repo", lambda _root: "acme/repo")
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if argv[0] == "api" and argv[1].endswith("/pulls"):
+            rows = [
+                {"number": 1, "state": "closed", "base": {"repo": {"full_name": "acme/repo"}}},
+                {"number": 2, "state": "open", "base": {"repo": {"full_name": "acme/repo"}}},
+            ]
+            return (0, json.dumps(rows), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    assert github_resource._resolve_pr_via_commit(str(repo)) == (2, "acme/repo")
+
+
+def test_resolve_pr_via_commit_rejects_closed_only(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only closed/merged rows → None. On master the endpoint returns the merged
+    PR that introduced the tip; that's a false positive, not the branch's PR."""
+    monkeypatch.setattr(github_resource, "_commit_lookup_repo", lambda _root: "mlflow/mlflow")
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if argv[0] == "api" and argv[1].endswith("/pulls"):
+            # A merged PR whose base is master — what /commits/{master-tip}/pulls returns.
+            rows = [
+                {
+                    "number": 20050,
+                    "state": "closed",
+                    "base": {"ref": "master", "repo": {"full_name": "mlflow/mlflow"}},
+                }
+            ]
+            return (0, json.dumps(rows), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    assert github_resource._resolve_pr_via_commit(str(repo)) is None
+
+
+def test_resolve_pr_via_commit_none_without_repo(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No push-target repo (no remote) → returns None without an API call."""
+    monkeypatch.setattr(github_resource, "_commit_lookup_repo", lambda _root: None)
+    called: list[tuple[str, ...]] = []
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        called.append(tuple(argv))
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    assert github_resource._resolve_pr_via_commit(str(repo)) is None
+    assert not any(c[0] == "api" for c in called)
+
+
+def test_commit_lookup_repo_prefers_tracking_remote(repo: Path) -> None:
+    """The single push target is the branch's tracking remote (the fork), not the
+    base — and just `origin` when no tracking remote is configured."""
+    _run(["git", "remote", "add", "origin", "git@github.com:daniellok-db/repo.git"], repo)
+    _run(["git", "remote", "add", "upstream", "git@github.com:acme/repo.git"], repo)
+    # No branch.feature.remote yet → falls back to origin.
+    assert github_resource._commit_lookup_repo(str(repo)) == "daniellok-db/repo"
+    # With a tracking remote set, that wins.
+    _run(["git", "config", "branch.feature.remote", "upstream"], repo)
+    assert github_resource._commit_lookup_repo(str(repo)) == "acme/repo"
+
+
+def test_head_commit_shas_includes_head(repo: Path) -> None:
+    """HEAD is always a candidate SHA (a fresh branch has no @{push})."""
+    import subprocess as _sp
+
+    head = _sp.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    assert head in github_resource._head_commit_shas(str(repo))
+
+
+def test_github_info_enumerates_accounts_only_when_repo_unreachable(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Accounts (for the selector) are enumerated only when the repo can't be
+    reached — no PR resolves AND `gh repo view` fails."""
+    hosts = {
+        "hosts": {
+            "github.com": [
+                {"login": "alice", "active": True, "state": "success"},
+                {"login": "bob", "active": False, "state": "success"},
+            ]
+        }
+    }
+    monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/x")
+    monkeypatch.setattr(github_resource._config, "github_account_preference", lambda _key: None)
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if list(argv[:4]) == ["auth", "status", "--json", "hosts"]:
+            return (0, json.dumps(hosts), "")
+        # No PR, and the repo can't be reached → repo-unresolved.
+        return (1, "", "no access")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert {a["login"] for a in info["accounts"]} == {"alice", "bob"}
+    # No stored preference → the active account is selected. No `remotes` field.
+    assert info["selected_account"] == "alice"
+    assert "remotes" not in info and "default_remote" not in info
+
+
+def test_github_info_skips_account_enumeration_on_happy_path(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When a PR resolves, github_info skips `gh auth status` and `gh repo view`
+    entirely (deriving the repo from the PR URL)."""
+    monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/x")
+    monkeypatch.setattr(github_resource._config, "github_account_preference", lambda _key: None)
+    pr = {
+        "number": 42,
+        "title": "t",
+        "state": "OPEN",
+        "url": "https://github.com/acme/repo/pull/42",
+        "isDraft": False,
+        "author": {"login": "a"},
+        "baseRefName": "main",
+        "headRefName": "feature",
+        "statusCheckRollup": [],
+    }
+    calls: list[tuple[str, ...]] = []
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        if tuple(argv[:2]) == ("pr", "view"):
+            return (0, json.dumps(pr), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    assert info["pr"]["number"] == 42
+    assert info["repo"] == {"name_with_owner": "acme/repo"}  # derived from pr.url
+    assert info["authenticated"] is True
+    # The two per-poll network calls are gone on the happy path.
+    assert not any(c[:4] == ("auth", "status", "--json", "hosts") for c in calls)
+    assert not any(c[:2] == ("repo", "view") for c in calls)
+    assert "accounts" not in info
+
+
+def test_github_info_runs_gh_as_preferred_account(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The workspace's stored account is applied as GH_TOKEN on the API calls."""
+    monkeypatch.delenv("IS_SANDBOX", raising=False)
+    monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/omnigent")
+    monkeypatch.setattr(
+        github_resource._config,
+        "github_account_preference",
+        lambda key: "bob" if key == "/ws/omnigent" else None,
+    )
+    monkeypatch.setattr(github_resource, "_gh_auth_token", lambda _root, login: f"tok-{login}")
+    seen: dict[str, str | None] = {}
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if tuple(argv[:2]) == ("repo", "view"):
+            seen["repo_view"] = token
+            return (0, json.dumps({"nameWithOwner": "acme/repo"}), "")
+        if tuple(argv[:2]) == ("pr", "view"):
+            seen["pr_view"] = token
+            return (1, "", "no pr")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    # No PR (pr view fails) → falls to the repo-view reachability probe; both run
+    # as the preferred account's token.
+    github_info(str(repo))
+    assert seen["pr_view"] == "tok-bob"
+    assert seen["repo_view"] == "tok-bob"
+
+
+def test_github_changed_files_via_pr_view(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The changed-files list resolves the PR number via bare ``gh pr view``, then fetches."""
     files = [{"filename": "a.py", "status": "added", "additions": 1, "deletions": 0}]
 
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
-        if tuple(argv[:2]) == ("pr", "list"):
-            return (0, json.dumps([{"number": 9}]), "")
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if tuple(argv[:2]) == ("pr", "view"):
+            return (0, json.dumps({"number": 9}), "")
         if argv and argv[0] == "api":
             return (0, json.dumps(files), "")
         return (1, "", "no stub")
@@ -344,22 +570,20 @@ def test_github_pr_diff_no_pr(monkeypatch: pytest.MonkeyPatch) -> None:
     assert github_pr_diff("/root") == {"object": "session.github.pr_diff", "patch": ""}
 
 
-def test_github_pr_diff_via_pr_list_head(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The whole-PR diff resolves the PR number via ``gh pr list --head``, then diffs it.
-
-    Mirrors the fork / triangular case: a bare ``gh pr diff`` can't resolve the
-    head, so the number is resolved by the pushed ref (``branch.<n>.merge``) and
-    passed to ``gh pr diff <number>``.
-    """
-    _set_pushed_ref(repo, "alice/feature")
+def test_github_pr_diff_resolves_number_then_diffs(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole-PR diff resolves the number via ``gh pr view``, then ``gh pr diff <n>``."""
     patch = "diff --git a/a.py b/a.py\n@@ -1 +1 @@\n-x\n+y\n"
     calls: list[tuple[str, ...]] = []
 
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
         calls.append(tuple(argv))
         head = tuple(argv[:2])
-        if head == ("pr", "list"):
-            return (0, json.dumps([{"number": 9}]), "")
+        if head == ("pr", "view"):
+            return (0, json.dumps({"number": 9}), "")
         if head == ("pr", "diff"):
             return (0, patch, "")
         return (1, "", "no stub")
@@ -369,6 +593,131 @@ def test_github_pr_diff_via_pr_list_head(repo: Path, monkeypatch: pytest.MonkeyP
     assert result == {"object": "session.github.pr_diff", "patch": patch}
     # The diff was fetched by the resolved number, never a bare 'gh pr diff'.
     assert [c for c in calls if c[:2] == ("pr", "diff")] == [("pr", "diff", "9")]
+
+
+# ── Account selection ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/acme/repo.git", "acme/repo"),
+        ("https://github.com/acme/repo", "acme/repo"),
+        ("https://user@github.com/acme/repo.git", "acme/repo"),
+        ("git@github.com:alice/repo.git", "alice/repo"),
+        ("ssh://git@github.com/acme/repo.git", "acme/repo"),
+        ("not a url", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_owner_repo_from_url(url: str | None, expected: str | None) -> None:
+    """Owner/repo parsing handles HTTPS / SSH / scp forms and rejects junk."""
+    assert github_resource._owner_repo_from_url(url) == expected
+
+
+def test_list_accounts_parses_hosts_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`gh auth status --json hosts` yields the accounts and the authed boolean."""
+    hosts = {
+        "hosts": {
+            "github.com": [
+                {"login": "alice", "active": True, "state": "success"},
+                {"login": "bob", "active": False, "state": "success"},
+            ]
+        }
+    }
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if list(argv[:4]) == ["auth", "status", "--json", "hosts"]:
+            return (0, json.dumps(hosts), "")
+        return (1, "", "")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    authed, accounts = github_resource._list_accounts("/root")
+    assert authed is True
+    assert [a["login"] for a in accounts] == ["alice", "bob"]
+    assert accounts[0]["active"] is True
+
+
+def test_list_accounts_falls_back_on_old_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An old gh without ``--json hosts`` → plain ``gh auth status`` decides the bool."""
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if "--json" in argv:
+            return (1, "", "unknown flag: --json")
+        if tuple(argv[:2]) == ("auth", "status"):
+            return (0, "", "")
+        return (1, "", "")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    authed, accounts = github_resource._list_accounts("/root")
+    assert authed is True
+    assert accounts == []
+
+
+def test_account_token_for_none_in_sandbox(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sandbox keeps its single broker identity — never a per-workspace override."""
+    monkeypatch.setenv("IS_SANDBOX", "1")
+    monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/omnigent")
+    monkeypatch.setattr(github_resource._config, "github_account_preference", lambda _key: "bob")
+    assert github_resource._account_token_for("/root") is None
+
+
+def test_account_token_for_none_without_preference(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No stored preference → no override (gh's active account is used)."""
+    monkeypatch.delenv("IS_SANDBOX", raising=False)
+    monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/omnigent")
+    monkeypatch.setattr(github_resource._config, "github_account_preference", lambda _key: None)
+    assert github_resource._account_token_for("/root") is None
+
+
+def test_set_github_preference_sets_default_and_account(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A selection runs ``gh repo set-default`` (remote) and stores the account pref
+    keyed by the workspace, not the base repo."""
+    calls: list[tuple[str, ...]] = []
+    saved: dict[str, str | None] = {}
+    monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/omnigent")
+    monkeypatch.setattr(
+        github_resource._config,
+        "set_github_account_preference",
+        lambda key, login, *a, **k: saved.update({"key": key, "login": login}),
+    )
+    monkeypatch.setattr(github_resource, "github_info", lambda _root: {"stub": True})
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        calls.append(tuple(argv))
+        return (0, "", "")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    out = github_resource.set_github_preference(str(repo), account="bob", remote="fork")
+    assert ("repo", "set-default", "fork") in calls
+    assert saved == {"key": "/ws/omnigent", "login": "bob"}
+    assert out == {"stub": True}
+
+
+def test_workspace_key_shared_across_worktrees(repo: Path) -> None:
+    """The key is the main worktree path, so a linked worktree resolves to it too."""
+    import os
+
+    key_main = github_resource._workspace_key(str(repo))
+    assert key_main is not None
+    # Points at the main worktree (realpath-compared: git resolves symlinks).
+    assert os.path.realpath(key_main) == os.path.realpath(str(repo))
+    # A linked worktree of the same repo yields the SAME key (shared .git).
+    wt = repo.parent / f"{repo.name}-wt"
+    _run(["git", "worktree", "add", "-b", "wt-feature", str(wt)], repo)
+    assert github_resource._workspace_key(str(wt)) == key_main
+
+
+# ── _gh environment handling ─────────────────────────────────────────────────
 
 
 def test_summarize_checks_mixed() -> None:
@@ -443,7 +792,9 @@ def test_github_info_includes_body_and_comments(
         ],
     }
 
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
         head = tuple(argv[:2])
         if head == ("auth", "status"):
             return (0, "", "")
@@ -485,7 +836,9 @@ def test_github_info_empty_body_is_null(repo: Path, monkeypatch: pytest.MonkeyPa
         "comments": [],
     }
 
-    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
         head = tuple(argv[:2])
         if head == ("auth", "status"):
             return (0, "", "")
@@ -559,3 +912,22 @@ def test_gh_inherits_env_outside_sandbox(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(github_resource, "_run", fake_run)
     github_resource._gh(["pr", "diff"], cwd="/tmp")
     assert captured["env"] is None
+
+
+def test_gh_applies_account_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An explicit token runs this one call as the selected account: GH_TOKEN is
+    # set to it and any stray GITHUB_TOKEN is dropped so it can't win.
+    monkeypatch.delenv("IS_SANDBOX", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "stray")
+    captured: dict[str, object] = {}
+
+    def fake_run(argv: Sequence[str], *, cwd: str, timeout: float, env=None):
+        captured["env"] = env
+        return 0, "", ""
+
+    monkeypatch.setattr(github_resource, "_run", fake_run)
+    github_resource._gh(["pr", "view"], cwd="/tmp", token="chosen-tok")
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GH_TOKEN"] == "chosen-tok"
+    assert "GITHUB_TOKEN" not in env

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -5747,6 +5747,10 @@ class _OfflineRunnerClient:
         del params, timeout
         raise OmnigentError(f"runner is not connected ({url})", code=ErrorCode.RUNNER_UNAVAILABLE)
 
+    async def post(self, url: str, *, json: Any = None, timeout: float | None = None) -> Any:
+        del json, timeout
+        raise OmnigentError(f"runner is not connected ({url})", code=ErrorCode.RUNNER_UNAVAILABLE)
+
 
 @pytest.fixture
 def offline_env_app(
@@ -5926,6 +5930,49 @@ async def test_github_diff_falls_back_to_host_when_runner_offline(
     assert resp.json()["after"] == "changed"
     assert captured["op"] == "github_diff"
     assert captured["params"] == {"base": "main", "path": "app.py"}
+
+
+@pytest.mark.asyncio
+async def test_github_set_preference_falls_back_to_host_when_runner_offline(
+    offline_env_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The preference WRITE is served over the host tunnel when the runner is offline.
+
+    Proves the POST endpoint's runner-offline branch routes to the host write op
+    with the selection params, and returns the refreshed info.
+    """
+    from omnigent.server.routes import _host_filesystem
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_write(
+        *,
+        host_registry: Any,
+        host_conn: Any,
+        op: str,
+        workspace: str,
+        session_id: str,
+        params: Any,
+    ) -> dict[str, Any]:
+        del host_registry, host_conn, session_id
+        captured["op"] = op
+        captured["workspace"] = workspace
+        captured["params"] = params
+        return {"object": "session.github.info", "available": True, "selected_account": "octocat"}
+
+    monkeypatch.setattr(_host_filesystem, "write_workspace_from_host", _fake_write)
+
+    resp = await offline_env_client.post(
+        f"/v1/sessions/{_OFFLINE_SESSION}/resources/github/preferences",
+        json={"account": "octocat"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["selected_account"] == "octocat"
+    assert captured["op"] == "github_set_preference"
+    assert captured["workspace"] == _OFFLINE_WORKSPACE
+    assert captured["params"] == {"account": "octocat", "remote": None}
 
 
 # ── Workspace-file gzip (GZipFileContentRoute) ───────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import pytest
 
-from omnigent.config import _merge_effective_config, global_config_path, load_effective_config
+from omnigent.config import (
+    _merge_effective_config,
+    github_account_preference,
+    global_config_path,
+    load_effective_config,
+    load_global_config,
+    save_global_config,
+    set_github_account_preference,
+)
 
 
 def test_effective_config_deep_merges_harness_mapping(
@@ -79,3 +87,49 @@ def test_effective_config_merges_project_over_user(
     monkeypatch.chdir(project)
 
     assert load_effective_config() == {"profile": "local", "model": "global-model"}
+
+
+def test_github_account_preference_round_trip(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    key = "/Users/daniel.lok/omnigent"
+    assert github_account_preference(key, cfg) is None
+    set_github_account_preference(key, "daniellok-db", cfg)
+    assert github_account_preference(key, cfg) == "daniellok-db"
+    # The key is a filesystem path, matched verbatim — NOT case-folded.
+    assert github_account_preference(key.upper(), cfg) is None
+
+
+def test_set_github_account_preference_preserves_other_workspaces(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    set_github_account_preference("/Users/daniel.lok/omnigent", "daniellok-db", cfg)
+    set_github_account_preference("/Users/daniel.lok/mlflow", "daniel-lok_data", cfg)
+    # A second workspace's pref doesn't clobber the first.
+    assert github_account_preference("/Users/daniel.lok/omnigent", cfg) == "daniellok-db"
+    assert github_account_preference("/Users/daniel.lok/mlflow", cfg) == "daniel-lok_data"
+
+
+def test_set_github_account_preference_clear(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    key = "/Users/daniel.lok/omnigent"
+    set_github_account_preference(key, "daniellok-db", cfg)
+    set_github_account_preference(key, "", cfg)  # empty clears the entry
+    assert github_account_preference(key, cfg) is None
+
+
+def test_save_global_config_preserves_unrelated_keys(tmp_path: Path) -> None:
+    cfg = tmp_path / "config.yaml"
+    set_github_account_preference("/Users/daniel.lok/omnigent", "daniellok-db", cfg)
+    save_global_config({"default_agent": "/x/agent.yaml"}, path=cfg)
+    # The general writer merges rather than truncating: both keys survive.
+    assert github_account_preference("/Users/daniel.lok/omnigent", cfg) == "daniellok-db"
+    assert load_global_config(cfg).get("default_agent") == "/x/agent.yaml"
+
+
+def test_save_global_config_respects_config_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    set_github_account_preference("/Users/daniel.lok/omnigent", "daniellok-db")
+    # Written to (and read back from) OMNIGENT_CONFIG_HOME/config.yaml.
+    assert (tmp_path / "config.yaml").exists()
+    assert github_account_preference("/Users/daniel.lok/omnigent") == "daniellok-db"

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -397,7 +397,7 @@ def test_github_changes_lists_pr_files(tmp_path: Path, monkeypatch) -> None:
 
     _git_branch_repo(tmp_path)
 
-    def fake_gh(argv, *, cwd):
+    def fake_gh(argv, *, cwd, token=None):
         if tuple(argv[:2]) == ("pr", "view"):
             return (0, '{"number": 3}', "")
         if tuple(argv[:1]) == ("api",):
@@ -434,7 +434,7 @@ def test_github_pr_diff_returns_whole_patch(tmp_path: Path, monkeypatch) -> None
 
     _git_branch_repo(tmp_path)
 
-    def fake_gh(argv, *, cwd):
+    def fake_gh(argv, *, cwd, token=None):
         if tuple(argv[:2]) == ("pr", "view"):
             return (0, '{"number": 3}', "")
         if tuple(argv[:2]) == ("pr", "diff"):

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -13,7 +13,7 @@
 // Runner-offline (503 runner_unavailable) and no-os_env (404) are handled the
 // same way as the workspace filesystem hooks — reusing their helpers.
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
 import {
   isRunnerUnavailable503,
@@ -78,6 +78,16 @@ export interface GithubRepo {
   name_with_owner: string | null;
 }
 
+/** A `gh`-configured account — one option in the panel's account selector. */
+export interface GithubAccount {
+  login: string;
+  /** Whether this is gh's currently-active account for the host. */
+  active: boolean;
+  /** gh's per-account validation state, e.g. "success" (null on old gh). */
+  state: string | null;
+  host: string | null;
+}
+
 /** Why the panel can't show GitHub content.
  *  - `not_a_git_repo` — the workspace exists but isn't a git checkout.
  *  - `no_os_env` — no workspace/filesystem to read (404 from a current host).
@@ -102,6 +112,11 @@ export interface GithubInfo {
   /** The PR's base branch; null when there's no PR (the tab is a PR view). */
   base_ref?: string | null;
   pr?: GithubPr | null;
+  /** Configured gh accounts (the account selector's options). */
+  accounts?: GithubAccount[];
+  /** The login gh runs as for this workspace — the per-workspace preference,
+   *  else the active account. */
+  selected_account?: string | null;
 }
 
 /** A file changed on the branch relative to its base. Same shape as the
@@ -261,6 +276,54 @@ export function useGithubInfo(conversationId: string | undefined, options?: { po
     staleTime: 30_000,
     refetchInterval: options?.poll ? (query) => computeGithubPollInterval(query.state.data) : false,
     refetchIntervalInBackground: false,
+  });
+}
+
+/** The account (a gh login) and/or base repo (a git remote name or `owner/repo`)
+ *  to pin for this session's workspace. Either may be omitted to leave it as-is;
+ *  an empty `account` clears the per-repo preference. */
+export interface GithubPreferenceInput {
+  account?: string;
+  remote?: string;
+}
+
+async function postGithubPreference(
+  conversationId: string,
+  body: GithubPreferenceInput,
+): Promise<GithubInfo> {
+  const res = await authenticatedFetch(
+    `/v1/sessions/${encodeURIComponent(conversationId)}/resources/github/preferences`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  if (res.status === 503 && (await isRunnerUnavailable503(res))) {
+    throw new RunnerOfflineError();
+  }
+  if (!res.ok) throw await errorFromResponse(res);
+  return (await res.json()) as GithubInfo;
+}
+
+/**
+ * Apply the panel's account / base-repo selection for a session.
+ *
+ * The runner persists the choice (`gh repo set-default` for the base repo; a
+ * per-repo account preference in the user config) and returns the refreshed
+ * info, which we seed straight into the `github-info` cache. Because a different
+ * account/base can resolve a different PR, the PR-derived queries (changed files,
+ * whole-PR diff) are invalidated so they refetch. Requires the runner online.
+ */
+export function useSetGithubPreference(conversationId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: GithubPreferenceInput) => postGithubPreference(conversationId!, body),
+    onSuccess: (info) => {
+      queryClient.setQueryData(["github-info", conversationId], info);
+      queryClient.invalidateQueries({ queryKey: ["github-changed-files", conversationId] });
+      queryClient.invalidateQueries({ queryKey: ["github-pr-diff", conversationId] });
+    },
   });
 }
 

--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -36,6 +36,14 @@ vi.mock("@/hooks/useGithub", () => ({
     isFetching: false,
   }),
   fetchGithubFileContents: async () => ({ before: "old", after: "new" }),
+  // The account selector (shown in the repo-unresolved empty state) calls this;
+  // stub the mutation shape it reads.
+  useSetGithubPreference: () => ({
+    mutate: () => {},
+    isPending: false,
+    isError: false,
+    error: null,
+  }),
 }));
 
 // The diff rendering (@pierre/diffs) is exercised by the library itself; here

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -53,6 +53,13 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/h
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { MessageResponse } from "@/components/ai-elements/message";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { useResizableColumn } from "@/hooks/useResizableColumn";
 import { RunnerOfflineError } from "@/hooks/useWorkspaceChangedFiles";
@@ -63,6 +70,7 @@ import {
   useGithubChangedFiles,
   useGithubInfo,
   useGithubPrDiff,
+  useSetGithubPreference,
   type GithubChangedFile,
   type GithubCheckRun,
   type GithubChecks,
@@ -83,22 +91,76 @@ function PanelMessage({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Full-panel empty state: an icon, a title, and an optional hint line. Used
- *  for every "no GitHub content to show" reason so they read as one family. */
+/** Full-panel empty state: an icon, a title, an optional hint line, and optional
+ *  children below (the account/remote selectors). Used for every "no GitHub
+ *  content to show" reason so they read as one family. */
 function GithubEmptyState({
   icon: Icon,
   title,
   hint,
+  children,
 }: {
   icon: LucideIcon;
   title: React.ReactNode;
   hint?: React.ReactNode;
+  children?: React.ReactNode;
 }) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
       <Icon className="size-8 text-muted-foreground/50" />
       <p className="text-ui font-medium text-foreground">{title}</p>
       {hint && <p className="max-w-xs text-ui text-muted-foreground">{hint}</p>}
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Account switcher — the one PR-resolution lever that can't be inferred: it picks
+ * which signed-in identity `gh` runs as, i.e. which account can even see the repo.
+ * Shown ONLY when the upstream repo can't be reached (the `repo-unresolved` empty
+ * state), since that's an access problem the account can fix. Once the repo
+ * resolves, the account is correct — surfacing the knob then would just invite a
+ * misconfiguration, so it's absent from the header and the `no-pr` state. Renders
+ * nothing with a single account (nothing to choose).
+ */
+function GithubAccountSelector({
+  conversationId,
+  info,
+}: {
+  conversationId: string;
+  info: GithubInfo;
+}) {
+  const setPref = useSetGithubPreference(conversationId);
+  const accounts = info.accounts ?? [];
+  if (accounts.length <= 1) return null;
+
+  const selectedAccount = info.selected_account ?? undefined;
+
+  return (
+    <div className="flex w-full max-w-xs flex-col items-center gap-2 pt-2">
+      <Select
+        value={selectedAccount}
+        onValueChange={(login) => setPref.mutate({ account: login })}
+        disabled={setPref.isPending}
+      >
+        <SelectTrigger aria-label="GitHub account" className="h-8 w-full text-ui">
+          <SelectValue placeholder="Account" />
+        </SelectTrigger>
+        <SelectContent>
+          {accounts.map((a) => (
+            <SelectItem key={a.login} value={a.login}>
+              {a.login}
+              {a.active ? " (active)" : ""}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {setPref.isError && (
+        <p className="text-ui text-red-600 dark:text-red-400">
+          Couldn’t apply: {(setPref.error as Error).message}
+        </p>
+      )}
     </div>
   );
 }
@@ -884,14 +946,18 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
           title="Can’t reach the upstream repo"
           hint={
             <>
-              Run <span className="font-mono">gh auth status</span> on the host to confirm the
-              GitHub CLI is signed in to the right account.
+              Pick the account to use, or run <span className="font-mono">gh auth status</span> on
+              the host to confirm the GitHub CLI is signed in.
             </>
           }
-        />
+        >
+          {info.data && <GithubAccountSelector conversationId={conversationId} info={info.data} />}
+        </GithubEmptyState>
       );
     case "no-pr":
       // TODO: offer a "Create PR" action here once the panel can open PRs.
+      // No account selector here: the repo resolved, so the account is correct —
+      // this is a genuine "no PR yet", not a misconfiguration to fix.
       return (
         <GithubEmptyState
           icon={GitPullRequestIcon}


### PR DESCRIPTION
## Related issue

Closes # <!-- no tracked issue; UX/reliability improvement to the session GitHub panel -->


https://github.com/user-attachments/assets/6fdd8e70-4f55-4aee-981d-9ec878cd407a


## Summary

Reworks how the session **GitHub rail** resolves a branch's PR and which `gh` identity it runs as, so fork / triangular PRs resolve reliably (and faster), and a wrong-account state is fixable from the UI. Builds on top of the Summary/Changes tabs from #6678.

- **Deterministic PR resolution.** Replaces the old branch-name / `gh pr list --head` heuristic. When `gh pr view` can't name the head (a fork, or a renamed remote branch from `git pp` / `git-stack`), the PR is looked up by the **pushed commit** via `repos/{owner}/{repo}/commits/{sha}/pulls` against the push-target repo — which reports the PR's own base repo, so the fetch doesn't depend on `gh repo set-default`. Only **open** PRs are accepted, so `main`/`master` (whose tip is always "introduced by" a merged PR) no longer surfaces a stale merged PR.
- **Per-workspace account selection.** A preference keyed by the **main worktree path** (so it's shared across a repo's worktrees) runs every `gh` call as the chosen login — `GH_TOKEN=$(gh auth token --user <login>)` — gated to local dev. The **account selector shows only in the "can't reach the upstream repo" empty state** — the one place it fixes something; once the repo resolves, the account is correct, so no knob is shown (header/no-PR states don't offer it). The base repo needs no selector: it's auto-resolved from the PR, and `gh repo set-default` is set under the hood for the terminal's own `gh`.
- **Works with the runner asleep.** The preference write is served over the host tunnel (new `HostFsWriteFrame`) when the runner is offline, matching the existing read fallbacks.
- **Fewer network calls.** `github_info` resolves the PR first, so `gh auth status` and `gh repo view` are skipped on the happy path; the commit fallback queries a single push-target repo.

**ELI5:** the panel used to *guess* who you are and which repo when finding your PR, and could show a stale merged PR. Now it finds the PR by the commit you pushed, and only asks you to pick a GitHub account when it genuinely can't reach the repo.

```
gh pr view --json  ──▶ hit? use it (repo derived from the PR URL)
        │ miss (fork / renamed head)
        ▼
commit fallback:  repos/<push-target>/commits/<@{push}|HEAD>/pulls  ──▶ open PR only
        │  (→ number + base repo)                                        (closed/merged → skip: no default-branch false positive)
        ▼
gh pr view <n> -R <base> --json   run as the workspace's preferred account
```

## Test Plan

- **Unit (backend):** `tests/runner/test_github_resource.py`, `tests/test_config.py`, `tests/test_workspace_fs.py`, `tests/server/routes/test_session_resources.py`, `tests/host/test_frames.py`, `tests/host/test_connect.py` — all green. Covers commit-identity resolution, the open-only filter (no default-branch false positive), the per-workspace account key + `GH_TOKEN` application (and its sandbox no-op), the host-served preference write, and the perf reorder (`auth status` / `repo view` skipped once a PR resolves).
- **Web:** `GithubPanel.test.tsx` (21) green; `tsc -b`, `oxlint`, and `prettier --check` clean.
- **Lint/type (py):** `ruff` + `pyrefly` (0 errors); `openapi.json` regenerated (`scripts/dump_openapi.py --check` clean) for the new preferences route.
- **Manual (local dev, two `gh` accounts):**
  - `~/mlflow` on `master` → correctly shows **"No open PR"** (previously surfaced a merged PR).
  - Fork PR via `git pp` (`~/mlflow`) and `git stack` (`~/universe`) → resolves by commit even though the remote branch name differs from the checkout; `~/universe` also required the non-active account, exercising the selector.
  - Switching the account in the "can't reach the upstream repo" state re-resolves the PR; `~/.omnigent/config.yaml` gains `github.accounts["/Users/.../<repo>"]`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

UI/frontend change, but the added visible surface is small — an account dropdown in the "can't reach the upstream repo" empty state (the Summary/Changes tabs themselves are from #6678). Repro: local dev with two `gh` accounts; open the GitHub tab on a repo the active account can't reach → the account dropdown appears → pick the account with access → the PR + diff render. A short screen recording can be attached here.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification (above) covered fork / `git pp` / `git-stack` resolution, the `master` no-false-positive case, and the account selector, on a real two-account local setup. Automated tests cover the resolution / selection / host-write logic. The account override is local-dev-only — a managed sandbox keeps its single broker identity (`_gh` scrubs ambient `GH_TOKEN` there) — so it isn't exercisable in CI.

## Changelog

The session GitHub panel now resolves fork and stacked-branch PRs reliably, no longer shows a stale merged PR on the default branch, and lets you pick which GitHub account to use when the repo can't be reached.
