### PR TITLE
feat(web): round-trip a message's image through copy and paste

### DIFF
--- a/tests/e2e_ui/chat/test_message_copy_attachment.py
+++ b/tests/e2e_ui/chat/test_message_copy_attachment.py
@@ -13,15 +13,20 @@ need a browser.
 This drives both halves back-to-back: click Copy on a message with an inline
 image and confirm the clipboard write carried both MIME types, then simulate
 pasting that same (text, image) pair into the composer and confirm both the
-text and the attachment chip land — the full round trip a user relies on.
+text and the attachment chip land — the full round trip a user relies on. A
+second test covers a JPEG attachment: ``toPngBlob``'s transcode path needs
+``createImageBitmap``/``OffscreenCanvas``, which jsdom has neither of, so it
+is only reachable here, in a real browser.
 
 The copy-side assertion avoids ``clipboard-read``/``clipboard-write``
 permissions (contrast ``test_user_message_copy.py``, which grants them):
 ``navigator.clipboard.write`` is wrapped via ``page.add_init_script`` before
-the SPA loads, recording each written item's MIME types before calling
-through to the real implementation. Chromium's own clipboard-write
-permission handling is irrelevant to what actually needs proving here — that
-the app builds a `ClipboardItem` carrying both types.
+the SPA loads, recording each written item's MIME types (and, for the
+transcode test, the transcoded image's own bytes) before calling through to
+the real implementation. Chromium's own clipboard-write permission handling
+is irrelevant to what actually needs proving here — that the app builds a
+``ClipboardItem`` carrying both types, and that its `image/png` bytes really
+are PNG-encoded.
 """
 
 from __future__ import annotations
@@ -32,22 +37,54 @@ from tests.e2e_ui.chat.test_imported_inline_image import _INLINE_PNG
 from tests.e2e_ui.conftest import seed_committed_items
 
 _PROMPT = "Here is the pasted screenshot."
+_JPEG_PROMPT = "Here is a pasted JPEG screenshot."
 _COMPOSER_PLACEHOLDER = "Send a message…"
 _COMPOSER_SELECTOR = '[aria-label="Message the agent"]'
 _ATTACHED_NAME = "shot.png"
 
+# 1x1 red JPEG (Pillow: Image.new("RGB", (1, 1), (255, 0, 0)).save(buf, "JPEG",
+# quality=50)) — a real JPEG, not a renamed PNG, so the transcode test proves
+# toPngBlob actually re-encodes rather than passing bytes through unchanged.
+_INLINE_JPEG = (
+    "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDABALDA4MChAODQ4SERAT"
+    "GCgaGBYWGDEjJR0oOjM9PDkzODdASFxOQERXRTc4UG1RV19iZ2hnPk1xeXBkeFxlZ2P/2wBDAR"
+    "ESEhgVGC8aGi9jQjhCY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2Nj"
+    "Y2NjY2NjY2P/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBg"
+    "cICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS"
+    "0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dn"
+    "d4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ"
+    "2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8"
+    "QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLR"
+    "ChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6go"
+    "OEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk"
+    "5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDFoooryz7w/9k="
+)
+
 # Records what navigator.clipboard.write actually received, before Chromium's
 # own clipboard permissioning (irrelevant here — see module docstring) can
-# reject the call. An init script must be an IIFE (or bare statements): a
-# bare arrow-function expression, unlike page.evaluate, is never called by
-# add_init_script — it would just be created and discarded.
+# reject the call. Also reads back the written image/png bytes' first 4 bytes
+# via ClipboardItem.getType, which resolves the Blob independent of any
+# clipboard permission — that call never touches the OS clipboard. An init
+# script must be an IIFE (or bare statements): a bare arrow-function
+# expression, unlike page.evaluate, is never called by add_init_script — it
+# would just be created and discarded.
 _RECORD_COPIED_TYPES = """
 (() => {
   window.__omnigentCopiedTypes = null;
+  window.__omnigentCopiedImageMagic = null;
   if (!navigator.clipboard || !navigator.clipboard.write) return;
   const originalWrite = navigator.clipboard.write.bind(navigator.clipboard);
   navigator.clipboard.write = (items) => {
-    window.__omnigentCopiedTypes = items[0] ? Array.from(items[0].types) : [];
+    const item = items[0];
+    window.__omnigentCopiedTypes = item ? Array.from(item.types) : [];
+    if (item && item.types.includes("image/png")) {
+      item
+        .getType("image/png")
+        .then((blob) => blob.arrayBuffer())
+        .then((buf) => {
+          window.__omnigentCopiedImageMagic = Array.from(new Uint8Array(buf).slice(0, 4));
+        });
+    }
     return originalWrite(items);
   };
 })();
@@ -74,10 +111,12 @@ _DISPATCH_PASTE = """
 """
 
 
-def _seed_turn_with_inline_image(session_id: str) -> None:
+def _seed_turn_with_inline_image(session_id: str, prompt: str, image_url: str) -> None:
     """Commit a user turn holding text plus an inline image block.
 
     :param session_id: Session to append the turn to.
+    :param prompt: The message's text.
+    :param image_url: The ``input_image`` block's inline data URI.
     """
     from omnigent.entities import MessageData, NewConversationItem
 
@@ -90,8 +129,8 @@ def _seed_turn_with_inline_image(session_id: str) -> None:
                 data=MessageData(
                     role="user",
                     content=[
-                        {"type": "input_text", "text": _PROMPT},
-                        {"type": "input_image", "image_url": _INLINE_PNG, "detail": "auto"},
+                        {"type": "input_text", "text": prompt},
+                        {"type": "input_image", "image_url": image_url, "detail": "auto"},
                     ],
                 ),
             ),
