### PR TITLE
fix(pi): replay startup model override for own-login sessions

### DIFF
--- a/omnigent/harnesses/pi_native/bridge.py
+++ b/omnigent/harnesses/pi_native/bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import hashlib
 import itertools
@@ -31,6 +32,7 @@ _CONFIG_FILE = "config.json"
 _EXTENSION_FILE = "omnigent_pi_native_extension.js"
 _EXTENSION_PACKAGE = "omnigent.resources.pi_native"
 _INBOX_DIR = "inbox"
+_ACK_DIR = "acks"
 _SESSIONS_DIR = "sessions"
 
 
@@ -61,6 +63,7 @@ def prepare_bridge_dir(session_id: str) -> Path:
     bridge_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(bridge_dir, 0o700)
     (bridge_dir / _INBOX_DIR).mkdir(mode=0o700, exist_ok=True)
+    (bridge_dir / _ACK_DIR).mkdir(mode=0o700, exist_ok=True)
     (bridge_dir / _SESSIONS_DIR).mkdir(mode=0o700, exist_ok=True)
     # Owner-pid marker for the periodic dead-owner prune; refreshed every
     # turn so it always names the current runner. See native_bridge_common.
@@ -237,7 +240,12 @@ def enqueue_thinking_level_change(bridge_dir: Path, level: str) -> str:
     return change_id
 
 
-def enqueue_model_change(bridge_dir: Path, model: str) -> str:
+def enqueue_model_change(
+    bridge_dir: Path,
+    model: str,
+    *,
+    wait_for_ack: bool = False,
+) -> str:
     """
     Queue a UI-originated model switch for the resident Pi extension.
 
@@ -251,6 +259,9 @@ def enqueue_model_change(bridge_dir: Path, model: str) -> str:
     :param bridge_dir: Native Pi bridge directory.
     :param model: Model id to switch to, e.g.
         ``"databricks-claude-sonnet-4-6"``.
+    :param wait_for_ack: Ask the resident extension to write an acknowledgement
+        after Pi has accepted or rejected the model. Used during startup replay;
+        ordinary mid-session changes remain fire-and-forget.
     :returns: Opaque model-change id.
     """
     model_change_id = f"model_change_{uuid.uuid4().hex}"
@@ -260,8 +271,42 @@ def enqueue_model_change(bridge_dir: Path, model: str) -> str:
         "model": model,
         "created_at": time.time(),
     }
+    if wait_for_ack:
+        payload["ack_id"] = model_change_id
     _enqueue_payload(bridge_dir, model_change_id, payload)
     return model_change_id
+
+
+async def wait_for_model_change_ack(
+    bridge_dir: Path,
+    change_id: str,
+    *,
+    timeout: float = 15.0,
+) -> bool:
+    """Wait for Pi to accept or reject an acknowledged model change.
+
+    The extension writes the acknowledgement only after ``setModel`` resolves,
+    so a successful return proves the new Pi process actually applied the
+    persisted web selection rather than merely consuming the inbox file.
+
+    :returns: ``True`` when Pi accepted the model; ``False`` on rejection,
+        timeout, malformed acknowledgement, or bridge I/O failure.
+    """
+    ack_path = bridge_dir / _ACK_DIR / f"{change_id}.json"
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            payload = json.loads(await asyncio.to_thread(ack_path.read_text, encoding="utf-8"))
+            if isinstance(payload, dict) and payload.get("id") == change_id:
+                with contextlib.suppress(FileNotFoundError):
+                    ack_path.unlink()
+                return payload.get("ok") is True
+        except FileNotFoundError:
+            pass
+        except (OSError, ValueError):
+            return False
+        await asyncio.sleep(0.1)
+    return False
 
 
 def _enqueue_payload(bridge_dir: Path, item_id: str, payload: _JsonObject) -> None:

--- a/omnigent/resources/pi_native/omnigent_pi_native_extension.js
+++ b/omnigent/resources/pi_native/omnigent_pi_native_extension.js
@@ -972,6 +972,30 @@ async function postModelChangeError(config, message) {
   });
 }
 
