### PR TITLE
docs(repro/resolve): stop filming videos of static text

### DIFF
--- a/dev/recording-lanes.md
+++ b/dev/recording-lanes.md
@@ -18,12 +18,29 @@ which clip `kind` it produces and where it goes; this file is the how.
 ## What is expected to yield a recording
 
 A `web` / `mobile` / `terminal` / `cli` / `desktop` facet is expected to yield a recording:
-drive it on that surface and film it. Only an `api` facet — a failure no user
-observes on any surface (a wrong value in a response, an internal state a pytest
-asserts) — legitimately has no recording; `recordings: []` is correct there and is
-not a gap. Tests may drive and verify the journey, but the clip itself must show
-the product surface and user-visible outcome, never the test process, pytest
-output, assertions, logs, or a synthetic evidence-summary slide.
+drive it on that surface and film it. A facet legitimately has no recording when
+its outcome is not something a user *watches* — an `api` failure no user observes
+on any surface (a wrong value in a response, an internal state a pytest asserts),
+or a facet whose whole user-visible outcome is a static piece of text (an error
+string, a value, a log line) with nothing that moves on screen. For those,
+`recordings: []` is correct and not a gap: state the observed text and how you
+confirmed it in your prose/evidence instead. Tests may drive and verify the
+journey, but the clip itself must show the product surface and user-visible
+outcome, never the test process, pytest output, assertions, logs, or a synthetic
+evidence-summary slide.
+
+**A valid clip shows a live action producing the outcome — not static text
+asserting it.** A recording earns its place only when there is something to
+*watch*: a user action drives the surface and the product visibly responds — a
+terminal command executing and printing its result, a screen changing, a value
+updating, an error appearing in response to input. That is why filming a
+`terminal`/`cli` command is legitimate: the pane is live, the command runs, the
+output is the product's own behavior. What is **never** a recording is a clip
+whose content is just text sitting on screen — a summary slide, a narrated page,
+the reproduction test's own console output, or a hand-typed sentence "claiming"
+the bug reproduces. Those film your *assertion*, not the product, and a viewer
+learns nothing a written line wouldn't tell them better; describe the outcome in
+prose instead of manufacturing a video of it.
 
 **One verdict-appropriate clip per facet — nothing else.** Every recording must
 correspond to a facet, and its `kind` must match that facet's verdict. Do **not**

