### PR TITLE
fix(claude-native): hide unroutable managed-gateway models

### DIFF
--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from prompt_toolkit.layout.controls import FormattedTextControl
     from prompt_toolkit.styles import Style
 
+    from omnigent.onboarding.ambient import ClaudeManagedSettings
     from omnigent.onboarding.provider_config import ProviderEntry
     from omnigent.spec.types import AgentSpec
 
@@ -439,21 +440,64 @@ def _serves_canonical_anthropic_ids(claude_config: ClaudeNativeUcodeConfig) -> b
     return host == "anthropic.com" or host.endswith(".anthropic.com")
 
 
-def _ambient_env_is_non_anthropic_gateway() -> bool:
-    """Whether the ambient process env routes through a non-Anthropic gateway.
+def _managed_claude_settings() -> ClaudeManagedSettings | None:
+    """Read Claude Code's authoritative managed-settings launch state."""
+    from omnigent.onboarding.ambient import claude_managed_settings
 
-    Used as the ``claude_config is None`` counterpart to
-    :func:`_serves_canonical_anthropic_ids`: when managed settings (e.g. Isaac)
-    set ``ANTHROPIC_BASE_URL`` to a Databricks gateway, the catalog and its
-    fingerprint must treat the env as a non-canonical endpoint.
+    return claude_managed_settings(_managed_settings_paths())
+
+
+def _ambient_claude_gateway_base_url_from(
+    managed_settings: ClaudeManagedSettings | None,
+) -> str | None:
+    """Return the effective ambient endpoint from one settings snapshot."""
+    ambient = os.environ.get(_UCODE_CLAUDE_BASE_URL_ENV, "").strip()
+    if ambient:
+        return ambient
+    return managed_settings.base_url if managed_settings is not None else None
+
+
+def _ambient_claude_gateway_base_url() -> str | None:
+    """The endpoint a config-less Claude launch actually inferences against.
+
+    An enterprise install pins the gateway in Claude Code's managed settings,
+    which omnigent never adopts as a provider, so it is absent from this
+    process env. Reading the env alone reports such a launch as canonical
+    Anthropic when it is really a gateway.
+
+    :returns: The base URL, or ``None`` when no endpoint override applies.
     """
-    from urllib.parse import urlparse
+    return _ambient_claude_gateway_base_url_from(_managed_claude_settings())
 
-    base_url = os.environ.get(_UCODE_CLAUDE_BASE_URL_ENV, "")
+
+def _ambient_env_is_non_anthropic_gateway_from(
+    managed_settings: ClaudeManagedSettings | None,
+) -> bool:
+    """Classify the ambient endpoint using one managed-settings snapshot."""
+    ambient_base_url = os.environ.get(_UCODE_CLAUDE_BASE_URL_ENV, "").strip()
+    base_url = ambient_base_url or (
+        managed_settings.base_url if managed_settings is not None else None
+    )
     if not base_url:
+        return False
+    if not ambient_base_url and not _managed_claude_model_pins_have_catalog_prefix_from(
+        managed_settings
+    ):
         return False
     host = (urlparse(base_url).hostname or "").lower()
     return host != "anthropic.com" and not host.endswith(".anthropic.com")
+
+
+def _ambient_env_is_non_anthropic_gateway() -> bool:
+    """Whether a config-less launch routes through a non-Anthropic gateway.
+
+    The ``claude_config is None`` counterpart to
+    :func:`_serves_canonical_anthropic_ids`. An explicit process env keeps its
+    existing endpoint semantics. A managed-settings endpoint counts only when
+    its model pins prove that it uses catalog-prefixed ids, so an unrelated
+    third-party gateway that accepts bare Anthropic ids is left unchanged.
+    """
+    return _ambient_env_is_non_anthropic_gateway_from(_managed_claude_settings())
 
 
 def _claude_family(token: str) -> str | None:
@@ -747,31 +791,49 @@ def _claude_model_display_name(tier: str, model_id: str) -> str:
     return f"{family} {'.'.join(version_parts)}" if version_parts else family
 
 
