### PR TITLE
fix(web): stabilize embedded navigation

### DIFF
--- a/web/src/lib/routing.test.tsx
+++ b/web/src/lib/routing.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, renderHook, screen } from "@testing-library/react";
 import { MemoryRouter, type To } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { basenamedRouting, Link as RoutingLink, reactRouterRouting } from "./routing";
@@ -64,6 +64,27 @@ describe("basenamedRouting Link rebasing", () => {
     // (no `/`, `?`, or `#` at the boundary), so it gets rebased like any other
     // app-absolute path.
     expect(renderRebasedLink("/mount", "/mounting")).toBe("/mount/mounting");
+  });
+});
+
+describe("basenamedRouting navigation", () => {
+  it("keeps the rebased navigate callback stable across renders", async () => {
+    const baseNavigate = vi.fn();
+    const base = {
+      ...reactRouterRouting,
+      useNavigate: () => baseNavigate,
+    };
+    const { result, rerender } = renderHook(
+      ({ basename }) => basenamedRouting(basename, base).useNavigate(),
+      { initialProps: { basename: "/mount" } },
+    );
+    const navigate = result.current;
+
+    rerender({ basename: "/next" });
+
+    expect(result.current).toBe(navigate);
+    await result.current("/c/abc");
+    expect(baseNavigate).toHaveBeenCalledWith("/next/c/abc", undefined);
   });
 });
 

--- a/web/src/lib/routing.tsx
+++ b/web/src/lib/routing.tsx
@@ -29,7 +29,9 @@ import {
   type RefAttributes,
   createContext,
   forwardRef,
+  useCallback,
   useContext,
+  useRef,
 } from "react";
 import {
   Link as RRLink,
@@ -154,10 +156,15 @@ export function basenamedRouting(
     ...base,
     useNavigate: () => {
       const navigate = base.useNavigate();
-      return ((to: To | number, options?: NavigateOptions) => {
-        if (typeof to === "number") return navigate(to);
-        return navigate(rebaseTo(to, basename), options);
-      }) as ReturnType<typeof useRRNavigate>;
+      const basenameRef = useRef(basename);
+      basenameRef.current = basename;
+      return useCallback(
+        ((to: To | number, options?: NavigateOptions) => {
+          if (typeof to === "number") return navigate(to);
+          return navigate(rebaseTo(to, basenameRef.current), options);
+        }) as ReturnType<typeof useRRNavigate>,
+        [navigate],
+      );
     },
     Link: forwardRef<HTMLAnchorElement, OmnigentLinkProps>((props, ref) => {
       const Impl = base.Link;


### PR DESCRIPTION
## Related issue

N/A — discovered while validating the same-root embed path.

## Summary

- Keep `basenamedRouting().useNavigate()` referentially stable while its underlying router navigation function is stable.
- Read the latest basename through a ref so a host mount-path change cannot leave the stable callback with stale routing.
- Prevent embedded consumers from invalidating navigation-dependent callbacks and effects on every render.

ELI5: the embed previously created a new navigation function whenever anything rendered. Components treated that as a routing change and rebuilt dependent state. The adapter now keeps one function and updates only the path information it reads.

```text
render -> stable navigate -> stable dependent callbacks/effects
                     |
                     +-> latest basename
```

## Test Plan

- `cd web && pnpm test src/lib/routing.test.tsx`
- `cd web && pnpm type-check`
- `cd web && pnpm exec prettier --check src/lib/routing.tsx src/lib/routing.test.tsx`
- `cd web && pnpm exec oxlint --deny-warnings --report-unused-disable-directives src/lib/routing.tsx src/lib/routing.test.tsx`
- `pre-commit run web-prettier`, `web-oxlint`, and `web-tsc` for the changed files

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression test rerenders the public basename routing hook, verifies that the returned navigation callback retains its identity, changes the basename, and verifies that navigation uses the new mount path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The OSS Playwright fixture serves the standalone app, which does not mount `OmnigentApp` with a basename and therefore cannot exercise this embed-only routing contract. The focused hook test directly reproduces the unstable identity and validates basename updates.

## Changelog

Embedded Canvas cards now remain responsive while dragging.
