### PR TITLE
feat(import): chunked local session import with per-session drop resilience

### DIFF
--- a/docs/session-compaction.md
+++ b/docs/session-compaction.md
@@ -1,0 +1,56 @@
+# Session compaction and imported history
+
+Coding harnesses compact their own context when a conversation approaches the
+model's context window: older messages are summarized into a single
+continuation summary, and the live agent resumes from that summary rather than
+from the full transcript. This note covers how compaction affects **importing**
+a local harness session into Omnigent.
+
+## The compaction boundary
+
+Each harness records the boundary differently:
+
+- **Claude Code** writes the continuation summary to its JSONL transcript as a
+  user record flagged `isCompactSummary: true`. Omnigent surfaces that record as
+  a single item flagged `is_compact_summary` (see
+  `omnigent/claude_native_bridge.py`), which is the reliable, always-present
+  compaction signal — the post-compaction `SessionStart source=compact` hook that
+  would otherwise persist the boundary is flaky and sometimes never fires. The
+  agent resumes from that summary, so the kept range is the summary and
+  everything after it.
+- **Codex** appends a `{type: "compacted", payload: {replacement_history: [...]}}`
+  record to its rollout JSONL after compacting. `replacement_history` is the
+  post-compaction context baseline it resumes from (the summary plus any retained
+  messages); the raw pre-compaction `response_item` records stay in the
+  append-only file but the agent no longer sees them. The kept range is the
+  replacement-history baseline and every `response_item` after the record.
+
+A transcript can be compacted more than once, so the boundary that matters is
+the **last** one: everything before it is already folded into that baseline.
+
+## Import trimming
+
+`load_claude_session` / `load_codex_session`
+(`omnigent/session_import/local.py`) mirror the agent's working context when
+importing:
+
+- **Transcript at or below `_IMPORT_COMPACT_TRIM_BYTES` (2 MB)** — the full
+  history is imported. The full record is cheap at this size and useful to
+  browse, and a short transcript may not have compacted at all. (For Codex this
+  means the raw pre-compaction records are kept and the `compacted` record is
+  ignored, matching the prior behavior.)
+- **Transcript larger than 2 MB** — it has almost certainly been compacted at
+  least once, so the import keeps only the items from the last compaction
+  boundary onward. This is what the agent itself would reconstruct on resume, and
+  it keeps a single import from replaying megabytes of pre-compaction records the
+  agent no longer holds.
+
+The threshold is on the on-disk transcript byte size, not on the serialized item
+count, so it reflects roughly the same signal the harness uses to decide when to
+compact. A transcript that grew past 2 MB without ever compacting imports whole —
+trimming only ever drops records the agent has already summarized away.
+
+This trimming is distinct from transport chunking (`iter_item_chunks` /
+`IMPORT_CHUNK_MAX_BYTES`), which splits an already-selected set of items into
+frame-sized batches for the host→server tunnel. Compaction trimming decides
+*which* items to import; chunking decides *how* they travel.

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -5921,6 +5921,33 @@ class _SessionImportResult:
     raw_exc: BaseException | None = None
 
 
