### PR TITLE
fix(codex-native): read a refused app-server connect as not-ready

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5258,7 +5258,16 @@ def create_runner_app(
             client_name="omnigent-codex-native-runner",
         )
         try:
-            await codex_client.connect()
+            try:
+                await codex_client.connect()
+            except (ConnectionError, FileNotFoundError) as exc:
+                # Bridge state is published before the app server binds its
+                # socket, so a refused connect means "not up yet", the same
+                # condition as missing state above — not a failure worth a
+                # warning and a stack trace on every poll.
+                raise _CodexNativeModelOptionsNotReady(
+                    "Codex-native app server is not accepting connections yet."
+                ) from exc
             rows = await list_codex_model_options(codex_client)
         finally:
             with contextlib.suppress(Exception):
@@ -10379,12 +10388,12 @@ def create_runner_app(
                 status_code=200,
                 content={"models": _with_model_configuration_source(session_id, models)},
             )
-        except _CodexNativeModelOptionsNotReady:
+        except _CodexNativeModelOptionsNotReady as exc:
             return JSONResponse(
                 status_code=503,
                 content={
                     "error": "codex_native_model_options_failed",
-                    "detail": "Codex-native model options are not ready yet.",
+                    "detail": str(exc),
                 },
             )
         except Exception as exc:  # noqa: BLE001 - surface Codex app-server failures to AP.

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -1025,6 +1025,118 @@ async def test_codex_native_model_options_query_model_list(
 
 
 @pytest.mark.asyncio
+async def test_codex_native_model_options_refused_connect_reads_as_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A refused connect to the Codex app server is startup, not a failure.
+
+    Bridge state is published before the app server binds its socket, so the
+    picker's poll lands in that gap and the connect is refused. Reporting it
+    through the generic handler logged a warning with a stack trace on every
+    poll, for the same "not up yet" condition the missing-state branch already
+    reports quietly.
+    """
+    from omnigent import codex_native_app_server
+    from omnigent.spec.types import ExecutorSpec
+
+    conv_id = "68ba0a62ebe928d26adf37c8974ce1ebc"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(conv_id)
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+
+    async def _fake_auto_create_codex(
+        session_id: str,
+        resource_registry: Any,
+        publish_event: Any,
+        **kwargs: Any,
+    ) -> SessionResourceView:
+        """Stand in for the codex launch, leaving the seeded bridge dir alone."""
+        del resource_registry, publish_event, kwargs
+        return SessionResourceView(
+            id="terminal_codex_main",
+            type="terminal",
+            session_id=session_id,
+            name="codex:main",
+            metadata={"terminal_name": "codex", "session_key": "main", "running": True},
+        )
+
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_codex_terminal",
+        _fake_auto_create_codex,
+    )
+
+    codex_native_bridge.write_bridge_state(
+        bridge_dir,
+        codex_native_bridge.CodexNativeBridgeState(
+            session_id=conv_id,
+            socket_path="ws://127.0.0.1:43211",
+            thread_id="thread_codex",
+            codex_home=str(codex_home),
+            active_turn_id=None,
+        ),
+    )
+
+    class _RefusingClient:
+        """App-server client whose connect is refused, as during startup."""
+
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def connect(self) -> None:
+            raise ConnectionRefusedError("Connect call failed ('127.0.0.1', 43211)")
+
+        async def close(self) -> None:
+            self.closed = True
+
+    refusing = _RefusingClient()
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "client_for_transport",
+        lambda transport, *, client_name="omnigent": refusing,
+    )
+
+    codex_native_spec = AgentSpec(
+        spec_version=1,
+        name="t",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "codex-native"}),
+    )
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        """Return the codex-native spec for any agent_id."""
+        del agent_id, session_id
+        return codex_native_spec
+
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+
+    with caplog.at_level("WARNING", logger="omnigent.runner.app"):
+        async with _runner_client(app) as client:
+            create_resp = await client.post(
+                "/v1/sessions",
+                json={"session_id": conv_id, "agent_id": "880b5afda28ad55ff74cbeb9b5fc67fb"},
+            )
+            assert create_resp.status_code == 201, create_resp.text
+
+            resp = await client.get(f"/v1/sessions/{conv_id}/codex-model-options")
+
+    # Still a retryable 503 so the picker polls again, but named for what it is.
+    assert resp.status_code == 503, resp.text
+    assert resp.json() == {
+        "error": "codex_native_model_options_failed",
+        "detail": "Codex-native app server is not accepting connections yet.",
+    }
+    assert not [r for r in caplog.records if "model/list failed" in r.getMessage()]
+    # The client is still closed on the way out, so the refused attempt leaks nothing.
+    assert refusing.closed
+
+
+@pytest.mark.asyncio
 async def test_claude_native_model_options_use_session_launch_catalog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

No filed issue — found by triaging WARNING volume in omnigent's own debug logs.

## Summary

Bridge state is written before the Codex app server binds its socket, so a model-options poll that lands in that window gets `ConnectionRefusedError` from `connect()`. That fell through the generic `except Exception` handler, which logged a warning with a full stack trace and returned a 503 whose `detail` was the raw errno string:

```
codex-native model options failed: [Errno 111] Connect call failed ('127.0.0.1', 50683)
```

This is the same "app server isn't up yet" condition the missing-bridge-state branch a few lines above already reports quietly as `_CodexNativeModelOptionsNotReady` — so it was being logged as a failure on every poll of an ordinary startup race.

- Classify a refused connect (and a missing unix socket) as `_CodexNativeModelOptionsNotReady`. The response stays a retryable 503 so the picker keeps polling.
- Surface the exception's own message in the 503 `detail` instead of a hardcoded string, so a client can tell the two not-ready causes apart.

## Test Plan

Added `test_codex_native_model_options_refused_connect_reads_as_not_ready`, which seeds real bridge state, hands the runner a client whose `connect()` raises `ConnectionRefusedError`, and asserts the endpoint returns 503 with the new detail, logs no `model/list failed` warning, and still closes the client.

```
pytest tests/runner/test_app_sessions_native_events_lifecycle.py \
  -k "refused_connect or returns_503_until_bridge_state"
2 passed
```

The whole file is green apart from `test_codex_native_model_options_query_model_list[*]`, which **fails identically on unmodified `main`** (verified by stashing this change) — pre-existing, unrelated to this PR.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

The Codex model picker no longer logs a stack trace while the Codex app server is still starting up.
