### PR TITLE
fix(pending-inputs): serialize external item retries

### DIFF
--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -15,6 +15,7 @@ import re
 import secrets
 import time
 import uuid
+import weakref
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any, Literal, cast
 
@@ -2210,7 +2211,41 @@ async def _persist_external_codex_subagent_start(
     )
 
 
+_external_item_persist_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
+    weakref.WeakValueDictionary()
+)
+
+
+def _external_item_persist_lock(session_id: str) -> asyncio.Lock:
+    """Return the lock serializing transcript persistence for one session."""
+    lock = _external_item_persist_locks.get(session_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _external_item_persist_locks[session_id] = lock
+    return lock
+
+
 async def _persist_external_conversation_item(
+    session_id: str,
+    conv: Conversation,
+    body: SessionEventInput,
+    conversation_store: ConversationStore,
+    created_by: str | None = None,
+    background_title_coordinator: BackgroundSessionTitleCoordinator | None = None,
+) -> str:
+    """Serialize pending-input reconciliation with the corresponding append."""
+    async with _external_item_persist_lock(session_id):
+        return await _persist_external_conversation_item_impl(
+            session_id,
+            conv,
+            body,
+            conversation_store,
+            created_by,
+            background_title_coordinator,
+        )
+
+
+async def _persist_external_conversation_item_impl(
     session_id: str,
     conv: Conversation,
     body: SessionEventInput,

--- a/tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py
+++ b/tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py
@@ -171,7 +171,8 @@ def forwarder_dedup_server() -> Iterator[str]:
                 if resp.status_code == 200:
                     break
             except (httpx.ConnectError, httpx.ReadError):
-                pass
+                # The subprocess may still be starting; retry until the deadline.
+                continue
             time.sleep(0.2)
         else:
             proc.terminate()

--- a/tests/e2e/test_claude_native_forwarder_stall_replay_dedup_e2e.py
+++ b/tests/e2e/test_claude_native_forwarder_stall_replay_dedup_e2e.py
@@ -329,7 +329,7 @@ async def _drive_forwarder_through_a_stall(
         finally:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await task
+                _ = await task
     finally:
         fwd._post_external_conversation_item = real_post
 

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import threading
+import time
 from collections.abc import AsyncIterator, Callable, Iterator
 from pathlib import Path
 from typing import Any
@@ -4391,6 +4393,55 @@ async def test_kiro_duplicate_repost_restores_skipped_entries_unpersisted() -> N
         assert [entry["pending_id"] for entry in snapshot] == recorded
     finally:
         pending_inputs.reset_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_external_item_persistence_is_serialized_per_session() -> None:
+    """Concurrent retries cannot interleave pending-input reconciliation."""
+    from omnigent.server.routes.sessions import _persist_external_conversation_item
+
+    class _ConcurrentStore(_ConversationStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.active = 0
+            self.max_active = 0
+            self.guard = threading.Lock()
+
+        def append(self, conversation_id: str, items: list[Any]) -> list[Any]:
+            with self.guard:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+            try:
+                time.sleep(0.05)
+                return super().append(conversation_id, items)
+            finally:
+                with self.guard:
+                    self.active -= 1
+
+    store = _ConcurrentStore()
+    sid = "823dbd1aab969b5a813fac59bb977a77"
+    conv = store.get_conversation(sid)
+    assert conv is not None
+    body = SessionEventInput(
+        type="external_conversation_item",
+        data={
+            "item_type": "message",
+            "item_data": {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hello"}],
+                "agent": "claude-native-ui",
+            },
+            "response_id": "response-1",
+            "source_id": "response-1:0",
+        },
+    )
+
+    await asyncio.gather(
+        _persist_external_conversation_item(sid, conv, body, store),  # type: ignore[arg-type]
+        _persist_external_conversation_item(sid, conv, body, store),  # type: ignore[arg-type]
+    )
+
+    assert store.max_active == 1
 
 
 @pytest.mark.asyncio

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -6237,9 +6237,9 @@ def test_repeated_persisted_twin_batch_leaves_conversation_metadata_alone(
     after it already persisted: every item resolves to the stored row, so
     nothing inserts and the conversation must not look active.
     """
-    import omnigent.stores.conversation_store.sqlalchemy_store as store_mod
-
-    monkeypatch.setattr(store_mod, "now_epoch", lambda: 1000)
+    monkeypatch.setattr(
+        "omnigent.stores.conversation_store.sqlalchemy_store.now_epoch", lambda: 1000
+    )
     conv = conversation_store.create_conversation()
     item = NewConversationItem(
         type="message",
@@ -6249,7 +6249,9 @@ def test_repeated_persisted_twin_batch_leaves_conversation_metadata_alone(
     )
     conversation_store.append(conv.id, [item])
 
-    monkeypatch.setattr(store_mod, "now_epoch", lambda: 2000)
+    monkeypatch.setattr(
+        "omnigent.stores.conversation_store.sqlalchemy_store.now_epoch", lambda: 2000
+    )
     [a, b] = conversation_store.append(conv.id, [item, item])
     assert a.deduplicated is True
     assert b.deduplicated is True


### PR DESCRIPTION
## Related issue

Follow-up to #6654.

## Summary

Serialize external transcript-item persistence per session so concurrent retries cannot interleave pending-input drain, Kiro skipped-item batching, append, and restore. This preserves pending-input FIFO order and prevents attachments or authors from being assigned to a later message.

ELI5: retries for one session now pass through one doorway at a time, so each retry finishes reconciling the queue before the next begins.

```text
retry A ─┐
         ├─ per-session lock → drain → batch append → restore/publish
retry B ─┘
```

Also addresses the remaining static-analysis review comments in the two E2E fixtures and the store test.

## Test Plan

- `uv run pytest -q tests/server/routes/test_session_resources.py -k "kiro_external_prompt or kiro_skipped_entries or kiro_duplicate_repost or external_item_persistence_is_serialized"`
- `uv run pytest -q tests/stores/test_conversation_store.py -k "stable_id or repeated_persisted_twin_batch"`
- `pre-commit run --files omnigent/server/routes/_sessions/orchestration.py tests/server/routes/test_session_resources.py tests/e2e/test_claude_native_forwarder_retry_dedup_e2e.py tests/e2e/test_claude_native_forwarder_stall_replay_dedup_e2e.py tests/stores/test_conversation_store.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The concurrency regression test instruments overlapping store appends and verifies the maximum concurrency for one session is exactly one.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The targeted route tests cover concurrent serialization, Kiro skipped-entry ordering, and duplicate queue restoration. Store idempotency tests remain green.