### PR TITLE
fix(web): use shared copyText helper in invite URL copy button

### DIFF
--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -49,6 +49,7 @@ import {
 import { getCurrentIsAdmin, resolveIdentity } from "@/lib/identity";
 import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode } from "@/lib/capabilities";
+import { copyText } from "@/lib/clipboard";
 
 export function MembersPage() {
   const info = useServerInfo();
@@ -441,11 +442,11 @@ function CopyableValue({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
   const onCopy = async () => {
     try {
-      await navigator.clipboard.writeText(value);
+      await copyText(value);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     } catch {
-      // No clipboard permission — the input is still selectable.
+      // Clipboard unavailable — the input is still selectable.
     }
   };
   return (


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- The **Copy** button in the Invite URL dialog was silently broken on non-HTTPS origins (e.g. `http://omni.local`): `navigator.clipboard.writeText` requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) and throws when the page is served over plain HTTP.
- The existing `copyText()` helper in `web/src/lib/clipboard.ts` already handles this by falling back to `document.execCommand('copy')` when the async Clipboard API is unavailable. `MembersPage.tsx` was calling `navigator.clipboard.writeText` directly instead of using the shared helper.
- Fix: import and use `copyText()` in `CopyableValue`, matching the pattern used by every other copy button in the codebase.

## Test Plan

1. Start the dev server over `http://omni.local` (or any non-HTTPS/non-localhost origin).
2. Open Settings → Members as an admin.
3. Create an invite.
4. Click **Copy** in the Invite URL dialog.
5. Paste into a text field — the URL should be pasted correctly.
6. The button should flash "Copied" for 1.5 s.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The existing `MembersPage.test.tsx` test covers invite creation and URL display. The clipboard fallback path is exercised by existing tests for `lib/clipboard.ts`.

## Changelog

Copy button in the Invite URL dialog now works on HTTP (non-localhost) origins.