### PR TITLE
feat(onboarding): detect local llama-server in ambient setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,14 +400,14 @@ works with four kinds of credentials:
 |---|---|---|
 | 🔑 | **API key** | A first-party vendor key for Anthropic, OpenAI, and similar providers |
 | 🎟️ | **Subscription** | A Claude Pro/Max or ChatGPT plan, via the official `claude` / `codex` CLIs |
-| 🌐 | **Gateway** | Any OpenAI- or Anthropic-compatible `base_url` and key (OpenRouter, LiteLLM, Ollama, vLLM, Azure) |
+| 🌐 | **Gateway** | Any OpenAI- or Anthropic-compatible `base_url` and key (OpenRouter, LiteLLM, Ollama, llama-server, vLLM, Azure) |
 | 🧱 | **Databricks** | A Databricks workspace profile (requires the `databricks` extra) |
 
 Defaults are per agent, so a Claude default and a Codex default coexist. You
 can also switch models in the middle of a session with the `/model` command.
 
 <details>
-<summary>Gateway base URLs (OpenRouter, Ollama)</summary>
+<summary>Gateway base URLs (OpenRouter, Ollama, llama-server)</summary>
 
 When you add a **Gateway** credential, `omnigent setup` asks for a base URL
 and a key. The base URL depends on which agent you point it at:
@@ -417,6 +417,7 @@ and a key. The base URL depends on which agent you point it at:
 | **OpenRouter** | Claude Code | `https://openrouter.ai/api` | your OpenRouter key (`sk-or-…`) |
 | **OpenRouter** | Codex / OpenAI agents | `https://openrouter.ai/api/v1` | your OpenRouter key (`sk-or-…`) |
 | **Ollama** (local) | Codex / OpenAI agents | `http://localhost:11434/v1` | any value (Ollama ignores it) |
+| **llama-server** (local) | Codex / OpenAI agents | `http://localhost:8080/v1` | any value (unless `llama-server` is configured with `--api-key`) |
 
 For Claude Code, point at OpenRouter's Anthropic-compatible endpoint
 (`…/api`, **not** `…/api/v1`). For Codex and the OpenAI-agents harness, use

--- a/deploy/islo/README.md
+++ b/deploy/islo/README.md
@@ -390,7 +390,7 @@ forwards the standard harness credential vars to its runners:
 | `ANTHROPIC_API_KEY` | Claude models on the Anthropic API |
 | `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` | Anthropic-compatible gateways (LiteLLM, Bedrock/Vertex bridges, corporate proxies) |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-code with a Claude **subscription** (no API key) |
-| `OPENAI_API_KEY` / `OPENAI_BASE_URL` | OpenAI or any OpenAI-compatible endpoint (OpenRouter, vLLM, Ollama, …) |
+| `OPENAI_API_KEY` / `OPENAI_BASE_URL` | OpenAI or any OpenAI-compatible endpoint (OpenRouter, vLLM, Ollama, llama-server, …) |
 | `CODEX_ACCESS_TOKEN` | codex with a ChatGPT Business/Enterprise workspace |
 | `GEMINI_API_KEY` | Gemini on the Google AI API |
 

