### PR TITLE
fix(codex-native): stop the delta barrier abandoning a draining backlog

### DIFF
--- a/omnigent/codex_native_forwarder.py
+++ b/omnigent/codex_native_forwarder.py
@@ -94,6 +94,11 @@ _DELTA_FLUSH_CHAR_THRESHOLD = 64
 # unbounded wait parks the caller for good. Under the runner's 10s auto-forwarder cancel
 # budget so this resolves first.
 _DELTA_MARKER_TIMEOUT_SECONDS = 5.0
+# Cap for a mid-turn flush barrier, which has no cancel budget to stay under and
+# whose whole purpose is ordering: extending the wait while the worker keeps
+# draining is better than returning early and reordering the caller's next event.
+# Teardown's stop marker keeps the tighter bound above.
+_DELTA_BARRIER_MAX_WAIT_SECONDS = 30.0
 _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE = "external_reasoning_effort_change"
 # Context-compaction progress edge. Publishes the same
 # ``response.compaction.in_progress`` / ``response.compaction.completed`` SSE
@@ -1200,6 +1205,12 @@ class _OutputTextDeltaCoalescer:
         )
         self._worker_task: asyncio.Task[None] | None = None
         self._next_index_by_message_id: dict[str, int] = {}
+        # Read by a barrier waiter to tell a worker draining a backlog from one
+        # that is genuinely wedged. A post slower than one wait window would
+        # otherwise look wedged, so an in-flight post counts as progress too;
+        # the caller's overall cap is what bounds a truly stuck worker.
+        self._flushes_completed = 0
+        self._post_in_flight = False
 
     async def append(self, delta: str, *, message_id: str | None = None) -> None:
         """
@@ -1238,7 +1249,11 @@ class _OutputTextDeltaCoalescer:
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
         self._queue.put_nowait(_DeltaFlushBarrier(done=done))
-        await self._await_marker(done, "flush barrier")
+        await self._await_marker(
+            done,
+            "flush barrier",
+            max_wait_seconds=_DELTA_BARRIER_MAX_WAIT_SECONDS,
+        )
 
     async def close(self) -> None:
         """
@@ -1264,7 +1279,13 @@ class _OutputTextDeltaCoalescer:
                 await self._worker_task
         self._worker_task = None
 
-    async def _await_marker(self, done: asyncio.Future[None], marker: str) -> None:
+    async def _await_marker(
+        self,
+        done: asyncio.Future[None],
+        marker: str,
+        *,
+        max_wait_seconds: float | None = None,
+    ) -> None:
         """
         Wait for the worker to resolve a queue marker.
 
@@ -1273,26 +1294,55 @@ class _OutputTextDeltaCoalescer:
         and the caller is arbitrary, so waiting on the marker alone stalls for the
         full bound on an ordinary shutdown.
 
+        The bound is per stall, not per wait: Codex streams fast enough to queue
+        many chunks ahead of a barrier, and the worker posts each batch as an
+        awaited request, so draining a backlog legitimately outlasts a single
+        bound. Waiting only that long abandoned the barrier mid-drain -- the
+        caller's ordering guarantee was silently dropped and every occurrence
+        logged a warning. So the wait extends while flushes keep completing and
+        gives up only once the worker stops making progress, still capped by
+        ``max_wait_seconds`` so a wedged worker cannot stall the caller
+        indefinitely.
+
         :param done: Future the worker resolves for this marker.
         :param marker: Marker name used in the timeout log.
+        :param max_wait_seconds: Overall cap across stalls, e.g. ``30.0``.
+            Defaults to one per-stall bound, which reproduces the single-shot
+            wait teardown needs to stay inside its cancel budget. Resolved at
+            call time so the bound stays patchable in tests.
         :returns: None once resolved, once the worker stops, or once the bound elapses.
         """
         worker = self._worker_task
         waiters: set[asyncio.Future[None] | asyncio.Task[None]] = {done}
         if worker is not None:
             waiters.add(worker)
