### PR TITLE
fix(web): don't crash message send on non-secure-context origins (crypto.randomUUID)

### DIFF
--- a/web/src/lib/analyticsEmit.ts
+++ b/web/src/lib/analyticsEmit.ts
@@ -19,6 +19,7 @@ import {
   type OmnigentInteractionKind,
   type OmnigentInteractionStatus,
 } from "@/lib/host";
+import { randomUUID } from "@/lib/randomUUID";
 
 /**
  * Emit one analytics event to the host sink. No-op when no host is configured.
@@ -58,15 +59,11 @@ export function emitInteractionPhase(args: InteractionPhaseArgs): void {
 }
 
 // A random correlation id for a timed interaction that has no natural subject id
-// (creating a session, loading the list). Guarded so a missing `crypto.randomUUID`
-// can never throw into the wrapped operation.
+// (creating a session, loading the list). Uses the secure-context-safe helper so
+// a missing `crypto.randomUUID` (plain-http origin) can never throw into the
+// wrapped operation.
 function newInteractionId(): string {
-  try {
-    if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
-  } catch {
-    // fall through to the timestamp fallback
-  }
-  return `iid-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  return `iid-${randomUUID()}`;
 }
 
 /** Handle for an in-flight timed interaction opened by `startTimedInteraction`. */

