### PR TITLE
chore(ios): bump marketing version to 0.2.0

### DIFF
--- a/web/ios/Omnigent.xcodeproj/project.pbxproj
+++ b/web/ios/Omnigent.xcodeproj/project.pbxproj
@@ -548,7 +548,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -579,7 +579,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.2;
+				MARKETING_VERSION = 0.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Related issue

N/A — release chore.

## Summary

- Bump the public iOS app marketing version from 0.1.2 to 0.2.0 for the next TestFlight build.
- Update both Debug and Release configurations of the shipping `Omnigent` target while leaving test bundle versions unchanged.
- Leave `CURRENT_PROJECT_VERSION` unchanged because the TestFlight lane computes and injects the next build number.

## Test Plan

- `plutil -lint web/ios/Omnigent.xcodeproj/project.pbxproj`
- Verified `xcodebuild -showBuildSettings` reports `MARKETING_VERSION = 0.2.0` and `PRODUCT_BUNDLE_IDENTIFIER = ai.omnigent.ios` for both Debug and Release.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

This changes build metadata only. The Xcode project was syntax-checked, and the resolved settings for both shipping configurations were read back from `xcodebuild`.
