### PR TITLE
Show pull request status in GitHub panel

### DIFF
--- a/tests/e2e_ui/github/test_github_tab.py
+++ b/tests/e2e_ui/github/test_github_tab.py
@@ -152,9 +152,10 @@ def test_github_tab_shows_summary_checks_and_file_tree(
     rail = page.get_by_role("complementary", name="Workspace")
     rail.get_by_role("tab", name="GitHub").click()
 
-    # PR header (shared across both inner tabs): title + number.
+    # PR header (shared across both inner tabs): title, number, and state.
     expect(rail.get_by_text("Add the GitHub tab")).to_be_visible(timeout=30_000)
     expect(rail.get_by_text(f"#{_PR_NUMBER}")).to_be_visible()
+    expect(rail.get_by_label("Pull request status: Open")).to_be_visible()
 
     # CI checks on their own line as labeled pills; a zero bucket shows nothing.
     expect(rail.get_by_text("Checks")).to_be_visible()

--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -201,6 +201,21 @@ describe("GithubPanel", () => {
     expect(screen.queryByText(/pending/)).toBeNull();
   });
 
+  it.each([
+    ["OPEN", "Open", "text-green-700"],
+    ["CLOSED", "Closed", "text-red-700"],
+    ["MERGED", "Merged", "text-brand-accent"],
+  ])("shows a %s status pill beside the PR title", (stateName, label, tone) => {
+    state.info!.data!.pr!.state = stateName;
+    renderPanel();
+
+    const pill = screen.getByLabelText(`Pull request status: ${label}`);
+    expect(pill).toHaveTextContent(label);
+    expect(pill).toHaveClass(tone, "h-5", "rounded-full", "border", "text-xs");
+    expect(pill.parentElement).toHaveClass("flex-nowrap");
+    expect(screen.getByRole("link", { name: /chore: dummy PR/ })).not.toHaveClass("flex-1");
+  });
+
   it("lands on the Summary tab, showing the PR description and comments", async () => {
     state.info!.data!.pr!.body = "## Overview\nThis PR does the thing.";
     state.info!.data!.pr!.comments = [

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -14,8 +14,8 @@
 // hooks/useGithub.ts), which shells out to `gh` + `git`. `deriveGithubPanelState`
 // is the single switch that turns the info query into what the panel shows: an
 // outdated host, a non-git workspace, a missing `gh` CLI, an unresolved
-// upstream repo, or no open PR each render their own empty state, and only an
-// open PR falls through to the header + stacked diff.
+// upstream repo, or no PR each render their own empty state, and an associated
+// PR falls through to the header + stacked diff.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -48,6 +48,7 @@ import {
 import { FileDiff } from "@pierre/diffs/react";
 import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -183,7 +184,7 @@ export type GithubPanelState =
  *
  * Order matters: transient states (loading/offline/error) first, then the
  * git-first availability reasons, then the `gh` enhancement layer (CLI → auth
- * → repo → PR). `ready` is reached only with an open PR to render. */
+ * → repo → PR). `ready` is reached only with an associated PR to render. */
 export function deriveGithubPanelState(info: {
   isLoading: boolean;
   error: unknown;
@@ -238,6 +239,37 @@ function IconButton({
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>
     </Tooltip>
+  );
+}
+
+/** Compact PR state shown beside the title in the shared panel header. */
+function PullRequestStatus({ state }: { state: string }) {
+  const normalized = state.toUpperCase();
+  const visual =
+    normalized === "OPEN"
+      ? {
+          label: "Open",
+          className: "border-green-500/25 bg-green-500/10 text-green-700 dark:text-green-400",
+        }
+      : normalized === "MERGED"
+        ? {
+            label: "Merged",
+            className: "border-brand-accent/25 bg-brand-accent/10 text-brand-accent",
+          }
+        : normalized === "CLOSED"
+          ? {
+              label: "Closed",
+              className: "border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-400",
+            }
+          : { label: state, className: "border-border bg-muted text-muted-foreground" };
+
+  return (
+    <Badge
+      aria-label={`Pull request status: ${visual.label}`}
+      className={cn("h-5 rounded-full border px-2 py-px text-xs leading-none", visual.className)}
+    >
+      {visual.label}
+    </Badge>
   );
 }
 
@@ -979,7 +1011,7 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
       );
   }
 
-  // ── Ready: an open PR to render as its header + the stacked diff ─────────
+  // ── Ready: an associated PR to render as its header + stacked diff ───────
   const data = info.data!;
   const pr = data.pr!;
   const checks = pr.checks;
@@ -1009,17 +1041,18 @@ export function GithubPanel({ conversationId }: { conversationId: string }) {
                 </>
               )}
             </span>
-            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+            <div className="mt-1 flex flex-nowrap items-center gap-2">
               <a
                 href={pr.url}
                 target="_blank"
                 rel="noreferrer"
-                className="group inline-flex min-w-0 items-center gap-1 text-ui font-medium hover:underline"
+                className="group flex min-w-0 items-center gap-1 text-ui font-medium hover:underline"
               >
                 <span className="truncate">{pr.title}</span>
                 <span className="shrink-0 text-muted-foreground">#{pr.number}</span>
                 <ExternalLinkIcon className="size-3 shrink-0 text-muted-foreground" />
               </a>
+              <PullRequestStatus state={pr.state} />
             </div>
           </div>
           {/* Tab bar (Summary | Changes); the diff controls live inside the


### PR DESCRIPTION
## Related issue

N/A — requested directly.

## Summary

Show a compact status pill beside the pull request title in the GitHub right panel. The pill reads the existing API `state` field and distinguishes open, closed, and merged pull requests with semantic theme colors and an accessible label.

## Test Plan

- `pnpm --dir web exec vitest run src/shell/GithubPanel.test.tsx` (24 passed)
- `.venv/bin/pytest tests/e2e_ui/github/test_github_tab.py -q` (3 passed)
- `pre-commit run --all-files`

The component test covers the Open, Closed, and Merged labels and colors. The GitHub panel E2E test verifies the Open status is visible in the rendered header.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

A Playwright screenshot was captured from the existing GitHub panel fixture. The Open pill appears immediately after the PR number in the header.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Rendered the GitHub right panel through its Playwright fixture and visually verified the Open pill’s placement, size, color, and surrounding header layout.

## Changelog

See whether a pull request is open, closed, or merged from the GitHub panel header.
