### PR TITLE
fix(web): keep provisional sessions in projects

### DIFF
--- a/web/src/shell/NewChatDialog.flow.test.tsx
+++ b/web/src/shell/NewChatDialog.flow.test.tsx
@@ -32,6 +32,8 @@ const setPendingInitialPromptMock = vi.fn();
 const beginLocalConversationMock = vi.fn();
 const hydrateLocalConversationMock = vi.fn();
 const removeLocalConversationMock = vi.fn();
+let searchParams = new URLSearchParams();
+let projects: { id: string | null; name: string }[] = [];
 
 const RECENT_KEY = "omnigent:recent-workspaces";
 // Prompt history is scoped per conversation; the landing composer writes under
@@ -47,9 +49,7 @@ const SEEDED_WORKSPACE = "/Users/corey/universe/src/foo";
 // flow's navigate() lands on our spy regardless of router/provider setup.
 vi.mock("@/lib/routing", () => ({
   useNavigate: () => navigateMock,
-  // The landing screen reads `?project=` to pre-fill the project chip; this
-  // flow suite never sets one, so an empty params object is enough.
-  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  useSearchParams: () => [searchParams, vi.fn()],
 }));
 
 // The screen hands the first message to ChatPage through the chatStore
@@ -119,12 +119,10 @@ vi.mock("@/hooks/useDirectorySessions", () => ({
 vi.mock("@/hooks/RunnerHealthProvider", () => ({
   useRunnerHealthRegistration: () => new Map<string, boolean>(),
 }));
-// The composer's project chip lists projects via useProjects; stub it to an
-// empty list so it doesn't fire its own authenticatedFetch (which would land
-// at mock.calls[0] and skew these create-POST call assertions).
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof UseConversationsModule>()),
-  useProjects: () => ({ data: [] }),
+  useProjects: () => ({ data: projects }),
+  useProjectConfig: () => ({ data: null, isLoading: false }),
   // Same reason as useProjects above: the landing reads useConversations for
   // hasNoSessions, so stub it to avoid an authenticatedFetch skewing calls[0].
   useConversations: () => ({ data: undefined }),
@@ -310,6 +308,8 @@ beforeEach(() => {
   resetLandingDraft();
   clearOptimisticTitles();
   localStorage.clear();
+  searchParams = new URLSearchParams();
+  projects = [];
   vi.mocked(useHostModelOptions).mockReturnValue({
     data: [
       { id: "opus", displayName: "Opus" },
@@ -331,6 +331,49 @@ afterEach(() => {
 });
 
 describe("NewChatLandingScreen create flow", () => {
+  it("keeps project placement on the provisional and rekeyed conversation", async () => {
+    searchParams = new URLSearchParams("project=Alpha");
+    projects = [{ id: "proj_alpha", name: "Alpha" }];
+    beginLocalConversationMock.mockReturnValue({
+      tempConvId: "temp:1234567890abcdef1234567890abcdef",
+      pendingMsgTempId: "pend_1",
+      createToken: "1234567890abcdef1234567890abcdef",
+    });
+    vi.mocked(authenticatedFetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "conv_new" }),
+    } as unknown as Response);
+
+    renderLanding();
+    await waitForWorkspaceSeed();
+    typeMessage("inspect the repo");
+    fireEvent.click(screen.getByTestId("new-chat-landing-submit"));
+
+    const project = { id: "proj_alpha", name: "Alpha" };
+    await waitFor(() =>
+      expect(beginLocalConversationMock).toHaveBeenCalledWith(
+        "inspect the repo",
+        [],
+        expect.any(Object),
+        project,
+      ),
+    );
+    await waitFor(() =>
+      expect(hydrateLocalConversationMock).toHaveBeenCalledWith(
+        "temp:1234567890abcdef1234567890abcdef",
+        "conv_new",
+        "ag_hello",
+        "inspect the repo",
+        [],
+        "pend_1",
+        null,
+        navigateMock,
+        expect.any(Function),
+        project,
+      ),
+    );
+  });
+
   it("posts host_id, workspace and agent_id to /v1/sessions and navigates", async () => {
     vi.mocked(authenticatedFetch).mockResolvedValueOnce({
       ok: true,
@@ -429,6 +472,7 @@ describe("NewChatLandingScreen create flow", () => {
         null,
         navigateMock,
         expect.any(Function),
+        undefined,
       ),
     );
     expect(resolveCreate).toBeTypeOf("function");
@@ -474,6 +518,7 @@ describe("NewChatLandingScreen create flow", () => {
         null,
         navigateMock,
         expect.any(Function),
+        undefined,
       ),
     );
   });
@@ -593,6 +638,7 @@ describe("NewChatLandingScreen create flow", () => {
         null,
         navigateMock,
         expect.any(Function),
+        undefined,
       ),
     );
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -4469,6 +4469,8 @@ export function NewChatLandingScreen() {
       // move). A label-only folder (no first-class row yet) keeps the legacy
       // label + post-create move, which creates the project row on demand.
       const createProjectId = selectedProject !== "" ? configProjectId : null;
+      const localProject =
+        selectedProject !== "" ? { id: createProjectId, name: selectedProject } : undefined;
       // Server-side default-fill: a slot still holding its untouched project-
       // config seed (per the source refs) is OMITTED so the server fills it
       // from the config. Any user interaction — even re-picking the exact
@@ -4549,7 +4551,7 @@ export function NewChatLandingScreen() {
         // Normal path: bind to an existing registered agent.
         const provisional = newTempConversation();
         try {
-          localConv = beginLocalConversation(initialPrompt, files, provisional);
+          localConv = beginLocalConversation(initialPrompt, files, provisional, localProject);
           if (localConv !== null) navigate(`/c/${localConv.tempConvId}`);
         } catch {
           /* non-fatal: the response still opens the server session */
@@ -4806,6 +4808,7 @@ export function NewChatLandingScreen() {
           skill,
           navigate,
           () => window.location.pathname.endsWith(tempRouteSuffix),
+          localProject,
         );
         void queryClient.refetchQueries({ queryKey: ["conversations"] });
       } else {

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -413,7 +413,7 @@ function conv(id: string, status: Conversation["status"]): Conversation {
 
 /** Seed the sidebar conversations infinite-query cache (default "" search variant). */
 function seedConversationsCache(convs: Conversation[]): void {
-  client.setQueryData<InfiniteData<ConversationsPage>>(["conversations", ""], {
+  client.setQueryData<InfiniteData<ConversationsPage>>(["conversations", "", false], {
     pages: [
       {
         data: convs,
@@ -428,7 +428,7 @@ function seedConversationsCache(convs: Conversation[]): void {
 
 /** Flatten the seeded conversations cache back to its rows. */
 function readConversationRows(): Conversation[] {
-  const data = client.getQueryData<InfiniteData<ConversationsPage>>(["conversations", ""]);
+  const data = client.getQueryData<InfiniteData<ConversationsPage>>(["conversations", "", false]);
   return data?.pages.flatMap((p) => p.data) ?? [];
 }
 
@@ -2444,6 +2444,43 @@ describe("chatStore — navigate-first first send (B1/B2 regressions)", () => {
     await tick();
     await tick();
   }
+
+  it.each([
+    {
+      project: { id: "proj_alpha", name: "Alpha" },
+      expected: { project_id: "proj_alpha", labels: {} },
+    },
+    {
+      project: { id: null, name: "Legacy" },
+      expected: { labels: { omni_project: "Legacy" } },
+    },
+  ])("keeps project placement across the provisional-to-real rekey", ({ project, expected }) => {
+    seedSession("conv_real");
+    seedConversationsCache([]);
+
+    const begun = beginLocalConversation("hello there", undefined, undefined, project)!;
+    expect(readConversationRows()).toEqual([
+      expect.objectContaining({ id: begun.tempConvId, provisional: true, ...expected }),
+    ]);
+
+    hydrateLocalConversation(
+      begun.tempConvId,
+      "conv_real",
+      "agent_xyz",
+      "hello there",
+      undefined,
+      begun.pendingMsgTempId,
+      null,
+      noopNavigate,
+      undefined,
+      project,
+    );
+
+    expect(readConversationRows()).toEqual([
+      expect.objectContaining({ id: "conv_real", ...expected }),
+    ]);
+    expect(readConversationRows()[0]?.provisional).toBeUndefined();
+  });
 
   it("happy path: reuses the bubble (no duplicate), stays streaming, arms the latch", async () => {
     seedSession("conv_real");

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -100,6 +100,7 @@ import {
   insertNewRowsIntoPages,
   markRecentlyCreated,
   overlayTitleIntoCaches,
+  PROJECT_LABEL_KEY,
   removeIdsFromPages,
   type ConversationsInfiniteData,
 } from "@/lib/sessionListCache";
@@ -178,7 +179,16 @@ export interface SendOptions {
  * session). `provisional` marks the client-only `temp:` row so the sidebar
  * disables per-row mutations until it's rekeyed to the real id.
  */
-function makeConvRow(id: string, provisional = false): Conversation {
+export interface LocalConversationProject {
+  id: string | null;
+  name: string;
+}
+
+function makeConvRow(
+  id: string,
+  provisional = false,
+  project?: LocalConversationProject,
+): Conversation {
   const now = Math.floor(Date.now() / 1000);
   return {
     id,
@@ -186,8 +196,9 @@ function makeConvRow(id: string, provisional = false): Conversation {
     title: null,
     created_at: now,
     updated_at: now,
-    labels: {},
+    labels: project?.id === null ? { [PROJECT_LABEL_KEY]: project.name } : {},
     permission_level: null,
+    ...(project?.id ? { project_id: project.id } : {}),
     ...(provisional ? { provisional: true } : {}),
   };
 }
@@ -216,9 +227,14 @@ function upsertConvRow(row: Conversation, removeId?: string): void {
  * keeps it in the first-page fetch until the search index catches up; the WS
  * `session_added` frame then finds it present and skips it (no duplicate).
  */
-function rekeyConvRow(tempId: string, realId: string, text: string): void {
+function rekeyConvRow(
+  tempId: string,
+  realId: string,
+  text: string,
+  project?: LocalConversationProject,
+): void {
   if (queryClient === null) return;
-  const realConv = makeConvRow(realId);
+  const realConv = makeConvRow(realId, false, project);
   recordOptimisticTitle(realId, text);
   markRecentlyCreated(realConv);
   upsertConvRow(realConv, tempId);
@@ -250,6 +266,7 @@ export function beginLocalConversation(
   text: string,
   files: File[] | undefined,
   provisional = newTempConversation(),
+  project?: LocalConversationProject,
 ): { tempConvId: string; pendingMsgTempId: string; createToken: string } | null {
   if (queryClient === null) return null;
   const { id: tempConvId, token: createToken } = provisional;
@@ -258,7 +275,7 @@ export function beginLocalConversation(
 
   // Sidebar row under the same id the URL shows.
   recordOptimisticTitle(tempConvId, text);
-  upsertConvRow(makeConvRow(tempConvId, true));
+  upsertConvRow(makeConvRow(tempConvId, true, project));
 
   const fileBlocks: MessageContentBlock[] = (files ?? []).map((file) => {
     const filename = file.name || "image.png";
@@ -312,6 +329,7 @@ export function hydrateLocalConversation(
   skill: { name: string; args: string } | null,
   navigate: (to: string, opts?: { replace?: boolean }) => void,
   isStillViewing: () => boolean = () => true,
+  project?: LocalConversationProject,
 ): void {
   // Registry entry (carrying the optimistic bubble) + the sidebar row, both
   // id-addressed. Rekey the row BEFORE the caller's refetch so a lagging index
@@ -319,7 +337,7 @@ export function hydrateLocalConversation(
   // id, so no send is ever keyed under it — the hydrating `send` below enters
   // the chain under the real id directly.
   conversationRegistry.rekey(tempConvId, realId);
-  rekeyConvRow(tempConvId, realId, text);
+  rekeyConvRow(tempConvId, realId, text, project);
 
   const stillViewing = useChatStore.getState().conversationId === tempConvId && isStillViewing();
   if (stillViewing) {


### PR DESCRIPTION
## Related issue

Follow-up to #6737.

## Summary

- Carry project membership into client-only provisional conversations so they render in the intended project immediately instead of flashing under Chats.
- Preserve first-class `project_id` and legacy `omni_project` placement when the temporary ID is rekeyed to the server ID.

### ELI5

A new project session now knows its folder before the server finishes creating it, and keeps that folder when its temporary ID becomes real.

```mermaid
flowchart LR
    Submit[Create in project] --> Temp[Temporary conversation in project]
    Temp --> Rekey[Replace temporary ID]
    Rekey --> Real[Real conversation stays in project]
```

## Test Plan

- `npm test -- --run src/store/chatStore.test.ts src/shell/NewChatDialog.flow.test.tsx` — 476 tests passed.
- `npm run type-check`
- `npm run format:check`
- `npm run lint`

## Demo

- [X] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

https://github.com/user-attachments/assets/8953109f-32da-485c-852d-a1fb9f0ce674

The component flow test verifies that `?project=Alpha` supplies project placement to both provisional creation and rekeying. Store tests verify first-class and legacy label-only project placement.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Store-level coverage exercises both project representations; component coverage exercises the project-scoped creation handoff.

## Changelog

New project sessions appear in their project immediately while they are being created.