### PR TITLE
Support handler + factory_params in native policy specs

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -138,6 +138,21 @@ rate_limit:
     limit: 50
 ```
 
+`factory_params` is equivalent to the inline `function: {path, arguments}`
+form, so the block above is the same as:
+
+```yaml
+rate_limit:
+  type: function
+  function:
+    path: omnigent.policies.builtins.safety.max_tool_calls_per_session
+    arguments:
+      limit: 50
+```
+
+Supply arguments through one of the two — declaring both `factory_params`
+and `function.arguments` on the same policy is rejected.
+
 ---
 
 ## For session users

--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -3408,6 +3408,14 @@ def _parse_function_policy(
     """
     Parse a ``type: function`` policy block.
 
+    The callable path comes from ``function:`` or its ``handler:``
+    alias. Factory arguments may be given inline as
+    ``function: {path, arguments}`` or via a sibling
+    ``factory_params:`` mapping (the ``handler`` + ``factory_params``
+    shape shared with the runtime Policy entity and the
+    ``/v1/policies`` API). The two argument sources are mutually
+    exclusive.
+
     :param name: Enclosing policy name (error messages +
         recorded on the spec).
     :param data: Raw YAML mapping for this policy.
@@ -3415,8 +3423,10 @@ def _parse_function_policy(
         policy types (``name``, ``on``, ``condition``,
         ``ask_timeout``).
     :returns: A populated :class:`FunctionPolicySpec`.
-    :raises OmnigentError: On missing ``function:`` field
-        or malformed ``action`` / ``set_labels`` values.
+    :raises OmnigentError: On missing ``function:`` field,
+        malformed ``set_labels`` / ``config`` values, a
+        non-mapping ``factory_params``, or arguments supplied via
+        both ``function.arguments`` and ``factory_params``.
     """
     # Accept both ``function:`` and ``handler:`` for the callable path.
     # ``handler`` is the proto/service-policies convention; ``function``
@@ -3438,9 +3448,30 @@ def _parse_function_policy(
             f"policy {name!r}: 'config' must be a dict, got {type(config).__name__}",
             code=ErrorCode.INVALID_INPUT,
         )
+    function = _parse_function_ref(function_raw, policy_name=name)
+    # ``factory_params:`` is a sibling-key alias for ``function.arguments`` —
+    # the ``handler:`` + ``factory_params:`` shape used by the runtime Policy
+    # entity, the ``/v1/policies`` API, and the docs. Fold it into the
+    # FunctionRef so the same block works in a spec bundle and the server
+    # ``--config``, not just the single-file omnigent loader.
+    factory_params = data.get("factory_params")
+    if factory_params is not None:
+        if not isinstance(factory_params, dict):
+            raise OmnigentError(
+                f"policy {name!r}: `factory_params` must be a mapping (or omitted), "
+                f"got {type(factory_params).__name__}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if function.arguments is not None:
+            raise OmnigentError(
+                f"policy {name!r}: set factory arguments via `function.arguments` or a "
+                f"sibling `factory_params:`, not both.",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        function = FunctionRef(path=function.path, arguments=factory_params)
     return FunctionPolicySpec(
         **base_kwargs,
-        function=_parse_function_ref(function_raw, policy_name=name),
+        function=function,
         set_labels=set_labels,
         config=config,
     )

--- a/tests/spec/test_policy_parser.py
+++ b/tests/spec/test_policy_parser.py
@@ -25,6 +25,7 @@ from omnigent.spec.parser import (
     _parse_condition,
     _parse_guardrails,
     parse,
+    parse_default_policies,
 )
 from omnigent.spec.types import (
     DEFAULT_ASK_TIMEOUT,
@@ -292,6 +293,105 @@ policies:
       arguments: [1, 2]
 """)
         )
+
+
+def test_parse_function_policy_factory_params_sibling() -> None:
+    """`handler:` + sibling `factory_params:` folds into `function.arguments`.
+
+    This is the ``handler`` + ``factory_params`` shape shared with the
+    runtime Policy entity and the ``/v1/policies`` API. It must produce
+    the same :class:`FunctionRef` as the inline ``function: {path,
+    arguments}`` form so a spec bundle / server ``--config`` accepts it.
+    """
+    spec = _parse_guardrails(
+        _yaml("""
+policies:
+  rate:
+    type: function
+    handler: myorg.policies.rate_limit
+    factory_params:
+      limit: 50
+""")
+    )
+    assert spec is not None and spec.policies is not None
+    p = spec.policies[0]
+    assert isinstance(p, FunctionPolicySpec)
+    assert p.function is not None
+    assert p.function.path == "myorg.policies.rate_limit"
+    assert p.function.arguments == {"limit": 50}
+
+
+def test_parse_function_policy_factory_params_with_function_string() -> None:
+    """`function:` bare string + sibling `factory_params:` also folds."""
+    spec = _parse_guardrails(
+        _yaml("""
+policies:
+  cost:
+    type: function
+    function: omnigent.policies.builtins.cost.cost_budget
+    factory_params:
+      max_cost_usd: 5.0
+      ask_thresholds_usd: [1.0]
+""")
+    )
+    assert spec is not None and spec.policies is not None
+    p = spec.policies[0]
+    assert isinstance(p, FunctionPolicySpec)
+    assert p.function is not None
+    assert p.function.path == "omnigent.policies.builtins.cost.cost_budget"
+    assert p.function.arguments == {"max_cost_usd": 5.0, "ask_thresholds_usd": [1.0]}
+
+
+def test_parse_function_policy_factory_params_non_dict_rejected() -> None:
+    """`factory_params: [1, 2]` → loud error."""
+    with pytest.raises(OmnigentError, match=r"factory_params. must be a mapping"):
+        _parse_guardrails(
+            _yaml("""
+policies:
+  broken:
+    type: function
+    handler: myorg.x
+    factory_params: [1, 2]
+""")
+        )
+
+
+def test_parse_function_policy_factory_params_and_arguments_conflict() -> None:
+    """Both `function.arguments` and sibling `factory_params:` → loud error."""
+    with pytest.raises(OmnigentError, match=r"not both"):
+        _parse_guardrails(
+            _yaml("""
+policies:
+  broken:
+    type: function
+    function:
+      path: myorg.x
+      arguments: {limit: 1}
+    factory_params:
+      limit: 2
+""")
+        )
+
+
+def test_parse_default_policies_accepts_factory_params() -> None:
+    """Server `--config` policies share the parser, so the
+    `handler` + `factory_params` shape folds there too."""
+    policies = parse_default_policies(
+        _yaml("""
+session_cost_guard:
+  type: function
+  handler: omnigent.policies.builtins.cost.cost_budget
+  factory_params:
+    max_cost_usd: 5.0
+    ask_thresholds_usd: [1.0]
+""")
+    )
+    assert len(policies) == 1
+    p = policies[0]
+    assert isinstance(p, FunctionPolicySpec)
+    assert p.function is not None
+    assert p.function.path == "omnigent.policies.builtins.cost.cost_budget"
+    assert p.function.arguments == {"max_cost_usd": 5.0, "ask_thresholds_usd": [1.0]}
 
 
 def test_parse_policies_preserve_yaml_order() -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- The native AgentSpec policy parser (`_parse_function_policy` in `omnigent/spec/parser.py`) read the callable path from `function:`/`handler:` and a nested `function.arguments`, but **silently dropped a sibling `factory_params:`**. That `handler` + `factory_params` shape only worked through the single-file omnigent loader (`omnigent/inner/loader.py`) — yet `docs/POLICIES.md` and `docs/AGENT_YAML_SPEC.md` already document it as *the* policy syntax.
- This folds a sibling `factory_params:` into `FunctionRef.arguments`, matching how the runtime `Policy` entity and the `/v1/policies` API already map it (`runtime/policies/builder.py`). Because `parse_default_policies` (server `--config`) and agent-spec `guardrails.policies:` both funnel through `_parse_function_policy`, the shape now works for **spec bundles and the server config** alike.
- Declaring both `function.arguments` and `factory_params` on the same policy is rejected (fail-loud); a non-mapping `factory_params` is rejected.

Before → after (both now parse to the same `FunctionRef`):

```yaml
# already worked
rate_limit:
  type: function
  function: {path: ...max_tool_calls_per_session, arguments: {limit: 50}}

# now also works in spec bundles + server --config (previously dropped `limit`)
rate_limit:
  type: function
  handler: ...max_tool_calls_per_session
  factory_params: {limit: 50}
```

## Test Plan

`python -m pytest tests/spec/test_policy_parser.py tests/spec/test_policy_validator.py tests/spec/test_omnigent_adapter.py tests/spec/test_omnigent_legacy_shim.py -q` → **143 passed**.

New tests in `tests/spec/test_policy_parser.py`:
- `handler` + `factory_params` folds into `function.arguments`
- `function:` bare string + `factory_params` folds
- non-mapping `factory_params` rejected
- `function.arguments` + `factory_params` conflict rejected
- `parse_default_policies` (server `--config`) accepts the shape

`pre-commit run --files ...` → passed (ruff format/check, pyrefly).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Pure parser change covered by unit tests exercising both the agent-spec (`_parse_guardrails`) and server-config (`parse_default_policies`) entry points, plus the two rejection paths.

## Changelog

Policy specs now accept the documented `handler` + `factory_params` shape in agent spec bundles and the server `--config`, not just single-file agents.

This pull request and its description were written by Isaac.