--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -376,6 +376,13 @@ leaked runner env), and the per-surface mechanics (`web` / `mobile` / `terminal`
 `not_reproduced` and `needs_more_info` facets have nothing to film — skip them.
 Name the clip `<before|fixed>-<facet>.<ext>` when you move it to a stable path.
 
+A clip must show a **live action producing the outcome** — a command executing
+and printing, a screen changing — never static text on screen asserting the bug.
+When a facet's whole user-visible outcome is a static piece of text (an error
+line, a value) with nothing to watch, do **not** manufacture a video of it: keep
+`recordings: []` and state the observed text in your evidence, per
+`dev/recording-lanes.md`.
+
 ## Output — the reproduction artifacts
 
 The **last thing in your final message** must be exactly one fenced ```json code
@@ -485,9 +492,12 @@ Field meanings:
   authored-but-unrendered VHS tape in the artifact, but do not declare it as a
   recording. Empty list when nothing valid was recorded.
 - `recording_unavailable_reason` — empty when every expected clip is present;
-  otherwise the concrete per-surface tooling or reachability blocker. For an
-  API-only bug, say that the evidence is textual. Never substitute a synthetic
-  fallback or test-runner video.
+  otherwise the concrete per-surface tooling or reachability blocker. For a bug
+  whose outcome is purely textual — an `api` facet, or a facet whose user-visible
+  result is just a static error line or value with nothing to watch — say the
+  evidence is textual and put the observed text in `evidence`; `recordings: []` is
+  correct and not a blocker. Never substitute a synthetic fallback or test-runner
+  video.
 
 Keep the prose before the block terse — the one exception is the full test
 source, which you paste in full. You produce the live-confirmed reproduction +

--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -614,7 +614,13 @@ produces*:
   and the handoff (`recordings`). Omit it **only** for the genuine environmental
   blockers named in `dev/recording-lanes.md` (tooling missing, server won't come
   online, `api`-surface facet with nothing to film) — and then say which, with the
-  evidence; never report an after-clip you didn't actually produce. When you run
+  evidence; never report an after-clip you didn't actually produce.
+- A clip must show a **live action producing the corrected outcome** — a command
+  runs and the pane prints it, a screen changes — never static text asserting the
+  fix works. When the fixed outcome is just a static line, value, or the absence
+  of an error with nothing to watch, do **not** film a video of text: keep
+  `recordings: []` for that facet and state the corrected text in your evidence
+  and the PR Demo section, per `dev/recording-lanes.md`. When you run
   inside a server-spawned runner (`OMNIGENT_RUNNER_ID` is set), a recorder
   `online: false` is **not** an environmental blocker until you have stripped the
   leaked runner/host env vars per `dev/recording-lanes.md`; an un-stripped
@@ -722,9 +728,12 @@ Once the set is genuinely green:
    before/after recordings in the **Demo** section: upload the files when your
    environment can attach media to the PR; otherwise link where they live (the
    CI run's artifact bundle, or the repro session) so reviewers can watch the
-   failure and the fix. When the bug is a Linear ticket and a Linear key is
-   available, also attach both recordings to the ticket (GraphQL `fileUpload` +
-   `attachmentCreate`) so the ticket carries the visual before/after.
+   failure and the fix. When a facet's outcome is purely textual (nothing to
+   film), put the observed before/after text in the **Demo** section in place of a
+   video, so the section is never left empty or padded with a video of text. When
+   the bug is a Linear ticket and a Linear key is available, also attach both
+   recordings to the ticket (GraphQL `fileUpload` + `attachmentCreate`) so the
+   ticket carries the visual before/after.
 5. **Emit an interim handoff now — the moment the PR is open.** As soon as
    `gh pr create` succeeds, print the full handoff json block (the Output schema)
    with `pr_url` set and `outcome` at its current best assessment, *before* you
@@ -1337,11 +1346,15 @@ Field meanings:
   review mode, the "after" entries are the drivers recorded against the reviewed
   PR head. The list is empty **only** when recording is genuinely blocked — the
   recorder tooling is missing, or the fixture can't come online after the SPA
-  build — never merely because the upstream run left no footage.
+  build — or when the outcome is purely textual with nothing to watch; never
+  merely because the upstream run left no footage.
 - `recording_unavailable_reason` — empty when every expected clip is present;
-  otherwise name the concrete blocker. For API-only evidence, say it is textual.
-  Missing or rejected footage never blocks the fix or PR, and must never be
-  replaced with a synthetic fallback or a video of the test runner.
+  otherwise name the concrete blocker. For purely textual evidence — an `api`
+  facet, or a facet whose fixed outcome is just a static line or value — say it is
+  textual and carry the observed text in the PR Demo section; `recordings: []` is
+  correct and not a blocker. Missing or rejected footage never blocks the fix or
+  PR, and must never be replaced with a synthetic fallback or a video of the test
+  runner.
 - `test_audit` — the result of the Step 2B.1 audit (author mode). In review mode,
   note whether the repro test was behavioral as-is.
 - `hermetic_check` — the result of the Step 2B.5 hostile-env re-run when the diff


### PR DESCRIPTION
## Summary

Fixes [OMNI-6011](https://linear.app/omnigent/issue/OMNI-6011/resolverepro-agents-take-a-video-of-texts) — the repro/resolve agents were recording screencasts whose entire content is text sitting on screen (a summary slide, a narrated page "claiming" the bug reproduces).

There is no automated video generator in this pipeline — the clip is whatever the agent drives. The recording policy in `dev/recording-lanes.md` made a clip **mandatory** on every user-facing facet and offered only one honest empty-list path: a tooling/reachability `recording_unavailable_reason`. A facet whose outcome is purely textual (a terminal line, an error string, a value) had no sanctioned home, so under the mandate the agent manufactured a video of static text instead of admitting there was nothing to watch.

The fix adds **one principle** rather than a new escape hatch: a valid clip must show a **live action producing the outcome** — a command executing and printing, a screen changing — never static text asserting it. This preserves the legitimate `terminal`/`cli` command recordings (the pane is live, the command actually runs) while killing the text-slide clip. A facet whose whole visible outcome is a static line/value folds into the **existing** textual-evidence path (`recordings: []` + the observed text in `evidence` / the PR Demo section), so no new handoff field is introduced.

## Test Plan

Docs-only change to agent instructions (no code, no schema change — both handoff JSON examples are unchanged in shape). Verified by:
- `pre-commit run --files dev/recording-lanes.md dev/repro-agent/AGENTS.md dev/resolve-agent/AGENTS.md` — passes.
- Reviewed the diff: the "live action vs. static text" rule reads clearly and explicitly protects real terminal-command recordings; textual outcomes route through the pre-existing `api`/textual-evidence path.

## Demo

N/A — documentation change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation

## Test coverage

- [x] Manual verification completed

## Coverage notes

Change is limited to agent-instruction markdown (`dev/recording-lanes.md`, `dev/repro-agent/AGENTS.md`, `dev/resolve-agent/AGENTS.md`); it governs autonomous CI agents, so it is verified by review of the instruction text and pre-commit, not by unit tests.

This pull request and its description were written by Isaac.