### PR TITLE
Default on background session titles with a user setting

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -392,6 +392,7 @@ class SqlUser(OmnigentBase):
     password_hash: Mapped[str | None] = mapped_column(String(256), nullable=True)
     created_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     last_login_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    background_session_titles_enabled: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
 
 class SqlAccountToken(OmnigentBase):

--- a/omnigent/db/migrations/versions/gd1b2c3d4e5f_add_background_session_titles_user_setting.py
+++ b/omnigent/db/migrations/versions/gd1b2c3d4e5f_add_background_session_titles_user_setting.py
@@ -1,0 +1,34 @@
+"""Add the per-user background session title preference.
+
+Revision ID: gd1b2c3d4e5f
+Revises: gc1b2c3d4e5f
+Create Date: 2026-09-08 00:00:00.000000
+
+``NULL`` and ``TRUE`` enable background titles; ``FALSE`` opts out.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "gd1b2c3d4e5f"
+down_revision: str | None = "gc1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable default-on preference to users."""
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.add_column(
+            sa.Column("background_session_titles_enabled", sa.Boolean(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    """Remove the background session title preference."""
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_column("background_session_titles_enabled")

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -102,6 +102,7 @@ from omnigent.server.routes.sessions import (
 from omnigent.server.routes.sharing import create_sharing_router
 from omnigent.server.routes.terminal_attach import create_terminal_attach_router
 from omnigent.server.routes.usage import create_usage_router
+from omnigent.server.routes.user_settings import create_user_settings_router
 from omnigent.server.runner_session_init import RunnerSessionInitializer
 from omnigent.server.scheduled import ScheduledTaskScheduler
 from omnigent.server.ws_origin import WebSocketOriginMiddleware
@@ -2724,6 +2725,11 @@ def create_app(
         ),
         prefix="/v1",
         tags=["sharing"],
+    )
+    app.include_router(
+        create_user_settings_router(auth_provider, permission_store),
+        prefix="/v1",
+        tags=["user_settings"],
     )
 
     # First-class projects (owner-private session containers). Mounted only

--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -403,10 +403,12 @@ def prepare_background_session_title(
     coordinator: BackgroundSessionTitleCoordinator | None,
     conversation: Conversation,
     event: SessionEventInput,
+    enabled: bool = True,
 ) -> PendingBackgroundSessionTitle | None:
     """Prepare a guarded first-turn title attempt for a top-level session."""
     if (
-        coordinator is None
+        not enabled
+        or coordinator is None
         or conversation.title is not None
         or conversation.parent_conversation_id is not None
         or not _background_session_title_harness_supported(conversation.harness_override)

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -130,7 +130,6 @@ from omnigent.server.routes._auth_helpers import (
     require_access as _require_access,
 )
 from omnigent.server.routes._errors import session_not_found as _session_not_found
-from omnigent.server.user_settings import background_session_titles_enabled_for_user
 from omnigent.server.routes._session_create_validation import (
     validate_session_agent,
     validate_session_model_metadata,
@@ -332,6 +331,7 @@ from omnigent.server.schemas import (
     SessionUsageEvent,
     SkillSummary,
 )
+from omnigent.server.user_settings import background_session_titles_enabled_for_user
 from omnigent.spec.types import (
     AgentSpec,
     Phase,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -130,6 +130,7 @@ from omnigent.server.routes._auth_helpers import (
     require_access as _require_access,
 )
 from omnigent.server.routes._errors import session_not_found as _session_not_found
+from omnigent.server.user_settings import background_session_titles_enabled_for_user
 from omnigent.server.routes._session_create_validation import (
     validate_session_agent,
     validate_session_model_metadata,
@@ -2218,6 +2219,8 @@ async def _persist_external_conversation_item(
     conversation_store: ConversationStore,
     created_by: str | None = None,
     background_title_coordinator: BackgroundSessionTitleCoordinator | None = None,
+    permission_store: PermissionStore | None = None,
+    user_id: str | None = None,
 ) -> str:
     """
     Persist and broadcast a conversation item produced outside AP.
@@ -2321,6 +2324,7 @@ async def _persist_external_conversation_item(
         coordinator=background_title_coordinator,
         conversation=conv,
         event=SessionEventInput(type=item.type, data=item.data.model_dump()),
+        enabled=await background_session_titles_enabled_for_user(permission_store, user_id),
     )
     persisted_items = await asyncio.to_thread(conversation_store.append, session_id, batch)
     persisted = persisted_items[-1]
@@ -8950,6 +8954,9 @@ async def _create_session_from_existing_agent(
                     coordinator=background_title_coordinator,
                     conversation=conv,
                     event=item,
+                    enabled=await background_session_titles_enabled_for_user(
+                        permission_store, user_id
+                    ),
                 )
                 await _dispatch_session_event_to_runner(
                     conv.id,

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -76,7 +76,6 @@ from omnigent.server.routes._auth_helpers import (
     require_user as _require_user,
 )
 from omnigent.server.routes._errors import session_not_found as _session_not_found
-from omnigent.server.user_settings import background_session_titles_enabled_for_user
 from omnigent.server.routes._sessions.common import (
     _ALLOWED_EVENT_TYPES,
     _APPROVAL_TYPE,
@@ -209,6 +208,7 @@ from omnigent.server.schemas import (
     McpServerStartup,
     SessionEventInput,
 )
+from omnigent.server.user_settings import background_session_titles_enabled_for_user
 from omnigent.stores import AgentStore, ConversationStore
 from omnigent.stores.artifact_store import ArtifactStore
 from omnigent.stores.file_store import FileStore

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -76,6 +76,7 @@ from omnigent.server.routes._auth_helpers import (
     require_user as _require_user,
 )
 from omnigent.server.routes._errors import session_not_found as _session_not_found
+from omnigent.server.user_settings import background_session_titles_enabled_for_user
 from omnigent.server.routes._sessions.common import (
     _ALLOWED_EVENT_TYPES,
     _APPROVAL_TYPE,
@@ -1171,6 +1172,8 @@ def register_events_routes(
                 conversation_store,
                 created_by=created_by,
                 background_title_coordinator=background_title_coordinator,
+                permission_store=permission_store,
+                user_id=user_id,
             )
             return {"queued": False, "item_id": item_id}
         if body.type == _EXTERNAL_OUTPUT_TEXT_DELTA_TYPE:
@@ -1926,6 +1929,7 @@ def register_events_routes(
             coordinator=background_title_coordinator,
             conversation=conv,
             event=body,
+            enabled=await background_session_titles_enabled_for_user(permission_store, user_id),
         )
         # Schedule display-name generation for child sessions (the
         # title coordinator skips children because their title is

--- a/omnigent/server/routes/user_settings.py
+++ b/omnigent/server/routes/user_settings.py
@@ -1,0 +1,59 @@
+"""Current-user settings API."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.auth import RESERVED_USER_LOCAL, AuthProvider
+from omnigent.server.routes._auth_helpers import require_user
+from omnigent.server.user_settings import background_session_titles_enabled_for_user
+from omnigent.stores.permission_store import PermissionStore
+
+
+class UserSettingsUpdate(BaseModel):
+    """Writable current-user settings."""
+
+    background_session_titles_enabled: bool
+
+
+def create_user_settings_router(
+    auth_provider: AuthProvider | None,
+    permission_store: PermissionStore | None,
+) -> APIRouter:
+    """Build the current-user settings router mounted under ``/v1``."""
+    router = APIRouter()
+
+    def current_user_id(request: Request) -> str:
+        user_id = require_user(request, auth_provider)
+        if user_id is not None:
+            return user_id
+        if auth_provider is None and permission_store is not None:
+            return RESERVED_USER_LOCAL
+        raise OmnigentError("Authentication required", code=ErrorCode.UNAUTHORIZED)
+
+    @router.get("/user-settings")
+    async def get_user_settings(request: Request) -> dict[str, bool]:
+        user_id = current_user_id(request)
+        enabled = await background_session_titles_enabled_for_user(permission_store, user_id)
+        return {"background_session_titles_enabled": enabled}
+
+    @router.put("/user-settings")
+    async def update_user_settings(
+        request: Request,
+        body: UserSettingsUpdate,
+    ) -> dict[str, bool]:
+        user_id = current_user_id(request)
+        if permission_store is None:
+            raise OmnigentError("User settings unavailable", code=ErrorCode.INTERNAL_ERROR)
+        await asyncio.to_thread(
+            permission_store.set_background_session_titles_enabled,
+            user_id,
+            body.background_session_titles_enabled,
+        )
+        return {"background_session_titles_enabled": body.background_session_titles_enabled}
+
+    return router

--- a/omnigent/server/user_settings.py
+++ b/omnigent/server/user_settings.py
@@ -1,0 +1,20 @@
+"""Per-user settings shared across authentication modes."""
+
+from __future__ import annotations
+
+import asyncio
+
+from omnigent.stores.permission_store import PermissionStore
+
+
+async def background_session_titles_enabled_for_user(
+    permission_store: PermissionStore | None,
+    user_id: str | None,
+) -> bool:
+    """Resolve background-title enablement, defaulting on without a stored opt-out."""
+    if permission_store is None or user_id is None:
+        return True
+    return await asyncio.to_thread(
+        permission_store.get_background_session_titles_enabled,
+        user_id,
+    )

--- a/omnigent/stores/permission_store/__init__.py
+++ b/omnigent/stores/permission_store/__init__.py
@@ -153,6 +153,16 @@ class PermissionStore(ABC):
         ...
 
     @abstractmethod
+    def get_background_session_titles_enabled(self, user_id: str) -> bool:
+        """Return the user's background-title preference, defaulting to enabled."""
+        ...
+
+    @abstractmethod
+    def set_background_session_titles_enabled(self, user_id: str, enabled: bool) -> None:
+        """Persist the user's background-title preference."""
+        ...
+
+    @abstractmethod
     def list_users(self, *, limit: int = 1000) -> list[Account]:
         """Return every real user row, for the admin user list.
 

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -424,6 +424,36 @@ class SqlAlchemyPermissionStore(PermissionStore):
             )
             return [_to_account(r) for r in rows if r.id not in _HIDDEN_LIST_USERS]
 
+    def get_background_session_titles_enabled(self, user_id: str) -> bool:
+        """Return the user's preference, treating missing and unset as enabled."""
+        with self._session("select_user_background_session_titles_setting") as session:
+            row = session.get(SqlUser, (current_workspace_id(), user_id))
+            return row is None or row.background_session_titles_enabled is not False
+
+    def set_background_session_titles_enabled(self, user_id: str, enabled: bool) -> None:
+        """Upsert the user's explicit background-title preference."""
+        with self._session("set_user_background_session_titles_setting") as session:
+            values = {
+                "id": user_id,
+                "is_admin": False,
+                "background_session_titles_enabled": enabled,
+            }
+            if self._engine.dialect.name == "sqlite":
+                stmt = sqlite_insert(SqlUser).values(**values).on_conflict_do_update(
+                    index_elements=["workspace_id", "id"],
+                    set_={"background_session_titles_enabled": enabled},
+                )
+            elif self._engine.dialect.name == "mysql":
+                stmt = mysql_insert(SqlUser).values(**values).on_duplicate_key_update(
+                    background_session_titles_enabled=enabled
+                )
+            else:
+                stmt = pg_insert(SqlUser).values(**values).on_conflict_do_update(
+                    index_elements=["workspace_id", "id"],
+                    set_={"background_session_titles_enabled": enabled},
+                )
+            session.execute(stmt)
+
     def is_admin(self, user_id: str) -> bool:
         """Check the admin flag. See base class for contract."""
         with self._session("select_user_admin_status") as session:

--- a/omnigent/stores/permission_store/sqlalchemy_store.py
+++ b/omnigent/stores/permission_store/sqlalchemy_store.py
@@ -439,18 +439,28 @@ class SqlAlchemyPermissionStore(PermissionStore):
                 "background_session_titles_enabled": enabled,
             }
             if self._engine.dialect.name == "sqlite":
-                stmt = sqlite_insert(SqlUser).values(**values).on_conflict_do_update(
-                    index_elements=["workspace_id", "id"],
-                    set_={"background_session_titles_enabled": enabled},
+                stmt = (
+                    sqlite_insert(SqlUser)
+                    .values(**values)
+                    .on_conflict_do_update(
+                        index_elements=["workspace_id", "id"],
+                        set_={"background_session_titles_enabled": enabled},
+                    )
                 )
             elif self._engine.dialect.name == "mysql":
-                stmt = mysql_insert(SqlUser).values(**values).on_duplicate_key_update(
-                    background_session_titles_enabled=enabled
+                stmt = (
+                    mysql_insert(SqlUser)
+                    .values(**values)
+                    .on_duplicate_key_update(background_session_titles_enabled=enabled)
                 )
             else:
-                stmt = pg_insert(SqlUser).values(**values).on_conflict_do_update(
-                    index_elements=["workspace_id", "id"],
-                    set_={"background_session_titles_enabled": enabled},
+                stmt = (
+                    pg_insert(SqlUser)
+                    .values(**values)
+                    .on_conflict_do_update(
+                        index_elements=["workspace_id", "id"],
+                        set_={"background_session_titles_enabled": enabled},
+                    )
                 )
             session.execute(stmt)
 

--- a/openapi.json
+++ b/openapi.json
@@ -8514,6 +8514,20 @@
         "title": "UsageReport",
         "type": "object"
       },
+      "UserSettingsUpdate": {
+        "description": "Writable current-user settings.",
+        "properties": {
+          "background_session_titles_enabled": {
+            "title": "Background Session Titles Enabled",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "background_session_titles_enabled"
+        ],
+        "title": "UserSettingsUpdate",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -14650,6 +14664,74 @@
         "summary": "Get Usage",
         "tags": [
           "usage"
+        ]
+      }
+    },
+    "/v1/user-settings": {
+      "get": {
+        "operationId": "get_user_settings_v1_user_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Get User Settings V1 User Settings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get User Settings",
+        "tags": [
+          "user_settings"
+        ]
+      },
+      "put": {
+        "operationId": "update_user_settings_v1_user_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Update User Settings V1 User Settings Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update User Settings",
+        "tags": [
+          "user_settings"
         ]
       }
     }

--- a/tests/db/test_migration_connections.py
+++ b/tests/db/test_migration_connections.py
@@ -34,7 +34,7 @@ def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
 def test_single_alembic_head() -> None:
     script = ScriptDirectory.from_config(_build_alembic_config("sqlite://"))
     heads = script.get_heads()
-    assert heads == ["gc1b2c3d4e5f"], f"expected a single head, got {heads!r}"
+    assert heads == ["gd1b2c3d4e5f"], f"expected a single head, got {heads!r}"
 
 
 def test_upgrade_creates_table_downgrade_drops_it(tmp_path: Path) -> None:

--- a/tests/e2e_ui/sessions/test_background_session_titles_setting.py
+++ b/tests/e2e_ui/sessions/test_background_session_titles_setting.py
@@ -1,0 +1,41 @@
+"""E2E: Settings → General background session-title preference.
+
+The toggle persists the user's server-side preference through
+``GET/PUT /v1/user-settings``. This covers the real browser and server round
+trip without launching an LLM title-generation turn.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+def _open_general_settings(page: Page, base_url: str):
+    """Navigate to Settings → General and wait for the toggle to mount."""
+    page.goto(f"{base_url}/settings/general")
+    return page.get_by_test_id("background-session-titles-toggle")
+
+
+def test_background_session_titles_defaults_on_and_persists(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """The preference starts on, survives an opt-out, and can be restored."""
+    base_url, _session_id = seeded_session
+    toggle = _open_general_settings(page, base_url)
+    expect(toggle).to_be_visible(timeout=30_000)
+    expect(toggle).to_have_attribute("aria-checked", "true")
+
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-checked", "false")
+
+    page.reload()
+    toggle = _open_general_settings(page, base_url)
+    expect(toggle).to_have_attribute("aria-checked", "false", timeout=30_000)
+
+    toggle.click()
+    expect(toggle).to_have_attribute("aria-checked", "true")
+
+    page.reload()
+    toggle = _open_general_settings(page, base_url)
+    expect(toggle).to_have_attribute("aria-checked", "true", timeout=30_000)

--- a/tests/server/routes/test_user_settings.py
+++ b/tests/server/routes/test_user_settings.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from omnigent.server.auth import AuthProvider
+from omnigent.server.routes.user_settings import create_user_settings_router
+from omnigent.stores.permission_store.sqlalchemy_store import SqlAlchemyPermissionStore
+
+pytestmark = pytest.mark.asyncio
+
+
+class _AuthProvider(AuthProvider):
+    def get_user_id(self, request: object) -> str | None:
+        return "alice@example.com"
+
+
+async def test_user_settings_default_on_and_round_trip(db_uri: str) -> None:
+    store = SqlAlchemyPermissionStore(db_uri)
+    store.ensure_user("alice@example.com")
+    app = FastAPI()
+    app.include_router(
+        create_user_settings_router(_AuthProvider(), store),
+        prefix="/v1",
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        initial = await client.get("/v1/user-settings")
+        disabled = await client.put(
+            "/v1/user-settings",
+            json={"background_session_titles_enabled": False},
+        )
+        persisted = await client.get("/v1/user-settings")
+
+    assert initial.status_code == 200
+    assert initial.json() == {"background_session_titles_enabled": True}
+    assert disabled.status_code == 200
+    assert disabled.json() == {"background_session_titles_enabled": False}
+    assert persisted.json() == {"background_session_titles_enabled": False}

--- a/tests/server/test_background_session_titles.py
+++ b/tests/server/test_background_session_titles.py
@@ -49,6 +49,29 @@ async def test_prepare_background_title_for_eligible_session(db_uri: str) -> Non
     assert pending is not None
 
 
+async def test_prepare_background_title_skips_when_user_setting_is_disabled(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conversation = store.create_conversation(kind="default")
+
+    async def generator(_request: BackgroundTitleRequest) -> str:
+        return "Unused title"
+
+    pending = prepare_background_session_title(
+        coordinator=BackgroundSessionTitleCoordinator(store, generator),
+        conversation=conversation,
+        event=SessionEventInput(
+            type="message",
+            data={
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+        ),
+        enabled=False,
+    )
+
+    assert pending is None
+
+
 async def test_prepare_background_title_from_message(db_uri: str) -> None:
     store = SqlAlchemyConversationStore(db_uri)
     agent_id = uuid.uuid4().hex

--- a/tests/stores/test_permission_store.py
+++ b/tests/stores/test_permission_store.py
@@ -59,6 +59,27 @@ def _create_conversation(db_uri: str) -> str:
     return conv.id
 
 
+# ── user settings ────────────────────────────────────────────────────────────
+
+
+def test_background_session_titles_default_on_when_unset(store: SqlAlchemyPermissionStore) -> None:
+    _ensure_user(store, "alice@test.com")
+
+    assert store.get_background_session_titles_enabled("alice@test.com") is True
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_background_session_titles_setting_round_trips(
+    store: SqlAlchemyPermissionStore,
+    enabled: bool,
+) -> None:
+    _ensure_user(store, "alice@test.com")
+
+    store.set_background_session_titles_enabled("alice@test.com", enabled)
+
+    assert store.get_background_session_titles_enabled("alice@test.com") is enabled
+
+
 # ── grant ────────────────────────────────────────────────────────────────────
 
 

--- a/web/src/lib/userSettingsApi.test.ts
+++ b/web/src/lib/userSettingsApi.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { authenticatedFetch } from "./identity";
 import { getUserSettings, updateUserSettings } from "./userSettingsApi";
 
+vi.mock("./identity", () => ({ authenticatedFetch: vi.fn() }));
+
 describe("userSettingsApi", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => vi.clearAllMocks());
 
   it("reads the current user's settings", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ background_session_titles_enabled: true }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    const fetchMock = vi
+      .mocked(authenticatedFetch)
+      .mockResolvedValue(
+        new Response(JSON.stringify({ background_session_titles_enabled: true }), { status: 200 }),
+      );
 
     await expect(getUserSettings()).resolves.toEqual({
       backgroundSessionTitlesEnabled: true,
@@ -18,11 +21,11 @@ describe("userSettingsApi", () => {
   });
 
   it("updates the current user's setting", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ background_session_titles_enabled: false }),
-    });
-    vi.stubGlobal("fetch", fetchMock);
+    const fetchMock = vi
+      .mocked(authenticatedFetch)
+      .mockResolvedValue(
+        new Response(JSON.stringify({ background_session_titles_enabled: false }), { status: 200 }),
+      );
 
     await expect(updateUserSettings({ backgroundSessionTitlesEnabled: false })).resolves.toEqual({
       backgroundSessionTitlesEnabled: false,

--- a/web/src/lib/userSettingsApi.test.ts
+++ b/web/src/lib/userSettingsApi.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getUserSettings, updateUserSettings } from "./userSettingsApi";
+
+describe("userSettingsApi", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("reads the current user's settings", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ background_session_titles_enabled: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getUserSettings()).resolves.toEqual({
+      backgroundSessionTitlesEnabled: true,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/v1/user-settings", { cache: "no-store" });
+  });
+
+  it("updates the current user's setting", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ background_session_titles_enabled: false }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(updateUserSettings({ backgroundSessionTitlesEnabled: false })).resolves.toEqual({
+      backgroundSessionTitlesEnabled: false,
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/v1/user-settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ background_session_titles_enabled: false }),
+    });
+  });
+});

--- a/web/src/lib/userSettingsApi.ts
+++ b/web/src/lib/userSettingsApi.ts
@@ -1,3 +1,5 @@
+import { authenticatedFetch } from "./identity";
+
 export interface UserSettings {
   backgroundSessionTitlesEnabled: boolean;
 }
@@ -13,13 +15,13 @@ function fromResponse(settings: UserSettingsResponse): UserSettings {
 }
 
 export async function getUserSettings(): Promise<UserSettings> {
-  const response = await fetch("/v1/user-settings", { cache: "no-store" });
+  const response = await authenticatedFetch("/v1/user-settings", { cache: "no-store" });
   if (!response.ok) throw new Error("Failed to load user settings");
   return fromResponse((await response.json()) as UserSettingsResponse);
 }
 
 export async function updateUserSettings(settings: UserSettings): Promise<UserSettings> {
-  const response = await fetch("/v1/user-settings", {
+  const response = await authenticatedFetch("/v1/user-settings", {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({

--- a/web/src/lib/userSettingsApi.ts
+++ b/web/src/lib/userSettingsApi.ts
@@ -1,0 +1,31 @@
+export interface UserSettings {
+  backgroundSessionTitlesEnabled: boolean;
+}
+
+interface UserSettingsResponse {
+  background_session_titles_enabled: boolean;
+}
+
+function fromResponse(settings: UserSettingsResponse): UserSettings {
+  return {
+    backgroundSessionTitlesEnabled: settings.background_session_titles_enabled,
+  };
+}
+
+export async function getUserSettings(): Promise<UserSettings> {
+  const response = await fetch("/v1/user-settings", { cache: "no-store" });
+  if (!response.ok) throw new Error("Failed to load user settings");
+  return fromResponse((await response.json()) as UserSettingsResponse);
+}
+
+export async function updateUserSettings(settings: UserSettings): Promise<UserSettings> {
+  const response = await fetch("/v1/user-settings", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      background_session_titles_enabled: settings.backgroundSessionTitlesEnabled,
+    }),
+  });
+  if (!response.ok) throw new Error("Failed to update user settings");
+  return fromResponse((await response.json()) as UserSettingsResponse);
+}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => ({
   projectNames: [] as string[],
   hasNextPage: false,
   fetchNextPage: vi.fn(),
+  getUserSettings: vi.fn(),
+  updateUserSettings: vi.fn(),
 }));
 
 vi.mock("next-themes", () => ({
@@ -58,6 +60,10 @@ vi.mock("@/lib/identity", () => ({
   resolveIdentity: () => Promise.resolve(mocks.me?.id ?? null),
   getCurrentIsAdmin: () => mocks.me?.is_admin ?? false,
   getCurrentUserId: () => mocks.me?.id ?? null,
+}));
+vi.mock("@/lib/userSettingsApi", () => ({
+  getUserSettings: mocks.getUserSettings,
+  updateUserSettings: mocks.updateUserSettings,
 }));
 vi.mock("@/hooks/useConversations", async () => {
   // A stateful mock that emulates useInfiniteQuery pagination: it tracks how
@@ -275,6 +281,30 @@ function installUpdateBridge(config: UpdateConfig = DEFAULT_UPDATE_CONFIG) {
 }
 
 describe("SettingsPage", () => {
+  beforeEach(() => {
+    mocks.getUserSettings.mockResolvedValue({ backgroundSessionTitlesEnabled: true });
+    mocks.updateUserSettings.mockImplementation(async (settings) => settings);
+  });
+
+  it("renders session auto-rename enabled by default", async () => {
+    renderPage("/settings/general");
+
+    expect(await screen.findByTestId("background-session-titles-toggle")).toBeChecked();
+  });
+
+  it("persists session auto-rename changes", async () => {
+    renderPage("/settings/general");
+    const toggle = await screen.findByTestId("background-session-titles-toggle");
+
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(mocks.updateUserSettings).toHaveBeenCalledWith({
+        backgroundSessionTitlesEnabled: false,
+      }),
+    );
+    expect(toggle).not.toBeChecked();
+  });
   it("renders composer shortcut guidance as two accessible lines", () => {
     renderPage("/settings/general");
     const toggle = screen.getByTestId("composer-submit-with-mod-enter-toggle");

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -226,6 +226,7 @@ import {
   updateBridge,
 } from "@/lib/nativeBridge";
 import { cn } from "@/lib/utils";
+import { getUserSettings, updateUserSettings } from "@/lib/userSettingsApi";
 
 // Admin-only management surfaces, rendered as the Members / Policies settings
 // sub-categories. Visible to admins in all modes (accounts, OIDC, single-user).
@@ -1273,6 +1274,62 @@ function ComposerSendShortcutControl() {
   );
 }
 
+function BackgroundSessionTitlesControl() {
+  const [enabled, setEnabled] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const labelId = useId();
+  const descriptionId = useId();
+
+  useEffect(() => {
+    let cancelled = false;
+    void getUserSettings()
+      .then((settings) => {
+        if (!cancelled) setEnabled(settings.backgroundSessionTitlesEnabled);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggle = useCallback(
+    (next: boolean) => {
+      const previous = enabled;
+      setEnabled(next);
+      setSaving(true);
+      void updateUserSettings({ backgroundSessionTitlesEnabled: next })
+        .then((settings) => setEnabled(settings.backgroundSessionTitlesEnabled))
+        .catch(() => setEnabled(previous))
+        .finally(() => setSaving(false));
+    },
+    [enabled],
+  );
+
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span id={labelId} className="text-ui font-medium">
+          Automatically name new sessions
+        </span>
+        <span id={descriptionId} className="text-ui text-muted-foreground">
+          Generate a concise title in the background after the first message. Turn this off to keep
+          the default session name.
+        </span>
+      </div>
+      <Switch
+        aria-labelledby={labelId}
+        aria-describedby={descriptionId}
+        checked={enabled}
+        disabled={saving}
+        onCheckedChange={toggle}
+        data-testid="background-session-titles-toggle"
+        className="mt-0.5 shrink-0"
+        componentId="settings.general.background_session_titles"
+      />
+    </div>
+  );
+}
+
 /** App-wide behavior settings. */
 function GeneralSection() {
   return (
@@ -1284,6 +1341,10 @@ function GeneralSection() {
           <div className="mt-4 border-t border-border pt-4">
             <AlwaysSteerControl />
           </div>
+        </div>
+        <h2 className="mt-3 text-ui font-medium">Sessions</h2>
+        <div className="rounded-xl border border-border bg-card p-4">
+          <BackgroundSessionTitlesControl />
         </div>
       </div>
     </Section>


### PR DESCRIPTION
## Related issue

Closes [OMNI-6849 — Managed session naming not happening properly](https://linear.app/omnigent/issue/OMNI-6849/managed-session-naming-not-happening-proplery)

## Summary

**ELI5:** Omnigent now names new sessions automatically unless the user turns that off in Settings.

- Enable first-turn background session titles by default, with a nullable per-user preference (`NULL` means enabled).
- Add the Settings-page toggle **“Automatically name new sessions”** and `GET/PUT /v1/user-settings` persistence.
- Ignore `OMNIGENT_SESSION_RENAME` entirely; it is no longer the primary gate and can be removed from deployments. No fleet-level env override was added so the user preference remains the primary, restart-free control.

```text
first user turn → read user preference → prepare guarded title job → runner generates title → apply only if still safe
```

## Test Plan

- CI is running the complete automated suites for the pushed branch. The branch includes focused coverage for default-on, user opt-out, router persistence, store round-trip, Settings-page rendering, API mapping, and a Playwright Settings-page persistence test.
- Reviewer commands:
  - `pytest tests/server/test_background_session_titles.py -q`
  - `pytest tests/server/routes/test_user_settings.py -q`
  - `pytest tests/stores/test_permission_store.py -q`
  - `cd web && npm run test -- SettingsPage userSettingsApi`
- Live smoke on a fresh server and Vite app against the merged `main` base: the toggle defaults on, persists across reload, disabling it suppresses title generation, and re-enabling restores it. A real session auto-titled as **“Merged stack confirmation”** and reached `idle`.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Live smoke evidence: settings toggle defaults on in light and dark themes and persists across reload; a real enabled session generated and applied the title **“Merged stack confirmation”**.

**Visual demo:** [Settings toggle in light and dark themes](https://github.com/user-attachments/assets/ee16171e-c61a-4622-bc00-1636a4358b28)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the full user-visible behavior on a real local session: default-on, Settings persistence across reload, opt-out suppression, opt-in restoration, and successful title generation/application. `NULL` remains the stored default and resolves to enabled. `OMNIGENT_SESSION_RENAME` has no effect; deployments can remove it. The migration only adds the nullable column and does not rewrite existing rows.

## Changelog

New sessions are automatically named; users can turn this off in Settings.