### PR TITLE
fix(electron): avoid overlay IPC after window close

### DIFF
--- a/web/electron/src/update_overlay.js
+++ b/web/electron/src/update_overlay.js
@@ -81,7 +81,13 @@ function createUpdateOverlay({
 
   function notifyParentHeight(parent, height) {
     if (!parent || parent.isDestroyed()) return;
-    parent.webContents.send("omnigent:update-overlay-height", height);
+    const contents = parent.webContents;
+    // During BrowserWindow's "closed" event Electron may already have
+    // destroyed the renderer while the BrowserWindow wrapper has not yet
+    // started reporting isDestroyed(). The child overlay closes from that
+    // event and must not send its final height into the dead renderer.
+    if (!contents || contents.isDestroyed()) return;
+    contents.send("omnigent:update-overlay-height", height);
   }
 
   function collapse(parent, overlay) {

--- a/web/electron/test/update_overlay.test.js
+++ b/web/electron/test/update_overlay.test.js
@@ -11,10 +11,15 @@ class FakeWebContents extends EventEmitter {
     this.sent = [];
     this.url = "";
     this.windowOpenHandler = null;
+    this.destroyed = false;
   }
 
   getURL() {
     return this.url;
+  }
+
+  isDestroyed() {
+    return this.destroyed;
   }
 
   setWindowOpenHandler(handler) {
@@ -22,6 +27,7 @@ class FakeWebContents extends EventEmitter {
   }
 
   send(channel, payload) {
+    if (this.destroyed) throw new TypeError("Object has been destroyed");
     this.sent.push({ channel, payload });
   }
 }
@@ -67,8 +73,18 @@ class FakeWindow extends EventEmitter {
   }
 
   destroy() {
+    this.webContents.destroyed = true;
     this.destroyed = true;
     this.emit("closed");
+  }
+
+  close() {
+    // Electron destroys a window's renderer before all BrowserWindow "closed"
+    // listeners finish. Model the interval where isDestroyed() is still false
+    // but webContents.send() can no longer be called.
+    this.webContents.destroyed = true;
+    this.emit("closed");
+    this.destroyed = true;
   }
 }
 
@@ -174,6 +190,16 @@ describe("update overlay", () => {
       channel: "omnigent:update-overlay-height",
       payload: 0,
     });
+  });
+
+  it("does not notify a parent whose web contents were destroyed during close", () => {
+    const { controller } = makeOverlay();
+    const parent = new FakeWindow();
+    const overlay = controller.ensureOverlay(parent);
+
+    assert.doesNotThrow(() => parent.close());
+    assert.equal(overlay.isDestroyed(), true);
+    assert.deepEqual(parent.webContents.sent, []);
   });
 
   it("reports zero and keeps an empty overlay as a click-through sliver", () => {


### PR DESCRIPTION
## Summary

- guard update-overlay height IPC against a destroyed parent `webContents`
- model Electron's close ordering in the overlay unit fake
- add a regression test for closing the last macOS window without quitting the app

## Root cause

On macOS, closing a window keeps the application alive. During the parent `BrowserWindow`'s `closed` event, its renderer can already be destroyed while `parent.isDestroyed()` still returns false. The parent-close listener synchronously destroys the update-overlay child; the child's `closed` cleanup then calls `parent.webContents.send(...)`, which raises the uncaught `TypeError: Object has been destroyed` dialog.

The fix checks `parent.webContents.isDestroyed()` before sending the final overlay height.

## Test plan
before/after:

https://github.com/user-attachments/assets/36884b21-e7b1-4bd6-a3b1-6d470da62959


- Regression test failed before the production change with `TypeError: Object has been destroyed`
- `node --test test/update_overlay.test.js` (7 passed)
- `pnpm --dir web/electron test` (433 passed)
- pre-commit on both changed files (Prettier, oxlint, TypeScript, hygiene all passed)