-def _managed_claude_model_config() -> ClaudeNativeUcodeConfig | None:
-    """Read the model overrides Claude Code applies from managed settings."""
+def _managed_claude_model_config_from(
+    managed_settings: ClaudeManagedSettings | None,
+) -> ClaudeNativeUcodeConfig | None:
+    """Build model overrides from one managed-settings snapshot."""
+    if managed_settings is None:
+        return None
     allowed_env = {
         *_UCODE_CLAUDE_TIER_TO_ENV.values(),
         _ANTHROPIC_CUSTOM_MODEL_OPTION_ENV,
         _ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV,
     }
-    for path in _managed_settings_paths():
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
+    managed_env = dict(managed_settings.model_env)
+    model_env = {key: value for key, value in managed_env.items() if key in allowed_env}
+    default_model = managed_env.get(_ANTHROPIC_MODEL_ENV)
+    if not model_env and not default_model:
+        return None
+    return ClaudeNativeUcodeConfig(env=model_env, model=default_model)
+
+
+def _managed_claude_model_config() -> ClaudeNativeUcodeConfig | None:
+    """Read the model overrides Claude Code applies from managed settings."""
+    return _managed_claude_model_config_from(_managed_claude_settings())
+
+
+def _managed_claude_model_pins_have_catalog_prefix_from(
+    managed_settings: ClaudeManagedSettings | None,
+) -> bool:
+    """Check all model pins in one managed-settings snapshot for a namespace."""
+    from omnigent.models.claude_model_vocabulary import prefix_folded_model_id
+
+    if managed_settings is None:
+        return False
+    for env_var, model in managed_settings.model_env:
+        if env_var == _ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV:
             continue
-        raw_env = payload.get("env") if isinstance(payload, dict) else None
-        if not isinstance(raw_env, dict):
-            continue
-        model_env = {
-            key: value.strip()
-            for key, value in raw_env.items()
-            if key in allowed_env and isinstance(value, str) and value.strip()
-        }
-        if model_env:
-            raw_default = raw_env.get(_ANTHROPIC_MODEL_ENV)
-            default_model = raw_default.strip() if isinstance(raw_default, str) else None
-            return ClaudeNativeUcodeConfig(env=model_env, model=default_model or None)
-    return None
+        if prefix_folded_model_id(model) != model.lower():
+            return True
+    return False
+
+
+def _managed_claude_model_pins_have_catalog_prefix() -> bool:
+    """Whether managed settings pin a model in a known gateway namespace."""
+    return _managed_claude_model_pins_have_catalog_prefix_from(_managed_claude_settings())
 
 
 def managed_claude_gateway_signal() -> tuple[str | None, bool]:
@@ -1207,8 +1269,36 @@ async def probe_claude_model_options(
     )
 
 
+def _claude_catalog_fingerprint(
+    claude_config: ClaudeNativeUcodeConfig | None,
+    managed_settings: ClaudeManagedSettings | None,
+) -> str:
+    """Build a launch fingerprint from one managed-settings snapshot."""
+    from omnigent.claude_launcher import resolve_claude_launch
+    from omnigent.models.model_catalog_store import binary_identity, fingerprint_of
+
+    command, _ = resolve_claude_launch("claude", [])
+    ambient_gateway = (
+        _ambient_claude_gateway_base_url_from(managed_settings) if claude_config is None else None
+    )
+    managed_model_env = (
+        managed_settings.model_env
+        if claude_config is None and managed_settings is not None
+        else None
+    )
+    return fingerprint_of(
+        "claude-native",
+        sorted(claude_config.env.items()) if claude_config is not None else None,
+        claude_config.api_key_helper if claude_config is not None else None,
+        claude_config.model if claude_config is not None else None,
+        binary_identity(command),
+        ambient_gateway,
+        managed_model_env,
+    )
+
+
 def claude_catalog_fingerprint(claude_config: ClaudeNativeUcodeConfig | None) -> str:
-    """The launch fingerprint keying claude's shared model catalog.
+    """The launch fingerprint keying Claude's shared model catalog.
 
     One formula for every consumer (host boot probe, runner launch, session
     listing), so they read and write the same catalog file.
