### PR TITLE
fix(runtime): stop re-warning per poll when git status keeps failing

### DIFF
--- a/omnigent/runtime/filesystem_registry.py
+++ b/omnigent/runtime/filesystem_registry.py
@@ -36,6 +36,8 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from omnigent.process_logging import log_once
+
 try:
     import fcntl
 except ImportError:  # pragma: no cover - Windows has no flock.
@@ -989,25 +991,30 @@ class GitFilesystemRegistry(FilesystemRegistry):
             )
             raise GitStatusUnavailable(f"git status timed out after {elapsed:.1f}s") from exc
         except OSError as exc:
-            elapsed = time.monotonic() - started
-            _logger.warning(
-                "GitFilesystemRegistry.list_changed_files: %r in %s could not run after %.2fs: %s",
+            log_once(
+                _logger,
+                logging.WARNING,
+                "GitFilesystemRegistry.list_changed_files: %r in %s could not run: %s",
                 argv,
                 self._git_root,
-                elapsed,
                 exc,
             )
             raise GitStatusUnavailable(f"git status could not run: {exc}") from exc
 
-        elapsed = time.monotonic() - started
         if result.returncode != 0:
             stderr = result.stderr.decode("utf-8", errors="replace").strip()
-            _logger.warning(
-                "GitFilesystemRegistry.list_changed_files: %r in %s exited %d after %.2fs: %s",
+            # The file panel polls this, so a workspace that is simply not a
+            # repo fails identically on every poll -- hundreds of lines for one
+            # unchanging condition. Elapsed time is left out of the message so
+            # it stays a stable dedup key; the timeout branch above keeps it,
+            # since there the duration is the finding.
+            log_once(
+                _logger,
+                logging.WARNING,
+                "GitFilesystemRegistry.list_changed_files: %r in %s exited %d: %s",
                 argv,
                 self._git_root,
                 result.returncode,
-                elapsed,
                 stderr,
             )
             raise GitStatusUnavailable(
@@ -1084,25 +1091,25 @@ class GitFilesystemRegistry(FilesystemRegistry):
             )
             raise GitStatusUnavailable(f"git status timed out after {elapsed:.1f}s") from exc
         except OSError as exc:
-            elapsed = time.monotonic() - started
-            _logger.warning(
-                "GitFilesystemRegistry.get_changed_file: %r in %s could not run after %.2fs: %s",
+            log_once(
+                _logger,
+                logging.WARNING,
+                "GitFilesystemRegistry.get_changed_file: %r in %s could not run: %s",
                 argv,
                 self._git_root,
-                elapsed,
                 exc,
             )
             raise GitStatusUnavailable(f"git status could not run: {exc}") from exc
 
-        elapsed = time.monotonic() - started
         if result.returncode != 0:
             stderr = result.stderr.decode("utf-8", errors="replace").strip()
-            _logger.warning(
-                "GitFilesystemRegistry.get_changed_file: %r in %s exited %d after %.2fs: %s",
+            log_once(
+                _logger,
+                logging.WARNING,
+                "GitFilesystemRegistry.get_changed_file: %r in %s exited %d: %s",
                 argv,
                 self._git_root,
                 result.returncode,
-                elapsed,
                 stderr,
             )
             raise GitStatusUnavailable(

--- a/tests/runtime/test_filesystem_registry.py
+++ b/tests/runtime/test_filesystem_registry.py
@@ -571,6 +571,40 @@ def test_git_list_changed_files_raises_on_nonzero_exit(tmp_path: Path, monkeypat
         reg.list_changed_files("any-conv", limit=100)
 
 
+def test_git_status_failure_warns_once_across_polls(
+    tmp_path: Path,
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A workspace that is not a repo must not warn once per poll.
+
+    The file panel polls ``list_changed_files``, so an unchanging condition —
+    a session opened outside any repo — logged hundreds of identical warnings
+    for one setup problem, drowning real failures in the logs. The failure must
+    still raise every time; only the logging is deduplicated.
+    """
+
+    def _not_a_repo(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args="git status",
+            returncode=128,
+            stdout=b"",
+            stderr=b"fatal: not a git repository (or any parent up to mount point /)",
+        )
+
+    monkeypatch.setattr("omnigent.runtime.filesystem_registry.subprocess.run", _not_a_repo)
+
+    reg = GitFilesystemRegistry(watch_path=tmp_path, git_root=tmp_path)
+    with caplog.at_level(logging.WARNING, logger="omnigent.runtime.filesystem_registry"):
+        for _ in range(5):
+            with pytest.raises(GitStatusUnavailable, match="exited 128"):
+                reg.list_changed_files("any-conv", limit=100)
+
+    warnings = [r for r in caplog.records if "list_changed_files" in r.getMessage()]
+    assert len(warnings) == 1, f"expected one warning across five polls, got {len(warnings)}"
+    assert "not a git repository" in warnings[0].getMessage()
+
+
 def test_git_get_changed_file_raises_on_timeout(tmp_path: Path, monkeypatch) -> None:
     """A ``git status`` timeout in the single-file lookup must raise, not return ``None``.
 


### PR DESCRIPTION
## Related issue

No filed issue — found by triaging WARNING volume in omnigent's own debug logs.

## Summary

The file panel polls `list_changed_files`, and every failing poll logged a warning. A workspace that is simply not a git repository — a session opened in a home directory, say — fails identically forever, so one setup problem produces hundreds of identical lines and buries real failures:

```
GitFilesystemRegistry.list_changed_files: ['git', 'status', ...] in /home/<user> exited 128
after 0.01s: fatal: not a git repository (or any parent up to mount point /)
```

- Route the non-zero-exit and could-not-run branches through `log_once`, whose dedup key is the formatted message — so a *changed* failure still logs while identical repeats are dropped.
- Drop elapsed time from those two messages to keep the key stable (it varies per call, which would defeat the dedup). The timeout branch keeps it, since there the duration *is* the finding.
- Same treatment for `get_changed_file`, which had the identical per-call warning.

Both branches still raise `GitStatusUnavailable` on every call — only the logging is deduplicated, so no caller's error handling changes.

## Test Plan

Added `test_git_status_failure_warns_once_across_polls`: stubs `git status` to fail with `exited 128 / not a git repository`, calls `list_changed_files` five times, and asserts all five still raise while exactly one warning is logged.

```
pytest tests/runtime/test_filesystem_registry.py
79 passed
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

Opening a session outside a git repository no longer floods the logs with one warning per file-panel refresh.
