### PR TITLE
fix(server): answer 400 for malformed session item data instead of 500

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -6346,10 +6346,17 @@ def _build_new_item(
     """
     Construct a :class:`NewConversationItem` from a POSTed event.
 
-    Validates the data payload via ``parse_item_data`` (the same
-    validator the route boundary already invoked) and wraps the
+    Validates the data payload via ``parse_item_data`` and wraps the
     result with the response_id linkage required by the conversation
     store.
+
+    The item *type* is checked at the route boundary, but ``data`` is a
+    free-form dict there, so a caller can name a known type and omit the
+    fields it requires — ``{"type": "message"}`` with no ``role`` or
+    ``content`` is the shape seen in production. That is bad input, so the
+    raised ``ValidationError`` becomes an
+    :class:`~omnigent.errors.OmnigentError` the caller can act on rather
+    than escaping as an unhandled 500.
 
     :param body: Validated event input — guaranteed to be a known
         item type (the route checked ``_ALLOWED_EVENT_TYPES``).
@@ -6361,8 +6368,16 @@ def _build_new_item(
         single-user mode.
     :returns: A :class:`NewConversationItem` ready for delivery
         or persistence.
+    :raises OmnigentError: When ``body.data`` does not satisfy the
+        payload schema for ``body.type``.
     """
-    data = parse_item_data(body.type, {"type": body.type, **body.data})
+    try:
+        data = parse_item_data(body.type, {"type": body.type, **body.data})
+    except ValidationError as exc:
+        raise OmnigentError(
+            f"invalid data for {body.type!r} item: {exc}",
+            code=ErrorCode.INVALID_INPUT,
+        ) from exc
     return NewConversationItem(
         type=body.type,
         response_id=response_id,

--- a/tests/server/integration/test_sessions_invalid_item_data.py
+++ b/tests/server/integration/test_sessions_invalid_item_data.py
@@ -1,0 +1,118 @@
+"""Integration tests for malformed item ``data`` on the session routes.
+
+The route boundary validates an item's *type* against
+``_ALLOWED_EVENT_TYPES``, but ``data`` arrives as a free-form dict — so a
+caller can name a known type and omit the fields that type requires.
+``_build_new_item`` is where that mismatch surfaces, and an escaping
+pydantic ``ValidationError`` made it an unhandled 500 instead of a
+client error naming the bad field.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.routes.sessions import _build_new_item
+from omnigent.server.schemas import SessionEventInput
+from tests.server.helpers import create_test_agent
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Route helper: bad data is a client error, not a crash ────────────────────
+
+
+@pytest.mark.parametrize(
+    "item_type,data",
+    [
+        # The shape seen in production: a known type, no payload at all.
+        ("message", {}),
+        # Present but incomplete — ``content`` is still required.
+        ("message", {"role": "user"}),
+        # Right keys, wrong type for ``content``.
+        ("message", {"role": "user", "content": "not a list"}),
+    ],
+)
+def test_build_new_item_rejects_invalid_data(item_type: str, data: dict[str, Any]) -> None:
+    """Incomplete item ``data`` raises a client error naming the item type.
+
+    ``parse_item_data`` raises pydantic's ``ValidationError``, which is not
+    an ``OmnigentError`` and so had no registered handler on the session
+    routes — it escaped as an unhandled 500 with a full traceback in the
+    server error log.
+    """
+    body = SessionEventInput(type=item_type, data=data)
+
+    with pytest.raises(OmnigentError) as excinfo:
+        _build_new_item(body, "resp_1")
+
+    assert excinfo.value.code == ErrorCode.INVALID_INPUT
+    assert item_type in excinfo.value.message
+
+
+def test_build_new_item_still_accepts_valid_data() -> None:
+    """The guard does not disturb a well-formed item."""
+    body = SessionEventInput(
+        type="message",
+        data={"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    )
+
+    item = _build_new_item(body, "resp_1")
+
+    assert item.type == "message"
+    assert item.response_id == "resp_1"
+
+
+# ── End to end: the create route answers 4xx, not 500 ────────────────────────
+
+
+async def test_create_session_with_malformed_initial_item_is_client_error(
+    client: httpx.AsyncClient,
+) -> None:
+    """``POST /v1/sessions`` rejects an unusable ``initial_items`` entry.
+
+    With no runner bound the items are persisted as a history-only seed,
+    which is the path that reached ``_build_new_item`` unguarded in
+    production.
+    """
+    agent = await create_test_agent(client)
+
+    resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "initial_items": [{"type": "message", "data": {}}],
+        },
+    )
+
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == ErrorCode.INVALID_INPUT
+
+
+async def test_create_session_with_valid_initial_item_still_succeeds(
+    client: httpx.AsyncClient,
+) -> None:
+    """A well-formed seed item is unaffected by the guard."""
+    agent = await create_test_agent(client)
+
+    resp = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "initial_items": [
+                {
+                    "type": "message",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "kick off"}],
+                    },
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 201, resp.text


### PR DESCRIPTION
## Related issue

No issue filed

Closes #

## Summary

A caller can crash `POST /v1/sessions` with a **500** by sending an
`initial_items` entry whose `data` is incomplete.

The route boundary validates an item's *type* against `_ALLOWED_EVENT_TYPES`, but
`data` arrives as a free-form dict — so naming a known type with a payload that
type cannot accept is reachable input. `_build_new_item` hands it to
`parse_item_data`, and pydantic's `ValidationError` is **not** an `OmnigentError`,
so it has no registered handler and escapes as an unhandled 500 with a full
traceback in the server error log.

Translate it to `OmnigentError(code=INVALID_INPUT)` → **HTTP 400**, naming the
item type so the caller learns which item it got wrong. The guard sits in
`_build_new_item` rather than at one route because all five call sites share the
same free-form `data` contract.

### ELI5

If you ask Omnigent to start a session and hand it a message with no text and no
sender, the right answer is "that message is missing its fields." Instead the
server crashed and told you nothing — and logged the crash as if it were its own
bug rather than a bad request.

```
Unhandled exception: 2 validation errors for MessageData
role
  Field required [type=missing, input_value={'type': 'message'}, input_type=dict]
content
  Field required [type=missing, input_value={'type': 'message'}, input_type=dict]

  .../omnigent/server/routes/_sessions/orchestration.py, in create_session
    _build_new_item(item, "seed", created_by=_attribution_user(user_id))
  .../omnigent/server/routes/_sessions/helpers.py, in _build_new_item
    data = parse_item_data(body.type, {"type": body.type, **body.data})
  .../omnigent/entities/conversation.py, in parse_item_data
    return cls(**raw)
```

The frame is the no-runner seed path, so the volume is low — but it is a
client-triggerable unhandled 500, and the traceback it logs looks like a server
defect during triage.

## Test Plan

New `tests/server/integration/test_sessions_invalid_item_data.py`:

```bash
pytest tests/server/integration/test_sessions_invalid_item_data.py    # 6 passed
```

Regressions around the touched helper:

```bash
pytest tests/server/integration/test_sessions_attribution.py \
       tests/server/integration/test_sessions_model_override.py \
       tests/server/integration/test_sessions_external_item_idempotency.py \
       tests/server/integration/test_sessions_invalid_item_data.py    # 48 passed
```

Confirmed to **fail on the unguarded code** — 4 failed / 2 passed, the two
passing ones being the "well-formed input still works" cases that must not
change:

```
FAILED ...::test_build_new_item_rejects_invalid_data[message-data0]
FAILED ...::test_build_new_item_rejects_invalid_data[message-data1]
FAILED ...::test_build_new_item_rejects_invalid_data[message-data2]
FAILED ...::test_create_session_with_malformed_initial_item_is_client_error
```

`ruff check` / `ruff format --check` clean; `pyrefly check` reports zero errors in
the touched file.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

```
POST /v1/sessions  {"agent_id": "...", "initial_items":[{"type":"message","data":{}}]}

before:  HTTP 500  {"detail": "Internal server error"}    + traceback in the error log
after :  HTTP 400  {"error": {"code": "invalid_input",
                              "message": "invalid data for 'message' item: ..."}}
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The parametrized helper cases cover the three ways `data` can be unusable (absent,
partial, wrong type for a present key). Each behaviour is paired with a
"still accepts valid data" test at both levels — helper and route — so the guard
cannot start rejecting well-formed items unnoticed.

## Changelog

A session created with a malformed initial item now returns a 400 naming the bad item instead of failing with an internal error
