### PR TITLE
feat(files): add path and native reveal actions to tree, tabs, and viewer

### DIFF
--- a/tests/e2e_ui/files/test_file_link_sharing.py
+++ b/tests/e2e_ui/files/test_file_link_sharing.py
@@ -1,4 +1,4 @@
-"""E2E: the FileViewer "Copy link to file" button yields a shareable URL.
+"""E2E: the FileViewer "Copy Omnigent Link" button yields a shareable URL.
 
 The toolbar's copy-link action writes ``window.location.href`` (carrying
 ``?file=<path>``) to the clipboard and flashes a "Copied!" confirmation
@@ -25,6 +25,8 @@ from pathlib import Path
 import httpx
 import pytest
 from playwright.sync_api import Browser, Page, expect
+
+from tests.e2e_ui.conftest import open_right_rail
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -72,7 +74,7 @@ def test_copy_link_is_shareable_in_a_new_browser(
 
     # Click the copy-link toolbar action and confirm the "Copied!" feedback
     # (the button swaps to a check icon; its tooltip becomes "Copied!").
-    copy_btn = file_viewer.get_by_role("button", name="Copy link to file")
+    copy_btn = file_viewer.get_by_role("button", name="Copy Omnigent Link")
     expect(copy_btn).to_be_visible()
     copy_btn.click()
 
@@ -96,3 +98,53 @@ def test_copy_link_is_shareable_in_a_new_browser(
         expect(fresh_viewer.get_by_text(_FILE_BODY).first).to_be_visible(timeout=20_000)
     finally:
         fresh_context.close()
+
+
+def test_file_menus_copy_paths_without_copying_the_app_url(
+    page: Page,
+    seeded_shareable_session: tuple[str, str],
+) -> None:
+    """Tree, tab, path and overflow actions copy real filesystem paths."""
+    base_url, session_id = seeded_shareable_session
+    page.context.grant_permissions(["clipboard-read", "clipboard-write"])
+    env = page.request.get(f"{base_url}/v1/sessions/{session_id}/resources/environments/default")
+    assert env.ok, env.text()
+    absolute_path = f"{env.json()['metadata']['root'].rstrip('/')}/{_FILE_PATH}"
+    page.goto(f"{base_url}/c/{session_id}")
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name=re.compile("^Files")).click()
+    row = rail.get_by_role("button", name=_FILE_PATH, exact=True)
+    expect(row).to_be_visible(timeout=30_000)
+    row.click(button="right")
+    expect(page.get_by_role("menuitem", name=re.compile("^Show in"))).to_have_count(0)
+    page.get_by_role("menuitem", name="Copy Path", exact=True).click()
+    expect(page.get_by_text("Path copied", exact=True).first).to_be_visible()
+    assert page.evaluate("() => navigator.clipboard.readText()") == absolute_path
+    expect(rail.get_by_test_id("file-viewer")).to_have_count(0)
+
+    row.click()
+    viewer = rail.get_by_test_id("file-viewer")
+    expect(viewer.get_by_text(_FILE_BODY).first).to_be_visible(timeout=20_000)
+    tab = rail.locator(f'div[role="button"][title="{_FILE_PATH}"]')
+    tab.click(button="right")
+    page.get_by_role("menuitem", name="Copy Relative Path", exact=True).click()
+    assert page.evaluate("() => navigator.clipboard.readText()") == _FILE_PATH
+    expect(tab).to_have_attribute("aria-current", "true")
+
+    viewer.locator(f'span[title="{_FILE_PATH}"]').click(button="right")
+    page.get_by_role("menuitem", name="Copy Path", exact=True).click()
+    assert page.evaluate("() => navigator.clipboard.readText()") == absolute_path
+
+    viewer.get_by_role("button", name="View settings", exact=True).click()
+    page.get_by_role("menuitem", name="Copy Relative Path", exact=True).click()
+    assert page.evaluate("() => navigator.clipboard.readText()") == _FILE_PATH
+
+    # Shrink through the real resize control to exercise the collapsed menu.
+    handle = rail.get_by_role("separator", name="Resize panel")
+    for _ in range(20):
+        handle.press("ArrowRight")
+    viewer.get_by_role("button", name="More actions", exact=True).click()
+    expect(page.get_by_role("menuitem", name="Copy Omnigent Link", exact=True)).to_be_visible()
+    page.get_by_role("menuitem", name="Copy Relative Path", exact=True).click()
+    assert page.evaluate("() => navigator.clipboard.readText()") == _FILE_PATH

--- a/web/electron/src/fileReveal.js
+++ b/web/electron/src/fileReveal.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+/** Reveal local host items through the OS file manager, never execute them. */
+function registerFileReveal({ ipcMain, shell, isPinnedOriginSender, localHostId }) {
+  ipcMain.handle("omnigent:reveal-file", (event, hostId, filePath) => {
+    if (!isPinnedOriginSender(event)) return false;
+    if (typeof hostId !== "string" || !hostId || hostId !== localHostId()) return false;
+    if (typeof filePath !== "string" || filePath.includes("\0") || !path.isAbsolute(filePath)) {
+      return false;
+    }
+    try {
+      if (!fs.existsSync(filePath)) return false;
+      shell.showItemInFolder(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+module.exports = { registerFileReveal };

--- a/web/electron/src/main.js
+++ b/web/electron/src/main.js
@@ -33,6 +33,7 @@ const { autoUpdater } = require("electron-updater");
 const { createDesktopUpdater } = require("./desktop_updater");
 const { createUpdateOverlay } = require("./update_overlay");
 const { createAboutWindow, resolveAppIconDataUrl } = require("./about_window");
+const { registerFileReveal } = require("./fileReveal");
 const fs = require("node:fs");
 const path = require("node:path");
 const { pathToFileURL } = require("node:url");
@@ -2919,6 +2920,13 @@ function registerIpc() {
       }
     };
     return serverManager.startLocalServer(cliPath, onLine);
+  });
+
+  registerFileReveal({
+    ipcMain,
+    shell,
+    isPinnedOriginSender,
+    localHostId: () => omnigentCli.localHostId(),
   });
 
   // SPA → this machine's identity: is the CLI installed, and its host id. Both

--- a/web/electron/src/preload.js
+++ b/web/electron/src/preload.js
@@ -101,6 +101,8 @@ contextBridge.exposeInMainWorld("omnigentDesktop", {
   openServerSetup: () => {
     ipcRenderer.send("omnigent:open-server-setup");
   },
+  /** Reveal a local host item in the OS file manager. */
+  revealFile: (hostId, path) => ipcRenderer.invoke("omnigent:reveal-file", hostId, path),
   /**
    * This machine's identity — `{ cliInstalled, hostId }` — read from local
    * config with no subprocess, so it's instant. Lets the SPA recognize "this

--- a/web/electron/test/fileReveal.test.js
+++ b/web/electron/test/fileReveal.test.js
@@ -1,0 +1,69 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { registerFileReveal } = require("../src/fileReveal");
+
+function setup(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "omni-reveal-"));
+  const file = path.join(directory, "a file.txt");
+  fs.writeFileSync(file, "test");
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  let handler;
+  const shown = [];
+  const shell = { showItemInFolder: (value) => shown.push(value) };
+  registerFileReveal({
+    ipcMain: {
+      handle: (channel, callback) => {
+        assert.equal(channel, "omnigent:reveal-file");
+        handler = callback;
+      },
+    },
+    shell,
+    isPinnedOriginSender: (event) => event.trusted === true,
+    localHostId: () => "local",
+  });
+  return { directory, file, shown, shell, reveal: (...args) => handler(...args) };
+}
+
+test("reveals existing files and directories without opening their contents", (t) => {
+  const { reveal, shown, file, directory } = setup(t);
+  assert.equal(reveal({ trusted: true }, "local", file), true);
+  assert.equal(reveal({ trusted: true }, "local", directory), true);
+  assert.deepEqual(shown, [file, directory]);
+});
+
+test("rejects untrusted senders and remote or unknown hosts", (t) => {
+  const { reveal, shown, file } = setup(t);
+  assert.equal(reveal({}, "local", file), false);
+  for (const host of ["remote", "", null, undefined, {}]) {
+    assert.equal(reveal({ trusted: true }, host, file), false);
+  }
+  assert.deepEqual(shown, []);
+});
+
+test("rejects relative, malformed, URL and missing paths", (t) => {
+  const { reveal, shown, file } = setup(t);
+  for (const value of [
+    "relative.txt",
+    "file:///tmp/file",
+    "https://example.com",
+    null,
+    {},
+    `${file}\0`,
+    `${file}.missing`,
+  ]) {
+    assert.equal(reveal({ trusted: true }, "local", value), false);
+  }
+  assert.deepEqual(shown, []);
+});
+
+test("reports native reveal failures", (t) => {
+  const { reveal, shell, file } = setup(t);
+  shell.showItemInFolder = () => {
+    throw new Error("Unavailable");
+  };
+  assert.equal(reveal({ trusted: true }, "local", file), false);
+});

--- a/web/src/lib/nativeBridge.test.ts
+++ b/web/src/lib/nativeBridge.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   getServerPicker,
+  revealFile,
+  supportsFileReveal,
   isAndroidShell,
   isElectronShell,
   isIOSShell,
@@ -591,5 +593,28 @@ describe("getServerPicker / switchServer over the iOS bridge", () => {
     setIOS(true, true, true);
     iosGetServerPicker.mockRejectedValueOnce(new Error("bridge down"));
     await expect(getServerPicker()).resolves.toBeNull();
+  });
+});
+
+describe("native file reveal", () => {
+  it("degrades gracefully in browsers and older shells", async () => {
+    setElectron(false);
+    expect(supportsFileReveal()).toBe(false);
+    expect(await revealFile("host", "/file")).toBe(false);
+    setElectron(true);
+    expect(supportsFileReveal()).toBe(false);
+    expect(await revealFile("host", "/file")).toBe(false);
+  });
+  it("forwards the host and path and reports IPC failures", async () => {
+    const reveal = vi.fn().mockResolvedValue(true);
+    (window as unknown as Record<string, unknown>).omnigentDesktop = {
+      kind: "electron",
+      revealFile: reveal,
+    };
+    expect(supportsFileReveal()).toBe(true);
+    expect(await revealFile("local", "/a file")).toBe(true);
+    expect(reveal).toHaveBeenCalledWith("local", "/a file");
+    reveal.mockRejectedValueOnce(new Error("IPC disconnected"));
+    expect(await revealFile("local", "/a file")).toBe(false);
   });
 });

--- a/web/src/lib/nativeBridge.ts
+++ b/web/src/lib/nativeBridge.ts
@@ -168,6 +168,8 @@ interface ElectronDesktopApi extends NativeShellApi {
    * idle, so the web never shows a (duplicate) banner. Absent on older shells.
    */
   updates?: ElectronUpdateBridge;
+  /** Reveal an item belonging to this machine in its native file manager. */
+  revealFile?: (hostId: string, path: string) => Promise<boolean>;
   /** This machine's identity (CLI installed + host id) — fast, no subprocess. */
   getHostIdentity?: () => Promise<HostIdentity | null>;
   /** Start / stop / restart this machine's host daemon for the window's server. */
@@ -889,5 +891,18 @@ export async function resetCliPath(): Promise<CliStatus | null> {
   } catch (err) {
     console.warn("[nativeBridge] electron resetCliPath failed:", err);
     return null;
+  }
+}
+
+/** Whether the desktop shell can reveal local files. */
+export function supportsFileReveal(): boolean {
+  return typeof electronApi()?.revealFile === "function";
+}
+
+export async function revealFile(hostId: string, path: string): Promise<boolean> {
+  try {
+    return (await electronApi()?.revealFile?.(hostId, path)) ?? false;
+  } catch {
+    return false;
   }
 }

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -93,6 +93,7 @@ import { useResizableSidebar } from "@/hooks/useResizableSidebar";
 import { ChatHeader } from "./ChatHeader";
 import { ExecutionLogsPanel } from "./ExecutionLogsPanel";
 import { FileViewer } from "./FileViewer";
+import { FileMenuProvider } from "./FileContextMenu";
 import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
@@ -1855,7 +1856,7 @@ export function AppShell() {
     !filesPanelOpen,
   );
 
-  return (
+  const shellContent = (
     <FileViewerContext.Provider value={fileViewerContextValue}>
       <TerminalFirstContextProvider value={terminalFirstContextValue}>
         <ForkDialogContextProvider value={forkDialogContextValue}>
@@ -2282,6 +2283,11 @@ export function AppShell() {
         </ForkDialogContextProvider>
       </TerminalFirstContextProvider>
     </FileViewerContext.Provider>
+  );
+  return (
+    <FileMenuProvider root={workspaceRoot} hostId={activeSession?.hostId ?? null}>
+      {shellContent}
+    </FileMenuProvider>
   );
 }
 

--- a/web/src/shell/FileContextMenu.test.tsx
+++ b/web/src/shell/FileContextMenu.test.tsx
@@ -26,10 +26,15 @@ beforeEach(() => {
   mocks.reveal.mockResolvedValue(true);
 });
 
-function openMenu(hostId = "local", deleted = false, root = "/Users/test/repo/src") {
+function openMenu(
+  hostId = "local",
+  deleted = false,
+  root = "/Users/test/repo/src",
+  path = "nested/file.txt",
+) {
   const view = render(
     <FileMenuProvider root={root} hostId={hostId}>
-      <FileContextMenu path="nested/file.txt" deleted={deleted}>
+      <FileContextMenu path={path} deleted={deleted}>
         <button type="button">File</button>
       </FileContextMenu>
     </FileMenuProvider>,
@@ -118,4 +123,23 @@ it("updates the absolute path after navigating to another directory", () => {
   );
   fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
   expect(mocks.copy).toHaveBeenCalledWith("/tmp/other/nested/file.txt");
+});
+
+it("reveals absolute viewer paths outside the workspace without prefixing the root", async () => {
+  openMenu("local", false, "/workspace", "/tmp/report.md");
+  fireEvent.click(await screen.findByRole("menuitem", { name: "Show in Finder" }));
+  expect(mocks.reveal).toHaveBeenCalledWith("local", "/tmp/report.md");
+});
+
+it("does not offer a misleading relative path for an outside-workspace file", () => {
+  openMenu("remote", false, "/workspace", "/workspace-other/report.md");
+  expect(screen.queryByRole("menuitem", { name: "Copy Relative Path" })).toBeNull();
+  fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
+  expect(mocks.copy).toHaveBeenCalledWith("/workspace-other/report.md");
+});
+
+it("copies a workspace-relative path for an absolute viewer path inside it", () => {
+  openMenu("remote", false, "/workspace", "/workspace/docs/report.md");
+  fireEvent.click(screen.getByRole("menuitem", { name: "Copy Relative Path" }));
+  expect(mocks.copy).toHaveBeenCalledWith("docs/report.md");
 });

--- a/web/src/shell/FileContextMenu.test.tsx
+++ b/web/src/shell/FileContextMenu.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileContextMenu, FileMenuProvider, resolveFileMenuPath } from "./FileContextMenu";
+
+const mocks = vi.hoisted(() => ({
+  copy: vi.fn(),
+  reveal: vi.fn(),
+  identity: vi.fn(),
+  supported: vi.fn(),
+  mac: vi.fn(),
+}));
+vi.mock("@/lib/clipboard", () => ({ copyText: mocks.copy }));
+vi.mock("@/lib/nativeBridge", () => ({
+  supportsFileReveal: mocks.supported,
+  isMacElectronShell: mocks.mac,
+  getHostIdentity: mocks.identity,
+  revealFile: mocks.reveal,
+}));
+afterEach(cleanup);
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.supported.mockReturnValue(true);
+  mocks.mac.mockReturnValue(true);
+  mocks.identity.mockResolvedValue({ hostId: "local" });
+  mocks.copy.mockResolvedValue(undefined);
+  mocks.reveal.mockResolvedValue(true);
+});
+
+function openMenu(hostId = "local", deleted = false, root = "/Users/test/repo/src") {
+  const view = render(
+    <FileMenuProvider root={root} hostId={hostId}>
+      <FileContextMenu path="nested/file.txt" deleted={deleted}>
+        <button type="button">File</button>
+      </FileContextMenu>
+    </FileMenuProvider>,
+  );
+  fireEvent.contextMenu(screen.getByText("File"));
+  return view;
+}
+
+describe("file context menu", () => {
+  it("copies the absolute path from the current browse location", async () => {
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
+    await waitFor(() =>
+      expect(mocks.copy).toHaveBeenCalledWith("/Users/test/repo/src/nested/file.txt"),
+    );
+  });
+
+  it("copies the row's relative path", async () => {
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Relative Path" }));
+    await waitFor(() => expect(mocks.copy).toHaveBeenCalledWith("nested/file.txt"));
+  });
+
+  it("reveals a local item at the filesystem root", async () => {
+    openMenu("local", false, "/");
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Show in Finder" }));
+    expect(mocks.reveal).toHaveBeenCalledWith("local", "/nested/file.txt");
+  });
+
+  it.each([
+    ["remote", false],
+    ["local", true],
+  ] as const)("does not reveal unavailable items (%s, deleted=%s)", async (hostId, deleted) => {
+    openMenu(hostId, deleted);
+    await waitFor(() => expect(mocks.identity).toHaveBeenCalled());
+    expect(screen.queryByRole("menuitem", { name: "Show in Finder" })).toBeNull();
+  });
+});
+
+describe("file menu paths", () => {
+  it.each([
+    ["/", "nested/file.txt", "/nested/file.txt"],
+    ["/home/user/repo/", "src/file.txt", "/home/user/repo/src/file.txt"],
+    ["C:\\", "src/file.txt", "C:\\src\\file.txt"],
+    ["C:/Users/test", "src/file.txt", "C:\\Users\\test\\src\\file.txt"],
+    ["\\\\server\\share", "dir/file.txt", "\\\\server\\share\\dir\\file.txt"],
+  ])("resolves %s + %s", (root, relative, expected) => {
+    expect(resolveFileMenuPath(root, relative)).toBe(expected);
+  });
+  it("does not invent an absolute path before environment metadata loads", () => {
+    expect(resolveFileMenuPath(null, "file.txt")).toBeNull();
+  });
+});
+
+it("keeps copying available in browsers and older desktop shells", () => {
+  mocks.supported.mockReturnValue(false);
+  openMenu();
+  expect(screen.queryByRole("menuitem", { name: /Show in/ })).toBeNull();
+  expect(mocks.identity).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
+  expect(mocks.copy).toHaveBeenCalledWith("/Users/test/repo/src/nested/file.txt");
+});
+
+it.each([
+  ["Mozilla/5.0 (Windows NT 10.0; Win64; x64)", "Show in File Explorer"],
+  ["Mozilla/5.0 (X11; Linux x86_64)", "Show in File Manager"],
+])("uses the platform's file manager label (%s)", async (userAgent, label) => {
+  mocks.mac.mockReturnValue(false);
+  const agent = vi.spyOn(navigator, "userAgent", "get").mockReturnValue(userAgent);
+  try {
+    openMenu();
+    expect(await screen.findByRole("menuitem", { name: label })).toBeInTheDocument();
+  } finally {
+    agent.mockRestore();
+  }
+});
+
+it("updates the absolute path after navigating to another directory", () => {
+  const view = openMenu();
+  view.rerender(
+    <FileMenuProvider root="/tmp/other" hostId="local">
+      <FileContextMenu path="nested/file.txt">
+        <button type="button">File</button>
+      </FileContextMenu>
+    </FileMenuProvider>,
+  );
+  fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
+  expect(mocks.copy).toHaveBeenCalledWith("/tmp/other/nested/file.txt");
+});

--- a/web/src/shell/FileContextMenu.tsx
+++ b/web/src/shell/FileContextMenu.tsx
@@ -56,7 +56,63 @@ export function FileMenuProvider({
   return <FileMenuContext.Provider value={value}>{children}</FileMenuContext.Provider>;
 }
 
-/** A row's paths are relative to the currently browsed directory. */
+/** Shared by row/tab context menus and the viewer's toolbar menu. */
+export function useFileMenuActions(path: string, deleted = false) {
+  const { root, localHostId } = useContext(FileMenuContext);
+  const absolutePath = resolveFileMenuPath(root, path);
+  const relativePath = relativeFileMenuPath(root, path);
+  async function copy(value: string) {
+    try {
+      await copyText(value);
+      toast.success("Path copied");
+    } catch {
+      toast.error("Failed to copy path");
+    }
+  }
+  const actions = [];
+  if (localHostId && absolutePath && !deleted) {
+    actions.push({
+      key: "reveal-file",
+      label: isMacElectronShell()
+        ? "Show in Finder"
+        : navigator.userAgent.includes("Windows")
+          ? "Show in File Explorer"
+          : "Show in File Manager",
+      icon: <FolderOpenIcon className="size-4" />,
+      active: false,
+      disabled: false,
+      onSelect: () => {
+        void revealFile(localHostId, absolutePath).then((ok) => {
+          if (!ok) toast.error("Could not show this item in the file manager");
+        });
+      },
+    });
+  }
+  actions.push({
+    key: "copy-path",
+    label: "Copy Path",
+    icon: <CopyIcon className="size-4" />,
+    active: false,
+    disabled: !absolutePath,
+    onSelect: () => {
+      if (absolutePath) void copy(absolutePath);
+    },
+  });
+  if (relativePath !== null) {
+    actions.push({
+      key: "copy-relative-path",
+      label: "Copy Relative Path",
+      icon: <CopyIcon className="size-4" />,
+      active: false,
+      disabled: false,
+      onSelect: () => {
+        void copy(relativePath);
+      },
+    });
+  }
+  return actions;
+}
+
 export function FileContextMenu({
   path,
   deleted = false,
@@ -66,64 +122,47 @@ export function FileContextMenu({
   deleted?: boolean;
   children: ReactElement;
 }) {
-  const { root, localHostId } = useContext(FileMenuContext);
-  const absolutePath = resolveFileMenuPath(root, path);
-  async function copy(value: string) {
-    try {
-      await copyText(value);
-      toast.success("Path copied");
-    } catch {
-      toast.error("Failed to copy path");
-    }
-  }
+  const actions = useFileMenuActions(path, deleted);
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
       <ContextMenuContent>
-        {localHostId && absolutePath && !deleted && (
-          <ContextMenuItem
-            onSelect={() => {
-              void revealFile(localHostId, absolutePath).then((ok) => {
-                if (!ok) toast.error("Could not show this item in the file manager");
-              });
-            }}
-          >
-            <FolderOpenIcon />
-            {isMacElectronShell()
-              ? "Show in Finder"
-              : navigator.userAgent.includes("Windows")
-                ? "Show in File Explorer"
-                : "Show in File Manager"}
+        {actions.map((action) => (
+          <ContextMenuItem key={action.key} disabled={action.disabled} onSelect={action.onSelect}>
+            {action.icon}
+            {action.label}
           </ContextMenuItem>
-        )}
-        <ContextMenuItem
-          disabled={!absolutePath}
-          onSelect={() => {
-            if (absolutePath) void copy(absolutePath);
-          }}
-        >
-          <CopyIcon />
-          Copy Path
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() => {
-            void copy(path);
-          }}
-        >
-          <CopyIcon />
-          Copy Relative Path
-        </ContextMenuItem>
+        ))}
       </ContextMenuContent>
     </ContextMenu>
   );
 }
 
-/** Directory API rows use slash-separated paths, including on Windows hosts. */
-export function resolveFileMenuPath(root: string | null, relativePath: string): string | null {
+function isAbsoluteFilePath(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:[/\\]/.test(path) || path.startsWith("\\\\");
+}
+
+/** Directory rows are relative; viewer tabs can also address files outside the workspace. */
+export function resolveFileMenuPath(root: string | null, path: string): string | null {
+  if (isAbsoluteFilePath(path)) return path;
   if (!root) return null;
   const windows = /^[A-Za-z]:[/\\]/.test(root) || root.startsWith("\\\\");
   const separator = windows ? "\\" : "/";
   const normalizedRoot = windows ? root.replace(/\//g, "\\") : root;
   const base = normalizedRoot.replace(/[/\\]+$/, "");
-  return `${base}${separator}${windows ? relativePath.replace(/\//g, "\\") : relativePath}`;
+  return `${base}${separator}${windows ? path.replace(/\//g, "\\") : path}`;
+}
+
+/** Do not label an outside-workspace absolute path as a relative path. */
+function relativeFileMenuPath(root: string | null, path: string): string | null {
+  if (!isAbsoluteFilePath(path)) return path;
+  if (!root) return null;
+  const windows = /^[A-Za-z]:[/\\]/.test(root) || root.startsWith("\\\\");
+  const normalize = (value: string) => (windows ? value.replace(/\\/g, "/") : value);
+  const prefix = `${normalize(root).replace(/\/+$/, "")}/`;
+  const normalized = normalize(path);
+  const matches = windows
+    ? normalized.toLowerCase().startsWith(prefix.toLowerCase())
+    : normalized.startsWith(prefix);
+  return matches ? normalized.slice(prefix.length) : null;
 }

--- a/web/src/shell/FileContextMenu.tsx
+++ b/web/src/shell/FileContextMenu.tsx
@@ -1,0 +1,129 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { CopyIcon, FolderOpenIcon } from "lucide-react";
+import { toast } from "sonner";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { copyText } from "@/lib/clipboard";
+import {
+  getHostIdentity,
+  isMacElectronShell,
+  revealFile,
+  supportsFileReveal,
+} from "@/lib/nativeBridge";
+
+const FileMenuContext = createContext<{ root: string | null; localHostId: string | null }>({
+  root: null,
+  localHostId: null,
+});
+
+export function FileMenuProvider({
+  root,
+  hostId,
+  children,
+}: {
+  root: string | null;
+  hostId: string | null;
+  children: ReactNode;
+}) {
+  const [machineHostId, setMachineHostId] = useState<string | null>(null);
+  useEffect(() => {
+    let active = true;
+    if (supportsFileReveal()) {
+      void getHostIdentity().then((identity) => {
+        if (active) setMachineHostId(identity?.hostId ?? null);
+      });
+    }
+    return () => {
+      active = false;
+    };
+  }, []);
+  const value = useMemo(
+    () => ({ root, localHostId: hostId && hostId === machineHostId ? hostId : null }),
+    [root, hostId, machineHostId],
+  );
+  return <FileMenuContext.Provider value={value}>{children}</FileMenuContext.Provider>;
+}
+
+/** A row's paths are relative to the currently browsed directory. */
+export function FileContextMenu({
+  path,
+  deleted = false,
+  children,
+}: {
+  path: string;
+  deleted?: boolean;
+  children: ReactElement;
+}) {
+  const { root, localHostId } = useContext(FileMenuContext);
+  const absolutePath = resolveFileMenuPath(root, path);
+  async function copy(value: string) {
+    try {
+      await copyText(value);
+      toast.success("Path copied");
+    } catch {
+      toast.error("Failed to copy path");
+    }
+  }
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent>
+        {localHostId && absolutePath && !deleted && (
+          <ContextMenuItem
+            onSelect={() => {
+              void revealFile(localHostId, absolutePath).then((ok) => {
+                if (!ok) toast.error("Could not show this item in the file manager");
+              });
+            }}
+          >
+            <FolderOpenIcon />
+            {isMacElectronShell()
+              ? "Show in Finder"
+              : navigator.userAgent.includes("Windows")
+                ? "Show in File Explorer"
+                : "Show in File Manager"}
+          </ContextMenuItem>
+        )}
+        <ContextMenuItem
+          disabled={!absolutePath}
+          onSelect={() => {
+            if (absolutePath) void copy(absolutePath);
+          }}
+        >
+          <CopyIcon />
+          Copy Path
+        </ContextMenuItem>
+        <ContextMenuItem
+          onSelect={() => {
+            void copy(path);
+          }}
+        >
+          <CopyIcon />
+          Copy Relative Path
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/** Directory API rows use slash-separated paths, including on Windows hosts. */
+export function resolveFileMenuPath(root: string | null, relativePath: string): string | null {
+  if (!root) return null;
+  const windows = /^[A-Za-z]:[/\\]/.test(root) || root.startsWith("\\\\");
+  const separator = windows ? "\\" : "/";
+  const normalizedRoot = windows ? root.replace(/\//g, "\\") : root;
+  const base = normalizedRoot.replace(/[/\\]+$/, "");
+  return `${base}${separator}${windows ? relativePath.replace(/\//g, "\\") : relativePath}`;
+}

--- a/web/src/shell/FileViewer.test.tsx
+++ b/web/src/shell/FileViewer.test.tsx
@@ -1,3 +1,7 @@
+import { FileMenuProvider } from "./FileContextMenu";
+import { copyText } from "@/lib/clipboard";
+
+vi.mock("@/lib/clipboard", () => ({ copyText: vi.fn(() => Promise.resolve()) }));
 // Tests for FileViewer's comments-panel open/close semantics and URL sync:
 //
 //   1. Panel stays closed on fresh open regardless of whether the file has comments.
@@ -237,15 +241,17 @@ function viewerTree({
   return (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[url]}>
-        <LocationDisplay />
-        <FileViewer
-          open={open}
-          conversationId="conv_1"
-          path={path}
-          onClose={onClose}
-          sort={sort}
-          onNavigateTo={onNavigateTo}
-        />
+        <FileMenuProvider root="/workspace" hostId={null}>
+          <LocationDisplay />
+          <FileViewer
+            open={open}
+            conversationId="conv_1"
+            path={path}
+            onClose={onClose}
+            sort={sort}
+            onNavigateTo={onNavigateTo}
+          />
+        </FileMenuProvider>
       </MemoryRouter>
     </QueryClientProvider>
   );
@@ -799,7 +805,7 @@ describe("FileViewer copy-link button", () => {
     useCommentsMock.mockReturnValue(makeCommentsQuery([]));
     renderViewer({ open: true });
 
-    expect(screen.getByRole("button", { name: "Copy link to file" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy Omnigent Link" })).toBeInTheDocument();
   });
 });
 
@@ -1775,5 +1781,38 @@ describe("FileViewer 3D model files", () => {
     renderViewer({ open: true, path: "mesh.obj" });
     expect(screen.queryByRole("button", { name: /^View mode/ })).toBeNull();
     expect(screen.queryByRole("button", { name: "View source" })).toBeNull();
+  });
+});
+
+describe("viewer filesystem actions", () => {
+  beforeEach(() => useCommentsMock.mockReturnValue(makeCommentsQuery([])));
+
+  it.each([false, true])(
+    "copies the filesystem path from the ellipsis menu (collapsed=%s)",
+    (collapsed) => {
+      if (collapsed) installCollapsedToolbar();
+      renderViewer({ open: true, path: "src/main.py" });
+      fireEvent.pointerDown(
+        screen.getByRole("button", { name: collapsed ? "More actions" : "View settings" }),
+        { button: 0 },
+      );
+      fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
+      expect(copyText).toHaveBeenCalledWith("/workspace/src/main.py");
+    },
+  );
+
+  it("offers path copying on the displayed path itself", () => {
+    renderViewer({ open: true, path: "src/main.py" });
+    fireEvent.contextMenu(screen.getByTitle("src/main.py"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Relative Path" }));
+    expect(copyText).toHaveBeenCalledWith("src/main.py");
+  });
+
+  it("explicitly identifies the URL-sharing action in the overflow menu", () => {
+    installCollapsedToolbar();
+    renderViewer({ open: true });
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions" }), { button: 0 });
+    expect(screen.getByRole("menuitem", { name: "Copy Omnigent Link" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Copy link" })).toBeNull();
   });
 });

--- a/web/src/shell/FileViewer.tsx
+++ b/web/src/shell/FileViewer.tsx
@@ -67,6 +67,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { FileContextMenu, useFileMenuActions } from "./FileContextMenu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { downloadWorkspaceFile, useFileContent } from "@/hooks/useFileContent";
 import { useFileDiff } from "@/hooks/useFileDiff";
@@ -895,6 +896,7 @@ function FileViewerBody({
     icon: ReactNode;
     onSelect: () => void;
     active: boolean;
+    disabled?: boolean;
     /** Keep the menu open after selecting — for toggles the user may flip in a
      * row (e.g. wrap + whitespace). Action items (Find) omit it so the menu
      * closes as they hand off. */
@@ -1062,7 +1064,9 @@ function FileViewerBody({
   // — handy when the viewer runs in a narrow pane — and mirrors GitHub's
   // diff-settings menu. The toggles keep the menu open; actions close it as they
   // hand off.
+  const fileMenuActions = useFileMenuActions(path, isDeletedFile);
   const settingsMenu: ToolbarOption[] = [
+    ...fileMenuActions,
     {
       key: "search",
       label: "Find in file",
@@ -1111,8 +1115,8 @@ function FileViewerBody({
   });
   toolbarActions.push({
     key: "copy-link",
-    label: "Copy link to file",
-    tooltip: linkCopied ? "Copied!" : "Copy link",
+    label: "Copy Omnigent Link",
+    tooltip: linkCopied ? "Omnigent link copied!" : "Copy Omnigent Link",
     icon: linkCopied ? (
       <CheckIcon className="size-4 text-green-500" />
     ) : (
@@ -1176,6 +1180,7 @@ function FileViewerBody({
             {action.menu.map((item) => (
               <DropdownMenuItem
                 key={item.key}
+                disabled={item.disabled}
                 className="whitespace-nowrap"
                 onSelect={
                   interactive
@@ -1311,7 +1316,11 @@ function FileViewerBody({
             </div>
           )}
           {/* Always show the file path/name in the toolbar, in every view. */}
-          <span className="min-w-0 truncate font-mono text-sm text-muted-foreground">{path}</span>
+          <FileContextMenu path={path} deleted={isDeletedFile}>
+            <span title={path} className="min-w-0 truncate font-mono text-sm text-muted-foreground">
+              {path}
+            </span>
+          </FileContextMenu>
         </div>
         <div
           className="relative flex min-w-0 items-center justify-end gap-1"
@@ -1418,6 +1427,7 @@ function FileViewerBody({
                       action.menu.map((option) => (
                         <DropdownMenuItem
                           key={option.key}
+                          disabled={option.disabled}
                           className="whitespace-nowrap"
                           onSelect={(e) => {
                             if (option.keepOpen) e.preventDefault();

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -37,6 +37,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { type ChangedSort, FlatFileList } from "./FlatFileList";
+import { FileMenuProvider } from "./FileContextMenu";
 import { FolderTree } from "./FolderTree";
 import { useScrollRestore } from "./useScrollRestore";
 
@@ -584,27 +585,29 @@ export function FilesPanel({
             runnerWentOffline={runnerWentOffline}
           />
         ) : (
-          <FolderTree
-            files={allFilesQuery.data?.data}
-            isLoading={allFilesQuery.isLoading}
-            isError={allFilesQuery.isError}
-            error={allFilesQuery.error}
-            onFileSelect={openTreeFile}
-            conversationId={conversationId}
-            showHidden={showHidden}
-            onShowHidden={() => onShowHiddenChange(true)}
-            changedFiles={changedQuery.data?.data}
-            sort={changedSort}
-            runnerWentOffline={runnerWentOffline}
-            searchQuery={debouncedTreeSearch}
-            searchResults={treeSearchQuery.data}
-            isSearching={treeSearchQuery.isFetching}
-            isSearchError={treeSearchQuery.isError}
-            searchError={treeSearchQuery.error instanceof Error ? treeSearchQuery.error : null}
-            browseLocation={locationParam}
-            onNavigateDir={navigateToChild}
-            scrollParentRef={scrollRef}
-          />
+          <FileMenuProvider root={workingDir} hostId={session?.hostId ?? null}>
+            <FolderTree
+              files={allFilesQuery.data?.data}
+              isLoading={allFilesQuery.isLoading}
+              isError={allFilesQuery.isError}
+              error={allFilesQuery.error}
+              onFileSelect={openTreeFile}
+              conversationId={conversationId}
+              showHidden={showHidden}
+              onShowHidden={() => onShowHiddenChange(true)}
+              changedFiles={changedQuery.data?.data}
+              sort={changedSort}
+              runnerWentOffline={runnerWentOffline}
+              searchQuery={debouncedTreeSearch}
+              searchResults={treeSearchQuery.data}
+              isSearching={treeSearchQuery.isFetching}
+              isSearchError={treeSearchQuery.isError}
+              searchError={treeSearchQuery.error instanceof Error ? treeSearchQuery.error : null}
+              browseLocation={locationParam}
+              onNavigateDir={navigateToChild}
+              scrollParentRef={scrollRef}
+            />
+          </FileMenuProvider>
         )}
       </section>
     </div>

--- a/web/src/shell/FolderTree.stories.tsx
+++ b/web/src/shell/FolderTree.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
 import type { WorkspaceChangedFile, WorkspaceFile } from "@/hooks/useWorkspaceChangedFiles";
 import { StoryQueryRouter } from "@/storybook/StoryProviders";
+import { FileMenuProvider } from "./FileContextMenu";
 import { FolderTree } from "./FolderTree";
 
 const file = (path: string, bytes: number): WorkspaceFile => ({
@@ -106,5 +107,24 @@ export const ExpandedFolders: Story = {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByRole("button", { name: "src/" }));
     await userEvent.click(canvas.getByRole("button", { name: "lib/" }));
+  },
+};
+
+export const ContextMenuActions: Story = {
+  tags: ["!visual-snapshot"],
+  args: {
+    ...TreeWithChanges.args,
+    conversationId: "story-file-menu",
+  },
+  decorators: [
+    (Story) => (
+      <FileMenuProvider root="/Users/demo/project" hostId="story-local-host">
+        <Story />
+      </FileMenuProvider>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.pointer({ keys: "[MouseRight]", target: canvas.getByText("App.tsx") });
   },
 };

--- a/web/src/shell/FolderTree.test.tsx
+++ b/web/src/shell/FolderTree.test.tsx
@@ -391,3 +391,27 @@ describe("FolderTree default expansion on conversation switch", () => {
     expect(screen.getByRole("button", { name: "beta/" })).toHaveAttribute("aria-expanded", "true");
   });
 });
+
+it("offers a file's path on right-click without opening the file", () => {
+  const select = vi.fn();
+  renderTree({
+    files: [{ path: "src/main.ts", name: "main.ts", type: "file", bytes: 10, modified_at: null }],
+    onFileSelect: select,
+  });
+  fireEvent.contextMenu(screen.getByText("main.ts"));
+  fireEvent.click(screen.getByRole("menuitem", { name: "Copy Relative Path" }));
+  expect(copyTextMock).toHaveBeenCalledWith("src/main.ts");
+  expect(select).not.toHaveBeenCalled();
+});
+
+it("offers a folder's path on right-click without toggling it", () => {
+  renderTree({
+    files: [{ path: "src/main.ts", name: "main.ts", type: "file", bytes: 10, modified_at: null }],
+  });
+  const folder = screen.getByRole("button", { name: "src/" });
+  expect(folder).toHaveAttribute("aria-expanded", "true");
+  fireEvent.contextMenu(folder);
+  fireEvent.click(screen.getByRole("menuitem", { name: "Copy Relative Path" }));
+  expect(copyTextMock).toHaveBeenCalledWith("src");
+  expect(folder).toHaveAttribute("aria-expanded", "true");
+});

--- a/web/src/shell/FolderTree.tsx
+++ b/web/src/shell/FolderTree.tsx
@@ -21,6 +21,7 @@ import {
   gitStatusLabel,
   gitStatusLetter,
 } from "./fileStatusUtils";
+import { FileContextMenu } from "./FileContextMenu";
 import { CopyPathButton } from "./CopyPathButton";
 import { FileDownloadButton } from "./FileDownloadButton";
 import { useCursorTooltip } from "./useCursorTooltip";
@@ -744,74 +745,76 @@ function FileRowItem({
 
   return (
     <li className="list-none">
-      <div
-        className="group relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 hover:bg-muted"
-        style={{ paddingLeft: `${indentFor(depth)}px` }}
-      >
-        <IndentGuides depth={depth} />
-        <button
-          type="button"
-          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
-          onClick={() => !isDeleted && onFileSelect(path)}
-          disabled={isDeleted}
+      <FileContextMenu path={path} deleted={isDeleted}>
+        <div
+          className="group relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 hover:bg-muted"
+          style={{ paddingLeft: `${indentFor(depth)}px` }}
         >
-          <FileIcon
-            className={cn("size-3.5 shrink-0", fileColorClass ?? "text-muted-foreground")}
-          />
-          <span
-            className={cn(
-              "min-w-0 flex-1 truncate font-mono text-ui md:text-sm",
-              labelIsPath ? "[direction:rtl]" : fileStatus === "created" && "font-semibold",
-              isDeleted && "line-through opacity-50",
-              fileColorClass,
-            )}
-            {...handlers}
+          <IndentGuides depth={depth} />
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+            onClick={() => !isDeleted && onFileSelect(path)}
+            disabled={isDeleted}
           >
-            {labelIsPath ? <bdi>{displayLabel}</bdi> : displayLabel}
-          </span>
-          {fileStatus && (
-            // Centred in the shared status column so the A/M/D badge lands in
-            // the same x as a directory row's dirty dot.
+            <FileIcon
+              className={cn("size-3.5 shrink-0", fileColorClass ?? "text-muted-foreground")}
+            />
             <span
-              className={cn("flex shrink-0 items-center justify-center", ROW_STATUS_SLOT_CLASS)}
+              className={cn(
+                "min-w-0 flex-1 truncate font-mono text-ui md:text-sm",
+                labelIsPath ? "[direction:rtl]" : fileStatus === "created" && "font-semibold",
+                isDeleted && "line-through opacity-50",
+                fileColorClass,
+              )}
+              {...handlers}
             >
-              <span
-                className={cn(
-                  "rounded px-1 py-0.5 font-mono text-[10px]",
-                  isDeleted
-                    ? "bg-destructive/10 text-destructive"
-                    : fileStatus === "created"
-                      ? "bg-green-500/10 text-green-600 dark:text-green-400"
-                      : "bg-amber-500/10 text-amber-600 dark:text-amber-400",
-                )}
-                title={gitStatusLabel(fileStatus)}
-              >
-                {gitStatusLetter(fileStatus)}
-              </span>
+              {labelIsPath ? <bdi>{displayLabel}</bdi> : displayLabel}
             </span>
-          )}
-        </button>
-        {/* One trailing column, always rendered so every row (directories
+            {fileStatus && (
+              // Centred in the shared status column so the A/M/D badge lands in
+              // the same x as a directory row's dirty dot.
+              <span
+                className={cn("flex shrink-0 items-center justify-center", ROW_STATUS_SLOT_CLASS)}
+              >
+                <span
+                  className={cn(
+                    "rounded px-1 py-0.5 font-mono text-[10px]",
+                    isDeleted
+                      ? "bg-destructive/10 text-destructive"
+                      : fileStatus === "created"
+                        ? "bg-green-500/10 text-green-600 dark:text-green-400"
+                        : "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+                  )}
+                  title={gitStatusLabel(fileStatus)}
+                >
+                  {gitStatusLetter(fileStatus)}
+                </span>
+              </span>
+            )}
+          </button>
+          {/* One trailing column, always rendered so every row (directories
             included) shares it: metadata at rest, the copy/download pair on
             hover. */}
-        <span
-          className={cn("relative flex shrink-0 items-center justify-end", ROW_META_SLOT_CLASS)}
-        >
-          {bytes !== null && !isDeleted && (
-            <span className="text-muted-foreground text-[10px] group-hover:invisible">
-              {formatBytes(bytes)}
-            </span>
-          )}
-          <span className="absolute inset-0 flex items-center justify-end gap-0.5">
-            {!isDeleted && conversationId ? (
-              <FileDownloadButton conversationId={conversationId} path={path} />
-            ) : (
-              <span className={cn("shrink-0", ROW_ACTION_SIZE_CLASS)} aria-hidden />
+          <span
+            className={cn("relative flex shrink-0 items-center justify-end", ROW_META_SLOT_CLASS)}
+          >
+            {bytes !== null && !isDeleted && (
+              <span className="text-muted-foreground text-[10px] group-hover:invisible">
+                {formatBytes(bytes)}
+              </span>
             )}
-            <CopyPathButton path={path} revealOnHover />
+            <span className="absolute inset-0 flex items-center justify-end gap-0.5">
+              {!isDeleted && conversationId ? (
+                <FileDownloadButton conversationId={conversationId} path={path} />
+              ) : (
+                <span className={cn("shrink-0", ROW_ACTION_SIZE_CLASS)} aria-hidden />
+              )}
+              <CopyPathButton path={path} revealOnHover />
+            </span>
           </span>
-        </span>
-      </div>
+        </div>
+      </FileContextMenu>
       {tooltip}
     </li>
   );
@@ -936,56 +939,60 @@ const TreeNodeRow = memo(function TreeNodeRow({
     // toggle, and a button nested inside a button is invalid HTML. The toggle
     // still spans everything up to the copy button, so the clickable area is
     // effectively unchanged.
-    <div
-      className="group relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 hover:bg-muted"
-      style={{ paddingLeft: `${indentFor(depth)}px` }}
-    >
-      <IndentGuides depth={depth} />
-      <button
-        type="button"
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
-        onClick={() => onTogglePath(node.path)}
-        // Finder's contract: single click expands in place, double click opens
-        // the folder as the new working folder. The browser fires the two
-        // single clicks first, so the row toggles twice (a no-op) before
-        // re-rooting replaces the tree outright.
-        onDoubleClick={onNavigateDir ? () => onNavigateDir(node.path) : undefined}
-        aria-expanded={open}
+    <FileContextMenu path={node.path}>
+      <div
+        className="group relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 hover:bg-muted"
+        style={{ paddingLeft: `${indentFor(depth)}px` }}
       >
-        <ChevronRightIcon
-          className={cn(
-            "size-3.5 shrink-0 text-muted-foreground transition-transform",
-            open && "rotate-90",
-          )}
-        />
-        <span
-          className={cn(
-            "min-w-0 flex-1 truncate font-mono text-ui md:text-sm",
-            dirStatus === "created" && "font-semibold",
-            dirDotClass,
-          )}
+        <IndentGuides depth={depth} />
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+          onClick={() => onTogglePath(node.path)}
+          // Finder's contract: single click expands in place, double click opens
+          // the folder as the new working folder. The browser fires the two
+          // single clicks first, so the row toggles twice (a no-op) before
+          // re-rooting replaces the tree outright.
+          onDoubleClick={onNavigateDir ? () => onNavigateDir(node.path) : undefined}
+          aria-expanded={open}
         >
-          {node.name}/
-        </span>
-        {dirStatus && (
+          <ChevronRightIcon
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-90",
+            )}
+          />
           <span
-            className={cn("flex shrink-0 items-center justify-center", ROW_STATUS_SLOT_CLASS)}
-            aria-hidden
+            className={cn(
+              "min-w-0 flex-1 truncate font-mono text-ui md:text-sm",
+              dirStatus === "created" && "font-semibold",
+              dirDotClass,
+            )}
           >
-            <span className={cn("text-[8px] leading-none", dirDotClass)}>●</span>
+            {node.name}/
           </span>
-        )}
-      </button>
-      {/* The same trailing column as a file row. A folder has no size and
+          {dirStatus && (
+            <span
+              className={cn("flex shrink-0 items-center justify-center", ROW_STATUS_SLOT_CLASS)}
+              aria-hidden
+            >
+              <span className={cn("text-[8px] leading-none", dirDotClass)}>●</span>
+            </span>
+          )}
+        </button>
+        {/* The same trailing column as a file row. A folder has no size and
           nothing to download, so the column shows only the copy button — with
           the download's footprint reserved beside it so that button lands in
           the same x as every file row's. */}
-      <span className={cn("relative flex shrink-0 items-center justify-end", ROW_META_SLOT_CLASS)}>
-        <span className="absolute inset-0 flex items-center justify-end gap-0.5">
-          <span className={cn("shrink-0", ROW_ACTION_SIZE_CLASS)} aria-hidden />
-          <CopyPathButton path={node.path} label="Copy folder path" revealOnHover />
+        <span
+          className={cn("relative flex shrink-0 items-center justify-end", ROW_META_SLOT_CLASS)}
+        >
+          <span className="absolute inset-0 flex items-center justify-end gap-0.5">
+            <span className={cn("shrink-0", ROW_ACTION_SIZE_CLASS)} aria-hidden />
+            <CopyPathButton path={node.path} label="Copy folder path" revealOnHover />
+          </span>
         </span>
-      </span>
-    </div>
+      </div>
+    </FileContextMenu>
   );
 });

--- a/web/src/shell/WorkspacePanel.stories.tsx
+++ b/web/src/shell/WorkspacePanel.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryQueryRouter } from "@/storybook/StoryProviders";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { FileMenuProvider } from "./FileContextMenu";
+import { WorkspacePanel } from "./WorkspacePanel";
+
+const noop = () => undefined;
+const sessionId = "story-file-viewer-menu";
+const meta = {
+  title: "Components/Shell/WorkspacePanel",
+  component: WorkspacePanel,
+  args: {
+    conversationId: sessionId,
+    width: 520,
+    handleProps: { tabIndex: 0 },
+    rightRailTab: "files",
+    onRightRailTabChange: noop,
+    showFilesPanel: true,
+    showGithubTab: false,
+    showBrowserTab: false,
+    changedCount: 0,
+    subagentsWorking: 0,
+    agentCount: 1,
+    rootSessionId: null,
+    selectedFilePath: "docs/README.md",
+    openFiles: ["docs/README.md", "src/main.ts"],
+    openFileViewer: noop,
+    onCloseFile: noop,
+    onShowScopeView: noop,
+    onCommentsOpenChange: noop,
+    openTerminalTab: noop,
+    openTerminals: [],
+    selectedTerminalKey: null,
+    onCloseTerminal: noop,
+    maximized: false,
+    onToggleMaximized: noop,
+    permissionLevel: null,
+    filesPanelSort: "recent",
+    onSortChange: noop,
+    filesPanelShowHidden: false,
+    onShowHiddenChange: noop,
+  },
+  decorators: [
+    (Story) => (
+      <StoryQueryRouter
+        seed={(client) => {
+          client.setQueryData(["file-content", sessionId, "docs/README.md"], {
+            object: "session.environment.filesystem.file_content",
+            path: "docs/README.md",
+            content_type: "text/markdown",
+            encoding: "utf-8",
+            content:
+              "# Project notes\n\nOpen a file's location or copy its path from the tab, the displayed path, or the menu beside it.\n",
+          });
+          client.setQueryData(["workspace-changed-files", sessionId], { data: [] });
+          client.setQueryData(["comments", sessionId, "docs/README.md"], []);
+          client.setQueryData(["session-agent", sessionId], { id: "story-agent", terminals: [] });
+        }}
+      >
+        <TooltipProvider>
+          <FileMenuProvider root="/Users/demo/project" hostId="story-local-host">
+            <div className="flex h-[450px]">
+              <Story />
+            </div>
+          </FileMenuProvider>
+        </TooltipProvider>
+      </StoryQueryRouter>
+    ),
+  ],
+} satisfies Meta<typeof WorkspacePanel>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const OpenFileMenus: Story = {};

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -1,3 +1,7 @@
+import { FileMenuProvider } from "./FileContextMenu";
+import { copyText } from "@/lib/clipboard";
+
+vi.mock("@/lib/clipboard", () => ({ copyText: vi.fn(() => Promise.resolve()) }));
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -96,38 +100,40 @@ function renderWorkspace(
   const onToggleMaximized = vi.fn();
   render(
     <TooltipProvider delayDuration={0}>
-      <WorkspacePanel
-        conversationId="conv_ws"
-        width={360}
-        handleProps={{ tabIndex: 0 }}
-        rightRailTab={overrides.rightRailTab ?? "files"}
-        onRightRailTabChange={onRightRailTabChange}
-        showFilesPanel
-        showGithubTab={overrides.showGithubTab ?? false}
-        showBrowserTab={overrides.showBrowserTab ?? false}
-        changedCount={overrides.changedCount ?? 0}
-        subagentsWorking={0}
-        agentCount={1}
-        rootSessionId={null}
-        selectedFilePath={overrides.selectedFilePath ?? null}
-        openFiles={overrides.openFiles ?? []}
-        openFileViewer={openFileViewer}
-        onCloseFile={onCloseFile}
-        onShowScopeView={vi.fn()}
-        onCommentsOpenChange={vi.fn()}
-        openTerminalTab={openTerminalTab}
-        openTerminals={overrides.openTerminals ?? []}
-        selectedTerminalKey={overrides.selectedTerminalKey ?? null}
-        onCloseTerminal={onCloseTerminal}
-        maximized={overrides.maximized ?? false}
-        onToggleMaximized={onToggleMaximized}
-        permissionLevel={null}
-        filesPanelSort={"recent" as ChangedSort}
-        onSortChange={vi.fn()}
-        filesPanelShowHidden={false}
-        onShowHiddenChange={vi.fn()}
-        liveness={overrides.liveness}
-      />
+      <FileMenuProvider root="/workspace" hostId={null}>
+        <WorkspacePanel
+          conversationId="conv_ws"
+          width={360}
+          handleProps={{ tabIndex: 0 }}
+          rightRailTab={overrides.rightRailTab ?? "files"}
+          onRightRailTabChange={onRightRailTabChange}
+          showFilesPanel
+          showGithubTab={overrides.showGithubTab ?? false}
+          showBrowserTab={overrides.showBrowserTab ?? false}
+          changedCount={overrides.changedCount ?? 0}
+          subagentsWorking={0}
+          agentCount={1}
+          rootSessionId={null}
+          selectedFilePath={overrides.selectedFilePath ?? null}
+          openFiles={overrides.openFiles ?? []}
+          openFileViewer={openFileViewer}
+          onCloseFile={onCloseFile}
+          onShowScopeView={vi.fn()}
+          onCommentsOpenChange={vi.fn()}
+          openTerminalTab={openTerminalTab}
+          openTerminals={overrides.openTerminals ?? []}
+          selectedTerminalKey={overrides.selectedTerminalKey ?? null}
+          onCloseTerminal={onCloseTerminal}
+          maximized={overrides.maximized ?? false}
+          onToggleMaximized={onToggleMaximized}
+          permissionLevel={null}
+          filesPanelSort={"recent" as ChangedSort}
+          onSortChange={vi.fn()}
+          filesPanelShowHidden={false}
+          onShowHiddenChange={vi.fn()}
+          liveness={overrides.liveness}
+        />
+      </FileMenuProvider>
     </TooltipProvider>,
   );
   return {
@@ -719,4 +725,16 @@ describe("WorkspacePanel browser tab", () => {
     // And the file scope views are not mounted in that branch.
     expect(screen.queryByTestId("files-panel-stub")).toBeNull();
   });
+});
+
+it("right-clicking an inactive file tab acts on that file without switching or closing it", () => {
+  const { openFileViewer, onCloseFile } = renderWorkspace({
+    openFiles: ["src/active.ts", "docs/other.md"],
+    selectedFilePath: "src/active.ts",
+  });
+  fireEvent.contextMenu(screen.getByTitle("docs/other.md"));
+  fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
+  expect(copyText).toHaveBeenCalledWith("/workspace/docs/other.md");
+  expect(openFileViewer).not.toHaveBeenCalled();
+  expect(onCloseFile).not.toHaveBeenCalled();
 });

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -44,6 +44,7 @@ import { SuppressBrowserView } from "@/hooks/useSuppressBrowserView";
 import GithubMono from "@lobehub/icons/es/Github/components/Mono";
 import { readPreferredShell, resolveDefaultShell, writePreferredShell } from "./preferredShell";
 import { FilesPanel } from "./FilesPanel";
+import { FileContextMenu } from "./FileContextMenu";
 import { FileViewer } from "./FileViewer";
 import { GithubPanel } from "./GithubPanel";
 import type { ChangedSort } from "./FlatFileList";
@@ -331,64 +332,65 @@ function FileTabsStrip({
         const name = path.split("/").pop() ?? path;
         const active = path === activeFilePath;
         return (
-          <div
-            key={path}
-            ref={active ? activeTabRef : undefined}
-            role="button"
-            tabIndex={0}
-            aria-current={active}
-            title={path}
-            onClick={() => onFileSelect(path)}
-            onAuxClick={(e) => {
-              // Middle click (button 1) closes the tab, matching browser /
-              // editor tab conventions.
-              if (e.button === 1) {
-                e.preventDefault();
-                onCloseFile(path);
-              }
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onFileSelect(path);
-              }
-            }}
-            className={cn(
-              // Match the fixed TabsTrigger pill's box metrics (h-24 / px-8 /
-              // rounded-8 / 13px medium) so file tabs and Files/Terminals tabs
-              // are the same height and the active chip lines up across both
-              // sets. `group/tab` drives the hover-revealed close overlay below.
-              // `overflow-hidden` clips the hover-close gradient overlay to the
-              // pill's rounded corners so its rectangular edges can't poke out.
-              "group/tab relative flex h-[24px] min-w-0 max-w-[320px] shrink-0 cursor-pointer items-center justify-center gap-[6px] overflow-hidden rounded-md px-2 text-ui font-medium leading-5 transition-colors",
-              active
-                ? "bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] text-foreground"
-                : "text-muted-foreground hover:bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] hover:text-foreground",
-            )}
-          >
-            <FileIcon className="size-4 shrink-0" />
-            <span className="min-w-0 truncate">{name}</span>
-            {/* Close button: hidden until hover, then revealed over a gradient
+          <FileContextMenu key={path} path={path}>
+            <div
+              ref={active ? activeTabRef : undefined}
+              role="button"
+              tabIndex={0}
+              aria-current={active}
+              title={path}
+              onClick={() => onFileSelect(path)}
+              onAuxClick={(e) => {
+                // Middle click (button 1) closes the tab, matching browser /
+                // editor tab conventions.
+                if (e.button === 1) {
+                  e.preventDefault();
+                  onCloseFile(path);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onFileSelect(path);
+                }
+              }}
+              className={cn(
+                // Match the fixed TabsTrigger pill's box metrics (h-24 / px-8 /
+                // rounded-8 / 13px medium) so file tabs and Files/Terminals tabs
+                // are the same height and the active chip lines up across both
+                // sets. `group/tab` drives the hover-revealed close overlay below.
+                // `overflow-hidden` clips the hover-close gradient overlay to the
+                // pill's rounded corners so its rectangular edges can't poke out.
+                "group/tab relative flex h-[24px] min-w-0 max-w-[320px] shrink-0 cursor-pointer items-center justify-center gap-[6px] overflow-hidden rounded-md px-2 text-ui font-medium leading-5 transition-colors",
+                active
+                  ? "bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] text-foreground"
+                  : "text-muted-foreground hover:bg-[color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))] hover:text-foreground",
+              )}
+            >
+              <FileIcon className="size-4 shrink-0" />
+              <span className="min-w-0 truncate">{name}</span>
+              {/* Close button: hidden until hover, then revealed over a gradient
                 that fades the truncated filename into the tab's background so
                 the "x" never collides with the text. The overlay only shows on
                 hover, where both active and inactive tabs share the same OPAQUE
                 selection surface — fade to that exact color. (A translucent
                 fade like var(--muted) would stack over the hover background and
                 darken the right edge into a visible gradient patch.) */}
-            <span className="absolute inset-y-0 right-0 flex items-center pl-[12px] pr-[4px] opacity-0 transition-opacity group-hover/tab:opacity-100 [background:linear-gradient(to_right,transparent,color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))_40%)]">
-              <button
-                type="button"
-                aria-label={`Close ${name}`}
-                className="flex size-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCloseFile(path);
-                }}
-              >
-                <XIcon className="size-4" />
-              </button>
-            </span>
-          </div>
+              <span className="absolute inset-y-0 right-0 flex items-center pl-[12px] pr-[4px] opacity-0 transition-opacity group-hover/tab:opacity-100 [background:linear-gradient(to_right,transparent,color-mix(in_srgb,var(--muted-foreground)_15%,var(--card))_40%)]">
+                <button
+                  type="button"
+                  aria-label={`Close ${name}`}
+                  className="flex size-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCloseFile(path);
+                  }}
+                >
+                  <XIcon className="size-4" />
+                </button>
+              </span>
+            </div>
+          </FileContextMenu>
         );
       })}
     </div>


### PR DESCRIPTION
## Related issue

Closes #6689

## Summary

Files now expose the same filesystem actions from tree rows, open tabs, the viewer's displayed path, and its ellipsis menu: Copy Path (absolute), Copy Relative Path, and native reveal for local desktop items. The reveal label follows the OS: Finder, File Explorer, or File Manager. Right-clicking an inactive tab acts on that file without switching tabs.

The viewer's URL-sharing action is explicitly labeled **Copy Omnigent Link**, so users can distinguish a server page URL from a filesystem path. Absolute paths outside the workspace remain absolute; relative copying is offered only when the path can be expressed under the current root.

In everyday terms, use any place that names an open file to find it on your computer or copy its path.

```mermaid
flowchart LR
  Tree[Tree row] --> Actions[Shared file actions]
  Tab[Open file tab] --> Actions
  Viewer[Viewer path or ellipsis] --> Actions
  Actions --> Copy[Copy filesystem path]
  Actions --> Local{Local desktop host?}
  Local -->|Yes| Reveal[OS file manager]
```

## Test Plan

- Frontend tests: context-menu actions, browse-location changes, Windows drive/UNC paths, platform labels, browser/older-shell fallback, and preserving file/folder click behavior.
- Electron tests: trusted sender/local-host checks, file and directory reveal, invalid/missing paths, native failures.
- Related frontend suites: 304 tests passed, with one pre-existing expected failure. The final targeted run passed 155 tests plus that expected failure. Tests cover tree rows, inactive tabs, viewer path and both ellipsis layouts, outside-workspace paths, and explicit URL-sharing labels.
- 5 targeted Electron tests passed. TypeScript and all applicable repository pre-commit checks passed.
- Playwright exercised the actual Storybook components with a simulated desktop bridge for macOS and Windows, checking copied paths and reveal arguments.

- Real-server browser E2E: `pytest tests/e2e_ui/files/test_file_link_sharing.py --ui-skip-build --browser-channel chrome -v` — 2 passed against a freshly built SPA. Verifies shareable URLs in a fresh browser context, absolute/relative clipboard paths from the tree, tab, displayed path, and both toolbar layouts, plus absence of native reveal in a browser.
- macOS Electron 42.7.0 smoke test used the actual preload and reveal IPC handler with the real `shell.showItemInFolder`: local test-file reveal returned true; remote-host and missing-file requests returned false. This verifies native dispatch, not a visual assertion of Finder's selection.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Screenshots (simulated OS bridge; actual tree, tabs, and viewer UI):

![macOS context menu](https://raw.githubusercontent.com/nakazax/omnigent/e0ec3171798a6fc33374ec456c25ed7455614b8f/file-menu-macos.png)

![Windows context menu](https://raw.githubusercontent.com/nakazax/omnigent/e0ec3171798a6fc33374ec456c25ed7455614b8f/file-menu-windows.png)

![Open file tab](https://raw.githubusercontent.com/nakazax/omnigent/e0ec3171798a6fc33374ec456c25ed7455614b8f/file-tab-menu.png)

![Viewer overflow menu](https://raw.githubusercontent.com/nakazax/omnigent/e0ec3171798a6fc33374ec456c25ed7455614b8f/file-viewer-overflow-menu.png)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Screenshots use a simulated Electron bridge. The additional macOS smoke test exercised real Electron-to-Finder dispatch; Finder selection still needs visual confirmation. Windows and Linux native window behavior remains unverified. Automated tests cover path resolution, platform labels, and the Electron handler.

The existing Windows workflow excludes `web/**`; frontend CI runs on Ubuntu. Windows Explorer integration has therefore not been validated by this PR’s current checks.

Manual check: in an updated desktop build, open a local session → Files → All, right-click a file or folder, copy both path forms, and reveal it in the OS file manager. Repeat after navigating into a subfolder. A remote session should retain copying and omit local reveal.

## Changelog

Copy file paths or reveal local files from tree rows, open tabs, and viewer menus; shared page URLs are now labeled Copy Omnigent Link.

