### PR TITLE
fix(server): don't return WRONG_REPLICA for an absent host on a single-replica deployment

### DIFF
--- a/omnigent/server/routes/_host_launch.py
+++ b/omnigent/server/routes/_host_launch.py
@@ -18,6 +18,8 @@ Centralizing the checks here keeps the two call sites from drifting
 
 from __future__ import annotations
 
+import functools
+import importlib.util
 from dataclasses import dataclass
 
 from fastapi import HTTPException
@@ -80,7 +82,24 @@ def resolve_host_owner(
     return host
 
 
-def host_absent_error(host: Host) -> OmnigentError:
+@functools.cache
+def _deployment_is_sharded() -> bool:
+    """Whether this deployment shards host traffic across replicas by host_id.
+
+    Only the Databricks managed deployment runs multiple replicas behind the
+    host_id-sharding router (Dicer); a single-process / OSS server has exactly
+    one replica, so an absent host is simply offline. The server can't see the
+    sharding layer directly (Dicer strips its routing header), so we detect the
+    managed deployment by the presence of the internal lakebox launcher module —
+    the same signal that gates ``databricks_features`` in ``server_info`` and
+    mirrors the client's own ``isDatabricksWorkspace()`` re-address gate. Cached:
+    ``find_spec`` is side-effect-free but the answer is fixed for the process
+    lifetime.
+    """
+    return importlib.util.find_spec("omnigent.onboarding.sandboxes.lakebox") is not None
+
+
+def host_absent_error(host: Host, *, sharded: bool | None = None) -> OmnigentError:
     """Classify a "host not on this replica" miss for a host-scoped route.
 
     Every route that reaches a host over its live tunnel looks it up in the
@@ -89,17 +108,28 @@ def host_absent_error(host: Host) -> OmnigentError:
     tunnel — the same wrong-replica case ``RunnerRouter`` handles for runner
     dispatch. Tell the two apart from the host record the caller already loaded:
 
-    - still **live** (online + fresh heartbeat) → up on some replica, just not
-      here → :data:`~ErrorCode.WRONG_REPLICA` (400) so the client re-addresses
-      WITHOUT the key.
-    - otherwise → genuinely offline → ``CONFLICT`` (409).
+    - **sharded** deployment and still **live** (online + fresh heartbeat) → up
+      on some replica, just not here → :data:`~ErrorCode.WRONG_REPLICA` (400) so
+      the client re-addresses WITHOUT the key.
+    - otherwise → genuinely unreachable here → ``CONFLICT`` (409).
+
+    On a single-replica deployment the local registry is authoritative: an
+    absent host is unreachable, full stop. Claiming ``WRONG_REPLICA`` there is a
+    lie the client can't satisfy — there is no other replica to re-address to,
+    so a stale-but-``online`` DB row (a host that went away without a clean
+    ``set_offline`` — version swap, crash) would drive an endless 400 poll loop.
+    So ``WRONG_REPLICA`` is emitted only when the deployment is actually sharded.
 
     :param host: The host's persistent record (owner-checked by the caller).
+    :param sharded: Whether this deployment shards by host_id. Defaults to
+        auto-detection (:func:`_deployment_is_sharded`); overridable for tests.
     :returns: The ``OmnigentError`` to raise; the global handler maps its code
         to the HTTP status and the ``{"error": {"code": ...}}`` body the
         client's re-address matches on.
     """
-    if host_is_live(host):
+    if sharded is None:
+        sharded = _deployment_is_sharded()
+    if sharded and host_is_live(host):
         return OmnigentError("host is on another replica", code=ErrorCode.WRONG_REPLICA)
     return OmnigentError("host is offline", code=ErrorCode.CONFLICT)
 

--- a/tests/server/routes/test_host_launch.py
+++ b/tests/server/routes/test_host_launch.py
@@ -14,6 +14,7 @@ from fastapi import HTTPException
 from omnigent.entities import Conversation
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.server.routes._host_launch import (
+    host_absent_error,
     resolve_host_launch,
     resolve_host_owner,
 )
@@ -146,3 +147,28 @@ class TestResolveHostLaunch:
         )
         assert result.host.host_id == "host_1"
         assert result.conv.id == "s1"
+
+
+# ── host_absent_error (single-replica vs sharded) ─────────────────────
+
+
+class TestHostAbsentError:
+    def test_sharded_live_host_is_wrong_replica(self) -> None:
+        """On a sharded deployment a live-but-absent host re-addresses (400)."""
+        host = _FakeHost(host_id="host_1", status="online", updated_at=now_epoch())
+        err = host_absent_error(host, sharded=True)
+        assert err.code == ErrorCode.WRONG_REPLICA
+
+    def test_single_replica_live_host_is_offline(self) -> None:
+        """On a single-replica deployment there is no other replica to re-address
+        to, so a live-but-absent host is reported offline (409), not the
+        un-satisfiable WRONG_REPLICA that would drive an endless client poll."""
+        host = _FakeHost(host_id="host_1", status="online", updated_at=now_epoch())
+        err = host_absent_error(host, sharded=False)
+        assert err.code == ErrorCode.CONFLICT
+
+    def test_offline_host_is_conflict_regardless_of_sharding(self) -> None:
+        """A stale/offline row is a genuine 409 whether or not we're sharded."""
+        host = _FakeHost(host_id="host_1", status="offline", updated_at=0)
+        assert host_absent_error(host, sharded=True).code == ErrorCode.CONFLICT
+        assert host_absent_error(host, sharded=False).code == ErrorCode.CONFLICT

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -653,13 +653,22 @@ def _host_import_client(db_uri: str, host_registry: HostRegistry) -> httpx.Async
     return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")
 
 
