### PR TITLE
Validate agent cache paths

### DIFF
--- a/omnigent/runtime/agent_cache.py
+++ b/omnigent/runtime/agent_cache.py
@@ -60,8 +60,11 @@ class AgentCache:
         ):
             raise ValueError(f"unsafe agent id for cache path: {agent_id!r}")
         cache_root = self._cache_dir.resolve(strict=False)
-        path = (cache_root / f"{component}{suffix}").resolve(strict=False)
-        if path.parent != cache_root:
+        normalized_path = os.path.normpath(cache_root / f"{component}{suffix}")
+        if not normalized_path.startswith(os.path.join(cache_root, "")):
+            raise ValueError(f"unsafe agent id for cache path: {agent_id!r}")
+        path = Path(normalized_path)
+        if path.parent != cache_root or path.resolve(strict=False) != path:
             raise ValueError(f"unsafe agent id for cache path: {agent_id!r}")
         return path
 

--- a/omnigent/runtime/agent_cache.py
+++ b/omnigent/runtime/agent_cache.py
@@ -48,6 +48,23 @@ class AgentCache:
         self._cache_dir = cache_dir
         self._specs: dict[str, AgentSpec] = {}
 
+    def _cache_path(self, agent_id: str, *, suffix: str = "") -> Path:
+        """Return a direct child of the cache root for an agent id."""
+        component = os.path.basename(agent_id)
+        if (
+            not component
+            or component in {".", ".."}
+            or component != agent_id
+            or "\\" in component
+            or "\x00" in component
+        ):
+            raise ValueError(f"unsafe agent id for cache path: {agent_id!r}")
+        cache_root = self._cache_dir.resolve(strict=False)
+        path = (cache_root / f"{component}{suffix}").resolve(strict=False)
+        if path.parent != cache_root:
+            raise ValueError(f"unsafe agent id for cache path: {agent_id!r}")
+        return path
+
     def load(
         self,
         agent_id: str,
@@ -79,7 +96,7 @@ class AgentCache:
         :returns: A LoadedAgent with the parsed spec and the
             on-disk working directory.
         """
-        workdir = self._cache_dir / agent_id
+        workdir = self._cache_path(agent_id)
 
         # Tier 1: in-memory spec. The cached spec was parsed with the
         # *expand_env* value of whichever caller populated it first.
@@ -130,8 +147,8 @@ class AgentCache:
         :returns: A LoadedAgent with the new spec and working
             directory.
         """
-        workdir = self._cache_dir / agent_id
-        staging_dir = self._cache_dir / f"{agent_id}_staging"
+        workdir = self._cache_path(agent_id)
+        staging_dir = self._cache_path(agent_id, suffix="_staging")
 
         # Extract new bundle to staging directory
         tmp_fd, tmp_name = tempfile.mkstemp(suffix=".tar.gz")
@@ -166,8 +183,8 @@ class AgentCache:
         :param agent_id: Unique agent identifier,
             e.g. ``"ag_abc123"``.
         """
+        workdir = self._cache_path(agent_id)
         self._specs.pop(agent_id, None)
-        workdir = self._cache_dir / agent_id
         if workdir.is_dir():
             shutil.rmtree(workdir)
 

--- a/tests/runtime/test_agent_cache.py
+++ b/tests/runtime/test_agent_cache.py
@@ -196,9 +196,49 @@ def test_evict_noop_for_uncached_agent(
     agent_cache.evict("never-loaded")
 
 
+def test_cache_operations_allow_symlinked_cache_root(
+    artifact_store: LocalArtifactStore,
+    cache_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """The configured root may be a symlink; individual entries may not."""
+    target = tmp_path / "real-cache"
+    target.mkdir()
+    try:
+        cache_dir.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable")
+    agent_cache = AgentCache(artifact_store, cache_dir)
+    bundle_location = "agent-1/abc123"
+    bundle_bytes = _store_bundle(artifact_store, bundle_location)
+
+    loaded = agent_cache.load("agent-1", bundle_location)
+    assert loaded.workdir == target.resolve() / "agent-1"
+    assert agent_cache.load("agent-1", bundle_location).spec is loaded.spec
+    disk_cache = AgentCache(artifact_store, cache_dir)
+    assert disk_cache.load("agent-1", bundle_location).workdir == loaded.workdir
+    assert agent_cache.replace("agent-1", bundle_location, bundle_bytes).workdir == loaded.workdir
+    agent_cache.evict("agent-1")
+
+    assert not loaded.workdir.exists()
+    assert cache_dir.is_symlink()
+    assert target.is_dir()
+
+
 @pytest.mark.parametrize(
     "agent_id",
-    ["", ".", "..", "../outside", "nested/agent", r"..\outside", "/tmp/outside"],
+    [
+        "",
+        ".",
+        "..",
+        "../outside",
+        "nested/agent",
+        r"..\outside",
+        "/tmp/outside",
+        "agent\x00id",
+        r"C:\outside",
+        r"\\server\share\agent",
+    ],
 )
 def test_cache_operations_reject_unsafe_agent_ids(
     agent_cache: AgentCache,
@@ -216,26 +256,78 @@ def test_cache_operations_reject_unsafe_agent_ids(
     assert not cache_dir.exists()
 
 
-def test_cache_operations_reject_symlink_escape(
+@pytest.mark.parametrize("operation", ["load", "replace", "evict"])
+@pytest.mark.parametrize("target_name", ["outside", "cache-sibling", "cache/other-agent"])
+@pytest.mark.parametrize("warm_cache", [False, True])
+def test_cache_operations_reject_symlink_redirect(
     agent_cache: AgentCache,
+    artifact_store: LocalArtifactStore,
     cache_dir: Path,
     tmp_path: Path,
+    operation: str,
+    target_name: str,
+    warm_cache: bool,
 ) -> None:
-    """An existing cache symlink cannot redirect a load outside the root."""
-    outside = tmp_path / "outside"
-    outside.mkdir()
-    marker = outside / "marker"
-    marker.write_text("keep", encoding="utf-8")
+    """Neither cache tier can follow a symlink into another directory."""
     cache_dir.mkdir()
+    target = tmp_path / target_name
+    target.mkdir()
+    (target / "config.yaml").write_text(_MINIMAL_CONFIG, encoding="utf-8")
+    marker = target / "marker"
+    marker.write_text("keep", encoding="utf-8")
+    bundle_location = "linked-agent/abc123"
+    bundle_bytes = _store_bundle(artifact_store, bundle_location)
+    if warm_cache:
+        loaded = agent_cache.load("linked-agent", bundle_location)
+        loaded.workdir.rename(tmp_path / "original-agent")
+    cached_specs = dict(agent_cache._specs)
     try:
-        (cache_dir / "linked-agent").symlink_to(outside, target_is_directory=True)
+        (cache_dir / "linked-agent").symlink_to(target, target_is_directory=True)
     except OSError:
         pytest.skip("directory symlinks are unavailable")
 
     with pytest.raises(ValueError, match="unsafe agent id"):
-        agent_cache.load("linked-agent", "unused")
+        if operation == "load":
+            agent_cache.load("linked-agent", bundle_location)
+        elif operation == "replace":
+            agent_cache.replace("linked-agent", bundle_location, bundle_bytes)
+        else:
+            agent_cache.evict("linked-agent")
 
     assert marker.read_text(encoding="utf-8") == "keep"
+    assert agent_cache._specs == cached_specs
+    assert (cache_dir / "linked-agent").is_symlink()
+    assert not (cache_dir / "linked-agent_staging").exists()
+
+
+@pytest.mark.parametrize("target_name", ["outside", "cache-sibling", "cache/other-agent"])
+def test_replace_rejects_staging_symlink_redirect(
+    agent_cache: AgentCache,
+    artifact_store: LocalArtifactStore,
+    cache_dir: Path,
+    tmp_path: Path,
+    target_name: str,
+) -> None:
+    """Reject redirected staging before changing either cache tier."""
+    bundle_location = "agent-1/abc123"
+    bundle_bytes = _store_bundle(artifact_store, bundle_location)
+    loaded = agent_cache.load("agent-1", bundle_location)
+    target = tmp_path / target_name
+    target.mkdir()
+    marker = target / "marker"
+    marker.write_text("keep", encoding="utf-8")
+    try:
+        (cache_dir / "agent-1_staging").symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(ValueError, match="unsafe agent id"):
+        agent_cache.replace("agent-1", bundle_location, bundle_bytes)
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert (cache_dir / "agent-1_staging").is_symlink()
+    assert (loaded.workdir / "config.yaml").read_text(encoding="utf-8") == _MINIMAL_CONFIG
+    assert agent_cache.load("agent-1", bundle_location).spec is loaded.spec
 
 
 # ── env-var expansion is gated on provenance ──────────

--- a/tests/runtime/test_agent_cache.py
+++ b/tests/runtime/test_agent_cache.py
@@ -196,6 +196,48 @@ def test_evict_noop_for_uncached_agent(
     agent_cache.evict("never-loaded")
 
 
+@pytest.mark.parametrize(
+    "agent_id",
+    ["", ".", "..", "../outside", "nested/agent", r"..\outside", "/tmp/outside"],
+)
+def test_cache_operations_reject_unsafe_agent_ids(
+    agent_cache: AgentCache,
+    cache_dir: Path,
+    agent_id: str,
+) -> None:
+    """Cache operations reject ids that could escape the cache root."""
+    with pytest.raises(ValueError, match="unsafe agent id"):
+        agent_cache.load(agent_id, "unused")
+    with pytest.raises(ValueError, match="unsafe agent id"):
+        agent_cache.replace(agent_id, "unused", b"not-a-bundle")
+    with pytest.raises(ValueError, match="unsafe agent id"):
+        agent_cache.evict(agent_id)
+
+    assert not cache_dir.exists()
+
+
+def test_cache_operations_reject_symlink_escape(
+    agent_cache: AgentCache,
+    cache_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """An existing cache symlink cannot redirect a load outside the root."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "marker"
+    marker.write_text("keep", encoding="utf-8")
+    cache_dir.mkdir()
+    try:
+        (cache_dir / "linked-agent").symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("directory symlinks are unavailable")
+
+    with pytest.raises(ValueError, match="unsafe agent id"):
+        agent_cache.load("linked-agent", "unused")
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
 # ── env-var expansion is gated on provenance ──────────
 #
 # A tenant-uploaded (session-scoped) bundle must NOT have its ${VAR}


### PR DESCRIPTION
## Related issue

CodeQL path-injection alert [#153](https://github.com/omnigent-ai/omnigent/security/code-scanning/153).

## Summary

- Validate agent IDs before using them as cache directory names.
- Require cache paths to resolve to direct children of the configured cache root.
- Apply the guard consistently to load, replace, and eviction operations.
- Reject traversal, nested-path, cross-platform separator, and symlink-escape cases.

## Test Plan

- `uv run --frozen pytest -q tests/runtime/test_agent_cache.py` — 19 passed
- `uv run --frozen pre-commit run --files omnigent/runtime/agent_cache.py tests/runtime/test_agent_cache.py`
- `git diff --check`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Unit tests verify valid cache behavior remains unchanged and unsafe IDs cannot redirect any cache operation outside its root.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage exercises traversal-style IDs across load, replace, and eviction, plus an existing symlink that resolves outside the cache root.
