### PR TITLE
feat(github): degrade the Summary tab gracefully on an old gh CLI

### DIFF
--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -57,11 +57,16 @@ _DEFAULT_GH_TIMEOUT_SECONDS = 15.0
 
 # Fields requested from ``gh pr view``. Always pass ``--json`` — bare
 # ``gh pr view`` opens an interactive/pager view and misbehaves in a
-# non-interactive subprocess. ``body`` + ``comments`` feed the Summary tab;
-# both are accepted by ``gh pr list`` too, so the fork-fallback path shares them.
-_PR_VIEW_FIELDS = (
-    "number,title,state,url,isDraft,author,baseRefName,headRefName,statusCheckRollup,body,comments"
-)
+# non-interactive subprocess.
+#
+# The core set is returned by every supported ``gh``. ``body`` + ``comments``
+# (the Summary tab's description and conversation) are appended in the full set;
+# an older ``gh`` that predates the ``comments`` field rejects the whole call, so
+# ``github_info`` refetches the core set and flags the summary as unavailable.
+# Both sets are accepted by ``gh pr list`` too, so the fork-fallback path shares
+# them.
+_PR_CORE_FIELDS = "number,title,state,url,isDraft,author,baseRefName,headRefName,statusCheckRollup"
+_PR_VIEW_FIELDS = f"{_PR_CORE_FIELDS},body,comments"
 
 
 def _gh_timeout_seconds() -> float:
@@ -257,8 +262,19 @@ def _pushed_head_ref(root: str, branch: str) -> str | None:
     return out.strip().removeprefix("refs/heads/") or None
 
 
-def _pr_view_json(root: str, fields: str) -> dict[str, Any] | None:
-    """Return the branch's PR as a ``gh``-JSON object for ``fields``, or ``None``.
+def _is_unknown_field_error(stderr: str) -> bool:
+    """Whether ``gh`` failed because a requested ``--json`` field is unknown.
+
+    An older ``gh`` that predates a field (e.g. ``comments``) exits non-zero with
+    ``Unknown JSON field: "<name>"`` — distinct from a "no PR"/auth/network
+    failure, so the caller can retry with a smaller field set rather than treat
+    the branch as having no PR.
+    """
+    return "unknown json field" in stderr.lower()
+
+
+def _pr_view_json(root: str, fields: str) -> tuple[dict[str, Any] | None, bool]:
+    """Return the branch's PR as a ``gh``-JSON object for ``fields``.
 
     Resolves the PR in a single ``gh`` call, choosing the query from a cheap git
     signal: whether the pushed ref (``branch.<name>.merge``) was *renamed* from
@@ -274,11 +290,16 @@ def _pr_view_json(root: str, fields: str) -> dict[str, Any] | None:
     ``master``. Using ``gh pr list --head`` there would be wrong — it matches on
     the head ref name alone, so on ``master`` it returns a stranger's unrelated
     PR whose head merely happens to be named ``master``.
