### PR TITLE
feat(files): search directories in the Working folder tab

### DIFF
--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -709,6 +709,11 @@ stop = False
 def match_dir(dirpath, dname):
     dfull = os.path.join(dirpath, dname)
     dp = os.path.relpath(dfull, start)
+    # Every dir reaching here already passed the exc filter in scan()'s kept
+    # loop; re-checking keeps match_dir/match_file symmetric so a future
+    # refactor of that pre-filter can't silently leak excluded dirs.
+    if exc and any(r.match(dp) for r in exc):
+        return
     if inc and not any(r.match(dp) for r in inc):
         return
     if q not in dname.lower() and q not in dp.lower():
@@ -746,13 +751,19 @@ def scan(root, defer):
     for dirpath, dirnames, filenames in os.walk(root):
         kept = []
         for d in sorted(dirnames):
-            dp = os.path.relpath(os.path.join(dirpath, d), start)
+            full = os.path.join(dirpath, d)
+            dp = os.path.relpath(full, start)
             if any(r.match(dp) for r in exc):
                 continue
             if defer and d in depri:
                 # Match the dir itself now, but walk its subtree later (pass 2)
-                # so it can't starve the real tree of scan budget.
-                deferred.append(os.path.join(dirpath, d))
+                # so it can't starve the real tree of scan budget. Never defer a
+                # symlinked dir: os.walk(root) follows a top-level symlink, so a
+                # committed 'node_modules -> ..' would let pass 2 escape the
+                # workspace. os.walk(followlinks=False) never crosses symlinks
+                # mid-tree; deferring only real dirs keeps that boundary intact.
+                if not os.path.islink(full):
+                    deferred.append(full)
             kept.append(d)
         dirnames[:] = [d for d in kept if not (defer and d in depri)]
         for dname in kept:

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -791,10 +791,10 @@ def scan(root, defer):
 scan(start, True)
 while deferred and not stop:
     scan(deferred.pop(0), False)
-# Deferred subtrees left unwalked because the budget ran out mean the scan was
-# not exhaustive, so "no more matches" would be a lie.
-if deferred and not stop:
-    truncated = True
+# When the walk stops early it is always because scan() tripped the budget
+# (which sets truncated) or the result limit (signaled by has_more upstream);
+# the loop exits only once deferred is drained or stop is set, so no extra
+# truncation flag is needed here.
 
 print(json.dumps({'r': results, 't': truncated}))
 """

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -682,6 +682,7 @@ class CallerProcessFilesystem:
         _header = "\n".join(
             [
                 "import os, json, re",
+                "from collections import deque",
                 f"q = {_json.dumps(q)}",
                 f"limit = {limit}",
                 f"start = {_json.dumps(start)}",
@@ -700,7 +701,7 @@ class CallerProcessFilesystem:
         # if budget remains. A query's own tree is scanned first, whole.
         _body = r"""
 results = []
-deferred = []
+deferred = deque()
 scanned = 0
 truncated = False
 stop = False
@@ -767,8 +768,10 @@ def scan(root, defer):
             kept.append(d)
         dirnames[:] = [d for d in kept if not (defer and d in depri)]
         for dname in kept:
+            # Count then check `> budget`, not `>= budget`: a tree of exactly
+            # `budget` entries is fully enumerable and must not report truncated.
             scanned += 1
-            if scanned >= budget:
+            if scanned > budget:
                 truncated = True
                 stop = True
                 return
@@ -778,7 +781,7 @@ def scan(root, defer):
                 return
         for fname in sorted(filenames):
             scanned += 1
-            if scanned >= budget:
+            if scanned > budget:
                 truncated = True
                 stop = True
                 return
@@ -790,7 +793,7 @@ def scan(root, defer):
 
 scan(start, True)
 while deferred and not stop:
-    scan(deferred.pop(0), False)
+    scan(deferred.popleft(), False)
 # When the walk stops early it is always because scan() tripped the budget
 # (which sets truncated) or the result limit (signaled by has_more upstream);
 # the loop exits only once deferred is drained or stop is set, so no extra

--- a/omnigent/runner/environment_filesystem.py
+++ b/omnigent/runner/environment_filesystem.py
@@ -623,23 +623,27 @@ class CallerProcessFilesystem:
         exclude: list[str] | None = None,
         limit: int = 500,
     ) -> tuple[list[FilesystemEntry], bool]:
-        """Search for files recursively by name/path substring and glob filters.
+        """Search recursively by name/path substring and glob filters.
 
         Walks the full directory tree via ``os.walk()`` inside the sandbox and
-        returns files that satisfy all of the supplied filters:
+        returns entries — both files and directories — that satisfy all of the
+        supplied filters:
 
-        - ``exclude`` (highest priority): the file is dropped if its path
+        - ``exclude`` (highest priority): the entry is dropped if its path
           matches any exclude glob. Excluded subtrees are pruned from the
           walk where possible, so a pattern like ``"**/node_modules"`` avoids
           descending into those directories.
-        - ``include``: when non-empty, the file is kept only if its path
+        - ``include``: when non-empty, the entry is kept only if its path
           matches at least one include glob.
-        - ``query``: when non-empty, the file's name or relative path must
+        - ``query``: when non-empty, the entry's name or relative path must
           contain ``query`` (case-insensitive substring match).
 
+        Directory matches let the UI reveal a folder from a search, so a query
+        like ``"src"`` surfaces the ``src`` directory alongside files under it.
+
         Glob patterns use the VSCode/Cursor subset documented on
-        :func:`_glob_to_regex` and are matched case-insensitively. Only files
-        (not directories) are returned, capped at ``limit`` entries.
+        :func:`_glob_to_regex` and are matched case-insensitively. Files and
+        directories are both returned, capped at ``limit`` entries.
 
         A non-empty ``query`` is required: a whitespace-only query would match
         every file, so the method returns an empty list instead of walking the
@@ -675,7 +679,7 @@ class CallerProcessFilesystem:
         # All caller-derived values (q and the pre-translated regexes) are
         # embedded via json.dumps so they become valid Python literals and
         # cannot inject code; the whole script is shell-quoted below.
