### PR TITLE
docs: correct data-dir layout inaccuracies from PR #6799 review

### DIFF
--- a/docs/DATA_DIR_LAYOUT.md
+++ b/docs/DATA_DIR_LAYOUT.md
@@ -23,11 +23,15 @@ Two related resolvers exist for narrower scopes:
   `resolve_data_dir()` in `omnigent/server/admin_list.py`. It honors
   `OMNIGENT_ADMIN_CREDENTIALS_PATH` (its parent dir anchors the data dir on a
   mounted volume) and otherwise falls back to `~/.omnigent`.
-- CLI flows use a local data-dir helper so two worktrees don't silently share
-  one `chat.db`; see `omnigent/cli.py`.
+- CLI and local-server flows resolve their data dir via `_local_data_dir()` in
+  `omnigent/host/local_server.py` (imported by `omnigent/cli.py`), which also
+  honors `OMNIGENT_DATA_DIR`, else `~/.omnigent`. Two worktrees still share
+  `~/.omnigent/chat.db` unless each sets `OMNIGENT_DATA_DIR` — that env var is
+  the knob for isolating a worktree's runtime DB; there is no automatic split.
 
-Paths below are the defaults under `~/.omnigent`. Everything moves together
-when `OMNIGENT_DATA_DIR` is set unless noted.
+Most paths below move with `OMNIGENT_DATA_DIR`. A handful, marked **†**, are
+pinned to `~/.omnigent` regardless — they resolve `Path.home() / ".omnigent"`
+directly instead of going through `data_dir()`.
 
 ## Top-level files
 
@@ -35,13 +39,13 @@ when `OMNIGENT_DATA_DIR` is set unless noted.
 |------|---------|------------|
 | `config.yaml` | User-level config: harness auth references, settings. Overridable with `OMNIGENT_CONFIG_HOME`. | `omnigent/config.py` |
 | `chat.db` (+ `-shm`, `-wal`) | Main SQLite runtime DB — conversations, sessions, messages. Machine-global unless a project-local `.omnigent/` is used. | `omnigent/cli.py`, `omnigent/host/local_server.py` |
-| `auth_tokens.json` (+ `.lock`) | Per-server OIDC/session tokens keyed by server URL; written with user-only permissions. | `omnigent/cli_auth.py` |
+| `auth_tokens.json` / `auth_tokens.lock` | Per-server OIDC/session tokens keyed by server URL, written with user-only permissions, plus its lock file (`.json` is replaced by `.lock`, so it is `auth_tokens.lock`, not `auth_tokens.json.lock`). | `omnigent/cli_auth.py` |
 | `local_server.pid` / `local_server.sig` | Recorded pid/port and signature of the running local server. | `omnigent/host/local_server.py` |
 | `host.pid` | Recorded pid of the local host process. | `omnigent/cli.py` |
 | `telemetry.json` | Telemetry state, including the persistent `installation_id`. | `omnigent/telemetry/installation_id.py` |
-| `.update_check.json` | Cached result of the (potentially slow) update check. | `omnigent/update_check.py` |
+| `.update_check.json` **†** | Cached result of the (potentially slow) update check. | `omnigent/update_check.py` |
 | `install_ledger.json` | Record of what the installer wrote, used by uninstall/purge. | `omnigent/install_ledger.py` |
-| `admins`, `allowed_domains` | OSS server operator state: admin list and OIDC allowed-domains, co-located so operator-editable files live together. | `omnigent/server/admin_list.py`, `omnigent/server/oidc_access.py` |
+| `admins`, `allowed_domains` | OSS server operator state: admin list and OIDC allowed-domains, co-located so operator-editable files live together. Operator-managed input files — the cited modules read them. | Read by `omnigent/server/admin_list.py`, `omnigent/server/oidc_access.py` |
 | `sharing_mode`, `public_sharing` | Server-side sharing settings. | `omnigent/server/sharing_settings.py` |
 
 ## Directories
@@ -50,30 +54,37 @@ when `OMNIGENT_DATA_DIR` is set unless noted.
 |-----------|---------|------------|
 | `logs/` | Process logs split by role: `cli/`, `host/`, `runner/`, `server/`. | `logs_root()` / `process_log_dir()` in `omnigent/process_logging.py` |
 | `artifacts/` | Stored artifacts, one directory per artifact ID; paired with `chat.db`. | `omnigent/chat.py`, `omnigent/host/local_server.py` |
-| `runners/` | Runner identity `runner_id` (stable per-machine id), plus per-runner state/workspace subdirs — `runner_<id>/` for local runners and `runner_token_<hash>/` for remote `run --server` runners — each holding `pending-tokens/`. | `omnigent/runner/identity.py` |
+| `runners/` | Runner identity: `runner_id` (stable per-machine id), created by `identity.py`. Also holds per-runner workspace subdirs — `runner_<id>/` and, for token-bound remote `run --server` runners, `runner_token_<hash>/` — each with a `pending-tokens/` dir; those are created by the host/runner launch path, not `identity.py`. | `omnigent/runner/identity.py` (`runner_id`) |
 | `daemons/` | Daemon lifecycle registry, one JSON record per target. | `daemon_registry_dir()` in `omnigent/host/daemon_lifecycle.py` |
 | `crashes/` | Crash reports, `crash-<timestamp>.md`. | `omnigent/crash_handler.py` |
