### PR TITLE
feat(import): trim large Claude/Codex imports to last compaction boundary

### DIFF
--- a/docs/session-compaction.md
+++ b/docs/session-compaction.md
@@ -1,0 +1,51 @@
+# Session compaction and imported history
+
+Coding harnesses compact their own context when a conversation approaches the
+model's context window: older messages are summarized into a single
+continuation summary, and the live agent resumes from that summary rather than
+from the full transcript. This note covers how compaction affects **importing**
+a local harness session into Omnigent.
+
+## The compaction boundary
+
+Each harness records the boundary differently:
+
+- **Claude Code** writes the continuation summary to its JSONL transcript as a
+  user record flagged `isCompactSummary: true`. Omnigent surfaces that record as
+  a single item flagged `is_compact_summary` (see
+  `omnigent/harnesses/claude_native/bridge.py`), which is the reliable,
+  always-present compaction signal — the post-compaction `SessionStart
+  source=compact` hook that would otherwise persist the boundary is flaky and
+  sometimes never fires. The agent resumes from that summary, so the kept range
+  is the summary and everything after it.
+- **Codex** appends a `{type: "compacted", payload: {replacement_history: [...]}}`
+  record to its rollout JSONL after compacting. `replacement_history` is the
+  post-compaction context baseline it resumes from (the summary plus any retained
+  messages); the raw pre-compaction `response_item` records stay in the
+  append-only file but the agent no longer sees them. The kept range is the
+  replacement-history baseline and every `response_item` after the record.
+
+A transcript can be compacted more than once, so the boundary that matters is
+the **last** one: everything before it is already folded into that baseline.
+
+## Import trimming
+
+`load_claude_session` / `load_codex_session`
+(`omnigent/session_import/local.py`) mirror the agent's working context when
+importing:
+
+- **Transcript at or below `_IMPORT_COMPACT_TRIM_BYTES` (2 MB)** — the full
+  history is imported. The full record is cheap at this size and useful to
+  browse, and a short transcript may not have compacted at all. (For Codex this
+  means the raw pre-compaction records are kept and the `compacted` record is
+  ignored, matching the prior behavior.)
+- **Transcript larger than 2 MB** — it has almost certainly been compacted at
+  least once, so the import keeps only the items from the last compaction
+  boundary onward. This is what the agent itself would reconstruct on resume, and
+  it keeps a single import from replaying megabytes of pre-compaction records the
+  agent no longer holds.
+
+The threshold is on the on-disk transcript byte size, not on the serialized item
+count, so it reflects roughly the same signal the harness uses to decide when to
+compact. A transcript that grew past 2 MB without ever compacting imports whole —
+trimming only ever drops records the agent has already summarized away.

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -7,12 +7,16 @@ import os
 import re
 import sqlite3
 import subprocess
+from collections.abc import Sequence
 from hashlib import sha256
 from pathlib import Path
 from typing import get_args
 
 from omnigent.entities import NewConversationItem, parse_item_data
