### PR TITLE
Use purple for merged pull request status

### DIFF
--- a/web/src/shell/GithubPanel.test.tsx
+++ b/web/src/shell/GithubPanel.test.tsx
@@ -204,7 +204,7 @@ describe("GithubPanel", () => {
   it.each([
     ["OPEN", "Open", "text-green-700"],
     ["CLOSED", "Closed", "text-red-700"],
-    ["MERGED", "Merged", "text-brand-accent"],
+    ["MERGED", "Merged", "text-purple-700"],
   ])("shows a %s status pill beside the PR title", (stateName, label, tone) => {
     state.info!.data!.pr!.state = stateName;
     renderPanel();

--- a/web/src/shell/GithubPanel.tsx
+++ b/web/src/shell/GithubPanel.tsx
@@ -254,7 +254,7 @@ function PullRequestStatus({ state }: { state: string }) {
       : normalized === "MERGED"
         ? {
             label: "Merged",
-            className: "border-brand-accent/25 bg-brand-accent/10 text-brand-accent",
+            className: "border-purple-500/25 bg-purple-500/10 text-purple-700 dark:text-purple-400",
           }
         : normalized === "CLOSED"
           ? {


### PR DESCRIPTION
## Related issue

Follow-up to #6795.

## Summary

Keep the Merged pull-request status visually consistent across themes by replacing the configurable brand accent with an explicit purple border, tint, and text color.

## Test Plan

- `pnpm --dir web exec vitest run src/shell/GithubPanel.test.tsx` (24 passed)
- `pre-commit run --all-files`
- Rendered the GitHub panel with a stubbed `MERGED` API state in Playwright and verified the purple pill in context.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The Playwright render confirms that Merged uses a purple border, background tint, and text in the existing status-pill layout.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Rendered the panel using the existing Playwright GitHub fixture with `pr.state` set to `MERGED` and visually checked the purple treatment in the full header.

## Changelog

Show merged pull requests with a consistent purple status pill.