--- a/web/src/lib/randomUUID.test.ts
+++ b/web/src/lib/randomUUID.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "./randomUUID";
+
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("randomUUID", () => {
+  it("returns a well-formed v4 UUID and is unique across calls", () => {
+    const ids = Array.from({ length: 1000 }, () => randomUUID());
+    for (const id of ids) expect(id).toMatch(V4);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("uses the native crypto.randomUUID when present", () => {
+    const native = vi.fn(() => "11111111-1111-4111-8111-111111111111");
+    vi.stubGlobal("crypto", {
+      randomUUID: native,
+      getRandomValues: globalThis.crypto.getRandomValues,
+    });
+    expect(randomUUID()).toBe("11111111-1111-4111-8111-111111111111");
+    expect(native).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to getRandomValues when crypto.randomUUID is missing (insecure context)", () => {
+    // A plain-http, non-localhost origin exposes getRandomValues but not randomUUID.
+    const getRandomValues = vi.fn((arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i++) arr[i] = i;
+      return arr;
+    });
+    vi.stubGlobal("crypto", { getRandomValues });
+    const id = randomUUID();
+    expect(id).toMatch(V4);
+    expect(getRandomValues).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to Math.random when crypto is entirely absent", () => {
+    vi.stubGlobal("crypto", undefined);
+    expect(randomUUID()).toMatch(V4);
+  });
+});

--- a/web/src/lib/randomUUID.ts
+++ b/web/src/lib/randomUUID.ts
@@ -1,0 +1,28 @@
+// Secure-context-safe UUID generation.
+//
+// `crypto.randomUUID` is only defined in a secure context (HTTPS, or the
+// `localhost` / `127.0.0.1` / `*.localhost` loopback exceptions). A self-hosted
+// Omnigent served over plain `http` on an intranet host or IP is NOT a secure
+// context, so calling `crypto.randomUUID()` there throws
+// ("crypto.randomUUID is not a function") and breaks whatever path depends on
+// it (e.g. the composer's send stable-id). Prefer the native implementation,
+// fall back to an RFC-4122 v4 built from `crypto.getRandomValues` (which IS
+// available in insecure contexts), and only then to `Math.random`.
+
+/** A v4 UUID string, e.g. `"1e2f…-…-4…-…-…"`. Safe in insecure contexts. */
+export function randomUUID(): string {
+  const c = typeof crypto !== "undefined" ? crypto : undefined;
+  if (c && typeof c.randomUUID === "function") {
+    return c.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (c && typeof c.getRandomValues === "function") {
+    c.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (Math.random() * 256) | 0;
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 10xx
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/web/src/shell/HtmlCommentViewer.tsx
+++ b/web/src/shell/HtmlCommentViewer.tsx
@@ -15,6 +15,7 @@ import { MessageSquarePlusIcon } from "lucide-react";
 import type { Comment } from "@/hooks/useComments";
 import { useCanEdit } from "@/hooks/usePermissions";
 import { getEmbedRoot } from "@/lib/host";
+import { randomUUID } from "@/lib/randomUUID";
 import { type ActiveSelection, HTML_PREVIEW_SANDBOX } from "./codeViewerHelpers";
 import {
   anchorOccurrence,
@@ -46,9 +47,7 @@ interface FloatingAnchor {
 }
 
 function genNonce(): string {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
-  // Deterministic-enough fallback for environments without crypto.randomUUID.
-  return Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
+  return randomUUID();
 }
 
 /** Bridge payload for one comment: its id, anchor text, and which occurrence of

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -69,6 +69,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { authenticatedFetch } from "@/lib/identity";
 import { fetchGithubBranches, fetchGithubRepos, type GithubRepo } from "@/lib/githubIntegration";
 import { isImeCompositionKeyEvent } from "@/lib/ime";
+import { randomUUID } from "@/lib/randomUUID";
 import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
 import { recordOptimisticTitle } from "@/lib/optimisticTitles";
@@ -2932,11 +2933,11 @@ export function NewChatLandingScreen() {
   );
 
   // Fill the branch field with a unique auto-generated name so the user can
-  // spin up a throwaway worktree without inventing one. crypto.randomUUID is
-  // available in every browser the app targets; the short prefix keeps the
-  // dir/branch readable (worktree-1a2b3c4d).
+  // spin up a throwaway worktree without inventing one. Uses the secure-context-
+  // safe UUID helper (a plain-http self-hosted origin has no `crypto.randomUUID`);
+  // the short prefix keeps the dir/branch readable (worktree-1a2b3c4d).
   const generateBranchName = useCallback(() => {
-    const suffix = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+    const suffix = randomUUID().replace(/-/g, "").slice(0, 8);
     const name = `worktree-${suffix}`;
     setBranchName(name);
     return name;

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -79,6 +79,7 @@ import type {
   StreamEvent,
 } from "@/lib/events";
 import { createPresenceIdleTracker } from "@/lib/presenceIdle";
+import { randomUUID } from "@/lib/randomUUID";
 import { conversationRegistry, type ConversationEntry } from "./conversationRegistry";
 import { createInitialConversationState, isConversationStateKey } from "./conversationState";
 import { getStreamSlotManager, type StreamSlot } from "./streamSlots";
@@ -1399,7 +1400,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     if (conversationId === null) return;
     queueSeq += 1;
     const queueId = `q_${queueSeq}`;
-    const stableId = crypto.randomUUID().replace(/-/g, "");
+    const stableId = randomUUID().replace(/-/g, "");
     setActive((s) => ({
       queuedMessages: [
         ...s.queuedMessages,
@@ -1625,7 +1626,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     }
     const retryId = get().pendingRetryStableId;
     if (retryId !== null) setActive({ pendingRetryStableId: null });
-    const stableId = opts?.stableId ?? retryId ?? crypto.randomUUID().replace(/-/g, "");
+    const stableId = opts?.stableId ?? retryId ?? randomUUID().replace(/-/g, "");
     // Sending while a response is already streaming is allowed — the
     // session API queues item-typed events and the server delivers them
     // into the running task's inbox. Keep `activeResponse` untouched in


### PR DESCRIPTION
## Related issue

Resolves [OMNI-6736](https://linear.app/omnigent/issue/OMNI-6736). (Linear-tracked; no GitHub issue.)

## Summary

Sending a chat message from the web app silently did nothing when the SPA was served from a **non–secure-context origin** — plain `http://` on a host that isn't `localhost`/`127.0.0.1` (a LAN IP, or a custom hostname like `http://omni.local:6767`). The composer's send path threw:

```
TypeError: crypto.randomUUID is not a function   // chatStore.send
```

`crypto.randomUUID()` only exists in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS, or the `localhost`/`127.0.0.1`/`*.localhost` loopback exceptions), so over plain http on any other host it's `undefined` and the call throws before the message is dispatched. Terminal view was unaffected (it never calls `randomUUID`), which made it look auth- or harness-related. This breaks message send for self-hosted deployments served over plain http on an intranet host/IP.

**Fix:** add a shared `randomUUID()` helper (`web/src/lib/randomUUID.ts`) that prefers the native implementation, falls back to an RFC-4122 v4 built from `crypto.getRandomValues` (which *is* available in insecure contexts), and only then to `Math.random`. Route the unguarded call sites through it (chatStore `send()` + queued-message stable ids, `NewChatDialog` worktree suffix), and fold the existing inline-guarded copies (`HtmlCommentViewer`, `analyticsEmit`) onto the same helper. The browser-agent snapshot JS keeps its own guard — it runs in the browsed page, not the SPA.

## Test Plan

- New unit test `web/src/lib/randomUUID.test.ts`: valid v4 shape + uniqueness over 1000 calls; native path used when present; **fallback to `getRandomValues` when `crypto.randomUUID` is missing** (the insecure-context case); fallback to `Math.random` when `crypto` is entirely absent. Passes (`vitest run`).
- `tsc --noEmit`, `prettier --check`, and `oxlint` clean on all changed files.
- Manual repro: serve the SPA over `http://` on a non-loopback host (e.g. `127.0.0.1 omni.local` in `/etc/hosts`, open `http://omni.local:<port>`), open a session, hit Send → before: console `TypeError`, nothing sent; after: message sends normally.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Behavior change is "Send works instead of throwing"; evidence is the unit test's insecure-context fallback case plus the manual repro above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The helper's three branches (native / `getRandomValues` fallback / `Math.random` fallback) are unit-tested by stubbing `globalThis.crypto`. The call-site swaps are behavior-preserving in a secure context (still `crypto.randomUUID`) and only change the insecure-context path from "throw" to "valid UUID"; verified manually over plain-http on a non-loopback host.

## Changelog

Fixed message send failing in the web app when self-hosted over plain http on a non-localhost host (`crypto.randomUUID` is unavailable there).