--- a/deploy/modal/README.md
+++ b/deploy/modal/README.md
@@ -348,7 +348,7 @@ like [OpenRouter](https://openrouter.ai) and
 | `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL` | Anthropic-compatible gateways — point claude-code at a LiteLLM proxy, a Bedrock/Vertex bridge, or a corporate gateway |
 | `CLAUDE_CODE_OAUTH_TOKEN` | claude-code with a Claude subscription (no API key) |
 | `OPENAI_API_KEY` | OpenAI models on the OpenAI API (codex, openai-agents harnesses) |
-| `OPENAI_BASE_URL` | Any OpenAI-compatible endpoint — the de-facto standard API of the open-model ecosystem. Gateways (OpenRouter, LiteLLM), hosted open-weights providers (Together, Fireworks, Groq), or self-hosted vLLM / Ollama — this is how Llama, Qwen, DeepSeek, and friends plug in |
+| `OPENAI_BASE_URL` | Any OpenAI-compatible endpoint — the de-facto standard API of the open-model ecosystem. Gateways (OpenRouter, LiteLLM), hosted open-weights providers (Together, Fireworks, Groq), or self-hosted vLLM / Ollama / llama-server — this is how Llama, Qwen, DeepSeek, and friends plug in |
 | `CODEX_ACCESS_TOKEN` | codex with a ChatGPT Business/Enterprise workspace |
 | `GEMINI_API_KEY` | Gemini models on the Google AI API |
 

--- a/omnigent/cli_config.py
+++ b/omnigent/cli_config.py
@@ -1094,7 +1094,7 @@ def _adopt_detected_providers() -> list[str]:
     """Persist ambient-detected providers into the config, returning new names.
 
     Opening ``configure harnesses`` adopts any detected credential (env key,
-    CLI login, local Ollama) not already in ``providers:`` as a real,
+    CLI login, local Ollama or llama-server) not already in ``providers:`` as a real,
     editable entry — so the tree shows one uniform provider list with no
     "detected vs configured" split. Writes the merged view (explicit +
     detected, with detected auto-defaulting per family) wholesale, and only
@@ -1203,7 +1203,8 @@ def _compact_credential_label(det: DetectedProvider) -> str:
     ``"Claude Subscription"`` / ``"ChatGPT Subscription"`` — so a single
     comma-joined callout listing several credentials at once stays unambiguous
     without a per-line source. API keys and local endpoints reuse the shared
-    ``credential_label`` (``"Anthropic API Key"``, ``"Ollama"``).
+    ``credential_label`` (``"Anthropic API Key"``, ``"Ollama"``,
+    ``"llama-server"``).
 
     :param det: A credential found by
         :func:`omnigent.onboarding.ambient.detect_providers`.
@@ -1270,7 +1271,8 @@ def _adopt_ambient_credentials(progress: RunnerStartupProgress | None = None) ->
     (:func:`_run_configure_harnesses_interactive`): it (1) backfills a legacy
     databricks ``auth:`` block into a real provider, (2) adopts any
     ambient-detected credential (env API key, logged-in ``claude`` / ``codex``
-    CLI, local Ollama) not already configured as an ordinary provider entry,
+    CLI, local Ollama or llama-server) not already configured as an ordinary
+    provider entry,
     and (3) prints a callout naming exactly the credentials it just
     auto-configured. Idempotent: a second open adopts nothing, so no callout
     prints.

--- a/omnigent/llms/LLMCLIENT.md
+++ b/omnigent/llms/LLMCLIENT.md
@@ -49,7 +49,7 @@ llms/
   adapters/
     __init__.py            # get_adapter() registry
     base.py                # BaseAdapter ABC
-    openai.py              # OpenAI + OpenAI-compatible (Groq, DeepSeek, xAI, OpenRouter, Ollama)
+    openai.py              # OpenAI + OpenAI-compatible (Groq, DeepSeek, xAI, OpenRouter, Ollama, llama-server)
     anthropic.py           # Anthropic Messages API
     gemini.py              # Gemini generateContent API
     bedrock.py             # AWS Bedrock Converse API
@@ -216,6 +216,7 @@ Chat Completions IS the native format. Minimal translation (add model to payload
 | `xai` | `https://api.x.ai/v1` | `XAI_API_KEY` |
 | `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
 | `ollama` | `http://localhost:11434/v1` | (none) |
+| `llama-server` | `http://localhost:8080/v1` | (none) |
 
 HTTP via sync `httpx` (already a project dependency).
 

--- a/omnigent/llms/adapters/__init__.py
+++ b/omnigent/llms/adapters/__init__.py
@@ -56,6 +56,7 @@ def _create_adapter(provider: str, **kwargs: Any) -> BaseAdapter:
         "xai": "https://api.x.ai/v1",
         "openrouter": "https://openrouter.ai/api/v1",
         "ollama": "http://localhost:11434/v1",
+        "llama-server": "http://localhost:8080/v1",
         "moonshot": "https://api.moonshot.cn/v1",
     }
 

--- a/omnigent/llms/adapters/openai.py
+++ b/omnigent/llms/adapters/openai.py
@@ -1,7 +1,7 @@
 """
 OpenAI and OpenAI-compatible provider adapter.
 
-Handles OpenAI, Groq, DeepSeek, xAI, OpenRouter, and Ollama — any
+Handles OpenAI, Groq, DeepSeek, xAI, OpenRouter, Ollama, and llama-server — any
 provider that speaks the OpenAI Chat Completions API format.
 """
 

--- a/omnigent/llms/context_window.py
+++ b/omnigent/llms/context_window.py
@@ -302,8 +302,9 @@ def fetch_model_pricing_with_provider(
     2. MLflow catalog via :func:`fetch_model_pricing` (for known vendor models)
     3. ``None`` (unpriced)
 
-    This enables cost tracking for self-hosted models (Ollama, vLLM, custom
-    gateways) and gateway endpoints that expose catalog-known model IDs but
+    This enables cost tracking for self-hosted models (Ollama, llama-server,
+    vLLM, custom gateways) and gateway endpoints that expose
+    catalog-known model IDs but
     charge their own configured rates. Custom pricing takes precedence when
     configured, so a self-hosted provider serving ``claude-opus-4`` can
     override the vendor catalog rate with its own.

--- a/omnigent/llms/routing.py
+++ b/omnigent/llms/routing.py
@@ -28,6 +28,7 @@ PROVIDER_CONFIGS: dict[str, str | None] = {
     "xai": "https://api.x.ai/v1",
     "openrouter": "https://openrouter.ai/api/v1",
     "ollama": "http://localhost:11434/v1",
+    "llama-server": "http://localhost:8080/v1",
     "moonshot": "https://api.moonshot.cn/v1",
 }
 

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -7,8 +7,10 @@ server — so the setup flow can offer them as one-tap choices instead of
 asking the user to paste keys they already have.
 
 Detection is almost entirely pure standard library (``os``, ``socket``,
-``pathlib``) and performs no network I/O beyond a single non-blocking
-localhost TCP probe for Ollama. The one exception is macOS Claude detection:
+``pathlib``) and performs no network I/O beyond a pair of non-blocking
+localhost TCP probes, one for Ollama and one for llama-server.
+The one exception is macOS Claude detection:
+
 Claude Code stores its subscription OAuth in the macOS Keychain (not a file),
 so on macOS — and only when the file check comes up empty — Claude detection
 falls back to a ``claude auth status`` subprocess (see
@@ -63,6 +65,14 @@ _OLLAMA_URL = f"http://{_OLLAMA_HOST}:{_OLLAMA_PORT}"
 # when nothing is listening.
 _OLLAMA_PROBE_TIMEOUT = 0.25
 
+# llama-server's default OpenAI-compatible endpoint.
+_LLAMA_SERVER_HOST = "localhost"
+_LLAMA_SERVER_PORT = 8080
+_LLAMA_SERVER_URL = f"http://{_LLAMA_SERVER_HOST}:{_LLAMA_SERVER_PORT}"
+
+# Timeout (seconds) for the llama-server TCP probe
+_LLAMA_SERVER_PROBE_TIMEOUT = 0.25
+
 # Claude Code's enterprise "managed settings" chain, highest precedence first.
 # An enterprise install (the shape ``isaac configure claude`` writes) configures
 # Claude Code here and nowhere else: an ``env`` block pinning
@@ -99,7 +109,7 @@ class DetectedProvider:
 
     :param name: The provider/source name, e.g. ``"anthropic"``,
         ``"openai"``, ``"openrouter"``, ``"gemini"``, ``"claude"``,
-        ``"codex"``, or ``"ollama"``.
+        ``"codex"``, ``"ollama"``, or ``"llama-server"``.
     :param kind: How the credential authenticates — ``"key"`` (an API key
         in the environment), ``"subscription"`` (a logged-in CLI), or
         ``"local"`` (a self-hosted endpoint).
@@ -625,6 +635,25 @@ def _ollama_reachable() -> bool:
         return False
 
 
+def _llama_server_reachable() -> bool:
+    """Return whether a local llama-server accepts TCP connections.
+
+    Performs a single short-timeout connect to ``localhost:8080``, mirroring
+    :func:`_ollama_reachable`. Isolated in its own helper so tests can
+    monkeypatch it without real network I/O.
+
+    :returns: ``True`` when ``localhost:8080`` accepts a TCP connection,
+        ``False`` on refusal, timeout, or any socket error.
+    """
+    try:
+        with socket.create_connection(
+            (_LLAMA_SERVER_HOST, _LLAMA_SERVER_PORT), timeout=_LLAMA_SERVER_PROBE_TIMEOUT
+        ):
+            return True
+    except OSError:
+        return False
+
+
 # One-shot prewarmed detection result, produced by
 # :func:`prewarm_detect_providers` and consumed by the next
 # :func:`detect_providers` call. Guarded by ``_prewarm_lock``.
@@ -688,10 +717,13 @@ def detect_providers() -> list[DetectedProvider]:
     4. A logged-in Codex CLI (``~/.codex/auth.json`` exists *and* carries a
        usable credential — see :func:`codex_auth_has_credential`).
     5. A reachable local Ollama (``localhost:11434`` TCP-connectable).
+    6. A reachable local llama-server (``localhost:8080``
+         TCP-connectable).
 
-    No network I/O is performed except the single Ollama probe (see
-    :func:`_ollama_reachable`). On macOS, a ``claude auth status`` subprocess
-    may run as the Claude Keychain fallback (see :func:`_claude_login_detected`).
+    No network I/O is performed except the Ollama and llama-server TCP probes
+    (see :func:`_ollama_reachable` and :func:`_llama_server_reachable`). On
+    macOS, a ``claude auth status`` subprocess may run as the Claude Keychain
+    fallback (see :func:`_claude_login_detected`).
 
     :returns: One :class:`DetectedProvider` per credential found, in the
         priority order above. Empty when nothing is detected.
@@ -816,6 +848,17 @@ def _detect_providers_now() -> list[DetectedProvider]:
                 kind=LOCAL_KIND,
                 family=OPENAI_FAMILY,
                 source=_OLLAMA_URL,
+            )
+        )
+
+    # 6. Local llama-server.
+    if _llama_server_reachable():
+        detected.append(
+            DetectedProvider(
+                name="llama-server",
+                kind=LOCAL_KIND,
+                family=OPENAI_FAMILY,
+                source=_LLAMA_SERVER_URL,
             )
         )
 

--- a/omnigent/onboarding/configure_models.py
+++ b/omnigent/onboarding/configure_models.py
@@ -254,6 +254,7 @@ _PROVIDER_DISPLAY_NAME: dict[str, str] = {
     "google": "Google Gemini",
     "databricks": "Databricks",
     "ollama": "Ollama",
+    "llama-server": "llama-server",
 }
 
 

--- a/omnigent/onboarding/detected.py
+++ b/omnigent/onboarding/detected.py
@@ -201,9 +201,10 @@ def _synthesize_entry(det: DetectedProvider) -> dict[str, object] | None:
         )
 
     if det.kind == "local":
-        # A self-hosted OpenAI-compatible server (Ollama). ``det.source`` is
-        # the base host (e.g. ``http://localhost:11434``); append the
-        # OpenAI-compatible ``/v1`` path. The key is a placeholder the
+        # A self-hosted OpenAI-compatible server (Ollama, llama-server, …).
+        # ``det.source`` is the base host (e.g.
+        # ``http://localhost:11434`` or ``http://localhost:8080``); append
+        # the OpenAI-compatible ``/v1`` path. The key is a placeholder the
         # server ignores but the family block requires a credential source.
         base_url = det.source.rstrip("/") + "/v1"
         return {

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -2,7 +2,8 @@
 
 For open-source users who route coding agents through a non-Databricks
 endpoint (a vendor API key, a subscription CLI login, a gateway like
-OpenRouter, a local Ollama, or a Databricks profile), the ``providers:``
+OpenRouter, a local Ollama or llama-server, or a Databricks profile), the
+``providers:``
 block in ``~/.omnigent/config.yaml`` is the source of truth for the
 active model selection. Defaults are **per family**: a provider marked
 **``default: true``** is the default for the family/families it serves,
@@ -115,7 +116,8 @@ _VALID_WIRE_API = (RESPONSES_WIRE_API, CHAT_WIRE_API)
 # - ``subscription``: a logged-in CLI (``claude`` / ``codex``) — no families,
 #   no base_url; the CLI carries its own auth.
 # - ``gateway``: an OpenAI/Anthropic-compatible proxy (OpenRouter, LiteLLM).
-# - ``local``: a self-hosted endpoint (Ollama, vLLM) reached via families.
+# - ``local``: a self-hosted endpoint (Ollama, llama-server, vLLM)
+#   reached via families.
 # - ``databricks``: a Databricks profile from ``~/.databrickscfg``.
 # - ``cli-config``: a custom model provider the harness CLI's own config
 #   file defines and authenticates (today: a ``[model_providers.X]`` table
@@ -295,8 +297,10 @@ class FamilyConfig:
     active harness does not consume never forces its secret to exist.
 
     :param base_url: Endpoint base URL the harness talks to, e.g.
-        ``"https://openrouter.ai/api/v1"`` (a gateway) or
-        ``"http://localhost:11434/v1"`` (a local Ollama). Required. As
+        ``"https://openrouter.ai/api/v1"`` (a gateway),
+        ``"http://localhost:11434/v1"`` (a local Ollama), or
+        ``"http://localhost:8080/v1"`` (a local llama-server).
+        Required. As
         stored on :attr:`Provider.families` this may still contain a raw
         ``$VAR`` reference; it is expanded by :meth:`Provider.family`.
     :param api_key: Inline static API key, possibly a ``$VAR`` reference
@@ -319,7 +323,8 @@ class FamilyConfig:
         ``default`` key consulted when the spec declares no model, e.g.
         ``{"default": "gpt-4o", "opus": "claude-opus-4"}``.
     :param pricing: Optional custom per-million-token pricing for
-        self-hosted models and gateways (e.g., Ollama, vLLM, custom endpoints).
+        self-hosted models and gateways (e.g., Ollama, llama-server, vLLM,
+        custom endpoints).
         When configured, this pricing takes precedence over catalog lookup,
         allowing self-hosted providers serving catalog-known model IDs to use
         their own rates. ``None`` (the default) means no custom pricing — falls

--- a/tests/cli/test_configure_models.py
+++ b/tests/cli/test_configure_models.py
@@ -94,15 +94,18 @@ def isolated_config(tmp_path, monkeypatch):
     # Redirect CLI-detected credential homes so a developer's real
     # ~/.claude / ~/.codex logins don't leak into ambient detection.
     monkeypatch.setenv("HOME", str(tmp_path))
-    # Stub out the two ambient-detection helpers that read real machine
+    # Stub out the ambient-detection helpers that read real machine
     # state regardless of HOME / env-var isolation:
     # - _ollama_reachable: TCP-probes localhost:11434; a running Ollama
     #   would otherwise add an entry to the harness menu and shift option
     #   numbers, making input sequences non-deterministic.
+    # - _llama_server_reachable: TCP-probes localhost:8080; a running
+    #   llama-server would have the same effect.
     # - _claude_login_detected: on macOS falls back to `claude auth status`
     #   which reads the Keychain (not HOME), so a real Claude subscription
     #   leaks through even with HOME redirected to tmp_path.
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
+    monkeypatch.setattr("omnigent.onboarding.ambient._llama_server_reachable", lambda: False)
     monkeypatch.setattr("omnigent.onboarding.ambient._claude_login_detected", lambda: False)
     return tmp_path
 

--- a/tests/llms/test_custom_pricing_integration.py
+++ b/tests/llms/test_custom_pricing_integration.py
@@ -17,22 +17,29 @@ from omnigent.onboarding.provider_config import (
 )
 
 
-def test_parse_family_with_custom_pricing():
-    """Test that _parse_family correctly parses custom pricing."""
+@pytest.mark.parametrize(
+    ("endpoint", "api_key", "model"),
+    [
+        ("http://localhost:11434/v1", "ollama", "llama3.2:latest"),
+        ("http://localhost:8080/v1", "llama-server", "llama-3.2-8b"),
+    ],
+)
+def test_parse_family_with_custom_pricing(endpoint: str, api_key: str, model: str) -> None:
+    """Local Ollama and llama-server endpoints preserve custom pricing."""
     raw = {
-        "base_url": "http://localhost:11434/v1",
-        "api_key": "ollama",
+        "base_url": endpoint,
+        "api_key": api_key,
         "pricing": {
             "input_per_million": 0.0,
             "output_per_million": 0.0,
         },
-        "models": {"default": "llama3.2:latest"},
+        "models": {"default": model},
     }
 
     family = _parse_family("test-provider", "openai", raw)
 
-    assert family.base_url == "http://localhost:11434/v1"
-    assert family.api_key == "ollama"
+    assert family.base_url == endpoint
+    assert family.api_key == api_key
     assert family.pricing is not None
     assert family.pricing.input_per_million == 0.0
     assert family.pricing.output_per_million == 0.0

--- a/tests/llms/test_routing.py
+++ b/tests/llms/test_routing.py
@@ -41,6 +41,10 @@ from omnigent.llms.routing import RoutedModel, infer_harness_from_model, parse_m
             RoutedModel(provider="ollama", model="llama3"),
         ),
         (
+            "llama-server/llama-3.2-8b",
+            RoutedModel(provider="llama-server", model="llama-3.2-8b"),
+        ),
+        (
             "gemini/gemini-2.5-pro",
             RoutedModel(provider="gemini", model="gemini-2.5-pro"),
         ),

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -1,10 +1,12 @@
 """Tests for omnigent.onboarding.ambient — machine credential detection.
 
-Detection reads the environment, two CLI-login files under ``$HOME``, a single
-localhost TCP probe for Ollama, and — on macOS only — a ``claude auth status``
-fallback for the Keychain-stored Claude credential. These tests redirect
-``$HOME`` to a tmp dir, control the environment explicitly, and monkeypatch
-both :func:`omnigent.onboarding.ambient._ollama_reachable` and
+Detection reads the environment, two CLI-login files under ``$HOME``, a pair of
+localhost TCP probes (Ollama and llama-server), and — on macOS
+only — a ``claude auth status`` fallback for the Keychain-stored Claude
+credential. These tests redirect ``$HOME`` to a tmp dir, control the
+environment explicitly, and monkeypatch
+:func:`omnigent.onboarding.ambient._ollama_reachable`,
+:func:`omnigent.onboarding.ambient._llama_server_reachable`, and
 :func:`omnigent.onboarding.harness_install.harness_cli_logged_in` so no real
 network or subprocess I/O occurs. Each test asserts the exact
 :class:`DetectedProvider` fields (name / kind / family / source), not just the
@@ -62,6 +64,7 @@ def clean_env(tmp_path, monkeypatch: pytest.MonkeyPatch):
     for var in _PROVIDER_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr(ambient, "_ollama_reachable", lambda: False)
+    monkeypatch.setattr(ambient, "_llama_server_reachable", lambda: False)
     # Neutralize the macOS Keychain fallback by default (the file check already
     # sees no creds under the tmp HOME). The detected/absent tests override this.
     monkeypatch.setattr(harness_install, "harness_cli_logged_in", lambda key: False)
@@ -447,8 +450,60 @@ def test_ollama_detected_when_reachable(clean_env, monkeypatch: pytest.MonkeyPat
     ]
 
 
+def test_llama_server_probe_uses_default_endpoint_and_handles_refusal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The llama-server probe targets its default port and treats refusal as absent."""
+    calls: list[tuple[tuple[str, int], float]] = []
+
+    def refused(address: tuple[str, int], *, timeout: float):
+        calls.append((address, timeout))
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(ambient.socket, "create_connection", refused)
+
+    assert ambient._llama_server_reachable() is False
+    assert calls == [
+        (("localhost", 8080), ambient._LLAMA_SERVER_PROBE_TIMEOUT),
+    ]
+
+
+def test_llama_server_detected_when_reachable(clean_env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reachable local llama-server is detected as a local openai provider.
+
+    Uses the monkeypatched ``_llama_server_reachable`` so no real socket is
+    opened. Failure means a running local llama-server would not be
+    offered.
+    """
+    monkeypatch.setattr(ambient, "_llama_server_reachable", lambda: True)
+    detected = detect_providers()
+    assert detected == [
+        DetectedProvider(
+            name="llama-server",
+            kind="local",
+            family="openai",
+            source="http://localhost:8080",
+        )
+    ]
+
+
+def test_ollama_and_llama_server_both_detected_when_reachable(
+    clean_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ollama and llama-server are detected independently, not as alternatives.
+
+    They listen on different default ports (11434 vs 8080), so both can be
+    running at once. Failure here would mean one is being treated as a
+    fallback for the other instead of an independent probe.
+    """
+    monkeypatch.setattr(ambient, "_ollama_reachable", lambda: True)
+    monkeypatch.setattr(ambient, "_llama_server_reachable", lambda: True)
+    detected = detect_providers()
+    assert [d.name for d in detected] == ["ollama", "llama-server"]
+
+
 def test_detection_priority_order(clean_env, monkeypatch: pytest.MonkeyPatch) -> None:
-    """All signals together are returned in env → claude → codex → ollama order.
+    """All signals together are returned in env → claude → codex → local order.
 
     Failure means the stable ordering broke, so the setup UI would present
     detected providers in a non-deterministic / surprising order.
@@ -469,11 +524,20 @@ def test_detection_priority_order(clean_env, monkeypatch: pytest.MonkeyPatch) ->
         '{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-codex-real"}', encoding="utf-8"
     )
     monkeypatch.setattr(ambient, "_ollama_reachable", lambda: True)
+    monkeypatch.setattr(ambient, "_llama_server_reachable", lambda: True)
 
     detected = detect_providers()
     # Env keys first, in PROVIDER_ENV_VARS iteration order (openai precedes
-    # anthropic in that dict), then claude login, codex login, ollama.
-    assert [d.name for d in detected] == ["openai", "anthropic", "claude", "codex", "ollama"]
+    # anthropic in that dict), then claude login, codex login, ollama,
+    # llama-server.
+    assert [d.name for d in detected] == [
+        "openai",
+        "anthropic",
+        "claude",
+        "codex",
+        "ollama",
+        "llama-server",
+    ]
 
 
 # ── Codex config.toml custom provider (cli-config) detection ───────────────

--- a/tests/onboarding/test_detected.py
+++ b/tests/onboarding/test_detected.py
@@ -242,6 +242,18 @@ def test_synthesize_local_ollama() -> None:
     assert entries["ollama"]["openai"]["base_url"] == "http://localhost:11434/v1"
 
 
+def test_synthesize_local_llama_server() -> None:
+    """A reachable llama-server becomes a local OpenAI-compatible /v1 entry."""
+    det = DetectedProvider(
+        name="llama-server", kind="local", family=OPENAI_FAMILY, source="http://localhost:8080"
+    )
+    entries = synthesize_detected_entries([det])
+    assert entries["llama-server"] == {
+        "kind": "local",
+        "openai": {"base_url": "http://localhost:8080/v1", "api_key": "ollama"},
+    }
+
+
 def test_effective_merges_and_auto_defaults_per_family() -> None:
     """Empty config + ambient creds → both merged and each its family default.
 

--- a/tests/repl/test_repl.py
+++ b/tests/repl/test_repl.py
@@ -1848,9 +1848,9 @@ def test_build_startup_header_creds_line_hints_first_available(tmp_path, monkeyp
         "    kind: databricks\n"
         "    profile: gtm-ws\n"
     )
-    # Hermetic: ignore a dev machine's ambient providers. A running local Ollama
-    # (TCP-probed at localhost:11434) serves openai and would outrank the
-    # Databricks fallback under test, so pin detection to none.
+    # Hermetic: ignore a dev machine's ambient providers. A running local
+    # OpenAI-compatible server (Ollama or llama-server) would serve openai and
+    # outrank the Databricks fallback under test, so pin detection to none.
     monkeypatch.setattr("omnigent.onboarding.detected.detect_providers", list)
     header = _build_startup_header(
         "claude-sdk", "Two-headed brainstorming partner.", ["anthropic", "openai"]

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -144,7 +144,21 @@ def _worker_spec(harness: str, **executor_kwargs: object) -> AgentSpec:
                 "name": "ollama",
                 "host": "localhost:11434",
             },
-            id="local",
+            id="local-ollama",
+        ),
+        pytest.param(
+            ResolvedModelProvider(
+                kind="local",
+                detail="provider 'llama-server'",
+                base_url="http://localhost:8080/v1",
+            ),
+            {
+                "kind": "local",
+                "label": "Local",
+                "name": "llama-server",
+                "host": "localhost:8080",
+            },
+            id="local-llama-server",
         ),
         pytest.param(
             ResolvedModelProvider(

--- a/tests/test_native_codex_provider.py
+++ b/tests/test_native_codex_provider.py
@@ -27,6 +27,7 @@ def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
     monkeypatch.setenv("OMNIGENT_DISABLE_KEYRING", "1")
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("omnigent.onboarding.ambient._llama_server_reachable", lambda: False)
     for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "CODEX_HOME"):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
@@ -250,7 +251,7 @@ def test_resolve_native_codex_launch_subscription_no_login_falls_through_to_key(
     overrides → Codex login prompt.
     """
     # No ambient providers, so the fall-through target is unambiguously the
-    # explicitly-configured key (not a detected env key / Ollama).
+    # explicitly-configured key (not a detected env key / local server).
     monkeypatch.setattr("omnigent.onboarding.ambient._ollama_reachable", lambda: False)
     _seed(
         _isolated,


### PR DESCRIPTION
## Related issue

Closes #2542 

## Summary

- Add `_llama_server_reachable()` to `omnigent/onboarding/ambient.py`, mirroring `_ollama_reachable()` — a short-timeout TCP probe against `localhost:8080` (llama.cpp's `llama-server` default port).
- Wire it into `detect_providers()` as an independent detection step (not a fallback): Ollama and llama-server are checked separately since both can be reachable at once on their different default ports.
- Register `llama-server` alongside `ollama` everywhere a local OpenAI-compatible provider is known: `llms/routing.py`, `llms/adapters/__init__.py`, `llms/adapters/openai.py` docstring, `onboarding/configure_models.py`, and `onboarding/provider_config.py` docstrings.
- Update `README.md`, `deploy/islo/README.md`, `deploy/modal/README.md`, and `llms/LLMCLIENT.md` to document `llama-server` as a supported local gateway alongside Ollama.

## Test Plan

- `_llama_server_reachable()` unit-tested directly: verifies it targets `localhost:8080` with the expected timeout and treats connection refusal as "absent" (`tests/onboarding/test_ambient.py::test_llama_server_probe_uses_default_endpoint_and_handles_refusal`).
- New detection tests confirm a reachable llama-server is surfaced as a `local` / `openai`-family provider (`test_llama_server_detected_when_reachable`), and that Ollama + llama-server are both detected independently when reachable together, not as alternatives (`test_ollama_and_llama_server_both_detected_when_reachable`).
- `test_detection_priority_order` updated to include llama-server in the expected ordering (env → claude → codex → ollama → llama-server).
- `test_synthesize_local_llama_server` (`tests/onboarding/test_detected.py`) confirms the detected entry synthesizes into the correct `/v1` base URL and provider block.
- `test_routing.py` and `test_custom_pricing_integration.py` updated/parametrized to cover `llama-server/<model>` string parsing and custom pricing on a llama-server endpoint.
- Manually verified end-to-end against a real `llama-server` process: started it on the default port, ran `omni setup`, confirmed it was offered/auto-adopted, then confirmed it disappeared from detection once the process was stopped.

Ran the below test suite:

```python
uv run --no-sync python -m pytest \
  tests/cli/test_configure_models.py \
  tests/llms/test_custom_pricing_integration.py \
  tests/llms/test_routing.py \
  tests/onboarding/test_ambient.py \
  tests/onboarding/test_detected.py \
  tests/repl/test_repl.py \
  tests/test_model_catalog.py \
  tests/test_native_codex_provider.py
```

## Demo

- [ X] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

https://github.com/user-attachments/assets/d61daaeb-4279-45f6-b318-76b3fc40f7e3

## Type of change

- [ ] Bug fix
- [ X] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ X] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ X] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: ran a real `llama-server` locally on the default port and confirmed detection picks it up (offered/auto-adopted in `omni setup`) and correctly drops it once the process is stopped — this exercises the live TCP probe path that's mocked out in the unit tests.

## Changelog

`omni setup` now auto-detects a locally running llama.cpp `llama-server` (default port 8080), the same way it already does for Ollama.