### PR TITLE
refactor(web): simplify archive tombstone lifecycle

### DIFF
--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -12,7 +12,6 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  clearRecentlyCreated,
   clearSessionTombstones,
   useArchiveConversation,
   type Conversation,
@@ -98,10 +97,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  // Tombstones and the recently-created keep-alive are module-level state;
-  // clear them so an archive in one test can't suppress rows in the next.
   clearSessionTombstones();
-  clearRecentlyCreated();
 });
 
 describe("SessionUpdatesProvider watch-set", () => {
@@ -324,7 +320,7 @@ describe("SessionUpdatesProvider fingerprint pruning", () => {
 });
 
 describe("SessionUpdatesProvider archive tombstone", () => {
-  it("a stale changed frame carrying archived:false cannot resurrect an archiving row", async () => {
+  it("does not let a stale changed frame resurrect an archiving row", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -333,60 +329,52 @@ describe("SessionUpdatesProvider archive tombstone", () => {
         json: async () => ({ ...conv("conv_a"), archived: true, updated_at: 10 }),
       }),
     );
-    try {
-      const client = new QueryClient();
-      seedConversations(client, ["conv_a", "conv_b"]);
-      client.setQueryData<ConversationsInfiniteData>(["conversations", "", true], {
-        pages: [
-          {
-            data: [{ ...conv("conv_c"), archived: true }],
-            first_id: "conv_c",
-            last_id: "conv_c",
-            has_more: false,
-          },
-        ],
-        pageParams: [undefined],
-      });
-      renderProvider(client, ["/"]);
-      const handler = frameHandler();
+    const client = new QueryClient();
+    seedConversations(client, ["conv_a", "conv_b"]);
+    client.setQueryData<ConversationsInfiniteData>(["conversations", "", true], {
+      pages: [
+        {
+          data: [{ ...conv("conv_c"), archived: true }],
+          first_id: "conv_c",
+          last_id: "conv_c",
+          has_more: false,
+        },
+      ],
+      pageParams: [undefined],
+    });
+    renderProvider(client, ["/"]);
+    const handler = frameHandler();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
 
-      // Drive the real archive mutation: onMutate tombstones the id and the
-      // optimistic overlay drops the row from this non-archived list.
-      const wrapper = ({ children }: { children: ReactNode }) => (
-        <QueryClientProvider client={client}>{children}</QueryClientProvider>
-      );
-      const { result } = renderHook(() => useArchiveConversation(), { wrapper });
-      result.current.mutate({ id: "conv_a", archived: true });
-      await waitFor(() => {
-        const data = client.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
-        expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_b"]);
-      });
+    archive.result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => {
+      expect(
+        client
+          .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+          .pages[0].data.map((row) => row.id),
+      ).toEqual(["conv_b"]);
+    });
 
-      // A pre-commit changed frame still carries archived:false for the row.
-      // The tombstone pins archived:true: the row stays out of the non-archived
-      // list but still merges (title applied, into the include-archived list).
-      act(() =>
-        handler({
-          type: "changed",
-          items: [{ ...conv("conv_a"), archived: false, title: "Late edit" }],
-        }),
-      );
-      const data = client.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
-      expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_b"]);
-      const archivedData = client.getQueryData<ConversationsInfiniteData>([
-        "conversations",
-        "",
-        true,
-      ]);
-      expect(archivedData!.pages[0].data.map((c) => c.id)).toEqual(["conv_a", "conv_c"]);
-      expect(archivedData!.pages[0].data[0]).toMatchObject({
-        title: "Late edit",
-        archived: true,
-      });
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    act(() =>
+      handler({
+        type: "changed",
+        items: [{ ...conv("conv_a"), archived: false, title: "Late edit" }],
+      }),
+    );
+    expect(
+      client
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
+        .pages[0].data.map((row) => row.id),
+    ).toEqual(["conv_b"]);
+    expect(
+      client
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((row) => row.id === "conv_a"),
+    ).toMatchObject({ title: "Late edit", archived: true });
+    await waitFor(() => expect(archive.result.current.isSuccess).toBe(true));
   });
 });
 

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -69,9 +69,6 @@ function applyItemsToCache(
   // Frames are full rows with explicit nulls; convert null → undefined so a
   // cleared field overlays the cache in the same shape GET /v1/sessions
   // produces (absent), without tripping the permission_level === null sentinel.
-  // Frames for a session with an optimistic delete in flight are dropped.
-  // For an optimistic archive the frame still merges with `archived` pinned
-  // to true, so a stale pre-commit frame can't resurrect or hide the row.
   const itemsById = new Map<string, SessionListWireItem>();
   for (const item of items) {
     if (isSessionDeleting(item.id)) continue;

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -60,7 +60,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  // Tombstones are module-level state that would leak into the next test.
   clearSessionTombstones();
   // Same for the recently-created keep-alive.
   clearRecentlyCreated();
@@ -2365,13 +2364,12 @@ describe("useMoveToProject", () => {
 });
 
 describe("useArchiveConversation", () => {
-  // A list page the search index keeps serving while it lags the PATCH.
   const staleListPage = {
     object: "list",
     data: [{ id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 5 }],
     first_id: "conv_a",
     last_id: "conv_a",
-    has_more: false,
+    has_more: true,
   };
 
   it("PATCHes archived, overlays the flag optimistically, and doesn't race the reindex", async () => {
@@ -2483,74 +2481,51 @@ describe("useArchiveConversation", () => {
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["conversations"] });
   });
 
-  it("keeps the row out when a stale sidebar-list refetch lands mid-archive", async () => {
-    // Hold the PATCH open so the refetch lands while the server (and the
-    // search index behind it) still lists the session with archived:false.
-    let settlePatch = (_res: Response) => {};
-    const pendingPatch = new Promise<Response>((resolve) => {
-      settlePatch = resolve;
-    });
-    fetchMock.mockImplementationOnce(() => pendingPatch);
+  it("does not restore a row with a concurrent delete in flight", async () => {
+    let settleArchive = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settleArchive = resolve;
+        }),
+    );
     const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
     queryClient.setQueryData(
-      ["conversations", "", false],
-      infinitePage([conversation({ id: "conv_a" }), conversation({ id: "conv_other" })]),
+      ["conversations", "", true],
+      infinitePage([conversation({ id: "conv_a" })]),
     );
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
-    // An active observer on the sidebar's own key, so the refetch below runs
-    // the real queryFn (the seeded data is fresh, so mounting fetches nothing).
-    renderHook(() => useConversations("", false), { wrapper });
-    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
+    const archive = renderHook(() => useArchiveConversation(), { wrapper });
+    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
+    const cachedRow = () =>
+      queryClient
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
+        .pages[0].data.find((row) => row.id === "conv_a");
 
-    result.current.mutate({ id: "conv_a", archived: true });
-    // The optimistic overlay drops the row from the default list immediately.
-    await waitFor(() => {
-      const data = queryClient.getQueryData<ConversationsInfiniteData>([
-        "conversations",
-        "",
-        false,
-      ]);
-      expect(data!.pages[0].data.map((c) => c.id)).toEqual(["conv_other"]);
-    });
+    archive.result.current.mutate({ id: "conv_a", archived: true });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    // A stale refetch of the sidebar list lands mid-archive (debounced WS
-    // invalidation or reconcile poll). The tombstone drops the row, as the
-    // server would have, and cursors re-anchor on the survivor.
-    const stalePage = {
-      object: "list",
-      data: [
-        { id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 5 },
-        { id: "conv_other", object: "conversation", title: "B", created_at: 0, updated_at: 4 },
-      ],
-      first_id: "conv_a",
-      last_id: "conv_other",
-      has_more: false,
-    };
-    fetchMock.mockResolvedValueOnce(mockResponse(stalePage));
-    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", false] }));
-    const page = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
-      .pages[0];
-    expect(page.data.map((c) => c.id)).toEqual(["conv_other"]);
-    expect([page.first_id, page.last_id]).toEqual(["conv_other", "conv_other"]);
-
-    // The same stale page on an include-archived list keeps the row visible
-    // (the Archived tab), pinned archived:true.
-    fetchMock.mockResolvedValueOnce(mockResponse(stalePage));
-    const archivedList = renderHook(() => useConversations("", true), { wrapper });
-    await waitFor(() => expect(archivedList.result.current.data).toBeDefined());
-    const archivedRow = archivedList.result.current.data!.pages[0].data.find(
-      (c) => c.id === "conv_a",
+    fetchMock.mockResolvedValueOnce(mockResponse({}));
+    let settleDelete = (_res: Response) => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          settleDelete = resolve;
+        }),
     );
-    expect(archivedRow?.archived).toBe(true);
+    del.result.current.mutate({ id: "conv_a" });
+    await waitFor(() => expect(cachedRow()).toBeUndefined());
 
-    settlePatch(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-    );
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    settleArchive(mockResponse({ error: "late" }, { ok: false, status: 500 }));
+    await waitFor(() => expect(archive.result.current.isError).toBe(true));
+    expect(cachedRow()).toBeUndefined();
+
+    settleDelete(mockResponse({ id: "conv_a", deleted: true }));
+    await waitFor(() => expect(del.result.current.isSuccess).toBe(true));
   });
 
-  it("keeps pagination alive when archive tombstones empty a fetched page", async () => {
+  it("filters stale refetches without stopping pagination", async () => {
     let settlePatch = (_res: Response) => {};
     fetchMock.mockImplementationOnce(
       () =>
@@ -2562,35 +2537,25 @@ describe("useArchiveConversation", () => {
     const seeded = infinitePage([conversation({ id: "conv_a" })]);
     seeded.pages[0].has_more = true;
     queryClient.setQueryData(["conversations", "", false], seeded);
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
     const wrapper = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: queryClient }, children);
     const list = renderHook(() => useConversations("", false), { wrapper });
     const archive = renderHook(() => useArchiveConversation(), { wrapper });
 
     archive.result.current.mutate({ id: "conv_a", archived: true });
-    await waitFor(() => expect(list.result.current.data!.pages[0].data).toEqual([]));
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
 
-    fetchMock.mockResolvedValueOnce(mockResponse({ ...staleListPage, has_more: true }));
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
     await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", false] }));
-
-    const page = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
-      .pages[0];
-    expect(page.data).toEqual([]);
-    expect(page.last_id).toBe("conv_a");
-    expect(list.result.current.hasNextPage).toBe(true);
+    const first = list.result.current.data!.pages[0];
+    expect(first.data).toEqual([]);
+    expect(first.last_id).toBe("conv_a");
 
     fetchMock.mockResolvedValueOnce(
       mockResponse({
-        data: [
-          {
-            id: "conv_other",
-            object: "conversation",
-            title: "Older",
-            created_at: 0,
-            updated_at: 4,
-          },
-        ],
+        data: [conversation({ id: "conv_other" })],
         first_id: "conv_other",
         last_id: "conv_other",
         has_more: false,
@@ -2599,536 +2564,15 @@ describe("useArchiveConversation", () => {
     await act(() => list.result.current.fetchNextPage());
     expect(fetchMock.mock.calls[2][0]).toContain("after=conv_a");
 
+    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
+    const archivedList = renderHook(() => useConversations("", true), { wrapper });
+    await waitFor(() => expect(archivedList.result.current.data).toBeDefined());
+    expect(archivedList.result.current.data!.pages[0].data[0].archived).toBe(true);
+
     settlePatch(
       mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
     );
     await waitFor(() => expect(archive.result.current.isSuccess).toBe(true));
-  });
-
-  it("cancels in-flight conversations AND project-sessions fetches on archive", async () => {
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-    );
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([conversation({ id: "conv_a" })]),
-    );
-    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
-
-    result.current.mutate({ id: "conv_a", archived: true });
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    // Parity with rename/delete: a stale project-folder fetch resolving after
-    // the overlay would resurrect the row in its folder.
-    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["conversations"] });
-    expect(cancelSpy).toHaveBeenCalledWith({ queryKey: ["project-sessions"] });
-  });
-
-  it("clears the tombstone on unarchive so the returning row is never suppressed", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([conversation({ id: "conv_a", archived: false })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    renderHook(() => useConversations("", true), { wrapper });
-    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
-
-    const cachedRow = () =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === "conv_a");
-
-    // Archive succeeds; the tombstone pins the row archived:true for the
-    // grace window, so a stale refetch can't show it active again.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-    );
-    await result.current.mutateAsync({ id: "conv_a", archived: true });
-    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
-    expect(cachedRow()?.archived).toBe(true);
-
-    // Unarchive clears the tombstone, so the SAME stale page now comes back
-    // with the flag the server sent — the returning row is never suppressed.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 11 }),
-    );
-    await result.current.mutateAsync({ id: "conv_a", archived: false });
-    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
-    expect(cachedRow()?.archived).toBeFalsy();
-  });
-
-  it("keeps the tombstone when a session is re-archived inside the first archive's grace window", async () => {
-    vi.useFakeTimers();
-    try {
-      // Stream connected → no safety poll would fire while time is advanced.
-      vi.mocked(useSessionUpdatesConnected).mockReturnValue(true);
-      const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-      queryClient.setQueryData(
-        ["conversations", "", true],
-        infinitePage([conversation({ id: "conv_a" })]),
-      );
-      const wrapper = ({ children }: { children: ReactNode }) =>
-        createElement(QueryClientProvider, { client: queryClient }, children);
-      renderHook(() => useConversations("", true), { wrapper });
-      const { result } = renderHook(() => useArchiveConversation(), { wrapper });
-
-      fetchMock.mockResolvedValueOnce(
-        mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-      );
-      await result.current.mutateAsync({ id: "conv_a", archived: true });
-      // Half the grace window passes, then an unarchive (clears the tombstone
-      // and its pending expiry)…
-      vi.advanceTimersByTime(30_000);
-      fetchMock.mockResolvedValueOnce(
-        mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 11 }),
-      );
-      await result.current.mutateAsync({ id: "conv_a", archived: false });
-      // …and a second archive re-arms both.
-      fetchMock.mockResolvedValueOnce(
-        mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
-      );
-      await result.current.mutateAsync({ id: "conv_a", archived: true });
-
-      // Past the FIRST archive's original expiry: its timer was cleared by the
-      // unarchive, so it must not clear the second archive's live tombstone.
-      vi.advanceTimersByTime(31_000);
-      fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-      await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
-      const row = queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === "conv_a");
-      expect(row?.archived).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("re-arms the tombstone when an unarchive fails inside the grace window", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([conversation({ id: "conv_a", archived: false })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    renderHook(() => useConversations("", true), { wrapper });
-    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
-
-    // Archive succeeds — the tombstone is armed for the grace window.
-    const toasts: string[] = [];
-    window.addEventListener("omnigent:toast", (e) => {
-      toasts.push(String((e as CustomEvent<{ content: unknown }>).detail.content));
-    });
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-    );
-    result.current.mutate({ id: "conv_a", archived: true });
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    // The unarchive fails: onMutate cleared the tombstone and onError must
-    // re-arm it — the session is still archived server-side, so a stale
-    // refetch must keep the row flagged archived.
-    fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
-    result.current.mutate({ id: "conv_a", archived: false });
-    await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(toasts).toEqual(["Couldn't unarchive the session."]);
-
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({
-        object: "list",
-        data: [{ id: "conv_a", object: "conversation", title: "A", created_at: 0, updated_at: 5 }],
-        first_id: "conv_a",
-        last_id: "conv_a",
-        has_more: false,
-      }),
-    );
-    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
-    const row = queryClient
-      .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-      .pages[0].data.find((c) => c.id === "conv_a");
-    expect(row?.archived).toBe(true);
-  });
-
-  it("a failed unarchive after a newer archive neither rolls back nor toasts", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([conversation({ id: "conv_a", archived: false })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    renderHook(() => useConversations("", true), { wrapper });
-    const archive = renderHook(() => useArchiveConversation(), { wrapper });
-    const unarchive = renderHook(() => useArchiveConversation(), { wrapper });
-    const toasts: string[] = [];
-    window.addEventListener("omnigent:toast", (e) => {
-      toasts.push(String((e as CustomEvent<{ content: unknown }>).detail.content));
-    });
-    const cachedRow = () =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === "conv_a");
-
-    // Archive succeeds; the row is pinned archived for the grace window.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-    );
-    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
-
-    // An unarchive starts (PATCH held open)…
-    let settleUnarchive = (_res: Response) => {};
-    fetchMock.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          settleUnarchive = resolve;
-        }),
-    );
-    unarchive.result.current.mutate({ id: "conv_a", archived: false });
-    await waitFor(() => expect(cachedRow()?.archived).toBe(false));
-
-    // …then a NEWER archive succeeds and owns the tombstone again.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
-    );
-    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
-
-    // The unarchive's PATCH fails last: the newer archive owns what the user
-    // sees, so no snapshot rollback and no failure toast.
-    settleUnarchive(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
-    await waitFor(() => expect(unarchive.result.current.isError).toBe(true));
-    expect(cachedRow()?.archived).toBe(true);
-    expect(toasts).toEqual([]);
-  });
-
-  it("delete inside the archive grace window takes over the tombstone (no stranded pin)", async () => {
-    vi.useFakeTimers();
-    try {
-      // Stream connected → no safety poll would fire while time is advanced.
-      vi.mocked(useSessionUpdatesConnected).mockReturnValue(true);
-      const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-      queryClient.setQueryData(
-        ["conversations", "", true],
-        infinitePage([conversation({ id: "conv_a" })]),
-      );
-      const wrapper = ({ children }: { children: ReactNode }) =>
-        createElement(QueryClientProvider, { client: queryClient }, children);
-      renderHook(() => useConversations("", true), { wrapper });
-      const archive = renderHook(() => useArchiveConversation(), { wrapper });
-      const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
-
-      fetchMock.mockResolvedValueOnce(
-        mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-      );
-      await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
-
-      // Delete while the archive pin is still in its grace window: the
-      // independent delete tombstone takes visibility precedence.
-      fetchMock.mockResolvedValueOnce(mockResponse({}));
-      fetchMock.mockResolvedValueOnce(mockResponse({ id: "conv_a", deleted: true }));
-      await del.result.current.mutateAsync({ id: "conv_a" });
-
-      // Past the grace window both tombstones are gone, so a stale page comes
-      // back exactly as the server sent it — no pin left behind.
-      vi.advanceTimersByTime(61_000);
-      fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-      await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", true] }));
-      const row = queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === "conv_a");
-      expect(row?.archived).toBeFalsy();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("a failed archive cannot release an active delete tombstone", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", false],
-      infinitePage([conversation({ id: "conv_a" })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    renderHook(() => useConversations("", false), { wrapper });
-    const archive = renderHook(() => useArchiveConversation(), { wrapper });
-    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
-    const defaultIds = () =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
-        .pages[0].data.map((c) => c.id);
-
-    fetchMock.mockResolvedValueOnce(mockResponse({}));
-    let settleDelete = (_res: Response) => {};
-    fetchMock.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          settleDelete = resolve;
-        }),
-    );
-    del.result.current.mutate({ id: "conv_a" });
-    await waitFor(() => expect(defaultIds()).toEqual([]));
-
-    fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
-    archive.result.current.mutate({ id: "conv_a", archived: true });
-    await waitFor(() => expect(archive.result.current.isError).toBe(true));
-
-    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-    await act(() => queryClient.refetchQueries({ queryKey: ["conversations", "", false] }));
-    expect(defaultIds()).toEqual([]);
-
-    settleDelete(mockResponse({ id: "conv_a", deleted: true }));
-    await waitFor(() => expect(del.result.current.isSuccess).toBe(true));
-  });
-
-  it("a failed delete inside the archive grace window re-arms the archive pin", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([conversation({ id: "conv_a", archived: false })]),
-    );
-    queryClient.setQueryData(
-      ["conversations", "", false],
-      infinitePage([conversation({ id: "conv_a" })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    renderHook(() => useConversations("", true), { wrapper });
-    renderHook(() => useConversations("", false), { wrapper });
-    const archive = renderHook(() => useArchiveConversation(), { wrapper });
-    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
-
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-    );
-    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
-
-    // The delete fails (stop ok, DELETE 500): onError releases only the delete
-    // tombstone, so the independent archive pin survives the rollback.
-    fetchMock.mockResolvedValueOnce(mockResponse({}));
-    fetchMock.mockResolvedValueOnce(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
-    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-    del.result.current.mutate({ id: "conv_a" });
-    await waitFor(() => expect(del.result.current.isError).toBe(true));
-    // updated_at:5 only arrives via the stale refetch, proving it landed.
-    await waitFor(() => {
-      const row = queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === "conv_a");
-      expect(row).toMatchObject({ archived: true, updated_at: 5 });
-    });
-    const defaultIds = queryClient
-      .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
-      .pages[0].data.map((c) => c.id);
-    expect(defaultIds).toEqual([]);
-  });
-
-  it("a failed bulk archive keeps a row a newer delete owns out of the restored lists", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", false],
-      infinitePage([conversation({ id: "conv_a" }), conversation({ id: "conv_b" })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    const bulk = renderHook(() => useBulkArchiveConversations(), { wrapper });
-    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
-    const defaultIds = () =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
-        .pages[0].data.map((c) => c.id);
-
-    // Bulk archive of conv_a: PATCH held open; the overlay drops the row.
-    let settleArchive = (_res: Response) => {};
-    fetchMock.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          settleArchive = resolve;
-        }),
-    );
-    bulk.result.current.mutate({ ids: ["conv_a"], archived: true });
-    await waitFor(() => expect(defaultIds()).toEqual(["conv_b"]));
-
-    // A newer delete takes over conv_a's tombstone and succeeds.
-    fetchMock.mockResolvedValueOnce(mockResponse({}));
-    fetchMock.mockResolvedValueOnce(mockResponse({ id: "conv_a", deleted: true }));
-    await del.result.current.mutateAsync({ id: "conv_a" });
-
-    // The bulk archive's PATCH finally fails: rolling its snapshot back must
-    // not resurrect the row the delete owns.
-    settleArchive(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
-    await waitFor(() => expect(bulk.result.current.isError).toBe(true));
-    expect(defaultIds()).toEqual(["conv_b"]);
-  });
-
-  it("a failed bulk unarchive keeps a newer archive's pin on a succeeded id", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([
-        conversation({ id: "conv_a", archived: true }),
-        conversation({ id: "conv_b", archived: true }),
-      ]),
-    );
-    queryClient.setQueryData(
-      ["conversations", "", false],
-      infinitePage([conversation({ id: "conv_c" })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    const bulk = renderHook(() => useBulkArchiveConversations(), { wrapper });
-    const archive = renderHook(() => useArchiveConversation(), { wrapper });
-    const archivedRow = (id: string) =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === id);
-
-    // Bulk UNarchive of both: PATCHes held open; the overlay flags them active.
-    const settlers: ((res: Response) => void)[] = [];
-    fetchMock.mockImplementation(
-      () =>
-        new Promise<Response>((resolve) => {
-          settlers.push(resolve);
-        }),
-    );
-    bulk.result.current.mutate({ ids: ["conv_a", "conv_b"], archived: false });
-    await waitFor(() => expect(archivedRow("conv_a")?.archived).toBe(false));
-
-    // A newer single archive of conv_a succeeds and owns its tombstone.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
-    );
-    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
-
-    // The bulk settles: conv_a's PATCH ok, conv_b's fails. The rollback must
-    // not strip the archive pin the newer mutation owns; conv_b rolls back.
-    settlers[0](
-      mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 13 }),
-    );
-    settlers[1](mockResponse({ error: "nope" }, { ok: false, status: 500 }));
-    await waitFor(() => expect(bulk.result.current.isError).toBe(true));
-    expect(archivedRow("conv_a")?.archived).toBe(true);
-    expect(archivedRow("conv_b")?.archived).toBe(true);
-    const defaultIds = queryClient
-      .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
-      .pages[0].data.map((c) => c.id);
-    expect(defaultIds).toEqual(["conv_c"]);
-  });
-
-  it("a failed delete keeps a newer archive's pin through the snapshot rollback", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([conversation({ id: "conv_a", archived: false })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    const archive = renderHook(() => useArchiveConversation(), { wrapper });
-    const del = renderHook(() => useStopAndDeleteConversation(), { wrapper });
-    const archivedRow = () =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === "conv_a");
-
-    // Delete starts: the row is spliced out; the DELETE is held open.
-    fetchMock.mockResolvedValueOnce(mockResponse({}));
-    let settleDelete = (_res: Response) => {};
-    fetchMock.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          settleDelete = resolve;
-        }),
-    );
-    del.result.current.mutate({ id: "conv_a" });
-    await waitFor(() => expect(archivedRow()).toBeUndefined());
-
-    // A newer archive takes over the id's tombstone and succeeds.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 10 }),
-    );
-    await archive.result.current.mutateAsync({ id: "conv_a", archived: true });
-
-    // The delete fails: its snapshot rollback restores the row archived:false
-    // — the live archive tombstone must re-pin it (no refetch involved).
-    settleDelete(mockResponse({ error: "nope" }, { ok: false, status: 500 }));
-    await waitFor(() => expect(del.result.current.isError).toBe(true));
-    expect(archivedRow()?.archived).toBe(true);
-  });
-
-  it("a superseded archive's late failure cannot release the newer tombstone", async () => {
-    const queryClient = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
-    queryClient.setQueryData(
-      ["conversations", "", true],
-      infinitePage([conversation({ id: "conv_a", archived: false })]),
-    );
-    queryClient.setQueryData(
-      ["conversations", "", false],
-      infinitePage([conversation({ id: "conv_a" })]),
-    );
-    const wrapper = ({ children }: { children: ReactNode }) =>
-      createElement(QueryClientProvider, { client: queryClient }, children);
-    renderHook(() => useConversations("", true), { wrapper });
-    renderHook(() => useConversations("", false), { wrapper });
-    const { result } = renderHook(() => useArchiveConversation(), { wrapper });
-
-    const archivedRow = () =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", true])!
-        .pages[0].data.find((c) => c.id === "conv_a");
-    const defaultIds = () =>
-      queryClient
-        .getQueryData<ConversationsInfiniteData>(["conversations", "", false])!
-        .pages[0].data.map((c) => c.id);
-
-    // Archive #1: PATCH held open; the overlay drops the row from the
-    // default list immediately. A separate hook instance, so its isError
-    // reflects #1 even after later mutations run on the other instance.
-    let settleFirst = (_res: Response) => {};
-    fetchMock.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          settleFirst = resolve;
-        }),
-    );
-    const first = renderHook(() => useArchiveConversation(), { wrapper });
-    first.result.current.mutate({ id: "conv_a", archived: true });
-    await waitFor(() => expect(defaultIds()).toEqual([]));
-
-    // Unarchive, then archive #2 — both settle while #1 is still in flight,
-    // so #2 owns the live tombstone.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: false, updated_at: 11 }),
-    );
-    await result.current.mutateAsync({ id: "conv_a", archived: false });
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ id: "conv_a", object: "conversation", archived: true, updated_at: 12 }),
-    );
-    await result.current.mutateAsync({ id: "conv_a", archived: true });
-
-    // Archive #1's PATCH finally fails: its onError must neither release the
-    // tombstone archive #2 owns nor roll the caches back to its own stale
-    // snapshot — the rows stay exactly as archive #2 painted them.
-    settleFirst(mockResponse({ error: "late" }, { ok: false, status: 500 }));
-    await waitFor(() => expect(first.result.current.isError).toBe(true));
-    expect(archivedRow()?.archived).toBe(true);
-    expect(defaultIds()).toEqual([]);
-
-    // A stale refetch of either list still finds the server mid-commit: the
-    // live tombstone pins the row archived:true on the include-archived page
-    // and drops it from the default page.
-    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-    fetchMock.mockResolvedValueOnce(mockResponse(staleListPage));
-    await act(() => queryClient.refetchQueries({ queryKey: ["conversations"] }));
-    expect(archivedRow()?.archived).toBe(true);
-    expect(defaultIds()).toEqual([]);
   });
 });
 

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -254,131 +254,129 @@ export interface ConversationsPage {
   has_more: boolean;
 }
 
