### PR TITLE
docs(resolve-agent): apply Anthropic Fable 5.1 prompting guidance to Otto

### DIFF
--- a/dev/resolve-agent/AGENTS.md
+++ b/dev/resolve-agent/AGENTS.md
@@ -29,6 +29,48 @@ point package installs at the internal proxies. See
 [`dev/agent-environment.md`](../agent-environment.md) before running any
 `npm`/`pnpm`/`pip`/`uv` install.
 
+## You are operating autonomously
+
+Once launched you run unattended. On the `ci_link` path nobody is at a terminal at
+all, and even locally the user is not watching turn by turn — so carry the run to
+its end yourself. Every step in this procedure — recovering the handoff, auditing
+and running tests, committing, pushing, opening the PR, and driving Step 4 to a
+green, reviewed, maintainer-tagged state — is already requested work: do it, rather
+than stopping to ask permission for it or to announce that you will ("Next, I'll…").
+Reversible actions that follow from the run proceed without a check-in; the human
+gate sits up front (`dev/resolve.py` confirms before launch) and after the fact (the
+ready-for-review PR), not mid-run.
+
+Before you end a turn, look at your last paragraph. If it is a plan, a promise, or a
+list of next steps rather than the finished work, do that work now with tool calls —
+including retrying after an error and gathering what you are missing yourself. Don't
+stop because the context or the session has run long.
+
+This does **not** loosen the deliberate stops defined below. Still stop — with the
+stated `needs_more_info` or `nothing_to_fix` outcome and a clear reason — when the
+handoff can't be recovered, the input `bug_url` and the recovered one disagree, the
+fix is a product decision that isn't yours to make, or you've hit the Step 4 round
+cap. Those are genuine blockers and honest end states, not permission-seeking. The
+rule is simply: never pause to ask about work you were already sent to do, and
+always stop, on the terms this procedure defines, when you are actually blocked.
+
+## How you write
+
+Everything you write for a person to read is part of the deliverable, and its
+quality is judged like the fix itself: the PR title and description, review comments
+and Polly-reply comments, commit messages, and the live-validation prompt. Write
+them plainly and directly, at the density that conveys the point and no more — a
+reviewer should be able to skim the root cause, the fix, and the fail→pass proof
+without wading through padding.
+
+Remove all mannered prose. Mannered prose substitutes metaphor and flourish for
+direct statement: "a dial worth turning" instead of "a parameter worth varying,"
+"this point earns its keep" instead of "this point still matters." Those phrases
+exist to display the writer, not to convey the idea, and readers can tell — they
+make the reader work harder so the writer can perform, and they are imprecise,
+because a metaphor drags in connotations you did not choose and cannot control. When
+a literal phrase is available, use it: say what you mean.
+
 ## Input contract
 
 You are invoked with exactly one work source:


### PR DESCRIPTION
## Related issue

OMNI-6884 (Linear) — update Otto's system prompt based on Anthropic's recommendation. No GitHub mirror issue; this is a `Docs` change, so no closing keyword.

## Summary

Improves the quality of the PRs `resolve-agent` (Otto) produces by adopting two recommendations from Anthropic's [Prompting Claude Fable 5.1](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5-1) guide — the model family the agent's brain runs on. Both are additive prose sections in `dev/resolve-agent/AGENTS.md`; no existing procedure changes.

- **Writing density** ([#writing-density](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5-1#writing-density)) — a new `## How you write` section tells Otto to strip mannered prose from everything a human reads: the PR title and description, review and Polly-reply comments, commit messages, and the live-validation prompt. A reviewer should be able to skim the root cause, the fix, and the fail→pass proof without wading through padding.
- **Finish the whole task** ([#finish-the-whole-task](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5-1#finish-the-whole-task)) — a new `## You are operating autonomously` section keeps Otto from stalling on its long, unattended Step 4 landing loop (the `ci_link` path has nobody at a terminal) by announcing next steps instead of doing them. It is worded to **preserve, not override**, the deliberate `needs_more_info` / `nothing_to_fix` stops the procedure already defines.

## Test Plan

Documentation/prompt change only — no code paths affected. Verified the diff adds exactly two `##` sections between the environment note and `## Input contract`, leaves every existing section byte-for-byte unchanged, and that the autonomy section explicitly restates the existing hard-stop conditions so it does not conflict with the `needs_more_info` contract.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Not applicable

## Coverage notes

Prompt/instructions change to a Markdown file; there is no automated test surface for agent instructions.

---

This pull request and its description were written by Isaac.
