### PR TITLE
fix(cli): preserve server organization selector on export

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -686,6 +686,7 @@ def _remote_headers(
     server_url: str | None = None,
     *,
     host_id: str | None,
+    org_id: str | None = None,
 ) -> dict[str, str]:
     """
     Build headers for remote AP-server requests.
@@ -711,6 +712,8 @@ def _remote_headers(
         request that keys off the runner-env host_id). Required-keyword with
         no default so every call site consciously decides — pass the request
         path's host when it has one rather than silently defaulting to unkeyed.
+    :param org_id: Workspace selector captured from the current server URL, or
+        ``None`` to fall back to the stored login record.
     :returns: Headers to pass to httpx / OmnigentClient.
     """
     # Resolve the bearer in the documented precedence order (one credential
@@ -746,7 +749,7 @@ def _remote_headers(
     if server_url:
         from omnigent.cli_auth import databricks_request_headers
 
-        headers.update(databricks_request_headers(server_url, host_id=host_id))
+        headers.update(databricks_request_headers(server_url, host_id=host_id, org_id=org_id))
     return headers
 
 

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6542,17 +6542,21 @@ def session_export(session_id: str, output: str | None, server: str | None) -> N
     from omnigent.chat import _remote_headers
 
     cfg = _load_effective_config()
-    base_url = _resolve_attach_server(server, cfg.get("server"))
-    if base_url is None:
+    resolved_server = _resolve_attach_server_url(server, cfg.get("server"))
+    if resolved_server is None:
         startup = ensure_local_omnigent_server()
-        base_url = startup.url
+        resolved_server = ServerUrl(startup.url)
 
-    base_url = base_url.rstrip("/")
+    base_url = resolved_server.api_base
     out_path = Path(output) if output else Path(f"{session_id}.jsonl")
 
     with httpx.Client(
         base_url=base_url,
-        headers=_remote_headers(server_url=base_url, host_id=None),
+        headers=_remote_headers(
+            server_url=base_url,
+            host_id=None,
+            org_id=resolved_server.org_id,
+        ),
         timeout=30.0,
         trust_env=_trust_env_for(base_url),
     ) as client:
@@ -7813,11 +7817,25 @@ def _resolve_attach_server(server: str | None, configured_server: str | None) ->
         ``server`` key of the effective merged config), or ``None``.
     :returns: Normalized base URL without a trailing slash, or ``None``.
     """
+    resolved = _resolve_attach_server_url(server, configured_server)
+    return resolved.api_base if resolved is not None else None
+
+
+def _resolve_attach_server_url(
+    server: str | None, configured_server: str | None
+) -> ServerUrl | None:
+    """Resolve an attach target without discarding its workspace selector.
+
+    :param server: Explicit ``--server`` value, or ``None``.
+    :param configured_server: Configured server fallback, or ``None``.
+    :returns: The resolved server value, including a SPOG workspace selector,
+        or ``None`` when no remote or running local server is available.
+    """
     chosen = server if server is not None else configured_server
     if chosen:
-        return _resolve_server_url(chosen).api_base
+        return _resolve_server_url(chosen)
     local = local_server_url_if_healthy()
-    return local.rstrip("/") if local else None
+    return ServerUrl(local) if local else None
 
 
 def _require_live_conversation(

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -587,6 +587,7 @@ def databricks_request_headers(
     *,
     bearer_token: str | None = None,
     host_id: str | None = None,
+    org_id: str | None = None,
 ) -> dict[str, str]:
     """Build the headers for a request to a Databricks-fronted server.
 
