### PR TITLE
fix(sessions): summarize created child tasks

### DIFF
--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -7,12 +7,14 @@ import logging
 import re
 import time
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
 from omnigent.entities.conversation import (
     DEFAULT_GENERATED_TITLE_MAX_CHARS,
     USER_SESSION_TITLE_MAX_CHARS,
+    MessageData,
+    SlashCommandData,
 )
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import background_title_generators
@@ -20,7 +22,7 @@ from omnigent.runner.background_titles.service import FOLLOW_USER_LANGUAGE_TITLE
 from omnigent.stores.conversation_store import ConversationStore
 
 if TYPE_CHECKING:
-    from omnigent.entities.conversation import Conversation
+    from omnigent.entities.conversation import Conversation, ConversationItem
     from omnigent.runner.routing import RunnerRouter
     from omnigent.server.schemas import SessionEventInput
 
@@ -61,6 +63,7 @@ _TITLE_WRAPPERS = "'\"`“”‘’"
 _TRAILING_PUNCTUATION = re.compile(r"[.!?;:,]+$")
 BACKGROUND_TITLE_MAX_CHARS = DEFAULT_GENERATED_TITLE_MAX_CHARS
 CUSTOM_BACKGROUND_TITLE_MAX_CHARS = USER_SESSION_TITLE_MAX_CHARS
