### PR TITLE
fix(claude-native): fail bounded sub-agent delivery outages

### DIFF
--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -117,6 +117,7 @@ _FORWARD_LOOP_STALL_DEADLINE_S = 300.0
 _POST_TIMEOUT_S = 10.0
 _MAX_SEEN_SOURCE_IDS = 2000
 _SUBAGENT_FORWARD_CONCURRENCY = 8
+_SUBAGENT_ITEM_MAX_TRANSIENT_ATTEMPTS = 12
 _CURSOR_FINGERPRINT_BYTES = 256
 _FORK_COMMAND_NAMES = frozenset({"/branch", "/fork"})
 _HTTP_POST_MAX_PERMANENT_FAILURES = 3
@@ -140,6 +141,7 @@ _HTTP_TRANSIENT_STATUS_CODES = {408, 409, 425, 429}
 # shared server. The budget spans the backoff schedule (capped at 30 s) ⇒ a few
 # minutes, comfortably covering the dispatch race.
 _SUBAGENT_DELIVERY_NOT_CONFIRMED_MAX_ATTEMPTS = 12
+_SUBAGENT_DROPPED_ITEM_REASON = "sub-agent transcript incomplete: an item could not be delivered"
 _SUPERVISOR_INITIAL_BACKOFF_S = 1.0
 _SUPERVISOR_MAX_BACKOFF_S = 30.0
 _SUPERVISOR_HEALTHY_UPTIME_S = 60.0
@@ -422,6 +424,8 @@ class SubagentEntry:
         sub-agent — used to dedupe so we don't spam ``running`` or
         ``idle`` events on every tick when nothing changed. ``None``
         means no status has been posted yet.
+    :param delivery_error: Durable reason the mirrored transcript is
+        incomplete. Its quiescence edge is ``failed`` instead of ``idle``.
     """
 
     subagent_id: str
@@ -431,6 +435,7 @@ class SubagentEntry:
     seen_source_ids: tuple[str, ...] = ()
     last_activity_ts: float | None = None
     last_status: str | None = None
+    delivery_error: str | None = None
 
 
 @dataclass(frozen=True)
@@ -698,8 +703,7 @@ class _PostRetryDecision:
     :param attempts: Number of failed attempts for this event after
         the current failure.
     :param delay_s: Seconds until the next retry should be attempted.
-    :param exhausted: Whether a permanent failure exceeded the retry
-        budget and the cursor should advance past the event.
+    :param exhausted: Whether the applicable retry budget was exhausted.
     :param permanent: Whether the failure is classified as a
         permanent HTTP rejection.
     """
@@ -730,6 +734,7 @@ class _PostRetryTracker:
         *,
         max_permanent_attempts: int = _HTTP_POST_MAX_PERMANENT_FAILURES,
         max_not_confirmed_attempts: int = _SUBAGENT_DELIVERY_NOT_CONFIRMED_MAX_ATTEMPTS,
+        max_transient_attempts: int | None = None,
         base_delay_s: float = _HTTP_POST_RETRY_BASE_DELAY_S,
         max_delay_s: float = _HTTP_POST_RETRY_MAX_DELAY_S,
     ) -> None:
@@ -740,12 +745,17 @@ class _PostRetryTracker:
             failure is exhausted.
         :param max_not_confirmed_attempts: Attempts before a
             ``subagent_delivery_not_confirmed`` 503 is exhausted.
