### PR TITLE
Fix claude-native catalog filter for managed gateway settings

### DIFF
--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -439,6 +439,23 @@ def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig) -> b
     return host == "anthropic.com" or host.endswith(".anthropic.com")
 
 
+def _ambient_env_is_non_anthropic_gateway() -> bool:
+    """Whether the ambient process env routes through a non-Anthropic gateway.
+
+    Used as the ``claude_config is None`` counterpart to
+    :func:`_serves_canonical_anthropic_ids`: when managed settings (e.g. Isaac)
+    set ``ANTHROPIC_BASE_URL`` to a Databricks gateway, the catalog and its
+    fingerprint must treat the env as a non-canonical endpoint.
+    """
+    from urllib.parse import urlparse
+
+    base_url = os.environ.get(_UCODE_CLAUDE_BASE_URL_ENV, "")
+    if not base_url:
+        return False
+    host = (urlparse(base_url).hostname or "").lower()
+    return host != "anthropic.com" and not host.endswith(".anthropic.com")
+
+
 def _claude_family(token: str) -> str | None:
     """
     The family alias a model id or alias folds onto, bracket markers dropped.
@@ -1208,12 +1225,14 @@ def claude_catalog_fingerprint(claude_config: ClaudeNativeUcodeConfig | None) ->
     from omnigent.model_catalog_store import binary_identity, fingerprint_of
 
     command, _ = resolve_claude_launch("claude", [])
+    ambient_gateway = os.environ.get(_UCODE_CLAUDE_BASE_URL_ENV) if claude_config is None else None
     return fingerprint_of(
         "claude-native",
         sorted(claude_config.env.items()) if claude_config is not None else None,
         claude_config.api_key_helper if claude_config is not None else None,
         claude_config.model if claude_config is not None else None,
         binary_identity(command),
+        ambient_gateway,
     )
 
 
@@ -1240,7 +1259,10 @@ async def claude_model_catalog(
     if probe is None:
         return None
     rows = list(probe.alias_rows)
-    if claude_config is not None and not _serves_canonical_anthropic_ids(claude_config):
+    _non_canonical = (
+        claude_config is not None and not _serves_canonical_anthropic_ids(claude_config)
+    ) or (claude_config is None and _ambient_env_is_non_anthropic_gateway())
+    if _non_canonical:
         rows = [row for row in rows if not str(row.get("model", "")).startswith("claude-")]
 
     configured_pin = claude_config.model if claude_config is not None else None
@@ -1262,11 +1284,10 @@ async def claude_model_catalog(
         # Append the observed default as its own honest row — but never
         # claim a bare Anthropic id is launchable on an endpoint that
         # rejects that spelling.
-        servable = (
-            claude_config is None
-            or _serves_canonical_anthropic_ids(claude_config)
-            or not default_model.startswith("claude-")
-        )
+        _canonical_ids_ok = (
+            claude_config is None and not _ambient_env_is_non_anthropic_gateway()
+        ) or (claude_config is not None and _serves_canonical_anthropic_ids(claude_config))
+        servable = _canonical_ids_ok or not default_model.startswith("claude-")
         if servable:
             # The probe's printed label describes the ENUMERATION run's
             # model; it only names a config-pinned default when the two are
@@ -2195,7 +2216,7 @@ def _fetch_external_session_id_for_redirect(
         if resp.status_code >= 400:
             return None
         payload = resp.json()
-    except Exception:  # noqa: BLE001
+    except Exception:
         _logger.warning(
             "failed to fetch external Claude session id for redirect; session=%s",
             session_id,
@@ -2698,7 +2719,7 @@ def _ucode_config_for_profile(
             live_catalog = discover_databricks_claude_catalog(creds.host, creds.token)
             live_models = live_catalog.families
             routable_models = live_catalog.model_ids
-        except Exception:  # noqa: BLE001
+        except Exception:
             _logger.warning(
                 "native-claude: live Databricks model discovery failed for profile %r; "
                 "using cached ucode models",
@@ -3226,7 +3247,7 @@ def _wrapper_spec_raw_instructions(spec_path: Path) -> str | None:
 
     try:
         spec = load_agent_spec(spec_path, expand_env=False)
-    except Exception:  # noqa: BLE001
+    except Exception:
         _logger.warning(
             "Could not resolve raw instructions from wrapper spec %s",
             spec_path,
@@ -3647,7 +3668,7 @@ async def _attach_with_transcript_forwarder(
                 await forwarder
             except asyncio.CancelledError:
                 pass
-            except Exception:  # noqa: BLE001
+            except Exception:
                 # The forwarder is best-effort mirroring. A bug there
                 # (corrupt transcript JSONL, file-system error, anything
                 # uncaught in the parser) must not skip the Omnigent terminal
@@ -3745,7 +3766,7 @@ async def _attach_with_reconnect(
         if not first_attempt and recover is not None:
             try:
                 await recover()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _logger.warning(
                     "%s-native reconnect recovery callback raised; retrying attach anyway",
                     session_name.lower(),

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -2216,7 +2216,7 @@ def _fetch_external_session_id_for_redirect(
         if resp.status_code >= 400:
             return None
         payload = resp.json()
-    except Exception:  # noqa: BLE001
+    except Exception:
         _logger.warning(
             "failed to fetch external Claude session id for redirect; session=%s",
             session_id,
@@ -2719,7 +2719,7 @@ def _ucode_config_for_profile(
             live_catalog = discover_databricks_claude_catalog(creds.host, creds.token)
             live_models = live_catalog.families
             routable_models = live_catalog.model_ids
-        except Exception:  # noqa: BLE001
+        except Exception:
             _logger.warning(
                 "native-claude: live Databricks model discovery failed for profile %r; "
                 "using cached ucode models",
@@ -3247,7 +3247,7 @@ def _wrapper_spec_raw_instructions(spec_path: Path) -> str | None:
 
     try:
         spec = load_agent_spec(spec_path, expand_env=False)
-    except Exception:  # noqa: BLE001
+    except Exception:
         _logger.warning(
             "Could not resolve raw instructions from wrapper spec %s",
             spec_path,
@@ -3668,7 +3668,7 @@ async def _attach_with_transcript_forwarder(
                 await forwarder
             except asyncio.CancelledError:
                 pass
-            except Exception:  # noqa: BLE001
+            except Exception:
                 # The forwarder is best-effort mirroring. A bug there
                 # (corrupt transcript JSONL, file-system error, anything
                 # uncaught in the parser) must not skip the Omnigent terminal
@@ -3766,7 +3766,7 @@ async def _attach_with_reconnect(
         if not first_attempt and recover is not None:
             try:
                 await recover()
-            except Exception:  # noqa: BLE001
+            except Exception:
                 _logger.warning(
                     "%s-native reconnect recovery callback raised; retrying attach anyway",
                     session_name.lower(),

--- a/omnigent/claude_native.py
+++ b/omnigent/claude_native.py
@@ -2216,7 +2216,7 @@ def _fetch_external_session_id_for_redirect(
         if resp.status_code >= 400:
             return None
         payload = resp.json()
-    except Exception:
+    except Exception:  # noqa: BLE001
         _logger.warning(
             "failed to fetch external Claude session id for redirect; session=%s",
             session_id,
@@ -2719,7 +2719,7 @@ def _ucode_config_for_profile(
             live_catalog = discover_databricks_claude_catalog(creds.host, creds.token)
             live_models = live_catalog.families
             routable_models = live_catalog.model_ids
-        except Exception:
+        except Exception:  # noqa: BLE001
             _logger.warning(
                 "native-claude: live Databricks model discovery failed for profile %r; "
                 "using cached ucode models",
@@ -3247,7 +3247,7 @@ def _wrapper_spec_raw_instructions(spec_path: Path) -> str | None:
 
     try:
         spec = load_agent_spec(spec_path, expand_env=False)
-    except Exception:
+    except Exception:  # noqa: BLE001
         _logger.warning(
             "Could not resolve raw instructions from wrapper spec %s",
             spec_path,
@@ -3668,7 +3668,7 @@ async def _attach_with_transcript_forwarder(
                 await forwarder
             except asyncio.CancelledError:
                 pass
-            except Exception:
+            except Exception:  # noqa: BLE001
                 # The forwarder is best-effort mirroring. A bug there
                 # (corrupt transcript JSONL, file-system error, anything
                 # uncaught in the parser) must not skip the Omnigent terminal
@@ -3766,7 +3766,7 @@ async def _attach_with_reconnect(
         if not first_attempt and recover is not None:
             try:
                 await recover()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 _logger.warning(
                     "%s-native reconnect recovery callback raised; retrying attach anyway",
                     session_name.lower(),

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -10752,3 +10752,133 @@ def test_catalog_fingerprint_survives_a_missing_binary(
     _point_claude_at(monkeypatch, tmp_path / "absent")
 
     assert isinstance(claude_native.claude_catalog_fingerprint(None), str)
+
+
+# ── ambient gateway detection ─────────────────────────────
+
+
+def test_ambient_env_is_non_anthropic_gateway_detects_databricks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambient ANTHROPIC_BASE_URL pointing to Databricks is a gateway."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://gw.example.databricks.com/serving/v1")
+    assert claude_native._ambient_env_is_non_anthropic_gateway() is True
+
+
+def test_ambient_env_is_non_anthropic_gateway_allows_anthropic_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambient ANTHROPIC_BASE_URL pointing to Anthropic is NOT a gateway."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+    assert claude_native._ambient_env_is_non_anthropic_gateway() is False
+
+
+def test_ambient_env_is_non_anthropic_gateway_allows_anthropic_subdomain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ambient ANTHROPIC_BASE_URL on an Anthropic subdomain is NOT a gateway."""
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://test.anthropic.com")
+    assert claude_native._ambient_env_is_non_anthropic_gateway() is False
+
+
+def test_ambient_env_is_non_anthropic_gateway_returns_false_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ambient ANTHROPIC_BASE_URL means not a gateway."""
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    assert claude_native._ambient_env_is_non_anthropic_gateway() is False
+
+
+def test_catalog_fingerprint_includes_ambient_gateway_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fingerprint changes when ANTHROPIC_BASE_URL changes in ambient env.
+
+    When claude_config is None (managed settings), the ambient gateway URL
+    must be part of the fingerprint so gateway and non-gateway environments
+    don't share a catalog cache entry.
+    """
+    _point_claude_at(monkeypatch, tmp_path / "claude")
+    (tmp_path / "claude").write_text("binary")
+
+    # No gateway set
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    fp_no_gateway = claude_native.claude_catalog_fingerprint(None)
+
+    # Gateway set
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://gw.example.com/anthropic")
+    fp_with_gateway = claude_native.claude_catalog_fingerprint(None)
+
+    # Different gateway
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://gw.databricks.com/anthropic")
+    fp_different_gateway = claude_native.claude_catalog_fingerprint(None)
+
+    # All three should be different
+    assert fp_no_gateway != fp_with_gateway
+    assert fp_no_gateway != fp_different_gateway
+    assert fp_with_gateway != fp_different_gateway
+
+
+async def test_claude_model_catalog_filters_canonical_ids_for_ambient_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When claude_config is None but ANTHROPIC_BASE_URL is a gateway, filter canonical IDs.
+
+    Managed settings (e.g. Isaac) may set ANTHROPIC_BASE_URL to a Databricks
+    gateway. The catalog must filter canonical claude-* IDs even when
+    claude_config is None.
+    """
+
+    async def _fake_probe(config: object) -> claude_native.ClaudeModelProbe:
+        del config
+        return claude_native.ClaudeModelProbe(
+            alias_rows=[
+                {"id": "sonnet", "model": "claude-sonnet-4-6", "displayName": "Sonnet 4.6"},
+                {
+                    "id": "sonnet-gateway",
+                    "model": "system.ai.claude-sonnet-4-6[1m]",
+                    "displayName": "Sonnet 4.6 (Gateway)",
+                },
+                {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5"},
+            ],
+            default_model="system.ai.claude-sonnet-4-6[1m]",
+            default_label="Sonnet 4.6 (Gateway)",
+        )
+
+    monkeypatch.setattr(claude_native, "probe_claude_model_options", _fake_probe)
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://gw.example.com/anthropic")
+
+    rows = await claude_native.claude_model_catalog(None)
+
+    assert rows is not None
+    # Only the gateway-namespaced model should remain
+    assert [row["id"] for row in rows] == ["sonnet-gateway"]
+    # No canonical claude-* models
+    assert all(not str(row.get("model", "")).startswith("claude-") for row in rows)
+
+
+async def test_claude_model_catalog_keeps_canonical_ids_without_ambient_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When claude_config is None and no gateway URL is set, keep canonical IDs."""
+
+    async def _fake_probe(config: object) -> claude_native.ClaudeModelProbe:
+        del config
+        return claude_native.ClaudeModelProbe(
+            alias_rows=[
+                {"id": "sonnet", "model": "claude-sonnet-4-6", "displayName": "Sonnet 4.6"},
+                {"id": "opus", "model": "claude-opus-5", "displayName": "Opus 5"},
+            ],
+            default_model="claude-opus-5",
+            default_label="Opus 5",
+        )
+
+    monkeypatch.setattr(claude_native, "probe_claude_model_options", _fake_probe)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+    rows = await claude_native.claude_model_catalog(None)
+
+    assert rows is not None
+    # Both canonical models should be present
+    assert [row["id"] for row in rows] == ["sonnet", "opus"]
+    assert rows[1]["isDefault"] is True


