### PR TITLE
fix(runner): keep session creation working when the launch cwd is gone

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -719,6 +719,34 @@ def _required_runner_env(name: str) -> str:
     return value
 
 
+def _native_launch_workspace() -> str:
+    """
+    Resolve the workspace a native terminal launches in.
+
+    ``OMNIGENT_RUNNER_WORKSPACE`` is the runner's own launch directory and
+    wins whenever it is set; the process cwd only stands in for runners
+    started without it. Read lazily on purpose: a long-lived runner can
+    outlive the directory it was started in (the user deletes that
+    worktree), and reading the cwd eagerly failed terminal creation even
+    when the environment already named a perfectly good workspace.
+
+    :returns: Workspace path for the terminal cwd.
+    :raises RuntimeError: If the environment names no workspace and the
+        process cwd is unreadable.
+    """
+    workspace = os.environ.get("OMNIGENT_RUNNER_WORKSPACE")
+    if workspace:
+        return workspace
+    try:
+        return str(Path.cwd())
+    except OSError as exc:
+        raise RuntimeError(
+            "Cannot resolve a workspace for this session: the runner's working "
+            "directory no longer exists and OMNIGENT_RUNNER_WORKSPACE is unset. "
+            "Restart the host from a directory that exists."
+        ) from exc
+
+
 def _codex_session_workspace(session_workspace: str | None) -> Path:
     """
     Resolve the cwd for a runner-owned Codex terminal.
@@ -6597,7 +6625,7 @@ async def _auto_create_claude_terminal(
     workspace = (
         session_init.snapshot.workspace
         if session_init is not None and session_init.snapshot.workspace
-        else os.environ.get("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))
+        else _native_launch_workspace()
     )
     started_at = time.monotonic()
     _logger.info(
@@ -7465,7 +7493,7 @@ async def _auto_create_repl_terminal(
     from omnigent.inner.datamodel import OSEnvSpec, TerminalEnvSpec
 
     started_at = time.monotonic()
-    workspace = os.environ.get("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))
+    workspace = _native_launch_workspace()
     server_url = os.environ.get("RUNNER_SERVER_URL", "http://localhost:6767")
     # Inherit the agent's os_env so its sandbox (e.g. ``type: none``) is honoured;
     # without sandbox= here and parent_os_env below, launch_terminal falls back to

--- a/omnigent/runner/tool_dispatch.py
+++ b/omnigent/runner/tool_dispatch.py
@@ -602,9 +602,16 @@ def build_native_relay_tool_schemas(spec: AgentSpec | None) -> list[_JsonObject]
     from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
     from omnigent.inner.os_env import create_os_environment
 
+    # A long-lived runner can outlive the directory it was started in, making
+    # Path.cwd() raise. This environment exists purely for schema extraction,
+    # so any directory that exists serves equally well.
+    try:
+        _schema_cwd = str(Path.cwd())
+    except OSError:
+        _schema_cwd = tempfile.gettempdir()
     _os_spec = OSEnvSpec(
         type="caller_process",
-        cwd=str(Path.cwd()),
+        cwd=_schema_cwd,
         sandbox=OSEnvSandboxSpec(type="none"),
         fork=False,
     )

--- a/omnigent/tools/builtins/load_skill.py
+++ b/omnigent/tools/builtins/load_skill.py
@@ -48,13 +48,24 @@ class LoadSkillTool(Tool):
         # but fall back to cwd — in production the server process
         # runs from the user's project, so cwd finds .claude/skills/
         # even when agent_root is a cache dir.
-        discovery_root = agent_root or Path.cwd()
+        discovery_root = agent_root
+        if discovery_root is None:
+            try:
+                discovery_root = Path.cwd()
+            except OSError:
+                # A long-lived runner can outlive its own working directory —
+                # deleting the worktree it was started in makes os.getcwd()
+                # raise. Host-scope discovery is an enrichment, so degrade to
+                # bundled skills instead of failing the caller, which would
+                # take down whatever is building the tool list.
+                discovery_root = None
         from omnigent.spec.parser import discover_host_skills
 
         bundled_names = {s.name for s in skills}
-        for hs in discover_host_skills(discovery_root, skills_filter):
-            if hs.name not in bundled_names:
-                all_skills.append(hs)
+        if discovery_root is not None:
+            for hs in discover_host_skills(discovery_root, skills_filter):
+                if hs.name not in bundled_names:
+                    all_skills.append(hs)
         self._skills = all_skills
         self._skills_by_name: dict[str, SkillSpec] = {s.name: s for s in all_skills}
 

--- a/tests/e2e/test_deleted_worktree_cwd_relay_e2e.py
+++ b/tests/e2e/test_deleted_worktree_cwd_relay_e2e.py
@@ -1,0 +1,211 @@
+"""E2E regression test: ``Path.cwd()`` on a deleted working directory must
+not crash comment-relay pre-start or turn setup.
+
+Reported journey (a native-harness — e.g. ``claude-native`` — session whose
+runner is rooted in a git worktree that is deleted underneath it)::
+
+    1. launch a native-harness session; its runner's process cwd is a git
+       worktree W (``omnigent run`` from a transient worktree, or a host runner
+       rooted in one),
+    2. run a turn (works),
+    3. delete W underneath the running runner (``git worktree remove --force``),
+    4. observable failure: the very next relay pre-start or turn dies with
+       ``FileNotFoundError: [Errno 2] No such file or directory`` and the runner
+       logs ``Failed to pre-start comment relay for <id>`` / ``turn setup failed
+       for <id>: [Errno 2] ...``.
+
+Root cause (one cause, two reported signatures): building the native-relay tool
+list constructs a :class:`~omnigent.tools.manager.ToolManager` **without a
+workdir**, so :class:`~omnigent.tools.builtins.load_skill.LoadSkillTool` is
+instantiated with ``agent_root=None`` and falls back to ``Path.cwd()`` for
+host-scope skill discovery (``omnigent/tools/builtins/load_skill.py`` — the
+``discovery_root = agent_root or Path.cwd()`` line). When the process cwd has
+been removed, ``os.getcwd()`` raises ``FileNotFoundError`` and the exception
+escapes.
+
+The report names both crash sites as reached through the same function:
+
+* ``omnigent/runner/app.py`` ``_start_claude_relay_early``  → relay pre-start
+  → ``Failed to pre-start comment relay for %s`` (9 attempts), and
+* ``omnigent/runner/app.py`` ``_run_turn_bg``               → turn setup
+  → ``turn setup failed for %s: %s`` (5 attempts, hit released users),
+
+both via ``omnigent/runner/tool_dispatch.py``
+``build_native_relay_tool_schemas`` — the single reach point exercised here.
+The native TUI (claude-native/codex-native) needs an interactive login and
+cannot run in CI, so this drives the exact shared reach function against a real
+deleted git worktree instead of the TUI, reproducing the identical crash at the
+identical call site.
+
+``test_native_relay_tool_schemas_build_with_live_worktree_cwd`` is the baseline
+(passes on any build) proving the schema build succeeds — and registers
+``load_skill`` — when the worktree cwd exists. ``test_native_relay_tool_schemas_
+survive_deleted_worktree_cwd`` is the regression guard: it FAILS on the buggy
+build (``build_native_relay_tool_schemas`` raises ``FileNotFoundError`` from a
+``Path.cwd()`` read — ``load_skill.py``'s discovery fallback, then the OS-tool
+schema-extraction spec in ``tool_dispatch.py``) and passes once no step of the
+schema build requires the process cwd to still exist.
+
+Linux-only: a removed cwd makes ``os.getcwd()`` raise on Linux (the reported
+traceback is ``/usr/lib/python3.12/pathlib.py`` → ``os.getcwd()``); other
+platforms may keep serving the stale path.
+
+Runs against no server and needs no credentials::
+
+    pytest tests/e2e/test_deleted_worktree_cwd_relay_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+from omnigent.runner.tool_dispatch import build_native_relay_tool_schemas
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason=(
+        "a removed cwd makes os.getcwd() raise on Linux (the reported traceback); "
+        "other platforms may keep serving the stale path"
+    ),
+)
+
+
+def _make_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a git repo with one worktree W (the runner's launch cwd).
+
+    :param tmp_path: Per-test temp dir.
+    :returns: ``(repo, W)`` — the repo dir and the worktree path.
+    """
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.email=e2e@test",
+            "-c",
+            "user.name=e2e",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+        check=True,
+    )
+    w = tmp_path / "worktrees" / "W"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            "-q",
+            str(w),
+            "-b",
+            f"w-{uuid.uuid4().hex[:8]}",
+        ],
+        check=True,
+    )
+    return repo, w
+
+
+def _native_spec() -> AgentSpec:
+    """A resolved ``claude-native`` agent spec.
+
+    The exact shape the runner hands to ``build_native_relay_tool_schemas`` from
+    both ``_start_claude_relay_early`` (relay pre-start) and ``_run_turn_bg``
+    (turn setup) via ``_ensure_comment_relay_started``.
+
+    :returns: A minimal non-``None`` native-harness :class:`AgentSpec`.
+    """
+    return AgentSpec(
+        spec_version=1,
+        name="deleted-cwd-native",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+    )
+
+
+def test_native_relay_tool_schemas_build_with_live_worktree_cwd(tmp_path: Path) -> None:
+    """Baseline: with the worktree cwd present, the native relay schema build
+    succeeds and registers ``load_skill``.
+
+    Isolates the deleted cwd as the trigger: the identical call in the identical
+    process succeeds here, so a failure in the sibling test is caused only by the
+    removed working directory, not by the spec or the build itself.
+    """
+    _repo, w = _make_worktree(tmp_path)
+    original_cwd = os.getcwd()
+    spec = _native_spec()
+    try:
+        os.chdir(w)
+        schemas = build_native_relay_tool_schemas(spec)
+    finally:
+        os.chdir(original_cwd)
+
+    names = {s["name"] for s in schemas}
+    assert schemas, "expected a non-empty native relay tool surface"
+    assert "load_skill" in names, (
+        "load_skill must ride the native relay (it is what discovers host-scope "
+        f"skills); got {sorted(names)}"
+    )
+
+
+def test_native_relay_tool_schemas_survive_deleted_worktree_cwd(tmp_path: Path) -> None:
+    """Regression guard: building the native relay tool schemas must not
+    crash when the runner's process cwd (a git worktree) has been deleted
+    underneath it.
+
+    On the unfixed build ``build_native_relay_tool_schemas`` constructs a
+    ``ToolManager`` with no workdir, so ``LoadSkillTool`` falls back to
+    ``Path.cwd()`` → ``os.getcwd()`` → ``FileNotFoundError: [Errno 2]``. That is
+    exactly the relay pre-start crash (``Failed to pre-start comment relay``) and
+    the turn-setup crash (``turn setup failed: [Errno 2] ...``) the report
+    describes. This test therefore FAILS on the buggy build (the call raises)
+    and passes once no step of the schema build requires the process cwd to
+    still exist.
+    """
+    repo, w = _make_worktree(tmp_path)
+    original_cwd = os.getcwd()
+    spec = _native_spec()
+    try:
+        os.chdir(w)
+
+        # Sanity: the schema build works while the worktree cwd is live.
+        assert build_native_relay_tool_schemas(spec), "precondition: build works with live cwd"
+
+        # The reported journey: the worktree is removed underneath the running
+        # runner (`git worktree remove --force`), leaving the process cwd gone.
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "remove", "--force", str(w)],
+            check=False,
+        )
+        shutil.rmtree(w, ignore_errors=True)
+        assert not w.exists()
+
+        # THE observable: on the buggy build this raises FileNotFoundError from
+        # load_skill.py's `Path.cwd()`; after the fix it returns the schemas.
+        schemas = build_native_relay_tool_schemas(spec)
+    finally:
+        os.chdir(original_cwd)
+
+    names = {s["name"] for s in schemas}
+    assert schemas, (
+        "build_native_relay_tool_schemas returned no schemas on a deleted cwd; "
+        "the native relay surface must survive a removed working directory"
+    )
+    assert "load_skill" in names, (
+        "load_skill must still be registered on the native relay when the process "
+        f"cwd has been deleted (host-scope discovery yields nothing); got {sorted(names)}"
+    )

--- a/tests/runner/test_app_sessions_native_terminals_autocreate.py
+++ b/tests/runner/test_app_sessions_native_terminals_autocreate.py
@@ -4319,3 +4319,55 @@ async def test_auto_create_claude_terminal_default_pin_requires_a_fresh_catalog(
         assert model_catalog_store.read_catalog("claude-native", fingerprint) == refreshed
 
     await fake_client.aclose()
+
+
+def _unreadable_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``Path.cwd()`` behave as it does when the cwd was deleted."""
+
+    def _boom() -> Path:
+        raise FileNotFoundError(2, "No such file or directory")
+
+    monkeypatch.setattr(Path, "cwd", staticmethod(_boom))
+
+
+def test_native_launch_workspace_prefers_env_over_a_deleted_cwd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A runner can outlive the directory it was started in. The environment
+    already names the workspace in that case, so resolution must not touch
+    the cwd at all — reading it eagerly aborted terminal creation with a
+    bare ``FileNotFoundError``.
+    """
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", "/srv/launch-dir")
+    _unreadable_cwd(monkeypatch)
+
+    from omnigent.runner.native.orchestration import _native_launch_workspace
+
+    assert _native_launch_workspace() == "/srv/launch-dir"
+
+
+def test_native_launch_workspace_falls_back_to_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Runners started without the env var still get the process cwd."""
+    monkeypatch.delenv("OMNIGENT_RUNNER_WORKSPACE", raising=False)
+    monkeypatch.setattr(Path, "cwd", staticmethod(lambda: Path("/srv/inherited")))
+
+    from omnigent.runner.native.orchestration import _native_launch_workspace
+
+    assert _native_launch_workspace() == "/srv/inherited"
+
+
+def test_native_launch_workspace_reports_when_nothing_is_resolvable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    No env var and no readable cwd is a genuinely broken environment, so it
+    must surface as an actionable message rather than a bare errno.
+    """
+    monkeypatch.delenv("OMNIGENT_RUNNER_WORKSPACE", raising=False)
+    _unreadable_cwd(monkeypatch)
+
+    from omnigent.runner.native.orchestration import _native_launch_workspace
+
+    with pytest.raises(RuntimeError, match="OMNIGENT_RUNNER_WORKSPACE is unset"):
+        _native_launch_workspace()

--- a/tests/runner/test_native_relay_deleted_cwd.py
+++ b/tests/runner/test_native_relay_deleted_cwd.py
@@ -1,0 +1,71 @@
+"""The native relay tool surface survives a deleted working directory.
+
+A long-lived runner can outlive the directory it was started in — the user
+deletes the worktree the host was launched from. ``build_native_relay_tool_
+schemas`` sits on both the comment-relay pre-start and turn-setup paths, so an
+unhandled ``FileNotFoundError`` from reading the vanished cwd kills relay
+pre-start ("Failed to pre-start comment relay") and the next turn ("turn setup
+failed: [Errno 2] ..."). The schema build must not depend on the process cwd
+existing, and the surface it relays — including the ``sys_os_*`` tools, whose
+schema-extraction environment used to be rooted at ``Path.cwd()`` — must be
+identical with and without a live cwd.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from omnigent.runner.tool_dispatch import build_native_relay_tool_schemas
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="a removed cwd makes os.getcwd() raise on Linux; other platforms may serve stale paths",
+)
+
+_OS_TOOLS = {"sys_os_read", "sys_os_write", "sys_os_edit", "sys_os_shell"}
+
+
+def _native_spec() -> AgentSpec:
+    """A resolved native-harness spec, as the runner hands to the relay build.
+
+    :returns: A minimal non-``None`` native-harness :class:`AgentSpec`.
+    """
+    return AgentSpec(
+        spec_version=1,
+        name="deleted-cwd-relay-probe",
+        executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+    )
+
+
+def test_relay_surface_is_identical_after_cwd_is_deleted(tmp_path: Path) -> None:
+    """Deleting the process cwd must not shrink (or crash) the relay surface.
+
+    The ``sys_os_*`` schemas are relayed unconditionally to override
+    harness-static versions and centralize policy enforcement, so they must
+    stay present even when the cwd is gone — the schema-extraction environment
+    only needs *a* directory, not the launch directory.
+    """
+    doomed = tmp_path / "doomed"
+    doomed.mkdir()
+    original_cwd = os.getcwd()
+    spec = _native_spec()
+    try:
+        os.chdir(doomed)
+        live_names = {s["name"] for s in build_native_relay_tool_schemas(spec)}
+
+        doomed.rmdir()
+        gone_names = {s["name"] for s in build_native_relay_tool_schemas(spec)}
+    finally:
+        os.chdir(original_cwd)
+
+    assert live_names >= _OS_TOOLS, "precondition: sys_os_* ride the relay with a live cwd"
+    assert gone_names == live_names, (
+        "the native relay surface must not change when the process cwd is "
+        f"deleted; lost {sorted(live_names - gone_names)}, "
+        f"gained {sorted(gone_names - live_names)}"
+    )

--- a/tests/tools/builtins/test_load_skill.py
+++ b/tests/tools/builtins/test_load_skill.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -310,3 +312,31 @@ def test_load_skill_tool_accepts_namespaced_alias(tmp_path: Path, tool_ctx: Tool
     tool = LoadSkillTool([skill])
     result = tool.invoke(json.dumps({"name": "myplugin:brand-review"}), tool_ctx)
     assert result == "Review the brand."
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="a removed cwd makes os.getcwd() raise on Linux; other platforms may serve stale paths",
+)
+def test_deleted_cwd_degrades_to_bundled_skills(
+    tmp_path: Path, skill_no_resources: SkillSpec, tool_ctx: ToolContext
+) -> None:
+    """
+    A long-lived runner can outlive its working directory. With no
+    ``agent_root``, host-scope discovery falls back to the process cwd; when
+    that directory has been deleted, construction must degrade to the bundled
+    skills instead of raising into whatever is building the tool list.
+    """
+    doomed = tmp_path / "doomed"
+    doomed.mkdir()
+    original_cwd = os.getcwd()
+    os.chdir(doomed)
+    try:
+        doomed.rmdir()
+        tool = LoadSkillTool([skill_no_resources])
+    finally:
+        os.chdir(original_cwd)
+
+    assert [s.name for s in tool.skills] == [skill_no_resources.name]
+    result = tool.invoke(json.dumps({"name": skill_no_resources.name}), tool_ctx)
+    assert result == skill_no_resources.content


### PR DESCRIPTION
## Related issue

Closes #

## Summary

A long-lived runner can outlive the directory it was started in — the user deletes the worktree the host was launched from. Two session-creation paths then read that cwd unconditionally and abort the session with a bare `FileNotFoundError: [Errno 2] No such file or directory`.

- **`os.environ.get("OMNIGENT_RUNNER_WORKSPACE", str(Path.cwd()))` evaluates its default eagerly.** `Path.cwd()` runs *even when the environment already names a perfectly good workspace*, so native terminal creation failed on hosts where the variable was set and only the cwd was missing. Both call sites (`_auto_create_claude_terminal`, `_auto_create_repl_terminal`) now resolve through `_native_launch_workspace()`, which reads the environment first, falls back to the cwd, and reports an actionable message when neither is available.
- **`LoadSkillTool` has the same shape.** It falls back to `Path.cwd()` for host-scope skill discovery, and an unreadable cwd propagated straight out of `__init__`, failing whatever was building the tool list — `build_native_relay_tool_schemas` is on both the turn-setup and comment-relay-pre-start paths, so the whole turn dies. Discovery is an enrichment, so it now degrades to the bundled skills.

ELI5: we asked "where should I run?" by always computing a fallback answer first, and computing the fallback crashed — even when we already had the real answer in hand.

```
before:  os.environ.get(KEY, str(Path.cwd()))
                              └─ always evaluated ──> FileNotFoundError, session dead

after:   env = os.environ.get(KEY)
         if env: return env          <-- deleted cwd never touched
         try:   return str(Path.cwd())
         except OSError: raise RuntimeError("...restart the host from a directory that exists")
```

## Test Plan

Three unit tests on the new helper plus one on `LoadSkillTool`, each verified to fail before the fix and pass after:

```
python -m pytest tests/runner/test_app_sessions_native_terminals_autocreate.py -k native_launch_workspace
python -m pytest tests/tools/builtins/test_load_skill.py -k deleted_cwd
```

The eager-default defect on its own, isolated (env var set to a valid path, cwd unreadable):

```
env var is set to: /srv/launch-dir
OLD expression raised: FileNotFoundError [Errno 2] No such file or directory
NEW (lazy) expression -> /srv/launch-dir
```

Full suites for the touched modules:

- `tests/tools/builtins/test_load_skill.py` — 20 passed
- `tests/runner/test_app_sessions_native_terminals_autocreate.py` — 96 passed, 1 failed (`test_auto_create_claude_terminal_registers_permission_hook`, fails identically on a pristine `origin/main`)
- `tests/runner/test_app_sessions_native_terminals_runtime.py` — 39 passed, 5 failed, the same 5 failing on a pristine `origin/main` (pi/codex workspace threading, untouched here)

Manual reproduction of the original failure:

1. `mkdir /tmp/doomed && cd /tmp/doomed`, start a host from there, open a session.
2. From another shell, `rm -rf /tmp/doomed`.
3. Ask the session for a new native terminal. Before: the turn fails with `[Errno 2] No such file or directory`. After: the terminal launches in `OMNIGENT_RUNNER_WORKSPACE`, and with that unset the failure names the cause and the fix.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The manual step above is the deleted-worktree scenario, which the unit tests simulate by making `Path.cwd()` raise. Pre-existing failures in the two runner suites were confirmed by running the same selections on a pristine `origin/main` worktree.

## Changelog

Creating a session no longer fails when the directory the host was started in has been deleted.

## Issues

Resolves [OMNI-6865](https://linear.app/omnigent/issue/OMNI-6865/omnigent-pathcwd-on-a-deleted-working-directory-crashes-comment-relay)
