### PR TITLE
fix(server): give a detail-less native failure something the user can read

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2442,6 +2442,24 @@ def _session_status_to_task_status(status: object) -> str | None:
     return None
 
 
+def _exception_detail(exc: BaseException) -> str:
+    """
+    Return exception text for a failure message, never empty.
+
+    Some exceptions stringify to ``""`` (e.g. a bare ``CancelledError``
+    or ``RuntimeError()``), which turns a message like
+    ``f"turn setup failed: {exc}"`` into a prefix with the cause
+    dropped. Fall back to the class name so the published detail always
+    carries something diagnosable.
+
+    :param exc: The caught exception.
+    :returns: ``str(exc)``, or the exception class name when that is
+        blank, e.g. ``"CancelledError"``.
+    """
+    text = str(exc).strip()
+    return text or type(exc).__name__
+
+
 def _normalize_turn_error(error: Mapping[str, object]) -> dict[str, str]:
     """
     Coerce a turn-failure ``error`` dict into a ``{code, message}`` shape.
@@ -7251,7 +7269,9 @@ def create_runner_app(
                 exc_info=True,
                 extra={"session_id": conv},
             )
-            _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
+            _on_proxy_stream_end(
+                conv, error={"message": f"turn setup failed: {_exception_detail(exc)}"}
+            )
             raise
         except Exception as exc:
             _logger.error(
@@ -7261,7 +7281,9 @@ def create_runner_app(
                 exc_info=True,
                 extra={"session_id": conv},
             )
-            _on_proxy_stream_end(conv, error={"message": f"turn setup failed: {exc}"})
+            _on_proxy_stream_end(
+                conv, error={"message": f"turn setup failed: {_exception_detail(exc)}"}
+            )
         finally:
             # Permanent-wedge floor: guarantee _active_turns is never left stale,
             # however the body exits — including a BaseException that escapes
@@ -7734,7 +7756,7 @@ def create_runner_app(
             _on_proxy_stream_end(
                 session_id,
                 error={
-                    "message": f"background turn drain failed: {exc}",
+                    "message": f"background turn drain failed: {_exception_detail(exc)}",
                 },
             )
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2471,6 +2471,43 @@ def _build_skipped_kiro_items(
     return items
 
 
+# Stand-ins for a relayed ``failed`` status whose error message carries no
+# usable reason. The runner logs the original exception with a traceback, so
+# point the reader there rather than publishing an empty detail.
+_RELAYED_FAILURE_WITHOUT_MESSAGE = (
+    "The turn failed but the runner reported no detail. See the runner log for details."
+)
+_RELAYED_FAILURE_REASON_STAND_IN = "no reason reported (see the runner log for details)"
+
+
+def _ensure_relayed_failure_reason(error: ErrorDetail) -> ErrorDetail:
+    """
+    Give a relayed failed-turn error a non-empty, diagnosable reason.
+
+    A runner can relay a failure whose message is blank, or one built as
+    ``f"turn setup failed: {exc}"`` from an exception whose ``str()`` was
+    empty -- leaving nothing after the colon. Published verbatim, that
+    detail is untriageable (the broken-turn ERROR log and
+    ``last_task_error`` both carry it), so substitute or complete it with
+    a stand-in that points at the runner log. Runner messages are
+    machine-built sentences, so a trailing colon is reliably the
+    dropped-reason shape, not prose.
+
+    :param error: The relayed error detail, e.g.
+        ``ErrorDetail(code="runner_error", message="turn setup failed: ")``.
+    :returns: The same detail, with ``message`` repaired when it carried
+        no reason; unchanged otherwise.
+    """
+    message = error.message.strip()
+    if not message:
+        return error.model_copy(update={"message": _RELAYED_FAILURE_WITHOUT_MESSAGE})
+    if message.endswith(":"):
+        return error.model_copy(
+            update={"message": f"{message} {_RELAYED_FAILURE_REASON_STAND_IN}"}
+        )
+    return error
+
+
 async def _enrich_terminal_status_with_subagent_output(
     data: dict[str, Any],
     status: str,
@@ -6427,6 +6464,11 @@ async def _relay_runner_stream_once(
                                 else None
                             )
                             if status == "failed" and status_error is not None:
+                                # An old runner can relay a detail whose
+                                # reason was dropped (blank, or a bare
+                                # "turn setup failed:") -- repair it before
+                                # it reaches the log and last_task_error.
+                                status_error = _ensure_relayed_failure_reason(status_error)
                                 await _persist_session_status_error_labels(
                                     session_id,
                                     status_error,

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -242,6 +242,14 @@ _TRANSIENT_AUDIT_EVENT_TYPES = frozenset(
 )
 
 
+# Stand-in detail for a native ``failed`` status edge that carries no output.
+# The harness genuinely reported nothing, but a failure the user cannot read is
+# worse than a vague one, so point them at the log that does have the reason.
+_NATIVE_FAILURE_WITHOUT_DETAIL = (
+    "The turn failed but the agent reported no detail. See the runner log for details."
+)
+
+
 def _retry_recovery_lock(session_id: str) -> asyncio.Lock:
     """Return the process-local lock coordinating one session's retry."""
     lock = _retry_recovery_locks.get(session_id)