+function writeModelChangeAck(config, ackId, ok, error) {
+  if (!config || !config.bridgeDir || typeof ackId !== "string" || !ackId) return;
+  const ackDir = path.join(config.bridgeDir, "acks");
+  const ackPath = path.join(ackDir, `${ackId}.json`);
+  const tmpPath = `${ackPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.mkdirSync(ackDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(
+      tmpPath,
+      JSON.stringify({
+        id: ackId,
+        ok: ok === true,
+        ...(typeof error === "string" && error ? { error } : {}),
+      }),
+      "utf8",
+    );
+    fs.renameSync(tmpPath, ackPath);
+  } catch (_err) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch (_cleanupErr) {}
+  }
+}
+
 function modelReference(model) {
   const modelId = model && typeof model.id === "string" ? model.id : "";
   if (!modelId) return "";
@@ -1162,9 +1186,26 @@ function startInboxPoller(
         // handleModelChange owns its visible-error item and posts nothing on
         // success — the paired model_select handler mirrors the applied model
         // back — so the returned promise is intentionally discarded.
-        handleModelChange(
-          typeof payload.model === "string" ? payload.model : undefined,
-        );
+        Promise.resolve(
+          handleModelChange(
+            typeof payload.model === "string" ? payload.model : undefined,
+          ),
+        )
+          .then((ok) => {
+            if (typeof payload.ack_id === "string") {
+              writeModelChangeAck(config, payload.ack_id, ok === true);
+            }
+          })
+          .catch((err) => {
+            if (typeof payload.ack_id === "string") {
+              writeModelChangeAck(
+                config,
+                payload.ack_id,
+                false,
+                err && err.message ? String(err.message) : "model change failed",
+              );
+            }
+          });
       }
       if (payload.type === "thinking_level_change") {
         // Point-in-time: one delivery attempt, then always consume the file.

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -481,9 +481,10 @@ class _PiNativeLaunchConfig:
 
     A generic session-snapshot reader shared by the pi-native and
     cursor-native launch paths (workspace + terminal_launch_args +
-    model_override). Each path consumes the subset it needs: pi-native
-    uses ``model_override`` as ``--model`` (overrides the spec's pinned
-    model); cursor-native does the same.
+    model_override). Each path consumes the subset it needs: managed
+    pi-native providers use ``model_override`` as ``--model`` while Pi's
+    own-login path replays it through the extension after startup; cursor-native
+    passes it as ``--model``.
 
     :param workspace: Workspace cwd for the native TUI.
     :param server_url: Omnigent server URL for the extension/forwarder.
@@ -500,8 +501,9 @@ class _PiNativeLaunchConfig:
         the cursor-native launch to replay prior turns as a text preamble on
         the first message.
     :param model_override: Persisted per-session ``/model`` override, e.g.
-        ``"claude-4.6-sonnet-medium"``; ``None`` when unset. Consumed by the
-        cursor-native launch (``--model``), ignored by pi-native.
+        ``"claude-4.6-sonnet-medium"``; ``None`` when unset. Consumed by
+        managed pi-native launches as ``--model`` and replayed through the
+        extension for Pi's own-login path; cursor-native also uses ``--model``.
     :param reasoning_effort: Persisted per-session effort, e.g. ``"high"``.
         Consumed by the pi-native launch as ``--thinking``; ``None`` leaves
         Pi's model default in place.
@@ -2193,6 +2195,7 @@ async def _auto_create_pi_terminal(
     # falls back to its own login). Writes a managed per-session Pi config dir,
     # never touching the user's global ``~/.pi/agent``.
     credential_warning: str | None = None
+    startup_model_replay_model: str | None = None
     if not _pi_args_have_provider(launch_config.terminal_launch_args or []):
         from omnigent.harnesses.pi_native.credentials import (
             pi_native_provider_launch,
@@ -2221,6 +2224,12 @@ async def _auto_create_pi_terminal(
                 or provider.credential_warning
                 or launch.effort_warning
             )
+        elif launch_config.model_override:
+            # Pi's own-login provider cannot be represented by Omnigent's
+            # managed ``--provider/--model`` launch path. Replay the persisted
+            # web selection through the resident extension after startup so a
+            # fresh process does not silently fall back to Pi's global default.
+            startup_model_replay_model = launch_config.model_override
     # Inherit the agent's os_env so its sandbox (e.g. ``type: none``),
     # egress_rules and env_passthrough are honoured. Without ``sandbox`` here
     # and ``parent_os_env`` below, launch_required_terminal falls back to
@@ -2246,6 +2255,30 @@ async def _auto_create_pi_terminal(
             tmux_start_on_attach=False,
         ),
     )
+    if startup_model_replay_model is not None:
+        from omnigent.harnesses.pi_native.bridge import (
+            enqueue_model_change,
+            wait_for_model_change_ack,
+        )
+
+        # The launch API has returned, so Pi has been spawned. Queue the
+        # persisted UI selection now; the extension will acknowledge only
+        # after its session_start handler has installed the inbox poller and
+        # Pi's setModel call has completed.
+        startup_model_replay_id = await asyncio.to_thread(
+            enqueue_model_change,
+            bridge_dir,
+            startup_model_replay_model,
+            wait_for_ack=True,
+        )
+        applied = await wait_for_model_change_ack(bridge_dir, startup_model_replay_id)
+        if not applied:
+            _logger.warning(
+                "Pi-native startup model replay was not acknowledged for session %s (model=%s)",
+                session_id,
+                startup_model_replay_model,
+                extra={"session_id": session_id},
+            )
     publish_event(
         session_id,
         {

--- a/tests/test_pi_native_bridge.py
+++ b/tests/test_pi_native_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import stat
 from pathlib import Path
@@ -117,6 +118,65 @@ def test_enqueue_model_change_payload_shape(tmp_path: Path) -> None:
     assert payload["type"] == "model_change"
     assert payload["model"] == "databricks-claude-sonnet-4-6"
     assert isinstance(payload["created_at"], (int, float))
+
+
+def test_enqueue_model_change_acknowledgement_envelope(tmp_path: Path) -> None:
+    """Startup replay requests carry an acknowledgement id; ordinary changes do not."""
+    bridge_dir = tmp_path / "bridge"
+    (bridge_dir / "inbox").mkdir(parents=True)
+
+    acknowledged_id = pi_native_bridge.enqueue_model_change(
+        bridge_dir, "openai-codex/gpt-5.6-sol", wait_for_ack=True
+    )
+    ordinary_id = pi_native_bridge.enqueue_model_change(bridge_dir, "openai-codex/gpt-5.6-terra")
+
+    payloads = {
+        payload["id"]: payload
+        for payload in (
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in (bridge_dir / "inbox").glob("*.json")
+        )
+    }
+    assert payloads[acknowledged_id]["ack_id"] == acknowledged_id
+    assert "ack_id" not in payloads[ordinary_id]
+
+
+def test_wait_for_model_change_ack_returns_acceptance(tmp_path: Path) -> None:
+    """An acknowledgement is consumed only when its id matches the request."""
+    bridge_dir = tmp_path / "bridge"
+    (bridge_dir / "acks").mkdir(parents=True)
+    change_id = "model_change_ack-test"
+    ack_path = bridge_dir / "acks" / f"{change_id}.json"
+    ack_path.write_text(json.dumps({"id": change_id, "ok": True}), encoding="utf-8")
+
+    assert asyncio.run(pi_native_bridge.wait_for_model_change_ack(bridge_dir, change_id)) is True
+    assert not ack_path.exists()
+
+
+def test_wait_for_model_change_ack_returns_false_for_rejection_and_timeout(tmp_path: Path) -> None:
+    """Rejected and missing acknowledgements never make startup replay look successful."""
+    bridge_dir = tmp_path / "bridge"
+    (bridge_dir / "acks").mkdir(parents=True)
+    change_id = "model_change_rejected-test"
+    (bridge_dir / "acks" / f"{change_id}.json").write_text(
+        json.dumps({"id": change_id, "ok": False, "error": "not available"}),
+        encoding="utf-8",
+    )
+
+    assert (
+        asyncio.run(
+            pi_native_bridge.wait_for_model_change_ack(bridge_dir, change_id, timeout=0.01)
+        )
+        is False
+    )
+    assert (
+        asyncio.run(
+            pi_native_bridge.wait_for_model_change_ack(
+                bridge_dir, "model_change_missing", timeout=0.01
+            )
+        )
+        is False
+    )
 
 
 def test_enqueue_user_message_payload_shape(tmp_path: Path) -> None:

--- a/tests/test_pi_native_extension.py
+++ b/tests/test_pi_native_extension.py
@@ -1587,7 +1587,12 @@ fs.mkdirSync(inboxDir, { recursive: true });
 fs.writeFileSync(payloadPath, JSON.stringify({ id: "compact-1", type: "compact" }));
 fs.writeFileSync(
   configPath,
-  JSON.stringify({ serverUrl: "http://omnigent.test", sessionId: "session-1", inboxDir }),
+  JSON.stringify({
+    serverUrl: "http://omnigent.test",
+    sessionId: "session-1",
+    inboxDir,
+    bridgeDir: inboxDir,
+  }),
 );
 
 process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
@@ -2654,7 +2659,12 @@ const inboxDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-model-inbox-"));
 const configPath = path.join(inboxDir, "config.json");
 fs.writeFileSync(
   configPath,
-  JSON.stringify({ serverUrl: "http://omnigent.test", sessionId: "session-1", inboxDir }),
+  JSON.stringify({
+    serverUrl: "http://omnigent.test",
+    sessionId: "session-1",
+    inboxDir,
+    bridgeDir: inboxDir,
+  }),
 );
 process.env.OMNIGENT_PI_NATIVE_CONFIG = configPath;
 
@@ -2783,6 +2793,48 @@ def test_inbox_model_change_unknown_model_posts_error(tmp_path: Path) -> None:
   const errs = errorItems();
   assert.equal(errs.length, 1, JSON.stringify(posted));
   assert.match(errs[0].data.item_data.message, /not available/);
+  finish();
+})().catch((error) => {
+  finish();
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+});
+"""
+    )
+    _run_extension_script(node, _extension_path(), script)
+
+
+def test_inbox_model_change_acknowledges_startup_replay(tmp_path: Path) -> None:
+    """An acknowledged model change writes success only after ``setModel`` resolves."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required for the pi-native extension e2e test")
+
+    script = (
+        _MODEL_SWITCH_HARNESS
+        + r"""
+(async () => {
+  await handlers.session_start({}, ctx);
+  const changeId = "model_change_startup-test";
+  const ackPath = path.join(inboxDir, "acks", `${changeId}.json`);
+  const file = path.join(inboxDir, "000-startup-model.json");
+  fs.writeFileSync(
+    file,
+    JSON.stringify({
+      id: changeId,
+      type: "model_change",
+      model: "omnigent/databricks-claude-opus-4-1",
+      ack_id: changeId,
+    }),
+  );
+  const deadline = Date.now() + 3000;
+  while (!fs.existsSync(ackPath)) {
+    if (Date.now() > deadline) throw new Error("model_change ack was not written");
+    await sleep(20);
+  }
+  const ack = JSON.parse(fs.readFileSync(ackPath, "utf8"));
+  assert.deepEqual(ack, { id: changeId, ok: true });
+  assert.equal(setModelCalls.length, 1, JSON.stringify(setModelCalls));
   finish();
 })().catch((error) => {
   finish();


### PR DESCRIPTION
## Summary

Part of #6427.

Pi-native sessions using Pi's own login path currently ignore the persisted web `model_override` on a fresh launch. The session starts with Pi's global default, while the same model can be applied later from the terminal view.

This change replays the persisted model selection through the existing Pi extension inbox after the process starts, and waits for an acknowledgement that `setModel` accepted or rejected it.

## Changes

- Add an opt-in acknowledgement envelope to Pi-native `model_change` payloads.
- Have the extension atomically write an acknowledgement after `setModel` resolves.
- Replay a persisted model override after a fresh own-login Pi terminal launches.
- Keep ordinary mid-session model changes fire-and-forget.
- Add bridge and extension coverage for startup replay acknowledgement, rejection, and timeout paths.

Managed Omnigent providers continue to use the existing startup `--provider/--model` path.

## Tests

- `.venv/bin/python -m pytest --noconftest -o addopts='' -q tests/test_pi_native_bridge.py tests/test_pi_native_extension.py`: 62 passed
- `.venv/bin/python -m pytest --noconftest -o addopts='' -q tests/runner/test_app_sessions_native_terminals_autocreate.py -k 'pi_terminal'`: 3 passed
- `node --check omnigent/resources/pi_native/omnigent_pi_native_extension.js`: passed