+
+    :returns: ``(data, fields_unsupported)``. ``data`` is the PR object, or
+        ``None`` when no PR resolves or ``gh`` failed. ``fields_unsupported`` is
+        ``True`` only when ``gh`` rejected a requested ``--json`` field (a CLI
+        that predates it), so the caller can retry with a reduced set.
     """
     branch = _current_branch(root)
     pushed_ref = _pushed_head_ref(root, branch) if branch is not None else None
     if pushed_ref is not None and pushed_ref != branch:
-        rc, out, _ = _gh(
+        rc, out, err = _gh(
             [
                 "pr",
                 "list",
@@ -294,23 +315,23 @@ def _pr_view_json(root: str, fields: str) -> dict[str, Any] | None:
             cwd=root,
         )
         if rc != 0:
-            return None
+            return None, _is_unknown_field_error(err)
         try:
             rows = json.loads(out)
         except ValueError:
-            return None
+            return None, False
         if isinstance(rows, list) and rows and isinstance(rows[0], dict):
-            return rows[0]
-        return None
+            return rows[0], False
+        return None, False
 
-    rc, out, _ = _gh(["pr", "view", "--json", fields], cwd=root)
+    rc, out, err = _gh(["pr", "view", "--json", fields], cwd=root)
     if rc != 0:
-        return None
+        return None, _is_unknown_field_error(err)
     try:
         data = json.loads(out)
     except ValueError:
-        return None
-    return data if isinstance(data, dict) else None
+        return None, False
+    return (data, False) if isinstance(data, dict) else (None, False)
 
 
 def github_info(root: str) -> dict[str, Any]:
@@ -364,7 +385,16 @@ def github_info(root: str) -> dict[str, Any]:
             pass
 
     pr: dict[str, Any] | None = None
-    data = _pr_view_json(root, _PR_VIEW_FIELDS)
+    data, fields_unsupported = _pr_view_json(root, _PR_VIEW_FIELDS)
+    # An older ``gh`` rejects the whole call over the ``comments`` field. Refetch
+    # the core set so the PR (header + diff) still resolves, and flag the summary
+    # unavailable so the UI can prompt a ``gh`` upgrade instead of the diff
+    # silently claiming the branch has no PR.
+    summary_supported = True
+    if data is None and fields_unsupported:
+        data, _ = _pr_view_json(root, _PR_CORE_FIELDS)
+        if data is not None:
+            summary_supported = False
     if data is not None:
         author = data.get("author")
         body = data.get("body")
@@ -382,6 +412,9 @@ def github_info(root: str) -> dict[str, Any]:
             # empty body is null so the UI shows its "no description" state.
             "body": body if isinstance(body, str) and body.strip() else None,
             "comments": _shape_comments(data.get("comments")),
+            # False only when a too-old ``gh`` couldn't return body/comments;
+            # the Summary tab then prompts an upgrade.
+            "summary_supported": summary_supported,
         }
     payload["pr"] = pr
 
@@ -450,7 +483,7 @@ def _pr_number(root: str) -> int | None:
     :returns: The associated PR's number, or ``None`` when no PR resolves (none
         for the branch, ``gh`` missing, or not authenticated).
     """
