### PR TITLE
feat(web): open new conversations instantly

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -619,30 +619,21 @@ async def _drive_permission_mode(base_url: str, session_id: str) -> None:
             await browser.close()
 
 
-def test_start_session_send_shows_busy_spinner(seeded_session: tuple[str, str]) -> None:
-    """Send shows a busy spinner while the create is in flight, then navigates.
-
-    The create awaits the backend (session bootstrap + git worktree setup)
-    before navigating, so the landing screen lingers for the whole round-trip.
-    Without feedback the Send button just goes inert and the typed message sits
-    in the composer, so the click reads as "frozen". This holds the create POST
-    open with a gate so that in-flight window is observable, and asserts the
-    Send button flips to a busy/spinning state (disabled + ``aria-busy`` +
-    "Starting session" label) before the response lands and navigation happens.
-    """
+def test_start_session_opens_immediately_with_proposed_id(
+    seeded_session: tuple[str, str],
+) -> None:
+    """Send opens a provisional chat before the create response arrives."""
     base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_send_busy_spinner(base_url, session_id))
+    _run_in_fresh_loop(_drive_open_immediately(base_url, session_id))
 
 
-async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
+async def _drive_open_immediately(base_url: str, session_id: str) -> None:
     async with async_playwright() as pw:
         browser = await pw.chromium.launch()
         page = await browser.new_page()
         try:
             create_bodies: list[dict[str, Any]] = []
-            # A gate the create handler awaits before responding, so the POST
-            # stays pending long enough to observe the button's busy state. The
-            # test opens it after asserting the spinner, letting navigation run.
+            # Hold the response so immediate client-side navigation is observable.
             release_create = asyncio.Event()
 
             async def handle_hosts(route: Route) -> None:
@@ -706,170 +697,23 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
 
             submit = page.get_by_test_id("new-chat-landing-submit")
             await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
-            # Idle with a message typed: enabled, not busy (arrow, no spin).
+            # Idle with a message typed: enabled, not busy.
             await expect(submit).to_be_enabled()
             await expect(submit).to_have_attribute("aria-busy", "false")
 
             await submit.click()
 
-            # The POST reached the server (proving we're truly in flight, not
-            # blocked by a disabled button) and the button shows the busy state.
+            # The POST includes the same client-selected id used by the URL.
             await _wait_until(lambda: len(create_bodies) == 1)
-            await expect(submit).to_be_disabled()
-            await expect(submit).to_have_attribute("aria-busy", "true")
-            await expect(submit).to_have_attribute("aria-label", "Starting session")
-            # Still on the landing screen — the "frozen"-looking window.
-            await expect(page.get_by_test_id("new-chat-landing-input")).to_be_visible()
-
-            # Release the create: the flow completes and navigates to the
-            # session, so the landing composer unmounts.
-            release_create.set()
-            await expect(page.get_by_test_id("new-chat-landing-input")).to_have_count(
-                0, timeout=30_000
-            )
-        finally:
-            await browser.close()
-
-
-def test_start_session_opens_before_the_create_responds(seeded_session: tuple[str, str]) -> None:
-    """Send opens the session on the stream's announcement, not the response.
-
-    ``POST /v1/sessions`` doesn't answer until the host has finished spawning a
-    runner — a process boot, seconds of it — and the landing screen used to sit
-    on that whole wait before routing anywhere. But the server writes the
-    session row and announces it on ``WS /v1/sessions/updates`` almost
-    immediately, so the id is available long before the response is. This holds
-    the create POST open for the entire test and announces the session over the
-    stream: the chat page must open anyway.
-
-    A regression that goes back to awaiting the response would never leave the
-    landing screen here, since the create never answers.
-
-    The announcement is injected through a mocked updates socket rather than a
-    real create, because this suite has no host daemon for a host-bound create
-    to actually succeed against. The row carries the stubbed agent/host the
-    composer just asked for — that pairing is what the screen matches on to
-    tell its own new session apart from every other session the stream
-    announces to this user.
-    """
-    base_url, session_id = seeded_session
-    _run_in_fresh_loop(_drive_open_before_create_responds(base_url, session_id))
-
-
-async def _drive_open_before_create_responds(base_url: str, session_id: str) -> None:
-    async with async_playwright() as pw:
-        browser = await pw.chromium.launch()
-        page = await browser.new_page()
-        try:
-            create_seen = asyncio.Event()
-            # Released only at teardown, so the create is pending for every
-            # assertion below.
-            release_create = asyncio.Event()
-            sockets: list[Any] = []
-
-            def handle_updates(ws: Any) -> None:
-                # Mocked (never connected to the server), so this test owns
-                # exactly what the page receives on the stream.
-                sockets.append(ws)
-
-            await page.route_web_socket(re.compile(r"/v1/sessions/updates"), handle_updates)
-
-            async def handle_hosts(route: Route) -> None:
-                await route.fulfill(
-                    status=200, content_type="application/json", body=_hosts_body()
-                )
-
-            async def handle_agents(route: Route) -> None:
-                await route.fulfill(
-                    status=200, content_type="application/json", body=_agents_body()
-                )
-
-            async def handle_events(route: Route) -> None:
-                await route.fulfill(
-                    status=200,
-                    content_type="application/json",
-                    body=json.dumps({"queued": True, "item_id": "ci_e2e"}),
-                )
-
-            async def handle_sessions(route: Route) -> None:
-                if route.request.method == "POST":
-                    create_seen.set()
-                    await release_create.wait()
-                    await route.fulfill(
-                        status=200,
-                        content_type="application/json",
-                        body=json.dumps({"id": session_id}),
-                    )
-                else:
-                    await route.continue_()
-
-            await page.route("**/v1/hosts", handle_hosts)
-            await page.route("**/v1/agents", handle_agents)
-            await page.route("**/v1/sessions/*/events", handle_events)
-            await page.route(_SESSIONS_RE, handle_sessions)
-
-            async def handle_agent_scan(route: Route) -> None:
-                await route.fulfill(
-                    status=200,
-                    content_type="application/json",
-                    body=json.dumps({"data": []}),
-                )
-
-            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
-
-            await page.add_init_script(
-                f"""window.localStorage.setItem(
-                    "omnigent:recent-workspaces",
-                    JSON.stringify({{ {_HOST_ID}: ["/work/repo"] }})
-                );"""
-            )
-
-            await page.goto(f"{base_url}/")
-            await page.get_by_test_id("new-chat-landing-input").wait_for(
-                state="visible", timeout=30_000
-            )
-            await _wait_until(lambda: len(sockets) == 1)
-
-            await page.get_by_test_id("new-chat-landing-input").fill("set up the project")
-            await page.get_by_test_id("new-chat-landing-submit").click()
-            # The create is in flight and will stay that way.
-            await _wait_until(create_seen.is_set)
-
-            # A brand-new session the page has never seen, on the agent and
-            # host the composer just asked for: the server's announcement of
-            # the row it wrote before starting the runner.
-            announced_id = "conv_announced_e2e"
-            sockets[0].send(
-                json.dumps(
-                    {
-                        "type": "changed",
-                        "items": [
-                            {
-                                "id": announced_id,
-                                "object": "conversation",
-                                "agent_id": "ag_claude_e2e",
-                                "host_id": _HOST_ID,
-                                "parent_session_id": None,
-                                "title": None,
-                                "created_at": 1_800_000_000,
-                                "updated_at": 1_800_000_000,
-                                "labels": {},
-                                "archived": False,
-                            }
-                        ],
-                    }
-                )
-            )
-
-            # KEY ASSERTION: routed to the announced session while the create
-            # is still pending — the landing composer is gone and the URL is
-            # the announced id, not the one the (unanswered) create would
-            # eventually return.
-            await expect(page).to_have_url(f"{base_url}/c/{announced_id}", timeout=20_000)
+            proposed_id = create_bodies[0]["id"]
+            assert re.fullmatch(r"[0-9a-f]{32}", proposed_id)
+            await expect(page).to_have_url(f"{base_url}/c/{proposed_id}")
             await expect(page.get_by_test_id("new-chat-landing-input")).to_have_count(0)
-            assert not release_create.is_set(), "the create must still be unanswered here"
-        finally:
+
+            # This stub emulates an old backend returning a different authoritative id.
             release_create.set()
+            await expect(page).to_have_url(f"{base_url}/c/{session_id}", timeout=30_000)
+        finally:
             await browser.close()
 
 

--- a/web/src/hooks/RunnerHealthProvider.tsx
+++ b/web/src/hooks/RunnerHealthProvider.tsx
@@ -32,6 +32,7 @@ import {
   useState,
 } from "react";
 import { useActiveConversationId } from "@/hooks/useActiveConversationId";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import { useConversations } from "@/hooks/useConversations";
 import { type RunnerHealthInput, useRunnerHealth } from "@/hooks/useRunnerHealth";
 import { useSession } from "@/hooks/useSession";
