### PR TITLE
fix(web): surface blockless stream failures

### DIFF
--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -8977,6 +8977,79 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     expect(useChatStore.getState().abortController).toBeNull();
   });
 
+  it("surfaces one error across repeated 401 give-ups when the active response has no bubble", async () => {
+    seedSession("conv_401_blank", []);
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/[^/]+\/stream$/.test(url)) {
+        return mockResponse({}, { ok: false, status: 401 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    useChatStore.setState({
+      conversationId: "conv_401_blank",
+      sessionStatus: "running",
+      activeResponse: { responseId: "resp_401_blank", state: "streaming", error: null },
+    });
+
+    const giveUp = async () => {
+      const controller = new AbortController();
+      useChatStore.setState({ abortController: controller });
+      const loop = startStreamPump("conv_401_blank", controller, setState, getState);
+      await vi.advanceTimersByTimeAsync(6_000);
+      await loop;
+    };
+    await giveUp();
+    await giveUp();
+
+    const state = useChatStore.getState();
+    expect(state.activeResponse).toMatchObject({
+      responseId: "resp_401_blank",
+      state: "failed",
+      error: "stream unavailable (401)",
+    });
+    const errors = state.blocks.filter((block) => block.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ code: "stream_unavailable" });
+  });
+
+  it("renders a 401 failure on an existing assistant bubble without a standalone error", async () => {
+    const response = assistantMessage("resp_401_visible", "Partial reply");
+    seedSession("conv_401_visible", [response]);
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/[^/]+\/stream$/.test(url)) {
+        return mockResponse({}, { ok: false, status: 401 });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    useChatStore.setState({
+      conversationId: "conv_401_visible",
+      abortController: controller,
+      sessionStatus: "running",
+      blocks: itemsToBlocks([response]),
+      activeResponse: { responseId: "resp_401_visible", state: "streaming", error: null },
+    });
+
+    const loop = startStreamPump("conv_401_visible", controller, setState, getState);
+    await vi.advanceTimersByTimeAsync(6_000);
+    await loop;
+
+    const state = useChatStore.getState();
+    expect(state.blocks.filter((block) => block.type === "error")).toHaveLength(0);
+    expect(buildBubbles(state.blocks, state.activeResponse)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "assistant",
+          responseId: "resp_401_visible",
+          lifecycle: "failed",
+          error: "stream unavailable (401)",
+        }),
+      ]),
+    );
+  });
+
   it("gives up after exhausting the transient-404 retry cap", async () => {
     seedSession("conv_404", []);
     let opens = 0;

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -57,6 +57,7 @@ import { userInputElicitationKey } from "@/lib/askUserQuestion";
 import { LIVE_ITEM_PREFIX, PENDING_FILE_PREFIX, structuredErrorFields } from "@/lib/blocks";
 import { BlockStream } from "@/lib/blockStream";
 import { itemsToBlocks } from "@/lib/itemsToBlocks";
+import { buildBubbles } from "@/lib/renderItems";
 import { emitBrowserActionRequest } from "@/lib/browserActionBus";
 import {
   ApiError,
@@ -4514,7 +4515,7 @@ export async function startStreamPump(
           // surfaces as offline liveness via ConnectionIndicator.
           if (streamRes.status === 401 || streamRes.status === 403) {
             console.warn(`Session ${id}: stream unavailable (${streamRes.status}), giving up`);
-            finalizeActive(set, "failed", `stream unavailable (${streamRes.status})`, null);
+            failUnavailableStream(set, `stream unavailable (${streamRes.status})`);
             set({ status: "idle" });
             break;
           }
@@ -6573,6 +6574,39 @@ function finalizeActive(
     const responseId = s.activeResponse?.responseId ?? responseIdOverride ?? "";
     return {
       activeResponse: { responseId, state, error, completedAt: Date.now() },
+    };
+  });
+}
+
+const STREAM_UNAVAILABLE_CODE = "stream_unavailable";
+
+/** Fail the active turn and surface one fallback when no bubble can show it. */
+function failUnavailableStream(set: Setter, error: string): void {
+  set((s) => {
+    const activeResponse =
+      s.activeResponse === null
+        ? null
+        : { ...s.activeResponse, state: "failed" as const, error, completedAt: Date.now() };
+    const blocks = s.blocks.filter(
+      (block) => block.type !== "error" || block.code !== STREAM_UNAVAILABLE_CODE,
+    );
+    const hasVisibleFailure =
+      activeResponse !== null &&
+      buildBubbles(blocks, activeResponse).some(
+        (bubble) => bubble.kind === "assistant" && bubble.responseId === activeResponse.responseId,
+      );
+    if (hasVisibleFailure) {
+      return blocks.length === s.blocks.length ? { activeResponse } : { activeResponse, blocks };
+    }
+    return {
+      ...(activeResponse !== null ? { activeResponse } : {}),
+      blocks: [
+        ...blocks,
+        makeClientErrorBlock(
+          "The live connection to the assistant is unavailable. Reload the page to reconnect.",
+          STREAM_UNAVAILABLE_CODE,
+        ),
+      ],
     };
   });
 }


### PR DESCRIPTION
## Related issue

Resolves [OMNI-6061](https://linear.app/omnigent/issue/OMNI-6061/assistant-responses-intermittently-render-empty)

## Summary

- Determine whether a stream failure is visible from the bubbles the renderer actually produces, rather than treating any `activeResponse` as visible.
- Upsert one coded fallback error when a block-less response cannot render its own failure, avoiding silent turns and duplicate errors across rebinds.

### ELI5

Omnigent displays an assistant's reply as it arrives over a live connection. The ticket describes cases where that connection disappears while Claude Code is still answering—for example, after an authentication token expires. Claude may continue or finish the turn, but the browser can miss the reply. The page then advances to later prompts with an empty space where the assistant's response or an explanation should have appeared.

The old code recorded that the response had failed and assumed this automatically made the failure visible. That assumption was wrong: after a reload, Omnigent can know a response is active before it has received any visible text or tool blocks for it. In that state there is a response record, but no reply bubble on screen to carry the error. It is like attaching an error note to a box that has not been built—the note exists in memory, but the user sees nothing.

This fix first asks the same renderer used by the page whether a real reply bubble exists. If it does, the failure appears on that bubble. If it does not, Omnigent adds one standalone error card so the turn cannot look silently empty. Reconnects replace that fallback card instead of adding another copy, so a persistent connection problem does not produce a stack of identical errors.

```mermaid
flowchart LR
  A[Live reply connection fails] --> B[Mark response failed]
  B --> C{Visible reply bubble exists?}
  C -->|Yes| D[Show failure on that bubble]
  C -->|No| E[Show one standalone error card]
```

## Test Plan

- `cd web && pnpm exec vitest run src/store/chatStore.test.ts` — 399 tests passed.
- `cd web && pnpm run type-check`
- `cd web && pnpm exec oxlint --deny-warnings --report-unused-disable-directives src/store/chatStore.ts src/store/chatStore.test.ts`
- `cd web && pnpm exec prettier --check src/store/chatStore.ts src/store/chatStore.test.ts`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The store regression tests cover both the block-less hydration race and the existing partial-response bubble path, including repeated stream give-ups.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage verifies that a hydrated active response with no renderable blocks receives exactly one fallback error, while a response with visible content renders the failure on its existing bubble without an extra card.

## Changelog

Assistant stream failures no longer leave blank turns or stack duplicate error cards.