### PR TITLE
Fix Canvas layout and session persistence

### DIFF
--- a/tests/e2e_ui/sessions/test_canvas_page.py
+++ b/tests/e2e_ui/sessions/test_canvas_page.py
@@ -123,6 +123,16 @@ def test_canvas_page_groups_sessions_by_project_and_opens_them(
     expect(page.get_by_text("1 session", exact=True)).to_be_visible()
     expect(cards).to_have_count(1)
 
+    # Leaving and coming back through the sidebar reopens the last selected canvas.
+    page.goto(live_server)
+    expect(page.get_by_text("Main session 0", exact=True).first).to_be_visible()
+    page.get_by_test_id("canvas-nav").click()
+    expect(page).to_have_url(re.compile(r"/canvas\?canvas=project-release$"))
+    expect(page.get_by_role("tab", name="Release", exact=True)).to_have_attribute(
+        "aria-selected", "true"
+    )
+    expect(cards).to_have_count(1)
+
     cards.dblclick()
     expect(page).to_have_url(re.compile(r"/c/project-session$"))
 
@@ -131,53 +141,67 @@ def test_canvas_page_remembers_a_dragged_card_across_reloads(
     page: Page,
     live_server: str,
 ) -> None:
-    """A card dropped elsewhere keeps its spot after a reload; Reset layout regrids it."""
-    sessions = [_session("only", "Only session", 1)]
+    """A dropped card snaps to the grid and keeps its spot after a reload, while the card
+    left alone stays in its slot; Reset layout regrids the canvas."""
+    sessions = [_session("only", "Only session", 2), _session("other", "Other session", 1)]
     _stub_server_info(page, canvas=True)
     page.route("**/v1/sessions?*", _serve_list(sessions))
     page.route("**/v1/sessions/projects", lambda route: route.fulfill(json=[]))
 
     page.goto(f"{live_server}/canvas")
-    card = page.get_by_test_id("session-card")
+    card = page.get_by_test_id("session-card").filter(has_text="Only session")
+    other = page.locator(".react-flow__node").filter(has_text="Other session")
     expect(card).to_be_visible()
-    before = card.bounding_box()
-    assert before is not None
-
-    page.mouse.move(before["x"] + 20, before["y"] + 20)
-    page.mouse.down()
-    page.mouse.move(before["x"] + 140, before["y"] + 120, steps=8)
-    page.mouse.up()
-    # The layout entry is keyed by server and viewer; match on the prefix.
+    expect(other).to_be_visible()
+    # Both grid slots are saved as soon as the list is complete.
     read_layout = (
         "() => { const key = Object.keys(localStorage)"
         ".find(k => k.startsWith('omnigent:canvas-layout:')); "
         "return key ? JSON.parse(localStorage.getItem(key)) : null; }"
     )
     page.wait_for_function(
-        f"() => Object.keys((({read_layout})() ?? {{}}).positions ?? {{}}).length === 1"
+        f"() => Object.keys((({read_layout})() ?? {{}}).positions ?? {{}}).length === 2"
+    )
+    other_slot = other.evaluate("el => el.style.transform")
+    assert other_slot == "translate(320px, 0px)"
+    before = card.bounding_box()
+    assert before is not None
+
+    page.mouse.move(before["x"] + 20, before["y"] + 20)
+    page.mouse.down()
+    page.mouse.move(before["x"] + 140, before["y"] + 300, steps=8)
+    page.mouse.up()
+    page.wait_for_function(
+        f"() => JSON.stringify((({read_layout})() ?? {{}}).positions?.only) !== '[0,0]'"
     )
     moved = card.bounding_box()
     assert moved is not None
-    assert abs(moved["x"] - before["x"]) > 60
+    assert abs(moved["y"] - before["y"]) > 60
 
     # The view is fitted on every load, so compare the card's canvas coordinates
-    # (the node's translate) rather than where it sits on screen.
-    node = page.locator(".react-flow__node").first
+    # (the node's translate) rather than where it sits on screen. The drop snapped
+    # to the 32px lattice.
+    node = page.locator(".react-flow__node").filter(has_text="Only session")
     dropped_at = node.evaluate("el => el.style.transform")
-    assert "translate(0px, 0px)" not in dropped_at
+    match = re.fullmatch(r"translate\((-?\d+)px, (-?\d+)px\)", dropped_at)
+    assert match is not None, dropped_at
+    assert int(match.group(1)) % 32 == 0 and int(match.group(2)) % 32 == 0
+    assert dropped_at != "translate(0px, 0px)"
 
     page.reload()
-    expect(page.get_by_test_id("session-card")).to_be_visible()
-    expect(page.locator(".react-flow__node").first).to_have_css("transform", re.compile(".+"))
-    assert (
-        page.locator(".react-flow__node").first.evaluate("el => el.style.transform") == dropped_at
-    )
+    expect(page.get_by_test_id("session-card")).to_have_count(2)
+    node = page.locator(".react-flow__node").filter(has_text="Only session")
+    expect(node).to_have_css("transform", re.compile(".+"))
+    assert node.evaluate("el => el.style.transform") == dropped_at
+    # The card that was never moved did not slide into the vacated slot.
+    other = page.locator(".react-flow__node").filter(has_text="Other session")
+    assert other.evaluate("el => el.style.transform") == other_slot
 
     page.get_by_role("button", name="Reset layout").click()
-    expect(page.locator(".react-flow__node").first).to_have_attribute(
-        "style", re.compile(r"translate\(0px, 0px\)")
+    expect(node).to_have_attribute("style", re.compile(r"translate\(0px, 0px\)"))
+    page.wait_for_function(
+        f"() => JSON.stringify((({read_layout})() ?? {{}}).positions?.only) === '[0,0]'"
     )
-    page.wait_for_function(f"() => !((({read_layout})() ?? {{}}).positions ?? {{}}).only")
 
 
 def test_canvas_cards_follow_live_session_updates(page: Page, live_server: str) -> None:

--- a/web/src/canvas/canvasLayout.test.ts
+++ b/web/src/canvas/canvasLayout.test.ts
@@ -2,15 +2,16 @@ import { describe, expect, it } from "vitest";
 import type { Conversation, ProjectSummary } from "@/hooks/useConversations";
 import { PROJECT_LABEL_KEY } from "@/lib/sessionListCache";
 import {
-  CARD_GAP,
   CARD_HEIGHT,
   CARD_WIDTH,
+  GRID_STEP,
   MAIN_CANVAS_ID,
   canvasIdFor,
+  gridPosition,
   mergeCanvasPositions,
   mergeSessionPositions,
   projectCanvasId,
-  prunePositions,
+  samePositions,
   sessionsOnCanvas,
 } from "./canvasLayout";
 
@@ -40,11 +41,9 @@ describe("mergeSessionPositions", () => {
 
     expect(second).toEqual(first);
     expect(first.new).toEqual({ x: 0, y: 0 });
-    expect(first.middle).toEqual({ x: CARD_WIDTH + CARD_GAP, y: 0 });
+    expect(first.middle).toEqual({ x: GRID_STEP * 10, y: 0 });
     const unique = new Set(
-      Object.values(first).map(
-        ({ x, y }) => `${x / (CARD_WIDTH + CARD_GAP)}:${y / (CARD_HEIGHT + CARD_GAP)}`,
-      ),
+      Object.values(first).map(({ x, y }) => `${x / GRID_STEP}:${y / GRID_STEP}`),
     );
     expect(unique.size).toBe(3);
   });
@@ -61,11 +60,33 @@ describe("mergeSessionPositions", () => {
   });
 });
 