-    data = _pr_view_json(root, "number")
+    data, _ = _pr_view_json(root, "number")
     if data is None:
         return None
     number = data.get("number")

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -458,6 +458,8 @@ def test_github_info_includes_body_and_comments(
 
     info = github_info(str(repo))
     assert info["pr"]["body"] == "## Summary\nDoes things."
+    # A modern gh returned the fields, so the summary is marked supported.
+    assert info["pr"]["summary_supported"] is True
     # The minimized comment is dropped; the survivor is flattened to snake_case.
     assert info["pr"]["comments"] == [
         {
@@ -499,6 +501,53 @@ def test_github_info_empty_body_is_null(repo: Path, monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
 
     info = github_info(str(repo))
+    assert info["pr"]["body"] is None
+    assert info["pr"]["comments"] == []
+
+
+def test_github_info_old_gh_degrades_summary(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An old ``gh`` that rejects ``comments`` still resolves the PR, sans summary.
+
+    The full ``gh pr view`` (which requests ``body,comments``) fails with the
+    "Unknown JSON field" error an older CLI emits. The PR must still resolve from
+    the core fields — otherwise the panel would misreport "no PR" — with the
+    summary flagged unavailable and body/comments empty.
+    """
+    core_view = {
+        "number": 8,
+        "title": "t",
+        "state": "OPEN",
+        "url": "u",
+        "isDraft": False,
+        "author": {"login": "a"},
+        "baseRefName": "main",
+        "headRefName": "feature",
+        "statusCheckRollup": [],
+    }
+
+    def fake_gh(argv: Sequence[str], *, cwd: str) -> tuple[int, str, str]:
+        head = tuple(argv[:2])
+        if head == ("auth", "status"):
+            return (0, "", "")
+        if head == ("repo", "view"):
+            return (0, json.dumps({"nameWithOwner": "o/r"}), "")
+        if head == ("pr", "view"):
+            # argv == ["pr", "view", "--json", <fields>]. Old gh rejects the full
+            # set (it predates ``comments``) but serves the core fields.
+            fields = argv[3] if len(argv) > 3 else ""
+            if "comments" in fields:
+                return (1, "", 'Unknown JSON field: "comments"\nAvailable fields:\n  additions')
+            return (0, json.dumps(core_view), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    monkeypatch.setattr(github_resource.shutil, "which", lambda _name: "/usr/bin/gh")
+
+    info = github_info(str(repo))
+    # The PR resolved from the core fields despite the failed full call.
+    assert info["pr"] is not None
+    assert info["pr"]["number"] == 8
+    assert info["pr"]["summary_supported"] is False
     assert info["pr"]["body"] is None
     assert info["pr"]["comments"] == []
 

--- a/web/src/hooks/useGithub.ts
+++ b/web/src/hooks/useGithub.ts
@@ -72,6 +72,10 @@ export interface GithubPr {
   body?: string | null;
   /** Top-level PR comments GitHub shows by default; absent from an older host. */
   comments?: GithubComment[];
+  /** False when the host's `gh` CLI was too old to return the body/comments (it
+   *  rejects the `comments` field); the Summary tab then prompts a gh upgrade.
+   *  Undefined on hosts predating this flag — treated as supported. */
+  summary_supported?: boolean;
 }
 
 export interface GithubRepo {

--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -220,6 +220,18 @@ describe("GithubPanel", () => {
     expect(screen.queryByTestId("diff")).toBeNull();
   });
 
+  it("prompts to upgrade gh when the PR summary is unsupported", () => {
+    // A too-old gh on the host couldn't return the body/comments.
+    state.info!.data!.pr!.summary_supported = false;
+    renderPanel();
+    expect(screen.getByText("Update the GitHub CLI to see the summary")).toBeInTheDocument();
+    // The upgrade prompt replaces the description/comments empty states…
+    expect(screen.queryByText("No description provided.")).toBeNull();
+    expect(screen.queryByText("No comments yet.")).toBeNull();
+    // …but checks still render (they come from the core PR fetch).
+    expect(screen.getByText("Checks")).toBeInTheDocument();
+  });
+
   it("reveals the stacked diff after switching to the Changes tab", async () => {
     renderPanel();
     expect(screen.queryByTestId("diff")).toBeNull();

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -433,15 +433,19 @@ function GithubCommentCard({ comment }: { comment: GithubComment }) {
   );
 }
 
-/** The Summary tab body: CI checks, the PR description, then its comments. */
+/** The Summary tab body: CI checks, the PR description, then its comments.
+ *  When the host's `gh` is too old to return the body/comments, the description
+ *  and comments give way to an upgrade prompt (checks still render). */
 function GithubSummaryTab({
   checks,
   body,
   comments,
+  summarySupported,
 }: {
   checks: GithubChecks;
   body: string | null | undefined;
   comments: GithubComment[];
+  summarySupported: boolean;
 }) {
   return (
     // Extra bottom padding so the last comment can scroll clear of the very
@@ -479,32 +483,50 @@ function GithubSummaryTab({
           </div>
         </section>
       )}
-      <section className="space-y-1.5">
-        <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          Description
-        </h3>
-        {body ? (
-          <div className="text-ui break-words">
-            <MessageResponse>{body}</MessageResponse>
+      {!summarySupported ? (
+        // Too-old gh on the host: it couldn't return the body/comments, so
+        // point the user at the fix rather than showing empty description /
+        // comments sections that read as "there are none".
+        <div className="flex items-start gap-2 rounded-lg border border-border bg-muted/30 p-3 text-ui text-muted-foreground">
+          <TerminalIcon className="mt-0.5 size-4 shrink-0" />
+          <div className="space-y-0.5">
+            <p className="font-medium text-foreground">Update the GitHub CLI to see the summary</p>
+            <p>
+              The PR description and comments need a newer <span className="font-mono">gh</span> on
+              the host. Update it, then reconnect the session.
+            </p>
           </div>
-        ) : (
-          <p className="text-ui text-muted-foreground italic">No description provided.</p>
-        )}
-      </section>
-      <section className="space-y-2">
-        <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          {comments.length > 0 ? `Comments (${comments.length})` : "Comments"}
-        </h3>
-        {comments.length === 0 ? (
-          <p className="text-ui text-muted-foreground">No comments yet.</p>
-        ) : (
-          <ul className="space-y-2">
-            {comments.map((c, i) => (
-              <GithubCommentCard key={c.url ?? `${c.author}-${i}`} comment={c} />
-            ))}
-          </ul>
-        )}
-      </section>
+        </div>
+      ) : (
+        <>
+          <section className="space-y-1.5">
+            <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              Description
+            </h3>
+            {body ? (
+              <div className="text-ui break-words">
+                <MessageResponse>{body}</MessageResponse>
+              </div>
+            ) : (
+              <p className="text-ui text-muted-foreground italic">No description provided.</p>
+            )}
+          </section>
+          <section className="space-y-2">
+            <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              {comments.length > 0 ? `Comments (${comments.length})` : "Comments"}
+            </h3>
+            {comments.length === 0 ? (
+              <p className="text-ui text-muted-foreground">No comments yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {comments.map((c, i) => (
+                  <GithubCommentCard key={c.url ?? `${c.author}-${i}`} comment={c} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
     </div>
   );
 }
@@ -972,7 +994,12 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
 
         {/* Summary: CI checks + the PR description + its conversation comments. */}
         <TabsContent value="summary" className="min-h-0 flex-1 overflow-y-auto">
-          <GithubSummaryTab checks={checks} body={pr.body} comments={comments} />
+          <GithubSummaryTab
+            checks={checks}
+            body={pr.body}
+            comments={comments}
+            summarySupported={pr.summary_supported !== false}
+          />
         </TabsContent>
 
         {/* Changes: a controls row, then the sidebar (jump-to-file) + one scroll


### PR DESCRIPTION
## Related issue

N/A — follow-up to the Summary/Changes tab split (#6678).

## Summary

- The Summary tab requests `body` + `comments` from `gh pr view`. An older `gh` that predates the `comments` `--json` field **rejects the entire call** (`Unknown JSON field: "comments"`, exit 1) — which silently made the panel resolve **no PR at all**, so it showed "No open PR for this branch" even when one exists.
- **Backend:** split the requested PR fields into a core set (`number,title,…,statusCheckRollup`) and the summary fields (`body,comments`). When the full fetch fails specifically with gh's unknown-field error, refetch the core set so the PR — header, CI checks, and the whole diff — still resolves, and flag `pr.summary_supported = false`. The extra call happens only on that degraded path; a modern `gh`, and the ordinary "no PR" case, stay single-call.
- **Frontend:** when `summary_supported` is `false`, the Summary tab replaces the description/comments sections with a short prompt to update the GitHub CLI on the host. CI checks still render (they come from the core fetch).

**ELI5:** the PR-summary feature needs a recent `gh`. Before, a too-old `gh` made the whole GitHub panel act like there was no PR. Now the diff and checks keep working, and the summary area just says "update `gh` on the host to see the description and comments."

**Why behavior-based, not a version check:** we key off gh's actual `Unknown JSON field` failure rather than parsing `gh --version` against a hardcoded minimum — it can't drift as gh evolves, and it degrades correctly no matter which field is the new one.

## Test Plan

- Backend: `pytest tests/runner/test_github_resource.py` → 22 passed. New `test_github_info_old_gh_degrades_summary` stubs `_gh` so the full `pr view` (with `comments`) returns gh's unknown-field error while the core fields succeed, and asserts the PR still resolves with `summary_supported == False` and empty body/comments. The happy-path test now also asserts `summary_supported is True`.
- Frontend: `vitest src/shell/GithubPanel.test.tsx` → 22 passed. New test sets `summary_supported: false` and asserts the upgrade prompt shows, the description/comments empty states don't, and Checks still render.
- `tsc -b`, `oxlint`, `prettier`, `ruff check` / `ruff format` all clean.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

> Note: UI change, but a live screenshot wasn't captured from the dev environment. To see it: point a session's host at a `gh` older than the `comments` field (or temporarily rename the field), open the GitHub tab on a branch with a PR — the diff/checks load and the Summary tab shows "Update the GitHub CLI to see the summary". A screenshot should be added before merge.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The degradation path and the frontend prompt are covered by new unit tests on both sides. Live in-app manual verification (and a screenshot) against a genuinely old `gh` is still pending — see Demo.

## Changelog

The GitHub panel now keeps working on an older `gh` CLI and prompts you to update it to see the PR summary, instead of appearing to have no PR.

---

This pull request and its description were written by Isaac.