@@ -619,6 +620,9 @@ def databricks_request_headers(
         sharding layer that reads it. ``None`` defaults to the runner's own
         host_id inside a runner process (via ``OMNIGENT_RUNNER_SLICE_KEY``) and
         otherwise leaves routing to the default.
+    :param org_id: An explicit workspace selector captured from the current
+        server URL. When omitted, the selector from the stored login record is
+        used. An explicit value wins over stored state.
     :returns: A header dict carrying ``Authorization``, ``X-Databricks-Org-Id``,
         ``X-Databricks-Omnigent-Slice-Key``, and/or the configured extra headers
         as available, possibly empty.
@@ -626,7 +630,7 @@ def databricks_request_headers(
     headers: dict[str, str] = {}
     if bearer_token:
         headers["Authorization"] = f"Bearer {bearer_token}"
-    org_id = load_databricks_org_id(server_url)
+    org_id = org_id or load_databricks_org_id(server_url)
     if org_id:
         headers[DATABRICKS_ORG_ID_HEADER] = org_id
     # Resolve the slice-key host_id when the caller names none, so every

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -316,6 +316,20 @@ def test_databricks_request_headers_org_only(token_dir) -> None:
     assert databricks_request_headers("https://single.databricks.com/api/2.0/omnigent") == {}
 
 
+def test_databricks_request_headers_explicit_org_wins(token_dir) -> None:
+    """The current URL selector overrides a stale stored workspace selector."""
+    from omnigent.cli_auth import databricks_request_headers, store_databricks_auth
+
+    server = "https://acme.databricks.com/api/2.0/omnigent"
+    store_databricks_auth(
+        server_url=server,
+        workspace_host="https://acme.databricks.com",
+        org_id="111",
+    )
+
+    assert databricks_request_headers(server, org_id="222")["X-Databricks-Org-Id"] == "222"
+
+
 def test_databricks_request_headers_pairs_bearer_and_org(token_dir) -> None:
     """The paired minter always emits the bearer and the ?o= header together.
 

--- a/tests/host/test_cli_session_export.py
+++ b/tests/host/test_cli_session_export.py
@@ -12,8 +12,11 @@ import respx
 from click.testing import CliRunner
 
 from omnigent.cli import cli
+from omnigent.util.server_url import ServerUrl
 
 _BASE = "http://localhost:6767"
+_SPOG_DISPLAY = "https://example.databricks.com/omnigent?o=123"
+_SPOG_API = "https://example.databricks.com/api/2.0/omnigent"
 
 _SESSION_META = {
     "id": "conv_abc123",
@@ -54,7 +57,10 @@ _ITEMS_PAGE = {
 
 def _patch_server(base_url: str = _BASE) -> Any:
     """Patch the CLI so it uses *base_url* without spawning a real server."""
-    return patch("omnigent.cli._resolve_attach_server", return_value=base_url)
+    return patch(
+        "omnigent.cli._resolve_attach_server_url",
+        return_value=ServerUrl(base_url),
+    )
 
 
 @respx.mock
@@ -90,6 +96,40 @@ def test_session_export_writes_jsonl(tmp_path: Path) -> None:
     assert all(r["record_type"] == "item" for r in item_lines)
     assert [r["role"] for r in item_lines] == ["user", "assistant"]
     assert item_lines[1]["content"] == [{"type": "output_text", "text": "hi there"}]
+
+
+@respx.mock
+def test_session_export_spog_url_sends_workspace_selector(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """A pasted SPOG URL keeps its ``?o=`` selector in request headers."""
+    monkeypatch.setattr(
+        "omnigent.cli._workspace_api_server_url",
+        lambda _server: _SPOG_API,
+    )
+    session_route = respx.get(f"{_SPOG_API}/v1/sessions/conv_abc123").mock(
+        return_value=httpx.Response(200, json=_SESSION_META)
+    )
+    respx.get(f"{_SPOG_API}/v1/sessions/conv_abc123/items").mock(
+        return_value=httpx.Response(200, json={**_ITEMS_PAGE, "data": []})
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "session",
+            "export",
+            "--id",
+            "conv_abc123",
+            "--output",
+            str(tmp_path / "out.jsonl"),
+            "--server",
+            _SPOG_DISPLAY,
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert session_route.calls[0].request.headers["X-Databricks-Org-Id"] == "123"
 
 
 @respx.mock


### PR DESCRIPTION
## Summary

- Preserve the organization selector parsed from a `--server` URL until `session export` builds its request.
- Allow the current URL's selector to override a stale stored-login selector.

ELI5: a shared server endpoint may route multiple organizations, so export must retain the selector separately while it builds API paths.

```text
--server .../omnigent?o=123
          -> ServerUrl(api_base=..., org_id=123)
          -> export request with organization selector
```

## Test Plan

- `uv run --no-sync pytest -q tests/host/test_cli_session_export.py tests/test_server_url.py tests/cli/test_chat.py tests/cli/test_cli_auth.py` (203 passed)
- Changed-file pre-commit gate, including Ruff and full-project Pyrefly (passed)

## Verification

- Added a CLI regression test that exports through a synthetic selector-bearing URL and asserts that the selector reaches the request headers.
- Added coverage proving that a selector supplied by the current URL takes precedence over stale stored-login state.
- Reproduced the original behavior against a temporary authenticated session:
  1. Export through the canonical server URL succeeded and produced a reference JSONL file.
  2. Export of the same session through the selector-bearing URL failed with HTTP 400 using the unpatched CLI.
  3. The identical selector-bearing command succeeded with this patch.
  4. The patched output and reference output matched byte-for-byte.
- Deleted the temporary session after verification.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The regression test exercises the CLI boundary where the selector was previously discarded, while the manual check verifies the complete export request and resulting file.

## Changelog

`omnigent session export` now works with server URLs that include an organization selector.