### PR TITLE
fix(import): keep importing the rest of a batch when one local session fails

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2243,8 +2243,9 @@ class HostProcess:
         total). It reads + normalizes each and sends it immediately
         (``host.import_local_session``) so a large batch never rides in one frame
         and the server persists as each arrives. A terminal ``host.import_local_done``
-        closes the stream. Sessions that fail to load are skipped; a single-harness
-        enumeration failure fails the request.
+        closes the stream. A session that fails to load or normalize is skipped
+        and counted so the rest of the batch still uploads; only a single-harness
+        enumeration failure fails the whole request.
         """
 
         def _targets() -> tuple[list[tuple[str, str]], str | None]:
@@ -2307,7 +2308,19 @@ class HostProcess:
             total = len(ordered)
             load_failed = 0
             for source, session_id in ordered:
-                session = await asyncio.to_thread(_load, source, session_id)
+                try:
+                    session = await asyncio.to_thread(_load, source, session_id)
+                except Exception:
+                    # One session's read/normalize blowing up must not drop the
+                    # rest of the batch — count it and move on so the remaining
+                    # sessions still upload. ws.send stays outside this guard: a
+                    # dead tunnel raises ConnectionClosed and should abort, not be
+                    # swallowed here as a skipped session.
+                    _logger.exception(
+                        "import_local: skipping session source=%r id=%r", source, session_id
+                    )
+                    load_failed += 1
+                    continue
                 if session is None:
                     # Unreadable/corrupt transcript: no frame to send, but report
                     # it on the done frame so the server's counts stay honest.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -2243,9 +2243,10 @@ class HostProcess:
         total). It reads + normalizes each and sends it immediately
         (``host.import_local_session``) so a large batch never rides in one frame
         and the server persists as each arrives. A terminal ``host.import_local_done``
-        closes the stream. A session that fails to load or normalize is skipped
-        and counted so the rest of the batch still uploads; only a single-harness
-        enumeration failure fails the whole request.
+        closes the stream. A session that fails to load, normalize, encode, or
+        send is skipped and counted so the rest of the batch still uploads; only
+        a dead tunnel (ConnectionClosed) or a single-harness enumeration failure
+        fails the whole request.
         """
 
         def _targets() -> tuple[list[tuple[str, str]], str | None]:
@@ -2310,29 +2311,31 @@ class HostProcess:
             for source, session_id in ordered:
                 try:
                     session = await asyncio.to_thread(_load, source, session_id)
+                    if session is None:
+                        # Unreadable/corrupt transcript: no frame to send, but
+                        # report it on the done frame so the counts stay honest.
+                        load_failed += 1
+                        continue
+                    await ws.send(
+                        encode_host_frame(
+                            HostImportLocalSessionFrame(
+                                request_id=frame.request_id, total=total, session=session
+                            )
+                        )
+                    )
+                except ConnectionClosed:
+                    # Dead tunnel: abort the batch (recovery is owned upstream),
+                    # never a per-session skip — nothing more can be sent.
+                    raise
                 except Exception:
-                    # One session's read/normalize blowing up must not drop the
-                    # rest of the batch — count it and move on so the remaining
-                    # sessions still upload. ws.send stays outside this guard: a
-                    # dead tunnel raises ConnectionClosed and should abort, not be
-                    # swallowed here as a skipped session.
+                    # Any other failure reading, normalizing, encoding, or sending
+                    # one session must not drop the rest of the batch: count it and
+                    # move on so the remaining sessions still upload.
                     _logger.exception(
                         "import_local: skipping session source=%r id=%r", source, session_id
                     )
                     load_failed += 1
                     continue