@@ -1221,19 +1311,66 @@ def claude_catalog_fingerprint(claude_config: ClaudeNativeUcodeConfig | None) ->
     :param claude_config: The resolved launch config, or ``None``.
     :returns: A stable fingerprint string.
     """
-    from omnigent.claude_launcher import resolve_claude_launch
-    from omnigent.models.model_catalog_store import binary_identity, fingerprint_of
+    managed_settings = _managed_claude_settings() if claude_config is None else None
+    return _claude_catalog_fingerprint(claude_config, managed_settings)
 
-    command, _ = resolve_claude_launch("claude", [])
-    ambient_gateway = os.environ.get(_UCODE_CLAUDE_BASE_URL_ENV) if claude_config is None else None
-    return fingerprint_of(
-        "claude-native",
-        sorted(claude_config.env.items()) if claude_config is not None else None,
-        claude_config.api_key_helper if claude_config is not None else None,
-        claude_config.model if claude_config is not None else None,
-        binary_identity(command),
-        ambient_gateway,
-    )
+
+async def _claude_model_catalog(
+    claude_config: ClaudeNativeUcodeConfig | None,
+    managed_settings: ClaudeManagedSettings | None,
+) -> list[dict[str, object]] | None:
+    """Build a Claude catalog from one managed-settings snapshot."""
+    probe = await probe_claude_model_options(claude_config)
+    if probe is None:
+        return None
+    rows = list(probe.alias_rows)
+    non_canonical = (
+        claude_config is not None and not _serves_canonical_anthropic_ids(claude_config)
+    ) or (claude_config is None and _ambient_env_is_non_anthropic_gateway_from(managed_settings))
+    if non_canonical:
+        rows = [row for row in rows if not str(row.get("model", "")).startswith("claude-")]
+
+    from omnigent.models.claude_model_vocabulary import prefix_folded_model_id
+
+    configured_pin = claude_config.model if claude_config is not None else None
+    default_model = configured_pin or probe.default_model
+    folded_default = prefix_folded_model_id(default_model) if default_model else ""
+    marked = False
+    out: list[dict[str, object]] = []
+    for row in rows:
+        is_default = (
+            bool(default_model)
+            and not marked
+            and (
+                prefix_folded_model_id(str(row.get("model", ""))) == folded_default
+                or row.get("id") == default_model
+            )
+        )
+        if is_default:
+            marked = True
+            out.append({**row, "isDefault": True})
+        else:
+            out.append({key: value for key, value in row.items() if key != "isDefault"})
+    if default_model and not marked:
+        canonical_ids_ok = (claude_config is None and not non_canonical) or (
+            claude_config is not None and _serves_canonical_anthropic_ids(claude_config)
+        )
+        servable = canonical_ids_ok or not default_model.startswith("claude-")
+        if servable:
+            label = (
+                probe.default_label
+                if default_model == probe.default_model and probe.default_label
+                else default_model
+            )
+            out.append(
+                {
+                    "id": default_model,
+                    "model": default_model,
+                    "displayName": label,
+                    "isDefault": True,
+                }
+            )
+    return out
 
 
 async def claude_model_catalog(
@@ -1255,57 +1392,8 @@ async def claude_model_catalog(
     :param claude_config: The resolved launch config, or ``None``.
     :returns: Catalog rows, or ``None`` when the probe failed.
     """