-| `cache/` | Derived caches: `model-catalogs/` (per-harness model lists) and `codex-model-probe/`. | `omnigent/models/model_catalog_store.py`, `omnigent/harnesses/codex_native/app_server.py` |
-| `models/` | Downloaded models, e.g. `dictation/asr` and `dictation/punct`. | `omnigent/server/dictation.py` |
-| `agents/` | User-level agent directory (`_GLOBAL_AGENTS_DIR`). | `omnigent/cli.py` |
+| `cache/` | Derived caches: `model-catalogs/` (per-harness model lists) and `codex-model-probe/` **†**. | `omnigent/models/model_catalog_store.py`, `omnigent/harnesses/codex_native/app_server.py` |
+| `models/` **†** | Downloaded models, e.g. `dictation/asr` and `dictation/punct`. | `omnigent/server/dictation.py` |
+| `agents/` **†** | User-level agent directory (`_GLOBAL_AGENTS_DIR`). | `omnigent/cli.py` |
 | `profiles/` | cProfile output when CLI profiling is enabled. | `omnigent/cli.py` |
-| `debug/` | Per-session JSONL event tapes, `events-<session_id>.jsonl`. | `omnigent/repl/_event_tape.py` |
+| `debug/` **†** | Per-session JSONL event tapes, `events-<session_id>.jsonl`. | `omnigent/repl/_event_tape.py` |
 
 ### Native harness state
 
-Each native (TUI) harness keeps resumable session state under its own
-directory: `claude-native/`, `codex-native/`, `pi-native/`,
-`antigravity-native/`, `opencode-native/`, `qwen-native/`, `hermes-native/`.
+Some native (TUI) harnesses keep resumable session state under `~/.omnigent`:
+`claude-native/`, `codex-native/`, `opencode-native/` (all via `data_dir()`),
+and `pi-native/` **†** and `antigravity-native/` **†** (pinned to
+`~/.omnigent`).
 
-Within each, session state lives in a subdirectory named
-`sha256(conversation_id)[:32]` holding e.g. `launch.json` — how that native
-session was launched, so it can be resumed. See
+Within each, session state lives in a subdirectory named by a digest of the
+conversation id (a leading `conv_` is normalized before hashing, and a legacy
+prefixed digest is used when one is already present), holding e.g.
+`launch.json` — how that native session was launched, so it can be resumed. See
 `omnigent/harnesses/claude_native/state.py` and
 `omnigent/harnesses/codex_native/state.py`.
 
 `codex-native/` additionally holds `process-registry.json` (+ `.lock`) and
 `process-owners/`, tracking spawned CLI processes
 (`omnigent/harnesses/codex_native/process_registry.py`).
+
+Not every native harness lives here: `qwen-native`, `hermes-native`, and
+`cursor-native` root their per-session bridge dirs in the system temp
+directory (`$TMPDIR/omnigent-<uid>/<harness>-native/`), so they are outside the
+data dir. See e.g. `omnigent/harnesses/qwen_native/bridge.py`.
 
 ## Notes
 


### PR DESCRIPTION
## Related issue

<!-- Docs change — no issue required per template. -->

## Summary

Follow-up to #6799 (merged), correcting factual inaccuracies flagged by the
Polly review on that PR. Each was verified against the code before changing:

- Drops the blanket "everything moves with `OMNIGENT_DATA_DIR`" claim. Paths
  that resolve `Path.home() / ".omnigent"` directly — `.update_check.json`,
  `cache/codex-model-probe`, `models/`, `agents/`, `debug/`, `pi-native`,
  `antigravity-native` — are now marked **†** ("pinned to `~/.omnigent`").
- Removes `qwen-native`/`hermes-native` from the `~/.omnigent` native-harness
  list — they (and `cursor-native`) root their bridge dirs in the system temp
  dir (`$TMPDIR/omnigent-<uid>/<harness>-native/`), so they're out of scope.
- Fixes the CLI helper description: `_local_data_dir()` lives in
  `host/local_server.py` (`cli.py` imports it), and worktrees still share
  `chat.db` unless `OMNIGENT_DATA_DIR` is set — there is no automatic split.
- Fixes the auth lock filename (`auth_tokens.lock`, not `auth_tokens.json.lock`).
- Scopes the `runners/` "Defined in" to `runner_id`; per-runner subdirs are
  created by the launch path, not `identity.py`.
- Clarifies `admins`/`allowed_domains` are operator-managed inputs the cited
  modules read.
- Notes the session-subdir digest normalizes a leading `conv_` / legacy prefix
  rather than a bare `sha256`.

## Test Plan

Docs-only. Verified every corrected claim against the cited source:
`update_check.py:63`, `harnesses/codex_native/app_server.py:972`,
`server/dictation.py:223`, `cli.py:648`, `repl/_event_tape.py:755`,
`harnesses/qwen_native/bridge.py:55`, `harnesses/hermes_native/bridge.py:52`,
`harnesses/pi_native/bridge.py:29`, `harnesses/antigravity_native/bridge.py:33`,
`host/local_server.py:26`, `cli_auth.py:364`.
`pre-commit run --files docs/DATA_DIR_LAYOUT.md` passes.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Documentation only, no code paths to test. Manual verification was cross-checking
each corrected path/claim against the current source at the lines listed in the
Test Plan.