-        _script = "\n".join(
+        _header = "\n".join(
             [
                 "import os, json, re",
                 f"q = {_json.dumps(q)}",
@@ -685,54 +689,105 @@ class CallerProcessFilesystem:
                 f"depri = set({_json.dumps(list(_DEFAULT_DEPRIORITIZED_DIRS))})",
                 f"inc = [re.compile(p, re.IGNORECASE) for p in {_json.dumps(include_regexes)}]",
                 f"exc = [re.compile(p, re.IGNORECASE) for p in {_json.dumps(exclude_regexes)}]",
-                "results = []",
-                "scanned = 0",
-                "truncated = False",
-                "for dirpath, dirnames, filenames in os.walk(start):",
-                "    # Prune excluded subtrees (e.g. node_modules) from the walk.",
-                "    kept = []",
-                "    for d in sorted(dirnames):",
-                "        dp = os.path.relpath(os.path.join(dirpath, d), start)",
-                "        if any(r.match(dp) for r in exc):",
-                "            continue",
-                "        kept.append(d)",
-                "    # Spend the scan budget on the real tree first: dependency and",
-                "    # cache dirs are walked last, and are what a capped scan drops.",
-                "    kept.sort(key=lambda d: d in depri)",
-                "    dirnames[:] = kept",
-                "    scanned += len(kept)",
-                "    for fname in sorted(filenames):",
-                "        # A query matching little or nothing never trips the result",
-                "        # cap, so the walk needs its own bound. Counted per entry:",
-                "        # per-directory would let one huge directory overshoot it.",
-                "        scanned += 1",
-                "        if scanned >= budget:",
-                "            truncated = True",
-                "            break",
-                "        full = os.path.join(dirpath, fname)",
-                "        p = os.path.relpath(full, start)",
-                "        if exc and any(r.match(p) for r in exc):",
-                "            continue",
-                "        if inc and not any(r.match(p) for r in inc):",
-                "            continue",
-                "        if q not in fname.lower() and q not in p.lower():",
-                "            continue",
-                "        try:",
-                "            # stat the FULL path: p is relative to `start`, but the",
-                "            # helper's cwd is the workspace root, so stat(p) would",
-                "            # miss -- or worse, stat a same-named workspace file.",
-                "            st = os.stat(full)",
-                "            results.append({'n': fname, 'p': p, 's': st.st_size,",
-                "                'm': int(st.st_mtime)})",
-                "        except OSError:",
-                "            results.append({'n': fname, 'p': p, 's': None, 'm': None})",
-                "        if len(results) >= limit:",
-                "            break",
-                "    if truncated or len(results) >= limit:",
-                "        break",
-                "print(json.dumps({'r': results, 't': truncated}))",
             ]
         )
+        # Two-pass walk. Reordering depri siblings within one directory isn't
+        # enough: a deep ``node_modules`` nested under an earlier-sorted real
+        # dir (``ap-web/node_modules/...``) would swallow the whole scan budget
+        # before the walk ever reaches a later top-level dir like ``examples``.
+        # So pass 1 walks the real tree and DEFERS every depri subtree (records
+        # its root, does not descend); pass 2 drains those deferred roots only
+        # if budget remains. A query's own tree is scanned first, whole.
+        _body = r"""
+results = []
+deferred = []
+scanned = 0
+truncated = False
+stop = False
+
+
+def match_dir(dirpath, dname):
+    dfull = os.path.join(dirpath, dname)
+    dp = os.path.relpath(dfull, start)
+    if inc and not any(r.match(dp) for r in inc):
+        return
+    if q not in dname.lower() and q not in dp.lower():
+        return
+    try:
+        st = os.stat(dfull)
+        results.append({'n': dname, 'p': dp, 's': None, 'm': int(st.st_mtime), 'd': True})
+    except OSError:
+        results.append({'n': dname, 'p': dp, 's': None, 'm': None, 'd': True})
+
+
+def match_file(dirpath, fname):
+    # stat the FULL path: p is relative to `start`, but the helper's cwd is the
+    # workspace root, so stat(p) would miss -- or worse, stat a same-named file.
+    full = os.path.join(dirpath, fname)
+    p = os.path.relpath(full, start)
+    if exc and any(r.match(p) for r in exc):
+        return
+    if inc and not any(r.match(p) for r in inc):
+        return
+    if q not in fname.lower() and q not in p.lower():
+        return
+    try:
+        st = os.stat(full)
+        results.append({'n': fname, 'p': p, 's': st.st_size, 'm': int(st.st_mtime), 'd': False})
+    except OSError:
+        results.append({'n': fname, 'p': p, 's': None, 'm': None, 'd': False})
+
+
+def scan(root, defer):
+    # A query matching little or nothing never trips the result cap, so the walk
+    # needs its own bound. Counted per entry: per-directory would let one huge
+    # directory overshoot it.
+    global scanned, truncated, stop
+    for dirpath, dirnames, filenames in os.walk(root):
+        kept = []
+        for d in sorted(dirnames):
+            dp = os.path.relpath(os.path.join(dirpath, d), start)
+            if any(r.match(dp) for r in exc):
+                continue
+            if defer and d in depri:
+                # Match the dir itself now, but walk its subtree later (pass 2)
+                # so it can't starve the real tree of scan budget.
+                deferred.append(os.path.join(dirpath, d))
+            kept.append(d)
+        dirnames[:] = [d for d in kept if not (defer and d in depri)]
+        for dname in kept:
+            scanned += 1
+            if scanned >= budget:
+                truncated = True
+                stop = True
+                return
+            match_dir(dirpath, dname)
+            if len(results) >= limit:
+                stop = True
+                return
+        for fname in sorted(filenames):
+            scanned += 1
+            if scanned >= budget:
+                truncated = True
+                stop = True
+                return
+            match_file(dirpath, fname)
+            if len(results) >= limit:
+                stop = True
+                return
+
+
+scan(start, True)
+while deferred and not stop:
+    scan(deferred.pop(0), False)
+# Deferred subtrees left unwalked because the budget ran out mean the scan was
+# not exhaustive, so "no more matches" would be a lie.
+if deferred and not stop:
+    truncated = True
+
+print(json.dumps({'r': results, 't': truncated}))
+"""
+        _script = _header + "\n" + _body
         result = await _run_os_env_async(
             self._os_env.shell,
             f"python3 -c {_shell_quote(_script)}",
@@ -755,7 +810,7 @@ class CallerProcessFilesystem:
                     id=item["p"],
                     name=item["n"],
                     path=item["p"],
-                    type="file",
+                    type="directory" if item.get("d") else "file",
                     bytes=item["s"],
                     modified_at=item["m"],
                 )

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -418,10 +418,10 @@ class WorkspaceReader:
         scan(str(self._root), True)
         while deferred and not stop:
             scan(deferred.pop(0), False)
-        # Deferred subtrees left unwalked because the budget ran out mean the
-        # scan was not exhaustive, so "no more matches" would be a lie.
-        if deferred and not stop:
-            truncated = True
+        # When the walk stops early it is always because scan() tripped the
+        # budget (which sets truncated) or the result limit (signaled by
+        # has_more); the loop exits only once deferred is drained or stop is
+        # set, so no extra truncation flag is needed here.
 
         results.sort(key=lambda entry: cast(str, entry["path"]))
         return {

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -326,61 +326,96 @@ class WorkspaceReader:
         exc = [re.compile(_glob_to_regex(p), re.IGNORECASE) for p in split_glob_list(exclude)]
 
         results: list[_WorkspacePayload] = []
-        scanned = 0
+        # State the two-pass walk mutates via closures. A list holds `scanned`
+        # so the nested helpers can rebind it without a `nonlocal` per call.
+        deferred: list[str] = []
+        counters = {"scanned": 0}
         truncated = False
-        for dirpath, dirnames, filenames in os.walk(self._root):
+        stop = False
+
+        def rel(dirpath: str, name: str) -> str:
             rel_dir = os.path.relpath(dirpath, self._root)
-            # Prune excluded subtrees so a "**/node_modules" pattern
-            # avoids descending, matching the runner's search walk.
-            kept = []
-            for d in sorted(dirnames):
-                dp = os.path.normpath(os.path.join("" if rel_dir == "." else rel_dir, d))
-                if any(r.match(dp) for r in exc):
-                    continue
-                kept.append(d)
-            # Spend the scan budget on the real tree first, as the runner does.
-            kept.sort(key=lambda d: d in _DEFAULT_DEPRIORITIZED_DIRS)
-            dirnames[:] = kept
-            scanned += len(kept)
-            for fname in sorted(filenames):
-                # Counted per entry: a per-directory check lets one huge
-                # directory overshoot the budget before `truncated` trips.
-                scanned += 1
-                if scanned >= _SEARCH_SCAN_BUDGET:
-                    truncated = True
-                    break
-                p = os.path.normpath(os.path.join("" if rel_dir == "." else rel_dir, fname))
-                if exc and any(r.match(p) for r in exc):
-                    continue
-                if inc and not any(r.match(p) for r in inc):
-                    continue
-                if q not in fname.lower() and q not in p.lower():
-                    continue
-                try:
-                    st = (Path(dirpath) / fname).stat()
-                    size: int | None = st.st_size
-                    mtime: int | None = int(st.st_mtime)
-                except OSError:
-                    size = None
-                    mtime = None
-                results.append(
-                    {
-                        "id": p,
-                        "object": "session.environment.filesystem.entry",
-                        "name": fname,
-                        "path": p,
-                        "type": "file",
-                        "bytes": size,
-                        "modified_at": mtime,
-                    }
-                )
-                if len(results) >= limit:
-                    break
-            # A query matching little or nothing never fills the result cap,
-            # so the walk needs its own bound -- the same one the runner
-            # applies, so search behaves identically whether the agent is awake.
-            if truncated or len(results) >= limit:
-                break
+            return os.path.normpath(os.path.join("" if rel_dir == "." else rel_dir, name))
+
+        def match(dirpath: str, name: str, *, is_dir: bool) -> None:
+            # A directory carries no byte size; a file stats for size + mtime.
+            p = rel(dirpath, name)
+            if exc and any(r.match(p) for r in exc):
+                return
+            if inc and not any(r.match(p) for r in inc):
+                return
+            if q not in name.lower() and q not in p.lower():
+                return
+            try:
+                st = (Path(dirpath) / name).stat()
+                size: int | None = None if is_dir else st.st_size
+                mtime: int | None = int(st.st_mtime)
+            except OSError:
+                size = None
+                mtime = None
+            results.append(
+                {
+                    "id": p,
+                    "object": "session.environment.filesystem.entry",
+                    "name": name,
+                    "path": p,
+                    "type": "directory" if is_dir else "file",
+                    "bytes": size,
+                    "modified_at": mtime,
+                }
+            )
+
+        def scan(root: str, defer: bool) -> None:
+            # A query matching little or nothing never fills the result cap, so
+            # the walk needs its own bound. Counted per entry: a per-directory
+            # check lets one huge directory overshoot before `truncated` trips.
+            nonlocal truncated, stop
+            for dirpath, dirnames, filenames in os.walk(root):
+                kept = []
+                for d in sorted(dirnames):
+                    dp = rel(dirpath, d)
+                    if any(r.match(dp) for r in exc):
+                        continue
+                    if defer and d in _DEFAULT_DEPRIORITIZED_DIRS:
+                        # Match the dir now, but walk its subtree later (pass 2)
+                        # so it can't starve the real tree of scan budget.
+                        deferred.append(os.path.join(dirpath, d))
+                    kept.append(d)
+                dirnames[:] = [d for d in kept if not (defer and d in _DEFAULT_DEPRIORITIZED_DIRS)]
+                for dname in kept:
+                    counters["scanned"] += 1
+                    if counters["scanned"] >= _SEARCH_SCAN_BUDGET:
+                        truncated = True
+                        stop = True
+                        return
+                    match(dirpath, dname, is_dir=True)
+                    if len(results) >= limit:
+                        stop = True
+                        return
+                for fname in sorted(filenames):
+                    counters["scanned"] += 1
+                    if counters["scanned"] >= _SEARCH_SCAN_BUDGET:
+                        truncated = True
+                        stop = True
+                        return
+                    match(dirpath, fname, is_dir=False)
+                    if len(results) >= limit:
+                        stop = True
+                        return
+
+        # Pass 1 walks the real tree and defers dependency/cache subtrees;
+        # reordering siblings isn't enough, because a deep node_modules nested
+        # under an earlier-sorted real dir would still swallow the whole budget
+        # before the walk reached a later top-level dir. Pass 2 drains the
+        # deferred roots only if budget remains. Mirrors the runner's walk.
+        scan(str(self._root), True)
+        while deferred and not stop:
+            scan(deferred.pop(0), False)
+        # Deferred subtrees left unwalked because the budget ran out mean the
+        # scan was not exhaustive, so "no more matches" would be a lie.
+        if deferred and not stop:
+            truncated = True
+
         results.sort(key=lambda entry: cast(str, entry["path"]))
         return {
             "object": "list",

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -36,6 +36,7 @@ import base64
 import mimetypes
 import os
 import re
+from collections import deque
 from pathlib import Path
 from typing import TypeAlias, cast
 
@@ -326,10 +327,11 @@ class WorkspaceReader:
         exc = [re.compile(_glob_to_regex(p), re.IGNORECASE) for p in split_glob_list(exclude)]
 
         results: list[_WorkspacePayload] = []
-        # State the two-pass walk mutates via closures. A dict holds `scanned`
-        # so the nested helpers can rebind it without a `nonlocal` per call.
-        deferred: list[str] = []
-        counters = {"scanned": 0}
+        # State the two-pass walk mutates via closures (rebound through the
+        # `nonlocal` in scan()). deferred is a FIFO of noise-dir roots to drain
+        # in pass 2.
+        deferred: deque[str] = deque()
+        scanned = 0
         truncated = False
         stop = False
 
@@ -369,7 +371,7 @@ class WorkspaceReader:
             # A query matching little or nothing never fills the result cap, so
             # the walk needs its own bound. Counted per entry: a per-directory
             # check lets one huge directory overshoot before `truncated` trips.
-            nonlocal truncated, stop
+            nonlocal scanned, truncated, stop
             for dirpath, dirnames, filenames in os.walk(root):
                 kept = []
                 for d in sorted(dirnames):
@@ -390,8 +392,11 @@ class WorkspaceReader:
                     kept.append(d)
                 dirnames[:] = [d for d in kept if not (defer and d in _DEFAULT_DEPRIORITIZED_DIRS)]
                 for dname in kept:
-                    counters["scanned"] += 1
-                    if counters["scanned"] >= _SEARCH_SCAN_BUDGET:
+                    # Count then check `> budget`, not `>= budget`: a tree of
+                    # exactly `budget` entries is fully enumerable and must not
+                    # report truncated.
+                    scanned += 1
+                    if scanned > _SEARCH_SCAN_BUDGET:
                         truncated = True
                         stop = True
                         return
@@ -400,8 +405,8 @@ class WorkspaceReader:
                         stop = True
                         return
                 for fname in sorted(filenames):
-                    counters["scanned"] += 1
-                    if counters["scanned"] >= _SEARCH_SCAN_BUDGET:
+                    scanned += 1
+                    if scanned > _SEARCH_SCAN_BUDGET:
                         truncated = True
                         stop = True
                         return
@@ -417,7 +422,7 @@ class WorkspaceReader:
         # deferred roots only if budget remains. Mirrors the runner's walk.
         scan(str(self._root), True)
         while deferred and not stop:
-            scan(deferred.pop(0), False)
+            scan(deferred.popleft(), False)
         # When the walk stops early it is always because scan() tripped the
         # budget (which sets truncated) or the result limit (signaled by
         # has_more); the loop exits only once deferred is drained or stop is

--- a/omnigent/workspace_fs.py
+++ b/omnigent/workspace_fs.py
@@ -326,7 +326,7 @@ class WorkspaceReader:
         exc = [re.compile(_glob_to_regex(p), re.IGNORECASE) for p in split_glob_list(exclude)]
 
         results: list[_WorkspacePayload] = []
-        # State the two-pass walk mutates via closures. A list holds `scanned`
+        # State the two-pass walk mutates via closures. A dict holds `scanned`
         # so the nested helpers can rebind it without a `nonlocal` per call.
         deferred: list[str] = []
         counters = {"scanned": 0}
@@ -373,13 +373,20 @@ class WorkspaceReader:
             for dirpath, dirnames, filenames in os.walk(root):
                 kept = []
                 for d in sorted(dirnames):
+                    full = os.path.join(dirpath, d)
                     dp = rel(dirpath, d)
                     if any(r.match(dp) for r in exc):
                         continue
                     if defer and d in _DEFAULT_DEPRIORITIZED_DIRS:
                         # Match the dir now, but walk its subtree later (pass 2)
-                        # so it can't starve the real tree of scan budget.
-                        deferred.append(os.path.join(dirpath, d))
+                        # so it can't starve the real tree of scan budget. Never
+                        # defer a symlinked dir: os.walk(root) follows a top-level
+                        # symlink, so a committed 'node_modules -> ..' would let
+                        # pass 2 escape the workspace. os.walk(followlinks=False)
+                        # never crosses symlinks mid-tree; deferring only real
+                        # dirs keeps that boundary intact.
+                        if not os.path.islink(full):
+                            deferred.append(full)
                     kept.append(d)
                 dirnames[:] = [d for d in kept if not (defer and d in _DEFAULT_DEPRIORITIZED_DIRS)]
                 for dname in kept:

--- a/tests/e2e_ui/files/test_file_search.py
+++ b/tests/e2e_ui/files/test_file_search.py
@@ -141,20 +141,32 @@ def test_search_matches_and_reveals_a_directory(
     rail = page.get_by_role("complementary", name="Workspace")
     search = rail.get_by_role("searchbox", name="Search all files")
     expect(search).to_be_visible(timeout=30_000)
+    # Match rows by exact accessible name — a slash inside a Playwright
+    # name-regex is invalid, and the trailing-slash folder label collides with
+    # the file path otherwise. The folder row's name is the path + "/"; the
+    # flat file result's name is the full file path.
+    folder_row = rail.get_by_role("button", name=f"{_DIR_NAME}/", exact=True)
+    # Match the file result by its slash-free basename: _row builds a name-regex
+    # and a slash inside a Playwright regex is invalid, but the substring match
+    # still resolves the full-path button ("widgets/gadget.py").
+    file_result = _row(rail, "gadget.py")
     # The seeded folder must be listed before searching so the panel has
     # settled out of its mount-time re-render (see _search_for).
-    expect(_row(rail, f"{_DIR_NAME}/")).to_be_visible(timeout=30_000)
+    expect(folder_row).to_be_visible(timeout=30_000)
 
-    # The query matches the directory by name; it appears as a folder row whose
-    # label carries the full path with a trailing slash.
+    # The query matches both the directory (folder row) and the file under it.
     _search_for(search, _DIR_NAME)
-    dir_result = rail.get_by_role("button", name=re.compile(rf"{re.escape(_DIR_NAME)}/"))
-    expect(dir_result.first).to_be_visible(timeout=15_000)
+    # Wait until search-RESULTS mode is actually active before clicking: the
+    # flat file result only exists in search mode (in the tree it's hidden
+    # inside the collapsed folder), and while it's showing the tree is
+    # unmounted, so the only "widgets/" button left is the search folder row.
+    # Without this gate the ~300ms debounce lets the click land on the tree's
+    # folder toggle instead, which expands in place rather than revealing.
+    expect(file_result).to_be_visible(timeout=15_000)
 
     # Clicking the folder result reveals it in the tree: search clears and the
     # folder is shown as an (expandable) tree row, not opened as a file.
-    dir_result.first.click()
+    folder_row.click()
     expect(search).to_have_value("")
-    # Back in tree mode the folder row is present and its file becomes reachable
-    # once expanded — assert the folder itself is shown as a tree node.
-    expect(_row(rail, f"{_DIR_NAME}/")).to_be_visible(timeout=15_000)
+    # Back in tree mode the folder row is still present as a tree node.
+    expect(folder_row).to_be_visible(timeout=15_000)

--- a/tests/e2e_ui/files/test_file_search.py
+++ b/tests/e2e_ui/files/test_file_search.py
@@ -32,6 +32,10 @@ _ALPHA_TWO = "alpha_two.py"
 _BETA = "beta_three.txt"
 _ALL_FILES = (_ALPHA_ONE, _ALPHA_TWO, _BETA)
 
+# A file under a subdirectory so the walk yields a matchable directory entry.
+_DIR_NAME = "widgets"
+_DIR_FILE = f"{_DIR_NAME}/gadget.py"
+
 
 def _put_file(base_url: str, session_id: str, path: str) -> None:
     resp = httpx.put(
@@ -48,6 +52,17 @@ def all_search_session(seeded_session: tuple[str, str]) -> Iterator[tuple[str, s
     base_url, session_id = seeded_session
     for path in _ALL_FILES:
         _put_file(base_url, session_id, path)
+    try:
+        yield (base_url, session_id)
+    finally:
+        shutil.rmtree(_REPO_ROOT / session_id, ignore_errors=True)
+
+
+@pytest.fixture
+def dir_search_session(seeded_session: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """A file under a subdirectory so the tree has a matchable folder."""
+    base_url, session_id = seeded_session
+    _put_file(base_url, session_id, _DIR_FILE)
     try:
         yield (base_url, session_id)
     finally:
@@ -106,3 +121,40 @@ def test_search_filters_all_files(
     expect(_row(rail, _ALPHA_ONE)).to_be_visible(timeout=15_000)
     expect(_row(rail, _ALPHA_TWO)).to_be_visible()
     expect(_row(rail, _BETA)).to_have_count(0)
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+def test_search_matches_and_reveals_a_directory(
+    page: Page,
+    dir_search_session: tuple[str, str],
+) -> None:
+    """Searching a folder name lists it and clicking it reveals it in the tree.
+
+    Directory search is the feature under test: the server ``/search`` now
+    emits directory entries, the results render them as folder rows, and
+    clicking one exits search and expands the folder in the tree (rather than
+    opening a file). Covers the reveal + exit-search interaction end to end.
+    """
+    base_url, session_id = dir_search_session
+    page.goto(f"{base_url}/c/{session_id}?view=explore")
+
+    rail = page.get_by_role("complementary", name="Workspace")
+    search = rail.get_by_role("searchbox", name="Search all files")
+    expect(search).to_be_visible(timeout=30_000)
+    # The seeded folder must be listed before searching so the panel has
+    # settled out of its mount-time re-render (see _search_for).
+    expect(_row(rail, f"{_DIR_NAME}/")).to_be_visible(timeout=30_000)
+
+    # The query matches the directory by name; it appears as a folder row whose
+    # label carries the full path with a trailing slash.
+    _search_for(search, _DIR_NAME)
+    dir_result = rail.get_by_role("button", name=re.compile(rf"{re.escape(_DIR_NAME)}/"))
+    expect(dir_result.first).to_be_visible(timeout=15_000)
+
+    # Clicking the folder result reveals it in the tree: search clears and the
+    # folder is shown as an (expandable) tree row, not opened as a file.
+    dir_result.first.click()
+    expect(search).to_have_value("")
+    # Back in tree mode the folder row is present and its file becomes reachable
+    # once expanded — assert the folder itself is shown as a tree node.
+    expect(_row(rail, f"{_DIR_NAME}/")).to_be_visible(timeout=15_000)

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -1813,6 +1813,40 @@ async def test_search_scan_budget_bounds_a_no_match_walk(
 
 
 @pytest.mark.asyncio
+async def test_search_tree_of_exactly_budget_size_is_not_truncated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tree with exactly `budget` entries is fully enumerable, not truncated.
+
+    The walk counts an entry then checks `> budget` (not `>= budget`), so a
+    tree whose entry count equals the budget is walked to completion and must
+    report ``truncated=False``. One more entry would flip it to True.
+    """
+    # 3 files + their parent dir = 4 walked entries. Budget 4 exactly covers it.
+    d = tmp_path / "d"
+    d.mkdir()
+    for i in range(3):
+        (d / f"f{i}.txt").write_text("x")
+
+    monkeypatch.setattr("omnigent.runner.environment_filesystem._SEARCH_SCAN_BUDGET", 4)
+    fs = CallerProcessFilesystem(
+        create_os_environment(
+            OSEnvSpec(
+                type="caller_process",
+                cwd=str(tmp_path),
+                sandbox=OSEnvSandboxSpec(type="none"),
+            )
+        )
+    )
+    _entries, truncated = await fs.search_files("zznomatchzz")
+
+    assert truncated is False, (
+        "a tree of exactly budget size is fully enumerable and must not be flagged truncated"
+    )
+
+
+@pytest.mark.asyncio
 async def test_search_defers_deep_noise_subtree_to_reach_later_real_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -1351,25 +1351,27 @@ async def test_search_no_matches_returns_empty_list(
 
 
 @pytest.mark.asyncio
-async def test_search_returns_only_files_not_directories(
+async def test_search_returns_matching_directories(
     client: httpx.AsyncClient,
 ) -> None:
-    """GET /search results contain only file-type entries, not directory entries.
+    """GET /search returns directory entries whose name/path matches the query.
 
-    The workspace has a 'src' directory; a query matching it by name must not
-    return it as a result — directories are not useful for file-open actions.
+    The workspace has a 'src' directory; a query matching it by name must
+    surface it as a directory-type entry so the UI can reveal the folder,
+    alongside any files under it.
     """
     resp = await client.get(
         f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/search?q=src"
     )
     assert resp.status_code == 200
-    for entry in resp.json()["data"]:
-        # Any directory entry in the results would indicate the search walk is
-        # including directories, which the UI cannot open.
-        assert entry["type"] == "file", (
-            f"Expected only file-type entries in search results, "
-            f"but got type={entry['type']!r} for path={entry['path']!r}."
-        )
+    entries = resp.json()["data"]
+    src = next((e for e in entries if e["path"] == "src"), None)
+    assert src is not None, f"Expected the 'src' directory in results, got: {entries}"
+    assert src["type"] == "directory", (
+        f"Expected 'src' to be a directory-type entry, got type={src['type']!r}."
+    )
+    # A directory has no byte size; bytes must be null for it.
+    assert src["bytes"] is None, "A directory entry must report null bytes."
 
 
 @pytest.mark.asyncio
@@ -1594,27 +1596,29 @@ async def test_search_glob_filters(
 
 
 @pytest.mark.asyncio
-async def test_search_glob_filter_returns_only_files(
+async def test_search_directory_match_honors_exclude_glob(
     glob_client: httpx.AsyncClient,
 ) -> None:
-    """A glob-scoped search returns file entries only, never directories.
+    """A directory match is dropped when an exclude glob prunes its subtree.
 
-    ``src/**`` matches the ``src/deep`` directory by path, but directories
-    must be filtered out so the UI only offers openable files. ``q=.`` matches
-    every file (all have extensions) so the include glob is what is exercised.
+    ``q=deep`` matches the ``src/deep`` directory by name. Without an exclude
+    it surfaces as a directory entry; with ``exclude=**/deep`` the subtree is
+    pruned from the walk so the directory itself never appears.
     """
-    resp = await glob_client.get(
-        f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/search?q=.&include=src/**"
-    )
+    base = f"/v1/sessions/conv_test/resources/environments/{DEFAULT_ENVIRONMENT_ID}/search"
+    resp = await glob_client.get(f"{base}?q=deep")
     assert resp.status_code == 200, resp.text
-    data = resp.json()["data"]
-    assert data, "q=.&include=src/** should match files under src/"
-    for entry in data:
-        # A directory entry would mean the file-type filter in search_files
-        # regressed; the UI cannot open directories.
-        assert entry["type"] == "file", (
-            f"Expected only file entries, got type={entry['type']!r} for {entry['path']!r}"
-        )
+    paths = {(e["path"], e["type"]) for e in resp.json()["data"]}
+    assert ("src/deep", "directory") in paths, (
+        f"q=deep should surface the src/deep directory, got {paths}"
+    )
+
+    resp = await glob_client.get(f"{base}?q=deep&exclude=**/deep")
+    assert resp.status_code == 200, resp.text
+    excluded = {e["path"] for e in resp.json()["data"]}
+    assert "src/deep" not in excluded, (
+        f"exclude=**/deep must prune the src/deep directory, got {excluded}"
+    )
 
 
 # ── Per-session filesystem registry (worktree) ──────────────────────────────
@@ -1806,6 +1810,56 @@ async def test_search_scan_budget_bounds_a_no_match_walk(
 
     assert entries == []
     assert truncated is True, "a budget-exhausted search must not look like 'no matches'"
+
+
+@pytest.mark.asyncio
+async def test_search_defers_deep_noise_subtree_to_reach_later_real_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deep dependency subtree must not starve a later-sorted real directory.
+
+    Layout (``aaa`` sorts before ``zzz``)::
+
+        aaa/node_modules/<many files>   # deprioritized, huge
+        zzz/target/keep.txt             # the real match, deep and late
+
+    Reordering only *sibling* dirs isn't enough: without globally deferring the
+    ``node_modules`` subtree, the walk descends all of ``aaa/node_modules``
+    first and exhausts a tight budget before it ever reaches ``zzz/target`` —
+    so a query for ``target`` would come back empty. Deferring noise subtrees
+    lets the real tree be scanned first, so the match is found.
+    """
+    noise = tmp_path / "aaa" / "node_modules"
+    noise.mkdir(parents=True)
+    for i in range(40):
+        (noise / f"dep{i}.js").write_text("x")
+    target = tmp_path / "zzz" / "target"
+    target.mkdir(parents=True)
+    (target / "keep.txt").write_text("y")
+
+    # Budget large enough for the whole real tree but far smaller than the noise
+    # subtree, so a non-deferring walk would run out inside node_modules.
+    monkeypatch.setattr(
+        "omnigent.runner.environment_filesystem._SEARCH_SCAN_BUDGET",
+        20,
+    )
+    fs = CallerProcessFilesystem(
+        create_os_environment(
+            OSEnvSpec(
+                type="caller_process",
+                cwd=str(tmp_path),
+                sandbox=OSEnvSandboxSpec(type="none"),
+            )
+        )
+    )
+    entries, _truncated = await fs.search_files("target")
+
+    paths = {e.path for e in entries}
+    assert "zzz/target" in paths, (
+        f"the real 'zzz/target' directory must be reached despite the earlier "
+        f"aaa/node_modules subtree, got {paths}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_environment_filesystem.py
+++ b/tests/runner/test_environment_filesystem.py
@@ -1863,6 +1863,44 @@ async def test_search_defers_deep_noise_subtree_to_reach_later_real_dir(
 
 
 @pytest.mark.asyncio
+async def test_search_does_not_follow_symlinked_deprioritized_dir(
+    tmp_path: Path,
+) -> None:
+    """A symlinked deprioritized dir must not let the walk escape the workspace.
+
+    The deferred second pass walks each noise root directly, and ``os.walk``
+    follows a *top-level* symlink. A committed ``node_modules`` symlink pointing
+    outside the workspace would otherwise disclose file names/sizes/mtimes from
+    the target — content the single-pass ``os.walk(followlinks=False)`` could
+    never reach. Deferring only real directories preserves that boundary.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("leaked")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    # A committed noise-named symlink pointing at the sibling outside/ dir.
+    (ws / "node_modules").symlink_to(outside, target_is_directory=True)
+
+    fs = CallerProcessFilesystem(
+        create_os_environment(
+            OSEnvSpec(
+                type="caller_process",
+                cwd=str(ws),
+                sandbox=OSEnvSandboxSpec(type="none"),
+            )
+        )
+    )
+    entries, _truncated = await fs.search_files("secret")
+
+    paths = {e.path for e in entries}
+    assert not any("secret" in p for p in paths), (
+        f"search must not descend a symlinked node_modules and leak the target's "
+        f"contents, got {paths}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_scoped_search_reports_the_matched_files_own_size(tmp_path: Path) -> None:
     """A scoped search must stat the file it actually matched.
 

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -274,6 +274,54 @@ def test_search_exclude_glob_prunes_results(tmp_path: Path) -> None:
     assert paths == {"keep.py"}
 
 
+def test_search_returns_matching_directories(tmp_path: Path) -> None:
+    """A query matching a directory name surfaces it as a directory entry.
+
+    Mirrors the runner's ``/search`` so a folder can be revealed from the
+    Explore tab whether the runner or the host answers.
+    """
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("x")
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.search("src")
+
+    by_path = {e["path"]: e for e in result["data"]}
+    assert by_path["src"]["type"] == "directory"
+    # A directory has no byte size.
+    assert by_path["src"]["bytes"] is None
+
+
+def test_search_defers_deep_noise_subtree_to_reach_later_real_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deep dependency subtree must not starve a later-sorted real directory.
+
+    ``aaa/node_modules/<many>`` sorts before ``zzz/target``; without globally
+    deferring the noise subtree, a tight budget is exhausted inside
+    node_modules before the walk reaches the real match. Mirrors the runner.
+    """
+    noise = tmp_path / "aaa" / "node_modules"
+    noise.mkdir(parents=True)
+    for i in range(40):
+        (noise / f"dep{i}.js").write_text("x")
+    target = tmp_path / "zzz" / "target"
+    target.mkdir(parents=True)
+    (target / "keep.txt").write_text("y")
+
+    monkeypatch.setattr("omnigent.workspace_fs._SEARCH_SCAN_BUDGET", 20)
+    reader = WorkspaceReader(tmp_path)
+
+    result = reader.search("target")
+
+    paths = {e["path"] for e in result["data"]}
+    assert "zzz/target" in paths, (
+        f"the real 'zzz/target' directory must be reached despite the earlier "
+        f"aaa/node_modules subtree, got {paths}"
+    )
+
+
 # ── changes / diff (git mode) ─────────────────────────────────────────
 
 

--- a/tests/test_workspace_fs.py
+++ b/tests/test_workspace_fs.py
@@ -322,6 +322,31 @@ def test_search_defers_deep_noise_subtree_to_reach_later_real_dir(
     )
 
 
+def test_search_does_not_follow_symlinked_deprioritized_dir(tmp_path: Path) -> None:
+    """A symlinked noise dir must not let the walk escape the workspace root.
+
+    Mirrors the runner: the deferred second pass walks each noise root directly,
+    and ``os.walk`` follows a top-level symlink, so a committed ``node_modules``
+    symlink pointing outside the workspace would disclose the target's contents.
+    Deferring only real directories preserves the ``followlinks=False`` boundary.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("leaked")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "node_modules").symlink_to(outside, target_is_directory=True)
+    reader = WorkspaceReader(ws)
+
+    result = reader.search("secret")
+
+    paths = {e["path"] for e in result["data"]}
+    assert not any("secret" in p for p in paths), (
+        f"search must not descend a symlinked node_modules and leak the target's "
+        f"contents, got {paths}"
+    )
+
+
 # ── changes / diff (git mode) ─────────────────────────────────────────
 
 

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -149,10 +149,15 @@ function environmentResult(
   } as unknown as ReturnType<typeof useWorkspaceEnvironment>;
 }
 
-function searchResult(files: WorkspaceFile[] | undefined = undefined, isFetching = false) {
+function searchResult(
+  files: WorkspaceFile[] | undefined = undefined,
+  isFetching = false,
+  isPlaceholderData = false,
+) {
   return {
     data: files,
     isFetching,
+    isPlaceholderData,
     isLoading: false,
     isError: false,
     error: null,
@@ -169,6 +174,7 @@ function renderPanel({
   workingDir = null,
   treeSearchResults = [],
   isSearching = false,
+  isSearchPlaceholder = false,
   reachable = null,
   onFileSelect = vi.fn(),
 }: {
@@ -181,6 +187,7 @@ function renderPanel({
   workingDir?: string | null;
   treeSearchResults?: WorkspaceFile[] | undefined;
   isSearching?: boolean;
+  isSearchPlaceholder?: boolean;
   reachable?: {
     unconfined: boolean;
     roots: { path: string; access: string; origin: string }[];
@@ -191,7 +198,7 @@ function renderPanel({
   useChangedFilesMock.mockReturnValue(changedFilesResult(changedFiles));
   useDirectoryMock.mockReturnValue(directoryResult());
   useEnvironmentMock.mockReturnValue(environmentResult(workingDir, reachable));
-  useSearchMock.mockReturnValue(searchResult(treeSearchResults, isSearching));
+  useSearchMock.mockReturnValue(searchResult(treeSearchResults, isSearching, isSearchPlaceholder));
 
   return render(
     <MemoryRouter initialEntries={[`/c/${conversationId}`]}>
@@ -795,6 +802,34 @@ describe("FilesPanel tree (Explore) search", () => {
     // on the flat result paths that prove search mode is active
     expect(screen.getByText((t) => t.includes("abc/test.md"))).toBeInTheDocument();
     expect(screen.getByText((t) => t.includes("src/main.py"))).toBeInTheDocument();
+  });
+
+  it("does not render stale results from a previous query while the new one loads", () => {
+    // React Query keeps the prior term's results (placeholderData) in `data`
+    // while the new term is fetching. Those must NOT render as if they matched
+    // the new query — a slow runner would otherwise show a previous search's
+    // answers. FilesPanel drops placeholder data, so the tree shows "Searching…".
+    vi.useFakeTimers();
+
+    renderPanel({
+      conversationId: "conv_tree_search_stale",
+      files: [file("src/App.tsx")],
+      // These are the PREVIOUS query's results, still in `data` as placeholder.
+      treeSearchResults: [file("stale/prev.md")],
+      isSearching: true,
+      isSearchPlaceholder: true,
+    });
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search all files" }), {
+      target: { value: "fresh" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // The stale result must not appear; the loading state shows instead.
+    expect(screen.queryByText((t) => t.includes("stale/prev.md"))).toBeNull();
+    expect(screen.getByText("Searching…")).toBeInTheDocument();
   });
 
   it("drops back to the tree synchronously when a folder result is revealed", () => {

--- a/web/src/shell/FilesPanel.test.tsx
+++ b/web/src/shell/FilesPanel.test.tsx
@@ -80,6 +80,16 @@ function file(path: string, bytes = 10): WorkspaceFile {
   };
 }
 
+function dir(path: string): WorkspaceFile {
+  return {
+    bytes: null,
+    modified_at: null,
+    name: path.split("/").at(-1) ?? path,
+    path,
+    type: "directory",
+  };
+}
+
 function changedFile(
   path: string,
   status: WorkspaceChangedFile["status"] = "modified",
@@ -785,6 +795,40 @@ describe("FilesPanel tree (Explore) search", () => {
     // on the flat result paths that prove search mode is active
     expect(screen.getByText((t) => t.includes("abc/test.md"))).toBeInTheDocument();
     expect(screen.getByText((t) => t.includes("src/main.py"))).toBeInTheDocument();
+  });
+
+  it("drops back to the tree synchronously when a folder result is revealed", () => {
+    // Revealing a folder from search must clear the DEBOUNCED query too, not
+    // just the raw input — FolderTree renders search mode off the debounced
+    // value, so clearing only the raw query would leave the flat results up for
+    // the 300ms window and the reveal scroll would target unmounted rows. We
+    // assert the results list is gone WITHOUT advancing timers.
+    vi.useFakeTimers();
+
+    renderPanel({
+      conversationId: "conv_tree_reveal_exits_search",
+      files: [file("src/App.tsx"), dir("src")],
+      treeSearchResults: [dir("src")],
+    });
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search all files" }), {
+      target: { value: "src" },
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // Search mode is active: the folder shows as a result row (trailing slash).
+    const folderResult = screen.getByRole("button", { name: /src\// });
+    fireEvent.click(folderResult);
+
+    // No timer advance here. If exitTreeSearch only cleared the raw query, the
+    // debounced value would still be "src" and search mode would persist. The
+    // hook must now be called with an empty query (tree mode) right away.
+    expect(
+      useSearchMock.mock.calls.at(-1)?.[1],
+      "revealing a folder must clear the debounced query immediately",
+    ).toBe("");
   });
 
   it("returns to the tree view when the search query is cleared", () => {

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -387,6 +387,17 @@ export function FilesPanel({
     return () => clearTimeout(timer);
   }, [treeSearch, treeInclude, treeExclude]);
 
+  // Exit search when a folder is revealed from the results. Clears BOTH the raw
+  // and debounced queries: FolderTree renders search mode off the debounced
+  // value, so clearing only `treeSearch` would leave the flat results list up
+  // for the ~300ms debounce window — during which the tree's reveal scroll
+  // fires against rows that aren't mounted yet and never re-fires. Clearing the
+  // debounced value too drops back to the tree synchronously so the scroll lands.
+  const exitTreeSearch = useCallback(() => {
+    setTreeSearch("");
+    setDebouncedTreeSearch("");
+  }, []);
+
   // Only fire search queries on the Explore tab. The include/exclude globs
   // narrow an active text query; globs alone do not search.
   const treeSearchQuery = useWorkspaceFileSearch(
@@ -603,7 +614,7 @@ export function FilesPanel({
             searchError={treeSearchQuery.error instanceof Error ? treeSearchQuery.error : null}
             browseLocation={locationParam}
             onNavigateDir={navigateToChild}
-            onExitSearch={() => setTreeSearch("")}
+            onExitSearch={exitTreeSearch}
             scrollParentRef={scrollRef}
           />
         )}

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -603,6 +603,7 @@ export function FilesPanel({
             searchError={treeSearchQuery.error instanceof Error ? treeSearchQuery.error : null}
             browseLocation={locationParam}
             onNavigateDir={navigateToChild}
+            onExitSearch={() => setTreeSearch("")}
             scrollParentRef={scrollRef}
           />
         )}

--- a/web/src/shell/FilesPanel.tsx
+++ b/web/src/shell/FilesPanel.tsx
@@ -608,7 +608,11 @@ export function FilesPanel({
             sort={changedSort}
             runnerWentOffline={runnerWentOffline}
             searchQuery={debouncedTreeSearch}
-            searchResults={treeSearchQuery.data}
+            // Suppress keep-previous placeholder data: while a new query is in
+            // flight React Query returns the PRIOR term's results (isPlaceholderData),
+            // which would otherwise render as if they matched the new term. Drop
+            // them so the tree shows "Searching…" until the real results land.
+            searchResults={treeSearchQuery.isPlaceholderData ? undefined : treeSearchQuery.data}
             isSearching={treeSearchQuery.isFetching}
             isSearchError={treeSearchQuery.isError}
             searchError={treeSearchQuery.error instanceof Error ? treeSearchQuery.error : null}

--- a/web/src/shell/FolderTree.test.tsx
+++ b/web/src/shell/FolderTree.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { copyTextMock } = vi.hoisted(() => ({ copyTextMock: vi.fn(() => Promise.resolve()) }));
@@ -302,6 +303,95 @@ describe("FolderTree double-click to open a folder", () => {
     fireEvent.doubleClick(folder);
 
     expect(folder).toBeInTheDocument();
+  });
+});
+
+describe("FolderTree directory search results", () => {
+  it("renders a matched directory as a folder row above matched files", () => {
+    // The server-side search returns files AND directories; directories sort
+    // first so a folder to open reads above the files sharing its name.
+    renderTree({
+      searchQuery: "src",
+      searchResults: [file("src/main.py"), dir("src")],
+    });
+
+    const rows = screen.getAllByRole("listitem");
+    // Folder row first (label carries the trailing slash), then the file.
+    expect(rows[0]).toHaveTextContent("src/");
+    expect(rows[1]).toHaveTextContent("src/main.py");
+  });
+
+  it("reveals the directory and exits search when a folder result is clicked", () => {
+    // Clicking a folder in search behaves like clicking one in the tree: the
+    // panel drops back to the tree (search cleared) with that folder expanded.
+    const onExitSearch = vi.fn();
+    const onFileSelect = vi.fn();
+    renderTree({
+      searchQuery: "src",
+      searchResults: [dir("src/components")],
+      onExitSearch,
+      onFileSelect,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /src\/components\// }));
+
+    expect(onExitSearch).toHaveBeenCalledTimes(1);
+    // A folder is not a file — it must not be opened in the viewer.
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+
+  it("scrolls to and flashes the revealed folder, expanding only its ancestors", async () => {
+    // Search-mode is parent-controlled, so drive the whole flow through a
+    // wrapper that clears searchQuery on exit — the way FilesPanel does. The
+    // tree's own files show src/ containing sub/, so revealing "src/sub"
+    // expands the ancestor (src) but leaves the target (sub) collapsed, then
+    // scrolls it into view and flashes it.
+    // jsdom leaves scrollTo undefined; the virtualizer's scrollToIndex calls
+    // it, so define a no-op to keep the reveal effect from throwing.
+    Object.defineProperty(Element.prototype, "scrollTo", {
+      value: vi.fn(),
+      configurable: true,
+      writable: true,
+    });
+    lazyChildren.set("src", [dir("src/sub")]);
+
+    function Harness() {
+      const [query, setQuery] = useState("sub");
+      return (
+        <FolderTree
+          files={[dir("src")]}
+          isLoading={false}
+          isError={false}
+          error={null}
+          onFileSelect={vi.fn()}
+          conversationId="conv_reveal"
+          showHidden={false}
+          changedFiles={undefined}
+          sort="alpha"
+          searchQuery={query}
+          searchResults={[dir("src/sub")]}
+          onExitSearch={() => setQuery("")}
+        />
+      );
+    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Harness />
+      </QueryClientProvider>,
+    );
+
+    // Click the folder result → exit search, expand ancestors, reveal the row.
+    fireEvent.click(screen.getByRole("button", { name: /src\/sub\// }));
+
+    // The tree is back: the target row appears (ancestor src auto-expanded so
+    // its lazy child sub/ renders) and carries the flash class while active.
+    const subRow = await screen.findByRole("button", { name: "sub/" });
+    const rowContainer = subRow.closest("div.group");
+    expect(rowContainer).toHaveClass("animate-user-msg-flash");
+    // The ancestor was auto-expanded (its lazy child rendered); the target
+    // itself stays collapsed, like clicking a folder in the tree.
+    expect(subRow).toHaveAttribute("aria-expanded", "false");
   });
 });
 

--- a/web/src/shell/FolderTree.test.tsx
+++ b/web/src/shell/FolderTree.test.tsx
@@ -393,6 +393,56 @@ describe("FolderTree directory search results", () => {
     // itself stays collapsed, like clicking a folder in the tree.
     expect(subRow).toHaveAttribute("aria-expanded", "false");
   });
+
+  it("flashes a deep revealed folder once its ancestors' lazy levels resolve", async () => {
+    // Reveal a deep target (a/b/target) whose ancestors' listings arrive in
+    // separate lazy steps, so `flatRows` changes several times before the row
+    // materializes. The scroll/flash effect re-runs on each change but is gated
+    // (pendingRevealRef) to act once the row first appears — the highlight
+    // lands on exactly the target and no other row.
+    Object.defineProperty(Element.prototype, "scrollTo", {
+      value: vi.fn(),
+      configurable: true,
+      writable: true,
+    });
+    lazyChildren.set("a", [dir("a/b")]);
+    lazyChildren.set("a/b", [dir("a/b/target")]);
+
+    function Harness() {
+      const [query, setQuery] = useState("target");
+      return (
+        <FolderTree
+          files={[dir("a")]}
+          isLoading={false}
+          isError={false}
+          error={null}
+          onFileSelect={vi.fn()}
+          conversationId="conv_reveal_deep"
+          showHidden={false}
+          changedFiles={undefined}
+          sort="alpha"
+          searchQuery={query}
+          searchResults={[dir("a/b/target")]}
+          onExitSearch={() => setQuery("")}
+        />
+      );
+    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <Harness />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /a\/b\/target\// }));
+
+    // Wait for the deep row to materialize after both lazy levels resolve.
+    const targetRow = await screen.findByRole("button", { name: "target/" });
+    expect(targetRow.closest("div.group")).toHaveClass("animate-user-msg-flash");
+    // Exactly one row flashes — the reveal doesn't smear the highlight across
+    // ancestors as their levels land.
+    expect(container.querySelectorAll(".animate-user-msg-flash")).toHaveLength(1);
+  });
 });
 
 describe("FolderTree nested lazy loading", () => {

--- a/web/src/shell/FolderTree.tsx
+++ b/web/src/shell/FolderTree.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon, FileIcon } from "lucide-react";
+import { ChevronRightIcon, FileIcon, FolderIcon } from "lucide-react";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -372,6 +372,7 @@ export function FolderTree({
   searchError = null,
   browseLocation = "",
   onNavigateDir,
+  onExitSearch,
   scrollParentRef,
 }: {
   files: WorkspaceFile[] | undefined;
@@ -413,6 +414,12 @@ export function FolderTree({
    * matching Finder; a single click still just expands in place.
    */
   onNavigateDir?: (relativePath: string) => void;
+  /**
+   * Clear the active search query so the tree returns. Called after the user
+   * reveals a directory from the search results, mirroring a click on a folder
+   * in the tree: the panel drops back to the tree with that folder expanded.
+   */
+  onExitSearch?: () => void;
   /**
    * The scroll container the tree lives in (FilesPanel's `<section>`). When
    * provided, the virtualizer windows rows against THIS element so it shares
@@ -500,6 +507,34 @@ export function FolderTree({
     [cacheKey],
   );
 
+  // A directory just revealed from search results: the tree scrolls it into
+  // view and flashes a brief highlight so the eye can find it after the flat
+  // list collapses back to the tree. Cleared once the flash fades.
+  const [revealedPath, setRevealedPath] = useState<string | null>(null);
+  const revealFlashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reveal a directory the user picked from search results: expand it and every
+  // ancestor (so the row is visible once the flat tree returns), then leave
+  // search mode. The lazy-fetch fixpoint (see `lazyPaths`) resolves each newly
+  // expanded level as its parent's listing lands; an effect below scrolls to
+  // and highlights the row once it appears.
+  const revealDirectory = useCallback(
+    (path: string) => {
+      setExpandedPaths((prev) => {
+        const next = new Set(prev);
+        const parts = path.split("/");
+        // Expand every ancestor, but not the target itself — revealing a folder
+        // scrolls to it collapsed, the way clicking it in the tree would.
+        for (let i = 1; i < parts.length; i++) next.add(parts.slice(0, i).join("/"));
+        if (cacheKey) expandedPathsCache.set(cacheKey, next);
+        return next;
+      });
+      setRevealedPath(path);
+      onExitSearch?.();
+    },
+    [cacheKey, onExitSearch],
+  );
+
   // Build the nested top-level tree once per files/sort/showHidden change.
   // Hoisted above the early returns (Rules of Hooks) and memoized so an
   // unrelated re-render (a background refetch toggling isFetching, a store tick)
@@ -551,6 +586,23 @@ export function FolderTree({
     getItemKey: (index) => flatRows[index]?.key ?? index,
   });
 
+  // Once a revealed directory's row exists in the flat tree (its ancestors'
+  // lazy listings have landed), smooth-scroll it into view and start the
+  // highlight flash. Runs when `flatRows` changes, so it fires on the render
+  // after each expansion level resolves — no-op until the target row appears.
+  useEffect(() => {
+    if (!revealedPath) return;
+    const index = flatRows.findIndex((r) => r.kind === "node" && r.key === revealedPath);
+    if (index === -1) return; // row not materialized yet; a later level is loading
+    rowVirtualizer.scrollToIndex(index, { align: "center", behavior: "smooth" });
+    // Clear once the shared flash animation (800ms) has played out.
+    if (revealFlashTimer.current) clearTimeout(revealFlashTimer.current);
+    revealFlashTimer.current = setTimeout(() => setRevealedPath(null), 800);
+    return () => {
+      if (revealFlashTimer.current) clearTimeout(revealFlashTimer.current);
+    };
+  }, [revealedPath, flatRows, rowVirtualizer]);
+
   // When a search query is active, render a flat filtered list instead of the tree.
   if (searchQuery.trim().length > 0) {
     if (isSearching && !searchResults) {
@@ -590,14 +642,24 @@ export function FolderTree({
         </p>
       );
     }
+    // Directories first (like the tree), then files — each group by the active
+    // sort. A folder is a place to go, so it reads better above the matched
+    // files sharing its name.
+    const orderedResults = [...visibleResults].sort((a, b) => {
+      const aDir = a.type === "directory";
+      const bDir = b.type === "directory";
+      if (aDir !== bDir) return aDir ? -1 : 1;
+      return compareChangedFiles(sort)(a, b);
+    });
     return (
       <TooltipProvider>
         <ul className="flex flex-col gap-0.5">
-          {[...visibleResults].sort(compareChangedFiles(sort)).map((file) => (
+          {orderedResults.map((file) => (
             <SearchResultRow
               key={file.path}
               file={file}
               onFileSelect={onFileSelect}
+              onRevealDir={revealDirectory}
               conversationId={conversationId}
               changedFileMap={changedFileMap}
             />
@@ -671,6 +733,7 @@ export function FolderTree({
                 changedFileMap={changedFileMap}
                 dirtyDirMap={dirtyDirMap}
                 onNavigateDir={onNavigateDir}
+                highlighted={row.kind === "node" && row.key === revealedPath}
               />
             )}
           </div>
@@ -824,14 +887,20 @@ function FileRowItem({
 function SearchResultRow({
   file,
   onFileSelect,
+  onRevealDir,
   conversationId,
   changedFileMap,
 }: {
   file: WorkspaceFile;
   onFileSelect: (path: string) => void;
+  /** Reveal a matched directory in the tree (expand it + ancestors). */
+  onRevealDir: (path: string) => void;
   conversationId: string | undefined;
   changedFileMap: Map<string, WorkspaceChangedFile["status"]>;
 }) {
+  if (file.type === "directory") {
+    return <SearchDirRow file={file} onRevealDir={onRevealDir} />;
+  }
   return (
     <FileRowItem
       path={file.path}
@@ -842,6 +911,49 @@ function SearchResultRow({
       onFileSelect={onFileSelect}
       conversationId={conversationId}
     />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SearchDirRow — flat directory row used in search-results mode
+// ---------------------------------------------------------------------------
+
+/**
+ * A matched directory in search results. Clicking it reveals the folder in the
+ * tree (expands it and its ancestors, exits search) rather than opening a file
+ * — folders have nothing to show in the viewer. The full path is shown with
+ * rtl truncation and a trailing "/" so it reads as a directory.
+ */
+function SearchDirRow({
+  file,
+  onRevealDir,
+}: {
+  file: WorkspaceFile;
+  onRevealDir: (path: string) => void;
+}) {
+  return (
+    <li className="list-none">
+      <div className="group relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 pl-2 hover:bg-muted">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+          onClick={() => onRevealDir(file.path)}
+        >
+          <FolderIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate font-mono text-ui md:text-sm [direction:rtl]">
+            <bdi>{file.path}/</bdi>
+          </span>
+        </button>
+        <span
+          className={cn("relative flex shrink-0 items-center justify-end", ROW_META_SLOT_CLASS)}
+        >
+          <span className="absolute inset-0 flex items-center justify-end gap-0.5">
+            <span className={cn("shrink-0", ROW_ACTION_SIZE_CLASS)} aria-hidden />
+            <CopyPathButton path={file.path} label="Copy folder path" revealOnHover />
+          </span>
+        </span>
+      </div>
+    </li>
   );
 }
 
@@ -896,6 +1008,7 @@ const TreeNodeRow = memo(function TreeNodeRow({
   changedFileMap,
   dirtyDirMap,
   onNavigateDir,
+  highlighted = false,
 }: {
   node: TreeNode;
   depth: number;
@@ -908,6 +1021,8 @@ const TreeNodeRow = memo(function TreeNodeRow({
   dirtyDirMap: Map<string, WorkspaceChangedFile["status"]>;
   /** Re-root onto a directory (double-click), path relative to the root. */
   onNavigateDir?: (relativePath: string) => void;
+  /** Briefly flash this row — used when a folder is revealed from search. */
+  highlighted?: boolean;
 }) {
   if (node.type === "file") {
     return (
@@ -937,7 +1052,12 @@ const TreeNodeRow = memo(function TreeNodeRow({
     // still spans everything up to the copy button, so the clickable area is
     // effectively unchanged.
     <div
-      className="group relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 hover:bg-muted"
+      className={cn(
+        "group relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 hover:bg-muted",
+        // Reveal flash: reuse the chat nav-jump ring pulse so a folder opened
+        // from search catches the eye briefly, then settles.
+        highlighted && "animate-user-msg-flash",
+      )}
       style={{ paddingLeft: `${indentFor(depth)}px` }}
     >
       <IndentGuides depth={depth} />

--- a/web/src/shell/FolderTree.tsx
+++ b/web/src/shell/FolderTree.tsx
@@ -512,6 +512,13 @@ export function FolderTree({
   // list collapses back to the tree. Cleared once the flash fades.
   const [revealedPath, setRevealedPath] = useState<string | null>(null);
   const revealFlashTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The path still awaiting its one scroll+flash. The scroll effect re-runs as
+  // each lazy level lands, but must act exactly once per reveal — otherwise a
+  // later level re-fires scrollToIndex and restarts the 800ms timer, so the
+  // flash lingers through a multi-level load. Cleared when the row is handled.
+  const pendingRevealRef = useRef<string | null>(null);
+  // Clear any in-flight flash timer on unmount only (not per flatRows change).
+  useEffect(() => () => clearTimeout(revealFlashTimer.current ?? undefined), []);
 
   // Reveal a directory the user picked from search results: expand it and every
   // ancestor (so the row is visible once the flat tree returns), then leave
@@ -529,6 +536,7 @@ export function FolderTree({
         if (cacheKey) expandedPathsCache.set(cacheKey, next);
         return next;
       });
+      pendingRevealRef.current = path;
       setRevealedPath(path);
       onExitSearch?.();
     },
@@ -588,20 +596,21 @@ export function FolderTree({
 
   // Once a revealed directory's row exists in the flat tree (its ancestors'
   // lazy listings have landed), smooth-scroll it into view and start the
-  // highlight flash. Runs when `flatRows` changes, so it fires on the render
-  // after each expansion level resolves — no-op until the target row appears.
+  // highlight flash — exactly once. Re-runs as `flatRows` changes so it can
+  // catch the row when a later lazy level resolves, but `pendingRevealRef`
+  // gates it to a single scroll + timer per reveal (a later level must not
+  // re-fire the scroll or restart the 800ms flash).
   useEffect(() => {
-    if (!revealedPath) return;
-    const index = flatRows.findIndex((r) => r.kind === "node" && r.key === revealedPath);
+    const pending = pendingRevealRef.current;
+    if (!pending) return;
+    const index = flatRows.findIndex((r) => r.kind === "node" && r.key === pending);
     if (index === -1) return; // row not materialized yet; a later level is loading
+    pendingRevealRef.current = null; // handled — don't scroll/flash again
     rowVirtualizer.scrollToIndex(index, { align: "center", behavior: "smooth" });
     // Clear once the shared flash animation (800ms) has played out.
-    if (revealFlashTimer.current) clearTimeout(revealFlashTimer.current);
+    clearTimeout(revealFlashTimer.current ?? undefined);
     revealFlashTimer.current = setTimeout(() => setRevealedPath(null), 800);
-    return () => {
-      if (revealFlashTimer.current) clearTimeout(revealFlashTimer.current);
-    };
-  }, [revealedPath, flatRows, rowVirtualizer]);
+  }, [flatRows, rowVirtualizer]);
 
   // When a search query is active, render a flat filtered list instead of the tree.
   if (searchQuery.trim().length > 0) {


### PR DESCRIPTION
## Related issue

Closes #

## Summary

The **Working folder** file-panel search only ever surfaced files — the server-side `/search` walk emitted file entries and skipped directories, so a query like `examples` or `polly` could never reveal a folder. It also had a scan-budget starvation bug: a deep `node_modules` nested under an earlier-sorted real directory would exhaust the walk budget before reaching later real dirs, hiding matches like `examples/polly` entirely.

- **`search_files` (runner)** and **`WorkspaceReader.search` (host)** now match directories too, emitting them as `type="directory"` entries. The two implementations stay byte-identical, so search behaves the same whether the runner or the sleeping-agent host answers.
- Both walks are now **two-pass**: pass 1 walks the real tree and defers dependency/cache subtrees (`node_modules`, `.venv`, …); pass 2 drains those deferred roots only if scan budget remains. This keeps a deep noise subtree from starving later real directories.
- **Frontend**: search results sort directories first, render matched folders as folder rows, and clicking one **reveals it in the tree** (expands ancestors, exits search) with a smooth scroll and a brief chat-style flash highlight — folders are never opened in the file viewer.

## Test Plan

- Backend: `pytest tests/runner/test_environment_filesystem.py tests/test_workspace_fs.py` — 101 passed, 1 skipped. New tests assert directories are returned, that a directory match honors exclude globs, and that a deep noise subtree can't starve a later real dir (runner + host, kept in parity).
- Frontend: `vitest run` — full suite green (7064 passed). New `FolderTree` tests cover directory-first ordering, reveal-on-click (exits search, doesn't open a file), and scroll + flash on reveal.
- Verified host↔runner return byte-identical results for the same query against a real repo.
- `npm run build` (tsc + vite) passes; pre-commit (ruff, pyrefly, prettier, oxlint, tsc) all green.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Manually verified in a live local server (:8000 + :5174 UI): searching `examples` surfaces the `examples/` folder at the top of results; searching `polly` now surfaces `examples/polly`; clicking a folder result scrolls to and briefly highlights it in the tree. (Screen recording to be attached — the reveal-scroll + flash is the main visual.)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification covered the live end-to-end reveal UX (scroll + flash) and the host-served path (agent asleep), which the unit tests can't exercise directly. Automated tests cover the backend directory-matching + budget-deferral logic (runner and host in parity) and the frontend rendering/reveal behavior.

## Changelog

The Working folder file search now matches directories and reveals a folder in the tree when you click it