-    probe = await probe_claude_model_options(claude_config)
-    if probe is None:
-        return None
-    rows = list(probe.alias_rows)
-    _non_canonical = (
-        claude_config is not None and not _serves_canonical_anthropic_ids(claude_config)
-    ) or (claude_config is None and _ambient_env_is_non_anthropic_gateway())
-    if _non_canonical:
-        rows = [row for row in rows if not str(row.get("model", "")).startswith("claude-")]
-
-    configured_pin = claude_config.model if claude_config is not None else None
-    default_model = configured_pin or probe.default_model
-    marked = False
-    out: list[dict[str, object]] = []
-    for row in rows:
-        is_default = (
-            bool(default_model)
-            and not marked
-            and (row.get("model") == default_model or row.get("id") == default_model)
-        )
-        if is_default:
-            marked = True
-            out.append({**row, "isDefault": True})
-        else:
-            out.append({key: value for key, value in row.items() if key != "isDefault"})
-    if default_model and not marked:
-        # Append the observed default as its own honest row — but never
-        # claim a bare Anthropic id is launchable on an endpoint that
-        # rejects that spelling.
-        _canonical_ids_ok = (
-            claude_config is None and not _ambient_env_is_non_anthropic_gateway()
-        ) or (claude_config is not None and _serves_canonical_anthropic_ids(claude_config))
-        servable = _canonical_ids_ok or not default_model.startswith("claude-")
-        if servable:
-            # The probe's printed label describes the ENUMERATION run's
-            # model; it only names a config-pinned default when the two are
-            # the same model.
-            label = (
-                probe.default_label
-                if default_model == probe.default_model and probe.default_label
-                else default_model
-            )
-            out.append(
-                {
-                    "id": default_model,
-                    "model": default_model,
-                    "displayName": label,
-                    "isDefault": True,
-                }
-            )
-    return out
+    managed_settings = _managed_claude_settings() if claude_config is None else None
+    return await _claude_model_catalog(claude_config, managed_settings)
 
 
 async def claude_launch_catalog(
@@ -1323,9 +1411,12 @@ async def claude_launch_catalog(
     """
     from omnigent.models import model_catalog_store
 
-    fingerprint = claude_catalog_fingerprint(claude_config)
+    managed_settings = _managed_claude_settings() if claude_config is None else None
+    fingerprint = _claude_catalog_fingerprint(claude_config, managed_settings)
     return await model_catalog_store.ensure_catalog(
-        "claude-native", fingerprint, lambda: claude_model_catalog(claude_config)
+        "claude-native",
+        fingerprint,
+        lambda: _claude_model_catalog(claude_config, managed_settings),
     )
 
 
@@ -1344,9 +1435,12 @@ async def claude_reprobed_launch_catalog(
     """
     from omnigent.models import model_catalog_store
 
-    fingerprint = claude_catalog_fingerprint(claude_config)
+    managed_settings = _managed_claude_settings() if claude_config is None else None
+    fingerprint = _claude_catalog_fingerprint(claude_config, managed_settings)
     return await model_catalog_store.reprobe_catalog(
-        "claude-native", fingerprint, lambda: claude_model_catalog(claude_config)
+        "claude-native",
+        fingerprint,
+        lambda: _claude_model_catalog(claude_config, managed_settings),
     )
 
 
@@ -1359,8 +1453,9 @@ def claude_launch_catalog_is_stale(claude_config: ClaudeNativeUcodeConfig | None
     """
     from omnigent.models import model_catalog_store
 
+    managed_settings = _managed_claude_settings() if claude_config is None else None
     return model_catalog_store.catalog_is_stale(
-        "claude-native", claude_catalog_fingerprint(claude_config)
+        "claude-native", _claude_catalog_fingerprint(claude_config, managed_settings)
     )
 
 

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -77,6 +77,16 @@ CLAUDE_CODE_MANAGED_SETTINGS_PATHS: tuple[Path, ...] = (
     Path(os.environ.get("PROGRAMDATA", "C:/ProgramData")) / "ClaudeCode" / "managed-settings.json",
 )
 
+
+@dataclass(frozen=True)
+class ClaudeManagedSettings:
+    """Non-secret launch state from Claude Code's authoritative managed settings."""
+
+    base_url: str | None
+    has_credential: bool
+    model_env: tuple[tuple[str, str], ...]
+
+
 # Maps each provider whose env key we surface to the served model family.
 # Providers absent here (or mapped to ``None``) are reported with
 # ``family=None`` — their key is detected but no harness surface is
@@ -492,30 +502,17 @@ def claude_auth_has_credential(creds_path: Path) -> bool:
     return False
 
 
-def claude_managed_gateway(
+def claude_managed_settings(
     paths: tuple[Path, ...] | None = None,
-) -> tuple[str | None, bool]:
-    """Read the credential Claude Code applies from its managed settings chain.
+) -> ClaudeManagedSettings | None:
+    """Read the first authoritative object in Claude Code's managed settings chain.
 
-    The single canonical parser for Claude Code's managed-settings credential,
-    shared by ambient detection, the readiness gate, and the Smart-Routing
-    gateway check (:func:`omnigent.harnesses.claude_native.main.managed_claude_gateway_signal`
-    delegates here). A credential counts as delivered when the file carries a
-    top-level ``apiKeyHelper`` (a token-printing command) or a truthy
-    ``env.CLAUDE_CODE_USE_GATEWAY``.
-
-    The **first readable, object-shaped** file decides, matching Claude Code's
-    own precedence: a settings file that exists but pins no credential reports
-    "none" rather than falling through to a lower-precedence file it would
-    itself override.
+    Only non-secret fields that affect launch behavior are returned. Model env
+    pairs are sorted so callers can safely include them in cache fingerprints.
 
     :param paths: Settings files to read, highest precedence first; defaults to
         :data:`CLAUDE_CODE_MANAGED_SETTINGS_PATHS`.
-    :returns: ``(base_url, has_credential)`` from the first readable file, or
-        ``(None, False)`` when none is present or parseable. ``base_url`` is the
-        gateway ``env.ANTHROPIC_BASE_URL`` (``None`` when unset — a helper alone
-        credentials api.anthropic.com); ``has_credential`` is whether Claude
-        Code has a usable credential to apply at launch.
+    :returns: The first readable object as non-secret launch state, or ``None``.
     """
     for path in CLAUDE_CODE_MANAGED_SETTINGS_PATHS if paths is None else paths:
         try:
@@ -534,8 +531,44 @@ def claude_managed_gateway(
             "0",
             "false",
         )
-        return base_url or None, has_helper or use_gateway
-    return None, False
+        model_env = tuple(
+            sorted(
+                (key, value.strip())
+                for key, value in env.items()
+                if isinstance(key, str)
+                and isinstance(value, str)
+                and value.strip()
+                and (
+                    key == "ANTHROPIC_MODEL"
+                    or key == "ANTHROPIC_CUSTOM_MODEL_OPTION"
+                    or key == "ANTHROPIC_CUSTOM_MODEL_OPTION_NAME"
+                    or (key.startswith("ANTHROPIC_DEFAULT_") and key.endswith("_MODEL"))
+                )
+            )
+        )
+        return ClaudeManagedSettings(
+            base_url=base_url or None,
+            has_credential=has_helper or use_gateway,
+            model_env=model_env,
+        )
+    return None
+
+
+def claude_managed_gateway(
+    paths: tuple[Path, ...] | None = None,
+) -> tuple[str | None, bool]:
+    """Read the credential Claude Code applies from its managed settings chain.
+
+    The first readable, object-shaped file decides, matching Claude Code's own
+    precedence. Credential commands and tokens never leave the parser.
+
+    :param paths: Settings files to read, highest precedence first.
+    :returns: ``(base_url, has_credential)``, or ``(None, False)``.
+    """
+    settings = claude_managed_settings(paths)
+    if settings is None:
+        return None, False
+    return settings.base_url, settings.has_credential
 
 
 def claude_managed_gateway_display_name(paths: tuple[Path, ...] | None = None) -> str | None:

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -990,3 +990,31 @@ def test_claude_managed_gateway_first_readable_file_decides(clean_env, monkeypat
     low.write_text(json.dumps(_ISAAC_CLAUDE_SETTINGS))
     monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (high, low))
     assert ambient.claude_managed_gateway() == (None, False)
+
+
+def test_claude_managed_settings_returns_normalized_model_pins(clean_env, monkeypatch) -> None:
+    """The launch snapshot exposes sorted, trimmed model state but no secrets."""
+    path = _write_managed_settings(
+        clean_env,
+        monkeypatch,
+        {
+            "env": {
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": " system.ai.claude-sonnet-4-6 ",
+                "ANTHROPIC_MODEL": "system.ai.claude-opus-4-8",
+                "ANTHROPIC_BASE_URL": " https://gateway.example.com/anthropic ",
+                "ANTHROPIC_API_KEY": "secret",
+            },
+            "apiKeyHelper": "print-secret",
+        },
+    )
+
+    settings = ambient.claude_managed_settings((path,))
+
+    assert settings == ambient.ClaudeManagedSettings(
+        base_url="https://gateway.example.com/anthropic",
+        has_credential=True,
+        model_env=(
+            ("ANTHROPIC_DEFAULT_SONNET_MODEL", "system.ai.claude-sonnet-4-6"),
+            ("ANTHROPIC_MODEL", "system.ai.claude-opus-4-8"),
+        ),
+    )

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -3989,14 +3989,14 @@ async def test_auto_create_claude_terminal_refreshes_a_stale_catalog_before_rese
         refreshed_rows.append({"id": "haiku", "model": "claude-haiku-4-5-20251001"})
     probes: list[int] = []
 
-    async def _probe(config: object) -> list[dict[str, object]]:
-        del config
+    async def _probe(config: object, settings: object) -> list[dict[str, object]]:
+        del config, settings
         probes.append(1)
         if refresh == "fails":
             raise OSError("provider unreachable")
         return refreshed_rows
 
-    monkeypatch.setattr("omnigent.harnesses.claude_native.main.claude_model_catalog", _probe)
+    monkeypatch.setattr("omnigent.harnesses.claude_native.main._claude_model_catalog", _probe)
     fingerprint = claude_catalog_fingerprint(None)
     model_catalog_store.write_catalog("claude-native", fingerprint, stale_rows)
     path = model_catalog_store.catalog_path("claude-native", fingerprint)
@@ -4235,12 +4235,12 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
     )
     refreshed = [{"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}]
 
-    async def _fake_probe_catalog(config: object) -> list[dict[str, object]]:
-        del config
+    async def _fake_probe_catalog(config: object, settings: object) -> list[dict[str, object]]:
+        del config, settings
         return refreshed
 
     monkeypatch.setattr(
-        "omnigent.harnesses.claude_native.main.claude_model_catalog", _fake_probe_catalog
+        "omnigent.harnesses.claude_native.main._claude_model_catalog", _fake_probe_catalog
     )
     fingerprint = claude_catalog_fingerprint(None)
     model_catalog_store.write_catalog(

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -56,6 +56,10 @@ from tests._image_fixtures import (
 
 @pytest.fixture(autouse=True)
 def _stub_catalog_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The gateway lookup reads Claude Code's managed settings, so leave the
+    # host's real file out of it: an enterprise install would otherwise make
+    # every "no ambient gateway" case read as a gateway.
+    monkeypatch.setattr(claude_native, "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS", ())
     monkeypatch.setattr(
         "omnigent.models.model_catalog.resolve_catalog_model",
         lambda provider_name, *, family, **kwargs: SimpleNamespace(
@@ -10352,12 +10356,12 @@ async def test_claude_launch_catalog_reads_the_store_then_probes_once(
     monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
     calls: list[int] = []
 
-    async def _fake_catalog(config: object) -> list[dict[str, object]]:
-        del config
+    async def _fake_catalog(config: object, settings: object) -> list[dict[str, object]]:
+        del config, settings
         calls.append(1)
         return [{"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}]
 
-    monkeypatch.setattr(claude_native, "claude_model_catalog", _fake_catalog)
+    monkeypatch.setattr(claude_native, "_claude_model_catalog", _fake_catalog)
     first = await claude_native.claude_launch_catalog(None)
     second = await claude_native.claude_launch_catalog(None)
     assert first == second == [{"id": "sonnet", "model": "claude-sonnet-5", "isDefault": True}]
@@ -10819,6 +10823,48 @@ def test_catalog_fingerprint_includes_ambient_gateway_url(
     assert fp_with_gateway != fp_different_gateway
 
 
+def test_catalog_fingerprint_changes_when_managed_model_pins_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin-only managed-settings edits cannot reuse the previous catalog."""
+    binary = tmp_path / "claude"
+    binary.write_text("binary")
+    _point_claude_at(monkeypatch, binary)
+    managed_settings = tmp_path / "managed-settings.json"
+    monkeypatch.setattr(
+        claude_native,
+        "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS",
+        (managed_settings,),
+    )
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    base_env = {"ANTHROPIC_BASE_URL": "https://gateway.example.com/anthropic"}
+    managed_settings.write_text(
+        json.dumps(
+            {
+                "env": {
+                    **base_env,
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8[1m]",
+                }
+            }
+        )
+    )
+    bare_pin = claude_native.claude_catalog_fingerprint(None)
+
+    managed_settings.write_text(
+        json.dumps(
+            {
+                "env": {
+                    **base_env,
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "system.ai.claude-opus-4-8[1m]",
+                }
+            }
+        )
+    )
+    prefixed_pin = claude_native.claude_catalog_fingerprint(None)
+
+    assert bare_pin != prefixed_pin
+
+
 async def test_claude_model_catalog_filters_canonical_ids_for_ambient_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -10855,6 +10901,211 @@ async def test_claude_model_catalog_filters_canonical_ids_for_ambient_gateway(
     assert [row["id"] for row in rows] == ["sonnet-gateway"]
     # No canonical claude-* models
     assert all(not str(row.get("model", "")).startswith("claude-") for row in rows)
+
+
+def _isaac_managed_settings(tmp_path: Path) -> Path:
+    """Managed settings shaped like an enterprise install writes them.
+
+    The gateway and the family pins live here and nowhere else, so omnigent
+    resolves no provider config and its own env names no endpoint. Only
+    opus/sonnet/haiku are pinned, mirroring what Isaac writes.
+    """
+    path = tmp_path / "managed-settings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://dbc-test.cloud.databricks.com/ai-gateway/anthropic",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "system.ai.claude-opus-4-8[1m]",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "system.ai.claude-sonnet-4-6[1m]",
+                },
+                "apiKeyHelper": "printf token",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+async def test_claude_model_catalog_drops_bare_ids_on_a_managed_gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A managed-settings gateway counts even though it never enters the env.
+
+    Claude Code resolves every alias no ``ANTHROPIC_DEFAULT_*_MODEL`` pins to a
+    canonical Anthropic id the gateway rejects. Reading only the process env
+    reported this launch as canonical Anthropic, which switched the servability
+    filter off and published those rows as launchable.
+    """
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        claude_native,
+        "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS",
+        (_isaac_managed_settings(tmp_path),),
+    )
+
+    async def _fake_probe(config: object) -> claude_native.ClaudeModelProbe:
+        del config
+        return claude_native.ClaudeModelProbe(
+            alias_rows=[
+                {
+                    "id": "opus",
+                    "model": "system.ai.claude-opus-4-8[1m]",
+                    "displayName": "Opus 4.8 (1M context)",
+                },
+                {"id": "fable", "model": "claude-fable-5-1", "displayName": "Fable 5.1"},
+            ],
+            default_model="system.ai.claude-opus-4-8[1m]",
+            default_label="Opus 4.8 (1M context)",
+        )
+
+    monkeypatch.setattr(claude_native, "probe_claude_model_options", _fake_probe)
+    rows = await claude_native.claude_model_catalog(None)
+    assert rows is not None
+    assert [row["id"] for row in rows] == ["opus"]
+
+
+async def test_claude_model_catalog_keeps_bare_ids_for_unprefixed_managed_gateway(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A custom managed gateway needs prefix evidence before filtering rows."""
+    managed_settings = tmp_path / "managed-settings.json"
+    managed_settings.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://gateway.example.com/anthropic",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8[1m]",
+                },
+                "apiKeyHelper": "printf token",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        claude_native,
+        "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS",
+        (managed_settings,),
+    )
+
+    async def _fake_probe(config: object) -> claude_native.ClaudeModelProbe:
+        del config
+        return claude_native.ClaudeModelProbe(
+            alias_rows=[
+                {
+                    "id": "opus",
+                    "model": "claude-opus-4-8[1m]",
+                    "displayName": "Opus 4.8 (1M context)",
+                },
+                {"id": "fable", "model": "claude-fable-5-1", "displayName": "Fable 5.1"},
+            ],
+            default_model="claude-opus-4-8[1m]",
+            default_label="Opus 4.8 (1M context)",
+        )
+
+    monkeypatch.setattr(claude_native, "probe_claude_model_options", _fake_probe)
+    rows = await claude_native.claude_model_catalog(None)
+    assert rows is not None
+    assert [row["id"] for row in rows] == ["opus", "fable"]
+
+
+def test_managed_gateway_uses_one_file_for_url_and_prefix_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lower-precedence namespace pin cannot classify the winning URL."""
+    high = tmp_path / "high.json"
+    high.write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://gateway.example.com/anthropic"}})
+    )
+    low = tmp_path / "low.json"
+    low.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://ignored.example.com/anthropic",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "system.ai.claude-opus-4-8[1m]",
+                }
+            }
+        )
+    )
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setattr(claude_native, "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (high, low))
+
+    assert claude_native._ambient_env_is_non_anthropic_gateway() is False
+
+
+def test_managed_global_model_pin_is_catalog_prefix_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ANTHROPIC_MODEL participates in managed gateway classification."""
+    managed_settings = tmp_path / "managed-settings.json"
+    managed_settings.write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://gateway.example.com/anthropic",
+                    "ANTHROPIC_MODEL": "system.ai.claude-opus-4-8[1m]",
+                }
+            }
+        )
+    )
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        claude_native,
+        "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS",
+        (managed_settings,),
+    )
+
+    assert claude_native._ambient_env_is_non_anthropic_gateway() is True
+
+
+async def test_claude_model_catalog_marks_a_bare_reported_default_on_its_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare reported default marks its gateway-spelled row, not a second one.
+
+    Claude Code names its default in its own spelling, which can be the bare
+    Anthropic id where the alias row carries the gateway's ``system.ai.`` one.
+    Comparing verbatim left the row unmarked and appended the bare id as its own
+    row: two rows one version of one family apart, only one of them routable.
+    """
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        claude_native,
+        "_CLAUDE_CODE_MANAGED_SETTINGS_PATHS",
+        (_isaac_managed_settings(tmp_path),),
+    )
+
+    async def _fake_probe(config: object) -> claude_native.ClaudeModelProbe:
+        del config
+        return claude_native.ClaudeModelProbe(
+            alias_rows=[
+                {
+                    "id": "opus",
+                    "model": "system.ai.claude-opus-4-8[1m]",
+                    "displayName": "Opus 4.8 (1M context)",
+                }
+            ],
+            default_model="claude-opus-4-8[1m]",
+            default_label="Opus 4.8 (1M context)",
+        )
+
+    monkeypatch.setattr(claude_native, "probe_claude_model_options", _fake_probe)
+    rows = await claude_native.claude_model_catalog(None)
+    assert rows == [
+        {
+            "id": "opus",
+            "model": "system.ai.claude-opus-4-8[1m]",
+            "displayName": "Opus 4.8 (1M context)",
+            "isDefault": True,
+        }
+    ]
 
 
 async def test_claude_model_catalog_keeps_canonical_ids_without_ambient_gateway(


### PR DESCRIPTION
## Related issue

[OMNI-6867](https://linear.app/omnigent/issue/OMNI-6867/duplicate-model-issue)

## Summary

Claude Code enterprise installs can configure an AI Gateway only through `managed-settings.json`. Omnigent did not recognize that endpoint while building the Claude-native model catalog, so it exposed bare Anthropic model IDs that the gateway could not serve and sometimes duplicated the configured default.

- Parse one authoritative managed-settings snapshot and use it consistently for the endpoint, model pins, namespace evidence, and catalog fingerprint.
- Remove bare `claude-*` rows only when managed model pins (including `ANTHROPIC_MODEL`) prove that the endpoint uses a known catalog namespace (`system.ai.` or `databricks-`), preserving third-party gateways that accept bare IDs.
- Invalidate the catalog when normalized managed model pins change, even when the gateway URL stays the same.
- Match a reported default to its gateway-prefixed row without dropping the distinct `[1m]` context marker.

ELI5: Claude knew it was using a company gateway, but Omnigent thought it was talking directly to Anthropic and offered model names the gateway did not recognize. Omnigent now reads the same managed signal and keeps only names proven appropriate for that gateway.

```text
managed-settings.json
  base URL + catalog-prefixed model pins
                   |
                   v
Claude model probe ---> Omnigent catalog filter
                              |
                              v
                 one routable default/model row
```

## Test Plan

- `pre-commit run --all-files`
- `pytest -q tests/onboarding/test_ambient.py tests/test_claude_native.py -k 'claude_managed or claude_model_catalog or claude_launch_catalog or catalog_fingerprint or ambient_env_is_non_anthropic_gateway or managed_gateway or managed_global_model_pin'` — 34 passed
- Runner catalog refresh regressions — 5 passed
- Regression coverage verifies `system.ai.*` managed gateways, unprefixed third-party gateways, pin-only fingerprint changes, cross-file precedence, and global `ANTHROPIC_MODEL` namespace evidence.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The focused regression suite reproduces the catalog rows directly: prefixed managed gateways discard unroutable bare rows, while unprefixed managed gateways retain them.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated regressions cover the affected managed-settings catalog composition and the OSS-safe unprefixed-gateway behavior.

## Changelog

Claude's model picker no longer offers duplicate or unroutable models when enterprise managed settings use a catalog-prefixed AI Gateway.