+        :param max_transient_attempts: Optional attempt budget for transient
+            failures. ``None`` preserves indefinite retries.
         :param base_delay_s: Initial retry delay in seconds.
         :param max_delay_s: Maximum retry delay in seconds.
         :returns: None.
         """
         self._max_permanent_attempts = max(1, max_permanent_attempts)
         self._max_not_confirmed_attempts = max(1, max_not_confirmed_attempts)
+        self._max_transient_attempts = (
+            max(1, max_transient_attempts) if max_transient_attempts is not None else None
+        )
         self._base_delay_s = max(0.0, base_delay_s)
         self._max_delay_s = max(0.0, max_delay_s)
         self._entries: dict[str, _PostRetryEntry] = {}
@@ -796,8 +806,15 @@ class _PostRetryTracker:
         entry.attempts += 1
         permanent = _is_permanent_http_error(exc)
         not_confirmed = _is_subagent_delivery_not_confirmed(exc)
-        give_up = (permanent and entry.attempts >= self._max_permanent_attempts) or (
-            not_confirmed and entry.attempts >= self._max_not_confirmed_attempts
+        give_up = (
+            (permanent and entry.attempts >= self._max_permanent_attempts)
+            or (not_confirmed and entry.attempts >= self._max_not_confirmed_attempts)
+            or (
+                not permanent
+                and not not_confirmed
+                and self._max_transient_attempts is not None
+                and entry.attempts >= self._max_transient_attempts
+            )
         )
         if give_up:
             self._entries.pop(key, None)
@@ -904,7 +921,9 @@ async def forward_claude_transcript_to_session(
     item_retries = _PostRetryTracker()
     status_retries = _PostRetryTracker()
     subagent_start_retries = _PostRetryTracker()
-    subagent_item_retries = _PostRetryTracker()
+    subagent_item_retries = _PostRetryTracker(
+        max_transient_attempts=_SUBAGENT_ITEM_MAX_TRANSIENT_ATTEMPTS
+    )
     subagent_status_retries = _PostRetryTracker()
     session_event_batch_capability = _SessionEventBatchCapability()
     # Dedupe: Claude rewrites the same usage block every poll until
@@ -1001,7 +1020,9 @@ async def forward_claude_transcript_to_session(
                         item_retries = _PostRetryTracker()
                         status_retries = _PostRetryTracker()
                         subagent_start_retries = _PostRetryTracker()
-                        subagent_item_retries = _PostRetryTracker()
+                        subagent_item_retries = _PostRetryTracker(
+                            max_transient_attempts=_SUBAGENT_ITEM_MAX_TRANSIENT_ATTEMPTS
+                        )
                         subagent_status_retries = _PostRetryTracker()
                         external_session_id_mirrored = False
                         task_subjects = {}
@@ -1039,7 +1060,9 @@ async def forward_claude_transcript_to_session(
                         item_retries = _PostRetryTracker()
                         status_retries = _PostRetryTracker()
                         subagent_start_retries = _PostRetryTracker()
-                        subagent_item_retries = _PostRetryTracker()
+                        subagent_item_retries = _PostRetryTracker(
+                            max_transient_attempts=_SUBAGENT_ITEM_MAX_TRANSIENT_ATTEMPTS
+                        )
                         subagent_status_retries = _PostRetryTracker()
                         external_session_id_mirrored = False
                         task_subjects = {}
@@ -1292,6 +1315,9 @@ def _read_subagent_forward_state(bridge_dir: Path) -> SubagentForwardState:
             seen_source_ids=tuple(seen_source_ids),
             last_activity_ts=last_activity_ts,
             last_status=last_status,
+            delivery_error=(
+                row.get("delivery_error") if isinstance(row.get("delivery_error"), str) else None
+            ),
         )
     return SubagentForwardState(subagents=entries)
 
@@ -1314,6 +1340,7 @@ def _write_subagent_forward_state(bridge_dir: Path, state: SubagentForwardState)
                 "seen_source_ids": list(entry.seen_source_ids),
                 "last_activity_ts": entry.last_activity_ts,
                 "last_status": entry.last_status,
+                "delivery_error": entry.delivery_error,
             }
             for entry in state.subagents.values()
         },
@@ -1791,6 +1818,11 @@ async def _forward_one_subagent(
                 http_status=413,
             )
             completed_items.extend(batch)
+            new_entry = replace(
+                new_entry,
+                last_activity_ts=now,
+                delivery_error=_SUBAGENT_DROPPED_ITEM_REASON,
+            )
         else:
             try:
                 await _post_external_conversation_items(
@@ -1816,47 +1848,19 @@ async def _forward_one_subagent(
                         extra={"session_id": parent_session_id},
                     )
                     break
-                _logger.warning(
-                    "Re-driving claude-native sub-agent transcript batch individually "
-                    "after HTTP failures; child=%s items=%s attempts=%s http_status=%s",
-                    entry.child_conversation_id,
-                    len(batch),
-                    decision.attempts,
-                    _http_status_for_log(exc),
-                    extra={"session_id": parent_session_id},
-                )
-                for pending_item in batch:
-                    item = pending_item.item
-                    try:
-                        await _post_external_conversation_item(
-                            client,
-                            session_id=entry.child_conversation_id,
-                            item=item,
-                        )
-                    except httpx.HTTPError as item_exc:
-                        if not (
-                            _is_permanent_http_error(item_exc)
-                            or _is_subagent_delivery_not_confirmed(item_exc)
-                        ):
-                            stop_after_batch = True
-                            _logger.warning(
-                                "Failed to re-drive claude-native sub-agent transcript "
-                                "item; child=%s source_id=%s http_status=%s",
-                                entry.child_conversation_id,
-                                item.source_id,
-                                _http_status_for_log(item_exc),
-                                exc_info=True,
-                                extra={"session_id": parent_session_id},
-                            )
-                            break
-                        _logger.error(
-                            "Dropping claude-native sub-agent transcript item after "
-                            "individual rejection; child=%s source_id=%s http_status=%s",
-                            entry.child_conversation_id,
-                            item.source_id,
-                            _http_status_for_log(item_exc),
-                            extra={"session_id": parent_session_id},
-                        )
+                if not decision.permanent and not _is_subagent_delivery_not_confirmed(exc):
+                    _logger.error(
+                        "Dropping claude-native sub-agent transcript batch after "
+                        "transient delivery retries were exhausted; child=%s items=%s "
+                        "attempts=%s http_status=%s",
+                        entry.child_conversation_id,
+                        len(batch),
+                        decision.attempts,
+                        _http_status_for_log(exc),
+                        extra={"session_id": parent_session_id},
+                    )
+                    for pending_item in batch:
+                        item = pending_item.item
                         append_dead_letter(
                             bridge_dir,
                             session_id=entry.child_conversation_id,
@@ -1867,13 +1871,80 @@ async def _forward_one_subagent(
                                 "item_data": item.data,
                                 "response_id": item.response_id,
                             },
-                            reason="permanent HTTP failure after retries",
+                            reason="transient HTTP failure after retries",
                             delivered_ambiguous=False,
-                            http_status=_http_status_for_log(item_exc),
+                            http_status=_http_status_for_log(exc),
                         )
-                    else:
-                        delivered = True
-                    completed_items.append(pending_item)
+                    completed_items.extend(batch)
+                    new_entry = replace(
+                        new_entry,
+                        last_activity_ts=now,
+                        delivery_error=_SUBAGENT_DROPPED_ITEM_REASON,
+                    )
+                else:
+                    _logger.warning(
+                        "Re-driving claude-native sub-agent transcript batch individually "
+                        "after HTTP failures; child=%s items=%s attempts=%s http_status=%s",
+                        entry.child_conversation_id,
+                        len(batch),
+                        decision.attempts,
+                        _http_status_for_log(exc),
+                        extra={"session_id": parent_session_id},
+                    )
+                    for pending_item in batch:
+                        item = pending_item.item
+                        try:
+                            await _post_external_conversation_item(
+                                client,
+                                session_id=entry.child_conversation_id,
+                                item=item,
+                            )
+                        except httpx.HTTPError as item_exc:
+                            if not (
+                                _is_permanent_http_error(item_exc)
+                                or _is_subagent_delivery_not_confirmed(item_exc)
+                            ):
+                                stop_after_batch = True
+                                _logger.warning(
+                                    "Failed to re-drive claude-native sub-agent transcript "
+                                    "item; child=%s source_id=%s http_status=%s",
+                                    entry.child_conversation_id,
+                                    item.source_id,
+                                    _http_status_for_log(item_exc),
+                                    exc_info=True,
+                                    extra={"session_id": parent_session_id},
+                                )
+                                break
+                            _logger.error(
+                                "Dropping claude-native sub-agent transcript item after "
+                                "individual rejection; child=%s source_id=%s http_status=%s",
+                                entry.child_conversation_id,
+                                item.source_id,
+                                _http_status_for_log(item_exc),
+                                extra={"session_id": parent_session_id},
+                            )
+                            append_dead_letter(
+                                bridge_dir,
+                                session_id=entry.child_conversation_id,
+                                event_type="external_conversation_item",
+                                payload={
+                                    "source_id": item.source_id,
+                                    "item_type": item.item_type,
+                                    "item_data": item.data,
+                                    "response_id": item.response_id,
+                                },
+                                reason="permanent HTTP failure after retries",
+                                delivered_ambiguous=False,
+                                http_status=_http_status_for_log(item_exc),
+                            )
+                            new_entry = replace(
+                                new_entry,
+                                last_activity_ts=now,
+                                delivery_error=_SUBAGENT_DROPPED_ITEM_REASON,
+                            )
+                        else:
+                            delivered = True
+                        completed_items.append(pending_item)
             else:
                 completed_items.extend(batch)
                 delivered = True
@@ -1898,15 +1969,16 @@ async def _forward_one_subagent(
         if stop_after_batch:
             break
 
+    delivery_pending = any(item.item.source_id not in seen for item in pending)
     desired_status: str | None = None
     if had_item:
         desired_status = "running"
     elif (
-        new_entry.last_activity_ts is not None
+        not delivery_pending
+        and new_entry.last_activity_ts is not None
         and now - new_entry.last_activity_ts > _SUBAGENT_IDLE_QUIESCENCE_S
-        and new_entry.last_status != "idle"
     ):
-        desired_status = "idle"
+        desired_status = "failed" if new_entry.delivery_error else "idle"
     if desired_status is None or desired_status == new_entry.last_status:
         return
     retry_key = f"subagent_status:{entry.child_conversation_id}"
@@ -1917,6 +1989,7 @@ async def _forward_one_subagent(
             client,
             session_id=entry.child_conversation_id,
             status=desired_status,
+            output=new_entry.delivery_error if desired_status == "failed" else None,
         )
     except httpx.HTTPError as exc:
         decision = status_retry_tracker.record_failure(retry_key, exc)
@@ -3466,7 +3539,7 @@ async def _forward_available_status_events(
                                         extra={"session_id": session_id},
                                     )
                                     return durable
-                        except Exception:  # noqa: BLE001
+                        except Exception:
                             # Non-HTTP failure (e.g. reading Claude session
                             # messages). Hold the cursor and retry next poll.
                             _logger.warning(
@@ -3886,7 +3959,7 @@ async def _handle_compact_summary_item(
             extra={"session_id": session_id},
         )
         return False
-    except Exception:  # noqa: BLE001
+    except Exception:
         # Non-HTTP failure (e.g. reading Claude session messages). Retry.
         _logger.warning(
             "Unexpected error persisting compaction boundary (transcript path) for %s; seq=%s",
@@ -5217,7 +5290,7 @@ async def _persist_native_compaction_item(
                 for m in msgs
                 if isinstance(m.message, dict)
             ]
-    except Exception:  # noqa: BLE001
+    except Exception:
         _logger.debug(
             "Failed to read Claude session messages for compaction persist",
             exc_info=True,

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -3539,7 +3539,7 @@ async def _forward_available_status_events(
                                         extra={"session_id": session_id},
                                     )
                                     return durable
-                        except Exception:
+                        except Exception:  # noqa: BLE001
                             # Non-HTTP failure (e.g. reading Claude session
                             # messages). Hold the cursor and retry next poll.
                             _logger.warning(
@@ -3959,7 +3959,7 @@ async def _handle_compact_summary_item(
             extra={"session_id": session_id},
         )
         return False
-    except Exception:
+    except Exception:  # noqa: BLE001
         # Non-HTTP failure (e.g. reading Claude session messages). Retry.
         _logger.warning(
             "Unexpected error persisting compaction boundary (transcript path) for %s; seq=%s",
@@ -5290,7 +5290,7 @@ async def _persist_native_compaction_item(
                 for m in msgs
                 if isinstance(m.message, dict)
             ]
-    except Exception:
+    except Exception:  # noqa: BLE001
         _logger.debug(
             "Failed to read Claude session messages for compaction persist",
             exc_info=True,

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -9,8 +9,9 @@ import logging
 import os
 import queue
 import threading
+import time
 from collections.abc import Callable, Generator, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -6323,6 +6324,201 @@ async def test_subagent_history_drains_eight_children_concurrently(tmp_path: Pat
             timeout=3.0,
         )
     assert maximum_active == 8
+
+
+@pytest.mark.asyncio
+async def test_concurrent_subagent_502s_recover_without_phantom_completion(
+    tmp_path: Path,
+) -> None:
+    """A failed fan-out retries every child before any child can finish idle."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    old_activity = time.time() - forwarder._SUBAGENT_IDLE_QUIESCENCE_S - 60
+    entries: dict[str, forwarder.SubagentEntry] = {}
+    for index in range(5):
+        subagent_id = f"recover-{index}"
+        _seed_subagent_on_disk(
+            transcript_path=transcript_path,
+            subagent_id=subagent_id,
+            agent_type="Explore",
+            description="concurrent retry",
+            tool_use_id=f"toolu_recover_{index}",
+            transcript_records=[
+                {
+                    "isSidechain": True,
+                    "type": "assistant",
+                    "uuid": f"recover-message-{index}",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": str(index)}],
+                    },
+                }
+            ],
+        )
+        entries[subagent_id] = forwarder.SubagentEntry(
+            subagent_id=subagent_id,
+            child_conversation_id=f"conv_recover_{index}",
+            last_activity_ts=old_activity,
+            last_status="running",
+        )
+
+    attempts: dict[str, int] = {}
+    statuses: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        child_id = request.url.path.split("/")[-2]
+        if isinstance(body, list):
+            attempts[child_id] = attempts.get(child_id, 0) + 1
+            if attempts[child_id] == 1:
+                return httpx.Response(502, text="bad gateway")
+            return httpx.Response(202, json=[{"item_id": f"item-{child_id}"}])
+        if body.get("type") == "external_session_status":
+            statuses.append((child_id, body["data"]["status"]))
+        return httpx.Response(202, json={})
+
+    tracker = forwarder._PostRetryTracker(
+        base_delay_s=0.0,
+        max_transient_attempts=3,
+    )
+    state = forwarder.SubagentForwardState(subagents=entries)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+        assert statuses == []
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+        quiet_entries = {
+            subagent_id: replace(entry, last_activity_ts=old_activity)
+            for subagent_id, entry in state.subagents.items()
+        }
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents=quiet_entries),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    assert set(attempts.values()) == {2}
+    assert sorted(status for _, status in statuses) == ["idle"] * 5
+    assert all(entry.delivery_error is None for entry in state.subagents.values())
+
+
+@pytest.mark.asyncio
+async def test_persistent_subagent_502_ends_as_explicit_failure(tmp_path: Path) -> None:
+    """A child that exhausts 502 retries fails with recoverable dead letters."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("", encoding="utf-8")
+    subagent_id = "persistent-502"
+    _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id=subagent_id,
+        agent_type="Explore",
+        description="persistent outage",
+        tool_use_id="toolu_persistent_502",
+        transcript_records=[
+            {
+                "isSidechain": True,
+                "type": "assistant",
+                "uuid": "persistent-message",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "lost output"}],
+                },
+            }
+        ],
+    )
+    state = forwarder.SubagentForwardState(
+        subagents={
+            subagent_id: forwarder.SubagentEntry(
+                subagent_id=subagent_id,
+                child_conversation_id="conv_persistent_502",
+            )
+        }
+    )
+    statuses: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode("utf-8"))
+        if isinstance(body, list):
+            return httpx.Response(502, text="bad gateway")
+        if body.get("type") == "external_session_status":
+            statuses.append(body["data"])
+        return httpx.Response(202, json={})
+
+    tracker = forwarder._PostRetryTracker(
+        base_delay_s=0.0,
+        max_transient_attempts=2,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        for _ in range(2):
+            state = await forwarder._forward_available_subagents(
+                client=client,
+                parent_session_id="conv_parent",
+                bridge_dir=bridge_dir,
+                transcript_path=transcript_path,
+                state=state,
+                agent_name="claude-native-ui",
+                start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+                item_retry_tracker=tracker,
+                status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            )
+        failed_entry = replace(
+            state.subagents[subagent_id],
+            last_activity_ts=time.time() - forwarder._SUBAGENT_IDLE_QUIESCENCE_S - 60,
+        )
+        state = await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            transcript_path=transcript_path,
+            state=forwarder.SubagentForwardState(subagents={subagent_id: failed_entry}),
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+    assert statuses == [{"status": "failed", "output": forwarder._SUBAGENT_DROPPED_ITEM_REASON}]
+    assert state.subagents[subagent_id].delivery_error == forwarder._SUBAGENT_DROPPED_ITEM_REASON
+    persisted = forwarder._read_subagent_forward_state(bridge_dir)
+    assert (
+        persisted.subagents[subagent_id].delivery_error == forwarder._SUBAGENT_DROPPED_ITEM_REASON
+    )
+    dead_letters = (bridge_dir / "dead_letter.jsonl").read_text("utf-8").splitlines()
+    assert len(dead_letters) == 1
+    assert json.loads(dead_letters[0])["http_status"] == 502
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Closes #4447

## Summary

- Keep concurrent child transcript batches non-terminal while 502 delivery retries are pending.
- Bound child-item transient retries to twelve attempts (about 3.5 minutes at the existing capped exponential backoff), then dead-letter the undelivered items and durably mark the child transcript incomplete.
- Publish the child's quiescence edge as `failed` with a useful error instead of a successful empty `idle` completion.

ELI5: temporary server overload pauses completion until the missing output arrives. If delivery never recovers, the parent receives an explicit failure and the original payload remains recoverable on disk.

```text
child batch -> 502 -> backoff/retry -> delivered -> normal idle
                            |
                            `-> budget exhausted -> dead letter -> failed
```

## Test Plan

- `uv run pytest -q tests/test_claude_native_forwarder.py` — 170 passed.
- Added a five-child concurrent fan-out regression where every first batch receives 502, then recovers without an early terminal status.
- Added persistent-502 coverage proving bounded retries, durable failure state, dead-letter recovery data, and explicit failed status.
- `uvx pre-commit run --files omnigent/harnesses/claude_native/forwarder.py tests/test_claude_native_forwarder.py` — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The mock transport exercises both recovery and exhaustion deterministically while the existing full forwarder suite covers cursor, batching, restart, and status behavior.

## Changelog

Concurrent Claude sub-agents no longer appear to complete successfully when their output could not be delivered.
