### PR TITLE
fix(claude-native): preserve terminals waiting for startup input

### DIFF
--- a/omnigent/claude_native_bridge.py
+++ b/omnigent/claude_native_bridge.py
@@ -262,6 +262,10 @@ _FOREIGN_DIALOG_HINTS = (
     "Do you want to ",
     "Yes, and don't ask again",
 )
+# Footer under every Claude Code selection dialog's options. Matched instead of
+# the dialog titles, which are open-ended — each release adds prompts. Lowercase
+# and the confirm half only: the cancel half has several spellings.
+_PENDING_DIALOG_FOOTER = "enter to confirm"
 # Seconds to wait for a confirmation dialog before concluding none appears.
 # Bounds the common no-dialog case (a fresh session never pops one) while
 # still covering the slow warm-session render.
@@ -370,6 +374,15 @@ def validate_claude_hook_interpreter_compatibility(
 
 class ClaudePromptTimeout(RuntimeError):
     """Claude Code's input box did not render before delivery timed out."""
+
+
+class ClaudePromptBlocked(ClaudePromptTimeout):
+    """Claude Code is waiting on a dialog only a person can answer.
+
+    A subclass because the delivery still failed, so existing
+    ``except ClaudePromptTimeout`` handlers stay correct. Only the remedy
+    differs: the terminal is healthy, so leave it alone instead of reaping it.
+    """
 
 
 class TmuxSessionNotAdvertised(RuntimeError):
@@ -4497,6 +4510,11 @@ def _wait_for_claude_prompt_ready(
         :func:`_format_terminal_failure_tail`) so the true failure mode —
         a startup crash, a torn/empty capture under a mid-turn repaint, or
         a box that never appeared — is diagnosable from the error alone.
+    :raises ClaudePromptBlocked: If the composer never mounted because a
+        dialog is parked awaiting a keypress. A ``ClaudePromptTimeout``
+        subclass, so a caller that only cares "delivery failed" needs no
+        change; a caller that reaps the terminal must skip the reap, since
+        the terminal is healthy and holds the prompt to be answered.
     """
     deadline = time.monotonic() + timeout_s
     polls = 0
@@ -4522,7 +4540,17 @@ def _wait_for_claude_prompt_ready(
         if time.monotonic() >= deadline:
             break
         time.sleep(_CLAUDE_READY_POLL_INTERVAL_S)
-    # Timed out. The poll/empty-capture counts separate the failure modes:
+    # Timed out. A dialog awaiting a keypress is not a boot failure — the TUI
+    # is healthy and simply cannot mount the composer until someone answers —
+    # so it gets its own error, and the caller leaves the terminal alone.
+    if _PENDING_DIALOG_FOOTER in last_nonempty.lower():
+        raise ClaudePromptBlocked(
+            "Claude Code is waiting for an answer in its terminal, so the "
+            f"message was not delivered (waited {timeout_s}s). Open the "
+            "terminal and answer the prompt, then send again."
+            + _format_terminal_failure_tail(last_nonempty)
+        )
+    # The poll/empty-capture counts separate the remaining failure modes:
     # mostly-empty captures point at a torn read under a busy repaint (the
     # session is alive but capture-pane came back blank); non-empty captures
     # with no box point at Claude never rendering the prompt (a boot crash,

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -13,6 +13,7 @@ from omnigent.claude_native_bridge import (
     BRIDGE_DIR_ENV_VAR,
     REQUEST_SESSION_ID_ENV_VAR,
     SWITCH_MODEL_DIALOG_HINT,
+    ClaudePromptBlocked,
     ClaudePromptTimeout,
     TmuxSessionNotAdvertised,
     inject_slash_command,
@@ -198,6 +199,15 @@ class ClaudeNativeExecutor(Executor):
                         self._bridge_dir,
                         content=text,
                     )
+        except ClaudePromptBlocked as exc:
+            # Parked on a dialog, so there is nothing to reap: killing the pane
+            # would discard the session and the prompt awaiting an answer.
+            _logger.warning(
+                "claude-native: harness is waiting on a dialog; message not delivered",
+                extra={"session_id": self._request_session_id},
+            )
+            yield ExecutorError(message=describe_exception(exc))
+            return
         except ClaudePromptTimeout as exc:
             _logger.exception(
                 "claude-native: prompt delivery to harness timed out",

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -12,6 +12,7 @@ import pytest
 
 from omnigent.claude_native_bridge import (
     REQUEST_SESSION_ID_ENV_VAR,
+    ClaudePromptBlocked,
     ClaudePromptTimeout,
     TmuxSessionNotAdvertised,
 )
@@ -1361,3 +1362,46 @@ async def test_run_turn_ignores_missing_tmux_during_timeout_reap(
 
     assert isinstance(events[0], ExecutorError)
     assert events[0].message == "terminal did not become ready"
+
+
+@pytest.mark.asyncio
+async def test_run_turn_leaves_the_pane_alive_when_a_dialog_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A harness parked on a dialog is not reaped.
+
+    ``ClaudePromptBlocked`` means the terminal is alive and waiting on a
+    prompt, so the turn must fail without killing the session holding it.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :param tmp_path: Pytest temporary directory fixture.
+    :returns: None.
+    """
+    killed: list[Path] = []
+
+    def blocked_inject(bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0) -> None:
+        del bridge_dir_arg, content, timeout_s
+        raise ClaudePromptBlocked("Claude Code is waiting for an answer in its terminal")
+
+    monkeypatch.setattr(claude_native_executor, "inject_user_message", blocked_inject)
+    monkeypatch.setattr(
+        claude_native_executor,
+        "kill_session",
+        lambda bridge_dir_arg, *, timeout_s: killed.append(bridge_dir_arg),
+    )
+
+    executor = ClaudeNativeExecutor(tmp_path / "bridge")
+    events = [
+        event
+        async for event in executor.run_turn(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            system_prompt="",
+        )
+    ]
+
+    assert killed == []
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+    assert "waiting for an answer" in events[0].message

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -9416,3 +9416,42 @@ def test_prune_orphaned_bridge_dirs_only_removes_dead_owners(
     assert not dead_dir.exists()
     assert live_dir.exists()
     assert unmarked_dir.exists()
+
+
+def test_wait_for_claude_prompt_ready_reports_a_pending_dialog_separately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dialog awaiting a keypress raises ``ClaudePromptBlocked``, not a boot timeout.
+
+    A selection dialog blocks the composer until a person answers. Calling that
+    a failed boot misdiagnoses a healthy terminal and, via the executor's reap,
+    kills the session holding the unanswered prompt.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: None.
+    """
+    dialog_pane = "\n".join(
+        [
+            "  New MCP server found in this project: example",
+            "  MCP servers may execute code or access system resources.",
+            "    Use this MCP server",
+            "  ❯ Continue without using this MCP server",
+            "  Enter to confirm · Esc to cancel",
+        ]
+    )
+    monkeypatch.setattr(
+        "omnigent.claude_native_bridge._capture_pane",
+        lambda socket_path, tmux_target: dialog_pane,
+    )
+    with pytest.raises(claude_native_bridge.ClaudePromptBlocked) as excinfo:
+        claude_native_bridge._wait_for_claude_prompt_ready(
+            "/tmp/example/tmux.sock",
+            "claude:0.0",
+            timeout_s=0.0,
+        )
+    message = str(excinfo.value)
+    assert "waiting for an answer in its terminal" in message
+    # The boot-failure wording must not be used for a healthy terminal.
+    assert "did not become ready" not in message
+    # The dialog itself is attached so the person knows what to answer.
+    assert "New MCP server found in this project" in message


### PR DESCRIPTION
## Related issue

Closes #7333.

## Summary

Claude-native readiness timeouts currently kill the terminal even when it is waiting for a confirmation, password, or browser sign-in. Distinguish these recognizable startup prompts from failed boots, tell the user how to continue, and preserve the terminal. Ordinary readiness failures still clean up the pane.

ELI5: leave the unanswered question available so the user can finish startup and retry their message.

```text
readiness deadline
  known input prompt -> explain next step -> preserve terminal
  other failure      -> report timeout   -> existing cleanup
```

## Test Plan

- `python -m pytest tests/test_claude_native_bridge.py tests/inner/test_claude_native_executor.py -q` — 408 passed.
- New password and browser-login cases failed with the previous implementation.
- All applicable pre-commit hooks passed, including the full Python type check.
- Human check: start a Claude session whose launcher requests a password or browser sign-in, leave that step pending, and send a chat message. Confirm that the terminal stays open; complete startup and resend the message.

## Demo

N/A — non-visual lifecycle change; automated cases cover confirmation dialogs, password prompts, browser sign-in, and preserved cleanup for other failures.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Pane captures and executor cleanup are tested without credentials or a live Claude process. Recognition covers the observed startup prompts; unrecognized prompts still follow the normal timeout path. Manual steps above are provided for review and were not performed against a live authenticated harness.

## Changelog

Claude sessions waiting for a startup confirmation, password, or browser sign-in remain available so you can complete the prompt and retry.

## Issues

Resolves [OMNI-7746](https://linear.app/omnigent/issue/OMNI-7746/claude-readiness-timeout-kills-terminals-waiting-for-startup-input)
