### PR TITLE
Redact Claude bridge paths from logs

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5753,9 +5753,8 @@ def create_runner_app(
                 # forwarder to reconcile the row.
                 _logger.warning(
                     "claude-native model change for session=%s could not be verified: "
-                    "no statusLine snapshot in %s",
+                    "no statusLine snapshot",
                     conv_id,
-                    bridge_dir,
                     extra={"session_id": conv_id},
                 )
                 return Response(status_code=204)

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -6630,9 +6630,8 @@ async def _auto_create_claude_terminal(
     await _cancel_auto_forwarder_task(session_id)
     reset_transcript_forward_state(bridge_dir)
     _logger.info(
-        "Claude terminal bridge prepared: session=%s bridge_dir=%s",
+        "Claude terminal bridge prepared: session=%s",
         session_id,
-        bridge_dir,
         extra={"session_id": session_id},
     )
     # Pre-accept Claude's first-run trust + onboarding TUI prompts for this

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from pathlib import Path
 from typing import Any
@@ -2205,6 +2206,29 @@ async def test_events_model_change_confirms_against_the_status_file(
         ["claude-opus-4-6", "claude-opus-4-6", "claude-opus-4-7"],
     )
     assert resp.status_code == 204, resp.text
+
+
+@pytest.mark.asyncio
+async def test_events_model_change_without_status_omits_bridge_path_from_log(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unverifiable model switch logs session context without the bridge path."""
+    with caplog.at_level(logging.WARNING, logger="omnigent.runner.app"):
+        resp = await _post_model_change_with_status_sequence(monkeypatch, [None])
+
+    assert resp.status_code == 204, resp.text
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "model change" in record.getMessage() and "could not be verified" in record.getMessage()
+    ]
+    assert messages == [
+        "claude-native model change for session=68c7c1acc5eeec3978c5e62043da51a5 "
+        "could not be verified: no statusLine snapshot"
+    ]
+    bridge_dir = bridge_dir_for_bridge_id("68c7c1acc5eeec3978c5e62043da51a5")
+    assert str(bridge_dir) not in messages[0]
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -656,6 +656,7 @@ async def test_auto_create_claude_terminal_passes_session_effort(
     use_envelope: bool,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     Host-spawned terminal launch reads session effort and passes ``--effort``.
@@ -743,18 +744,26 @@ async def test_auto_create_claude_terminal_passes_session_effort(
         else None
     )
 
-    await _auto_create_claude_terminal(
-        session_id,
-        _FakeResourceRegistry(),
-        lambda _sid, _evt: None,
-        server_client=fake_client,
-        session_init=session_init,
-    )
+    with caplog.at_level(logging.INFO, logger="omnigent.runner.app"):
+        await _auto_create_claude_terminal(
+            session_id,
+            _FakeResourceRegistry(),
+            lambda _sid, _evt: None,
+            server_client=fake_client,
+            session_init=session_init,
+        )
 
     args = captured["spec"].args
     assert "--effort" in args
     effort_idx = args.index("--effort")
     assert args[effort_idx + 1] == "high"
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "Claude terminal bridge prepared" in record.getMessage()
+    ]
+    assert messages == [f"Claude terminal bridge prepared: session={session_id}"]
+    assert str(bridge_dir_for_bridge_id(session_id)) not in messages[0]
 
     await fake_client.aclose()
 


### PR DESCRIPTION
## Related issue

- CodeQL alert [#219](https://github.com/omnigent-ai/omnigent/security/code-scanning/219)
- CodeQL alert [#239](https://github.com/omnigent-ai/omnigent/security/code-scanning/239)

## Summary

- Stop logging absolute Claude bridge directory paths derived from the host's temporary directory.
- Preserve the session ID and event context needed for debugging; bridge behavior is unchanged.
- Add regressions covering both affected log statements.

## Test Plan

- `uv run --frozen pytest -q tests/runner/test_app_sessions_native_events_options.py::test_events_model_change_without_status_omits_bridge_path_from_log`
- `uv run --frozen pytest -q tests/runner/test_app_sessions_native_terminals_autocreate.py -k test_auto_create_claude_terminal_passes_session_effort`
- `uv run --frozen pre-commit run --files omnigent/runner/app.py omnigent/runner/native/orchestration.py tests/runner/test_app_sessions_native_events_options.py tests/runner/test_app_sessions_native_terminals_autocreate.py`
- `git diff --check`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The focused tests assert that the logs retain session context while omitting the host-specific bridge path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused regressions exercise both CodeQL-reported logging paths.