-describe("prunePositions", () => {
-  it("keeps only IDs from a complete live session set", () => {
-    expect(prunePositions({ one: { x: 1, y: 2 }, two: { x: 3, y: 4 } }, ["two"])).toEqual({
+describe("grid lattice", () => {
+  it("lays cards out in whole snap steps so dragged cards line up with the grid", () => {
+    const firstRow = gridPosition(0, 2);
+    const secondColumn = gridPosition(1, 2);
+    const secondRow = gridPosition(2, 2);
+    expect(secondColumn.x - firstRow.x).toBeGreaterThan(CARD_WIDTH);
+    expect(secondRow.y - firstRow.y).toBeGreaterThan(CARD_HEIGHT);
+    expect(secondColumn.x % GRID_STEP).toBe(0);
+    expect(secondRow.y % GRID_STEP).toBe(0);
+  });
+
+  it("drops saved spots of sessions that are gone", () => {
+    const merged = mergeSessionPositions([session("two", 1)], {
+      one: { x: 1, y: 2 },
       two: { x: 3, y: 4 },
     });
+    expect(merged).toEqual({ two: { x: 3, y: 4 } });
+  });
+});
+
+describe("samePositions", () => {
+  it("compares card sets and coordinates", () => {
+    const left = { a: { x: 1, y: 2 }, b: { x: 3, y: 4 } };
+    expect(samePositions(left, { b: { x: 3, y: 4 }, a: { x: 1, y: 2 } })).toBe(true);
+    expect(samePositions(left, { a: { x: 1, y: 2 } })).toBe(false);
+    expect(samePositions(left, { a: { x: 1, y: 2 }, b: { x: 3, y: 5 } })).toBe(false);
+    expect(samePositions(left, { a: { x: 1, y: 2 }, c: { x: 3, y: 4 } })).toBe(false);
   });
 });
 

--- a/web/src/canvas/canvasLayout.ts
+++ b/web/src/canvas/canvasLayout.ts
@@ -4,13 +4,14 @@
 import type { Conversation, ProjectSummary } from "@/hooks/useConversations";
 import { sessionBelongsToProject } from "@/shell/sidebarNav";
 
+/** Cards snap to this lattice; layout cells are whole steps so every card lines up. */
+export const GRID_STEP = 32;
 export const CARD_WIDTH = 280;
 export const CARD_HEIGHT = 132;
-export const CARD_GAP = 32;
 /** Sessions outside any project (or whose project is gone) live on this canvas. */
 export const MAIN_CANVAS_ID = "main";
-const CELL_WIDTH = CARD_WIDTH + CARD_GAP;
-const CELL_HEIGHT = CARD_HEIGHT + CARD_GAP;
+const CELL_WIDTH = GRID_STEP * 10;
+const CELL_HEIGHT = GRID_STEP * 5;
 
 export interface CanvasPosition {
   x: number;
@@ -109,10 +110,9 @@ export function mergeCanvasPositions(
   return positions;
 }
 
-export function prunePositions(
-  positions: CanvasPositions,
-  sessionIds: Iterable<string>,
-): CanvasPositions {
-  const live = new Set(sessionIds);
-  return Object.fromEntries(Object.entries(positions).filter(([id]) => live.has(id)));
+/** True when both hold the same cards at the same spots. */
+export function samePositions(left: CanvasPositions, right: CanvasPositions): boolean {
+  const ids = Object.keys(left);
+  if (ids.length !== Object.keys(right).length) return false;
+  return ids.every((id) => right[id]?.x === left[id].x && right[id]?.y === left[id].y);
 }

--- a/web/src/canvas/canvasSessions.test.ts
+++ b/web/src/canvas/canvasSessions.test.ts
@@ -14,7 +14,11 @@ import {
   useCanvasSessions,
 } from "./canvasSessions";
 
-vi.mock("@/lib/identity", () => ({ authenticatedFetch: vi.fn() }));
+vi.mock("@/lib/identity", () => ({
+  authenticatedFetch: vi.fn(),
+  getCurrentUserId: vi.fn(() => null),
+  resolveIdentity: vi.fn(async () => null),
+}));
 
 function session(
   id: string,
@@ -52,8 +56,16 @@ function requestedQueries(): URLSearchParams[] {
     .mock.calls.map(([path]) => new URLSearchParams(String(path).split("?")[1]));
 }
 
+function resolveViewer(viewerId = "me"): void {
+  vi.mocked(identity.getCurrentUserId).mockReturnValue(viewerId);
+  vi.mocked(identity.resolveIdentity).mockResolvedValue(viewerId);
+}
+
 beforeEach(() => {
   vi.mocked(identity.authenticatedFetch).mockReset();
+  vi.mocked(identity.getCurrentUserId).mockReset().mockReturnValue(null);
+  vi.mocked(identity.resolveIdentity).mockReset().mockResolvedValue(null);
+  window.sessionStorage.clear();
 });
 
 afterEach(() => {
@@ -217,9 +229,172 @@ describe("useCanvasSessions", () => {
       resolvePage(jsonResponse(page([session("fresh", 9)], null, false)));
     });
     await waitFor(() => expect(result.current.complete).toBe(true));
+    expect(result.current.networkConfirmed).toBe(true);
     expect(result.current.sessions.map((row) => row.id)).toEqual(["fresh"]);
     expect(result.current.loadingMore).toBe(false);
     expect(result.current.error).toBeNull();
+  });
+
+  it("paints the last complete list at once on a later visit and refreshes quietly", async () => {
+    resolveViewer();
+    const client = new QueryClient();
+    vi.mocked(identity.authenticatedFetch).mockResolvedValueOnce(
+      jsonResponse(page([session("a", 9), session("b", 8)], null, false)),
+    );
+    const first = renderHook(() => useCanvasSessions(), { wrapper: wrapper(client) });
+    await waitFor(() => expect(first.result.current.complete).toBe(true));
+    first.unmount();
+
+    let resolvePage!: (value: Response) => void;
+    vi.mocked(identity.authenticatedFetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+    const second = renderHook(() => useCanvasSessions(), { wrapper: wrapper(client) });
+
+    // Every card from the previous visit is there before the refresh answers.
+    expect(second.result.current.sessions.map((row) => row.id)).toEqual(["a", "b"]);
+    expect(second.result.current).toMatchObject({
+      loaded: true,
+      complete: true,
+      networkConfirmed: false,
+    });
+    await waitFor(() => expect(identity.authenticatedFetch).toHaveBeenCalledTimes(2));
+    expect(second.result.current.loadingMore).toBe(false);
+    // A remembered list means the refresh starts with a full page.
+    expect(requestedQueries()[1].get("limit")).toBe(String(SESSION_PAGE_LIMIT));
+
+    await act(async () => {
+      resolvePage(jsonResponse(page([session("a", 10)], null, false)));
+    });
+    await waitFor(() => expect(second.result.current.sessions.map((row) => row.id)).toEqual(["a"]));
+    expect(second.result.current.networkConfirmed).toBe(true);
+  });
+
+  it("keeps a load that finishes after Canvas unmounts for the next visit", async () => {
+    resolveViewer();
+    const client = new QueryClient();
+    let resolveLastPage!: (value: Response) => void;
+    vi.mocked(identity.authenticatedFetch)
+      .mockResolvedValueOnce(jsonResponse(page([session("a", 9)], "a", true)))
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveLastPage = resolve;
+        }),
+      );
+
+    const first = renderHook(() => useCanvasSessions(), { wrapper: wrapper(client) });
+    await waitFor(() => expect(first.result.current.sessions.map((row) => row.id)).toEqual(["a"]));
+    expect(first.result.current.complete).toBe(false);
+    first.unmount();
+
+    await act(async () => {
+      resolveLastPage(jsonResponse(page([session("b", 8)], null, false)));
+      await Promise.resolve();
+    });
+
+    // Keep the revisit refresh pending so this assertion only observes the cache.
+    vi.mocked(identity.authenticatedFetch).mockReturnValueOnce(new Promise<Response>(() => {}));
+    const second = renderHook(() => useCanvasSessions(), { wrapper: wrapper(client) });
+    expect(second.result.current.sessions.map((row) => row.id)).toEqual(["a", "b"]);
+    expect(second.result.current).toMatchObject({
+      loaded: true,
+      complete: true,
+      networkConfirmed: false,
+    });
+  });
+
+  it("restores the complete list from session storage after a page reload", async () => {
+    resolveViewer();
+    const firstClient = new QueryClient();
+    const liveShaped = session("a", 9);
+    delete (liveShaped as Partial<Conversation>).object;
+    delete (liveShaped as Partial<Conversation>).status;
+    vi.mocked(identity.authenticatedFetch).mockResolvedValueOnce(
+      jsonResponse(page([liveShaped, session("b", 8)], null, false)),
+    );
+    const first = renderHook(() => useCanvasSessions(), { wrapper: wrapper(firstClient) });
+    await waitFor(() => expect(first.result.current.complete).toBe(true));
+    first.unmount();
+
+    // A new QueryClient models a full page reload; keep its refresh pending so
+    // the assertion can only pass from the persisted complete-list cache.
+    vi.mocked(identity.authenticatedFetch).mockReturnValueOnce(new Promise<Response>(() => {}));
+    const second = renderHook(() => useCanvasSessions(), {
+      wrapper: wrapper(new QueryClient()),
+    });
+    expect(second.result.current.sessions.map((row) => row.id)).toEqual(["a", "b"]);
+    expect(second.result.current).toMatchObject({
+      loaded: true,
+      complete: true,
+      networkConfirmed: false,
+    });
+  });
+
+  it("waits for identity before reading a viewer-scoped reload cache", async () => {
+    resolveViewer();
+    const firstClient = new QueryClient();
+    vi.mocked(identity.authenticatedFetch).mockResolvedValueOnce(
+      jsonResponse(page([session("a", 9), session("b", 8)], null, false)),
+    );
+    const first = renderHook(() => useCanvasSessions(), { wrapper: wrapper(firstClient) });
+    await waitFor(() => expect(first.result.current.complete).toBe(true));
+    first.unmount();
+
+    vi.mocked(identity.getCurrentUserId).mockReturnValue(null);
+    vi.mocked(identity.resolveIdentity).mockResolvedValue("me");
+    const reloadedClient = new QueryClient();
+    reloadedClient.setQueryData(["conversations", "", true], {
+      pageParams: [undefined],
+      pages: [page([session("preview", 10)], null, false)],
+    });
+    vi.mocked(identity.authenticatedFetch).mockReturnValueOnce(new Promise<Response>(() => {}));
+    const reloaded = renderHook(() => useCanvasSessions(), {
+      wrapper: wrapper(reloadedClient),
+    });
+
+    // Do not flash the short preview while the persisted cache's viewer resolves.
+    expect(reloaded.result.current).toMatchObject({ sessions: [], loaded: false });
+    await waitFor(() =>
+      expect(reloaded.result.current.sessions.map((row) => row.id)).toEqual(["a", "b"]),
+    );
+    expect(reloaded.result.current).toMatchObject({
+      loaded: true,
+      complete: true,
+      networkConfirmed: false,
+    });
+  });
+
+  it("resolves identity before fetching and never stores an authenticated list as anonymous", async () => {
+    let finishIdentity!: (viewerId: string) => void;
+    vi.mocked(identity.resolveIdentity).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        finishIdentity = resolve;
+      }),
+    );
+    vi.mocked(identity.authenticatedFetch).mockResolvedValueOnce(
+      jsonResponse(page([session("a", 9)], null, false)),
+    );
+
+    const { result } = renderHook(() => useCanvasSessions(), {
+      wrapper: wrapper(new QueryClient()),
+    });
+    await waitFor(() => expect(identity.resolveIdentity).toHaveBeenCalled());
+    expect(identity.authenticatedFetch).not.toHaveBeenCalled();
+    expect(window.sessionStorage.length).toBe(0);
+
+    await act(async () => {
+      finishIdentity("me");
+    });
+    await waitFor(() => expect(result.current.networkConfirmed).toBe(true));
+    expect(identity.authenticatedFetch).toHaveBeenCalledTimes(1);
+    const keys = Array.from({ length: window.sessionStorage.length }, (_, index) =>
+      window.sessionStorage.key(index),
+    );
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toMatch(/:me$/);
+    expect(keys[0]).not.toContain(":anonymous");
   });
 
   it("mirrors a stream patch to the sidebar cache without re-fetching", async () => {

--- a/web/src/canvas/canvasSessions.test.ts
+++ b/web/src/canvas/canvasSessions.test.ts
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
+import * as host from "@/lib/host";
 import * as identity from "@/lib/identity";
 import {
   applyLiveRows,
@@ -18,6 +19,10 @@ vi.mock("@/lib/identity", () => ({
   authenticatedFetch: vi.fn(),
   getCurrentUserId: vi.fn(() => null),
   resolveIdentity: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/host", () => ({
+  getOmnigentServerIdentity: vi.fn(() => "server-a"),
 }));
 
 function session(
@@ -62,6 +67,7 @@ function resolveViewer(viewerId = "me"): void {
 }
 
 beforeEach(() => {
+  vi.mocked(host.getOmnigentServerIdentity).mockReset().mockReturnValue("server-a");
   vi.mocked(identity.authenticatedFetch).mockReset();
   vi.mocked(identity.getCurrentUserId).mockReset().mockReturnValue(null);
   vi.mocked(identity.resolveIdentity).mockReset().mockResolvedValue(null);
@@ -270,6 +276,43 @@ describe("useCanvasSessions", () => {
     });
     await waitFor(() => expect(second.result.current.sessions.map((row) => row.id)).toEqual(["a"]));
     expect(second.result.current.networkConfirmed).toBe(true);
+  });
+
+  it("does not reuse an in-memory list after switching servers for the same viewer", async () => {
+    resolveViewer();
+    const client = new QueryClient();
+    vi.mocked(identity.authenticatedFetch).mockResolvedValueOnce(
+      jsonResponse(page([session("same", 9)], null, false)),
+    );
+    const first = renderHook(() => useCanvasSessions(), { wrapper: wrapper(client) });
+    await waitFor(() => expect(first.result.current.complete).toBe(true));
+    first.unmount();
+
+    vi.mocked(host.getOmnigentServerIdentity).mockReturnValue("server-b");
+    let resolvePage!: (value: Response) => void;
+    vi.mocked(identity.authenticatedFetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+    const second = renderHook(() => useCanvasSessions(), { wrapper: wrapper(client) });
+
+    expect(second.result.current).toMatchObject({ sessions: [], complete: false });
+    await waitFor(() => expect(identity.authenticatedFetch).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      resolvePage(jsonResponse(page([session("same", 9)], null, false)));
+    });
+    await waitFor(() => expect(second.result.current.networkConfirmed).toBe(true));
+
+    const keys = Array.from({ length: window.sessionStorage.length }, (_, index) =>
+      window.sessionStorage.key(index),
+    );
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/:server-a:me$/),
+        expect.stringMatching(/:server-b:me$/),
+      ]),
+    );
   });
 
   it("keeps a load that finishes after Canvas unmounts for the next visit", async () => {

--- a/web/src/canvas/canvasSessions.ts
+++ b/web/src/canvas/canvasSessions.ts
@@ -10,7 +10,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type InfiniteData, type QueryClient, useQueryClient } from "@tanstack/react-query";
 import type { Conversation, ConversationsPage } from "@/hooks/useConversations";
-import { authenticatedFetch } from "@/lib/identity";
+import { getOmnigentServerIdentity } from "@/lib/host";
+import { authenticatedFetch, getCurrentUserId, resolveIdentity } from "@/lib/identity";
 import { dedupeConversationsById } from "@/shell/sidebarNav";
 
 /** First page when nothing is cached: small, so the first paint is quick. */
@@ -20,6 +21,8 @@ export const SESSION_PAGE_LIMIT = 1_000;
 export const MAX_SESSION_PAGES = 200;
 export const MAX_SESSIONS = 5_000;
 export const SESSION_POLL_INTERVAL_MS = 30_000;
+const SESSION_CACHE_VERSION = 1;
+const SESSION_CACHE_KEY_PREFIX = "omnigent:canvas-sessions";
 
 export interface SessionLoadProgress {
   sessions: Conversation[];
@@ -34,8 +37,143 @@ export interface CanvasSessions {
   loadingMore: boolean;
   /** True once a full canonical load has finished at least once. */
   complete: boolean;
+  /** True only after this page has confirmed the complete list with the server. */
+  networkConfirmed: boolean;
   error: string | null;
   refresh: () => Promise<void>;
+}
+
+// QueryClient survives route changes; scoping the remembered list to it keeps
+// separate app roots and tests isolated while making revisits instantaneous.
+interface RememberedCanvasSessions {
+  viewerId: string;
+  sessions: Conversation[];
+  storedSignature: string | null;
+}
+
+const completeSessionsByClient = new WeakMap<QueryClient, RememberedCanvasSessions>();
+
+interface StoredCanvasSessions {
+  version: number;
+  sessions: Conversation[];
+}
+
+function sessionCachePrefix(): string {
+  const server = getOmnigentServerIdentity() ?? "default";
+  return `${SESSION_CACHE_KEY_PREFIX}:${server}`;
+}
+
+function sessionCacheKey(viewerId: string): string {
+  return `${sessionCachePrefix()}:${viewerId}`;
+}
+
+function hasStoredSessionsForServer(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const prefix = `${sessionCachePrefix()}:`;
+    return Array.from({ length: window.sessionStorage.length }, (_, index) =>
+      window.sessionStorage.key(index),
+    ).some((key) => key?.startsWith(prefix));
+  } catch {
+    return false;
+  }
+}
+
+function isStoredConversation(value: unknown): value is Conversation {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const row = value as Partial<Conversation>;
+  return (
+    typeof row.id === "string" &&
+    typeof row.updated_at === "number" &&
+    Number.isFinite(row.updated_at) &&
+    (row.status === undefined || typeof row.status === "string")
+  );
+}
+
+function readStoredSessions(viewerId: string): Conversation[] | undefined {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.sessionStorage.getItem(sessionCacheKey(viewerId));
+    if (!raw) return undefined;
+    const stored = JSON.parse(raw) as Partial<StoredCanvasSessions> | null;
+    if (
+      !stored ||
+      stored.version !== SESSION_CACHE_VERSION ||
+      !Array.isArray(stored.sessions) ||
+      stored.sessions.length > MAX_SESSIONS ||
+      !stored.sessions.every(isStoredConversation)
+    ) {
+      return undefined;
+    }
+    return dedupeConversationsById(stored.sessions.filter(isTopLevelActive));
+  } catch {
+    return undefined;
+  }
+}
+
+function sessionSignature(sessions: readonly Conversation[]): string {
+  return sessions
+    .map((row) =>
+      [
+        row.id,
+        row.updated_at,
+        row.status,
+        row.title,
+        row.pending_elicitations_count,
+        row.git_branch,
+        row.project_id,
+        row.workspace,
+        row.archived,
+        row.parent_session_id,
+        row.owner,
+        row.permission_level,
+        row.labels?.omni_project,
+      ].join("\0"),
+    )
+    .join("\x01");
+}
+
+function rememberedSessions(
+  queryClient: QueryClient,
+  viewerId: string | null,
+): Conversation[] | undefined {
+  if (viewerId === null) return undefined;
+  const remembered = completeSessionsByClient.get(queryClient);
+  if (remembered?.viewerId === viewerId) return remembered.sessions;
+  const stored = readStoredSessions(viewerId);
+  if (stored) {
+    const signature = sessionSignature(stored);
+    completeSessionsByClient.set(queryClient, {
+      viewerId,
+      sessions: stored,
+      storedSignature: signature,
+    });
+  }
+  return stored;
+}
+
+function rememberCompleteSessions(
+  queryClient: QueryClient,
+  viewerId: string,
+  sessions: Conversation[],
+): void {
+  const signature = sessionSignature(sessions);
+  const previous = completeSessionsByClient.get(queryClient);
+  const storedSignature = previous?.viewerId === viewerId ? previous.storedSignature : null;
+  completeSessionsByClient.set(queryClient, { viewerId, sessions, storedSignature });
+  if (storedSignature === signature) return;
+  if (typeof window === "undefined") return;
+  try {
+    const stored: StoredCanvasSessions = { version: SESSION_CACHE_VERSION, sessions };
+    window.sessionStorage.setItem(sessionCacheKey(viewerId), JSON.stringify(stored));
+    completeSessionsByClient.set(queryClient, {
+      viewerId,
+      sessions,
+      storedSignature: signature,
+    });
+  } catch {
+    // Memory caching still works when storage is disabled or full.
+  }
 }
 
 export function isTopLevelActive(session: Conversation): boolean {
@@ -184,18 +322,28 @@ export function applyLiveRows(
 
 export function useCanvasSessions(): CanvasSessions {
   const queryClient = useQueryClient();
+  const [awaitingStoredIdentity, setAwaitingStoredIdentity] = useState(() => {
+    const viewerId = getCurrentUserId();
+    if (rememberedSessions(queryClient, viewerId) !== undefined) return false;
+    return viewerId === null && hasStoredSessionsForServer();
+  });
   const [state, setState] = useState(() => {
-    const preview = cachedSessionPreview(queryClient);
+    const remembered = awaitingStoredIdentity
+      ? undefined
+      : rememberedSessions(queryClient, getCurrentUserId());
+    const sessions =
+      remembered ?? (awaitingStoredIdentity ? [] : cachedSessionPreview(queryClient));
     return {
-      sessions: preview,
-      loaded: preview.length > 0,
+      sessions,
+      loaded: remembered !== undefined || sessions.length > 0,
       loadingMore: false,
-      complete: false,
+      complete: remembered !== undefined,
+      networkConfirmed: false,
       error: null as string | null,
     };
   });
   const sessionsRef = useRef(state.sessions);
-  const completeRef = useRef(false);
+  const completeRef = useRef(state.complete);
   const inFlightRef = useRef<Promise<void> | null>(null);
   const aliveRef = useRef(true);
 
@@ -206,6 +354,30 @@ export function useCanvasSessions(): CanvasSessions {
     };
   }, []);
 
+  // A persisted cache may be keyed by an identity that is still resolving on
+  // startup. Wait rather than flashing the short anonymous sidebar preview.
+  useEffect(() => {
+    if (!awaitingStoredIdentity) return;
+    let cancelled = false;
+    void resolveIdentity().then((viewerId) => {
+      if (cancelled) return;
+      const remembered = rememberedSessions(queryClient, viewerId);
+      const sessions = remembered ?? cachedSessionPreview(queryClient);
+      sessionsRef.current = sessions;
+      completeRef.current = remembered !== undefined;
+      setState((current) => ({
+        ...current,
+        sessions,
+        loaded: remembered !== undefined || sessions.length > 0,
+        complete: remembered !== undefined,
+      }));
+      setAwaitingStoredIdentity(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [awaitingStoredIdentity, queryClient]);
+
   const refresh = useCallback((): Promise<void> => {
     if (inFlightRef.current) return inFlightRef.current;
     const existing = sessionsRef.current;
@@ -215,18 +387,27 @@ export function useCanvasSessions(): CanvasSessions {
     }
     const request = (async () => {
       try {
+        const viewerId = await resolveIdentity();
         await loadAllSessions(existing, (progress) => {
-          if (!aliveRef.current) return;
           const sessions = progress.hasMore
             ? mergePartial(existing, progress.sessions)
             : progress.sessions;
+          // Keep the completed list even if this page unmounted while loading.
+          // A later Canvas visit can then paint the whole list immediately.
+          if (!progress.hasMore && viewerId !== null) {
+            rememberCompleteSessions(queryClient, viewerId, sessions);
+          }
+          if (!aliveRef.current) return;
           sessionsRef.current = sessions;
-          if (!progress.hasMore) completeRef.current = true;
+          if (!progress.hasMore) {
+            completeRef.current = true;
+          }
           setState((current) => ({
             ...current,
             sessions,
             loaded: true,
             complete: current.complete || !progress.hasMore,
+            networkConfirmed: current.networkConfirmed || !progress.hasMore,
             error: null,
           }));
         });
@@ -248,11 +429,12 @@ export function useCanvasSessions(): CanvasSessions {
       if (inFlightRef.current === request) inFlightRef.current = null;
     });
     return request;
-  }, []);
+  }, [queryClient]);
 
   // Initial load, then poll like the sidebar does and catch up when the tab
   // becomes visible or the window regains focus.
   useEffect(() => {
+    if (awaitingStoredIdentity) return;
     void refresh();
     const refreshIfVisible = () => {
       if (!document.hidden) void refresh();
@@ -265,7 +447,7 @@ export function useCanvasSessions(): CanvasSessions {
       window.removeEventListener("focus", refreshIfVisible);
       document.removeEventListener("visibilitychange", refreshIfVisible);
     };
-  }, [refresh]);
+  }, [awaitingStoredIdentity, refresh]);
 
   // Live updates: the sessions stream patches the sidebar's cache in place;
   // mirror those rows so cards change with the sidebar instead of on the next poll.
@@ -280,6 +462,15 @@ export function useCanvasSessions(): CanvasSessions {
         return;
       }
       sessionsRef.current = next;
+      const viewerId = getCurrentUserId();
+      if (completeRef.current && viewerId !== null) {
+        const previous = completeSessionsByClient.get(queryClient);
+        completeSessionsByClient.set(queryClient, {
+          viewerId,
+          sessions: next,
+          storedSignature: previous?.viewerId === viewerId ? previous.storedSignature : null,
+        });
+      }
       setState((current) => ({ ...current, sessions: next }));
     };
     const unsubscribe = queryClient.getQueryCache().subscribe((event) => {

--- a/web/src/canvas/canvasSessions.ts
+++ b/web/src/canvas/canvasSessions.ts
@@ -46,6 +46,7 @@ export interface CanvasSessions {
 // QueryClient survives route changes; scoping the remembered list to it keeps
 // separate app roots and tests isolated while making revisits instantaneous.
 interface RememberedCanvasSessions {
+  serverId: string;
   viewerId: string;
   sessions: Conversation[];
   storedSignature: string | null;
@@ -58,13 +59,16 @@ interface StoredCanvasSessions {
   sessions: Conversation[];
 }
 
-function sessionCachePrefix(): string {
-  const server = getOmnigentServerIdentity() ?? "default";
-  return `${SESSION_CACHE_KEY_PREFIX}:${server}`;
+function currentServerId(): string {
+  return getOmnigentServerIdentity() ?? "default";
 }
 
-function sessionCacheKey(viewerId: string): string {
-  return `${sessionCachePrefix()}:${viewerId}`;
+function sessionCachePrefix(serverId: string = currentServerId()): string {
+  return `${SESSION_CACHE_KEY_PREFIX}:${serverId}`;
+}
+
+function sessionCacheKey(viewerId: string, serverId: string = currentServerId()): string {
+  return `${sessionCachePrefix(serverId)}:${viewerId}`;
 }
 
 function hasStoredSessionsForServer(): boolean {
@@ -90,10 +94,13 @@ function isStoredConversation(value: unknown): value is Conversation {
   );
 }
 
-function readStoredSessions(viewerId: string): Conversation[] | undefined {
+function readStoredSessions(
+  viewerId: string,
+  serverId: string = currentServerId(),
+): Conversation[] | undefined {
   if (typeof window === "undefined") return undefined;
   try {
-    const raw = window.sessionStorage.getItem(sessionCacheKey(viewerId));
+    const raw = window.sessionStorage.getItem(sessionCacheKey(viewerId, serverId));
     if (!raw) return undefined;
     const stored = JSON.parse(raw) as Partial<StoredCanvasSessions> | null;
     if (
@@ -138,12 +145,16 @@ function rememberedSessions(
   viewerId: string | null,
 ): Conversation[] | undefined {
   if (viewerId === null) return undefined;
+  const serverId = currentServerId();
   const remembered = completeSessionsByClient.get(queryClient);
-  if (remembered?.viewerId === viewerId) return remembered.sessions;
-  const stored = readStoredSessions(viewerId);
+  if (remembered?.serverId === serverId && remembered.viewerId === viewerId) {
+    return remembered.sessions;
+  }
+  const stored = readStoredSessions(viewerId, serverId);
   if (stored) {
     const signature = sessionSignature(stored);
     completeSessionsByClient.set(queryClient, {
+      serverId,
       viewerId,
       sessions: stored,
       storedSignature: signature,
@@ -154,19 +165,24 @@ function rememberedSessions(
 
 function rememberCompleteSessions(
   queryClient: QueryClient,
+  serverId: string,
   viewerId: string,
   sessions: Conversation[],
 ): void {
   const signature = sessionSignature(sessions);
   const previous = completeSessionsByClient.get(queryClient);
-  const storedSignature = previous?.viewerId === viewerId ? previous.storedSignature : null;
-  completeSessionsByClient.set(queryClient, { viewerId, sessions, storedSignature });
+  const storedSignature =
+    previous?.serverId === serverId && previous.viewerId === viewerId
+      ? previous.storedSignature
+      : null;
+  completeSessionsByClient.set(queryClient, { serverId, viewerId, sessions, storedSignature });
   if (storedSignature === signature) return;
   if (typeof window === "undefined") return;
   try {
     const stored: StoredCanvasSessions = { version: SESSION_CACHE_VERSION, sessions };
-    window.sessionStorage.setItem(sessionCacheKey(viewerId), JSON.stringify(stored));
+    window.sessionStorage.setItem(sessionCacheKey(viewerId, serverId), JSON.stringify(stored));
     completeSessionsByClient.set(queryClient, {
+      serverId,
       viewerId,
       sessions,
       storedSignature: signature,
@@ -387,6 +403,7 @@ export function useCanvasSessions(): CanvasSessions {
     }
     const request = (async () => {
       try {
+        const serverId = currentServerId();
         const viewerId = await resolveIdentity();
         await loadAllSessions(existing, (progress) => {
           const sessions = progress.hasMore
@@ -395,7 +412,7 @@ export function useCanvasSessions(): CanvasSessions {
           // Keep the completed list even if this page unmounted while loading.
           // A later Canvas visit can then paint the whole list immediately.
           if (!progress.hasMore && viewerId !== null) {
-            rememberCompleteSessions(queryClient, viewerId, sessions);
+            rememberCompleteSessions(queryClient, serverId, viewerId, sessions);
           }
           if (!aliveRef.current) return;
           sessionsRef.current = sessions;
@@ -464,11 +481,16 @@ export function useCanvasSessions(): CanvasSessions {
       sessionsRef.current = next;
       const viewerId = getCurrentUserId();
       if (completeRef.current && viewerId !== null) {
+        const serverId = currentServerId();
         const previous = completeSessionsByClient.get(queryClient);
         completeSessionsByClient.set(queryClient, {
+          serverId,
           viewerId,
           sessions: next,
-          storedSignature: previous?.viewerId === viewerId ? previous.storedSignature : null,
+          storedSignature:
+            previous?.serverId === serverId && previous.viewerId === viewerId
+              ? previous.storedSignature
+              : null,
         });
       }
       setState((current) => ({ ...current, sessions: next }));

--- a/web/src/canvas/canvasStorage.test.ts
+++ b/web/src/canvas/canvasStorage.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  activeCanvasStorageKey,
   canvasLayoutStorageKey,
   EMPTY_CANVAS_LAYOUT,
   LAYOUT_VERSION,
   MAX_SAVED_POSITIONS,
+  readActiveCanvas,
   readCanvasLayout,
-  withoutPositions,
   withPosition,
+  writeActiveCanvas,
   writeCanvasLayout,
 } from "./canvasStorage";
 
@@ -76,14 +78,15 @@ describe("canvas layout storage", () => {
     expect(layout.positions.a).toEqual({ x: 2, y: 3 });
   });
 
-  it("forgets only the given cards' spots", () => {
-    const placed = withPosition(
-      withPosition(EMPTY_CANVAS_LAYOUT, "onMain", { x: 1, y: 1 }),
-      "onProject",
-      { x: 2, y: 2 },
+  it("remembers the selected canvas per server and viewer", () => {
+    expect(activeCanvasStorageKey("user_1")).toBe(
+      `omnigent:canvas-active:${window.location.origin}:user_1`,
     );
-    expect(withoutPositions(placed, ["onMain"])).toEqual({
-      positions: { onProject: { x: 2, y: 2 } },
-    });
+    expect(readActiveCanvas("user_1")).toBeNull();
+    writeActiveCanvas("proj_a", "user_1");
+    expect(readActiveCanvas("user_1")).toBe("proj_a");
+    expect(readActiveCanvas("user_2")).toBeNull();
+    writeActiveCanvas("", "user_1");
+    expect(readActiveCanvas("user_1")).toBeNull();
   });
 });

--- a/web/src/canvas/canvasStorage.ts
+++ b/web/src/canvas/canvasStorage.ts
@@ -1,12 +1,12 @@
-// Persisted card positions for the Canvas page. The view itself is not saved:
-// every canvas opens fitted to its cards.
+// Persisted card positions and the selected canvas for the Canvas page. The
+// view itself is not saved: every canvas opens fitted to its cards.
 //
-// One localStorage entry per server and user (keyed by the server identity,
-// so an embedded host that proxies several backends keeps their layouts
-// apart, and by the viewer's user id, so two people sharing a browser profile
-// against one server never see or overwrite each other's layout).
-// Reads never throw — a missing, malformed, or older-version entry reads as
-// an empty layout. Writes may throw (quota); callers surface that as a warning.
+// One layout entry per server and user (keyed by the server identity, so an
+// embedded host that proxies several backends keeps their layouts apart, and
+// by the viewer's user id, so two people sharing a browser profile against one
+// server never see or overwrite each other's layout). Reads never throw — a
+// missing, malformed, or older-version entry reads as an empty layout. Writes
+// may throw (quota); callers surface that as a warning.
 
 import { getOmnigentServerIdentity } from "@/lib/host";
 import type { CanvasPosition, CanvasPositions } from "./canvasLayout";
@@ -16,6 +16,7 @@ export const LAYOUT_VERSION = 1;
 export const MAX_SAVED_POSITIONS = 5_000;
 const MAX_ABS_COORDINATE = 1_000_000;
 const STORAGE_KEY_PREFIX = "omnigent:canvas-layout";
+const ACTIVE_CANVAS_KEY_PREFIX = "omnigent:canvas-active";
 
 export interface CanvasLayout {
   positions: CanvasPositions;
@@ -30,6 +31,29 @@ export const EMPTY_CANVAS_LAYOUT: CanvasLayout = { positions: {} };
 
 export function canvasLayoutStorageKey(viewerId: string | null): string {
   return `${STORAGE_KEY_PREFIX}:${getOmnigentServerIdentity() ?? "default"}:${viewerId ?? "anonymous"}`;
+}
+
+export function activeCanvasStorageKey(viewerId: string | null): string {
+  return `${ACTIVE_CANVAS_KEY_PREFIX}:${getOmnigentServerIdentity() ?? "default"}:${viewerId ?? "anonymous"}`;
+}
+
+/** The canvas last selected on this server, or null when none is remembered. */
+export function readActiveCanvas(viewerId: string | null): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(activeCanvasStorageKey(viewerId)) || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Remember the selected canvas. A failed write is not worth a warning: the URL carries it too. */
+export function writeActiveCanvas(canvasId: string, viewerId: string | null): void {
+  try {
+    window.localStorage.setItem(activeCanvasStorageKey(viewerId), canvasId);
+  } catch {
+    // Quota or disabled storage; the selection still lives in the URL.
+  }
 }
 
 function boundedCoordinate(value: number): number {
@@ -97,14 +121,4 @@ export function withPosition(
 
 export function withPositions(layout: CanvasLayout, positions: CanvasPositions): CanvasLayout {
   return { ...layout, positions };
-}
-
-/** Forget the given cards' spots (one canvas's cards); other canvases keep theirs. */
-export function withoutPositions(layout: CanvasLayout, sessionIds: Iterable<string>): CanvasLayout {
-  const removed = new Set(sessionIds);
-  return {
-    positions: Object.fromEntries(
-      Object.entries(layout.positions).filter(([id]) => !removed.has(id)),
-    ) as CanvasPositions,
-  };
 }

--- a/web/src/canvas/canvasStorage.ts
+++ b/web/src/canvas/canvasStorage.ts
@@ -49,6 +49,7 @@ export function readActiveCanvas(viewerId: string | null): string | null {
 
 /** Remember the selected canvas. A failed write is not worth a warning: the URL carries it too. */
 export function writeActiveCanvas(canvasId: string, viewerId: string | null): void {
+  if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(activeCanvasStorageKey(viewerId), canvasId);
   } catch {

--- a/web/src/pages/CanvasPage.test.tsx
+++ b/web/src/pages/CanvasPage.test.tsx
@@ -106,6 +106,7 @@ function sessionsStub(
     loaded: true,
     loadingMore: false,
     complete: true,
+    networkConfirmed: true,
     error: null,
     refresh: vi.fn(async () => undefined),
     ...overrides,
@@ -173,6 +174,7 @@ describe("CanvasPage", () => {
       sessionsStub([conversation("conv_1", 3), conversation("conv_2", 2)], {
         loadingMore: true,
         complete: false,
+        networkConfirmed: false,
       }),
     );
     renderPage();
@@ -200,6 +202,8 @@ describe("CanvasPage", () => {
     const nodes = flowProps.current?.nodes as { initialWidth: number; initialHeight: number }[];
     expect(nodes).toHaveLength(600);
     expect(nodes[0]).toMatchObject({ initialWidth: 280, initialHeight: 132 });
+    // Cards snap to the layout lattice while dragging.
+    expect(flowProps.current).toMatchObject({ snapToGrid: true, snapGrid: [32, 32] });
   });
 
   it("refits on a tab change or layout reset, but not on status-only updates", async () => {
@@ -277,12 +281,35 @@ describe("CanvasPage", () => {
     expect(screen.getByTestId("location")).toHaveTextContent(/^\/canvas$/);
   });
 
+  it("reopens the last selected canvas on a visit without a URL parameter", () => {
+    vi.mocked(conversationsHook.useProjects).mockReturnValue(projectsStub(PROJECTS));
+    const { unmount } = renderPage();
+    fireEvent.click(screen.getByRole("tab", { name: "Alpha" }));
+    unmount();
+
+    const revisit = renderPage();
+    expect(screen.getByRole("tab", { name: "Alpha" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("location")).toHaveTextContent("/canvas?canvas=proj_a");
+    revisit.unmount();
+
+    // An explicit URL still wins over the remembered canvas.
+    renderPage("/canvas?canvas=name%3ALegacy");
+    expect(screen.getByRole("tab", { name: "Legacy" })).toHaveAttribute("aria-selected", "true");
+    cleanup();
+    renderPage();
+    expect(screen.getByRole("tab", { name: "Legacy" })).toHaveAttribute("aria-selected", "true");
+  });
+
   it("falls back to Main when the URL names a canvas that no longer exists", () => {
     vi.mocked(conversationsHook.useProjects).mockReturnValue(projectsStub(PROJECTS));
     renderPage("/canvas?canvas=proj_gone");
 
     expect(screen.getByRole("tab", { name: "Main" })).toHaveAttribute("aria-selected", "true");
     expect(screen.getByTestId("location")).toHaveTextContent(/^\/canvas$/);
+    // The stale choice is forgotten too, so the next visit does not retry it.
+    cleanup();
+    renderPage();
+    expect(screen.getByRole("tab", { name: "Main" })).toHaveAttribute("aria-selected", "true");
   });
 
   it("shows explicit empty states per canvas", () => {
@@ -319,31 +346,67 @@ describe("CanvasPage", () => {
     expect(screen.getByTestId("location")).toHaveTextContent("/c/conv_1");
   });
 
-  it("persists dragged positions and restores them on the next mount", async () => {
+  it("saves every card's spot once complete, so a moved card leaves the others in place", async () => {
     vi.mocked(canvasSessions.useCanvasSessions).mockReturnValue(
       sessionsStub([conversation("conv_1", 2), conversation("conv_2", 1)]),
     );
     const { unmount } = renderPage();
+    // Grid slots are saved as soon as the full list is known, not only after a drag.
+    expect(readCanvasLayout(null)).toEqual({
+      positions: { conv_1: { x: 0, y: 0 }, conv_2: { x: 320, y: 0 } },
+    });
     const dragStop = flowProps.current?.onNodeDragStop as (
       event: MouseEvent,
       node: { id: string; position: { x: number; y: number } },
     ) => void;
     act(() => {
-      dragStop(new MouseEvent("mouseup"), { id: "conv_2", position: { x: 400.4, y: 120.6 } });
+      dragStop(new MouseEvent("mouseup"), { id: "conv_1", position: { x: 960.4, y: 480.6 } });
     });
-    expect(readCanvasLayout(null)).toEqual({ positions: { conv_2: { x: 400, y: 121 } } });
+    expect(readCanvasLayout(null).positions).toEqual({
+      conv_2: { x: 320, y: 0 },
+      conv_1: { x: 960, y: 481 },
+    });
     unmount();
 
     renderPage();
     await waitFor(() =>
-      expect(screen.getByTestId("flow-node-conv_2")).toHaveAttribute("data-x", "400"),
+      expect(screen.getByTestId("flow-node-conv_1")).toHaveAttribute("data-x", "960"),
     );
-    expect(screen.getByTestId("flow-node-conv_2")).toHaveAttribute("data-y", "121");
+    expect(screen.getByTestId("flow-node-conv_1")).toHaveAttribute("data-y", "481");
+    // The unmoved card keeps its slot instead of sliding into the vacated one.
+    expect(screen.getByTestId("flow-node-conv_2")).toHaveAttribute("data-x", "320");
     // The restored layout is fitted like any other first paint.
     await waitFor(() => expect(flowFitView).toHaveBeenCalled());
   });
 
-  it("resets only the active canvas's saved positions", () => {
+  it("does not save grid slots while the list is still loading", () => {
+    vi.mocked(canvasSessions.useCanvasSessions).mockReturnValue(
+      sessionsStub([conversation("conv_1", 2)], {
+        loadingMore: true,
+        complete: false,
+        networkConfirmed: false,
+      }),
+    );
+    renderPage();
+    expect(readCanvasLayout(null)).toEqual({ positions: {} });
+  });
+
+  it("does not prune positions while the complete list is only cached", () => {
+    window.localStorage.setItem(
+      canvasLayoutStorageKey(null),
+      JSON.stringify({ version: 1, positions: { conv_cached_out: [11, 12], conv_1: [7, 7] } }),
+    );
+    vi.mocked(canvasSessions.useCanvasSessions).mockReturnValue(
+      sessionsStub([conversation("conv_1", 1)], { networkConfirmed: false }),
+    );
+    renderPage();
+    expect(readCanvasLayout(null).positions).toEqual({
+      conv_cached_out: { x: 11, y: 12 },
+      conv_1: { x: 7, y: 7 },
+    });
+  });
+
+  it("resets only the active canvas's positions to grid slots", () => {
     vi.mocked(conversationsHook.useProjects).mockReturnValue(projectsStub(PROJECTS));
     vi.mocked(canvasSessions.useCanvasSessions).mockReturnValue(
       sessionsStub([
@@ -364,7 +427,10 @@ describe("CanvasPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Reset layout" }));
 
     expect(screen.getByTestId("flow-node-conv_main")).toHaveAttribute("data-x", "0");
-    expect(readCanvasLayout(null)).toEqual({ positions: { conv_alpha: { x: 50, y: 50 } } });
+    expect(readCanvasLayout(null).positions).toEqual({
+      conv_alpha: { x: 50, y: 50 },
+      conv_main: { x: 0, y: 0 },
+    });
   });
 
   it("forgets saved spots of deleted sessions once the list is complete", () => {
@@ -406,7 +472,13 @@ describe("CanvasPage", () => {
   it("shows an initial error with retry, then a quiet banner once cards exist", () => {
     const refresh = vi.fn(async () => undefined);
     vi.mocked(canvasSessions.useCanvasSessions).mockReturnValue(
-      sessionsStub([], { loaded: false, complete: false, error: "boom", refresh }),
+      sessionsStub([], {
+        loaded: false,
+        complete: false,
+        networkConfirmed: false,
+        error: "boom",
+        refresh,
+      }),
     );
     const { unmount } = renderPage();
     expect(screen.getByRole("alert")).toHaveTextContent("Canvas could not load");

--- a/web/src/pages/CanvasPage.test.tsx
+++ b/web/src/pages/CanvasPage.test.tsx
@@ -13,10 +13,14 @@ import type { Conversation, ProjectSummary } from "@/hooks/useConversations";
 import * as conversationsHook from "@/hooks/useConversations";
 import * as canvasSessions from "@/canvas/canvasSessions";
 import { PROJECT_LABEL_KEY } from "@/lib/sessionListCache";
-import { canvasLayoutStorageKey, readCanvasLayout } from "@/canvas/canvasStorage";
+import {
+  activeCanvasStorageKey,
+  canvasLayoutStorageKey,
+  readCanvasLayout,
+} from "@/canvas/canvasStorage";
 import { CanvasPage } from "./CanvasPage";
 
-const { flowProps, flowFitView, flowSetViewport, flowApi } = vi.hoisted(() => {
+const { flowProps, flowFitView, flowSetViewport, flowApi, viewerIdRef } = vi.hoisted(() => {
   const fitViewMock = vi.fn();
   const setViewportMock = vi.fn(async () => true);
   return {
@@ -30,6 +34,7 @@ const { flowProps, flowFitView, flowSetViewport, flowApi } = vi.hoisted(() => {
       zoomIn: vi.fn(),
       zoomOut: vi.fn(),
     },
+    viewerIdRef: { current: null as string | null },
   };
 });
 
@@ -71,6 +76,7 @@ vi.mock("@/hooks/useConversations", async (importActual) => ({
   useProjects: vi.fn(),
 }));
 vi.mock("@/canvas/canvasSessions", () => ({ useCanvasSessions: vi.fn() }));
+vi.mock("@/hooks/useViewerId", () => ({ useViewerId: () => viewerIdRef.current }));
 vi.mock("@/hooks/useGithub", () => ({
   fetchGithubInfo: vi.fn(async () => ({ object: "session.github.info", available: false })),
 }));
@@ -157,6 +163,7 @@ const PROJECTS: ProjectSummary[] = [
 
 beforeEach(() => {
   window.localStorage.clear();
+  viewerIdRef.current = null;
   flowProps.current = null;
   flowFitView.mockClear();
   flowSetViewport.mockClear();
@@ -282,6 +289,7 @@ describe("CanvasPage", () => {
   });
 
   it("reopens the last selected canvas on a visit without a URL parameter", () => {
+    viewerIdRef.current = "me";
     vi.mocked(conversationsHook.useProjects).mockReturnValue(projectsStub(PROJECTS));
     const { unmount } = renderPage();
     fireEvent.click(screen.getByRole("tab", { name: "Alpha" }));
@@ -298,6 +306,28 @@ describe("CanvasPage", () => {
     cleanup();
     renderPage();
     expect(screen.getByRole("tab", { name: "Legacy" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("waits for viewer identity before restoring a remembered canvas", async () => {
+    vi.mocked(conversationsHook.useProjects).mockReturnValue(projectsStub(PROJECTS));
+    window.localStorage.setItem(activeCanvasStorageKey(null), "proj_a");
+    window.localStorage.setItem(activeCanvasStorageKey("me"), "name:Legacy");
+    const { rerender } = renderPage();
+
+    expect(screen.getByRole("tab", { name: "Main" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("location")).toHaveTextContent(/^\/canvas$/);
+
+    viewerIdRef.current = "me";
+    rerender(pageTree());
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Legacy" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      ),
+    );
+    expect(screen.getByTestId("location")).toHaveTextContent("/canvas?canvas=name%3ALegacy");
+    expect(window.localStorage.getItem(activeCanvasStorageKey("me"))).toBe("name:Legacy");
   });
 
   it("falls back to Main when the URL names a canvas that no longer exists", () => {

--- a/web/src/pages/CanvasPage.test.tsx
+++ b/web/src/pages/CanvasPage.test.tsx
@@ -406,6 +406,27 @@ describe("CanvasPage", () => {
     });
   });
 
+  it("keeps unloaded sessions' saved spots when resetting a cached canvas", () => {
+    window.localStorage.setItem(
+      canvasLayoutStorageKey(null),
+      JSON.stringify({
+        version: 1,
+        positions: { conv_cached_out: [11, 12], conv_1: [700, 700] },
+      }),
+    );
+    vi.mocked(canvasSessions.useCanvasSessions).mockReturnValue(
+      sessionsStub([conversation("conv_1", 1)], { networkConfirmed: false }),
+    );
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset layout" }));
+
+    expect(readCanvasLayout(null).positions).toEqual({
+      conv_cached_out: { x: 11, y: 12 },
+      conv_1: { x: 0, y: 0 },
+    });
+  });
+
   it("resets only the active canvas's positions to grid slots", () => {
     vi.mocked(conversationsHook.useProjects).mockReturnValue(projectsStub(PROJECTS));
     vi.mocked(canvasSessions.useCanvasSessions).mockReturnValue(

--- a/web/src/pages/CanvasPage.test.tsx
+++ b/web/src/pages/CanvasPage.test.tsx
@@ -321,10 +321,7 @@ describe("CanvasPage", () => {
     rerender(pageTree());
 
     await waitFor(() =>
-      expect(screen.getByRole("tab", { name: "Legacy" })).toHaveAttribute(
-        "aria-selected",
-        "true",
-      ),
+      expect(screen.getByRole("tab", { name: "Legacy" })).toHaveAttribute("aria-selected", "true"),
     );
     expect(screen.getByTestId("location")).toHaveTextContent("/canvas?canvas=name%3ALegacy");
     expect(window.localStorage.getItem(activeCanvasStorageKey("me"))).toBe("name:Legacy");

--- a/web/src/pages/CanvasPage.tsx
+++ b/web/src/pages/CanvasPage.tsx
@@ -166,7 +166,7 @@ function CanvasSurface() {
   const [activeCanvas, setActiveCanvas] = useState(
     () =>
       searchParams.get(CANVAS_QUERY_PARAM) ??
-      (viewerId === null ? MAIN_CANVAS_ID : readActiveCanvas(viewerId) ?? MAIN_CANVAS_ID),
+      (viewerId === null ? MAIN_CANVAS_ID : (readActiveCanvas(viewerId) ?? MAIN_CANVAS_ID)),
   );
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
   const activeCanvasRef = useRef(activeCanvas);

--- a/web/src/pages/CanvasPage.tsx
+++ b/web/src/pages/CanvasPage.tsx
@@ -432,8 +432,12 @@ function CanvasSurface() {
     trackClick("canvas.reset-layout");
     const ids = visibleSessions.map((session) => session.id);
     const removed = new Set(ids);
+    // A cached session list can be stale until the network confirms it. Start
+    // from the persisted map so resetting the visible canvas cannot discard
+    // saved spots for sessions that have not appeared yet.
+    const currentPositions = { ...layoutRef.current.positions, ...positionsRef.current };
     const kept = Object.fromEntries(
-      Object.entries(positionsRef.current).filter(([id]) => !removed.has(id)),
+      Object.entries(currentPositions).filter(([id]) => !removed.has(id)),
     ) as CanvasPositions;
     positionsRef.current = { ...kept, ...mergeSessionPositions(visibleSessions, {}) };
     scheduleFit();

--- a/web/src/pages/CanvasPage.tsx
+++ b/web/src/pages/CanvasPage.tsx
@@ -160,9 +160,13 @@ function CanvasSurface() {
   const projects = projectsQuery.data ?? EMPTY_PROJECTS;
 
   const [nodes, setNodes] = useState<SessionCardNode[]>([]);
-  // The URL names the canvas; without it, reopen the one last selected here.
+  // The URL names the canvas; without it, reopen the viewer's last selection
+  // once identity is known. Never hydrate an authenticated view from the
+  // anonymous storage slot while embedded identity is still resolving.
   const [activeCanvas, setActiveCanvas] = useState(
-    () => searchParams.get(CANVAS_QUERY_PARAM) ?? readActiveCanvas(viewerId) ?? MAIN_CANVAS_ID,
+    () =>
+      searchParams.get(CANVAS_QUERY_PARAM) ??
+      (viewerId === null ? MAIN_CANVAS_ID : readActiveCanvas(viewerId) ?? MAIN_CANVAS_ID),
   );
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
   const activeCanvasRef = useRef(activeCanvas);
@@ -345,6 +349,8 @@ function CanvasSurface() {
       writeCanvasParam(activeCanvas);
     }
     if (
+      viewerId !== null &&
+      activeCanvasRef.current === activeCanvas &&
       projectsQuery.data !== undefined &&
       (activeCanvas === MAIN_CANVAS_ID ||
         projects.some((project) => projectCanvasId(project) === activeCanvas))

--- a/web/src/pages/CanvasPage.tsx
+++ b/web/src/pages/CanvasPage.tsx
@@ -15,10 +15,13 @@
  * - Pull requests come through the GitHub panel's query cache
  *   (`fetchGithubInfo`), throttled per session by `usePullRequests`.
  * - Card positions live in localStorage (`canvasStorage.ts`), keyed by server
- *   identity; the server never learns the layout. The view itself is not
- *   saved: every canvas opens fitted to its cards and stays fitted until the
- *   user pans or zooms by hand.
- * - The selected canvas lives in `?canvas=<id>` so a reload keeps the tab.
+ *   identity and viewer; the server never learns the layout. Every card's spot
+ *   is saved once the full list is known — grid slots included — so nothing
+ *   moves on a reload, and cards snap to a `GRID_STEP` lattice while dragging.
+ *   The view itself is not saved: every canvas opens fitted to its cards and
+ *   stays fitted until the user pans or zooms by hand.
+ * - The selected canvas lives in `?canvas=<id>` so a reload keeps the tab, and
+ *   is remembered per server so coming back to `/canvas` reopens it.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -42,21 +45,23 @@ import {
 import {
   CARD_HEIGHT,
   CARD_WIDTH,
+  GRID_STEP,
   MAIN_CANVAS_ID,
   mergeCanvasPositions,
   mergeSessionPositions,
   projectCanvasId,
-  prunePositions,
+  samePositions,
   sessionsOnCanvas,
   type CanvasPositions,
 } from "@/canvas/canvasLayout";
 import { useCanvasSessions } from "@/canvas/canvasSessions";
 import {
   EMPTY_CANVAS_LAYOUT,
+  readActiveCanvas,
   readCanvasLayout,
-  withoutPositions,
   withPosition,
   withPositions,
+  writeActiveCanvas,
   writeCanvasLayout,
   type CanvasLayout,
 } from "@/canvas/canvasStorage";
@@ -77,6 +82,7 @@ import "@xyflow/react/dist/style.css";
 const nodeTypes = { session: SessionCard };
 const proOptions = { hideAttribution: true };
 const FIT_VIEW = { padding: 0.2, maxZoom: 1 };
+const SNAP_GRID: [number, number] = [GRID_STEP, GRID_STEP];
 const MIN_ZOOM = 0.05;
 const MAX_ZOOM = 2.5;
 const RESIZE_REFIT_DELAY_MS = 100;
@@ -149,16 +155,19 @@ function CanvasSurface() {
   const { trackClick } = useOmnigentAnalytics();
   const { fitView } = useReactFlow();
   const viewerId = useViewerId();
-  const { sessions, loaded, loadingMore, complete, error, refresh } = useCanvasSessions();
+  const { sessions, loaded, loadingMore, networkConfirmed, error, refresh } = useCanvasSessions();
   const projectsQuery = useProjects();
   const projects = projectsQuery.data ?? EMPTY_PROJECTS;
 
   const [nodes, setNodes] = useState<SessionCardNode[]>([]);
+  // The URL names the canvas; without it, reopen the one last selected here.
   const [activeCanvas, setActiveCanvas] = useState(
-    () => searchParams.get(CANVAS_QUERY_PARAM) ?? MAIN_CANVAS_ID,
+    () => searchParams.get(CANVAS_QUERY_PARAM) ?? readActiveCanvas(viewerId) ?? MAIN_CANVAS_ID,
   );
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
   const activeCanvasRef = useRef(activeCanvas);
+  const activeCanvasViewerRef = useRef(viewerId);
+  const userSelectedCanvasRef = useRef(false);
   // Loaded per viewer (the store is keyed by server and user) in the positions
   // effect below, so identity resolving after mount swaps in the right layout.
   const layoutRef = useRef<CanvasLayout>(EMPTY_CANVAS_LAYOUT);
@@ -271,7 +280,16 @@ function CanvasSurface() {
       { ...layoutRef.current.positions, ...positionsRef.current },
       viewerId,
     );
-  }, [sessions, projects, viewerId]);
+    // Once the full list is known, save every card's spot, grid slots included,
+    // so unmoved cards stay put on the next load; spots of deleted sessions go.
+    if (
+      networkConfirmed &&
+      projectsQuery.data !== undefined &&
+      !samePositions(layoutRef.current.positions, positionsRef.current)
+    ) {
+      persist(withPositions(layoutRef.current, positionsRef.current));
+    }
+  }, [networkConfirmed, persist, projects, projectsQuery.data, sessions, viewerId]);
 
   // Cards follow the active canvas; drags update the node state directly and
   // land in positionsRef on drop, so rebuilding here never loses a move.
@@ -308,10 +326,38 @@ function CanvasSurface() {
     [setSearchParams],
   );
 
+  // Identity can resolve after mount. A bare visit then restores that viewer's
+  // canvas; an explicit URL or a tab picked meanwhile keeps precedence.
+  useEffect(() => {
+    if (activeCanvasViewerRef.current === viewerId) return;
+    activeCanvasViewerRef.current = viewerId;
+    if (searchParams.has(CANVAS_QUERY_PARAM) || userSelectedCanvasRef.current) return;
+    const remembered = readActiveCanvas(viewerId) ?? MAIN_CANVAS_ID;
+    activeCanvasRef.current = remembered;
+    setActiveCanvas(remembered);
+    scheduleFit();
+  }, [scheduleFit, searchParams, viewerId]);
+
+  // Keep a restored project in the URL and remember explicit deep links once
+  // the project list confirms they are valid.
+  useEffect(() => {
+    if (!searchParams.has(CANVAS_QUERY_PARAM) && activeCanvas !== MAIN_CANVAS_ID) {
+      writeCanvasParam(activeCanvas);
+    }
+    if (
+      projectsQuery.data !== undefined &&
+      (activeCanvas === MAIN_CANVAS_ID ||
+        projects.some((project) => projectCanvasId(project) === activeCanvas))
+    ) {
+      writeActiveCanvas(activeCanvas, viewerId);
+    }
+  }, [activeCanvas, projects, projectsQuery.data, searchParams, viewerId, writeCanvasParam]);
+
   const selectCanvas = useCallback(
     (canvasId: string) => {
       if (activeCanvasRef.current === canvasId) return;
       trackClick("canvas.tab");
+      userSelectedCanvasRef.current = true;
       activeCanvasRef.current = canvasId;
       setActiveCanvas(canvasId);
       writeCanvasParam(canvasId);
@@ -329,19 +375,6 @@ function CanvasSurface() {
     writeCanvasParam(MAIN_CANVAS_ID);
     scheduleFit();
   }, [activeCanvas, projects, projectsQuery.data, scheduleFit, writeCanvasParam]);
-
-  // Once the full list is known, forget spots of sessions that no longer exist.
-  useEffect(() => {
-    if (!complete) return;
-    const layout = layoutRef.current;
-    const pruned = prunePositions(
-      layout.positions,
-      sessions.map((session) => session.id),
-    );
-    if (Object.keys(pruned).length !== Object.keys(layout.positions).length) {
-      persist(withPositions(layout, pruned));
-    }
-  }, [complete, persist, sessions]);
 
   // A project created from the tab strip is selected once the list includes it.
   useEffect(() => {
@@ -405,7 +438,7 @@ function CanvasSurface() {
     positionsRef.current = { ...kept, ...mergeSessionPositions(visibleSessions, {}) };
     scheduleFit();
     setNodes(nodesFor(visibleSessions, positionsRef.current, pullRequests));
-    persist(withoutPositions(layoutRef.current, ids));
+    persist(withPositions(layoutRef.current, positionsRef.current));
   }, [nodesFor, persist, pullRequests, scheduleFit, trackClick, visibleSessions]);
 
   const newSession = () => {
@@ -540,13 +573,15 @@ function CanvasSurface() {
           zoomOnDoubleClick={false}
           panOnScroll
           nodeDragThreshold={3}
+          snapToGrid
+          snapGrid={SNAP_GRID}
           onlyRenderVisibleElements
           minZoom={MIN_ZOOM}
           maxZoom={MAX_ZOOM}
           proOptions={proOptions}
         >
           {visibleSessions.length > 0 && (
-            <Background color="var(--border)" bgColor="var(--background)" />
+            <Background gap={GRID_STEP} color="var(--border)" bgColor="var(--background)" />
           )}
           <CanvasControls
             onZoom={markViewportDirty}


### PR DESCRIPTION
## Related issue

N/A — reported directly during pre-release Canvas testing.

## Summary

- Persist every Canvas card's computed position so unmoved cards no longer collapse into vacated grid slots after refresh.
- Reuse the complete session list across navigation and page reloads, avoiding the delayed jump from a short preview to the full Canvas.
- Restore the last-selected project and snap cards to a coarser 32 px grid.
- Treat cached sessions as display-only until a live complete response confirms membership, so stale cache entries cannot prune saved positions.
- Scope session and selected-project caches by server and viewer, and avoid rewriting unchanged full-list snapshots.

ELI5: Canvas now remembers the cards it already loaded, which project you were viewing, and where every card was placed—not only cards you dragged. It still refreshes quietly before using the latest list to remove obsolete positions.

```text
load Canvas -> restore full cached list + selected project -> restore every card position
            -> refresh sessions quietly in background -> persist the complete fresh list
```

## Test Plan

- `cd web && npm test -- --run` (373 files passed, 1 skipped; 7,065 tests passed, 3 expected failures, 1 skipped)
- `pnpm --filter web run type-check`
- `pnpm --filter web run lint`
- `pnpm --filter web run format:check`
- `/Users/corey.zumar/omnigent/.venv/bin/python -m pytest tests/e2e_ui/sessions/test_canvas_page.py -v` (4 passed)
- Updated Canvas unit and E2E coverage for full-list caching, reloads, background completion, stale-cache pruning safety, viewer identity races, project restoration, grid snapping, and moved/unmoved card persistence.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Cold-cache loading state (the short-list state that previously flashed again on every reload):

![Cold-cache Canvas loading a complete session list](https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/canvas-pagination-preview.png)

Complete Canvas state. After the first full load, this entire list is restored synchronously on navigation or reload while the server refresh runs quietly:

![Complete Canvas session list](https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/canvas-pagination-complete.png)

Manually verified through a local proxy against a 624-session Databricks workspace: a reload painted all 624 cards on the first render with no loading spinner or short-list flash. Repeated with `/v1/sessions` blocked after the initial load to prove the first render came from the complete persisted cache.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually tested at `http://127.0.0.1:6769/canvas` through the local authenticated proxy to `omnigents-3272836215725701.aws.databricksapps.com`. Confirmed the complete card set rendered immediately after reload (626/626 in the final verification), card positions survived reloads, the selected project survived navigation, and dragging snapped to the coarser grid.

## Changelog

Canvas now remembers all loaded sessions, the selected project, and every card's position while using a coarser snap grid.