-                if session is None:
-                    # Unreadable/corrupt transcript: no frame to send, but report
-                    # it on the done frame so the server's counts stay honest.
-                    load_failed += 1
-                    continue
-                await ws.send(
-                    encode_host_frame(
-                        HostImportLocalSessionFrame(
-                            request_id=frame.request_id, total=total, session=session
-                        )
-                    )
-                )
             await ws.send(
                 encode_host_frame(
                     HostImportLocalDoneFrame(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5725,6 +5725,71 @@ async def test_handle_import_local_reports_unreadable_sessions_as_failed(
     assert done_frames[0].status == "ok" and done_frames[0].failed == 1
 
 
+async def test_handle_import_local_unexpected_error_skips_only_that_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected error loading one session must not abort the whole batch.
+
+    ``_load`` returns None for the expected read failures, but a surprise
+    exception type (here ``RuntimeError``) escapes it; the handler still has to
+    skip just that session and keep uploading the rest, ending status="ok".
+    """
+    from omnigent.host.frames import (
+        HostImportLocalDoneFrame,
+        HostImportLocalSessionFrame,
+        decode_host_frame,
+    )
+
+    host = _make_host_process()
+
+    # "bad" is streamed between two good sessions so a batch abort would drop
+    # the trailing "after" session.
+    def _fake_across(*, limit: int) -> list[tuple[str, str]]:
+        return [("claude", "before"), ("claude", "bad"), ("claude", "after")]
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        if session_id == "bad":
+            raise RuntimeError("normalizer blew up")
+        item = SimpleNamespace(
+            type="message",
+            response_id="r1",
+            data=SimpleNamespace(model_dump=lambda **_kw: {"role": "user"}),
+        )
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=[item],
+            title="ok",
+            source=source,
+        )
+
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_sessions_across_harnesses", _fake_across
+    )
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            sent.append(text)
+
+    await host._handle_import_local(
+        _FakeWs(),  # type: ignore[arg-type]
+        HostImportLocalFrame(request_id="req_boom", source="all", limit=5),
+    )
+
+    frames = [decode_host_frame(text) for text in sent]
+    session_frames = [f for f in frames if isinstance(f, HostImportLocalSessionFrame)]
+    done_frames = [f for f in frames if isinstance(f, HostImportLocalDoneFrame)]
+
+    # The batch runs (oldest first): both good sessions streamed, the bad one
+    # counted, and the stream closed cleanly rather than status="failed".
+    assert [f.session.external_session_id for f in session_frames] == ["after", "before"]
+    assert len(done_frames) == 1
+    assert done_frames[0].status == "ok" and done_frames[0].failed == 1
+
+
 async def test_dispatch_fs_write_op_routes_github_set_preference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5790,6 +5790,114 @@ async def test_handle_import_local_unexpected_error_skips_only_that_session(
     assert done_frames[0].status == "ok" and done_frames[0].failed == 1
 
 
+async def test_handle_import_local_send_failure_skips_only_that_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-ConnectionClosed error while sending one session frame is skipped.
+
+    Encoding/sending one session can fail (e.g. a bad payload TypeError) without
+    the tunnel being dead; that session must be counted and skipped, not abort
+    the batch.
+    """
+    from omnigent.host.frames import (
+        HostImportLocalDoneFrame,
+        HostImportLocalSessionFrame,
+        decode_host_frame,
+    )
+
+    host = _make_host_process()
+
+    def _fake_across(*, limit: int) -> list[tuple[str, str]]:
+        return [("claude", "before"), ("claude", "bad"), ("claude", "after")]
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        item = SimpleNamespace(
+            type="message",
+            response_id="r1",
+            data=SimpleNamespace(model_dump=lambda **_kw: {"role": "user"}),
+        )
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=[item],
+            title="ok",
+            source=source,
+        )
+
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_sessions_across_harnesses", _fake_across
+    )
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    sent: list[str] = []
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            frame = decode_host_frame(text)
+            if (
+                isinstance(frame, HostImportLocalSessionFrame)
+                and frame.session.external_session_id == "bad"
+            ):
+                raise TypeError("frame not serializable")
+            sent.append(text)
+
+    await host._handle_import_local(
+        _FakeWs(),  # type: ignore[arg-type]
+        HostImportLocalFrame(request_id="req_send", source="all", limit=5),
+    )
+
+    frames = [decode_host_frame(text) for text in sent]
+    session_frames = [f for f in frames if isinstance(f, HostImportLocalSessionFrame)]
+    done_frames = [f for f in frames if isinstance(f, HostImportLocalDoneFrame)]
+
+    # The send that raised is skipped; the other two sessions still stream and
+    # the batch closes ok with the failed one counted.
+    assert [f.session.external_session_id for f in session_frames] == ["after", "before"]
+    assert len(done_frames) == 1
+    assert done_frames[0].status == "ok" and done_frames[0].failed == 1
+
+
+async def test_handle_import_local_send_connection_closed_aborts_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead tunnel (ConnectionClosed) on send aborts, never a per-session skip."""
+    host = _make_host_process()
+
+    def _fake_across(*, limit: int) -> list[tuple[str, str]]:
+        return [("claude", "s1"), ("claude", "s2")]
+
+    def _fake_load(source: str, session_id: str) -> SimpleNamespace:
+        item = SimpleNamespace(
+            type="message",
+            response_id="r1",
+            data=SimpleNamespace(model_dump=lambda **_kw: {"role": "user"}),
+        )
+        return SimpleNamespace(
+            external_session_id=session_id,
+            workspace="/repo",
+            items=[item],
+            title="ok",
+            source=source,
+        )
+
+    monkeypatch.setattr(
+        "omnigent.session_import.local.list_recent_sessions_across_harnesses", _fake_across
+    )
+    monkeypatch.setattr("omnigent.session_import.local.load_local_session", _fake_load)
+
+    class _FakeWs:
+        async def send(self, text: str) -> None:
+            raise ConnectionClosedError(None, None)
+
+    # Propagates so _run_frame_handler owns reconnect; it is not swallowed as a
+    # skipped session nor turned into a status="failed" done frame.
+    with pytest.raises(ConnectionClosedError):
+        await host._handle_import_local(
+            _FakeWs(),  # type: ignore[arg-type]
+            HostImportLocalFrame(request_id="req_cc", source="all", limit=5),
+        )
+
+
 async def test_dispatch_fs_write_op_routes_github_set_preference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

No tracking issue.

## Summary

When a host streams its local transcripts for the web "Import sessions" flow, a single session that raised an unexpected error while being read or normalized escaped into the handler's terminal `except`, sent a `status="failed"` done frame, and aborted the whole batch. The remaining sessions never uploaded, and the UI showed a bare error instead of the sessions that did import.

- Isolate each session in the host stream loop: a read/normalize failure is counted and skipped so the rest of the batch still uploads.
- `ws.send` stays outside the guard, so a genuinely dead tunnel (`ConnectionClosed`) still aborts the batch rather than being swallowed as a skipped session.

## Test Plan

```
uv run pytest tests/host/test_connect.py -k import_local   # 4 passed
ruff check / ruff format --check on the changed files      # clean
```

New regression test `test_handle_import_local_unexpected_error_skips_only_that_session`: three sessions where the middle one raises an unexpected error; the other two still stream and the done frame is `status="ok", failed=1`. It fails before the fix (the batch aborts) and passes after.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Host-side change with no frontend edits; behavior is covered by the test above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — automated coverage added.

## Changelog

One unreadable local session no longer stops the rest of a batch from importing.
