### PR TITLE
Fix lightbox close button hidden behind status bar on mobile

### DIFF
--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -279,7 +279,13 @@ export function ImageLightboxProvider({ children }: { children: React.ReactNode 
               <Button
                 variant="ghost"
                 size="icon-sm"
-                className="absolute top-3 right-3 bg-background/70 hover:bg-background/90"
+                // Offset by the top safe-area inset so the button clears the
+                // status bar / notch on native shells and stays tappable.
+                style={{
+                  top: "calc(0.75rem + var(--omnigent-safe-top, 0px))",
+                  right: "calc(0.75rem + var(--omnigent-safe-right, 0px))",
+                }}
+                className="absolute bg-background/70 hover:bg-background/90"
               >
                 <XIcon />
                 <span className="sr-only">Close</span>


### PR DESCRIPTION
## Related issue

Closes #

## Summary

- On mobile, opening the image lightbox showed a close (X) button pinned to a static `top-3` (12px) offset. Because the lightbox content is `fixed inset-0` and fills the viewport edge-to-edge, the button rendered behind the device status bar / notch on native shells and was not tappable — leaving no way to dismiss the viewer and return to the chat.
- Offset the button by the top/right safe-area insets using the same `--omnigent-safe-*` CSS variables the chat header and command palette already use. On web the insets are `0`, so desktop positioning is unchanged.

## Test Plan

Manual verification on a device with a notch/status bar:

1. Run the mobile app (`just run-ios` / `just run-android`).
2. Open a chat containing an image and tap the image to open the full-screen lightbox.
3. Confirm the X button now sits below the status bar and is tappable; tapping it closes the viewer and returns to the chat.
4. Web regression (`just dev`): open the lightbox and confirm the X is still in its usual top-right spot.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<!-- Requires a physical device / simulator with a safe-area inset to reproduce; see Test Plan. -->

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The bug only reproduces on a native shell with a non-zero top safe-area inset (notch/status bar), which the e2e UI suite doesn't emulate. Verified manually per the Test Plan; the change is a purely positional CSS offset guarded by `var(--omnigent-safe-top, 0px)`, which is `0` on web so existing behavior there is unchanged.

## Changelog

Fixed the image viewer close button being hidden behind the status bar on mobile

This pull request and its description were written by Isaac.
