### PR TITLE
Add oh-my-pi (omp) as a supported harness backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ omnigent run --harness grok           # 'grok-build' also works
 curl -fsSL https://cli.devin.ai/install.sh | bash
 devin auth login
 omnigent run --harness devin
+
 ```
 
 Both speak the [Agent Client Protocol](https://agentclientprotocol.com) over
@@ -309,6 +310,22 @@ If you need the key route, pass it explicitly with
 declares the passthrough.
 
 </details>
+
+#### Oh My Pi
+
+Oh My Pi (`omp`) is a full harness backend — it runs `omp --mode rpc` with
+model override, gateway routing, and policy gates, like the `pi` harness:
+
+```bash
+npm install -g @oh-my-pi/pi-coding-agent   # or: curl -fsSL https://omp.sh/install | sh
+omp auth-broker login <provider>            # e.g. anthropic; or `/login` inside omp
+omnigent run --harness omp                  # 'oh-my-pi' also works
+omnigent run --harness omp --model anthropic/claude-opus-4-6
+```
+
+`omni setup` installs the CLI and shows the omp credential row next to Pi's.
+Without an Omnigent provider, omp runs on its own `~/.omp/agent` login; with
+one, Omnigent routes it through a generated `models.yml` gateway.
 
 #### 🐙 Polly and 🟠🔵 Debby
 

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3916,7 +3916,7 @@ def _spec_used_families(agent_yaml: Path | None) -> list[str]:
     else:
         return []
     try:
-        from omnigent.onboarding.provider_config import PI_SURFACE, harness_family
+        from omnigent.onboarding.provider_config import OMP_SURFACE, PI_SURFACE, harness_family
         from omnigent.spec import parse
 
         spec = parse(root, expand_env=False)
@@ -3932,12 +3932,12 @@ def _spec_used_families(agent_yaml: Path | None) -> list[str]:
         fam = harness_family(harness)
         if fam is not None:
             families.add(fam)
-        elif harness == PI_SURFACE:
-            # pi spans both model families, so it has no single family —
-            # it contributes its own surface, and the header resolves that
-            # surface's effective credential (explicit pi default, else
+        elif harness in (PI_SURFACE, OMP_SURFACE):
+            # pi/omp span both model families, so neither has a single family —
+            # each contributes its own surface, and the header resolves that
+            # surface's effective credential (explicit scope default, else
             # the cross-family fallback).
-            families.add(PI_SURFACE)
+            families.add(harness)
         for child in node.sub_agents:
             _walk(child)
 

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -492,15 +492,16 @@ def _credential_source_hint(entry: ProviderEntry, family: str) -> str | None:
     """
     from omnigent.onboarding.provider_config import (
         ANTHROPIC_FAMILY,
+        OMP_SURFACE,
         OPENAI_FAMILY,
         PI_SURFACE,
     )
 
     raw = entry.families.get(family)
-    if raw is None and family == PI_SURFACE:
-        # The pi surface carries no family block of its own — pi consumes
-        # the credential of whichever family it routes through (anthropic
-        # preferred), so describe that family's source instead.
+    if raw is None and family in (PI_SURFACE, OMP_SURFACE):
+        # The pi/omp surfaces carry no family block of their own — each
+        # consumes the credential of whichever family it routes through
+        # (anthropic preferred), so describe that family's source instead.
         for fam in (ANTHROPIC_FAMILY, OPENAI_FAMILY):
             raw = entry.families.get(fam)
             if raw is not None:
@@ -574,6 +575,25 @@ def _family_credential_label(  # type: ignore[explicit-any]  # config is a yaml-
     return f"{base} ({hint})" if hint else base
 
 
+def _surface_claim_key(surface: str) -> tuple[int, str]:
+    """Order default-claiming so model families precede harness scopes.
+
+    The pi/omp surfaces resolve an *effective* default (explicit scope, else
+    the cross-family fallback), so the add/adopt loops must evaluate them
+    AFTER the families: a scope sorts alphabetically ("omp" < "openai"), and
+    claiming it before the family default exists needlessly pins the scope
+    (``default: [omp, openai]`` instead of ``default: true``), freezing the
+    scope to that provider when it would otherwise follow the family default
+    like pi does.
+
+    :param surface: A harness surface, e.g. ``"openai"`` or ``"omp"``.
+    :returns: Sort key with families first, scopes second, name within.
+    """
+    from omnigent.onboarding.provider_config import OMP_SURFACE, PI_SURFACE
+
+    return (surface in (PI_SURFACE, OMP_SURFACE), surface)
+
+
 def _configure_harness_add(family: str | None = None) -> str | None:
     """Run the interactive ``add a provider`` flow and persist the entry.
 
@@ -616,6 +636,7 @@ def _configure_harness_add(family: str | None = None) -> str | None:
         CHAT_WIRE_API,
         CLI_CONFIG_KIND,
         DATABRICKS_KIND,
+        OMP_SURFACE,
         OPENAI_FAMILY,
         PI_SURFACE,
         RESPONSES_WIRE_API,
@@ -629,7 +650,12 @@ def _configure_harness_add(family: str | None = None) -> str | None:
     # user adds Databricks from a specific harness page, we configure ucode for
     # ONLY that harness (not all of claude/codex/pi) so ucode touches just the
     # one tool the user is wiring up.
-    _FAMILY_UCODE_AGENT = {ANTHROPIC_FAMILY: "claude", OPENAI_FAMILY: "codex", PI_SURFACE: "pi"}
+    _FAMILY_UCODE_AGENT = {
+        ANTHROPIC_FAMILY: "claude",
+        OPENAI_FAMILY: "codex",
+        PI_SURFACE: "pi",
+        OMP_SURFACE: "omp",
+    }
 
     # A flat, credential-aware menu: the user picks "OpenAI — API key" or
     # "Claude — subscription" directly (rather than a bare kind then
@@ -1061,9 +1087,10 @@ def _configure_harness_add(family: str | None = None) -> str | None:
     # so a first provider "just works". An existing default is left alone —
     # the user changes defaults by selecting a provider in the harness tree
     # (per-surface, so a shared provider can default one harness, not both).
-    # The pi surface checks its *effective* default: a family default already
-    # drives pi via the fallback, so claiming the explicit pi scope then
-    # would silently re-route pi away from it.
+    # The pi/omp surfaces check their *effective* default: a family default
+    # already drives them via the fallback, so claiming an explicit scope then
+    # would silently re-route them away from it (families claim first — see
+    # :func:`_surface_claim_key`).
     parsed = load_providers({"providers": {name: entry}})[name]
     # Databricks routing is configured in ucode PER HARNESS (we only ran
     # `ucode configure` for the surface the user drilled into), so it must only
@@ -1074,7 +1101,7 @@ def _configure_harness_add(family: str | None = None) -> str | None:
     if entry["kind"] == DATABRICKS_KIND and family is not None:
         default_families = [family]
     else:
-        default_families = sorted(provider_families(parsed))
+        default_families = sorted(provider_families(parsed), key=_surface_claim_key)
     became_default: list[str] = []
     for fam in default_families:
         cfg = _load_global_config()
@@ -1165,7 +1192,7 @@ def _promote_global_auth_to_provider() -> str | None:
         deep_merge_keys=("providers",),
     )
     parsed = load_providers({"providers": {name: entry}})[name]
-    for fam in sorted(provider_families(parsed)):
+    for fam in sorted(provider_families(parsed), key=_surface_claim_key):
         cfg = _load_global_config()
         # Effective check (matters for the pi surface): a default that
         # already drives the surface — explicitly or via pi's fallback —
@@ -3554,6 +3581,7 @@ def _run_configure_harnesses_interactive() -> None:
     from omnigent.onboarding.provider_config import (
         ANTHROPIC_FAMILY,
         GEMINI_FAMILY,
+        OMP_SURFACE,
         OPENAI_FAMILY,
         PI_SURFACE,
         surface_default_provider,
@@ -3616,7 +3644,7 @@ def _run_configure_harnesses_interactive() -> None:
     _ACP_ADD = "\x00acp-add"
     _ACP_AGENT_PREFIX = "\x00acp-agent:"
     _ACP_CLI_PREFIX = "\x00acp-cli:"
-    families = [ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE]
+    families = [ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE, OMP_SURFACE]
 
     # Status glyph + Rich color per readiness kind: "ready" is a configured,
     # launchable harness (green ✓); "missing" is an absent CLI/SDK (red ✗);
@@ -3803,6 +3831,7 @@ def _run_configure_harnesses_interactive() -> None:
             )
 
         rows.append(_family_row(PI_SURFACE))
+        rows.append(_family_row(OMP_SURFACE))
 
         # Antigravity — native agy sign-in OR Gemini key (SDK extra is soft, like Cursor).
         if antigravity_api_key_configured(config) or any(

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -541,6 +541,21 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         streaming=True,
         instruction_delivery=_ID.COMPOSED_PER_TURN,
     ),
+    # omp runs its own RPC wrap (``omp --mode rpc``) with the same integration
+    # mode, resume, and delivery semantics as pi (same gateway models, same
+    # thinking ladder, same per-turn composition).
+    "omp": _C(
+        _IM.CLI_SUBPROCESS,
+        _EL.NONE,
+        _RS.COLD_ONLY,
+        _EF.PI,
+        _MF.MULTI,
+        _AU.OMNIGENT_CREDENTIAL,
+        subagents=False,
+        interrupt=True,
+        streaming=True,
+        instruction_delivery=_ID.COMPOSED_PER_TURN,
+    ),
     "openai-agents": _C(
         _IM.SDK_IN_PROCESS,
         _EL.NONE,
@@ -685,6 +700,10 @@ _BUILTIN_CAPABILITIES["devin"] = dataclasses.replace(
     subagents=DEVIN_ACP_EXTENSION.surfaces_subagents,
 )
 
+# ``omp`` runs its own RPC wrap (``omnigent.inner.omp_harness``), not the
+# generic ACP wrap, so it carries ``pi``'s declared profile (same integration
+# mode, resume, and delivery semantics).
+
 
 _BUILTIN_CONTRIBUTION = HarnessContribution(
     name="omnigent",
@@ -710,6 +729,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
             "open-responses",
             "openai-agents",
             "opencode-native",
+            "omp",
             "pi",
             "pi-native",
             "qwen",
@@ -726,6 +746,9 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         # ...except a row with vendor behavior, which runs its own thin wrap to
         # inject an AcpExtension into the same shared executor.
         "devin": "omnigent.inner.devin.harness",
+        # ``omp`` runs its own RPC wrap (``omp --mode rpc``), not the generic
+        # ACP wrap.
+        "omp": "omnigent.inner.omp_harness",
         "antigravity": "omnigent.inner.antigravity_harness",
         "antigravity-native": "omnigent.inner.antigravity_native_harness",
         "claude-native": "omnigent.inner.claude_native_harness",
@@ -757,6 +780,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "github-copilot": "copilot",
         "google-antigravity": "antigravity",
         "kimi-code": "kimi",
+        "oh-my-pi": "omp",
         "native-agy": "antigravity-native",
         "native-antigravity": "antigravity-native",
         "native-goose": "goose-native",
@@ -831,6 +855,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         "hermes": "HARNESS_HERMES_MODEL",
         "kimi": "HARNESS_KIMI_MODEL",
         "openai-agents": "HARNESS_OPENAI_AGENTS_MODEL",
+        "omp": "HARNESS_OMP_MODEL",
         "pi": "HARNESS_PI_MODEL",
         "qwen": "HARNESS_QWEN_MODEL",
     },
@@ -859,7 +884,7 @@ _BUILTIN_CONTRIBUTION = HarnessContribution(
         # openai-agents is intentionally omitted from the picker catalog: it
         # stays a valid harness for YAML specs (and the credential-free
         # integration mock LLM), but is no longer offered as a UI pick.
-        "pi": "Pi",
+        "omp": "Oh My Pi",
         **{name: row.label for name, row in ACP_CLI_HARNESSES.items()},
     },
     capabilities=_BUILTIN_CAPABILITIES,

--- a/omnigent/inner/omp_executor.py
+++ b/omnigent/inner/omp_executor.py
@@ -2079,7 +2079,7 @@ class OmpExecutor(Executor):
                 workspace_url,
                 self._databricks_token,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 — metadata is best-effort; fall back to the yml catalog
             logger.warning(
                 "omp could not fetch Databricks model metadata; "
                 "the picker will show only the selected model",
@@ -2093,7 +2093,7 @@ class OmpExecutor(Executor):
                 model_catalog.catalog_model_entries,
                 "databricks",
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 — enrichment is best-effort; the live list survives without it
             logger.info(
                 "omp could not enrich the live Databricks model list with MLflow metadata",
                 exc_info=True,
@@ -2280,7 +2280,7 @@ class OmpExecutor(Executor):
                 {"type": "get_available_thinking_levels", "id": "thinking_levels"},
                 "get_available_thinking_levels",
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 — probe is best-effort; a failed probe just skips clamping
             logger.debug("OmpExecutor: get_available_thinking_levels failed", exc_info=True)
             return None
         data = response.get("data") if response else None

--- a/omnigent/inner/omp_executor.py
+++ b/omnigent/inner/omp_executor.py
@@ -1,0 +1,2770 @@
+"""OmpExecutor: run agents through the oh-my-pi coding agent's RPC mode.
+
+Spawns omp (``omp --mode rpc``) as a subprocess and communicates via a JSONL
+protocol over stdin/stdout.  omp manages its own agent loop, tool execution,
+context window, and compaction internally.  This executor translates the omp
+event stream into Omnigent ExecutorEvents.
+
+Omnigent tools are bridged into omp via a generated JavaScript extension
+that registers each tool with ``pi.registerTool()`` (omp keeps upstream pi's
+extension surface, including the ``pi`` host object name).  Tool execution is
+proxied over a local TCP socket to the Omnigent Python process, so
+policies, history recording, sub-agents, runtime, and all other Omnigent
+features work exactly as they do with the Claude SDK and Codex harnesses.
+
+When ``os_env`` is set, the omp subprocess is wrapped in the same
+sandbox used for other harnesses.
+
+Databricks support: a temporary ``models.yml`` is generated with three
+providers (OpenAI Responses for GPT, Anthropic Messages for Claude, and
+OpenAI Completions for others) and ``PI_CODING_AGENT_DIR`` is set so omp
+picks it up (omp kept the ``PI_CODING_AGENT_DIR`` name; it relocates the
+``~/.omp/agent`` base).
+
+Requirements:
+    The ``omp`` CLI must be installed and on PATH.
+
+Environment (Databricks):
+    DATABRICKS_CONFIG_PROFILE — optional Databricks profile selector
+    ~/.databrickscfg          — host + token profile for workspace access
+    (or ~/.databrickscfg with a profile containing host + token)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import hmac
+import json
+import logging
+import os
+import pathlib
+import re
+import secrets
+import shutil
+import subprocess
+import tempfile
+from asyncio import Queue, Task
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Any, NotRequired, TypeAlias, TypedDict, cast
+from urllib.parse import urlparse as _urlparse
+
+import yaml
+
+from omnigent import model_catalog
+from omnigent.inner.agent_env import clean_agent_env
+from omnigent.inner.native_attachments import parse_data_uri
+from omnigent.json_types import JsonObject as _JsonObject
+from omnigent.json_types import JsonValue
+from omnigent.llms._usage_observer import notify_from_dict as _notify_usage_from_dict
+from omnigent.model_metadata import ModelWireAPI
+from omnigent.onboarding.provider_config import CHAT_WIRE_API, RESPONSES_WIRE_API
+from omnigent.pi_model_compatibility import (
+    SYSTEM_AI_RESPONSES_KEYWORDS,
+    databricks_model_aliases,
+    enrich_databricks_model_catalog,
+    pi_model_is_reasoning,
+    pi_model_json_entry,
+    unsupported_in_pi,
+)
+from omnigent.pi_native_credentials import (
+    _databricks_workspace_url_for_gateway,
+    _is_databricks_ai_gateway_url,
+)
+from omnigent.reasoning_effort import (
+    EFFORT_CLEAR_VALUES,
+    PI_EFFORTS,
+    nearest_pi_thinking_level,
+    to_pi_thinking_level,
+    validate_effort,
+)
+from omnigent.runner.identity import OMNIGENT_SESSION_ENV_VAR
+from omnigent.spec.types import RetryPolicy
+
+from ._subprocess_lifecycle import close_subprocess_transport
+from .async_utils import run_sync_on_thread
+from .databricks_executor import _read_databrickscfg
+from .datamodel import OSEnvSandboxSpec, OSEnvSpec
+from .executor import (
+    Executor,
+    ExecutorConfig,
+    ExecutorError,
+    ExecutorEvent,
+    Message,
+    ReasoningChunk,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
+    ToolSpec,
+    TurnComplete,
+)
+
+logger = logging.getLogger(__name__)
+
+# Each line of omp's JSONL output; the event schema is owned by the omp CLI
+# not us, and varies across subcommands (response ack, message_update,
+# tool_execution_start/end, agent_end, message_end, etc.).
+OmpEvent: TypeAlias = dict[str, Any]  # type: ignore[explicit-any]
+
+
+def _fetch_shell_command_token(command: str) -> str | None:
+    """Run an auth helper command and return its stdout token.
+
+    :param command: Shell command that prints a bearer token.
+    :returns: The stripped token, or ``None`` when the command fails or
+        prints no token.
+    """
+    result = subprocess.run(
+        ["sh", "-c", command],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    token = result.stdout.strip()
+    if result.returncode != 0 or not token:
+        logger.debug("omp Databricks auth command failed: %s", result.stderr.strip())
+        return None
+    return token
+
+
+# Tool-server callback provided by ``Session._wire_sdk_executor``. Invoked
+# with a tool name and argument dict; may return the result dict directly
+# or a coroutine/future yielding one.
+ToolExecutor: TypeAlias = Callable[  # type: ignore[explicit-any]
+    [str, dict[str, Any]],
+    Awaitable[dict[str, Any]] | dict[str, Any],
+]
+
+# Native-tool policy gate wired by :class:`OmpExecutor`. Invoked with a native
+# (non-bridged) tool name + argument dict; returns ``{"block": bool, "reason":
+# str}``. omp's native tools (e.g. ``read``, enabled for skill loading) execute
+# inside the omp process and never traverse the bridged ``/mcp`` path, so the
+# ``tool_call`` extension hook routes them here for a TOOL_CALL policy verdict.
+NativePolicyGate: TypeAlias = Callable[  # type: ignore[explicit-any]
+    [str, dict[str, Any]],
+    Awaitable[dict[str, Any]] | dict[str, Any],
+]
+
+
+class _OmpProviderConfig(TypedDict):
+    baseUrl: str
+    apiKey: str
+    api: str
+    models: list[_JsonObject]
+    authHeader: NotRequired[bool]
+    compat: NotRequired[_JsonObject]
+
+
+class _OmpModelsConfig(TypedDict):
+    providers: dict[str, _OmpProviderConfig]
+
+
+class _OmpMessageUsage(TypedDict):
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cache_read_input_tokens: int
+    cache_creation_input_tokens: int
+    model: str | None
+
+
+class _OmpTurnUsage(_OmpMessageUsage):
+    context_tokens: int
+
+
+# ---------------------------------------------------------------------------
+# TCP tool server — serves Omnigent tools to the omp extension
+# ---------------------------------------------------------------------------
+
+
+def _safe_dumps(response: dict[str, Any], req_id: str | None) -> str:  # type: ignore[explicit-any]
+    """Serialize a tool-server response, never raising on bad payloads.
+
+    Tool callbacks may return values ``json.dumps`` can't encode (a
+    ``datetime``, ``set``, ``bytes``, custom object, ...). Encoding happens
+    on the response path *outside* :meth:`_ToolServer._execute`'s try, so an
+    unguarded ``json.dumps`` would propagate and the connection would close
+    with zero bytes written — leaving the JS ``callTool`` promise pending and
+    hanging the entire omp turn. Mirrors codex's ``_result_text`` guard: on a
+    serialization failure, fall back to an ``{"error": ...}`` envelope so the
+    client always receives a valid frame.
+
+    :param response: The response dict to serialize.
+    :param req_id: The originating request id, echoed back on the error
+        envelope so the client correlates the failure with its call.
+    :returns: A compact JSON string (no trailing newline).
+    """
+    try:
+        return json.dumps(response, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        # Stringify ``req_id`` so the fallback envelope itself can never raise
+        # on a non-serializable id (the caller passes a ``str`` today, but the
+        # guard must hold for any future caller). ``None`` stays ``None`` so the
+        # client still sees a null id rather than the literal "None".
+        safe_id: str | None = req_id if req_id is None or isinstance(req_id, str) else str(req_id)
+        return json.dumps(
+            {"id": safe_id, "error": f"unserializable tool result: {exc}"},
+            separators=(",", ":"),
+        )
+
+
+class _ToolServer:
+    """Async TCP server that handles tool-call requests from the omp extension.
+
+    Protocol (JSONL over TCP):
+        Request:  {"id":"...","token":"...","tool":"tool_name","args":{...}}
+        Response: {"id":"...","result":{...}} or {"id":"...","error":"..."}
+
+    The loopback socket is reachable by any co-located process, so every
+    request must carry :attr:`token` (a per-server secret embedded only in
+    the generated omp extension); frames with a missing or wrong token are
+    rejected before dispatch.
+    """
+
+    def __init__(self) -> None:
+        self._server: asyncio.Server | None = None
+        self.port: int = 0
+        self._tool_executor: ToolExecutor | None = None
+        # Policy gate for native (non-bridged) omp tool calls, set by
+        # :meth:`OmpExecutor._ensure_tool_server`. ``None`` (single-process
+        # / test paths) means native tool calls are not gated.
+        self._policy_gate: NativePolicyGate | None = None
+        # Per-server bearer token required on every request. Minted at
+        # construction (never None) so auth is always enforced.
+        self.token: str = secrets.token_urlsafe(32)
+
+    async def start(self) -> int:
+        """Start listening on a random port. Returns the port number."""
+        self._server = await asyncio.start_server(
+            self._handle_client,
+            "127.0.0.1",
+            0,
+        )
+        addr = self._server.sockets[0].getsockname()
+        self.port = addr[1]
+        logger.debug("OmpExecutor tool server listening on port %d", self.port)
+        return self.port
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            while True:
+                raw = await reader.readline()
+                if not raw:
+                    break
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    request = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                # Authenticate before any dispatch; close the connection on
+                # failure (unlike the malformed-frame ``continue`` below).
+                if not self._token_ok(request.get("token")):
+                    writer.write(
+                        json.dumps(
+                            {"id": request.get("id"), "error": "unauthorized"},
+                            separators=(",", ":"),
+                        ).encode("utf-8")
+                        + b"\n"
+                    )
+                    await writer.drain()
+                    break
+                raw_req_id = request.get("id")
+                raw_tool_name = request.get("tool")
+                # The omp extension always supplies ``id`` and ``tool``
+                # on a tool request. Drop malformed frames rather than
+                # executing under an empty-string tool name.
+                if not isinstance(raw_req_id, str) or not isinstance(raw_tool_name, str):
+                    continue
+                tool_args = request.get("args", {})
+                if request.get("kind") == "policy_eval":
+                    # The ``tool_call`` extension hook asks for a TOOL_CALL
+                    # verdict on a native (non-bridged) tool — evaluate only,
+                    # never execute (omp runs the tool itself on ALLOW).
+                    verdict = await self._evaluate_policy(raw_tool_name, tool_args)
+                    response = {"id": raw_req_id, "verdict": verdict}
+                else:
+                    response = await self._execute(raw_tool_name, tool_args)
+                    response["id"] = raw_req_id
+                # Serialize defensively: a tool result may carry a value
+                # ``json.dumps`` can't encode (e.g. ``datetime``/``set``).
+                # If it raises here — outside ``_execute``'s try — the frame
+                # is never written and the JS ``callTool`` promise hangs the
+                # whole turn (no ``data``/``error`` event). Always emit a JSON
+                # frame: a serializable error envelope when the response can't
+                # be encoded, mirroring codex's ``_result_text`` guard.
+                out = _safe_dumps(response, raw_req_id) + "\n"
+                writer.write(out.encode("utf-8"))
+                await writer.drain()
+        except (asyncio.CancelledError, ConnectionError):
+            pass
+        finally:
+            writer.close()
+
+    def _token_ok(self, presented: JsonValue) -> bool:
+        """
+        Validate a request's ``token`` against this server's secret.
+
+        :param presented: The ``token`` field from the request JSON — a
+            ``str`` when authenticated, any JSON type (or ``None``) on a
+            malformed/forged frame, hence the ``isinstance`` guard.
+        :returns: ``True`` only when *presented* is a string equal to
+            :attr:`token`, compared in constant time.
+        """
+        return isinstance(presented, str) and hmac.compare_digest(presented, self.token)
+
+    async def _execute(  # type: ignore[explicit-any]
+        self,
+        name: str,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        if self._tool_executor is None:
+            return {"error": f"No tool executor for '{name}'"}
+        try:
+            raw = self._tool_executor(name, args)
+            resolved = await raw if asyncio.iscoroutine(raw) or asyncio.isfuture(raw) else raw
+            if not isinstance(resolved, dict):
+                resolved = {"result": resolved}
+            return {"result": resolved}
+        except Exception as exc:  # noqa: BLE001 — tool errors are surfaced via the JSON response envelope
+            return {"error": str(exc)}
+
+    async def _evaluate_policy(  # type: ignore[explicit-any]
+        self,
+        name: str,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Evaluate a native (non-bridged) tool call against TOOL_CALL policy.
+
+        Routes through the :attr:`_policy_gate` wired by
+        :meth:`OmpExecutor._ensure_tool_server`. Returns ``{"block": bool,
+        "reason": str}``.
+
+        Fail-open (allow) when no gate is wired or the gate raises: this
+        mirrors the runner/scaffold policy-evaluation contract, which also
+        defaults to ALLOW on a stalled or failed verdict so a transient
+        Omnigent outage can't wedge the agent mid-turn.
+        """
+        if self._policy_gate is None:
+            return {"block": False, "reason": ""}
+        try:
+            raw = self._policy_gate(name, args)
+            resolved = await raw if asyncio.iscoroutine(raw) or asyncio.isfuture(raw) else raw
+            if isinstance(resolved, dict):
+                return {
+                    "block": bool(resolved.get("block")),
+                    "reason": str(resolved.get("reason") or ""),
+                }
+            return {"block": False, "reason": ""}
+        except Exception as exc:  # noqa: BLE001 — fail-open; the verdict path must never wedge omp
+            logger.warning("omp native-tool policy eval failed for %r: %s", name, exc)
+            return {"block": False, "reason": ""}
+
+
+# ---------------------------------------------------------------------------
+# omp extension generator — bridges Omnigent tools into omp
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_schema(schema: ToolSpec) -> ToolSpec:
+    """Strip JSON Schema features unsupported by the OpenAI Responses/Completions APIs.
+
+    Removes ``anyOf``, ``oneOf``, ``allOf``, ``examples``, ``default``,
+    ``additionalProperties``, and ``$ref``.  Union keywords are collapsed
+    to the first ``object`` branch when one exists (it carries the
+    structured properties the model needs), else the first typed branch.
+    This ensures the schema is accepted by Databricks serving endpoints.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    result: ToolSpec = {}
+    for key, value in schema.items():
+        if key in ("examples", "default", "$ref", "additionalProperties"):
+            continue
+        if key in ("anyOf", "oneOf", "allOf"):
+            # Prefer the object branch: collapsing to a primitive drops the properties.
+            if isinstance(value, list) and value:
+                typed = [c for c in value if isinstance(c, dict) and "type" in c]
+                for candidate in typed:
+                    if candidate["type"] == "object":
+                        return _sanitize_schema(candidate)
+                if typed:
+                    return _sanitize_schema(typed[0])
+            continue
+        if key == "properties" and isinstance(value, dict):
+            result[key] = {k: _sanitize_schema(v) for k, v in value.items()}
+        elif key == "items" and isinstance(value, dict):
+            result[key] = _sanitize_schema(value)
+        else:
+            result[key] = value
+    return result
+
+
+def _generate_extension_js(port: int, tool_schemas: list[ToolSpec], token: str) -> str:
+    """Generate a JavaScript omp extension that registers Omnigent tools.
+
+    Each tool is forwarded to the TCP tool server at ``127.0.0.1:<port>``.
+
+    :param port: TCP port the Omnigent tool server is listening on, e.g.
+        ``54321``.
+    :param tool_schemas: Omnigent tool schemas to register with omp.
+    :param token: The tool server's bearer token
+        (:attr:`_ToolServer.token`), embedded in the extension and sent
+        on every request so the server can authenticate this omp process.
+    """
+    # Build tool descriptors for the JS code. ``ToolSpec`` is the
+    # same JSON-shaped ``dict[str, Any]`` we consume.
+    descriptors: list[ToolSpec] = []
+    for s in tool_schemas:
+        raw_name = s.get("name")
+        # omp requires a concrete name on each registered tool; skip
+        # malformed entries rather than registering an unnamed tool.
+        if not isinstance(raw_name, str) or not raw_name:
+            continue
+        raw_desc = s.get("description")
+        # Description is optional; omp's JS bridge expects ``str`` on
+        # both ``description`` and ``promptSnippet``.
+        desc: str = raw_desc if isinstance(raw_desc, str) else ""
+        descriptors.append(
+            {
+                "name": raw_name,
+                "description": desc,
+                "promptSnippet": desc[:120],
+                "parameters": _sanitize_schema(
+                    s.get("parameters", {"type": "object", "properties": {}})
+                ),
+            }
+        )
+    tools_json = json.dumps(descriptors, indent=2)
+    # json.dumps so the secret is correctly JS-string-escaped.
+    token_json = json.dumps(token)
+
+    return f"""\
+// Auto-generated Omnigent tool bridge extension for omp.
+// Connects to the Omnigent TCP tool server on port {port}.
+import net from "node:net";
+
+const TOOLS = {tools_json};
+const BRIDGED = new Set(TOOLS.map((t) => t.name));
+const PORT = {port};
+const TOKEN = {token_json};
+
+/** Send a tool call request over TCP and return the result. */
+function callTool(toolName, args) {{
+  return new Promise((resolve) => {{
+    // Idempotent settle: a tool call must resolve exactly once. Route every
+    // resolve through finish() so a late "close" after a real "data" response
+    // can't clobber the result, and a bare close with no data still resolves
+    // (rather than hanging omp's agent loop forever).
+    let settled = false;
+    const finish = (v) => {{ if (!settled) {{ settled = true; resolve(v); }} }};
+    const errorResult = (text) => ({{
+      content: [{{ type: "text", text: JSON.stringify({{ error: text }}) }}],
+      isError: true
+    }});
+    const client = net.createConnection({{ port: PORT, host: "127.0.0.1" }}, () => {{
+      const id = Math.random().toString(36).slice(2);
+      const req = JSON.stringify({{ id, token: TOKEN, tool: toolName, args }}) + "\\n";
+      let buf = "";
+      client.on("data", (chunk) => {{
+        buf += chunk.toString();
+        const nl = buf.indexOf("\\n");
+        if (nl !== -1) {{
+          try {{
+            const resp = JSON.parse(buf.slice(0, nl));
+            client.end();
+            if (resp.error) {{
+              finish(errorResult(resp.error));
+            }} else {{
+              const text = typeof resp.result === "string"
+                ? resp.result
+                : JSON.stringify(resp.result);
+              const isError = resp.result && (resp.result.error || resp.result.blocked);
+              finish({{ content: [{{ type: "text", text }}], isError: !!isError }});
+            }}
+          }} catch (e) {{
+            client.end();
+            finish(errorResult(e.message));
+          }}
+        }}
+      }});
+      client.on("error", (err) => {{
+        finish(errorResult(err.message));
+      }});
+      // A clean FIN with no bytes (e.g. the server failed to serialize the
+      // result and closed) emits neither "data" nor "error"; without this
+      // the promise would hang forever. finish() is a no-op if already settled.
+      client.on("close", () => {{
+        finish(errorResult("tool server closed connection without a response"));
+      }});
+      client.write(req);
+    }});
+    client.on("error", (err) => {{
+      finish(errorResult(err.message));
+    }});
+  }});
+}}
+
+/**
+ * Ask the Omnigent tool server for a TOOL_CALL policy verdict on a native
+ * (non-bridged) omp tool. Resolves to the verdict object {{ block, reason }}
+ * or null. Fail-open (null) on any transport error: a wedged native tool
+ * would break omp worse than a missed gate, and bridged tools stay gated
+ * server-side regardless.
+ */
+function evalNativePolicy(toolName, args) {{
+  return new Promise((resolve) => {{
+    const client = net.createConnection({{ port: PORT, host: "127.0.0.1" }}, () => {{
+      const id = Math.random().toString(36).slice(2);
+      const frame = {{ id, token: TOKEN, kind: "policy_eval", tool: toolName, args }};
+      const req = JSON.stringify(frame) + "\\n";
+      let buf = "";
+      client.on("data", (chunk) => {{
+        buf += chunk.toString();
+        const nl = buf.indexOf("\\n");
+        if (nl !== -1) {{
+          client.end();
+          try {{
+            const resp = JSON.parse(buf.slice(0, nl));
+            resolve(resp && resp.verdict ? resp.verdict : null);
+          }} catch (e) {{
+            resolve(null);
+          }}
+        }}
+      }});
+      client.on("error", () => resolve(null));
+      client.write(req);
+    }});
+    client.on("error", () => resolve(null));
+  }});
+}}
+
+export default function(pi) {{
+  // Gate native (non-bridged) tool calls through Omnigent policy. omp's
+  // native tools (e.g. ``read``, enabled for skill loading) run in-process
+  // and never traverse the bridged /mcp path, so without this hook they
+  // escape all guardrails. Bridged tools ARE evaluated server-side at /mcp,
+  // so skip them here to avoid double-evaluation (and double ASK prompts).
+  pi.on("tool_call", async (event) => {{
+    if (!event || typeof event.toolName !== "string") return;
+    if (BRIDGED.has(event.toolName)) return;
+    const verdict = await evalNativePolicy(event.toolName, event.input || {{}});
+    if (verdict && verdict.block) {{
+      return {{ block: true, reason: verdict.reason || "blocked by Omnigent policy" }};
+    }}
+  }});
+
+  for (const tool of TOOLS) {{
+    // omp passes tool.parameters directly to the LLM as JSON Schema, so we
+    // can use the Omnigent schema as-is without TypeBox conversion.
+    pi.registerTool({{
+      name: tool.name,
+      label: tool.name,
+      description: tool.description,
+      promptSnippet: tool.promptSnippet || tool.description,
+      parameters: tool.parameters || {{ type: "object", properties: {{}} }},
+      async execute(_toolCallId, _params, _signal, _onUpdate, _ctx) {{
+        return callTool(tool.name, _params);
+      }},
+    }});
+  }}
+}};
+"""
+
+
+# ---------------------------------------------------------------------------
+# Credential helpers (shared pattern with codex_executor / claude_sdk_executor)
+# ---------------------------------------------------------------------------
+
+
+def _find_omp_cli() -> str | None:
+    """Find the ``omp`` CLI on PATH."""
+    return shutil.which("omp")
+
+
+def _omp_supports_auto_approve(executable: str) -> bool:
+    """Return ``True`` when the omp CLI at *executable* lists ``--auto-approve``.
+
+    omp errors hard on unknown flags, so the trust pre-accept must be
+    feature-detected, not assumed. Fails open — returns ``False`` on any
+    probe error so an older omp keeps working without the flag.
+
+    :param executable: Resolved path to the omp CLI.
+    :returns: ``True`` iff ``omp --help`` advertises ``--auto-approve``.
+    """
+    try:
+        proc = subprocess.run(
+            [executable, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    # Token-boundary match: a bare substring also fires on prose (e.g. the
+    # ``--plan-yolo`` help line mentions "auto-approve the plan" without the
+    # flag existing) or on a longer/negated flag name. A false positive is a
+    # hard spawn error (omp rejects unknown flags), so require the exact
+    # token.
+    help_text = proc.stdout or ""
+    return proc.returncode == 0 and re.search(r"--auto-approve(?![\w-])", help_text) is not None
+
+
+# ---------------------------------------------------------------------------
+# Databricks models.yml generation
+# ---------------------------------------------------------------------------
+
+# Databricks exposes API styles at different URL paths. Live Unity Catalog
+# model services populate each provider; MLflow metadata adds token limits.
+
+# Prefix-matched env var names allowed into the omp subprocess. Only
+# known-safe categories pass: omp's own config knobs, proxy settings,
+# TLS trust overrides, Node.js runtime knobs (omp is a Node CLI), and
+# locale. Credential families (``DATABRICKS_*``, ``AWS_*``, LLM
+# provider API keys, ...) deliberately do NOT match.
+_OMP_ENV_ALLOW_PREFIXES: tuple[str, ...] = (
+    "PI_",
+    "HTTP_",
+    "HTTPS_",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "SSL_",
+    "NODE_",
+    "XDG_",
+    "LANG",
+    "LC_",
+)
+
+# Exact-matched env var names allowed into the omp subprocess: the
+# minimal set a POSIX CLI reasonably expects.
+_OMP_ENV_ALLOW_EXACT: frozenset[str] = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "TERM",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TZ",
+        OMNIGENT_SESSION_ENV_VAR,  # "inside Omnigent" marker (CLAUDE_CODE/CODEX analog)
+    }
+)
+_STREAM_READ_CHUNK_SIZE = 65536
+# How long _OmpRpcSession.close() waits for the omp subprocess to exit on its own
+# after SIGTERM before falling back to SIGKILL. The interrupt-slice budget in
+# _executor_adapter must be >= this value so the slice never fires first and
+# inject a CancelledError that bypasses the SIGKILL path.
+_RPC_SESSION_CLOSE_REAP_TIMEOUT_S = 2.0
+
+# Idle budget for one stdout read during a turn. Expiry alone never ends
+# the turn (a long tool call may stay silent past it); only a real stdout
+# EOF does. Module-level so tests can patch it.
+_TURN_STDOUT_IDLE_TIMEOUT_S = 120.0
+
+# Post-error drain budget: after an errored message the only line left to
+# consume is the already-emitted ``agent_end``. Module-level so tests can
+# patch it.
+_TURN_STDOUT_ERROR_DRAIN_TIMEOUT_S = 10.0
+
+# CLI flags whose values are sensitive (e.g. the full system prompt) and must
+# not be written to logs verbatim. The value following these flags is replaced
+# with a length-only placeholder.
+_REDACTED_ARGV_FLAGS = frozenset({"--append-system-prompt", "--system-prompt"})
+
+
+def _redact_argv_for_log(args: Sequence[str]) -> list[str]:
+    """
+    Return a copy of ``args`` with sensitive flag values redacted for logging.
+
+    The system prompt value (e.g. passed via ``--append-system-prompt``) is
+    replaced with a ``[system prompt N chars]`` placeholder so it never leaks
+    into debug logs. Two argv forms are handled:
+
+    * the two-token form ``--append-system-prompt <value>`` (what the current
+      spawn code emits), and
+    * the equals-joined form ``--append-system-prompt=<value>`` (not emitted
+      today, but redacted defensively in case a future refactor switches to it).
+
+    All other tokens are preserved so the command remains useful for debugging.
+    """
+    redacted: list[str] = []
+    redact_next = False
+    for arg in args:
+        if redact_next:
+            redacted.append(f"[system prompt {len(arg)} chars]")
+            redact_next = False
+            continue
+        if arg in _REDACTED_ARGV_FLAGS:
+            # Two-token form: redact the following value token.
+            redacted.append(arg)
+            redact_next = True
+            continue
+        flag, sep, value = arg.partition("=")
+        if sep and flag in _REDACTED_ARGV_FLAGS:
+            # Equals-joined form: redact the inline value, keep the flag name.
+            redacted.append(f"{flag}=[system prompt {len(value)} chars]")
+            continue
+        redacted.append(arg)
+    return redacted
+
+
+def _build_models_yml(
+    host: str,
+    token: str,
+    base_urls: dict[str, str] | None = None,
+    model: str | None = None,
+    catalog_models: Sequence[model_catalog.ModelEntry] = (),
+    model_wire_apis: Mapping[str, frozenset[ModelWireAPI]] | None = None,
+    openai_wire_api: str | None = None,
+) -> _OmpModelsConfig:
+    # omp's models.yml mixes str/int/bool/list/dict across provider configs;
+    """Build an omp ``models.yml`` with protocol-specific gateway providers.
+
+    Each provider targets a different API gateway path and wire format so
+    the correct protocol is used for each model family. Live catalog models
+    populate omp's picker; *model* additionally registers the resolved run
+    model so an offline catalog or generic gateway still launches. omp only
+    accepts ``provider/<model>`` selectors whose id is registered there.
+
+    :param host: Databricks workspace URL used for legacy profile-only
+        defaults.
+    :param token: Bearer token to write into omp's provider entries.
+    :param base_urls: Optional provider base URLs keyed by model family,
+        e.g. ``{"claude": "...", "openai": "..."}`` — from ucode state or
+        a generic (OpenRouter/LiteLLM) provider entry.
+    :param model: The resolved model id this run will select, e.g.
+        ``"moonshotai/kimi-k2.6"``; registered (bare ``{"id": ...}``, the
+        same shape ucode writes) under the provider
+        :func:`_omp_provider_for_model` routes it to when absent from the
+        catalog. ``None`` skips registration (omp picks its default).
+    :param catalog_models: Live Databricks model-service entries, optionally
+        enriched with MLflow limits. Empty leaves only *model* registered.
+    :param model_wire_apis: Databricks model ids mapped to catalog-reported
+        wire surfaces. Missing GPT metadata defaults to Responses.
+    :param openai_wire_api: Configured wire for a generic OpenAI-compatible
+        provider. ``None`` defaults generic providers to Chat Completions.
+    :returns: omp ``models.yml`` contents.
+    """
+    h = host.rstrip("/")
+    serving_endpoints_url = f"{h}/serving-endpoints"
+    codex_gateway_url = f"{h}/ai-gateway/codex/v1"
+    mlflow_gateway_url = f"{h}/ai-gateway/mlflow/v1"
+    raw_openai_base_url = (base_urls or {}).get("openai")
+    is_databricks_openai_gateway = bool(
+        raw_openai_base_url
+        and (
+            "/ai-gateway/" in raw_openai_base_url
+            or _is_databricks_ai_gateway_url(raw_openai_base_url)
+        )
+    )
+    # Databricks Codex URLs only accept Responses; Chat uses the workspace.
+    if raw_openai_base_url and is_databricks_openai_gateway:
+        openai_base_url = serving_endpoints_url
+    else:
+        openai_base_url = raw_openai_base_url or serving_endpoints_url
+    # For non-Databricks providers (e.g. OpenAI API key, LiteLLM) the
+    # /ai-gateway/* paths don't exist — use the generic base URL for all paths.
+    is_generic_provider = bool(raw_openai_base_url and not is_databricks_openai_gateway)
+    generic_openai_wire_api = openai_wire_api or CHAT_WIRE_API if is_generic_provider else None
+    wire_catalog = model_wire_apis or {}
+    if is_databricks_openai_gateway:
+        assert raw_openai_base_url is not None
+        codex_gateway_url = raw_openai_base_url
+    elif is_generic_provider:
+        codex_gateway_url = openai_base_url
+        mlflow_gateway_url = openai_base_url
+    claude_base_url = (base_urls or {}).get("claude") or f"{h}/serving-endpoints/anthropic"
+    _openai_responses_compat: _JsonObject = {
+        "supportsDeveloperRole": False,
+        "supportsStore": False,
+        "supportsStrictMode": False,
+        "supportsReasoningEffort": False,
+    }
+    provider_models: dict[str, list[_JsonObject]] = {
+        "databricks-openai": [],
+        "databricks": [],
+        "databricks-anthropic": [],
+        "databricks-mlflow": [],
+        "databricks-completions": [],
+    }
+    for catalog_model in catalog_models:
+        model_id = catalog_model.id
+        if unsupported_in_pi(model_id.lower()):
+            continue
+        wire_apis = wire_catalog.get(model_id.lower(), catalog_model.metadata.wire_apis)
+        provider_name = _omp_provider_for_model(model_id, wire_apis)
+        registered_model = catalog_model
+        if model is not None and model.lower() in databricks_model_aliases(model_id):
+            registered_model = replace(catalog_model, id=model)
+        # ``JsonObject`` is the open bag this builder assembles; a TypedDict is
+        # not assignable to it (dict value types are invariant), so copy.
+        entry: _JsonObject = dict(pi_model_json_entry(registered_model))
+        provider_models[provider_name].append(entry)
+    config: _OmpModelsConfig = {
+        "providers": {
+            # Models advertising Responses support use the AI Gateway's Codex
+            # surface, including tool-result chaining on subsequent turns.
+            "databricks-openai": {
+                "baseUrl": codex_gateway_url,
+                "apiKey": token,
+                "api": "openai-responses",
+                "authHeader": True,
+                "compat": _openai_responses_compat,
+                "models": provider_models["databricks-openai"],
+            },
+            # Older GPT models → OpenAI Chat Completions at serving-endpoints.
+            "databricks": {
+                "baseUrl": openai_base_url,
+                "apiKey": token,
+                "api": "openai-completions",
+                # Generic (non-Databricks) OpenAI-compatible gateways expect
+                # ``Authorization: Bearer <token>``; the Databricks workspace
+                # endpoint uses a different auth scheme so authHeader is omitted
+                # on the native path.
+                **({"authHeader": True} if is_generic_provider else {}),
+                "compat": _openai_responses_compat,
+                "models": provider_models["databricks"],
+            },
+            # Claude models → Anthropic Messages API.
+            # ``authHeader`` sends ``Authorization: Bearer <token>`` instead
+            # of the default Anthropic ``x-api-key`` header.
+            "databricks-anthropic": {
+                "baseUrl": claude_base_url,
+                "apiKey": token,
+                "api": "anthropic-messages",
+                "authHeader": True,
+                "models": provider_models["databricks-anthropic"],
+            },
+            # system.ai.* models not needing Responses API (Gemini, Llama) → mlflow gateway.
+            "databricks-mlflow": {
+                "baseUrl": mlflow_gateway_url,
+                "apiKey": token,
+                "api": "openai-completions",
+                "authHeader": True,
+                "compat": {
+                    "supportsDeveloperRole": False,
+                    "supportsStore": False,
+                    "supportsStrictMode": False,
+                    "supportsReasoningEffort": False,
+                    "supportsUsageInStreaming": False,
+                },
+                "models": provider_models["databricks-mlflow"],
+            },
+            # Everything else (Llama, etc.) → same endpoint, same API
+            "databricks-completions": {
+                "baseUrl": openai_base_url,
+                "apiKey": token,
+                "api": "openai-completions",
+                # Same rationale as the "databricks" entry above.
+                **({"authHeader": True} if is_generic_provider else {}),
+                "compat": {
+                    "supportsDeveloperRole": False,
+                    "supportsStore": False,
+                    "supportsStrictMode": False,
+                    "supportsReasoningEffort": False,
+                    # Gemini/Qwen/Llama/inkling models reject stream_options
+                    # (which carries include_usage) with 400 "unknown field".
+                    "supportsUsageInStreaming": False,
+                },
+                "models": provider_models["databricks-completions"],
+            },
+        },
+    }
+    if model is not None:
+        # Explicit selections must launch even when picker compatibility
+        # filtering hides the equivalent discovered entry.
+        provider = config["providers"][
+            _omp_provider_for_model(
+                model,
+                wire_catalog.get(model.lower()),
+                generic_openai_wire_api=generic_openai_wire_api,
+            )
+        ]
+        if not any(entry.get("id") == model for entry in provider["models"]):
+            # Declare image input: omp's transformMessages drops every image
+            # block ("model does not support images") unless the model entry
+            # advertises it, so a dynamically-registered vision model would
+            # silently lose its images (#515). We assert capability for ALL
+            # dynamically-routed ids (no per-model vision metadata here): for a
+            # genuinely text-only model this turns a silent image drop into a
+            # provider-side 400 on image turns — a deliberate trade (loud error
+            # over silent loss), since most current gateway models are
+            # multimodal and text-only turns are unaffected.
+            entry: _JsonObject = {"id": model, "input": ["text", "image"]}
+            if pi_model_is_reasoning(model):
+                entry["reasoning"] = True
+            provider["models"] = [*provider["models"], entry]
+    return config
+
+
+# Model-id fragments of completions-gateway models that stream their output on
+# the ``reasoning_content`` channel (DeepSeek-R1, ...). omp's openai-completions
+# parser only consumes that channel when the model entry declares
+# ``reasoning: true``; without it the stream carries no ``content`` and the
+# turn dies with "Stream ended without finish_reason".
+# Note: GLM, kimi, and inkling now route via Responses API (system.ai.* ids)
+# so they no longer need this flag.
+def _omp_needs_responses_api(
+    model: str,
+    wire_apis: frozenset[ModelWireAPI] | None = None,
+) -> bool:
+    """Return whether omp should use the Databricks Responses surface.
+
+    Catalog metadata is authoritative when available. The system-model family
+    fallback remains for endpoints whose documented chat surface omits the
+    finish reason omp requires. Unknown GPT metadata fails toward Responses,
+    which is the forward-compatible tool-capable surface.
+    """
+    lower = model.lower()
+    if lower.startswith("system.ai.") and any(
+        keyword in lower for keyword in SYSTEM_AI_RESPONSES_KEYWORDS
+    ):
+        return True
+    if wire_apis is not None:
+        return ModelWireAPI.OPENAI_RESPONSES in wire_apis
+    return "gpt" in lower
+
+
+def _omp_provider_for_model(
+    model: str,
+    wire_apis: frozenset[ModelWireAPI] | None = None,
+    *,
+    generic_openai_wire_api: str | None = None,
+) -> str:
+    """Return the omp provider name to use for a given Databricks model."""
+    lower = model.lower()
+    if "claude" in lower:
+        return "databricks-anthropic"
+    if generic_openai_wire_api is not None:
+        if generic_openai_wire_api == RESPONSES_WIRE_API:
+            return "databricks-openai"
+        return "databricks-completions"
+    if lower.startswith("system.ai."):
+        return (
+            "databricks-openai"
+            if _omp_needs_responses_api(model, wire_apis)
+            else "databricks-mlflow"
+        )
+    if "gpt" in lower:
+        return "databricks-openai" if _omp_needs_responses_api(model, wire_apis) else "databricks"
+    return "databricks-completions"
+
+
+def _databricks_model_wire_catalog(
+    models: Sequence[model_catalog.ModelEntry],
+) -> dict[str, frozenset[ModelWireAPI]]:
+    """Index UC wire metadata by both system and serving-endpoint aliases."""
+    catalog: dict[str, frozenset[ModelWireAPI]] = {}
+    for model in models:
+        for alias in databricks_model_aliases(model.id):
+            catalog[alias] = model.metadata.wire_apis
+    return catalog
+
+
+async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> asyncio.subprocess.Process:  # type: ignore[explicit-any]
+    """
+    Indirection point for ``asyncio.create_subprocess_exec``.
+
+    Exists so tests can stub subprocess creation without patching
+    ``asyncio.create_subprocess_exec`` globally (patching
+    ``omnigent.inner.omp_executor.asyncio.create_subprocess_exec``
+    walks the dotted path into the real ``asyncio`` module singleton
+    and leaks the mock into every other test in the process).
+
+    :param args: Positional argv components forwarded to
+        ``asyncio.create_subprocess_exec``.
+    :param kwargs: Keyword args (``stdin``, ``stdout``, ``stderr``,
+        ``env``, ``cwd``, ...) forwarded as-is.
+    :returns: The spawned subprocess handle.
+    """
+    return await asyncio.create_subprocess_exec(*args, **kwargs)
+
+
+def _clean_omp_env(extra_allowed: Sequence[str] | None = None) -> dict[str, str]:
+    """
+    Build a filtered copy of ``os.environ`` for the omp subprocess.
+
+    Thin wrapper over :func:`omnigent.inner.agent_env.clean_agent_env`. The
+    previous additive ``{**os.environ, **env}`` merge leaked every host secret
+    — cloud tokens, API keys — into the omp process, sandboxed or not.
+    Credential families are deliberately not allowlisted: gateway runs
+    authenticate through the generated ``models.yml``, and a spec that
+    legitimately needs a variable inside the omp process opts in via
+    ``os_env.sandbox.env_passthrough``.
+
+    :param extra_allowed: Extra exact names to pass through, e.g. the spec's
+        ``os_env.sandbox.env_passthrough`` entries. ``None`` means no extras.
+    :returns: Filtered environment dict, ready to extend with the executor's
+        own variables (``PI_CODING_AGENT_DIR``, ...).
+    """
+    return clean_agent_env(
+        allow_prefixes=_OMP_ENV_ALLOW_PREFIXES,
+        allow_exact=_OMP_ENV_ALLOW_EXACT,
+        extra_allowed=extra_allowed or (),
+    )
+
+
+# ---------------------------------------------------------------------------
+# omp RPC subprocess wrapper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _OmpRpcSession:
+    """Manages a single omp subprocess in RPC mode."""
+
+    process: asyncio.subprocess.Process | None = None
+    _read_task: Task[None] | None = None
+    _stderr_task: Task[None] | None = None
+    # Non-optional: initialized eagerly so the reader/writer paths don't
+    # need to None-narrow on every access. ``None`` sentinel values are
+    # pushed onto the queue to signal EOF to ``read_line``.
+    _line_queue: Queue[str | None] = field(default_factory=Queue)
+    _stderr_lines: list[str] = field(default_factory=list)
+    _tmp_dir: str | None = None
+
+    async def start(
+        self,
+        omp_path: str,
+        *,
+        env: dict[str, str],
+        cwd: str | None = None,
+        model: str | None = None,
+        system_prompt: str | None = None,
+        thinking: str | None = None,
+        extra_args: list[str] | None = None,
+    ) -> None:
+        """
+        Spawn the omp subprocess in RPC mode and start the I/O readers.
+
+        :param omp_path: Path to spawn — the ``omp`` binary or the
+            sandbox launcher script wrapping it.
+        :param env: The COMPLETE subprocess environment. Deliberately
+            not merged with ``os.environ`` — the caller builds it from
+            the :func:`_clean_omp_env` allowlist so host/server secrets
+            (e.g. ``DATABRICKS_TOKEN``) never leak into the (possibly
+            sandboxed) omp process.
+        :param cwd: Working directory for the subprocess, or ``None``
+            to inherit the parent's.
+        :param model: omp model selector, e.g.
+            ``"databricks-anthropic/gateway-model-id"``.
+            ``None`` lets omp pick its default.
+        :param system_prompt: Text appended to omp's default system
+            prompt via ``--append-system-prompt``. ``None`` skips it.
+        :param thinking: omp thinking level in omp's own vocabulary
+            (``off``/``minimal``/.../``max``), passed as ``--thinking``.
+            ``None`` omits the flag so omp's model default applies.
+        :param extra_args: Extra CLI tokens (``--extension``,
+            ``--tools``, ...). ``None`` appends nothing.
+        """
+        args = [omp_path, "--mode", "rpc", "--no-session"]
+        if model:
+            omp_coding_agent_dir = env.get("PI_CODING_AGENT_DIR")
+            args.extend(
+                [
+                    "--model",
+                    f"databricks/{model}"
+                    if omp_coding_agent_dir is not None and "databricks" in omp_coding_agent_dir
+                    else model,
+                ]
+            )
+        if thinking:
+            args.extend(["--thinking", thinking])
+        if system_prompt:
+            # Use --append-system-prompt instead of --system-prompt so omp
+            # keeps its default prompt (which includes tool descriptions from
+            # promptSnippet and guidelines).  Using --system-prompt would
+            # replace the default prompt entirely, stripping tool awareness.
+            args.extend(["--append-system-prompt", system_prompt])
+        if extra_args:
+            args.extend(extra_args)
+
+        logger.debug("OmpExecutor: spawning %s", " ".join(_redact_argv_for_log(args)))
+        self.process = await _create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+        )
+        self._read_task = asyncio.create_task(self._reader())
+        self._stderr_task = asyncio.create_task(self._stderr_reader())
+
+    async def _reader(self) -> None:
+        """Background task: read lines from omp stdout and enqueue them."""
+        assert self.process is not None and self.process.stdout is not None
+        try:
+            async for raw_line in self._iter_stream_lines(self.process.stdout):
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
+                if line:
+                    self._line_queue.put_nowait(line)
+        except asyncio.CancelledError:
+            return
+        except Exception as exc:  # noqa: BLE001 — reader loop logs and exits on any unexpected error
+            logger.debug("OmpExecutor reader error: %s", exc)
+        finally:
+            self._line_queue.put_nowait(None)
+
+    async def _stderr_reader(self) -> None:
+        """Drain stderr in the background."""
+        if self.process is None or self.process.stderr is None:
+            return
+        try:
+            async for raw_line in self._iter_stream_lines(self.process.stderr):
+                text = raw_line.decode("utf-8", errors="replace").rstrip("\n\r")
+                if text:
+                    logger.debug("omp stderr: %s", text)
+                    if len(self._stderr_lines) < 50:
+                        self._stderr_lines.append(text)
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001 — stderr drainer is best-effort; never crashes
+            pass
+
+    @staticmethod
+    async def _iter_stream_chunks(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
+        while True:
+            chunk = await stream.read(_STREAM_READ_CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk
+
+    @staticmethod
+    async def _iter_stream_lines(stream: asyncio.StreamReader) -> AsyncIterator[bytes]:
+        buffer = bytearray()
+        async for chunk in _OmpRpcSession._iter_stream_chunks(stream):
+            buffer.extend(chunk)
+            while True:
+                newline_index = buffer.find(b"\n")
+                if newline_index < 0:
+                    break
+                line = bytes(buffer[: newline_index + 1])
+                del buffer[: newline_index + 1]
+                yield line
+        if buffer:
+            yield bytes(buffer)
+
+    async def send_command(self, command: OmpEvent) -> None:
+        """Send a JSONL command to omp's stdin."""
+        if self.process is None or self.process.stdin is None:
+            raise RuntimeError("omp process not running")
+        line = json.dumps(command, separators=(",", ":")) + "\n"
+        self.process.stdin.write(line.encode("utf-8"))
+        await self.process.stdin.drain()
+
+    async def request(
+        self,
+        command: OmpEvent,
+        expected: str,
+        *,
+        timeout: float = 15.0,
+    ) -> OmpEvent | None:
+        """Send *command* and return its ``response`` line's payload.
+
+        Only safe between turns: lines that arrive before the response are
+        re-queued in order, but a caller reading them concurrently would race.
+
+        :param command: The RPC command to send; must carry an ``id``.
+        :param expected: The ``command`` value the response must name.
+        :returns: The response event, or ``None`` on EOF/timeout/failure.
+        """
+        await self.send_command(command)
+        deferred: list[str] = []
+        result: OmpEvent | None = None
+        try:
+            while True:
+                line = await self.read_line(timeout=timeout)
+                if line is None:
+                    break
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if (
+                    isinstance(event, dict)
+                    and event.get("type") == "response"
+                    and event.get("command") == expected
+                ):
+                    result = event if event.get("success", True) else None
+                    break
+                deferred.append(line)
+        finally:
+            for line in deferred:
+                self._line_queue.put_nowait(line)
+        return result
+
+    async def read_line(self, timeout: float = _TURN_STDOUT_IDLE_TIMEOUT_S) -> str | None:
+        """Read the next JSONL line from omp's stdout.
+
+        Returns ``None`` on EOF **or** timeout; callers that must tell
+        the two apart check :meth:`stdout_at_eof`.
+        """
+        try:
+            return await asyncio.wait_for(self._line_queue.get(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    def stdout_at_eof(self) -> bool:
+        """Whether omp's stdout is exhausted (process exited / pipe closed).
+
+        The background reader runs until EOF and pushes the ``None``
+        sentinel from its ``finally``, so a finished (or never-started)
+        reader means no further stdout lines can arrive, while a live
+        reader means a ``read_line`` ``None`` was only an idle timeout.
+        Also requires an empty queue so already-buffered lines are
+        drained before the stream is declared exhausted.
+        """
+        return (self._read_task is None or self._read_task.done()) and self._line_queue.empty()
+
+    async def close(self) -> None:
+        for task in (self._read_task, self._stderr_task):
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+        self._read_task = None
+        self._stderr_task = None
+        if self.process is not None:
+            with contextlib.suppress(ProcessLookupError):
+                self.process.terminate()
+            try:
+                await asyncio.wait_for(
+                    self.process.wait(), timeout=_RPC_SESSION_CLOSE_REAP_TIMEOUT_S
+                )
+            except (asyncio.TimeoutError, ProcessLookupError, RuntimeError):
+                # RuntimeError can happen when the subprocess was created on a
+                # different event loop (e.g. test fixtures that call close() in
+                # a fresh loop).  Fall back to synchronous kill.
+                with contextlib.suppress(ProcessLookupError):
+                    self.process.kill()
+            close_subprocess_transport(self.process)
+            self.process = None
+        if self._tmp_dir is not None:
+            shutil.rmtree(self._tmp_dir, ignore_errors=True)
+            self._tmp_dir = None
+
+
+# ---------------------------------------------------------------------------
+# OmpExecutor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _OmpSessionState:
+    rpc: _OmpRpcSession | None = None
+    system_prompt: str | None = None
+    model: str | None = None
+    # Thinking level (omp vocabulary) this process is known to be running at,
+    # so an unchanged effort costs no RPC and a changed one is applied live.
+    applied_thinking: str | None = None
+    _has_sent_prompt: bool = False
+
+
+@dataclass(frozen=True)
+class BlockedCheck:
+    """Result of inspecting an omp tool result for a policy-blocked payload.
+
+    :param blocked: ``True`` when the result is (or wraps) a
+        ``{"blocked": true, "reason": "..."}`` dict.
+    :param reason: The human-readable block reason when ``blocked`` is
+        ``True``; an empty string otherwise.
+    """
+
+    blocked: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class OmpSubprocessConfig:
+    """Materialized environment + CLI args for an omp subprocess.
+
+    :param env: The complete environment for the omp process — the
+        :func:`_clean_omp_env` allowlist base, plus
+        ``PI_CODING_AGENT_DIR`` when Databricks model routing is in use.
+    :param tmp_dir: Temp directory that owns any ``models.yml`` /
+        ``omnigent_tools.mjs`` files generated for this subprocess.  The
+        caller is responsible for cleaning it up on shutdown.
+    :param extra_args: Extra CLI arguments to append to the omp invocation,
+        e.g. ``["--extension", ".../omnigent_tools.mjs"]``.
+    """
+
+    env: dict[str, str]
+    tmp_dir: str
+    extra_args: list[str]
+
+
+def _extract_text(msg: Message) -> str:
+    """
+    Extract text content from a message dict.
+
+    :param msg: A conversation message dict.
+    :returns: Plain text content of the message.
+    """
+    content = msg.get("content")
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            text = part.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+        return " ".join(parts)
+    return str(content)
+
+
+def _extract_latest_user_content(
+    messages: list[Message],
+) -> str | list[_JsonObject]:
+    """
+    Extract the latest user message content.
+
+    Returns a plain string for text-only messages. When the
+    message carries multimodal content blocks, returns the
+    block list so the caller can pass structured input to omp.
+
+    :param messages: Conversation history.
+    :returns: A string prompt or a list of content block dicts.
+    """
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            content = msg.get("content")
+            if content is None:
+                return ""
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                return cast(list[_JsonObject], content)
+            return str(content)
+    return ""
+
+
+def _split_omp_prompt(blocks: list[_JsonObject]) -> tuple[str, list[dict[str, str]]]:
+    """Split content blocks into omp's prompt ``message`` text and ``images``.
+
+    omp's RPC ``prompt`` command carries text in ``message`` and images in a
+    native ``images`` field (``ImageContent = {type, data, mimeType}``), which
+    the ``openai-completions`` provider converts to ``image_url`` blocks.
+    JSON-encoding the blocks into ``message`` instead (the previous behavior)
+    makes omp forward the image data URI as literal text, so the model never
+    sees the image (#515).
+
+    :param blocks: Responses-API content block dicts. ``input_text`` →
+        message text; ``input_image`` → omp ``images``; ``input_file`` (a
+        resolved attachment data URI) → its text payload is decoded into the
+        message for text-like MIME types and skipped (with a warning) for
+        binary ones, mirroring the Codex harness — omp has no native file
+        channel, but a text file's content is still useful inline, and the
+        old ``json.dumps(prompt)`` path surfaced it as text, so neither a
+        silent drop nor a hard failure is the right default here. A genuinely
+        unknown block type raises ``ValueError`` (→ ``ExecutorError`` in
+        ``run_turn``) so a new shape fails loudly rather than vanishing.
+    :returns: ``(message, images)`` — joined text and a list of omp
+        ``ImageContent`` dicts.
+    :raises ValueError: On a malformed ``input_image`` or an unhandled
+        block type.
+    """
+    text_parts: list[str] = []
+    images: list[dict[str, str]] = []
+    for block in blocks:
+        block_type = block.get("type")
+        if block_type in ("input_text", "output_text", "text"):
+            text_parts.append(str(block.get("text") or ""))
+        elif block_type == "input_image":
+            image_url = block.get("image_url")
+            if not isinstance(image_url, str) or not image_url.startswith("data:"):
+                raise ValueError(
+                    "input_image 'image_url' must be an inline data URI "
+                    "('data:<mime>;base64,...'); omp forwards images inline and "
+                    "cannot fetch external URLs or resolve file references "
+                    f"(got {str(image_url)[:48]!r})."
+                )
+            parsed = parse_data_uri(image_url)
+            images.append(
+                {"type": "image", "data": parsed.base64_payload, "mimeType": parsed.mime_type}
+            )
+        elif block_type == "input_file":
+            # omp has no file channel, so inline text-like files into the
+            # message (the model can still reason about them) and skip binary
+            # ones. Matches codex_executor's input_file fallback.
+            file_data = block.get("file_data") or ""
+            if isinstance(file_data, str) and file_data.startswith("data:"):
+                parsed = parse_data_uri(file_data)
+                if not parsed.mime_type.startswith("text/"):
+                    logger.warning(
+                        "omp harness: skipping non-text input_file (%s) — omp "
+                        "cannot consume binary attachments inline.",
+                        parsed.mime_type,
+                    )
+                    continue
+                try:
+                    decoded = base64.b64decode(parsed.base64_payload).decode("utf-8", "replace")
+                except ValueError as exc:  # binascii.Error subclasses ValueError
+                    raise ValueError(
+                        f"input_file has an undecodable base64 payload: {exc}"
+                    ) from exc
+                text_parts.append(decoded)
+            elif isinstance(file_data, str) and file_data:
+                # Already-inline text (no data: wrapper).
+                text_parts.append(file_data)
+        else:
+            raise ValueError(
+                f"Unsupported content block type {block_type!r} for the omp "
+                "harness: only 'input_text', 'input_image', and 'input_file' "
+                "blocks can be forwarded. Dropping it silently would lose the "
+                "attachment, so the turn fails loudly instead."
+            )
+    return "\n".join(text_parts), images
+
+
+def _build_omp_prompt(messages: list[Message], *, is_first_turn: bool) -> str | list[_JsonObject]:
+    """
+    Build the prompt to send to omp.
+
+    On the first turn with prior history (e.g. sub-agent with
+    ``pass_history=True``), serializes the full conversation so
+    the omp process has context. Otherwise returns just the
+    latest user message content (may be multimodal).
+
+    :param messages: Omnigent conversation history for the
+        turn.
+    :param is_first_turn: ``True`` when this is the first turn
+        against a freshly-started omp subprocess, so the full
+        history needs to be serialized into the prompt.
+    :returns: A string prompt or a list of content block dicts.
+    """
+    user_messages = [m for m in messages if m.get("role") == "user"]
+
+    if is_first_turn and len(messages) > 1 and len(user_messages) > 1:
+        lines = ["Conversation so far:"]
+        for msg in messages:
+            role = str(msg.get("role") or "user").replace("_", " ")
+            text = _extract_text(msg)
+            lines.append(f"{role}: {text}")
+        lines.append("")
+        lines.append(
+            "Respond to the latest user message, using the conversation above as context."
+        )
+        return "\n".join(lines)
+
+    return _extract_latest_user_content(messages)
+
+
+@dataclass(frozen=True)
+class SandboxedOmpCli:
+    """Result of wrapping the omp CLI in a sandbox.
+
+    :param launch_path: The path the executor should actually spawn.  Either
+        the original ``omp_path`` (sandbox skipped) or a generated wrapper
+        script that applies the sandbox before exec-ing omp.
+    :param sandboxed: ``True`` when the wrapper script is active.
+    """
+
+    launch_path: str
+    sandboxed: bool
+
+
+def _try_sandbox_omp(
+    omp_path: str,
+    os_env: OSEnvSpec | None,
+    cwd: str | None,
+    spawn_env_names: Sequence[str] | None = None,
+) -> SandboxedOmpCli:
+    """Wrap the omp CLI in a sandbox if ``os_env`` requests it.
+
+    :param omp_path: Path to the resolved ``omp`` binary.
+    :param os_env: The agent's ``os_env`` spec.  ``None`` or a ``"none"``
+        sandbox skips wrapping.
+    :param cwd: Working directory the sandbox should consider the root.
+    :param spawn_env_names: Env-var names the executor deliberately
+        passes in the omp subprocess env (the :func:`_clean_omp_env`
+        keys plus per-spawn extras like ``PI_CODING_AGENT_DIR``).
+        Baked into the launcher policy so :func:`run_launcher` prunes
+        anything else its environment picks up — defense in depth
+        against host-env leakage into the sandbox. ``None`` skips the
+        prune.
+    """
+    if os_env is None:
+        return SandboxedOmpCli(launch_path=omp_path, sandboxed=False)
+    sandbox_spec = os_env.sandbox or OSEnvSandboxSpec()
+    if sandbox_spec.type == "none":
+        return SandboxedOmpCli(launch_path=omp_path, sandboxed=False)
+    try:
+        import pathlib
+
+        from .sandbox import (
+            create_exec_launcher,
+            resolve_sandbox,
+            with_additional_read_roots,
+            with_additional_write_roots,
+            with_spawn_env_allowlist,
+        )
+
+        resolved_cwd = pathlib.Path(cwd or os.getcwd()).resolve(strict=False)
+        sandbox = resolve_sandbox(os_env, resolved_cwd)
+        if not sandbox.active:
+            return SandboxedOmpCli(launch_path=omp_path, sandboxed=False)
+        # omp needs to read its own installation + node_modules.
+        omp_dir = pathlib.Path(omp_path).resolve().parent.parent
+        sandbox = with_additional_read_roots(sandbox, [omp_dir])
+        # omp writes to ~/.omp, /tmp, and $TMPDIR (on macOS $TMPDIR is a
+        # per-user dir under /var/folders/, not /tmp — grant both so
+        # PI_CODING_AGENT_DIR (created via tempfile.mkdtemp) is reachable.
+        home_omp = pathlib.Path(os.path.expanduser("~/.omp"))
+        sys_tmpdir = pathlib.Path(tempfile.gettempdir())
+        sandbox = with_additional_write_roots(
+            sandbox, [home_omp, pathlib.Path("/tmp"), sys_tmpdir]
+        )
+        sandbox = with_spawn_env_allowlist(sandbox, spawn_env_names)
+        launcher = create_exec_launcher(omp_path, sandbox)
+        return SandboxedOmpCli(launch_path=launcher, sandboxed=True)
+    except (OSError, ImportError, NotImplementedError) as exc:
+        logger.warning("Could not apply sandbox for omp: %s", exc)
+        return SandboxedOmpCli(launch_path=omp_path, sandboxed=False)
+
+
+def _resolve_omp_skill_args(
+    skills_filter: str | list[str],
+    _bundle_dir: pathlib.Path | None,
+) -> list[str]:
+    """
+    Translate ``skills_filter`` into omp CLI args.
+
+    omp exposes two skill knobs at the CLI: ``--no-skills`` (suppress
+    auto-discovery + loading) and ``--skills=a,b`` (comma-separated
+    name allowlist over the discovered set, via the
+    ``skills.includeSkills`` session override). Unlike pi there is no
+    ``--skill <path>`` explicit-load flag, so this helper composes
+    the two knobs based on the spec's ``skills_filter``:
+
+    - ``"all"`` → no flags. omp auto-discovery runs; bundle skills
+      surface only when they are on omp's discovery path.
+    - ``"none"`` → ``["--no-skills"]``. Discovery AND loading are
+      suppressed.
+    - ``list[str]`` → ``["--skills=a,b"]`` (allowlist over
+      discovered skills). Names omp never discovers resolve to
+      nothing — matches the SDK convention where a missing skill
+      is no-op, not an error.
+
+    :param skills_filter: ``"all"`` / ``"none"`` / list of skill
+        names from the spec.
+    :param _bundle_dir: The agent bundle's extracted on-disk path.
+        Currently unused — omp has no explicit-load flag that could
+        point at it. Kept for signature parity with the ``pi`` wrap.
+    :returns: A list of CLI tokens to extend ``self._extra_args``
+        with. Empty for ``"all"`` and unknown shapes (omp defaults:
+        auto-discovery on).
+    """
+    if skills_filter == "all":
+        return []
+    if skills_filter == "none":
+        return ["--no-skills"]
+    if isinstance(skills_filter, list):
+        return [f"--skills={','.join(name for name in skills_filter if isinstance(name, str))}"]
+    # Unknown shape — fall back to omp's defaults (auto-discovery on).
+    # The harness wrap's resolver should have validated upstream, so
+    # this branch is belt-and-suspenders.
+    return []
+
+
+def _extract_omp_turn_usage(
+    message: object,
+    fallback_model: str | None,
+) -> _OmpMessageUsage | None:
+    """Map an omp assistant message's ``usage`` object onto the wire shape
+    that :class:`TurnComplete` consumes, so omp sub-agent cost is priced
+    the same way as ``claude-sdk`` and ``codex`` turns.
+
+    omp (``@oh-my-pi/pi-coding-agent``) forwards assistant messages
+    whose ``usage`` dict carries ``input`` / ``output`` / ``cacheRead`` /
+    ``cacheWrite`` / ``totalTokens`` token counts, and the message itself
+    carries the resolved ``model``. This translates those into omnigent's
+    usage schema (see :class:`omnigent.inner.executor.TurnComplete`).
+
+    :param message: An omp message dict (e.g. ``event["message"]`` from a
+        ``message_end`` event, or an entry from ``event["messages"]`` on
+        ``agent_end``). Defensive against non-dict shapes.
+    :param fallback_model: The executor's configured model, used for
+        cost pricing when the assistant message omits ``model``.
+    :returns: The mapped usage dict, or ``None`` when ``message`` is not
+        an assistant message carrying a ``usage`` dict — callers leave
+        ``TurnComplete.usage`` as ``None`` in that case.
+    """
+    if not isinstance(message, dict):
+        return None
+    if message.get("role") != "assistant":
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    raw_model = message.get("model")
+    model = raw_model if isinstance(raw_model, str) and raw_model else fallback_model
+    return {
+        "input_tokens": int(usage.get("input") or 0),
+        "output_tokens": int(usage.get("output") or 0),
+        "total_tokens": int(usage.get("totalTokens") or 0),
+        "cache_read_input_tokens": int(usage.get("cacheRead") or 0),
+        "cache_creation_input_tokens": int(usage.get("cacheWrite") or 0),
+        "model": model,
+    }
+
+
+def _aggregate_omp_turn_usage(
+    message_usages: list[_OmpMessageUsage],
+    fallback_model: str | None,
+) -> _OmpTurnUsage | None:
+    """Aggregate per-message omp usage into one turn-level usage dict.
+
+    A single Omnigent turn drives omp's full agent loop, which may make
+    several LLM calls (one assistant message per iteration of a tool-use
+    loop), each forwarded as its own ``message_end``. Mirrors the
+    openai-agents executor's billing/context split (see
+    ``openai_agents_sdk_executor``): token counts are SUMMED across those
+    calls because each call is billed for the full input it sends, while
+    ``context_tokens`` reflects only the LAST call's total — the proxy for
+    how full the context window is going into the next request (summing
+    inputs would double-count the re-sent history).
+
+    :param message_usages: Per-message usage dicts from
+        :func:`_extract_omp_turn_usage`, in arrival order. Empty when omp
+        reported no usage for the turn.
+    :param fallback_model: The executor's configured model id, used only
+        when no captured message carried a ``model``,
+        e.g. ``"gateway-model-id"``.
+    :returns: A turn-level usage dict for ``TurnComplete.usage`` carrying
+        summed ``input_tokens`` / ``output_tokens`` / ``total_tokens`` /
+        ``cache_read_input_tokens`` / ``cache_creation_input_tokens``, a
+        last-call ``context_tokens``, and the pricing ``model``; or
+        ``None`` when no usable usage was captured.
+    """
+    if not message_usages:
+        return None
+    input_tokens = sum(u["input_tokens"] for u in message_usages)
+    output_tokens = sum(u["output_tokens"] for u in message_usages)
+    total_tokens = sum(u["total_tokens"] for u in message_usages)
+    cache_read = sum(u["cache_read_input_tokens"] for u in message_usages)
+    cache_write = sum(u["cache_creation_input_tokens"] for u in message_usages)
+    # No countable tokens means omp reported empty usage objects — treat as
+    # "no usage" so the server leaves the session unpriced rather than
+    # recording a $0.00 turn.
+    if not (input_tokens or output_tokens):
+        return None
+    last = message_usages[-1]
+    # context_tokens = the LAST call's total context (the proxy for
+    # next-request context fill); recompute from components when the
+    # provider omitted ``totalTokens``.
+    context_tokens = last["total_tokens"] or (
+        last["input_tokens"]
+        + last["output_tokens"]
+        + last["cache_read_input_tokens"]
+        + last["cache_creation_input_tokens"]
+    )
+    # _extract_omp_turn_usage already applied the per-message
+    # message-model-else-fallback precedence, so the last entry's model is
+    # the authoritative one to price the turn with.
+    model = last["model"] if last["model"] else fallback_model
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens or (input_tokens + output_tokens),
+        "cache_read_input_tokens": cache_read,
+        "cache_creation_input_tokens": cache_write,
+        "context_tokens": context_tokens,
+        "model": model,
+    }
+
+
+def _omp_thinking_from_config(config: ExecutorConfig | None) -> str | None:
+    """Resolve the per-turn ``--thinking``/RPC level from a turn's config.
+
+    Canonical omnigent efforts (:data:`PI_EFFORTS`) are translated to omp's
+    vocabulary; a clear value (``default``/``off``/``reset``) resolves to
+    ``None``, which leaves a live session at its current level and omits
+    ``--thinking`` on the next spawn so omp's model default applies.
+
+    :param config: The turn's executor config, or ``None``.
+    :returns: An omp thinking level, or ``None`` when no effort is requested.
+    :raises ValueError: If the requested effort is not one omp supports.
+    """
+    cfg = config or ExecutorConfig()
+    raw = cfg.extra.get("reasoning_effort")
+    if isinstance(raw, str) and raw in EFFORT_CLEAR_VALUES:
+        return None
+    effort = validate_effort(raw, "omp", PI_EFFORTS)
+    return to_pi_thinking_level(effort) if effort is not None else None
+
+
+class OmpExecutor(Executor):
+    """Execute agent turns via the omp coding agent (``omp --mode rpc``)."""
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        os_env: OSEnvSpec | None = None,
+        model: str | None = None,
+        omp_path: str | None = None,
+        gateway: bool = False,
+        databricks_profile: str | None = None,
+        gateway_host: str | None = None,
+        base_url_override: str | None = None,
+        base_urls_override: dict[str, str] | None = None,
+        openai_wire_api: str | None = None,
+        gateway_auth_command: str | None = None,
+        retry_policy: RetryPolicy | None = None,
+        bundle_dir: pathlib.Path | None = None,
+        agent_name: str | None = None,
+        skills_filter: str | list[str] = "all",
+    ) -> None:
+        """Create a OmpExecutor.
+
+        :param cwd: Working directory for the omp subprocess.
+        :param os_env: Optional OS environment / sandbox spec.  When set, the
+            omp subprocess is wrapped in the same sandbox other
+            harnesses use.
+        :param model: Override the model name, e.g. ``"gateway-model-id"``.
+        :param omp_path: Absolute path to an ``omp`` CLI binary.  When ``None``
+            the executor searches ``PATH``.
+        :param gateway: When ``True``, write a ``models.yml`` pointing omp
+            at a vendor-neutral gateway. The Databricks AI gateway is one
+            producer of this transport; generic providers are another.
+        :param databricks_profile: Databricks-specific config profile from
+            ``~/.databrickscfg``, e.g. ``"<your-profile>"``.  Only used on the
+            Databricks producer path. ``None`` falls back to
+            ``DATABRICKS_CONFIG_PROFILE`` then the first valid profile.
+        :param gateway_host: Gateway workspace host origin, e.g.
+            ``"https://example.databricks.com"``.  Set from
+            ``HARNESS_OMP_GATEWAY_HOST`` (written by the Omnigent workflow layer).
+            When set, skips profile host lookup.
+        :param base_url_override: Override the workspace host used when
+            building omp's ``models.yml``.  Expected to be the Anthropic
+            gateway URL from ucode state.json (``base_urls.claude``), e.g.
+            ``"https://example.databricks.com/ai-gateway/anthropic"``.
+            The host portion is extracted and used as the base for all
+            omp provider URLs.  ``None`` falls back to deriving the host from
+            the Databricks profile credentials.
+        :param base_urls_override: ucode-provided omp gateway URLs keyed by
+            model family, e.g. ``{"claude": "...", "openai": "..."}``.
+        :param openai_wire_api: Configured generic-provider OpenAI wire,
+            ``"responses"`` or ``"chat"``. Databricks ignores this and uses
+            live Unity Catalog metadata.
+        :param gateway_auth_command: Shell command that prints a bearer token,
+            e.g.
+            ``"databricks auth token --host https://example.databricks.com ..."``
+            or ``"printf %s sk-..."``. Set from
+            ``HARNESS_OMP_GATEWAY_AUTH_COMMAND``.
+        :param retry_policy: The spec's ``llm.retry`` budget. Threads
+            ``policy.pi.settings()`` into omp's ``.omp/settings.json``
+            before subprocess spawn — omp natively does exponential
+            backoff and Retry-After honoring; this just sets the
+            budget. ``None`` resolves to ``RetryPolicy()`` defaults.
+            See Phase 1f of ``designs/RETRY_ACROSS_HARNESSES.md``.
+        :param bundle_dir: The agent bundle's extracted on-disk path.
+            When set, ``<bundle_dir>/skills/<dir>/SKILL.md`` files
+            are currently unused by omp (it discovers skills itself).
+            ``None`` disables nothing.
+        :param agent_name: Optional agent display name. Reserved for
+            future use; currently unused by omp.
+        :param skills_filter: Host-skill filter (``"all"`` / ``"none"``
+            / ``list[str]``). ``"all"`` (default) passes no skill flags
+            so omp's auto-discovery runs; ``"none"`` adds ``--no-skills``;
+            a list adds ``--skills=a,b`` (allowlist over discovered
+            skills).
+        """
+        resolved_omp = omp_path or _find_omp_cli()
+        if not resolved_omp:
+            raise ImportError(
+                "OmpExecutor requires the 'omp' CLI on PATH. "
+                "Install it with: npm install -g @oh-my-pi/pi-coding-agent"
+            )
+        self._omp_path = resolved_omp
+        self._cwd = cwd
+        self._os_env_spec = os_env
+        self._model_override = model
+        self._gateway = gateway
+        self._databricks_profile = databricks_profile
+        self._gateway_host_override = gateway_host.rstrip("/") if gateway_host else None
+        self._base_url_override = base_url_override
+        self._base_urls_override = base_urls_override
+        if openai_wire_api not in (None, RESPONSES_WIRE_API, CHAT_WIRE_API):
+            raise ValueError(f"unsupported omp OpenAI wire API: {openai_wire_api!r}")
+        self._openai_wire_api = openai_wire_api
+        self._gateway_model_entries: tuple[model_catalog.ModelEntry, ...] | None = None
+        self._gateway_model_wire_apis: dict[str, frozenset[ModelWireAPI]] | None = None
+        self._gateway_auth_command = gateway_auth_command
+        # Retry policy → omp's .omp/settings.json before subprocess spawn.
+        # See ``RetryPolicy.pi.settings()`` for the schema (omp kept pi's
+        # settings shape). omp natively does exponential backoff +
+        # Retry-After honoring; we just set the budget.
+        self._retry_policy = retry_policy if retry_policy is not None else RetryPolicy()
+        # Allowlisted base env for the omp subprocess — never the full
+        # host environ. The spec's os_env.sandbox.env_passthrough is the
+        # opt-in for anything beyond the base set (e.g. a provider API
+        # key on a direct, non-gateway run).
+        self._env: dict[str, str] = _clean_omp_env(
+            os_env.sandbox.env_passthrough if os_env is not None and os_env.sandbox else None
+        )
+        # ``--no-tools`` disables built-ins AND extension tools by
+        # default; we re-enable just the bridged tool names per turn via
+        # ``--tools <comma-list>`` in :meth:`_build_env_and_dir`. The
+        # combined effect is: omp's native read/bash/edit/write stay off
+        # (they don't route through Omnigent policies / history and can
+        # 400 against the Databricks Responses API), and the bridge
+        # extension's tools are explicitly allowlisted.
+        self._extra_args: list[str] = ["--no-tools"]
+        if _omp_supports_auto_approve(self._omp_path):
+            # Pre-accept the project-folder trust dialog. omp shows a
+            # blocking TUI prompt on first launch in a directory with
+            # .omp/ resources. In a runner-driven session there is nobody
+            # at the terminal to answer it, so we approve when the flag
+            # is supported.
+            self._extra_args.append("--auto-approve")
+        self._bundle_dir = bundle_dir
+        self._agent_name = agent_name
+        self._skills_filter = skills_filter
+        # Resolve once at construction (the bundle layout doesn't
+        # change across turns within a session). Each turn's
+        # ``_build_env_and_dir`` copies ``self._extra_args`` so this
+        # extension is read-only after init.
+        self._extra_args.extend(_resolve_omp_skill_args(skills_filter, bundle_dir))
+        # Set by Session._wire_sdk_executor().
+        self._tool_executor: ToolExecutor | None = None
+
+        if gateway:
+            creds = None
+            if self._gateway_host_override is None:
+                creds = _read_databrickscfg(databricks_profile)
+                if creds is None:
+                    raise OSError(
+                        "OmpExecutor(gateway=True) requires gateway credentials via "
+                        "the gateway base URL / auth command or a valid "
+                        "~/.databrickscfg profile."
+                    )
+            if self._gateway_host_override is not None:
+                self._databricks_host = self._gateway_host_override
+                if gateway_auth_command is None:
+                    raise OSError(
+                        "OmpExecutor(gateway=True) with a gateway workspace host "
+                        "requires a gateway auth command."
+                    )
+                token = _fetch_shell_command_token(gateway_auth_command)
+                if token is None:
+                    raise OSError(
+                        "OmpExecutor(gateway=True) could not fetch a gateway token "
+                        "for the workspace host."
+                    )
+                self._databricks_token = token
+            elif base_url_override:
+                # Derive the workspace host from the Anthropic gateway URL
+                # ucode wrote to state.json.
+                _parsed = _urlparse(base_url_override)
+                self._databricks_host = f"{_parsed.scheme}://{_parsed.netloc}"
+                assert creds is not None
+                self._databricks_token = creds.token
+            else:
+                assert creds is not None
+                self._databricks_host = creds.host
+                self._databricks_token = creds.token
+
+        # True when the gateway transport was derived from a ~/.databrickscfg
+        # profile (no gateway host or base URL supplied directly). Gates the
+        # Databricks default model in :meth:`_resolve_model`; on the ucode /
+        # generic-provider paths the producer resolves a concrete model.
+        self._gateway_uses_databricks_profile = bool(
+            gateway and self._gateway_host_override is None and base_url_override is None
+        )
+        self._gateway_workspace_url = (
+            self._gateway_model_service_workspace_url() if gateway else None
+        )
+
+        # Apply sandbox.
+        # ``PI_CODING_AGENT_DIR`` is added per-spawn by
+        # ``_build_env_and_dir`` on the gateway path, so it must be in
+        # the launcher's prune allowlist even though it's not in
+        # ``self._env`` yet.
+        sandboxed = _try_sandbox_omp(
+            self._omp_path,
+            os_env,
+            cwd,
+            spawn_env_names=[*self._env, "PI_CODING_AGENT_DIR"],
+        )
+        self._omp_launch_path = sandboxed.launch_path
+        self._sandboxed = sandboxed.sandboxed
+
+        self._session_states: dict[str, _OmpSessionState] = {}
+        self._tool_server: _ToolServer | None = None
+
+    def supports_streaming(self) -> bool:
+        return True
+
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    def handles_tools_internally(self) -> bool:
+        return True
+
+    def supports_live_message_queue(self) -> bool:
+        return True
+
+    async def enqueue_session_message(  # type: ignore[explicit-any]
+        self,
+        session_key: str,
+        content: str | dict[str, Any],
+    ) -> bool:
+        """Send a steering message to omp mid-turn.
+
+        omp's RPC ``steer`` command injects a user message between tool calls
+        within the current agent turn, so the model sees it before its next
+        response.
+        """
+        state = self._session_states.get(session_key)
+        if state is None or state.rpc is None:
+            return False
+        text = content if isinstance(content, str) else str(content)
+        try:
+            await state.rpc.send_command(
+                {
+                    "type": "steer",
+                    "message": text,
+                }
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — steer is best-effort; any failure surfaces as False
+            logger.debug("OmpExecutor: failed to enqueue steer message: %s", exc)
+            return False
+
+    async def close_session(self, session_key: str) -> None:
+        state = self._session_states.pop(session_key, None)
+        if state is not None and state.rpc is not None:
+            await state.rpc.close()
+
+    async def interrupt_session(self, session_key: str) -> bool:
+        state = self._session_states.get(session_key)
+        if state is None or state.rpc is None:
+            return False
+        # Best-effort abort to halt the in-flight turn.
+        try:
+            await state.rpc.send_command({"type": "abort", "id": "abort"})
+        except Exception as exc:  # noqa: BLE001 — abort is best-effort
+            logger.debug("OmpExecutor: interrupt abort failed: %s", exc)
+        # Always drop the session so the next turn starts fresh and replays
+        # full history. A resumed subprocess sends only the latest user
+        # message, which would bypass the runner's "[System: interrupted]"
+        # marker and silently continue the abandoned request. See
+        # claude_sdk_executor.interrupt_session for the rationale.
+        try:
+            await self.close_session(session_key)
+            return True
+        except Exception as exc:  # noqa: BLE001 — close failures surface as False
+            logger.debug("OmpExecutor: session close after interrupt failed: %s", exc)
+            return False
+
+    async def close(self) -> None:
+        keys = list(self._session_states.keys())
+        for key in keys:
+            await self.close_session(key)
+        if self._tool_server is not None:
+            await self._tool_server.stop()
+            self._tool_server = None
+
+    def _session_key(self, messages: list[Message]) -> str:
+        if messages:
+            last = messages[-1]
+            if last.get("session_id"):
+                return str(last["session_id"])
+            meta = last.get("metadata", {})
+            if meta.get("session_id"):
+                return str(meta["session_id"])
+        return "__default__"
+
+    async def _resolve_model(self, config: ExecutorConfig | None) -> str | None:
+        """
+        Determine the model name to pass to omp.
+
+        ``cfg.model`` (per-request /model override) wins over the spec
+        default (``HARNESS_OMP_MODEL`` → ``self._model_override``). On the
+        Databricks-profile gateway path a missing model resolves from the
+        Databricks Claude catalog — omp's own default may be a direct-provider
+        id the gateway rejects. Elsewhere ``None`` lets omp pick its own default.
+
+        :param config: Optional :class:`ExecutorConfig` whose ``model``
+            takes precedence when set.
+        :returns: The resolved model string, or ``None`` when both
+            sources are unset off the Databricks-profile gateway path.
+        """
+        cfg = config or ExecutorConfig()
+        model = cfg.model or self._model_override
+        if model is None and self._gateway_uses_databricks_profile:
+            # DATABRICKS-PATCH(omp-live-model-discovery): resolve from the
+            # workspace, not the bundled catalog whose legacy `databricks-` ids
+            # the gateway answers with `501 … Use Unity Catalog model services`.
+            from omnigent.inner.claude_sdk_executor import _resolve_databricks_claude_model
+
+            model_id = await run_sync_on_thread(
+                _resolve_databricks_claude_model, self._databricks_profile
+            )
+            if not isinstance(model_id, str):
+                raise TypeError("Databricks model resolution returned a non-string model id")
+            return model_id
+        # Strip bracket suffixes (e.g. "[1m]") — context-window hints accepted
+        # by the direct Anthropic API but not by the Databricks AI Gateway.
+        if model and self._gateway:
+            model = re.sub(r"\[.*?\]$", "", model)
+        return model
+
+    def _generic_openai_wire_api(self) -> str | None:
+        """Return the configured wire only for a non-Databricks gateway."""
+        openai_base_url = (self._base_urls_override or {}).get("openai")
+        if openai_base_url:
+            is_databricks_gateway = (
+                "/ai-gateway/" in openai_base_url or _is_databricks_ai_gateway_url(openai_base_url)
+            )
+            if not is_databricks_gateway:
+                return self._openai_wire_api or CHAT_WIRE_API
+        return None
+
+    def _gateway_model_service_workspace_url(self) -> str | None:
+        """Return the workspace API origin for Databricks catalog discovery."""
+        if self._gateway_uses_databricks_profile:
+            return self._databricks_host
+        candidates = [
+            *(self._base_urls_override or {}).values(),
+            self._base_url_override,
+            self._gateway_host_override,
+        ]
+        for candidate in candidates:
+            if not candidate:
+                continue
+            workspace_url = _databricks_workspace_url_for_gateway(
+                candidate,
+                profile=self._databricks_profile,
+            )
+            if workspace_url is not None:
+                return workspace_url
+        return None
+
+    async def _load_gateway_model_wire_apis(self) -> dict[str, frozenset[ModelWireAPI]]:
+        """Fetch and cache the live Databricks model catalog."""
+        if self._gateway_model_wire_apis is not None:
+            return self._gateway_model_wire_apis
+        workspace_url = self._gateway_workspace_url if self._gateway else None
+        if workspace_url is None:
+            self._gateway_model_entries = ()
+            self._gateway_model_wire_apis = {}
+            return self._gateway_model_wire_apis
+        try:
+            models = await run_sync_on_thread(
+                model_catalog.fetch_databricks_model_service_entries,
+                workspace_url,
+                self._databricks_token,
+            )
+        except Exception:  # noqa: BLE001 — catalog outage uses conservative routing
+            logger.warning(
+                "omp could not fetch Databricks model metadata; "
+                "the picker will show only the selected model",
+                exc_info=True,
+            )
+            self._gateway_model_entries = ()
+            self._gateway_model_wire_apis = {}
+            return self._gateway_model_wire_apis
+        try:
+            metadata_models = await run_sync_on_thread(
+                model_catalog.catalog_model_entries,
+                "databricks",
+            )
+        except Exception:  # noqa: BLE001 — live availability remains authoritative
+            logger.info(
+                "omp could not enrich the live Databricks model list with MLflow metadata",
+                exc_info=True,
+            )
+        else:
+            models = enrich_databricks_model_catalog(models, metadata_models)
+        self._gateway_model_entries = tuple(models)
+        self._gateway_model_wire_apis = _databricks_model_wire_catalog(models)
+        return self._gateway_model_wire_apis
+
+    async def _ensure_tool_server(self, tools: list[ToolSpec]) -> int | None:
+        """Start the TCP tool server if there are Omnigent tools to bridge."""
+        if not tools:
+            return None
+        if self._tool_server is None:
+            self._tool_server = _ToolServer()
+            await self._tool_server.start()
+        self._tool_server._tool_executor = self._tool_executor
+        self._tool_server._policy_gate = self._gate_native_tool
+        return self._tool_server.port
+
+    async def _gate_native_tool(  # type: ignore[explicit-any]
+        self,
+        name: str,
+        args: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Evaluate a native omp tool call against Omnigent TOOL_CALL policy.
+
+        Bridges the tool server's :attr:`_ToolServer._policy_gate` to the
+        ``_policy_evaluator`` the harness scaffold installs on this executor
+        (the same round-trip the Claude SDK executor uses for LLM_REQUEST /
+        LLM_RESPONSE policies). Mirrors the claude-native / codex-native
+        PreToolUse hooks: the verdict is computed by the Omnigent server
+        against the session's full policy set (inherited parent session
+        policies + the agent spec's guardrails).
+
+        :param name: Native tool name, e.g. ``"read"`` or ``"bash"``.
+        :param args: The tool's argument dict.
+        :returns: ``{"block": bool, "reason": str}`` — block on DENY.
+            Allow when no evaluator is wired (single-process / test paths).
+            TOOL_CALL ASK is collapsed to ALLOW/DENY server-side before the
+            verdict returns, so only DENY blocks here.
+        """
+        # ``_policy_evaluator`` is installed best-effort by the harness
+        # scaffold's executor adapter; absent on single-process / pre-turn
+        # paths. Same fetch pattern as the Claude SDK executor.
+        evaluator = getattr(self, "_policy_evaluator", None)
+        if evaluator is None:
+            return {"block": False, "reason": ""}
+        verdict = await evaluator("PHASE_TOOL_CALL", {"name": name, "arguments": args})
+        if verdict.action == "POLICY_ACTION_DENY":
+            return {"block": True, "reason": verdict.reason or "blocked by policy"}
+        return {"block": False, "reason": ""}
+
+    def _build_env_and_dir(
+        self,
+        tools: list[ToolSpec],
+        tool_server_port: int | None,
+        tool_server_token: str | None,
+        model: str | None,
+    ) -> OmpSubprocessConfig:
+        """Build env dict, temp dir, and extra CLI args for an omp subprocess.
+
+        :param tools: Omnigent tool schemas to bridge into omp.
+        :param tool_server_port: TCP port the Omnigent tool server is
+            listening on, or ``None`` if no tools need bridging.
+        :param tool_server_token: The tool server's bearer token
+            (:attr:`_ToolServer.token`), embedded in the generated
+            extension so requests authenticate. Non-``None`` whenever
+            *tool_server_port* is.
+        :param model: The resolved model id this subprocess will run, e.g.
+            ``"moonshotai/kimi-k2.6"``; registered in the generated
+            ``models.yml`` on the gateway path so the
+            ``provider/<model>`` selector resolves. ``None`` when no model
+            is pinned (omp picks its own default).
+        """
+        env = dict(self._env)
+        tmp_dir = tempfile.mkdtemp(prefix="omnigent_omp_")
+        extra_args: list[str] = list(self._extra_args)
+
+        if self._gateway:
+            effective_model = model
+            models_yml = _build_models_yml(
+                self._gateway_workspace_url or self._databricks_host,
+                self._databricks_token,
+                self._base_urls_override,
+                model=effective_model,
+                catalog_models=self._gateway_model_entries or (),
+                model_wire_apis=self._gateway_model_wire_apis,
+                openai_wire_api=self._openai_wire_api,
+            )
+            models_path = os.path.join(tmp_dir, "models.yml")
+            with open(models_path, "w") as f:
+                yaml.safe_dump(models_yml, f, sort_keys=True)
+            env["PI_CODING_AGENT_DIR"] = tmp_dir
+            # Gateway mode relocates omp's agent root — copy the user's global
+            # settings (extensions, packages, …) and symlink install trees so
+            # ``omp install`` packages still resolve. See #1423.
+            from omnigent.inner.pi_settings import prepare_managed_omp_agent_dir
+
+            prepare_managed_omp_agent_dir(
+                pathlib.Path(tmp_dir),
+                overlay=self._retry_policy.pi.settings(),
+            )
+
+        # omp natively supports retry config via ``.omp/settings.json``
+        # (see ``RetryPolicy.pi.settings()`` for schema). On the non-gateway
+        # path, merge the retry block into ``<cwd>/.omp/settings.json``.
+        # Gateway runs apply retry via :func:`prepare_managed_omp_agent_dir`
+        # into the managed agent dir instead.
+        if not self._gateway:
+            retry_settings = self._retry_policy.pi.settings()
+            settings_dir_root = self._cwd or tmp_dir
+            settings_path = os.path.join(settings_dir_root, ".omp", "settings.json")
+            try:
+                if os.path.exists(settings_path):
+                    with open(settings_path) as f:
+                        existing_settings = json.load(f)
+                    if not isinstance(existing_settings, dict):
+                        existing_settings = {}
+                else:
+                    existing_settings = {}
+                existing_settings.update(retry_settings)
+                os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+                with open(settings_path, "w") as f:
+                    json.dump(existing_settings, f, indent=2)
+            except OSError:
+                fallback_path = os.path.join(tmp_dir, ".omp", "settings.json")
+                os.makedirs(os.path.dirname(fallback_path), exist_ok=True)
+                with open(fallback_path, "w") as f:
+                    json.dump(retry_settings, f, indent=2)
+
+        # Generate the Omnigent tool bridge extension if tools are available.
+        if tools and tool_server_port is not None:
+            if tool_server_token is None:
+                # A port without a token would spawn the bridge
+                # unauthenticated; fail loud instead.
+                raise ValueError("tool_server_token is required when tool_server_port is set")
+            ext_path = os.path.join(tmp_dir, "omnigent_tools.mjs")
+            with open(ext_path, "w") as f:
+                f.write(_generate_extension_js(tool_server_port, tools, tool_server_token))
+            extra_args.extend(["--extension", ext_path])
+            # Allowlist the bridged tool names. ``--no-tools`` (set in
+            # __init__) disables every tool by default in pi 0.68+;
+            # ``--tools`` adds specific names back. Without this pass
+            # the bridge extension's tools register but pi never
+            # exposes them to the LLM — symptom: model replies "I
+            # don't have a calculate tool available."
+            tool_names = [
+                name for name in (s.get("name") for s in tools) if isinstance(name, str) and name
+            ]
+            # omp's system prompt (system-prompt.ts) gates skill-index
+            # injection on ``selectedTools`` including ``"read"``. omp's
+            # native ``read`` is a local filesystem read that runs
+            # in-process and never traverses the bridged /mcp path — so
+            # enabling it lets the model see (and load) skills from omp's
+            # own discovery. As a native tool it would
+            # otherwise escape all guardrails, so the generated extension's
+            # ``tool_call`` hook routes it (and any other native tool) through
+            # an Omnigent TOOL_CALL policy verdict; see
+            # :func:`_generate_extension_js` and
+            # :meth:`OmpExecutor._gate_native_tool`.
+            if self._skills_filter != "none":
+                tool_names.append("read")
+            if tool_names:
+                extra_args.extend(["--tools", ",".join(tool_names)])
+
+        return OmpSubprocessConfig(env=env, tmp_dir=tmp_dir, extra_args=extra_args)
+
+    async def _available_thinking_levels(self, rpc: _OmpRpcSession) -> list[str] | None:
+        """Ask omp which thinking levels the current model offers.
+
+        omp has no ``get_available_thinking_levels`` command (it answers
+        ``Unknown command``), so the probe fast-fails to ``None`` and the
+        caller applies the requested level unclamped via
+        ``set_thinking_level``. If omp ever gains the command, this starts
+        clamping with no further change.
+
+        :returns: The reported levels, or ``None`` when omp did not answer —
+            the caller then skips clamping.
+        """
+        try:
+            response = await rpc.request(
+                {"type": "get_available_thinking_levels", "id": "thinking_levels"},
+                "get_available_thinking_levels",
+            )
+        except Exception:  # noqa: BLE001 — a probe failure must not sink the turn
+            logger.debug("OmpExecutor: get_available_thinking_levels failed", exc_info=True)
+            return None
+        data = response.get("data") if response else None
+        levels = data.get("levels") if isinstance(data, dict) else None
+        if not isinstance(levels, list):
+            return None
+        return [level for level in levels if isinstance(level, str)]
+
+    async def _apply_thinking_level(
+        self,
+        state: _OmpSessionState,
+        rpc: _OmpRpcSession,
+        thinking: str | None,
+        *,
+        spawned: bool,
+    ) -> None:
+        """Make the live omp session run at *thinking*, clamping if unsupported.
+
+        A fresh spawn already carries the level on its argv, so it only needs
+        an RPC when the model doesn't offer that rung; a live session gets
+        ``set_thinking_level`` whenever the requested level changed.
+
+        :param state: Session state whose ``applied_thinking`` is updated.
+        :param rpc: The live omp RPC session.
+        :param thinking: Requested level in omp vocabulary, or ``None`` to leave
+            the session alone (clear-to-default is a no-op mid-session).
+        :param spawned: ``True`` when *rpc* was just spawned with ``--thinking``.
+        """
+        if thinking is None:
+            return
+        if not spawned and thinking == state.applied_thinking:
+            return
+        supported = await self._available_thinking_levels(rpc)
+        level = nearest_pi_thinking_level(thinking, supported) if supported else None
+        if level is None:
+            level = thinking
+        if level != thinking:
+            logger.warning(
+                "OmpExecutor: model %s does not support thinking level %r; using %r",
+                state.model,
+                thinking,
+                level,
+            )
+        elif spawned:
+            return
+        await rpc.send_command(
+            {"type": "set_thinking_level", "level": level, "id": f"thinking_{level}"}
+        )
+        state.applied_thinking = thinking
+
+    async def _ensure_rpc(
+        self,
+        session_key: str,
+        system_prompt: str,
+        model: str | None,
+        tools: list[ToolSpec],
+        thinking: str | None = None,
+    ) -> _OmpRpcSession:
+        """Get or create an omp RPC subprocess for the given session.
+
+        :param thinking: omp thinking level for a fresh spawn (``--thinking``).
+            A change on a live process is applied over RPC instead — see
+            :meth:`_apply_thinking_level` — so it is not part of the reuse
+            signature. A model change respawns, which re-asserts the level.
+        """
+        state = self._session_states.setdefault(session_key, _OmpSessionState())
+
+        effective_model = model
+
+        if (
+            state.rpc is not None
+            and state.rpc.process is not None
+            and state.rpc.process.returncode is None
+            and state.system_prompt == system_prompt
+            and state.model == effective_model
+        ):
+            return state.rpc
+
+        wire_catalog = await self._load_gateway_model_wire_apis()
+
+        if state.rpc is not None:
+            await state.rpc.close()
+
+        tool_server_port = await self._ensure_tool_server(tools)
+        tool_server_token = self._tool_server.token if self._tool_server is not None else None
+        subprocess_config = self._build_env_and_dir(
+            tools, tool_server_port, tool_server_token, effective_model
+        )
+        env = subprocess_config.env
+        tmp_dir = subprocess_config.tmp_dir
+        extra_args = subprocess_config.extra_args
+        # For Databricks models, prefix with the provider name so omp resolves
+        # the model from our custom provider in models.yml.
+        omp_model: str | None
+        if self._gateway and effective_model:
+            provider = _omp_provider_for_model(
+                effective_model,
+                wire_catalog.get(effective_model.lower()),
+                generic_openai_wire_api=self._generic_openai_wire_api(),
+            )
+            head, sep, _ = effective_model.partition("/")
+            # An already-qualified selector for the provider this model routes
+            # to passes through untouched — re-prefixing would stack to
+            # ``provider/provider/model``, which omp cannot resolve.
+            omp_model = (
+                effective_model if sep and head == provider else f"{provider}/{effective_model}"
+            )
+        else:
+            omp_model = effective_model
+        rpc = _OmpRpcSession()
+        rpc._tmp_dir = tmp_dir
+
+        await rpc.start(
+            self._omp_launch_path,
+            env=env,
+            cwd=self._cwd,
+            model=omp_model or None,
+            system_prompt=system_prompt or None,
+            thinking=thinking,
+            extra_args=extra_args or None,
+        )
+        state.rpc = rpc
+        state.system_prompt = system_prompt
+        state.model = effective_model
+        state.applied_thinking = thinking
+        state._has_sent_prompt = False
+        return rpc
+
+    async def run_turn(
+        self,
+        messages: list[Message],
+        tools: list[ToolSpec],
+        system_prompt: str,
+        config: ExecutorConfig | None = None,
+    ) -> AsyncIterator[ExecutorEvent]:
+        if self._gateway:
+            if self._gateway_host_override is None:
+                creds = _read_databrickscfg(self._databricks_profile)
+                if creds is not None:
+                    self._databricks_token = creds.token
+            else:
+                assert self._gateway_auth_command is not None
+                token = _fetch_shell_command_token(self._gateway_auth_command)
+                if token:
+                    self._databricks_token = token
+        session_key = self._session_key(messages)
+        model = await self._resolve_model(config)
+        try:
+            thinking = _omp_thinking_from_config(config)
+        except ValueError as exc:
+            yield ExecutorError(message=str(exc), retryable=False)
+            return
+
+        prior_rpc = (self._session_states.get(session_key) or _OmpSessionState()).rpc
+        try:
+            rpc = await self._ensure_rpc(session_key, system_prompt, model, tools, thinking)
+        except Exception as exc:  # noqa: BLE001 — executor boundary surfaces startup errors as ExecutorError
+            yield ExecutorError(message=f"Failed to start omp: {exc}")
+            return
+
+        turn_state = self._session_states.get(session_key)
+        if turn_state is not None:
+            try:
+                await self._apply_thinking_level(
+                    turn_state, rpc, thinking, spawned=rpc is not prior_rpc
+                )
+            except Exception as exc:  # noqa: BLE001 — executor boundary: an effort failure must not sink the turn
+                logger.warning("OmpExecutor: could not apply thinking level: %s", exc)
+
+        # Build the prompt to send to omp.  On the first turn of a new omp
+        # process, if there are prior messages (e.g. parent history passed
+        # to a sub-agent), we serialize the full conversation so omp has
+        # context.  On subsequent turns the omp process already has context,
+        # so we only send the latest user message.
+        state = self._session_states.get(session_key)
+        is_first_turn = state is not None and not state._has_sent_prompt
+
+        prompt = _build_omp_prompt(messages, is_first_turn=is_first_turn)
+
+        if not prompt:
+            # No prompt built (e.g. empty message list on a resumed session) —
+            # end the turn with no assistant text rather than fabricating one.
+            yield TurnComplete(response=None)
+            return
+
+        if state is not None:
+            state._has_sent_prompt = True
+
+        # Send prompt command. omp's JSONL protocol carries text in ``message``
+        # and images in a native ``images`` field. Split multimodal blocks into
+        # both (rather than JSON-encoding them into the text) so the model
+        # actually receives attached images instead of a base64 text blob (#515).
+        message: str
+        images: list[dict[str, str]] = []
+        if isinstance(prompt, list):
+            try:
+                message, images = _split_omp_prompt(prompt)
+            except Exception as exc:  # noqa: BLE001 — prompt-prep boundary: any failure (malformed/unsupported block, bad data URI) surfaces as ExecutorError, never an uncaught crash, matching the send_command path below
+                yield ExecutorError(message=f"Failed to prepare prompt for omp: {exc}")
+                return
+        else:
+            message = prompt
+        cmd_id = f"turn_{id(messages)}"
+        # streamingBehavior='followUp' lets omp queue the prompt when its isStreaming
+        # flag is still set after a race with a not-yet-confirmed-dead subprocess,
+        # rather than surfacing the raw 'Agent is already processing' protocol error.
+        command: OmpEvent = {
+            "type": "prompt",
+            "message": message,
+            "id": cmd_id,
+            "streamingBehavior": "followUp",
+        }
+        if images:
+            command["images"] = images
+        try:
+            await rpc.send_command(command)
+        except Exception as exc:  # noqa: BLE001 — executor boundary surfaces prompt-send errors as ExecutorError
+            yield ExecutorError(message=f"Failed to send prompt to omp: {exc}")
+            return
+
+        # Read events until agent_end.
+        response_text = ""
+        streamed_any = False
+        # Per-LLM-call token usage captured from each assistant message omp
+        # forwards (``message_end`` is the capture site; ``agent_end`` is a
+        # fallback). Summed into a turn-level usage dict at completion so a
+        # multi-step (tool-loop) turn bills for every call, not just the
+        # last. Empty when omp reports no usage — cost tracking is skipped.
+        message_usages: list[_OmpMessageUsage] = []
+        # Error reported by a ``message_end`` (stopReason=error); surfaced at
+        # ``agent_end`` so the terminal event is consumed off the RPC stream.
+        pending_error: str | None = None
+
+        while True:
+            # After an errored message the only thing left to drain is the
+            # already-emitted agent_end, so don't wait the full idle budget.
+            line = await rpc.read_line(
+                timeout=_TURN_STDOUT_IDLE_TIMEOUT_S
+                if pending_error is None
+                else _TURN_STDOUT_ERROR_DRAIN_TIMEOUT_S
+            )
+            if line is None:
+                if pending_error is None and not rpc.stdout_at_eof():
+                    # Idle timeout, not process death: omp's stdout reader is
+                    # still running — e.g. a long tool call silent past the
+                    # idle budget. Keep waiting; a dead omp process delivers
+                    # a real EOF (reader finishes) instead. True hangs are
+                    # bounded by the harness-level idle watchdog.
+                    logger.debug("OmpExecutor: stdout idle past budget; omp running, waiting")
+                    continue
+                if pending_error is not None:
+                    yield ExecutorError(message=pending_error)
+                elif not streamed_any and not response_text:
+                    stderr = "\n".join(rpc._stderr_lines) if rpc._stderr_lines else ""
+                    stderr_suffix = f" Stderr: {stderr}" if stderr else ""
+                    yield ExecutorError(
+                        message=f"omp process ended without response.{stderr_suffix}"
+                    )
+                else:
+                    turn_usage = _aggregate_omp_turn_usage(message_usages, model)
+                    _notify_usage_from_dict(model=model, usage=turn_usage)
+                    yield TurnComplete(
+                        response=response_text,
+                        usage=dict(turn_usage) if turn_usage is not None else None,
+                    )
+                return
+
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                logger.debug("OmpExecutor: non-JSON line: %s", line[:200])
+                continue
+
+            raw_event_type = event.get("type")
+            event_type: str | None = raw_event_type if isinstance(raw_event_type, str) else None
+
+            # Skip the command-ack response — except a local-only prompt
+            # completion, which arrives here instead of as ``agent_end``.
+            if event_type == "response":
+                if not event.get("success", True):
+                    yield ExecutorError(message=event.get("error", "omp command failed"))
+                    return
+                ack_data = event.get("data")
+                if (
+                    event.get("command") == "prompt"
+                    and isinstance(ack_data, dict)
+                    and ack_data.get("agentInvoked") is False
+                ):
+                    yield TurnComplete(response=None)
+                    return
+                continue
+
+            # omp startup / protocol frames that carry no turn content: the
+            # ``ready`` frame emitted before the first command processes,
+            # and any ``rpc_chunk`` continuation (unreachable while we stay
+            # on protocol v1 — we never send ``negotiate_protocol`` — but
+            # skipped defensively so a future CLI can't wedge the loop).
+            if event_type in ("ready", "rpc_chunk"):
+                continue
+
+            # Late local-only prompt completion (see the ``response`` ack
+            # above): the prompt resolved without an agent turn, so no
+            # ``agent_end`` follows. Anything else here is not a
+            # completion signal — keep draining.
+            if event_type == "prompt_result":
+                result_data = event.get("data")
+                if event.get("agentInvoked") is False or (
+                    isinstance(result_data, dict) and result_data.get("agentInvoked") is False
+                ):
+                    yield TurnComplete(response=None)
+                    return
+                continue
+
+            # Streaming text and thinking deltas.
+            if event_type == "message_update":
+                ame = event.get("assistantMessageEvent", {})
+                ame_type = ame.get("type")
+                if ame_type == "text_delta":
+                    raw_delta = ame.get("delta")
+                    if isinstance(raw_delta, str) and raw_delta:
+                        yield TextChunk(text=raw_delta)
+                        response_text += raw_delta
+                        streamed_any = True
+                elif ame_type == "thinking_start":
+                    # Anchors the "Thinking…" indicator before the first delta.
+                    yield ReasoningChunk(delta="", event_type="reasoning_started")
+                elif ame_type == "thinking_delta":
+                    raw_delta = ame.get("delta")
+                    if isinstance(raw_delta, str) and raw_delta:
+                        # Reasoning stays out of response_text — it is not assistant text.
+                        yield ReasoningChunk(delta=raw_delta, event_type="reasoning_text")
+                continue
+
+            # Tool execution events.
+            if event_type == "tool_execution_start":
+                tool_name = event.get("toolName", "unknown")
+                args = event.get("args", {})
+                yield ToolCallRequest(
+                    name=tool_name,
+                    args=args if isinstance(args, dict) else {},
+                )
+                continue
+
+            if event_type == "tool_execution_end":
+                tool_name = event.get("toolName", "unknown")
+                is_error = event.get("isError", False)
+                result = event.get("result")
+                # omp may report isError at the top level OR only inside
+                # the result dict (result.isError).  Check both.
+                if isinstance(result, dict) and result.get("isError"):
+                    is_error = True
+                # Detect policy-blocked results coming back from the tool
+                # server.  The _execute_tool callback returns
+                # {"blocked": True, "reason": "..."} when a policy blocks
+                # the call.  By the time it reaches us, the result may be:
+                #   - a dict with "blocked" key (direct)
+                #   - a dict with "content" list containing JSON text (from omp extension)
+                #   - a string containing JSON with "blocked" key
+                result_str = str(result) if result is not None else ""
+                is_blocked = False
+
+                def _check_blocked(obj: JsonValue) -> BlockedCheck:
+                    """Check if obj represents a blocked tool result."""
+                    if isinstance(obj, dict):
+                        if obj.get("blocked"):
+                            return BlockedCheck(blocked=True, reason=str(obj.get("reason", obj)))
+                        # omp extension wraps in {content: [{type:"text", text:"..."}]}
+                        content = obj.get("content")
+                        if isinstance(content, list):
+                            for item in content:
+                                if isinstance(item, dict) and item.get("type") == "text":
+                                    text = item.get("text")
+                                    if not isinstance(text, str):
+                                        continue
+                                    try:
+                                        parsed = json.loads(text)
+                                        if isinstance(parsed, dict) and parsed.get("blocked"):
+                                            return BlockedCheck(
+                                                blocked=True,
+                                                reason=str(parsed.get("reason", text)),
+                                            )
+                                    except (json.JSONDecodeError, TypeError):
+                                        pass
+                    elif isinstance(obj, str):
+                        try:
+                            parsed = json.loads(obj)
+                            if isinstance(parsed, dict) and parsed.get("blocked"):
+                                return BlockedCheck(
+                                    blocked=True,
+                                    reason=str(parsed.get("reason", obj)),
+                                )
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    return BlockedCheck(blocked=False, reason="")
+
+                if is_error:
+                    check = _check_blocked(result)
+                    is_blocked = check.blocked
+                    if is_blocked:
+                        result_str = check.reason
+
+                if is_blocked:
+                    status = ToolCallStatus.BLOCKED
+                elif is_error:
+                    status = ToolCallStatus.ERROR
+                else:
+                    status = ToolCallStatus.SUCCESS
+
+                yield ToolCallComplete(
+                    name=tool_name,
+                    status=status,
+                    result=result,
+                    error=result_str if (is_error or is_blocked) else "",
+                )
+                continue
+
+            # Agent ended — the turn is complete, unless omp says more work
+            # is scheduled (``isTerminal: false`` covers maintenance/async
+            # delivery that resumes the session before its true final
+            # settle). Absent means terminal (older runtimes). A
+            # non-terminal end is not a completion — keep draining.
+            if event_type == "agent_end" and event.get("isTerminal") is False:
+                continue
+            if event_type == "agent_end":
+                if pending_error is not None:
+                    yield ExecutorError(message=pending_error)
+                    return
+                end_messages = event.get("messages", [])
+                if not response_text:
+                    for m in reversed(end_messages):
+                        if m.get("role") == "assistant":
+                            content = m.get("content", [])
+                            if isinstance(content, str):
+                                response_text = content
+                            elif isinstance(content, list):
+                                text_parts: list[str] = []
+                                for part in content:
+                                    if not (isinstance(part, dict) and part.get("type") == "text"):
+                                        continue
+                                    part_text = part.get("text")
+                                    if isinstance(part_text, str):
+                                        text_parts.append(part_text)
+                                response_text = "".join(text_parts)
+                            break
+                # Fallback usage capture: if no ``message_end`` carried
+                # usage, pull it from the last assistant message in
+                # ``messages`` (only the last — ``messages`` may hold the
+                # whole conversation, so summing it would overcount).
+                if not message_usages and isinstance(end_messages, list):
+                    for m in reversed(end_messages):
+                        captured = _extract_omp_turn_usage(m, model)
+                        if captured is not None:
+                            message_usages.append(captured)
+                            break
+                turn_usage = _aggregate_omp_turn_usage(message_usages, model)
+                _notify_usage_from_dict(model=model, usage=turn_usage)
+                yield TurnComplete(
+                    response=response_text,
+                    usage=dict(turn_usage) if turn_usage is not None else None,
+                )
+                return
+
+            # message_end carries one completed assistant message, whose
+            # ``usage`` object holds that LLM call's token counts — collect
+            # each for the turn-level sum before handling error stop reasons.
+            if event_type == "message_end":
+                msg = event.get("message", {})
+                if isinstance(msg, dict):
+                    captured = _extract_omp_turn_usage(msg, model)
+                    if captured is not None:
+                        message_usages.append(captured)
+                    raw_stop = msg.get("stopReason")
+                    stop: str | None = raw_stop if isinstance(raw_stop, str) else None
+                    if stop == "aborted":
+                        err = msg.get("errorMessage", stop)
+                        yield ExecutorError(message=str(err))
+                        return
+                    if stop == "error":
+                        # omp emits the turn-terminal ``agent_end`` after an
+                        # errored LLM call; returning here would leave it
+                        # queued, so the next turn on this RPC session reads
+                        # the stale event as its own end. Record the error
+                        # and keep draining until ``agent_end``.
+                        pending_error = str(msg.get("errorMessage", stop))
+                continue
+
+            logger.debug("OmpExecutor: ignoring event type=%s", event_type)

--- a/omnigent/inner/omp_harness.py
+++ b/omnigent/inner/omp_harness.py
@@ -1,0 +1,288 @@
+"""
+``harness: omp`` wrap.
+
+Thin module exposing :func:`create_app` — the entrypoint the
+shared :mod:`omnigent.runtime.harnesses._runner` invokes after
+the parent process resolves ``"omp"`` to this module via
+:data:`omnigent.runtime.harnesses._HARNESS_MODULES`.
+
+Internally, instantiates :class:`omnigent.runtime.harnesses._executor_adapter.ExecutorAdapter`
+around a :class:`omnigent.inner.omp_executor.OmpExecutor`
+configured from env vars the parent process sets before spawning.
+Mirrors the claude-sdk wrap (``claude_sdk_harness.py``) and codex
+wrap (``codex_harness.py``); see the claude-sdk module's docstring
+for the v1 config-flow rationale (env vars vs per-request).
+
+Env vars read at startup:
+
+- ``HARNESS_OMP_MODEL``: model identifier, e.g.
+  ``"databricks-claude-sonnet-4-6"``. ``None`` falls back to the
+  Databricks default model on the profile-derived gateway path,
+  else to omp's own default.
+- ``HARNESS_OMP_GATEWAY``: ``"1"`` / ``"true"`` to write a
+  ``models.yml`` pointing omp at a vendor-neutral gateway (base
+  URLs + bearer-token command + model). The Databricks AI gateway
+  is one producer of this transport; generic ``key`` / ``gateway``
+  providers are another. Otherwise the executor uses omp's built-in
+  API path.
+- ``HARNESS_OMP_DATABRICKS_PROFILE``: Databricks-specific
+  ``~/.databrickscfg`` profile name, used by the executor for
+  Databricks credential resolution / token refresh when the
+  gateway transport was fed from a Databricks profile, e.g.
+  ``"<your-profile>"``.
+- ``HARNESS_OMP_GATEWAY_BASE_URLS``: JSON object of gateway base
+  URLs keyed by model family, e.g.
+  ``{"claude": "https://example.databricks.com/ai-gateway/anthropic"}``.
+- ``HARNESS_OMP_GATEWAY_OPENAI_WIRE_API``: ``"responses"`` or ``"chat"``
+  for a configured generic OpenAI-compatible provider.
+- ``HARNESS_OMP_CWD``: working directory the executor launches
+  the omp CLI in. ``None`` falls back to ``OMNIGENT_RUNNER_WORKSPACE`` if set,
+  then to the subprocess's inherited cwd.
+- ``OMNIGENT_OMP_PATH``: absolute path to an ``omp`` CLI binary.
+  ``None`` searches ``PATH``. (Unlike ``pi`` there is no legacy
+  ``HARNESS_OMP_PATH`` alias — :func:`resolve_harness_path` honors
+  one only for harnesses that historically documented it.)
+- ``HARNESS_OMP_OS_ENV``: JSON-encoded :class:`OSEnvSpec`
+  (from :func:`dataclasses.asdict`). When unset, the wrap
+  falls back to a default
+  ``OSEnvSpec(type="caller_process", sandbox=type="none")`` so
+  Omnigent mode parity with the legacy non-AP path holds for
+  specs that don't declare an ``os_env:`` block.
+- ``HARNESS_OMP_SKILLS_FILTER``: JSON-encoded
+  ``str | list[str]`` carrying ``spec.skills_filter``. When
+  unset, falls back to ``"all"``. The omp executor translates
+  the filter into omp CLI args at construction time:
+  ``"all"`` passes nothing (omp auto-discovers host skills);
+  ``"none"`` adds ``--no-skills`` to suppress everything; a list
+  adds ``--skills=a,b`` (omp's comma-separated skill-name filter,
+  an allowlist over discovered skills). omp has no ``--skill <path>``
+  explicit-load flag, so — unlike ``pi`` — bundle skills surface
+  only when they are on omp's discovery path.
+- ``HARNESS_OMP_BUNDLE_DIR``: Absolute path to the agent
+  bundle's extracted root. Reserved for future use; currently only
+  threaded through for API parity with the ``pi`` wrap.
+- ``HARNESS_OMP_AGENT_NAME``: Agent display name. Reserved for
+  future use; currently unused by omp.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+
+from omnigent.harness_startup_config import resolve_harness_path
+from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
+from omnigent.inner.executor import Executor
+from omnigent.inner.omp_executor import OmpExecutor
+from omnigent.runtime.harnesses._executor_adapter import ExecutorAdapter
+
+_logger = logging.getLogger(__name__)
+
+# Env-var keys the wrap reads at executor construction time. See
+# the module docstring for semantics. Centralizing as constants
+# so misconfigurations surface as a single grep target.
+_ENV_MODEL = "HARNESS_OMP_MODEL"
+_ENV_GATEWAY = "HARNESS_OMP_GATEWAY"
+_ENV_DATABRICKS_PROFILE = "HARNESS_OMP_DATABRICKS_PROFILE"
+_ENV_GATEWAY_HOST = "HARNESS_OMP_GATEWAY_HOST"
+_ENV_CWD = "HARNESS_OMP_CWD"
+_ENV_OS_ENV = "HARNESS_OMP_OS_ENV"
+_ENV_SKILLS_FILTER = "HARNESS_OMP_SKILLS_FILTER"
+_ENV_BUNDLE_DIR = "HARNESS_OMP_BUNDLE_DIR"
+_ENV_AGENT_NAME = "HARNESS_OMP_AGENT_NAME"
+_ENV_GATEWAY_BASE_URL = "HARNESS_OMP_GATEWAY_BASE_URL"
+_ENV_GATEWAY_BASE_URLS = "HARNESS_OMP_GATEWAY_BASE_URLS"
+_ENV_GATEWAY_OPENAI_WIRE_API = "HARNESS_OMP_GATEWAY_OPENAI_WIRE_API"
+_ENV_GATEWAY_AUTH_COMMAND = "HARNESS_OMP_GATEWAY_AUTH_COMMAND"
+_ENV_GATEWAY_AUTH_REFRESH_INTERVAL_MS = "HARNESS_OMP_GATEWAY_AUTH_REFRESH_INTERVAL_MS"
+
+# Truthy strings the wrap accepts for boolean env vars. Must
+# match the claude-sdk and codex wraps' parsers for consistency
+# — operators learn one set of conventions, not five.
+_TRUTHY_STRINGS = ("1", "true", "yes")
+
+
+def _parse_truthy(env_var: str, default: bool) -> bool:
+    """
+    Parse a boolean-style env var the same way the claude-sdk
+    and codex wraps do.
+
+    :param env_var: The env-var name (e.g. ``HARNESS_OMP_GATEWAY``).
+    :param default: The fallback when the env var is unset or
+        empty.
+    :returns: ``True`` if the value is in :data:`_TRUTHY_STRINGS`
+        (case-insensitive); ``False`` for any other non-empty
+        value; *default* when unset or empty.
+    """
+    raw = os.environ.get(env_var, "").strip().lower()
+    if not raw:
+        return default
+    return raw in _TRUTHY_STRINGS
+
+
+def _resolve_gateway_base_urls() -> dict[str, str] | None:
+    """
+    Decode omp gateway base URLs from the gateway transport env var.
+
+    :returns: Mapping of omp provider family to base URL, or ``None`` when
+        unset or invalid.
+    """
+    raw = os.environ.get(_ENV_GATEWAY_BASE_URLS, "").strip()
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        _logger.warning("Ignoring invalid %s JSON", _ENV_GATEWAY_BASE_URLS)
+        return None
+    if not isinstance(value, dict):
+        _logger.warning("Ignoring non-object %s value", _ENV_GATEWAY_BASE_URLS)
+        return None
+    return {str(key): str(item) for key, item in value.items() if isinstance(item, str)}
+
+
+def _resolve_os_env() -> OSEnvSpec:
+    """
+    Resolve the inner-executor :class:`OSEnvSpec` from env config.
+
+    Reads :data:`_ENV_OS_ENV` and decodes the JSON-encoded dict
+    Omnigent serialized via :func:`dataclasses.asdict` on its
+    :class:`OSEnvSpec`. When the env var is missing or
+    malformed, falls back to ``caller_process + sandbox=none``
+    so AP-bridged tools stay enabled — matches the legacy
+    non-AP path's default for specs without an
+    ``os_env:`` block.
+
+    :returns: An :class:`OSEnvSpec` to hand to
+        :class:`OmpExecutor`.
+    """
+    raw = os.environ.get(_ENV_OS_ENV, "").strip()
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _logger.warning(
+                "%s is not valid JSON (%s); falling back to default os_env",
+                _ENV_OS_ENV,
+                exc,
+            )
+            payload = None
+        if isinstance(payload, dict):
+            sandbox_payload = payload.get("sandbox")
+            sandbox = (
+                OSEnvSandboxSpec(**sandbox_payload) if isinstance(sandbox_payload, dict) else None
+            )
+            return OSEnvSpec(
+                type=str(payload.get("type", "caller_process")),
+                cwd=payload.get("cwd"),
+                sandbox=sandbox,
+                fork=bool(payload.get("fork", False)),
+            )
+    # Default: enable natives, no sandbox. Matches the simplest
+    # working config; operators who want real sandbox enforcement
+    # configure ``os_env.sandbox`` explicitly in the spec.
+    return OSEnvSpec(
+        type="caller_process",
+        cwd=None,
+        sandbox=OSEnvSandboxSpec(type="none"),
+        fork=False,
+    )
+
+
+def _build_omp_executor() -> Executor:
+    """
+    Construct a :class:`OmpExecutor` from env-var config.
+
+    Called lazily by the :class:`ExecutorAdapter` on the first
+    turn. Heavyweight init (CLI discovery, eager Databricks
+    credential resolution) happens at this point — operators
+    see the failure surface as a startup error on the first
+    request, not at FastAPI app boot.
+
+    :returns: A configured :class:`OmpExecutor` instance.
+    :raises ImportError: If the ``omp`` CLI isn't on PATH and
+        ``OMNIGENT_OMP_PATH`` isn't set — the inner executor's
+        constructor surfaces this as a clear ImportError.
+    :raises OSError: If ``HARNESS_OMP_GATEWAY`` is set but
+        credentials are missing — the inner executor's
+        constructor fails loud.
+    """
+    bundle_dir_raw = os.environ.get(_ENV_BUNDLE_DIR, "").strip()
+    bundle_dir = Path(bundle_dir_raw) if bundle_dir_raw else None
+    agent_name_raw = os.environ.get(_ENV_AGENT_NAME, "").strip()
+    agent_name = agent_name_raw or None
+    return OmpExecutor(
+        cwd=os.environ.get(_ENV_CWD) or os.environ.get("OMNIGENT_RUNNER_WORKSPACE"),
+        os_env=_resolve_os_env(),
+        model=os.environ.get(_ENV_MODEL),
+        omp_path=resolve_harness_path("omp"),
+        gateway=_parse_truthy(_ENV_GATEWAY, default=False),
+        databricks_profile=os.environ.get(_ENV_DATABRICKS_PROFILE),
+        gateway_host=os.environ.get(_ENV_GATEWAY_HOST) or None,
+        base_url_override=os.environ.get(_ENV_GATEWAY_BASE_URL) or None,
+        base_urls_override=_resolve_gateway_base_urls(),
+        openai_wire_api=os.environ.get(_ENV_GATEWAY_OPENAI_WIRE_API) or None,
+        gateway_auth_command=os.environ.get(_ENV_GATEWAY_AUTH_COMMAND) or None,
+        bundle_dir=bundle_dir,
+        agent_name=agent_name,
+        skills_filter=_resolve_skills_filter(),
+    )
+
+
+def _resolve_skills_filter() -> str | list[str]:
+    """
+    Resolve the inner-executor ``skills_filter`` from env config.
+
+    Reads :data:`_ENV_SKILLS_FILTER` and decodes the JSON-encoded
+    ``str | list[str]`` (``"all"``, ``"none"``, or a list of skill
+    names). Falls back to ``"all"`` on missing or malformed input
+    — matches the SDK default behavior.
+
+    :returns: ``"all"``, ``"none"``, or a list of skill names.
+    """
+    raw = os.environ.get(_ENV_SKILLS_FILTER, "").strip()
+    if not raw:
+        return "all"
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _logger.warning(
+            "%s is not valid JSON (%s); falling back to 'all'",
+            _ENV_SKILLS_FILTER,
+            exc,
+        )
+        return "all"
+    if isinstance(decoded, str) and decoded in ("all", "none"):
+        return decoded
+    if isinstance(decoded, list) and all(isinstance(s, str) for s in decoded):
+        return decoded
+    _logger.warning(
+        "%s decoded to unsupported shape %r; falling back to 'all'",
+        _ENV_SKILLS_FILTER,
+        decoded,
+    )
+    return "all"
+
+
+def create_app() -> FastAPI:
+    """
+    Build the omp harness's FastAPI app.
+
+    Required entry point per the harness contract — the runner
+    imports this module (resolved from
+    :data:`omnigent.runtime.harnesses._HARNESS_MODULES`) and
+    invokes ``create_app()`` to get the app it serves.
+
+    :returns: The FastAPI app from :class:`ExecutorAdapter`'s
+        :meth:`build` method, with all routes from the harness
+        API subset wired up. The wrapped :class:`OmpExecutor`
+        is constructed lazily on the first turn (so an absent
+        ``omp`` CLI surfaces as a request-time error, not a
+        FastAPI app-boot crash).
+    """
+    adapter = ExecutorAdapter(executor_factory=_build_omp_executor)
+    return adapter.build()

--- a/omnigent/inner/pi_settings.py
+++ b/omnigent/inner/pi_settings.py
@@ -1,4 +1,4 @@
-"""Helpers for seeding a managed Pi agent dir (``PI_CODING_AGENT_DIR``).
+"""Helpers for seeding managed agent dirs (``PI_CODING_AGENT_DIR``).
 
 When the pi harness runs in gateway mode it relocates Pi's agent root to a
 per-session temp directory (for ``models.json``). That hides the user's global
@@ -6,6 +6,11 @@ per-session temp directory (for ``models.json``). That hides the user's global
 the global settings metadata into the managed dir and symlinks install
 directories so Pi's native loader still sees extensions and ``pi install``
 packages — without mutating the user's home directory.
+
+The omp harness (``omp --mode rpc``) relocates ``~/.omp/agent`` the same way
+(for ``models.yml``); :func:`prepare_managed_omp_agent_dir` is its
+counterpart. omp kept the ``PI_CODING_AGENT_DIR`` variable name — it
+relocates the ``~/.omp/agent`` base.
 """
 
 from __future__ import annotations
@@ -26,6 +31,10 @@ DEFAULT_PI_AGENT_DIR = Path.home() / ".pi" / "agent"
 # Install / checkout trees Pi places under the agent dir. Symlinked into the
 # managed dir so ``packages`` entries in settings keep resolving.
 _PI_AGENT_RESOURCE_DIRS: tuple[str, ...] = ("npm", "git")
+
+# Default global omp agent root (``PI_CODING_AGENT_DIR`` when unset — omp kept
+# the variable name; it relocates the ``~/.omp/agent`` base).
+DEFAULT_OMP_AGENT_DIR = Path.home() / ".omp" / "agent"
 
 
 def _read_settings_file(path: Path) -> _Settings:
@@ -111,6 +120,47 @@ def prepare_managed_pi_agent_dir(
         )
     except OSError as exc:
         _logger.warning("Could not write managed Pi settings at %s: %s", settings_path, exc)
+        return
+
+    _symlink_agent_resource_dirs(managed_dir, agent_root)
+
+
+def prepare_managed_omp_agent_dir(
+    managed_dir: Path,
+    *,
+    overlay: Mapping[str, object] | None = None,
+    global_agent_dir: Path | None = None,
+) -> None:
+    """
+    Seed a managed ``PI_CODING_AGENT_DIR`` with the user's global omp settings.
+
+    Copies (merges) ``settings.json`` from the user's global agent dir into
+    *managed_dir*, applies *overlay* (e.g. Omnigent retry policy), and
+    symlinks install trees (``npm/``, ``git/``) so ``packages`` entries keep
+    working. The user's ``~/.omp/agent`` is never modified.
+
+    Project-scoped ``.omp/settings.json`` at the session cwd is still read by
+    omp at runtime and overrides these global settings per omp's normal rules.
+
+    :param managed_dir: Per-session agent root (already contains ``models.yml``).
+    :param overlay: Settings merged on top of the copied global file.
+    :param global_agent_dir: Override for tests; defaults to
+        :data:`DEFAULT_OMP_AGENT_DIR`.
+    """
+    agent_root = global_agent_dir if global_agent_dir is not None else DEFAULT_OMP_AGENT_DIR
+    settings = _read_settings_file(agent_root / "settings.json")
+    if overlay:
+        settings = _deep_merge_settings(settings, overlay)
+
+    managed_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = managed_dir / "settings.json"
+    try:
+        settings_path.write_text(
+            json.dumps(settings, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        _logger.warning("Could not write managed omp settings at %s: %s", settings_path, exc)
         return
 
     _symlink_agent_resource_dirs(managed_dir, agent_root)

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -41,6 +41,7 @@ from omnigent.onboarding.provider_config import (
     GEMINI_FAMILY,
     KEY_KIND,
     LOCAL_KIND,
+    OMP_SURFACE,
     OPENAI_FAMILY,
     PI_SURFACE,
     SUBSCRIPTION_KIND,
@@ -93,6 +94,7 @@ _FAMILY_LABEL: dict[str, str] = {
     OPENAI_FAMILY: "Codex",
     GEMINI_FAMILY: "Gemini",
     PI_SURFACE: "Pi",
+    OMP_SURFACE: "Omp",
 }
 
 # The concrete harness ids each surface powers, shown as a dim annotation
@@ -103,6 +105,7 @@ _FAMILY_HARNESS_IDS: dict[str, str] = {
     OPENAI_FAMILY: "codex, native-codex, openai-agents",
     GEMINI_FAMILY: "antigravity, antigravity-native",
     PI_SURFACE: "pi",
+    OMP_SURFACE: "omp",
 }
 
 
@@ -112,9 +115,9 @@ def family_label(family: str) -> str:
     Public accessor for :data:`_FAMILY_LABEL`, so the CLI tree renders the
     same brand names as the listing without importing the private map.
 
-    :param family: ``"anthropic"``, ``"openai"``, or ``"pi"``.
+    :param family: ``"anthropic"``, ``"openai"``, ``"pi"``, or ``"omp"``.
     :returns: ``"Claude"`` for anthropic, ``"Codex"`` for openai, ``"Pi"``
-        for pi; the family name itself for any other value.
+        for pi, ``"Omp"`` for omp; the family name itself for any other value.
     """
     return _FAMILY_LABEL.get(family, family)
 
@@ -122,7 +125,7 @@ def family_label(family: str) -> str:
 def family_harness_ids(family: str) -> str:
     """Return the dim harness-id annotation for a surface.
 
-    :param family: ``"anthropic"``, ``"openai"``, or ``"pi"``.
+    :param family: ``"anthropic"``, ``"openai"``, ``"pi"``, or ``"omp"``.
     :returns: A comma-separated harness-id string, e.g.
         ``"claude-sdk, native-claude"``; empty for an unknown surface.
     """
@@ -510,21 +513,21 @@ def _add_option_families(opt: AddOption) -> frozenset[str]:
     """Return the surfaces an add-menu *opt* can serve.
 
     Used to scope the add menu to the harness the user drilled into
-    (``configure harness`` → Claude / Codex / Gemini / Pi → "Add a
+    (``configure harness`` → Claude / Codex / Gemini / Pi / Omp → "Add a
     provider"): a Claude add should not offer an OpenAI-only key, and vice
-    versa. Gateways and Databricks serve the anthropic / openai / pi surfaces —
-    but NOT Gemini, which is key-only (the antigravity harness needs a real
-    GEMINI_API_KEY, not a proxy). An anthropic / openai API key can also drive
-    pi (it consumes both model families); a gemini key serves ONLY the Gemini
-    surface; subscriptions never drive pi (a CLI login is unusable outside its
-    own CLI).
+    versa. Gateways and Databricks serve the anthropic / openai / pi / omp
+    surfaces — but NOT Gemini, which is key-only (the antigravity harness
+    needs a real GEMINI_API_KEY, not a proxy). An anthropic / openai API key
+    can also drive pi/omp (they consume both model families); a gemini key
+    serves ONLY the Gemini surface; subscriptions never drive pi/omp (a CLI
+    login is unusable outside its own CLI).
 
     :param opt: One add-menu option.
     :returns: The surfaces this option can configure — a subset of
-        ``{"anthropic", "openai", "gemini", "pi"}``.
+        ``{"anthropic", "openai", "gemini", "pi", "omp"}``.
     """
     if opt.kind == GATEWAY_KIND or opt.kind == DATABRICKS_KIND:
-        return frozenset({ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE})
+        return frozenset({ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE, OMP_SURFACE})
     if opt.kind == BEDROCK_KIND:
         # Bedrock mode drives only the native Claude terminal (anthropic
         # family); codex/pi reject it, so it never serves their surfaces.
@@ -540,7 +543,7 @@ def _add_option_families(opt: AddOption) -> frozenset[str]:
     if opt.kind == KEY_KIND:
         if opt.other:
             # The catch-all tail (Groq, DeepSeek, …) are all openai-family.
-            return frozenset({OPENAI_FAMILY, PI_SURFACE})
+            return frozenset({OPENAI_FAMILY, PI_SURFACE, OMP_SURFACE})
         if opt.provider is not None:
             family = family_for_key_provider(opt.provider)
             # The Gemini surface (antigravity) is not a pi model family — pi
@@ -549,7 +552,7 @@ def _add_option_families(opt: AddOption) -> frozenset[str]:
             # pi.
             if family == GEMINI_FAMILY:
                 return frozenset({GEMINI_FAMILY})
-            return frozenset({family, PI_SURFACE})
+            return frozenset({family, PI_SURFACE, OMP_SURFACE})
     return frozenset()
 
 
@@ -614,7 +617,7 @@ def render_provider_listing_by_harness(
     if not providers:
         console.print("  [dim]none configured yet[/dim]")
         return
-    for family in (ANTHROPIC_FAMILY, OPENAI_FAMILY, GEMINI_FAMILY, PI_SURFACE):
+    for family in (ANTHROPIC_FAMILY, OPENAI_FAMILY, GEMINI_FAMILY, PI_SURFACE, OMP_SURFACE):
         console.print(f"  [bold]{_FAMILY_LABEL[family]}[/]")
         serving = [
             (name, entry)
@@ -641,19 +644,19 @@ def _provider_default_families(entry: ProviderEntry, config: dict[str, object]) 
 
     Cross-checks the per-surface default resolved from *config* against
     *entry* so the listing marks ``(default · Claude)`` / ``(default ·
-    Codex)`` / ``(default · Pi)`` only on the provider that actually wins
-    that surface. Pi resolves its *effective* default (explicit pi scope,
-    else the cross-family fallback), so the marker names the provider the
-    pi harness would really route through.
+    Codex)`` / ``(default · Pi)`` / ``(default · Omp)`` only on the provider
+    that actually wins that surface. Pi/omp resolve their *effective* default
+    (explicit scope, else the cross-family fallback), so the marker names the
+    provider the harness would really route through.
 
     :param entry: The provider entry being rendered.
     :param config: The parsed config mapping (``providers:`` block), used
         to resolve each surface's default.
     :returns: Surface names this entry is the default for, in
-        ``[anthropic, openai, gemini, pi]`` order, e.g. ``["anthropic", "pi"]``.
+        ``[anthropic, openai, gemini, pi, omp]`` order, e.g. ``["anthropic", "pi"]``.
     """
     result: list[str] = []
-    for family in (ANTHROPIC_FAMILY, OPENAI_FAMILY, GEMINI_FAMILY, PI_SURFACE):
+    for family in (ANTHROPIC_FAMILY, OPENAI_FAMILY, GEMINI_FAMILY, PI_SURFACE, OMP_SURFACE):
         default = surface_default_provider(config, family)
         if default is not None and default.name == entry.name:
             result.append(family)

--- a/omnigent/onboarding/harness_auth.py
+++ b/omnigent/onboarding/harness_auth.py
@@ -133,6 +133,7 @@ def _pin_defaults_after_write(
     sibling default flags a deep-merge can't reach), so each pin re-reads first.
     """
     from omnigent.onboarding.provider_config import (
+        OMP_SURFACE,
         PI_SURFACE,
         default_provider_for_harness,
         get_default_provider,
@@ -151,6 +152,11 @@ def _pin_defaults_after_write(
 
     _pin(family, get_default_provider(load(), family))
     _pin(PI_SURFACE, default_provider_for_harness(load(), PI_SURFACE))
+    # omp resolves independently of pi (its own surface default, else the
+    # same cross-family fallback) and has no CLI login either — pin its
+    # scope too, or a fresh key leaves omp stuck at "needs-auth" while pi
+    # already resolves.
+    _pin(OMP_SURFACE, default_provider_for_harness(load(), OMP_SURFACE))
 
 
 def store_harness_credential(

--- a/omnigent/onboarding/harness_install.py
+++ b/omnigent/onboarding/harness_install.py
@@ -62,6 +62,10 @@ from omnigent.opencode_native_client import (
 # first-run ``run`` flow falls back to it, so it has install metadata too.
 PI_KEY = "pi"
 
+# Oh My Pi ships the ``omp`` binary (curl installer primary, npm
+# ``@oh-my-pi/pi-coding-agent`` as the one-click path).
+OMP_KEY = "omp"
+
 # Qwen Code uses npm installation and has login/logout commands similar to
 # other coding CLIs. The binary name is ``qwen``.
 QWEN_KEY = "qwen"
@@ -207,6 +211,17 @@ _HARNESS_INSTALL: dict[str, HarnessInstallSpec] = {
         # ``pi >= 0.79.0``; older CLIs would prompt mid-session.
         min_version=_PI_MIN_VERSION,
     ),
+    OMP_KEY: HarnessInstallSpec(
+        "Oh My Pi",
+        "omp",
+        "@oh-my-pi/pi-coding-agent",
+        # No login/logout/status commands: omp authenticates per-provider
+        # (``omp auth-broker login <provider>`` or in-TUI ``/login``), so
+        # setup shows the auth hint instead of running a login step.
+        auth_hint="run `omp auth-broker login <provider>` or `/login` in omp",
+        # No min_version: the executor feature-detects ``--auto-approve``
+        # at runtime and degrades gracefully on older CLIs.
+    ),
     # Pin the install to the supported 1.18.x range: opencode-ai's npm ``latest``
     # is a ``0.0.0-beta-*`` pre-release, so a bare ``opencode-ai`` would install a
     # version the runtime version-check (``check_opencode_version``,
@@ -336,6 +351,10 @@ _HARNESS_NAME_TO_KEY: dict[str, str] = {
     "codex-native": OPENAI_FAMILY,
     PI_KEY: PI_KEY,
     "pi-native": PI_KEY,
+    # Oh My Pi (``harness: omp``, drives ``omp --mode rpc``) wraps the
+    # ``omp`` CLI.
+    OMP_KEY: OMP_KEY,
+    "oh-my-pi": OMP_KEY,
     # Kimi is multi-provider but binary-gated: cannot launch without the
     # ``kimi`` CLI on PATH. Listed here so ``required_cli_for_harness``
     # returns its install spec and ``missing_harness_cli`` fails loud
@@ -391,6 +410,7 @@ _UI_INSTALLABLE_HARNESS_TO_KEY: dict[str, str] = {
     "claude": ANTHROPIC_FAMILY,
     "codex": OPENAI_FAMILY,
     PI_KEY: PI_KEY,
+    OMP_KEY: OMP_KEY,
     OPENCODE_KEY: OPENCODE_KEY,
     QWEN_KEY: QWEN_KEY,
 }
@@ -461,7 +481,9 @@ def ui_installable_harnesses() -> frozenset[str]:
 # (omnigent stores no key for them), so they are NOT credential-configurable.
 # ``pi`` consumes anthropic/openai and is handled by the host store-secret
 # handler, so it's included via its own key.
-_UI_CREDENTIAL_FAMILIES: frozenset[str] = frozenset({ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_KEY})
+_UI_CREDENTIAL_FAMILIES: frozenset[str] = frozenset(
+    {ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_KEY, OMP_KEY}
+)
 
 
 def ui_credential_configurable_harnesses() -> frozenset[str]:
@@ -538,6 +560,18 @@ _UI_AUTH_STEP_BY_KEY: dict[str, SetupStep] = {
         # "ready").
         title="Set up authentication",
         detail="Add an API key or a gateway so Pi can run.",
+        action="auth",
+        command=None,
+        status_key="authed",
+    ),
+    OMP_KEY: SetupStep(
+        kind="auth",
+        # Same neutral "set up auth" framing as pi — the dialog opens a
+        # form listing the ways to authenticate. omp has no subscription
+        # CLI login either (``command=None``), so the detail names only the
+        # applicable paths.
+        title="Set up authentication",
+        detail="Add an API key or a gateway so Oh My Pi can run.",
         action="auth",
         command=None,
         status_key="authed",

--- a/omnigent/onboarding/harness_readiness.py
+++ b/omnigent/onboarding/harness_readiness.py
@@ -46,6 +46,7 @@ from omnigent.onboarding.harness_install import (
     HERMES_KEY,
     KIMI_KEY,
     KIRO_KEY,
+    OMP_KEY,
     OPENCODE_KEY,
     PI_KEY,
     QWEN_KEY,
@@ -59,6 +60,7 @@ from omnigent.onboarding.provider_config import (
     _HARNESS_FAMILY,
     ANTHROPIC_FAMILY,
     GEMINI_FAMILY,
+    OMP_SURFACE,
     OPENAI_FAMILY,
     PI_SURFACE,
     SUBSCRIPTION_KIND,
@@ -104,6 +106,11 @@ _FAMILY_CREDENTIAL_CHECK: dict[str, Callable[[], bool]] = {
 # ``_HARNESS_FAMILY`` entry — pi uses the ``PI_SURFACE`` sentinel — so they must
 # be gated explicitly or they fail open like an unknown harness.
 _PI_HARNESSES: frozenset[str] = frozenset({PI_SURFACE, "pi-native"})
+
+# CLI-wrapping omp harness (``omp --mode rpc``). Like pi it has no
+# ``_HARNESS_FAMILY`` entry — omp uses the ``OMP_SURFACE`` sentinel — so it
+# must be gated explicitly or it fails open like an unknown harness.
+_OMP_HARNESSES: frozenset[str] = frozenset({"omp"})
 
 # Surface name for Kimi Code in the readiness map. Mirrors :data:`PI_SURFACE`
 # — kimi is a CLI-backed harness with its own backend (Moonshot AI's), not a
@@ -495,14 +502,28 @@ def _harness_availability(canonical: str) -> HarnessAvailability:
         except Exception:
             pass
         return "needs-auth"
+    if canonical in _OMP_HARNESSES:
+        # omp has no CLI login — its only credential is either an
+        # omnigent-managed provider (an API key / gateway) or its own
+        # ~/.omp/agent auth (``omp auth-broker login`` / in-TUI ``/login``).
+        # Two-step signal mirrors pi: installed-but-no-provider is the
+        # yellow "needs-auth" state the setup dialog acts on. Unlike pi
+        # there is no subscription carve-out — omp cannot consume Pi's
+        # native auth.
+        binary_state = _binary_availability_reason(OMP_KEY)
+        if binary_state is not True:
+            return binary_state
+        if _family_provider_configured(OMP_SURFACE):
+            return True
+        return "needs-auth"
     return _harness_availability_core(canonical)
 
 
 def harness_is_configured(harness: str) -> bool:
     """Return whether *harness* can be launched on this machine.
 
-    Only CLI-wrapping harnesses are assessed (native Claude/Codex/Kiro and
-    ``pi`` / ``pi-native``): they cannot run without their binary on
+    Only CLI-wrapping harnesses are assessed (native Claude/Codex/Kiro,
+    ``pi`` / ``pi-native``, and ``omp``): they cannot run without their binary on
     ``PATH``, and that is the one thing the daemon can check reliably and
     locally. SDK harnesses and unknown harnesses always return ``True`` —
     their readiness depends on runtime/ambient credentials the daemon
@@ -550,6 +571,7 @@ def configured_harness_map() -> dict[str, HarnessAvailability]:
     spellings.update(_EXECUTOR_TYPE_HARNESS_ALIASES)
     spellings.update(HARNESS_ALIASES)
     spellings.update(_PI_HARNESSES)
+    spellings.update(_OMP_HARNESSES)
     spellings.update(_OPENCODE_HARNESSES)
     spellings.update(_CURSOR_NATIVE_HARNESSES)
     spellings.update(_KIRO_NATIVE_HARNESSES)

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -103,6 +103,15 @@ _PI_FALLBACK_FAMILIES = (ANTHROPIC_FAMILY, OPENAI_FAMILY)
 # default, skipping the non-pi kinds (see :func:`default_provider_for_harness`).
 PI_SURFACE = "pi"
 
+# The omp harness's *default scope*. Mirrors :data:`PI_SURFACE`: omp consumes
+# the same families (anthropic/openai, gateway/local/databricks, cli-config
+# Databricks gateways — never gemini, never another CLI's subscription), but
+# defaults it independently, so ``default: ["omp"]`` pins omp without moving
+# pi. A ``kind="subscription", cli="pi"`` entry serves only :data:`PI_SURFACE`
+# (omp cannot use Pi's native auth), and ``default: true`` expands to neither
+# harness scope (both are claimed explicitly only).
+OMP_SURFACE = "omp"
+
 # Accepted ``wire_api`` values. ``responses`` is the OpenAI Responses API;
 # ``chat`` is Chat Completions. Only meaningful for the ``openai`` family
 # (the ``anthropic`` family always speaks the Messages API).
@@ -802,7 +811,12 @@ def _parse_family(provider_name: str, family_name: str, raw: dict[str, object]) 
 
 
 def _parse_default_families(
-    name: str, default_raw: object, served: set[str], *, pi_capable: bool = False
+    name: str,
+    default_raw: object,
+    served: set[str],
+    *,
+    pi_capable: bool = False,
+    omp_capable: bool = False,
 ) -> frozenset[str]:
     """Resolve a raw ``default:`` value into the scopes it applies to.
 
@@ -813,20 +827,26 @@ def _parse_default_families(
     - a family name (``"openai"``) → just that family.
     - a list of family names (``["anthropic", "openai"]``) → those.
 
-    A pi-capable provider may additionally name the :data:`PI_SURFACE`
-    scope explicitly (``default: ["anthropic", "pi"]``). ``default: true``
-    deliberately does **not** expand to the pi scope: ``true`` means "all
-    families served", and two coexisting ``default: true`` providers (one
-    per family) are valid — if ``true`` claimed pi on both, they would
-    collide on the pi slot. The pi scope is only ever claimed explicitly.
+    A pi/omp-capable provider may additionally name the :data:`PI_SURFACE` /
+    :data:`OMP_SURFACE` scopes explicitly (``default: ["anthropic", "pi"]``).
+    ``default: true`` deliberately does **not** expand to either harness
+    scope: ``true`` means "all families served", and two coexisting
+    ``default: true`` providers (one per family) are valid — if ``true``
+    claimed a harness scope on both, they would collide on that slot. Each
+    harness scope is only ever claimed explicitly.
 
     :param name: Provider name, for error messages.
     :param default_raw: The raw ``default`` value from the entry.
     :param served: The model families this provider actually serves; a
-        default may only name these (plus ``"pi"`` when *pi_capable*).
+        default may only name these (plus ``"pi"`` / ``"omp"`` when
+        *pi_capable* / *omp_capable*).
     :param pi_capable: Whether this provider's kind can drive the pi
         harness (every kind except ``subscription``), allowing an explicit
         ``"pi"`` in the default scope.
+    :param omp_capable: Whether this provider's kind can drive the omp
+        harness (same kinds as pi, except a ``cli="pi"`` subscription —
+        omp cannot use Pi's native auth), allowing an explicit ``"omp"``
+        in the default scope.
     :returns: The (validated) scopes the provider is the default for.
     :raises OmnigentError: If ``default`` is an unsupported type, or names
         a scope the provider does not serve.
@@ -858,7 +878,8 @@ def _parse_default_families(
     # "pi"]`` at parse time (parity with how a subscription's pi scope is
     # rejected), rather than failing loudly only at pi launch.
     pi_ok = pi_capable and (bool(served & frozenset(_PI_FALLBACK_FAMILIES)) or not served)
-    allowed = served | {PI_SURFACE} if pi_ok else served
+    omp_ok = omp_capable and (bool(served & frozenset(_PI_FALLBACK_FAMILIES)) or not served)
+    allowed = served | ({PI_SURFACE} if pi_ok else set()) | ({OMP_SURFACE} if omp_ok else set())
     invalid = requested - allowed
     if invalid:
         raise OmnigentError(
@@ -888,7 +909,11 @@ def _default_raw_value(default_families: frozenset[str], served: set[str]) -> ob
     # the pi scope (see _parse_default_families), so a default set that
     # includes pi must stay explicit — rendering it as ``True`` would drop
     # the pi scope on the next parse.
-    if PI_SURFACE not in default_families and default_families == frozenset(served) - {PI_SURFACE}:
+    if (
+        PI_SURFACE not in default_families
+        and OMP_SURFACE not in default_families
+        and default_families == frozenset(served) - {PI_SURFACE, OMP_SURFACE}
+    ):
         return True
     if len(default_families) == 1:
         return next(iter(default_families))
@@ -954,7 +979,7 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
             kind=kind,
             cli=cli_raw,
             default_families=_parse_default_families(
-                name, default_raw, served, pi_capable=(cli_raw == "pi")
+                name, default_raw, served, pi_capable=(cli_raw == "pi"), omp_capable=False
             ),
         )
 
@@ -991,11 +1016,11 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
             # without reading the ambient ~/.codex/config.toml at parse — so a
             # user can pin pi→Databricks; whether the pinned provider is a *real*
             # Databricks gateway is validated at pi launch, which falls back to
-            # Pi's own login when it is not (see :func:`_cli_config_serves_pi`
+            # Pi's own login when it is not (see :func:`_cli_config_serves_pi_omp`
             # and ``resolve_pi_native_provider``). A codex subscription stays
             # pi-incapable (its ``default: pi`` is still rejected at parse).
             default_families=_parse_default_families(
-                name, default_raw, {OPENAI_FAMILY}, pi_capable=True
+                name, default_raw, {OPENAI_FAMILY}, pi_capable=True, omp_capable=True
             ),
         )
 
@@ -1015,7 +1040,11 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
             kind=kind,
             profile=profile_raw,
             default_families=_parse_default_families(
-                name, default_raw, set(_VALID_FAMILIES) - {GEMINI_FAMILY}, pi_capable=True
+                name,
+                default_raw,
+                set(_VALID_FAMILIES) - {GEMINI_FAMILY},
+                pi_capable=True,
+                omp_capable=True,
             ),
         )
 
@@ -1056,7 +1085,7 @@ def _parse_provider(name: str, raw: dict[str, object]) -> ProviderEntry:
         kind=kind,
         families=families,
         default_families=_parse_default_families(
-            name, default_raw, served_for_default, pi_capable=True
+            name, default_raw, served_for_default, pi_capable=True, omp_capable=True
         ),
     )
 
@@ -1178,8 +1207,8 @@ def harness_family(harness: str) -> str | None:
     return _HARNESS_FAMILY.get(harness)
 
 
-def _cli_config_serves_pi(entry: ProviderEntry) -> bool:
-    """Return whether a ``cli-config`` *entry* can drive the ``pi`` harness.
+def _cli_config_serves_pi_omp(entry: ProviderEntry) -> bool:
+    """Return whether a ``cli-config`` *entry* can drive the ``pi``/``omp`` harnesses.
 
     Most ``cli-config`` providers (a custom codex ``[model_providers.X]``) are
     unusable outside their own CLI, so they never serve pi. The exception is a
@@ -1197,7 +1226,7 @@ def _cli_config_serves_pi(entry: ProviderEntry) -> bool:
 
     :param entry: The provider entry to classify.
     :returns: ``True`` iff *entry* is a ``cli-config`` Databricks AI Gateway
-        Pi can route through.
+        pi/omp can route through.
     """
     if entry.kind != CLI_CONFIG_KIND:
         return False
@@ -1216,18 +1245,20 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
     provider is a default *candidate* for:
 
     - ``key`` / ``gateway`` / ``local``: the families it declares inline,
-      plus the :data:`PI_SURFACE` scope (pi consumes either family).
+      plus the :data:`PI_SURFACE` / :data:`OMP_SURFACE` scopes (pi/omp
+      consume either family).
     - ``subscription`` / ``cli-config``: derived from the CLI — ``claude``
       serves the ``anthropic`` surface, ``codex`` serves the ``openai``
       surface, ``pi`` serves only the :data:`PI_SURFACE` scope (signals
-      "use Pi's own native auth"). Other CLIs serve nothing.
-    - ``databricks``: both families plus pi — ucode routes the Claude,
-      Codex, and pi surfaces.
+      "use Pi's own native auth"; omp cannot use it). Other CLIs serve
+      nothing.
+    - ``databricks``: both families plus pi/omp — ucode routes the Claude,
+      Codex, pi, and omp surfaces.
 
     :param entry: The provider entry to classify.
     :returns: The scope names this provider can be the default for, e.g.
         ``frozenset({"anthropic"})`` for a Claude subscription, or
-        ``frozenset({"anthropic", "openai", "pi"})`` for a Databricks
+        ``frozenset({"anthropic", "openai", "pi", "omp"})`` for a Databricks
         profile.
     """
     if entry.kind == BEDROCK_KIND:
@@ -1255,7 +1286,7 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
         # break pi launch. A multi-family key keeps pi via its anthropic/openai
         # family.
         if served & frozenset(_PI_FALLBACK_FAMILIES):
-            return served | {PI_SURFACE}
+            return served | {PI_SURFACE, OMP_SURFACE}
         return served
     if entry.kind in (SUBSCRIPTION_KIND, CLI_CONFIG_KIND):
         if entry.cli == "claude":
@@ -1265,27 +1296,26 @@ def provider_families(entry: ProviderEntry) -> frozenset[str]:
             # only the pi scope (no model family directly).
             return frozenset({PI_SURFACE})
         if entry.cli == "codex":
-            # A codex *cli-config* provider may ALSO serve pi: a Databricks AI
-            # Gateway exposes an Anthropic Messages surface Pi speaks natively
-            # (pi-native translates it via ``_cli_config_pi_provider``; the
-            # gateway-harness pi path routes it via
-            # ``configure_agent_harness_with_provider``). This is reported at the
-            # KIND level — structurally, without reading the ambient
+            # A codex *cli-config* provider may ALSO serve pi/omp: a Databricks
+            # AI Gateway exposes an Anthropic Messages surface both speak
+            # natively (pi-native translates it via ``_cli_config_pi_provider``;
+            # the gateway-harness pi/omp paths route it via
+            # ``configure_agent_harness_with_provider``). This is reported at
+            # the KIND level — structurally, without reading the ambient
             # ~/.codex/config.toml — so ``provider_families`` stays pure (the
-            # setup menus / ``set_default_provider`` may offer/accept the pi
-            # scope for a codex cli-config). Whether the pinned provider is a
-            # *real* Databricks gateway is validated at resolution time
-            # (``default_provider_for_harness`` fallback + the pi launch), which
-            # falls back gracefully when it is not. A codex *subscription* never
-            # serves pi — a CLI login is unusable outside its own CLI.
+            # setup menus / ``set_default_provider`` may offer/accept the
+            # pi/omp scopes for a codex cli-config). Whether the pinned
+            # provider is a *real* Databricks gateway is validated at
+            # resolution time (``default_provider_for_harness`` fallback + the
+            # pi/omp launch), which falls back gracefully when it is not. A
+            # codex *subscription* never serves pi/omp — a CLI login is
+            # unusable outside its own CLI.
             if entry.kind == CLI_CONFIG_KIND:
-                return frozenset({OPENAI_FAMILY, PI_SURFACE})
+                return frozenset({OPENAI_FAMILY, PI_SURFACE, OMP_SURFACE})
             return frozenset({OPENAI_FAMILY})
         return frozenset()
     if entry.kind == DATABRICKS_KIND:
-        # ucode routes anthropic/openai + pi, never the Gemini surface (which
-        # needs the antigravity SDK + GEMINI_API_KEY, not a gateway).
-        return (frozenset(_VALID_FAMILIES) - {GEMINI_FAMILY}) | {PI_SURFACE}
+        return (frozenset(_VALID_FAMILIES) - {GEMINI_FAMILY}) | {PI_SURFACE, OMP_SURFACE}
     return frozenset()
 
 
@@ -1326,7 +1356,7 @@ def first_available_provider(config: dict[str, object], family: str) -> Provider
     Unlike :func:`get_default_provider` (which requires an explicit
     ``default:``), this returns the first provider whose served families
     include *family* regardless of default status — the credential a launch
-    falls back to when no default is configured for the family. Shared by the
+    would use even without a default. Shared by the REPL startup header, the
     runtime spawn-env builders (so a head still launches) and the REPL startup
     creds line (so the readout names exactly what the launch will use), keeping
     the two provably in agreement.
@@ -1349,14 +1379,15 @@ def default_provider_for_harness(config: dict[str, object], harness: str) -> Pro
 
     Maps the harness to its family (claude-sdk/native-claude→anthropic;
     codex/native-codex/openai-agents→openai) and returns that family's
-    default. The ``pi`` harness (and any unmapped harness) consumes both
-    families: an explicit :data:`PI_SURFACE` default wins; otherwise it
+    default. The ``pi`` / ``omp`` harnesses (and any other unmapped
+    harness) consume both families: an explicit surface default
+    (``PI_SURFACE`` for pi, ``OMP_SURFACE`` for omp) wins; otherwise it
     falls back to the ``anthropic`` then ``openai`` family default,
     skipping ``subscription`` and ``bedrock`` defaults (a CLI login is
     unusable outside its own CLI, and ``bedrock`` is native-``omnigent
     claude`` only — routing pi to either fails). A ``cli-config`` default is
     skipped UNLESS it is a pi-consumable Databricks AI Gateway (see
-    :func:`_cli_config_serves_pi`): such a gateway exposes an Anthropic
+    :func:`_cli_config_serves_pi_omp`): such a gateway exposes an Anthropic
     surface Pi speaks natively, so pi-native translates it
     (``_cli_config_pi_provider``) and the gateway-harness pi path routes it
     (``configure_agent_harness_with_provider``). A non-Databricks cli-config
@@ -1373,8 +1404,10 @@ def default_provider_for_harness(config: dict[str, object], harness: str) -> Pro
     family = _HARNESS_FAMILY.get(harness)
     if family is not None:
         return get_default_provider(config, family)
-    # Unmapped (e.g. pi): an explicit pi-scope default is authoritative.
-    explicit = get_default_provider(config, PI_SURFACE)
+    # Unmapped (e.g. pi, omp): an explicit surface default is authoritative —
+    # the pi scope for pi, the omp scope for omp.
+    surface = OMP_SURFACE if harness == "omp" else PI_SURFACE
+    explicit = get_default_provider(config, surface)
     if explicit is not None:
         return explicit
     # Fall back across the pi-capable surfaces — prefer anthropic's default,
@@ -1399,7 +1432,7 @@ def default_provider_for_harness(config: dict[str, object], harness: str) -> Pro
         # by ``configure_agent_harness_with_provider`` for the gateway-harness
         # pi path). Route pi to it rather than skipping; a non-Databricks
         # cli-config still falls through (it can't serve pi).
-        if provider.kind == CLI_CONFIG_KIND and not _cli_config_serves_pi(provider):
+        if provider.kind == CLI_CONFIG_KIND and not _cli_config_serves_pi_omp(provider):
             continue
         return provider
     return None
@@ -1411,8 +1444,9 @@ def surface_default_provider(config: dict[str, object], surface: str) -> Provide
     The display-side companion to :func:`default_provider_for_harness`,
     keyed by surface name rather than harness id: the ``anthropic`` /
     ``openai`` surfaces resolve their explicit per-family default, and the
-    :data:`PI_SURFACE` surface resolves the pi harness's effective default
-    (explicit pi scope, else the cross-family fallback). Used by the
+    :data:`PI_SURFACE` / :data:`OMP_SURFACE` surfaces resolve their
+    harness's effective default (explicit scope, else the cross-family
+    fallback). Used by the
     ``setup`` harness menus and the REPL startup header so every surface
     shows the provider its harness would actually route through.
 
@@ -1423,8 +1457,8 @@ def surface_default_provider(config: dict[str, object], surface: str) -> Provide
     :raises OmnigentError: If a provider is malformed, or more than one
         default serves a scope.
     """
-    if surface == PI_SURFACE:
-        return default_provider_for_harness(config, PI_SURFACE)
+    if surface in (PI_SURFACE, OMP_SURFACE):
+        return default_provider_for_harness(config, surface)
     return get_default_provider(config, surface)
 
 
@@ -1443,7 +1477,7 @@ def surface_default_model(entry: ProviderEntry, surface: str) -> str | None:
         ``subscription`` / ``databricks`` kinds, always — the CLI /
         profile picks the model).
     """
-    if surface != PI_SURFACE:
+    if surface not in (PI_SURFACE, OMP_SURFACE):
         return entry.family_default_model(surface)
     for family_name in _PI_FALLBACK_FAMILIES:
         if family_name in entry.families:
@@ -1636,7 +1670,7 @@ def set_default_provider(
         "openrouter": {"kind": "gateway", ...}}``.
     :param name: The provider to make the default, e.g. ``"openrouter"``.
     :param family: The single scope to make the default for — ``"anthropic"``,
-        ``"openai"``, or ``"pi"`` (the per-harness path). ``None`` makes
+        ``"openai"``, ``"pi"`` or ``"omp"`` (the per-harness path). ``None`` makes
         *name* the default for **all** scopes it serves (the legacy
         whole-provider behavior), clearing those scopes from siblings.
     :returns: A new ``providers:`` mapping with *name* default for the chosen

--- a/omnigent/repl/_repl.py
+++ b/omnigent/repl/_repl.py
@@ -5091,6 +5091,7 @@ def _build_model_readout_lines(
         kind_glyph,
     )
     from omnigent.onboarding.provider_config import (
+        OMP_SURFACE,
         PI_SURFACE,
         describe_active_credential,
         harness_family,
@@ -5151,12 +5152,12 @@ def _build_model_readout_lines(
 
     # List the OTHER configured providers that serve THIS harness's family,
     # so the user only sees relevant alternatives (a Codex run shouldn't list
-    # Claude-only providers). A both-family harness (pi) maps to no single
-    # family — filter its alternates on the pi surface instead, which every
-    # kind but subscription serves (a CLI login can't drive pi).
+    # Claude-only providers). A both-family harness (pi/omp) maps to no single
+    # family — filter its alternates on its own surface instead, which every
+    # kind but subscription serves (a CLI login can't drive pi/omp).
     providers = load_providers(config)
     fam = harness_family(harness)
-    surface = fam if fam is not None else PI_SURFACE
+    surface = fam if fam is not None else (OMP_SURFACE if harness == "omp" else PI_SURFACE)
     others = [
         (name, entry)
         for name, entry in providers.items()

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11715,7 +11715,7 @@ async def _resolve_harness_config(
 _HARNESS_MODEL_ENV_KEY: dict[str, str] = {
     "claude-sdk": "HARNESS_CLAUDE_SDK_MODEL",
     "codex": "HARNESS_CODEX_MODEL",
-    "pi": "HARNESS_PI_MODEL",
+    "omp": "HARNESS_OMP_MODEL",
     "openai-agents": "HARNESS_OPENAI_AGENTS_MODEL",
     "cursor": "HARNESS_CURSOR_MODEL",
     # cursor-native is intentionally omitted here (and from
@@ -11850,6 +11850,7 @@ def _build_spawn_env_from_spec(
             _build_goose_spawn_env,
             _build_hermes_spawn_env,
             _build_kimi_spawn_env,
+            _build_omp_spawn_env,
             _build_openai_agents_sdk_spawn_env,
             _build_pi_spawn_env,
             _build_qwen_spawn_env,
@@ -11861,6 +11862,8 @@ def _build_spawn_env_from_spec(
             env = _build_codex_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "pi":
             env = _build_pi_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
+        elif harness == "omp":
+            env = _build_omp_spawn_env(effective_spec, cwd=cwd, workdir=workdir)
         elif harness == "openai-agents":
             env = _build_openai_agents_sdk_spawn_env(effective_spec)
         elif harness == "cursor":

--- a/omnigent/runtime/workflow.py
+++ b/omnigent/runtime/workflow.py
@@ -147,7 +147,7 @@ _logger = logging.getLogger(__name__)
 
 
 AgentHarnessType = Literal[
-    "claude-sdk", "codex", "pi", "openai-agents-sdk", "antigravity", "kimi", "qwen", "goose"
+    "claude-sdk", "codex", "pi", "omp", "openai-agents-sdk", "antigravity", "kimi", "qwen", "goose"
 ]
 
 
@@ -212,6 +212,17 @@ _UCODE_HARNESS_CONFIGS: dict[AgentHarnessType, UcodeHarnessConfig] = {
         host_key="HARNESS_PI_GATEWAY_HOST",
         auth_key="HARNESS_PI_GATEWAY_AUTH_COMMAND",
         refresh_key="HARNESS_PI_GATEWAY_AUTH_REFRESH_INTERVAL_MS",
+        catalog_family="claude",
+    ),
+    "omp": UcodeHarnessConfig(
+        agent_name="omp",
+        model_key="HARNESS_OMP_MODEL",
+        base_url_key="HARNESS_OMP_GATEWAY_BASE_URL",
+        base_url_family="claude",
+        base_urls_key="HARNESS_OMP_GATEWAY_BASE_URLS",
+        host_key="HARNESS_OMP_GATEWAY_HOST",
+        auth_key="HARNESS_OMP_GATEWAY_AUTH_COMMAND",
+        refresh_key="HARNESS_OMP_GATEWAY_AUTH_REFRESH_INTERVAL_MS",
         catalog_family="claude",
     ),
     "openai-agents-sdk": UcodeHarnessConfig(
@@ -414,6 +425,7 @@ _HARNESS_GATEWAY_FLAG: dict[AgentHarnessType, str] = {
     "claude-sdk": "HARNESS_CLAUDE_SDK_GATEWAY",
     "codex": "HARNESS_CODEX_GATEWAY",
     "pi": "HARNESS_PI_GATEWAY",
+    "omp": "HARNESS_OMP_GATEWAY",
     "qwen": "HARNESS_QWEN_GATEWAY",
 }
 
@@ -434,6 +446,7 @@ _HARNESS_DATABRICKS_PROFILE: dict[AgentHarnessType, str] = {
     "claude-sdk": "HARNESS_CLAUDE_SDK_DATABRICKS_PROFILE",
     "codex": "HARNESS_CODEX_DATABRICKS_PROFILE",
     "pi": "HARNESS_PI_DATABRICKS_PROFILE",
+    "omp": "HARNESS_OMP_DATABRICKS_PROFILE",
     "openai-agents-sdk": "HARNESS_OPENAI_AGENTS_DATABRICKS_PROFILE",
     "qwen": "HARNESS_QWEN_DATABRICKS_PROFILE",
     # NB: no ``antigravity`` — it has no Databricks/gateway path (Gemini-native).
@@ -597,13 +610,16 @@ def configure_agent_harness_with_provider(
         return
 
     if entry.kind == CLI_CONFIG_KIND:
-        # The pi harness consumes both families and can route a cli-config
-        # Databricks AI Gateway (the gateway's Anthropic Messages surface is one
-        # Pi speaks natively) — the same provider pi-native routes via
-        # ``_cli_config_pi_provider``. Translate it into the pi gateway
-        # transport rather than failing loud; a non-Databricks cli-config is
-        # never selected for pi (see ``default_provider_for_harness``), so it
-        # won't reach here.
+        # The pi/omp harnesses consume both families and can route a
+        # cli-config Databricks AI Gateway (the gateway's Anthropic Messages
+        # surface is one both speak natively) — the same provider pi-native
+        # routes via ``_cli_config_pi_provider``. Translate it into the
+        # harness gateway transport rather than failing loud; a
+        # non-Databricks cli-config is never selected for pi/omp (see
+        # ``default_provider_for_harness``), so it won't reach here.
+        if harness_type == "omp":
+            _apply_cli_config_databricks_to_omp(env, entry)
+            return
         if harness_type == "pi":
             _apply_cli_config_databricks_to_pi(env, entry)
             return
@@ -644,6 +660,9 @@ def configure_agent_harness_with_provider(
         return
 
     # Inline-family kinds: key / gateway / local.
+    if harness_type == "omp":
+        _apply_provider_to_omp(env, entry)
+        return
     if harness_type == "pi":
         _apply_provider_to_pi(env, entry)
         return
@@ -905,6 +924,73 @@ def _apply_provider_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:
         env["HARNESS_PI_MODEL"] = _catalog_default_model(auth_family)
 
 
+def _apply_provider_to_omp(env: dict[str, str], entry: ProviderEntry) -> None:
+    """Apply a provider to the omp harness, which consumes both families.
+
+    omp reads ``HARNESS_OMP_GATEWAY_BASE_URLS`` (a JSON object keyed by the
+    same ``"claude"`` / ``"openai"`` family names pi uses) and a single auth
+    command. When both families are configured with different credentials
+    omp can only carry one — it uses the ``anthropic`` family's auth when
+    present, else the ``openai`` family's. For a single-key gateway (e.g. a
+    LiteLLM proxy) this is exact.
+
+    A family whose credential env var is unset is skipped (not fatal) so a
+    user who exported only one vendor's key can still run omp on that family.
+    If neither family resolves, this fails loud, including the original
+    credential resolution error(s) so the user knows which env var to set.
+
+    :param env: Mutable spawn-env dict, modified in place.
+    :param entry: The resolved provider entry (at least one inline family).
+    :raises OmnigentError: If no configured family's credentials resolve,
+        or no model can be resolved for the chosen family.
+    """
+    anthropic, anthropic_err = _optional_provider_family(entry, ANTHROPIC_FAMILY)
+    openai, openai_err = _optional_provider_family(entry, OPENAI_FAMILY)
+    base_urls: dict[str, str] = {}
+    if anthropic is not None:
+        base_urls[_PI_FAMILY_KEY[ANTHROPIC_FAMILY]] = anthropic.base_url
+    if openai is not None:
+        base_urls[_PI_FAMILY_KEY[OPENAI_FAMILY]] = openai.base_url
+    if not base_urls:
+        # At least one family was configured (the provider passed parse-time
+        # validation) but its credential could not be resolved. Surface the
+        # original error(s) so the user knows which env var to set, rather
+        # than a generic "set the api_key env var" message that omits the name.
+        cred_errors = [str(err) for err in (anthropic_err, openai_err) if err is not None]
+        detail = (
+            f" ({'; '.join(cred_errors)})"
+            if cred_errors
+            else " — set the api_key env var for its 'anthropic' or 'openai' family in your shell"
+        )
+        raise OmnigentError(
+            f"omp harness: provider {entry.name!r} configures no family whose "
+            f"credentials resolve{detail}, then retry.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    # omp carries a single credential: anthropic's when present, else openai's.
+    # The model fallback must match the family that supplied that credential.
+    auth_source: FamilyConfig | None
+    if anthropic is not None:
+        auth_source = anthropic
+        auth_family = ANTHROPIC_FAMILY
+    else:
+        auth_source = openai
+        auth_family = OPENAI_FAMILY
+    assert auth_source is not None  # base_urls non-empty ⇒ one family resolved
+    env[_HARNESS_GATEWAY_FLAG["omp"]] = "true"
+    env["HARNESS_OMP_GATEWAY_BASE_URLS"] = json.dumps(base_urls, sort_keys=True)
+    if openai is not None and openai.wire_api is not None:
+        env["HARNESS_OMP_GATEWAY_OPENAI_WIRE_API"] = openai.wire_api
+    env["HARNESS_OMP_GATEWAY_HOST"] = _origin_of(next(iter(base_urls.values())))
+    env["HARNESS_OMP_GATEWAY_AUTH_COMMAND"] = _provider_auth_command(auth_source)
+    # Model precedence: spec model > provider ``models.default`` > catalog
+    # family default (of the auth-source family) > fail loud.
+    if "HARNESS_OMP_MODEL" not in env and auth_source.default_model:
+        env["HARNESS_OMP_MODEL"] = auth_source.default_model
+    if "HARNESS_OMP_MODEL" not in env:
+        env["HARNESS_OMP_MODEL"] = _catalog_default_model(auth_family)
+
+
 def _apply_cli_config_databricks_to_pi(env: dict[str, str], entry: ProviderEntry) -> None:
     """Apply a cli-config Databricks AI Gateway to the pi (gateway-harness) path.
 
@@ -956,6 +1042,58 @@ def _apply_cli_config_databricks_to_pi(env: dict[str, str], entry: ProviderEntry
     # gateway transport env var wants the bare shell command, so strip the "!".
     env["HARNESS_PI_GATEWAY_AUTH_COMMAND"] = provider.api_key.lstrip("!")
     env["HARNESS_PI_MODEL"] = provider.model
+
+
+def _apply_cli_config_databricks_to_omp(env: dict[str, str], entry: ProviderEntry) -> None:
+    """Apply a cli-config Databricks AI Gateway to the omp (gateway-harness) path.
+
+    The gateway-harness omp launch (``omnigent run`` / agents) resolves the
+    same default provider (:func:`default_provider_for_harness`) as pi, so
+    when that default is a ``cli-config`` Databricks AI Gateway, this path
+    must route it rather than fail loud. We reuse the pi-native translation
+    (:func:`omnigent.pi_native_credentials._cli_config_pi_provider`) — which
+    reads the codex ``[model_providers.X]`` transport, rewrites the base URL to
+    the gateway's Anthropic Messages surface (``/anthropic``) omp speaks
+    natively, and builds the per-request bearer-token ``!command`` apiKey — then
+    maps its fields onto the ``HARNESS_OMP_GATEWAY_*`` env vars the omp harness
+    wrap reads (the same vars :func:`_apply_provider_to_omp` emits).
+
+    :param env: Mutable spawn-env dict, modified in place.
+    :param entry: The resolved ``cli-config`` provider entry (a Databricks
+        gateway — selection guarantees a non-Databricks cli-config never
+        reaches here).
+    :raises OmnigentError: If the cli-config entry cannot be translated into a
+        gateway provider (its codex table can't be resolved or it is not a
+        recognized Databricks AI Gateway) — selection should prevent this, so a
+        failure here is a real misconfiguration worth surfacing.
+    """
+    # Imported lazily: pi_native_credentials is on the runner's session-create
+    # hot path and pulls onboarding-only deps; keep this off workflow import.
+    from omnigent.pi_native_credentials import _cli_config_pi_provider
+
+    # The spec model (if any) is already in HARNESS_OMP_MODEL; thread it so the
+    # gateway translation honors an explicit override, else its default.
+    model_override = env.get("HARNESS_OMP_MODEL")
+    provider = _cli_config_pi_provider(entry, model=model_override)
+    if provider is None:
+        raise OmnigentError(
+            f"provider {entry.name!r} (kind 'cli-config') was selected for the 'omp' "
+            "harness but its codex [model_providers] table could not be resolved as a "
+            "Databricks AI Gateway. Check the [model_providers] base_url + auth in "
+            "~/.codex/config.toml, or configure a key/gateway provider for omp in "
+            "~/.omnigent/config.yaml.",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    # omp speaks the gateway's Anthropic Messages surface — register it under
+    # the "claude" family key (mirrors _apply_provider_to_omp's anthropic path).
+    base_urls = {_PI_FAMILY_KEY[ANTHROPIC_FAMILY]: provider.base_url}
+    env[_HARNESS_GATEWAY_FLAG["omp"]] = "true"
+    env["HARNESS_OMP_GATEWAY_BASE_URLS"] = json.dumps(base_urls, sort_keys=True)
+    env["HARNESS_OMP_GATEWAY_HOST"] = _origin_of(provider.base_url)
+    # provider.api_key is a "!command" form (omp's models.yml convention); the
+    # gateway transport env var wants the bare shell command, so strip the "!".
+    env["HARNESS_OMP_GATEWAY_AUTH_COMMAND"] = provider.api_key.lstrip("!")
+    env["HARNESS_OMP_MODEL"] = provider.model
 
 
 def _synthesize_databricks_provider(profile: str | None) -> ProviderEntry:
@@ -1431,6 +1569,56 @@ def _build_pi_spawn_env(
     if os_env_payload is not None:
         env["HARNESS_PI_OS_ENV"] = os_env_payload
     _apply_harness_path_override(env, "pi")
+    return env
+
+
+def _build_omp_spawn_env(
+    spec: AgentSpec,
+    *,
+    cwd: Path | None = None,
+    workdir: Path | None = None,
+) -> dict[str, str]:
+    """Build the spawn env for the omp harness (``omp --mode rpc``).
+
+    Mirrors :func:`_build_pi_spawn_env` — same per-spawn env-var
+    pattern: model override, provider/gateway translation into the
+    ``HARNESS_OMP_*`` transport, skills bridge, path override.
+
+    :param spec: The agent spec.
+    :param cwd: Runtime working directory for the omp CLI. This is the
+        session workspace, not the agent bundle workdir.
+    :param workdir: The bundle's on-disk path (extracted by the
+        agent cache). Threaded through as ``HARNESS_OMP_BUNDLE_DIR``.
+    :returns: A dict of env-var overrides for
+        :meth:`HarnessProcessManager.get_client(env=...)`.
+    """
+    env: dict[str, str] = {}
+    model = _resolve_spec_model(spec)
+    if model is not None:
+        env["HARNESS_OMP_MODEL"] = model
+
+    # Generic-provider branch (slotted ahead of the legacy-profile /
+    # databricks-prefix path): a ProviderAuth on the spec, or — when the spec
+    # declares no auth — the per-family global default. omp consumes both
+    # families (see :func:`_apply_provider_to_omp`). Otherwise the existing
+    # path is unchanged.
+    provider = _resolve_provider_for_build(spec, harness_type="omp", for_launch=True)
+    if provider is not None:
+        configure_agent_harness_with_provider(env, provider, harness_type="omp")
+    # Skills bridge — same shape as the pi variant. Always set so the
+    # harness wrap doesn't fall back to ``"all"`` and override an explicit
+    # ``skills: none`` from the spec.
+    env["HARNESS_OMP_SKILLS_FILTER"] = json.dumps(spec.skills_filter)
+    if spec.name:
+        env["HARNESS_OMP_AGENT_NAME"] = spec.name
+    if cwd is not None:
+        env["HARNESS_OMP_CWD"] = str(cwd)
+    if workdir is not None:
+        env["HARNESS_OMP_BUNDLE_DIR"] = str(workdir)
+    os_env_payload = _serialize_os_env(spec.os_env)
+    if os_env_payload is not None:
+        env["HARNESS_OMP_OS_ENV"] = os_env_payload
+    _apply_harness_path_override(env, "omp")
     return env
 
 

--- a/omnigent/server/smart_routing.py
+++ b/omnigent/server/smart_routing.py
@@ -102,6 +102,12 @@ _HARNESS_FAMILY: dict[str, str] = {
     "claude_sdk": "claude",
     "claude-native": "claude",
     "pi": "pi",
+    # omp speaks the same gateway models as pi (same families, same
+    # models.yml provider routing), so it shares pi's family. Without this,
+    # subagent routing for omp parents degrades: catalog rows from pi-family
+    # workers never match, there is no static-model fallback, and a picked
+    # pi-family model redirects the child off "omp" instead of staying put.
+    "omp": "pi",
     "codex": "gpt",
     "codex-native": "gpt",
     "openai-agents": "gpt",

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -1741,6 +1741,7 @@ def test_overview_lists_all_harnesses_in_priority_order(isolated_config, monkeyp
         "OpenCode",
         "Hermes",
         "Pi",
+        "Omp",
         "Antigravity",
         "Qwen Code",
         "Goose",
@@ -1911,7 +1912,7 @@ def test_setup_imports_openclaw_agents(isolated_config) -> None:
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1933,7 +1934,7 @@ def test_setup_imports_openclaw_agents_from_user_selected_path(isolated_config) 
         encoding="utf-8",
     )
 
-    stdin = "\n".join(["15", "", str(selected), "", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -1950,7 +1951,7 @@ def test_setup_rejects_user_selected_unrelated_file(isolated_config) -> None:
     selected = isolated_config / "package.json"
     selected.write_text('{"name": "unrelated"}', encoding="utf-8")
 
-    stdin = "\n".join(["15", "", str(selected), "2", "q"]) + "\n"
+    stdin = "\n".join(["16", "", str(selected), "2", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
 
     assert result.exit_code == 0, result.output
@@ -2139,16 +2140,21 @@ def test_overview_truncates_long_status_for_narrow_terminal(isolated_config, mon
     [
         ("4", "_manage_opencode_harness"),
         ("5", "_manage_hermes_harness"),
-        ("8", "_manage_qwen_harness"),
-        ("9", "_manage_goose_harness"),
-        # 10-11 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
-        # every row after them shifted down by two when that block landed.
-        ("10", "_show_acp_cli_harness"),
+        # 7 is the Omp surface row (after Pi); family surfaces share the
+        # providers drill-in — this pins Omp's position→sentinel→manager.
+        ("7", "_manage_harness_providers"),
+        ("8", "_manage_antigravity_harness"),
+        ("9", "_manage_qwen_harness"),
+        ("10", "_manage_goose_harness"),
+        # 11-12 are the builtin ACP CLI rows (Devin, Grok Build — sorted by id);
+        # every row after them shifted down by two when that block landed, and
+        # every row after Omp shifted down by one more when it landed.
         ("11", "_show_acp_cli_harness"),
-        ("12", "_manage_copilot_harness"),
-        ("13", "_manage_kiro_harness"),
-        ("14", "_manage_kimi_harness"),
-        ("16", "_add_acp_agent"),
+        ("12", "_show_acp_cli_harness"),
+        ("13", "_manage_copilot_harness"),
+        ("14", "_manage_kiro_harness"),
+        ("15", "_manage_kimi_harness"),
+        ("17", "_add_acp_agent"),
     ],
 )
 def test_overview_dispatches_to_correct_manager(
@@ -2996,9 +3002,9 @@ def test_antigravity_set_api_key_paste_writes_block_and_secret(
     Proves the api-key path: the secret lands in the store (never plaintext in
     config) and the config references it via ``keychain:antigravity``.
     """
-    # L1 7=Antigravity → antigravity menu 1=Set API key →
+    # L1 8=Antigravity → antigravity menu 1=Set API key →
     # paste key (AIza → no warn) → antigravity menu q=back → L1 q=quit.
-    stdin = "\n".join(["7", "1", "AIza_test_key_123", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "AIza_test_key_123", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3018,9 +3024,9 @@ def test_antigravity_adopt_env_api_key_writes_env_ref(
     at the live environment variable so the key never leaves the user's shell.
     """
     monkeypatch.setenv("GEMINI_API_KEY", "AIza_env_key_456")
-    # L1 7=Antigravity → 1=Set API key →
+    # L1 8=Antigravity → 1=Set API key →
     # "y" adopt detected $GEMINI_API_KEY → q back → q quit.
-    stdin = "\n".join(["7", "1", "y", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "y", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3036,11 +3042,11 @@ def test_antigravity_sign_in_runs_agy_auth_service(
     login = Mock(return_value=True)
     monkeypatch.setattr("omnigent.onboarding.harness_install.harness_login", login)
 
-    # L1 7=Antigravity → 2=Sign in → q back → q quit.
+    # L1 8=Antigravity → 2=Sign in → q back → q quit.
     result = CliRunner().invoke(
         cli,
         ["setup", "--no-internal-beta"],
-        input="\n".join(["7", "2", "q", "q"]) + "\n",
+        input="\n".join(["8", "2", "q", "q"]) + "\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -3061,7 +3067,7 @@ def test_antigravity_sign_in_skips_sdk_install_prompt(isolated_config, monkeypat
     result = CliRunner().invoke(
         cli,
         ["setup", "--no-internal-beta"],
-        input="\n".join(["7", "2", "q", "q"]) + "\n",
+        input="\n".join(["8", "2", "q", "q"]) + "\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -3079,9 +3085,9 @@ def test_antigravity_remove_api_key_drops_block_and_secret(
     with open(config_path, "w") as f:
         yaml.safe_dump({"antigravity": {"api_key_ref": "keychain:antigravity"}}, f)
 
-    # L1 7=Antigravity → antigravity menu (key set:
+    # L1 8=Antigravity → antigravity menu (key set:
     # 1=Replace 2=Remove 3=Back) → 2=Remove → q back → q quit.
-    stdin = "\n".join(["7", "2", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "2", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3106,9 +3112,9 @@ def test_antigravity_remove_does_not_delete_foreign_keychain_secret(
     with open(config_path, "w") as f:
         yaml.safe_dump({"antigravity": {"api_key_ref": "keychain:shared-gemini"}}, f)
 
-    # L1 7=Antigravity → antigravity menu 2=Remove →
+    # L1 8=Antigravity → antigravity menu 2=Remove →
     # q back → q quit.
-    stdin = "\n".join(["7", "2", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "2", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3126,9 +3132,9 @@ def test_antigravity_set_api_key_non_aiza_declined_is_not_stored(
     The soft prefix check warns and asks to store anyway; declining must leave
     both the secret store and the config untouched.
     """
-    # L1 7=Antigravity → 1=Set API key →
+    # L1 8=Antigravity → 1=Set API key →
     # paste non-AIza key → "n" decline warning → q back → q quit.
-    stdin = "\n".join(["7", "1", "sk-not-a-gemini-key", "n", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "sk-not-a-gemini-key", "n", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3228,12 +3234,12 @@ def test_copilot_overview_install_command_is_selection_only(
             "Cursor — no API key yet",
         ),
         (
-            "7",
+            "8",
             "omnigent.onboarding.antigravity_auth.antigravity_sdk_installed",
             "Antigravity — no Gemini API key yet",
         ),
         (
-            "10",
+            "13",
             "omnigent.onboarding.copilot_auth.copilot_sdk_installed",
             "Copilot — no GitHub token yet",
         ),
@@ -3265,9 +3271,9 @@ def test_antigravity_drillin_offers_install_when_sdk_missing(
     The user picks "show the command" (choice 3), which prints the command and falls
     through to the key menu, then backs out.
     """
-    # L1 7=Antigravity → install offer 3=show command →
+    # L1 8=Antigravity → install offer 3=show command →
     # key menu q=back → L1 q.
-    stdin = "\n".join(["7", "3", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "3", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
     out = result.output
@@ -3284,9 +3290,9 @@ def test_antigravity_key_settable_when_sdk_missing(
     gate key management on it. The user declines ("set the key anyway" = choice 2),
     then sets the key, which must persist as it does with the SDK present.
     """
-    # L1 7=Antigravity → install offer 2=set key anyway →
+    # L1 8=Antigravity → install offer 2=set key anyway →
     # key menu 1=Set → paste AIza key → key menu q=back → L1 q=quit.
-    stdin = "\n".join(["7", "2", "1", "AIza_key_no_sdk", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "2", "1", "AIza_key_no_sdk", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 
@@ -3315,9 +3321,9 @@ def test_antigravity_install_now_invokes_runner_without_index(
     monkeypatch.setattr("omnigent.onboarding.extra_install.shutil.which", lambda name: None)
     monkeypatch.setattr("omnigent.onboarding.antigravity_auth.subprocess.run", _run)
 
-    # L1 7=Antigravity → install offer 1=install now →
+    # L1 8=Antigravity → install offer 1=install now →
     # key menu q=back → L1 q.
-    stdin = "\n".join(["7", "1", "q", "q"]) + "\n"
+    stdin = "\n".join(["8", "1", "q", "q"]) + "\n"
     result = CliRunner().invoke(cli, ["setup", "--no-internal-beta"], input=stdin)
     assert result.exit_code == 0, result.output
 

--- a/tests/e2e/omnigent/snapshots/test_per_harness_omp.json
+++ b/tests/e2e/omnigent/snapshots/test_per_harness_omp.json
@@ -1,0 +1,5 @@
+{
+    "exit_code": {"kind": "exact", "value": 0},
+    "stderr_is_clean": {"kind": "exact", "value": true},
+    "assistant_text": {"kind": "min_length", "value": 4}
+}

--- a/tests/e2e/omnigent/test_per_harness_omp.py
+++ b/tests/e2e/omnigent/test_per_harness_omp.py
@@ -1,0 +1,161 @@
+"""Phase 0 characterization test — omp harness, one-shot prompt.
+
+Runs ``omnigent run hello_world.yaml --harness omp --model
+<mock-model> -p "..."`` as a real subprocess against the mock LLM
+server and snapshots structural observations (exit code, stderr
+cleanliness, assistant text length).
+
+**What breaks if this fails:**
+- Omnigent' ``OmpExecutor`` regresses (the ``omp --mode rpc``
+  subprocess lifecycle, the JSONL event protocol, the TCP
+  ``_ToolServer`` that proxies tool calls back to Python, or
+  the generated JavaScript extension that registers
+  Omnigent tools with ``pi.registerTool()``).
+- The ``omp`` CLI binary disappears from PATH or its
+  ``--mode rpc`` subcommand changes its startup contract.
+- ``omnigent.cli._run_agent`` for the ``-p`` one-shot path
+  stops printing assistant text to stdout on turn complete.
+
+Design reference: ``designs/OMNIGENT_INTEGRATION.md`` §Phase 0
+per-harness suite.
+
+**Serial execution note:** These tests are designed for serial
+execution — do NOT run them under pytest-xdist or any parallel
+runner that shares the mock LLM server process. Each test uses a
+UUID-keyed model name, so concurrent tests use separate queues and
+queue cross-contamination is impossible even without ``reset_mock_llm``.
+The ``reset_mock_llm`` call is kept as a safety guard to clear any
+leftover state from prior test runs in the same session, but it
+would wipe another test's queue if two tests ran simultaneously.
+
+**Mock routing note (omp):** The omp executor translates the ambient
+mock credential (``OPENAI_API_KEY``/``OPENAI_BASE_URL``) into a
+generated ``models.yml`` gateway pointing at the mock server, and
+registers the ``--model`` id under the routed provider — the same
+shape as the pi harness's ``models.json`` path. If a particular omp
+build read ``~/.databrickscfg`` instead and ignored the gateway
+transport, the test would connect to a real endpoint rather than
+the mock server and fail or behave non-deterministically. The
+module-level ``pytestmark`` skips the test when ``omp`` is absent;
+on CI the binary should either be absent (skip) or honor the
+gateway transport.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.e2e._harness_probes import cli_unavailable_reason
+from tests.e2e.omnigent._snapshot import compare_snapshot
+from tests.e2e.omnigent.conftest import configure_mock_llm, reset_mock_llm
+
+_HARNESS = "omp"
+_PROMPT = "say hi in 5 words"
+
+# Minimum assistant-text length. Anything longer than "hi" proves
+# the turn produced a real model reply rather than an empty
+# response or a pure error banner.
+_MIN_ASSISTANT_CHARS = 4
+
+# Subprocess timeout. omp spawns a JS subprocess with its own
+# init path and registers tools via the generated extension
+# before accepting the first turn — slower than openai-agents,
+# comparable to claude-sdk. 180s matches the other slow-harness
+# tests.
+_RUN_TIMEOUT_SEC = 180
+
+_pytest_omp_unavailable = cli_unavailable_reason("omp")
+pytestmark = pytest.mark.skipif(
+    _pytest_omp_unavailable is not None,
+    reason=(
+        "omp harness e2e requires a runnable 'omp' CLI; "
+        f"{_pytest_omp_unavailable}. Install/fix Oh My Pi to run this test."
+    ),
+)
+
+
+def test_per_harness_omp_one_shot(
+    omnigent_repo_root: Path,
+    omnigent_python: Path,
+    mock_credentials_env: dict[str, str],
+    mock_llm_server_url: str,
+) -> None:
+    """
+    ``omnigent run hello_world.yaml --harness omp -p <prompt>``
+    exits 0 and emits a non-trivial assistant reply.
+
+    Uses the mock LLM server so the test runs without real API
+    credentials or a Databricks workspace. The omp executor routes
+    model calls through the generated ``models.yml`` gateway
+    (translated from the ambient mock credential).
+
+    :param omnigent_python: Interpreter with omnigent
+        installed and importable.
+    :param omnigent_repo_root: Cwd for the subprocess so the
+        YAML spec and example tool modules resolve on sys.path.
+    :param mock_credentials_env: Env vars pointing at the mock
+        LLM server.
+    :param mock_llm_server_url: Base URL of the mock server for
+        configuring canned responses.
+    """
+    model = f"mock-harness-omp-{uuid.uuid4().hex[:8]}"
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": "Hello there, how are you today?"}],
+        key=model,
+    )
+
+    yaml_path = omnigent_repo_root / "tests" / "resources" / "examples" / "hello_world.yaml"
+
+    result = subprocess.run(
+        [
+            str(omnigent_python),
+            "-m",
+            "omnigent",
+            "run",
+            str(yaml_path),
+            "--model",
+            model,
+            "--harness",
+            _HARNESS,
+            "-p",
+            _PROMPT,
+            "--no-log",
+            "--no-session",
+        ],
+        env=mock_credentials_env,
+        cwd=str(omnigent_repo_root),
+        capture_output=True,
+        text=True,
+        timeout=_RUN_TIMEOUT_SEC,
+    )
+
+    observed: dict[str, Any] = {
+        "exit_code": result.returncode,
+        "stderr_is_clean": result.stderr.strip() == "",
+        # Trimmed because whitespace around LLM output is noisy
+        # and not something we want the snapshot comparator to
+        # trip on.
+        "assistant_text": result.stdout.strip(),
+    }
+
+    # Full stderr surfaced on failure so CI logs show WHY the run
+    # went wrong — stderr here is opaque unless we dump it.
+    diffs = compare_snapshot("test_per_harness_omp", observed)
+    assert diffs == [], (
+        "Snapshot mismatch for omp run:\n"
+        + "\n".join(diffs)
+        + f"\n\nstdout:\n{result.stdout!r}\n\nstderr:\n{result.stderr!r}"
+    )
+    # Separate assertion so a length regression names the length
+    # check directly instead of being buried in the snapshot diff.
+    assert len(observed["assistant_text"]) >= _MIN_ASSISTANT_CHARS, (
+        f"omp assistant text shorter than {_MIN_ASSISTANT_CHARS} "
+        f"chars; got {observed['assistant_text']!r}"
+    )

--- a/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
+++ b/tests/e2e/omnigent/test_run_harness_without_agent_e2e.py
@@ -226,7 +226,13 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
     terminal-first TUI launched via ``omni hermes`` (tmux pane + bridge dir), not
     ``omnigent run --harness hermes-native``, AND it wraps the ``hermes`` CLI
     binary. Its coverage is the dedicated hermes-native bridge/executor/forwarder/
-    approval-mirror unit tests.
+
+    ``omp`` is excluded for the same reason as ``hermes``: it requires the
+    ``omp`` CLI binary and authenticates through its own provider logins or
+    the generated ``models.yml`` gateway transport — not the shared
+    Databricks gateway/profile probe wiring this matrix drives. Its live
+    round-trip is covered by the dedicated
+    ``tests/e2e/omnigent/test_per_harness_omp.py`` suite.
 
     Builtin ACP CLI harnesses (every row of ``ACP_CLI_HARNESSES``) are excluded
     for the same reason as ``goose``: each wraps an own-auth vendor CLI, so its
@@ -254,6 +260,7 @@ def test_run_harness_live_matrix_covers_registered_coding_harnesses() -> None:
         "kimi-native",
         "hermes",
         "hermes-native",
+        "omp",
         *ACP_CLI_HARNESSES,
     }
     assert {probe.harness for probe in HARNESS_PROBES} == expected_live_harnesses

--- a/tests/inner/test_omp_executor.py
+++ b/tests/inner/test_omp_executor.py
@@ -1,0 +1,1617 @@
+"""Tests for OmpExecutor's omp-specific surface (not the pi-parity core).
+
+The transport, tool bridge, policy gates, resume, and usage aggregation are
+ported verbatim from :mod:`omnigent.inner.pi_executor` and keep that module's
+contract; these tests pin what differs for omp:
+
+* spawn argv (``omp`` binary, ``--mode rpc``) and CLI feature detection
+  (``--auto-approve`` vs pi's ``--approve``, ``--skills`` filter vs pi's
+  ``--skill <path>`` explicit load)
+* the ``models.yml`` gateway writer (YAML, not ``models.json``)
+* protocol frames pi never emits: the startup ``ready`` frame,
+  non-terminal ``agent_end`` (``isTerminal: false``), and local-only prompt
+* omp identity: binary discovery, sandbox roots, env allowlist
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yaml
+
+import omnigent.inner.omp_executor as omp_mod
+from omnigent.inner.executor import (
+    ExecutorConfig,
+    ExecutorError,
+    ReasoningChunk,
+    TextChunk,
+    ToolCallComplete,
+    ToolCallRequest,
+    ToolCallStatus,
+    TurnComplete,
+)
+from omnigent.inner.omp_executor import (
+    OmpExecutor,
+    _aggregate_omp_turn_usage,
+    _build_models_yml,
+    _clean_omp_env,
+    _extract_omp_turn_usage,
+    _find_omp_cli,
+    _generate_extension_js,
+    _omp_needs_responses_api,
+    _omp_provider_for_model,
+    _omp_supports_auto_approve,
+    _omp_thinking_from_config,
+    _OmpRpcSession,
+    _OmpSessionState,
+    _redact_argv_for_log,
+    _resolve_omp_skill_args,
+    _split_omp_prompt,
+)
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+
+
+class _FakeStreamWriter:
+    def __init__(self):
+        self.data: list[bytes] = []
+
+    def write(self, chunk: bytes) -> None:
+        self.data.append(chunk)
+
+    async def drain(self) -> None:
+        return None
+
+
+def _make_executor(**kwargs: Any) -> OmpExecutor:
+    with patch.object(omp_mod, "_omp_supports_auto_approve", return_value=False):
+        return OmpExecutor(omp_path="/fake/omp", gateway=False, **kwargs)
+
+
+def _scripted_session(lines: list[str]) -> _OmpRpcSession:
+    """A fake RPC session replaying scripted stdout lines."""
+    rpc = _OmpRpcSession()
+    rpc._line_queue = asyncio.Queue()
+    for line in lines:
+        rpc._line_queue.put_nowait(line)
+    rpc.process = MagicMock()
+    rpc.process.returncode = None
+    rpc.process.stdin = _FakeStreamWriter()
+    rpc._stderr_lines = []
+    return rpc
+
+
+def _drive_turn(executor: OmpExecutor, rpc: _OmpRpcSession) -> list[Any]:
+    async def fake_ensure_rpc(*args: Any, **kwargs: Any) -> _OmpRpcSession:
+        return rpc
+
+    executor._ensure_rpc = fake_ensure_rpc  # type: ignore[method-assign]
+
+    async def _collect():
+        return [
+            event
+            async for event in executor.run_turn(
+                [{"role": "user", "content": "hello"}],
+                [],
+                "system",
+            )
+        ]
+
+    return _run(_collect())
+
+
+# ---------------------------------------------------------------------------
+# Binary discovery + feature detection
+# ---------------------------------------------------------------------------
+
+
+def test_find_omp_cli_resolves_omp_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI discovery looks up ``omp``, not ``pi``."""
+    monkeypatch.setattr(omp_mod.shutil, "which", lambda name: f"/bin/{name}")
+    assert _find_omp_cli() == "/bin/omp"
+
+
+def test_supports_auto_approve_reads_help_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--auto-approve`` is feature-detected via ``omp --help``."""
+
+    def _ok(*args: Any, **kwargs: Any) -> Any:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = "  --auto-approve   Auto-approve all tool calls\n"
+        return proc
+
+    monkeypatch.setattr(omp_mod.subprocess, "run", _ok)
+    assert _omp_supports_auto_approve("/fake/omp") is True
+
+
+def test_supports_auto_approve_absent_without_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CLI without the flag (older omp) reports unsupported."""
+
+    def _old(*args: Any, **kwargs: Any) -> Any:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = "  --approve   something else\n"
+        return proc
+
+    monkeypatch.setattr(omp_mod.subprocess, "run", _old)
+    assert _omp_supports_auto_approve("/fake/omp") is False
+
+
+def test_supports_auto_approve_fails_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A probe error never blocks the spawn — the flag is just omitted."""
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd="omp", timeout=15)
+
+    monkeypatch.setattr(omp_mod.subprocess, "run", _boom)
+    assert _omp_supports_auto_approve("/fake/omp") is False
+
+
+# ---------------------------------------------------------------------------
+# Skills filter mapping
+# ---------------------------------------------------------------------------
+
+
+def test_skill_args_all_passes_nothing() -> None:
+    """``"all"`` relies on omp auto-discovery (no explicit-load flag exists)."""
+    assert _resolve_omp_skill_args("all", None) == []
+
+
+def test_skill_args_none_disables_discovery() -> None:
+    assert _resolve_omp_skill_args("none", None) == ["--no-skills"]
+
+
+def test_skill_args_list_becomes_name_filter() -> None:
+    """A named list maps to omp's comma-separated ``--skills`` allowlist."""
+    assert _resolve_omp_skill_args(["a", "b"], None) == ["--skills=a,b"]
+
+
+def test_skill_args_unknown_shape_falls_back_to_defaults() -> None:
+    assert _resolve_omp_skill_args("bogus", None) == []  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Spawn argv
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_argv_uses_omp_binary_and_rpc_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_OmpRpcSession.start`` emits the omp headless-RPC argv."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_spawn(*args: Any, **kwargs: Any) -> Any:
+        captured["argv"] = list(args)
+
+        async def _empty_stream():
+            return
+            yield  # pragma: no cover - never yields
+
+        proc = MagicMock()
+        proc.stdout = _empty_stream()
+        proc.stderr = None
+        proc.stdin = _FakeStreamWriter()
+        proc.returncode = 0
+        proc.wait = AsyncMock(return_value=0)
+        return proc
+
+    monkeypatch.setattr(omp_mod, "_create_subprocess_exec", _fake_spawn)
+
+    async def _test() -> None:
+        rpc = _OmpRpcSession()
+        await rpc.start(
+            "/fake/omp",
+            env={"PATH": "/usr/bin"},
+            model="probe-gw/probe-model",
+            thinking="high",
+            system_prompt="sys",
+            extra_args=["--extension", "/tmp/ext.js"],
+        )
+        await rpc.close()
+
+    _run(_test())
+
+    argv = captured["argv"]
+    assert argv[:4] == ["/fake/omp", "--mode", "rpc", "--no-session"]
+    assert "--model" in argv and "probe-gw/probe-model" in argv
+    assert argv[argv.index("--thinking") + 1] == "high"
+    assert argv[argv.index("--append-system-prompt") + 1] == "sys"
+    assert "--extension" in argv
+    assert "--approve" not in argv
+
+
+def test_constructor_emits_auto_approve_when_supported() -> None:
+    """The trust pre-accept uses omp's flag name, never pi's ``--approve``."""
+    with patch.object(omp_mod, "_omp_supports_auto_approve", return_value=True):
+        executor = OmpExecutor(omp_path="/fake/omp", gateway=False)
+    assert "--auto-approve" in executor._extra_args
+    assert "--approve" not in executor._extra_args
+
+
+# ---------------------------------------------------------------------------
+# models.yml gateway writer
+# ---------------------------------------------------------------------------
+
+
+def test_build_models_yml_registers_gateway_providers() -> None:
+    """The builder emits omp's ``models.yml`` provider schema as YAML."""
+    config = _build_models_yml(
+        "https://example.com",
+        "token-123",
+        {"claude": "https://example.com/anthropic", "openai": "https://example.com/openai"},
+        model="my-model",
+    )
+    assert set(config["providers"]) >= {
+        "databricks-anthropic",
+        "databricks-completions",
+    }
+    anthropic = config["providers"]["databricks-anthropic"]
+    assert anthropic["baseUrl"] == "https://example.com/anthropic"
+    assert anthropic["apiKey"] == "token-123"
+    assert anthropic["api"] == "anthropic-messages"
+    # YAML round-trip: the file omp reads must parse back identically.
+    assert yaml.safe_load(yaml.safe_dump(config, sort_keys=True)) == config
+    # The explicit model is registered so its provider/model selector resolves.
+    model_ids = [
+        entry["id"] for provider in config["providers"].values() for entry in provider["models"]
+    ]
+    assert "my-model" in model_ids
+
+
+# ---------------------------------------------------------------------------
+# Extension bridge identity
+# ---------------------------------------------------------------------------
+
+
+def test_generate_extension_js_targets_omp() -> None:
+    """The generated extension registers tools and carries the server token."""
+    js = _generate_extension_js(
+        54321,
+        [{"name": "calculate", "description": "Do math", "parameters": {"type": "object"}}],
+        "secret-token",
+    )
+    assert "pi.registerTool" in js
+    assert "54321" in js
+    assert "secret-token" in js
+    assert "calculate" in js
+
+
+def test_clean_omp_env_passes_agent_dir_but_not_api_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``PI_CODING_AGENT_DIR`` (omp's agent root) passes; keys do not."""
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", "/tmp/managed-agent")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-pwned")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-pwned")
+    env = _clean_omp_env()
+    assert env["PI_CODING_AGENT_DIR"] == "/tmp/managed-agent"
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
+# ---------------------------------------------------------------------------
+# Protocol deltas: frames pi never emits
+# ---------------------------------------------------------------------------
+
+
+def test_ready_frame_is_skipped() -> None:
+    """The startup ``ready`` frame carries no turn content."""
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            json.dumps({"type": "ready", "protocolVersion": 1}),
+            json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "hi"},
+                }
+            ),
+            json.dumps({"type": "agent_end", "messages": []}),
+        ]
+    )
+    events = _drive_turn(executor, rpc)
+    assert isinstance(events[0], TextChunk) and events[0].text == "hi"
+    assert isinstance(events[-1], TurnComplete)
+    assert events[-1].response == "hi"
+
+
+def test_non_terminal_agent_end_keeps_draining() -> None:
+    """``agent_end`` with ``isTerminal: false`` is maintenance, not completion."""
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            json.dumps({"type": "agent_end", "messages": [], "isTerminal": False}),
+            json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "late"},
+                }
+            ),
+            json.dumps({"type": "agent_end", "messages": [], "isTerminal": True}),
+        ]
+    )
+    events = _drive_turn(executor, rpc)
+    assert isinstance(events[-1], TurnComplete)
+    assert events[-1].response == "late"
+
+
+def test_absent_is_terminal_still_completes() -> None:
+    """Older runtimes omit ``isTerminal`` — the end is terminal."""
+    executor = _make_executor()
+    rpc = _scripted_session([json.dumps({"type": "agent_end", "messages": []})])
+    events = _drive_turn(executor, rpc)
+    assert isinstance(events[-1], TurnComplete)
+
+
+def test_local_only_prompt_ack_completes_without_agent_end() -> None:
+    """A ``prompt`` ack with ``agentInvoked: false`` ends the turn immediately."""
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            json.dumps(
+                {
+                    "type": "response",
+                    "command": "prompt",
+                    "success": True,
+                    "data": {"agentInvoked": False},
+                }
+            ),
+        ]
+    )
+    events = _drive_turn(executor, rpc)
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response is None
+
+
+def test_prompt_result_completes_without_agent_end() -> None:
+    """A late ``prompt_result`` with ``agentInvoked: false`` ends the turn."""
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            json.dumps({"type": "prompt_result", "id": "turn_1", "agentInvoked": False}),
+        ]
+    )
+    events = _drive_turn(executor, rpc)
+    assert len(events) == 1
+    assert isinstance(events[0], TurnComplete)
+    assert events[0].response is None
+
+
+def test_prompt_error_surfaces_executor_error() -> None:
+    """A failed ``prompt`` command (e.g. no model selected) is a turn error."""
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            json.dumps(
+                {
+                    "type": "response",
+                    "command": "prompt",
+                    "success": False,
+                    "error": "No model selected",
+                }
+            ),
+        ]
+    )
+    events = _drive_turn(executor, rpc)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "No model selected" in events[0].message
+
+
+# ---------------------------------------------------------------------------
+# Feature detection: token-boundary matching
+# ---------------------------------------------------------------------------
+
+
+def _help_proc(stdout: str, returncode: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.returncode = returncode
+    return proc
+
+
+def test_supports_auto_approve_ignores_prose_mention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``--plan-yolo`` help prose mentions "auto-approve" without the flag.
+
+    A bare substring check would treat that prose as feature support and emit
+    ``--auto-approve`` — a hard spawn error on CLIs that never had the flag —
+    so detection requires the exact flag token.
+    """
+    monkeypatch.setattr(
+        omp_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: _help_proc(
+            "  --plan-yolo  Force plan mode, auto-approve the plan on resolve\n"
+        ),
+    )
+    assert _omp_supports_auto_approve("/fake/omp") is False
+
+
+def test_supports_auto_approve_rejects_longer_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hypothetical ``--auto-approve-tools`` must not imply ``--auto-approve``."""
+    monkeypatch.setattr(
+        omp_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: _help_proc("  --auto-approve-tools  Approve tool calls\n"),
+    )
+    assert _omp_supports_auto_approve("/fake/omp") is False
+
+
+def test_supports_auto_approve_accepts_flag_with_trailing_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real flag line (``--auto-approve  Auto-approve all tool calls``) matches."""
+    monkeypatch.setattr(
+        omp_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: _help_proc(
+            "  --plan-yolo  Force plan mode, auto-approve the plan\n"
+            "  --auto-approve  Auto-approve all tool calls (skip approval prompts)\n"
+        ),
+    )
+    assert _omp_supports_auto_approve("/fake/omp") is True
+
+
+def test_supports_auto_approve_requires_zero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Help text on a failing probe means nothing — fail closed to no-flag."""
+    monkeypatch.setattr(
+        omp_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: _help_proc("  --auto-approve  Auto-approve\n", returncode=1),
+    )
+    assert _omp_supports_auto_approve("/fake/omp") is False
+
+
+# ---------------------------------------------------------------------------
+# Model → provider routing
+# ---------------------------------------------------------------------------
+
+
+def test_provider_for_model_routes_families() -> None:
+    """Claude/GPT/system.ai ids land on their gateway providers."""
+    assert _omp_provider_for_model("databricks-claude-sonnet-4-6") == "databricks-anthropic"
+    assert _omp_provider_for_model("databricks-gpt-5-codex") == "databricks-openai"
+    assert _omp_provider_for_model("my-llama-3") == "databricks-completions"
+
+
+def test_provider_for_model_system_ai_split() -> None:
+    """System models split on Responses capability (GLM/kimi vs plain)."""
+    assert _omp_provider_for_model("system.ai.glm-5") == "databricks-openai"
+    assert _omp_provider_for_model("system.ai.llama-4") == "databricks-mlflow"
+
+
+def test_provider_for_model_generic_wire() -> None:
+    """A generic gateway's configured wire picks the provider, not the id."""
+    assert (
+        _omp_provider_for_model("anything", generic_openai_wire_api="responses")
+        == "databricks-openai"
+    )
+    assert (
+        _omp_provider_for_model("anything", generic_openai_wire_api="chat")
+        == "databricks-completions"
+    )
+
+
+def test_needs_responses_api_catalog_authoritative() -> None:
+    """Catalog wire metadata beats id-substring guessing."""
+    from omnigent.model_metadata import ModelWireAPI
+
+    assert (
+        _omp_needs_responses_api(
+            "system.ai.quiet-llama", frozenset({ModelWireAPI.OPENAI_RESPONSES})
+        )
+        is True
+    )
+    assert (
+        _omp_needs_responses_api("databricks-gpt-legacy", frozenset({ModelWireAPI.OPENAI_CHAT}))
+        is False
+    )
+    # Unknown GPT metadata fails toward Responses (the tool-capable surface).
+    assert _omp_needs_responses_api("databricks-gpt-odd") is True
+
+
+# ---------------------------------------------------------------------------
+# models.yml routing variants
+# ---------------------------------------------------------------------------
+
+
+def _catalog_entry(model_id: str, wire_apis: frozenset) -> Any:
+    from omnigent.model_catalog import ModelEntry
+    from omnigent.model_metadata import ModelMetadata
+
+    return ModelEntry(id=model_id, family="openai", metadata=ModelMetadata(wire_apis=wire_apis))
+
+
+def test_build_models_yml_routes_catalog_models() -> None:
+    """Catalog ids land under the provider their wire metadata selects."""
+    from omnigent.model_metadata import ModelWireAPI
+
+    catalog = [
+        _catalog_entry("claude-x", frozenset({ModelWireAPI.ANTHROPIC_MESSAGES})),
+        _catalog_entry("gpt-x", frozenset({ModelWireAPI.OPENAI_RESPONSES})),
+        _catalog_entry("gpt-old", frozenset({ModelWireAPI.OPENAI_CHAT})),
+        _catalog_entry("system.ai.kimi-z", frozenset({ModelWireAPI.OPENAI_RESPONSES})),
+        _catalog_entry("system.ai.llama-z", frozenset({ModelWireAPI.OPENAI_CHAT})),
+    ]
+    config = _build_models_yml("https://h.example.com/", "tok", catalog_models=catalog)
+    providers = config["providers"]
+    assert [e["id"] for e in providers["databricks-anthropic"]["models"]] == ["claude-x"]
+    assert [e["id"] for e in providers["databricks-openai"]["models"]] == [
+        "gpt-x",
+        "system.ai.kimi-z",
+    ]
+    assert [e["id"] for e in providers["databricks"]["models"]] == ["gpt-old"]
+    assert [e["id"] for e in providers["databricks-mlflow"]["models"]] == ["system.ai.llama-z"]
+    # Host trailing slashes never leak into provider URLs.
+    assert providers["databricks-openai"]["baseUrl"].endswith("/ai-gateway/codex/v1")
+
+
+def test_build_models_yml_generic_provider_uses_one_base_url() -> None:
+    """Non-Databricks gateways (LiteLLM) reuse their base URL on every path."""
+    config = _build_models_yml(
+        "https://unused.example.com",
+        "tok",
+        {"openai": "https://proxy.example.com/v1", "claude": "https://proxy.example.com/v1"},
+        model="proxy-model",
+        openai_wire_api="chat",
+    )
+    providers = config["providers"]
+    assert providers["databricks"]["baseUrl"] == "https://proxy.example.com/v1"
+    assert providers["databricks-openai"]["baseUrl"] == "https://proxy.example.com/v1"
+    # Chat wire + generic provider → completions provider, Bearer auth header.
+    routed = providers["databricks-completions"]["models"]
+    assert [e["id"] for e in routed] == ["proxy-model"]
+    assert providers["databricks-completions"]["authHeader"] is True
+    entry = routed[0]
+    # Dynamically registered models assert image input so omp never silently
+    # drops attached images (the vision-guard checks ``input`` for "image").
+    assert entry["input"] == ["text", "image"]
+
+
+def test_build_models_yml_marks_reasoning_models() -> None:
+    """A dynamically registered reasoning id carries ``reasoning: true``."""
+    config = _build_models_yml("https://h.example.com", "tok", model="deepseek-r1")
+    providers = config["providers"]
+    entry = next(
+        e
+        for provider in providers.values()
+        for e in provider["models"]
+        if e["id"] == "deepseek-r1"
+    )
+    assert entry["reasoning"] is True
+
+
+def test_build_models_yml_no_model_registers_nothing() -> None:
+    """``model=None`` leaves every provider list empty for omp's own default."""
+    config = _build_models_yml("https://h.example.com", "tok")
+    assert all(provider["models"] == [] for provider in config["providers"].values())
+
+
+def test_build_models_yml_skips_unsupported_models() -> None:
+    """Ids ``unsupported_in_pi`` rejects never reach any provider list."""
+    import omnigent.inner.omp_executor as mod
+
+    catalog = [_catalog_entry("some-model", frozenset())]
+    with (
+        patch.object(mod, "unsupported_in_pi", return_value=True),
+        patch.object(
+            mod,
+            "pi_model_json_entry",
+            side_effect=AssertionError("must not build skipped entries"),
+        ),
+    ):
+        config = _build_models_yml("https://h.example.com", "tok", catalog_models=catalog)
+    assert all(provider["models"] == [] for provider in config["providers"].values())
+
+
+# ---------------------------------------------------------------------------
+# Usage extraction + aggregation
+# ---------------------------------------------------------------------------
+
+
+def _assistant_msg(**overrides: Any) -> dict[str, Any]:
+    msg: dict[str, Any] = {
+        "role": "assistant",
+        "model": "databricks-anthropic/wire-model",
+        "usage": {
+            "input": 100,
+            "output": 50,
+            "cacheRead": 1000,
+            "cacheWrite": 200,
+            "totalTokens": 1350,
+        },
+    }
+    msg.update(overrides)
+    return msg
+
+
+def test_extract_usage_maps_wire_shape() -> None:
+    """omp's camelCase ``usage`` maps onto the turn-pricing schema."""
+    usage = _extract_omp_turn_usage(_assistant_msg(), "fallback-model")
+    assert usage is not None
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 50
+    assert usage["total_tokens"] == 1350
+    assert usage["cache_read_input_tokens"] == 1000
+    assert usage["cache_creation_input_tokens"] == 200
+    assert usage["model"] == "databricks-anthropic/wire-model"
+
+
+def test_extract_usage_falls_back_to_configured_model() -> None:
+    """A message without ``model`` prices against the executor's model."""
+    msg = _assistant_msg()
+    del msg["model"]
+    usage = _extract_omp_turn_usage(msg, "fallback-model")
+    assert usage is not None
+    assert usage["model"] == "fallback-model"
+
+
+def test_extract_usage_rejects_non_assistant_or_missing() -> None:
+    """Non-assistant messages, missing usage, and non-dicts yield ``None``."""
+    assert _extract_omp_turn_usage({"role": "user", "usage": {"input": 1}}, "m") is None
+    assert _extract_omp_turn_usage({"role": "assistant"}, "m") is None
+    assert _extract_omp_turn_usage({"role": "assistant", "usage": [1]}, "m") is None
+    assert _extract_omp_turn_usage("not-a-dict", "m") is None
+    # Missing counters default to zero rather than raising.
+    usage = _extract_omp_turn_usage({"role": "assistant", "usage": {}}, "m")
+    assert usage is not None
+    assert usage["input_tokens"] == 0
+
+
+def test_aggregate_usage_sums_calls_last_context() -> None:
+    """Token counts sum across a tool-loop's calls; context is the last call."""
+    first = _extract_omp_turn_usage(_assistant_msg(), "m")
+    second_msg = _assistant_msg(
+        usage={"input": 1300, "output": 60, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 1360}
+    )
+    second = _extract_omp_turn_usage(second_msg, "m")
+    assert first is not None and second is not None
+    turn = _aggregate_omp_turn_usage([first, second], "m")
+    assert turn is not None
+    assert turn["input_tokens"] == 1400
+    assert turn["output_tokens"] == 110
+    assert turn["context_tokens"] == 1360
+
+
+def test_aggregate_usage_empty_or_zero_is_none() -> None:
+    """No captures (or all-zero captures) leave the turn unpriced."""
+    assert _aggregate_omp_turn_usage([], "m") is None
+    zero = _extract_omp_turn_usage({"role": "assistant", "usage": {}}, "m")
+    assert zero is not None
+    assert _aggregate_omp_turn_usage([zero], "m") is None
+
+
+# ---------------------------------------------------------------------------
+# Prompt splitting (multimodal blocks)
+# ---------------------------------------------------------------------------
+
+
+def test_split_prompt_joins_text_blocks() -> None:
+    """Text blocks join into the ``message`` with no images."""
+    message, images = _split_omp_prompt(
+        [
+            {"type": "input_text", "text": "look at this"},
+            {"type": "output_text", "text": "prior reply"},
+        ]
+    )
+    assert message == "look at this\nprior reply"
+    assert images == []
+
+
+def test_split_prompt_routes_data_uri_images() -> None:
+    """Inline data-URI images become native ``images`` entries, not text."""
+    import base64
+
+    payload = base64.b64encode(b"fakepng").decode()
+    message, images = _split_omp_prompt(
+        [
+            {"type": "input_text", "text": "describe"},
+            {"type": "input_image", "image_url": f"data:image/png;base64,{payload}"},
+        ]
+    )
+    assert message == "describe"
+    assert images == [{"type": "image", "data": payload, "mimeType": "image/png"}]
+
+
+def test_split_prompt_rejects_remote_image() -> None:
+    """omp forwards images inline — a URL it cannot fetch fails loudly."""
+    with pytest.raises(ValueError, match="data URI"):
+        _split_omp_prompt([{"type": "input_image", "image_url": "https://x/y.png"}])
+
+
+def test_split_prompt_inlines_text_files_skips_binary() -> None:
+    """Text attachments inline; binary ones skip (omp has no file channel)."""
+    import base64
+
+    text_payload = base64.b64encode(b"file contents here").decode()
+    bin_payload = base64.b64encode(b"\x00\x01").decode()
+    message, images = _split_omp_prompt(
+        [
+            {"type": "input_file", "file_data": f"data:text/plain;base64,{text_payload}"},
+            {"type": "input_file", "file_data": f"data:image/png;base64,{bin_payload}"},
+            {"type": "input_file", "file_data": "already inline text"},
+        ]
+    )
+    assert message == "file contents here\nalready inline text"
+    assert images == []
+
+
+def test_split_prompt_rejects_unknown_block() -> None:
+    """A new block shape fails the turn rather than vanishing silently."""
+    with pytest.raises(ValueError, match="Unsupported content block type"):
+        _split_omp_prompt([{"type": "input_audio", "audio_url": "data:audio/x;base64,AAA"}])
+
+
+# ---------------------------------------------------------------------------
+# Argv redaction
+# ---------------------------------------------------------------------------
+
+
+def test_redact_argv_for_log_hides_system_prompt() -> None:
+    """System-prompt values never reach logs in either argv form."""
+    redacted = _redact_argv_for_log(
+        ["omp", "--mode", "rpc", "--append-system-prompt", "supersecret", "--tools", "read"]
+    )
+    assert redacted == [
+        "omp",
+        "--mode",
+        "rpc",
+        "--append-system-prompt",
+        "[system prompt 11 chars]",
+        "--tools",
+        "read",
+    ]
+    redacted_eq = _redact_argv_for_log(["omp", "--append-system-prompt=topsecret"])
+    assert redacted_eq == ["omp", "--append-system-prompt=[system prompt 9 chars]"]
+
+
+# ---------------------------------------------------------------------------
+# run_turn: tool events, errors, EOF, late failures, unknown frames
+# ---------------------------------------------------------------------------
+
+
+def _drive(
+    executor: OmpExecutor,
+    rpc: _OmpRpcSession,
+    *,
+    tools: list | None = None,
+    config: Any = None,
+    messages: list | None = None,
+) -> list[Any]:
+    async def fake_ensure_rpc(*args: Any, **kwargs: Any) -> _OmpRpcSession:
+        return rpc
+
+    executor._ensure_rpc = fake_ensure_rpc  # type: ignore[method-assign]
+
+    async def _collect():
+        return [
+            event
+            async for event in executor.run_turn(
+                messages if messages is not None else [{"role": "user", "content": "hello"}],
+                tools if tools is not None else [],
+                "system",
+                config,
+            )
+        ]
+
+    return _run(_collect())
+
+
+def _agent_end(messages: list | None = None, **fields: Any) -> str:
+    import json as _json
+
+    event: dict[str, Any] = {"type": "agent_end", "messages": messages or []}
+    event.update(fields)
+    return _json.dumps(event)
+
+
+def test_tool_call_success_round_trip() -> None:
+    """Tool start/end events surface as request + success completion."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {"type": "tool_execution_start", "toolName": "calculate", "args": {"x": 1}}
+            ),
+            _json.dumps(
+                {
+                    "type": "tool_execution_end",
+                    "toolName": "calculate",
+                    "isError": False,
+                    "result": {"value": 3},
+                }
+            ),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[0], ToolCallRequest)
+    assert events[0].name == "calculate"
+    assert events[0].args == {"x": 1}
+    assert isinstance(events[1], ToolCallComplete)
+    assert events[1].status == ToolCallStatus.SUCCESS
+    assert events[1].result == {"value": 3}
+    assert isinstance(events[2], TurnComplete)
+
+
+def test_tool_call_non_dict_args_become_empty() -> None:
+    """Malformed tool args never crash the turn — they degrade to ``{}``."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps({"type": "tool_execution_start", "toolName": "t", "args": [1, 2]}),
+            _json.dumps({"type": "tool_execution_end", "toolName": "t", "result": "ok"}),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[0], ToolCallRequest)
+    assert events[0].args == {}
+
+
+def test_tool_call_error_status() -> None:
+    """A natively errored tool completes as ERROR with the result text."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "tool_execution_end",
+                    "toolName": "bash",
+                    "isError": True,
+                    "result": "boom",
+                }
+            ),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[0], ToolCallComplete)
+    assert events[0].status == ToolCallStatus.ERROR
+    assert events[0].error == "boom"
+
+
+def test_tool_call_blocked_forms() -> None:
+    """Policy-blocked results map to BLOCKED in every envelope the bridge emits."""
+    import json as _json
+
+    cases = [
+        # Direct dict from the tool server.
+        {"blocked": True, "reason": "denied-direct"},
+        # Wrapped in MCP content text by the extension.
+        {
+            "content": [
+                {"type": "text", "text": _json.dumps({"blocked": True, "reason": "denied-wrap"})}
+            ]
+        },
+        # Bare JSON string.
+        _json.dumps({"blocked": True, "reason": "denied-str"}),
+    ]
+    for result in cases:
+        executor = _make_executor()
+        rpc = _scripted_session(
+            [
+                _json.dumps(
+                    {
+                        "type": "tool_execution_end",
+                        "toolName": "read",
+                        "isError": True,
+                        "result": result,
+                    }
+                ),
+                _agent_end(),
+            ]
+        )
+        events = _drive(executor, rpc)
+        assert isinstance(events[0], ToolCallComplete)
+        assert events[0].status == ToolCallStatus.BLOCKED
+        assert "denied" in (events[0].error or "")
+
+
+def test_tool_error_inside_result_dict_counts() -> None:
+    """``result.isError`` alone (no top-level flag) still marks ERROR."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "tool_execution_end",
+                    "toolName": "edit",
+                    "result": {"isError": True, "detail": "nope"},
+                }
+            ),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[0], ToolCallComplete)
+    assert events[0].status == ToolCallStatus.ERROR
+
+
+def test_message_end_error_drains_to_agent_end() -> None:
+    """An errored LLM call reports only after the terminal ``agent_end`` drains."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "stopReason": "error",
+                        "errorMessage": "provider exploded",
+                    },
+                }
+            ),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "provider exploded" in events[0].message
+
+
+def test_message_end_aborted_fails_fast() -> None:
+    """An aborted call ends the turn immediately (no drain wait)."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {"role": "assistant", "stopReason": "aborted"},
+                }
+            ),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+
+
+def test_message_end_usage_sums_into_turn() -> None:
+    """Per-call ``message_end`` usage aggregates onto the TurnComplete."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "hi"},
+                }
+            ),
+            _json.dumps({"type": "message_end", "message": _assistant_msg()}),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    complete = events[-1]
+    assert isinstance(complete, TurnComplete)
+    assert complete.response == "hi"
+    assert complete.usage is not None
+    assert complete.usage["input_tokens"] == 100
+
+
+def test_eof_without_response_is_error_with_stderr() -> None:
+    """A dead process with no text surfaces stderr for diagnosis."""
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    rpc._stderr_lines = ["FATAL: something broke"]
+    with patch.object(omp_mod, "_TURN_STDOUT_IDLE_TIMEOUT_S", 0.01):
+        events = _drive(executor, rpc)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "something broke" in events[0].message
+
+
+def test_late_prompt_scheduling_error_fails_turn() -> None:
+    """Upstream may report async prompt-scheduling failure on the prompt id."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps({"type": "response", "command": "prompt", "success": True}),
+            _json.dumps(
+                {
+                    "type": "response",
+                    "command": "prompt",
+                    "success": False,
+                    "error": "session is streaming",
+                }
+            ),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "session is streaming" in events[0].message
+
+
+def test_ack_invoked_true_waits_for_agent_end() -> None:
+    """``agentInvoked: true`` is not a completion — the turn ends at ``agent_end``."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "response",
+                    "command": "prompt",
+                    "success": True,
+                    "data": {"agentInvoked": True},
+                }
+            ),
+            _json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "late"},
+                }
+            ),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[-1], TurnComplete)
+    assert events[-1].response == "late"
+
+
+def test_future_frames_are_ignored() -> None:
+    """Frames the executor does not consume never wedge the loop."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps({"type": "ready", "protocolVersion": 1}),
+            _json.dumps({"type": "extension_ui_request", "id": "w1", "method": "setWidget"}),
+            _json.dumps({"type": "available_commands_update", "commands": []}),
+            _json.dumps({"type": "rpc_frame_error", "error": "overflow elsewhere"}),
+            _json.dumps({"type": "turn_start"}),
+            _json.dumps({"type": "notice", "level": "info", "message": "hi"}),
+            _json.dumps({"type": "thinking_level_changed"}),
+            "not json at all",
+            _json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "ok"},
+                }
+            ),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[-1], TurnComplete)
+    assert events[-1].response == "ok"
+
+
+def test_thinking_deltas_stay_out_of_response() -> None:
+    """Reasoning streams as ``ReasoningChunk`` and never pollutes the reply."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {"type": "message_update", "assistantMessageEvent": {"type": "thinking_start"}}
+            ),
+            _json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "thinking_delta", "delta": "hmm"},
+                }
+            ),
+            _json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "done"},
+                }
+            ),
+            _agent_end(),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[0], ReasoningChunk)
+    assert isinstance(events[1], ReasoningChunk)
+    assert isinstance(events[2], TextChunk)
+    assert isinstance(events[3], TurnComplete)
+    assert events[1].delta == "hmm"
+    assert events[-1].response == "done"
+
+
+def test_agent_end_text_fallback() -> None:
+    """Unstreamed turns recover text from the ``agent_end`` message list."""
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _agent_end(
+                [
+                    {"role": "user", "content": "q"},
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "fallback reply"}],
+                    },
+                ]
+            ),
+        ]
+    )
+    events = _drive(executor, rpc)
+    assert isinstance(events[-1], TurnComplete)
+    assert events[-1].response == "fallback reply"
+
+
+def test_invalid_effort_fails_turn_without_spawn() -> None:
+    """An unsupported effort is a turn error, never a doomed subprocess."""
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    config = ExecutorConfig(extra={"reasoning_effort": "bogus-level"})
+    events = _drive(executor, rpc, config=config)
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "bogus-level" in events[0].message
+    # No prompt was ever sent — the turn died before session setup.
+    assert rpc.process.stdin.data == []
+
+
+# ---------------------------------------------------------------------------
+# Thinking resolution + application
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_from_config_maps_efforts() -> None:
+    """Canonical efforts translate to omp's vocabulary; clears resolve to None."""
+    assert _omp_thinking_from_config(None) is None
+    assert _omp_thinking_from_config(ExecutorConfig()) is None
+    assert _omp_thinking_from_config(ExecutorConfig(extra={"reasoning_effort": "off"})) is None
+    assert _omp_thinking_from_config(ExecutorConfig(extra={"reasoning_effort": "high"})) == "high"
+    assert _omp_thinking_from_config(ExecutorConfig(extra={"reasoning_effort": "none"})) == "off"
+    assert _omp_thinking_from_config(ExecutorConfig(extra={"reasoning_effort": "ultra"})) == "max"
+    with pytest.raises(ValueError, match="bogus"):
+        _omp_thinking_from_config(ExecutorConfig(extra={"reasoning_effort": "bogus"}))
+
+
+def _sent_commands(rpc: _OmpRpcSession) -> list[dict]:
+    import json as _json
+
+    return [_json.loads(chunk.decode()) for chunk in rpc.process.stdin.data]
+
+
+def test_apply_thinking_skips_when_cleared() -> None:
+    """``thinking=None`` leaves a live session untouched (no probe, no RPC)."""
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    state = _OmpSessionState()
+    with patch.object(
+        executor, "_available_thinking_levels", side_effect=AssertionError("no probe")
+    ):
+        _run(executor._apply_thinking_level(state, rpc, None, spawned=False))
+    assert _sent_commands(rpc) == []
+
+
+def test_apply_thinking_spawned_same_level_sends_nothing() -> None:
+    """A fresh spawn already carries ``--thinking`` — only the probe runs."""
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    state = _OmpSessionState(applied_thinking="high")
+    with patch.object(executor, "_available_thinking_levels", return_value=None):
+        _run(executor._apply_thinking_level(state, rpc, "high", spawned=True))
+    assert _sent_commands(rpc) == []
+
+
+def test_apply_thinking_live_change_sends_level() -> None:
+    """A changed level on a live session issues ``set_thinking_level``."""
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    state = _OmpSessionState(applied_thinking="low")
+    with patch.object(executor, "_available_thinking_levels", return_value=None):
+        _run(executor._apply_thinking_level(state, rpc, "high", spawned=False))
+    commands = _sent_commands(rpc)
+    assert commands == [{"type": "set_thinking_level", "level": "high", "id": "thinking_high"}]
+    assert state.applied_thinking == "high"
+
+
+def test_apply_thinking_clamps_to_supported_rung() -> None:
+    """An unsupported rung clamps down and warns instead of 400ing the turn."""
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    state = _OmpSessionState(applied_thinking="low")
+    with patch.object(executor, "_available_thinking_levels", return_value=["low"]):
+        _run(executor._apply_thinking_level(state, rpc, "high", spawned=False))
+    commands = _sent_commands(rpc)
+    assert commands == [{"type": "set_thinking_level", "level": "low", "id": "thinking_low"}]
+    # Records the request so a repeat turn does not re-warn.
+    assert state.applied_thinking == "high"
+
+
+def test_available_levels_probe_failure_means_unclamped() -> None:
+    """omp answers the probe with ``success: false`` — levels stay ``None``."""
+    import json as _json
+
+    executor = _make_executor()
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "response",
+                    "command": "get_available_thinking_levels",
+                    "success": False,
+                    "error": "Unknown command: get_available_thinking_levels",
+                }
+            )
+        ]
+    )
+    assert _run(executor._available_thinking_levels(rpc)) is None
+
+
+# ---------------------------------------------------------------------------
+# Session messaging: steer, interrupt, close
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_steers_live_session() -> None:
+    """Steering text reaches the in-flight turn via the ``steer`` command."""
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    executor._session_states["k"] = _OmpSessionState(rpc=rpc)
+    assert _run(executor.enqueue_session_message("k", "wait, use tabs")) is True
+    assert _sent_commands(rpc) == [{"type": "steer", "message": "wait, use tabs"}]
+
+
+def test_enqueue_without_session_is_false() -> None:
+    """Steering with no live session (or dead process) reports failure."""
+    executor = _make_executor()
+    assert _run(executor.enqueue_session_message("missing", "hi")) is False
+    rpc = _scripted_session([])
+    rpc.process = None
+    executor._session_states["dead"] = _OmpSessionState(rpc=rpc)
+    assert _run(executor.enqueue_session_message("dead", "hi")) is False
+
+
+def test_interrupt_aborts_and_drops_session() -> None:
+    """Interrupt aborts the turn and drops state so the next turn replays history."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_executor()
+    rpc = _scripted_session([])
+    rpc.process.wait = AsyncMock(return_value=0)
+    executor._session_states["k"] = _OmpSessionState(rpc=rpc)
+    stdin = rpc.process.stdin
+    assert _run(executor.interrupt_session("k")) is True
+    import json as _json
+
+    assert [_json.loads(chunk.decode()) for chunk in stdin.data] == [
+        {"type": "abort", "id": "abort"}
+    ]
+    assert "k" not in executor._session_states
+
+
+def test_interrupt_without_session_is_false() -> None:
+    """Interrupting nothing is a no-op ``False``, not an error."""
+    executor = _make_executor()
+    assert _run(executor.interrupt_session("missing")) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_env_and_dir: bridge, tools allowlist, retry settings, gateway files
+# ---------------------------------------------------------------------------
+
+
+def _tool(name: str) -> dict:
+    return {"name": name, "description": f"{name} tool", "parameters": {"type": "object"}}
+
+
+def test_env_and_dir_writes_bridge_and_allowlists_read() -> None:
+    """Bridged tools register via ``--extension`` and re-enable under ``--tools``."""
+    executor = _make_executor()
+    config = executor._build_env_and_dir([_tool("calculate")], 54321, "tok", None)
+    try:
+        ext = next(a for a in config.extra_args if a.endswith("omnigent_tools.mjs"))
+        with open(ext) as f:
+            js = f.read()
+        assert "calculate" in js
+        assert "tok" in js
+        tools_idx = config.extra_args.index("--tools")
+        allowlisted = config.extra_args[tools_idx + 1].split(",")
+        # Bridged names plus native ``read`` (skill-index injection needs it).
+        assert "calculate" in allowlisted
+        assert "read" in allowlisted
+        assert "--no-tools" in config.extra_args
+    finally:
+        import shutil
+
+        shutil.rmtree(config.tmp_dir, ignore_errors=True)
+
+
+def test_env_and_dir_skills_none_omits_read() -> None:
+    """``skills: none`` suppresses discovery — ``read`` stays out of ``--tools``."""
+    executor = _make_executor(skills_filter="none")
+    assert "--no-skills" in executor._extra_args
+    config = executor._build_env_and_dir([_tool("calculate")], 54321, "tok", None)
+    try:
+        tools_idx = config.extra_args.index("--tools")
+        assert config.extra_args[tools_idx + 1].split(",") == ["calculate"]
+    finally:
+        import shutil
+
+        shutil.rmtree(config.tmp_dir, ignore_errors=True)
+
+
+def test_env_and_dir_no_tools_means_no_bridge() -> None:
+    """A tool-less turn spawns no extension and no ``--tools`` flag."""
+    executor = _make_executor()
+    config = executor._build_env_and_dir([], None, None, None)
+    try:
+        assert not [a for a in config.extra_args if a.endswith(".mjs")]
+        assert "--tools" not in config.extra_args
+    finally:
+        import shutil
+
+        shutil.rmtree(config.tmp_dir, ignore_errors=True)
+
+
+def test_env_and_dir_port_without_token_is_loud() -> None:
+    """A port with no token would bridge unauthenticated — refuse instead."""
+    executor = _make_executor()
+    with pytest.raises(ValueError, match="tool_server_token"):
+        executor._build_env_and_dir([_tool("calculate")], 54321, None, None)
+
+
+def test_env_and_dir_merges_retry_into_project_settings(tmp_path) -> None:
+    """Retry budgets merge into ``<cwd>/.omp/settings.json``, keeping user keys."""
+    import json as _json
+
+    settings_path = tmp_path / ".omp" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(_json.dumps({"custom": True}))
+    executor = _make_executor(cwd=str(tmp_path))
+    config = executor._build_env_and_dir([], None, None, None)
+    try:
+        merged = _json.loads(settings_path.read_text())
+        assert merged["custom"] is True
+        assert merged["retry"]["enabled"] is True
+        assert merged["retry"]["maxRetries"] >= 0
+    finally:
+        import shutil
+
+        shutil.rmtree(config.tmp_dir, ignore_errors=True)
+
+
+def _make_gateway_executor(**kwargs: Any) -> OmpExecutor:
+    """Gateway executor with Databricks credentials stubbed (no network)."""
+    from omnigent.inner.databricks_executor import DatabricksCredentials
+
+    with (
+        patch.object(omp_mod, "_omp_supports_auto_approve", return_value=False),
+        patch.object(
+            omp_mod,
+            "_read_databrickscfg",
+            return_value=DatabricksCredentials(host="https://h.example.com", token="tok"),
+        ),
+    ):
+        return OmpExecutor(omp_path="/fake/omp", gateway=True, **kwargs)
+
+
+def test_env_and_dir_gateway_writes_models_yml() -> None:
+    """Gateway runs relocate the agent dir and point omp at ``models.yml``."""
+    import yaml as _yaml
+
+    executor = _make_gateway_executor()
+    config = executor._build_env_and_dir([], None, None, "my-claude-x")
+    try:
+        assert config.env["PI_CODING_AGENT_DIR"] == config.tmp_dir
+        models_path = f"{config.tmp_dir}/models.yml"
+        with open(models_path) as f:
+            models = _yaml.safe_load(f)
+        assert models["providers"]["databricks-anthropic"]["apiKey"] == "tok"
+        routed = [e["id"] for provider in models["providers"].values() for e in provider["models"]]
+        assert "my-claude-x" in routed
+    finally:
+        import shutil
+
+        shutil.rmtree(config.tmp_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_rpc: model qualification, reuse, respawn
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_rpc_qualifies_gateway_model() -> None:
+    """Gateway models launch as ``provider/model`` selectors omp can resolve."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_gateway_executor()
+    starter = AsyncMock()
+    with (
+        patch.object(omp_mod._OmpRpcSession, "start", starter),
+        patch.object(OmpExecutor, "_load_gateway_model_wire_apis", new=AsyncMock(return_value={})),
+    ):
+        rpc = _run(executor._ensure_rpc("s", "sys", "my-claude-x", [], None))
+    assert starter.call_count == 1
+    assert starter.call_args.kwargs["model"] == "databricks-anthropic/my-claude-x"
+    assert rpc._tmp_dir is not None
+    import shutil
+
+    shutil.rmtree(rpc._tmp_dir, ignore_errors=True)
+
+
+def test_ensure_rpc_passes_through_qualified_selector() -> None:
+    """An already-qualified selector is not stacked to ``provider/provider/id``."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_gateway_executor()
+    starter = AsyncMock()
+    with (
+        patch.object(omp_mod._OmpRpcSession, "start", starter),
+        patch.object(OmpExecutor, "_load_gateway_model_wire_apis", new=AsyncMock(return_value={})),
+    ):
+        _run(executor._ensure_rpc("s", "sys", "databricks-anthropic/my-claude-x", [], None))
+    assert starter.call_args.kwargs["model"] == "databricks-anthropic/my-claude-x"
+
+
+def test_ensure_rpc_reroutes_mismatched_qualifier() -> None:
+    """A qualifier for the wrong provider defers to routing, not the typo."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_gateway_executor()
+    starter = AsyncMock()
+    with (
+        patch.object(omp_mod._OmpRpcSession, "start", starter),
+        patch.object(OmpExecutor, "_load_gateway_model_wire_apis", new=AsyncMock(return_value={})),
+    ):
+        _run(executor._ensure_rpc("s", "sys", "databricks/my-claude-x", [], None))
+    assert starter.call_args.kwargs["model"] == "databricks-anthropic/databricks/my-claude-x"
+
+
+def test_ensure_rpc_reuses_live_session() -> None:
+    """Same prompt + model reuses the process instead of respawning."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_executor()
+    starter = AsyncMock()
+    with patch.object(omp_mod._OmpRpcSession, "start", starter):
+        first = _run(executor._ensure_rpc("s", "sys", None, [], None))
+        # The mocked ``start`` never assigns a process; simulate the live one
+        # or the reuse check (``process.returncode is None``) respawns.
+        first.process = MagicMock()
+        first.process.returncode = None
+        first.process.wait = AsyncMock(return_value=0)
+        second = _run(executor._ensure_rpc("s", "sys", None, [], None))
+    assert first is second
+    assert starter.call_count == 1
+    _run(first.close())
+
+
+def test_ensure_rpc_respawns_on_model_change() -> None:
+    """A model change drops the old process and starts a fresh one."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_executor()
+    starter = AsyncMock()
+    with patch.object(omp_mod._OmpRpcSession, "start", starter):
+        first = _run(executor._ensure_rpc("s", "sys", "model-a", [], None))
+        second = _run(executor._ensure_rpc("s", "sys", "model-b", [], None))
+    assert first is not second
+    assert starter.call_count == 2
+    assert first.process is None  # closed on respawn
+
+
+# ---------------------------------------------------------------------------
+# _resolve_model: overrides, gateway strip, discovery
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_prefers_request_override() -> None:
+    """Per-request ``/model`` beats the spec default."""
+    executor = _make_executor(model="spec-model")
+    assert _run(executor._resolve_model(ExecutorConfig(model="req-model"))) == "req-model"
+    assert _run(executor._resolve_model(None)) == "spec-model"
+
+
+def test_resolve_model_strips_bracket_suffix_on_gateway() -> None:
+    """``[1m]`` context hints die before the gateway (it rejects them)."""
+    executor = _make_gateway_executor(model="my-claude-x[1m]")
+    assert _run(executor._resolve_model(None)) == "my-claude-x"
+
+
+def test_resolve_model_keeps_bracket_suffix_off_gateway() -> None:
+    """Direct-provider runs pass the id through untouched."""
+    executor = _make_executor(model="my-claude-x[1m]")
+    assert _run(executor._resolve_model(None)) == "my-claude-x[1m]"
+
+
+def test_resolve_model_discovers_databricks_default() -> None:
+    """No pinned model on the profile path resolves the live Claude default."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_gateway_executor()
+    with patch.object(omp_mod, "run_sync_on_thread", new=AsyncMock(return_value="live-claude")):
+        assert _run(executor._resolve_model(None)) == "live-claude"
+
+
+def test_resolve_model_rejects_non_string_discovery() -> None:
+    """A corrupt discovery result fails loudly instead of spawning blind."""
+    from unittest.mock import AsyncMock
+
+    executor = _make_gateway_executor()
+    with patch.object(omp_mod, "run_sync_on_thread", new=AsyncMock(return_value=123)):
+        with pytest.raises(TypeError, match="non-string"):
+            _run(executor._resolve_model(None))
+
+
+# ---------------------------------------------------------------------------
+# _OmpRpcSession.request: correlation + line requeue
+# ---------------------------------------------------------------------------
+
+
+def test_request_requeues_unrelated_lines_in_order() -> None:
+    """Lines arriving before the awaited response are deferred, not dropped."""
+    import json as _json
+
+    rpc = _scripted_session(
+        [
+            _json.dumps(
+                {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "x"},
+                }
+            ),
+            _json.dumps({"type": "response", "command": "other", "success": True}),
+            _json.dumps(
+                {
+                    "type": "response",
+                    "command": "wanted",
+                    "success": True,
+                    "data": {"level": "high"},
+                }
+            ),
+        ]
+    )
+
+    async def _call():
+        return await rpc.request({"type": "wanted", "id": "w1"}, "wanted", timeout=1.0)
+
+    response = _run(_call())
+    assert response is not None
+    assert response["data"] == {"level": "high"}
+    # The prompt command went out on stdin; deferred lines came back in order.
+    assert _run(rpc.read_line(timeout=1.0)) is not None
+    assert _run(rpc.read_line(timeout=1.0)) is not None

--- a/tests/inner/test_omp_harness.py
+++ b/tests/inner/test_omp_harness.py
@@ -1,0 +1,426 @@
+"""
+Tests for the ``harness: omp`` wrap shape.
+
+Mirror of ``tests/inner/test_codex_harness.py`` and
+``tests/inner/test_claude_sdk_harness.py`` — verifies the wrap
+module has the same shape (registry entry, FastAPI app routes,
+env-var-driven lazy executor construction). Does NOT exercise
+the real omp CLI; the inner ``OmpExecutor.__init__`` is mocked so
+the tests pass without a ``omp`` binary on PATH.
+
+End-to-end pi verification (real CLI, real API) lives in the
+e2e suite, gated on the binary being available.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from omnigent.inner import omp_harness
+from omnigent.runtime.harnesses import _HARNESS_MODULES
+
+
+def test_harness_module_registered_in_module_registry() -> None:
+    """``"omp"`` resolves to the harness module path.
+
+    Without this entry, the runner subprocess can't find the wrap
+    when AP-side tries to spawn it for a ``harness: omp`` spec.
+    """
+    assert _HARNESS_MODULES.get("omp") == "omnigent.inner.omp_harness"
+
+
+def test_create_app_returns_fastapi_with_required_routes() -> None:
+    """``create_app()`` returns a FastAPI app exposing the harness API.
+
+    Verifies the wrap successfully:
+    - Imports the executor adapter + omp executor module.
+    - Builds the FastAPI app via ExecutorAdapter.build().
+    - Mounts the standard harness routes.
+
+    The actual OmpExecutor is constructed lazily on the first
+    turn (not at app build time), so this test passes without
+    a real ``omp`` CLI on PATH.
+    """
+    app = omp_harness.create_app()
+    paths = {route.path for route in app.routes}  # type: ignore[attr-defined]
+    # Session-keyed harness API: liveness probe + single
+    # discriminated-event endpoint per §The Harness API Subset.
+    assert "/health" in paths
+    assert "/v1/sessions/{conversation_id}/events" in paths
+
+
+def test_executor_factory_reads_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory passes env-var values through to OmpExecutor.
+
+    Locks in the v1 config-flow contract: env vars set in AP's
+    process before spawning the subprocess (which inherits
+    them) are how the wrap learns its config. Verifies model,
+    databricks, profile, cwd, omp_path all thread through.
+    """
+    monkeypatch.setenv("HARNESS_OMP_MODEL", "test-model-id")
+    monkeypatch.setenv("HARNESS_OMP_GATEWAY", "true")
+    monkeypatch.setenv("HARNESS_OMP_DATABRICKS_PROFILE", "test-profile")
+    monkeypatch.setenv("HARNESS_OMP_GATEWAY_HOST", "https://example.databricks.com")
+    monkeypatch.setenv(
+        "HARNESS_OMP_GATEWAY_BASE_URL",
+        "https://example.databricks.com/ai-gateway/anthropic",
+    )
+    monkeypatch.setenv(
+        "HARNESS_OMP_GATEWAY_BASE_URLS",
+        json.dumps(
+            {
+                "claude": "https://example.databricks.com/ai-gateway/anthropic",
+                "openai": "https://example.databricks.com/ai-gateway/codex/v1",
+            }
+        ),
+    )
+    monkeypatch.setenv("HARNESS_OMP_GATEWAY_OPENAI_WIRE_API", "responses")
+    monkeypatch.setenv("HARNESS_OMP_GATEWAY_AUTH_COMMAND", "printf token")
+    monkeypatch.setenv("HARNESS_OMP_CWD", "/tmp/test-cwd")
+    # Unlike pi there is no legacy ``HARNESS_OMP_PATH`` alias: a stale
+    # deprecated-style var must NOT resolve — only ``OMNIGENT_OMP_PATH``
+    # (deleted here) or PATH discovery.
+    monkeypatch.setenv("HARNESS_OMP_PATH", "/usr/local/bin/omp")
+    monkeypatch.delenv("OMNIGENT_OMP_PATH", raising=False)
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(
+        self: Any,
+        *,
+        cwd: str | None,
+        os_env: Any,
+        model: str | None,
+        omp_path: str | None,
+        gateway: bool,
+        databricks_profile: str | None,
+        gateway_host: str | None,
+        base_url_override: str | None,
+        base_urls_override: dict[str, str] | None,
+        openai_wire_api: str | None,
+        gateway_auth_command: str | None,
+        **_kwargs: Any,
+    ) -> None:
+        captured["cwd"] = cwd
+        captured["os_env"] = os_env
+        captured["model"] = model
+        captured["omp_path"] = omp_path
+        captured["gateway"] = gateway
+        captured["databricks_profile"] = databricks_profile
+        captured["gateway_host"] = gateway_host
+        captured["base_url_override"] = base_url_override
+        captured["base_urls_override"] = base_urls_override
+        captured["openai_wire_api"] = openai_wire_api
+        captured["gateway_auth_command"] = gateway_auth_command
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    # Each env var threaded through to the corresponding
+    # constructor kwarg.
+    assert captured["model"] == "test-model-id"
+    assert captured["gateway"] is True
+    assert captured["databricks_profile"] == "test-profile"
+    assert captured["gateway_host"] == "https://example.databricks.com"
+    assert captured["base_url_override"] == "https://example.databricks.com/ai-gateway/anthropic"
+    assert captured["base_urls_override"] == {
+        "claude": "https://example.databricks.com/ai-gateway/anthropic",
+        "openai": "https://example.databricks.com/ai-gateway/codex/v1",
+    }
+    assert captured["openai_wire_api"] == "responses"
+    assert captured["gateway_auth_command"] == "printf token"
+    assert captured["cwd"] == "/tmp/test-cwd"
+    assert captured["omp_path"] is None
+    # Default os_env when no HARNESS_OMP_OS_ENV is set: the
+    # parity-preserving caller_process + sandbox=none.
+    os_env_value = captured["os_env"]
+    assert os_env_value is not None
+    assert os_env_value.type == "caller_process"
+    assert os_env_value.sandbox is not None
+    assert os_env_value.sandbox.type == "none"
+
+
+def test_executor_factory_uses_omnigient_omp_path_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``OMNIGENT_OMP_PATH`` resolves as the omp CLI override."""
+    monkeypatch.setenv("OMNIGENT_OMP_PATH", "/custom/omp")
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    assert captured["omp_path"] == "/custom/omp"
+
+
+def test_executor_factory_decodes_os_env_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HARNESS_OMP_OS_ENV`` decodes into the inner OSEnvSpec.
+
+    Omnigent serializes ``spec.os_env`` via :func:`dataclasses.asdict`
+    and JSON-encodes the result; the wrap must reconstruct an
+    :class:`OSEnvSpec` (with nested sandbox spec) so
+    :class:`OmpExecutor` sees the same config a non-AP mode
+    invocation would.
+    """
+    import json
+
+    monkeypatch.setenv(
+        "HARNESS_OMP_OS_ENV",
+        json.dumps(
+            {
+                "type": "caller_process",
+                "cwd": "/tmp/projected-cwd",
+                "sandbox": {
+                    "type": "linux_bwrap",
+                    "read_paths": ["/srv/data"],
+                    "write_paths": None,
+                    "write_files": None,
+                    "allow_network": False,
+                },
+                "fork": False,
+            }
+        ),
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured["os_env"] = kwargs["os_env"]
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    os_env_value = captured["os_env"]
+    assert os_env_value is not None
+    assert os_env_value.cwd == "/tmp/projected-cwd"
+    assert os_env_value.sandbox is not None
+    assert os_env_value.sandbox.type == "linux_bwrap"
+    assert os_env_value.sandbox.allow_network is False
+    assert os_env_value.sandbox.read_paths == ["/srv/data"]
+
+
+def test_executor_factory_falls_back_on_malformed_os_env_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed ``HARNESS_OMP_OS_ENV`` falls back to default.
+
+    A malformed payload should NOT crash the wrap — that would
+    bring the whole subprocess down on first turn. The wrap
+    instead logs a warning and defaults to the parity-preserving
+    ``caller_process + sandbox=none``.
+    """
+    monkeypatch.setenv("HARNESS_OMP_OS_ENV", "{this-is-not-json")
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured["os_env"] = kwargs["os_env"]
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    os_env_value = captured["os_env"]
+    assert os_env_value is not None
+    assert os_env_value.type == "caller_process"
+    assert os_env_value.sandbox is not None
+    assert os_env_value.sandbox.type == "none"
+
+
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("0", False),
+        ("false", False),
+        ("", False),
+        ("anything else", False),
+    ],
+)
+def test_databricks_env_var_truthy_parsing(
+    raw_value: str,
+    expected: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HARNESS_OMP_GATEWAY`` parses truthy strings only.
+
+    Mirrors the claude-sdk and codex wraps' parsers so operators
+    learn ONE set of truthy conventions, not five.
+    """
+    monkeypatch.setenv("HARNESS_OMP_GATEWAY", raw_value)
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    assert captured["gateway"] is expected
+
+
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ('"all"', "all"),
+        ('"none"', "none"),
+        ('["alpha"]', ["alpha"]),
+        ('["alpha","beta","gamma"]', ["alpha", "beta", "gamma"]),
+    ],
+)
+def test_skills_filter_env_var_decodes(
+    raw_value: str,
+    expected: str | list[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HARNESS_OMP_SKILLS_FILTER`` decodes JSON into ``str`` or
+    ``list[str]``.
+
+    Mirrors the claude-sdk and codex env-var bridges. Without
+    this bridge the harness wrap falls back to the constructor's
+    ``"all"`` default and silently overrides explicit
+    ``skills: none`` from the spec — same regression that
+    prompted the original bridge work.
+    """
+    monkeypatch.setenv("HARNESS_OMP_SKILLS_FILTER", raw_value)
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    assert captured["skills_filter"] == expected
+
+
+def test_skills_filter_env_var_missing_falls_back_to_all(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing ``HARNESS_OMP_SKILLS_FILTER`` defaults to ``"all"``."""
+    monkeypatch.delenv("HARNESS_OMP_SKILLS_FILTER", raising=False)
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    assert captured["skills_filter"] == "all"
+
+
+def test_bundle_dir_and_agent_name_env_vars_thread_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HARNESS_OMP_BUNDLE_DIR`` / ``_AGENT_NAME`` reach the inner
+    executor.
+
+    Bundle dir gates the omp resolver's bundle source — without it
+    the agent-shipped skills are invisible to the executor, so
+    ``"all"`` and named-list cases would silently drop them.
+    """
+    from pathlib import Path
+
+    monkeypatch.setenv("HARNESS_OMP_BUNDLE_DIR", "/tmp/fake/pi/bundle")
+    monkeypatch.setenv("HARNESS_OMP_AGENT_NAME", "my_omp_agent")
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    assert captured["bundle_dir"] == Path("/tmp/fake/pi/bundle")
+    assert captured["agent_name"] == "my_omp_agent"
+
+
+def test_bundle_dir_unset_passes_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing ``HARNESS_OMP_BUNDLE_DIR`` resolves to ``None``,
+    not ``Path("")`` — a bogus path would crash the resolver."""
+    monkeypatch.delenv("HARNESS_OMP_BUNDLE_DIR", raising=False)
+    monkeypatch.delenv("HARNESS_OMP_AGENT_NAME", raising=False)
+    captured: dict[str, Any] = {}
+
+    def _fake_init(self: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    with patch(
+        "omnigent.inner.omp_harness.OmpExecutor.__init__",
+        _fake_init,
+    ):
+        omp_harness._build_omp_executor()
+
+    assert captured["bundle_dir"] is None
+    assert captured["agent_name"] is None
+
+
+@pytest.mark.parametrize(
+    "raw_value, expected",
+    [
+        ("", None),
+        ("{not-json", None),
+        ("[1, 2]", None),
+        ('"just-a-string"', None),
+        ('{"claude": 123}', {}),
+        (
+            '{"claude": "https://a.example.com", "openai": 42}',
+            {"claude": "https://a.example.com"},
+        ),
+    ],
+)
+def test_gateway_base_urls_rejects_bad_shapes(
+    raw_value: str,
+    expected: dict[str, str] | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed ``HARNESS_OMP_GATEWAY_BASE_URLS`` degrades, never crashes.
+
+    Non-object JSON and non-string URLs cannot drive the models.yml writer,
+    so they resolve to ``None`` (unset) or drop the bad entries — the
+    executor then falls back to workspace-derived defaults.
+    """
+    if raw_value:
+        monkeypatch.setenv("HARNESS_OMP_GATEWAY_BASE_URLS", raw_value)
+    else:
+        monkeypatch.delenv("HARNESS_OMP_GATEWAY_BASE_URLS", raising=False)
+    assert omp_harness._resolve_gateway_base_urls() == expected

--- a/tests/inner/test_omp_settings.py
+++ b/tests/inner/test_omp_settings.py
@@ -1,0 +1,87 @@
+"""Tests for managed omp agent dir seeding (extensions / packages)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from omnigent.inner.pi_settings import prepare_managed_omp_agent_dir
+
+
+def test_prepare_managed_omp_agent_dir_copies_settings_and_symlinks_npm(
+    tmp_path: Path,
+) -> None:
+    """Gateway managed dir gets global settings metadata and npm install tree."""
+    global_agent = tmp_path / "global-agent"
+    global_agent.mkdir()
+    (global_agent / "settings.json").write_text(
+        json.dumps(
+            {
+                "extensions": ["/tmp/my-ext.ts"],
+                "packages": ["npm:@foo/bar"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    npm_dir = global_agent / "npm" / "foo"
+    npm_dir.mkdir(parents=True)
+
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "models.yml").write_text("{}", encoding="utf-8")
+
+    prepare_managed_omp_agent_dir(
+        managed,
+        overlay={"retry": {"maxRetries": 5}},
+        global_agent_dir=global_agent,
+    )
+
+    written = json.loads((managed / "settings.json").read_text(encoding="utf-8"))
+    assert written["extensions"] == ["/tmp/my-ext.ts"]
+    assert written["packages"] == ["npm:@foo/bar"]
+    assert written["retry"] == {"maxRetries": 5}
+    assert (managed / "npm").is_symlink()
+    assert (managed / "npm").resolve() == (global_agent / "npm").resolve()
+
+
+def test_prepare_managed_omp_agent_dir_empty_global_writes_overlay_only(
+    tmp_path: Path,
+) -> None:
+    """Missing global settings still writes the Omnigent overlay."""
+    global_agent = tmp_path / "empty-global"
+    global_agent.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+
+    prepare_managed_omp_agent_dir(
+        managed,
+        overlay={"retry": {"enabled": True}},
+        global_agent_dir=global_agent,
+    )
+
+    written = json.loads((managed / "settings.json").read_text(encoding="utf-8"))
+    assert written == {"retry": {"enabled": True}}
+
+
+def test_prepare_managed_omp_agent_dir_deep_merges_nested_overlay(tmp_path: Path) -> None:
+    """Nested settings (e.g. compaction) merge like omp project overrides."""
+    global_agent = tmp_path / "global-agent"
+    global_agent.mkdir()
+    (global_agent / "settings.json").write_text(
+        json.dumps({"compaction": {"enabled": True, "reserveTokens": 16384}}),
+        encoding="utf-8",
+    )
+    managed = tmp_path / "managed"
+    managed.mkdir()
+
+    prepare_managed_omp_agent_dir(
+        managed,
+        overlay={"compaction": {"reserveTokens": 8192}},
+        global_agent_dir=global_agent,
+    )
+
+    written = json.loads((managed / "settings.json").read_text(encoding="utf-8"))
+    assert written["compaction"] == {
+        "enabled": True,
+        "reserveTokens": 8192,
+    }

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -1270,6 +1270,17 @@ def test_ui_setup_steps_pi_auth_is_ui_authable_and_tracked() -> None:
     assert steps[1].status_key == "authed"
 
 
+def test_ui_setup_steps_omp_auth_is_ui_authable_and_tracked() -> None:
+    """omp is UI-authable like pi: its auth step opens the credential form."""
+    steps = hi.ui_setup_steps("omp")
+    assert [s.kind for s in steps] == ["install", "auth"]
+    assert steps[1].action == "auth"
+    assert steps[1].command is None
+    assert steps[1].status_key == "authed"
+    assert [s.as_dict() for s in hi.ui_setup_steps("oh-my-pi")] == [
+        s.as_dict() for s in steps
+    ]
+
 def test_ui_setup_steps_qwen_auth_stays_untracked_setup_fallback() -> None:
     """Qwen is env-auth (not UI-authable), so its auth step stays an untracked
     ``omni setup`` signpost — the case that must NOT gain the form."""

--- a/tests/onboarding/test_harness_install.py
+++ b/tests/onboarding/test_harness_install.py
@@ -1277,9 +1277,8 @@ def test_ui_setup_steps_omp_auth_is_ui_authable_and_tracked() -> None:
     assert steps[1].action == "auth"
     assert steps[1].command is None
     assert steps[1].status_key == "authed"
-    assert [s.as_dict() for s in hi.ui_setup_steps("oh-my-pi")] == [
-        s.as_dict() for s in steps
-    ]
+    assert [s.as_dict() for s in hi.ui_setup_steps("oh-my-pi")] == [s.as_dict() for s in steps]
+
 
 def test_ui_setup_steps_qwen_auth_stays_untracked_setup_fallback() -> None:
     """Qwen is env-auth (not UI-authable), so its auth step stays an untracked

--- a/tests/onboarding/test_harness_readiness.py
+++ b/tests/onboarding/test_harness_readiness.py
@@ -320,6 +320,9 @@ def test_configured_harness_map_covers_all_spellings(
         "pi",
         "pi-native",
         "native-pi",
+        # Oh My Pi (``omp --mode rpc``) + alias; gates on the omp CLI.
+        "omp",
+        "oh-my-pi",
         "cursor",
         # Native Cursor (``omni cursor``) — gates on the cursor-agent CLI.
         "cursor-native",

--- a/tests/onboarding/test_provider_config.py
+++ b/tests/onboarding/test_provider_config.py
@@ -10,6 +10,7 @@ from omnigent.errors import OmnigentError
 from omnigent.onboarding.provider_config import (
     ANTHROPIC_FAMILY,
     GEMINI_FAMILY,
+    OMP_SURFACE,
     OPENAI_FAMILY,
     PI_SURFACE,
     default_provider_for_harness,
@@ -388,7 +389,7 @@ def test_gemini_key_cannot_claim_pi_scope_at_parse() -> None:
 
 
 def test_databricks_does_not_serve_gemini_surface() -> None:
-    """Databricks routes anthropic/openai + pi, NOT the Gemini surface.
+    """Databricks routes anthropic/openai + pi/omp, NOT the Gemini surface.
 
     The antigravity-native harness drives Gemini via the Google SDK + a
     GEMINI_API_KEY / OAuth, not an OpenAI-compatible gateway, so a databricks
@@ -398,7 +399,9 @@ def test_databricks_does_not_serve_gemini_surface() -> None:
     """
     config = {"providers": {"dbx": {"kind": "databricks", "profile": "ws", "default": True}}}
     entry = load_providers(config)["dbx"]
-    assert provider_families(entry) == frozenset({ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE})
+    assert provider_families(entry) == frozenset(
+        {ANTHROPIC_FAMILY, OPENAI_FAMILY, PI_SURFACE, OMP_SURFACE}
+    )
     assert GEMINI_FAMILY not in provider_families(entry)
     # A default databricks profile does NOT become the gemini-surface default.
     assert default_provider_for_harness(config, "antigravity-native") is None
@@ -428,8 +431,8 @@ def test_gateway_local_does_not_serve_gemini_surface(kind: str) -> None:
     entry = load_providers({"providers": {"gw": raw}})["gw"]
     served = provider_families(entry)
     assert GEMINI_FAMILY not in served
-    # The real (anthropic) surface — and its pi capability — are untouched.
-    assert served == frozenset({ANTHROPIC_FAMILY, PI_SURFACE})
+    # The real (anthropic) surface — and its pi/omp capability — are untouched.
+    assert served == frozenset({ANTHROPIC_FAMILY, PI_SURFACE, OMP_SURFACE})
     # And it can never become the gemini-surface default…
     cfg = {"providers": {"gw": {**raw, "default": True}}}
     assert default_provider_for_harness(cfg, "antigravity-native") is None
@@ -508,7 +511,9 @@ def test_key_with_gemini_block_still_serves_gemini() -> None:
         "gemini": {"base_url": "https://y/v1beta", "api_key_ref": "env:G"},
     }
     multi_entry = load_providers({"providers": {"multi": multi}})["multi"]
-    assert provider_families(multi_entry) == frozenset({OPENAI_FAMILY, GEMINI_FAMILY, PI_SURFACE})
+    assert provider_families(multi_entry) == frozenset(
+        {OPENAI_FAMILY, GEMINI_FAMILY, PI_SURFACE, OMP_SURFACE}
+    )
 
 
 def test_subscription_cannot_claim_pi_scope() -> None:
@@ -701,7 +706,7 @@ def test_parse_cli_config_entry() -> None:
     # surface), so it can claim the pi scope. (``default: true`` deliberately
     # never expands to pi — only an explicit ``pi`` does — so default_families
     # stays openai-only here.)
-    assert provider_families(entry) == frozenset({OPENAI_FAMILY, PI_SURFACE})
+    assert provider_families(entry) == frozenset({OPENAI_FAMILY, PI_SURFACE, OMP_SURFACE})
     assert entry.default_families == frozenset({OPENAI_FAMILY})
 
 

--- a/tests/runtime/test_omp_spawn_env.py
+++ b/tests/runtime/test_omp_spawn_env.py
@@ -1,0 +1,370 @@
+"""
+Tests for ``_build_omp_spawn_env`` in ``omnigent/runtime/workflow.py``.
+
+The spawn-env builder maps ``spec.executor`` fields to ``HARNESS_OMP_*``
+env vars that the pi harness wrap reads at executor-construction time.
+Mirrors ``test_claude_sdk_spawn_env.py`` — pi must have the same
+Databricks-gateway default-model parity that claude-sdk has.
+
+This is a unit test — no subprocess spawn, no real pi CLI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent.runtime.workflow import _build_omp_spawn_env
+from omnigent.spec.types import AgentSpec, ExecutorSpec, LLMConfig
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """
+    Point OMNIGENT_CONFIG_HOME at an empty temp dir for every test in
+    this file so the developer's real ``~/.omnigent/config.yaml`` (e.g.
+    a default provider) cannot hijack the legacy-profile path under test.
+
+    ``HOME`` is redirected there too. An empty omnigent config is not enough
+    isolation on its own: ambient provider detection also reads
+    ``~/.codex/config.toml`` and ``~/.databrickscfg``, so a developer whose
+    codex config pins a Databricks gateway has pi consume that detected
+    cli-config provider and stall in databricks-sdk workspace lookups.
+    ``USERPROFILE`` is the Windows spelling of the same home.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Temporary directory for the isolated config and home.
+    """
+    monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_catalog_default_model",
+        lambda provider_name, family, *, context: f"catalog-{provider_name}-{family}-default",
+    )
+
+
+def _make_spec(*, model: str | None = None, profile: str | None = None) -> AgentSpec:
+    """
+    Build a minimal pi :class:`AgentSpec` for spawn-env tests.
+
+    :param model: Model identifier threaded into executor config and
+        ``spec.llm``, e.g. ``"databricks-claude-sonnet-4-6"``. ``None``
+        omits it (no model pinned in YAML — the nessie shape).
+    :param profile: Legacy profile set via ``executor.config["profile"]``.
+        ``None`` omits it (no profile declared in YAML).
+    :returns: A populated :class:`AgentSpec`.
+    """
+    config: dict[str, object] = {"harness": "omp"}
+    if model is not None:
+        config["model"] = model
+    if profile is not None:
+        config["profile"] = profile
+    return AgentSpec(
+        spec_version=1,
+        name="test-pi",
+        instructions="You are a test agent.",
+        executor=ExecutorSpec(type="omnigent", config=config, model=model),
+        llm=LLMConfig(model=model) if model is not None else None,
+    )
+
+
+def test_pi_spawn_env_threads_cwd_separately_from_bundle_dir(tmp_path: Path) -> None:
+    """
+    omp gets the session workspace as ``HARNESS_OMP_CWD``.
+
+    ``workdir`` is the extracted agent bundle, not the user's project
+    workspace. If these are conflated, omp launches in the wrong repository.
+    """
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    bundle_dir = tmp_path / "runner-specs" / "ag_pi-v1"
+    bundle_dir.mkdir(parents=True)
+
+    env = _build_omp_spawn_env(_make_spec(), cwd=workspace, workdir=bundle_dir)
+
+    assert env["HARNESS_OMP_CWD"] == str(workspace)
+    assert env["HARNESS_OMP_BUNDLE_DIR"] == str(bundle_dir)
+
+
+def _ucode_state_for_pi(
+    monkeypatch: pytest.MonkeyPatch, *, model: str | None, with_pi_entry: bool
+):
+    """
+    Mock ucode resolution to a workspace state with or without a pi agent.
+
+    Builds a workspace state whose ``omp`` agent carries gateway URLs +
+    auth command but ``model=model``, then monkeypatches the workflow
+    module's ucode lookups to return it.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param model: Per-agent ucode model, e.g. ``None`` to simulate a
+        workspace that caches no model, or ``"databricks-claude-sonnet-4-6"``.
+    :param with_pi_entry: ``False`` builds a state with no ``omp`` agent
+        entry at all, exercising the early-return in
+        ``configure_agent_harness_with_ucode``.
+    """
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    agents = (
+        {
+            "omp": UcodeAgentState(
+                model=model,
+                base_urls={
+                    "claude": "https://example.databricks.com/ai-gateway/anthropic",
+                    "openai": "https://example.databricks.com/ai-gateway/codex/v1",
+                },
+                auth_command="printf token",
+            )
+        }
+        if with_pi_entry
+        else {}
+    )
+    state = UcodeWorkspaceState(
+        workspace_url="https://example.databricks.com",
+        agents=agents,
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.get_workspace_url_for_profile",
+        lambda profile: "https://example.databricks.com",
+    )
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow.read_ucode_state",
+        lambda workspace_url: state,
+    )
+
+
+def test_ucode_state_without_model_falls_back_to_databricks_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A modelless ucode state resolves the Databricks gateway default model.
+
+    Reproduces the nessie failure shape on pi: a profile-backed pi agent
+    with no spec model, whose workspace ucode state caches gateway URLs but
+    no model. Without the producer default pi falls back to its own host
+    default (an Anthropic-direct id the gateway rejects), so the model env
+    var must be set to a routable ``databricks-*`` endpoint name.
+    """
+    _ucode_state_for_pi(monkeypatch, model=None, with_pi_entry=True)
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_omp_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_OMP_GATEWAY"] == "true"
+    # The verified routable gateway endpoint name, not pi's own default.
+    assert env["HARNESS_OMP_MODEL"] == "catalog-databricks-claude-default"
+
+
+def test_ucode_state_with_model_is_not_overridden_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A ucode-supplied model is used as-is; the default does not clobber it.
+
+    Failure means the producer's missing-model fallback would override a
+    workspace that correctly caches its own model.
+    """
+    _ucode_state_for_pi(monkeypatch, model="databricks-claude-sonnet-4-6", with_pi_entry=True)
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_omp_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_OMP_MODEL"] == "databricks-claude-sonnet-4-6"
+
+
+def test_spec_model_wins_over_ucode_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    A spec-pinned model takes precedence over both ucode and the default.
+
+    Failure means the ucode/default plumbing clobbers an explicit
+    ``executor.model`` from the agent YAML.
+    """
+    _ucode_state_for_pi(monkeypatch, model=None, with_pi_entry=True)
+
+    spec = _make_spec(model="databricks-gpt-5-4", profile="oss")
+    env = _build_omp_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_OMP_MODEL"] == "databricks-gpt-5-4"
+
+
+def test_no_ucode_pi_entry_leaves_model_to_executor_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Without a ucode ``omp`` entry the producer sets no model env var.
+
+    ``configure_agent_harness_with_ucode`` early-returns before its
+    default-model fallback when the workspace state has no ``omp`` agent.
+    The spawn env must still enable the gateway + carry the profile so
+    the executor's own profile-derived Databricks default (see
+    ``OmpExecutor._resolve_model``) covers this path — asserting the model
+    var is absent proves that executor-side fallback is actually reached.
+    """
+    _ucode_state_for_pi(monkeypatch, model=None, with_pi_entry=False)
+
+    spec = _make_spec(model=None, profile="oss")
+    env = _build_omp_spawn_env(spec, workdir=None)
+
+    assert env["HARNESS_OMP_GATEWAY"] == "true"
+    assert env["HARNESS_OMP_DATABRICKS_PROFILE"] == "oss"
+    # No producer model — the executor's profile-path default applies.
+    assert "HARNESS_OMP_MODEL" not in env
+
+
+# ---------------------------------------------------------------------------
+# _apply_provider_to_omp: inline key/gateway families
+# ---------------------------------------------------------------------------
+
+
+def _key_entry(**families: Any) -> Any:
+    """A ``key``-kind provider entry with literal-key families."""
+    from omnigent.onboarding.provider_config import FamilyConfig, ProviderEntry
+
+    return ProviderEntry(
+        name="test-keys",
+        kind="key",
+        families={
+            name: FamilyConfig(base_url=cfg["base_url"], api_key=cfg["api_key"])
+            for name, cfg in families.items()
+        },
+    )
+
+
+def test_apply_provider_prefers_anthropic_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both families configured → anthropic auth wins, both base URLs thread."""
+    from omnigent.runtime.workflow import _apply_provider_to_omp
+
+    entry = _key_entry(
+        anthropic={"base_url": "https://api.anthropic.com", "api_key": "sk-a"},
+        openai={"base_url": "https://api.openai.com/v1", "api_key": "sk-o"},
+    )
+    env: dict[str, str] = {}
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._catalog_default_model",
+        lambda family: f"catalog-{family}",
+    )
+    _apply_provider_to_omp(env, entry)
+    import json as _json
+
+    assert env["HARNESS_OMP_GATEWAY"] == "true"
+    assert _json.loads(env["HARNESS_OMP_GATEWAY_BASE_URLS"]) == {
+        "claude": "https://api.anthropic.com",
+        "openai": "https://api.openai.com/v1",
+    }
+    assert env["HARNESS_OMP_GATEWAY_AUTH_COMMAND"] == "printf %s sk-a"
+    assert env["HARNESS_OMP_MODEL"] == "catalog-anthropic"
+
+
+def test_apply_provider_openai_only_uses_openai_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single openai family drives the run on the openai credential + default."""
+    from omnigent.runtime.workflow import _apply_provider_to_omp
+
+    entry = _key_entry(openai={"base_url": "https://api.openai.com/v1", "api_key": "sk-o"})
+    env: dict[str, str] = {}
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._catalog_default_model",
+        lambda family: f"catalog-{family}",
+    )
+    _apply_provider_to_omp(env, entry)
+    assert env["HARNESS_OMP_MODEL"] == "catalog-openai"
+
+
+def test_apply_provider_unresolved_credentials_fail_loud() -> None:
+    """No resolvable family names the missing variable instead of launching blind."""
+    from omnigent.errors import OmnigentError
+    from omnigent.onboarding.provider_config import FamilyConfig, ProviderEntry
+    from omnigent.runtime.workflow import _apply_provider_to_omp
+
+    entry = ProviderEntry(
+        name="test-broken",
+        kind="key",
+        families={
+            "anthropic": FamilyConfig(
+                base_url="https://api.anthropic.com", api_key="$DEFINITELY_UNSET_VAR_XYZ"
+            )
+        },
+    )
+    with pytest.raises(OmnigentError, match="DEFINITELY_UNSET_VAR_XYZ"):
+        _apply_provider_to_omp({}, entry)
+
+
+def test_apply_provider_threads_wire_api_and_spec_model() -> None:
+    """The openai wire api threads through; a spec model is never overridden."""
+    from omnigent.onboarding.provider_config import FamilyConfig, ProviderEntry
+    from omnigent.runtime.workflow import _apply_provider_to_omp
+
+    entry = ProviderEntry(
+        name="test-wire",
+        kind="gateway",
+        families={
+            "openai": FamilyConfig(
+                base_url="https://proxy.example.com/v1",
+                api_key="sk-p",
+                wire_api="responses",
+            )
+        },
+    )
+    env: dict[str, str] = {"HARNESS_OMP_MODEL": "spec-model"}
+    _apply_provider_to_omp(env, entry)
+    assert env["HARNESS_OMP_GATEWAY_OPENAI_WIRE_API"] == "responses"
+    assert env["HARNESS_OMP_MODEL"] == "spec-model"
+
+
+# ---------------------------------------------------------------------------
+# _apply_cli_config_databricks_to_omp
+# ---------------------------------------------------------------------------
+
+
+def test_cli_config_databricks_maps_gateway_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A codex cli-config Databricks gateway routes through the omp transport."""
+    from types import SimpleNamespace
+
+    from omnigent.onboarding.provider_config import ProviderEntry
+    from omnigent.runtime.workflow import _apply_cli_config_databricks_to_omp
+
+    monkeypatch.setattr(
+        "omnigent.pi_native_credentials._cli_config_pi_provider",
+        lambda entry, model=None: SimpleNamespace(
+            base_url="https://example.databricks.com/ai-gateway/anthropic",
+            api_key="!databricks auth token --host https://example.databricks.com",
+            model="gateway-model",
+        ),
+    )
+    entry = ProviderEntry(name="codex-databricks", kind="cli-config", cli="codex")
+    env: dict[str, str] = {}
+    _apply_cli_config_databricks_to_omp(env, entry)
+    import json as _json
+
+    assert env["HARNESS_OMP_GATEWAY"] == "true"
+    assert _json.loads(env["HARNESS_OMP_GATEWAY_BASE_URLS"]) == {
+        "claude": "https://example.databricks.com/ai-gateway/anthropic"
+    }
+    assert (
+        env["HARNESS_OMP_GATEWAY_AUTH_COMMAND"]
+        == "databricks auth token --host https://example.databricks.com"
+    )
+    assert env["HARNESS_OMP_MODEL"] == "gateway-model"
+
+
+def test_cli_config_databricks_untranslatable_fails_loud(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cli-config entry that is not a Databricks gateway names the problem."""
+    from omnigent.errors import OmnigentError
+    from omnigent.onboarding.provider_config import ProviderEntry
+    from omnigent.runtime.workflow import _apply_cli_config_databricks_to_omp
+
+    monkeypatch.setattr(
+        "omnigent.pi_native_credentials._cli_config_pi_provider",
+        lambda entry, model=None: None,
+    )
+    entry = ProviderEntry(name="codex-other", kind="cli-config", cli="codex")
+    with pytest.raises(OmnigentError, match="codex-other"):
+        _apply_cli_config_databricks_to_omp(env={}, entry=entry)

--- a/tests/server/test_smart_routing.py
+++ b/tests/server/test_smart_routing.py
@@ -306,6 +306,33 @@ def test_infer_models_unknown_harness() -> None:
     assert infer_models(None) is None
 
 
+def test_omp_shares_pi_family() -> None:
+    """omp routes as a pi-family harness (same gateway models, same wires).
+
+    Without the entry, omp subagent routing degrades three ways: catalog
+    rows from pi-family workers never match, there is no static-model
+    fallback, and a picked pi-family model redirects the child off "omp".
+    """
+    from omnigent.runner.subagent_routing import _target_harness
+    from omnigent.server.smart_routing import (
+        _HARNESS_FAMILY,
+        catalog_models_for_harness,
+        models_in_family,
+    )
+
+    assert _HARNESS_FAMILY["omp"] == "pi"
+    assert infer_models("omp") == infer_models("pi")
+    assert infer_models("omp") is not None
+    # A pi worker row serves an omp session (matched by family, not id).
+    assert catalog_models_for_harness({"pi": ["databricks-claude-x"]}, "omp") == [
+        "databricks-claude-x"
+    ]
+    # pi-family filtering is permissive — every model passes, as for pi.
+    assert models_in_family("omp", ["anything"]) == ["anything"]
+    # A picked pi-family model keeps the child on omp instead of redirecting.
+    assert _target_harness("omp", "pi", "pi") == "omp"
+
+
 def test_models_fixture_unknown_harness() -> None:
     assert _models_for("cursor") is None
     assert _models_for("antigravity") is None

--- a/web/src/lib/harnessSetup.test.ts
+++ b/web/src/lib/harnessSetup.test.ts
@@ -163,7 +163,9 @@ describe("harnessCredentialFamily", () => {
     expect(harnessCredentialFamily("codex-native")).toBe("openai");
     // Pi resolves to its preferred anthropic fallback family.
     expect(harnessCredentialFamily("pi")).toBe("anthropic");
-    expect(harnessCredentialFamily("pi-native")).toBe("anthropic");
+    // Omp resolves like Pi (preferred anthropic fallback family).
+    expect(harnessCredentialFamily("omp")).toBe("anthropic");
+    expect(harnessCredentialFamily("oh-my-pi")).toBe("anthropic");
   });
 
   it("returns null for harnesses the UI can't authenticate", () => {
@@ -184,7 +186,8 @@ describe("harnessCredentialAdoptFamilies", () => {
 
   it("returns BOTH families for Pi (it consumes anthropic + openai)", () => {
     expect(harnessCredentialAdoptFamilies("pi")).toEqual(["anthropic", "openai"]);
-    expect(harnessCredentialAdoptFamilies("pi-native")).toEqual(["anthropic", "openai"]);
+    expect(harnessCredentialAdoptFamilies("omp")).toEqual(["anthropic", "openai"]);
+    expect(harnessCredentialAdoptFamilies("oh-my-pi")).toEqual(["anthropic", "openai"]);
   });
 
   it("returns an empty list for harnesses the UI can't authenticate", () => {
@@ -200,6 +203,7 @@ describe("harnessAuthableOnHost", () => {
   it("true for Claude/Codex/Pi families when feature on and host online", () => {
     expect(harnessAuthableOnHost(info(), "codex-native", online)).toBe(true);
     expect(harnessAuthableOnHost(info(), "claude-native", online)).toBe(true);
+    expect(harnessAuthableOnHost(info(), "omp", online)).toBe(true);
     expect(harnessAuthableOnHost(info(), "pi", online)).toBe(true);
   });
 

--- a/web/src/lib/harnessSetup.ts
+++ b/web/src/lib/harnessSetup.ts
@@ -145,7 +145,7 @@ export function harnessCredentialFamily(harness: string | null | undefined): str
   if (!harness) return null;
   if (["claude", "claude-native", "native-claude"].includes(harness)) return "anthropic";
   if (["codex", "codex-native", "native-codex"].includes(harness)) return "openai";
-  if (["pi", "pi-native", "native-pi"].includes(harness)) return "anthropic";
+  if (["pi", "pi-native", "native-pi", "omp", "oh-my-pi"].includes(harness)) return "anthropic";
   return null;
 }
 
@@ -164,7 +164,8 @@ export function harnessCredentialFamily(harness: string | null | undefined): str
 export function harnessCredentialAdoptFamilies(harness: string | null | undefined): string[] {
   const family = harnessCredentialFamily(harness);
   if (family === null) return [];
-  if (["pi", "pi-native", "native-pi"].includes(harness as string)) return ["anthropic", "openai"];
+  if (["pi", "pi-native", "native-pi", "omp", "oh-my-pi"].includes(harness as string))
+    return ["anthropic", "openai"];
   return [family];
 }
 


### PR DESCRIPTION
## Related issue

Closes #6714

## Summary

- `omp` (oh-my-pi, `@oh-my-pi/pi-coding-agent`) is now a first-class harness: picker row "Oh My Pi" (`oh-my-pi` alias), `omnigent run --harness omp`, `omni setup` install + readiness gating.
- Runs `omp --mode rpc` through a dedicated `OmpExecutor`: ESM tool bridge, `models.yml` gateway translation, native-tool policy gate, per-turn usage aggregation. Pi behavior untouched (shared helpers reused, pi suites green).
- Own `OMP_SURFACE` provider scope: omp defaults independently of pi and never consumes Pi-native subscription auth.

```mermaid
flowchart LR
    A[omnigent run --harness omp] --> B[_build_omp_spawn_env]
    B --> C[OmpExecutor: omp --mode rpc]
    C --> D[models.yml gateway transport]
    C --> E[ESM bridge: bridged tools]
    C --> F[tool_call hook: native policy gate]
    E --> G[TCP tool server]
    F --> G
    C --> H[agent_end → TurnComplete + usage]
```

## Test Plan

- `tests/e2e/omnigent/test_per_harness_omp.py`: real `omp --mode rpc` turn through the mock gateway (~16s).
- New unit suites: `test_omp_executor` (86), `test_omp_harness`, `test_omp_settings`, `test_omp_spawn_env`; updated registry/onboarding/menu/routing contracts.
- Regression: pi executor/harness/settings/spawn suites, pi+omp live e2e, full `tests/cli` + `tests/repl`, ruff + pyrefly clean. One crash-handler ANSI failure is pre-existing on HEAD.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: probed the live CLI to confirm the `ready` frame, fast unknown-command error (thinking-level probe), and `--auto-approve` / `--skills` / `--tools` flag semantics against oh-my-pi 18.1.13 source + upstream RPC doc.

## Changelog

`omp` (oh-my-pi) is now a supported harness: pick "Oh My Pi", run with `--harness omp`, install via `omni setup`