-        await asyncio.wait(
-            waiters,
-            return_when=asyncio.FIRST_COMPLETED,
-            timeout=_DELTA_MARKER_TIMEOUT_SECONDS,
-        )
-        if not done.done() and (worker is None or not worker.done()):
-            _logger.warning(
-                "codex delta coalescer %s timed out after %.1fs (session=%s)",
-                marker,
-                _DELTA_MARKER_TIMEOUT_SECONDS,
-                self._session_id,
+        max_wait = _DELTA_MARKER_TIMEOUT_SECONDS if max_wait_seconds is None else max_wait_seconds
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        while True:
+            flushes_before = self._flushes_completed
+            remaining = max_wait - (loop.time() - started)
+            await asyncio.wait(
+                waiters,
+                return_when=asyncio.FIRST_COMPLETED,
+                timeout=min(_DELTA_MARKER_TIMEOUT_SECONDS, max(0.0, remaining)),
             )
+            if done.done() or (worker is not None and worker.done()):
+                return
+            waited = loop.time() - started
+            made_progress = self._flushes_completed != flushes_before or self._post_in_flight
+            if made_progress and waited < max_wait:
+                continue
+            _logger.warning(
+                "codex delta coalescer %s timed out after %.1fs (session=%s, "
+                "flushes_completed=%d, draining=%s)",
+                marker,
+                waited,
+                self._session_id,
+                self._flushes_completed,
+                made_progress,
+            )
+            return
 
     def _ensure_worker(self) -> None:
         """
@@ -1386,6 +1436,7 @@ class _OutputTextDeltaCoalescer:
         assert chunk is not None
         delta = "".join(buffer)
         if chunk.tool_call_id is not None:
+            self._post_in_flight = True
             try:
                 await _post_tool_output_delta(
                     self._client,
@@ -1395,6 +1446,9 @@ class _OutputTextDeltaCoalescer:
                 )
             except Exception:  # noqa: BLE001 - preserve the long-lived forwarder.
                 _logger.warning("Codex forwarder tool-output delta flush failed", exc_info=True)
+            finally:
+                self._post_in_flight = False
+            self._flushes_completed += 1
             return
         index: int | None = None
         final: bool | None = None
@@ -1402,6 +1456,7 @@ class _OutputTextDeltaCoalescer:
             index = self._next_index_by_message_id.get(chunk.message_id, 0)
             self._next_index_by_message_id[chunk.message_id] = index + 1
             final = False
+        self._post_in_flight = True
         try:
             await _post_output_text_delta(
                 self._client,
@@ -1413,6 +1468,9 @@ class _OutputTextDeltaCoalescer:
             )
         except Exception:  # noqa: BLE001 - preserve the long-lived forwarder.
             _logger.warning("Codex forwarder delta flush failed", exc_info=True)
+        finally:
+            self._post_in_flight = False
+        self._flushes_completed += 1
 
 
 class _SessionUsageCoalescer:

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -2827,6 +2827,96 @@ async def test_delta_coalescer_close_gives_up_on_a_wedged_worker(
 
 
 @pytest.mark.asyncio
+async def test_delta_coalescer_flush_waits_out_a_draining_backlog(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``flush()`` must not abandon its barrier while the worker is still posting.
+
+    Codex queues chunks faster than each awaited post drains them, so a backlog
+    outlives any single bound. Giving up then returned before the queued text was
+    posted -- reordering it after whatever the caller sent next -- and logged a
+    timeout every time.
+    """
+
+    class _SlowClient:
+        """Client whose posts are slower than one per-stall bound."""
+
+        def __init__(self) -> None:
+            self.posts: list[tuple[str, dict]] = []
+
+        async def post(self, url: str, *, json: dict) -> httpx.Response:
+            await asyncio.sleep(0.02)
+            self.posts.append((url, json))
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+    # One stall is far shorter than the backlog takes to drain, so the old
+    # single-shot wait would expire mid-drain.
+    monkeypatch.setattr(fwd, "_DELTA_MARKER_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(fwd, "_DELTA_BARRIER_MAX_WAIT_SECONDS", 30.0)
+    client = _SlowClient()
+    coalescer = _coalescer(client)
+    coalescer._ensure_worker()
+    # Distinct message ids so each chunk flushes as its own post.
+    for i in range(10):
+        coalescer._queue.put_nowait(
+            fwd._DeltaChunk(message_id=f"m{i}", tool_call_id=None, delta=f"chunk-{i}\n")
+        )
+
+    with caplog.at_level("WARNING", logger="omnigent.codex_native_forwarder"):
+        await asyncio.wait_for(coalescer.flush(), timeout=30.0)
+
+    # The ordering guarantee held: every queued delta was posted before flush returned.
+    assert len(client.posts) == 10
+    assert not [r for r in caplog.records if "timed out" in r.getMessage()]
+
+    await coalescer.close()
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_flush_gives_up_on_a_wedged_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A worker making no progress must still release ``flush()`` on the cap.
+
+    The progress extension must not become an unbounded wait: with the worker
+    stuck inside one post, no flush ever completes, so the caller gives up.
+    """
+
+    class _HangingClient:
+        """Client whose post never returns, wedging the worker inside a flush."""
+
+        def __init__(self) -> None:
+            self.entered = asyncio.Event()
+
+        async def post(self, *args: object, **kwargs: object) -> None:
+            self.entered.set()
+            await asyncio.sleep(3600)
+
+    monkeypatch.setattr(fwd, "_DELTA_MARKER_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(fwd, "_DELTA_BARRIER_MAX_WAIT_SECONDS", 0.2)
+    client = _HangingClient()
+    coalescer = _coalescer(client)
+    coalescer._ensure_worker()
+    coalescer._queue.put_nowait(fwd._DeltaChunk(message_id="m1", tool_call_id=None, delta="x\n"))
+    await asyncio.wait_for(client.entered.wait(), timeout=5.0)
+    worker = coalescer._worker_task
+    assert worker is not None
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    with caplog.at_level("WARNING", logger="omnigent.codex_native_forwarder"):
+        await asyncio.wait_for(coalescer.flush(), timeout=5.0)
+
+    # Released on the cap, not held for the worker's 3600s post.
+    assert loop.time() - started < 1.0
+    timeouts = [r for r in caplog.records if "timed out" in r.getMessage()]
+    assert timeouts, "a wedged worker must still report the timeout"
+    worker.cancel()
+
+
+@pytest.mark.asyncio
 async def test_delta_coalescer_worker_survives_an_already_settled_marker() -> None:
     """Resolving a marker whose future is already settled must not kill the worker.
 


### PR DESCRIPTION
## Related issue

No filed issue — found by triaging WARNING volume in omnigent's own debug logs, where this is the single widest signature.

## Summary

`flush()` queues a barrier and waits one 5s bound for the worker to reach it. But Codex streams faster than the worker drains: each batch is an awaited HTTP post, and the buffer flushes every 64 chars **or on any newline**, so a long assistant response becomes hundreds of serial posts. A backlog therefore routinely outlasts the bound, and the wait returned with the barrier still unresolved.

Two consequences, and the logging one is the less important:

1. **The ordering guarantee was silently dropped.** `flush()` exists so queued text is posted before the caller's next event; returning early lets that event land ahead of the text.
2. Every occurrence logged `codex delta coalescer flush barrier timed out after 5.0s`, which reads like a wedged worker when the worker was healthy and busy.

The fix makes the bound **per stall rather than per wait**: keep waiting while flushes keep completing, and give up only when progress stops. An in-flight post counts as progress, so one post slower than a single window isn't mistaken for a wedge — the overall `_DELTA_BARRIER_MAX_WAIT_SECONDS` cap is what bounds a genuinely stuck worker.

**Teardown deliberately keeps the old tight bound.** `close()`'s stop marker still gets one single-shot 5s wait so it resolves inside the runner's 10s auto-forwarder-cancel budget (the reason the 5s constant was chosen). That's why the cap is a parameter rather than a second module constant applied to both, and it's resolved at call time so both bounds stay patchable in tests.

## Test Plan

Two new tests:

- `test_delta_coalescer_flush_waits_out_a_draining_backlog` — 10 queued chunks against a client whose posts each outlast one stall window. Asserts all 10 posts landed **before `flush()` returned** (the ordering guarantee) and that no timeout was logged. Fails on `main`: 0 of 10 posted.
- `test_delta_coalescer_flush_gives_up_on_a_wedged_worker` — worker stuck in a post that never returns. Asserts `flush()` is still released on the cap and still logs the timeout, so the progress extension cannot become an unbounded wait.

The pre-existing `test_delta_coalescer_close_gives_up_on_a_wedged_worker` covers the teardown bound and still passes unchanged, which is the check that `close()` did not inherit the longer cap.

```
pytest tests/test_codex_native_forwarder.py
121 passed
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

## Changelog

Streamed Codex output no longer arrives out of order after a burst of fast output.
