### PR TITLE
test: remove stale and unplanned strict-xfail guards

### DIFF
--- a/tests/server/integration/test_builtin_agents.py
+++ b/tests/server/integration/test_builtin_agents.py
@@ -360,55 +360,6 @@ async def test_list_builtin_agents_empty_when_none_registered(
     assert body["has_more"] is False
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "AgentObject exposes no availability / unavailable_reason fields "
-        "yet. The Add Agent picker can't grey out an agent that "
-        "can't be launched in the current environment, nor explain why. "
-        "Flips to a failing XPASS when the catalog grows the metadata — "
-        "promote this to a real contract test then."
-    ),
-)
-async def test_catalog_entry_exposes_availability_and_reason(
-    agent_store: SqlAlchemyAgentStore,
-    artifact_store: LocalArtifactStore,
-    agents_client: httpx.AsyncClient,
-) -> None:
-    """
-    Each ``GET /v1/agents`` entry should report whether it is launchable
-    plus a reason when it is not.
-
-    Discoverability is only half the Add Agent contract: the picker also
-    needs to know which catalog entries it may actually launch for this
-    user/environment/session and why a disabled one is disabled. The two
-    field names below are the proposed wire contract — strict xfail so the
-    suite trips the moment the schema gains them and forces this test to
-    be turned into a positive assertion.
-    """
-    bundle = build_agent_bundle(
-        name="codex-reviewer",
-        executor={"type": "omnigent", "config": {"harness": "codex"}},
-    )
-    _register_builtin_agent(
-        agent_store,
-        artifact_store,
-        agent_id="77b35426aef3c1495c2912cecb232108",
-        name="codex-reviewer",
-        bundle=bundle,
-    )
-
-    resp = await agents_client.get("/v1/agents")
-
-    assert resp.status_code == 200, resp.text
-    entry = next(a for a in resp.json()["data"] if a["id"] == "77b35426aef3c1495c2912cecb232108")
-    # availability gates whether the picker can launch the entry;
-    # unavailable_reason explains a disabled one. Both absent from the
-    # AgentObject schema today, so these key lookups fail (the xfail).
-    assert "availability" in entry
-    assert "unavailable_reason" in entry
-
-
 async def test_catalog_description_falls_back_to_spec_when_row_unset(
     agent_store: SqlAlchemyAgentStore,
     artifact_store: LocalArtifactStore,

--- a/tests/server/integration/test_comments_routes.py
+++ b/tests/server/integration/test_comments_routes.py
@@ -453,58 +453,6 @@ async def test_send_marks_comments_addressed_and_formats_message(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="send must not auto-resolve comments before verification.",
-)
-async def test_send_leaves_comments_open_until_verified(
-    auth_client: httpx.AsyncClient,
-    db_uri: str,
-) -> None:
-    """Spec: sending to the agent should NOT auto-resolve comments.
-
-    Sending comments creates a request for the agent, but the feedback is
-    not actually resolved until the requested change is verified (explicit
-    user action or a verified-resolution workflow). The current endpoint
-    optimistically flips ``draft`` -> ``addressed`` on send, which hides
-    unresolved feedback if the agent fails, ignores, or mis-handles a
-    comment. This strict xfail documents the desired contract: the comment
-    stays ``draft`` immediately after ``/comments/send``.
-
-    :param auth_client: HTTP client backed by the auth-enabled app.
-    :param db_uri: Per-test SQLite URI used to seed the edit grant.
-    """
-    session_id = _seed_session_with_grants(db_uri, {"alice@example.com": LEVEL_EDIT})
-
-    comment = await _add_comment(
-        auth_client,
-        session_id,
-        user="alice@example.com",
-        path="src/review.py",
-        body="Please fix this edge case",
-        start_index=0,
-        end_index=4,
-    )
-
-    send_resp = await auth_client.post(
-        f"/v1/sessions/{session_id}/comments/send",
-        json={"comment_ids": [comment["id"]]},
-        headers={"X-Forwarded-Email": "alice@example.com"},
-    )
-    send_resp.raise_for_status()
-
-    list_resp = await auth_client.get(
-        f"/v1/sessions/{session_id}/comments",
-        headers={"X-Forwarded-Email": "alice@example.com"},
-    )
-    list_resp.raise_for_status()
-    status = {c["id"]: c["status"] for c in list_resp.json()}[comment["id"]]
-    assert status == "draft", (
-        f"Comment should remain 'draft' (open) until verified, got {status!r}. "
-        "Sending to the agent should not optimistically auto-resolve feedback."
-    )
-
-
 async def test_comment_api_serializes_updated_at(
     auth_client: httpx.AsyncClient,
     db_uri: str,

--- a/tests/server/integration/test_sessions_add_agent.py
+++ b/tests/server/integration/test_sessions_add_agent.py
@@ -294,28 +294,3 @@ async def test_added_child_history_and_resources_resolve_independently(
     assert res.status_code == 200, res.text
     assert res.json()["object"] == "list"
     assert isinstance(res.json()["data"], list)
-
-
-# ── Available agents catalog (blocked — tripwire) ────────
-
-
-@pytest.mark.xfail(
-    reason=(
-        "No mounted GET /api/agents catalog route (documented in "
-        "omnigent/server/API.md, not wired in app.py). Flips to XPASS "
-        "when the route lands."
-    ),
-    strict=False,
-)
-async def test_available_agents_catalog_endpoint_exists(
-    client: httpx.AsyncClient,
-) -> None:
-    """``GET /api/agents`` lists launchable template agents for Add Agent."""
-    await create_test_agent(client, name="catalog-codex", executor=_CODEX_EXECUTOR)
-
-    resp = await client.get("/api/agents")
-    assert resp.status_code == 200, f"catalog endpoint not available: {resp.status_code}"
-    body = resp.json()
-    assert body["object"] == "list"
-    assert isinstance(body["data"], list)
-    assert any(a.get("name") == "catalog-codex" for a in body["data"])


### PR DESCRIPTION
## Related issue

Test-only cleanup; no issue required (`Test / CI`).

## Summary

Removes three strict-xfail tests that no longer function as valid guards. Follow-on to the same cleanup theme as the claude-sdk xfail removal — an xfail is only useful if it will flip to XPASS when the described gap closes; these won't, or guard behavior we don't want.

- **`test_send_leaves_comments_open_until_verified`** (`test_comments_routes.py`) — documented a *desired* contract (sending to the agent must **not** auto-resolve a comment, keep it `draft`). That's the opposite of the shipped, intended behavior: the sibling test `test_send_marks_comments_addressed` asserts send flips `draft → addressed`. Auto-resolve on send is what we want, so this guard encodes a rejected spec.
- **`test_available_agents_catalog_endpoint_exists`** (`test_sessions_add_agent.py`) — waits for a `GET /api/agents` route that was **intentionally removed and replaced** by `GET /v1/agents` (see `omnigent/server/routes/builtin_agents.py`: *"the read-only successor to the removed `GET /api/agents` list"*). The premise is obsolete and the successor route is already covered by `test_builtin_agents.py`. (It was also `strict=False`, so it wouldn't even fail loudly if the old route reappeared.)
- **`test_catalog_entry_exposes_availability_and_reason`** (`test_builtin_agents.py`) — guards a proposed `availability` / `unavailable_reason` wire contract for the Add Agent picker. There's no plan to build picker-availability, so this "future contract" guard is just noise.

Kept: the `sandbox=none` `/shell` workspace-escape xfails in `test_filesystem_path_isolation_e2e.py` — those guard a real, still-open sharing-safety gap (a shared session's guest can escape the workspace root when no OS sandbox is active).

## Test Plan

- `python3 -m pytest tests/server/integration/test_comments_routes.py tests/server/integration/test_sessions_add_agent.py tests/server/integration/test_builtin_agents.py --collect-only` → collects cleanly (no orphaned imports/helpers; shared fixtures still used by other tests).
- `ruff check` / `ruff format --check` clean on all three files.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual verification completed
- [ ] Not applicable

## Coverage notes

Test-only deletions. Two removed guards were for rejected/obsolete contracts (auto-resolve is intended; `/api/agents` was replaced by `/v1/agents`, already covered elsewhere); one was for an unplanned feature. No production code changed.

This pull request and its description were written by Isaac.