### PR TITLE
fix(web): keep file viewers off provisional sessions

### DIFF
--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -589,6 +589,19 @@ describe("AppShell header", () => {
     expect(screen.getByTestId("fork-probe")).toHaveAttribute("data-can-fork", "false");
   });
 
+  it("does not mount file viewers for a temp route with a stale file selection", () => {
+    writeSessionWorkspaceState("temp:12345678", {
+      open: true,
+      openFiles: ["README.md"],
+      selectedFilePath: "README.md",
+    });
+    mockConversations([{ id: "temp:12345678", permission_level: null, provisional: true }]);
+    renderShell("/c/temp:12345678");
+
+    expect(screen.queryByTestId("file-viewer")).toBeNull();
+    expect(screen.queryByTestId("file-viewer-inline")).toBeNull();
+  });
+
   it("shows owner actions for a top-level session omitted from conversation pages", () => {
     mockConversations([]);
     useSessionMock.mockReturnValue({

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1859,7 +1859,7 @@ export function AppShell() {
     [canClone],
   );
   const workspacePanelVisible = Boolean(
-    conversationId &&
+    serverConversationId &&
     hasRailContent &&
     rightPanelOpen &&
     (terminalFirst || !panelOpen) &&
@@ -2082,9 +2082,9 @@ export function AppShell() {
               rectangle (e.g. a no-filesystem agent with no terminals).
               Sits inside the group so the header overlay spans it; the
               push panels below sit outside the group. */}
-                {conversationId && workspacePanelVisible && (
+                {serverConversationId && workspacePanelVisible && (
                   <WorkspacePanel
-                    conversationId={conversationId}
+                    conversationId={serverConversationId}
                     width={inlinePanelWidth}
                     inert={inlinePanelWidth === 0}
                     handleProps={inlinePanelHandleProps}
@@ -2194,11 +2194,11 @@ export function AppShell() {
                 </MobilePanelDrawer>
               )}
               {/* Mobile-only push panel — on desktop the viewer lives inside the inline aside. */}
-              {conversationId && selectedFilePath !== null && (
+              {serverConversationId && selectedFilePath !== null && (
                 <div className="md:hidden">
                   <FileViewer
                     open
-                    conversationId={conversationId}
+                    conversationId={serverConversationId}
                     path={selectedFilePath}
                     onClose={closeFileViewer}
                     onNavigateTo={openFileViewer}


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Route desktop workspace and mobile file viewers through the confirmed server session ID.
- Prevent stale file selections from mounting viewers and issuing `/v1/sessions/temp:*` file or comment requests while a new conversation is provisional.
- Add regression coverage for a temporary route carrying persisted file-viewer state.

## Test Plan

- `npm test -- --run src/shell/AppShell.test.tsx` — 124 tests passed.
- `npm run type-check && npm run lint && npm run format:check`
- `git diff --check`

## Demo

Non-visual request-suppression fix. To verify manually, open a file in one session, start a new conversation, and revisit its temporary row before creation resolves; DevTools should show no file or comment request containing `/v1/sessions/temp:`.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression seeds stale workspace state for a `temp:` route and verifies neither desktop nor mobile file viewer mounts.

## Changelog

File and comment requests no longer target temporary conversations while a new session is being created.