### PR TITLE
fix(github): harden the panel's account-token lookup, config write, and preferences route

### DIFF
--- a/omnigent/config.py
+++ b/omnigent/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 from collections.abc import Mapping
 from pathlib import Path
@@ -129,6 +130,10 @@ def save_global_config(
     tmp = resolved.with_name(resolved.name + ".tmp")
     with tmp.open("w") as config_file:
         yaml.safe_dump(cfg, config_file, default_flow_style=False, sort_keys=True)
+    # Carry over the existing file's permissions so a private config (0600 — it
+    # can hold provider credentials) isn't silently widened to the umask default.
+    with contextlib.suppress(FileNotFoundError):
+        os.chmod(tmp, resolved.stat().st_mode & 0o777)
     os.replace(tmp, resolved)
 
 

--- a/omnigent/runner/github_resource.py
+++ b/omnigent/runner/github_resource.py
@@ -275,12 +275,31 @@ def _workspace_key(root: str) -> str | None:
     return None
 
 
-def _gh_auth_token(root: str, login: str) -> str | None:
-    """Return *login*'s GitHub token via ``gh auth token --user`` (never logged)."""
-    rc, out, _ = _gh(["auth", "token", "--user", login, "-h", "github.com"], cwd=root)
+def _gh_auth_token(root: str, login: str, host: str = "github.com") -> str | None:
+    """Return *login*'s token on *host* via ``gh auth token --user`` (never logged).
+
+    :param host: The gh host the account lives on. Accounts can be on an
+        Enterprise host, so pass the account's own host rather than assuming
+        ``github.com`` — a token lookup pinned to the wrong host fails (or, for a
+        login present on both, returns the wrong identity).
+    """
+    rc, out, _ = _gh(["auth", "token", "--user", login, "-h", host], cwd=root)
     if rc != 0:
         return None
     return out.strip() or None
+
+
+def _host_for_login(root: str, login: str) -> str:
+    """The gh host the preferred *login* is configured on; ``github.com`` if unknown.
+
+    Only consulted when a per-workspace account preference is set (an
+    ``auth status`` call), so it stays off the happy path.
+    """
+    _, accounts = _list_accounts(root)
+    for account in accounts:
+        if account.get("login") == login and account.get("host"):
+            return str(account["host"])
+    return "github.com"
 
 
 def _account_token_for(root: str, workspace_key: str | None = None) -> str | None:
@@ -300,7 +319,7 @@ def _account_token_for(root: str, workspace_key: str | None = None) -> str | Non
     login = _config.github_account_preference(key)
     if not login:
         return None
-    return _gh_auth_token(root, login)
+    return _gh_auth_token(root, login, _host_for_login(root, login))
 
 
 # Cap the per-check list so a pathological rollup can't bloat the payload; the

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -2637,8 +2637,25 @@ def register_resources_routes(
         :returns: The refreshed ``session.github.info`` object.
         """
         conv = await _validate_session(session_id, request, LEVEL_EDIT)
-        body = await request.json()
-        params = {"account": body.get("account"), "remote": body.get("remote")}
+        try:
+            body = await request.json()
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="request body must be valid JSON") from exc
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail="request body must be a JSON object")
+        account = body.get("account")
+        remote = body.get("remote")
+        for field_name, field_value in (("account", account), ("remote", remote)):
+            if field_value is not None and not isinstance(field_value, str):
+                raise HTTPException(
+                    status_code=400, detail=f"'{field_name}' must be a string or null"
+                )
+        # ``remote`` is forwarded to ``gh repo set-default <remote>`` as a
+        # positional arg; reject a leading dash so a value like ``--unset`` can't
+        # be smuggled in as a flag.
+        if isinstance(remote, str) and remote.startswith("-"):
+            raise HTTPException(status_code=400, detail="'remote' must not start with '-'")
+        params = {"account": account, "remote": remote}
         try:
             status, result = await _proxy_post_to_runner(
                 session_id,

--- a/tests/runner/test_github_resource.py
+++ b/tests/runner/test_github_resource.py
@@ -450,7 +450,10 @@ def test_github_info_runs_gh_as_preferred_account(
         "github_account_preference",
         lambda key: "bob" if key == "/ws/omnigent" else None,
     )
-    monkeypatch.setattr(github_resource, "_gh_auth_token", lambda _root, login: f"tok-{login}")
+    monkeypatch.setattr(
+        github_resource, "_gh_auth_token", lambda _root, login, _host="github.com": f"tok-{login}"
+    )
+    monkeypatch.setattr(github_resource, "_host_for_login", lambda _root, _login: "github.com")
     seen: dict[str, str | None] = {}
 
     def fake_gh(
@@ -673,6 +676,60 @@ def test_account_token_for_none_without_preference(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/omnigent")
     monkeypatch.setattr(github_resource._config, "github_account_preference", lambda _key: None)
     assert github_resource._account_token_for("/root") is None
+
+
+def test_account_token_uses_the_accounts_own_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A preferred account on an Enterprise host has its token fetched from THAT
+    host, not a hardcoded github.com."""
+    monkeypatch.delenv("IS_SANDBOX", raising=False)
+    monkeypatch.setattr(github_resource, "_workspace_key", lambda _root: "/ws/omnigent")
+    monkeypatch.setattr(github_resource._config, "github_account_preference", lambda _key: "alice")
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if list(argv[:4]) == ["auth", "status", "--json", "hosts"]:
+            hosts = {"hosts": {"ghe.corp.com": [{"login": "alice", "state": "success"}]}}
+            return (0, json.dumps(hosts), "")
+        if tuple(argv[:3]) == ("auth", "token", "--user"):
+            # Assert the token lookup targets the account's host, not github.com.
+            assert argv[argv.index("-h") + 1] == "ghe.corp.com"
+            return (0, "tok-ghe\n", "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    assert github_resource._account_token_for("/root") == "tok-ghe"
+
+
+def test_host_for_login_defaults_to_github_when_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A login not found among enumerated accounts defaults to github.com."""
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        if list(argv[:4]) == ["auth", "status", "--json", "hosts"]:
+            return (0, json.dumps({"hosts": {}}), "")
+        return (1, "", "no stub")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    assert github_resource._host_for_login("/root", "nobody") == "github.com"
+
+
+def test_gh_auth_token_passes_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_gh_auth_token`` pins the lookup to the given host."""
+    seen: dict[str, str] = {}
+
+    def fake_gh(
+        argv: Sequence[str], *, cwd: str, token: str | None = None
+    ) -> tuple[int, str, str]:
+        seen["host"] = argv[argv.index("-h") + 1]
+        return (0, "tok\n", "")
+
+    monkeypatch.setattr(github_resource, "_gh", fake_gh)
+    assert github_resource._gh_auth_token("/root", "alice", "ghe.corp.com") == "tok"
+    assert seen["host"] == "ghe.corp.com"
 
 
 def test_set_github_preference_sets_default_and_account(

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -5975,6 +5975,39 @@ async def test_github_set_preference_falls_back_to_host_when_runner_offline(
     assert captured["params"] == {"account": "octocat", "remote": None}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("body", "detail_contains"),
+    [
+        (["not", "an", "object"], "must be a JSON object"),
+        ({"account": 123}, "'account' must be a string"),
+        ({"remote": ["x"]}, "'remote' must be a string"),
+        ({"remote": "--unset"}, "must not start with '-'"),
+    ],
+)
+async def test_github_set_preference_rejects_bad_body(
+    offline_env_client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    body: Any,
+    detail_contains: str,
+) -> None:
+    """A malformed body is a 400 (client error), not a 500, and never reaches the
+    runner/host write."""
+    from omnigent.server.routes import _host_filesystem
+
+    async def _boom(**_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("write must not be attempted for an invalid body")
+
+    monkeypatch.setattr(_host_filesystem, "write_workspace_from_host", _boom)
+
+    resp = await offline_env_client.post(
+        f"/v1/sessions/{_OFFLINE_SESSION}/resources/github/preferences",
+        json=body,
+    )
+    assert resp.status_code == 400, resp.text
+    assert detail_contains in resp.text
+
+
 # ── Workspace-file gzip (GZipFileContentRoute) ───────────────────
 #
 # These exercise the real routes through the real router, because the whole

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -133,3 +133,14 @@ def test_save_global_config_respects_config_home(
     # Written to (and read back from) OMNIGENT_CONFIG_HOME/config.yaml.
     assert (tmp_path / "config.yaml").exists()
     assert github_account_preference("/Users/daniel.lok/omnigent") == "daniellok-db"
+
+
+def test_save_global_config_preserves_file_mode(tmp_path: Path) -> None:
+    import os
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("default_agent: /x\n")
+    os.chmod(cfg, 0o600)  # a locked-down config (may hold provider credentials)
+    save_global_config({"model": "y"}, path=cfg)
+    # The atomic rewrite must not widen 0600 to the umask default.
+    assert (cfg.stat().st_mode & 0o777) == 0o600


### PR DESCRIPTION
## Related issue

Follow-up to #6680 (merged), addressing the automated review left on that PR.

## Summary

The Polly review on #6680 ran against its **first** commit (the original "two selectors, per-repo account key" design), so its two **blocking** findings — the account preference being dropped / mis-keyed when no base repo resolves — no longer apply: the merged version keys the preference by the **workspace path** (`_workspace_key`), unconditionally. This PR addresses the review items that *do* still apply to the merged code:

- **Enterprise-host token lookup.** `_gh_auth_token` hardcoded `-h github.com`, but `_list_accounts` enumerates accounts across all hosts (and records each account's `host`). A GitHub Enterprise account was selectable but its token lookup hit the wrong host — failing, or (for a login present on both) returning a github.com identity. `_account_token_for` now resolves the preferred account's own host and passes it through. The host lookup runs only when a per-workspace preference is set, so the happy path keeps its reduced call count.
- **Config file-mode preservation.** `save_global_config` wrote `config.yaml.tmp` under the default umask and `os.replace`d it, silently widening a `0600` `~/.omnigent/config.yaml` (which can hold provider credentials) to `0644`. It now carries the existing file's mode across the atomic rewrite.
- **Preferences-route input validation.** The `POST …/github/preferences` body wasn't validated: a non-object body made `body.get(...)` raise → 500, and `account`/`remote` weren't type-checked. It now returns **400** for a non-object body or non-string field, and rejects a flag-like `remote` (e.g. `--unset`) before it reaches `gh repo set-default`.

Deliberately **not** changed (from the review's lower-severity notes): the `gh repo set-default` return code on the now-UI-unused `remote` escape hatch (no functional impact — the base is auto-resolved), the single-user temp-file-name race, and the config's comment/key-order stripping (intentional parity with the CLI writer).

## Test Plan

- `tests/runner/test_github_resource.py` — GHE token host is threaded through (`_account_token_for` uses the account's host; `_host_for_login` defaults to `github.com`; `_gh_auth_token` honors the passed host).
- `tests/test_config.py` — `save_global_config` preserves a `0600` mode.
- `tests/server/routes/test_session_resources.py` — the preferences route returns 400 for a non-object body, non-string `account`/`remote`, and a leading-dash `remote`, and never attempts the write.
- Full `test_github_resource.py` + `test_config.py` green; `ruff` + `pyrefly` clean on the changed modules.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Backend-only hardening; no user-visible UI change. Evidence is the unit tests above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Each of the three fixes has a focused unit test (host threading, file-mode preservation, route 400s). The GHE path can't be exercised in CI (no Enterprise host / two-account gh setup), so it's covered by asserting the host is passed to the token lookup rather than by a live Enterprise call.

## Changelog

The GitHub panel uses a GitHub Enterprise account's own host when fetching its token, preserves `~/.omnigent/config.yaml` permissions on write, and rejects malformed preference requests with a 400.
