### PR TITLE
fix(cli): canonicalize host id before daemon reuse

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2875,7 +2875,9 @@ def _daemon_host_identity_changed(record: _HostDaemonRecord) -> bool:
     if record.host_id is None:
         return False
     current_host_id = _load_existing_host_id()
-    return record.host_id != current_host_id
+    from omnigent.db.db_models import normalize_uuid
+
+    return normalize_uuid(record.host_id) != normalize_uuid(current_host_id)
 
 
 def _terminate_host_unit(record: _HostDaemonRecord, *, reason: str) -> None:

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -457,6 +457,46 @@ def test_ensure_host_daemon_respawns_on_host_identity_change(
     assert "args" in captured
 
 
+@pytest.mark.parametrize(
+    "configured_host_id",
+    [
+        "host_329c39d03aad39ccf2f8597d596676bd",
+        "329c39d0-3aad-39cc-f2f8-597d596676bd",
+    ],
+)
+def test_ensure_host_daemon_reuses_equivalent_host_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    configured_host_id: str,
+) -> None:
+    """Legacy and dashed forms do not replace a daemon using the bare UUID."""
+    captured: dict[str, object] = {}
+    _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    target = "https://server.example.com"
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target=target,
+        mode="server",
+        server_url=target,
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+        host_id="329c39d03aad39ccf2f8597d596676bd",
+        config_sig=cli.server_config_signature(),
+    )
+    monkeypatch.setattr(cli, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_load_existing_host_id", lambda: configured_host_id)
+    torn_down: list[str] = []
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    _ensure_host_daemon(target)
+
+    assert "args" not in captured
+    assert torn_down == []
+
+
 def test_ensure_host_daemon_respawns_on_config_drift(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Related issue

 N/A — reported from an upgraded `isaac omni` installation.

 ## Summary

 - Canonicalize configured and recorded host IDs before comparing daemon identity.
 - Prevent equivalent legacy `host_<uuid>`, dashed UUID, and bare UUID forms from unnecessarily restarting the daemon and disconnecting its sessions.

 ELI5: compare the UUID itself rather than how it is formatted.

 ## Test Plan

 - `.venv/bin/pytest tests/cli/test_backend.py -q` (`102 passed`)
 - `.venv/bin/ruff check omnigent/cli.py tests/cli/test_backend.py`
 - `.venv/bin/ruff format --check omnigent/cli.py tests/cli/test_backend.py`
 - Manually patched the `isaac omni` client runtime and verified repeated launches no longer restart the daemon or terminate existing sessions.

 ## Demo

 - [ ] Visual demo attached below
 - [x] Non-visual evidence provided below or in Test Plan
 - [ ] Not applicable — no behavioral change

 ## Type of change

 - [x] Bug fix
 - [ ] Feature
 - [ ] UI / frontend change
 - [ ] Refactor / chore
 - [ ] Docs
 - [ ] Test / CI
 - [ ] Breaking change

 ## Test coverage

 - [x] Unit tests added / updated
 - [ ] Integration tests added / updated
 - [ ] E2E tests added / updated
 - [x] Manual verification completed
 - [x] Existing tests cover this change
 - [ ] Not applicable

 ## Coverage notes

 Regression tests cover legacy-prefixed and dashed UUID forms. Existing coverage verifies that genuinely different identities still restart the daemon. Manual validation confirmed the original `isaac omni` failure is fixed.

 ## Changelog

 Upgraded hosts with legacy-prefixed IDs no longer restart their daemon and disconnect existing sessions on every launch.