### PR DESCRIPTION
## Related issue

Fixes the root cause where Omnigent claude-native sub-agents fail to launch when auth is managed via system-level Claude Code settings (e.g., Isaac/Databricks) and the ambient environment routes through a non-Anthropic gateway.

## Summary

When an Omnigent claude-native sub-agent launches without explicit provider config (`claude_config is None`), the catalog filtering now correctly checks the ambient `ANTHROPIC_BASE_URL` environment variable to determine if canonical Anthropic model IDs should be filtered out.

**Root cause:** When auth is managed via system-level settings, `resolve_native_claude_config` returns `None`, but the ambient env may still point to a non-Anthropic gateway via `ANTHROPIC_BASE_URL`. The catalog filter previously only checked the explicit config, allowing canonical model IDs like `claude-sonnet-4-6` to slip through. Gateways reject these with 404 errors.

**Changes:**
- Add `_ambient_env_is_non_anthropic_gateway()` helper to check ambient `ANTHROPIC_BASE_URL` when `claude_config is None`
- Update `claude_catalog_fingerprint()` to include ambient gateway URL in the cache key (fixes cache coherency bug where gateway and non-gateway environments would share cache entries)
- Update `claude_model_catalog()` to filter canonical IDs when ambient gateway is detected, and apply the same logic to the servability check

## Test Plan

Added unit tests:
- `test_ambient_env_is_non_anthropic_gateway_*`: Verifies the new helper correctly detects Databricks/gateway URLs vs Anthropic URLs
- `test_catalog_fingerprint_includes_ambient_gateway_url`: Verifies cache coherency - different gateway URLs produce different fingerprints
- `test_claude_model_catalog_filters_canonical_ids_for_ambient_gateway`: Verifies canonical model IDs are filtered when gateway URL is set in ambient env
- `test_claude_model_catalog_keeps_canonical_ids_without_ambient_gateway`: Verifies canonical IDs are kept when no gateway is set

Run tests with: `uv run pytest tests/test_claude_native.py -k ambient -xvs`

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<img width="1593" height="609" alt="image" src="https://github.com/user-attachments/assets/0fc0d963-c2fd-4d23-ac47-ddb40aa2cdca" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A

## Changelog

Claude-native sub-agents now correctly launch when using managed gateway settings (e.g., Isaac/Databricks)