@@ -106,7 +145,7 @@ def test_copy_message_with_image_then_paste_round_trips(
     """Copying a message with an image writes both MIME types; pasting them
     back into the composer restores the text and re-attaches the image."""
     base_url, session_id = seeded_session
-    _seed_turn_with_inline_image(session_id)
+    _seed_turn_with_inline_image(session_id, _PROMPT, _INLINE_PNG)
 
     page.add_init_script(_RECORD_COPIED_TYPES)
     page.goto(f"{base_url}/c/{session_id}")
@@ -137,3 +176,44 @@ def test_copy_message_with_image_then_paste_round_trips(
         timeout=10_000
     )
     expect(composer).to_have_value(_PROMPT)
+
+
+def test_copy_message_with_jpeg_attachment_transcodes_to_png(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A JPEG attachment is re-encoded to PNG before it reaches the clipboard.
+
+    Chromium rejects a blob whose bytes don't match the MIME key it's
+    announced under, so ``copyTextWithImage`` always writes its image under
+    ``image/png`` — which only works if ``toPngBlob`` actually transcodes a
+    non-PNG source rather than passing its bytes through unchanged. Checking
+    the written MIME type alone can't tell the two apart; this reads the
+    written bytes back and checks the PNG magic number.
+    """
+    base_url, session_id = seeded_session
+    _seed_turn_with_inline_image(session_id, _JPEG_PROMPT, _INLINE_JPEG)
+
+    page.add_init_script(_RECORD_COPIED_TYPES)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    bubble = page.locator('[data-testid="message-bubble"][data-role="user"]').filter(
+        has_text=_JPEG_PROMPT
+    )
+    expect(bubble).to_be_visible(timeout=30_000)
+
+    copy_button = bubble.locator('[data-component-id="chat.message.copy_user"]')
+    expect(copy_button).to_have_count(1)
+    copy_button.click()
+
+    page.wait_for_function(
+        "() => window.__omnigentCopiedImageMagic !== null",
+        timeout=10_000,
+    )
+    assert page.evaluate("() => window.__omnigentCopiedTypes") == ["text/plain", "image/png"]
+
+    magic = page.evaluate("() => window.__omnigentCopiedImageMagic")
+    assert bytes(magic) == b"\x89PNG", (
+        f"transcoded image did not start with the PNG magic number, got bytes {magic!r} "
+        "— toPngBlob may not be re-encoding the JPEG source"
+    )

--- a/tests/e2e_ui/chat/test_message_copy_attachment.py
+++ b/tests/e2e_ui/chat/test_message_copy_attachment.py
@@ -1,0 +1,139 @@
+"""E2E: copying a message's image attachment and pasting it back.
+
+Two client-side changes have to work together for a copied prompt with an
+image to be reusable: the composer's paste handler keeps pasted text
+alongside pasted files (see ``test_composer_attachments.py``'s sibling
+``lib/composerPaste.ts`` unit coverage), and the message bubble's Copy
+button now puts the message's first image on the clipboard next to its text
+(``lib/attachmentClipboard.ts``, ``lib/clipboard.ts``'s ``copyTextWithImage``).
+Neither half is provable by a component test: writing a real
+``ClipboardItem`` and reading ``clipboardData`` on a real ``paste`` event both
+need a browser.
+
+This drives both halves back-to-back: click Copy on a message with an inline
+image and confirm the clipboard write carried both MIME types, then simulate
+pasting that same (text, image) pair into the composer and confirm both the
+text and the attachment chip land — the full round trip a user relies on.
+
+The copy-side assertion avoids ``clipboard-read``/``clipboard-write``
+permissions (contrast ``test_user_message_copy.py``, which grants them):
+``navigator.clipboard.write`` is wrapped via ``page.add_init_script`` before
+the SPA loads, recording each written item's MIME types before calling
+through to the real implementation. Chromium's own clipboard-write
+permission handling is irrelevant to what actually needs proving here — that
+the app builds a `ClipboardItem` carrying both types.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.chat.test_imported_inline_image import _INLINE_PNG
+from tests.e2e_ui.conftest import seed_committed_items
+
+_PROMPT = "Here is the pasted screenshot."
+_COMPOSER_PLACEHOLDER = "Send a message…"
+_COMPOSER_SELECTOR = '[aria-label="Message the agent"]'
+_ATTACHED_NAME = "shot.png"
+
+# Records what navigator.clipboard.write actually received, before Chromium's
+# own clipboard permissioning (irrelevant here — see module docstring) can
+# reject the call. An init script must be an IIFE (or bare statements): a
+# bare arrow-function expression, unlike page.evaluate, is never called by
+# add_init_script — it would just be created and discarded.
+_RECORD_COPIED_TYPES = """
+(() => {
+  window.__omnigentCopiedTypes = null;
+  if (!navigator.clipboard || !navigator.clipboard.write) return;
+  const originalWrite = navigator.clipboard.write.bind(navigator.clipboard);
+  navigator.clipboard.write = (items) => {
+    window.__omnigentCopiedTypes = items[0] ? Array.from(items[0].types) : [];
+    return originalWrite(items);
+  };
+})();
+"""
+
+# Synthesises a paste carrying both a file and plain text, mirroring what a
+# real "copy message" clipboard write produces. Playwright can't drive the OS
+# clipboard directly, but a page-built ClipboardEvent fires the same handler.
+_DISPATCH_PASTE = """
+([selector, text, filename, base64Png]) => {
+  const target = document.querySelector(selector);
+  if (!target) throw new Error(`no paste target for ${selector}`);
+  const raw = atob(base64Png);
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+  const file = new File([bytes], filename, { type: "image/png" });
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(file);
+  dataTransfer.setData("text/plain", text);
+  target.dispatchEvent(
+    new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: dataTransfer }),
+  );
+}
+"""
+
+
+def _seed_turn_with_inline_image(session_id: str) -> None:
+    """Commit a user turn holding text plus an inline image block.
+
+    :param session_id: Session to append the turn to.
+    """
+    from omnigent.entities import MessageData, NewConversationItem
+
+    seed_committed_items(
+        session_id,
+        [
+            NewConversationItem(
+                type="message",
+                response_id="codex:history",
+                data=MessageData(
+                    role="user",
+                    content=[
+                        {"type": "input_text", "text": _PROMPT},
+                        {"type": "input_image", "image_url": _INLINE_PNG, "detail": "auto"},
+                    ],
+                ),
+            ),
+        ],
+    )
+
+
+def test_copy_message_with_image_then_paste_round_trips(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Copying a message with an image writes both MIME types; pasting them
+    back into the composer restores the text and re-attaches the image."""
+    base_url, session_id = seeded_session
+    _seed_turn_with_inline_image(session_id)
+
+    page.add_init_script(_RECORD_COPIED_TYPES)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    bubble = page.locator('[data-testid="message-bubble"][data-role="user"]').filter(
+        has_text=_PROMPT
+    )
+    expect(bubble).to_be_visible(timeout=30_000)
+
+    copy_button = bubble.locator('[data-component-id="chat.message.copy_user"]')
+    expect(copy_button).to_have_count(1)
+    copy_button.click()
+
+    page.wait_for_function(
+        "() => window.__omnigentCopiedTypes !== null",
+        timeout=10_000,
+    )
+    assert page.evaluate("() => window.__omnigentCopiedTypes") == ["text/plain", "image/png"]
+
+    # The round trip: paste that same (text, image) pair into the composer.
+    composer = page.get_by_placeholder(_COMPOSER_PLACEHOLDER)
+    expect(composer).to_be_visible()
+
+    base64_png = _INLINE_PNG.split(",", 1)[1]
+    page.evaluate(_DISPATCH_PASTE, [_COMPOSER_SELECTOR, _PROMPT, _ATTACHED_NAME, base64_png])
+
+    expect(page.get_by_role("button", name=f"Remove {_ATTACHED_NAME}")).to_be_visible(
+        timeout=10_000
+    )
+    expect(composer).to_have_value(_PROMPT)

--- a/web/src/components/chat/chatBubbleParts.tsx
+++ b/web/src/components/chat/chatBubbleParts.tsx
@@ -68,7 +68,8 @@ import { isSessionScopedDecision, showsRoutingDecisionChip } from "@/lib/routing
 import { useWorkingLabelTick } from "@/hooks/useWorkingLabelTick";
 import { useForkDialog } from "@/shell/ForkDialogContext";
 import { InlineImage, SessionImage } from "@/components/SessionImage";
-import { copyText } from "@/lib/clipboard";
+import { copyText, copyTextWithImage } from "@/lib/clipboard";
+import { firstImageLoader, sessionFileContentPath } from "@/lib/attachmentClipboard";
 import { showToast } from "@/components/ui/toast";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
 import type { SessionStatus } from "@/lib/types";
@@ -545,10 +546,11 @@ export const BubbleView = memo(
 /**
  * Copy-to-clipboard handler for a message bubble's "Copy" action.
  *
- * @param getText - Produces the text to copy at click time.
+ * @param getContent - Produces the text (and, for a user bubble with an
+ *   attached image, a loader for that image) to copy at click time.
  * @returns `{ isCopied, handleCopy }` for the action button.
  */
-function useCopyMessage(getText: () => string): {
+function useCopyMessage(getContent: () => { text: string; image?: () => Promise<Blob> }): {
   isCopied: boolean;
   handleCopy: () => void;
 } {
@@ -560,9 +562,10 @@ function useCopyMessage(getText: () => string): {
 
   const handleCopy = useCallback(() => {
     if (isCopied) return;
-    const text = getText();
-    if (!text) return;
-    copyText(text).then(
+    const { text, image } = getContent();
+    if (!text && !image) return;
+    const copied = image ? copyTextWithImage(text, image) : copyText(text);
+    copied.then(
       () => {
         setIsCopied(true);
         window.clearTimeout(timeoutRef.current);
@@ -575,7 +578,7 @@ function useCopyMessage(getText: () => string): {
         console.warn("Failed to copy message", error);
       },
     );
-  }, [getText, isCopied, isMobile]);
+  }, [getContent, isCopied, isMobile]);
 
   return { isCopied, handleCopy };
 }
@@ -610,7 +613,16 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
   const mentionedChips = extractAttachedPaths(bubble.content);
   // Equality selector so Zustand only re-renders the matching bubble.
   const flashing = useChatStore((s) => s.flashItemId === bubble.itemId);
-  const { isCopied, handleCopy } = useCopyMessage(() => text);
+  // The first attached image the clipboard can actually pull bytes from, so a
+  // copied prompt with a screenshot can paste back in full. Resolved once per
+  // render (not lazily inside the copy handler) so the render gates below and
+  // the click-time copy agree on whether one exists.
+  const imageLoader = firstImageLoader(bubble.content, sessionId);
+  const hasCopyableImage = imageLoader !== null;
+  const { isCopied, handleCopy } = useCopyMessage(() => ({
+    text,
+    image: imageLoader ?? undefined,
+  }));
   const ts = formatBubbleTimestamp(bubble.createdAtS);
   // Runtime-injected `[System: ...]` notifications ride in on role=user. When
   // the content is a pure system marker, swap in a muted centered indicator.
@@ -675,9 +687,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
                       <SessionImage
                         key={key}
                         path={
-                          sessionId
-                            ? `/v1/sessions/${encodeURIComponent(sessionId)}/resources/files/${encodeURIComponent(preview.fileId)}/content`
-                            : undefined
+                          sessionId ? sessionFileContentPath(sessionId, preview.fileId) : undefined
                         }
                         alt={preview.alt}
                         // Sizing lives in SessionImage, which reserves a matching
@@ -745,7 +755,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
         </div>
         {/* Skip an empty row when there is neither a timestamp nor a copy
             action. 40%-visible on touch, hover/focus-reveal on desktop. */}
-        {(ts || text) && (
+        {(ts || text || hasCopyableImage) && (
           <div className="flex items-center justify-end gap-3 py-1 opacity-40 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100">
             {ts && (
               <span
@@ -755,7 +765,7 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
                 {ts}
               </span>
             )}
-            {text && (
+            {(text || hasCopyableImage) && (
               <MessageActions>
                 <MessageAction
                   tooltip="Copy"
@@ -796,7 +806,9 @@ function AssistantBubble({
     s.blocks.some((b) => b.type === "elicitation" && b.status === "pending"),
   );
   // Getter computes the markdown lazily at click time.
-  const { isCopied, handleCopy } = useCopyMessage(() => collectBubbleMarkdown(bubble.items));
+  const { isCopied, handleCopy } = useCopyMessage(() => ({
+    text: collectBubbleMarkdown(bubble.items),
+  }));
   // null outside AppShell's provider (isolated tests) → hide the action.
   const forkDialog = useForkDialog();
   const handleRetryError = useCallback(async () => {

--- a/web/src/lib/attachmentClipboard.test.ts
+++ b/web/src/lib/attachmentClipboard.test.ts
@@ -95,6 +95,35 @@ describe("firstImageLoader", () => {
     expect(authenticatedFetch).not.toHaveBeenCalled();
   });
 
+  it("returns null when the first image has no session id, even though the second would resolve", () => {
+    // Strict first-image semantics: a resolvable second image must never be
+    // substituted for an unresolvable first one — that would silently copy a
+    // different image than the one the user meant to copy.
+    const loader = firstImageLoader(
+      [
+        { type: "input_image", file_id: "file_1", filename: "first.png" },
+        { type: "input_image", image_url: INLINE_PNG, filename: "second.png" },
+      ],
+      null,
+    );
+
+    expect(loader).toBeNull();
+    expect(authenticatedFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the first image is still pending, even though the second would resolve", () => {
+    const loader = firstImageLoader(
+      [
+        { type: "input_image", file_id: "pending:first.png" },
+        { type: "input_image", image_url: INLINE_PNG, filename: "second.png" },
+      ],
+      "conv_1",
+    );
+
+    expect(loader).toBeNull();
+    expect(authenticatedFetch).not.toHaveBeenCalled();
+  });
+
   it("rejects a non-PNG blob when there is no OffscreenCanvas to transcode with", async () => {
     // jsdom has neither createImageBitmap nor OffscreenCanvas, so the
     // transcode path itself is only reachable in a real browser (the e2e

--- a/web/src/lib/attachmentClipboard.test.ts
+++ b/web/src/lib/attachmentClipboard.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MessageContentBlock } from "./blocks";
+
+const authenticatedFetch = vi.fn();
+
+vi.mock("./identity", () => ({
+  authenticatedFetch: (path: string) => authenticatedFetch(path),
+}));
+
+import { firstImageLoader, sessionFileContentPath } from "./attachmentClipboard";
+
+// 1x1 PNG, inline exactly as an imported transcript carries it.
+const INLINE_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+describe("sessionFileContentPath", () => {
+  it("builds the file-content route, encoding both ids", () => {
+    expect(sessionFileContentPath("conv a/b", "file c/d")).toBe(
+      "/v1/sessions/conv%20a%2Fb/resources/files/file%20c%2Fd/content",
+    );
+  });
+});
+
+describe("firstImageLoader", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads an uploaded image via authenticatedFetch at its session file-content path", async () => {
+    const blob = new Blob([], { type: "image/png" });
+    authenticatedFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) });
+
+    const loader = firstImageLoader(
+      [{ type: "input_image", file_id: "file_1", filename: "shot.png" }],
+      "conv_1",
+    );
+
+    expect(loader).not.toBeNull();
+    const result = await loader!();
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      "/v1/sessions/conv_1/resources/files/file_1/content",
+    );
+    expect(result).toBe(blob);
+  });
+
+  it("loads an inline data-URI image without any fetch", async () => {
+    const loader = firstImageLoader(
+      [{ type: "input_image", image_url: INLINE_PNG, filename: "shot.png" }],
+      null,
+    );
+
+    expect(loader).not.toBeNull();
+    const blob = await loader!();
+    expect(blob.type).toBe("image/png");
+    expect(authenticatedFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a pending upload", () => {
+    const loader = firstImageLoader(
+      [{ type: "input_image", file_id: "pending:shot.png" }],
+      "conv_1",
+    );
+    expect(loader).toBeNull();
+  });
+
+  it("returns null for an image block with nothing renderable", () => {
+    expect(firstImageLoader([{ type: "input_image" }], "conv_1")).toBeNull();
+  });
+
+  it("returns null when content has only non-image blocks", () => {
+    const content: MessageContentBlock[] = [
+      { type: "input_text", text: "notes attached" },
+      { type: "input_file", file_id: "file_1", filename: "notes.pdf" },
+    ];
+    expect(firstImageLoader(content, "conv_1")).toBeNull();
+  });
+
+  it("returns null for an uploaded image when there is no session id", () => {
+    expect(firstImageLoader([{ type: "input_image", file_id: "file_1" }], null)).toBeNull();
+  });
+
+  it("picks the first image when the message carries two", async () => {
+    const loader = firstImageLoader(
+      [
+        { type: "input_image", image_url: INLINE_PNG, filename: "first.png" },
+        { type: "input_image", file_id: "file_2", filename: "second.png" },
+      ],
+      "conv_1",
+    );
+
+    expect(loader).not.toBeNull();
+    await loader!();
+    // The first (inline) image resolved with no fetch; the second was never
+    // even considered.
+    expect(authenticatedFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-PNG blob when there is no OffscreenCanvas to transcode with", async () => {
+    // jsdom has neither createImageBitmap nor OffscreenCanvas, so the
+    // transcode path itself is only reachable in a real browser (the e2e
+    // suite covers it). This pins the rejection that copyTextWithImage's
+    // text-only fallback depends on when transcoding isn't possible.
+    const jpeg = new Blob([], { type: "image/jpeg" });
+    authenticatedFetch.mockResolvedValue({ ok: true, blob: () => Promise.resolve(jpeg) });
+
+    const loader = firstImageLoader(
+      [{ type: "input_image", file_id: "file_1", filename: "shot.jpg" }],
+      "conv_1",
+    );
+
+    await expect(loader!()).rejects.toThrow();
+  });
+});

--- a/web/src/lib/attachmentClipboard.ts
+++ b/web/src/lib/attachmentClipboard.ts
@@ -4,7 +4,7 @@
 
 import { dataUrlToFile } from "./designModePrompt";
 import { authenticatedFetch } from "./identity";
-import { imagePreview, type MessageContentBlock } from "./blocks";
+import { imagePreview, type ImageContentBlock, type MessageContentBlock } from "./blocks";
 
 /** Web file-content path for an uploaded session attachment. */
 export function sessionFileContentPath(sessionId: string, fileId: string): string {
@@ -40,30 +40,29 @@ function uploadedLoader(sessionId: string, fileId: string): () => Promise<Blob> 
 }
 
 /**
- * Loader for the first copyable image in `content`, or `null` when none of
- * its `input_image` blocks can be loaded.
+ * Loader for the message's first image, or `null` when that image can't be
+ * loaded.
  *
- * Walks blocks in order and classifies each with `imagePreview`: an
- * `uploaded` block needs `sessionId` to build its fetch path, an `inline`
- * block decodes straight from its data URI, and `pending` / `unavailable`
- * blocks are skipped in favor of a later image.
+ * Strictly the FIRST `input_image` block — never a later one. Copying a
+ * "first image" that turns out to be the second one (because the real first
+ * image was still uploading, or uploaded with no `sessionId` to fetch it, or
+ * inline but undecodable) would hand the user a different image than the one
+ * they meant to copy, with nothing telling them it was swapped. An
+ * unresolvable first image falls back to a text-only copy instead.
  */
 export function firstImageLoader(
   content: MessageContentBlock[],
   sessionId: string | null,
 ): (() => Promise<Blob>) | null {
-  for (const block of content) {
-    if (block.type !== "input_image") continue;
-    const preview = imagePreview(block);
-    if (preview.kind === "uploaded") {
-      if (!sessionId) continue;
-      return uploadedLoader(sessionId, preview.fileId);
-    }
-    if (preview.kind === "inline") {
-      const file = dataUrlToFile(preview.src, preview.alt);
-      if (!file) continue;
-      return () => toPngBlob(file);
-    }
+  const block = content.find((c): c is ImageContentBlock => c.type === "input_image");
+  if (!block) return null;
+  const preview = imagePreview(block);
+  if (preview.kind === "uploaded") {
+    return sessionId ? uploadedLoader(sessionId, preview.fileId) : null;
+  }
+  if (preview.kind === "inline") {
+    const file = dataUrlToFile(preview.src, preview.alt);
+    return file ? () => toPngBlob(file) : null;
   }
   return null;
 }

--- a/web/src/lib/attachmentClipboard.ts
+++ b/web/src/lib/attachmentClipboard.ts
@@ -1,0 +1,69 @@
+// Resolves the first copyable image in a user message's content blocks into a
+// loader the clipboard can pull bytes from, for "copy message" (see
+// components/chat/chatBubbleParts.tsx and lib/clipboard.ts's copyTextWithImage).
+
+import { dataUrlToFile } from "./designModePrompt";
+import { authenticatedFetch } from "./identity";
+import { imagePreview, type MessageContentBlock } from "./blocks";
+
+/** Web file-content path for an uploaded session attachment. */
+export function sessionFileContentPath(sessionId: string, fileId: string): string {
+  return `/v1/sessions/${encodeURIComponent(sessionId)}/resources/files/${encodeURIComponent(fileId)}/content`;
+}
+
+/**
+ * Re-encode `blob` as `image/png` if it isn't already.
+ *
+ * The clipboard write always announces `image/png`: Chromium rejects a blob
+ * whose bytes don't match the MIME key it was written under, so a JPEG or
+ * WebP upload has to be transcoded rather than copied as-is.
+ */
+async function toPngBlob(blob: Blob): Promise<Blob> {
+  if (blob.type === "image/png") return blob;
+  if (typeof createImageBitmap === "undefined" || typeof OffscreenCanvas === "undefined") {
+    throw new Error("Image transcoding is not supported in this browser");
+  }
+  const bitmap = await createImageBitmap(blob);
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not get a 2D context to transcode the image");
+  ctx.drawImage(bitmap, 0, 0);
+  return canvas.convertToBlob({ type: "image/png" });
+}
+
+function uploadedLoader(sessionId: string, fileId: string): () => Promise<Blob> {
+  const path = sessionFileContentPath(sessionId, fileId);
+  return () =>
+    authenticatedFetch(path)
+      .then((res) => (res.ok ? res.blob() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then(toPngBlob);
+}
+
+/**
+ * Loader for the first copyable image in `content`, or `null` when none of
+ * its `input_image` blocks can be loaded.
+ *
+ * Walks blocks in order and classifies each with `imagePreview`: an
+ * `uploaded` block needs `sessionId` to build its fetch path, an `inline`
+ * block decodes straight from its data URI, and `pending` / `unavailable`
+ * blocks are skipped in favor of a later image.
+ */
+export function firstImageLoader(
+  content: MessageContentBlock[],
+  sessionId: string | null,
+): (() => Promise<Blob>) | null {
+  for (const block of content) {
+    if (block.type !== "input_image") continue;
+    const preview = imagePreview(block);
+    if (preview.kind === "uploaded") {
+      if (!sessionId) continue;
+      return uploadedLoader(sessionId, preview.fileId);
+    }
+    if (preview.kind === "inline") {
+      const file = dataUrlToFile(preview.src, preview.alt);
+      if (!file) continue;
+      return () => toPngBlob(file);
+    }
+  }
+  return null;
+}

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { copyText } from "./clipboard";
+import { copyText, copyTextWithImage } from "./clipboard";
 
 const clipboardDescriptor = Object.getOwnPropertyDescriptor(Navigator.prototype, "clipboard");
 const execCommandDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "execCommand");
@@ -117,5 +117,105 @@ describe("copyText", () => {
 
     expect(writeText).toHaveBeenCalledWith("fallback text");
     expect(document.execCommand).toHaveBeenCalledWith("copy");
+  });
+});
+
+/** Records what it was constructed with, mirroring the real ClipboardItem
+ *  enough for these tests: a `types` list and the raw per-type data. */
+class StubClipboardItem {
+  types: string[];
+  data: Record<string, Blob | PromiseLike<Blob>>;
+  constructor(data: Record<string, Blob | PromiseLike<Blob>>) {
+    this.data = data;
+    this.types = Object.keys(data);
+  }
+}
+
+describe("copyTextWithImage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("writes one item with both types, calling write before the image settles", async () => {
+    let resolveImage!: (blob: Blob) => void;
+    const loadImage = vi.fn(
+      () =>
+        new Promise<Blob>((resolve) => {
+          resolveImage = resolve;
+        }),
+    );
+    const written: StubClipboardItem[] = [];
+    const write = vi.fn((items: StubClipboardItem[]) => {
+      written.push(...items);
+      return Promise.resolve();
+    });
+    vi.stubGlobal("ClipboardItem", StubClipboardItem);
+    Object.defineProperty(Navigator.prototype, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+
+    const result = copyTextWithImage("a screenshot", loadImage);
+
+    // The write must already have happened — proving it ran synchronously,
+    // not after the image promise resolved.
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(written).toHaveLength(1);
+    expect(written[0]!.types).toEqual(["text/plain", "image/png"]);
+
+    resolveImage(new Blob([], { type: "image/png" }));
+    await expect(result).resolves.toBeUndefined();
+    const image = await written[0]!.data["image/png"];
+    expect(image?.type).toBe("image/png");
+  });
+
+  it("omits text/plain when there is no text", async () => {
+    const written: StubClipboardItem[] = [];
+    const write = vi.fn((items: StubClipboardItem[]) => {
+      written.push(...items);
+      return Promise.resolve();
+    });
+    vi.stubGlobal("ClipboardItem", StubClipboardItem);
+    Object.defineProperty(Navigator.prototype, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+
+    await expect(
+      copyTextWithImage("", () => Promise.resolve(new Blob([], { type: "image/png" }))),
+    ).resolves.toBeUndefined();
+
+    expect(written[0]!.types).toEqual(["image/png"]);
+  });
+
+  it("falls back to writeText when ClipboardItem is unavailable", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const write = vi.fn();
+    // ClipboardItem is left unstubbed — undefined in this environment.
+    Object.defineProperty(Navigator.prototype, "clipboard", {
+      configurable: true,
+      value: { write, writeText },
+    });
+
+    await expect(copyTextWithImage("fallback text", vi.fn())).resolves.toBeUndefined();
+
+    expect(writeText).toHaveBeenCalledWith("fallback text");
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("falls back to writeText when clipboard.write rejects", async () => {
+    const write = vi.fn().mockRejectedValue(new Error("denied"));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("ClipboardItem", StubClipboardItem);
+    Object.defineProperty(Navigator.prototype, "clipboard", {
+      configurable: true,
+      value: { write, writeText },
+    });
+
+    await expect(
+      copyTextWithImage("fallback text", () => Promise.resolve(new Blob())),
+    ).resolves.toBeUndefined();
+
+    expect(writeText).toHaveBeenCalledWith("fallback text");
   });
 });

--- a/web/src/lib/clipboard.test.ts
+++ b/web/src/lib/clipboard.test.ts
@@ -218,4 +218,33 @@ describe("copyTextWithImage", () => {
 
     expect(writeText).toHaveBeenCalledWith("fallback text");
   });
+
+  it("rejects rather than blanking the clipboard when there is no text and ClipboardItem is unavailable", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    // ClipboardItem is left unstubbed — undefined in this environment.
+    Object.defineProperty(Navigator.prototype, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await expect(copyTextWithImage("", vi.fn())).rejects.toThrow();
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("rejects rather than blanking the clipboard when there is no text and clipboard.write rejects", async () => {
+    const write = vi.fn().mockRejectedValue(new Error("denied"));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("ClipboardItem", StubClipboardItem);
+    Object.defineProperty(Navigator.prototype, "clipboard", {
+      configurable: true,
+      value: { write, writeText },
+    });
+
+    await expect(
+      copyTextWithImage("", () => Promise.resolve(new Blob([], { type: "image/png" }))),
+    ).rejects.toThrow("denied");
+
+    expect(writeText).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -9,16 +9,22 @@
  *
  * Falls back to `copyText` (text only) when the Async Clipboard API's write
  * path isn't available, or when the write itself rejects (e.g. `loadImage`
- * fails, or the browser refuses the image).
+ * fails, or the browser refuses the image) — but only when there is text to
+ * fall back to. An image-only copy (no text) that can't be written must
+ * reject rather than fall back: `copyText("")` would silently overwrite
+ * whatever the user already had on their clipboard with an empty string,
+ * which is worse than a failed copy the "Copied" state never confirms.
  */
 export function copyTextWithImage(text: string, loadImage: () => Promise<Blob>): Promise<void> {
   if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
-    return copyText(text);
+    return text ? copyText(text) : Promise.reject(new Error("Clipboard API not available"));
   }
   const data: Record<string, Blob | PromiseLike<Blob>> = {};
   if (text) data["text/plain"] = new Blob([text], { type: "text/plain" });
   data["image/png"] = loadImage();
-  return navigator.clipboard.write([new ClipboardItem(data)]).catch(() => copyText(text));
+  return navigator.clipboard
+    .write([new ClipboardItem(data)])
+    .catch((error) => (text ? copyText(text) : Promise.reject(error)));
 }
 
 export async function copyText(text: string): Promise<void> {

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,3 +1,26 @@
+/**
+ * Copy `text` to the clipboard alongside an image, as one clipboard item so a
+ * paste elsewhere gets both. Deliberately not `async`: `navigator.clipboard.write`
+ * must be called synchronously, in the same tick as the user gesture that
+ * triggered the copy — Safari and some Chromium builds reject a clipboard write
+ * that happens after an `await` because it no longer looks user-initiated.
+ * `loadImage`'s promise is handed to `ClipboardItem` directly, so the write
+ * starts immediately and only the item's data resolves later.
+ *
+ * Falls back to `copyText` (text only) when the Async Clipboard API's write
+ * path isn't available, or when the write itself rejects (e.g. `loadImage`
+ * fails, or the browser refuses the image).
+ */
+export function copyTextWithImage(text: string, loadImage: () => Promise<Blob>): Promise<void> {
+  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+    return copyText(text);
+  }
+  const data: Record<string, Blob | PromiseLike<Blob>> = {};
+  if (text) data["text/plain"] = new Blob([text], { type: "text/plain" });
+  data["image/png"] = loadImage();
+  return navigator.clipboard.write([new ClipboardItem(data)]).catch(() => copyText(text));
+}
+
 export async function copyText(text: string): Promise<void> {
   if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
     try {

--- a/web/src/lib/composerPaste.test.ts
+++ b/web/src/lib/composerPaste.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { insertTextAtCaret } from "./composerPaste";
+
+describe("insertTextAtCaret", () => {
+  it("inserts into an empty draft", () => {
+    expect(insertTextAtCaret("", 0, 0, "hello")).toEqual({ next: "hello", caret: 5 });
+  });
+
+  it("inserts at the caret mid-string, leaving both sides intact", () => {
+    expect(insertTextAtCaret("abcdef", 3, 3, "XYZ")).toEqual({ next: "abcXYZdef", caret: 6 });
+  });
+
+  it("replaces a non-empty selection with the pasted text", () => {
+    expect(insertTextAtCaret("abcdef", 2, 4, "XYZ")).toEqual({ next: "abXYZef", caret: 5 });
+  });
+
+  it("clamps a caret index below 0 to the start of the draft", () => {
+    expect(insertTextAtCaret("abc", -5, -5, "X")).toEqual({ next: "Xabc", caret: 1 });
+  });
+
+  it("clamps a caret index past the end to the draft's length", () => {
+    expect(insertTextAtCaret("abc", 99, 99, "X")).toEqual({ next: "abcX", caret: 4 });
+  });
+});

--- a/web/src/lib/composerPaste.ts
+++ b/web/src/lib/composerPaste.ts
@@ -1,0 +1,30 @@
+// Shared caret-insertion for composer paste handlers.
+//
+// A paste that carries both files and plain text used to drop the text: the
+// paste handlers only look at `clipboardData.items` for files and call
+// `preventDefault`, which silently discards whatever text/plain sat alongside
+// them. This inserts that text at the caret so a copied prompt with an image
+// still pastes back in full.
+
+/**
+ * Replace the selection `[start, end)` in `current` with `text`, inserted
+ * verbatim (no padding — a paste should land exactly as copied).
+ *
+ * Indices are clamped to `[0, current.length]` so a stale selection can't
+ * throw or write out of bounds.
+ */
+export function insertTextAtCaret(
+  current: string,
+  start: number,
+  end: number,
+  text: string,
+): { next: string; caret: number } {
+  const from = Math.min(Math.max(start, 0), current.length);
+  const to = Math.min(Math.max(end, 0), current.length);
+  const lo = Math.min(from, to);
+  const hi = Math.max(from, to);
+  return {
+    next: current.slice(0, lo) + text + current.slice(hi),
+    caret: lo + text.length,
+  };
+}

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -2116,6 +2116,12 @@ describe("Composer file-attachment focus", () => {
     render(<Composer {...composerProps()} />);
     const ta = textarea();
     fireEvent.change(ta, { target: { value: "draft text" } });
+    // A non-empty selection strictly inside the draft: a collapsed
+    // end-of-string caret can't distinguish "no text to insert" from a
+    // missing empty-text guard, since inserting "" at a collapsed caret is a
+    // no-op either way. A real selection makes the two paths diverge — the
+    // guard leaves it alone, but an unguarded insert would delete it.
+    ta.setSelectionRange(3, 7);
 
     const file = new File([new Uint8Array(10)], "shot.png", { type: "image/png" });
     firePaste(ta, pasteClipboardData({ file }));

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -2081,6 +2081,48 @@ describe("Composer file-attachment focus", () => {
 
     expect(screen.queryByText(/can't be attached/)).toBeNull();
   });
+
+  /** A stub clipboardData carrying an optional pasted file plus plain text. */
+  function pasteClipboardData(opts: { file?: File; text?: string }) {
+    return {
+      items: opts.file ? [{ kind: "file", getAsFile: () => opts.file! }] : [],
+      getData: (type: string) => (type === "text/plain" ? (opts.text ?? "") : ""),
+    };
+  }
+
+  // jsdom doesn't expose a ClipboardEvent constructor, so a plain Event
+  // stands in and clipboardData is attached directly (same approach as the
+  // copy-event tests in clipboard.test.ts).
+  function firePaste(target: HTMLElement, clipboardData: unknown) {
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { configurable: true, value: clipboardData });
+    fireEvent(target, event);
+  }
+
+  it("keeps pasted text and attaches a pasted image together", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "look at this: " } });
+    ta.setSelectionRange(ta.value.length, ta.value.length);
+
+    const file = new File([new Uint8Array(10)], "image.png", { type: "image/png" });
+    firePaste(ta, pasteClipboardData({ file, text: "a screenshot" }));
+
+    expect(ta.value).toBe("look at this: a screenshot");
+    expect(screen.getByRole("button", { name: "Remove image.png" })).toBeTruthy();
+  });
+
+  it("leaves the draft unchanged for a file-only paste", () => {
+    render(<Composer {...composerProps()} />);
+    const ta = textarea();
+    fireEvent.change(ta, { target: { value: "draft text" } });
+
+    const file = new File([new Uint8Array(10)], "shot.png", { type: "image/png" });
+    firePaste(ta, pasteClipboardData({ file }));
+
+    expect(ta.value).toBe("draft text");
+    expect(screen.getByRole("button", { name: "Remove shot.png" })).toBeTruthy();
+  });
 });
 
 // The "Chatting with sub-agent …" tray peeks above the composer only when a

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -37,6 +37,7 @@ import { useAppName } from "@/lib/branding";
 import { cn } from "@/lib/utils";
 import { QueuedMessagesStrip } from "@/pages/QueuedMessagesStrip";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
+import { insertTextAtCaret } from "@/lib/composerPaste";
 import {
   serverSwitcherHiddenForSurface,
   useSurfaceFrontmost,
@@ -3397,10 +3398,23 @@ function ComposerImpl({
         if (file) pastedFiles.push(file);
       }
     }
-    if (pastedFiles.length > 0) {
-      e.preventDefault();
-      addFiles(pastedFiles);
+    if (pastedFiles.length === 0) return;
+    // A controlled textarea would otherwise re-render from setFiles below and
+    // overwrite a native insertion with the stale React value, so the paste
+    // is always intercepted and, when there's text alongside the files, is
+    // replayed onto the draft ourselves.
+    e.preventDefault();
+    const ta = e.currentTarget;
+    const text = e.clipboardData.getData("text/plain");
+    if (text) {
+      const { next, caret } = insertTextAtCaret(value, ta.selectionStart, ta.selectionEnd, text);
+      setValue(next);
+      dirtyRef.current = true;
+      queueMicrotask(() => {
+        ta.setSelectionRange(caret, caret);
+      });
     }
+    addFiles(pastedFiles);
   };
 
   return (

--- a/web/src/pages/ChatPage.userBubble.test.tsx
+++ b/web/src/pages/ChatPage.userBubble.test.tsx
@@ -1,9 +1,19 @@
+import type * as ClipboardModule from "@/lib/clipboard";
+
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MessageContentBlock } from "@/lib/blocks";
 import type { Bubble } from "@/lib/renderItems";
 import { FileViewerContext } from "@/shell/FileViewerContext";
+import { copyTextWithImage } from "@/lib/clipboard";
 import { BubbleView } from "./ChatPage";
+
+// Only copyTextWithImage is replaced — the plain-text copy tests below drive
+// the real copyText, stubbing navigator/document instead.
+vi.mock("@/lib/clipboard", async (importOriginal) => {
+  const actual = await importOriginal<typeof ClipboardModule>();
+  return { ...actual, copyTextWithImage: vi.fn().mockResolvedValue(undefined) };
+});
 
 // UserBubble renders its text through the same markdown renderer as the
 // assistant bubble (FilePathAwareMessageResponse → Streamdown). These tests
@@ -353,6 +363,40 @@ describe("UserBubble copy button", () => {
       }),
     );
     expect(screen.queryByRole("button", { name: "Copy" })).toBeNull();
+  });
+
+  const INLINE_PNG =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+  it("copies the bubble text and an inline image together", async () => {
+    const { container } = renderBubble(
+      userBubble("look at this", {
+        content: [
+          { type: "input_text", text: "look at this" },
+          { type: "input_image", image_url: INLINE_PNG, filename: "shot.png" },
+        ],
+      }),
+    );
+
+    const button = container.querySelector('[data-component-id="chat.message.copy_user"]');
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+
+    await waitFor(() => expect(copyTextWithImage).toHaveBeenCalledTimes(1));
+    const [text, image] = vi.mocked(copyTextWithImage).mock.calls[0]!;
+    expect(text).toBe("look at this");
+    expect(typeof image).toBe("function");
+  });
+
+  it("renders a copy button for an attachment-only message when the image is copyable", () => {
+    // The gate widens for an inline image specifically: unlike the "uploaded"
+    // case above, an inline data URI needs no session id to be copyable.
+    renderBubble(
+      userBubble("", {
+        content: [{ type: "input_image", image_url: INLINE_PNG, filename: "shot.png" }],
+      }),
+    );
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
   });
 });
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3516,6 +3516,69 @@ describe("NewChatLandingScreen attachments", () => {
 
     expect(screen.queryByTestId("new-chat-landing-attachment-error")).toBeNull();
   });
+
+  /** A stub clipboardData carrying an optional pasted file plus plain text. */
+  function pasteClipboardData(opts: { file?: File; text?: string }) {
+    return {
+      items: opts.file ? [{ kind: "file", getAsFile: () => opts.file! }] : [],
+      getData: (type: string) => (type === "text/plain" ? (opts.text ?? "") : ""),
+    };
+  }
+
+  // jsdom doesn't expose a ClipboardEvent constructor, so a plain Event
+  // stands in and clipboardData is attached directly (same approach as the
+  // in-session composer's paste tests in ChatPage.composer.test.tsx).
+  function firePaste(target: HTMLElement, clipboardData: unknown) {
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", { configurable: true, value: clipboardData });
+    fireEvent(target, event);
+  }
+
+  it("keeps pasted text and attaches a pasted image together", () => {
+    renderLanding();
+    const ta = screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: "look at this: " } });
+    ta.setSelectionRange(ta.value.length, ta.value.length);
+
+    const file = new File([new Uint8Array(10)], "image.png", { type: "image/png" });
+    firePaste(ta, pasteClipboardData({ file, text: "a screenshot" }));
+
+    expect(ta.value).toBe("look at this: a screenshot");
+    expect(screen.getByRole("button", { name: "Remove image.png" })).toBeTruthy();
+  });
+
+  it("leaves the draft unchanged for a file-only paste", () => {
+    renderLanding();
+    const ta = screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: "draft text" } });
+
+    const file = new File([new Uint8Array(10)], "shot.png", { type: "image/png" });
+    firePaste(ta, pasteClipboardData({ file }));
+
+    expect(ta.value).toBe("draft text");
+    expect(screen.getByRole("button", { name: "Remove shot.png" })).toBeTruthy();
+  });
+
+  it("persists pasted text into the landing draft across an unmount", () => {
+    // The landing draft has no dirty-flag gate (see NewChatDialog.tsx's
+    // unmount effect) — draftRef.current mirrors live state on every render,
+    // so whatever the paste handler puts in `message` rides along
+    // unconditionally. This proves the round trip end to end, through the
+    // same module-level draft a real navigation-away would populate.
+    renderLanding();
+    const ta = screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement;
+
+    const file = new File([new Uint8Array(10)], "shot.png", { type: "image/png" });
+    firePaste(ta, pasteClipboardData({ file, text: "a pasted caption" }));
+    expect(ta.value).toBe("a pasted caption");
+
+    cleanup();
+    // No resetLandingDraft() here — restoring from the same module-level
+    // singleton the unmount just wrote is exactly what's under test.
+    renderLanding();
+
+    expect(screen.getByTestId("new-chat-landing-input")).toHaveValue("a pasted caption");
+  });
 });
 
 // The "@"-file-mention browser on the launcher mirrors the in-session

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -3551,6 +3551,12 @@ describe("NewChatLandingScreen attachments", () => {
     renderLanding();
     const ta = screen.getByTestId("new-chat-landing-input") as HTMLTextAreaElement;
     fireEvent.change(ta, { target: { value: "draft text" } });
+    // A non-empty selection strictly inside the draft: a collapsed
+    // end-of-string caret can't distinguish "no text to insert" from a
+    // missing empty-text guard, since inserting "" at a collapsed caret is a
+    // no-op either way. A real selection makes the two paths diverge — the
+    // guard leaves it alone, but an unguarded insert would delete it.
+    ta.setSelectionRange(3, 7);
 
     const file = new File([new Uint8Array(10)], "shot.png", { type: "image/png" });
     firePaste(ta, pasteClipboardData({ file }));

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -73,6 +73,7 @@ import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { randomUUID } from "@/lib/randomUUID";
 import { isComposerSendKey, readSubmitWithModEnter } from "@/lib/composerSendShortcutPreferences";
 import { attachmentKey, validateAttachments } from "@/lib/attachments";
+import { insertTextAtCaret } from "@/lib/composerPaste";
 import { recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
@@ -5045,15 +5046,31 @@ export function NewChatLandingScreen() {
                 }}
                 onPaste={(e) => {
                   // Pasted images/files attach instead of inserting as text,
-                  // mirroring the in-session composer.
+                  // mirroring the in-session composer. Any text/plain
+                  // alongside them still lands at the caret — see
+                  // insertTextAtCaret for why this can't be left to the
+                  // browser's native paste.
                   const pasted = Array.from(e.clipboardData.items)
                     .filter((item) => item.kind === "file")
                     .map((item) => item.getAsFile())
                     .filter((f): f is File => f !== null);
-                  if (pasted.length > 0) {
-                    e.preventDefault();
-                    addFiles(pasted);
+                  if (pasted.length === 0) return;
+                  e.preventDefault();
+                  const ta = e.currentTarget;
+                  const text = e.clipboardData.getData("text/plain");
+                  if (text) {
+                    const { next, caret } = insertTextAtCaret(
+                      message,
+                      ta.selectionStart,
+                      ta.selectionEnd,
+                      text,
+                    );
+                    setMessage(next);
+                    queueMicrotask(() => {
+                      ta.setSelectionRange(caret, caret);
+                    });
                   }
+                  addFiles(pasted);
                 }}
                 // Suppress the native placeholder when the overlay supplies its
                 // own prompt text; aria-label preserves the accessible name.


### PR DESCRIPTION
## Related issue

Closes #6861

## Summary

- The composer's paste handler discarded any pasted `text/plain` whenever the clipboard also carried a file, so pasting a prompt that included an image lost the text. Both paste handlers (`ChatPage.tsx`, `NewChatDialog.tsx`) now insert that text at the caret via a shared `insertTextAtCaret` helper before attaching the files as before.
- The message bubble's Copy button only ever copied text, so a prompt with an image couldn't be reused. `copyTextWithImage` (`lib/clipboard.ts`) writes one `ClipboardItem` carrying both the text and the message's first image; `lib/attachmentClipboard.ts` resolves an uploaded or inline `input_image` block into a loader (transcoding to PNG when the source isn't already PNG, since Chromium rejects a mismatched MIME/bytes pair). The user bubble's Copy button now uses it, and its render gate widens so an image-only message (no text) still shows a Copy button.

Together these make the full round trip work: copy a message with an image, paste it elsewhere and get both back.

## Test Plan

```
cd web && pnpm exec vitest run src/lib/composerPaste.test.ts src/pages/ChatPage.composer.test.tsx \
  src/lib/clipboard.test.ts src/lib/attachmentClipboard.test.ts src/pages/ChatPage.userBubble.test.tsx
cd web && pnpm run lint && pnpm run type-check && pnpm run format:check
uv run pytest tests/e2e_ui/chat/test_message_copy_attachment.py -v
pre-commit run --from-ref HEAD~1 --to-ref HEAD
```

All green — see Coverage notes for exact output.

## Demo

No video from this environment — reproduction steps a reviewer can run instead:

1. Open a session with a message that has an attached image (or paste an image into the composer with some text, then send it).
2. Hover the message and click Copy. Paste the clipboard elsewhere (a text editor) — the caption text lands.
3. In the composer, paste the same clipboard content — the caption text and the image attachment chip both appear (task 1's fix).

The new e2e test (`tests/e2e_ui/chat/test_message_copy_attachment.py`) automates exactly this against a real Chromium browser: it clicks Copy, asserts the `ClipboardItem` carried both `text/plain` and `image/png`, then dispatches a synthetic paste of that same content into the composer and asserts both the text and the attachment chip land.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

- `composerPaste.test.ts` (new): `insertTextAtCaret` — empty draft, mid-string insert, selection replace, out-of-range caret clamping.
- `ChatPage.composer.test.tsx`: paste with both a file and text keeps the text and attaches the file; a file-only paste is unchanged.
- `clipboard.test.ts`: `copyTextWithImage` — writes one item with both MIME types (and calls `write` before the image promise resolves), omits `text/plain` when there's no text, falls back to `writeText` when `ClipboardItem` is unavailable or `write` rejects.
- `attachmentClipboard.test.ts` (new): `firstImageLoader` — uploaded block fetches via `authenticatedFetch` at the session file-content path, inline block decodes with no fetch, `pending`/`unavailable`/non-image content/no-session-id all return `null`, first-of-two is chosen, and a non-PNG blob rejects when there's no `OffscreenCanvas` to transcode with (jsdom has neither `createImageBitmap` nor `OffscreenCanvas`, so the PNG-transcode path itself is only reachable in a real browser — the e2e test's image is already PNG, so it doesn't exercise transcoding either; that's the one path this PR doesn't have direct coverage for).
- `ChatPage.userBubble.test.tsx`: Copy on a message with text + inline image calls `copyTextWithImage` with the text and a loader; an attachment-only message (no text) still renders a Copy button when the image is copyable.
- `tests/e2e_ui/chat/test_message_copy_attachment.py` (new): full round trip against a real Chromium browser (see Demo).

All commands above were run locally and passed; full web vitest suite also run clean (376 files, 7128 tests passed, 3 expected-fail, 1 skipped — unrelated to this change).

## Changelog

Copying a chat message now brings its attached image along, and pasting a copied prompt keeps its text even when an image comes with it