-// ── Hidden-session tombstones (delete / archive in flight) ──────────
-interface SessionTombstone {
-  gen: number;
-  timer?: ReturnType<typeof setTimeout>;
-}
+// ── Deleting-session tombstones ───────────────────────────────────────
+//
+// Delete paints optimistically: the row leaves the sidebar the moment the
+// user confirms, long before the server finishes tearing the session down
+// (stop, runner resources, worktree, managed sandbox — seconds). Until
+// that lands, `GET /v1/sessions` still returns the session, and on the
+// search-indexed deployment it keeps returning it for a while after. Any
+// list fetch in that window — the reconcile poll, the refetch a WS frame
+// schedules, expanding a project folder — would repaint the row the user
+// just deleted.
+//
+// Ids recorded here are filtered out of every list fetch until the delete
+// settles: dropped immediately when it fails (the row comes back), or
+// after a grace window once it succeeds (the server's async reindex).
+const deletingSessionIds = new Set<string>();
 
-// Delete and archive lifecycles are independent, so archive cannot release
-// the stronger delete tombstone.
-const deletingSessionTombstones = new Map<string, SessionTombstone>();
-const archivingSessionTombstones = new Map<string, SessionTombstone>();
-let tombstoneGen = 0;
-
-/** Grace window for the server's async list-index catch-up. */
+/** Grace window for the server's async delete reindex. */
 const DELETED_TOMBSTONE_MS = 60_000;
 
