### PR TITLE
fix(ios): keep Databricks authentication in the web view

### DIFF
--- a/web/ios/Omnigent/OmnigentWebView.swift
+++ b/web/ios/Omnigent/OmnigentWebView.swift
@@ -520,7 +520,8 @@ struct OmnigentWebView: UIViewRepresentable {
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
       if let url = webView.url,
         ["http", "https"].contains(url.scheme?.lowercased() ?? ""),
-        url.omnigentOrigin != pinnedOrigin
+        url.omnigentOrigin != pinnedOrigin,
+        !usesInWebViewAuth(pinnedOrigin)
       {
         webView.stopLoading()
         startLogin(in: webView)
@@ -618,6 +619,21 @@ struct OmnigentWebView: UIViewRepresentable {
         ["http", "https"].contains(scheme),
         url.omnigentOrigin != pinnedOrigin
       {
+        if usesInWebViewAuth(pinnedOrigin) {
+          // Databricks authentication sets its session cookies through the
+          // WebView redirect chain. Keep IdP interactions inline, but preserve
+          // normal external-link behavior for links tapped on the app page.
+          if webView.url?.omnigentOrigin == pinnedOrigin,
+            navigationAction.navigationType == .linkActivated
+          {
+            openExternal(url)
+            decisionHandler(.cancel)
+          } else {
+            decisionHandler(.allow)
+          }
+          return
+        }
+
         if navigationAction.navigationType == .linkActivated {
           openExternal(url)
         } else {

--- a/web/ios/Omnigent/URL+Omnigent.swift
+++ b/web/ios/Omnigent/URL+Omnigent.swift
@@ -1,6 +1,17 @@
 import Foundation
 import WebKit
 
+/// Server domains whose platform SSO must run inside the WebView so its cookies
+/// land in the WebView's own cookie store.
+private let inWebViewAuthDomains = ["databricks.com", "azuredatabricks.net", "databricksapps.com"]
+
+/// Whether the pinned server uses an authentication redirect chain that must
+/// remain in the WebView rather than Omnigent's system-browser OIDC handoff.
+func usesInWebViewAuth(_ origin: String?) -> Bool {
+  guard let origin, let host = URL(string: origin)?.host?.lowercased() else { return false }
+  return inWebViewAuthDomains.contains { host == $0 || host.hasSuffix(".\($0)") }
+}
+
 extension URL {
   var omnigentOrigin: String? {
     guard let scheme, let host else { return nil }

--- a/web/ios/OmnigentTests/ServerURLTests.swift
+++ b/web/ios/OmnigentTests/ServerURLTests.swift
@@ -51,6 +51,35 @@ final class ServerURLTests: XCTestCase {
   }
 }
 
+final class InWebViewAuthTests: XCTestCase {
+  func testDatabricksHostsUseInWebViewAuth() {
+    for origin in [
+      "https://databricks.com",
+      "https://dbc-123.cloud.databricks.com",
+      "https://azuredatabricks.net",
+      "https://adb-123.azuredatabricks.net",
+      "https://databricksapps.com",
+      "https://my-app.aws.databricksapps.com",
+      "https://DBC-123.CLOUD.DATABRICKS.COM",
+    ] {
+      XCTAssertTrue(usesInWebViewAuth(origin), origin)
+    }
+  }
+
+  func testOtherHostsUseSystemBrowserAuth() {
+    for origin in [
+      "https://example.com",
+      "https://notdatabricks.com",
+      "https://databricks.com.example.org",
+      "https://databricksapps.com.example.org",
+      "not a URL",
+    ] {
+      XCTAssertFalse(usesInWebViewAuth(origin), origin)
+    }
+    XCTAssertFalse(usesInWebViewAuth(nil))
+  }
+}
+
 final class AppDeviceSupportTests: XCTestCase {
   func testAppSupportsIPhoneAndIPad() throws {
     let deviceFamilies = try XCTUnwrap(


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Databricks platform SSO sets cookies in the embedded browser, so sending its redirects through the standalone Omnigent OIDC handoff leaves iOS unauthenticated.
- Keep authentication redirects and IdP interactions inline for Databricks workspace and Apps hosts while preserving external-link behavior from the app page.
- Add domain-boundary tests for supported Databricks hosts and lookalikes.

## Test Plan

- `xcodebuild test -project web/ios/Omnigent.xcodeproj -scheme Omnigent -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' -skip-testing:OmnigentUITests -only-testing:OmnigentTests/InWebViewAuthTests CODE_SIGNING_ALLOWED=NO -quiet`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The targeted iOS unit tests verify exact Databricks domains, subdomains, case normalization, unrelated hosts, and domain-boundary lookalikes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit cases cover the host allowlist boundary; the targeted Xcode test build also compiles the updated navigation delegate.

## Changelog

Databricks-hosted servers now complete sign-in inside the iOS app.
