### PR TITLE
fix(host): make forced stop immediate

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -10051,7 +10051,11 @@ def _terminate_daemon(record: _HostDaemonRecord, *, force: bool) -> None:
     is_flag=True,
     help="Terminate daemon processes without first stopping sessions.",
 )
-@click.option("--force", is_flag=True, help="Continue after failures and use SIGKILL if needed.")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Skip session draining and use SIGKILL if needed.",
+)
 @click.pass_context
 def host_stop(
     ctx: click.Context,
@@ -10068,7 +10072,7 @@ def host_stop(
         ``"https://example.databricksapps.com"``.
     :param all_targets: Whether to stop every known daemon target.
     :param daemon_only: Skip server-side session stop calls when ``True``.
-    :param force: Continue after failures and use SIGKILL if needed.
+    :param force: Skip session draining and use SIGKILL if needed.
     """
     if server is None:
         server = _host_group_option(ctx, "server")
@@ -10078,7 +10082,7 @@ def host_stop(
         return
     for record in records:
         stopped = 0
-        if not daemon_only:
+        if not daemon_only and not force:
             stopped = _stop_daemon_sessions(record, force=force)
         _terminate_daemon(record, force=force)
         click.echo(

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -1726,10 +1726,10 @@ def test_host_stop_session_list_timeout_points_at_force(
     assert "--daemon-only" in result.output
 
 
-def test_host_stop_force_terminates_after_session_list_timeout(
+def test_host_stop_force_skips_session_stop(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """``--force`` stops the daemon when the session pre-check times out."""
+    """``--force`` terminates immediately without making session API calls."""
     monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
     _write_daemon_registry_record(
         tmp_path,
@@ -1741,10 +1741,7 @@ def test_host_stop_force_terminates_after_session_list_timeout(
     monkeypatch.setattr(
         cli,
         "_host_http_json",
-        lambda **kwargs: cli._HostHttpResult(
-            status_code=0,
-            body="ReadTimeout: The read operation timed out",
-        ),
+        lambda **kwargs: pytest.fail(f"unexpected HTTP call: {kwargs}"),
     )
     terminated: list[str] = []
     monkeypatch.setattr(


### PR DESCRIPTION
## Related issue

N/A — reported directly during CLI use.

## Summary

- Make `omni host stop --force` bypass remote session discovery and draining.
- Terminate the local host daemon immediately, retaining forced SIGKILL behavior.
- Update CLI help and regression coverage to match the immediate-stop contract.

ELI5: asking for a forced stop now pulls the plug immediately instead of first waiting for every remote session to answer.

```text
Before: --force -> list all sessions -> stop each session serially -> terminate daemon
After:  --force ---------------------------------------------> terminate daemon
```

## Test Plan

- `UV_CACHE_DIR=/private/tmp/omnigent-uv-cache uv run --group test python -m pytest -q tests/cli/test_backend.py -k host_stop` (5 passed)
- `pre-commit run --files omnigent/cli.py tests/cli/test_backend.py`: Ruff format/check and repository hygiene hooks passed. Pyrefly was blocked by unrelated untracked session-summary files and missing optional telemetry packages in the existing workspace.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression test fails on any attempted HTTP request, proving forced stop reaches daemon termination without session API calls.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused unit test asserts that `--force` makes no remote HTTP calls and still terminates the selected daemon.

## Changelog

`omni host stop --force` now stops the host immediately instead of waiting for remote sessions to drain.