@@ -61,7 +62,12 @@ export function RunnerHealthProvider({ children }: { children: ReactNode }) {
   // cover it. Fold the open session into the fallback poll set so it
   // resolves to a real liveness state even when off-sidebar. Its snapshot
   // is already cached by the chat stream bind, so this is a cache hit.
-  const activeSession = useSession(useActiveConversationId()).session;
+  // A provisional id during create has no server session — skip
+  // the fetch so it doesn't hit `/v1/sessions/<provisional>` during the create window.
+  const activeConversationId = useActiveConversationId();
+  const activeSession = useSession(
+    isProvisionalConversationId(activeConversationId) ? undefined : activeConversationId,
+  ).session;
   const activeId = activeSession?.id;
 
   // Sessions registered by transient views (e.g. the new-session dialog)

--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -12,6 +12,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
 import type { ConversationsInfiniteData } from "@/lib/sessionListCache";
+import {
+  clearProvisionalConversationIds,
+  registerProvisionalConversationId,
+} from "@/lib/provisionalConversationId";
 
 // Mock the socket transport so setWatched is observable and start/stop are
 // inert. subscribe/subscribeStatus return no-op unsubscribers.
@@ -91,6 +95,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  clearProvisionalConversationIds();
 });
 
 describe("SessionUpdatesProvider watch-set", () => {
@@ -116,6 +121,14 @@ describe("SessionUpdatesProvider watch-set", () => {
     seedConversations(client, ["conv_open", "conv_b"]);
     renderProvider(client, ["/c/conv_open"]);
     expect(lastWatched()).toEqual(["conv_b", "conv_open"]);
+  });
+
+  it("does not send provisional ids in the watch-set", () => {
+    registerProvisionalConversationId("12345678123456781234567812345678");
+    const client = new QueryClient();
+    seedConversations(client, ["conv_real", "12345678123456781234567812345678"]);
+    renderProvider(client, ["/c/12345678123456781234567812345678"]);
+    expect(lastWatched()).toEqual(["conv_real"]);
   });
 
   it("re-pushes the watch-set with the new open id on navigation", () => {

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/sessionListCache";
 import { isModalHostResolved, resolveModalHost } from "@/lib/sessionHost";
 import { type SessionUpdatesFrame, sessionUpdatesSocket } from "@/lib/sessionUpdatesSocket";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 
 // Coalesce bursts of structural changes / watch-set recomputes into one
 // action. 250 ms is short enough to feel live, long enough to batch the
@@ -218,7 +219,7 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
         }
       }
     }
-    sessionUpdatesSocket.setWatched(ids);
+    sessionUpdatesSocket.setWatched(ids.filter((id) => !isProvisionalConversationId(id)));
   }, [queryClient]);
 
   // Navigating to an off-sidebar child changes the open session without

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -9,6 +9,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 
 export interface McpServerSummary {
   name: string;
@@ -160,10 +161,13 @@ async function fetchSessionAgent(sessionId: string): Promise<Agent> {
  * sessions-derived agent list. Only fires when `sessionId` is non-null.
  */
 export function useSessionAgent(sessionId: string | null) {
+  // A registered provisional id (navigate-first new-chat window) has no server session —
+  // never fetch its agent.
+  const serverId = isProvisionalConversationId(sessionId) ? null : sessionId;
   return useQuery({
-    queryKey: ["session-agent", sessionId],
-    queryFn: () => fetchSessionAgent(sessionId!),
-    enabled: sessionId !== null,
+    queryKey: ["session-agent", serverId],
+    queryFn: () => fetchSessionAgent(serverId!),
+    enabled: serverId !== null,
     staleTime: Infinity,
   });
 }

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -34,6 +34,7 @@ import {
   PINNED_LABEL_KEY,
   PROJECT_FOLDER_FILTERS,
   PROJECT_LABEL_KEY,
+  recentlyCreatedSessions,
   removeIdsFromPages,
   type ConversationsInfiniteData,
   type SessionListWireItem,
@@ -188,6 +189,14 @@ export interface Conversation {
    */
   archived?: boolean;
   /**
+   * Client-only: a provisional row shown while `createSession` is in flight (the
+   * navigate-first new-chat window). There is no server session behind it yet,
+   * so the sidebar disables per-row mutations (rename / delete / archive / pin /
+   * move) until it's rekeyed to the real id — otherwise they'd hit
+   * `/v1/sessions/<provisional>`. Never set on a server row.
+   */
+  provisional?: boolean;
+  /**
    * Total review comments (any status) on this session. Together with
    * `comments_updated_at` it forms a change fingerprint: an add or edit
    * bumps the timestamp, a delete changes the count. SessionUpdatesProvider
@@ -312,30 +321,10 @@ function withoutDeletingSessions(page: ConversationsPage): ConversationsPage {
   };
 }
 
-// ── Recently-created keep-alive ───────────────────────────────────────
-//
-// The push stream inserts a just-created session into the sidebar instantly
-// (SessionUpdatesProvider → insertNewRowsIntoPages), but the create path also
-// fires a `["conversations"]` refetch, and on the search-indexed deployment
-// that fetch lags the write — so it comes back WITHOUT the new session and
-// replaces the cache, dropping the row until the index catches up (it flashes
-// in, then out). We keep the row in the first-page fetch until the index
-// reflects it — the additive mirror of the delete tombstone above.
-const recentlyCreatedSessions = new Map<string, Conversation>();
-
-/** Grace window for the server's async create reindex. */
-const CREATED_KEEPALIVE_MS = 60_000;
-
-/** Keep a just-created session in the first-page list fetch until it's indexed. */
-export function markRecentlyCreated(conv: Conversation): void {
-  recentlyCreatedSessions.set(conv.id, conv);
-  setTimeout(() => recentlyCreatedSessions.delete(conv.id), CREATED_KEEPALIVE_MS);
-}
-
-/** Clear the keep-alive map — exported for test cleanup (mirrors `unmarkSessionsDeleting`). */
-export function clearRecentlyCreated(): void {
-  recentlyCreatedSessions.clear();
-}
+// The recently-created keep-alive map + its mutators live in the leaf
+// `sessionListCache` module (so the chat store can arm it on optimistic create
+// without an import cycle); re-exported here for existing callers.
+export { markRecentlyCreated, clearRecentlyCreated } from "@/lib/sessionListCache";
 
 /**
  * Prepend recently-created rows the first page doesn't yet include (the index

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -15,6 +15,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { authenticatedFetch } from "@/lib/identity";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import {
   isRunnerUnavailable503,
   RunnerOfflineError,
@@ -246,7 +247,11 @@ export function computeGithubPollInterval(info: GithubInfo | undefined): number 
  * Disabled when the runner is known offline. Retries the runner-offline case
  * with capped backoff so a cold-booting runner resolves before any error UI.
  */
-export function useGithubInfo(conversationId: string | undefined, options?: { poll?: boolean }) {
+export function useGithubInfo(rawConversationId: string | undefined, options?: { poll?: boolean }) {
+  // A registered provisional id (navigate-first new-chat window) has no server session.
+  const conversationId = isProvisionalConversationId(rawConversationId)
+    ? undefined
+    : rawConversationId;
   const serveable = useWorkspaceServeable(conversationId);
   // Turn-end backstop: refetch when the focused session goes active→idle, so a
   // just-opened PR appears without opening the tab. Keys off the turn lifecycle,

--- a/web/src/hooks/usePermissions.ts
+++ b/web/src/hooks/usePermissions.ts
@@ -13,6 +13,7 @@ import {
   listPermissions,
   revokePermission,
 } from "@/lib/permissionsApi";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import { useConversations } from "./useConversations";
 import { useSession } from "./useSession";
 
@@ -25,7 +26,9 @@ function sessionOwnerKey(sessionId: string) {
 }
 
 /** Fetch all permission grants for a session. */
-export function usePermissions(sessionId: string | null) {
+export function usePermissions(rawSessionId: string | null) {
+  // A registered provisional id (navigate-first new-chat window) has no server session.
+  const sessionId = isProvisionalConversationId(rawSessionId) ? null : rawSessionId;
   return useQuery({
     queryKey: permissionsKey(sessionId ?? ""),
     queryFn: () => listPermissions(sessionId!),

--- a/web/src/hooks/useSession.test.tsx
+++ b/web/src/hooks/useSession.test.tsx
@@ -11,6 +11,10 @@ vi.mock("@/lib/sessionsApi", async (importOriginal) => ({
 }));
 
 import { getSessionSlim } from "@/lib/sessionsApi";
+import {
+  clearProvisionalConversationIds,
+  registerProvisionalConversationId,
+} from "@/lib/provisionalConversationId";
 import type { Session } from "@/lib/types";
 import { useSession } from "./useSession";
 
@@ -52,6 +56,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  clearProvisionalConversationIds();
   vi.useRealTimers();
 });
 
@@ -62,6 +67,16 @@ describe("useSession — refresh_state", () => {
     await flush();
     expect(getSessionSlimMock).toHaveBeenCalledTimes(1);
     expect(refreshFlags()).toEqual([true]);
+  });
+
+  it("never fetches for a provisional id (no /v1/sessions/<provisional>)", async () => {
+    registerProvisionalConversationId("0a1b2c3d0a1b2c3d0a1b2c3d0a1b2c3d");
+    const { Wrapper } = harness();
+    renderHook(() => useSession("0a1b2c3d0a1b2c3d0a1b2c3d0a1b2c3d"), { wrapper: Wrapper });
+    await flush();
+    // The navigate-first invariant: a provisional id has no server session, so the
+    // query is disabled by construction — no request is issued.
+    expect(getSessionSlimMock).not.toHaveBeenCalled();
   });
 
   // Switching the session's agent invalidates this query. The refetch has to

--- a/web/src/hooks/useSession.ts
+++ b/web/src/hooks/useSession.ts
@@ -13,6 +13,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getSessionSlim } from "@/lib/sessionsApi";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import type { Session } from "@/lib/types";
 
 /**
@@ -48,10 +49,15 @@ interface UseSessionResult {
  * for the refresh to thrash those caches.
  */
 export function useSession(conversationId: string | null | undefined): UseSessionResult {
+  // A registered provisional id is a client-only routing token with no server session behind
+  // it (navigate-first new-chat window). Disable the fetch by construction so no
+  // caller can leak a `GET /v1/sessions/<provisional>` — cheaper than gating every
+  // call site.
+  const serverId = isProvisionalConversationId(conversationId) ? null : (conversationId ?? null);
   const { data, isLoading, error } = useQuery({
-    queryKey: conversationId ? ["session", conversationId] : ["session", null],
-    queryFn: () => getSessionSlim(conversationId as string, { refreshState: true }),
-    enabled: Boolean(conversationId),
+    queryKey: serverId ? ["session", serverId] : ["session", null],
+    queryFn: () => getSessionSlim(serverId as string, { refreshState: true }),
+    enabled: serverId !== null,
     staleTime: Infinity,
     retry: false,
   });

--- a/web/src/hooks/useTerminals.ts
+++ b/web/src/hooks/useTerminals.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { authenticatedFetch } from "../lib/identity";
 import { useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 import { showToast } from "@/components/ui/toast";
 
@@ -368,9 +369,13 @@ export function useDeleteTerminal(conversationId: string) {
  * the fetched list with whatever is already cached, deduped by id.
  */
 export function useTerminals(
-  conversationId: string | null,
+  rawConversationId: string | null,
   options?: UseTerminalsOptions,
 ): UseTerminalsResult {
+  // A registered provisional id is a client-only routing token (navigate-first new-chat
+  // window) with no server session — normalize it to null so no fetch/poll
+  // hits `/v1/sessions/<provisional>/resources/terminals`, by construction.
+  const conversationId = isProvisionalConversationId(rawConversationId) ? null : rawConversationId;
   const queryClient = useQueryClient();
   const reconcileWhilePending = options?.reconcileWhilePending ?? false;
   // The terminal list is SSE-primary: live `session.resource.{created,deleted}`

--- a/web/src/hooks/useWorkspaceChangedFiles.ts
+++ b/web/src/hooks/useWorkspaceChangedFiles.ts
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSessionHostOnline, useSessionRunnerOnline } from "@/hooks/RunnerHealthProvider";
 import { authenticatedFetch } from "@/lib/identity";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import { useChatStore } from "@/store/chatStore";
 
 /** True when `id` is the focused conversation and its agent loop is live. */
@@ -845,9 +846,15 @@ async function fetchWorkspaceEnvironment(conversationId: string): Promise<Worksp
  * (``metadata.root`` absent in the 200 response).
  */
 export function useWorkspaceEnvironment(
-  conversationId: string | undefined,
+  rawConversationId: string | undefined,
   options: WorkspaceQueryOptions = {},
 ) {
+  // A registered provisional id (navigate-first new-chat window) has no server workspace —
+  // normalize to undefined so nothing (env, and the changed/all-files queries
+  // that gate on its result) hits `/v1/sessions/<provisional>/resources/*`.
+  const conversationId = isProvisionalConversationId(rawConversationId)
+    ? undefined
+    : rawConversationId;
   const serveable = useWorkspaceServeable(conversationId);
   return useQuery({
     queryKey: ["workspace-environment", conversationId],

--- a/web/src/lib/provisionalConversationId.test.ts
+++ b/web/src/lib/provisionalConversationId.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearProvisionalConversationIds,
+  isProvisionalConversationId,
+  proposeConversationId,
+  registerProvisionalConversationId,
+  removeProvisionalConversationId,
+} from "./provisionalConversationId";
+import * as randomUuidModule from "./randomUUID";
+
+afterEach(clearProvisionalConversationIds);
+
+describe("provisionalConversationId", () => {
+  it("generates a bare lowercase 32-character UUID", () => {
+    vi.spyOn(randomUuidModule, "randomUUID").mockReturnValue(
+      "AABBCCDD-EEFF-4011-8233-445566778899",
+    );
+
+    const id = proposeConversationId();
+
+    expect(id).toBe("aabbccddeeff40118233445566778899");
+    expect(isProvisionalConversationId(id)).toBe(false);
+  });
+
+  it("tracks membership independently of id shape", () => {
+    const id = "12345678123456781234567812345678";
+
+    expect(isProvisionalConversationId(id)).toBe(false);
+    registerProvisionalConversationId(id);
+    expect(isProvisionalConversationId(id)).toBe(true);
+    removeProvisionalConversationId(id);
+    expect(isProvisionalConversationId(id)).toBe(false);
+  });
+});

--- a/web/src/lib/provisionalConversationId.ts
+++ b/web/src/lib/provisionalConversationId.ts
@@ -1,0 +1,23 @@
+import { randomUUID } from "./randomUUID";
+
+const provisionalIds = new Set<string>();
+
+export function proposeConversationId(): string {
+  return randomUUID().replaceAll("-", "").toLowerCase();
+}
+
+export function registerProvisionalConversationId(id: string): void {
+  provisionalIds.add(id);
+}
+
+export function isProvisionalConversationId(id: string | null | undefined): boolean {
+  return id != null && provisionalIds.has(id);
+}
+
+export function removeProvisionalConversationId(id: string): void {
+  provisionalIds.delete(id);
+}
+
+export function clearProvisionalConversationIds(): void {
+  provisionalIds.clear();
+}

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -312,6 +312,33 @@ export function mergeItemsIntoPages(
   return { data: { ...data, pages }, found, needsRefetch };
 }
 
+// ── Recently-created keep-alive ───────────────────────────────────────
+//
+// The push stream inserts a just-created session into the sidebar instantly
+// (SessionUpdatesProvider → insertNewRowsIntoPages), but the create path also
+// fires a `["conversations"]` refetch, and on the search-indexed deployment
+// that fetch lags the write — so it comes back WITHOUT the new session and
+// replaces the cache, dropping the row until the index catches up (it flashes
+// in, then out). We keep the row in the first-page fetch until the index
+// reflects it — the additive mirror of the delete tombstone. Lives in this
+// leaf module so both `useConversations` (the reader) and the chat store (the
+// optimistic-create writer) can reach it without an import cycle.
+export const recentlyCreatedSessions = new Map<string, Conversation>();
+
+/** Grace window for the server's async create reindex. */
+const CREATED_KEEPALIVE_MS = 60_000;
+
+/** Keep a just-created session in the first-page list fetch until it's indexed. */
+export function markRecentlyCreated(conv: Conversation): void {
+  recentlyCreatedSessions.set(conv.id, conv);
+  setTimeout(() => recentlyCreatedSessions.delete(conv.id), CREATED_KEEPALIVE_MS);
+}
+
+/** Clear the keep-alive map — exported for test cleanup (mirrors `unmarkSessionsDeleting`). */
+export function clearRecentlyCreated(): void {
+  recentlyCreatedSessions.clear();
+}
+
 /**
  * Prepend brand-new rows (a create here or elsewhere, a share) to page 0 so the
  * sidebar shows them the instant the push lands, instead of after the debounced

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -71,6 +71,7 @@ import {
   type QueuedMessage,
   useChatStore,
 } from "@/store/chatStore";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import {
   isNativeTerminalSession,
   nativeCodingAgentForSession,
@@ -363,6 +364,10 @@ function truncateTitle(raw: string, max = 60): string {
  */
 export function ChatPage() {
   const { conversationId: urlConvId } = useParams<{ conversationId: string }>();
+  // The id for every server-scoped fetch/hook — `undefined` while the URL holds
+  // a provisional id, so none of them hit `/v1/sessions/<provisional>/*` before
+  // the session exists. `switchTo` still gets the raw `urlConvId`.
+  const sessionConvId = isProvisionalConversationId(urlConvId) ? undefined : urlConvId;
   const navigate = useNavigate();
   const appName = useAppName();
   // Optional first message handed off by the landing composer through the
@@ -413,7 +418,10 @@ export function ChatPage() {
   // Clear the "unseen messages" sidebar dot for the conversation the
   // user is currently viewing. Re-fires when conversations refresh
   // (every 4 s) so messages arriving while viewing are marked seen.
-  useMarkConversationSeen(urlConvId, conversations?.find((c) => c.id === urlConvId)?.updated_at);
+  useMarkConversationSeen(
+    sessionConvId,
+    conversations?.find((c) => c.id === sessionConvId)?.updated_at,
+  );
 
   // Sync the store's active conversation to the URL. Single source of
   // truth: URL is what's "current"; store mirrors it. The effect is
@@ -490,8 +498,8 @@ export function ChatPage() {
   // Read runner liveness from the app-level batch poller (see
   // RunnerHealthProvider). `undefined` = not yet polled — the indicator
   // stays hidden until the first poll for this session resolves.
-  const runnerOnline = useSessionRunnerOnline(urlConvId);
-  useRefreshSessionStateOnRunnerOnline(urlConvId, runnerOnline);
+  const runnerOnline = useSessionRunnerOnline(sessionConvId);
+  useRefreshSessionStateOnRunnerOnline(sessionConvId, runnerOnline);
   // OR'd into "Working…" so cross-client turns surface a shimmer.
   const sessionStatus = useChatStore((s) => s.sessionStatus);
   const backgroundTaskCount = useChatStore((s) => s.backgroundTaskCount);
@@ -504,7 +512,7 @@ export function ChatPage() {
   // agent object for the active session. Drives the picker's
   // name/description; the same react-query cache also feeds the header
   // info icon (AgentInfoButton) its tools & policies.
-  const { data: boundAgentBySession } = useSessionAgent(urlConvId ?? null);
+  const { data: boundAgentBySession } = useSessionAgent(sessionConvId ?? null);
   const hasMoreHistory = useChatStore((s) => s.hasMoreHistory);
   const loadingMoreHistory = useChatStore((s) => s.loadingMoreHistory);
 
@@ -624,7 +632,7 @@ export function ChatPage() {
   // Must be declared BEFORE the early-return guards below — otherwise
   // the hook is skipped on renders that hit the loading/error branches,
   // tripping React's "rendered fewer hooks than expected".
-  const { session: activeSession, isLoading: sessionLoading } = useSession(urlConvId ?? null);
+  const { session: activeSession, isLoading: sessionLoading } = useSession(sessionConvId ?? null);
 
   // Orchestrator-only: polly's children inherit its agentName, so the gate
   // needs the session predicate (parent linkage), not a bare name check. An
@@ -651,7 +659,7 @@ export function ChatPage() {
   const subAgentLabel = subAgentComposerLabel(activeSession);
 
   // Hoisted above the early-return guards so the title-update effect can read them.
-  const activeConv = urlConvId ? conversations?.find((c) => c.id === urlConvId) : null;
+  const activeConv = sessionConvId ? conversations?.find((c) => c.id === sessionConvId) : null;
 
   // `isWorking` gates the parent's OWN turn (Stop/Interrupt) and must NOT
   // include child-session activity. `showsWorking` is display-only (tab title
@@ -727,7 +735,7 @@ export function ChatPage() {
   const viewerId = getCurrentAuthorId();
   const sessionOwner = activeConv?.owner ?? null;
   const viewerOwnsSession = sessionOwner !== null && sessionOwner === viewerId;
-  const { data: ownerGrants } = usePermissions(viewerOwnsSession ? (urlConvId ?? null) : null);
+  const { data: ownerGrants } = usePermissions(viewerOwnsSession ? (sessionConvId ?? null) : null);
   const isSessionShared = isSessionSharedWithOthers(sessionOwner, viewerId, ownerGrants);
 
   // The open session's derived liveness — the single signal the chat
@@ -775,7 +783,7 @@ export function ChatPage() {
   // Host-switch launch marker; see the store field. Keeps this surface's
   // liveness in step with AppShell's, which drives the startup spinner.
   const runnerLaunchedAt = useChatStore((s) => s.runnerLaunchedAt);
-  const liveness = useSessionLiveness(urlConvId ?? undefined, livenessRow, {
+  const liveness = useSessionLiveness(sessionConvId ?? undefined, livenessRow, {
     turnActive: status === "streaming",
     launchedAt: runnerLaunchedAt,
   });
@@ -848,6 +856,8 @@ export function ChatPage() {
   const onSend = useCallback(
     (text: string, files?: File[]) => {
       if (!agentId) return;
+      // No server session yet (still creating) — nothing to POST to.
+      if (isProvisionalConversationId(urlConvId)) return;
       // An unbound coding clone (fork-source label) needs a directory before
       // it can run: open the picker and stash this message to replay after
       // the bind. Pin the prompt to THIS session so it replays here, never
@@ -948,7 +958,11 @@ export function ChatPage() {
     urlConvId,
     conversationsData !== undefined,
   );
-  const readOnlyReason = readOnlyReasonForSessionLabels(activeSession, activeConv);
+  // Client-only conversation: no server session to POST a follow-up to yet, so
+  // the composer stays read-only until the create resolves and the id hydrates.
+  const readOnlyReason = isProvisionalConversationId(urlConvId)
+    ? "Starting the session…"
+    : readOnlyReasonForSessionLabels(activeSession, activeConv);
   // Once present, the live session snapshot is authoritative. Memoized so the
   // derived props it feeds (modelPickerKind, effortLevels, wrapperLabel) keep a
   // stable identity across the switch's re-render burst.
@@ -2168,6 +2182,10 @@ function ComposerStatusLine({
   onHostReconnect?: () => void;
 }) {
   const conversationId = useChatStore((s) => s.conversationId);
+  // A provisional id has no server session — gate the server-scoped hooks
+  // below on it so they never fetch `/v1/sessions/<provisional>` during the create
+  // window (mirrors ChatPage's top-level `sessionConvId`).
+  const sessionId = isProvisionalConversationId(conversationId) ? null : conversationId;
   const contextWindow = useChatStore((s) => s.contextWindow);
   const tokensUsed = useChatStore((s) => s.tokensUsed);
   const codexPlanMode = useChatStore((s) => s.codexPlanMode);
@@ -2178,12 +2196,12 @@ function ComposerStatusLine({
 
   // Host binding drives whether the HostBadge has anything to show — read it
   // from the same source the badge does so the tray's render guard matches.
-  const { session } = useSession(conversationId);
+  const { session } = useSession(sessionId);
   const isHostBound = !!session?.hostId;
 
   // PR link → opens the workspace rail's GitHub tab. Shares the info query's
   // cache with the GitHub panel, so opening the tab is instant.
-  const github = useGithubInfo(conversationId ?? undefined);
+  const github = useGithubInfo(sessionId ?? undefined);
   const openGithubTab = useOpenGithubTab();
   const prNumber = github.data?.pr?.number ?? null;
   const showPr = !!conversationId && !isSubAgentSession && prNumber !== null && !!openGithubTab;
@@ -2644,7 +2662,10 @@ function ComposerImpl({
     unreachable,
     maybeFlushQueuedHead,
   ]);
-  const { goal, setGoal: setGoalState } = useGoalState(conversationId, showGoalControl);
+  // No server session behind a provisional id — gate goal/workspace fetches on it so
+  // the create window issues no `/v1/sessions/<provisional>` requests.
+  const composerSessionId = isProvisionalConversationId(conversationId) ? null : conversationId;
+  const { goal, setGoal: setGoalState } = useGoalState(composerSessionId, showGoalControl);
   // "@"-file-mention is scoped to the native coding-agent harnesses: their
   // vendor CLIs run in the workspace and read an on-disk file from an
   // attachment marker the executor already emits. In-process SDK sessions
@@ -2657,7 +2678,7 @@ function ComposerImpl({
   // so the composer's "@" entry point can't split-brain from the file viewer's
   // "Attach to agent" gate (``canAttachToAgent``), which already uses it.
   const mentionEnabled = nativeCodingAgentForHarness(sessionHarness) !== undefined;
-  const workspaceFilesQuery = useWorkspaceAllFiles(conversationId ?? undefined, {
+  const workspaceFilesQuery = useWorkspaceAllFiles(composerSessionId ?? undefined, {
     enabled: mentionEnabled,
   });
   const valueRef = useRef(value);

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -20,6 +20,10 @@ import type { ServerInfo } from "@/lib/capabilities";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 import { writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 import { writeWorkspacePanelDefault } from "@/lib/workspacePanelPreferences";
+import {
+  clearProvisionalConversationIds,
+  registerProvisionalConversationId,
+} from "@/lib/provisionalConversationId";
 
 const runnerHealthState = vi.hoisted(() => ({
   runnerOnline: undefined as boolean | undefined,
@@ -462,6 +466,7 @@ function mockConversations(
     runner_id?: string | null;
     workspace?: string | null;
     created_at?: number;
+    provisional?: boolean;
   }[],
 ) {
   useConvMock.mockReturnValue({
@@ -479,6 +484,7 @@ function mockConversations(
             host_id: c.host_id ?? null,
             runner_id: c.runner_id ?? null,
             workspace: c.workspace ?? null,
+            provisional: c.provisional,
           })),
           first_id: null,
           last_id: null,
@@ -561,13 +567,70 @@ beforeEach(() => {
   });
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  clearProvisionalConversationIds();
+});
 
 describe("AppShell header", () => {
   it("renders the sidebar toggle on all pages", () => {
     mockConversations([]);
     renderShell("/");
     expect(screen.getByRole("button", { name: /sidebar/i })).toBeInTheDocument();
+  });
+
+  it("does not fetch child sessions for a provisional id in debug mode", () => {
+    registerProvisionalConversationId("12345678123456781234567812345678");
+    mockConversations([]);
+    renderShell("/c/12345678123456781234567812345678?debug=1");
+
+    expect(useChildSessionsMock).not.toHaveBeenCalledWith("12345678123456781234567812345678");
+    expect(screen.queryByTestId("execution-logs-card")).toBeNull();
+  });
+
+  it("does not expose conversation actions for a provisional row", () => {
+    registerProvisionalConversationId("12345678123456781234567812345678");
+    mockConversations([
+      { id: "12345678123456781234567812345678", permission_level: null, provisional: true },
+    ]);
+    renderShell("/c/12345678123456781234567812345678");
+
+    expect(screen.queryByRole("button", { name: "Conversation actions" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
+    expect(screen.getByTestId("fork-probe")).toHaveAttribute("data-can-fork", "false");
+  });
+
+  it("does not expose or query agent info for a provisional session", async () => {
+    const provisionalId = "55555555555545558555555555555555";
+    registerProvisionalConversationId(provisionalId);
+    mockConversations([{ id: provisionalId, permission_level: null, provisional: true }]);
+    useSessionAgentMock.mockReturnValue({
+      data: {
+        id: "ag_info",
+        name: "hello_world",
+        mcp_servers: [{ name: "files", command: "files" }],
+      },
+    } as ReturnType<typeof useSessionAgent>);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise<Response>(() => {}));
+
+    try {
+      renderShell(`/c/${provisionalId}`);
+      const trigger = screen.queryByTestId("agent-info-trigger");
+      if (trigger) {
+        fireEvent.pointerEnter(trigger);
+        fireEvent.click(trigger);
+      }
+      await Promise.resolve();
+
+      expect(trigger).toBeNull();
+      expect(
+        fetchSpy.mock.calls.filter(([input]) =>
+          String(input).includes(`/v1/sessions/${provisionalId}`),
+        ),
+      ).toEqual([]);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("shows owner actions for a top-level session omitted from conversation pages", () => {

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -83,6 +83,7 @@ import { useServerInfo } from "@/lib/CapabilitiesContext";
 import { isSingleUserMode } from "@/lib/capabilities";
 import { isCurrentServerLocal } from "@/lib/serverOrigin";
 import { useChatStore } from "@/store/chatStore";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import {
   STARTING_GRACE_S,
   livenessRowFromSession,
@@ -222,6 +223,13 @@ export function AppShell() {
     conversationId: string;
     extensionId: string;
   }>();
+  // A provisional id shown while `createSession` is in flight
+  // has no server session behind it. Feed every server-scoped hook this instead
+  // of the raw route id so none of them fetch `/v1/sessions/<provisional>` during the
+  // create window (or on a stale temp reload, before ChatPage redirects).
+  const serverConversationId = isProvisionalConversationId(conversationId)
+    ? undefined
+    : conversationId;
   const [fileViewerCommentsOpen, setFileViewerCommentsOpen] = useState(false);
   const [rightRailTab, setRightRailTab] = useState<RightRailTab>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
@@ -412,7 +420,7 @@ export function AppShell() {
   // terminal. The hook is react-query-backed and dedup'd with the rail.
   // reconcileWhilePending: self-heals if the live resource.created SSE was
   // missed (see UseTerminalsOptions for the why).
-  const { terminals } = useTerminals(conversationId ?? null, {
+  const { terminals } = useTerminals(serverConversationId ?? null, {
     reconcileWhilePending: terminalPending,
   });
   const agentTerminal = useMemo(() => findAgentTerminal(terminals), [terminals]);
@@ -435,16 +443,17 @@ export function AppShell() {
   );
   useSeedReadState(allConversations);
   const activeConv = useMemo(() => {
-    if (!conversationId) return null;
+    if (!serverConversationId) return null;
     return (
-      conversationsData?.pages.flatMap((p) => p.data).find((c) => c.id === conversationId) ?? null
+      conversationsData?.pages.flatMap((p) => p.data).find((c) => c.id === serverConversationId) ??
+      null
     );
-  }, [conversationId, conversationsData]);
+  }, [serverConversationId, conversationsData]);
   // Single-conversation snapshot (shared cache with chatStore.bindStream).
   // For sub-agent (child) sessions the sidebar list omits the row, so this
   // is the only path through which the UI learns the user's permission
   // level. ``derivePermissionLevel`` prefers this over ``activeConv``.
-  const { session: activeSession, isLoading: sessionLoading } = useSession(conversationId);
+  const { session: activeSession, isLoading: sessionLoading } = useSession(serverConversationId);
   // Same liveness the chat surface switches on (see ChatPage / useSessionLiveness).
   // AppShell reads it only to drive the Terminal pill's "loading" state: a session
   // in `starting` (a relaunch the moment a message is sent — `turnActive`) is
@@ -465,7 +474,7 @@ export function AppShell() {
   });
   // Full agent object (mcp_servers + policies) for the header info icon.
   // react-query-cached, so this shares the fetch ChatPage's picker makes.
-  const { data: boundAgent } = useSessionAgent(conversationId ?? null);
+  const { data: boundAgent } = useSessionAgent(serverConversationId ?? null);
   const permissionLevel = derivePermissionLevel(
     activeSession,
     sessionLoading,
@@ -606,7 +615,7 @@ export function AppShell() {
     (isKnownTopLevel || isChildSession) &&
     (permissionLevel === null || permissionLevel >= 1);
   // Agent tools/policies exist to show.
-  const hasAgentInfo = !!conversationId && agentHasInfo(boundAgent, conversationId);
+  const hasAgentInfo = !!serverConversationId && agentHasInfo(boundAgent, serverConversationId);
   // Whether the mobile three-dot menu has any entry to offer.
   const hasHeaderMenu = canShare || hasAgentInfo;
   // The live snapshot is authoritative; the sidebar row is only a fallback
@@ -683,12 +692,15 @@ export function AppShell() {
   // resolution lands (a no-op transition once it does).
   const stickyRootRef = useRef<string | null>(null);
   const queryClient = useQueryClient();
-  const walkedRoot = useRootSessionId(conversationId ?? null, activeSession?.parentSessionId);
+  // Derive the root from `serverConversationId` (undefined for a provisional id) so the
+  // fallback below never yields the provisional id — otherwise `useChildSessions` would
+  // fetch `GET /v1/sessions/<provisional>/child_sessions` during the create window.
+  const walkedRoot = useRootSessionId(serverConversationId ?? null, activeSession?.parentSessionId);
   const { rootSessionId, rootSessionResolved } = useMemo(() => {
-    if (!conversationId) return { rootSessionId: null, rootSessionResolved: false };
+    if (!serverConversationId) return { rootSessionId: null, rootSessionResolved: false };
     // Snapshot resolved for a top-level session → it is its own root.
     if (activeSession && activeSession.parentSessionId == null) {
-      return { rootSessionId: conversationId, rootSessionResolved: true };
+      return { rootSessionId: serverConversationId, rootSessionResolved: true };
     }
     // Snapshot resolved for a descendant + walk complete → authoritative.
     if (activeSession && walkedRoot) {
@@ -699,18 +711,18 @@ export function AppShell() {
     const sticky = stickyRootRef.current;
     if (
       sticky !== null &&
-      (sticky === conversationId ||
-        cachedTreeContains(queryClient, sticky, conversationId, MAX_TREE_DEPTH))
+      (sticky === serverConversationId ||
+        cachedTreeContains(queryClient, sticky, serverConversationId, MAX_TREE_DEPTH))
     ) {
       return { rootSessionId: sticky, rootSessionResolved: true };
     }
     // No sticky context (e.g. a deep link straight into a sub-agent):
     // fall back one hop until the walk resolves the true root.
     return {
-      rootSessionId: activeSession?.parentSessionId ?? conversationId,
+      rootSessionId: activeSession?.parentSessionId ?? serverConversationId,
       rootSessionResolved: false,
     };
-  }, [conversationId, activeSession, walkedRoot, queryClient]);
+  }, [serverConversationId, activeSession, walkedRoot, queryClient]);
   // One-shot fetch (no polling) for the Subagents tab's count badge.
   // SubagentsPanel mounts its own polling usage of the hook against
   // the same rootSessionId, so the cache is shared.
@@ -752,7 +764,7 @@ export function AppShell() {
   // resource instead of the root filesystem listing: it is enough to prove
   // availability without paying for directory contents. The probe is disabled
   // for a non-browsing viewer so it never fires a request the server refuses.
-  const environmentQuery = useWorkspaceEnvironment(conversationId, {
+  const environmentQuery = useWorkspaceEnvironment(serverConversationId, {
     enabled: canBrowseWorkspace,
   });
   const showFilesPanel = canBrowseWorkspace && environmentQuery.data?.available !== false;
@@ -763,7 +775,7 @@ export function AppShell() {
   // gate. While the info is still loading the tab stays, matching the Files
   // gate's no-flash default. Shares ChatPage's status-line query cache, so no
   // extra fetch.
-  const githubInfoQuery = useGithubInfo(conversationId);
+  const githubInfoQuery = useGithubInfo(serverConversationId);
   const showGithubTab = showFilesPanel && githubInfoQuery.data?.reason !== "not_a_git_repo";
   // Per-tab availability for the right workspace rail — the single source
   // of truth shared by the tab-fallback effect below, the rail's mount
@@ -933,7 +945,7 @@ export function AppShell() {
   // because it contains full relative paths like `web/src/shell/Foo.tsx`.
   // Disabled for a viewer who may not browse the workspace: the server refuses
   // the read, so the fetch would only 403.
-  const changedFilesQuery = useWorkspaceChangedFiles(conversationId, {
+  const changedFilesQuery = useWorkspaceChangedFiles(serverConversationId, {
     enabled: canBrowseWorkspace,
   });
   const changedFilePaths = useMemo(
@@ -1999,6 +2011,7 @@ export function AppShell() {
                     projectIcon={headerProjectIcon}
                     titleLinkTo={headerTitleLinkTo}
                     boundAgent={boundAgent}
+                    agentInfoSessionId={serverConversationId}
                     wrapperLabel={wrapperLabel}
                     canShare={canShare}
                     shareDisabled={shareDisabled}
@@ -2050,10 +2063,10 @@ export function AppShell() {
               push panel is open (the panel itself becomes the focus). Only
               rendered in debug mode so the column doesn't occupy space in
               normal use. */}
-                {conversationId && debugMode && !panelOpen && !executionLogsOpen && (
+                {serverConversationId && debugMode && !panelOpen && !executionLogsOpen && (
                   <div className="hidden md:flex md:flex-col md:w-56 md:shrink-0 md:border-l md:border-border md:overflow-y-auto md:px-2 md:pb-2 md:pt-12 md:gap-2">
                     <SessionRail
-                      conversationId={conversationId}
+                      conversationId={serverConversationId}
                       onExpandExecutionLogs={openExecutionLogsPanel}
                       suppressed={false}
                     />
@@ -2246,7 +2259,7 @@ export function AppShell() {
                     Tools and policies configured for the active agent.
                   </DialogDescription>
                 </DialogHeader>
-                <AgentInfoContent agent={boundAgent} sessionId={conversationId} />
+                <AgentInfoContent agent={boundAgent} sessionId={serverConversationId} />
               </DialogContent>
             </Dialog>
           )}

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -136,6 +136,8 @@ interface ChatHeaderProps {
   titleLinkTo?: string;
   /** The bound agent (mcp_servers + policies) for the info popover. */
   boundAgent: Agent | undefined;
+  /** Server-confirmed session id for agent-info queries. */
+  agentInfoSessionId?: string;
   /**
    * The session's ``omnigent.wrapper`` label, or ``null``. Names the vendor
    * in the sub-agent breadcrumb: a native sub-agent child reuses its
@@ -208,6 +210,7 @@ export function ChatHeader({
   projectIcon,
   titleLinkTo,
   boundAgent,
+  agentInfoSessionId,
   wrapperLabel,
   canShare,
   shareDisabled = false,
@@ -506,7 +509,9 @@ export function ChatHeader({
             "Fork from here" action on assistant bubbles (ChatPage). */}
         {/* Agent info: tools & policies for the bound agent. Desktop-only
             popover; self-hides when the agent has neither configured. */}
-        {conversationId && <AgentInfoButton agent={boundAgent} sessionId={conversationId} />}
+        {agentInfoSessionId && (
+          <AgentInfoButton agent={boundAgent} sessionId={agentInfoSessionId} />
+        )}
         {/* Chat/Terminal switcher for terminal-first sessions — self-gates to
             null otherwise. Renders on every shell, iOS included. */}
         {conversationId && <ViewModeToggle />}

--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -27,6 +27,9 @@ import { writeDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 // layers are stubbed so the test isolates that wiring.
 const navigateMock = vi.fn();
 const setPendingInitialPromptMock = vi.fn();
+const beginProvisionalConversationMock = vi.fn();
+const resolveProvisionalConversationMock = vi.fn();
+const removeProvisionalConversationMock = vi.fn();
 
 const RECENT_KEY = "omnigent:recent-workspaces";
 // Prompt history is scoped per conversation; the landing composer writes under
@@ -50,6 +53,10 @@ vi.mock("@/lib/routing", () => ({
 // The screen hands the first message to ChatPage through the chatStore
 // (keyed by conversation id), not router state — assert on that call.
 vi.mock("@/store/chatStore", () => ({
+  beginProvisionalConversation: (...args: unknown[]) => beginProvisionalConversationMock(...args),
+  resolveProvisionalConversation: (...args: unknown[]) =>
+    resolveProvisionalConversationMock(...args),
+  removeProvisionalConversation: (...args: unknown[]) => removeProvisionalConversationMock(...args),
   setPendingInitialPrompt: (...args: unknown[]) => setPendingInitialPromptMock(...args),
 }));
 
@@ -262,6 +269,11 @@ function saveConfig(): void {
 beforeEach(() => {
   navigateMock.mockReset();
   setPendingInitialPromptMock.mockReset();
+  beginProvisionalConversationMock.mockReset();
+  beginProvisionalConversationMock.mockReturnValue(null);
+  resolveProvisionalConversationMock.mockReset();
+  removeProvisionalConversationMock.mockReset();
+  removeProvisionalConversationMock.mockReturnValue(false);
   pushMatchers.length = 0;
   announcePushedSession = null;
   vi.mocked(authenticatedFetch).mockReset();
@@ -316,11 +328,127 @@ describe("NewChatLandingScreen create flow", () => {
       host_id: "host_1",
       workspace: SEEDED_WORKSPACE,
     });
+    expect(body.id).toMatch(/^[0-9a-f]{32}$/);
     // A plain YAML agent carries no terminal-wrapper labels.
     expect(body.labels).toBeUndefined();
 
     // On success the screen routes to the freshly created session.
     await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_new"));
+  });
+
+  it("uses the response id for a navigate-first create instead of matching a pushed row", async () => {
+    let resolveCreate!: (response: Response) => void;
+    vi.mocked(authenticatedFetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolveCreate = resolve;
+      }) as ReturnType<typeof authenticatedFetch>,
+    );
+    beginProvisionalConversationMock.mockImplementation((proposedConvId: string) => ({
+      proposedConvId,
+      pendingMsgTempId: "pend_1",
+    }));
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("inspect the repo");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    await waitFor(() => expect(beginProvisionalConversationMock).toHaveBeenCalled());
+    const proposedId = beginProvisionalConversationMock.mock.calls[0]![0] as string;
+    expect(proposedId).toMatch(/^[0-9a-f]{32}$/);
+    expect(navigateMock).toHaveBeenCalledWith(`/c/${proposedId}`);
+    const [, init] = vi.mocked(authenticatedFetch).mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).id).toBe(proposedId);
+    expect(pushMatchers).toHaveLength(0);
+
+    resolveCreate({
+      ok: true,
+      json: async () => ({ id: "conv_authoritative" }),
+    } as unknown as Response);
+    await waitFor(() =>
+      expect(resolveProvisionalConversationMock).toHaveBeenCalledWith(
+        proposedId,
+        "conv_authoritative",
+        "ag_hello",
+        "inspect the repo",
+        [],
+        "pend_1",
+        null,
+        navigateMock,
+        expect.any(Function),
+      ),
+    );
+  });
+
+  it("keeps a failed create's restored draft when a newer create succeeds", async () => {
+    let resolveFirst!: (response: Response) => void;
+    let resolveSecond!: (response: Response) => void;
+    vi.mocked(authenticatedFetch)
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        }) as ReturnType<typeof authenticatedFetch>,
+      )
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveSecond = resolve;
+        }) as ReturnType<typeof authenticatedFetch>,
+      );
+    beginProvisionalConversationMock
+      .mockReturnValueOnce({
+        proposedConvId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        pendingMsgTempId: "pend_a",
+      })
+      .mockReturnValueOnce({
+        proposedConvId: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        pendingMsgTempId: "pend_b",
+      });
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("restore this draft");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(1));
+    cleanup();
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("newer successful create");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+    await waitFor(() => expect(authenticatedFetch).toHaveBeenCalledTimes(2));
+    cleanup();
+
+    resolveFirst({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "first create failed" }),
+    } as unknown as Response);
+    await waitFor(() =>
+      expect(removeProvisionalConversationMock).toHaveBeenCalledWith(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ),
+    );
+
+    resolveSecond({
+      ok: true,
+      json: async () => ({ id: "conv_second" }),
+    } as unknown as Response);
+    await waitFor(() =>
+      expect(resolveProvisionalConversationMock).toHaveBeenCalledWith(
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "conv_second",
+        "ag_hello",
+        "newer successful create",
+        [],
+        "pend_b",
+        null,
+        navigateMock,
+        expect.any(Function),
+      ),
+    );
+
+    renderLanding();
+    expect(screen.getByTestId("new-chat-landing-input")).toHaveValue("restore this draft");
   });
 
   it("records the launched workspace under its host without corrupting other recents", async () => {

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -2538,20 +2538,15 @@ describe("NewChatLandingScreen", () => {
     // The sandbox option is pinned FIRST in the menu, above the host list —
     // DOCUMENT_POSITION_FOLLOWING means the host item comes after it.
     const sandboxOption = screen.getByTestId("new-chat-landing-sandbox-option");
-    const hostItem = screen
-      .getAllByText("This machine")
-      .find((el) => el.closest('[role="menuitem"]') !== null);
-    expect(hostItem).toBeTruthy();
+    const hostItem = screen.getByTestId("new-chat-landing-host-host_1");
     expect(
-      sandboxOption.compareDocumentPosition(hostItem!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      sandboxOption.compareDocumentPosition(hostItem) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     // Picking the host restores the workspace flow (file-browser chip,
     // worktree chip) — the sandbox default doesn't wedge the normal path.
-    fireEvent.click(hostItem!);
+    fireEvent.click(hostItem);
     await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
-        "This machine",
-      ),
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain("Sandbox"),
     );
     expect(screen.getByTestId("new-chat-landing-workspace-chip")).toBeTruthy();
     expect(screen.getByTestId("new-chat-landing-branch-chip")).toBeTruthy();
@@ -3812,15 +3807,9 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
       expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
     );
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
-    const hostItem = screen
-      .getAllByText("This machine")
-      .find((el) => el.closest('[role="menuitem"]') !== null);
-    expect(hostItem).toBeTruthy();
-    fireEvent.click(hostItem!);
+    fireEvent.click(screen.getByTestId("new-chat-landing-host-host_1"));
     await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
-        "This machine",
-      ),
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain("Sandbox"),
     );
     // With no custom agents yet, the create item is a top-level row (no
     // "Custom agents" submenu to hide it behind) and opens the dialog.
@@ -3839,14 +3828,9 @@ describe("NewChatLandingScreen custom-agent sandbox gating", () => {
       expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain("Sandbox"),
     );
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
-    const hostItem = screen
-      .getAllByText("This machine")
-      .find((el) => el.closest('[role="menuitem"]') !== null);
-    fireEvent.click(hostItem!);
+    fireEvent.click(screen.getByTestId("new-chat-landing-host-host_1"));
     await waitFor(() =>
-      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).toContain(
-        "This machine",
-      ),
+      expect(screen.getByTestId("new-chat-landing-host-chip").textContent).not.toContain("Sandbox"),
     );
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-agent-select"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-create-agent"));

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -101,7 +101,13 @@ import {
   rankedSlashCommandNames,
   SlashCommandMenu,
 } from "@/components/SlashCommandMenu";
-import { setPendingInitialPrompt } from "@/store/chatStore";
+import {
+  beginProvisionalConversation,
+  resolveProvisionalConversation,
+  removeProvisionalConversation,
+  setPendingInitialPrompt,
+} from "@/store/chatStore";
+import { proposeConversationId } from "@/lib/provisionalConversationId";
 import { markSessionCreated } from "@/store/interactionTelemetry";
 import { appendPromptHistoryEntry } from "@/hooks/usePromptHistory";
 import { useIsCoarsePointer } from "@/hooks/useIsCoarsePointer";
@@ -2195,12 +2201,18 @@ interface LandingDraft {
 }
 
 let landingDraft: LandingDraft | null = null;
+let landingDraftRevision = 0;
+
+function writeLandingDraft(draft: LandingDraft | null): void {
+  landingDraft = draft;
+  landingDraftRevision += 1;
+}
 
 // Test-only: clears the preserved landing draft so each case starts from a
 // clean module state (the draft is module-scoped and survives unmount by
 // design, which would otherwise leak between tests).
 export function resetLandingDraft(): void {
-  landingDraft = null;
+  writeLandingDraft(null);
 }
 
 export function NewChatLandingScreen() {
@@ -2685,6 +2697,7 @@ export function NewChatLandingScreen() {
   // `submittedRef` is flipped once the draft is sent to a create, so the
   // snapshot is dropped instead of resurrected.
   const submittedRef = useRef(false);
+  const submittedDraftRevisionRef = useRef<number | null>(null);
   // Whether this composer is still on screen. The create POST can outlive
   // it — the user opens another session while the session bootstraps — and
   // the post-create navigation must not follow them there.
@@ -2722,7 +2735,11 @@ export function NewChatLandingScreen() {
     onScreenRef.current = true;
     return () => {
       onScreenRef.current = false;
-      landingDraft = submittedRef.current ? null : draftRef.current;
+      if (!submittedRef.current) {
+        writeLandingDraft(draftRef.current);
+      } else if (submittedDraftRevisionRef.current === landingDraftRevision) {
+        writeLandingDraft(null);
+      }
     };
   }, []);
 
@@ -4234,7 +4251,8 @@ export function NewChatLandingScreen() {
   // dropped it on the strength of the submit.
   function returnDraftToUser() {
     submittedRef.current = false;
-    if (!onScreenRef.current) landingDraft = draftRef.current;
+    submittedDraftRevisionRef.current = null;
+    if (!onScreenRef.current) writeLandingDraft(draftRef.current);
   }
 
   async function handleCreate() {
@@ -4259,11 +4277,31 @@ export function NewChatLandingScreen() {
     }
     setCreating(true);
     setCreateError(null);
+    const proposedSessionId =
+      effectiveAgentId !== null && effectiveAgentId !== PENDING_AGENT_ID
+        ? proposeConversationId()
+        : null;
+    let localConv: { proposedConvId: string; pendingMsgTempId: string } | null = null;
+    // Single teardown for EVERY create-failure exit (the `catch` and the
+    // `"error" in created` early return): drop the provisional conversation and,
+    // if the user is still on it, send them back to landing so the restored
+    // draft (and the create error) have somewhere to surface. Without this, a
+    // failure after the navigate-first jump strands a read-only provisional chat.
+    const tearDownLocalConversation = () => {
+      if (localConv === null) return;
+      const stillOnProposedRoute = window.location.pathname.endsWith(
+        `/c/${localConv.proposedConvId}`,
+      );
+      const wasViewing = removeProvisionalConversation(localConv.proposedConvId);
+      // Gated on `wasViewing` (not `onScreenRef` — the landing already unmounted).
+      if (wasViewing && stillOnProposedRoute) navigate("/");
+    };
     // The draft is spent from the moment it is submitted: it belongs to the
     // session now being created, so a detour back to this screen must not
     // hand it back pre-filled. Flipped here rather than on the response
     // because the create outlives an unmount; a create that fails hands the
     // draft back via returnDraftToUser.
+    submittedDraftRevisionRef.current = landingDraftRevision;
     submittedRef.current = true;
     try {
       const trimmedBranch = branchName.trim();
@@ -4316,6 +4354,22 @@ export function NewChatLandingScreen() {
       const initialPrompt =
         buildMentionPreamble(mentionedItems, selectedAgent?.harness ?? null) +
         sanitizeInitialPrompt(message);
+      // Navigate-first: mint a provisional conversation, show the prompt, and
+      // jump into it now; the create runs below and hydrates the provisional id to the
+      // real one (`resolveProvisionalConversation`). Skipped for a pending custom
+      // agent — it has no agent id to POST with until its create binds one, so
+      // that path stays server-first.
+      if (effectiveAgentId !== null && effectiveAgentId !== PENDING_AGENT_ID) {
+        try {
+          const local = beginProvisionalConversation(proposedSessionId!, initialPrompt, files);
+          if (local !== null) {
+            localConv = local;
+            navigate(`/c/${local.proposedConvId}`);
+          }
+        } catch {
+          /* non-fatal: falls through to the server-first path below */
+        }
+      }
 
       // Native terminal agents open terminal-first: `omnigent.ui: terminal`
       // tells the UI to render the terminal wrapper, and `omnigent.wrapper`
@@ -4432,7 +4486,7 @@ export function NewChatLandingScreen() {
         // A sandbox create has no host to match on until the sandbox
         // registers one, so it waits for the response like before.
         const matchOwnCreate =
-          sandboxSelected || !selectedHostId
+          localConv !== null || sandboxSelected || !selectedHostId
             ? null
             : (item: SessionListWireItem) =>
                 !knownSessionIds.has(item.id) &&
@@ -4443,6 +4497,7 @@ export function NewChatLandingScreen() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
+            id: proposedSessionId,
             // Config-seeded agent on a `project_id` create: omitted so the
             // server default-fills it from the project config.
             ...(agentFromProjectConfig ? {} : { agent_id: effectiveAgentId }),
@@ -4532,12 +4587,10 @@ export function NewChatLandingScreen() {
               smartRoutingHarnessSelected || pinnedNativeRoutes ? initialPrompt : undefined,
           }),
         });
-        // The create doesn't answer until the host has spawned a runner — a
-        // process boot, seconds of it — but the session row exists (and is
-        // announced on the updates stream) almost immediately. Open the chat
-        // on whichever id lands first: the pushed row typically wins by
-        // seconds, and the chat page renders from the id alone, showing its
-        // own starting spinner while the runner comes up.
+        // The server-first fallback can still open from the pushed row before
+        // the create responds. Navigate-first is already showing its provisional chat,
+        // so it waits for the response's authoritative id instead of guessing
+        // which same-agent/host push belongs to this request.
         const abortPush = new AbortController();
         const pushedRow =
           matchOwnCreate === null
@@ -4571,7 +4624,12 @@ export function NewChatLandingScreen() {
         // error the user needed to see on this screen.
         if ("error" in created) {
           returnDraftToUser();
-          setCreateError(created.error);
+          // On the navigate-first path the landing screen is unmounted, so tear
+          // down the provisional chat, return to landing, and surface the error as a
+          // toast (survives the remount); inline error only when still on landing.
+          tearDownLocalConversation();
+          if (localConv !== null) showToast(created.error);
+          else setCreateError(created.error);
           return;
         }
         data = { id: created.id };
@@ -4645,44 +4703,57 @@ export function NewChatLandingScreen() {
       // next time. Recorded only on a successful create, so a harness the user
       // merely browsed past never earns a primary slot.
       if (selectedNativeHarness !== null) addRecentHarness(selectedNativeHarness);
-      // Fire-and-forget: don't block navigation on the sidebar list refresh.
-      // The background refetch (or the WS session_added push) backfills the
-      // new session's row within ~1s of landing in the chat; the chat itself
-      // loads from the session id and never reads the sidebar cache.
-      void queryClient.refetchQueries({ queryKey: ["conversations"] });
-      void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
-      // A first message matching one of the agent's bundled skills is
-      // handed off as a structured invocation so ChatPage auto-sends it
-      // as a `slash_command` event (server resolves the skill) instead
-      // of plain text the agent would see as a literal "/name". Native
-      // terminal agents keep plain text — their CLI owns slash commands.
-      setPendingInitialPrompt(data.id, {
-        text: initialPrompt,
-        skill: isNativeTerminalAgent
-          ? null
-          : matchSkillInvocation(initialPrompt, agent?.skills ?? []),
-        files,
-      });
-      // Label the new row with the prompt until the server's seed title lands.
-      recordOptimisticTitle(data.id, initialPrompt);
+      // A first message matching one of the agent's bundled skills is sent as a
+      // structured `slash_command` (server resolves the skill) rather than the
+      // literal "/name". Native terminal agents keep plain text — their CLI owns
+      // slash commands.
+      const skill = isNativeTerminalAgent
+        ? null
+        : matchSkillInvocation(initialPrompt, agent?.skills ?? []);
       // Scope the recall entry to the new session id so ArrowUp surfaces it in
-      // the freshly-opened chat (whose composer reads the same per-conversation
-      // key). Sanitized text so recall reproduces exactly what was sent.
+      // the freshly-opened chat. Sanitized text so recall reproduces what was sent.
       appendPromptHistoryEntry(initialPrompt, data.id);
       // The session was created — drop any draft a detour back to this
       // screen stashed, so the next visit starts clean.
-      landingDraft = null;
-      // Only follow the create while the user is still on the landing
-      // screen. A create that outlived it means they moved on to another
-      // session; jumping them into this one now would hijack that. The
-      // session is created either way and its first message stays held
-      // for whenever they open it.
-      if (onScreenRef.current && window.location.href === createLocation) {
-        navigate(`/c/${data.id}`);
+      if (submittedDraftRevisionRef.current === landingDraftRevision) {
+        writeLandingDraft(null);
+      }
+      void queryClient.invalidateQueries({ queryKey: ["directory-sessions"] });
+
+      // `localConv` is set only when a real agent id was resolved up front, so
+      // it's safe to POST the first message with it.
+      if (localConv !== null && effectiveAgentId !== null) {
+        const proposedRouteSuffix = `/c/${localConv.proposedConvId}`;
+        // Confirm the proposed id or adopt the authoritative id and POST the first message.
+        resolveProvisionalConversation(
+          localConv.proposedConvId,
+          data.id,
+          effectiveAgentId,
+          initialPrompt,
+          files,
+          localConv.pendingMsgTempId,
+          skill,
+          navigate,
+          () => window.location.pathname.endsWith(proposedRouteSuffix),
+        );
+        void queryClient.refetchQueries({ queryKey: ["conversations"] });
+      } else {
+        // Server-first: a pending custom agent (or no client cache in tests).
+        // Label the row, stash the first message for ChatPage to send, navigate.
+        recordOptimisticTitle(data.id, initialPrompt);
+        void queryClient.refetchQueries({ queryKey: ["conversations"] });
+        setPendingInitialPrompt(data.id, { text: initialPrompt, skill, files });
+        if (onScreenRef.current && window.location.href === createLocation) {
+          navigate(`/c/${data.id}`);
+        }
       }
     } catch {
+      const msg = "Couldn't reach the server. Check your connection and try again.";
+      tearDownLocalConversation();
       returnDraftToUser();
-      setCreateError("Couldn't reach the server. Check your connection and try again.");
+      // Toast when the landing screen is gone (navigate-first); inline otherwise.
+      if (localConv !== null) showToast(msg);
+      else setCreateError(msg);
     } finally {
       setCreating(false);
     }

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -366,6 +366,28 @@ describe("Sidebar session list", () => {
     expect(screen.queryByText("Claude Code")).not.toBeInTheDocument();
   });
 
+  it("renders a provisional row as a bare navigable link with no mutating actions", () => {
+    // A provisional row has no server session, so its per-row mutations
+    // (kebab: rename/delete/archive/move/share) must be suppressed — invoking
+    // them would POST to /v1/sessions/<provisional> (Polly B-3).
+    mockConversations([
+      conv("0a1b2c3d0a1b2c3d0a1b2c3d0a1b2c3d", "Claude Code", {
+        title: "new chat",
+        provisional: true,
+      }),
+    ]);
+    renderSidebar();
+
+    // Navigable: the row is still a link into the (soon-to-exist) conversation.
+    const link = screen.getByRole("link", { name: /new chat/ });
+    expect(link).toHaveAttribute(
+      "href",
+      expect.stringContaining("/c/0a1b2c3d0a1b2c3d0a1b2c3d0a1b2c3d"),
+    );
+    // But no action affordances until it's rekeyed to the real id.
+    expect(screen.queryByRole("button", { name: "Conversation actions" })).not.toBeInTheDocument();
+  });
+
   it("uses the interface text token for session-list errors", () => {
     conversationsRef.current = [];
     useConvMock.mockReturnValue({

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -3539,6 +3539,10 @@ function ConversationRowImpl({
 }) {
   const hostsById = useContext(HostsByIdContext);
   const navigate = useNavigate();
+  // A provisional row (navigate-first create window): no server session
+  // yet, so per-row mutations are disabled until it's rekeyed to the real id —
+  // otherwise they'd POST to `/v1/sessions/<provisional>`. The row still navigates.
+  const isProvisionalRow = conversation.provisional === true;
   // Mobile has no real hover, so a tap that navigates would also trip the
   // project flyout's HoverCard and leave it lingering over the chat. Gate the
   // flyout off below the `md` breakpoint (see `projectFlyoutName`).
@@ -3719,7 +3723,7 @@ function ConversationRowImpl({
   } = useDraggable({
     id: conversation.id,
     data: { type: "session", label, project: currentProject, isPinned },
-    disabled: !isOwner || selectionMode || isArchived || isEditing,
+    disabled: !isOwner || selectionMode || isArchived || isEditing || isProvisionalRow,
   });
   // A drag ends with a synthetic click on the row's <Link> (mousedown + mouseup
   // on the same anchor still fires a click); swallow that one click so a drag
@@ -3918,6 +3922,7 @@ function ConversationRowImpl({
       onDoubleClick={(e) => {
         if (selectionMode) return;
         if (!isOwner) return;
+        if (isProvisionalRow) return; // no rename before the real session exists
         e.preventDefault();
         // The dblclick's own second click was already recorded above, so
         // exactly ONE recent click means the first click landed on a different
@@ -3950,6 +3955,17 @@ function ConversationRowImpl({
       </div>
     </Link>
   );
+
+  // Provisional row: navigable, but no mutating affordances (kebab,
+  // context menu, pin, archive, drag) until the real session exists — those
+  // would POST to `/v1/sessions/<provisional>`. Confirmation drops `provisional` and the full row renders.
+  if (isProvisionalRow) {
+    return (
+      <li ref={rowRef} className="group relative">
+        {rowLink}
+      </li>
+    );
+  }
 
   return (
     // Drag props on the <li> so the whole row is grabbable; `isDragging` dims
@@ -4390,6 +4406,7 @@ const RENDERED_CONVERSATION_FIELDS: readonly (keyof Conversation)[] = [
   "project_id",
   "owner",
   "pending_elicitations_count",
+  "provisional",
 ];
 
 function conversationRenderEqual(a: Conversation, b: Conversation): boolean {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -55,8 +55,10 @@ import type { TerminalInfo } from "@/hooks/useTerminals";
 import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
+  beginProvisionalConversation,
   consumePendingInitialPrompt,
   handleSessionEvent,
+  resolveProvisionalConversation,
   isStaleCompletedResponse,
   initChatStore,
   pumpStreamEvents,
@@ -69,6 +71,7 @@ import {
   bindConversationForTest,
   releaseConversation,
 } from "./chatStore";
+import { isProvisionalConversationId } from "@/lib/provisionalConversationId";
 import { conversationRegistry } from "./conversationRegistry";
 import { markSessionCreated, resetInteractionTelemetryForTests } from "./interactionTelemetry";
 import {
@@ -2400,6 +2403,315 @@ describe("chatStore — send (first-send ordering)", () => {
   });
 });
 
+describe("chatStore — navigate-first first send (B1/B2 regressions)", () => {
+  // Drives the navigate-first flow directly (NewChatDialog owns createSession;
+  // these exercise the store side): begin a client-only conversation, then
+  // hydrate it onto a real id, which fires the first-message `send` internally.
+  const noopNavigate = () => {};
+
+  // resolveProvisionalConversation fires `void send(...)`; flush enough microtasks +
+  // the timer-based fetch acks for it to settle.
+  async function settle() {
+    await tick();
+    await tick();
+  }
+
+  it("happy path: reuses the bubble (no duplicate), stays streaming, arms the latch", async () => {
+    const proposedId = "11111111111141118111111111111111";
+    seedSession(proposedId);
+    const begun = beginProvisionalConversation(proposedId, "hello there", undefined);
+    expect(begun).not.toBeNull();
+    const { proposedConvId, pendingMsgTempId } = begun!;
+    const provisionalEntry = conversationRegistry.peek(proposedId);
+    const navigate = vi.fn();
+    expect(isProvisionalConversationId(proposedConvId)).toBe(true);
+    // One optimistic bubble is shown under the provisional id, entry pre-streaming.
+    expect(useChatStore.getState().pendingUserMessages).toHaveLength(1);
+
+    resolveProvisionalConversation(
+      proposedConvId,
+      proposedId,
+      "agent_xyz",
+      "hello there",
+      undefined,
+      pendingMsgTempId,
+      null,
+      navigate,
+    );
+    await settle();
+
+    const state = useChatStore.getState();
+    // The bubble was reused, not duplicated.
+    expect(state.pendingUserMessages).toHaveLength(1);
+    expect(state.pendingUserMessages[0]!.tempId).toBe(pendingMsgTempId);
+    // The hydrating send armed the latch, so the stranded-latch watchdog is live.
+    const real = conversationRegistry.peek(proposedId)!.getState();
+    expect(conversationRegistry.peek(proposedId)).toBe(provisionalEntry);
+    expect(navigate).not.toHaveBeenCalled();
+    expect(real.sendLatchedAt).not.toBeNull();
+    // Exactly one POST /events for the real session (reuse ⇒ no second bubble/POST).
+    const posts = fetchMock.mock.calls.filter(
+      ([u, init]) =>
+        String(u) === `/v1/sessions/${proposedId}/events` &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(posts).toHaveLength(1);
+  });
+
+  it("confirms the matching sidebar row in place before a list refetch", () => {
+    const proposedId = "33333333333343338333333333333333";
+    seedSession(proposedId);
+    client.setQueryData<InfiniteData<ConversationsPage>>(["conversations", "", false], {
+      pages: [{ data: [], first_id: null, last_id: null, has_more: false }],
+      pageParams: [undefined],
+    });
+    const { pendingMsgTempId } = beginProvisionalConversation(proposedId, "hello", undefined)!;
+
+    resolveProvisionalConversation(
+      proposedId,
+      proposedId,
+      "agent_xyz",
+      "hello",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+
+    const data = client.getQueryData<InfiniteData<ConversationsPage>>(["conversations", "", false]);
+    expect(data?.pages[0]?.data.find((row) => row.id === proposedId)?.provisional).toBe(false);
+  });
+
+  it("reuses the matching provisional bubble for a skill-first send", async () => {
+    const proposedId = "44444444444444448444444444444444";
+    seedSession(proposedId);
+    const { pendingMsgTempId } = beginProvisionalConversation(
+      proposedId,
+      "/review-pr 123",
+      undefined,
+    )!;
+
+    resolveProvisionalConversation(
+      proposedId,
+      proposedId,
+      "agent_xyz",
+      "/review-pr 123",
+      undefined,
+      pendingMsgTempId,
+      { name: "review-pr", args: "123" },
+      noopNavigate,
+    );
+    await settle();
+
+    const pending = conversationRegistry.peek(proposedId)!.getState().pendingUserMessages;
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.tempId).toBe(pendingMsgTempId);
+  });
+
+  it("adopts an older backend's authoritative id and sends exactly once", async () => {
+    seedSession("conv_real");
+    const proposedId = "22222222222242228222222222222222";
+    const { pendingMsgTempId } = beginProvisionalConversation(proposedId, "hello", undefined)!;
+    const navigate = vi.fn();
+
+    resolveProvisionalConversation(
+      proposedId,
+      "conv_real",
+      "agent_xyz",
+      "hello",
+      undefined,
+      pendingMsgTempId,
+      null,
+      navigate,
+    );
+    await settle();
+
+    expect(conversationRegistry.has(proposedId)).toBe(false);
+    expect(isProvisionalConversationId(proposedId)).toBe(false);
+    expect(navigate).toHaveBeenCalledWith("/c/conv_real", { replace: true });
+    const posts = fetchMock.mock.calls.filter(
+      ([url, init]) =>
+        String(url) === "/v1/sessions/conv_real/events" &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(posts).toHaveLength(1);
+  });
+
+  it("B1: a failed first message settles to idle (not stuck streaming)", async () => {
+    seedSession("conv_real");
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url === "/v1/sessions/conv_real/events") {
+        return mockResponse(
+          { error: { code: "internal_error", message: "boom" } },
+          {
+            ok: false,
+            status: 500,
+          },
+        );
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const { proposedConvId, pendingMsgTempId } = beginProvisionalConversation(
+      "11111111111141118111111111111111",
+      "hi",
+      undefined,
+    )!;
+    resolveProvisionalConversation(
+      proposedConvId,
+      "conv_real",
+      "agent_xyz",
+      "hi",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+    await settle();
+
+    const real = conversationRegistry.peek("conv_real")!.getState();
+    // Without the fix the entry stays "streaming" forever with no latch; the
+    // fix arms the latch on the hydrating send and runs the failure-settle.
+    expect(real.status).toBe("idle");
+    expect(real.pendingUserMessages).toEqual([]);
+    // The failure is surfaced, not swallowed.
+    expect(real.blocks.filter((b) => b.type === "error")).toHaveLength(1);
+  });
+
+  it("B1: a policy-denied first message settles to idle", async () => {
+    seedSession("conv_real");
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url === "/v1/sessions/conv_real/events") {
+        return mockResponse({ queued: false, denied: true });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const { proposedConvId, pendingMsgTempId } = beginProvisionalConversation(
+      "11111111111141118111111111111111",
+      "blocked",
+      undefined,
+    )!;
+    resolveProvisionalConversation(
+      proposedConvId,
+      "conv_real",
+      "agent_xyz",
+      "blocked",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+    await settle();
+
+    const real = conversationRegistry.peek("conv_real")!.getState();
+    expect(real.status).toBe("idle");
+    expect(real.sessionStatus).toBe("idle");
+    expect(real.pendingUserMessages).toEqual([]);
+  });
+
+  it("B2: a bind failure after navigate-away settles the real session, not the visible one", async () => {
+    // The real session's snapshot fails, so ensureBoundSession rethrows the
+    // load error BEFORE postedSessionId is assigned — the catch's B2 path.
+    seedSession("conv_visible");
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/v1/sessions/conv_real" && (init?.method ?? "GET") === "GET") {
+        return mockResponse({}, { ok: false, status: 500 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const { proposedConvId, pendingMsgTempId } = beginProvisionalConversation(
+      "11111111111141118111111111111111",
+      "hi",
+      undefined,
+    )!;
+    // User navigates to another chat before the create resolves.
+    useChatStore.setState({
+      conversationId: "conv_visible",
+      abortController: new AbortController(),
+      status: "idle",
+      blocks: [],
+      pendingUserMessages: [],
+    });
+    conversationRegistry.setActive("conv_visible");
+
+    resolveProvisionalConversation(
+      proposedConvId,
+      "conv_real",
+      "agent_xyz",
+      "hi",
+      undefined,
+      pendingMsgTempId,
+      null,
+      noopNavigate,
+    );
+    await settle();
+
+    const visible = useChatStore.getState();
+    // The visible conversation is untouched — no stray error block or status flip.
+    expect(visible.conversationId).toBe("conv_visible");
+    expect(visible.blocks.filter((b) => b.type === "error")).toHaveLength(0);
+    expect(visible.status).toBe("idle");
+    // The real (background) session carried the failure and settled to idle.
+    const real = conversationRegistry.peek("conv_real")!.getState();
+    expect(real.status).toBe("idle");
+    expect(real.pendingUserMessages).toEqual([]);
+    expect(real.blocks.filter((b) => b.type === "error")).toHaveLength(1);
+  });
+
+  it("does not promote the visible store when the route already left the provisional chat", () => {
+    seedSession("conv_real");
+    const { proposedConvId, pendingMsgTempId } = beginProvisionalConversation(
+      "11111111111141118111111111111111",
+      "hi",
+      undefined,
+    )!;
+    const navigate = vi.fn();
+
+    resolveProvisionalConversation(
+      proposedConvId,
+      "conv_real",
+      "agent_xyz",
+      "hi",
+      undefined,
+      pendingMsgTempId,
+      null,
+      navigate,
+      () => false,
+    );
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(useChatStore.getState().conversationId).toBe(proposedConvId);
+  });
+
+  it("a pinned background send does not consume the visible conversation's retry id", async () => {
+    seedSession("conv_target");
+    seedSession("conv_visible");
+    await useChatStore.getState().switchTo("conv_target");
+    await useChatStore.getState().switchTo("conv_visible");
+    useChatStore.setState({ pendingRetryStableId: "retry_visible" });
+
+    await useChatStore.getState().send("background first message", "agent_xyz", undefined, {
+      pinnedConversationId: "conv_target",
+    });
+
+    expect(useChatStore.getState().pendingRetryStableId).toBe("retry_visible");
+    const post = fetchMock.mock.calls.find(
+      ([url, init]) =>
+        String(url) === "/v1/sessions/conv_target/events" &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(post).toBeDefined();
+    const body = JSON.parse((post![1] as RequestInit).body as string);
+    expect(body.data.stable_id).not.toBe("retry_visible");
+  });
+});
+
 describe("chatStore — sendSlashCommand", () => {
   /** Parse the JSON body of the single POST /events call. */
   function lastEventBody(): { type: string; data: Record<string, unknown> } {
@@ -3586,7 +3898,7 @@ describe("chatStore — send (file attachments)", () => {
 
   it("keeps the optimistic bubble's stable key on the native path (no pending_id adoption)", async () => {
     // The native POST returns a pending_id, but the optimistic bubble
-    // must KEEP its client temp id as its React key — swapping to the
+    // must KEEP its pending message key as its React key — swapping to the
     // server id mid-send remounts the bubble (a visible flink). The
     // image (real upload id) stays on the entry regardless.
     useChatStore.setState({
@@ -3613,7 +3925,7 @@ describe("chatStore — send (file attachments)", () => {
     const file = new File(["bytes"], "diagram.png", { type: "image/png" });
     await useChatStore.getState().send("draw this", "agent_xyz", [file]);
 
-    // The bubble keeps its client temp id (stable key) — NOT the server
+    // The bubble keeps its pending message key (stable key) — NOT the server
     // pending id — and carries the real-id image.
     const afterSend = useChatStore.getState();
     expect(afterSend.pendingUserMessages).toHaveLength(1);
@@ -5122,7 +5434,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       expect(promoted.type).toBe("user_message");
       expect(promoted.ctx.itemId).toBe("msg_persisted_first");
       expect(promoted.content).toEqual([{ type: "input_text", text: "first" }]);
-      // stableKey carries the popped optimistic temp id so the rendered
+      // stableKey carries the popped optimistic pending message key so the rendered
       // bubble keeps its React key (`user:pend_1`) across the
       // optimistic→committed swap — without it the key would change to
       // `user:msg_persisted_first`, remounting the node (the flink).
@@ -5279,7 +5591,7 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
 
       const promoted = useChatStore.getState().blocks[0] as UserMessageBlock;
       expect(promoted.ctx.createdBy).toBe("alice@example.com");
-      // stableKey still carries the optimistic temp id (no remount on swap).
+      // stableKey still carries the optimistic pending message key (no remount on swap).
       expect(promoted.stableKey).toBe("pend_1");
     });
 

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -94,7 +94,21 @@ import { clearSseLog, pushSseEvent } from "@/lib/sseEventLog";
 import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSessions";
 import { sessionItemsQueryKey } from "@/hooks/useSessionItems";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
-import { overlayTitleIntoCaches, type ConversationsInfiniteData } from "@/lib/sessionListCache";
+import {
+  filtersFromConversationQueryKey,
+  insertNewRowsIntoPages,
+  markRecentlyCreated,
+  mergeItemsIntoPages,
+  overlayTitleIntoCaches,
+  removeIdsFromPages,
+  type ConversationsInfiniteData,
+} from "@/lib/sessionListCache";
+import { recordOptimisticTitle } from "@/lib/optimisticTitles";
+import {
+  isProvisionalConversationId,
+  registerProvisionalConversationId,
+  removeProvisionalConversationId,
+} from "@/lib/provisionalConversationId";
 import { useTerminalActivityStore } from "./terminalActivity";
 import { terminalInfoFromResource, terminalsQueryKey, type TerminalInfo } from "@/lib/terminals";
 import type {
@@ -145,6 +159,198 @@ export interface SendOptions {
    * dedup recognises the retry and does not re-dispatch to the runner.
    */
   stableId?: string;
+  /**
+   * Reuse the optimistic bubble already on the target entry (pushed by
+   * `beginProvisionalConversation`) instead of pushing a fresh one, so the navigate-
+   * first flow's POST doesn't duplicate the message the user already sees. Its
+   * `content` is already set; `session.input.consumed` pops it FIFO as usual.
+   */
+  reusePendingTempId?: string;
+  /**
+   * Target session id, overriding the active `conversationId` — so the navigate-
+   * first background POST lands on the created session even after the user moves
+   * to another chat. Defaults to the active conversation.
+   */
+  pinnedConversationId?: string;
+}
+
+/**
+ * A title-less conversation row for the sidebar cache (renders like a fresh
+ * session). `provisional` marks the row so the sidebar disables per-row
+ * mutations until create confirms it.
+ */
+function makeConvRow(id: string, provisional = false): Conversation {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id,
+    object: "conversation",
+    title: null,
+    created_at: now,
+    updated_at: now,
+    labels: {},
+    permission_level: null,
+    provisional,
+  };
+}
+
+/** Upsert one row into every `["conversations", ...]` cache variant. */
+function upsertConvRow(row: Conversation, removeId?: string): void {
+  if (queryClient === null) return;
+  const rowMap = new Map([[row.id, row]]);
+  const removeSet = removeId ? new Set([removeId]) : null;
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    if (!data) continue;
+    const base = removeSet ? (removeIdsFromPages(data, removeSet).data ?? data) : data;
+    const filters = filtersFromConversationQueryKey(key);
+    const merged = mergeItemsIntoPages(base, rowMap, filters, undefined);
+    const missing = new Map([...rowMap].filter(([id]) => !merged.found.has(id)));
+    const { data: next } = insertNewRowsIntoPages(merged.data, missing, filters);
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+}
+
+/** Drop the sidebar row for a provisional id (on create failure). */
+function removeConvRow(id: string): void {
+  if (queryClient === null) return;
+  const ids = new Set([id]);
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    const { data: next } = removeIdsFromPages(data, ids);
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+}
+
+/**
+ * Start a provisional conversation synchronously before `createSession` runs:
+ * one proposed id shared by the sidebar row, registry entry, URL, and request;
+ * the optimistic first message is pushed into the entry and made active so the
+ * caller can `navigate('/c/<proposedConvId>')` at once. `switchTo` paints it and
+ * skips binding for a provisional id; ChatPage suppresses server-scoped fetches for it.
+ *
+ * Returns the provisional id + the bubble's `pendingMsgTempId` for
+ * `resolveProvisionalConversation`, or `null` with no query cache (tests).
+ */
+export function beginProvisionalConversation(
+  proposedConvId: string,
+  text: string,
+  files: File[] | undefined,
+): { proposedConvId: string; pendingMsgTempId: string } | null {
+  if (queryClient === null) return null;
+  registerProvisionalConversationId(proposedConvId);
+  pendingSeq += 1;
+  const pendingMsgTempId = `pend_${pendingSeq}`;
+
+  // Sidebar row under the same id the URL shows.
+  recordOptimisticTitle(proposedConvId, text);
+  upsertConvRow(makeConvRow(proposedConvId, true));
+
+  const fileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
+    const filename = file.name || "image.png";
+    const fileId = `pending:${attachmentKey(file)}`;
+    return file.type.startsWith("image/")
+      ? { type: "input_image" as const, file_id: fileId, filename }
+      : { type: "input_file" as const, file_id: fileId, filename };
+  });
+  const content: MessageContentBlock[] = [
+    ...fileBlocks,
+    ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
+  ];
+  const selfAuthor = getCurrentAuthorId();
+  const bubble: PendingUserMessage = {
+    tempId: pendingMsgTempId,
+    content,
+    createdAtS: Math.floor(Date.now() / 1000),
+    ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+  };
+
+  const entry = conversationRegistry.acquire(proposedConvId);
+  entry.setState({
+    pendingUserMessages: [bubble],
+    loadingConversation: false,
+    status: "streaming",
+  });
+  useChatStore.setState({ conversationId: proposedConvId });
+  conversationRegistry.setActive(proposedConvId);
+  mirrorActiveEntry();
+  return { proposedConvId, pendingMsgTempId };
+}
+
+/**
+ * Confirm the proposed id in place, or fall back to the server's authoritative
+ * id when an older backend ignored it. The first message is always pinned to
+ * the authoritative id, even if the user navigated away while create ran.
+ */
+export function resolveProvisionalConversation(
+  proposedConvId: string,
+  realId: string,
+  agentId: string,
+  text: string,
+  files: File[] | undefined,
+  pendingMsgTempId: string,
+  skill: { name: string; args: string } | null,
+  navigate: (to: string, opts?: { replace?: boolean }) => void,
+  isStillViewing: () => boolean = () => true,
+): void {
+  const stillViewing =
+    useChatStore.getState().conversationId === proposedConvId && isStillViewing();
+  const idMatches = proposedConvId === realId;
+  removeProvisionalConversationId(proposedConvId);
+
+  const confirmed = makeConvRow(realId);
+  recordOptimisticTitle(realId, text);
+  markRecentlyCreated(confirmed);
+  if (idMatches) {
+    upsertConvRow(confirmed);
+  } else {
+    removeConvRow(proposedConvId);
+    conversationRegistry.release(proposedConvId);
+    conversationRegistry.acquire(realId);
+    if (stillViewing) {
+      useChatStore.setState({ conversationId: realId });
+      conversationRegistry.setActive(realId);
+      mirrorActiveEntry();
+      navigate(`/c/${realId}`, { replace: true });
+    }
+    upsertConvRow(confirmed);
+  }
+
+  const store = useChatStore.getState();
+  if (skill !== null) {
+    // Let `sendSlashCommand` arm its own latch and reuse the matching create-window bubble.
+    setterFor(realId)({ status: "idle", sendLatchedAt: null });
+    void store.sendSlashCommand(skill.name, skill.args, agentId, {
+      pinnedConversationId: realId,
+      ...(idMatches ? { reusePendingTempId: pendingMsgTempId } : {}),
+    });
+    return;
+  }
+  // Plain message: reuse the bubble when the backend accepted the proposed id.
+  // `send` binds the authoritative session before posting.
+  void store.send(text, agentId, files, {
+    pinnedConversationId: realId,
+    ...(idMatches ? { reusePendingTempId: pendingMsgTempId } : {}),
+  });
+}
+
+/**
+ * Discard a client-only conversation (create failed): drop the sidebar row and
+ * the registry entry. Returns whether the discarded conversation was still the
+ * one on screen, so the caller can navigate back to the landing route.
+ */
+export function removeProvisionalConversation(proposedConvId: string): boolean {
+  const wasViewing = useChatStore.getState().conversationId === proposedConvId;
+  removeProvisionalConversationId(proposedConvId);
+  removeConvRow(proposedConvId);
+  if (wasViewing) {
+    // Reset the store to the landing state first (switchTo(null) does the full
+    // mirrored-field reset), THEN release the entry.
+    void useChatStore.getState().switchTo(null);
+  }
+  conversationRegistry.release(proposedConvId);
+  return wasViewing;
 }
 
 /**
@@ -1624,20 +1830,40 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     if (!agentId) {
       throw new Error("chatStore.send: no agentId");
     }
-    const retryId = get().pendingRetryStableId;
-    if (retryId !== null) setActive({ pendingRetryStableId: null });
+    // Target session: an explicit pin (navigate-first background POST) overrides
+    // the visible conversation, so a send whose session was created while the
+    // user moved to another chat still lands on the right one, not the one on
+    // screen. `pinnedSetter` routes every write for this send there.
+    const pinnedId = opts?.pinnedConversationId ?? null;
+    const pinnedSetter: typeof setActive = pinnedId === null ? setActive : setterFor(pinnedId);
+    const retryId =
+      pinnedId === null
+        ? get().pendingRetryStableId
+        : (setterForState(pinnedId)?.pendingRetryStableId ?? null);
+    if (retryId !== null) pinnedSetter({ pendingRetryStableId: null });
     const stableId = opts?.stableId ?? retryId ?? randomUUID().replace(/-/g, "");
     // Sending while a response is already streaming is allowed — the
     // session API queues item-typed events and the server delivers them
     // into the running task's inbox. Keep `activeResponse` untouched in
     // that case so the in-flight bubble keeps its "streaming" lifecycle
     // until its own `response.completed` arrives.
-    const alreadyStreaming = get().status === "streaming";
+    //
+    // `reusePendingTempId` is the navigate-first first turn: the entry was
+    // pre-set to "streaming" by `beginProvisionalConversation` (for the create-window
+    // shimmer) but has no `sendLatchedAt`. Treat it as NOT-already-streaming so
+    // this send arms the latch and owns the failure-settle — otherwise a failed
+    // first turn would strand the conversation in "streaming" with no watchdog.
+    const alreadyStreaming =
+      opts?.reusePendingTempId != null
+        ? false
+        : pinnedId === null
+          ? get().status === "streaming"
+          : setterForState(pinnedId)?.status === "streaming";
     if (!alreadyStreaming) {
       // Latch on the SAME entry as `status`, in one patch, so they can't
       // diverge — a new chat buffers both on root and `adoptPreSessionState`
       // moves them onto the entry together.
-      setActive({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
+      pinnedSetter({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
     }
 
     // Push to `pendingUserMessages` BEFORE the POST so the bubble
@@ -1646,8 +1872,16 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // response (separate TCP connections; either can resolve first).
     // FIFO promotion in the consumed handler matches this pending
     // entry to the eventual server item id.
-    pendingSeq += 1;
-    const tempId = `pend_${pendingSeq}`;
+    // Reuse a bubble already on the entry (navigate-first flow) rather than
+    // mint a new one, so the message the user has already seen isn't duplicated.
+    const reuseTempId = opts?.reusePendingTempId ?? null;
+    let tempId: string;
+    if (reuseTempId !== null) {
+      tempId = reuseTempId;
+    } else {
+      pendingSeq += 1;
+      tempId = `pend_${pendingSeq}`;
+    }
     const pendingFileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
       const filename = file.name || "image.png";
       // Key the placeholder id on the File's stable identity, not its name:
@@ -1665,30 +1899,33 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       ...(text.trim() ? [{ type: "input_text" as const, text }] : []),
     ];
     const selfAuthor = getCurrentAuthorId();
-    setActive((s) => ({
-      pendingUserMessages: [
-        ...s.pendingUserMessages,
-        {
-          tempId,
-          content,
-          createdAtS: Math.floor(Date.now() / 1000),
-          ...(selfAuthor !== null ? { author: selfAuthor } : {}),
-        },
-      ],
-      // A new turn does NOT supersede the background-shell tally: shells
-      // launched in an earlier turn keep running across the turn boundary, so
-      // the composer pill must stay lit alongside the "Working…" shimmer rather
-      // than blink off the moment the user sends. The count is sticky (see the
-      // `session_status` handler) and the next Stop hook re-reports it
-      // authoritatively. Only the parked-dialog reason clears — a fresh send is
-      // not parked on a dialog.
-      blockedOn: null,
-    }));
+    if (reuseTempId === null) {
+      pinnedSetter((s) => ({
+        pendingUserMessages: [
+          ...s.pendingUserMessages,
+          {
+            tempId,
+            content,
+            createdAtS: Math.floor(Date.now() / 1000),
+            ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+          },
+        ],
+        // A new turn does NOT supersede the background-shell tally: shells
+        // launched in an earlier turn keep running across the turn boundary, so
+        // the composer pill must stay lit alongside the "Working…" shimmer rather
+        // than blink off the moment the user sends. The count is sticky (see the
+        // `session_status` handler) and the next Stop hook re-reports it
+        // authoritatively. Only the parked-dialog reason clears — a fresh send is
+        // not parked on a dialog.
+        blockedOn: null,
+      }));
+    }
 
     // Pin the destination before joining the send chain: a stalled prior
     // send can delay this POST past a session switch, and resolving the
     // target afterward would leak the message into the now-active session.
-    const submitConversationId = get().conversationId;
+    // An explicit pin (navigate-first background POST) wins over the visible id.
+    const submitConversationId = pinnedId ?? get().conversationId;
 
     // Take our place in THIS conversation's send chain: wait for its prior
     // send's network work, then hand off to the next via `releaseSend` in the
@@ -1780,7 +2017,7 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
         }));
       }
       // Note: native-terminal messages return a `pending_id`, but the
-      // optimistic bubble deliberately keeps its client temp id as its
+      // optimistic bubble deliberately keeps its pending message key as its
       // stable React key — swapping it to the server id mid-send forces
       // a bubble remount (a visible flink). The eventual
       // `session.input.consumed` clears this bubble by FIFO order (its
@@ -1806,12 +2043,16 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       }
       // Settle the conversation this send targeted, wherever the user is now:
       // its bubble must roll back and its status must not stay "streaming"
-      // forever. When the throw came from session setup itself
-      // (`postedSessionId` never resolved) there is no target conversation, so
-      // it belongs to the active one — the landing composer's own failure.
-      const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
+      // forever. Target `postedSessionId ?? submitConversationId` (mirroring the
+      // draft restore above): a bind failure throws before `postedSessionId` is
+      // assigned, but the pin/submit id already names the session — so a failed
+      // navigate-first first turn settles the REAL new session, not whatever
+      // chat the user has since switched to. Null id (the landing composer's own
+      // failure) falls back to the active conversation.
+      const failTarget = postedSessionId ?? submitConversationId;
+      const failSet = failTarget === null ? setActive : setterFor(failTarget);
       const failGet = (): ChatState =>
-        postedSessionId === null ? get() : (setterForState(postedSessionId) ?? get());
+        failTarget === null ? get() : (setterForState(failTarget) ?? get());
       // Roll back the optimistic bubble — no server idle will fire.
       failSet((s) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
@@ -1854,12 +2095,19 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     if (!agentId) {
       throw new Error("chatStore.sendSlashCommand: no agentId");
     }
+    // See `send`: an explicit pin (navigate-first background dispatch) targets
+    // the just-created session even after the user moved to another chat.
+    const pinnedId = opts?.pinnedConversationId ?? null;
+    const pinnedSetter: typeof setActive = pinnedId === null ? setActive : setterFor(pinnedId);
     // Mirror `send`'s lifecycle scaffolding (streaming flag + send-chain
     // serialization) so a skill invocation behaves like any other turn.
-    const alreadyStreaming = get().status === "streaming";
+    const alreadyStreaming =
+      pinnedId === null
+        ? get().status === "streaming"
+        : setterForState(pinnedId)?.status === "streaming";
     if (!alreadyStreaming) {
       // See `send`: latch and status on one entry, in one patch.
-      setActive({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
+      pinnedSetter({ status: "streaming", activeResponse: null, sendLatchedAt: Date.now() });
     }
     // Optimistic echo of the typed command, mirroring `send`. Without it
     // the chat shows nothing until the server's `slash_command` receipt
@@ -1869,25 +2117,28 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
     // pump's `slash_command` case pops this FIFO entry the moment the
     // receipt (and its synthesized `${id}:user` echo block) lands, so the
     // optimistic bubble swaps for the committed one in the same flush.
-    pendingSeq += 1;
-    const tempId = `pend_${pendingSeq}`;
+    const reuseTempId = opts?.reusePendingTempId ?? null;
+    if (reuseTempId === null) pendingSeq += 1;
+    const tempId = reuseTempId ?? `pend_${pendingSeq}`;
     const commandText = args ? `/${name} ${args}` : `/${name}`;
     const selfAuthor = getCurrentAuthorId();
-    setActive((s) => ({
-      pendingUserMessages: [
-        ...s.pendingUserMessages,
-        {
-          tempId,
-          content: [{ type: "input_text" as const, text: commandText }],
-          createdAtS: Math.floor(Date.now() / 1000),
-          ...(selfAuthor !== null ? { author: selfAuthor } : {}),
-        },
-      ],
-    }));
+    if (reuseTempId === null) {
+      pinnedSetter((s) => ({
+        pendingUserMessages: [
+          ...s.pendingUserMessages,
+          {
+            tempId,
+            content: [{ type: "input_text" as const, text: commandText }],
+            createdAtS: Math.floor(Date.now() / 1000),
+            ...(selfAuthor !== null ? { author: selfAuthor } : {}),
+          },
+        ],
+      }));
+    }
 
     // Pin the destination at submit time — see `send` above for why a late
     // resolve mis-routes to the session the user has since switched to.
-    const submitConversationId = get().conversationId;
+    const submitConversationId = pinnedId ?? get().conversationId;
 
     const { waitForPrior, rekey, releaseSend } = enterSendChain(submitConversationId);
 
@@ -1942,10 +2193,12 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       const message = err instanceof Error ? err.message : String(err);
       // Settle the conversation this command targeted, wherever the user is
       // now: its echo must roll back and its status must not stay "streaming"
-      // forever. A throw from session setup itself (`postedSessionId` never
-      // resolved) has no target conversation, so it belongs to the active one —
-      // the landing composer's own failure. Mirrors `send`'s catch.
-      const failSet = postedSessionId === null ? setActive : setterFor(postedSessionId);
+      // forever. Target `postedSessionId ?? submitConversationId` (mirrors
+      // `send`'s catch): a bind failure throws before `postedSessionId` is set,
+      // but the pin/submit id already names the session, so a failed pinned
+      // command settles the real session, not the visible one. Null → active.
+      const failTarget = postedSessionId ?? submitConversationId;
+      const failSet = failTarget === null ? setActive : setterFor(failTarget);
       // Roll back the optimistic echo — no receipt will reconcile it.
       failSet((s) => ({
         pendingUserMessages: s.pendingUserMessages.filter((p) => p.tempId !== tempId),
@@ -2043,6 +2296,21 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // Landing route: nothing to project, so reset the mirrored fields to a
       // clean slate rather than leaving the last conversation painted.
       rootSetState(createInitialConversationState() as Parameters<typeof rootSetState>[0]);
+      return;
+    }
+
+    // A provisional conversation shown while `createSession` is in flight has
+    // no server session to bind. Its registry entry already holds the optimistic
+    // first-message bubble, so paint it without issuing a request.
+    if (isProvisionalConversationId(conversationId)) {
+      if (conversationRegistry.peek(conversationId) === undefined) {
+        conversationRegistry.setActive(null);
+        rootSetState({ conversationId: null } as Parameters<typeof rootSetState>[0]);
+        rootSetState(createInitialConversationState() as Parameters<typeof rootSetState>[0]);
+        return;
+      }
+      conversationRegistry.acquire(conversationId);
+      mirrorActiveEntry();
       return;
     }
 
@@ -5061,7 +5329,7 @@ function committedContentFor(
  *
  * @param itemId - Server-assigned conversation item id (for dedup + nav).
  * @param content - The committed message content.
- * @param stableKey - The optimistic bubble's temp id when this block is
+ * @param stableKey - The optimistic bubble's pending message key when this block is
  *   promoted from one, so the rendered bubble keeps the same React key
  *   across the swap (no remount/flink). Omit for foreign/TUI messages
  *   that had no optimistic predecessor — they mount fresh.
@@ -5819,7 +6087,7 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
                 ...s.pendingUserMessages.slice(0, idx),
                 ...s.pendingUserMessages.slice(idx + 1),
               ],
-              // stableKey = the optimistic bubble's temp id → the
+              // stableKey = the optimistic bubble's pending message key → the
               // promoted bubble keeps the same React key (no remount).
               blocks: [
                 ...s.blocks,
@@ -5853,7 +6121,7 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
           if (content === null) return {};
           return {
             pendingUserMessages: s.pendingUserMessages.slice(1),
-            // stableKey = the popped optimistic bubble's temp id so the
+            // stableKey = the popped optimistic bubble's pending message key so the
             // promoted bubble keeps the same React key (no remount/flink).
             blocks: [
               ...s.blocks,


### PR DESCRIPTION
Navigate with a proposed session ID before creation completes, then reconcile old servers that return a different authoritative ID without losing the first message.

**note: DEPENDS ON CHANGES CONTAINED IN https://github.com/omnigent-ai/omnigent/pull/6729**

<!--
For AI-written descriptions:
- Follow this template (Related issue, Summary, Test Plan, Demo, Type of change, Test coverage, Coverage notes).
- Keep it concise; reviewers skim long descriptions.
- For non-trivial changes, include an ELI5 and a diagram (ASCII or mermaid).
- Keep every section and checkbox row in place so reviewers can skim them.
- For UI changes (the "UI / frontend change" box below), fill in the Demo
  section: attach a screenshot or screen recording of the new behaviour.
-->

## Related issue

<!--
Link the issue this PR addresses with a closing keyword so GitHub auto-links it
(and closes it on merge): e.g. `Closes #123`. One issue per PR. Linking also
gives this PR the issue's priority in the review queue. If an older, still-open
community PR already closes the same issue, the newer one may be auto-closed as
a duplicate (maintainer PRs are exempt).

If this is either a `Refactor / chore`, `Docs`, or `Test / CI` *Type of change* 
below, then no issue is required to be associated. 
-->

Closes #

## Summary

<!-- What changed and why, in 1-3 bullets or a short paragraph. -->

## Test Plan

<!-- How was this change tested? Describe the steps, commands, or scenarios used to verify it. Include a screenshot or recording where helpful. -->

## Demo

<!--
Choose the evidence format that applies. UI / frontend changes require video or
images. For non-visual changes, put reproducible evidence here or in Test Plan.
-->

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

<!-- Check all that apply. Be honest: reviewers and agents use this to spot coverage gaps. -->

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

<!--
Optional — but required if you checked "Manual verification completed" or
"Not applicable" above. Describe what you verified manually, or why automated
test coverage is not needed for this change.
-->

## Changelog

<!--
One line, in the user's voice, describing the user-facing change. The category
is taken from the "Type of change" boxes above (e.g. UI / frontend change renders
as "[UI] <your line>"), so don't repeat it here — just describe the change. The
PR link is added for you.

Lower the bar than docs: DO keep this for small features and UX changes
(moved/renamed buttons, new flags, copy tweaks).

DELETE THIS WHOLE SECTION if the change isn't noteworthy (CI, refactors,
test-only changes, dependency bumps with no user impact) — it will simply be
left out of the changelog. A Breaking change must always keep this section.

Example:  `omnigent run --watch` reruns an agent when files change
-->

<Add a line to describe the change, else delete this section>
