### PR TITLE
fix(web): fix Copy button in Invite URL dialog on non-HTTPS origins

### DIFF
--- a/web/src/pages/MembersPage.tsx
+++ b/web/src/pages/MembersPage.tsx
@@ -23,7 +23,7 @@
  * accidentally caching secrets in a list endpoint.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CopyIcon, KeyRoundIcon, RefreshCwIcon, Trash2Icon, UserPlusIcon } from "lucide-react";
 import { PageScroll } from "@/components/PageScroll";
 import { Button } from "@/components/ui/button";
@@ -439,18 +439,38 @@ export function MembersPage() {
  */
 function CopyableValue({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(value);
+    let success = false;
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(value);
+        success = true;
+      } catch {
+        // Fall through to execCommand path.
+      }
+    }
+    if (!success && inputRef.current) {
+      // execCommand must run while focus is on an element inside the dialog —
+      // appending a temporary node to document.body fails because Radix
+      // Dialog's focus trap prevents it from receiving focus.
+      inputRef.current.focus();
+      inputRef.current.select();
+      try {
+        success = document.execCommand("copy");
+      } catch {
+        // Input text is selected; user can copy manually.
+      }
+    }
+    if (success) {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // No clipboard permission — the input is still selectable.
     }
   };
   return (
     <div className="flex items-center gap-2">
       <Input
+        ref={inputRef}
         value={value}
         readOnly
         className="font-mono text-sm"


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Two compounding problems caused the **Copy** button in the Invite URL dialog to silently do nothing:

1. **`navigator.clipboard.writeText` requires a secure context** (HTTPS or `localhost`). It throws — silently — on plain-HTTP origins like `http://omni.local`.

2. **The `execCommand` fallback also failed inside the dialog.** The existing `copyText()` helper in `lib/clipboard.ts` falls back by appending a temporary `<textarea>` to `document.body`. But Radix UI's `Dialog` component uses a focus trap that prevents elements *outside* the dialog from receiving focus programmatically — so `execCommand('copy')` never ran on anything.

**Fix:** add a `ref` to the `<Input>` that is already rendered *inside* the dialog. When the async Clipboard API is unavailable, `focus()` + `select()` that element directly (it's inside the dialog, so no focus-trap conflict) and call `execCommand('copy')` on it. On success the button flashes "Copied" as before.

## Test Plan

1. Start the dev server and access it over a non-HTTPS, non-localhost origin (e.g. `http://omni.local:6767`).
2. Settings → Members → Create invite.
3. Click **Copy** in the Invite URL dialog.
4. Paste into any text field — the full invite URL should appear.
5. The button should flash **Copied** for 1.5 s.

Also verify on `https://` / `localhost` (uses the clipboard API path) — same result expected.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change (button was broken; now works)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: verified both clipboard-API path (HTTPS/localhost) and execCommand fallback path (non-HTTPS origin). The `CopyableValue` component is not currently covered by unit tests; the `MembersPage.test.tsx` suite covers invite creation and URL display.

## Changelog

Copy button in the Invite URL dialog now works on HTTP (non-localhost) origins.