### PR TITLE
fix(terminals): discover interactive shells on the selected host

### DIFF
--- a/omnigent/_platform.py
+++ b/omnigent/_platform.py
@@ -223,26 +223,65 @@ _KNOWN_INTERACTIVE_SHELLS = frozenset({"bash", "zsh", "fish", "sh", "dash", "ksh
 _OFFERED_INTERACTIVE_SHELLS = ("bash", "zsh", "fish")
 
 
+#: Standard absolute locations for interactive shells, probed when a shell
+#: isn't on ``PATH``. The host daemon snapshots ``PATH`` at spawn; a daemon
+#: launched from a GUI / ``launchd`` / minimal-env context inherits a stripped
+#: ``PATH`` that omits ``/bin`` (or ``/usr/bin``), where the system shells live
+#: — so a bare ``shutil.which("zsh")`` misses them there even though they exist.
+_INTERACTIVE_SHELL_DIRS = ("/bin", "/usr/bin", "/usr/local/bin", "/opt/homebrew/bin")
+
+
+def _resolve_interactive_shell(name: str) -> str | None:
+    """Resolve an interactive-shell basename to an executable, off ``PATH`` too.
+
+    Tries ``PATH`` (:func:`shutil.which`) first, then the well-known absolute
+    shell dirs (:data:`_INTERACTIVE_SHELL_DIRS`). This survives the host
+    daemon's frozen/stripped ``PATH`` — the driver of the "only bash offered"
+    bug on GUI/launchd-launched hosts — where the shells exist on disk but not
+    on the daemon's ``PATH``.
+
+    :param name: A shell basename such as ``"zsh"`` or ``"bash"``.
+    :returns: An executable path, or ``None`` when the shell isn't installed.
+    """
+    import shutil
+
+    on_path = shutil.which(name)
+    if on_path is not None:
+        return on_path
+    for directory in _INTERACTIVE_SHELL_DIRS:
+        candidate = os.path.join(directory, name)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def default_interactive_shell() -> str:
     """
     Basename of the user's login shell for an interactive terminal.
 
     Reads ``$SHELL`` and keeps its basename when it names a known shell that
-    resolves on PATH; otherwise falls back to ``"bash"``. Returns a basename
-    (not the absolute ``$SHELL`` path) so it stays PATH-resolvable when the
-    terminal launches under a runner on a different host than the one that read
-    the env.
+    resolves — trusting ``$SHELL``'s own absolute path, then ``PATH``, then the
+    standard shell dirs (:func:`_resolve_interactive_shell`); otherwise falls
+    back to ``"bash"``. Returns a basename (not the absolute ``$SHELL`` path) so
+    it stays PATH-resolvable when the terminal launches under a runner on a
+    different host than the one that read the env.
 
     :returns: A shell basename such as ``"zsh"``, ``"fish"``, or ``"bash"``.
     """
     if IS_WINDOWS:
         # Native tmux/PTY terminals are unsupported on Windows anyway.
         return "bash"
-    import shutil
 
-    name = os.path.basename(os.environ.get("SHELL", "")).strip()
-    if name in _KNOWN_INTERACTIVE_SHELLS and shutil.which(name):
-        return name
+    shell = os.environ.get("SHELL", "").strip()
+    name = os.path.basename(shell)
+    if name in _KNOWN_INTERACTIVE_SHELLS:
+        # ``$SHELL`` is already an absolute executable path — trust it directly
+        # rather than re-resolving its basename against a ``PATH`` that may be
+        # stripped, so the login shell is honored even on a frozen-PATH daemon.
+        if os.path.isabs(shell) and os.access(shell, os.X_OK):
+            return name
+        if _resolve_interactive_shell(name):
+            return name
     return "bash"
 
 
@@ -252,9 +291,10 @@ def installed_interactive_shells() -> list[str]:
 
     The user's login shell (:func:`default_interactive_shell`) comes first — so
     the "New shell" affordance can treat entry ``[0]`` as the click default —
-    followed by any mainstream alternatives (bash/zsh/fish) that resolve on
-    PATH. Always non-empty (the default is always present, and bash is the
-    ultimate fallback).
+    followed by any mainstream alternatives (bash/zsh/fish) that resolve
+    (:func:`_resolve_interactive_shell`, which also probes standard shell dirs
+    off ``PATH``). Always non-empty (the default is always present, and bash is
+    the ultimate fallback).
 
     :returns: Basenames such as ``["zsh", "bash", "fish"]`` — the default first.
     """
@@ -263,10 +303,9 @@ def installed_interactive_shells() -> list[str]:
         # Native tmux/PTY terminals are unsupported on Windows anyway; the lone
         # bash default from above is all we can meaningfully offer.
         return ordered
-    import shutil
 
     for name in _OFFERED_INTERACTIVE_SHELLS:
-        if name not in ordered and shutil.which(name):
+        if name not in ordered and _resolve_interactive_shell(name):
             ordered.append(name)
     return ordered
 

--- a/omnigent/_platform.py
+++ b/omnigent/_platform.py
@@ -249,8 +249,9 @@ _INTERACTIVE_SHELL_DIRS = ("/bin", "/usr/bin", "/usr/local/bin", "/opt/homebrew/
 def _resolve_interactive_shell(name: str) -> str | None:
     """Resolve an interactive-shell basename to an executable, off ``PATH`` too.
 
-    Tries ``PATH`` (:func:`shutil.which`) first, then the well-known absolute
-    shell dirs (:data:`_INTERACTIVE_SHELL_DIRS`). This survives the host
+    Accepts known basenames only. A matching executable absolute ``$SHELL``
+    wins, followed by ``PATH`` and the well-known absolute shell dirs
+    (:data:`_INTERACTIVE_SHELL_DIRS`). This survives the host
     daemon's frozen/stripped ``PATH`` — the driver of the "only bash offered"
     bug on GUI/launchd-launched hosts — where the shells exist on disk but not
     on the daemon's ``PATH``.
@@ -259,6 +260,18 @@ def _resolve_interactive_shell(name: str) -> str | None:
     :returns: An executable path, or ``None`` when the shell isn't installed.
     """
     import shutil
+
+    if name not in _KNOWN_INTERACTIVE_SHELLS or os.path.basename(name) != name:
+        return None
+
+    login_shell = os.environ.get("SHELL", "").strip()
+    if (
+        os.path.isabs(login_shell)
+        and os.path.basename(login_shell) == name
+        and os.path.isfile(login_shell)
+        and os.access(login_shell, os.X_OK)
+    ):
+        return login_shell
 
     on_path = shutil.which(name)
     if on_path is not None:
@@ -277,9 +290,8 @@ def default_interactive_shell() -> str:
     Reads ``$SHELL`` and keeps its basename when it names a known shell that
     resolves — trusting ``$SHELL``'s own absolute path, then ``PATH``, then the
     standard shell dirs (:func:`_resolve_interactive_shell`); otherwise falls
-    back to ``"bash"``. Returns a basename (not the absolute ``$SHELL`` path) so
-    it stays PATH-resolvable when the terminal launches under a runner on a
-    different host than the one that read the env.
+    back to ``"bash"``. Returns a basename for the host inventory; the runner
+    on that host resolves the launch path and honors the same ``$SHELL``.
 
     :returns: A shell basename such as ``"zsh"``, ``"fish"``, or ``"bash"``.
     """
@@ -293,7 +305,7 @@ def default_interactive_shell() -> str:
         # ``$SHELL`` is already an absolute executable path — trust it directly
         # rather than re-resolving its basename against a ``PATH`` that may be
         # stripped, so the login shell is honored even on a frozen-PATH daemon.
-        if os.path.isabs(shell) and os.access(shell, os.X_OK):
+        if os.path.isabs(shell) and os.path.isfile(shell) and os.access(shell, os.X_OK):
             return name
         if _resolve_interactive_shell(name):
             return name

--- a/omnigent/_platform.py
+++ b/omnigent/_platform.py
@@ -223,6 +223,21 @@ _KNOWN_INTERACTIVE_SHELLS = frozenset({"bash", "zsh", "fish", "sh", "dash", "ksh
 _OFFERED_INTERACTIVE_SHELLS = ("bash", "zsh", "fish")
 
 
+def normalize_interactive_shells(shells: object) -> list[str]:
+    """Return supported shell basenames in input order, without duplicates."""
+    if not isinstance(shells, (list, tuple)):
+        return []
+    normalized: list[str] = []
+    for shell in shells:
+        if (
+            isinstance(shell, str)
+            and shell in _KNOWN_INTERACTIVE_SHELLS
+            and shell not in normalized
+        ):
+            normalized.append(shell)
+    return normalized
+
+
 #: Standard absolute locations for interactive shells, probed when a shell
 #: isn't on ``PATH``. The host daemon snapshots ``PATH`` at spawn; a daemon
 #: launched from a GUI / ``launchd`` / minimal-env context inherits a stripped

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -27,7 +27,12 @@ from typing import Any, Literal, Protocol, SupportsIndex, SupportsInt, cast
 import websockets.asyncio.client
 from websockets.exceptions import ConnectionClosed, InvalidStatus, InvalidURI
 
-from omnigent._platform import IS_POSIX, WINDOWS_ENV_PASSTHROUGH
+from omnigent._platform import (
+    IS_POSIX,
+    WINDOWS_ENV_PASSTHROUGH,
+    installed_interactive_shells,
+    normalize_interactive_shells,
+)
 from omnigent.cli_invocation import cli_invocation
 from omnigent.debug_logging import (
     ORIGIN_WORKSPACE_ID_ENV_VAR,
@@ -125,6 +130,7 @@ from omnigent.runner.identity import (
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
+    RUNNER_INTERACTIVE_SHELLS_ENV_VAR,
     RUNNER_LAUNCH_HARNESS_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
     RUNNER_SLICE_KEY_ENV_VAR,
@@ -752,6 +758,7 @@ def _build_runner_env(
     initial_auth_token: str | None = None,
     host_id: str | None = None,
     harness: str | None = None,
+    interactive_shells: list[str] | None = None,
 ) -> dict[str, str]:
     """
     Build the environment for a spawned runner subprocess.
@@ -834,6 +841,8 @@ def _build_runner_env(
         env[RUNNER_SLICE_KEY_ENV_VAR] = host_id
     if harness:
         env[RUNNER_LAUNCH_HARNESS_ENV_VAR] = harness
+    if interactive_shells is not None:
+        env[RUNNER_INTERACTIVE_SHELLS_ENV_VAR] = json.dumps(interactive_shells)
     return env
 
 
@@ -972,6 +981,7 @@ class HostProcess:
         identity: HostIdentity,
         server_url: str,
         lifecycle_lock: DaemonLifecycleLock | None = None,
+        interactive_shells: list[str] | None = None,
     ) -> None:
         """Initialize the host process.
 
@@ -980,9 +990,18 @@ class HostProcess:
         :param lifecycle_lock: Optional guard binding this daemon's lifetime
             to its registry record. When present, the daemon holds the lock
             and self-terminates once the record is deleted or reassigned.
+        :param interactive_shells: Optional shell inventory override for tests.
+            By default the host discovers its installed shells once at startup.
         """
         self._identity = identity
         self._server_url = server_url.rstrip("/")
+        self._interactive_shells = normalize_interactive_shells(
+            interactive_shells
+            if interactive_shells is not None
+            else installed_interactive_shells()
+        )
+        if not self._interactive_shells:
+            self._interactive_shells = ["bash"]
         self._runners: dict[str, _RunnerHandle] = {}
         # Retain the host's refreshable auth context after the first tunnel
         # handshake so runner launches can reuse its warm bearer. Failed or
@@ -1701,6 +1720,7 @@ class HostProcess:
             initial_auth_token=initial_auth_token,
             host_id=self._identity.host_id,
             harness=frame.harness,
+            interactive_shells=self._interactive_shells,
         )
         # The runner serves one primary session (plus any co-located subagents);
         # pass it so runner-level log records can be attributed to that session.
@@ -3847,6 +3867,7 @@ class HostProcess:
             runners=self._alive_runner_ids(),
             configured_harnesses=self._configured_harnesses,
             gateway_inference=self._gateway_inference,
+            interactive_shells=self._interactive_shells,
             telemetry_opt_out=_tel_opt_out,
             installation_id=_tel_install_id,
         )
@@ -4141,6 +4162,7 @@ def run_host_process(
     *,
     daemon_target: str | None = None,
     lifecycle_lock: DaemonLifecycleLock | None = None,
+    interactive_shells: list[str] | None = None,
 ) -> None:
     """Entry point for ``omnigent host``.
 
@@ -4158,6 +4180,8 @@ def run_host_process(
     :param lifecycle_lock: A lock already acquired by an auto-launched daemon
         before it claimed the registry record. When provided, it is retained
         for the host process lifetime instead of acquiring another handle.
+    :param interactive_shells: Optional shell inventory override for tests.
+        By default the host discovers its installed shells once at startup.
     :raises SystemExit: With :data:`HOST_FATAL_EXIT_CODE` when the tunnel
         fails permanently (auth / authorization / outdated server, or a
         loopback server that is gone). The actionable cause is printed
@@ -4232,7 +4256,12 @@ def run_host_process(
 
     if lifecycle_lock is None and daemon_target is not None:
         lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)
-    host = HostProcess(identity, server_url, lifecycle_lock=lifecycle_lock)
+    host = HostProcess(
+        identity,
+        server_url,
+        lifecycle_lock=lifecycle_lock,
+        interactive_shells=interactive_shells,
+    )
     try:
         asyncio.run(host.run())
     except HostConnectError as exc:

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -110,6 +110,9 @@ class HostHelloFrame:
         ``omnigent.gateway_inference``). A family that could not be evaluated
         is omitted. ``None`` means unknown (an older host, or a startup probe
         that failed) — never treat it as "nothing is gateway-backed".
+    :param interactive_shells: Ordered interactive shells installed on this
+        machine, with its login shell first. ``None`` means an older host did
+        not report an inventory.
     """
 
     version: str
@@ -118,6 +121,7 @@ class HostHelloFrame:
     runners: list[str] = field(default_factory=list)
     configured_harnesses: dict[str, HarnessAvailability] | None = None
     gateway_inference: dict[str, bool] | None = None
+    interactive_shells: list[str] | None = None
     telemetry_opt_out: bool = False
     installation_id: str | None = None
 
@@ -1076,6 +1080,7 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "runners": list(frame.runners),
                 "configured_harnesses": frame.configured_harnesses,
                 "gateway_inference": frame.gateway_inference,
+                "interactive_shells": frame.interactive_shells,
                 "telemetry_opt_out": frame.telemetry_opt_out,
                 "installation_id": frame.installation_id,
             }
@@ -1598,6 +1603,11 @@ def _decode_host_hello(msg: _JsonObject) -> HostHelloFrame:
         runners=_optional_str_list(msg, "runners"),
         configured_harnesses=_optional_str_availability_map(msg, "configured_harnesses"),
         gateway_inference=optional_str_bool_map(msg, "gateway_inference"),
+        interactive_shells=(
+            _optional_str_list(msg, "interactive_shells")
+            if msg.get("interactive_shells") is not None
+            else None
+        ),
         telemetry_opt_out=bool(msg.get("telemetry_opt_out", False)),
         installation_id=_optional_nullable_str(msg, "installation_id"),
     )

--- a/omnigent/native/native_coding_agents.py
+++ b/omnigent/native/native_coding_agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from omnigent._platform import installed_interactive_shells
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import (
     ANTIGRAVITY_NATIVE_CODING_AGENT,
@@ -95,19 +96,22 @@ def native_coding_agent_for_terminal_name(name: str | None) -> NativeCodingAgent
     return _BY_TERMINAL_NAME.get(name or "")
 
 
-def native_shell_terminal_spec(
-    shells: list[str] | tuple[str, ...] = ("bash",),
-) -> dict[str, dict[str, object]]:
+def native_shell_terminal_spec() -> dict[str, dict[str, object]]:
     """The user-shell terminals every native wrapper declares.
 
     Native sessions expose the web UI's "+ New shell" affordance, which lets a
-    user open an interactive shell. The host supplies its ordered shell
-    inventory at runtime; generated bundles use the portable ``bash`` default
-    until a host-bound runner replaces it. ``caller_process`` / no sandbox
-    matches the native CLI's own unsandboxed stance on the user's workspace.
+    user open an interactive shell. We declare one terminal per installed shell
+    (:func:`omnigent._platform.installed_interactive_shells`), keyed and
+    commanded by the shell basename (``zsh``/``bash``/``fish``), with the user's
+    ``$SHELL`` first so the UI can treat it as the click default and offer the
+    rest behind a picker. Host-bound runners replace these declarations with the
+    selected host's inventory. ``caller_process`` / no sandbox matches the
+    native CLI's own unsandboxed stance on the user's workspace. The block is
+    always non-empty, which is also what gates the MCP relay's
+    ``sys_terminal_*`` advertisement.
 
     :returns: A ``terminals:`` mapping, e.g. ``{"zsh": {...}, "bash": {...}}``,
-        with the host's login shell first.
+        with the user's login shell first.
     """
     return {
         shell: {
@@ -119,14 +123,18 @@ def native_shell_terminal_spec(
                 "sandbox": {"type": "none"},
             },
         }
-        for shell in shells
+        for shell in installed_interactive_shells()
     }
 
 
 def native_shell_terminal_specs(
     shells: list[str] | tuple[str, ...],
 ) -> dict[str, TerminalEnvSpec]:
-    """Build parsed terminal specs for a host's ordered shell inventory."""
+    """Build parsed terminal specs for a host's ordered shell inventory.
+
+    Resolution runs in the host-launched runner and honors a matching absolute
+    ``$SHELL`` path, including login shells outside the standard directories.
+    """
     from omnigent._platform import _resolve_interactive_shell
     from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
 

--- a/omnigent/native/native_coding_agents.py
+++ b/omnigent/native/native_coding_agents.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from omnigent._platform import installed_interactive_shells
+from typing import TYPE_CHECKING
+
 from omnigent.harness_aliases import canonicalize_harness
 from omnigent.harness_plugins import (
     ANTIGRAVITY_NATIVE_CODING_AGENT,
@@ -21,6 +22,9 @@ from omnigent.harness_plugins import (
 from omnigent.harness_plugins import (
     native_agents as _registry_native_agents,
 )
+
+if TYPE_CHECKING:
+    from omnigent.inner.datamodel import TerminalEnvSpec
 
 NATIVE_CODING_AGENTS = _registry_native_agents()
 
@@ -91,21 +95,19 @@ def native_coding_agent_for_terminal_name(name: str | None) -> NativeCodingAgent
     return _BY_TERMINAL_NAME.get(name or "")
 
 
-def native_shell_terminal_spec() -> dict[str, dict[str, object]]:
+def native_shell_terminal_spec(
+    shells: list[str] | tuple[str, ...] = ("bash",),
+) -> dict[str, dict[str, object]]:
     """The user-shell terminals every native wrapper declares.
 
     Native sessions expose the web UI's "+ New shell" affordance, which lets a
-    user open an interactive shell. We declare one terminal per installed shell
-    (:func:`omnigent._platform.installed_interactive_shells`), keyed and
-    commanded by the shell basename (``zsh``/``bash``/``fish``), with the user's
-    ``$SHELL`` first so the UI can treat it as the click default and offer the
-    rest behind a picker. ``caller_process`` / no sandbox matches the native
-    CLI's own unsandboxed stance on the user's workspace. The block is always
-    non-empty, which is also what gates the MCP relay's ``sys_terminal_*``
-    advertisement.
+    user open an interactive shell. The host supplies its ordered shell
+    inventory at runtime; generated bundles use the portable ``bash`` default
+    until a host-bound runner replaces it. ``caller_process`` / no sandbox
+    matches the native CLI's own unsandboxed stance on the user's workspace.
 
     :returns: A ``terminals:`` mapping, e.g. ``{"zsh": {...}, "bash": {...}}``,
-        with the user's login shell first.
+        with the host's login shell first.
     """
     return {
         shell: {
@@ -117,5 +119,26 @@ def native_shell_terminal_spec() -> dict[str, dict[str, object]]:
                 "sandbox": {"type": "none"},
             },
         }
-        for shell in installed_interactive_shells()
+        for shell in shells
+    }
+
+
+def native_shell_terminal_specs(
+    shells: list[str] | tuple[str, ...],
+) -> dict[str, TerminalEnvSpec]:
+    """Build parsed terminal specs for a host's ordered shell inventory."""
+    from omnigent._platform import _resolve_interactive_shell
+    from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec, TerminalEnvSpec
+
+    return {
+        shell: TerminalEnvSpec(
+            command=_resolve_interactive_shell(shell) or shell,
+            allow_cwd_override=True,
+            os_env=OSEnvSpec(
+                type="caller_process",
+                cwd=".",
+                sandbox=OSEnvSandboxSpec(type="none"),
+            ),
+        )
+        for shell in shells
     }

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import gc
+import json
 import logging
 import os
 import signal
@@ -24,7 +25,7 @@ from typing import TYPE_CHECKING, cast
 import httpx
 from fastapi import FastAPI
 
-from omnigent._platform import IS_WINDOWS
+from omnigent._platform import IS_WINDOWS, normalize_interactive_shells
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.inner import _proc
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 
     from omnigent.runner.native import ResolvedSpec
     from omnigent.runner.transports.ws_tunnel.serve import _ASGIApp
+    from omnigent.spec.types import AgentSpec
 
 _RUNNER_SERVER_URL_ENV_VAR = "RUNNER_SERVER_URL"
 _RUNNER_PREWARM_SPEC_PATH_ENV_VAR = "RUNNER_PREWARM_SPEC_PATH"
@@ -67,6 +69,34 @@ _logger = logging.getLogger(__name__)
 # shares the proxy bearer, even after RUNNER_INITIAL_AUTH_TOKEN has been
 # popped from the environment.
 _runner_auth_factory: Callable[[], str | None] | None = None
+
+
+def _host_interactive_shells_from_env() -> list[str] | None:
+    """Read the host daemon's ordered shell inventory from runner wiring."""
+    from omnigent.runner.identity import RUNNER_INTERACTIVE_SHELLS_ENV_VAR
+
+    raw = os.environ.get(RUNNER_INTERACTIVE_SHELLS_ENV_VAR)
+    if raw is None:
+        return None
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    shells = normalize_interactive_shells(decoded)
+    return shells or None
+
+
+def _apply_host_interactive_shells(spec: AgentSpec) -> None:
+    """Replace a native wrapper's portable terminals with its host inventory."""
+    from omnigent.native.native_coding_agents import (
+        native_coding_agent_for_agent_name,
+        native_shell_terminal_specs,
+    )
+
+    shells = _host_interactive_shells_from_env()
+    if shells is None or native_coding_agent_for_agent_name(getattr(spec, "name", None)) is None:
+        return
+    spec.terminals = native_shell_terminal_specs(shells)
 
 
 def _set_runner_auth_factory(factory: Callable[[], str | None] | None) -> None:
@@ -1308,6 +1338,7 @@ async def _resolve_agent_spec_from_server(
         dest.mkdir(parents=True)
         load(resp.content, dest=dest, expand_env=expand_env, prune_invalid_sub_agents=True)
     spec = load(dest, expand_env=expand_env, prune_invalid_sub_agents=True)
+    _apply_host_interactive_shells(spec)
     return ResolvedSpec(spec=spec, workdir=dest)
 
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -44,6 +44,7 @@ import httpx
 from fastapi import FastAPI, HTTPException, Query, Request, WebSocket
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from omnigent._platform import normalize_interactive_shells
 from omnigent.acp_cli_harnesses import ACP_CLI_HARNESSES
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.entities.session_resources import (
@@ -74,6 +75,7 @@ from omnigent.llms.summarize import (
     extract_summary_text,
 )
 from omnigent.native.native_coding_agents import (
+    native_coding_agent_for_agent_name,
     native_coding_agent_for_harness,
     native_coding_agent_for_terminal_name,
 )
@@ -9340,9 +9342,28 @@ def create_runner_app(
         agent_os_env = getattr(agent_spec, "os_env", None) if agent_spec is not None else None
 
         declared_terminal = None
+        terminals_map = {}
         if agent_spec is not None:
             terminals_map = getattr(agent_spec, "terminals", None) or {}
             declared_terminal = terminals_map.get(terminal_name)
+
+        if (
+            declared_terminal is None
+            and native_coding_agent_for_agent_name(getattr(agent_spec, "name", None)) is not None
+            and normalize_interactive_shells([terminal_name])
+        ):
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": {
+                        "code": ErrorCode.INVALID_INPUT,
+                        "message": (
+                            f"Shell {terminal_name!r} is not available on this host. "
+                            f"Available shells: {list(terminals_map) or 'none'}."
+                        ),
+                    }
+                },
+            )
 
         if declared_terminal is not None:
             from omnigent.tools.builtins.sys_terminal import (

--- a/omnigent/runner/identity.py
+++ b/omnigent/runner/identity.py
@@ -35,6 +35,9 @@ RUNNER_SLICE_KEY_ENV_VAR = "OMNIGENT_RUNNER_SLICE_KEY"
 # can start harness-specific prewarms before session init arrives. Absent
 # for CLI-local runners and hosts that predate the stamp.
 RUNNER_LAUNCH_HARNESS_ENV_VAR = "OMNIGENT_RUNNER_LAUNCH_HARNESS"
+# JSON-encoded ordered shell inventory discovered by the host daemon. The
+# runner uses this exact snapshot for native wrapper terminal declarations.
+RUNNER_INTERACTIVE_SHELLS_ENV_VAR = "OMNIGENT_RUNNER_INTERACTIVE_SHELLS"
 RUNNER_TUNNEL_TOKEN_HEADER = "X-Omnigent-Runner-Tunnel-Token"
 # Sentinel ``Origin`` header that the project's own non-browser WebSocket
 # clients (runner -> server tunnel, host/daemon -> server tunnel,

--- a/omnigent/runner/routing.py
+++ b/omnigent/runner/routing.py
@@ -319,6 +319,14 @@ class RunnerRouter:
                 return ErrorCode.WRONG_REPLICA
         return ErrorCode.RUNNER_UNAVAILABLE
 
+    def host_is_on_another_replica(self, host_id: str) -> bool:
+        """Return whether a live host is absent from this replica.
+
+        Host-scoped routes use this before consulting replica-local metadata,
+        so a misrouted request can be retried instead of using stale defaults.
+        """
+        return self._runner_absent_code(host_id) == ErrorCode.WRONG_REPLICA
+
     def _client_for_runner(self, runner_id: str) -> httpx.AsyncClient:
         """
         Return a cached tunnel-backed client for *runner_id*.

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -12,10 +12,9 @@ request/response traffic. No per-request reassembly queues needed.
 
 The registry also holds what connected hosts *report* about themselves and
 nothing persists — today the per-family gateway-inference map (see
-:mod:`omnigent.gateway_inference`). It is delivered on the connect handshake, so
-a replica that has never seen a host simply knows nothing about it, and the
-readers' unknown-is-backed rule covers that window until the host reconnects and
-re-reports.
+:mod:`omnigent.gateway_inference`) and interactive-shell inventory. They are
+delivered on the connect handshake, so a replica that has never seen a host
+simply knows nothing about them until the host reconnects and re-reports.
 """
 
 from __future__ import annotations
@@ -30,6 +29,7 @@ from typing import Any, Protocol
 
 from cachetools import TTLCache
 
+from omnigent._platform import normalize_interactive_shells
 from omnigent.db.db_models import InvalidUuidError, current_workspace_id, uuid_to_bytes
 from omnigent.host.frames import HostHelloFrame
 
@@ -344,6 +344,7 @@ class HostRegistry:
         # answer) and lost with the process, which is the point — a restarted
         # server re-learns it from the reconnect handshake.
         self._gateway_inference: dict[str, dict[str, bool]] = {}
+        self._interactive_shells: dict[str, list[str]] = {}
 
     def register(
         self,
@@ -402,6 +403,10 @@ class HostRegistry:
                 )
                 old.outbound_queue.put_nowait(None)
             self._hosts[key] = conn
+            if hello.interactive_shells is not None:
+                self._interactive_shells[host_id] = normalize_interactive_shells(
+                    hello.interactive_shells
+                )
         return conn
 
     def deregister(
@@ -542,6 +547,12 @@ class HostRegistry:
         with self._lock:
             reported = self._gateway_inference.get(_canonical_host_id(host_id))
         return dict(reported) if reported is not None else None
+
+    def interactive_shells(self, host_id: str) -> list[str] | None:
+        """Return the ordered shell inventory last reported by *host_id*."""
+        with self._lock:
+            reported = self._interactive_shells.get(_canonical_host_id(host_id))
+        return list(reported) if reported is not None else None
 
     def send_text(self, conn: HostConnection, data: str) -> None:
         """Enqueue a text frame for sending to the host.

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -407,6 +407,8 @@ class HostRegistry:
                 self._interactive_shells[host_id] = normalize_interactive_shells(
                     hello.interactive_shells
                 )
+            else:
+                self._interactive_shells.pop(host_id, None)
         return conn
 
     def deregister(

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -842,10 +842,8 @@ def host_interactive_shells_for_request(
     runner_router: RunnerRouter | None,
 ) -> list[str]:
     """Return this replica's host shells or signal a misrouted request."""
-    reported = host_registry.interactive_shells(host_id)
     if (
-        reported is None
-        and host_registry.get(host_id) is None
+        host_registry.get(host_id) is None
         and runner_router is not None
         and runner_router.host_is_on_another_replica(host_id)
     ):
@@ -853,7 +851,7 @@ def host_interactive_shells_for_request(
             "host shell inventory is on another replica",
             code=ErrorCode.WRONG_REPLICA,
         )
-    return normalize_interactive_shells(reported)
+    return normalize_interactive_shells(host_registry.interactive_shells(host_id))
 
 
 def set_server_host_registry(host_registry: HostRegistry | None) -> None:

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -18,10 +18,12 @@ import cachetools
 import httpx
 from pydantic import TypeAdapter
 
+from omnigent._platform import normalize_interactive_shells
 from omnigent.db.db_models import LABEL_VALUE_MAX_LEN
 from omnigent.entities.conversation import (
     ITEM_TYPE_TO_DATA_CLS,
 )
+from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.harness_capabilities import ForkHistory
 from omnigent.harness_plugins import (
     ANTIGRAVITY_NATIVE_CODING_AGENT,
@@ -833,6 +835,27 @@ def get_server_runner_router() -> RunnerRouter | None:
 _server_host_registry: HostRegistry | None = None
 
 
+def host_interactive_shells_for_request(
+    host_id: str,
+    *,
+    host_registry: HostRegistry,
+    runner_router: RunnerRouter | None,
+) -> list[str]:
+    """Return this replica's host shells or signal a misrouted request."""
+    reported = host_registry.interactive_shells(host_id)
+    if (
+        reported is None
+        and host_registry.get(host_id) is None
+        and runner_router is not None
+        and runner_router.host_is_on_another_replica(host_id)
+    ):
+        raise OmnigentError(
+            "host shell inventory is on another replica",
+            code=ErrorCode.WRONG_REPLICA,
+        )
+    return normalize_interactive_shells(reported)
+
+
 def set_server_host_registry(host_registry: HostRegistry | None) -> None:
     """Stash the live host registry for asleep-session catalog refills.
 
@@ -1032,6 +1055,7 @@ __all__ = [
     "_session_todos_cache",
     "get_server_host_registry",
     "get_server_runner_router",
+    "host_interactive_shells_for_request",
     "set_server_host_registry",
     "set_server_runner_router",
 ]

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -624,6 +624,7 @@ def create_hosts_router(
                     # emitted as-is so a client can tell "unknown" from "not
                     # gateway-backed".
                     "gateway_inference": host_registry.gateway_inference(host.host_id),
+                    "interactive_shells": host_registry.interactive_shells(host.host_id),
                 }
             )
         return {"hosts": result}
@@ -666,6 +667,7 @@ def create_hosts_router(
             # Same semantics as list_hosts: reported on connect and held in
             # memory, so ``None`` is "no report on this replica yet".
             "gateway_inference": host_registry.gateway_inference(host.host_id),
+            "interactive_shells": host_registry.interactive_shells(host.host_id),
             "runners": [],
         }
 

--- a/omnigent/server/routes/sessions/__init__.py
+++ b/omnigent/server/routes/sessions/__init__.py
@@ -980,6 +980,7 @@ def create_sessions_router(
         auth_provider=auth_provider,
         permission_store=permission_store,
         agent_cache=agent_cache,
+        host_registry=host_registry,
     )
 
     return router

--- a/omnigent/server/routes/sessions/routes_agent.py
+++ b/omnigent/server/routes/sessions/routes_agent.py
@@ -15,6 +15,7 @@ from fastapi import (
 )
 from fastapi.responses import Response
 
+from omnigent._platform import normalize_interactive_shells
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime.agent_cache import AgentCache
@@ -34,6 +35,7 @@ from omnigent.server.auth import (
     local_single_user_enabled,
 )
 from omnigent.server.bundles import bundle_location, validate_agent_bundle
+from omnigent.server.host_registry import HostRegistry
 from omnigent.server.routes._auth_helpers import (
     require_access as _require_access,
 )
@@ -87,6 +89,7 @@ def register_agent_routes(
     auth_provider: AuthProvider | None = None,
     permission_store: PermissionStore | None = None,
     agent_cache: AgentCache | None = None,
+    host_registry: HostRegistry | None = None,
 ) -> None:
     """Register the agent sub-resource routes on router."""
 
@@ -131,7 +134,16 @@ def register_agent_routes(
                 f"Agent not found: {conv.agent_id!r}",
                 code=ErrorCode.NOT_FOUND,
             )
-        return _to_agent_object(agent, agent_cache)
+        terminals_override = None
+        if conv.host_id is not None and host_registry is not None:
+            reported = host_registry.interactive_shells(conv.host_id)
+            normalized = normalize_interactive_shells(reported)
+            terminals_override = normalized or None
+        return _to_agent_object(
+            agent,
+            agent_cache,
+            terminals_override=terminals_override,
+        )
 
     @router.get(
         "/sessions/{session_id}/agent/contents",

--- a/omnigent/server/routes/sessions/routes_agent.py
+++ b/omnigent/server/routes/sessions/routes_agent.py
@@ -15,8 +15,8 @@ from fastapi import (
 )
 from fastapi.responses import Response
 
-from omnigent._platform import normalize_interactive_shells
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.native.native_coding_agents import native_coding_agent_for_agent_name
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.approval import _ELICITATION_MODE
@@ -52,6 +52,7 @@ from omnigent.server.routes._sessions.common import (
     _TURN_ACTOR_LABEL,
     _logger,
     get_server_runner_router,
+    host_interactive_shells_for_request,
     set_server_runner_router,
 )
 from omnigent.server.routes._sessions.helpers import (
@@ -135,9 +136,16 @@ def register_agent_routes(
                 code=ErrorCode.NOT_FOUND,
             )
         terminals_override = None
-        if conv.host_id is not None and host_registry is not None:
-            reported = host_registry.interactive_shells(conv.host_id)
-            normalized = normalize_interactive_shells(reported)
+        if (
+            conv.host_id is not None
+            and host_registry is not None
+            and native_coding_agent_for_agent_name(agent.name) is not None
+        ):
+            normalized = host_interactive_shells_for_request(
+                conv.host_id,
+                host_registry=host_registry,
+                runner_router=runner_router or get_server_runner_router(),
+            )
             terminals_override = normalized or None
         return _to_agent_object(
             agent,

--- a/omnigent/server/routes/sessions/routes_permissions.py
+++ b/omnigent/server/routes/sessions/routes_permissions.py
@@ -17,6 +17,7 @@ from omnigent.entities import (
     Agent,
 )
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.native.native_coding_agents import native_coding_agent_for_agent_name
 from omnigent.runtime.agent_cache import AgentCache
 from omnigent.runtime.policies.approval import _ELICITATION_MODE
 from omnigent.server._elicitation_registry import (
@@ -371,7 +372,12 @@ def _policy_description(spec: PolicySpec) -> str | None:
     return None
 
 
-def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
+def _to_agent_object(
+    agent: Agent,
+    cache: AgentCache | None,
+    *,
+    terminals_override: list[str] | None = None,
+) -> AgentObject:
     """
     Convert a runtime :class:`Agent` entity to an API-layer
     :class:`AgentObject`.
@@ -385,6 +391,8 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
 
     :param agent: The runtime agent entity.
     :param cache: Agent cache, or ``None`` in test setups.
+    :param terminals_override: Selected host's shell inventory. Applied only
+        when the loaded spec is a recognized native wrapper.
     :returns: An :class:`AgentObject` for the API response.
     """
     mcp_servers: list[MCPServerSummary] = []
@@ -409,7 +417,12 @@ def _to_agent_object(agent: Agent, cache: AgentCache | None) -> AgentObject:
                 description = loaded.spec.description
             # Declared terminal names, in spec order — the Web UI
             # gates its "new terminal" affordance on this list.
-            terminals = list(loaded.spec.terminals or {})
+            terminals = (
+                list(terminals_override)
+                if terminals_override is not None
+                and native_coding_agent_for_agent_name(loaded.spec.name) is not None
+                else list(loaded.spec.terminals or {})
+            )
             # Bundled skills only (mirrors GET /v1/agents); the merged
             # bundled + host-discovered set lives on the session snapshot.
             skills = [

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -24,7 +24,6 @@ from fastapi import (
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from starlette.types import Receive, Scope, Send
 
-from omnigent._platform import normalize_interactive_shells
 from omnigent.entities import (
     Conversation,
     StoredFile,
@@ -67,6 +66,7 @@ from omnigent.server.routes._origin import require_trusted_origin
 from omnigent.server.routes._sessions.common import (
     _logger,
     get_server_runner_router,
+    host_interactive_shells_for_request,
     set_server_runner_router,
 )
 from omnigent.server.routes._sessions.helpers import (
@@ -1235,8 +1235,10 @@ def register_resources_routes(
                 and host_registry is not None
                 and native_coding_agent_for_agent_name(spec.name) is not None
             ):
-                reported = normalize_interactive_shells(
-                    host_registry.interactive_shells(conv.host_id)
+                reported = host_interactive_shells_for_request(
+                    conv.host_id,
+                    host_registry=host_registry,
+                    runner_router=runner_router or get_server_runner_router(),
                 )
                 if reported:
                     declared = reported

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -24,6 +24,7 @@ from fastapi import (
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 from starlette.types import Receive, Scope, Send
 
+from omnigent._platform import normalize_interactive_shells
 from omnigent.entities import (
     Conversation,
     StoredFile,
@@ -31,6 +32,7 @@ from omnigent.entities import (
 from omnigent.entities.session_resources import session_resource_view_to_dict
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.native.native_coding_agents import (
+    native_coding_agent_for_agent_name,
     native_coding_agent_for_terminal_name,
 )
 from omnigent.runner.routing import RunnerRouter
@@ -1227,6 +1229,17 @@ def register_resources_routes(
         if not is_native_bootstrap:
             spec = await asyncio.to_thread(_load_agent_spec_for_session, conv, agent_store)
             declared = list(spec.terminals or {}) if spec is not None else []
+            if (
+                spec is not None
+                and conv.host_id is not None
+                and host_registry is not None
+                and native_coding_agent_for_agent_name(spec.name) is not None
+            ):
+                reported = normalize_interactive_shells(
+                    host_registry.interactive_shells(conv.host_id)
+                )
+                if reported:
+                    declared = reported
             if body.get("terminal") not in declared:
                 raise OmnigentError(
                     (

--- a/tests/e2e/test_host_e2e.py
+++ b/tests/e2e/test_host_e2e.py
@@ -32,6 +32,7 @@ import httpx
 import pytest
 import yaml
 
+from omnigent.native.native_coding_agents import CLAUDE_NATIVE_AGENT_NAME
 from omnigent.process_logging import PROCESS_LOG_FILE_ENV_VAR
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.conftest import (
@@ -67,6 +68,7 @@ def _spawn_host_daemon(
     tmp_path: Path,
     live_server: str,
     mock_llm_server_url: str,
+    interactive_shells: list[str] | None = None,
 ) -> _SpawnedHostDaemon:
     """
     Spawn an isolated host daemon for a single host e2e test.
@@ -89,6 +91,7 @@ def _spawn_host_daemon(
         ``"http://localhost:18501"``.
     :param mock_llm_server_url: Base URL of the mock LLM server, e.g.
         ``"http://127.0.0.1:12345"``.
+    :param interactive_shells: Optional deterministic host inventory for tests.
     :returns: The spawned daemon handle and its host_id.
     """
     omni_dir = tmp_path / ".omnigent"
@@ -114,13 +117,32 @@ def _spawn_host_daemon(
         "OPENAI_API_KEY": "mock-key",
         PROCESS_LOG_FILE_ENV_VAR: str(daemon_log),
     }
+    command = [
+        runner_executable(),
+        "-m",
+        "omnigent.host._daemon_entry",
+        "--server",
+        live_server,
+    ]
+    if interactive_shells is not None:
+        command = [
+            runner_executable(),
+            "-c",
+            (
+                "import sys; "
+                "from omnigent.host.connect import run_host_process; "
+                "run_host_process(sys.argv[1], interactive_shells=sys.argv[2:])"
+            ),
+            live_server,
+            *interactive_shells,
+        ]
     with open(daemon_log, "w") as log_fh:
         proc = subprocess.Popen(
             # Compat-aware: pinned OLD host venv in runner compat mode (Config 2),
             # else the test process's python. apply_runner_env drops the inherited
             # worktree PYTHONPATH in that mode; the old host launches old runners
             # (colocated) from its own venv.
-            [runner_executable(), "-m", "omnigent.host._daemon_entry", "--server", live_server],
+            command,
             env=apply_runner_env(env),
             cwd=compat_runner_cwd(),
             stdout=subprocess.DEVNULL,
@@ -264,6 +286,72 @@ def test_host_connect_and_list(
     resp = http_client.get(f"/v1/hosts/{host_id}")
     if resp.status_code == 200:
         assert resp.json()["status"] == "offline", "Host should be offline after daemon is killed"
+
+
+@pytest.mark.skipif(shutil.which("zsh") is None, reason="needs zsh on the server-side machine")
+def test_native_shells_follow_bash_only_host_inventory(
+    live_server: str,
+    http_client: httpx.Client,
+    tmp_path: Path,
+    mock_llm_server_url: str,
+) -> None:
+    """The UI-shaped native session offers and launches only host shells."""
+    daemon = _spawn_host_daemon(
+        tmp_path=tmp_path,
+        live_server=live_server,
+        mock_llm_server_url=mock_llm_server_url,
+        interactive_shells=["bash"],
+    )
+    try:
+        _wait_for_host_online(http_client, daemon.host_id, timeout=30.0)
+        host = http_client.get(f"/v1/hosts/{daemon.host_id}")
+        host.raise_for_status()
+        assert host.json()["interactive_shells"] == ["bash"]
+
+        agents = http_client.get("/v1/agents", params={"limit": 100})
+        agents.raise_for_status()
+        agent_id = next(
+            row["id"] for row in agents.json()["data"] if row["name"] == CLAUDE_NATIVE_AGENT_NAME
+        )
+        workspace = tmp_path / "bash-only-workspace"
+        workspace.mkdir()
+        created = http_client.post(
+            "/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "host_id": daemon.host_id,
+                "workspace": str(workspace),
+            },
+            timeout=60.0,
+        )
+        created.raise_for_status()
+        session_id = created.json()["id"]
+
+        agent = http_client.get(f"/v1/sessions/{session_id}/agent")
+        agent.raise_for_status()
+        assert agent.json()["terminals"] == ["bash"]
+
+        rejected = http_client.post(
+            f"/v1/sessions/{session_id}/resources/terminals",
+            json={"terminal": "zsh", "session_key": "missing"},
+            timeout=30.0,
+        )
+        assert rejected.status_code == 400, rejected.text
+
+        launched = http_client.post(
+            f"/v1/sessions/{session_id}/resources/terminals",
+            json={"terminal": "bash", "session_key": "e2e"},
+            timeout=90.0,
+        )
+        launched.raise_for_status()
+        assert launched.json()["metadata"]["terminal_name"] == "bash"
+    finally:
+        daemon.proc.send_signal(signal.SIGTERM)
+        try:
+            daemon.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            daemon.proc.kill()
+            daemon.proc.wait()
 
 
 def _wait_for_host_online_by_name(

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -65,6 +65,7 @@ from omnigent.runner.identity import (
     RUNNER_DELEGATED_AUTH_ENV_VAR,
     RUNNER_ID_ENV_VAR,
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
+    RUNNER_INTERACTIVE_SHELLS_ENV_VAR,
     RUNNER_LAUNCH_HARNESS_ENV_VAR,
     RUNNER_PARENT_PID_ENV_VAR,
     RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
@@ -1986,7 +1987,10 @@ def test_build_runner_env_allowlists_host_env_and_strips_secrets() -> None:
         workspace="/ws",
         parent_pid=42,
         initial_auth_token="host-bootstrap-bearer",
+        interactive_shells=["zsh", "bash"],
     )
+
+    assert env[RUNNER_INTERACTIVE_SHELLS_ENV_VAR] == '["zsh", "bash"]'
 
     # Process essentials + the locale family pass through.
     assert env["PATH"] == "/usr/bin:/bin"

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -230,6 +230,7 @@ def test_hello_frame_round_trip() -> None:
         frame_protocol_version=1,
         name="corey-laptop",
         runners=["runner_token_aaa", "runner_token_bbb"],
+        interactive_shells=["zsh", "bash"],
     )
     decoded = decode_host_frame(encode_host_frame(original))
     assert isinstance(decoded, HostHelloFrame)
@@ -237,6 +238,23 @@ def test_hello_frame_round_trip() -> None:
     assert decoded.frame_protocol_version == 1
     assert decoded.name == "corey-laptop"
     assert decoded.runners == ["runner_token_aaa", "runner_token_bbb"]
+    assert decoded.interactive_shells == ["zsh", "bash"]
+
+
+def test_hello_frame_without_interactive_shells_is_backward_compatible() -> None:
+    """An older host hello leaves its shell inventory unknown."""
+    decoded = decode_host_frame(
+        json.dumps(
+            {
+                "kind": "host.hello",
+                "version": "0.1.0",
+                "frame_protocol_version": 1,
+                "name": "old-host",
+            }
+        )
+    )
+    assert isinstance(decoded, HostHelloFrame)
+    assert decoded.interactive_shells is None
 
 
 def test_hello_frame_empty_runners() -> None:

--- a/tests/inner/test_proc_and_platform.py
+++ b/tests/inner/test_proc_and_platform.py
@@ -90,6 +90,15 @@ def test_default_interactive_shell_falls_back_to_bash(
     assert _platform.default_interactive_shell() == "bash"
 
 
+def test_normalize_interactive_shells_filters_and_deduplicates() -> None:
+    """Host and server accept only supported shell basenames."""
+    assert _platform.normalize_interactive_shells(["zsh", "bash", "zsh", "not-a-shell", 42]) == [
+        "zsh",
+        "bash",
+    ]
+    assert _platform.normalize_interactive_shells("bash") == []
+
+
 @pytest.mark.posix_only
 def test_default_interactive_shell_trusts_shell_absolute_path_off_path(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/inner/test_proc_and_platform.py
+++ b/tests/inner/test_proc_and_platform.py
@@ -121,6 +121,34 @@ def test_default_interactive_shell_trusts_shell_absolute_path_off_path(
     assert _platform.default_interactive_shell() == "zsh"
 
 
+@pytest.mark.posix_only
+def test_resolve_interactive_shell_uses_matching_absolute_login_shell(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A Nix-style login shell remains executable under a stripped PATH."""
+    fish = tmp_path / "profiles" / "default" / "bin" / "fish"
+    fish.parent.mkdir(parents=True)
+    fish.write_text("#!/bin/sh\n")
+    fish.chmod(0o755)
+    monkeypatch.setenv("SHELL", str(fish))
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr(_platform, "_INTERACTIVE_SHELL_DIRS", ())
+
+    assert _platform.default_interactive_shell() == "fish"
+    assert _platform._resolve_interactive_shell("fish") == str(fish)
+
+
+@pytest.mark.parametrize("name", ["/bin/bash", "../bash", "unknown"])
+def test_resolve_interactive_shell_rejects_paths_and_unknown_names(
+    name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The resolver accepts allowlisted basenames only."""
+    monkeypatch.setattr("shutil.which", lambda value: pytest.fail(f"resolved {value}"))
+    assert _platform._resolve_interactive_shell(name) is None
+
+
 def _fake_resolver(installed: set[str]):
     """A ``_resolve_interactive_shell`` stand-in: resolve only *installed*.
 

--- a/tests/inner/test_proc_and_platform.py
+++ b/tests/inner/test_proc_and_platform.py
@@ -72,18 +72,54 @@ def test_default_interactive_shell_honors_known_shell_on_path(
 def test_default_interactive_shell_falls_back_to_bash(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unset / unknown / not-on-PATH ``$SHELL`` all fall back to bash."""
-    # Unset $SHELL → bash (known shells resolve on PATH here).
-    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    """Unset / unknown / uninstalled ``$SHELL`` all fall back to bash."""
+    # Resolution is fully hermetic: neither PATH nor the standard shell dirs
+    # yield anything, so only $SHELL's own absolute path could rescue a value.
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setattr(_platform, "_resolve_interactive_shell", lambda name: None)
+    monkeypatch.setattr(os.path, "isabs", lambda path: False)
+    # Unset $SHELL → bash.
     monkeypatch.delenv("SHELL", raising=False)
     assert _platform.default_interactive_shell() == "bash"
-    # An unknown shell name is never honored, even if on PATH.
+    # An unknown shell name is never honored, even if it resolved.
     monkeypatch.setenv("SHELL", "/opt/weird/nushell")
     assert _platform.default_interactive_shell() == "bash"
-    # A known shell that does not resolve on PATH also falls back.
-    monkeypatch.setattr("shutil.which", lambda name: None)
+    # A known shell that resolves nowhere (not on PATH, not in a standard dir,
+    # $SHELL not usable as an absolute path) also falls back.
     monkeypatch.setenv("SHELL", "/bin/zsh")
     assert _platform.default_interactive_shell() == "bash"
+
+
+@pytest.mark.posix_only
+def test_default_interactive_shell_trusts_shell_absolute_path_off_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A known ``$SHELL`` whose absolute path is executable is honored even
+    when it does not resolve on a stripped ``PATH``.
+
+    Reproduces the frozen-PATH host daemon (GUI/launchd launch): ``$SHELL`` is
+    ``/bin/zsh`` but ``PATH`` omits ``/bin``, so a bare ``shutil.which("zsh")``
+    misses it. The login shell must still be honored.
+    """
+    zsh = tmp_path / "zsh"
+    zsh.write_text("#!/bin/sh\n")
+    zsh.chmod(0o755)
+    # Nothing resolves on PATH or in the standard shell dirs.
+    monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setattr(_platform, "_INTERACTIVE_SHELL_DIRS", ())
+    monkeypatch.setenv("SHELL", str(zsh))
+    assert _platform.default_interactive_shell() == "zsh"
+
+
+def _fake_resolver(installed: set[str]):
+    """A ``_resolve_interactive_shell`` stand-in: resolve only *installed*.
+
+    Fully hermetic — the real helper probes both PATH and standard shell dirs,
+    so patching it (not just ``shutil.which``) is what keeps a test from leaking
+    whatever shells the host machine actually has installed.
+    """
+    return lambda name: f"/usr/bin/{name}" if name in installed else None
 
 
 @pytest.mark.posix_only
@@ -91,7 +127,9 @@ def test_installed_interactive_shells_lists_default_first_then_alternatives(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The default ($SHELL) leads; installed alternatives follow, deduped."""
-    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        _platform, "_resolve_interactive_shell", _fake_resolver({"bash", "zsh", "fish"})
+    )
     monkeypatch.setenv("SHELL", "/bin/zsh")
     # zsh is the default → first; bash/fish follow in offer order; no dupes.
     assert _platform.installed_interactive_shells() == ["zsh", "bash", "fish"]
@@ -101,21 +139,44 @@ def test_installed_interactive_shells_lists_default_first_then_alternatives(
 def test_installed_interactive_shells_skips_uninstalled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Alternatives that don't resolve on PATH are omitted."""
+    """Alternatives that resolve nowhere are omitted."""
     # Only bash and zsh installed; fish absent.
-    monkeypatch.setattr(
-        "shutil.which", lambda name: f"/usr/bin/{name}" if name in {"bash", "zsh"} else None
-    )
+    monkeypatch.setattr(_platform, "_resolve_interactive_shell", _fake_resolver({"bash", "zsh"}))
     monkeypatch.setenv("SHELL", "/bin/bash")
     assert _platform.installed_interactive_shells() == ["bash", "zsh"]
+
+
+@pytest.mark.posix_only
+def test_installed_interactive_shells_offers_shells_off_stripped_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shells in a standard dir are offered even when ``PATH`` omits it.
+
+    Regression for the frozen-PATH host daemon: with ``SHELL=/bin/zsh`` but a
+    ``PATH`` missing ``/bin``, ``shutil.which`` finds nothing, yet the standard
+    shell dirs still resolve zsh/bash — so the picker must offer both instead of
+    collapsing to a lone (phantom) ``bash``.
+    """
+    monkeypatch.setattr("shutil.which", lambda name: None)  # nothing on PATH
+
+    # Both live in /bin, off the stripped PATH.
+    def in_bin(path: str) -> bool:
+        return os.path.basename(path) in {"zsh", "bash"} and path.startswith("/bin/")
+
+    monkeypatch.setattr("os.path.isfile", in_bin)
+    monkeypatch.setattr("os.access", lambda p, mode: True)
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    assert _platform.installed_interactive_shells() == ["zsh", "bash"]
 
 
 @pytest.mark.posix_only
 def test_installed_interactive_shells_always_nonempty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With nothing resolvable the bash fallback is still offered alone."""
+    """With nothing resolvable anywhere the bash fallback is still offered alone."""
     monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setattr(_platform, "_resolve_interactive_shell", lambda name: None)
+    monkeypatch.setattr(os.path, "isabs", lambda path: False)
     monkeypatch.delenv("SHELL", raising=False)
     assert _platform.installed_interactive_shells() == ["bash"]
 

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -21,6 +21,8 @@ from omnigent.runner._entry import (
     _DEFAULT_RUNNER_IDLE_TIMEOUT_S,
     _DEFAULT_RUNNER_THREADPOOL_MAX_WORKERS,
     _agent_cache_dest,
+    _apply_host_interactive_shells,
+    _host_interactive_shells_from_env,
     _InitialAuthTokenFactory,
     _install_crash_logging,
     _install_signal_handlers,
@@ -44,6 +46,7 @@ from omnigent.runner._entry import (
 )
 from omnigent.runner.identity import (
     RUNNER_INITIAL_AUTH_TOKEN_ENV_VAR,
+    RUNNER_INTERACTIVE_SHELLS_ENV_VAR,
     RUNNER_TUNNEL_TOKEN_HEADER,
 )
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
@@ -54,6 +57,39 @@ from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_P
 # here (via import_module, so there is no bound-but-unused import) resolves and
 # caches it with the real type.
 importlib.import_module("mcp.client.streamable_http")
+
+
+def test_host_interactive_shells_from_env_normalizes_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runner wiring accepts only supported, ordered shell basenames."""
+    monkeypatch.setenv(
+        RUNNER_INTERACTIVE_SHELLS_ENV_VAR,
+        '["zsh", "bash", "zsh", "not-a-shell"]',
+    )
+    assert _host_interactive_shells_from_env() == ["zsh", "bash"]
+
+
+def test_apply_host_interactive_shells_only_replaces_native_wrappers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom agent terminals remain authored while native fallbacks change."""
+    from types import SimpleNamespace
+
+    from omnigent.native.native_coding_agents import CLAUDE_NATIVE_AGENT_NAME
+
+    monkeypatch.setenv(RUNNER_INTERACTIVE_SHELLS_ENV_VAR, '["zsh", "bash"]')
+    native = SimpleNamespace(name=CLAUDE_NATIVE_AGENT_NAME, terminals={"bash": object()})
+    custom_terminal = object()
+    custom = SimpleNamespace(name="custom", terminals={"project": custom_terminal})
+
+    _apply_host_interactive_shells(native)
+    _apply_host_interactive_shells(custom)
+
+    assert list(native.terminals) == ["zsh", "bash"]
+    assert native.terminals["zsh"].command is not None
+    assert native.terminals["zsh"].command.endswith("zsh")
+    assert custom.terminals == {"project": custom_terminal}
 
 
 class _TrackingTerminalRegistry:

--- a/tests/runner/test_session_resources.py
+++ b/tests/runner/test_session_resources.py
@@ -1189,6 +1189,73 @@ async def test_create_terminal_uses_declared_terminal_spec_over_body(
 
 
 @pytest.mark.asyncio
+async def test_create_terminal_rejects_unavailable_native_shell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mixed-version request cannot silently substitute another shell."""
+    from omnigent.inner.datamodel import AgentDef
+    from omnigent.native.native_coding_agents import (
+        CLAUDE_NATIVE_AGENT_NAME,
+        native_shell_terminal_specs,
+    )
+
+    fish = tmp_path / "nix-profile" / "bin" / "fish"
+    fish.parent.mkdir(parents=True)
+    fish.write_text("#!/bin/sh\n")
+    fish.chmod(0o755)
+    monkeypatch.setenv("SHELL", str(fish))
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("omnigent._platform._INTERACTIVE_SHELL_DIRS", ())
+
+    agent = AgentDef(
+        name=CLAUDE_NATIVE_AGENT_NAME,
+        terminals=native_shell_terminal_specs(["fish"]),
+    )
+
+    async def _session_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "conv_test", "agent_id": "agent_native"})
+
+    async def _resolver(agent_id: str, session_id: str) -> AgentDef:
+        return agent
+
+    server_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_session_handler),
+        base_url="http://server",
+    )
+    resource_registry = _CapturingResourceRegistry(tmp_path)
+    app = create_runner_app(
+        resource_registry=resource_registry,
+        server_client=server_client,
+        spec_resolver=_resolver,
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with (
+        server_client,
+        httpx.AsyncClient(transport=transport, base_url="http://runner") as client,
+    ):
+        response = await client.post(
+            "/v1/sessions/conv_test/resources/terminals",
+            json={
+                "terminal": "zsh",
+                "session_key": "shell-1",
+                "spec": {"command": "zsh"},
+            },
+        )
+        success = await client.post(
+            "/v1/sessions/conv_test/resources/terminals",
+            json={"terminal": "fish", "session_key": "shell-2"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_input"
+    assert "not available on this host" in response.json()["error"]["message"]
+    assert success.status_code == 200
+    assert len(resource_registry.launches) == 1
+    assert resource_registry.launches[0].command == str(fish)
+
+
+@pytest.mark.asyncio
 async def test_create_terminal_resolves_declared_placeholder_cwd_to_workspace(
     tmp_path: Path,
 ) -> None:

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -876,6 +876,7 @@ async def create_test_agent(
     skills: list[dict[str, str]] | None = None,
     user: str | None = None,
     guardrails: dict[str, Any] | None = None,
+    terminals: dict[str, Any] | None = None,
     include_llm: bool = True,
     sub_agents: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -903,6 +904,8 @@ async def create_test_agent(
     :param guardrails: Optional ``guardrails:`` block for the agent
         spec (e.g. a ``cost_budget`` policy). Passed verbatim to
         :func:`build_agent_bundle`. ``None`` omits guardrails.
+    :param terminals: Optional ``terminals:`` block written verbatim
+        into the agent spec.
     :param include_llm: Whether to include the default ``llm:`` block.
         Set ``False`` for model-less harness tests.
     :param sub_agents: Optional sub-agent config dicts declared in the
@@ -921,6 +924,7 @@ async def create_test_agent(
         executor=executor,
         skills=skills,
         guardrails=guardrails,
+        terminals=terminals,
         include_llm=include_llm,
         sub_agents=sub_agents,
     )

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3250,24 +3250,11 @@ async def test_session_agent_terminals_follow_selected_host(
     app: Any,
     db_uri: str,
 ) -> None:
-    """Native shell choices come from the host; custom choices stay authored."""
+    """Fresh projections use the host for both old and new native sessions."""
     host_id = "6b9c07bfb42f687d53af44f018adebee"
-    HostStore(db_uri).upsert_on_connect(host_id, "bash-only-host", "owner@example.com")
-    app.state.host_registry.register(
-        host_id,
-        AsyncMock(),
-        HostHelloFrame(
-            version="0.1.0-test",
-            frame_protocol_version=1,
-            name="bash-only-host",
-            interactive_shells=["bash"],
-        ),
-        owner="owner@example.com",
-    )
-
     terminal_spec = {
-        "zsh": {
-            "command": "zsh",
+        "bash": {
+            "command": "bash",
             "os_env": {"type": "caller_process", "cwd": "."},
         }
     }
@@ -3281,9 +3268,30 @@ async def test_session_agent_terminals_follow_selected_host(
         native_session["id"], host_id=host_id, workspace="/tmp/native"
     )
 
+    HostStore(db_uri).upsert_on_connect(host_id, "zsh-host", "owner@example.com")
+    app.state.host_registry.register(
+        host_id,
+        AsyncMock(),
+        HostHelloFrame(
+            version="0.1.0-test",
+            frame_protocol_version=1,
+            name="zsh-host",
+            interactive_shells=["zsh", "bash"],
+        ),
+        owner="owner@example.com",
+    )
+
     native_response = await client.get(f"/v1/sessions/{native_session['id']}/agent")
     assert native_response.status_code == 200, native_response.text
-    assert native_response.json()["terminals"] == ["bash"]
+    assert native_response.json()["terminals"] == ["zsh", "bash"]
+
+    new_native_session = await _create_session(client, native_agent["id"])
+    SqlAlchemyConversationStore(db_uri).set_host_id(
+        new_native_session["id"], host_id=host_id, workspace="/tmp/new-native"
+    )
+    new_native_response = await client.get(f"/v1/sessions/{new_native_session['id']}/agent")
+    assert new_native_response.status_code == 200, new_native_response.text
+    assert new_native_response.json()["terminals"] == ["zsh", "bash"]
 
     custom_agent = await create_test_agent(
         client,
@@ -3297,15 +3305,17 @@ async def test_session_agent_terminals_follow_selected_host(
 
     custom_response = await client.get(f"/v1/sessions/{custom_session['id']}/agent")
     assert custom_response.status_code == 200, custom_response.text
-    assert custom_response.json()["terminals"] == ["zsh"]
+    assert custom_response.json()["terminals"] == ["bash"]
 
 
+@pytest.mark.parametrize("cached_inventory", [False, True])
 async def test_host_shell_inventory_miss_returns_wrong_replica(
     client: httpx.AsyncClient,
     app: Any,
     db_uri: str,
+    cached_inventory: bool,
 ) -> None:
-    """Replica-local shell metadata must not fall back before re-addressing."""
+    """Missing or stale replica-local metadata must trigger re-addressing."""
     host_id = "7b9c07bfb42f687d53af44f018adebee"
     HostStore(db_uri).upsert_on_connect(host_id, "remote-host", "owner@example.com")
     native_agent = await create_test_agent(
@@ -3322,6 +3332,19 @@ async def test_host_shell_inventory_miss_returns_wrong_replica(
     SqlAlchemyConversationStore(db_uri).set_host_id(
         session["id"], host_id=host_id, workspace="/tmp/native"
     )
+    if cached_inventory:
+        app.state.host_registry.register(
+            host_id,
+            AsyncMock(),
+            HostHelloFrame(
+                version="0.1.0-test",
+                frame_protocol_version=1,
+                name="former-local-host",
+                interactive_shells=["bash"],
+            ),
+            owner="owner@example.com",
+        )
+        app.state.host_registry.deregister(host_id)
 
     agent_response = await client.get(f"/v1/sessions/{session['id']}/agent")
     terminal_response = await client.post(

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3300,6 +3300,59 @@ async def test_session_agent_terminals_follow_selected_host(
     assert custom_response.json()["terminals"] == ["zsh"]
 
 
+async def test_host_shell_inventory_miss_returns_wrong_replica(
+    client: httpx.AsyncClient,
+    app: Any,
+    db_uri: str,
+) -> None:
+    """Replica-local shell metadata must not fall back before re-addressing."""
+    host_id = "7b9c07bfb42f687d53af44f018adebee"
+    HostStore(db_uri).upsert_on_connect(host_id, "remote-host", "owner@example.com")
+    native_agent = await create_test_agent(
+        client,
+        name=CLAUDE_NATIVE_AGENT_NAME,
+        terminals={
+            "zsh": {
+                "command": "zsh",
+                "os_env": {"type": "caller_process", "cwd": "."},
+            }
+        },
+    )
+    session = await _create_session(client, native_agent["id"])
+    SqlAlchemyConversationStore(db_uri).set_host_id(
+        session["id"], host_id=host_id, workspace="/tmp/native"
+    )
+
+    agent_response = await client.get(f"/v1/sessions/{session['id']}/agent")
+    terminal_response = await client.post(
+        f"/v1/sessions/{session['id']}/resources/terminals",
+        json={"terminal": "zsh", "session_key": "shell-1"},
+    )
+
+    assert agent_response.status_code == 400
+    assert agent_response.json()["error"]["code"] == "wrong_replica"
+    assert terminal_response.status_code == 400
+    assert terminal_response.json()["error"]["code"] == "wrong_replica"
+
+    custom_agent = await create_test_agent(
+        client,
+        name="custom-remote-agent",
+        terminals={
+            "zsh": {
+                "command": "zsh",
+                "os_env": {"type": "caller_process", "cwd": "."},
+            }
+        },
+    )
+    custom_session = await _create_session(client, custom_agent["id"])
+    SqlAlchemyConversationStore(db_uri).set_host_id(
+        custom_session["id"], host_id=host_id, workspace="/tmp/custom"
+    )
+    custom_response = await client.get(f"/v1/sessions/{custom_session['id']}/agent")
+    assert custom_response.status_code == 200
+    assert custom_response.json()["terminals"] == ["zsh"]
+
+
 async def test_claude_native_session_discoverable_with_terminal_metadata(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -30,7 +30,9 @@ from omnigent.entities import (
     MessageData,
     NewConversationItem,
 )
+from omnigent.host.frames import HostHelloFrame
 from omnigent.llms.context_window import ModelPricing
+from omnigent.native.native_coding_agents import CLAUDE_NATIVE_AGENT_NAME
 from omnigent.runtime.tool_output import MAX_TOOL_OUTPUT_BYTES
 from omnigent.server.background_session_titles import BackgroundTitleRequest
 from omnigent.server.routes._sessions.helpers import (
@@ -3241,6 +3243,61 @@ async def test_list_sessions_includes_external_session_id(
 
 
 # ── claude-native session discovery (list + snapshot) ────────────
+
+
+async def test_session_agent_terminals_follow_selected_host(
+    client: httpx.AsyncClient,
+    app: Any,
+    db_uri: str,
+) -> None:
+    """Native shell choices come from the host; custom choices stay authored."""
+    host_id = "6b9c07bfb42f687d53af44f018adebee"
+    HostStore(db_uri).upsert_on_connect(host_id, "bash-only-host", "owner@example.com")
+    app.state.host_registry.register(
+        host_id,
+        AsyncMock(),
+        HostHelloFrame(
+            version="0.1.0-test",
+            frame_protocol_version=1,
+            name="bash-only-host",
+            interactive_shells=["bash"],
+        ),
+        owner="owner@example.com",
+    )
+
+    terminal_spec = {
+        "zsh": {
+            "command": "zsh",
+            "os_env": {"type": "caller_process", "cwd": "."},
+        }
+    }
+    native_agent = await create_test_agent(
+        client,
+        name=CLAUDE_NATIVE_AGENT_NAME,
+        terminals=terminal_spec,
+    )
+    native_session = await _create_session(client, native_agent["id"])
+    SqlAlchemyConversationStore(db_uri).set_host_id(
+        native_session["id"], host_id=host_id, workspace="/tmp/native"
+    )
+
+    native_response = await client.get(f"/v1/sessions/{native_session['id']}/agent")
+    assert native_response.status_code == 200, native_response.text
+    assert native_response.json()["terminals"] == ["bash"]
+
+    custom_agent = await create_test_agent(
+        client,
+        name="custom-shell-agent",
+        terminals=terminal_spec,
+    )
+    custom_session = await _create_session(client, custom_agent["id"])
+    SqlAlchemyConversationStore(db_uri).set_host_id(
+        custom_session["id"], host_id=host_id, workspace="/tmp/custom"
+    )
+
+    custom_response = await client.get(f"/v1/sessions/{custom_session['id']}/agent")
+    assert custom_response.status_code == 200, custom_response.text
+    assert custom_response.json()["terminals"] == ["zsh"]
 
 
 async def test_claude_native_session_discoverable_with_terminal_metadata(

--- a/tests/server/routes/test_session_resources.py
+++ b/tests/server/routes/test_session_resources.py
@@ -16,6 +16,8 @@ from fastapi.responses import FileResponse, JSONResponse
 
 from omnigent.entities import DEFAULT_ENVIRONMENT_ID, Conversation, ConversationItem, PagedList
 from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.host.frames import HostHelloFrame
+from omnigent.native.native_coding_agents import CLAUDE_NATIVE_AGENT_NAME
 from omnigent.runtime import (
     _globals,
     session_stream,
@@ -24,6 +26,7 @@ from omnigent.runtime import (
     set_runner_router,
 )
 from omnigent.server._runner_ws_tunnel import DirectAttachEndpoint
+from omnigent.server.host_registry import HostRegistry
 from omnigent.server.routes.sessions import _ancestor_session_ids, create_sessions_router
 from omnigent.server.schemas import SessionEventInput
 
@@ -469,7 +472,9 @@ def app(runner_globals_reset: None) -> FastAPI:
     del runner_globals_reset
     app = FastAPI()
     conversation_store = _ConversationStore()
+    host_registry = HostRegistry()
     app.state.test_conversation_store = conversation_store
+    app.state.test_host_registry = host_registry
 
     @app.exception_handler(OmnigentError)
     async def _handle_omnigent_error(
@@ -496,6 +501,7 @@ def app(runner_globals_reset: None) -> FastAPI:
         create_sessions_router(
             conversation_store,  # type: ignore[arg-type]
             _StubAgentStore(),  # type: ignore[arg-type]
+            host_registry=host_registry,
         ),
         prefix="/v1",
     )
@@ -1290,6 +1296,40 @@ def bash_terminal_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture
+def bash_only_native_host(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bind the canned session to a native spec on a bash-only host."""
+    from omnigent.inner.datamodel import TerminalEnvSpec
+    from omnigent.server.routes import sessions as sessions_module
+    from omnigent.spec.types import AgentSpec
+
+    session_id = "79b22ebd2309e48fdeb450c65611d51b"
+    conv = app.state.test_conversation_store._conversations[session_id]
+    conv.host_id = "host_bash_only"
+    conv.workspace = "/workspace"
+    app.state.test_host_registry.register(
+        conv.host_id,
+        object(),  # type: ignore[arg-type]
+        HostHelloFrame(
+            version="0.1.0-test",
+            frame_protocol_version=1,
+            name="bash-only",
+            interactive_shells=["bash"],
+        ),
+        owner=None,
+    )
+    spec = AgentSpec(
+        spec_version=1,
+        name=CLAUDE_NATIVE_AGENT_NAME,
+        terminals={"zsh": TerminalEnvSpec(command="zsh")},
+    )
+    monkeypatch.setattr(
+        sessions_module,
+        "_load_agent_spec_for_session",
+        lambda conv, agent_store: spec,
+    )
+
+
 @pytest.mark.asyncio
 async def test_create_terminal_proxies_to_runner(
     client: httpx.AsyncClient,
@@ -1322,6 +1362,58 @@ async def test_create_terminal_proxies_to_runner(
     assert fake_runner.calls == [
         ("POST", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_create_terminal_uses_native_host_shell_inventory(
+    client: httpx.AsyncClient,
+    bash_only_native_host: None,
+) -> None:
+    """A native host shell is allowed even when the baked spec differs."""
+    terminal_resource = {
+        "id": "terminal_bash_s1",
+        "object": "session.resource",
+        "type": "terminal",
+        "session_id": "79b22ebd2309e48fdeb450c65611d51b",
+        "name": "bash:s1",
+        "environment": DEFAULT_ENVIRONMENT_ID,
+        "metadata": {
+            "terminal_name": "bash",
+            "session_key": "s1",
+            "running": True,
+        },
+    }
+    fake_runner = _FakeRunnerClient(payload=terminal_resource)
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.post(
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
+        json={"terminal": "bash", "session_key": "s1"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert fake_runner.calls == [
+        ("POST", "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_terminal_rejects_shell_absent_from_native_host(
+    client: httpx.AsyncClient,
+    bash_only_native_host: None,
+) -> None:
+    """A shell baked on the server cannot be launched on a host lacking it."""
+    fake_runner = _FakeRunnerClient(payload={})
+    set_runner_router(_FakeRunnerRouter(fake_runner))  # type: ignore[arg-type]
+
+    resp = await client.post(
+        "/v1/sessions/79b22ebd2309e48fdeb450c65611d51b/resources/terminals",
+        json={"terminal": "zsh", "session_key": "s1"},
+    )
+
+    assert resp.status_code == 400
+    assert "bash" in resp.json()["error"]["message"]
+    assert fake_runner.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_host_registry.py
+++ b/tests/server/test_host_registry.py
@@ -84,6 +84,18 @@ def test_interactive_shells_survive_disconnect() -> None:
     assert registry.interactive_shells("host_shells") == ["zsh", "bash"]
 
 
+def test_reconnect_without_shell_inventory_clears_snapshot() -> None:
+    """An older reconnecting host cannot retain a newer host's inventory."""
+    registry = HostRegistry()
+    hello = _make_hello()
+    hello.interactive_shells = ["zsh", "bash"]
+    registry.register("host_shells", FakeWebSocket(), hello, owner="alice")
+
+    registry.register("host_shells", FakeWebSocket(), _make_hello(), owner="alice")
+
+    assert registry.interactive_shells("host_shells") is None
+
+
 def test_deregister() -> None:
     """
     Verify that deregister removes the host from the registry.

--- a/tests/server/test_host_registry.py
+++ b/tests/server/test_host_registry.py
@@ -73,6 +73,17 @@ def test_register_and_get() -> None:
     assert fetched.hello.name == "test-host"
 
 
+def test_interactive_shells_survive_disconnect() -> None:
+    """A runner can outlive its host tunnel without losing the shell snapshot."""
+    registry = HostRegistry()
+    hello = _make_hello()
+    hello.interactive_shells = ["zsh", "invalid", "zsh", "bash"]
+    registry.register("host_shells", FakeWebSocket(), hello, owner="alice")
+    registry.deregister("host_shells")
+
+    assert registry.interactive_shells("host_shells") == ["zsh", "bash"]
+
+
 def test_deregister() -> None:
     """
     Verify that deregister removes the host from the registry.

--- a/tests/test_hermes_native.py
+++ b/tests/test_hermes_native.py
@@ -95,17 +95,22 @@ def test_create_app_builds() -> None:
 # --- CLI orchestration helpers (no server/daemon needed) ----------------------
 
 
-def test_materialize_agent_spec_is_terminal_first_hermes_native(tmp_path) -> None:
+def test_materialize_agent_spec_is_terminal_first_hermes_native(tmp_path, monkeypatch) -> None:
     import yaml
 
+    # Pin the host shells so the declared terminals are deterministic: zsh is
+    # $SHELL (default, first), bash/fish resolve on PATH.
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
     spec_path = hn._materialize_hermes_agent_spec(tmp_path)
     raw = yaml.safe_load(spec_path.read_text())
     assert raw["name"] == "hermes-native-ui"
     assert raw["executor"] == {"harness": "hermes-native"}
     assert raw["spawn"] is True
-    # Bundles carry a portable fallback until a host-bound runner replaces it.
-    assert list(raw["terminals"]) == ["bash"]
-    assert raw["terminals"]["bash"]["command"] == "bash"
+    # One terminal per installed shell, $SHELL first — a non-empty block also
+    # gates the MCP relay's sys_terminal_* advertisement.
+    assert list(raw["terminals"]) == ["zsh", "bash", "fish"]
+    assert raw["terminals"]["zsh"]["command"] == "zsh"
 
 
 def test_configured_hermes_command_default_and_override() -> None:

--- a/tests/test_hermes_native.py
+++ b/tests/test_hermes_native.py
@@ -95,22 +95,17 @@ def test_create_app_builds() -> None:
 # --- CLI orchestration helpers (no server/daemon needed) ----------------------
 
 
-def test_materialize_agent_spec_is_terminal_first_hermes_native(tmp_path, monkeypatch) -> None:
+def test_materialize_agent_spec_is_terminal_first_hermes_native(tmp_path) -> None:
     import yaml
 
-    # Pin the host shells so the declared terminals are deterministic: zsh is
-    # $SHELL (default, first), bash/fish resolve on PATH.
-    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setenv("SHELL", "/bin/zsh")
     spec_path = hn._materialize_hermes_agent_spec(tmp_path)
     raw = yaml.safe_load(spec_path.read_text())
     assert raw["name"] == "hermes-native-ui"
     assert raw["executor"] == {"harness": "hermes-native"}
     assert raw["spawn"] is True
-    # One terminal per installed shell, $SHELL first — a non-empty block also
-    # gates the MCP relay's sys_terminal_* advertisement.
-    assert list(raw["terminals"]) == ["zsh", "bash", "fish"]
-    assert raw["terminals"]["zsh"]["command"] == "zsh"
+    # Bundles carry a portable fallback until a host-bound runner replaces it.
+    assert list(raw["terminals"]) == ["bash"]
+    assert raw["terminals"]["bash"]["command"] == "bash"
 
 
 def test_configured_hermes_command_default_and_override() -> None:

--- a/tests/test_native_coding_agents.py
+++ b/tests/test_native_coding_agents.py
@@ -140,8 +140,17 @@ def test_native_shell_terminal_spec_offers_installed_shells_default_first(
 def test_native_shell_terminal_spec_falls_back_to_bash(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With no shells installed the spec still offers a single bash terminal."""
+    """With no shells resolvable anywhere the spec still offers a single bash.
+
+    Resolution is fully hermetic: nothing on PATH, nothing in the standard shell
+    dirs, and no usable ``$SHELL`` absolute path — otherwise the dir probe would
+    leak whatever shells the host actually has installed.
+    """
+    from omnigent import _platform
+
     monkeypatch.setattr("shutil.which", lambda name: None)
+    monkeypatch.setattr(_platform, "_resolve_interactive_shell", lambda name: None)
+    monkeypatch.setattr(_platform.os.path, "isabs", lambda path: False)
     monkeypatch.delenv("SHELL", raising=False)
     spec = native_shell_terminal_spec()
     assert list(spec) == ["bash"]

--- a/tests/test_native_coding_agents.py
+++ b/tests/test_native_coding_agents.py
@@ -16,6 +16,7 @@ from omnigent.native.native_coding_agents import (
     native_coding_agent_for_harness,
     native_coding_agent_for_wrapper_label,
     native_shell_terminal_spec,
+    native_shell_terminal_specs,
     public_agent_name,
 )
 
@@ -112,20 +113,15 @@ def test_public_agent_name_passes_through_regular_names() -> None:
 
 
 @pytest.mark.posix_only
-def test_native_shell_terminal_spec_offers_installed_shells_default_first(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """One terminal per installed shell, keyed by name, ``$SHELL`` first.
+def test_native_shell_terminal_spec_offers_host_shells_default_first() -> None:
+    """One terminal per host shell, keyed by name, with its default first.
 
     Every native wrapper declares this so "+ New shell" opens the user's login
     shell by default while still offering the other installed shells. Each entry
     is keyed and commanded by its basename and is an unsandboxed caller-process
     shell with cwd override allowed.
     """
-    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setenv("SHELL", "/usr/local/bin/fish")
-    spec = native_shell_terminal_spec()
-    # $SHELL (fish) leads, then the remaining offered shells in order.
+    spec = native_shell_terminal_spec(["fish", "bash", "zsh"])
     assert list(spec) == ["fish", "bash", "zsh"]
     for name, entry in spec.items():
         assert entry["command"] == name
@@ -137,21 +133,27 @@ def test_native_shell_terminal_spec_offers_installed_shells_default_first(
         }
 
 
-def test_native_shell_terminal_spec_falls_back_to_bash(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """With no shells resolvable anywhere the spec still offers a single bash.
-
-    Resolution is fully hermetic: nothing on PATH, nothing in the standard shell
-    dirs, and no usable ``$SHELL`` absolute path — otherwise the dir probe would
-    leak whatever shells the host actually has installed.
-    """
-    from omnigent import _platform
-
-    monkeypatch.setattr("shutil.which", lambda name: None)
-    monkeypatch.setattr(_platform, "_resolve_interactive_shell", lambda name: None)
-    monkeypatch.setattr(_platform.os.path, "isabs", lambda path: False)
-    monkeypatch.delenv("SHELL", raising=False)
+def test_native_shell_terminal_spec_falls_back_to_bash() -> None:
+    """Generated bundles carry a portable bash fallback before host binding."""
     spec = native_shell_terminal_spec()
     assert list(spec) == ["bash"]
     assert spec["bash"]["command"] == "bash"
+
+
+def test_native_shell_terminal_specs_builds_runtime_specs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runner can replace the fallback with parsed host terminal specs."""
+    monkeypatch.setattr(
+        "omnigent._platform._resolve_interactive_shell",
+        lambda shell: f"/resolved/{shell}",
+    )
+    spec = native_shell_terminal_specs(["zsh", "bash"])
+    assert list(spec) == ["zsh", "bash"]
+    assert spec["zsh"].command == "/resolved/zsh"
+    assert spec["zsh"].allow_cwd_override is True
+    assert spec["zsh"].os_env != "inherit"
+    assert spec["zsh"].os_env is not None
+    assert spec["zsh"].os_env.cwd == "."
+    assert spec["zsh"].os_env.sandbox is not None
+    assert spec["zsh"].os_env.sandbox.type == "none"

--- a/tests/test_native_coding_agents.py
+++ b/tests/test_native_coding_agents.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from omnigent._wrapper_labels import (
@@ -113,15 +115,21 @@ def test_public_agent_name_passes_through_regular_names() -> None:
 
 
 @pytest.mark.posix_only
-def test_native_shell_terminal_spec_offers_host_shells_default_first() -> None:
-    """One terminal per host shell, keyed by name, with its default first.
+def test_native_shell_terminal_spec_offers_installed_shells_default_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One terminal per installed shell, keyed by name, ``$SHELL`` first.
 
     Every native wrapper declares this so "+ New shell" opens the user's login
     shell by default while still offering the other installed shells. Each entry
     is keyed and commanded by its basename and is an unsandboxed caller-process
     shell with cwd override allowed.
     """
-    spec = native_shell_terminal_spec(["fish", "bash", "zsh"])
+    monkeypatch.setattr(
+        "omnigent.native.native_coding_agents.installed_interactive_shells",
+        lambda: ["fish", "bash", "zsh"],
+    )
+    spec = native_shell_terminal_spec()
     assert list(spec) == ["fish", "bash", "zsh"]
     for name, entry in spec.items():
         assert entry["command"] == name
@@ -133,8 +141,14 @@ def test_native_shell_terminal_spec_offers_host_shells_default_first() -> None:
         }
 
 
-def test_native_shell_terminal_spec_falls_back_to_bash() -> None:
-    """Generated bundles carry a portable bash fallback before host binding."""
+def test_native_shell_terminal_spec_falls_back_to_bash(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The materialized spec retains discovery's non-empty bash fallback."""
+    monkeypatch.setattr(
+        "omnigent.native.native_coding_agents.installed_interactive_shells",
+        lambda: ["bash"],
+    )
     spec = native_shell_terminal_spec()
     assert list(spec) == ["bash"]
     assert spec["bash"]["command"] == "bash"
@@ -157,3 +171,22 @@ def test_native_shell_terminal_specs_builds_runtime_specs(
     assert spec["zsh"].os_env.cwd == "."
     assert spec["zsh"].os_env.sandbox is not None
     assert spec["zsh"].os_env.sandbox.type == "none"
+
+
+@pytest.mark.posix_only
+def test_native_shell_terminal_specs_preserves_login_shell_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Runtime specs launch a nonstandard absolute login-shell executable."""
+    fish = tmp_path / "nix-profile" / "bin" / "fish"
+    fish.parent.mkdir(parents=True)
+    fish.write_text("#!/bin/sh\n")
+    fish.chmod(0o755)
+    monkeypatch.setenv("SHELL", str(fish))
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("omnigent._platform._INTERACTIVE_SHELL_DIRS", ())
+
+    spec = native_shell_terminal_specs(["fish"])
+
+    assert spec["fish"].command == str(fish)

--- a/tests/test_opencode_native.py
+++ b/tests/test_opencode_native.py
@@ -49,17 +49,13 @@ class _FakeClient:
 # ── _materialize_opencode_agent_spec ────────────────────────────────────────
 
 
-def test_materialize_spec_defaults_no_model(tmp_path: Path, monkeypatch) -> None:
-    # Pin the host shells so the declared terminals are deterministic.
-    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setenv("SHELL", "/bin/zsh")
+def test_materialize_spec_defaults_no_model(tmp_path: Path) -> None:
     spec = yaml.safe_load(_materialize_opencode_agent_spec(tmp_path).read_text())
     assert spec["executor"] == {"harness": "opencode-native"}
     assert spec["spawn"] is True
-    # One terminal per installed shell, $SHELL first — a non-empty block gates
-    # the relay's sys_terminal_* advertisement.
-    assert list(spec["terminals"]) == ["zsh", "bash", "fish"]
-    assert spec["terminals"]["zsh"]["command"] == "zsh"
+    # Bundles carry a portable fallback until a host-bound runner replaces it.
+    assert list(spec["terminals"]) == ["bash"]
+    assert spec["terminals"]["bash"]["command"] == "bash"
 
 
 def test_materialize_spec_pins_model(tmp_path: Path) -> None:

--- a/tests/test_opencode_native.py
+++ b/tests/test_opencode_native.py
@@ -49,13 +49,17 @@ class _FakeClient:
 # ── _materialize_opencode_agent_spec ────────────────────────────────────────
 
 
-def test_materialize_spec_defaults_no_model(tmp_path: Path) -> None:
+def test_materialize_spec_defaults_no_model(tmp_path: Path, monkeypatch) -> None:
+    # Pin the host shells so the declared terminals are deterministic.
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
     spec = yaml.safe_load(_materialize_opencode_agent_spec(tmp_path).read_text())
     assert spec["executor"] == {"harness": "opencode-native"}
     assert spec["spawn"] is True
-    # Bundles carry a portable fallback until a host-bound runner replaces it.
-    assert list(spec["terminals"]) == ["bash"]
-    assert spec["terminals"]["bash"]["command"] == "bash"
+    # One terminal per installed shell, $SHELL first — a non-empty block gates
+    # the relay's sys_terminal_* advertisement.
+    assert list(spec["terminals"]) == ["zsh", "bash", "fish"]
+    assert spec["terminals"]["zsh"]["command"] == "zsh"
 
 
 def test_materialize_spec_pins_model(tmp_path: Path) -> None:

--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -182,6 +182,20 @@ function wireItem(id: string, commentsCount: number, commentsUpdatedAt: number |
   return { ...conv(id), comments_count: commentsCount, comments_updated_at: commentsUpdatedAt };
 }
 
+describe("SessionUpdatesProvider host changes", () => {
+  it("invalidates cached session agents so shell inventories refresh", () => {
+    const client = new QueryClient();
+    seedConversations(client, ["conv_old"]);
+    renderProvider(client, ["/c/conv_old"]);
+    const invalidate = vi.spyOn(client, "invalidateQueries");
+
+    act(() => frameHandler()({ type: "hosts_changed" }));
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["hosts"] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["session-agent"] });
+  });
+});
+
 describe("SessionUpdatesProvider comments fingerprint", () => {
   it("invalidates the comments cache when a changed frame moves the fingerprint", () => {
     const client = new QueryClient();

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -324,6 +324,7 @@ export function SessionUpdatesProvider({ children }: { children: ReactNode }) {
           return;
         case "hosts_changed":
           void queryClient.invalidateQueries({ queryKey: ["hosts"] });
+          void queryClient.invalidateQueries({ queryKey: ["session-agent"] });
           return;
         case "removed":
           for (const id of frame.ids) commentsFingerprintsRef.current.delete(id);

--- a/web/src/shell/SwitchHostDialog.test.tsx
+++ b/web/src/shell/SwitchHostDialog.test.tsx
@@ -105,11 +105,12 @@ const updateSessionMock = vi.mocked(updateSession);
 
 function renderDialog() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  render(
     <QueryClientProvider client={client}>
       <SwitchHostDialog open onOpenChange={() => {}} sessionId="conv_1" currentHostId="host_old" />
     </QueryClientProvider>,
   );
+  return client;
 }
 
 beforeEach(() => {
@@ -135,7 +136,8 @@ afterEach(() => cleanup());
 
 describe("SwitchHostDialog", () => {
   it("releases the runner and the model override before launching on the new host", async () => {
-    renderDialog();
+    const client = renderDialog();
+    const invalidate = vi.spyOn(client, "invalidateQueries");
 
     const button = await screen.findByTestId("switch-host-button");
     await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(false));
@@ -157,6 +159,7 @@ describe("SwitchHostDialog", () => {
     expect(updateSessionMock.mock.invocationCallOrder[0]).toBeLessThan(
       launchRunnerMock.mock.invocationCallOrder[0],
     );
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ["session-agent", "conv_1"] });
   });
 
   it("offers the origin host again when the launch fails after the release", async () => {

--- a/web/src/shell/SwitchHostDialog.tsx
+++ b/web/src/shell/SwitchHostDialog.tsx
@@ -208,6 +208,7 @@ export function SwitchHostDialog({
       // sitting in "Switching…" long after the move has landed.
       handleOpenChange(false);
       void queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+      void queryClient.invalidateQueries({ queryKey: ["session-agent", sessionId] });
       void queryClient.invalidateQueries({ queryKey: ["conversations"] });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Couldn't switch hosts. Try again.");


### PR DESCRIPTION
## Related issue

N/A — reported remote-server/local-host shell discovery mismatch; no linked issue.

## Summary

- Discover interactive shells once in the `omni host` process and report the ordered inventory to the API server and spawned runners.
- Use the selected host's inventory for native-wrapper terminal presentation, authorization, and runtime specs while leaving custom agent terminals unchanged.
- Keep compatibility with older hosts and retain robust discovery when a host daemon inherits a stripped `PATH`.

ELI5: the shell picker used to inspect the server's toolbox even though terminals run in the host's toolbox. It now asks the selected host what it actually has and uses that same answer when launching a shell.

```mermaid
flowchart LR
    H[Host process] -->|discover shells| I[Ordered shell inventory]
    I -->|host.hello| S[API server]
    I -->|runner environment| R[Host runner]
    S -->|picker and authorization| UI[Session UI/API]
    R -->|resolved terminal command| T[Interactive shell]
```

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_proc_and_platform.py tests/test_native_coding_agents.py tests/host/test_frames.py tests/runner/test_runner_entry.py tests/server/test_host_registry.py tests/server/integration/test_sessions_endpoints.py::test_session_agent_terminals_follow_selected_host tests/server/routes/test_session_resources.py::test_create_terminal_uses_native_host_shell_inventory tests/server/routes/test_session_resources.py::test_create_terminal_rejects_shell_absent_from_native_host` — 270 passed, 8 skipped.
- `uv run --no-sync pytest -q tests/e2e/test_host_e2e.py::test_native_shells_follow_bash_only_host_inventory -s` — passed. This runs a real local server and host/runner processes, injects a bash-only host inventory while the server machine has zsh, verifies the API offers only bash, rejects zsh, and launches bash successfully.
- Staged `pre-commit run` — passed, including Ruff, Pyrefly, project test-quality lint, and file hygiene hooks.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The process-level E2E above reproduces the separate server/host topology locally with a deterministic bash-only host.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes host discovery and frame compatibility, runner propagation and runtime replacement, host-aware API projection, custom-agent preservation, terminal authorization, and a real-process bash-only launch.

## Changelog

Interactive shell choices now match the shells installed on the selected host, even when the API server runs on another machine.