@@ -1274,7 +1282,12 @@ def register_events_routes(
             # last_task_error, not only the sub-agent parent-inbox path.
             output = data.get("output")
             status_error: ErrorDetail | None = None
-            if status == "failed" and isinstance(output, str) and output.strip():
+            if status == "failed":
+                # A detail-less failed edge still has to carry a message: the
+                # web only renders an error block when the status edge has one,
+                # so dropping it flips the session to "failed" with nothing in
+                # the transcript to explain why.
+                detail = output.strip() if isinstance(output, str) and output.strip() else ""
                 status_error = ErrorDetail(
                     code=(
                         "codex_reauth_required"
@@ -1285,7 +1298,7 @@ def register_events_routes(
                             "codex_turn_error" if body.data.get("output") else "native_turn_error"
                         )
                     ),
-                    message=output.strip(),
+                    message=detail or _NATIVE_FAILURE_WITHOUT_DETAIL,
                 )
             if status_error is not None:
                 await _persist_session_status_error_labels(

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -1409,15 +1409,20 @@ def register_events_routes(
                 # so dropping it flips the session to "failed" with nothing in
                 # the transcript to explain why.
                 detail = output.strip() if isinstance(output, str) and output.strip() else ""
+                wire_output = body.data.get("output")
+                wire_detail = wire_output.strip() if isinstance(wire_output, str) else ""
                 status_error = ErrorDetail(
                     code=(
+                        # Forwarders attach a non-empty output alongside
+                        # reauth today; the fallback message covers a latent
+                        # detail-less reauth.
                         "codex_reauth_required"
                         if data.get("reauth_required") is True
                         # The store-enriched detail keeps a harness-neutral
-                        # code; a forwarder-sent detail keeps codex's.
-                        else (
-                            "codex_turn_error" if body.data.get("output") else "native_turn_error"
-                        )
+                        # code; a forwarder-sent detail keeps codex's. Both
+                        # normalize whitespace, so a blank wire output
+                        # classifies as detail-less rather than codex-sent.
+                        else ("codex_turn_error" if wire_detail else "native_turn_error")
                     ),
                     message=detail or _NATIVE_FAILURE_WITHOUT_DETAIL,
                 )

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -261,6 +261,14 @@ _NATIVE_FAILURE_WITHOUT_DETAIL = (
     "The turn failed but the agent reported no detail. See the runner log for details."
 )
 
+# Label for a failure detail backfilled from the session's persisted
+# transcript rather than reported by the forwarder. The trailing text can be
+# the harness's in-band error report -- or the turn's own successful reply --
+# so name the situation instead of presenting that prose as the error itself.
+_NATIVE_FAILURE_ENRICHED_DETAIL_PREFIX = (
+    "The turn failed without a reported reason; the last assistant message was: "
+)
+
 
 def _event_body_too_large() -> HTTPException:
     """Build the shared error for an oversized session-event request."""
@@ -1411,6 +1419,16 @@ def register_events_routes(
                 detail = output.strip() if isinstance(output, str) and output.strip() else ""
                 wire_output = body.data.get("output")
                 wire_detail = wire_output.strip() if isinstance(wire_output, str) else ""
+                if not detail:
+                    message = _NATIVE_FAILURE_WITHOUT_DETAIL
+                elif wire_detail:
+                    # The forwarder reported this reason itself: verbatim.
+                    message = detail
+                else:
+                    # Store-enriched: the transcript's latest assistant text,
+                    # not a reported reason -- label it so a successful
+                    # reply is never published as the error verbatim.
+                    message = f"{_NATIVE_FAILURE_ENRICHED_DETAIL_PREFIX}{detail}"
                 status_error = ErrorDetail(
                     code=(
                         # Forwarders attach a non-empty output alongside
@@ -1424,7 +1442,7 @@ def register_events_routes(
                         # classifies as detail-less rather than codex-sent.
                         else ("codex_turn_error" if wire_detail else "native_turn_error")
                     ),
-                    message=detail or _NATIVE_FAILURE_WITHOUT_DETAIL,
+                    message=message,
                 )
             if status_error is not None:
                 await _persist_session_status_error_labels(

--- a/tests/e2e/test_codex_native_unsupported_effort_silent_failure_e2e.py
+++ b/tests/e2e/test_codex_native_unsupported_effort_silent_failure_e2e.py
@@ -506,9 +506,7 @@ def _create_pinned_session(rig: _Rig, *, reasoning_effort: str) -> str:
             thread_live = True
             break
         time.sleep(1.0)
-    assert thread_live, (
-        f"codex-native thread never came live for {session_id}\n{rig.log_tails()}"
-    )
+    assert thread_live, f"codex-native thread never came live for {session_id}\n{rig.log_tails()}"
 
     # The report's PATCH: accepted by omnigent (CODEX_NATIVE_EFFORTS carries
     # the full ladder) ...

--- a/tests/e2e/test_codex_native_unsupported_effort_silent_failure_e2e.py
+++ b/tests/e2e/test_codex_native_unsupported_effort_silent_failure_e2e.py
@@ -1,0 +1,655 @@
+"""End-to-end: a codex-rejected reasoning effort must not fail the turn silently.
+
+Reported journey: set
+``reasoning_effort: minimal`` on a ``codex-native`` session pinned to
+``gpt-6-astra`` (a model whose advertised ladder has no ``minimal``): the
+session PATCH succeeds and a GET reports the effort back, but the first turn
+then ends ``status: failed`` with no output, no error item, and zero token
+usage. Nothing tells the user the model/effort pairing was rejected. The same
+brief at ``low`` works.
+
+Omnigent accepts the effort because ``CODEX_NATIVE_EFFORTS`` deliberately
+carries codex's full ladder (codex is the per-model authority,
+``omnigent/util/reasoning_effort.py``), and nothing re-checks the pairing
+against the model's ``model/list`` ``supportedReasoningEfforts``. When codex
+then ends the turn with a bare failed status and no ``TurnError`` payload,
+``_terminal_turn_status_edge`` (omnigent/harnesses/codex_native/forwarder.py)
+derives a ``failed`` edge with ``error=None`` and ``_post_turn_status_edge``
+publishes it with ``output=None`` -- a silent failed turn.
+
+This drives the real stack -- server subprocess, real ``omnigent.runner._entry``
+runner, the real codex-native bridge/executor/forwarder -- against a fake
+``codex`` CLI (an app-server speaking the same WebSocket JSON-RPC the real one
+does). The fake advertises ``gpt-6-astra`` without ``minimal`` in
+``supportedReasoningEfforts`` and, when a turn runs with an effort outside the
+model's advertised ladder, ends it with ``turn/failed`` carrying no error
+payload -- matching the report's "no provider error at all". The real codex CLI
+requires a live ChatGPT login and the real ``gpt-6-astra`` model, so this fake
+is a stand-in for the codex side; the omnigent side is fully real.
+
+While the bug is live, the ``minimal`` turn ends failed with no surfaced error
+anywhere (no error item, no failure output) and the test FAILS on that
+silence. It passes once an unsupported model/effort pairing surfaces a reason
+(a turn error naming the rejection) or is gated up front by the model's
+advertised levels -- either fix direction from the report.
+
+Run::
+
+    .venv/bin/python -m pytest \
+        tests/e2e/test_codex_native_unsupported_effort_silent_failure_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import secrets
+import signal
+import socket
+import subprocess
+import sys
+import tarfile
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix", reason="boots POSIX server/runner subprocesses with a fake codex CLI"
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_HEALTH_TIMEOUT_S = 90.0
+#: Terminal auto-create (app-server spawn + trust) plus one fake turn.
+_TURN_OUTCOME_TIMEOUT_S = 120.0
+_POLL_INTERVAL_S = 2.0
+
+#: The model the report pins -- advertised by the fake WITHOUT ``minimal``.
+_ASTRA_MODEL = "gpt-6-astra"
+
+# Proxy-blind client: CI forces an egress proxy via HTTP(S)_PROXY env vars
+# that must not intercept loopback requests to the spawned server.
+_client = httpx.Client(trust_env=False)
+
+# Shared fixtures/helpers use ambient ``httpx`` calls that DO trust env, so
+# also exclude loopback from any forced proxy at import time.
+for _var in ("NO_PROXY", "no_proxy"):
+    os.environ[_var] = ",".join(filter(None, [os.environ.get(_var, ""), "127.0.0.1,localhost"]))
+
+
+# The codex-native agent shape from the report, reduced to the fields that
+# pick the launch path under test. Sandbox none: the rig itself may already
+# run inside a container/bwrap where nested sandboxes cannot start.
+_CODEX_NATIVE_AGENT_YAML = """\
+spec_version: 1
+name: codex-effort-repro
+description: codex-native session shape for the unsupported-effort repro.
+
+executor:
+  type: omnigent
+  config:
+    harness: codex-native
+    yolo: true
+
+prompt: |
+  You are a codex-native session used to reproduce a reasoning-effort bug.
+
+os_env:
+  type: caller_process
+  cwd: .
+  sandbox:
+    type: none
+"""
+
+# A fake ``codex`` CLI: implements the app-server WebSocket JSON-RPC surface
+# the codex-native harness drives (initialize, model/list, hooks/list,
+# thread/resume, thread/settings/update, turn/start) plus ``--version`` and a
+# parked TUI mode for the tmux pane the runner opens. When a turn runs with a
+# reasoning effort outside the current model's advertised
+# ``supportedReasoningEfforts``, the turn ends with ``turn/failed`` and NO
+# error payload -- the report's observed silence ("no provider error at all").
+_FAKE_CODEX_TEMPLATE = """#!{python}
+'''Fake codex CLI (app-server) for the unsupported-effort silent-failure e2e.'''
+import asyncio
+import json
+import sys
+import uuid
+
+MODELS = [
+    {{"id": "gpt-6-codex", "model": "gpt-6-codex", "displayName": "GPT-6 Codex",
+      "isDefault": True,
+      "supportedReasoningEfforts": ["low", "medium", "high", "xhigh"],
+      "defaultReasoningEffort": "medium"}},
+    {{"id": "gpt-6-astra", "model": "gpt-6-astra", "displayName": "GPT-6 Astra",
+      "supportedReasoningEfforts": ["low", "medium", "high", "xhigh"],
+      "defaultReasoningEffort": "medium"}},
+]
+
+THREAD_ID = "thread_" + uuid.uuid4().hex
+
+
+def _pinned_model():
+    # The harness pins the session model into the private CODEX_HOME
+    # config.toml before the app-server boots; honor it like real codex.
+    import os
+    home = os.environ.get("CODEX_HOME", "")
+    if not home:
+        return None
+    try:
+        for line in open(os.path.join(home, "config.toml"), encoding="utf-8"):
+            line = line.strip()
+            if line.startswith("model =") or line.startswith("model="):
+                return line.split("=", 1)[1].strip().strip('"')
+    except OSError:
+        return None
+    return None
+
+
+STATE = {{"model": _pinned_model(), "effort": None, "turn_seq": 0}}
+CONNECTIONS = set()
+
+
+def _log(text):
+    import os
+    path = os.environ.get("FAKE_CODEX_LOG", "")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(text + chr(10))
+
+
+async def _broadcast(method, params):
+    payload = json.dumps({{"method": method, "params": params}})
+    for ws in list(CONNECTIONS):
+        try:
+            await ws.send(payload)
+        except Exception:
+            pass
+
+
+async def _announce_thread(ws):
+    await asyncio.sleep(0.5)
+    try:
+        await ws.send(json.dumps({{
+            "method": "thread/started",
+            "params": {{"thread": {{"id": THREAD_ID}}}},
+        }}))
+    except Exception:
+        pass
+
+
+async def _run_turn(turn_id):
+    await asyncio.sleep(0.3)
+    await _broadcast("turn/started", {{"threadId": THREAD_ID, "turn": {{"id": turn_id}}}})
+    await asyncio.sleep(0.5)
+    model = STATE["model"] or "gpt-6-codex"
+    effort = STATE["effort"]
+    row = next((r for r in MODELS if r["id"] == model), None)
+    supported = row["supportedReasoningEfforts"] if row else []
+    _log("turn " + turn_id + " model=" + str(model) + " effort=" + str(effort))
+    if effort and effort not in supported:
+        # The model does not offer this effort: codex ends the turn failed
+        # with no TurnError payload (the reported "no provider error at all").
+        await _broadcast("turn/failed", {{
+            "threadId": THREAD_ID,
+            "turn": {{"id": turn_id, "status": "failed", "items": []}},
+        }})
+        return
+    item = {{"id": "item_" + turn_id, "type": "agentMessage",
+             "text": "FAKE-CODEX-REPLY model=" + model + " effort=" + str(effort)}}
+    await _broadcast("item/completed",
+                     {{"threadId": THREAD_ID, "turnId": turn_id, "item": item}})
+    await _broadcast("turn/completed", {{
+        "threadId": THREAD_ID,
+        "turn": {{"id": turn_id, "status": "completed", "items": [item]}},
+    }})
+
+
+async def _handler(ws):
+    CONNECTIONS.add(ws)
+    try:
+        async for raw in ws:
+            msg = json.loads(raw)
+            if "id" not in msg:
+                continue  # client notification (e.g. "initialized")
+            method = msg.get("method")
+            params = msg.get("params") or {{}}
+            _log("request " + str(method) + " " + json.dumps(params)[:300])
+            if method == "initialize":
+                result = {{"serverInfo": {{"name": "fake-codex", "version": "0.153.4"}}}}
+            elif method == "model/list":
+                result = {{"data": MODELS, "nextCursor": None}}
+            elif method == "hooks/list":
+                cwds = params.get("cwds") or [""]
+                result = {{"data": [
+                    {{"cwd": cwd, "hooks": [{{
+                        "id": "omnigent-policy-hook",
+                        "command": "python -m omnigent.harnesses.codex_native.hook run",
+                        "trustStatus": "trusted",
+                        "currentHash": "fake-hash",
+                    }}]}} for cwd in cwds
+                ]}}
+            elif method in ("thread/start", "thread/resume"):
+                result = {{"thread": {{"id": THREAD_ID, "turns": []}}}}
+            elif method == "thread/settings/update":
+                for key in ("model", "effort"):
+                    if key in params:
+                        STATE[key] = params[key]
+                result = {{}}
+                asyncio.ensure_future(_broadcast("thread/settings/updated", {{
+                    "threadId": THREAD_ID,
+                    "threadSettings": {{"model": STATE["model"], "effort": STATE["effort"]}},
+                }}))
+            elif method == "turn/start":
+                STATE["turn_seq"] += 1
+                turn_id = "turn_" + str(STATE["turn_seq"])
+                result = {{"turn": {{"id": turn_id}}}}
+                asyncio.ensure_future(_run_turn(turn_id))
+            else:
+                result = {{}}
+            await ws.send(json.dumps({{"id": msg["id"], "result": result}}))
+            if method == "initialize":
+                asyncio.ensure_future(_announce_thread(ws))
+    finally:
+        CONNECTIONS.discard(ws)
+
+
+async def _serve(listen_url):
+    import websockets
+
+    host, _, port = listen_url.removeprefix("ws://").partition(":")
+    async with websockets.serve(_handler, host, int(port)):
+        await asyncio.Future()
+
+
+args = sys.argv[1:]
+if "--version" in args:
+    print("codex-cli 0.153.4")
+elif args and args[0] == "app-server" and "--listen" in args:
+    asyncio.run(_serve(args[args.index("--listen") + 1]))
+elif args[:2] == ["debug", "models"]:
+    sys.exit(2)  # tolerated: the catalog probe treats failure as "no catalog"
+else:
+    # The runner opens a codex TUI pane (``--remote``); park it -- the
+    # app-server above drives the whole session.
+    print("fake codex TUI (e2e stand-in); the app-server drives this session")
+    import time as _time
+    while True:
+        _time.sleep(3600)
+"""
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _no_proxy_env() -> dict[str, str]:
+    """Ambient env with loopback excluded from any forced HTTP(S) proxy.
+
+    Also drops any omnigent session/runner env leaked by the invoking
+    environment (data dir, runner identity, server URL): the rig must boot
+    its own isolated server and runner, not inherit a live session's.
+    """
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("OMNIGENT") and key != "RUNNER_SERVER_URL"
+    }
+    for var in ("NO_PROXY", "no_proxy"):
+        existing = env.get(var, "")
+        env[var] = ",".join(filter(None, [existing, "127.0.0.1,localhost"]))
+    return env
+
+
+def _spec_bundle() -> bytes:
+    """Gzip the codex-native agent spec as a session bundle."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = _CODEX_NATIVE_AGENT_YAML.encode()
+        info = tarfile.TarInfo("config.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+@dataclass
+class _Rig:
+    """A booted omnigent server + runner wired to the fake codex CLI."""
+
+    base_url: str
+    runner_id: str
+    server_log: Path
+    runner_log: Path
+    workspace: Path
+
+    def log_tails(self) -> str:
+        return (
+            f"server log tail:\n{self.server_log.read_text()[-2000:]}\n"
+            f"runner log tail:\n{self.runner_log.read_text()[-4000:]}"
+        )
+
+
+@pytest.fixture(scope="module")
+def fake_codex_rig(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_Rig]:
+    """Server + runner whose only codex CLI is the fake app-server above.
+
+    Isolated ``HOME`` / ``OMNIGENT_CONFIG_HOME`` / ``CODEX_HOME`` so the rig
+    sees no ambient providers; ``CODEX_HOME/auth.json`` carries a fake API key
+    so the codex launch router treats codex as logged in (``login_required``
+    false) instead of parking the session on the sign-in screen.
+    """
+    from omnigent.runner.identity import token_bound_runner_id
+
+    work = tmp_path_factory.mktemp("codex_effort_silent_failure")
+    bin_dir = work / "bin"
+    config_home = work / "config-home"
+    codex_home = work / "codex-home"
+    home_dir = work / "home"
+    state_dir = work / "codex-native-state"
+    artifacts = work / "artifacts"
+    workspace = work / "workspace"
+    for path in (bin_dir, config_home, codex_home, home_dir, state_dir, artifacts, workspace):
+        path.mkdir(parents=True, exist_ok=True)
+
+    fake_codex = bin_dir / "codex"
+    fake_codex.write_text(_FAKE_CODEX_TEMPLATE.format(python=sys.executable))
+    fake_codex.chmod(0o755)
+    # A stored codex login so resolve_native_codex_launch does not mark the
+    # launch login_required (which fails every chat turn fast by design).
+    (codex_home / "auth.json").write_text(json.dumps({"OPENAI_API_KEY": "sk-fake-e2e"}))
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    binding_token = secrets.token_urlsafe(32)
+    runner_id = token_bound_runner_id(binding_token)
+
+    shared_env = {
+        **_no_proxy_env(),
+        "PYTHONPATH": f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+        "OMNIGENT_CONFIG_HOME": str(config_home),
+        "OMNIGENT_CODEX_NATIVE_STATE_DIR": str(state_dir),
+        "OMNIGENT_CODEX_PATH": str(fake_codex),
+        "CODEX_HOME": str(codex_home),
+        "HOME": str(home_dir),
+    }
+    server_env = {**shared_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token}
+    runner_env = {
+        **shared_env,
+        "OMNIGENT_RUNNER_ID": runner_id,
+        "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+        "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+        "RUNNER_SERVER_URL": base_url,
+    }
+
+    server_log = work / "server.log"
+    runner_log = work / "runner.log"
+    server_handle = server_log.open("w")
+    runner_handle = runner_log.open("w")
+    server_proc: subprocess.Popen[bytes] | None = None
+    runner_proc: subprocess.Popen[bytes] | None = None
+    try:
+        server_proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "omnigent.cli",
+                "server",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--database-uri",
+                f"sqlite:///{work}/test.db",
+                "--artifact-location",
+                str(artifacts),
+            ],
+            env=server_env,
+            stdout=server_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+        runner_proc = subprocess.Popen(
+            [sys.executable, "-m", "omnigent.runner._entry"],
+            env=runner_env,
+            stdout=runner_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+        online = False
+        while time.monotonic() < deadline:
+            if server_proc.poll() is not None or runner_proc.poll() is not None:
+                break
+            try:
+                if _client.get(f"{base_url}/health", timeout=2).status_code == 200:
+                    status = _client.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+                    if status.status_code == 200 and status.json().get("online"):
+                        online = True
+                        break
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.5)
+        if not online:
+            raise RuntimeError(
+                "fake-codex rig did not come online within "
+                f"{_HEALTH_TIMEOUT_S:.0f}s.\nServer log:\n{server_log.read_text()[-3000:]}\n"
+                f"Runner log:\n{runner_log.read_text()[-3000:]}"
+            )
+        yield _Rig(
+            base_url=base_url,
+            runner_id=runner_id,
+            server_log=server_log,
+            runner_log=runner_log,
+            workspace=workspace,
+        )
+    finally:
+        for proc in (runner_proc, server_proc):
+            if proc is not None and proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+        for proc in (runner_proc, server_proc):
+            if proc is not None:
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+        server_handle.close()
+        runner_handle.close()
+
+
+def _create_pinned_session(rig: _Rig, *, reasoning_effort: str) -> str:
+    """Create a live codex-native session pinned to gpt-6-astra, then set the effort.
+
+    Mirrors the reported journey exactly: the session runs ``gpt-6-astra``
+    (explicit ``model_override``), and once the native thread is live the
+    ``reasoning_effort`` PATCH succeeds and a GET reports it back -- all
+    before the first turn.
+    """
+    create = _client.post(
+        f"{rig.base_url}/v1/sessions",
+        data={"metadata": json.dumps({"workspace": str(rig.workspace)})},
+        files={"bundle": ("codex.tar.gz", _spec_bundle(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+
+    pin = _client.patch(
+        f"{rig.base_url}/v1/sessions/{session_id}",
+        json={"model_override": _ASTRA_MODEL},
+        timeout=30.0,
+    )
+    assert pin.status_code < 400, f"model PATCH rejected: {pin.status_code} {pin.text}"
+
+    bind = _client.patch(
+        f"{rig.base_url}/v1/sessions/{session_id}",
+        json={"runner_id": rig.runner_id},
+        timeout=60.0,
+    )
+    bind.raise_for_status()
+
+    # Wait for the runner to adopt the native codex thread (terminal +
+    # app-server up), so the effort PATCH lands on a live session exactly as
+    # in the report.
+    deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+    thread_live = False
+    while time.monotonic() < deadline:
+        snapshot = _client.get(f"{rig.base_url}/v1/sessions/{session_id}", timeout=10.0)
+        if snapshot.status_code == 200 and snapshot.json().get("external_session_id"):
+            thread_live = True
+            break
+        time.sleep(1.0)
+    assert thread_live, (
+        f"codex-native thread never came live for {session_id}\n{rig.log_tails()}"
+    )
+
+    # The report's PATCH: accepted by omnigent (CODEX_NATIVE_EFFORTS carries
+    # the full ladder) ...
+    effort_patch = _client.patch(
+        f"{rig.base_url}/v1/sessions/{session_id}",
+        json={"reasoning_effort": reasoning_effort},
+        timeout=30.0,
+    )
+    assert effort_patch.status_code < 400, (
+        f"reasoning_effort PATCH rejected: {effort_patch.status_code} {effort_patch.text}"
+    )
+
+    # ... and a GET reports it back.
+    snapshot = _client.get(f"{rig.base_url}/v1/sessions/{session_id}", timeout=10.0)
+    snapshot.raise_for_status()
+    body = snapshot.json()
+    assert body.get("model_override") == _ASTRA_MODEL, body.get("model_override")
+    assert body.get("reasoning_effort") == reasoning_effort, body.get("reasoning_effort")
+    return session_id
+
+
+def _send_user_message(rig: _Rig, session_id: str, text: str) -> None:
+    send = _client.post(
+        f"{rig.base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "message",
+            "data": {"role": "user", "content": [{"type": "input_text", "text": text}]},
+        },
+        timeout=30.0,
+    )
+    assert send.status_code == 202, f"send rejected: {send.status_code} {send.text}"
+
+
+@dataclass
+class _TurnOutcome:
+    """Observed terminal state of one codex-native turn."""
+
+    session_status: str
+    assistant_texts: list[str]
+    error_messages: list[str]
+    error_label: str
+    items: list[dict]
+
+    def surfaced_errors(self) -> list[str]:
+        """Every user-visible failure explanation this turn produced."""
+        return [msg for msg in [*self.error_messages, self.error_label] if msg.strip()]
+
+
+def _wait_for_turn_outcome(rig: _Rig, session_id: str) -> _TurnOutcome:
+    """Poll until the turn reaches a terminal, user-visible outcome."""
+    deadline = time.monotonic() + _TURN_OUTCOME_TIMEOUT_S
+    last: _TurnOutcome | None = None
+    while time.monotonic() < deadline:
+        session = _client.get(f"{rig.base_url}/v1/sessions/{session_id}", timeout=10.0)
+        session_body = session.json() if session.status_code == 200 else {}
+        status = str(session_body.get("status", ""))
+        labels = session_body.get("labels") or {}
+        items_resp = _client.get(
+            f"{rig.base_url}/v1/sessions/{session_id}/items?limit=100", timeout=10.0
+        )
+        items = list(items_resp.json().get("data", [])) if items_resp.status_code == 200 else []
+        assistant_texts = [
+            json.dumps(item.get("content", item))
+            for item in items
+            if item.get("type") == "message" and item.get("role") == "assistant"
+        ]
+        error_messages = [
+            str(item.get("message", "")) for item in items if item.get("type") == "error"
+        ]
+        last = _TurnOutcome(
+            session_status=status,
+            assistant_texts=assistant_texts,
+            error_messages=error_messages,
+            error_label=str(labels.get("omnigent.last_task_error_message", "") or ""),
+            items=items,
+        )
+        if status == "failed" or error_messages or assistant_texts:
+            return last
+        time.sleep(_POLL_INTERVAL_S)
+    raise AssertionError(
+        f"turn reached no terminal outcome within {_TURN_OUTCOME_TIMEOUT_S:.0f}s; "
+        f"last={last}\n{rig.log_tails()}"
+    )
+
+
+@pytest.mark.timeout(600)
+def test_supported_effort_low_turn_completes(fake_codex_rig: _Rig) -> None:
+    """Control: the same brief at ``low`` works (the report's working run).
+
+    Proves the rig itself is sound so the repro test below fails only on the
+    bug's silence, never on a broken fixture.
+    """
+    session_id = _create_pinned_session(fake_codex_rig, reasoning_effort="low")
+    _send_user_message(fake_codex_rig, session_id, "Say hello.")
+    outcome = _wait_for_turn_outcome(fake_codex_rig, session_id)
+    assert outcome.assistant_texts, (
+        f"low-effort control turn produced no assistant reply: {outcome}\n"
+        f"{fake_codex_rig.log_tails()}"
+    )
+    # The reply text proves the pinned model AND the patched effort reached
+    # codex through the real settings-update path -- rig fidelity, not luck.
+    reply = " ".join(outcome.assistant_texts)
+    assert "FAKE-CODEX-REPLY" in reply and "effort=low" in reply, reply
+    assert not outcome.surfaced_errors(), (
+        f"low-effort control turn errored: {outcome.surfaced_errors()}\n"
+        f"{fake_codex_rig.log_tails()}"
+    )
+
+
+@pytest.mark.timeout(600)
+def test_unsupported_effort_minimal_failure_is_surfaced(fake_codex_rig: _Rig) -> None:
+    """An effort the model doesn't offer must not kill the turn silently.
+
+    Journey (the report's): pin ``gpt-6-astra`` + ``reasoning_effort:
+    minimal`` on a codex-native session (PATCH succeeds, GET reports it
+    back), send the first message, wait for the turn to end.
+
+    While the bug is live the turn ends ``status: failed`` with no output and
+    no error item -- pure silence -- and this test FAILS on the missing
+    explanation. After a fix the turn must either surface an error naming the
+    rejected model/effort pairing, or complete because the effort was gated
+    to the model's advertised levels.
+    """
+    session_id = _create_pinned_session(fake_codex_rig, reasoning_effort="minimal")
+    _send_user_message(fake_codex_rig, session_id, "Say hello.")
+    outcome = _wait_for_turn_outcome(fake_codex_rig, session_id)
+
+    if outcome.assistant_texts and outcome.session_status != "failed":
+        # Fix direction 2: the effort was gated/clamped to the model's
+        # advertised ladder and the turn completed -- not silent, acceptable.
+        return
+
+    # The turn failed: the failure must carry a user-visible reason -- an
+    # error item, or a failure output persisted as the session's
+    # last_task_error (what a failed edge with output produces).
+    assert outcome.surfaced_errors(), (
+        "codex-native turn with an effort the model doesn't offer "
+        f"(model={_ASTRA_MODEL!r}, effort='minimal') ended "
+        f"status={outcome.session_status!r} with NO error item, no failure "
+        "output, and no last_task_error -- the silent failure from the "
+        "report. Items seen: "
+        f"{json.dumps(outcome.items)[:1500]}\n"
+        f"{fake_codex_rig.log_tails()}"
+    )

--- a/tests/e2e_ui/chat/test_codex_native_detail_less_failure_surfaces_error.py
+++ b/tests/e2e_ui/chat/test_codex_native_detail_less_failure_surfaces_error.py
@@ -1,0 +1,245 @@
+"""A codex-rejected effort pairing must surface an error, not fail silently.
+
+Journey (from the report): create a ``codex-native`` session running
+``gpt-6-astra`` -> set ``reasoning_effort: minimal`` via session PATCH
+(``CODEX_NATIVE_EFFORTS`` deliberately carries the full ladder because codex is
+the per-model authority on levels, so omnigent accepts the pairing: the PATCH
+succeeds and a GET reports it back) -> send the first brief -> codex rejects the
+``minimal`` + ``gpt-6-astra`` pairing and ends the turn with a bare failed
+status (``turn.status: "failed"`` and **no** ``turn.error`` payload) -> the
+codex-native forwarder maps that to ``external_session_status {status:
+"failed"}`` with **no** ``output`` -> the session flips to failed with zero
+token usage and the transcript shows nothing explaining why.
+
+While the bug is live, the server (`routes_events.py`) only builds a
+``status_error`` when a native ``failed`` edge carries a non-empty ``output``;
+a detail-less rejection leaves ``error`` null on the published status edge, and
+the web (`chatStore.ts`) appends an error block only when the edge carries one.
+So the session goes ``failed`` and no error pill ever renders -- the user is
+left staring at a bare failed session with no reason.
+
+The final expectation below is the fix's contract: a detail-less native
+failure still surfaces a readable error pill (so the turn's failure is visible,
+not silent). The assertion is pinned to the ``native_turn_error`` pill headline
+so only THIS turn's surfaced failure satisfies it -- an unrelated error pill
+(say, an ambient codex CLI failing its launch) cannot. While the bug is live
+that expectation times out -- no such pill appears -- reproducing the silence.
+
+The turn is driven through the same ``/v1/sessions/{id}/events`` route the real
+codex-native forwarder posts to. A live codex process + gpt-6-astra needs real
+OpenAI/ChatGPT auth and a proprietary model, neither of which this suite has;
+the detail-less ``failed`` edge published here is exactly the payload
+``_post_turn_status_edge`` derives from codex's error-less rejection (a
+``_CodexTurnStatusEdge`` with ``error=None`` posts ``output=None``). The
+config-acceptance half (PATCH succeeds, GET reports it back) is asserted against
+the real server, so the reproduction exercises the genuine product code end to
+end -- only the codex process's own terminal edge is injected.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import (
+    _REPO_ROOT,
+    _bind_session_runner,
+    _ensure_runner_online,
+    _server_state,
+)
+
+_WORKING = '[data-testid="working-indicator"]'
+_ERROR_PILL = '[data-testid="error-pill"]'
+
+_MODEL_ID = "gpt-6-astra"
+
+# The reporter's shape: a label-less custom agent bound to the native codex
+# executor, running gpt-6-astra. No ``omnigent.wrapper`` label is stamped --
+# this is a genuine ``codex-native`` session, exactly as the report describes.
+_CODEX_ASTRA_AGENT_YAML = f"""\
+spec_version: 1
+name: codex-astra-brief
+
+executor:
+  type: omnigent
+  model: {_MODEL_ID}
+  config:
+    harness: codex-native
+
+prompt: |
+  You are a focused coding assistant. Answer briefly.
+"""
+
+
+def _create_codex_native_session(base_url: str, runner_id: str) -> str:
+    """Register the codex-native agent bundle and bind its session.
+
+    Runner-owned codex terminals hard-require a session workspace, so one is
+    pinned in the create metadata (mirrors ``test_custom_codex_native_controls``).
+    No labels are passed, so the session carries no ``omnigent.wrapper`` label
+    and resolves as a plain ``codex-native`` harness -- the report's shape.
+
+    :param base_url: Spawned server base URL.
+    :param runner_id: The token-bound runner id to bind.
+    :returns: The new session/conversation id.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = _CODEX_ASTRA_AGENT_YAML.encode()
+        info = tarfile.TarInfo("config.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": json.dumps({"workspace": str(_REPO_ROOT)})},
+        files={"bundle": ("agent.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    _bind_session_runner(base_url, session_id, runner_id)
+    return session_id
+
+
+def _set_reasoning_effort(base_url: str, session_id: str, effort: str) -> None:
+    """PATCH the session's reasoning effort and require the store to accept it.
+
+    ``silent=True`` persists the effort without injecting a slash command into a
+    live pane (there is no live turn when a user picks an effort), so the row
+    ends up carrying ``minimal`` deterministically -- the config-set half of the
+    report's journey ("the PATCH succeeds").
+
+    :param base_url: Base URL of the local e2e server.
+    :param session_id: Session/conversation id.
+    :param effort: Reasoning effort to set, e.g. ``"minimal"``.
+    """
+    resp = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"reasoning_effort": effort, "silent": True},
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+
+
+def _publish_native_status(
+    base_url: str,
+    session_id: str,
+    status: str,
+    *,
+    response_id: str,
+    output: str | None = None,
+) -> None:
+    """Publish the status payload the codex-native forwarder posts.
+
+    ``_post_turn_status_edge`` sends ``{"status": ..., "response_id": ...}`` and
+    attaches ``output`` only when the terminal turn carried an error payload. A
+    codex rejection that ends the turn with a bare failed status (no
+    ``turn.error``) posts **no** ``output`` at all -- the exact detail-less
+    shape driven here.
+
+    :param base_url: Base URL of the local e2e server.
+    :param session_id: Session/conversation id.
+    :param status: Session status to publish, e.g. ``"running"`` / ``"failed"``.
+    :param response_id: In-flight turn id, carried on both the turn-start
+        ``running`` edge and the terminal ``failed`` edge.
+    :param output: Terminal detail; omitted (``None``) to reproduce the
+        error-less codex rejection.
+    """
+    data: dict[str, str] = {"status": status, "response_id": response_id}
+    if output is not None:
+        data["output"] = output
+    resp = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+
+
+def test_codex_native_detail_less_failed_turn_surfaces_error(
+    page: Page,
+    live_server: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """A codex-native turn that fails with no detail must not die silently.
+
+    Reproduces the reported journey: setting ``reasoning_effort: minimal`` on a
+    ``codex-native`` session running ``gpt-6-astra`` is accepted by omnigent,
+    the model rejects the pairing, and the turn ends ``failed`` with no output
+    and no error -- and the transcript shows nothing. The fix's contract, and
+    the assertion this test drives fail->pass, is that a detail-less native
+    failure still surfaces a readable error pill.
+
+    :param page: Playwright page fixture.
+    :param live_server: Spawned server fixture; its runner is reused.
+    :param tmp_path_factory: Pytest temp path factory (for a respawn log).
+    :returns: None.
+    """
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    runner_id = str(_server_state["runner_id"])
+    session_id = _create_codex_native_session(live_server, runner_id)
+    try:
+        # Precondition against the REAL server: this is a genuine codex-native
+        # session running gpt-6-astra with no wrapper presentation label.
+        snapshot = httpx.get(f"{live_server}/v1/sessions/{session_id}", timeout=10.0).json()
+        assert snapshot["harness"] == "codex-native", snapshot["harness"]
+        assert "omnigent.wrapper" not in (snapshot.get("labels") or {})
+
+        # The report's first observable: omnigent ACCEPTS minimal for a
+        # codex-native session (the full codex ladder is deliberate), so the
+        # PATCH succeeds and a GET reports it back.
+        _set_reasoning_effort(live_server, session_id, "minimal")
+        after = httpx.get(f"{live_server}/v1/sessions/{session_id}", timeout=10.0).json()
+        assert after["reasoning_effort"] == "minimal", after.get("reasoning_effort")
+
+        page.goto(f"{live_server}/c/{session_id}")
+        expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=20_000)
+
+        working = page.locator(_WORKING)
+        pills = page.locator(_ERROR_PILL)
+
+        # Turn starts: the id-bearing running edge lights the Working indicator.
+        _publish_native_status(
+            live_server, session_id, "running", response_id="codex_turn_minimal"
+        )
+        expect(working).to_be_visible(timeout=15_000)
+
+        # Codex rejects minimal/astra and ends the turn failed with NO detail:
+        # a bare failed status edge carrying no ``output`` -- the exact payload
+        # the codex-native forwarder derives from an error-less rejection.
+        _publish_native_status(live_server, session_id, "failed", response_id="codex_turn_minimal")
+
+        # The turn is over -- Working clears...
+        expect(working).to_have_count(0, timeout=15_000)
+
+        # ...and the failure must be SURFACED, not swallowed: a readable
+        # error pill for THIS turn's detail-less failure. Filter on the
+        # ``native_turn_error`` headline (the code the server stamps on a
+        # detail-less native failure) so an unrelated error pill -- e.g. a
+        # real codex CLI on PATH failing its launch during session adoption --
+        # can never satisfy the assertion.
+        #
+        # THIS IS THE BUG: while it is live, the status edge's ``error`` is
+        # null on a detail-less native failure and the web only appends an
+        # error block when the edge carries one, so no such pill ever renders
+        # and this expectation times out -- the silent failure. After the fix,
+        # the fallback error pill surfaces and this passes.
+        native_failure_pill = pills.filter(
+            has_text="The agent ran into an error during this turn."
+        )
+        expect(native_failure_pill.first).to_be_visible(timeout=15_000)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        if respawned is not None:
+            respawned.terminate()
+            try:
+                respawned.wait(timeout=5)
+            except Exception:
+                respawned.kill()
+                respawned.wait(timeout=5)

--- a/tests/runner/test_turn_failure_detail.py
+++ b/tests/runner/test_turn_failure_detail.py
@@ -1,0 +1,32 @@
+"""The runner's turn-failure messages must never drop the cause.
+
+Messages like ``f"turn setup failed: {exc}"`` published on a ``failed``
+status edge are the only reason a user (or the server's broken-turn ERROR
+log) ever sees. An exception whose ``str()`` is empty -- a bare
+``CancelledError`` or ``RuntimeError()`` -- used to leave nothing after the
+prefix, so the published detail read ``turn setup failed: `` and the actual
+cause was dropped. ``_exception_detail`` is the guard: it falls back to the
+exception class name so the detail always carries something diagnosable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from omnigent.runner.app import _exception_detail
+
+
+def test_exception_detail_keeps_nonempty_text() -> None:
+    """A normal exception's own text passes through unchanged."""
+    assert _exception_detail(RuntimeError("boom")) == "boom"
+
+
+def test_exception_detail_falls_back_to_class_name_when_str_is_empty() -> None:
+    """An empty ``str(exc)`` yields the class name, not an empty reason."""
+    assert _exception_detail(asyncio.CancelledError()) == "CancelledError"
+    assert _exception_detail(RuntimeError()) == "RuntimeError"
+
+
+def test_exception_detail_treats_whitespace_only_text_as_empty() -> None:
+    """Whitespace-only exception text classifies as empty too."""
+    assert _exception_detail(ValueError("   ")) == "ValueError"

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4582,6 +4582,78 @@ async def test_post_external_session_status_failed_forwards_persisted_assistant_
     assert "selected model" in error["message"]
 
 
+async def test_post_external_session_status_failed_without_detail_still_carries_a_message(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A ``failed`` edge with no wire ``output`` and nothing persisted to enrich
+    from must still publish a typed error.
+
+    The web only appends an error block when the status edge carries one, so
+    an ``error: null`` failure flips the session to "failed" and leaves the
+    transcript with nothing explaining why.
+    """
+    from omnigent.server.routes import sessions as sessions_module
+    from omnigent.server.routes.sessions.routes_events import (
+        _NATIVE_FAILURE_WITHOUT_DETAIL,
+    )
+
+    published: list[tuple[str, dict[str, Any]]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """
+        Accept whatever is forwarded to the fake runner.
+
+        :param request: Request sent to the fake runner.
+        :returns: Accepted response.
+        """
+        del request
+        return httpx.Response(204)
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+
+    async def _fake_get_runner_client(
+        session_id: str,
+        runner_router: object,
+    ) -> httpx.AsyncClient:
+        """
+        Resolve the session to the fake runner client.
+
+        :param session_id: Session id being routed.
+        :param runner_router: Real app runner router, unused here.
+        :returns: The fake runner client.
+        """
+        del session_id, runner_router
+        return fake_runner
+
+    monkeypatch.setattr(sessions_module, "_get_runner_client", _fake_get_runner_client)
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda session_id, event: published.append((session_id, event)),
+    )
+    try:
+        agent = await create_test_agent(client)
+        session = await _create_session(client, agent["id"])
+        status_resp = await client.post(
+            f"/v1/sessions/{session['id']}/events",
+            json={"type": "external_session_status", "data": {"status": "failed"}},
+        )
+    finally:
+        await fake_runner.aclose()
+
+    assert status_resp.status_code == 202, status_resp.text
+    failed_events = [ev for _sid, ev in published if ev.get("status") == "failed"]
+    assert failed_events, f"no failed status was published: {published}"
+    error = failed_events[0]["error"]
+    assert error is not None, "a failed status edge was published with no error detail"
+    assert error["code"] == "native_turn_error"
+    assert error["message"] == _NATIVE_FAILURE_WITHOUT_DETAIL
+
+
 async def test_post_external_session_status_failed_keeps_wire_output_and_codex_code(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4650,6 +4650,11 @@ async def test_post_external_session_status_failed_forwards_persisted_assistant_
     must attach it so the parent inbox shows it instead of the generic
     "Error: native sub-agent turn failed", and surface it as the session's
     typed error under the harness-neutral ``native_turn_error`` code.
+
+    The typed error labels the backfilled text as the transcript's own
+    message rather than presenting it verbatim: the same backfill would
+    otherwise publish a successful turn's own reply as the failure reason.
+    The parent-inbox forward still carries the raw text.
     """
     from omnigent.server.routes import sessions as sessions_module
 
@@ -4744,6 +4749,10 @@ async def test_post_external_session_status_failed_forwards_persisted_assistant_
     assert error is not None
     assert error["code"] == "native_turn_error"
     assert "selected model" in error["message"]
+    # Store-enriched text is labelled, never republished as the error
+    # verbatim -- a successful reply must not read as the failure reason.
+    assert error["message"] != detail
+    assert error["message"].startswith("The turn failed without a reported reason;")
 
 
 @pytest.mark.parametrize(

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4746,13 +4746,27 @@ async def test_post_external_session_status_failed_forwards_persisted_assistant_
     assert "selected model" in error["message"]
 
 
+@pytest.mark.parametrize(
+    ("extra_data", "expected_code"),
+    [
+        # No wire output at all: harness-neutral fallback.
+        ({}, "native_turn_error"),
+        # Whitespace-only wire output classifies as detail-less too, not as a
+        # codex-sent detail.
+        ({"output": "   "}, "native_turn_error"),
+        # A detail-less reauth keeps its reauth code with the fallback message.
+        ({"reauth_required": True}, "codex_reauth_required"),
+    ],
+)
 async def test_post_external_session_status_failed_without_detail_still_carries_a_message(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
+    extra_data: dict[str, Any],
+    expected_code: str,
 ) -> None:
     """
-    A ``failed`` edge with no wire ``output`` and nothing persisted to enrich
-    from must still publish a typed error.
+    A ``failed`` edge with no usable wire ``output`` and nothing persisted to
+    enrich from must still publish a typed error.
 
     The web only appends an error block when the status edge carries one, so
     an ``error: null`` failure flips the session to "failed" and leaves the
@@ -4804,7 +4818,10 @@ async def test_post_external_session_status_failed_without_detail_still_carries_
         session = await _create_session(client, agent["id"])
         status_resp = await client.post(
             f"/v1/sessions/{session['id']}/events",
-            json={"type": "external_session_status", "data": {"status": "failed"}},
+            json={
+                "type": "external_session_status",
+                "data": {"status": "failed", **extra_data},
+            },
         )
     finally:
         await fake_runner.aclose()
@@ -4814,7 +4831,7 @@ async def test_post_external_session_status_failed_without_detail_still_carries_
     assert failed_events, f"no failed status was published: {published}"
     error = failed_events[0]["error"]
     assert error is not None, "a failed status edge was published with no error detail"
-    assert error["code"] == "native_turn_error"
+    assert error["code"] == expected_code
     assert error["message"] == _NATIVE_FAILURE_WITHOUT_DETAIL
 
 

--- a/tests/server/routes/test_publish_status_failed_detail.py
+++ b/tests/server/routes/test_publish_status_failed_detail.py
@@ -1,0 +1,270 @@
+"""Failed turns must log a usable reason.
+
+The server-side broken-turn sink ``_publish_status`` funnels every
+server-originated ``failed`` turn through one ERROR log line::
+
+    session turn failed for <id>: <detail>
+
+In production ``<detail>`` degraded into one of three undebuggable shapes --
+each counted against the mid-session error KPI and none triageable by a
+human:
+
+1. the literal ``no detail`` -- the ``failed`` edge carried no error at all;
+2. ``turn setup failed:`` with an empty reason -- the cause was dropped by
+   the runner's ``f"turn setup failed: {exc}"`` when ``str(exc)`` was empty;
+3. the assistant's *own successful* final message, verbatim, as the "error"
+   -- a turn that produced output was then labelled a failure and the reason
+   was overwritten by (or fabricated from) that output.
+
+Each test below drives the real wire path that reaches ``_publish_status``
+-- the native-forwarder ``external_session_status`` POST (shapes 1 and 3)
+and the runner stream relay (shape 2) -- and captures the emitted ERROR
+record from the ``omnigent.server.routes.sessions`` logger (the ticket's
+``logger_name`` / ``func_name``).
+
+The assertions encode the *desired* behaviour (a non-empty, non-prose,
+diagnosable reason), so on the current build they FAIL -- reproducing the
+bug -- and a fix that always populates a usable detail turns them green.
+
+Runs against the in-process server harness in ``tests/server/conftest.py``
+(the same ``client`` / ``db_uri`` fixtures the existing ``_publish_status``,
+``external_session_status`` and relay tests use), because the observable is
+a server-side log record captured with ``caplog`` -- there is no user-facing
+screen for it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+import pytest
+
+from omnigent.server.routes import sessions as sessions_module
+from omnigent.stores.conversation_store.sqlalchemy_store import (
+    SqlAlchemyConversationStore,
+)
+from tests.server.helpers import create_test_agent
+from tests.server.routes.test_sessions_runner_relay import (
+    _TASK_TIMEOUT_S,
+    _ScriptedRunnerClient,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_SESSIONS_LOGGER = "omnigent.server.routes.sessions"
+_FAILED_PREFIX = "session turn failed for "
+
+
+def _failed_turn_details(caplog: pytest.LogCaptureFixture, session_id: str) -> list[str]:
+    """Return the ``<detail>`` from every ``session turn failed`` ERROR row.
+
+    Isolates the ``_publish_status`` broken-turn log lines for one session
+    from any other ERROR chatter the harness emits.
+
+    :param caplog: Pytest log-capture fixture holding the emitted records.
+    :param session_id: Session whose failure rows to extract.
+    :returns: The detail substrings (everything after ``"<id>: "``), in
+        emission order.
+    """
+    marker = f"{_FAILED_PREFIX}{session_id}: "
+    details: list[str] = []
+    for record in caplog.records:
+        if record.name != _SESSIONS_LOGGER or record.levelno != logging.ERROR:
+            continue
+        message = record.getMessage()
+        if message.startswith(marker):
+            details.append(message[len(marker) :])
+    return details
+
+
+async def _create_top_level_session(client: httpx.AsyncClient) -> str:
+    """Create a plain top-level session and return its id.
+
+    :param client: In-process test HTTP client.
+    :returns: The new session/conversation id.
+    """
+    agent = await create_test_agent(client, name="failed-turn-detail")
+    resp = await client.post("/v1/sessions", json={"agent_id": agent["id"]})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _post_status(
+    client: httpx.AsyncClient,
+    session_id: str,
+    status: str,
+    *,
+    response_id: str,
+) -> None:
+    """POST an ``external_session_status`` edge (the native-forwarder wire).
+
+    :param client: In-process test HTTP client.
+    :param session_id: Target session id.
+    :param status: Status value, e.g. ``"running"`` / ``"failed"``.
+    :param response_id: Turn/response id the forwarder attaches.
+    """
+    resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_session_status",
+            "data": {"status": status, "response_id": response_id},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+
+async def test_failed_status_with_no_reason_logs_no_detail(
+    client: httpx.AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Shape 1: a ``failed`` edge carrying no error logs a usable reason.
+
+    A native forwarder reports the turn ``failed`` without attaching a
+    reason and with no persisted assistant output to fall back on. The
+    server publishes ``failed`` with ``error=None`` and logs the literal
+    ``no detail`` -- which cannot be triaged.
+
+    :param client: In-process test HTTP client.
+    :param caplog: Pytest log-capture fixture.
+    """
+    session_id = await _create_top_level_session(client)
+
+    with caplog.at_level(logging.ERROR, logger=_SESSIONS_LOGGER):
+        await _post_status(client, session_id, "running", response_id="turn_no_detail")
+        await _post_status(client, session_id, "failed", response_id="turn_no_detail")
+
+    details = _failed_turn_details(caplog, session_id)
+    assert details, "expected a 'session turn failed' ERROR row for the failed turn"
+    detail = details[-1]
+    assert detail not in ("", "no detail"), (
+        "the failed turn was logged with an undebuggable reason "
+        f"({detail!r}); a failed turn must carry a usable, non-empty detail"
+    )
+
+
+async def test_failed_status_reuses_the_assistants_own_output_as_error(
+    client: httpx.AsyncClient,
+    db_uri: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Shape 3: a turn that produced output is failed with its own prose.
+
+    The turn streamed a normal, successful assistant message and was then
+    labelled ``failed`` with no reason of its own. The server backfills the
+    "error" from the latest persisted assistant text, so the logged failure
+    detail is the assistant's own successful sentence -- a false/undebuggable
+    failure.
+
+    :param client: In-process test HTTP client.
+    :param db_uri: SQLite URI shared with the app's store, for seeding.
+    :param caplog: Pytest log-capture fixture.
+    """
+    session_id = await _create_top_level_session(client)
+    success_prose = "All conflicts resolved. Continue the sync:"
+
+    with caplog.at_level(logging.ERROR, logger=_SESSIONS_LOGGER):
+        await _post_status(client, session_id, "running", response_id="turn_output_as_error")
+        # The turn produced a normal, successful assistant reply.
+        seed = await client.post(
+            f"/v1/sessions/{session_id}/events",
+            json={
+                "type": "external_assistant_message",
+                "data": {
+                    "agent": "assistant",
+                    "text": success_prose,
+                    "response_id": "turn_output_as_error",
+                },
+            },
+        )
+        assert seed.status_code == 202, seed.text
+        # ...and is then labelled failed without any error reason attached.
+        await _post_status(client, session_id, "failed", response_id="turn_output_as_error")
+
+    # Sanity: the successful message really is persisted, so the enrichment
+    # path had it to (mis)use.
+    store = SqlAlchemyConversationStore(db_uri)
+    messages = [item for item in store.list_items(session_id).data if item.type == "message"]
+    assert any(success_prose in str(getattr(m.data, "content", "")) for m in messages), (
+        "the successful assistant message should be persisted for this session"
+    )
+
+    details = _failed_turn_details(caplog, session_id)
+    assert details, "expected a 'session turn failed' ERROR row for the failed turn"
+    detail = details[-1]
+    assert detail != success_prose, (
+        "the failed turn's logged detail is the assistant's own successful "
+        f"message ({detail!r}); a successful turn's output must not be "
+        "published/logged as the failure reason"
+    )
+
+
+async def test_relay_failed_status_drops_the_setup_failure_reason(
+    db_uri: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Shape 2: a runner ``turn setup failed:`` with an empty reason.
+
+    The runner catches a setup exception whose ``str(exc)`` is empty and
+    forwards ``{"code": "runner_error", "message": "turn setup failed: "}``.
+    The relay republishes it verbatim, so the server logs
+    ``session turn failed for <id>: turn setup failed:`` -- the actual cause
+    was dropped and nothing after the prefix is diagnosable.
+
+    Drives the real relay stream (``_ensure_runner_relay_ready`` +
+    ``_ScriptedRunnerClient``) the way ``test_sessions_runner_relay.py`` does.
+
+    :param db_uri: SQLite URI for the conversation store.
+    :param caplog: Pytest log-capture fixture.
+    """
+    from omnigent.runtime import session_stream
+
+    sessions_module._runner_relay_tasks.clear()
+    store = SqlAlchemyConversationStore(db_uri)
+    conv = store.create_conversation()
+    session_id = conv.id
+    # A running turn is what the relay-close/failure path is meaningful for.
+    sessions_module._session_status_cache[session_id] = "running"
+
+    release = asyncio.Event()
+    # The runner's empty-reason setup failure, verbatim off the wire.
+    events: list[dict[str, Any]] = [
+        {
+            "type": "session.status",
+            "status": "failed",
+            "error": {"code": "runner_error", "message": "turn setup failed: "},
+        },
+    ]
+    fake_runner = _ScriptedRunnerClient(release, events)
+
+    try:
+        with caplog.at_level(logging.ERROR, logger=_SESSIONS_LOGGER):
+            handle = await sessions_module._ensure_runner_relay_ready(
+                session_id,
+                "runner_relay_setup_failed",
+                fake_runner,  # type: ignore[arg-type]
+                conversation_store=store,
+            )
+            assert handle is not None
+            release.set()
+            await asyncio.wait_for(handle.task, timeout=_TASK_TIMEOUT_S)
+
+        details = _failed_turn_details(caplog, session_id)
+        assert details, "expected a 'session turn failed' ERROR row from the relay"
+        detail = details[-1]
+        # The message is "turn setup failed: <reason>"; the reason was dropped.
+        reason = detail.split("turn setup failed:", 1)[-1].strip() if ":" in detail else detail
+        assert reason, (
+            "the failed turn's logged detail dropped the actual cause "
+            f"({detail!r}); 'turn setup failed:' must carry a non-empty reason"
+        )
+    finally:
+        release.set()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None:
+            await asyncio.wait_for(handle.task, timeout=_TASK_TIMEOUT_S)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)

--- a/tests/server/routes/test_sessions_runner_relay.py
+++ b/tests/server/routes/test_sessions_runner_relay.py
@@ -1325,3 +1325,84 @@ async def test_relay_does_not_fail_turn_during_server_shutdown(
         sessions_module._runner_relay_tasks.clear()
         sessions_module._session_status_cache.pop(session_id, None)
         session_stream.close(session_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("relayed_message", "expected_message"),
+    [
+        # Blank message: substituted wholesale with the stand-in.
+        (
+            "   ",
+            "The turn failed but the runner reported no detail. See the runner log for details.",
+        ),
+        # Reason dropped after the colon (str(exc) was empty runner-side):
+        # completed with a stand-in, keeping the recognizable prefix.
+        (
+            "turn setup failed: ",
+            "turn setup failed: no reason reported (see the runner log for details)",
+        ),
+    ],
+)
+async def test_relay_repairs_failed_error_without_reason(
+    relayed_message: str,
+    expected_message: str,
+) -> None:
+    """
+    A relayed ``failed`` error with no usable reason is repaired.
+
+    Old runners can relay ``{"code": "runner_error", "message": "turn setup
+    failed: "}`` (an exception whose ``str()`` was empty) or a blank message.
+    Republished verbatim, that detail reaches the broken-turn ERROR log and
+    ``last_task_error`` with nothing triageable in it -- the relay must
+    substitute or complete it with a stand-in pointing at the runner log.
+    """
+    from omnigent.runtime import session_stream
+    from omnigent.server.routes import sessions as sessions_module
+
+    sessions_module._runner_relay_tasks.clear()
+    release = asyncio.Event()
+    events: list[dict[str, Any]] = [
+        {
+            "type": "session.status",
+            "status": "failed",
+            "error": {"code": "runner_error", "message": relayed_message},
+        },
+    ]
+    fake_runner = _ScriptedRunnerClient(release, events)
+    store = _RecordingLabelStore(live_status="running")
+    session_id = "7c2f1a9e5d3b4c8fa1e6d0b2c4a8e7f3"
+    sessions_module._session_status_cache[session_id] = "running"
+
+    collector = None
+    try:
+        handle = await sessions_module._ensure_runner_relay_ready(
+            session_id,
+            "runner_relay_reasonless_failure",
+            fake_runner,  # type: ignore[arg-type]
+            conversation_store=store,  # type: ignore[arg-type]
+        )
+        assert handle is not None
+        # Subscribe BEFORE releasing the script so the published
+        # session.status event fans out to the collector.
+        collector = await start_session_stream_collector(session_id)
+        release.set()
+        await asyncio.wait_for(handle.task, timeout=_TASK_TIMEOUT_S)
+
+        event = await asyncio.wait_for(collector.queue.get(), timeout=_TASK_TIMEOUT_S)
+        assert event.get("type") == "session.status"
+        assert event.get("status") == "failed"
+        assert event["error"]["code"] == "runner_error"
+        assert event["error"]["message"] == expected_message
+    finally:
+        release.set()
+        if collector is not None:
+            await collector.stop()
+        handle = sessions_module._runner_relay_tasks.get(session_id)
+        if handle is not None and not handle.task.done():
+            handle.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(handle.task, timeout=_TASK_TIMEOUT_S)
+        sessions_module._runner_relay_tasks.clear()
+        sessions_module._session_status_cache.pop(session_id, None)
+        session_stream.close(session_id)


### PR DESCRIPTION
## Related issue

Closes #

## Summary

A native harness can post a `failed` session status with no `output`, and with nothing persisted for `_enrich_terminal_status_with_subagent_output` to enrich it from. The handler left `status_error` as `None` in that case, so the status edge went out with `error: null`.

That is a dead end for the user. The web appends an error block only when the status edge carries one:

```ts
if (event.status === "failed" && statusError != null && !hasMatchingStatusError) {
  patch.blocks = [...s.blocks, { type: "error", message: statusError.message, ... }];
}
```

So the session flips to **failed** and the transcript shows nothing explaining why — and server-side the same edge logs as `session turn failed for <id>: no detail`, which is equally undiagnosable for us.

This PR always builds the typed error on a `failed` edge, falling back to a message that names the situation and points at the log that does have the reason. It mirrors the guard `omnigent/runtime/harnesses/_executor_adapter.py` already applies to an empty harness message (`detail = event.message or "no detail reported (see runner/harness logs)"`).

Note for reviewers: because `status_error` is now non-`None` on this path, `_persist_session_status_error_labels` also records the fallback as `last_task_error`. That is intended — the turn did fail, and a labelled failure is more honest than a silent one — but it is a behaviour change beyond the log line.

## Test Plan

New integration test, verified to fail before the fix (`error` is `None`) and pass after:

```
python -m pytest tests/server/integration/test_sessions_endpoints.py -k without_detail_still_carries
```

It posts `external_session_status` with `{"status": "failed"}` and no `output` on a session with nothing persisted to enrich from, then asserts the published edge carries `code == "native_turn_error"` and the fallback message.

Full suite for the touched route:

- `tests/server/integration/test_sessions_endpoints.py` — **277 passed, 0 failed**

The two adjacent contracts are unchanged and still covered by their existing tests: a `failed` edge whose detail comes from a persisted assistant message still surfaces that text under `native_turn_error`, and a forwarder-sent `output` still stays verbatim under codex's code.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is server-side only; no web change was needed, because the existing client already renders any error the status edge carries. The rendering condition quoted above is the reason a `null` error was invisible.

## Changelog

A failed turn that the agent could not explain now shows a message in the transcript instead of failing silently.

## Issues

Closes #6814
Resolves [OMNI-6921](https://linear.app/omnigent/issue/OMNI-6921/bug-codex-native-an-effort-the-model-doesnt-offer-kills-the-turn-with)

## Issues

Resolves [OMNI-6863](https://linear.app/omnigent/issue/OMNI-6863/omnigent-turns-are-marked-failed-with-no-usable-error-detail-and)