-from omnigent.harnesses.claude_native.bridge import read_transcript_items_from_offset
+from omnigent.harnesses.claude_native.bridge import (
+    ClaudeTranscriptItem,
+    read_transcript_items_from_offset,
+)
 from omnigent.harnesses.codex_native.main import _CODEX_THREAD_ID_RE, _find_codex_rollout
 from omnigent.harnesses.kimi_native.credentials import resolve_user_kimi_home
 from omnigent.harnesses.kimi_native.forwarder import (
@@ -39,6 +43,27 @@ _OPENCODE_IMPORT_SESSION_ID_RE = re.compile(r"ses_[A-Za-z0-9_-]+")
 _MAX_EXTERNAL_SESSION_ID_LENGTH = 128
 _MAX_RESPONSE_ID_LENGTH = 64
 _OPENCODE_COMMAND_TIMEOUT_SECONDS = 120
+
+# Transcript byte size past which an import is trimmed to the last compaction
+# boundary instead of the full history. Below it the whole transcript imports
+# (cheap, and the full record is useful to browse); above it the file has almost
+# certainly been compacted at least once, so importing every pre-compaction
+# record replays megabytes the live agent no longer sees. Shared by the Claude
+# (``isCompactSummary``) and Codex (``compacted`` record) paths — see
+# docs/session-compaction.md.
+_IMPORT_COMPACT_TRIM_BYTES = 2 * 1024 * 1024
+
+
+def _exceeds_compaction_trim_size(path: Path) -> bool:
+    """Whether a transcript is large enough to trim to its last compaction.
+
+    An unreadable size falls back to ``False`` — import the whole transcript
+    rather than drop history on a failed ``stat``.
+    """
+    try:
+        return path.stat().st_size > _IMPORT_COMPACT_TRIM_BYTES
+    except OSError:
+        return False
 
 
 def _bounded_response_id(response_id: str) -> str:
@@ -371,6 +396,25 @@ def _claude_native_title(transcript_path: Path) -> str | None:
     return custom or ai
 
 
+def _items_from_last_compaction(
+    items: Sequence[ClaudeTranscriptItem],
+) -> Sequence[ClaudeTranscriptItem]:
+    """Slice ``items`` from the last compaction summary onward.
+
+    Claude flags the continuation summary it writes after compacting its own
+    context with ``is_compact_summary`` — the durable compaction boundary (see
+    :mod:`omnigent.harnesses.claude_native.bridge`). The live agent resumes from
+    that summary, not the full transcript, so keeping the summary and everything
+    after it mirrors the agent's working context. Returns ``items`` unchanged
+    when the transcript was never compacted.
+    """
+    last = None
+    for index, item in enumerate(items):
+        if item.is_compact_summary:
+            last = index
+    return items if last is None else items[last:]
+
+
 def load_claude_session(
     session_id: str,
     *,
@@ -390,13 +434,19 @@ def load_claude_session(
         start_line=0,
         agent_name="claude-native-ui",
     )
+    # A large transcript has almost certainly compacted; import only what the
+    # agent would still see (from the last compaction boundary). See
+    # docs/session-compaction.md.
+    source_items: Sequence[ClaudeTranscriptItem] = parsed.items
+    if _exceeds_compaction_trim_size(transcript_path):
+        source_items = _items_from_last_compaction(parsed.items)
     items = tuple(
         NewConversationItem(
             type=item.item_type,
             response_id=item.response_id,
             data=parse_item_data(item.item_type, item.data),
         )
-        for item in parsed.items
+        for item in source_items
     )
     if not items:
         raise SessionImportNotFoundError(
@@ -593,6 +643,28 @@ def _codex_native_title(home: Path, session_id: str) -> str | None:
     return None
 
 
+def _codex_compacted_baseline_items(payload: dict[str, object]) -> list[NewConversationItem]:
+    """Convert a Codex ``compacted`` record's replacement_history into items.
+
+    Codex appends ``{type: "compacted", payload: {replacement_history: [...]}}``
+    after compacting; ``replacement_history`` is the post-compaction context
+    baseline it resumes from (the summary plus any retained messages), each entry
+    response-item shaped. Unsupported entries (e.g. reasoning) parse to ``None``
+    and are skipped, mirroring the ordinary response-item path.
+    """
+    history = payload.get("replacement_history")
+    if not isinstance(history, list):
+        return []
+    baseline: list[NewConversationItem] = []
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        item = _codex_response_item(entry, response_id="codex:compaction")
+        if item is not None:
+            baseline.append(item)
+    return baseline
+
+
 def load_codex_session(
     session_id: str,
     *,
@@ -607,6 +679,11 @@ def load_codex_session(
     )
     if rollout_path is None:
         raise SessionImportNotFoundError(f"Codex session {session_id!r} was not found")
+
+    # Past the size threshold, restart from each compaction boundary so the
+    # import matches what the agent resumes with, dropping the pre-compaction
+    # records it no longer sees. See docs/session-compaction.md.
+    trim_at_compaction = _exceeds_compaction_trim_size(rollout_path)
 
     workspace: str | None = None
     turn_id = "history"
@@ -629,6 +706,17 @@ def load_codex_session(
                 candidate = payload.get("turn_id")
                 if isinstance(candidate, str) and candidate:
                     turn_id = candidate
+                continue
+            if record.get("type") == "compacted":
+                # replacement_history is the new context baseline; resetting to it
+                # discards prior items so only the last compaction's baseline and
+                # what follows survive (mirrors the terminal agent on resume). A
+                # boundary with no usable baseline is ignored rather than wiping
+                # history to nothing (matches _read_compacted_history's guard).
+                if trim_at_compaction:
+                    baseline = _codex_compacted_baseline_items(payload)
+                    if baseline:
+                        items = baseline
                 continue
             if record.get("type") != "response_item":
                 continue

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -25,7 +25,7 @@ from omnigent.session_import.local import (
     load_pi_session,
     load_qwen_session,
 )
-from omnigent.session_import.models import SessionImportNotFoundError
+from omnigent.session_import.models import LocalSessionImport, SessionImportNotFoundError
 
 
 def test_import_adapters_use_stable_forwarder_parser_contracts(tmp_path: Path) -> None:
@@ -478,6 +478,207 @@ def test_load_claude_session_rejects_empty_history(tmp_path: Path) -> None:
         load_claude_session(session_id, claude_home=tmp_path)
 
 
+def _write_claude_transcript_with_compaction(tmp_path: Path, session_id: str) -> Path:
+    """Write a transcript with a compaction summary splitting two turns."""
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "user",
+            "uuid": "user-pre",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "first question before compaction"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-pre",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "early reply"}]},
+        },
+        {
+            "type": "user",
+            "uuid": "compact-1",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "summary of the conversation so far"},
+        },
+        {
+            "type": "user",
+            "uuid": "user-post",
+            "message": {"role": "user", "content": "follow-up after compaction"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-post",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "later reply"}]},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+    return transcript
+
+
+def test_load_claude_session_keeps_full_history_below_size_threshold(tmp_path: Path) -> None:
+    """A small transcript imports whole, even when it contains a compaction summary."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_compaction(tmp_path, session_id)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    # Pre-compaction turn, the summary, and the post-compaction turn all present.
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    assert "first question before compaction" in texts
+    assert "summary of the conversation so far" in texts
+    assert "follow-up after compaction" in texts
+
+
+def test_load_claude_session_trims_to_last_compaction_when_large(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transcript past the size threshold imports only from the last compaction summary."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_compaction(tmp_path, session_id)
+    # Force the large-file path without writing multiple megabytes.
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    # Pre-compaction records the live agent no longer sees are dropped; the
+    # summary and everything after it are kept.
+    assert "first question before compaction" not in texts
+    assert "early reply" not in texts
+    assert "summary of the conversation so far" in texts
+    assert "follow-up after compaction" in texts
+    assert "later reply" in texts
+
+
+def test_load_claude_session_large_without_compaction_imports_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A large transcript that never compacted keeps its full history."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_titles(tmp_path, session_id, ai_title=None, custom_title=None)
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    # No isCompactSummary boundary → trimming is a no-op, first message stays.
+    assert imported.title == "inspect TODO.md"
+    assert imported.items
+
+
+def test_load_claude_session_trims_to_final_compaction_with_multiple(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With several compactions, only the last boundary onward is imported."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "user",
+            "uuid": "user-0",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "original"},
+        },
+        {
+            "type": "user",
+            "uuid": "compact-1",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "first summary"},
+        },
+        {
+            "type": "user",
+            "uuid": "compact-2",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "second summary"},
+        },
+        {
+            "type": "user",
+            "uuid": "user-final",
+            "message": {"role": "user", "content": "after second"},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    assert "original" not in texts
+    assert "first summary" not in texts
+    assert "second summary" in texts
+    assert "after second" in texts
+
+
+def test_load_claude_session_trims_at_real_two_mb_threshold(tmp_path: Path) -> None:
+    """Past the real 2 MB threshold, pre-compaction records are dropped (no patch)."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    filler = "x" * 4096  # ~4 KB per record; ~600 records clears 2 MB.
+    records: list[dict[str, object]] = [
+        {
+            "type": "user",
+            "uuid": f"pre-{i}",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": f"pre-compaction {i} {filler}"},
+        }
+        for i in range(600)
+    ]
+    records.append(
+        {
+            "type": "user",
+            "uuid": "compact-1",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "post compaction summary marker"},
+        }
+    )
+    records.append(
+        {
+            "type": "user",
+            "uuid": "post-1",
+            "message": {"role": "user", "content": "question after compaction marker"},
+        }
+    )
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+    assert transcript.stat().st_size > 2 * 1024 * 1024
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    assert not any(text.startswith("pre-compaction") for text in texts)
+    assert any("post compaction summary marker" in text for text in texts)
+    assert any("question after compaction marker" in text for text in texts)
+
+
 def test_list_recent_claude_sessions_orders_parents_and_applies_limit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -642,6 +843,231 @@ def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
         "call_id": "call_2",
         "output": "",
     }
+
+
+def _codex_item_texts(imported: LocalSessionImport) -> list[str]:
+    """Flatten the text of every message item in an imported Codex session."""
+    return [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and isinstance(block.get("text"), str)
+    ]
+
+
+def _write_codex_rollout_with_compaction(
+    tmp_path: Path, session_id: str, *, extra_pre: list[dict] | None = None
+) -> Path:
+    """Write a Codex rollout with a ``compacted`` record between two turns."""
+    rollout = (
+        tmp_path
+        / "sessions"
+        / "2026"
+        / "07"
+        / "15"
+        / f"rollout-2026-07-15T12-00-00-{session_id}.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    records: list[dict] = [
+        {"type": "session_meta", "payload": {"id": session_id, "cwd": "/repo"}},
+        {"type": "turn_context", "payload": {"turn_id": "turn_1", "cwd": "/repo"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "pre compaction question"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "pre compaction answer"}],
+            },
+        },
+    ]
+    records.extend(extra_pre or [])
+    records.append(
+        {
+            "type": "compacted",
+            "payload": {
+                "replacement_history": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "compaction summary baseline"}],
+                    }
+                ],
+                "window_id": 1,
+            },
+        }
+    )
+    records.extend(
+        [
+            {"type": "turn_context", "payload": {"turn_id": "turn_2", "cwd": "/repo"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "post compaction question"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "post compaction answer"}],
+                },
+            },
+        ]
+    )
+    rollout.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+    return rollout
+
+
+def test_load_codex_session_keeps_full_history_below_size_threshold(tmp_path: Path) -> None:
+    """A small rollout imports the raw history whole; the compacted record is ignored."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    _write_codex_rollout_with_compaction(tmp_path, session_id)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    assert "pre compaction question" in texts
+    assert "post compaction question" in texts
+    # The compacted record's replacement_history is not surfaced below threshold.
+    assert "compaction summary baseline" not in texts
+
+
+def test_load_codex_session_trims_to_last_compaction_when_large(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Past the threshold, only the compaction baseline and later turns import."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    _write_codex_rollout_with_compaction(tmp_path, session_id)
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    # Pre-compaction records the live agent no longer sees are dropped.
+    assert "pre compaction question" not in texts
+    assert "pre compaction answer" not in texts
+    # The replacement_history baseline and post-compaction turns are kept.
+    assert "compaction summary baseline" in texts
+    assert "post compaction question" in texts
+    assert "post compaction answer" in texts
+
+
+def test_load_codex_session_trims_to_final_compaction_with_multiple(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With two compactions, only the last baseline onward survives."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    # A second compaction after the first: its replacement_history is the final
+    # baseline, so the first summary must not survive.
+    extra_pre = [
+        {
+            "type": "compacted",
+            "payload": {
+                "replacement_history": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "first summary baseline"}],
+                    }
+                ]
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "between compactions"}],
+            },
+        },
+    ]
+    _write_codex_rollout_with_compaction(tmp_path, session_id, extra_pre=extra_pre)
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    assert "first summary baseline" not in texts
+    assert "between compactions" not in texts
+    assert "compaction summary baseline" in texts
+    assert "post compaction question" in texts
+
+
+def test_load_codex_session_ignores_empty_compaction_boundary_when_large(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A compacted record with no usable replacement_history does not wipe history."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    rollout = (
+        tmp_path
+        / "sessions"
+        / "2026"
+        / "07"
+        / "15"
+        / f"rollout-2026-07-15T12-00-00-{session_id}.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    records = [
+        {"type": "session_meta", "payload": {"id": session_id, "cwd": "/repo"}},
+        {"type": "turn_context", "payload": {"turn_id": "turn_1", "cwd": "/repo"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "only real turn"}],
+            },
+        },
+        # Degenerate boundary: empty replacement_history. Must not drop everything.
+        {"type": "compacted", "payload": {"replacement_history": []}},
+    ]
+    rollout.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    assert _codex_item_texts(imported) == ["only real turn"]
+
+
+def test_load_codex_session_trims_at_real_two_mb_threshold(tmp_path: Path) -> None:
+    """Past the real 2 MB threshold, pre-compaction Codex records are dropped (no patch)."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    filler = "x" * 4096
+    extra_pre = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": f"pre bulk {i} {filler}"}],
+            },
+        }
+        for i in range(600)
+    ]
+    rollout = _write_codex_rollout_with_compaction(tmp_path, session_id, extra_pre=extra_pre)
+    assert rollout.stat().st_size > 2 * 1024 * 1024
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    assert not any(text.startswith("pre bulk") for text in texts)
+    assert "pre compaction question" not in texts
+    assert "compaction summary baseline" in texts
+    assert "post compaction question" in texts
 
 
 def _write_codex_rollout(tmp_path: Path, session_id: str, *, first_message: str) -> None:


### PR DESCRIPTION
## Related issue

No tracking issue — small, self-contained import improvement. Happy to file one if maintainers prefer.

Closes #

## Summary

- When importing a local Claude or Codex session, a transcript over 2 MB has almost certainly compacted at least once. Importing every pre-compaction record replays context the live agent no longer sees (a 58 MB Claude transcript is ~15.5k items but the agent only holds ~640 after its last compaction).
- Past the 2 MB threshold, import only from the **last compaction boundary** onward, mirroring what the harness reconstructs on resume:
  - **Claude**: from the `isCompactSummary` continuation-summary item and everything after it.
  - **Codex**: from the last `compacted` record's `replacement_history` baseline plus the `response_item`s that follow.
- Transcripts at or below 2 MB import whole (unchanged), so short sessions are unaffected. The boundary detection reuses the existing `ClaudeTranscriptItem.is_compact_summary` flag and the `_codex_response_item` converter, so parsing can't drift from the normal path.

ELI5: a long chat gets summarized when it fills up; when we import an old chat, we start from the newest summary instead of re-reading the whole thing.

```
transcript (>2MB):  [old turns ...][COMPACTION SUMMARY][recent turns]
imported:                          ^-------- kept --------^
```

## Test Plan

- `uv run pytest tests/test_session_import.py` — 54 passed (added Claude + Codex cases: full history below threshold, trim to last boundary, trim to final boundary with multiple compactions, empty-boundary guard for Codex, and a real >2 MB transcript exercising the actual threshold).
- `uv run ruff check .` and `uv run ruff format --check .` clean; pyrefly clean.
- Validated against real local transcripts: a 58 MB Claude transcript (7 compaction boundaries) trims to exactly the last-boundary slice; a 13 MB Codex rollout (9 compactions) trims item-for-item to an independent reconstruction of the last `replacement_history` baseline plus following turns.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — non-visual (import normalization logic). Evidence in Test Plan.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification ran the real loaders against local `~/.claude` and `~/.codex` transcripts and confirmed the imported item set equals the last-compaction-boundary slice (compared against an independent reconstruction for Codex). Unit tests cover both harnesses across the threshold and the multiple-compaction and empty-boundary cases.

## Changelog

Large imported Claude and Codex sessions now start from their last compaction summary instead of replaying pre-compaction history.
