### PR TITLE
[Omnigent] Use persisted seed for background titles

### DIFF
--- a/omnigent/server/background_session_titles.py
+++ b/omnigent/server/background_session_titles.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any
 from omnigent.entities.conversation import (
     DEFAULT_GENERATED_TITLE_MAX_CHARS,
     USER_SESSION_TITLE_MAX_CHARS,
-    synthesize_conversation_title,
 )
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import background_title_generators
@@ -383,14 +382,15 @@ class PendingBackgroundSessionTitle:
 
     coordinator: BackgroundSessionTitleCoordinator
     request: BackgroundTitleRequest
-    expected_seed_title: str
 
-    def schedule(self) -> None:
-        """Start the prepared title attempt without blocking the caller."""
+    def schedule(self, *, expected_seed_title: str | None) -> None:
+        """Start the attempt using the title persisted by the active store."""
+        if expected_seed_title is None:
+            return
         self.coordinator.schedule(
             session_id=self.request.session_id,
             prompt=self.request.prompt,
-            expected_seed_title=self.expected_seed_title,
+            expected_seed_title=expected_seed_title,
             agent_id=self.request.agent_id,
             harness_override=self.request.harness_override,
             model_override=self.request.model_override,
@@ -419,9 +419,6 @@ def prepare_background_session_title(
     if not prompt:
         return None
 
-    expected_seed_title = synthesize_conversation_title([{"type": "input_text", "text": prompt}])
-    if expected_seed_title is None:
-        return None
     return PendingBackgroundSessionTitle(
         coordinator=coordinator,
         request=BackgroundTitleRequest(
@@ -432,7 +429,6 @@ def prepare_background_session_title(
             model_override=conversation.model_override,
             sub_agent_name=conversation.sub_agent_name,
         ),
-        expected_seed_title=expected_seed_title,
     )
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2349,7 +2349,7 @@ async def _persist_external_conversation_item(
             _publish_external_conversation_item(session_id, persisted_error)
     await _seed_missing_title_from_user_message(conv, item, conversation_store)
     if pending_background_title is not None:
-        pending_background_title.schedule()
+        pending_background_title.schedule(expected_seed_title=conv.title)
     _publish_external_conversation_item(
         session_id, persisted, cleared_pending_id=cleared_pending_id
     )
@@ -8972,7 +8972,7 @@ async def _create_session_from_existing_agent(
                     host_store=getattr(request.app.state, "host_store", None),
                 )
                 if pending_background_title is not None:
-                    pending_background_title.schedule()
+                    pending_background_title.schedule(expected_seed_title=conv.title)
     # Re-read rather than reusing the local ``conv``: the label-only branch
     # above and ``_forward_event_to_runner`` can mutate the row after it was
     # built, so a fresh read is what keeps the create response current.

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1965,7 +1965,7 @@ def register_events_routes(
                 created_by=created_by,
             )
             if pending_background_title is not None:
-                pending_background_title.schedule()
+                pending_background_title.schedule(expected_seed_title=conv.title)
             return {"queued": True, "item_id": item_id}
         dispatch = await _dispatch_session_event_to_runner(
             session_id,
@@ -1985,7 +1985,7 @@ def register_events_routes(
             host_store=getattr(request.app.state, "host_store", None),
         )
         if pending_background_title is not None:
-            pending_background_title.schedule()
+            pending_background_title.schedule(expected_seed_title=conv.title)
         response: dict[str, Any] = {"queued": True}
         if dispatch.item_id is not None:
             response["item_id"] = dispatch.item_id

--- a/tests/server/test_background_session_titles.py
+++ b/tests/server/test_background_session_titles.py
@@ -102,10 +102,9 @@ async def test_prepare_background_title_from_message(db_uri: str) -> None:
         prompt="please investigate the authentication timeout",
         agent_id=agent_id,
     )
-    assert pending.expected_seed_title == "please investigate the authentication timeout"
 
 
-async def test_prepare_background_title_from_slash_command(db_uri: str) -> None:
+async def test_slash_command_background_title_uses_persisted_seed(db_uri: str) -> None:
     store = SqlAlchemyConversationStore(db_uri)
     conversation = store.create_conversation(kind="default")
 
@@ -123,7 +122,12 @@ async def test_prepare_background_title_from_slash_command(db_uri: str) -> None:
 
     assert pending is not None
     assert pending.request.prompt == "/grill-me review this plan"
-    assert pending.expected_seed_title == "/grill-me review this plan"
+    persisted = store.update_conversation(conversation.id, title="grill-me review this plan")
+    assert persisted is not None
+    pending.schedule(expected_seed_title=persisted.title)
+    await pending.coordinator.wait_for_idle()
+
+    assert store.get_conversation(conversation.id).title == "Review migration plan"
 
 
 @pytest.mark.parametrize("excluded_session", ["titled", "child"])

--- a/tests/server/test_background_title_persisted_seed.py
+++ b/tests/server/test_background_title_persisted_seed.py
@@ -1,0 +1,127 @@
+"""Regression: background session titles must use the persisted seed.
+
+The background title coordinator's compare-and-swap guard
+(``expected_seed_title``) must be the exact deterministic title the
+conversation store persisted for the first turn. Deriving the guard
+independently from the raw prompt diverges from the persisted seed for
+multi-block first-turn content: a native session that attaches a file sends
+the user's typed text plus a standalone ``"[Attached: <path>]"``
+``input_text`` block (see ``omnigent/inner/*_native_executor.py`` /
+``omnigent/inner/native_attachments.py``), and
+``synthesize_conversation_title`` drops a line that is *exactly* an
+attachment marker, so:
+
+* the store persists the seed with the marker block dropped
+  (``"review this build failure"``), while
+* a guard re-derived from the *joined* prompt keeps the marker on the same
+  line (``"review this build failure [Attached: ...]"``).
+
+When the guard and the persisted seed diverge, ``_wait_for_seed`` sees a
+non-``None`` title that never equals the guard, returns ``False``, and the
+coordinator silently skips generation (and the later
+``rename_conversation_if_title_matches`` compare-and-swap is keyed on the
+same wrong guard anyway). The session then keeps its deterministic
+truncated-prompt title forever and the generated title is dropped.
+
+This exercises the real coordinator + real ``SqlAlchemyConversationStore`` +
+real ``prepare_background_session_title`` + real seed path
+(``_seed_missing_title_from_user_message``), scheduling with the persisted
+title exactly as the /events route does. Only the title generator is
+stubbed, standing in for the runner/LLM call -- the established seam in
+``tests/server/test_background_session_titles.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from omnigent.entities.conversation import MessageData, NewConversationItem
+from omnigent.server.background_session_titles import (
+    BackgroundSessionTitleCoordinator,
+    BackgroundTitleRequest,
+    prepare_background_session_title,
+)
+from omnigent.server.routes._sessions.helpers import _seed_missing_title_from_user_message
+from omnigent.server.schemas import SessionEventInput
+from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
+
+pytestmark = pytest.mark.asyncio
+
+# The first-turn message shape a native session produces when a file is
+# attached: the user's typed text followed by a standalone "[Attached: <path>]"
+# marker block injected by the native executor.
+_USER_TEXT = "review this build failure"
+_ATTACHMENT_MARKER = "[Attached: /tmp/omnigent-bridge/build.log]"
+_FIRST_TURN_CONTENT: list[dict[str, str]] = [
+    {"type": "input_text", "text": _USER_TEXT},
+    {"type": "input_text", "text": _ATTACHMENT_MARKER},
+]
+
+# What the title model would return for this session.
+_GENERATED_TITLE = "Review The Build Failure"
+
+
+async def test_background_title_uses_persisted_seed_for_attachment_first_turn(
+    db_uri: str,
+) -> None:
+    store = SqlAlchemyConversationStore(db_uri)
+    conversation = store.create_conversation(kind="default", agent_id=uuid.uuid4().hex)
+    # A native harness both injects the "[Attached: <path>]" marker block and is
+    # one of the harnesses that runs background title inference.
+    conversation.harness_override = "claude-native"
+
+    event = SessionEventInput(
+        type="message",
+        data={"role": "user", "content": _FIRST_TURN_CONTENT},
+    )
+
+    async def generator(_request: BackgroundTitleRequest) -> str:
+        return _GENERATED_TITLE
+
+    coordinator = BackgroundSessionTitleCoordinator(
+        store,
+        generator,
+        # Keep the seed wait short so a genuine miss fails fast instead of
+        # blocking the suite; the seed is persisted before scheduling below, so
+        # a correct build resolves immediately.
+        seed_wait_seconds=2.0,
+    )
+
+    # 1) Prepare the title attempt exactly as the /events route does, from the
+    #    raw first-turn event.
+    pending = prepare_background_session_title(
+        coordinator=coordinator,
+        conversation=conversation,
+        event=event,
+    )
+    assert pending is not None, "native first-turn message should schedule a title attempt"
+
+    # 2) Persist the deterministic seed the same way the /events route does,
+    #    from the same first-turn content. This is the value that actually lands
+    #    in the store; we do not hand-craft it. The helper also updates
+    #    ``conversation.title`` in place, which is what the route passes on.
+    item = NewConversationItem(
+        type="message",
+        response_id="resp_first_turn",
+        data=MessageData(role="user", content=_FIRST_TURN_CONTENT),
+    )
+    await _seed_missing_title_from_user_message(conversation, item, store)
+    persisted_seed = store.get_conversation(conversation.id).title
+    assert persisted_seed is not None, "store should seed a deterministic title"
+
+    # 3) Run the coordinator's one guarded attempt against the real store,
+    #    scheduling with the persisted title exactly as the route does.
+    pending.schedule(expected_seed_title=conversation.title)
+    await coordinator.wait_for_idle()
+
+    # The generated title must win. On a build whose compare-and-swap guard is
+    # re-derived from the joined prompt (keeping the attachment marker) instead
+    # of the persisted seed (marker block dropped), generation is skipped and
+    # the session keeps its deterministic truncated-prompt title.
+    final_title = store.get_conversation(conversation.id).title
+    assert final_title == _GENERATED_TITLE, (
+        f"background title was dropped: expected {_GENERATED_TITLE!r}, session "
+        f"still titled {final_title!r}; persisted seed was {persisted_seed!r}"
+    )


### PR DESCRIPTION
## Related issue

Closes #6782

## Summary

- Use the exact first-turn title persisted by the active conversation store as the background rename compare-and-swap guard.
- Keep the raw user or skill prompt unchanged for title generation, without introducing global title sanitization.
- Skip scheduling until a deterministic title has actually been persisted.

## Test Plan

- `uv run --no-sync pytest -q tests/server/test_background_session_titles.py`
- `uv run --no-sync pytest -q tests/server/test_background_session_titles.py tests/server/integration/test_sessions_endpoints.py -k 'background_title or skill_slash_command'`
- `uv run --no-sync pre-commit run --all-files`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused integration selection covers first-message, initial-item, native-item, manual-rename race, and skill slash-command title flows.

## Changelog

Sessions started with skills now receive generated background titles when storage normalizes their initial names.

## Issues

Resolves [OMNI-6900](https://linear.app/omnigent/issue/OMNI-6900/use-the-persisted-seed-for-background-session-titles)
