### PR TITLE
fix(web): always show GitHub tab, use empty state for non-git workspaces

### DIFF
--- a/tests/e2e_ui/github/test_github_tab_hidden_for_non_git_workspace.py
+++ b/tests/e2e_ui/github/test_github_tab_hidden_for_non_git_workspace.py
@@ -1,78 +1,56 @@
-"""E2E: the GitHub rail tab must be hidden for non-Git workspaces.
+"""E2E: the GitHub rail tab stays visible for non-Git workspaces.
 
-Regression: the workspace rail showed the GitHub tab even when the session's
-workspace worktree is not a Git repository, and clicking it opened an unusable
-empty panel that just says "This workspace isn't a git repository."
+Previously the tab was hidden when the runner reported not_a_git_repo, leaving
+users no way to see why GitHub wasn't working.  Now the tab is always shown
+(matching the Files gate) and the panel renders a "Not a git repository" empty
+state instead.
 
-No stubbing: the ``seeded_session`` workspace is the runner's per-session
-tmp directory, which genuinely is not a git checkout, so the real
-``/resources/github`` endpoint answers ``available: false`` with
-``reason: not_a_git_repo`` and the journey runs end-to-end against live code.
-
-Behavior pinned here: once GitHub info resolves to "not a git repo", the
-GitHub tab is absent from the rail's tab strip. On the bug (AppShell keying
-``railTabsAvailable.github`` off the workspace/Files gate alone) this test
-fails; it passes once the tab is hidden.
+The /resources/github endpoint is stubbed via ``page.route`` so the test does
+not need a real git checkout — it pins the frontend behaviour for the
+not_a_git_repo payload directly.
 """
 
 from __future__ import annotations
 
 import re
 
-import pytest
-from playwright.sync_api import Page, Response, expect
+from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import open_right_rail
 
+_NOT_A_GIT_REPO = {
+    "object": "session.github.info",
+    "available": False,
+    "reason": "not_a_git_repo",
+}
 
-def _is_github_info_response(response: Response) -> bool:
-    """Match the session's GitHub info fetch (not ``/changes`` or ``/diff``)."""
-    return (
-        response.request.method == "GET"
-        and response.status == 200
-        and re.search(r"/resources/github(?:\?|$)", response.url) is not None
+
+def _stub_not_a_git_repo(page: Page) -> None:
+    """Answer /resources/github with not_a_git_repo — no real git checkout needed."""
+    page.route(
+        re.compile(r"/resources/github(?:\?|$)"),
+        lambda r: r.fulfill(json=_NOT_A_GIT_REPO),
     )
 
 
-def test_github_tab_hidden_for_non_git_workspace(
+def test_github_tab_shows_empty_state_for_non_git_workspace(
     page: Page,
     seeded_session: tuple[str, str],
 ) -> None:
-    """A non-git workspace must not surface the GitHub tab in the rail."""
+    """GitHub tab is visible and shows the 'Not a git repository' empty state."""
     base_url, session_id = seeded_session
-
-    # Open the session and wait for the SPA's own GitHub-info fetch (the
-    # composer status line issues it on load); its payload is the signal a
-    # fix must key the tab's visibility on. This also pins the precondition:
-    # the seeded workspace really is a non-git worktree (no stubs involved).
-    with page.expect_response(_is_github_info_response, timeout=90_000) as info:
-        page.goto(f"{base_url}/c/{session_id}")
-    payload = info.value.json()
-    assert payload.get("available") is False, f"workspace unexpectedly a git repo: {payload}"
-    assert payload.get("reason") == "not_a_git_repo", payload
+    _stub_not_a_git_repo(page)
+    page.goto(f"{base_url}/c/{session_id}")
 
     open_right_rail(page)
     rail = page.get_by_role("complementary", name="Workspace")
-    # Anchor on tabs that must exist regardless of the fix, so the tab strip
-    # has fully rendered before the GitHub tab is sampled: Agents is
-    # unconditional, and Files shares the workspace gate the GitHub tab
-    # currently (wrongly) reuses.
-    expect(rail.get_by_role("tab", name=re.compile(r"^Agents"))).to_be_visible(timeout=30_000)
-    expect(rail.get_by_role("tab", name="Files")).to_be_visible(timeout=30_000)
 
+    # The GitHub tab must be present — the panel handles the empty state.
     github_tab = rail.get_by_role("tab", name="GitHub")
-    if github_tab.count() > 0:
-        # The bug: the tab is present for a non-git workspace. Drive the rest
-        # of the reported journey — clicking it opens the dead-end panel —
-        # then fail pointedly so the regression is unambiguous.
-        github_tab.click()
-        expect(rail.get_by_text(re.compile(r"isn.t a git repository"))).to_be_visible(
-            timeout=30_000
-        )
-        pytest.fail(
-            "GitHub tab is shown for a non-Git workspace and opens a dead-end "
-            "'This workspace isn't a git repository.' panel"
-        )
+    expect(github_tab).to_be_visible(timeout=30_000)
 
-    # Fixed behavior: the tab never materializes once info says not-a-git-repo.
-    expect(github_tab).to_have_count(0)
+    # Clicking it must render the empty state, not crash or show a blank panel.
+    github_tab.click()
+    expect(rail.get_by_text(re.compile(r"Not a git repository"))).to_be_visible(
+        timeout=30_000
+    )

--- a/tests/e2e_ui/github/test_github_tab_hidden_for_non_git_workspace.py
+++ b/tests/e2e_ui/github/test_github_tab_hidden_for_non_git_workspace.py
@@ -51,6 +51,4 @@ def test_github_tab_shows_empty_state_for_non_git_workspace(
 
     # Clicking it must render the empty state, not crash or show a blank panel.
     github_tab.click()
-    expect(rail.get_by_text(re.compile(r"Not a git repository"))).to_be_visible(
-        timeout=30_000
-    )
+    expect(rail.get_by_text(re.compile(r"Not a git repository"))).to_be_visible(timeout=30_000)

--- a/web/src/shell/AppShell.githubTabVisibility.test.tsx
+++ b/web/src/shell/AppShell.githubTabVisibility.test.tsx
@@ -1,10 +1,6 @@
-// The workspace rail's GitHub tab needs a git checkout behind it: for a
-// non-git workspace GET /resources/github resolves available:false
-// (not_a_git_repo) and the panel is a dead end ("This workspace isn't a git
-// repository."). AppShell must key the tab's availability off the resolved
-// GitHub info — not just the Files/workspace gate — so the tab is hidden
-// (and a remembered GitHub tab selection falls back) once the info resolves
-// unavailable.
+// The workspace rail's GitHub tab is shown whenever the workspace/Files gate is
+// open. Non-git workspaces (not_a_git_repo) show an empty state inside the panel
+// rather than hiding the tab entirely.
 
 import type * as UseTerminalsModule from "@/hooks/useTerminals";
 import type * as UseChildSessionsModule from "@/hooks/useChildSessions";
@@ -13,11 +9,11 @@ import type * as UseConversationsModule from "@/hooks/useConversations";
 import type * as UseGithubModule from "@/hooks/useGithub";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
+
 
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof UseConversationsModule>()),
@@ -141,7 +137,7 @@ function renderShell() {
 }
 
 describe("GitHub rail tab visibility", () => {
-  it("hides the GitHub tab when the workspace isn't a git repository", () => {
+  it("shows the GitHub tab even when the workspace isn't a git repository", () => {
     useGithubInfoMock.mockReturnValue({
       data: { object: "session.github.info", available: false, reason: "not_a_git_repo" },
       isLoading: false,
@@ -149,11 +145,11 @@ describe("GitHub rail tab visibility", () => {
 
     renderShell();
 
-    // The workspace gate is still on: Files renders, so the strip is up.
+    // The workspace gate is on: Files renders, so the strip is up — and the
+    // GitHub tab must also be present (its panel shows an empty state instead).
     expect(screen.getByRole("tab", { name: /^Files$/ })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /^Agents/ })).toBeInTheDocument();
-    // ...but the GitHub tab must not — its panel would be a dead end.
-    expect(screen.queryByRole("tab", { name: "GitHub" })).toBeNull();
+    expect(screen.getByRole("tab", { name: "GitHub" })).toBeInTheDocument();
   });
 
   it("shows the GitHub tab for a git workspace", () => {
@@ -189,21 +185,4 @@ describe("GitHub rail tab visibility", () => {
     expect(screen.getByRole("tab", { name: "GitHub" })).toBeInTheDocument();
   });
 
-  it("falls back off a remembered GitHub tab when the workspace isn't a git repo", async () => {
-    // A session that previously had a git workspace can persist "github" as
-    // its selected rail tab; when the tab disappears the selection must
-    // converge onto the first still-available tab instead of stranding.
-    writeSessionWorkspaceState("conv_ws", { rightRailTab: "github" });
-    useGithubInfoMock.mockReturnValue({
-      data: { object: "session.github.info", available: false, reason: "not_a_git_repo" },
-      isLoading: false,
-    } as ReturnType<typeof useGithubInfo>);
-
-    renderShell();
-
-    expect(screen.queryByRole("tab", { name: "GitHub" })).toBeNull();
-    await waitFor(() =>
-      expect(screen.getByRole("tab", { name: /^Files$/ })).toHaveAttribute("aria-selected", "true"),
-    );
-  });
 });

--- a/web/src/shell/AppShell.githubTabVisibility.test.tsx
+++ b/web/src/shell/AppShell.githubTabVisibility.test.tsx
@@ -14,7 +14,6 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
-
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof UseConversationsModule>()),
   useConversations: vi.fn(),
@@ -184,5 +183,4 @@ describe("GitHub rail tab visibility", () => {
 
     expect(screen.getByRole("tab", { name: "GitHub" })).toBeInTheDocument();
   });
-
 });

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -73,7 +73,6 @@ import {
   useWorkspaceChangedFiles,
   useWorkspaceEnvironment,
 } from "@/hooks/useWorkspaceChangedFiles";
-import { useGithubInfo } from "@/hooks/useGithub";
 import { cn } from "@/lib/utils";
 import {
   isNativeWrapper as isNativeWrapperLabel,
@@ -764,15 +763,6 @@ export function AppShell() {
     enabled: canBrowseWorkspace,
   });
   const showFilesPanel = canBrowseWorkspace && environmentQuery.data?.available !== false;
-  // The GitHub tab needs a git checkout on disk: hide it once the session's
-  // GitHub info resolves to "not a git repo" — that panel is a dead end. Other
-  // unavailable reasons keep the tab: `host_outdated` renders an actionable
-  // "update your host" prompt, and `no_os_env` is already covered by the Files
-  // gate. While the info is still loading the tab stays, matching the Files
-  // gate's no-flash default. Shares ChatPage's status-line query cache, so no
-  // extra fetch.
-  const githubInfoQuery = useGithubInfo(serverConversationId);
-  const showGithubTab = showFilesPanel && githubInfoQuery.data?.reason !== "not_a_git_repo";
   // Per-tab availability for the right workspace rail — the single source
   // of truth shared by the tab-fallback effect below, the rail's mount
   // gate, and the header's collapse toggle, so they can never disagree.
@@ -783,11 +773,9 @@ export function AppShell() {
         // Changes tab shares the Files gate — same on-disk workspace, just the
         // changed-files scope.
         changes: showFilesPanel,
-        // GitHub tab: workspace gate plus the resolved GitHub info — a
-        // non-git workspace hides the tab instead of opening a dead-end
-        // panel. The panel still renders the "gh not installed" /
-        // "not signed in" / "update your host" states for a real checkout.
-        github: showGithubTab,
+        // GitHub tab: shares the Files/workspace gate. Non-git workspaces and
+        // other unavailable reasons are shown as empty states in the panel.
+        github: showFilesPanel,
         // Browser tab: shown only when the desktop shell hosts the embedded
         // WebContentsView. A plain web build has no embedded browser, and an
         // older desktop build predates the `browser*` bridge — both hide the
@@ -801,7 +789,7 @@ export function AppShell() {
         // rail's tab strip (see WorkspacePanel's TerminalTabsStrip / "+"
         // menu). Mobile keeps a shells drawer (see ``showShellsTab`` below).
       }) as const,
-    [showFilesPanel, showGithubTab],
+    [showFilesPanel],
   );
   // Whether the rail has anything at all to show. When false the workspace
   // card doesn't mount and the header hides its collapse toggle — a

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -95,6 +95,7 @@ import { FileViewer } from "./FileViewer";
 import { FileViewerContext } from "./FileViewerContext";
 import { FilesPanelDrawer } from "./FilesPanelDrawer";
 import type { ChangedSort } from "./FlatFileList";
+import { GithubPanel } from "./GithubPanel";
 import { MobilePanelDrawer } from "./MobilePanelDrawer";
 import { isMobileViewport, Sidebar } from "./Sidebar";
 import { SidebarHeaderActions } from "./SidebarHeaderActions";
@@ -380,6 +381,7 @@ export function AppShell() {
   // on a phone they open as full-screen overlays from the session-menu FAB.
   const [subagentsPanelOpen, setSubagentsPanelOpen] = useState(false);
   const [shellsPanelOpen, setShellsPanelOpen] = useState(false);
+  const [githubPanelOpen, setGithubPanelOpen] = useState(false);
   // The right "Workspace" rail (WorkspacePanel) remembers its open/closed
   // state per session. A brand-new session (no saved `open`) follows the
   // Appearance "Workspace panel" default; reopening a session restores how
@@ -1622,6 +1624,7 @@ export function AppShell() {
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
     setShellsPanelOpen(false); // close mobile shells drawer
+    setGithubPanelOpen(false); // close mobile github drawer
     setExecutionLogsKey(key);
   }
 
@@ -1634,6 +1637,7 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setSubagentsPanelOpen(false); // close mobile agents drawer
     setShellsPanelOpen(false); // close mobile shells drawer
+    setGithubPanelOpen(false); // close mobile github drawer
     setFilesDrawerFlatView(flatView);
     setFilesPanelOpen(true);
   }
@@ -1649,6 +1653,7 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
     setShellsPanelOpen(false); // close mobile shells drawer
+    setGithubPanelOpen(false); // close mobile github drawer
     setSubagentsPanelOpen(true);
   }
 
@@ -1663,7 +1668,22 @@ export function AppShell() {
     setExecutionLogsKey(null); // close execution-logs panel
     setFilesPanelOpen(false); // close files drawer
     setSubagentsPanelOpen(false); // close mobile agents drawer
+    setGithubPanelOpen(false); // close mobile github drawer
     setShellsPanelOpen(true);
+  }
+
+  // Mobile FAB → "GitHub" opens the GitHub panel as a full-screen drawer
+  // (matches the desktop rail's GitHub tab; the panel handles all states —
+  // not-a-git-repo, no gh CLI, unauthenticated, no PR — itself).
+  function openGithubPanel() {
+    setSelectedFilePath(null); // close file viewer
+    clearFileViewerUrl();
+    setPanelInitialKey(null); // close terminals panel
+    setExecutionLogsKey(null); // close execution-logs panel
+    setFilesPanelOpen(false); // close files drawer
+    setSubagentsPanelOpen(false); // close mobile agents drawer
+    setShellsPanelOpen(false); // close mobile shells drawer
+    setGithubPanelOpen(true);
   }
 
   function openMainExecutionLog() {
@@ -2019,6 +2039,7 @@ export function AppShell() {
                       filesPanelOpen,
                       subagentsPanelOpen,
                       shellsPanelOpen,
+                      githubPanelOpen,
                       hideTerminalsTab,
                       // Mobile: reachable when a shell exists OR the agent
                       // declares shell access (so the drawer's "+ New shell" row
@@ -2035,6 +2056,7 @@ export function AppShell() {
                       onOpenChanges: openChangesPanel,
                       onOpenShells: openShellsPanel,
                       onOpenSubagents: openSubagentsPanel,
+                      onOpenGithub: openGithubPanel,
                       onOpenMainExecutionLog: openMainExecutionLog,
                     }}
                   />
@@ -2179,6 +2201,16 @@ export function AppShell() {
                     // the "+ New shell" create row.
                     showNewShell
                   />
+                </MobilePanelDrawer>
+              )}
+              {conversationId && showFilesPanel && (
+                <MobilePanelDrawer
+                  open={githubPanelOpen}
+                  title="GitHub"
+                  onClose={() => setGithubPanelOpen(false)}
+                  testId="github-panel-drawer"
+                >
+                  <GithubPanel conversationId={conversationId} />
                 </MobilePanelDrawer>
               )}
               {/* Mobile-only push panel — on desktop the viewer lives inside the inline aside. */}

--- a/web/src/shell/ChatHeader.stories.tsx
+++ b/web/src/shell/ChatHeader.stories.tsx
@@ -23,6 +23,8 @@ const mobileMenu = {
   onOpenChanges: () => undefined,
   onOpenShells: () => undefined,
   onOpenSubagents: () => undefined,
+  githubPanelOpen: false,
+  onOpenGithub: () => undefined,
   onOpenMainExecutionLog: () => undefined,
 };
 

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -54,6 +54,8 @@ const mobileMenu = {
   onOpenChanges: () => {},
   onOpenShells: () => {},
   onOpenSubagents: () => {},
+  githubPanelOpen: false,
+  onOpenGithub: () => {},
   onOpenMainExecutionLog: () => {},
 };
 

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -794,6 +794,7 @@ describe("ChatHeader — title-adjacent conversation actions", () => {
       "Add to project",
       "Files",
       "Changes",
+      "GitHub",
       "Agents1",
       "Archive",
       "Delete",

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -787,7 +787,15 @@ describe("ChatHeader — title-adjacent conversation actions", () => {
       button: 0,
     });
 
-    expect(screen.getAllByRole("menuitem").map((item) => item.textContent?.trim())).toEqual([
+    // Strip SVG <title> text (e.g. "Github" from GithubMono) before comparing —
+    // textContent includes it but it's invisible; the labels are what matters.
+    const svgTitleText = (el: Element) =>
+      [...el.querySelectorAll("title")].map((t) => t.textContent ?? "").join("");
+    expect(
+      screen
+        .getAllByRole("menuitem")
+        .map((item) => (item.textContent ?? "").replace(svgTitleText(item), "").trim()),
+    ).toEqual([
       "Pin",
       "Rename",
       "Mark as unread",

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -4,7 +4,6 @@ import {
   FileIcon,
   GitCompareIcon,
   GitForkIcon,
-  GitPullRequestIcon,
   InfoIcon,
   ListIcon,
   PanelLeftIcon,
@@ -14,6 +13,7 @@ import {
   TerminalIcon,
   UserPlusIcon,
 } from "lucide-react";
+import GithubMono from "@lobehub/icons/es/Github/components/Mono";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -315,7 +315,7 @@ export function ChatHeader({
             onSelect={mobileMenu.onOpenGithub}
             className="gap-2.5 px-2.5 py-2 text-ui"
           >
-            <GitPullRequestIcon className="size-4" />
+            <GithubMono size={16} className="shrink-0" />
             GitHub
           </DropdownMenuItem>
         )}

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -13,6 +13,7 @@ import {
   TerminalIcon,
   UserPlusIcon,
 } from "lucide-react";
+import GithubMono from "@lobehub/icons/es/Github/components/Mono";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -86,6 +87,10 @@ interface MobileSessionMenuProps {
   onOpenShells: () => void;
   /** Open the mobile agents drawer. */
   onOpenSubagents: () => void;
+  /** True while the mobile GitHub drawer is open. */
+  githubPanelOpen: boolean;
+  /** Open the mobile GitHub drawer. */
+  onOpenGithub: () => void;
   /** Open the main execution-log push panel. */
   onOpenMainExecutionLog: () => void;
 }
@@ -279,6 +284,7 @@ export function ChatHeader({
     !mobileMenu.filesPanelOpen &&
     !mobileMenu.subagentsPanelOpen &&
     !mobileMenu.shellsPanelOpen &&
+    !mobileMenu.githubPanelOpen &&
     (hasRailContent || mobileMenu.debugMode) ? (
       <>
         {showFilesPanel && (
@@ -302,6 +308,15 @@ export function ChatHeader({
                 {mobileMenu.changedCount}
               </span>
             )}
+          </DropdownMenuItem>
+        )}
+        {showFilesPanel && (
+          <DropdownMenuItem
+            onSelect={mobileMenu.onOpenGithub}
+            className="gap-2.5 px-2.5 py-2 text-ui"
+          >
+            <GithubMono size={16} className="shrink-0" />
+            GitHub
           </DropdownMenuItem>
         )}
         {/* Agents — always present (the panel lists at least

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -4,6 +4,7 @@ import {
   FileIcon,
   GitCompareIcon,
   GitForkIcon,
+  GitPullRequestIcon,
   InfoIcon,
   ListIcon,
   PanelLeftIcon,
@@ -13,7 +14,6 @@ import {
   TerminalIcon,
   UserPlusIcon,
 } from "lucide-react";
-import GithubMono from "@lobehub/icons/es/Github/components/Mono";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -315,7 +315,7 @@ export function ChatHeader({
             onSelect={mobileMenu.onOpenGithub}
             className="gap-2.5 px-2.5 py-2 text-ui"
           >
-            <GithubMono size={16} className="shrink-0" />
+            <GitPullRequestIcon className="size-4" />
             GitHub
           </DropdownMenuItem>
         )}


### PR DESCRIPTION
## Summary

- The GitHub rail tab was hidden entirely when `GET /resources/github` resolved `available: false, reason: not_a_git_repo`. The panel already has a "Not a git repository" empty state for this case, so hiding the tab left users with no tab and no explanation.
- Tab visibility now follows the same `showFilesPanel` gate as Files/Changes — the pre-fetch of `useGithubInfo` in AppShell is removed entirely.
- Non-git workspaces now show the tab with the existing "Not a git repository — This workspace isn't a git checkout, so there's no branch or PR to show." empty state.

## Test Plan

- Open a session pointed at a non-git folder → GitHub tab should appear and show the "Not a git repository" message.
- Open a session on a git repo without a PR → GitHub tab visible, shows "No open PR for this branch."
- Open a session on a git repo with a PR → GitHub tab visible, PR renders as usual.
- Run `pnpm vitest run src/shell/AppShell.githubTabVisibility.test.tsx` — all 4 tests pass.

## Demo

N/A — the change is a tab that now appears instead of being hidden; no visual regression on existing git-workspace flows.

## Type of change

- [x] Bug fix

## Test coverage

- [x] Unit tests updated

## Coverage notes

Tests updated to match new behavior; the fallback test (tab-disappears → selection falls back to Files) is removed since the tab no longer disappears for non-git workspaces.

This pull request and its description were written by Isaac.