### PR TITLE
Feat/GitHub policy write violation action: Closes #6700

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -310,6 +310,7 @@ Controls GitHub access across MCP tools and `git`/`gh` shell commands. Restricts
 | `read_repos` | string[] | `[]` | Repos readable when `read_all` is false (`owner/repo` or URLs) |
 | `write_repos` | string[] | `[]` | Repos the agent may write to |
 | `write_branches` | string[] | `[]` | Branches writable within allowed repos (empty = any) |
+| `write_violation_action` | `"DENY"` \| `"ASK"` | `"DENY"` | Verdict on a write outside the allowlist, or one whose target cannot be determined |
 | `mcp_tool_prefixes` | string[] | `["mcp__github__", "github__"]` | Tool-name prefixes to match |
 | `shell_tools` | string[] | `["sys_os_shell"]` | Shell tools whose commands are parsed for git/gh |
 
@@ -324,6 +325,22 @@ github_access:
     write_branches:
       - "feature/*"
       - "fix/*"
+```
+
+Set `write_violation_action: ASK` for a trusted allowlist that should still
+permit user-authorized work elsewhere: listed repos are written silently, and
+anything else asks instead of failing the turn. Destructive operations, force
+pushes and tag pushes keep denying, since those are refused on their own merits
+rather than for missing the allowlist.
+
+```yaml
+github_access:
+  type: function
+  handler: omnigent.policies.builtins.github.github_policy
+  factory_params:
+    write_repos:
+      - myorg/trusted-repo
+    write_violation_action: ASK
 ```
 
 ### Google Workspace

--- a/omnigent/policies/builtins/github.py
+++ b/omnigent/policies/builtins/github.py
@@ -945,6 +945,7 @@ def github_policy(
     read_repos: list[str] | None = None,
     write_repos: list[str] | None = None,
     write_branches: list[str] | None = None,
+    write_violation_action: str = "DENY",
     allow_destructive: bool = False,
     deny_tag_push: bool = True,
     deny_force_push: bool = True,
@@ -965,6 +966,11 @@ def github_policy(
     :param write_branches: Branches writable within an allowed repo, e.g.
         ``["main", "develop"]``. ``None`` / empty means branches are not
         restricted (any branch on an allowed repo is writable).
+    :param write_violation_action: Verdict on a write outside the repo / branch
+        allowlist, or one whose target could not be determined — ``"DENY"``
+        (default) or ``"ASK"``. ``"ASK"`` suits a trusted allowlist that should
+        still permit user-authorized work elsewhere. Destructive operations,
+        force pushes and tag pushes keep denying either way.
     :param allow_destructive: When ``False`` (default), irreversible destructive
         operations (deletes) are denied even on allowed repos. Set to ``True``
         to let destructive operations through normal write gating.
@@ -992,7 +998,15 @@ def github_policy(
     :param deny_reason: Reason prefix attached to DENY decisions.
     :returns: A one-argument policy callable returning a :class:`PolicyResponse`
         or ``None`` (abstain → ALLOW).
+    :raises ValueError: If ``write_violation_action`` is not ``"DENY"`` or
+        ``"ASK"``.
     """
+    write_violation = write_violation_action.strip().upper()
+    if write_violation not in ("DENY", "ASK"):
+        raise ValueError(
+            f"github_policy: write_violation_action must be 'DENY' or 'ASK', "
+            f"got {write_violation_action!r}"
+        )
     allowed_read_repos = _normalize_repos(read_repos)
     allowed_write_repos = _normalize_repos(write_repos)
     allowed_write_branches = _normalize_branches(write_branches)
@@ -1025,6 +1039,15 @@ def github_policy(
             f"this call targets {sorted(repos)}."
         )
 
+    def _write_violation(reason: str) -> PolicyResponse:
+        """
+        Build the configured verdict for an unauthorized write (DENY or ASK).
+
+        :param reason: Human-readable explanation of the violated allowlist.
+        :returns: A :class:`PolicyResponse` carrying ``write_violation_action``.
+        """
+        return {"result": write_violation, "reason": reason}  # type: ignore[typeddict-item]
+
     def _gate_write(
         repos: set[str],
         branches: set[str],
@@ -1032,6 +1055,7 @@ def github_policy(
         branch_targeted: bool,
         no_repo: PolicyResponse,
         no_branch: PolicyResponse,
+        destructive: bool = False,
     ) -> PolicyResponse | None:
         """
         Apply the write repo + branch allowlists to a write operation.
@@ -1051,12 +1075,17 @@ def github_policy(
         :param no_branch: Decision for a branch-targeted write whose branch could
             not be determined while branches are restricted (DENY for MCP, ASK
             for shell).
+        :param destructive: Whether the op is independently denied as
+            destructive. Such an op is never softened to ASK.
         :returns: ``None`` to allow, or a DENY / *no_repo* / *no_branch* decision.
         """
+        # A destructive op is refused outright, so an allowlist miss on one must
+        # keep denying even where the operator asked for ASK.
+        verdict = _deny if destructive else _write_violation
         if not repos:
             return no_repo
         if not (repos <= allowed_write_repos):
-            return _deny(
+            return verdict(
                 f"{deny_reason} Write is restricted to the configured repos; "
                 f"this call targets {sorted(repos)}."
             )
@@ -1064,7 +1093,7 @@ def github_policy(
             if branches:
                 bad = branches - allowed_write_branches
                 if bad:
-                    return _deny(
+                    return verdict(
                         f"{deny_reason} Write is restricted to branches "
                         f"{sorted(allowed_write_branches)}; this call targets {sorted(bad)}."
                     )
@@ -1105,16 +1134,19 @@ def github_policy(
             )
         # cls == "write"
         branches = _extract_branches_from_args(args)
+        is_destructive = not allow_destructive and _mcp_base(canonical) in _MCP_DESTRUCTIVE_TOOLS
+        unauthorized = _deny if is_destructive else _write_violation
         write_result = _gate_write(
             repos,
             branches,
             branch_targeted=_mcp_base(canonical) in _MCP_BRANCH_WRITE_TOOLS,
-            no_repo=_deny(f"{deny_reason} Write call carries no identifiable target repo."),
-            no_branch=_deny(
+            no_repo=unauthorized(f"{deny_reason} Write call carries no identifiable target repo."),
+            no_branch=unauthorized(
                 f"{deny_reason} Write is restricted to branches "
                 f"{sorted(allowed_write_branches)} and this call's target branch could "
                 f"not be determined."
             ),
+            destructive=is_destructive,
         )
         if write_result is not None:
             return write_result
@@ -1281,6 +1313,14 @@ POLICY_REGISTRY: list[dict[str, Any]] = [  # type: ignore[explicit-any]
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Branches writable within an allowed repo. Empty = any branch.",
+                },
+                "write_violation_action": {
+                    "type": "string",
+                    "enum": ["DENY", "ASK"],
+                    "description": "Verdict on a write outside the repo/branch allowlist, "
+                    "or one whose target cannot be determined. Destructive operations, "
+                    "force pushes and tag pushes keep denying either way.",
+                    "default": "DENY",
                 },
                 "allow_destructive": {
                     "type": "boolean",

--- a/tests/policies/builtins/test_github.py
+++ b/tests/policies/builtins/test_github.py
@@ -1061,6 +1061,109 @@ def test_force_push_plus_refspec_allowed_when_opt_out() -> None:
 
 
 # ══════════════════════════════════════════════════════════════════════════════
+# Layer 1 — write_violation_action escalation (DENY / ASK)
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_write_violation_defaults_to_deny() -> None:
+    """Omitting the argument keeps the historical hard-deny for unlisted repos."""
+    policy = github_policy(write_repos=[_REPO])
+    result = policy(tc("mcp__github__create_pull_request", {"owner": "octo", "repo": "other"}))
+    assert _action(result) == "DENY"
+
+
+def test_write_violation_action_ask_escalates_unlisted_repo() -> None:
+    """ASK routes an unlisted repo to the user instead of refusing outright."""
+    policy = github_policy(write_repos=[_REPO], write_violation_action="ASK")
+    result = policy(tc("mcp__github__create_pull_request", {"owner": "octo", "repo": "other"}))
+    assert _action(result) == "ASK"
+
+
+def test_write_violation_action_ask_escalates_unlisted_branch() -> None:
+    """A branch outside write_branches escalates on an otherwise allowed repo."""
+    policy = github_policy(
+        write_repos=[_REPO], write_branches=["main"], write_violation_action="ASK"
+    )
+    result = policy(
+        tc("mcp__github__push_files", {"owner": "octo", "repo": "hello", "branch": "wip"})
+    )
+    assert _action(result) == "ASK"
+
+
+def test_write_violation_action_ask_escalates_undeterminable_target() -> None:
+    """An MCP write naming no repo escalates rather than failing closed."""
+    policy = github_policy(write_repos=[_REPO], write_violation_action="ASK")
+    result = policy(tc("mcp__github__create_pull_request", {"title": "x"}))
+    assert _action(result) == "ASK"
+
+
+def test_write_violation_action_ask_still_allows_listed_repo() -> None:
+    """Escalation does not disturb the allow path for a listed repo."""
+    policy = github_policy(write_repos=[_REPO], write_violation_action="ASK")
+    assert policy(tc("mcp__github__create_issue", {"owner": "octo", "repo": "hello"})) is None
+
+
+def test_write_violation_action_ask_escalates_shell_writes_too() -> None:
+    """The shell surface reads the same setting as the MCP surface."""
+    policy = github_policy(write_repos=[_REPO], write_violation_action="ASK")
+    result = policy(_sh("git push https://github.com/octo/other.git main"))
+    assert _action(result) == "ASK"
+
+
+@pytest.mark.parametrize(
+    ("tool", "args"),
+    [
+        ("mcp__github__delete_branch", {"owner": "octo", "repo": "other", "branch": "x"}),
+        ("mcp__github__delete_file", {"owner": "octo", "repo": "other", "branch": "x"}),
+    ],
+)
+def test_destructive_on_unlisted_repo_still_denies_under_ask(
+    tool: str, args: dict[str, Any]
+) -> None:
+    """A destructive op is refused outright, so ASK must not soften it.
+
+    Without this the escalation would open a bypass: the allowlist miss would
+    ASK and return before the destructive guard was ever consulted.
+    """
+    policy = github_policy(write_repos=[_REPO], write_violation_action="ASK")
+    assert _action(policy(tc(tool, args))) == "DENY"
+
+
+def test_destructive_with_undeterminable_target_still_denies_under_ask() -> None:
+    """The same holds when the destructive op names no repo at all."""
+    policy = github_policy(write_repos=[_REPO], write_violation_action="ASK")
+    assert _action(policy(tc("mcp__github__delete_branch", {"branch": "x"}))) == "DENY"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push --force origin main",
+        "git push --tags origin",
+    ],
+)
+def test_force_and_tag_push_still_deny_under_ask(command: str) -> None:
+    """Force pushes and tag pushes are not allowlist misses and keep denying."""
+    policy = github_policy(write_repos=[_REPO], write_violation_action="ASK")
+    assert _action(policy(_sh(command))) == "DENY"
+
+
+@pytest.mark.parametrize("value", ["ask", " Ask ", "ASK"])
+def test_write_violation_action_is_case_and_space_insensitive(value: str) -> None:
+    """Operators write these in YAML, so accept the obvious spellings."""
+    policy = github_policy(write_repos=[_REPO], write_violation_action=value)
+    result = policy(tc("mcp__github__create_pull_request", {"owner": "octo", "repo": "other"}))
+    assert _action(result) == "ASK"
+
+
+@pytest.mark.parametrize("value", ["ALLOW", "prompt", "", "warn"])
+def test_write_violation_action_rejects_an_unusable_value(value: str) -> None:
+    """A typo must fail loudly at construction, not silently gate nothing."""
+    with pytest.raises(ValueError, match="write_violation_action"):
+        github_policy(write_repos=[_REPO], write_violation_action=value)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
 # Layer 2 — spec resolution through resolve_function_policy
 # ══════════════════════════════════════════════════════════════════════════════
 
@@ -1138,3 +1241,26 @@ def test_registry_validates_factory_params() -> None:
     err_unknown = validate_factory_params(_HANDLER, {"bogus": 1})
     assert err_unknown is not None and "bogus" in err_unknown
     assert validate_factory_params(_HANDLER, {"read_all": "yes"}) is not None
+
+
+@pytest.mark.parametrize("value", ["DENY", "ASK"])
+def test_registry_accepts_write_violation_action(value: str) -> None:
+    """The escalation setting is reachable from a bundle, not just Python."""
+    load_registry()
+    assert validate_factory_params(_HANDLER, {"write_violation_action": value}) is None
+
+
+def test_registry_publishes_the_write_violation_choices() -> None:
+    """The schema advertises the allowed verdicts so the registry UI can offer them.
+
+    Param validation is type-only, so a bad *string* passes here and is caught
+    by the factory's ValueError instead; the enum is the discoverable contract.
+    """
+    load_registry()
+    by_handler = {e.handler: e for e in get_registry()}
+    schema = by_handler[_HANDLER].params_schema
+    assert schema is not None
+    prop = schema["properties"]["write_violation_action"]
+    assert prop["enum"] == ["DENY", "ASK"]
+    assert prop["default"] == "DENY"
+    assert validate_factory_params(_HANDLER, {"write_violation_action": 1}) is not None


### PR DESCRIPTION
## Related issue

Closes #6700

Summary
github_policy’s write_repos was a hard allowlist: a write to any repo outside it was refused outright, with no way to route the decision to the user. That leaves no room for a common shape — a trusted allowlist that should still permit user-authorized work elsewhere. The alternatives were granting no writes at all, or paying inference cost and latency for an LLM prompt policy to re-derive a verdict this policy already parses deterministically.

Adds write_violation_action, defaulting to DENY so existing bundles are unchanged. It follows write_down_action in the sibling builtins/google.py rather than inventing a new convention: a string normalized and validated to DENY or ASK, with a ValueError on anything else, plus a schema property so it is reachable from a bundle. Both the MCP and git/gh shell surfaces read it from the shared write gate, so the two cannot drift, and it covers a write whose target could not be determined as well as one that misses the repo or branch allowlist.

Destructive operations, force pushes and tag pushes keep denying under ASK. Those are refused on their own merits rather than for missing the allowlist, and this is the one part that is not a one-line change. The MCP path consults its destructive guard after the allowlist gate — deliberately, so a delete on a non-allowed repo reports the repo denial. Escalating naively turns that ordering into a bypass: the allowlist miss returns ASK and returns before the destructive guard is ever reached, so delete_branch on an unlisted repo would prompt instead of refuse. The gate now refuses to soften a violation for an op that is independently denied, which also keeps every existing denial reason byte-identical in the default configuration.

Not a duplicate of #765, which the triage bot flagged as possibly related. That issue is about the runner collapsing ASK to DENY at the tool_result, output and sub-agent phases. This policy decides at tool_call, where ASK is honoured as a pending elicitation (runner/policy.py), and where the existing policy already returns ASK today for shell commands with unresolvable targets.

Test Plan
Reproduced the gap before fixing. A throwaway test asserted that the factory raised TypeError on write_violation_action and that validate_factory_params rejected it, proving the behaviour was unreachable from both Python and a bundle, alongside the hard DENY for an unlisted repo and an undeterminable target. All five assertions passed against unmodified main; the first two now fail by construction, and the rest were converted into the regression tests here.

uv run --no-sync pytest tests/policies -q
# 770 passed

uv run --no-sync pytest tests/policies/builtins/test_github.py -q
# 232 passed (211 before — 21 new)

uv run --no-sync pyrefly check omnigent/policies/builtins/github.py
# 0 errors

uv run --no-sync pre-commit run --files docs/POLICIES.md \
  omnigent/policies/builtins/github.py tests/policies/builtins/test_github.py
# ruff format, ruff check, pyrefly + all hooks: Passed
The first commit is independently green on the pre-existing suite (211 passed) without any test changes, so the behavioural default is provably untouched.

Manual verification:

With write_repos: [myorg/trusted] and write_violation_action: ASK, asking an agent to open a PR against a different repo produces an approval prompt naming the repo rather than a refusal that ends the turn. Removing the setting restores today’s refusal.
Still in ASK, asking it to delete a branch on that same unlisted repo refuses — the guard the ordering fix protects.
write_violation_action: warn fails loudly at construction with a message naming the parameter, instead of booting with the gate silently widened.
Demo
[ ] Visual demo attached below
[x] Non-visual evidence provided below or in Test Plan
[ ] Not applicable — no behavioral change
Non-visual change (a policy configuration surface), so here is the resolved verdict for every operation shape under both settings:

operation                         DENY (default)      ASK
----------------------------------------------------------
write allowlisted repo                     ALLOW    ALLOW
write unlisted repo                         DENY      ASK
write undeterminable target                 DENY      ASK
destructive on unlisted repo                DENY     DENY
shell push to unlisted repo                 DENY      ASK
shell force push                            DENY     DENY
shell tag push                              DENY     DENY
The DENY column is byte-identical to main, which is the backward-compatibility claim. The three DENY DENY rows are the guards that must survive escalation.

And the rejection of an unusable value:

'warn'     -> ValueError: github_policy: write_violation_action must be 'DENY' or 'ASK', got 'warn'
'ALLOW'    -> ValueError: github_policy: write_violation_action must be 'DENY' or 'ASK', got 'ALLOW'
''         -> ValueError: github_policy: write_violation_action must be 'DENY' or 'ASK', got ''
Type of change
[ ] Bug fix
[x] Feature
[ ] UI / frontend change
[ ] Refactor / chore
[ ] Docs
[ ] Test / CI
[ ] Breaking change
Test coverage
[x] Unit tests added / updated
[ ] Integration tests added / updated
[ ] E2E tests added / updated
[x] Manual verification completed
[x] Existing tests cover this change
[ ] Not applicable
Coverage notes
21 new unit tests across the file’s existing layers. They cover the DENY default, escalation for an unlisted repo, an unlisted branch, an undeterminable target and the shell surface, the YAML spellings an operator is likely to write (ask, Ask), and a ValueError for each unusable value.

The load-bearing ones are the guards that must survive ASK: a destructive op on an unlisted repo, a destructive op naming no repo at all, force pushes and tag pushes. Those are precisely what a naive escalation opens up, and each fails against an implementation that only swaps the verdict at the allowlist check.

At the registry layer, one test pins the published enum and default so the setting is discoverable, and asserts a wrong type is rejected. Worth noting for reviewers: validate_factory_params is type-only and does not enforce enum, so a bad string passes schema validation and is caught by the factory’s ValueError instead. That matches the sibling gdrive_policy exactly; the test documents the split rather than implying the schema is the gate.

Manual verification covered what unit tests cannot: that the ASK verdict actually surfaces as an interactive approval in a live session rather than being collapsed, and that a typo fails at construction instead of at some later write.

Changelog
github_policy accepts write_violation_action: ASK, so an agent with a trusted repo allowlist can ask for approval on writes elsewhere instead of failing the turn.