-async def test_import_local_live_host_off_replica_is_wrong_replica(db_uri: str) -> None:
+async def test_import_local_live_host_off_replica_is_wrong_replica(
+    db_uri: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A live host absent from this replica is WRONG_REPLICA, not "not connected".
 
     Regression: the route used to flatten every registry miss into a 409
     CONFLICT, so a host live on another replica never got the 400 wrong_replica
     signal the client re-addresses on — the import failed permanently.
+
+    Only a sharded (multi-replica) deployment has an "other replica" to
+    re-address to, so force the sharded signal on — the test host stack has no
+    lakebox module, which auto-detects as single-replica.
     """
+    from omnigent.server.routes import _host_launch
+
+    monkeypatch.setattr(_host_launch, "_deployment_is_sharded", lambda: True)
     host_id = "host_0123456789abcdef0123456789abcdef"
     HostStore(db_uri).upsert_on_connect(host_id, "laptop", "alice@example.com")
     async with _host_import_client(db_uri, HostRegistry()) as client:
@@ -669,6 +678,22 @@ async def test_import_local_live_host_off_replica_is_wrong_replica(db_uri: str) 
         )
     assert res.status_code == 400
     assert res.json()["error"]["code"] == ErrorCode.WRONG_REPLICA
+
+
+async def test_import_local_live_host_single_replica_is_conflict(db_uri: str) -> None:
+    """On a single-replica deployment a live-but-absent host is a 409, not a
+    WRONG_REPLICA the client can never satisfy (no other replica to re-address
+    to). Auto-detection reports single-replica when no lakebox module is present,
+    which is the default in the test stack."""
+    host_id = "host_0123456789abcdef0123456789abcded"
+    HostStore(db_uri).upsert_on_connect(host_id, "laptop", "alice@example.com")
+    async with _host_import_client(db_uri, HostRegistry()) as client:
+        res = await client.post(
+            "/v1/imports/local",
+            json={"host_id": host_id, "source": "all", "limit": 5},
+        )
+    assert res.status_code == 409
+    assert res.json()["error"]["code"] == ErrorCode.CONFLICT
 
 
 async def test_import_local_offline_host_is_conflict(db_uri: str) -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- Host-scoped requests (model-options, filesystem, worktrees) for a host absent from this replica's `HostRegistry` returned `WRONG_REPLICA` (HTTP 400, "on another replica") whenever the host's DB row was still `online`+fresh. That's the client's "re-address keyless to the replica holding the tunnel" signal.
- On a **single-replica** deployment (single-process / OSS server) there is no other replica, so a live-but-absent host is simply unreachable. A stale-but-`online` row — a host that went away without a clean `set_offline` (version swap, crash) — drove an **endless 400 poll loop**: the client's re-address lands back on the same server and 400s again. Seen as a stream of 400s on `/v1/hosts/{stale_id}/harnesses/*/model-options` from the New Chat host picker's 15s poll + retry backoff.
- Fix: gate `WRONG_REPLICA` on whether the deployment is actually **sharded**. Detect the managed (multi-replica, Dicer-fronted) deployment by the lakebox launcher module's presence — the same signal that gates `databricks_features` in `server_info` and mirrors the client's own `isDatabricksWorkspace()` re-address gate. A single-replica deployment now returns an honest **409 (host is offline)**, which the UI treats as terminal instead of retrying.

The nine `host_absent_error` call sites are unchanged; the sharded gate defaults to auto-detection (overridable for tests via the `sharded` kwarg).

## Test Plan

- `pytest tests/server/routes/test_host_launch.py tests/server/routes/test_imports.py` — 36 pass.
- `pytest tests/server/integration/test_hosts_filesystem.py tests/server/integration/test_hosts_api.py tests/server/integration/test_session_host_launch.py tests/server/integration/test_host_session_binding.py` — 92 pass.
- `ruff format` / `ruff check` clean; pre-commit hooks green.
- New unit coverage: sharded→400, single-replica→409, offline→409 either way; imports regression test forces `sharded=True`, new sibling asserts single-replica→409.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Covered by unit + integration tests above. No manual verification claimed.

## Changelog

Host-scoped requests to an offline host on a single-server deployment now return a clear "host is offline" instead of a 400 that triggered an endless retry loop.

This pull request and its description were written by Isaac.
