### PR TITLE
fix(claude-native): stop a best-effort tools-changed notify from failing a task

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -4052,7 +4052,13 @@ def post_tools_changed(
     :raises RuntimeError: If the bridge server is not ready, cannot
         be reached, or rejects the notification.
     """
-    server = _wait_for_server_info(bridge_dir, timeout_s=timeout_s)
+    try:
+        server = _wait_for_server_info(bridge_dir, timeout_s=timeout_s)
+    except OSError as exc:
+        # Reading the advertisement can fail for reasons other than the file
+        # being absent — fd exhaustion is the one seen in the wild. Callers
+        # treat this notification as best-effort and only expect RuntimeError.
+        raise RuntimeError(f"failed to read the Claude native bridge server info: {exc}") from exc
     token = server.get("token")
     url = server.get("url")
     if not isinstance(token, str) or not isinstance(url, str):

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -7209,10 +7209,15 @@ def create_runner_app(
                 await asyncio.get_running_loop().run_in_executor(
                     None, post_tools_changed, bridge_dir
                 )
-            except RuntimeError:
+            except (RuntimeError, OSError):
+                # Fire-and-forget below, so anything escaping here resurfaces as
+                # an unretrieved task exception at ERROR. Re-advertising the tool
+                # list is best-effort; a stale list costs one turn, a dead task
+                # loop costs the session.
                 _logger.debug(
                     "tools-changed notification skipped for session=%s (bridge server not ready)",
                     session_id,
+                    exc_info=True,
                     extra={"session_id": session_id},
                 )
 

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4886,6 +4886,26 @@ def test_post_tools_changed_normalizes_transport_errors(
     assert caught.value.__cause__ is transport_error
 
 
+def test_post_tools_changed_normalizes_server_info_read_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Reading the bridge advertisement can fail for reasons other than the file
+    being absent — a runner that has exhausted its file descriptors raises
+    ``OSError`` (EMFILE) on the read. That must arrive as the documented
+    ``RuntimeError`` so the fire-and-forget caller can swallow it instead of
+    leaving an unretrieved task exception behind.
+    """
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_wait_for_server_info",
+        Mock(side_effect=OSError(24, "Too many open files")),
+    )
+
+    with pytest.raises(RuntimeError, match="failed to read the Claude native bridge server info"):
+        post_tools_changed(tmp_path)
+
+
 def test_post_tools_changed_preserves_programming_errors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #

## Summary

Re-advertising the MCP tool list is fire-and-forget: the runner schedules `_notify_tools_changed` on a background task whose only done-callback is `discard`. Nothing ever retrieves that task's result, so any exception escaping the coroutine is reported by asyncio's loop exception handler at **ERROR** — a stale tool list, which costs at most one turn, gets logged as a session-level failure.

The coroutine catches `RuntimeError` only, and that was a fair contract: `post_tools_changed` documents `:raises RuntimeError:` and normalizes the POST's transport errors. But the **advertisement read that happens before the POST** does not honour it — `_wait_for_server_info` → `_read_json_file` catches only `FileNotFoundError`, so a runner that has exhausted its file descriptors raises `OSError` (EMFILE) from `path.read_text()` straight through the documented contract and past the caller's `except RuntimeError`.

- `post_tools_changed` now normalizes that read into the `RuntimeError` its docstring promises.
- `_notify_tools_changed` widens to `(RuntimeError, OSError)` and logs with `exc_info`, so a future leak degrades to a debug line rather than a dangling task.

```
_notify_tools_changed  (create_task, done_callback=discard)
  └─ post_tools_changed
       ├─ _wait_for_server_info -> _read_json_file   <-- OSError(EMFILE) leaked here
       └─ urlopen(...)                               <-- already normalized
```

## Test Plan

New unit test, verified to fail before the fix (the raw `OSError` escapes) and pass after:

```
python -m pytest tests/test_claude_native_bridge.py -k post_tools_changed
```

7 passed, covering the new EMFILE case alongside the existing transport-error and programming-error contracts.

Full suites for the touched modules:

- `tests/test_claude_native_bridge.py` — 306 passed, 1 failed (`test_curl_evaluate_policy_command_round_trips`, a known chronic flake in this suite)
- `tests/runner/test_app_sessions_native_terminals_runtime.py` — 39 passed, 5 failed, the same 5 failing on a pristine `origin/main`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The two pre-existing failures noted above were confirmed by running the same selections on a pristine `origin/main` worktree.