+def _server_supports_chunked_import(base_url: str) -> bool:
+    """Whether the server accepts an oversized session as append chunks.
+
+    Reads ``chunked_import_supported`` off ``GET /v1/info``. Any failure, or a
+    server old enough to lack the key, reads as ``False`` so the import falls
+    back to posting each session in one body (its historical behavior).
+    """
+    import httpx
+
+    from omnigent.chat import _remote_headers
+
+    try:
+        resp = httpx.get(
+            f"{base_url}/v1/info",
+            headers=_remote_headers(server_url=base_url, host_id=None),
+            timeout=30.0,
+        )
+    except httpx.RequestError:
+        return False
+    if resp.is_error:
+        return False
+    try:
+        return bool(resp.json().get("chunked_import_supported", False))
+    except (ValueError, AttributeError):
+        return False
+
+
 @cli.command("import")
 @click.option(
     "--harness",
@@ -5990,8 +6017,11 @@ def import_session_command(
     from omnigent.chat import _remote_headers
     from omnigent.conversation_browser import conversation_url
     from omnigent.session_import import (
+        IMPORT_CHUNK_MAX_BYTES,
         ImportSource,
         SessionImportNotFoundError,
+        iter_item_chunks,
+        total_item_bytes,
     )
     from omnigent.session_import.local import (
         list_recent_local_session_ids,
@@ -6041,6 +6071,19 @@ def import_session_command(
         base_url = ensure_local_omnigent_server().url
     base_url = base_url.rstrip("/")
 
+    # A session larger than one body posts as append chunks, but only to a server
+    # that accepts them (older servers post whole, their historical behavior).
+    # The /v1/info probe is lazy — only a truly oversized session triggers it —
+    # and cached, so the common small-session import makes no extra request.
+    _probe_lock = threading.Lock()
+    _probe_cache: dict[str, bool] = {}
+
+    def _chunking_supported() -> bool:
+        with _probe_lock:
+            if "value" not in _probe_cache:
+                _probe_cache["value"] = _server_supports_chunked_import(base_url)
+            return _probe_cache["value"]
+
     def _import_one(target: tuple[ImportSource, str]) -> _SessionImportResult:
         # Each target carries its own harness so an "all" batch can span them.
         current_source, sid = target
@@ -6051,64 +6094,89 @@ def import_session_command(
         except (OSError, TypeError, ValueError) as exc:
             return _SessionImportResult(sid, "load_error", message=str(exc), raw_exc=exc)
 
-        payload = {
-            "source": imported.source,
-            "external_session_id": imported.external_session_id,
-            "workspace": imported.workspace,
-            "title": imported.native_title,
-            "force": force,
-            "items": [
-                {
-                    "type": item.type,
-                    "response_id": item.response_id,
-                    "data": item.data.model_dump(mode="json", exclude_none=True),
-                }
-                for item in imported.items
-            ],
-        }
-        try:
-            response = httpx.post(
-                f"{base_url}/v1/imports",
-                json=payload,
-                headers=_remote_headers(server_url=base_url, host_id=None),
-                timeout=120.0,
-            )
-        except httpx.RequestError as exc:
-            return _SessionImportResult(
-                sid,
-                "unreachable",
-                message=f"Could not reach the Omnigent server: {exc}",
-                raw_exc=exc,
-            )
+        item_dicts = [
+            {
+                "type": item.type,
+                "response_id": item.response_id,
+                "data": item.data.model_dump(mode="json", exclude_none=True),
+            }
+            for item in imported.items
+        ]
+        # Split only an oversized session, and only when the server accepts
+        # chunks; otherwise one body carries the whole session as before.
+        if total_item_bytes(item_dicts) > IMPORT_CHUNK_MAX_BYTES and _chunking_supported():
+            batches = list(iter_item_chunks(item_dicts))
+        else:
+            batches = [item_dicts]
+        chunked = len(batches) > 1
+        last = len(batches) - 1
 
-        if response.is_error:
+        session_id: str | None = None
+        total_items = 0
+        for index, batch in enumerate(batches):
+            payload: dict[str, object] = {
+                "source": imported.source,
+                "external_session_id": imported.external_session_id,
+                "items": batch,
+            }
+            if index == 0:
+                # Session metadata and the replace decision belong to the create
+                # chunk; later chunks only append.
+                payload["workspace"] = imported.workspace
+                payload["title"] = imported.native_title
+                payload["force"] = force
+            if chunked:
+                # Only a genuinely split session carries chunk markers, so a
+                # single-body import stays byte-identical to the pre-chunk wire.
+                payload["chunk_index"] = index
+                payload["final"] = index == last
             try:
-                body = response.json()
-                detail = body.get("error", {}).get("message") or body.get("detail")
-            except (ValueError, AttributeError):
-                detail = None
-            message = f"Import failed ({response.status_code}): {detail or response.text}"
-            status = "already" if response.status_code == 409 else "failed"
-            return _SessionImportResult(sid, status, message=message)
+                response = httpx.post(
+                    f"{base_url}/v1/imports",
+                    json=payload,
+                    headers=_remote_headers(server_url=base_url, host_id=None),
+                    timeout=120.0,
+                )
+            except httpx.RequestError as exc:
+                return _SessionImportResult(
+                    sid,
+                    "unreachable",
+                    message=f"Could not reach the Omnigent server: {exc}",
+                    raw_exc=exc,
+                )
 
-        try:
-            result = response.json()
-            session_id = result["session_id"]
-            item_count = result["item_count"]
-        except (AttributeError, KeyError, TypeError, ValueError) as exc:
-            return _SessionImportResult(
-                sid,
-                "failed",
-                message="Import returned an invalid server response",
-                raw_exc=exc,
-            )
+            if response.is_error:
+                try:
+                    body = response.json()
+                    detail = body.get("error", {}).get("message") or body.get("detail")
+                except (ValueError, AttributeError):
+                    detail = None
+                message = f"Import failed ({response.status_code}): {detail or response.text}"
+                # Only the create chunk's 409 means "already imported"; a 409 on
+                # an append chunk is a real failure (its create was lost).
+                status = "already" if response.status_code == 409 and index == 0 else "failed"
+                return _SessionImportResult(sid, status, message=message)
+
+            try:
+                result = response.json()
+                session_id = result["session_id"]
+                total_items += result["item_count"]
+            except (AttributeError, KeyError, TypeError, ValueError) as exc:
+                return _SessionImportResult(
+                    sid,
+                    "failed",
+                    message="Import returned an invalid server response",
+                    raw_exc=exc,
+                )
+
+        assert session_id is not None
         # Surface the browser URL, not the bare id, so the user can open the
         # imported session straight into the web (where it offers the resume
         # picker). Maps a Databricks API base to its workspace SPA link.
         return _SessionImportResult(
             sid,
             "imported",
-            item_count=item_count,
+            item_count=total_items,
             link=conversation_url(base_url, session_id),
         )
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -55,6 +55,7 @@ from omnigent.host.frames import (
     HostHarnessReadinessFrame,
     HostHelloFrame,
     HostImportedLocalSession,
+    HostImportLocalByIdFrame,
     HostImportLocalDoneFrame,
     HostImportLocalFrame,
     HostImportLocalSessionFrame,
@@ -92,6 +93,7 @@ from omnigent.host.git_worktree import (
 from omnigent.host.identity import HostIdentity, load_or_create_host_identity
 from omnigent.host.runner_zygote import ZygoteManager, ZygoteRunnerProc, ZygoteUnavailable
 from omnigent.inner import _proc
+from omnigent.json_types import JsonObject
 from omnigent.onboarding.harness_auth import (
     adopt_env_credential,
     detect_adoptable_credentials,
@@ -881,6 +883,49 @@ class _RunnerHandle:
     proc: subprocess.Popen[bytes] | ZygoteRunnerProc
     log_path: Path
     session_id: str | None = None
+
+
+def _chunk_session_frames(
+    *,
+    request_id: str,
+    total: int,
+    session: HostImportedLocalSession,
+    max_chunk_bytes: int,
+) -> list[HostImportLocalSessionFrame]:
+    """Split one loaded session into the frames that stream it to the server.
+
+    A session at or under the budget (or any session when the server sent no
+    budget — an older peer that can't reassemble) rides in one frame, exactly
+    as before chunking. A larger one splits its items into byte-bounded batches
+    that share its ``external_session_id``; each frame repeats the session
+    metadata and carries one batch, with ``chunk_index`` counting up and
+    ``last_chunk`` set on the final frame so the server appends in order.
+    """
+    from omnigent.session_import import iter_item_chunks, total_item_bytes
+
+    def _frame(
+        items: list[JsonObject], chunk_index: int, last_chunk: bool
+    ) -> HostImportLocalSessionFrame:
+        return HostImportLocalSessionFrame(
+            request_id=request_id,
+            total=total,
+            chunk_index=chunk_index,
+            last_chunk=last_chunk,
+            session=HostImportedLocalSession(
+                external_session_id=session.external_session_id,
+                workspace=session.workspace,
+                items=items,
+                title=session.title,
+                source=session.source,
+            ),
+        )
+
+    if max_chunk_bytes <= 0 or total_item_bytes(session.items) <= max_chunk_bytes:
+        return [_frame(session.items, chunk_index=0, last_chunk=True)]
+
+    batches = list(iter_item_chunks(session.items, max_bytes=max_chunk_bytes))
+    last = len(batches) - 1
+    return [_frame(batch, chunk_index=i, last_chunk=i == last) for i, batch in enumerate(batches)]
 
 
 class HostRetryableConnectionError(Exception):
@@ -2085,17 +2130,21 @@ class HostProcess:
         )
 
     async def _handle_import_local(
-        self, ws: websockets.asyncio.client.ClientConnection, frame: HostImportLocalFrame
+        self,
+        ws: websockets.asyncio.client.ClientConnection,
+        frame: HostImportLocalFrame | HostImportLocalByIdFrame,
     ) -> None:
-        """Stream the host's recent local transcripts, one frame per session.
+        """Stream requested local transcripts, one frame per session.
 
-        The host owns the session files (``~/.claude`` etc.). It enumerates the
-        targets ("all" merges every harness into one global recency order, top
-        ``limit`` total), then reads + normalizes each and sends it immediately
+        The host owns the session files (``~/.claude`` etc.). An exact session
+        id is loaded directly; otherwise it enumerates the targets ("all"
+        merges every harness into one global recency order, top ``limit``
+        total). It reads + normalizes each and sends it immediately
         (``host.import_local_session``) so a large batch never rides in one frame
         and the server persists as each arrives. A terminal ``host.import_local_done``
-        closes the stream. Sessions that fail to load are skipped; a single-harness
-        enumeration failure fails the request.
+        closes the stream. A session that fails to load, normalize, or chunk is
+        skipped and counted so the rest of the batch still uploads; only a
+        single-harness enumeration failure fails the whole request.
         """
 
         def _targets() -> tuple[list[tuple[str, str]], str | None]:
@@ -2105,6 +2154,8 @@ class HostProcess:
             )
             from omnigent.session_import.models import ImportSource, SessionImportNotFoundError
 
+            if isinstance(frame, HostImportLocalByIdFrame):
+                return [(frame.source, frame.session_id)], None
             if frame.source == "all":
                 return list(list_recent_sessions_across_harnesses(limit=frame.limit)), None
             source = cast(ImportSource, frame.source)
@@ -2156,19 +2207,36 @@ class HostProcess:
             total = len(ordered)
             load_failed = 0
             for source, session_id in ordered:
-                session = await asyncio.to_thread(_load, source, session_id)
-                if session is None:
+                try:
+                    session = await asyncio.to_thread(_load, source, session_id)
+                    chunks = (
+                        None
+                        if session is None
+                        else _chunk_session_frames(
+                            request_id=frame.request_id,
+                            total=total,
+                            session=session,
+                            max_chunk_bytes=frame.max_chunk_bytes,
+                        )
+                    )
+                except Exception:
+                    # One session's read/normalize/chunk blowing up must not drop
+                    # the rest of the batch — count it and move on so the remaining
+                    # sessions still upload. ws.send stays outside this guard: a
+                    # dead tunnel raises ConnectionClosed and should abort, not be
+                    # swallowed here as a skipped session.
+                    _logger.exception(
+                        "import_local: skipping session source=%r id=%r", source, session_id
+                    )
+                    load_failed += 1
+                    continue
+                if chunks is None:
                     # Unreadable/corrupt transcript: no frame to send, but report
                     # it on the done frame so the server's counts stay honest.
                     load_failed += 1
                     continue
-                await ws.send(
-                    encode_host_frame(
-                        HostImportLocalSessionFrame(
-                            request_id=frame.request_id, total=total, session=session
-                        )
-                    )
-                )
+                for chunk in chunks:
+                    await ws.send(encode_host_frame(chunk))
             await ws.send(
                 encode_host_frame(
                     HostImportLocalDoneFrame(
@@ -3836,7 +3904,7 @@ class HostProcess:
                     error=f"model options resolution crashed for {frame.harness!r}",
                 )
             await ws.send(encode_host_frame(options_result))
-        elif isinstance(frame, HostImportLocalFrame):
+        elif isinstance(frame, (HostImportLocalFrame, HostImportLocalByIdFrame)):
             # Streams one host.import_local_session per session (reads run off the
             # event loop inside), then a terminal host.import_local_done.
             await self._handle_import_local(ws, frame)

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -75,6 +75,7 @@ class HostFrameKind(str, Enum):
     MODEL_OPTIONS = "host.model_options"
     MODEL_OPTIONS_RESULT = "host.model_options_result"
     IMPORT_LOCAL = "host.import_local"
+    IMPORT_LOCAL_BY_ID = "host.import_local_by_id"
     IMPORT_LOCAL_SESSION = "host.import_local_session"
     IMPORT_LOCAL_DONE = "host.import_local_done"
 
@@ -894,20 +895,42 @@ class HostImportedLocalSession:
 
 @dataclass
 class HostImportLocalFrame:
-    """Server → host: read the host's recent local transcripts for a harness.
+    """Server → host: read recent local transcripts for a harness.
 
     The host owns the transcripts (``~/.claude`` etc.); the server can't see
-    them, so it asks the host to enumerate + normalize the most recent ones.
+    them, so it asks the host to enumerate and normalize the most recent ones.
 
     :param request_id: Unique id for correlating the result.
     :param source: Harness whose local sessions to read, e.g. ``"claude"``, or
         ``"all"`` to read every supported harness on the host in one batch.
     :param limit: Maximum number of most-recent sessions to return per harness.
+    :param max_chunk_bytes: When positive, the host may split an oversized
+        session across several ``host.import_local_session`` frames whose item
+        batches stay near this budget. ``0`` (an older server that can't
+        reassemble chunks) means send each session in one frame.
     """
 
     request_id: str
     source: str
     limit: int = 10
+    max_chunk_bytes: int = 0
+
+
+@dataclass
+class HostImportLocalByIdFrame:
+    """Server → host: read one known local transcript without listing.
+
+    :param request_id: Unique id for correlating the result.
+    :param source: Harness namespace containing the session.
+    :param session_id: Exact harness-native session id to load.
+    :param max_chunk_bytes: Chunking budget, same meaning as on
+        :class:`HostImportLocalFrame`.
+    """
+
+    request_id: str
+    source: str
+    session_id: str
+    max_chunk_bytes: int = 0
 
 
 @dataclass
@@ -918,14 +941,25 @@ class HostImportLocalSessionFrame:
     server persists each on arrival). ``total`` is the number of sessions the
     host expects to stream for this request, so the server can report progress.
 
+    A session larger than the request's ``max_chunk_bytes`` is split across
+    several frames sharing one ``session.external_session_id``: ``chunk_index``
+    counts them from 0 and ``last_chunk`` marks the final one, so the server
+    appends each batch to the same conversation. A session that fits sends one
+    frame with ``chunk_index=0`` and ``last_chunk=True`` (an older host that
+    never chunks always sends exactly that).
+
     :param request_id: Correlates to the :class:`HostImportLocalFrame`.
     :param total: Total sessions the host will stream for this request.
-    :param session: The normalized session to persist.
+    :param session: The normalized session (or one item batch of it) to persist.
+    :param chunk_index: 0-based position of this batch within its session.
+    :param last_chunk: Whether this is the session's final batch.
     """
 
     request_id: str
     total: int
     session: HostImportedLocalSession
+    chunk_index: int = 0
+    last_chunk: bool = True
 
 
 @dataclass
@@ -980,6 +1014,7 @@ HostFrame = (
     | HostModelOptionsFrame
     | HostModelOptionsResultFrame
     | HostImportLocalFrame
+    | HostImportLocalByIdFrame
     | HostImportLocalSessionFrame
     | HostImportLocalDoneFrame
 )
@@ -1351,6 +1386,17 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "request_id": frame.request_id,
                 "source": frame.source,
                 "limit": frame.limit,
+                "max_chunk_bytes": frame.max_chunk_bytes,
+            }
+        )
+    if isinstance(frame, HostImportLocalByIdFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.IMPORT_LOCAL_BY_ID.value,
+                "request_id": frame.request_id,
+                "source": frame.source,
+                "session_id": frame.session_id,
+                "max_chunk_bytes": frame.max_chunk_bytes,
             }
         )
     if isinstance(frame, HostImportLocalSessionFrame):
@@ -1360,6 +1406,8 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "kind": HostFrameKind.IMPORT_LOCAL_SESSION.value,
                 "request_id": frame.request_id,
                 "total": frame.total,
+                "chunk_index": frame.chunk_index,
+                "last_chunk": frame.last_chunk,
                 "session": {
                     "external_session_id": s.external_session_id,
                     "workspace": s.workspace,
@@ -1509,6 +1557,8 @@ def _decode_known_host_frame(
             return _decode_model_options_result(msg)
         case HostFrameKind.IMPORT_LOCAL:
             return _decode_import_local(msg)
+        case HostFrameKind.IMPORT_LOCAL_BY_ID:
+            return _decode_import_local_by_id(msg)
         case HostFrameKind.IMPORT_LOCAL_SESSION:
             return _decode_import_local_session(msg)
         case HostFrameKind.IMPORT_LOCAL_DONE:
@@ -2041,6 +2091,17 @@ def _decode_import_local(msg: _JsonObject) -> HostImportLocalFrame:
         request_id=_required_str(msg, "request_id"),
         source=_required_str(msg, "source"),
         limit=_required_int(msg, "limit"),
+        max_chunk_bytes=_optional_nonneg_int(msg, "max_chunk_bytes"),
+    )
+
+
+def _decode_import_local_by_id(msg: _JsonObject) -> HostImportLocalByIdFrame:
+    """Decode a host.import_local_by_id frame."""
+    return HostImportLocalByIdFrame(
+        request_id=_required_str(msg, "request_id"),
+        source=_required_str(msg, "source"),
+        session_id=_required_str(msg, "session_id"),
+        max_chunk_bytes=_optional_nonneg_int(msg, "max_chunk_bytes"),
     )
 
 
@@ -2070,11 +2131,21 @@ def _decode_imported_local_session(raw: object) -> HostImportedLocalSession:
 
 
 def _decode_import_local_session(msg: _JsonObject) -> HostImportLocalSessionFrame:
-    """Decode a host.import_local_session frame (one streamed session)."""
+    """Decode a host.import_local_session frame (one streamed session).
+
+    ``chunk_index`` / ``last_chunk`` are absent from hosts predating chunked
+    import; they default to a single complete chunk so an old host's one frame
+    decodes as a whole session.
+    """
+    last_chunk = msg.get("last_chunk", True)
+    if not isinstance(last_chunk, bool):
+        raise ValueError("frame field must be a bool: 'last_chunk'")
     return HostImportLocalSessionFrame(
         request_id=_required_str(msg, "request_id"),
         total=_required_int(msg, "total"),
         session=_decode_imported_local_session(msg.get("session")),
+        chunk_index=_optional_nonneg_int(msg, "chunk_index"),
+        last_chunk=last_chunk,
     )
 
 
@@ -2117,6 +2188,19 @@ def _required_int(msg: _JsonObject, key: str) -> int:
     val = msg.get(key)
     if not isinstance(val, int) or isinstance(val, bool):
         raise ValueError(f"frame missing required int field: {key!r}")
+    return val
+
+
+def _optional_nonneg_int(msg: _JsonObject, key: str) -> int:
+    """Return a non-negative int field, or 0 when absent/invalid.
+
+    Backward-compatible reader for fields added after the frame shipped: an
+    older peer omits them, so a missing or malformed value reads as 0 rather
+    than failing decode. Negative values are clamped to 0.
+    """
+    val = msg.get(key)
+    if not isinstance(val, int) or isinstance(val, bool) or val < 0:
+        return 0
     return val
 
 

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -140,6 +140,10 @@ class ServerInfoResponse(BaseModel):
     harness_install_enabled: bool
     installable_harnesses: list[str]
     dictation_available: bool
+    # Whether POST /v1/imports accepts an oversized session as chunk_index /
+    # final batches. Absent on older servers, so a client reads a missing key
+    # as False and posts each session in one body.
+    chunked_import_supported: bool
     branding: BrandingInfo
 
 
@@ -2169,6 +2173,7 @@ def create_app(
                 "harness_install_enabled": harness_install_enabled,
                 "installable_harnesses": installable_harnesses,
                 "dictation_available": dictation_available,
+                "chunked_import_supported": True,
                 "branding": branding_snapshot.config(),
             }
         )

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -760,6 +760,8 @@ async def _receive_loop(
                         "session",
                         {
                             "total": frame.total,
+                            "chunk_index": frame.chunk_index,
+                            "last_chunk": frame.last_chunk,
                             "external_session_id": s.external_session_id,
                             "workspace": s.workspace,
                             "items": s.items,

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -3,20 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import secrets
 import threading
-from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
 from typing import Any, Literal, cast, get_args
 
 from fastapi import APIRouter, Depends, Request, Response
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from omnigent.db.utils import builtin_agent_id
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.errors import ErrorCode, OmnigentError
-from omnigent.host.frames import HostImportLocalFrame, encode_host_frame
+from omnigent.host.frames import HostImportLocalByIdFrame, HostImportLocalFrame, encode_host_frame
 from omnigent.native_coding_agents import native_coding_agent_for_harness
 from omnigent.server.auth import LEVEL_OWNER, AuthProvider
 from omnigent.server.host_registry import HostConnection, HostRegistry
@@ -26,6 +27,7 @@ from omnigent.server.routes._host_launch import resolve_host_owner
 from omnigent.server.routes._session_create_validation import resolve_project_session_create
 from omnigent.server.schemas import SessionCreateRequest
 from omnigent.session_import import (
+    IMPORT_CHUNK_MAX_BYTES,
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
     IMPORT_SOURCE_LABEL_KEY,
     ImportSource,
@@ -67,6 +69,12 @@ class ImportSessionRequest(BaseModel):
     ``project_id`` files the imported session into a first-class project the
     caller owns, with the same ownership, default-fill, and mismatch-warning
     semantics as ``POST /v1/sessions``.
+
+    A session too large for one request body posts as several chunks sharing
+    one ``(source, external_session_id)``: ``chunk_index`` 0 creates the
+    conversation (honoring ``force``) and each later chunk appends its items to
+    it, with ``final`` set on the last. A default single-chunk request (``final``
+    true, ``chunk_index`` 0) is the whole session, exactly as before chunking.
     """
 
     source: ImportSource
@@ -76,6 +84,8 @@ class ImportSessionRequest(BaseModel):
     force: bool = False
     project_id: str | None = None
     items: list[ImportItemInput] = Field(min_length=1, max_length=_MAX_IMPORT_ITEMS)
+    chunk_index: int = Field(default=0, ge=0)
+    final: bool = True
 
     @field_validator("external_session_id")
     @classmethod
@@ -88,7 +98,12 @@ class ImportSessionRequest(BaseModel):
 
 
 class ImportSessionResponse(BaseModel):
-    """Result of importing or locating one source session."""
+    """Result of importing or appending to one source session.
+
+    ``item_count`` is the number of items this request persisted (the whole
+    session for a single-chunk import; one chunk's items for a chunked one, the
+    caller sums them for a total).
+    """
 
     session_id: str
     status: Literal["imported"]
@@ -96,11 +111,13 @@ class ImportSessionResponse(BaseModel):
 
 
 class LocalImportRequest(BaseModel):
-    """Request to import the caller's recent local harness sessions from a host.
+    """Request to import local harness sessions from a host.
 
     Unlike ``/imports`` (the CLI posts already-normalized items), the server
     asks the chosen host to read + normalize its own transcripts over the
-    tunnel — the transcripts live on the caller's machine, not the server.
+    tunnel — the transcripts live on the caller's machine, not the server. A
+    supplied ``session_id`` loads that exact session without enumerating any
+    local history.
     """
 
     host_id: str
@@ -108,6 +125,25 @@ class LocalImportRequest(BaseModel):
     # the host in one batch (each imported session keeps its own source).
     source: ImportSource | Literal["all"]
     limit: int = Field(default=10, ge=1, le=100)
+    session_id: str | None = Field(default=None, min_length=1, max_length=128)
+
+    @field_validator("session_id")
+    @classmethod
+    def strip_session_id(cls, value: str | None) -> str | None:
+        """Reject an exact session id that is only whitespace."""
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            raise ValueError("session_id must not be blank")
+        return value
+
+    @model_validator(mode="after")
+    def exact_import_needs_harness(self) -> LocalImportRequest:
+        """An id is only meaningful within one harness namespace."""
+        if self.session_id is not None and self.source == "all":
+            raise ValueError("an exact session import requires a specific harness")
+        return self
 
 
 class ImportedSessionRef(BaseModel):
@@ -136,6 +172,39 @@ class _ImportLockEntry:
 
     lock: asyncio.Lock
     users: int = 0
+
+
+@dataclass
+class _LocalImportTally:
+    """Running counts for one ``/imports/local`` batch."""
+
+    imported: int = 0
+    already_imported: int = 0
+    failed: int = 0
+    sessions: list[ImportedSessionRef] = field(default_factory=list)
+
+
+@dataclass
+class _InProgressImport:
+    """The session currently streaming in from a host, across its chunk frames.
+
+    A session over the chunk budget arrives as several frames; this holds its
+    conversation identity while the middle chunks append. Each terminal state
+    is tallied once: ``skip`` (already imported) counts at chunk 0, ``broken``
+    (a chunk failed) at the break, a healthy session at its last chunk.
+    """
+
+    conversation_id: str | None = None
+    external_id: str | None = None
+    title: str | None = None
+    item_count: int = 0
+    # A session is streaming (chunk 0 seen, last chunk not yet).
+    open: bool = False
+    # Already imported: drain its remaining chunks without persisting.
+    skip: bool = False
+    # A chunk failed to validate or persist: drain the rest; the partial
+    # conversation (if any) is deleted and the session tallied failed already.
+    broken: bool = False
 
 
 _IMPORT_LOCKS: dict[tuple[ImportSource, str], _ImportLockEntry] = {}
@@ -177,23 +246,42 @@ async def _stream_local_sessions_from_host(
     host_conn: HostConnection,
     source: str,
     limit: int,
+    session_id: str | None = None,
     stats: dict[str, int] | None = None,
 ) -> AsyncIterator[dict[str, Any]]:
-    """Yield the host's recent local sessions one at a time as they stream in.
+    """Yield requested local session chunks one at a time as they stream in.
 
     Sends a ``host.import_local`` frame and drains the per-request queue the
-    tunnel fills: each ``host.import_local_session`` frame yields one session
-    dict (``{total, external_session_id, workspace, items, title, source}``); the
-    terminal ``host.import_local_done`` ends the stream. The caller persists each
-    session as it arrives, so a large batch never buffers in one frame.
+    tunnel fills: each ``host.import_local_session`` frame yields one dict
+    (``{total, chunk_index, last_chunk, external_session_id, workspace, items,
+    title, source}``); the terminal ``host.import_local_done`` ends the stream.
+    A session that exceeds the request's ``max_chunk_bytes`` arrives as several
+    contiguous chunks sharing one ``external_session_id`` (``chunk_index``
+    counting up, ``last_chunk`` on the final one); a session that fits is a
+    single ``chunk_index=0`` / ``last_chunk=True`` dict. The caller appends each
+    chunk to the session's conversation as it arrives, so no session ever
+    buffers whole in one frame.
 
     :raises OmnigentError: If the host connection drops, a frame times out, or
         the host reports a read failure.
     """
     request_id = secrets.token_hex(8)
-    frame = encode_host_frame(
-        HostImportLocalFrame(request_id=request_id, source=source, limit=limit)
+    request_frame = (
+        HostImportLocalByIdFrame(
+            request_id=request_id,
+            source=source,
+            session_id=session_id,
+            max_chunk_bytes=IMPORT_CHUNK_MAX_BYTES,
+        )
+        if session_id is not None
+        else HostImportLocalFrame(
+            request_id=request_id,
+            source=source,
+            limit=limit,
+            max_chunk_bytes=IMPORT_CHUNK_MAX_BYTES,
+        )
     )
+    frame = encode_host_frame(request_frame)
     queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
     host_conn.pending_import_local[request_id] = queue
     try:
@@ -228,6 +316,146 @@ async def _stream_local_sessions_from_host(
                 return
     finally:
         host_conn.pending_import_local.pop(request_id, None)
+
+
+async def _consume_local_import_stream(
+    chunks: AsyncIterator[dict[str, Any]],
+    *,
+    conversation_store: ConversationStore,
+    persist_import: Callable[..., Awaitable[tuple[str, str | None]]],
+    user_id: str | None,
+    request_source: str,
+    stats: dict[str, int],
+) -> LocalImportResponse:
+    """Persist the host's streamed session chunks, appending oversized ones.
+
+    A session at or under the host's budget arrives as a single
+    ``chunk_index=0`` / ``last_chunk=True`` frame and imports whole; a larger
+    one arrives as contiguous chunks that share an ``external_session_id``, so
+    chunk 0 creates the conversation and each later chunk appends to it. Each
+    session lands one tally: an already-imported session counts at chunk 0, a
+    session broken by a bad chunk counts at the break (its partial conversation
+    deleted), a healthy one at its last chunk.
+    """
+    valid_sources = set(get_args(ImportSource))
+    tally = _LocalImportTally()
+    cur = _InProgressImport()
+
+    async def _abandon_partial() -> None:
+        """Delete a half-appended conversation so a broken session leaves none."""
+        if cur.conversation_id is not None:
+            with contextlib.suppress(Exception):
+                await conversation_store.delete_conversation(cur.conversation_id)
+
+    def _parse_items(raw_items: list[object]) -> list[NewConversationItem]:
+        items = [ImportItemInput.model_validate(raw).to_item() for raw in raw_items]
+        if cur.item_count + len(items) > _MAX_IMPORT_ITEMS:
+            raise ValueError("import exceeds item cap")
+        return items
+
+    async def _handle_chunk(chunk: dict[str, Any]) -> None:
+        nonlocal cur
+        chunk_index = chunk.get("chunk_index") or 0
+        last_chunk = bool(chunk.get("last_chunk", True))
+        external_session_id = chunk.get("external_session_id")
+        raw_items = chunk.get("items")
+        session_source = chunk.get("source")
+        source = (
+            session_source
+            if session_source in valid_sources
+            else (request_source if request_source in valid_sources else None)
+        )
+
+        if chunk_index == 0:
+            # A new session begins; any earlier one has ended (the host always
+            # finishes a session before starting the next).
+            cur = _InProgressImport(external_id=cast("str | None", external_session_id))
+            if (
+                not isinstance(external_session_id, str)
+                or not isinstance(raw_items, list)
+                or source is None
+            ):
+                tally.failed += 1
+                cur.broken = True
+                return
+            # Narrowed to a concrete harness (get_args excludes "all").
+            source = cast(ImportSource, source)
+            existing = await asyncio.to_thread(
+                conversation_store.find_imported_conversation, source, external_session_id
+            )
+            if existing is not None:
+                tally.already_imported += 1
+                cur.skip = True
+                return
+            try:
+                items = _parse_items(raw_items)
+                workspace = chunk.get("workspace")
+                native_title = chunk.get("title")
+                session_id, title = await persist_import(
+                    source=source,
+                    external_session_id=external_session_id,
+                    items=items,
+                    workspace=workspace if isinstance(workspace, str) else None,
+                    user_id=user_id,
+                    native_title=native_title if isinstance(native_title, str) else None,
+                )
+            except (OmnigentError, ValueError):
+                tally.failed += 1
+                cur.broken = True
+                return
+            cur.conversation_id = session_id
+            cur.title = title
+            cur.item_count = len(items)
+            cur.open = True
+        else:
+            # A continuation chunk: append to the session chunk 0 created.
+            if cur.skip or cur.broken or not cur.open:
+                return
+            try:
+                if not isinstance(raw_items, list):
+                    raise ValueError("chunk items must be a list")
+                items = _parse_items(raw_items)
+                assert cur.conversation_id is not None
+                await asyncio.to_thread(conversation_store.append, cur.conversation_id, items)
+            except (OmnigentError, ValueError):
+                tally.failed += 1
+                await _abandon_partial()
+                # Closed as broken: the finally-cleanup must not re-delete or
+                # re-count it.
+                cur.broken = True
+                cur.open = False
+                return
+            cur.item_count += len(items)
+
+        if last_chunk and cur.open:
+            assert cur.conversation_id is not None
+            tally.imported += 1
+            tally.sessions.append(
+                ImportedSessionRef(session_id=cur.conversation_id, title=cur.title)
+            )
+            cur.open = False
+
+    try:
+        async for chunk in chunks:
+            await _handle_chunk(chunk)
+    finally:
+        # A partial left open here is either a stream that raised mid-chunk
+        # (host drop) or a misbehaving host that never sent the last chunk;
+        # either way drop it so a retry re-imports cleanly rather than skipping
+        # a truncated conversation as already-imported.
+        if cur.open:
+            await _abandon_partial()
+            tally.failed += 1
+
+    # Fold in sessions the host enumerated but couldn't read, so the counts
+    # account for every target the user asked to import.
+    tally.failed += stats.get("host_failed", 0)
+    return LocalImportResponse(
+        imported=tally.imported,
+        already_imported=tally.already_imported,
+        failed=tally.failed,
+        sessions=tally.sessions,
+    )
 
 
 def create_imports_router(
@@ -346,7 +574,14 @@ def create_imports_router(
         request: Request,
         response: Response,
     ) -> ImportSessionResponse:
-        """Import one normalized transcript, optionally replacing its prior import."""
+        """Import one normalized transcript, optionally replacing its prior import.
+
+        A large session posts as several chunks: ``chunk_index`` 0 creates the
+        conversation (replacing any prior import when ``force``); each later
+        chunk appends its items to that conversation. The per-source lock
+        (``_serialize_source_import``) keeps concurrent imports of the same
+        session from interleaving their chunks.
+        """
         user_id = require_user(request, auth_provider)
         items = [item.to_item() for item in body.items]
         existing = await asyncio.to_thread(
@@ -354,6 +589,27 @@ def create_imports_router(
             body.source,
             body.external_session_id,
         )
+
+        if body.chunk_index > 0:
+            # Continuation of a chunked import: append to the conversation an
+            # earlier chunk created. A missing conversation means chunk 0 never
+            # landed (or was rolled back) — nothing to append to.
+            if existing is None:
+                raise OmnigentError(
+                    f"No in-progress import to append to for this {body.source} session",
+                    code=ErrorCode.CONFLICT,
+                )
+            await require_access(
+                user_id, existing.id, LEVEL_OWNER, permission_store, conversation_store
+            )
+            await asyncio.to_thread(conversation_store.append, existing.id, items)
+            response.status_code = 200
+            return ImportSessionResponse(
+                session_id=existing.id,
+                status="imported",
+                item_count=len(items),
+            )
+
         if existing is not None:
             await require_access(
                 user_id,
@@ -397,13 +653,13 @@ def create_imports_router(
         body: LocalImportRequest,
         request: Request,
     ) -> LocalImportResponse:
-        """Import the caller's recent local transcripts from a chosen host.
+        """Import local transcripts from a chosen host.
 
         The transcripts live on the caller's machine, so the read happens on
         the connected host over its tunnel — the server can't see them. The
-        host enumerates + normalizes the most recent sessions; the server
-        imports those not already imported. Drives the web "Import sessions"
-        button.
+        host loads an exact id or enumerates recent sessions, then normalizes
+        them; the server imports those not already imported. Drives the web
+        "Import sessions" button.
 
         Not atomic: each session is persisted as its frame arrives. If the host
         drops mid-stream this raises after the sessions read so far are already
@@ -424,80 +680,25 @@ def create_imports_router(
                 code=ErrorCode.CONFLICT,
             )
 
-        # Each session carries its own source (an "all" import mixes harnesses),
-        # falling back to the request source for a single-harness import.
-        valid_sources = set(get_args(ImportSource))
-        imported = 0
-        already_imported = 0
-        failed = 0
-        sessions: list[ImportedSessionRef] = []
-        # Set by the stream to the count of sessions the host couldn't read (no
-        # frame arrives for them); folded into ``failed`` after the loop.
+        # The host streams each session as one or more chunk frames; the
+        # consumer creates on chunk 0 and appends each later chunk (an oversized
+        # session), so nothing ever buffers a whole transcript here. ``stats``
+        # is filled by the stream on its done frame and read after it drains.
         stats: dict[str, int] = {}
-        # Persist each session as it streams in from the host (one frame each),
-        # rather than buffering the whole batch.
-        async for session in _stream_local_sessions_from_host(
-            host_registry=host_registry,
-            host_conn=host_conn,
-            source=body.source,
-            limit=body.limit,
+        return await _consume_local_import_stream(
+            _stream_local_sessions_from_host(
+                host_registry=host_registry,
+                host_conn=host_conn,
+                source=body.source,
+                limit=body.limit,
+                session_id=body.session_id,
+                stats=stats,
+            ),
+            conversation_store=conversation_store,
+            persist_import=_persist_import,
+            user_id=user_id,
+            request_source=body.source,
             stats=stats,
-        ):
-            external_session_id = session.get("external_session_id")
-            raw_items = session.get("items")
-            session_source = session.get("source")
-            source = (
-                session_source
-                if session_source in valid_sources
-                else (body.source if body.source in valid_sources else None)
-            )
-            if (
-                not isinstance(external_session_id, str)
-                or not isinstance(raw_items, list)
-                or source is None
-                # Mirror the /imports item cap so one oversized transcript can't
-                # balloon a batch import's memory.
-                or len(raw_items) > _MAX_IMPORT_ITEMS
-            ):
-                failed += 1
-                continue
-            # The guard above rejected None and anything outside valid_sources
-            # (get_args(ImportSource), which excludes "all"), so this is a
-            # concrete harness — narrow off the request's ImportSource | "all".
-            source = cast(ImportSource, source)
-            existing = await asyncio.to_thread(
-                conversation_store.find_imported_conversation,
-                source,
-                external_session_id,
-            )
-            if existing is not None:
-                already_imported += 1
-                continue
-            try:
-                items = [ImportItemInput.model_validate(raw).to_item() for raw in raw_items]
-                workspace = session.get("workspace")
-                native_title = session.get("title")
-                session_id, title = await _persist_import(
-                    source=source,
-                    external_session_id=external_session_id,
-                    items=items,
-                    workspace=workspace if isinstance(workspace, str) else None,
-                    user_id=user_id,
-                    native_title=native_title if isinstance(native_title, str) else None,
-                )
-            except (OmnigentError, ValueError):
-                failed += 1
-                continue
-            imported += 1
-            sessions.append(ImportedSessionRef(session_id=session_id, title=title))
-        # Fold in sessions the host enumerated but couldn't read, so the counts
-        # account for every target the user asked to import.
-        failed += stats.get("host_failed", 0)
-        return LocalImportResponse(
-            imported=imported,
-            already_imported=already_imported,
-            failed=failed,
-            sessions=sessions,
         )
 
     return router

--- a/omnigent/session_import/__init__.py
+++ b/omnigent/session_import/__init__.py
@@ -1,5 +1,10 @@
 """Shared models for importing local coding-harness sessions."""
 
+from omnigent.session_import.chunking import (
+    IMPORT_CHUNK_MAX_BYTES,
+    iter_item_chunks,
+    total_item_bytes,
+)
 from omnigent.session_import.models import (
     IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
     IMPORT_PROVENANCE_LABEL_KEYS,
@@ -11,11 +16,14 @@ from omnigent.session_import.models import (
 )
 
 __all__ = [
+    "IMPORT_CHUNK_MAX_BYTES",
     "IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY",
     "IMPORT_PROVENANCE_LABEL_KEYS",
     "IMPORT_SOURCE_LABEL_KEY",
     "ImportSource",
     "LocalSessionImport",
     "SessionImportNotFoundError",
+    "iter_item_chunks",
     "title_from_items",
+    "total_item_bytes",
 ]

--- a/omnigent/session_import/chunking.py
+++ b/omnigent/session_import/chunking.py
@@ -1,0 +1,57 @@
+"""Split an imported session's items into transport-sized batches.
+
+One import session can be arbitrarily large, but the host->server tunnel caps a
+single websocket message and the CLI posts one HTTP body — so a session past a
+size threshold rides as several item batches appended to the same conversation
+instead of one payload. The host stream and the CLI share this one budget so a
+batch built on either side stays under the same wall.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Sequence
+from typing import TypeVar
+
+# Sessions whose serialized items total at or below this import in one shot (one
+# frame / one POST body), exactly as before chunking existed; only larger ones
+# are split and appended incrementally. Kept well under the 100 MB tunnel frame
+# cap (:data:`RUNNER_TUNNEL_MAX_MESSAGE_BYTES`) so an individual batch, plus its
+# frame envelope, never approaches it.
+IMPORT_CHUNK_MAX_BYTES = 2 * 1024 * 1024
+
+_T = TypeVar("_T")
+
+
+def _item_bytes(item: object) -> int:
+    """Approximate one item's serialized size, as the chunker measures it."""
+    return len(json.dumps(item, separators=(",", ":")).encode())
+
+
+def total_item_bytes(items: Sequence[object]) -> int:
+    """Serialized byte total of ``items`` under the chunker's own measure."""
+    return sum(_item_bytes(item) for item in items)
+
+
+def iter_item_chunks(
+    items: Sequence[_T], *, max_bytes: int = IMPORT_CHUNK_MAX_BYTES
+) -> Iterator[list[_T]]:
+    """Yield consecutive item batches each serializing to about ``max_bytes``.
+
+    A batch holds as many consecutive items as fit under the budget. A single
+    item larger than the budget rides alone in its own batch — the transport,
+    not this split, is the hard cap on absolute size. A non-empty input always
+    yields at least one batch; an empty input yields nothing.
+    """
+    batch: list[_T] = []
+    batch_bytes = 0
+    for item in items:
+        size = _item_bytes(item)
+        if batch and batch_bytes + size > max_bytes:
+            yield batch
+            batch = []
+            batch_bytes = 0
+        batch.append(item)
+        batch_bytes += size
+    if batch:
+        yield batch

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -7,11 +7,15 @@ import os
 import re
 import sqlite3
 import subprocess
+from collections.abc import Sequence
 from hashlib import sha256
 from pathlib import Path
 from typing import get_args
 
-from omnigent.claude_native_bridge import read_transcript_items_from_offset
+from omnigent.claude_native_bridge import (
+    ClaudeTranscriptItem,
+    read_transcript_items_from_offset,
+)
 from omnigent.codex_native import _CODEX_THREAD_ID_RE, _find_codex_rollout
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.kimi_native_credentials import resolve_user_kimi_home
@@ -39,6 +43,27 @@ _OPENCODE_IMPORT_SESSION_ID_RE = re.compile(r"ses_[A-Za-z0-9_-]+")
 _MAX_EXTERNAL_SESSION_ID_LENGTH = 128
 _MAX_RESPONSE_ID_LENGTH = 64
 _OPENCODE_COMMAND_TIMEOUT_SECONDS = 120
+
+# Transcript byte size past which an import is trimmed to the last compaction
+# boundary instead of the full history. Below it the whole transcript imports
+# (cheap, and the full record is useful to browse); above it the file has almost
+# certainly been compacted at least once, so importing every pre-compaction
+# record replays megabytes the live agent no longer sees. Shared by the Claude
+# (``isCompactSummary``) and Codex (``compacted`` record) paths — see
+# docs/session-compaction.md.
+_IMPORT_COMPACT_TRIM_BYTES = 2 * 1024 * 1024
+
+
+def _exceeds_compaction_trim_size(path: Path) -> bool:
+    """Whether a transcript is large enough to trim to its last compaction.
+
+    An unreadable size falls back to ``False`` — import the whole transcript
+    rather than drop history on a failed ``stat``.
+    """
+    try:
+        return path.stat().st_size > _IMPORT_COMPACT_TRIM_BYTES
+    except OSError:
+        return False
 
 
 def _bounded_response_id(response_id: str) -> str:
@@ -371,6 +396,25 @@ def _claude_native_title(transcript_path: Path) -> str | None:
     return custom or ai
 
 
+def _items_from_last_compaction(
+    items: Sequence[ClaudeTranscriptItem],
+) -> Sequence[ClaudeTranscriptItem]:
+    """Slice ``items`` from the last compaction summary onward.
+
+    Claude flags the continuation summary it writes after compacting its own
+    context with ``is_compact_summary`` — the durable compaction boundary (see
+    :mod:`omnigent.claude_native_bridge`). The live agent resumes from that
+    summary, not the full transcript, so keeping the summary and everything
+    after it mirrors the agent's working context. Returns ``items`` unchanged
+    when the transcript was never compacted.
+    """
+    last = None
+    for index, item in enumerate(items):
+        if item.is_compact_summary:
+            last = index
+    return items if last is None else items[last:]
+
+
 def load_claude_session(
     session_id: str,
     *,
@@ -390,13 +434,19 @@ def load_claude_session(
         start_line=0,
         agent_name="claude-native-ui",
     )
+    # A large transcript has almost certainly compacted; import only what the
+    # agent would still see (from the last compaction boundary). See
+    # docs/session-compaction.md.
+    source_items: Sequence[ClaudeTranscriptItem] = parsed.items
+    if _exceeds_compaction_trim_size(transcript_path):
+        source_items = _items_from_last_compaction(parsed.items)
     items = tuple(
         NewConversationItem(
             type=item.item_type,
             response_id=item.response_id,
             data=parse_item_data(item.item_type, item.data),
         )
-        for item in parsed.items
+        for item in source_items
     )
     if not items:
         raise SessionImportNotFoundError(
@@ -593,6 +643,28 @@ def _codex_native_title(home: Path, session_id: str) -> str | None:
     return None
 
 
+def _codex_compacted_baseline_items(payload: dict[str, object]) -> list[NewConversationItem]:
+    """Convert a Codex ``compacted`` record's replacement_history into items.
+
+    Codex appends ``{type: "compacted", payload: {replacement_history: [...]}}``
+    after compacting; ``replacement_history`` is the post-compaction context
+    baseline it resumes from (the summary plus any retained messages), each entry
+    response-item shaped. Unsupported entries (e.g. reasoning) parse to ``None``
+    and are skipped, mirroring the ordinary response-item path.
+    """
+    history = payload.get("replacement_history")
+    if not isinstance(history, list):
+        return []
+    baseline: list[NewConversationItem] = []
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        item = _codex_response_item(entry, response_id="codex:compaction")
+        if item is not None:
+            baseline.append(item)
+    return baseline
+
+
 def load_codex_session(
     session_id: str,
     *,
@@ -607,6 +679,11 @@ def load_codex_session(
     )
     if rollout_path is None:
         raise SessionImportNotFoundError(f"Codex session {session_id!r} was not found")
+
+    # Past the size threshold, restart from each compaction boundary so the
+    # import matches what the agent resumes with, dropping the pre-compaction
+    # records it no longer sees. See docs/session-compaction.md.
+    trim_at_compaction = _exceeds_compaction_trim_size(rollout_path)
 
     workspace: str | None = None
     turn_id = "history"
@@ -629,6 +706,17 @@ def load_codex_session(
                 candidate = payload.get("turn_id")
                 if isinstance(candidate, str) and candidate:
                     turn_id = candidate
+                continue
+            if record.get("type") == "compacted":
+                # replacement_history is the new context baseline; resetting to it
+                # discards prior items so only the last compaction's baseline and
+                # what follows survive (mirrors the terminal agent on resume). A
+                # boundary with no usable baseline is ignored rather than wiping
+                # history to nothing (matches _read_compacted_history's guard).
+                if trim_at_compaction:
+                    baseline = _codex_compacted_baseline_items(payload)
+                    if baseline:
+                        items = baseline
                 continue
             if record.get("type") != "response_item":
                 continue

--- a/openapi.json
+++ b/openapi.json
@@ -2251,13 +2251,25 @@
         "type": "object"
       },
       "ImportSessionRequest": {
-        "description": "Request body for importing one local harness session.\n\n`project_id` files the imported session into a first-class project the\ncaller owns, with the same ownership, default-fill, and mismatch-warning\nsemantics as `POST /v1/sessions`.",
+        "description": "Request body for importing one local harness session.\n\n`project_id` files the imported session into a first-class project the\ncaller owns, with the same ownership, default-fill, and mismatch-warning\nsemantics as `POST /v1/sessions`.\n\nA session too large for one request body posts as several chunks sharing\none `(source, external_session_id)`: `chunk_index` 0 creates the\nconversation (honoring `force`) and each later chunk appends its items to\nit, with `final` set on the last. A default single-chunk request (`final`\ntrue, `chunk_index` 0) is the whole session, exactly as before chunking.",
         "properties": {
+          "chunk_index": {
+            "default": 0,
+            "format": "int64",
+            "minimum": 0.0,
+            "title": "Chunk Index",
+            "type": "integer"
+          },
           "external_session_id": {
             "maxLength": 128,
             "minLength": 1,
             "title": "External Session Id",
             "type": "string"
+          },
+          "final": {
+            "default": true,
+            "title": "Final",
+            "type": "boolean"
           },
           "force": {
             "default": false,
@@ -2331,7 +2343,7 @@
         "type": "object"
       },
       "ImportSessionResponse": {
-        "description": "Result of importing or locating one source session.",
+        "description": "Result of importing or appending to one source session.\n\n`item_count` is the number of items this request persisted (the whole\nsession for a single-chunk import; one chunk's items for a chunked one, the\ncaller sums them for a total).",
         "properties": {
           "item_count": {
             "format": "int64",
@@ -2497,7 +2509,7 @@
         "type": "object"
       },
       "LocalImportRequest": {
-        "description": "Request to import the caller's recent local harness sessions from a host.\n\nUnlike `/imports` (the CLI posts already-normalized items), the server\nasks the chosen host to read + normalize its own transcripts over the\ntunnel \u2014 the transcripts live on the caller's machine, not the server.",
+        "description": "Request to import local harness sessions from a host.\n\nUnlike `/imports` (the CLI posts already-normalized items), the server\nasks the chosen host to read + normalize its own transcripts over the\ntunnel \u2014 the transcripts live on the caller's machine, not the server. A\nsupplied `session_id` loads that exact session without enumerating any\nlocal history.",
         "properties": {
           "host_id": {
             "title": "Host Id",
@@ -2510,6 +2522,19 @@
             "minimum": 1.0,
             "title": "Limit",
             "type": "integer"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
           },
           "source": {
             "anyOf": [
@@ -4005,6 +4030,10 @@
           "branding": {
             "$ref": "#/components/schemas/BrandingInfo"
           },
+          "chunked_import_supported": {
+            "title": "Chunked Import Supported",
+            "type": "boolean"
+          },
           "databricks_features": {
             "title": "Databricks Features",
             "type": "boolean"
@@ -4116,6 +4145,7 @@
           "harness_install_enabled",
           "installable_harnesses",
           "dictation_available",
+          "chunked_import_supported",
           "branding"
         ],
         "title": "ServerInfoResponse",
@@ -9021,7 +9051,7 @@
     },
     "/v1/imports": {
       "post": {
-        "description": "Import one normalized transcript, optionally replacing its prior import.",
+        "description": "Import one normalized transcript, optionally replacing its prior import.\n\nA large session posts as several chunks: `chunk_index` 0 creates the\nconversation (replacing any prior import when `force`); each later\nchunk appends its items to that conversation. The per-source lock\n(`_serialize_source_import`) keeps concurrent imports of the same\nsession from interleaving their chunks.",
         "operationId": "import_session_v1_imports_post",
         "requestBody": {
           "content": {
@@ -9063,7 +9093,7 @@
     },
     "/v1/imports/local": {
       "post": {
-        "description": "Import the caller's recent local transcripts from a chosen host.\n\nThe transcripts live on the caller's machine, so the read happens on\nthe connected host over its tunnel \u2014 the server can't see them. The\nhost enumerates + normalizes the most recent sessions; the server\nimports those not already imported. Drives the web \"Import sessions\"\nbutton.\n\nNot atomic: each session is persisted as its frame arrives. If the host\ndrops mid-stream this raises after the sessions read so far are already\ncommitted; a retry is idempotent (they come back as already-imported).",
+        "description": "Import local transcripts from a chosen host.\n\nThe transcripts live on the caller's machine, so the read happens on\nthe connected host over its tunnel \u2014 the server can't see them. The\nhost loads an exact id or enumerates recent sessions, then normalizes\nthem; the server imports those not already imported. Drives the web\n\"Import sessions\" button.\n\nNot atomic: each session is persisted as its frame arrives. If the host\ndrops mid-stream this raises after the sessions read so far are already\ncommitted; a retry is idempotent (they come back as already-imported).",
         "operationId": "import_local_sessions_v1_imports_local_post",
         "requestBody": {
           "content": {

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -114,6 +114,65 @@ def test_import_command_sends_force_override(tmp_path: Path) -> None:
     assert "conv_replaced" in result.output
 
 
+def _write_large_claude_transcript(
+    home: Path, session_id: str, *, records: int, chars: int
+) -> None:
+    """Write a multi-record transcript whose normalized items exceed the chunk budget."""
+    transcript = home / ".claude" / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps(
+            {
+                "type": "user",
+                "uuid": f"user-{i}",
+                "cwd": "/repo",
+                "message": {"role": "user", "content": "x" * chars},
+            }
+        )
+        for i in range(records)
+    ]
+    transcript.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@respx.mock
+def test_import_command_chunks_oversized_session_when_server_supports_it(tmp_path: Path) -> None:
+    """A >2 MB session probes /v1/info, then posts create + append chunks."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def0aaaaaaaa"
+    # ~2.2 MB of normalized items forces at least two ~2 MB batches.
+    _write_large_claude_transcript(tmp_path, session_id, records=40, chars=60_000)
+
+    info = respx.get(f"{_BASE}/v1/info").mock(
+        return_value=httpx.Response(200, json={"chunked_import_supported": True})
+    )
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        final = json.loads(request.content).get("final")
+        return httpx.Response(
+            200 if final is False else 201,
+            json={"session_id": "conv_big", "status": "imported", "item_count": 1},
+        )
+
+    route = respx.post(f"{_BASE}/v1/imports").mock(side_effect=_respond)
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--session", session_id],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    # The oversized session probed for chunk support, then split into >1 request.
+    assert info.called
+    assert route.call_count > 1
+    payloads = [json.loads(call.request.content) for call in route.calls]
+    assert [p["chunk_index"] for p in payloads] == list(range(len(payloads)))
+    assert payloads[0]["final"] is False and payloads[-1]["final"] is True
+    # Every chunk targets the one session; only the create chunk carries force.
+    assert {p["external_session_id"] for p in payloads} == {session_id}
+    assert "force" in payloads[0] and "force" not in payloads[-1]
+
+
 def test_import_command_rejects_cursor() -> None:
     """The import command rejects sources without a supported adapter."""
     result = CliRunner().invoke(

--- a/tests/e2e_ui/sessions/test_import_sessions.py
+++ b/tests/e2e_ui/sessions/test_import_sessions.py
@@ -90,6 +90,46 @@ def test_settings_import_panel_imports_and_links_sessions(
     assert captured["post"] == {"host_id": _HOST_ID, "source": "all", "limit": 25}
 
 
+def test_settings_import_panel_imports_one_session_by_id(
+    page: Page,
+    live_server: str,
+) -> None:
+    """Settings can import an exact harness session without showing a session list."""
+    captured: dict[str, object] = {}
+
+    def _handle_import(route: Route) -> None:
+        captured["post"] = route.request.post_data_json
+        _fulfill_json(
+            route,
+            {
+                "imported": 1,
+                "already_imported": 0,
+                "failed": 0,
+                "sessions": [{"session_id": "conv_exact", "title": "Exact import"}],
+            },
+        )
+
+    page.route("**/v1/hosts", lambda r: _fulfill_json(r, _HOSTS_BODY))
+    page.route("**/v1/imports/local", _handle_import)
+    page.goto(f"{live_server}/settings/import")
+
+    expect(page.get_by_test_id("import-sessions-panel")).to_be_visible(timeout=30_000)
+    page.get_by_test_id("import-mode-select").click()
+    page.get_by_role("option", name="Session by ID").click()
+    page.get_by_test_id("import-source-select").click()
+    page.get_by_role("option", name="Codex").click()
+    page.get_by_test_id("import-session-id").fill("session-exact")
+    page.get_by_test_id("import-submit").click()
+
+    expect(page.get_by_test_id("import-result")).to_contain_text("Imported 1", timeout=30_000)
+    assert captured["post"] == {
+        "host_id": _HOST_ID,
+        "source": "codex",
+        "limit": 25,
+        "session_id": "session-exact",
+    }
+
+
 def test_empty_landing_choose_what_to_import_opens_settings(
     page: Page,
     live_server: str,

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5137,6 +5137,180 @@ async def test_handle_import_local_all_streams_a_frame_per_session(
     assert len(done_frames) == 1 and done_frames[0].status == "ok"
 
 
+async def test_handle_import_local_splits_oversized_session_into_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session past the server's chunk budget streams as ordered chunk frames."""
+    from omnigent.host.frames import (
+        HostImportLocalDoneFrame,
+        HostImportLocalSessionFrame,
+        decode_host_frame,
+    )
+
+    host = _make_host_process()
+
+    def _fake_ids(source: str, *, limit: int) -> list[str]:
+        return ["big"]
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        # Ten ~1 KB items; a 2.5 KB budget forces several chunks.
+        items = [
+            SimpleNamespace(
+                type="message",
+                response_id=f"r{i}",
+                data=SimpleNamespace(model_dump=lambda **_kw: {"text": "x" * 1000}),
+            )
+            for i in range(10)
+        ]
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=items,
+            title="Big session",
+            source=source,
+        )
+
+    monkeypatch.setattr("omnigent.session_import.local.list_recent_local_session_ids", _fake_ids)
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            sent.append(text)
+
+    await host._handle_import_local(
+        _FakeWs(),  # type: ignore[arg-type]
+        HostImportLocalFrame(request_id="req_big", source="claude", limit=5, max_chunk_bytes=2500),
+    )
+
+    frames = [decode_host_frame(text) for text in sent]
+    session_frames = [f for f in frames if isinstance(f, HostImportLocalSessionFrame)]
+    done_frames = [f for f in frames if isinstance(f, HostImportLocalDoneFrame)]
+
+    # Several contiguous chunks, all one session, index counting up.
+    assert len(session_frames) > 1
+    assert [f.chunk_index for f in session_frames] == list(range(len(session_frames)))
+    assert [f.last_chunk for f in session_frames] == [False] * (len(session_frames) - 1) + [True]
+    assert {f.session.external_session_id for f in session_frames} == {"big"}
+    # Every item lands exactly once, in order, split across the chunks.
+    all_items = [item for f in session_frames for item in f.session.items]
+    assert len(all_items) == 10
+    assert len(done_frames) == 1 and done_frames[0].status == "ok"
+
+
+async def test_handle_import_local_single_frame_when_no_chunk_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no budget (an older server) a big session still rides in one frame."""
+    from omnigent.host.frames import HostImportLocalSessionFrame, decode_host_frame
+
+    host = _make_host_process()
+
+    def _fake_ids(source: str, *, limit: int) -> list[str]:
+        return ["big"]
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        items = [
+            SimpleNamespace(
+                type="message",
+                response_id=f"r{i}",
+                data=SimpleNamespace(model_dump=lambda **_kw: {"text": "x" * 1000}),
+            )
+            for i in range(10)
+        ]
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=items,
+            title="Big session",
+            source=source,
+        )
+
+    monkeypatch.setattr("omnigent.session_import.local.list_recent_local_session_ids", _fake_ids)
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            sent.append(text)
+
+    await host._handle_import_local(
+        _FakeWs(),  # type: ignore[arg-type]
+        # max_chunk_bytes defaults to 0 — the older-server case.
+        HostImportLocalFrame(request_id="req_big", source="claude", limit=5),
+    )
+
+    frames = [decode_host_frame(text) for text in sent]
+    session_frames = [f for f in frames if isinstance(f, HostImportLocalSessionFrame)]
+    assert len(session_frames) == 1
+    assert session_frames[0].chunk_index == 0 and session_frames[0].last_chunk is True
+    assert len(session_frames[0].session.items) == 10
+
+
+async def test_handle_import_local_exact_id_does_not_list_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exact harness/id request loads that transcript without enumeration."""
+    from omnigent.host.frames import (
+        HostImportLocalByIdFrame,
+        HostImportLocalDoneFrame,
+        HostImportLocalSessionFrame,
+        decode_host_frame,
+    )
+
+    host = _make_host_process()
+
+    def _unexpected_list(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("exact import must not enumerate local sessions")
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        assert (source, session_id) == ("codex", "session-exact")
+        item = SimpleNamespace(
+            type="message",
+            response_id="r1",
+            data=SimpleNamespace(model_dump=lambda **_kw: {"role": "user"}),
+        )
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=[item],
+            title="Exact session",
+            source=source,
+        )
+
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_sessions_across_harnesses", _unexpected_list
+    )
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_local_session_ids", _unexpected_list
+    )
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            sent.append(text)
+
+    await host._handle_import_local(
+        _FakeWs(),  # type: ignore[arg-type]
+        HostImportLocalByIdFrame(
+            request_id="req_exact",
+            source="codex",
+            session_id="session-exact",
+        ),
+    )
+
+    frames = [decode_host_frame(text) for text in sent]
+    session_frames = [f for f in frames if isinstance(f, HostImportLocalSessionFrame)]
+    done_frames = [f for f in frames if isinstance(f, HostImportLocalDoneFrame)]
+    assert [f.session.external_session_id for f in session_frames] == ["session-exact"]
+    assert session_frames[0].total == 1
+    assert len(done_frames) == 1 and done_frames[0].status == "ok"
+
+
 async def test_handle_import_local_reports_unreadable_sessions_as_failed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5190,5 +5364,70 @@ async def test_handle_import_local_reports_unreadable_sessions_as_failed(
 
     # Only the readable session got a frame; the corrupt one is counted, not sent.
     assert [f.session.external_session_id for f in session_frames] == ["good"]
+    assert len(done_frames) == 1
+    assert done_frames[0].status == "ok" and done_frames[0].failed == 1
+
+
+async def test_handle_import_local_unexpected_error_skips_only_that_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected error loading one session must not abort the whole batch.
+
+    ``_load`` returns None for the expected read failures, but a surprise
+    exception type (here ``RuntimeError``) escapes it; the handler still has to
+    skip just that session and keep uploading the rest, ending status="ok".
+    """
+    from omnigent.host.frames import (
+        HostImportLocalDoneFrame,
+        HostImportLocalSessionFrame,
+        decode_host_frame,
+    )
+
+    host = _make_host_process()
+
+    # "bad" is streamed between two good sessions so a batch abort would drop
+    # the trailing "after" session.
+    def _fake_across(*, limit: int) -> list[tuple[str, str]]:
+        return [("claude", "before"), ("claude", "bad"), ("claude", "after")]
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        if session_id == "bad":
+            raise RuntimeError("normalizer blew up")
+        item = SimpleNamespace(
+            type="message",
+            response_id="r1",
+            data=SimpleNamespace(model_dump=lambda **_kw: {"role": "user"}),
+        )
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=[item],
+            title="ok",
+            source=source,
+        )
+
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_sessions_across_harnesses", _fake_across
+    )
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            sent.append(text)
+
+    await host._handle_import_local(
+        _FakeWs(),  # type: ignore[arg-type]
+        HostImportLocalFrame(request_id="req_boom", source="all", limit=5),
+    )
+
+    frames = [decode_host_frame(text) for text in sent]
+    session_frames = [f for f in frames if isinstance(f, HostImportLocalSessionFrame)]
+    done_frames = [f for f in frames if isinstance(f, HostImportLocalDoneFrame)]
+
+    # The batch runs (oldest first): both good sessions streamed, the bad one
+    # counted, and the stream closed cleanly rather than status="failed".
+    assert [f.session.external_session_id for f in session_frames] == ["after", "before"]
     assert len(done_frames) == 1
     assert done_frames[0].status == "ok" and done_frames[0].failed == 1

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -20,6 +20,7 @@ from omnigent.host.frames import (
     HostHarnessReadinessFrame,
     HostHelloFrame,
     HostImportedLocalSession,
+    HostImportLocalByIdFrame,
     HostImportLocalDoneFrame,
     HostImportLocalFrame,
     HostImportLocalSessionFrame,
@@ -56,6 +57,21 @@ def test_import_local_frames_round_trip() -> None:
         encode_host_frame(HostImportLocalFrame(request_id="req_imp", source="claude", limit=3))
     )
     assert request == HostImportLocalFrame(request_id="req_imp", source="claude", limit=3)
+
+    exact_request = decode_host_frame(
+        encode_host_frame(
+            HostImportLocalByIdFrame(
+                request_id="req_exact",
+                source="codex",
+                session_id="0198d07d-session",
+            )
+        )
+    )
+    assert exact_request == HostImportLocalByIdFrame(
+        request_id="req_exact",
+        source="codex",
+        session_id="0198d07d-session",
+    )
 
     session = decode_host_frame(
         encode_host_frame(
@@ -107,6 +123,76 @@ def test_import_local_frames_round_trip() -> None:
     )
     assert isinstance(done_failed, HostImportLocalDoneFrame)
     assert done_failed.failed == 2
+
+
+def test_import_local_chunk_fields_round_trip_and_backfill() -> None:
+    """Chunk-import fields survive the tunnel and default sanely for old peers."""
+    # Request frames carry the server's chunk budget.
+    req = decode_host_frame(
+        encode_host_frame(
+            HostImportLocalFrame(
+                request_id="r", source="claude", limit=3, max_chunk_bytes=2_097_152
+            )
+        )
+    )
+    assert isinstance(req, HostImportLocalFrame)
+    assert req.max_chunk_bytes == 2_097_152
+
+    by_id = decode_host_frame(
+        encode_host_frame(
+            HostImportLocalByIdFrame(
+                request_id="r", source="codex", session_id="s", max_chunk_bytes=4096
+            )
+        )
+    )
+    assert isinstance(by_id, HostImportLocalByIdFrame)
+    assert by_id.max_chunk_bytes == 4096
+
+    # A non-final session chunk round-trips its index and last-chunk flag.
+    mid = decode_host_frame(
+        encode_host_frame(
+            HostImportLocalSessionFrame(
+                request_id="r",
+                total=1,
+                chunk_index=2,
+                last_chunk=False,
+                session=HostImportedLocalSession(
+                    external_session_id="s1", workspace=None, items=[], title=None, source="claude"
+                ),
+            )
+        )
+    )
+    assert isinstance(mid, HostImportLocalSessionFrame)
+    assert mid.chunk_index == 2 and mid.last_chunk is False
+
+    # An older peer omits the new keys: a request reads a 0 budget (don't chunk)
+    # and a session frame reads one complete chunk.
+    old_req = decode_host_frame(
+        json.dumps(
+            {"kind": "host.import_local", "request_id": "r", "source": "claude", "limit": 3}
+        )
+    )
+    assert isinstance(old_req, HostImportLocalFrame)
+    assert old_req.max_chunk_bytes == 0
+
+    old_session = decode_host_frame(
+        json.dumps(
+            {
+                "kind": "host.import_local_session",
+                "request_id": "r",
+                "total": 1,
+                "session": {
+                    "external_session_id": "s1",
+                    "workspace": None,
+                    "items": [],
+                    "title": None,
+                    "source": "claude",
+                },
+            }
+        )
+    )
+    assert isinstance(old_session, HostImportLocalSessionFrame)
+    assert old_session.chunk_index == 0 and old_session.last_chunk is True
 
 
 def test_model_options_frames_round_trip() -> None:

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -9,8 +9,13 @@ import httpx
 import pytest
 
 from omnigent.db.utils import builtin_agent_id
-from omnigent.errors import OmnigentError
-from omnigent.server.routes.imports import _stream_local_sessions_from_host
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.server.routes.imports import (
+    ImportedSessionRef,
+    LocalImportRequest,
+    _consume_local_import_stream,
+    _stream_local_sessions_from_host,
+)
 from omnigent.stores.agent_store.sqlalchemy_store import SqlAlchemyAgentStore
 from omnigent.stores.conversation_store.sqlalchemy_store import SqlAlchemyConversationStore
 
@@ -195,6 +200,63 @@ async def test_force_import_replaces_existing_session(
     assert [item["content"][0]["text"] for item in items.json()["data"]] == ["new prompt"]
 
 
+def _msg(text: str, response_id: str = "claude:turn") -> dict[str, object]:
+    """One valid normalized user message item for import payloads."""
+    return {
+        "type": "message",
+        "response_id": response_id,
+        "data": {"role": "user", "content": [{"type": "input_text", "text": text}]},
+    }
+
+
+async def test_chunked_import_creates_then_appends_across_requests(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A large session posts as create + append chunks into one conversation."""
+    _seed_claude_agent(db_uri)
+    base = {"source": "claude", "external_session_id": "claude-chunked-1"}
+
+    first = await client.post(
+        "/v1/imports",
+        json={**base, "title": "Chunked", "items": [_msg("one", "claude:1")], "final": False},
+    )
+    assert first.status_code == 201
+    session_id = first.json()["session_id"]
+
+    second = await client.post(
+        "/v1/imports",
+        json={**base, "chunk_index": 1, "items": [_msg("two", "claude:2")], "final": True},
+    )
+    assert second.status_code == 200
+    assert second.json()["session_id"] == session_id
+
+    # Both chunks' items land in the one conversation, in order.
+    items = await client.get(f"/v1/sessions/{session_id}/items")
+    assert items.status_code == 200
+    assert [i["content"][0]["text"] for i in items.json()["data"]] == ["one", "two"]
+
+
+async def test_chunked_import_append_without_create_is_rejected(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """An append chunk with no created session fails rather than orphaning items."""
+    _seed_claude_agent(db_uri)
+    resp = await client.post(
+        "/v1/imports",
+        json={
+            "source": "claude",
+            "external_session_id": "claude-orphan-1",
+            "chunk_index": 1,
+            "items": [_msg("stray")],
+            "final": True,
+        },
+    )
+    assert resp.status_code == 409
+    assert "in-progress import" in resp.text
+
+
 async def test_import_session_rejects_empty_history(client: httpx.AsyncClient) -> None:
     """An empty parser result cannot create a permanently claimed session."""
     response = await client.post(
@@ -220,6 +282,15 @@ def test_imported_session_ref_allows_null_title() -> None:
 
     assert ImportedSessionRef(session_id="conv_x").title is None
     assert ImportedSessionRef(session_id="conv_y", title=None).title is None
+
+
+def test_exact_local_import_requires_one_harness_and_trims_id() -> None:
+    """An exact id is normalized and cannot be paired with the all selector."""
+    request = LocalImportRequest(host_id="h1", source="claude", session_id="  exact-id  ")
+    assert request.session_id == "exact-id"
+
+    with pytest.raises(ValueError, match="requires a specific harness"):
+        LocalImportRequest(host_id="h1", source="all", session_id="exact-id")
 
 
 async def test_stream_local_sessions_yields_each_then_stops_on_done() -> None:
@@ -268,6 +339,37 @@ async def test_stream_local_sessions_yields_each_then_stops_on_done() -> None:
     assert [s["external_session_id"] for s in got] == ["c1", "c2"]
     # The per-request queue is removed once the stream ends.
     assert conn.pending_import_local == {}
+
+
+async def test_stream_local_sessions_sends_exact_session_id() -> None:
+    """The server carries an exact id through the host tunnel request."""
+    from omnigent.host.frames import HostImportLocalByIdFrame, decode_host_frame
+
+    conn = SimpleNamespace(host_id="h1", pending_import_local={})
+    sent: list[HostImportLocalByIdFrame] = []
+
+    class _Reg:
+        def send_text(self, host_conn: object, frame: str) -> None:
+            decoded = decode_host_frame(frame)
+            assert isinstance(decoded, HostImportLocalByIdFrame)
+            sent.append(decoded)
+            (queue,) = conn.pending_import_local.values()
+            queue.put_nowait(("done", {"status": "ok", "error": None}))
+
+    got = [
+        session
+        async for session in _stream_local_sessions_from_host(
+            host_registry=_Reg(),  # type: ignore[arg-type]
+            host_conn=conn,  # type: ignore[arg-type]
+            source="codex",
+            limit=10,
+            session_id="session-exact",
+        )
+    ]
+
+    assert got == []
+    assert sent[0].source == "codex"
+    assert sent[0].session_id == "session-exact"
 
 
 async def test_stream_local_sessions_surfaces_host_failed_count() -> None:
@@ -321,3 +423,191 @@ async def test_stream_local_sessions_raises_on_failed_done() -> None:
             )
         ]
     assert conn.pending_import_local == {}
+
+
+# ── _consume_local_import_stream (chunk reassembly + incremental append) ──
+
+
+class _FakeConvStore:
+    """Minimal conversation store recording what the chunk consumer persists."""
+
+    def __init__(self, existing: set[tuple[str, str]] | None = None) -> None:
+        self.existing = existing or set()
+        self.appended: dict[str, list[object]] = {}
+        self.deleted: list[str] = []
+
+    def find_imported_conversation(self, source: str, external_id: str) -> object | None:
+        if (source, external_id) in self.existing:
+            return SimpleNamespace(id=f"conv-{external_id}")
+        return None
+
+    def append(self, conversation_id: str, items: list[object]) -> None:
+        self.appended.setdefault(conversation_id, []).extend(items)
+
+    async def delete_conversation(self, conversation_id: str) -> None:
+        self.deleted.append(conversation_id)
+
+
+def _chunk(
+    external_id: str,
+    texts: list[str],
+    *,
+    chunk_index: int,
+    last_chunk: bool,
+    source: str = "claude",
+    title: str | None = None,
+) -> dict[str, object]:
+    """One streamed session-chunk dict, as host_tunnel enqueues it."""
+    return {
+        "total": 1,
+        "chunk_index": chunk_index,
+        "last_chunk": last_chunk,
+        "external_session_id": external_id,
+        "workspace": None,
+        "title": title,
+        "source": source,
+        "items": [
+            {
+                "type": "message",
+                "response_id": f"{source}:{external_id}:{i}",
+                "data": {"role": "user", "content": [{"type": "input_text", "text": t}]},
+            }
+            for i, t in enumerate(texts)
+        ],
+    }
+
+
+async def _astream(chunks: list[dict[str, object]]):  # type: ignore[no-untyped-def]
+    for chunk in chunks:
+        yield chunk
+
+
+async def test_consume_stream_appends_multichunk_session_into_one_conversation() -> None:
+    """A session split across chunks creates once and appends each later chunk."""
+    store = _FakeConvStore()
+    created: list[dict[str, object]] = []
+
+    async def _persist(**kwargs: object) -> tuple[str, str | None]:
+        created.append(kwargs)
+        return "conv-big", "Big"
+
+    result = await _consume_local_import_stream(
+        _astream(
+            [
+                _chunk("big", ["a", "b"], chunk_index=0, last_chunk=False, title="Big"),
+                _chunk("big", ["c"], chunk_index=1, last_chunk=False),
+                _chunk("big", ["d"], chunk_index=2, last_chunk=True),
+            ]
+        ),
+        conversation_store=store,  # type: ignore[arg-type]
+        persist_import=_persist,
+        user_id="u1",
+        request_source="claude",
+        stats={},
+    )
+
+    assert result.imported == 1 and result.failed == 0
+    assert result.sessions == [ImportedSessionRef(session_id="conv-big", title="Big")]
+    # Chunk 0 created with its two items; chunks 1 and 2 appended their items.
+    assert len(created) == 1
+    assert len(created[0]["items"]) == 2  # type: ignore[arg-type]
+    assert len(store.appended["conv-big"]) == 2
+    assert store.deleted == []
+
+
+async def test_consume_stream_single_chunk_backward_compatible() -> None:
+    """One frame (old host: chunk_index 0, last_chunk true) imports whole."""
+    store = _FakeConvStore()
+
+    async def _persist(**kwargs: object) -> tuple[str, str | None]:
+        return "conv-s", "S"
+
+    result = await _consume_local_import_stream(
+        _astream([_chunk("s", ["only"], chunk_index=0, last_chunk=True)]),
+        conversation_store=store,  # type: ignore[arg-type]
+        persist_import=_persist,
+        user_id="u1",
+        request_source="claude",
+        stats={},
+    )
+    assert result.imported == 1
+    assert store.appended == {}  # a single chunk needs no append
+
+
+async def test_consume_stream_skips_already_imported_and_drains_its_chunks() -> None:
+    """An already-imported session is counted once; its later chunks are ignored."""
+    store = _FakeConvStore(existing={("claude", "dup")})
+    persisted = False
+
+    async def _persist(**kwargs: object) -> tuple[str, str | None]:
+        nonlocal persisted
+        persisted = True
+        return "conv-dup", None
+
+    result = await _consume_local_import_stream(
+        _astream(
+            [
+                _chunk("dup", ["a"], chunk_index=0, last_chunk=False),
+                _chunk("dup", ["b"], chunk_index=1, last_chunk=True),
+            ]
+        ),
+        conversation_store=store,  # type: ignore[arg-type]
+        persist_import=_persist,
+        user_id="u1",
+        request_source="claude",
+        stats={},
+    )
+    assert result.already_imported == 1 and result.imported == 0
+    assert persisted is False and store.appended == {}
+
+
+async def test_consume_stream_deletes_partial_when_a_later_chunk_fails() -> None:
+    """A failed append chunk drops the partial conversation and tallies failed."""
+    store = _FakeConvStore()
+
+    async def _persist(**kwargs: object) -> tuple[str, str | None]:
+        return "conv-bad", "Bad"
+
+    def _boom(conversation_id: str, items: list[object]) -> None:
+        raise ValueError("append blew up")
+
+    store.append = _boom  # type: ignore[assignment,method-assign]
+
+    result = await _consume_local_import_stream(
+        _astream(
+            [
+                _chunk("bad", ["a"], chunk_index=0, last_chunk=False),
+                _chunk("bad", ["b"], chunk_index=1, last_chunk=True),
+            ]
+        ),
+        conversation_store=store,  # type: ignore[arg-type]
+        persist_import=_persist,
+        user_id="u1",
+        request_source="claude",
+        stats={},
+    )
+    assert result.imported == 0 and result.failed == 1
+    assert store.deleted == ["conv-bad"]
+
+
+async def test_consume_stream_drops_partial_when_stream_raises_midway() -> None:
+    """A host drop mid-session deletes the partial before propagating the error."""
+    store = _FakeConvStore()
+
+    async def _persist(**kwargs: object) -> tuple[str, str | None]:
+        return "conv-drop", "D"
+
+    async def _raising_stream():  # type: ignore[no-untyped-def]
+        yield _chunk("drop", ["a"], chunk_index=0, last_chunk=False)
+        raise OmnigentError("host dropped", code=ErrorCode.CONFLICT)
+
+    with pytest.raises(OmnigentError, match="host dropped"):
+        await _consume_local_import_stream(
+            _raising_stream(),
+            conversation_store=store,  # type: ignore[arg-type]
+            persist_import=_persist,
+            user_id="u1",
+            request_source="claude",
+            stats={},
+        )
+    assert store.deleted == ["conv-drop"]

--- a/tests/session_import/test_chunking.py
+++ b/tests/session_import/test_chunking.py
@@ -1,0 +1,38 @@
+"""Tests for splitting an imported session's items into transport-sized batches."""
+
+from __future__ import annotations
+
+from omnigent.session_import.chunking import iter_item_chunks, total_item_bytes
+
+
+def test_small_session_stays_one_batch() -> None:
+    """Items under the budget ride together in a single batch."""
+    items = [{"i": i} for i in range(5)]
+    batches = list(iter_item_chunks(items, max_bytes=10_000))
+    assert batches == [items]
+
+
+def test_oversized_session_splits_and_preserves_order() -> None:
+    """A session over budget splits into contiguous, order-preserving batches."""
+    items = [{"i": i, "blob": "x" * 1000} for i in range(50)]
+    batches = list(iter_item_chunks(items, max_bytes=5000))
+    assert len(batches) > 1
+    # Every item lands exactly once, in the original order.
+    assert [item for batch in batches for item in batch] == items
+    # No middle batch exceeds the budget (the last may be short, not over).
+    for batch in batches:
+        assert total_item_bytes(batch) <= 5000 or len(batch) == 1
+
+
+def test_single_item_larger_than_budget_rides_alone() -> None:
+    """One item bigger than the whole budget still ships, alone in its batch."""
+    items = [{"small": 1}, {"huge": "x" * 20_000}, {"small": 2}]
+    batches = list(iter_item_chunks(items, max_bytes=1000))
+    # The oversized item is isolated so it neither drops nor drags neighbors over.
+    assert [{"huge": "x" * 20_000}] in batches
+    assert [item for batch in batches for item in batch] == items
+
+
+def test_empty_session_yields_nothing() -> None:
+    """No items means no batches (an empty import is rejected upstream, not here)."""
+    assert list(iter_item_chunks([])) == []

--- a/tests/test_session_import.py
+++ b/tests/test_session_import.py
@@ -25,7 +25,7 @@ from omnigent.session_import.local import (
     load_pi_session,
     load_qwen_session,
 )
-from omnigent.session_import.models import SessionImportNotFoundError
+from omnigent.session_import.models import LocalSessionImport, SessionImportNotFoundError
 
 
 def test_import_adapters_use_stable_forwarder_parser_contracts(tmp_path: Path) -> None:
@@ -478,6 +478,207 @@ def test_load_claude_session_rejects_empty_history(tmp_path: Path) -> None:
         load_claude_session(session_id, claude_home=tmp_path)
 
 
+def _write_claude_transcript_with_compaction(tmp_path: Path, session_id: str) -> Path:
+    """Write a transcript with a compaction summary splitting two turns."""
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "user",
+            "uuid": "user-pre",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "first question before compaction"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-pre",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "early reply"}]},
+        },
+        {
+            "type": "user",
+            "uuid": "compact-1",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "summary of the conversation so far"},
+        },
+        {
+            "type": "user",
+            "uuid": "user-post",
+            "message": {"role": "user", "content": "follow-up after compaction"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "assistant-post",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "later reply"}]},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+    return transcript
+
+
+def test_load_claude_session_keeps_full_history_below_size_threshold(tmp_path: Path) -> None:
+    """A small transcript imports whole, even when it contains a compaction summary."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_compaction(tmp_path, session_id)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    # Pre-compaction turn, the summary, and the post-compaction turn all present.
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    assert "first question before compaction" in texts
+    assert "summary of the conversation so far" in texts
+    assert "follow-up after compaction" in texts
+
+
+def test_load_claude_session_trims_to_last_compaction_when_large(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transcript past the size threshold imports only from the last compaction summary."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_compaction(tmp_path, session_id)
+    # Force the large-file path without writing multiple megabytes.
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    # Pre-compaction records the live agent no longer sees are dropped; the
+    # summary and everything after it are kept.
+    assert "first question before compaction" not in texts
+    assert "early reply" not in texts
+    assert "summary of the conversation so far" in texts
+    assert "follow-up after compaction" in texts
+    assert "later reply" in texts
+
+
+def test_load_claude_session_large_without_compaction_imports_all(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A large transcript that never compacted keeps its full history."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    _write_claude_transcript_with_titles(tmp_path, session_id, ai_title=None, custom_title=None)
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    # No isCompactSummary boundary → trimming is a no-op, first message stays.
+    assert imported.title == "inspect TODO.md"
+    assert imported.items
+
+
+def test_load_claude_session_trims_to_final_compaction_with_multiple(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With several compactions, only the last boundary onward is imported."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    records = [
+        {
+            "type": "user",
+            "uuid": "user-0",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": "original"},
+        },
+        {
+            "type": "user",
+            "uuid": "compact-1",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "first summary"},
+        },
+        {
+            "type": "user",
+            "uuid": "compact-2",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "second summary"},
+        },
+        {
+            "type": "user",
+            "uuid": "user-final",
+            "message": {"role": "user", "content": "after second"},
+        },
+    ]
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    assert "original" not in texts
+    assert "first summary" not in texts
+    assert "second summary" in texts
+    assert "after second" in texts
+
+
+def test_load_claude_session_trims_at_real_two_mb_threshold(tmp_path: Path) -> None:
+    """Past the real 2 MB threshold, pre-compaction records are dropped (no patch)."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345678"
+    transcript = tmp_path / "projects" / "-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    filler = "x" * 4096  # ~4 KB per record; ~600 records clears 2 MB.
+    records: list[dict[str, object]] = [
+        {
+            "type": "user",
+            "uuid": f"pre-{i}",
+            "cwd": "/repo",
+            "message": {"role": "user", "content": f"pre-compaction {i} {filler}"},
+        }
+        for i in range(600)
+    ]
+    records.append(
+        {
+            "type": "user",
+            "uuid": "compact-1",
+            "isCompactSummary": True,
+            "message": {"role": "user", "content": "post compaction summary marker"},
+        }
+    )
+    records.append(
+        {
+            "type": "user",
+            "uuid": "post-1",
+            "message": {"role": "user", "content": "question after compaction marker"},
+        }
+    )
+    transcript.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8"
+    )
+    assert transcript.stat().st_size > 2 * 1024 * 1024
+
+    imported = load_claude_session(session_id, claude_home=tmp_path)
+
+    texts = [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and "text" in block
+    ]
+    assert not any(text.startswith("pre-compaction") for text in texts)
+    assert any("post compaction summary marker" in text for text in texts)
+    assert any("question after compaction marker" in text for text in texts)
+
+
 def test_list_recent_claude_sessions_orders_parents_and_applies_limit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -642,6 +843,231 @@ def test_load_codex_session_normalizes_response_items(tmp_path: Path) -> None:
         "call_id": "call_2",
         "output": "",
     }
+
+
+def _codex_item_texts(imported: LocalSessionImport) -> list[str]:
+    """Flatten the text of every message item in an imported Codex session."""
+    return [
+        block["text"]
+        for item in imported.items
+        for block in item.data.model_dump().get("content", [])
+        if isinstance(block, dict) and isinstance(block.get("text"), str)
+    ]
+
+
+def _write_codex_rollout_with_compaction(
+    tmp_path: Path, session_id: str, *, extra_pre: list[dict] | None = None
+) -> Path:
+    """Write a Codex rollout with a ``compacted`` record between two turns."""
+    rollout = (
+        tmp_path
+        / "sessions"
+        / "2026"
+        / "07"
+        / "15"
+        / f"rollout-2026-07-15T12-00-00-{session_id}.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    records: list[dict] = [
+        {"type": "session_meta", "payload": {"id": session_id, "cwd": "/repo"}},
+        {"type": "turn_context", "payload": {"turn_id": "turn_1", "cwd": "/repo"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "pre compaction question"}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "pre compaction answer"}],
+            },
+        },
+    ]
+    records.extend(extra_pre or [])
+    records.append(
+        {
+            "type": "compacted",
+            "payload": {
+                "replacement_history": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "compaction summary baseline"}],
+                    }
+                ],
+                "window_id": 1,
+            },
+        }
+    )
+    records.extend(
+        [
+            {"type": "turn_context", "payload": {"turn_id": "turn_2", "cwd": "/repo"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "post compaction question"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "post compaction answer"}],
+                },
+            },
+        ]
+    )
+    rollout.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+    return rollout
+
+
+def test_load_codex_session_keeps_full_history_below_size_threshold(tmp_path: Path) -> None:
+    """A small rollout imports the raw history whole; the compacted record is ignored."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    _write_codex_rollout_with_compaction(tmp_path, session_id)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    assert "pre compaction question" in texts
+    assert "post compaction question" in texts
+    # The compacted record's replacement_history is not surfaced below threshold.
+    assert "compaction summary baseline" not in texts
+
+
+def test_load_codex_session_trims_to_last_compaction_when_large(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Past the threshold, only the compaction baseline and later turns import."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    _write_codex_rollout_with_compaction(tmp_path, session_id)
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    # Pre-compaction records the live agent no longer sees are dropped.
+    assert "pre compaction question" not in texts
+    assert "pre compaction answer" not in texts
+    # The replacement_history baseline and post-compaction turns are kept.
+    assert "compaction summary baseline" in texts
+    assert "post compaction question" in texts
+    assert "post compaction answer" in texts
+
+
+def test_load_codex_session_trims_to_final_compaction_with_multiple(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With two compactions, only the last baseline onward survives."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    # A second compaction after the first: its replacement_history is the final
+    # baseline, so the first summary must not survive.
+    extra_pre = [
+        {
+            "type": "compacted",
+            "payload": {
+                "replacement_history": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "first summary baseline"}],
+                    }
+                ]
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "between compactions"}],
+            },
+        },
+    ]
+    _write_codex_rollout_with_compaction(tmp_path, session_id, extra_pre=extra_pre)
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    assert "first summary baseline" not in texts
+    assert "between compactions" not in texts
+    assert "compaction summary baseline" in texts
+    assert "post compaction question" in texts
+
+
+def test_load_codex_session_ignores_empty_compaction_boundary_when_large(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A compacted record with no usable replacement_history does not wipe history."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    rollout = (
+        tmp_path
+        / "sessions"
+        / "2026"
+        / "07"
+        / "15"
+        / f"rollout-2026-07-15T12-00-00-{session_id}.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    records = [
+        {"type": "session_meta", "payload": {"id": session_id, "cwd": "/repo"}},
+        {"type": "turn_context", "payload": {"turn_id": "turn_1", "cwd": "/repo"}},
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "only real turn"}],
+            },
+        },
+        # Degenerate boundary: empty replacement_history. Must not drop everything.
+        {"type": "compacted", "payload": {"replacement_history": []}},
+    ]
+    rollout.write_text("".join(f"{json.dumps(record)}\n" for record in records), encoding="utf-8")
+    monkeypatch.setattr(local_import, "_IMPORT_COMPACT_TRIM_BYTES", 0)
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    assert _codex_item_texts(imported) == ["only real turn"]
+
+
+def test_load_codex_session_trims_at_real_two_mb_threshold(tmp_path: Path) -> None:
+    """Past the real 2 MB threshold, pre-compaction Codex records are dropped (no patch)."""
+    session_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    filler = "x" * 4096
+    extra_pre = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": f"pre bulk {i} {filler}"}],
+            },
+        }
+        for i in range(600)
+    ]
+    rollout = _write_codex_rollout_with_compaction(tmp_path, session_id, extra_pre=extra_pre)
+    assert rollout.stat().st_size > 2 * 1024 * 1024
+
+    imported = load_codex_session(session_id, codex_home=tmp_path)
+
+    texts = _codex_item_texts(imported)
+    assert not any(text.startswith("pre bulk") for text in texts)
+    assert "pre compaction question" not in texts
+    assert "compaction summary baseline" in texts
+    assert "post compaction question" in texts
 
 
 def _write_codex_rollout(tmp_path: Path, session_id: str, *, first_message: str) -> None:

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -515,20 +515,30 @@ export interface LocalImportResult {
 }
 
 /**
- * Import the caller's most recent local transcripts via `POST /v1/imports/local`.
+ * Import local transcripts via `POST /v1/imports/local`.
  * The chosen host reads + normalizes its own transcripts over the tunnel (the
  * transcripts live on that machine, not the server); already-imported sessions
- * are skipped. `source` is a specific harness or "all" for every harness at once.
+ * are skipped. Passing `sessionId` loads that exact session from `source`
+ * without listing local history. Otherwise, `source` may be "all" for every
+ * harness at once.
  */
 export async function importLocalSessions(
   hostId: string,
   source: ImportSourceSelector,
   limit: number,
+  sessionId?: string,
 ): Promise<LocalImportResult> {
+  const body: {
+    host_id: string;
+    source: ImportSourceSelector;
+    limit: number;
+    session_id?: string;
+  } = { host_id: hostId, source, limit };
+  if (sessionId !== undefined) body.session_id = sessionId;
   const res = await authenticatedFetch("/v1/imports/local", {
     method: "POST",
     headers: { "Content-Type": "application/json", "X-Omnigent-Client": getClientSurface() },
-    body: JSON.stringify({ host_id: hostId, source, limit }),
+    body: JSON.stringify(body),
   });
   const wire = await readJsonOrThrow<{
     imported: number;

--- a/web/src/shell/ImportSessionsPanel.test.tsx
+++ b/web/src/shell/ImportSessionsPanel.test.tsx
@@ -94,4 +94,31 @@ describe("ImportSessionsPanel", () => {
     // A null title renders the placeholder rather than crashing.
     expect(screen.getByTestId("import-result-link-c2")).toHaveTextContent("Untitled session");
   });
+
+  it("imports one session by harness and ID without listing sessions", async () => {
+    useHostsMock.mockReturnValue({
+      data: [{ host_id: "host_1", name: "mac-laptop", owner: "alice", status: "online" }],
+    } as unknown as ReturnType<typeof useHosts>);
+    importLocalSessionsMock.mockResolvedValue({
+      imported: 1,
+      alreadyImported: 0,
+      failed: 0,
+      sessions: [{ id: "c1", title: "Exact session" }],
+    });
+
+    renderPanel();
+    fireEvent.change(screen.getAllByRole("combobox")[1], {
+      target: { value: "session" },
+    });
+
+    expect(screen.queryByTestId("import-limit-select")).toBeNull();
+    const idInput = screen.getByTestId("import-session-id");
+    expect(screen.getByTestId("import-submit")).toBeDisabled();
+    fireEvent.change(idInput, { target: { value: "  session-exact  " } });
+    fireEvent.click(screen.getByTestId("import-submit"));
+
+    await waitFor(() =>
+      expect(importLocalSessionsMock).toHaveBeenCalledWith("host_1", "claude", 25, "session-exact"),
+    );
+  });
 });

--- a/web/src/shell/ImportSessionsPanel.tsx
+++ b/web/src/shell/ImportSessionsPanel.tsx
@@ -4,6 +4,7 @@ import { useHosts } from "@/hooks/useHosts";
 import { Link } from "@/lib/routing";
 import { HostLabel } from "./HostLabel";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -31,6 +32,7 @@ const SOURCES: { value: ImportSourceSelector; label: string }[] = [
 ];
 
 const LIMITS = [25, 50, 100];
+type ImportMode = "recent" | "session";
 
 /**
  * Inline (non-modal) import UI for the Settings "Import sessions" section.
@@ -46,6 +48,8 @@ export function ImportSessionsPanel() {
   const [hostId, setHostId] = useState<string | null>(null);
   const [source, setSource] = useState<ImportSourceSelector>("all");
   const [limit, setLimit] = useState(25);
+  const [mode, setMode] = useState<ImportMode>("recent");
+  const [sessionId, setSessionId] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<LocalImportResult | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -71,11 +75,16 @@ export function ImportSessionsPanel() {
 
   async function handleImport(): Promise<void> {
     if (hostId === null) return;
+    const exactSessionId = sessionId.trim();
+    if (mode === "session" && exactSessionId.length === 0) return;
     setSubmitting(true);
     setError(null);
     setResult(null);
     try {
-      const res = await importLocalSessions(hostId, source, limit);
+      const res =
+        mode === "session"
+          ? await importLocalSessions(hostId, source, limit, exactSessionId)
+          : await importLocalSessions(hostId, source, limit);
       setResult(res);
       // Newly imported sessions land in the sidebar list.
       await queryClient.invalidateQueries({ queryKey: ["conversations"] });
@@ -119,13 +128,33 @@ export function ImportSessionsPanel() {
       </div>
 
       <div className="flex flex-col gap-2">
+        <span className="text-sm font-medium text-muted-foreground">Import</span>
+        <Select
+          value={mode}
+          onValueChange={(value) => {
+            const nextMode = value as ImportMode;
+            setMode(nextMode);
+            if (nextMode === "session" && source === "all") setSource("claude");
+          }}
+        >
+          <SelectTrigger className="w-full text-sm" data-testid="import-mode-select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="recent">Recent sessions</SelectItem>
+            <SelectItem value="session">Session by ID</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-2">
         <span className="text-sm font-medium text-muted-foreground">Harness</span>
         <Select value={source} onValueChange={(v) => setSource(v as ImportSourceSelector)}>
           <SelectTrigger className="w-full text-sm" data-testid="import-source-select">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {SOURCES.map((s) => (
+            {SOURCES.filter((s) => mode === "recent" || s.value !== "all").map((s) => (
               <SelectItem key={s.value} value={s.value} data-testid={`import-source-${s.value}`}>
                 {s.label}
               </SelectItem>
@@ -134,29 +163,49 @@ export function ImportSessionsPanel() {
         </Select>
       </div>
 
-      <div className="flex flex-col gap-2">
-        <span className="text-sm font-medium text-muted-foreground">
-          How many recent sessions{source === "all" ? " (across all harnesses)" : ""}
-        </span>
-        <Select value={String(limit)} onValueChange={(v) => setLimit(Number(v))}>
-          <SelectTrigger className="w-full text-sm" data-testid="import-limit-select">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {LIMITS.map((n) => (
-              <SelectItem key={n} value={String(n)}>
-                Last {n}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      {mode === "recent" ? (
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-muted-foreground">
+            How many recent sessions{source === "all" ? " (across all harnesses)" : ""}
+          </span>
+          <Select value={String(limit)} onValueChange={(v) => setLimit(Number(v))}>
+            <SelectTrigger className="w-full text-sm" data-testid="import-limit-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {LIMITS.map((n) => (
+                <SelectItem key={n} value={String(n)}>
+                  Last {n}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <label htmlFor="import-session-id" className="text-sm font-medium text-muted-foreground">
+            Session ID
+          </label>
+          <Input
+            id="import-session-id"
+            data-testid="import-session-id"
+            value={sessionId}
+            maxLength={128}
+            autoComplete="off"
+            placeholder="Enter a session ID"
+            onChange={(event) => setSessionId(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void handleImport();
+            }}
+          />
+        </div>
+      )}
 
       <div>
         <Button
           data-testid="import-submit"
           loading={submitting}
-          disabled={hostId === null}
+          disabled={hostId === null || (mode === "session" && sessionId.trim().length === 0)}
           onClick={() => void handleImport()}
         >
           Import


### PR DESCRIPTION
## Related issue

No tracking issue — feature/bugfix work on local session import.

## Summary

Makes importing local coding-agent transcripts handle large sessions and partial failures gracefully.

- **Chunked import.** An oversized session no longer has to fit in one host->server frame or one CLI POST body. It streams/posts as byte-bounded append chunks sharing one `(source, external_session_id)`: the server creates the conversation on chunk 0 and appends the rest, so nothing buffers a whole transcript. Small sessions still ride in one payload. A new `chunked_import_supported` flag on `/v1/info` gates it, so an older server (or the CLI against one) falls back to whole-body posting.
- **Compaction-aware trimming.** A transcript past 2MB is trimmed to its last compaction boundary (Claude `is_compact_summary`, Codex `compacted` record) so the import mirrors what the agent actually resumes with instead of replaying pre-compaction history. See `docs/session-compaction.md`.
- **Per-session drop resilience.** On the host stream, a session that fails to read, normalize, or chunk is now counted and skipped so the rest of the batch still uploads — previously one unexpected failure aborted the whole import and the UI showed a bare error instead of the sessions that did import. `ws.send` failures stay outside the guard so a dead tunnel still aborts.
- **UI.** The web "Import sessions" panel gains a mode toggle: *Recent sessions* (as before) or *Session by ID* (import one exact session).

## Test Plan

```
uv run pytest tests/session_import tests/test_session_import.py \
  tests/server/routes/test_imports.py tests/host/test_connect.py \
  tests/host/test_frames.py tests/cli/test_import.py        # 183 passed
uv run pre-commit run --files <changed files>               # clean
```

New regression test `test_handle_import_local_unexpected_error_skips_only_that_session` fails before the resilience fix (the batch aborts) and passes after. Chunking is covered by `tests/session_import/test_chunking.py` and round-trip append tests in `tests/server/routes/test_imports.py`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

UI screenshots for the new *Session by ID* mode are pending capture (draft). Backend/CLI behavior is covered by the tests above.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: ran the import against a live local host with a batch containing a session forced to fail normalization; the healthy sessions still imported and the panel reported the failure count rather than erroring out. UI screenshots for the new mode toggle still to be captured before this leaves draft.

## Changelog

Large local sessions now import in chunks, and one unreadable session no longer stops the rest of a batch from importing.