-/** Replace entries in one tombstone lifecycle; returns the owning generation. */
-function markSessionTombstones<T extends SessionTombstone>(
-  tombstones: Map<string, T>,
-  ids: Iterable<string>,
-  makeEntry: (gen: number) => T,
-): number {
-  const gen = ++tombstoneGen;
-  for (const id of ids) {
-    const prev = tombstones.get(id);
-    if (prev?.timer !== undefined) clearTimeout(prev.timer);
-    tombstones.set(id, makeEntry(gen));
-  }
-  return gen;
-}
-
-/** Release tombstones the caller still owns (`gen` matches) — the mutation failed or was undone. */
-function releaseSessionTombstones<T extends SessionTombstone>(
-  tombstones: Map<string, T>,
-  ids: Iterable<string>,
-  gen: number,
-): void {
-  for (const id of ids) {
-    const entry = tombstones.get(id);
-    if (entry === undefined || entry.gen !== gen) continue;
-    if (entry.timer !== undefined) clearTimeout(entry.timer);
-    tombstones.delete(id);
-  }
-}
-
-/** Hold settled tombstones through the reindex grace window, then release them. */
-function expireSessionTombstones<T extends SessionTombstone>(
-  tombstones: Map<string, T>,
-  ids: Iterable<string>,
-  gen: number,
-): void {
-  for (const id of ids) {
-    const entry = tombstones.get(id);
-    if (entry === undefined || entry.gen !== gen) continue;
-    if (entry.timer !== undefined) clearTimeout(entry.timer);
-    entry.timer = setTimeout(() => {
-      if (tombstones.get(id) === entry) tombstones.delete(id);
-    }, DELETED_TOMBSTONE_MS);
-  }
-}
-
-/** Re-arm archive tombstones a failed unarchive/delete cleared, with a fresh grace window. */
-function rearmArchiveTombstones(ids: readonly string[]): void {
-  const rearm = ids.filter((id) => archivingSessionTombstones.get(id) === undefined);
-  if (rearm.length === 0) return;
-  const gen = markSessionTombstones(archivingSessionTombstones, rearm, (entryGen) => ({
-    gen: entryGen,
-  }));
-  expireSessionTombstones(archivingSessionTombstones, rearm, gen);
-}
-
-function clearArchivingSessionTombstones(ids: Iterable<string>): void {
-  for (const id of ids) {
-    const entry = archivingSessionTombstones.get(id);
-    if (entry?.timer !== undefined) clearTimeout(entry.timer);
-    archivingSessionTombstones.delete(id);
-  }
-}
-
-/** Wipe every tombstone — exported for test cleanup. */
-export function clearSessionTombstones(): void {
-  for (const tombstones of [deletingSessionTombstones, archivingSessionTombstones]) {
-    for (const entry of tombstones.values()) {
-      if (entry.timer !== undefined) clearTimeout(entry.timer);
-    }
-    tombstones.clear();
-  }
+/** Hide these sessions from every list fetch (optimistic delete). */
+export function markSessionsDeleting(ids: Iterable<string>): void {
+  for (const id of ids) deletingSessionIds.add(id);
 }
 
 /** Whether a session has an optimistic delete in flight (tombstoned). */
 export function isSessionDeleting(id: string): boolean {
-  return deletingSessionTombstones.has(id);
-}
-
-/** Whether a session has an optimistic archive in flight (tombstoned). */
-export function isSessionArchiving(id: string): boolean {
-  return archivingSessionTombstones.has(id);
+  return deletingSessionIds.has(id);
 }
 
 /**
- * Apply tombstones to a freshly fetched page: drop deleting sessions; pin
- * archiving sessions to `archived: true` (or drop them when `dropArchiving`
- * — lists that never show archived rows). Cursors follow the survivors.
+ * Stop hiding sessions — their delete failed, so the rows return.
+ * Omit `ids` to release every tombstone at once.
+ */
+export function unmarkSessionsDeleting(ids?: Iterable<string>): void {
+  if (ids === undefined) {
+    deletingSessionIds.clear();
+    return;
+  }
+  for (const id of ids) deletingSessionIds.delete(id);
+}
+
+/** Release confirmed-delete tombstones once the server has caught up. */
+function expireSessionsDeleting(ids: string[]): void {
+  setTimeout(() => unmarkSessionsDeleting(ids), DELETED_TOMBSTONE_MS);
+}
+
+interface ArchiveTombstone {
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+const archivingSessions = new Map<string, ArchiveTombstone>();
+
+function markSessionsArchiving(ids: Iterable<string>): Map<string, ArchiveTombstone> {
+  const marked = new Map<string, ArchiveTombstone>();
+  for (const id of ids) {
+    const previous = archivingSessions.get(id);
+    if (previous?.timer !== undefined) clearTimeout(previous.timer);
+    const entry = {};
+    archivingSessions.set(id, entry);
+    marked.set(id, entry);
+  }
+  return marked;
+}
+
+function unmarkSessionsArchiving(
+  ids?: Iterable<string>,
+  marked?: Map<string, ArchiveTombstone>,
+): void {
+  const targets = ids ?? archivingSessions.keys();
+  for (const id of targets) {
+    const entry = archivingSessions.get(id);
+    if (entry === undefined || (marked !== undefined && marked.get(id) !== entry)) continue;
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    archivingSessions.delete(id);
+  }
+}
+
+function expireSessionsArchiving(
+  marked: Map<string, ArchiveTombstone>,
+  ids: Iterable<string>,
+): void {
+  for (const id of ids) {
+    const entry = marked.get(id);
+    if (entry === undefined || archivingSessions.get(id) !== entry) continue;
+    entry.timer = setTimeout(() => {
+      if (archivingSessions.get(id) === entry) archivingSessions.delete(id);
+    }, DELETED_TOMBSTONE_MS);
+  }
+}
+
+export function isSessionArchiving(id: string): boolean {
+  return archivingSessions.has(id);
+}
+
+/** Wipe module-level tombstones between tests. */
+export function clearSessionTombstones(): void {
+  unmarkSessionsDeleting();
+  unmarkSessionsArchiving();
+}
+
+/**
+ * Apply optimistic delete/archive state to a freshly fetched page.
  */
 function applySessionTombstones(page: ConversationsPage, dropArchiving = false): ConversationsPage {
-  if (deletingSessionTombstones.size === 0 && archivingSessionTombstones.size === 0) return page;
+  if (deletingSessionIds.size === 0 && archivingSessions.size === 0) return page;
   let changed = false;
   let lastArchivingId: string | null = null;
   const data: Conversation[] = [];
   for (const conv of page.data) {
-    const archiving = isSessionArchiving(conv.id);
     if (isSessionDeleting(conv.id)) {
       changed = true;
       continue;
     }
-    if (dropArchiving && archiving) {
-      changed = true;
+    if (!isSessionArchiving(conv.id)) {
+      data.push(conv);
+      continue;
+    }
+    changed = true;
+    if (dropArchiving) {
       lastArchivingId = conv.id;
-      continue;
+    } else {
+      data.push(conv.archived === true ? conv : { ...conv, archived: true });
     }
-    if (archiving && conv.archived !== true) {
-      changed = true;
-      data.push({ ...conv, archived: true });
-      continue;
-    }
-    data.push(conv);
   }
   if (!changed) return page;
   return {
@@ -537,7 +535,6 @@ async function fetchConversationsPage({
   // falling back to the modal. host_id is fixed for a session's life, so this
   // can't seed a stale value; a hostless row clears any prior mapping.
   for (const row of page.data) setSessionHost(row.id, row.host_id);
-  // Non-archived queries exclude archived rows server-side — drop, don't pin.
   return applySessionTombstones(
     withRecentlyCreated(
       page,
@@ -853,33 +850,21 @@ function dropFromPinnedCache(queryClient: QueryClient, ids: Iterable<string>): v
   );
 }
 
-/**
- * Paint an archive/unarchive before the server confirms it: tombstone the
- * ids (an unarchive clears it), cancel in-flight list refetches, then overlay
- * the flag into every cached list. Mirrors `paintConversationsDeleted`.
- */
 async function paintConversationsArchived(
   queryClient: QueryClient,
   ids: readonly string[],
   archived: boolean,
-): Promise<{ snapshot: ArchiveListsSnapshot; gen: number; restoreArchiving: string[] }> {
-  const restoreArchiving = ids.filter((id) => isSessionArchiving(id));
+): Promise<{ snapshot: ArchiveListsSnapshot; marked?: Map<string, ArchiveTombstone> }> {
   await Promise.all([
     queryClient.cancelQueries({ queryKey: ["conversations"] }),
     queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
   ]);
-  const gen = markSessionTombstones(
-    archivingSessionTombstones,
-    archived ? ids : [],
-    (entryGen) => ({ gen: entryGen }),
-  );
-  // Unarchive must not retain a true pin; overlapping rollbacks reconcile
-  // through the server refresh path rather than pinning archived:false.
-  if (!archived) clearArchivingSessionTombstones(ids);
+  const marked = archived ? markSessionsArchiving(ids) : undefined;
+  if (!archived) unmarkSessionsArchiving(ids);
   const snapshot = snapshotArchiveLists(queryClient);
   for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);
   if (archived) dropFromPinnedCache(queryClient, ids);
-  return { snapshot, gen, restoreArchiving };
+  return { snapshot, marked };
 }
 
 export function useArchiveConversation() {
@@ -889,18 +874,17 @@ export function useArchiveConversation() {
       archiveConversation(id, archived),
     onMutate: ({ id, archived }) => paintConversationsArchived(queryClient, [id], archived),
     onError: (_err, { id, archived }, context) => {
-      // A newer mutation owns the id — leave its tombstone and overlay alone.
-      const live = archivingSessionTombstones.get(id);
-      if (context && live !== undefined && live.gen !== context.gen) return;
-      if (archived && context) {
-        releaseSessionTombstones(archivingSessionTombstones, [id], context.gen);
+      if (archived && context?.marked !== undefined) {
+        const marked = context.marked.get(id);
+        const live = archivingSessions.get(id);
+        if (live !== undefined && live !== marked) return;
+        unmarkSessionsArchiving([id], context.marked);
       }
-      if (context) rearmArchiveTombstones(context.restoreArchiving);
       // Roll back to exactly the pre-archive caches, synchronously — so the
       // row (and any dropped pin) returns at once, rather than waiting on a
       // search-indexed refetch that lags the write.
-      if (context) restoreArchiveLists(queryClient, context.snapshot);
-      if (context) reapplyLiveTombstones(queryClient);
+      if (context?.snapshot) restoreArchiveLists(queryClient, context.snapshot);
+      reapplyLiveSessionTombstones(queryClient);
       showToast(
         archived
           ? "Couldn't archive the session — it's back in the sidebar."
@@ -909,8 +893,8 @@ export function useArchiveConversation() {
     },
     onSuccess: (updated, { archived }, context) => {
       markConversationSeen(updated.id, updated.updated_at);
-      if (archived && context) {
-        expireSessionTombstones(archivingSessionTombstones, [updated.id], context.gen);
+      if (archived && context?.marked !== undefined) {
+        expireSessionsArchiving(context.marked, [updated.id]);
       }
       // Archiving/unarchiving the last (or first) non-archived member of a
       // project removes/restores it from the server's project list, and adds
@@ -956,13 +940,12 @@ function removeConversationsFromLists(queryClient: QueryClient, ids: Set<string>
   );
 }
 
-/** Re-apply every live tombstone's optimistic state after a wholesale snapshot restore. */
-function reapplyLiveTombstones(queryClient: QueryClient): void {
-  const archived = new Set(archivingSessionTombstones.keys());
-  for (const id of archived) overlayArchivedIntoCaches(queryClient, id, true);
-  if (archived.size > 0) dropFromPinnedCache(queryClient, archived);
-  if (deletingSessionTombstones.size > 0) {
-    removeConversationsFromLists(queryClient, new Set(deletingSessionTombstones.keys()));
+function reapplyLiveSessionTombstones(queryClient: QueryClient): void {
+  const archiving = new Set(archivingSessions.keys());
+  for (const id of archiving) overlayArchivedIntoCaches(queryClient, id, true);
+  if (archiving.size > 0) dropFromPinnedCache(queryClient, archiving);
+  if (deletingSessionIds.size > 0) {
+    removeConversationsFromLists(queryClient, new Set(deletingSessionIds));
   }
 }
 
@@ -986,14 +969,12 @@ interface DeletedListsSnapshot {
 async function paintConversationsDeleted(
   queryClient: QueryClient,
   ids: readonly string[],
-): Promise<{ snapshot: DeletedListsSnapshot; gen: number }> {
+): Promise<DeletedListsSnapshot> {
+  markSessionsDeleting(ids);
   await Promise.all([
     queryClient.cancelQueries({ queryKey: ["conversations"] }),
     queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
   ]);
-  const gen = markSessionTombstones(deletingSessionTombstones, ids, (entryGen) => ({
-    gen: entryGen,
-  }));
   const snapshot: DeletedListsSnapshot = {
     lists: [
       ...queryClient.getQueriesData<ConversationsInfiniteData>({ queryKey: ["conversations"] }),
@@ -1002,32 +983,34 @@ async function paintConversationsDeleted(
     pinned: queryClient.getQueryData<PinnedConversationsResult>(PINNED_CONVERSATIONS_KEY),
   };
   removeConversationsFromLists(queryClient, new Set(ids));
-  return { snapshot, gen };
+  return snapshot;
 }
 
 /**
  * Put optimistically-removed rows back after a failed delete.
  *
  * Restores the snapshot wholesale (the same rollback shape
- * `useMoveToProject` uses), then re-applies live tombstones so ids a newer
- * mutation owns keep that mutation's state (and ids that DID delete in a
- * partial bulk failure stay gone). The lists are invalidated afterwards so
- * the server reconciles the window the snapshot froze over.
+ * `useMoveToProject` uses) rather than re-deriving positions, then
+ * re-splices whatever DID delete — a bulk delete can fail for only part
+ * of its selection. The lists are invalidated afterwards so the server
+ * reconciles the window the snapshot froze over.
  *
  * @param queryClient - The app QueryClient.
- * @param paint - Tombstone + cache state captured by `paintConversationsDeleted`.
+ * @param snapshot - Cache state captured by `paintConversationsDeleted`.
  * @param failedIds - Conversation ids whose delete failed (rows return).
+ * @param deletedIds - Conversation ids that did delete (rows stay gone).
  */
 function restoreDeletedConversations(
   queryClient: QueryClient,
-  paint: { snapshot: DeletedListsSnapshot; gen: number } | undefined,
+  snapshot: DeletedListsSnapshot | undefined,
   failedIds: readonly string[],
+  deletedIds: readonly string[] = [],
 ): void {
-  if (paint !== undefined) {
-    releaseSessionTombstones(deletingSessionTombstones, failedIds, paint.gen);
-    for (const [key, data] of paint.snapshot.lists) queryClient.setQueryData(key, data);
-    queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, paint.snapshot.pinned);
-    reapplyLiveTombstones(queryClient);
+  unmarkSessionsDeleting(failedIds);
+  if (snapshot) {
+    for (const [key, data] of snapshot.lists) queryClient.setQueryData(key, data);
+    queryClient.setQueryData(PINNED_CONVERSATIONS_KEY, snapshot.pinned);
+    if (deletedIds.length > 0) removeConversationsFromLists(queryClient, new Set(deletedIds));
   }
   void queryClient.invalidateQueries({ queryKey: ["conversations"] });
   void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
@@ -1043,17 +1026,12 @@ function restoreDeletedConversations(
  * @param queryClient - The app QueryClient.
  * @param ids - Conversation ids the server confirmed deleted.
  */
-function finalizeDeletedConversations(
-  queryClient: QueryClient,
-  ids: readonly string[],
-  gen: number,
-): void {
+function finalizeDeletedConversations(queryClient: QueryClient, ids: readonly string[]): void {
   for (const id of ids) {
     queryClient.removeQueries({ queryKey: ["conversation-backfill", id] });
     queryClient.removeQueries({ queryKey: ["session", id] });
   }
-  clearArchivingSessionTombstones(ids);
-  expireSessionTombstones(deletingSessionTombstones, ids, gen);
+  expireSessionsDeleting([...ids]);
   // Deleting the last member of a project empties it, so refresh the
   // project list to drop the now-empty folder. Unlike the conversations
   // list, /v1/sessions/projects reads the DB directly (no search-index
@@ -1119,11 +1097,11 @@ export function useStopAndDeleteConversation() {
       // Snapshot the label before the row leaves the cache — a failure
       // toast fired later can no longer look it up.
       const row = findCachedConversationRow(queryClient, id);
-      const paint = await paintConversationsDeleted(queryClient, [id]);
-      return { label: row ? conversationDisplayLabel(row) : null, paint };
+      const snapshot = await paintConversationsDeleted(queryClient, [id]);
+      return { label: row ? conversationDisplayLabel(row) : null, snapshot };
     },
     onError: (err, { id }, context) => {
-      restoreDeletedConversations(queryClient, context?.paint, [id]);
+      restoreDeletedConversations(queryClient, context?.snapshot, [id]);
       // The row is back in the sidebar but nothing else marks it as failed
       // (the row unmounted when it was spliced out, taking any in-row error
       // state with it), so the toast is the only failure signal. Keep it
@@ -1132,8 +1110,8 @@ export function useStopAndDeleteConversation() {
       // only hint for what to do next.
       showToast(deleteFailedToast(context?.label, err), { duration: 0 });
     },
-    onSuccess: (_data, { id }, context) => {
-      if (context !== undefined) finalizeDeletedConversations(queryClient, [id], context.paint.gen);
+    onSuccess: (_data, { id }) => {
+      finalizeDeletedConversations(queryClient, [id]);
     },
   });
 }
@@ -1238,25 +1216,27 @@ export function useBulkArchiveConversations() {
     },
     onMutate: ({ ids, archived }) => paintConversationsArchived(queryClient, ids, archived),
     onError: (err, { ids, archived }, context) => {
-      if (!context) return;
+      // Partial failure: restore the pre-archive caches, then RE-apply the
+      // overlay for the ids that DID archive so they stay hidden — only the
+      // failed ids return. Restoring from the snapshot rather than refetching
+      // ["conversations"] is what stops the search-index lag from resurrecting
+      // the successful archives (the exact regression this reconcile guards).
+      if (!context?.snapshot) return;
       const failed = new Set(err instanceof BulkConversationMutationError ? err.failed : ids);
       const succeeded = ids.filter((id) => !failed.has(id));
-      if (archived) {
-        releaseSessionTombstones(archivingSessionTombstones, failed, context.gen);
-        expireSessionTombstones(archivingSessionTombstones, succeeded, context.gen);
+      if (archived && context.marked !== undefined) {
+        unmarkSessionsArchiving(failed, context.marked);
+        expireSessionsArchiving(context.marked, succeeded);
       }
-      rearmArchiveTombstones(context.restoreArchiving.filter((id) => failed.has(id)));
       restoreArchiveLists(queryClient, context.snapshot);
-      reapplyLiveTombstones(queryClient);
-      // Succeeded unarchives own no tombstone — re-apply their flag by hand.
       if (!archived) {
-        for (const id of succeeded.filter((sid) => !archivingSessionTombstones.has(sid)))
-          overlayArchivedIntoCaches(queryClient, id, false);
+        for (const id of succeeded) overlayArchivedIntoCaches(queryClient, id, false);
       }
+      reapplyLiveSessionTombstones(queryClient);
     },
     onSuccess: (_data, { ids, archived }, context) => {
-      if (archived && context !== undefined) {
-        expireSessionTombstones(archivingSessionTombstones, ids, context.gen);
+      if (archived && context?.marked !== undefined) {
+        expireSessionsArchiving(context.marked, ids);
       }
     },
     onSettled: () => {
@@ -1320,19 +1300,17 @@ export function useBulkDeleteConversations() {
       return { succeeded, failed };
     },
     onMutate: ({ ids }) => paintConversationsDeleted(queryClient, ids),
-    onSuccess: (_data, { ids }, context) => {
-      if (context !== undefined) finalizeDeletedConversations(queryClient, ids, context.gen);
+    onSuccess: (_data, { ids }) => {
+      finalizeDeletedConversations(queryClient, ids);
     },
-    onError: (error, { ids }, context) => {
+    onError: (error, { ids }, snapshot) => {
       // Partial failure: the sessions that did delete stay gone; the rest
       // come back. A non-bulk error (nothing reported) restores everything.
       const bulk = error instanceof BulkConversationMutationError ? error : null;
       const failed = bulk ? bulk.failed : [...ids];
       const succeeded = bulk ? bulk.succeeded : [];
-      restoreDeletedConversations(queryClient, context, failed);
-      if (succeeded.length > 0 && context !== undefined) {
-        finalizeDeletedConversations(queryClient, succeeded, context.gen);
-      }
+      restoreDeletedConversations(queryClient, snapshot, failed, succeeded);
+      if (succeeded.length > 0) finalizeDeletedConversations(queryClient, succeeded);
       showToast(
         failed.length === 1
           ? "Couldn't delete 1 session — it's back in the sidebar."

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -345,8 +345,8 @@ export function clearRecentlyCreated(): void {
  * refetch (which lags the search index). A new row sorts newest-first, so page 0
  * is its home. Skips: search lists (membership unknown), archived/wrong-project
  * rows, sub-agent children (`parent_session_id` — they live off the sidebar),
- * and ids the caller excludes via `skip` (e.g. an optimistic delete or
- * archive in flight). `candidates` should already exclude rows the list holds.
+ * and ids the caller excludes via `skip` (e.g. an optimistic delete in flight).
+ * `candidates` should already exclude rows the list holds.
  */
 export function insertNewRowsIntoPages(
   data: ConversationsInfiniteData | undefined,
@@ -519,10 +519,13 @@ export function overlayTitleIntoCaches(
  *
  * Patched in place rather than invalidated, for the same reason rename/delete
  * are: GET /v1/sessions may be served from a search index that lags the PATCH,
- * so an immediate refetch races the reindex and bounces the row back. List
- * fetches and push deltas landing inside that lag window are pinned to
- * `archived: true` by the tombstone the archive mutations set (see
- * `markSessionTombstones` in useConversations).
+ * so an immediate refetch races the reindex and bounces the row back. The
+ * server-confirmed state converges via the WS stream and the reconcile poll.
+ *
+ * ponytail: a reconcile poll firing inside the reindex-lag window (before the
+ * index reflects the archive) can briefly bounce the row back; it self-heals on
+ * the next poll. Add a fetch-time flag override (like `withoutDeletingSessions`)
+ * if metrics show the bounce.
  */
 export function overlayArchivedIntoCaches(
   queryClient: QueryClient,


### PR DESCRIPTION
## Related issue

Follow-up to #6481.

## Summary

- Keep #6481's protection against stale list fetches and WebSocket frames resurrecting archived sessions.
- Restore the established delete tombstone path instead of coupling delete and archive rollback state.
- Replace the broad mutation-interleaving matrix with focused stale-fetch, pagination, WebSocket, and delete-rollback coverage, reducing the implementation by 590 net lines.
- Remove a racy Codex restart E2E probe that sampled server status before relay replay, while retaining the user-visible Working recovery assertion.

ELI5: archive and delete need separate sticky notes. Archive's note corrects stale archive data; delete keeps using its existing note. Neither operation needs a shared transaction system.

```
archive mutation ──> archive tombstone ──> list / project / pinned / WS filtering

delete mutation  ──> existing delete set ──> unchanged delete behavior
```

## Test Plan

From `web/`:

```
npx -y pnpm@11.15.1 vitest run src/hooks/useConversations.test.ts src/hooks/SessionUpdatesProvider.test.tsx src/lib/sessionListCache.test.ts
npx -y pnpm@11.15.1 run lint
npx -y pnpm@11.15.1 run format:check
npx -y pnpm@11.15.1 run type-check
```

From the repository root:

```
.venv/bin/pytest tests/e2e_ui/sessions/test_sidebar_archive.py -q
.venv/bin/pytest tests/e2e_ui/chat/test_codex_working_indicator_restart.py -q
```

Results: 135 focused frontend tests and the Chromium archive journey pass. The Codex restart test collects and passes static checks locally; CI supplies its Linux-only prebuilt sidecar for the full run.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

This refactor preserves #6481's user-visible behavior. Regression tests deterministically hold the archive PATCH open, inject stale list/WS data, verify pagination reaches older sessions, and confirm delete rollback precedence.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused unit coverage exercises stale list and WebSocket writers, empty-page cursor progression, archive failure rollback, and concurrent delete precedence. The existing browser archive test verifies the durable end-to-end behavior. The Codex restart E2E now waits on the browser-visible recovery instead of a one-shot server-cache sample.

## Changelog

N/A — no user-facing behavior change.