### PR TITLE
fix(deploy): pass --features to the bundle through BUNDLE_VAR_features

### DIFF
--- a/deploy/databricks/databricks.yml
+++ b/deploy/databricks/databricks.yml
@@ -2,7 +2,8 @@
 #
 # Every knob the app exposes lives here. deploy.py wraps `databricks
 # bundle deploy` + `bundle run`; per-app values are passed as `--var`
-# pairs (see deploy.py / README.md).
+# pairs, except `features`, which travels as BUNDLE_VAR_features because
+# the CLI splits `--var` values on commas (see deploy.py / README.md).
 
 bundle:
   name: omnigent

--- a/deploy/databricks/deploy.py
+++ b/deploy/databricks/deploy.py
@@ -891,6 +891,7 @@ def _ensure_bound(args: argparse.Namespace) -> None:
             *_bundle_vars(args),
         ],
         cwd=_deploy_dir(),
+        env=_bundle_env(args),
         capture_output=True,
         text=True,
     )
@@ -940,10 +941,6 @@ def _ensure_compute_size(
 
 def _bundle_vars(args: argparse.Namespace) -> list[str]:
     """CLI args to pass to `databricks bundle` as --var pairs."""
-    # The Apps API rejects an environment entry with an empty source. A single
-    # space is trimmed by the feature parser and therefore preserves the
-    # documented "no features" behavior while providing a valid value source.
-    features = args.features if args.features.strip() else " "
     return [
         "--var",
         f"app_name={args.app_name}",
@@ -955,9 +952,21 @@ def _bundle_vars(args: argparse.Namespace) -> list[str]:
         f"volume_name={args.volume_name}",
         "--var",
         f"otel_table_schema={args.otel_table_schema}",
-        "--var",
-        f"features={features}",
     ]
+
+
+def _bundle_env(args: argparse.Namespace) -> dict[str, str]:
+    """Environment for `databricks bundle` calls.
+
+    The CLI splits `--var` values on commas, so a multi-feature list such as
+    "usage_page,canvas" has to travel as the BUNDLE_VAR_features variable.
+    """
+    env = os.environ.copy()
+    # The Apps API rejects an environment entry with an empty source. A single
+    # space is trimmed by the feature parser and therefore preserves the
+    # documented "no features" behavior while providing a valid value source.
+    env["BUNDLE_VAR_features"] = args.features if args.features.strip() else " "
+    return env
 
 
 def _profile_arg(args: argparse.Namespace) -> list[str]:
@@ -1155,6 +1164,7 @@ def main() -> int:
             *_bundle_vars(args),
         ],
         cwd=_deploy_dir(),
+        env=_bundle_env(args),
         check=True,
     )
 
@@ -1173,6 +1183,7 @@ def main() -> int:
             *_bundle_vars(args),
         ],
         cwd=_deploy_dir(),
+        env=_bundle_env(args),
         check=True,
     )
 

--- a/tests/deploy/test_databricks_empty_features.py
+++ b/tests/deploy/test_databricks_empty_features.py
@@ -32,7 +32,7 @@ def deploy_mod() -> ModuleType:
         ("usage_page,harness_install", "usage_page,harness_install"),
     ],
 )
-def test_bundle_vars_provide_a_valid_empty_feature_source(
+def test_bundle_env_provides_a_valid_feature_source(
     deploy_mod: ModuleType, features: str, expected: str
 ) -> None:
     args = Namespace(
@@ -44,6 +44,6 @@ def test_bundle_vars_provide_a_valid_empty_feature_source(
         features=features,
     )
 
-    values = deploy_mod._bundle_vars(args)
-
-    assert values[-2:] == ["--var", f"features={expected}"]
+    # `--var` splits on commas, so features must travel through the environment.
+    assert not any(value.startswith("features=") for value in deploy_mod._bundle_vars(args))
+    assert deploy_mod._bundle_env(args)["BUNDLE_VAR_features"] == expected

--- a/tests/deploy/test_databricks_empty_features.py
+++ b/tests/deploy/test_databricks_empty_features.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from argparse import Namespace
@@ -47,3 +48,31 @@ def test_bundle_env_provides_a_valid_feature_source(
     # `--var` splits on commas, so features must travel through the environment.
     assert not any(value.startswith("features=") for value in deploy_mod._bundle_vars(args))
     assert deploy_mod._bundle_env(args)["BUNDLE_VAR_features"] == expected
+
+
+def _is_call_to(node: ast.expr, name: str) -> bool:
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == name
+
+
+def test_every_bundle_invocation_passes_the_feature_env() -> None:
+    """Each `databricks bundle` subprocess that spreads _bundle_vars must also pass _bundle_env."""
+    bundle_calls = [
+        node
+        for node in ast.walk(ast.parse(_DEPLOY_PY.read_text()))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "run"
+        and any(
+            isinstance(element, ast.Starred) and _is_call_to(element.value, "_bundle_vars")
+            for argument in node.args
+            if isinstance(argument, ast.List)
+            for element in argument.elts
+        )
+    ]
+    # bind, deploy, and run.
+    assert len(bundle_calls) == 3
+    for call in bundle_calls:
+        env = next((kw.value for kw in call.keywords if kw.arg == "env"), None)
+        assert env is not None and _is_call_to(env, "_bundle_env"), (
+            f"bundle call at line {call.lineno} does not pass env=_bundle_env(args)"
+        )


### PR DESCRIPTION
## Related issue

No issue; follow-up to #6753, which documented `--features usage_page,canvas` for the Databricks deploy.

## Summary

- The Databricks CLI splits `--var` values on commas, so any multi-feature deploy (`--features usage_page,canvas`, or the README's `usage_page,harness_install`) failed at `bundle deploy` with `unexpected flag value for variable assignment: canvas`. Single-value deploys worked, which is why this went unnoticed.
- `deploy.py` now carries the feature list in the `BUNDLE_VAR_features` environment variable for the `bundle deployment bind` / `deploy` / `run` calls (new `_bundle_env`), and `_bundle_vars` no longer emits `--var features=...`. The single-space value for an empty feature set is kept, since the Apps API rejects an empty env source.

## Test Plan

- `pytest tests/deploy` → 75 passed (`test_databricks_empty_features.py` now asserts the env var and that no `features=` `--var` is emitted).
- Live `databricks bundle validate --target prod --output json` with the CLI, driven through the same `_bundle_vars` + `env=_bundle_env(...)` shape:
  - `--var features=usage_page,canvas` → `Error: unexpected flag value for variable assignment: canvas` (the bug)
  - `BUNDLE_VAR_features=usage_page,canvas` → `OMNIGENT_FEATURES` resolves to `usage_page,canvas`
  - `BUNDLE_VAR_features=" "` → resolves to `" "` (empty feature set stays deployable)

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The CLI's comma handling can only be observed against the real `databricks` binary, so it was verified with `bundle validate` (see Test Plan); the unit test pins the contract that features travel via `BUNDLE_VAR_features` rather than `--var`.

## Changelog

`deploy/databricks/deploy.py --features` accepts a comma-separated list again (e.g. `usage_page,canvas`)