+_TASK_SUMMARY_PROMPT_MAX_CHARS = 4000
 
 
 def normalize_background_title(
@@ -202,7 +205,7 @@ class BackgroundSessionTitleCoordinator:
             self._run_task_summary(
                 request=BackgroundTitleRequest(
                     session_id=session_id,
-                    prompt=prompt,
+                    prompt=prompt[:_TASK_SUMMARY_PROMPT_MAX_CHARS],
                     agent_id=agent_id,
                     harness_override=harness_override,
                     model_override=model_override,
@@ -319,6 +322,18 @@ class BackgroundSessionTitleCoordinator:
         """Generate a task summary for a child session and write it to task_summary."""
         started = time.perf_counter()
         try:
+            conversation = await asyncio.to_thread(
+                self._conversation_store.get_conversation,
+                request.session_id,
+            )
+            if conversation is None or conversation.task_summary is not None:
+                return
+            seed_prompt = await asyncio.to_thread(
+                _first_persisted_seed_task_summary_prompt,
+                self._conversation_store,
+                request.session_id,
+            )
+            request = replace(request, prompt=seed_prompt or request.prompt)
             async with self._generation_slots:
                 generated = await asyncio.wait_for(
                     self._generator(request),
@@ -458,15 +473,78 @@ def schedule_background_child_task_summary(
     )
 
 
-def background_title_prompt(event: SessionEventInput) -> str:
-    if event.type == "slash_command":
-        name = event.data.get("name")
-        arguments = event.data.get("arguments", "")
-        if not isinstance(name, str) or not name.strip() or not isinstance(arguments, str):
-            return ""
-        return f"/{name.strip()} {arguments}".strip()
+def schedule_background_child_task_summary_for_event(
+    *,
+    coordinator: BackgroundSessionTitleCoordinator | None,
+    conversation: Conversation,
+    event: SessionEventInput,
+) -> bool:
+    """Schedule the first task-derived display summary for a child session."""
+    if (
+        coordinator is None
+        or conversation.parent_conversation_id is None
+        or conversation.task_summary is not None
+    ):
+        return False
+    if event.type == "message" and (
+        event.data.get("role") != "user" or event.data.get("is_meta") is True
+    ):
+        return False
+    if event.type == "slash_command" and event.data.get("kind", "skill") != "skill":
+        return False
+    if event.type not in {"message", "slash_command"}:
+        return False
+    prompt = background_title_prompt(event)
+    if not prompt:
+        return False
+    schedule_background_child_task_summary(
+        coordinator=coordinator,
+        session_id=conversation.id,
+        prompt=prompt,
+        agent_id=conversation.agent_id,
+        sub_agent_name=conversation.sub_agent_name,
+    )
+    return True
 
-    content = event.data.get("content")
+
+def _first_persisted_seed_task_summary_prompt(
+    conversation_store: ConversationStore,
+    session_id: str,
+) -> str:
+    """Return the earliest runnerless create-time prompt eligible for a task summary."""
+    after: str | None = None
+    while True:
+        page = conversation_store.list_items(
+            session_id,
+            limit=100,
+            after=after,
+            order="asc",
+        )
+        for item in page.data:
+            prompt = _persisted_seed_task_summary_prompt(item)
+            if prompt:
+                return prompt
+        if not page.has_more or page.last_id is None:
+            return ""
+        after = page.last_id
+
+
+def _persisted_seed_task_summary_prompt(item: ConversationItem) -> str:
+    if item.response_id != "seed":
+        return ""
+    if item.type == "slash_command":
+        if not isinstance(item.data, SlashCommandData) or item.data.kind != "skill":
+            return ""
+        arguments = item.data.arguments.strip()
+        return f"/{item.data.name} {arguments}".strip()[:_TASK_SUMMARY_PROMPT_MAX_CHARS]
+    if item.type != "message" or not isinstance(item.data, MessageData):
+        return ""
+    if item.data.role != "user" or item.data.is_meta:
+        return ""
+    return _input_text_prompt(item.data.content)
+
+
+def _input_text_prompt(content: object) -> str:
     if not isinstance(content, list):
         return ""
     parts: list[str] = []
@@ -475,4 +553,15 @@ def background_title_prompt(event: SessionEventInput) -> str:
             text = block.get("text", "")
             if isinstance(text, str):
                 parts.append(text)
-    return " ".join(parts)[:4000]
+    return " ".join(parts)[:_TASK_SUMMARY_PROMPT_MAX_CHARS]
+
+
+def background_title_prompt(event: SessionEventInput) -> str:
+    if event.type == "slash_command":
+        name = event.data.get("name")
+        arguments = event.data.get("arguments", "")
+        if not isinstance(name, str) or not name.strip() or not isinstance(arguments, str):
+            return ""
+        return f"/{name.strip()} {arguments}".strip()
+
+    return _input_text_prompt(event.data.get("content"))

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -6725,11 +6725,12 @@ async def _dispatch_skill_slash_command_to_runner(
         runner_body["harness_override"] = conv.harness_override
 
     try:
-        await runner_client.post(
+        response = await runner_client.post(
             f"/v1/sessions/{session_id}/events",
             json=runner_body,
             timeout=_RUNNER_FORWARD_TIMEOUT,
         )
+        response.raise_for_status()
         event = OutputItemDoneEvent(type="response.output_item.done", item=visible.to_api_dict())
         session_stream.publish(session_id, event.model_dump())
     except (httpx.HTTPError, ConnectionError) as exc:
@@ -6971,10 +6972,14 @@ class _SessionEventDispatchResult:
         ``"pending_a1b2c3"`` — surfaced to the sender so it can adopt
         the id and dedupe against the snapshot. ``None`` for non-native
         events (already persisted, so no separate pending entry).
+    :param accepted: Whether the runner accepted responsibility for
+        processing the event. ``False`` for a native terminal-start
+        failure that the AP persists as a completed failure turn.
     """
 
     item_id: str | None
     pending_id: str | None
+    accepted: bool
 
 
 def _extract_persistent_item_from_sse(

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -119,6 +119,7 @@ from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
     background_session_titles_enabled,
     prepare_background_session_title,
+    schedule_background_child_task_summary_for_event,
 )
 from omnigent.server.bundles import bundle_location, validate_agent_bundle
 from omnigent.server.host_registry import HostConnection, HostRegistry, RunnerExitReports
@@ -5879,7 +5880,11 @@ async def _dispatch_session_event_to_runner_impl(
                 runner_router,
                 created_by=created_by,
             )
-            return _SessionEventDispatchResult(item_id=item_id, pending_id=None)
+            return _SessionEventDispatchResult(
+                item_id=item_id,
+                pending_id=None,
+                accepted=False,
+            )
         if ensure_outcome.policy_notice is not None:
             # Terminal is up but policy enforcement is off (fail-open). Post
             # a durable, non-fatal banner; the user message still forwards.
@@ -6077,7 +6082,11 @@ async def _dispatch_session_event_to_runner_impl(
                     harness=_resolve_harness(conv),
                     decision_id=_native_decision_id,
                 )
-        return _SessionEventDispatchResult(item_id=None, pending_id=pending_id)
+        return _SessionEventDispatchResult(
+            item_id=None,
+            pending_id=pending_id,
+            accepted=True,
+        )
     item_id = await _forward_event_to_runner(
         session_id,
         conv,
@@ -6091,7 +6100,11 @@ async def _dispatch_session_event_to_runner_impl(
         created_by=created_by,
         host_store=host_store,
     )
-    return _SessionEventDispatchResult(item_id=item_id, pending_id=None)
+    return _SessionEventDispatchResult(
+        item_id=item_id,
+        pending_id=None,
+        accepted=True,
+    )
 
 
 # Transient runner-tunnel drops (Apps ingress recycles, sleep-wake
@@ -9024,6 +9037,7 @@ async def _create_session_from_existing_agent(
             )
             # Dispatch (not a plain forward) so native-terminal sessions take the
             # single-writer bypass — otherwise the forwarder's echo duplicates the kickoff.
+            task_summary_scheduled = False
             for item in body.initial_items:
                 pending_background_title = prepare_background_session_title(
                     coordinator=background_title_coordinator,
@@ -9031,7 +9045,7 @@ async def _create_session_from_existing_agent(
                     event=item,
                     enabled=background_session_titles_enabled(request.headers),
                 )
-                await _dispatch_session_event_to_runner(
+                dispatch = await _dispatch_session_event_to_runner(
                     conv.id,
                     conv,
                     item,
@@ -9045,7 +9059,13 @@ async def _create_session_from_existing_agent(
                     host_store=getattr(request.app.state, "host_store", None),
                     background_titles_enabled=background_session_titles_enabled(request.headers),
                 )
-                if pending_background_title is not None:
+                if dispatch.accepted and not task_summary_scheduled:
+                    task_summary_scheduled = schedule_background_child_task_summary_for_event(
+                        coordinator=background_title_coordinator,
+                        conversation=conv,
+                        event=item,
+                    )
+                if dispatch.accepted and pending_background_title is not None:
                     pending_background_title.schedule(expected_seed_title=conv.title)
     # Re-read rather than reusing the local ``conv``: the label-only branch
     # above and ``_forward_event_to_runner`` can mutate the row after it was

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -61,9 +61,8 @@ from omnigent.server.auth import (
 from omnigent.server.background_session_titles import (
     BackgroundSessionTitleCoordinator,
     background_session_titles_enabled,
-    background_title_prompt,
     prepare_background_session_title,
-    schedule_background_child_task_summary,
+    schedule_background_child_task_summary_for_event,
 )
 from omnigent.server.host_registry import HostRegistry, RunnerExitReports
 from omnigent.server.routes._auth_helpers import (
@@ -2051,23 +2050,6 @@ def register_events_routes(
             event=body,
             enabled=background_session_titles_enabled(request.headers),
         )
-        # Schedule display-name generation for child sessions (the
-        # title coordinator skips children because their title is
-        # the stable spawn-or-continue key).
-        if (
-            conv.parent_conversation_id is not None
-            and conv.task_summary is None
-            and background_title_coordinator is not None
-        ):
-            _prompt_for_display = background_title_prompt(body)
-            if _prompt_for_display:
-                schedule_background_child_task_summary(
-                    coordinator=background_title_coordinator,
-                    session_id=session_id,
-                    prompt=_prompt_for_display,
-                    agent_id=conv.agent_id,
-                    sub_agent_name=conv.sub_agent_name,
-                )
         if body.type == _SLASH_COMMAND_TYPE:
             if _agent is None:
                 raise OmnigentError(
@@ -2083,6 +2065,11 @@ def register_events_routes(
                 agent=_agent,
                 has_mcp_servers=_has_mcp_servers,
                 created_by=created_by,
+            )
+            schedule_background_child_task_summary_for_event(
+                coordinator=background_title_coordinator,
+                conversation=conv,
+                event=body,
             )
             if pending_background_title is not None:
                 pending_background_title.schedule(expected_seed_title=conv.title)
@@ -2105,8 +2092,16 @@ def register_events_routes(
             # serves this turn; absent, routing keeps its default posture.
             host_store=getattr(request.app.state, "host_store", None),
         )
-        if pending_background_title is not None:
-            pending_background_title.schedule(expected_seed_title=conv.title)
+        if dispatch.accepted:
+            # Child titles are stable spawn-or-continue keys, so derive a separate
+            # display summary only after the prompt was accepted by the runner.
+            schedule_background_child_task_summary_for_event(
+                coordinator=background_title_coordinator,
+                conversation=conv,
+                event=body,
+            )
+            if pending_background_title is not None:
+                pending_background_title.schedule(expected_seed_title=conv.title)
         response: dict[str, Any] = {"queued": True}
         if dispatch.item_id is not None:
             response["item_id"] = dispatch.item_id

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -925,13 +925,13 @@ class ConversationStore(ABC):
         conversation_id: str,
         task_summary: str,
     ) -> Conversation | None:
-        """Set a human-readable task summary on a sub-agent conversation.
+        """Set the first human-readable task summary on a sub-agent conversation.
 
         :param conversation_id: Conversation to update.
         :param task_summary: Short task-derived label, e.g.
             ``"Investigate auth token refresh"``.
         :returns: The updated conversation, or ``None`` when the row
-            does not exist.
+            does not exist or already has a task summary.
         """
         ...
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3098,7 +3098,7 @@ class SqlAlchemyConversationStore(ConversationStore):
         return self.get_conversation(conversation_id)
 
     def set_task_summary(self, conversation_id: str, task_summary: str) -> Conversation | None:
-        """Set a human-readable task summary on a sub-agent conversation."""
+        """Set the first human-readable task summary on a sub-agent conversation."""
         with self._session("set_task_summary") as session:
             result = cast(
                 _RowCountResult,
@@ -3107,6 +3107,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     .where(
                         SqlConversationMetadata.workspace_id == current_workspace_id(),
                         SqlConversationMetadata.id == conversation_id,
+                        SqlConversationMetadata.task_summary.is_(None),
                     )
                     .values(task_summary=task_summary)
                 ),

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -484,6 +484,457 @@ async def test_initial_item_schedules_background_semantic_title(
     assert snapshot.json()["title"] == "Debug authentication timeout"
 
 
+async def test_child_initial_item_and_followup_send_schedule_one_task_summary(
+    client: httpx.AsyncClient,
+    app: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[BackgroundTitleRequest] = []
+    generator_started = asyncio.Event()
+    release_generator = asyncio.Event()
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        requests.append(request)
+        generator_started.set()
+        await release_generator.wait()
+        return "Investigate authentication timeout"
+
+    coordinator = app.state.background_title_coordinator
+    coordinator._generator = generator
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(202, json={"queued": True})),
+        base_url="http://runner",
+    )
+
+    async def get_runner_client(
+        _session_id: str,
+        _runner_router: object,
+    ) -> httpx.AsyncClient:
+        return fake_runner
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._get_runner_client",
+        get_runner_client,
+    )
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    try:
+        create_response = await client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent["id"],
+                "parent_session_id": parent["id"],
+                "title": "researcher:researcher-1",
+                "initial_items": [
+                    {
+                        "type": "message",
+                        "data": {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": "please investigate the authentication timeout",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+        assert create_response.status_code == 201, create_response.text
+        child_id = create_response.json()["id"]
+        await asyncio.wait_for(generator_started.wait(), timeout=5)
+
+        send_response = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue investigating"}],
+                },
+            },
+        )
+        assert send_response.status_code == 202, send_response.text
+    finally:
+        release_generator.set()
+        await fake_runner.aclose()
+
+    await coordinator.wait_for_idle()
+    assert len(requests) == 1
+    assert requests[0].session_id == child_id
+    assert requests[0].prompt == "please investigate the authentication timeout"
+    children_response = await client.get(f"/v1/sessions/{parent['id']}/child_sessions")
+    child = next(item for item in children_response.json()["data"] if item["id"] == child_id)
+    assert child["task_summary"] == "Investigate authentication timeout"
+
+
+async def test_runnerless_child_initial_item_defers_summary_until_send(
+    client: httpx.AsyncClient,
+    app: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[BackgroundTitleRequest] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        requests.append(request)
+        return "Investigate authentication timeout"
+
+    app.state.background_title_coordinator._generator = generator
+    runner_available = False
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(202, json={"queued": True})),
+        base_url="http://runner",
+    )
+
+    async def get_runner_client(
+        _session_id: str,
+        _runner_router: object,
+    ) -> httpx.AsyncClient | None:
+        return fake_runner if runner_available else None
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._get_runner_client",
+        get_runner_client,
+    )
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    try:
+        response = await client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent["id"],
+                "parent_session_id": parent["id"],
+                "title": "researcher:researcher-1",
+                "initial_items": [
+                    {
+                        "type": "message",
+                        "data": {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": "please investigate the authentication timeout",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 201, response.text
+        child_id = response.json()["id"]
+        await app.state.background_title_coordinator.wait_for_idle()
+        assert requests == []
+
+        runner_available = True
+        send_response = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue investigating"}],
+                },
+            },
+        )
+        assert send_response.status_code == 202, send_response.text
+    finally:
+        await fake_runner.aclose()
+
+    await app.state.background_title_coordinator.wait_for_idle()
+    assert len(requests) == 1
+    assert requests[0].session_id == child_id
+    assert requests[0].prompt == "please investigate the authentication timeout"
+    children_response = await client.get(f"/v1/sessions/{parent['id']}/child_sessions")
+    child = next(item for item in children_response.json()["data"] if item["id"] == child_id)
+    assert child["task_summary"] == "Investigate authentication timeout"
+
+
+async def test_failed_child_dispatch_does_not_schedule_task_summary(
+    client: httpx.AsyncClient,
+    app: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[BackgroundTitleRequest] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        requests.append(request)
+        return "Unused summary"
+
+    async def reject_dispatch(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("runner rejected event")
+
+    app.state.background_title_coordinator._generator = generator
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(202, json={"queued": True})),
+        base_url="http://runner",
+    )
+
+    async def get_runner_client(
+        _session_id: str,
+        _runner_router: object,
+    ) -> httpx.AsyncClient:
+        return fake_runner
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._get_runner_client",
+        get_runner_client,
+    )
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._dispatch_session_event_to_runner",
+        reject_dispatch,
+    )
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    create_response = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "parent_session_id": parent["id"],
+            "title": "researcher:researcher-1",
+        },
+    )
+    assert create_response.status_code == 201, create_response.text
+    child = create_response.json()
+    try:
+        with pytest.raises(RuntimeError, match="runner rejected event"):
+            await client.post(
+                f"/v1/sessions/{child['id']}/events",
+                json={
+                    "type": "message",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Investigate timeout"}],
+                    },
+                },
+            )
+    finally:
+        await fake_runner.aclose()
+
+    await app.state.background_title_coordinator.wait_for_idle()
+    assert requests == []
+
+
+async def test_rejected_child_prompt_does_not_replace_later_accepted_summary_prompt(
+    client: httpx.AsyncClient,
+    app: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[BackgroundTitleRequest] = []
+    event_attempts = 0
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        requests.append(request)
+        return "Investigate accepted prompt"
+
+    def handle_runner_request(request: httpx.Request) -> httpx.Response:
+        nonlocal event_attempts
+        if request.url.path.endswith("/events"):
+            event_attempts += 1
+            if event_attempts == 1:
+                return httpx.Response(503, json={"detail": "runner rejected first prompt"})
+        return httpx.Response(202, json={"queued": True})
+
+    app.state.background_title_coordinator._generator = generator
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(handle_runner_request),
+        base_url="http://runner",
+    )
+
+    async def get_runner_client(
+        _session_id: str,
+        _runner_router: object,
+    ) -> httpx.AsyncClient:
+        return fake_runner
+
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions._get_runner_client",
+        get_runner_client,
+    )
+    agent = await create_test_agent(client)
+    parent = await _create_session(client, agent["id"])
+    created = await client.post(
+        "/v1/sessions",
+        json={
+            "agent_id": agent["id"],
+            "parent_session_id": parent["id"],
+            "title": "researcher:researcher-1",
+        },
+    )
+    assert created.status_code == 201, created.text
+    child = created.json()
+    try:
+        rejected = await client.post(
+            f"/v1/sessions/{child['id']}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Rejected prompt"}],
+                },
+            },
+        )
+        assert rejected.status_code >= 400, rejected.text
+
+        accepted = await client.post(
+            f"/v1/sessions/{child['id']}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Accepted prompt"}],
+                },
+            },
+        )
+        assert accepted.status_code == 202, accepted.text
+    finally:
+        await fake_runner.aclose()
+
+    await app.state.background_title_coordinator.wait_for_idle()
+    assert [request.prompt for request in requests] == ["Accepted prompt"]
+
+
+async def test_native_terminal_boot_failure_does_not_schedule_task_summary(
+    client: httpx.AsyncClient,
+    app: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.server.routes import sessions as sessions_module
+
+    requests: list[BackgroundTitleRequest] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        requests.append(request)
+        return "Unused summary"
+
+    app.state.background_title_coordinator._generator = generator
+
+    def handle_runner_request(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/resources/terminals"):
+            return httpx.Response(
+                503,
+                json={"error": "harness_spawn_failed", "detail": "terminal boot failed"},
+            )
+        return httpx.Response(202, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle_runner_request),
+        base_url="http://runner",
+    ) as runner:
+        monkeypatch.setattr(sessions_module, "_get_runner_client", AsyncMock(return_value=runner))
+        agent = await create_test_agent(client, name="claude-native-child")
+        parent = await _create_session(client, agent["id"])
+        created = await client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent["id"],
+                "parent_session_id": parent["id"],
+                "title": "claude:claude-1",
+                "labels": {
+                    "omnigent.ui": "terminal",
+                    "omnigent.wrapper": "claude-code-native-ui",
+                },
+            },
+        )
+        assert created.status_code == 201, created.text
+        child_id = created.json()["id"]
+        posted = await client.post(
+            f"/v1/sessions/{child_id}/events",
+            json={
+                "type": "message",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Investigate timeout"}],
+                },
+            },
+        )
+        assert posted.status_code == 202, posted.text
+
+    await app.state.background_title_coordinator.wait_for_idle()
+    assert requests == []
+    children_response = await client.get(f"/v1/sessions/{parent['id']}/child_sessions")
+    child = next(item for item in children_response.json()["data"] if item["id"] == child_id)
+    assert child["task_summary"] is None
+
+
+async def test_rejected_child_skill_does_not_schedule_task_summary(
+    client: httpx.AsyncClient,
+    app: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from omnigent.server.routes import sessions as sessions_module
+
+    requests: list[BackgroundTitleRequest] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        requests.append(request)
+        return "Unused summary"
+
+    app.state.background_title_coordinator._generator = generator
+
+    def handle_runner_request(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/skills/resolve"):
+            payload = json.loads(request.content)
+            skill = SkillSpec(
+                name="investigate",
+                description="Investigate a problem.",
+                content="Find the root cause.",
+            )
+            return httpx.Response(
+                200,
+                json={"meta_text": format_skill_meta_text(skill, payload.get("arguments", ""))},
+            )
+        if request.url.path.endswith("/events"):
+            return httpx.Response(503, json={"detail": "runner rejected skill"})
+        return httpx.Response(202, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle_runner_request),
+        base_url="http://runner",
+    ) as runner:
+        monkeypatch.setattr(sessions_module, "_get_runner_client", AsyncMock(return_value=runner))
+        agent = await create_test_agent(
+            client,
+            name="skill-child",
+            skills=[
+                {
+                    "name": "investigate",
+                    "description": "Investigate a problem.",
+                    "content": "Find the root cause.",
+                }
+            ],
+        )
+        parent = await _create_session(client, agent["id"])
+        created = await client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent["id"],
+                "parent_session_id": parent["id"],
+                "title": "researcher:researcher-1",
+            },
+        )
+        assert created.status_code == 201, created.text
+        child = created.json()
+
+        response = await client.post(
+            f"/v1/sessions/{child['id']}/events",
+            json={
+                "type": "slash_command",
+                "data": {
+                    "kind": "skill",
+                    "name": "investigate",
+                    "arguments": "authentication timeout",
+                },
+            },
+        )
+        assert response.status_code >= 400, response.text
+
+    await app.state.background_title_coordinator.wait_for_idle()
+    assert requests == []
+
+
 async def test_native_user_item_schedules_background_semantic_title(
     client: httpx.AsyncClient,
     app: Any,

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -4105,6 +4105,7 @@ async def test_native_dispatch_fast_fails_and_consumes_message_on_terminal_error
 
     assert result.pending_id is None
     assert result.item_id is not None
+    assert result.accepted is False
     assert [call[0] for call in client.post_json_calls] == [
         "/v1/sessions/64a784c3aa907d1774f44313546947c6/resources/terminals"
     ]
@@ -4157,6 +4158,7 @@ async def test_kiro_native_dispatch_forwards_without_persisting() -> None:
         assert result.item_id is None
         assert result.pending_id is not None
         assert result.pending_id.startswith("pending_")
+        assert result.accepted is True
         assert [call[0] for call in client.post_json_calls] == [
             "/v1/sessions/823dbd1aab969b5a813fac59bb977a77/resources/terminals",
             "/v1/sessions/823dbd1aab969b5a813fac59bb977a77/events",

--- a/tests/server/test_background_session_titles.py
+++ b/tests/server/test_background_session_titles.py
@@ -6,6 +6,7 @@ import uuid
 
 import pytest
 
+from omnigent.entities import MessageData, NewConversationItem, SlashCommandData
 from omnigent.runner.background_titles.service import FOLLOW_USER_LANGUAGE_TITLE_INSTRUCTION
 from omnigent.server.background_session_titles import (
     BACKGROUND_SESSION_TITLES_HEADER,
@@ -17,6 +18,7 @@ from omnigent.server.background_session_titles import (
     background_session_titles_enabled,
     normalize_background_title,
     prepare_background_session_title,
+    schedule_background_child_task_summary_for_event,
 )
 from omnigent.server.schemas import SessionEventInput
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
@@ -27,6 +29,16 @@ pytestmark = pytest.mark.asyncio
 def _seed_session(store: SqlAlchemyConversationStore, title: str) -> str:
     conversation = store.create_conversation(kind="default", title=title)
     return conversation.id
+
+
+def _seed_child_session(store: SqlAlchemyConversationStore) -> str:
+    parent = store.create_conversation(kind="default", title="parent")
+    child = store.create_conversation(
+        kind="default",
+        title="researcher:researcher-1",
+        parent_conversation_id=parent.id,
+    )
+    return child.id
 
 
 async def test_prepare_background_title_for_eligible_session(db_uri: str) -> None:
@@ -591,6 +603,252 @@ async def test_schedule_is_one_shot_per_session(db_uri: str) -> None:
 
     assert calls == 1
     assert store.get_conversation(session_id).title == "Debug authentication timeout"
+
+
+async def test_task_summary_retry_uses_latest_prompt_without_seed(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    session_id = _seed_child_session(store)
+    prompts: list[str] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str | None:
+        prompts.append(request.prompt)
+        if len(prompts) == 1:
+            return None
+        return "Investigate authentication timeout"
+
+    coordinator = BackgroundSessionTitleCoordinator(store, generator)
+    coordinator.schedule_task_summary(
+        session_id=session_id,
+        prompt="please investigate the authentication timeout",
+    )
+    await coordinator.wait_for_idle()
+    coordinator.schedule_task_summary(
+        session_id=session_id,
+        prompt="continue investigating",
+    )
+    await coordinator.wait_for_idle()
+
+    assert prompts == [
+        "please investigate the authentication timeout",
+        "continue investigating",
+    ]
+    conversation = store.get_conversation(session_id)
+    assert conversation is not None
+    assert conversation.task_summary == "Investigate authentication timeout"
+
+
+async def test_task_summary_retry_uses_earliest_persisted_seed_prompt(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    session_id = _seed_child_session(store)
+    store.append(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="seed",
+                data=MessageData(
+                    role="assistant",
+                    content=[{"type": "output_text", "text": "Ignore me"}],
+                    agent="researcher",
+                ),
+            ),
+            NewConversationItem(
+                type="slash_command",
+                response_id="seed",
+                data=SlashCommandData(
+                    agent="researcher",
+                    kind="skill",
+                    name="investigate",
+                    arguments="auth timeout",
+                ),
+            ),
+            NewConversationItem(
+                type="message",
+                response_id="seed",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "Later user prompt"}],
+                ),
+            ),
+        ],
+    )
+    prompts: list[str] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        prompts.append(request.prompt)
+        return "Investigate authentication timeout"
+
+    coordinator = BackgroundSessionTitleCoordinator(store, generator)
+    coordinator.schedule_task_summary(session_id=session_id, prompt="Fallback prompt")
+    await coordinator.wait_for_idle()
+
+    assert prompts == ["/investigate auth timeout"]
+
+
+async def test_task_summary_ignores_undelivered_persisted_prompt(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    session_id = _seed_child_session(store)
+    store.append(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="turn_rejected",
+                data=MessageData(
+                    role="user",
+                    content=[{"type": "input_text", "text": "Rejected prompt"}],
+                ),
+            )
+        ],
+    )
+    prompts: list[str] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        prompts.append(request.prompt)
+        return "Investigate accepted prompt"
+
+    coordinator = BackgroundSessionTitleCoordinator(store, generator)
+    coordinator.schedule_task_summary(session_id=session_id, prompt="Accepted prompt")
+    await coordinator.wait_for_idle()
+
+    assert prompts == ["Accepted prompt"]
+
+
+async def test_task_summary_prefers_first_accepted_prompt_over_persisted_skill(
+    db_uri: str,
+) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    session_id = _seed_child_session(store)
+    prompts: list[str] = []
+
+    async def generator(request: BackgroundTitleRequest) -> str:
+        prompts.append(request.prompt)
+        return "Investigate authentication timeout"
+
+    coordinator = BackgroundSessionTitleCoordinator(store, generator)
+    coordinator.schedule_task_summary(session_id=session_id, prompt="Native pending prompt")
+    store.append(
+        session_id,
+        [
+            NewConversationItem(
+                type="slash_command",
+                response_id="turn_later",
+                data=SlashCommandData(
+                    agent="researcher",
+                    kind="skill",
+                    name="investigate",
+                    arguments="later task",
+                ),
+            )
+        ],
+    )
+    await coordinator.wait_for_idle()
+
+    assert prompts == ["Native pending prompt"]
+
+
+async def test_completed_task_summary_skips_stale_reschedule(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    session_id = _seed_child_session(store)
+    stale_conversation = store.get_conversation(session_id)
+    assert stale_conversation is not None
+    calls = 0
+
+    async def generator(_request: BackgroundTitleRequest) -> str:
+        nonlocal calls
+        calls += 1
+        return "Investigate authentication timeout"
+
+    coordinator = BackgroundSessionTitleCoordinator(store, generator)
+    assert schedule_background_child_task_summary_for_event(
+        coordinator=coordinator,
+        conversation=stale_conversation,
+        event=SessionEventInput(
+            type="message",
+            data={
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Initial prompt"}],
+            },
+        ),
+    )
+    await coordinator.wait_for_idle()
+    assert schedule_background_child_task_summary_for_event(
+        coordinator=coordinator,
+        conversation=stale_conversation,
+        event=SessionEventInput(
+            type="message",
+            data={
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Follow-up prompt"}],
+            },
+        ),
+    )
+    await coordinator.wait_for_idle()
+
+    assert calls == 1
+
+
+async def test_concurrent_task_summary_writers_keep_first_completed_summary(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    session_id = _seed_child_session(store)
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    first_can_finish = asyncio.Event()
+    second_can_finish = asyncio.Event()
+    prompts: list[str] = []
+
+    async def first_generator(request: BackgroundTitleRequest) -> str:
+        prompts.append(request.prompt)
+        first_started.set()
+        await first_can_finish.wait()
+        return f"Summary for {request.prompt}"
+
+    async def second_generator(request: BackgroundTitleRequest) -> str:
+        prompts.append(request.prompt)
+        second_started.set()
+        await second_can_finish.wait()
+        return f"Summary for {request.prompt}"
+
+    first = BackgroundSessionTitleCoordinator(store, first_generator)
+    second = BackgroundSessionTitleCoordinator(store, second_generator)
+    first.schedule_task_summary(session_id=session_id, prompt="Initial prompt")
+    await asyncio.wait_for(first_started.wait(), timeout=5)
+    second.schedule_task_summary(session_id=session_id, prompt="Follow-up prompt")
+    await asyncio.wait_for(second_started.wait(), timeout=5)
+    second_can_finish.set()
+    await second.wait_for_idle()
+    first_can_finish.set()
+    await first.wait_for_idle()
+
+    conversation = store.get_conversation(session_id)
+    assert conversation is not None
+    assert prompts == ["Initial prompt", "Follow-up prompt"]
+    assert conversation.task_summary == "Summary for Follow-up prompt"
+
+
+async def test_child_task_summary_ignores_assistant_message(db_uri: str) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    session_id = _seed_child_session(store)
+    conversation = store.get_conversation(session_id)
+    assert conversation is not None
+
+    async def generator(_request: BackgroundTitleRequest) -> str:
+        return "Unused summary"
+
+    coordinator = BackgroundSessionTitleCoordinator(store, generator)
+    scheduled = schedule_background_child_task_summary_for_event(
+        coordinator=coordinator,
+        conversation=conversation,
+        event=SessionEventInput(
+            type="message",
+            data={
+                "role": "assistant",
+                "content": [{"type": "input_text", "text": "Do not summarize me"}],
+            },
+        ),
+    )
+
+    assert scheduled is False
 
 
 async def test_generation_concurrency_is_bounded(db_uri: str) -> None:

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -128,6 +128,22 @@ def test_rename_conversation_if_title_matches_is_atomic(
     assert conversation_store.get_conversation(conv.id).title == "Debug request timeout"  # type: ignore[union-attr]
 
 
+def test_set_task_summary_is_first_write_wins(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    conversation = conversation_store.create_conversation(title="researcher:researcher-1")
+
+    first = conversation_store.set_task_summary(conversation.id, "Investigate auth timeout")
+    stale = conversation_store.set_task_summary(conversation.id, "Overwrite from follow-up")
+
+    assert first is not None
+    assert first.task_summary == "Investigate auth timeout"
+    assert stale is None
+    reloaded = conversation_store.get_conversation(conversation.id)
+    assert reloaded is not None
+    assert reloaded.task_summary == "Investigate auth timeout"
+
+
 def test_get_conversations_bulk(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
## Related issue

Related to #5500.

## Summary

- Generate a child session's `task_summary` only after the runner accepts an eligible user message or skill command, while preserving the stable child `title` used for spawn-or-continue identity.
- Persist runnerless `sys_session_create(message=...)` initial items as `response_id="seed"`; after a later accepted send binds the runner, generate the summary from the earliest eligible seed prompt.
- Treat task summaries as best-effort metadata: retries without a seed may use the latest accepted prompt, while an atomic first-write-wins store update prevents stale jobs from overwriting an existing summary.
- Do not schedule summaries for rejected normal sends, rejected skill commands, assistant/meta messages, non-skill slash commands, or native terminal boot failures.

**ELI5:** child sessions keep their stable internal key, but the UI gets a readable task name once the runner successfully accepts work.

```text
sys_session_create(message, no runner) -> persisted seed
                                      -> later accepted send -> summary from seed

accepted sys_session_send -------------> background summary
rejected send / failed native boot ----> no summary job
```

## Test Plan

- `uv run pytest -q tests/server/test_background_session_titles.py` plus focused create/send, runnerless, rejection, native-terminal, skill, and atomic-store regressions — 43 passed.
- `uv run pre-commit run --files <changed files>` — passed.
- Independent critical review of the rebased diff — no actionable correctness or regression findings.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The integration coverage verifies create-with-initial-task, runnerless create followed by send, rejected dispatches, native terminal boot failure, rejected skill forwarding, and create-then-send deduplication.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover prompt selection, retries, concurrency, and atomic persistence. Integration tests cover runner acceptance and rejection across create, send, skill, and native-terminal paths.

## Changelog

Child sessions now get readable generated task names without renaming their stable spawn keys, and failed sends no longer trigger misleading summaries.
