### PR TITLE
feat(server): support client-selected session IDs

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -141,6 +141,7 @@ class BrandingInfo(BaseModel):
 
 
 class ServerInfoResponse(BaseModel):
+    client_session_ids: bool
     accounts_enabled: bool
     single_user: bool
     login_url: str | None
@@ -2441,6 +2442,7 @@ def create_app(
         dictation_available, _ = engine_availability()
         return ServerInfoResponse.model_validate(
             {
+                "client_session_ids": True,
                 "accounts_enabled": accounts_enabled,
                 "single_user": single_user,
                 "login_url": login_url,

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -9258,6 +9258,7 @@ def _persist_stored_session_bundle(
     """
     try:
         created = conversation_store.create_session_with_agent(
+            conversation_id=metadata.id,
             agent_id=agent_id,
             agent_name=agent_name,
             agent_bundle_location=agent_bundle_location,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -344,6 +344,7 @@ from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.conversation_store import (
     PINNED_LABEL_KEY,
+    ConversationAlreadyExistsError,
     ConversationNotFoundError,
     NameAlreadyExistsError,
     pinned_label_key,
@@ -8500,6 +8501,16 @@ async def _create_session_from_existing_agent(
                 if runner_owner is not None and runner_owner != user_id:
                     inherited_runner_id = None
 
+    if (
+        body.id is not None
+        and body.git is not None
+        and await asyncio.to_thread(conversation_store.get_conversation, body.id)
+    ):
+        raise OmnigentError(
+            f"conversation id {body.id!r} already exists",
+            code=ErrorCode.CONFLICT,
+        )
+
     # Workspace validation: if the caller is binding to a host,
     # they must also pass a workspace, and the workspace must
     # satisfy the agent's os_env.cwd boundary on that host (per
@@ -8658,9 +8669,10 @@ async def _create_session_from_existing_agent(
             workspace=canonical_workspace,
             git_branch=git_branch,
             terminal_launch_args=validated_launch_args,
+            conversation_id=body.id,
             project_id=project_resolution.project_id,
         )
-    except NameAlreadyExistsError as exc:
+    except (ConversationAlreadyExistsError, NameAlreadyExistsError) as exc:
         if (
             created_worktree_path is not None
             and body.host_id is not None

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1477,6 +1477,7 @@ class _SessionCreateRequestBase(BaseModel):
     # Declared here, in the legacy field position, so validation errors keep
     # main's ordering. Concrete public models narrow the wire type below.
     agent_id: Any
+    id: str | None = Field(default=None, pattern=r"^[0-9a-f]{32}$")
     project_id: str | None = None
     initial_items: list[SessionEventInput] = Field(default_factory=list)
     title: str | None = Field(default=None, max_length=USER_SESSION_TITLE_MAX_CHARS)
@@ -1641,6 +1642,7 @@ class SessionCreateMetadata(BaseModel):
         valid with ``host_type: "managed"``.
     """
 
+    id: str | None = Field(default=None, pattern=r"^[0-9a-f]{32}$")
     title: str | None = Field(default=None, max_length=USER_SESSION_TITLE_MAX_CHARS)
     project_id: str | None = None
     labels: dict[str, str] = Field(default_factory=dict)

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1518,6 +1518,7 @@ class ConversationStore(ABC):
     def create_session_with_agent(
         self,
         *,
+        conversation_id: str | None = None,
         agent_id: str,
         agent_name: str,
         agent_bundle_location: str,
@@ -1539,6 +1540,8 @@ class ConversationStore(ABC):
         database transaction. If either insert or any label write
         fails, none of the database rows are committed.
 
+        :param conversation_id: Optional caller-supplied session id.
+            ``None`` generates a new random id.
         :param agent_id: Pre-generated agent id, e.g.
             ``"ag_abc123"``.
         :param agent_name: Human-readable agent name from the

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3494,6 +3494,7 @@ class SqlAlchemyConversationStore(ConversationStore):
     def create_session_with_agent(
         self,
         *,
+        conversation_id: str | None = None,
         agent_id: str,
         agent_name: str,
         agent_bundle_location: str,
@@ -3518,6 +3519,8 @@ class SqlAlchemyConversationStore(ConversationStore):
         ``session_id`` pointing at that conversation, then backfills
         ``conversations.agent_id``.
 
+        :param conversation_id: Optional caller-supplied session id.
+            ``None`` generates a new random id.
         :param agent_id: Pre-generated agent id, e.g.
             ``"ag_abc123"``.
         :param agent_name: Human-readable agent name from the
@@ -3565,7 +3568,7 @@ class SqlAlchemyConversationStore(ConversationStore):
             conversation exists.
         """
         return self._create_session_with_agent_with_id(
-            generate_conversation_id(),
+            conversation_id if conversation_id is not None else generate_conversation_id(),
             agent_id=agent_id,
             agent_name=agent_name,
             agent_bundle_location=agent_bundle_location,

--- a/openapi.json
+++ b/openapi.json
@@ -4417,6 +4417,10 @@
           "branding": {
             "$ref": "#/components/schemas/BrandingInfo"
           },
+          "client_session_ids": {
+            "title": "Client Session Ids",
+            "type": "boolean"
+          },
           "databricks_features": {
             "title": "Databricks Features",
             "type": "boolean"
@@ -4518,6 +4522,7 @@
           }
         },
         "required": [
+          "client_session_ids",
           "accounts_enabled",
           "single_user",
           "login_url",

--- a/tests/server/integration/test_session_worktree_create.py
+++ b/tests/server/integration/test_session_worktree_create.py
@@ -246,6 +246,37 @@ async def test_create_without_base_branch_sends_none(
     assert cap.create[0].base_branch is None
 
 
+async def test_duplicate_caller_id_conflicts_before_worktree_create(
+    register_worktree_host: RegisterHost,
+    client: httpx.AsyncClient,
+) -> None:
+    """A known caller id is rejected before creating a git worktree."""
+    cap = register_worktree_host()
+    agent = await create_test_agent(client, name="wt-duplicate-id-agent")
+    session_id = "34567890abcdef1234567890abcdef12"
+    first = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "id": session_id},
+    )
+    assert first.status_code == 201, first.text
+
+    retry = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "id": session_id,
+            "host_id": _HOST_ID,
+            "workspace": _SOURCE_REPO,
+            "git": {"branch_name": "feature/must-not-exist"},
+        },
+    )
+
+    assert retry.status_code == 409, retry.text
+    assert retry.json()["error"]["code"] == "conflict"
+    assert cap.create == []
+    assert cap.remove == []
+
+
 async def test_create_with_invalid_base_branch_fails_400(
     register_worktree_host: RegisterHost,
     client: httpx.AsyncClient,

--- a/tests/server/integration/test_sessions_content_type_csrf.py
+++ b/tests/server/integration/test_sessions_content_type_csrf.py
@@ -351,6 +351,59 @@ async def test_create_session_accepts_multipart_bundled_create(
     assert "session_id" in resp.json()
 
 
+async def test_multipart_create_uses_caller_supplied_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """Multipart metadata may select the persisted session id."""
+    session_id = "1234567890abcdef1234567890abcdef"
+    bundle = build_agent_bundle(name="client-id-multipart-agent")
+
+    response = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"id": session_id})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["session_id"] == session_id
+    persisted = await client.get(f"/v1/sessions/{session_id}")
+    assert persisted.status_code == 200
+    assert persisted.json()["id"] == session_id
+
+
+async def test_multipart_create_duplicate_caller_id_returns_409(
+    client: httpx.AsyncClient,
+) -> None:
+    """Multipart caller-id collisions use the existing conflict response."""
+    session_id = "abcdef1234567890abcdef1234567890"
+
+    first = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"id": session_id})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                build_agent_bundle(name="client-id-first-agent"),
+                "application/gzip",
+            )
+        },
+    )
+    second = await client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({"id": session_id})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                build_agent_bundle(name="client-id-second-agent"),
+                "application/gzip",
+            )
+        },
+    )
+
+    assert first.status_code == 201, first.text
+    assert second.status_code == 409, second.text
+
+
 async def test_multipart_managed_create_reaches_managed_launch(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -152,6 +152,82 @@ async def test_create_session_without_title_returns_none(
     assert session["title"] is None
 
 
+async def test_create_session_uses_caller_supplied_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """A valid caller id is persisted and returned unchanged."""
+    agent = await create_test_agent(client)
+    session_id = "0123456789abcdef0123456789abcdef"
+
+    response = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "id": session_id},
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["id"] == session_id
+    persisted = await client.get(f"/v1/sessions/{session_id}")
+    assert persisted.status_code == 200
+    assert persisted.json()["id"] == session_id
+
+
+async def test_create_session_without_id_generates_one(
+    client: httpx.AsyncClient,
+) -> None:
+    """Omitting id preserves server-generated session identifiers."""
+    agent = await create_test_agent(client)
+
+    response = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+
+    assert response.status_code == 201, response.text
+    session_id = response.json()["id"]
+    assert len(session_id) == 32
+    assert all(char in "0123456789abcdef" for char in session_id)
+
+
+@pytest.mark.parametrize(
+    "session_id",
+    [
+        "0123456789abcdef0123456789abcde",
+        "0123456789abcdef0123456789abcdef0",
+        "01234567-89ab-cdef-0123-456789abcdef",
+        "0123456789ABCDEF0123456789ABCDEF",
+        "g123456789abcdef0123456789abcdef",
+    ],
+)
+async def test_create_session_rejects_malformed_caller_id(
+    client: httpx.AsyncClient,
+    session_id: str,
+) -> None:
+    """Caller ids must be bare 32-character lowercase hex strings."""
+    agent = await create_test_agent(client)
+
+    response = await client.post(
+        "/v1/sessions",
+        json={"agent_id": agent["id"], "id": session_id},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+async def test_create_session_duplicate_caller_id_returns_409(
+    client: httpx.AsyncClient,
+) -> None:
+    """Reusing a caller-supplied session id is a conflict."""
+    agent = await create_test_agent(client)
+    payload = {
+        "agent_id": agent["id"],
+        "id": "fedcba9876543210fedcba9876543210",
+    }
+
+    first = await client.post("/v1/sessions", json=payload)
+    second = await client.post("/v1/sessions", json=payload)
+
+    assert first.status_code == 201, first.text
+    assert second.status_code == 409, second.text
+    assert second.json()["error"]["code"] == "conflict"
+
+
 async def test_first_message_schedules_background_semantic_title(
     client: httpx.AsyncClient,
     app: Any,

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -458,6 +458,17 @@ async def test_info_includes_server_version(
     assert body["server_version"] == VERSION
 
 
+@pytest.mark.asyncio
+async def test_info_advertises_client_session_ids(
+    client: httpx.AsyncClient,
+) -> None:
+    """GET /v1/info advertises caller-selected session ids."""
+    resp = await client.get("/v1/info")
+
+    assert resp.status_code == 200
+    assert resp.json()["client_session_ids"] is True
+
+
 def _branding_png(color: tuple[int, int, int, int]) -> bytes:
     output = BytesIO()
     Image.new("RGBA", (2, 2), color).save(output, format="PNG")

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3159,6 +3159,24 @@ def test_create_session_with_agent_records_workspace(
     assert fetched.host_id is None
 
 
+def test_create_session_with_agent_uses_caller_supplied_conversation_id(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Bundled session creation uses a caller id when provided."""
+    conversation_id = "234567890abcdef1234567890abcdef1"
+
+    created = conversation_store.create_session_with_agent(
+        conversation_id=conversation_id,
+        agent_id="18373c2f7c4d68719e6dbc4b9599b9b1",
+        agent_name="client-id-bundle-agent",
+        agent_bundle_location="18373c2f7c4d68719e6dbc4b9599b9b1/bundle1",
+        agent_description=None,
+    )
+
+    assert created.conversation.id == conversation_id
+    assert conversation_store.get_conversation(conversation_id) is not None
+
+
 def test_create_session_with_agent_records_host_id_with_workspace(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Allow JSON and multipart session-create requests to provide an optional 32-character lowercase hexadecimal `id`.
- Preserve server-generated IDs when older clients omit the field, and advertise support through `GET /v1/info`.
- Return `409` for duplicate caller-selected IDs, including before git worktree side effects, and keep the checked-in OpenAPI schema synchronized.

### ELI5

New clients can choose a session ID before creation so they can navigate immediately. Old clients continue omitting it, so the server generates an ID exactly as before.

```mermaid
flowchart LR
    NewClient[New client] -->|"supplies id"| Server[Server create]
    OldClient[Old client] -->|"omits id"| Server
    Server -->|"uses supplied or generated id"| Store[Session store]
```

## Test Plan

- Focused backend regression suite: 13 tests passed for supplied/generated IDs, validation, duplicate handling, worktree preflight, multipart creation, store behavior, and capability reporting.
- `uv run --frozen pytest -q tests/server/test_openapi_drift.py::test_openapi_json_matches_generator_output`
- CI backward-compatibility smoke tests passed for both new-server/old-client and old-server/new-client configurations.

## Demo

Backend-only API contract; reproducible evidence is provided in the Test Plan.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration tests exercise both JSON and multipart request paths, generated-ID fallback, malformed and duplicate IDs, and the pre-worktree conflict path.

## Changelog

Session-create clients can provide their own stable session IDs while older clients retain server-generated IDs.