### PR TITLE
Normalize managed server URL routing

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11738,7 +11738,12 @@ def _resolve_server_url(server: str) -> ServerUrl:
 
     def _resolved(api_base: str) -> ServerUrl:
         if org_id is not None:
-            return ServerUrl(api_base=api_base, org_id=org_id)
+            resolved = ServerUrl(api_base=api_base, org_id=org_id)
+            if resolved.is_workspace_hosted:
+                from omnigent.cli_auth import store_databricks_org_id
+
+                store_databricks_org_id(resolved.api_base, org_id)
+            return resolved
         return ServerUrl.from_api_base(api_base)
 
     # A URL copied from the browser while a conversation is open carries the

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -11742,7 +11742,13 @@ def _resolve_server_url(server: str) -> ServerUrl:
             if resolved.is_workspace_hosted:
                 from omnigent.cli_auth import store_databricks_org_id
 
-                store_databricks_org_id(resolved.api_base, org_id)
+                try:
+                    store_databricks_org_id(resolved.api_base, org_id)
+                except OSError as exc:
+                    raise click.ClickException(
+                        "Could not persist the workspace routing selector. "
+                        "Check that the Omnigent data directory is writable, then retry."
+                    ) from exc
             return resolved
         return ServerUrl.from_api_base(api_base)
 

--- a/omnigent/cli_auth.py
+++ b/omnigent/cli_auth.py
@@ -1,7 +1,7 @@
 """CLI-side auth storage for ``omnigent login``.
 
 Persists per-server auth state in ``~/.omnigent/auth_tokens.json``
-keyed by server URL. Two record shapes live side by side:
+keyed by server URL. Three record shapes live side by side:
 
 - **Session JWTs** from the browser-based OIDC / accounts login flow
   (``{"token": ..., "user_id": ..., "expires_at": ...}``).
@@ -12,6 +12,9 @@ keyed by server URL. Two record shapes live side by side:
   just names the workspace whose host-keyed Databricks CLI OAuth cache
   (``databricks auth login --host <ws>``) mints fresh bearers on
   demand.
+- **Workspace routing selectors** (``{"org_id": ...}``) remembered while
+  normalizing a managed URL. They may stand alone or augment either credential
+  record so subprocesses route to the same workspace.
 
 See ``designs/OIDC_AUTH.md`` §CLI Login Flow.
 """
@@ -181,6 +184,9 @@ def store_token(
     }
     if refresh_token is not None:
         entry["refresh_token"] = refresh_token
+    existing_org_id = load_databricks_org_id(server_url)
+    if existing_org_id is not None:
+        entry["org_id"] = existing_org_id
     _store_entry(server_url, entry)
 
 
@@ -217,7 +223,28 @@ def store_databricks_auth(
         entry["user_id"] = user_id
     if org_id:
         entry["org_id"] = org_id
+    else:
+        existing_org_id = load_databricks_org_id(server_url)
+        if existing_org_id is not None:
+            entry["org_id"] = existing_org_id
     _store_entry(server_url, entry)
+
+
+def store_databricks_org_id(server_url: str, org_id: str) -> None:
+    """Persist a workspace selector without replacing existing credentials.
+
+    URL normalization calls this when a managed server URL carries ``?o=``.
+    Keeping the selector beside the server's existing auth record lets later
+    CLI helpers and child processes rebuild routing headers after the query has
+    been removed from the HTTP base URL.
+
+    :param server_url: Canonical server API base.
+    :param org_id: Workspace selector parsed from the user-supplied URL.
+    """
+    existing = _load_entry(server_url) or {}
+    if existing.get("org_id") == org_id:
+        return
+    _store_entry(server_url, {**existing, "org_id": org_id})
 
 
 def _load_entry(server_url: str) -> dict[str, str | float] | None:
@@ -524,16 +551,15 @@ def load_databricks_workspace_host(server_url: str) -> str | None:
 
 
 def load_databricks_org_id(server_url: str) -> str | None:
-    """Load the workspace org id from a Databricks pointer record.
+    """Load the workspace org id from a stored server record.
 
     :param server_url: The server URL, e.g.
         ``"https://example.databricks.com/api/2.0/omnigent"``.
     :returns: The org id, e.g. ``"2850744067564480"``, or ``None``
-        when the stored record (if any) is not a Databricks pointer
-        record or carries no org id.
+        when the stored record carries no org id.
     """
     entry = _load_entry(server_url)
-    if entry is None or entry.get("auth_type") != "databricks":
+    if entry is None:
         return None
     org_id = entry.get("org_id")
     return org_id if isinstance(org_id, str) and org_id else None

--- a/tests/cli/test_cli_auth.py
+++ b/tests/cli/test_cli_auth.py
@@ -330,6 +330,75 @@ def test_databricks_request_headers_explicit_org_wins(token_dir) -> None:
     assert databricks_request_headers(server, org_id="222")["X-Databricks-Org-Id"] == "222"
 
 
+def test_store_databricks_org_id_preserves_session_token(token_dir) -> None:
+    """Remembering URL routing must not replace an existing login session."""
+    from omnigent.cli_auth import (
+        load_databricks_org_id,
+        load_token,
+        store_databricks_org_id,
+        store_token,
+    )
+
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    store_token(server, "session-token", "user@example.com", time.time() + 3600)
+
+    store_databricks_org_id(server, "123")
+
+    assert load_token(server) == "session-token"
+    assert load_databricks_org_id(server) == "123"
+
+
+def test_store_token_preserves_databricks_org_id(token_dir) -> None:
+    """Refreshing a login session must retain remembered routing."""
+    from omnigent.cli_auth import (
+        load_databricks_org_id,
+        store_databricks_org_id,
+        store_token,
+    )
+
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    store_databricks_org_id(server, "123")
+
+    store_token(server, "session-token", "user@example.com", time.time() + 3600)
+
+    assert load_databricks_org_id(server) == "123"
+
+
+def test_store_databricks_org_id_preserves_databricks_pointer(token_dir) -> None:
+    """Remembering routing must retain the workspace used to mint credentials."""
+    from omnigent.cli_auth import (
+        load_databricks_org_id,
+        load_databricks_workspace_host,
+        store_databricks_auth,
+        store_databricks_org_id,
+    )
+
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    workspace = "https://workspace.example.com"
+    store_databricks_auth(server, workspace, org_id="111")
+
+    store_databricks_org_id(server, "222")
+
+    assert load_databricks_workspace_host(server) == workspace
+    assert load_databricks_org_id(server) == "222"
+
+
+def test_store_databricks_pointer_preserves_org_id_when_unspecified(token_dir) -> None:
+    """Updating a credential pointer must retain remembered routing."""
+    from omnigent.cli_auth import (
+        load_databricks_org_id,
+        store_databricks_auth,
+        store_databricks_org_id,
+    )
+
+    server = "https://example.databricks.com/api/2.0/omnigent"
+    store_databricks_org_id(server, "123")
+
+    store_databricks_auth(server, "https://workspace.example.com")
+
+    assert load_databricks_org_id(server) == "123"
+
+
 def test_databricks_request_headers_pairs_bearer_and_org(token_dir) -> None:
     """The paired minter always emits the bearer and the ?o= header together.
 

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -80,7 +80,7 @@ def _response(
     )
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def token_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Redirect auth_tokens.json and the global config to a temp dir.
 
@@ -1253,6 +1253,11 @@ def test_resolve_server_url_strips_query_and_expands(
     resolved = cli_mod._resolve_server_url(f"{_WORKSPACE}/?o=2850744067564480")
     assert resolved.api_base == _WORKSPACE_API_URL
     assert resolved.org_id == "2850744067564480"
+    from omnigent.cli_auth import databricks_request_headers
+
+    assert databricks_request_headers(resolved.api_base)["X-Databricks-Org-Id"] == (
+        "2850744067564480"
+    )
     # The probes hit the CLEAN root/mount — never a ?o=-corrupted URL (which
     # would push the path into the query string, e.g. ``…/?o=123/v1/me``).
     assert probed and all("o=" not in url and "%2F" not in url for url in probed)
@@ -1271,7 +1276,29 @@ def test_resolve_server_url_strips_query_on_full_mount(
     resolved = cli_mod._resolve_server_url(f"{_WORKSPACE_API_URL}?o=2850744067564480")
     assert resolved.api_base == _WORKSPACE_API_URL
     assert resolved.org_id == "2850744067564480"
+    from omnigent.cli_auth import databricks_request_headers
+
+    assert databricks_request_headers(resolved.api_base)["X-Databricks-Org-Id"] == (
+        "2850744067564480"
+    )
     assert probed == []
+
+
+def test_resolve_server_url_does_not_store_selector_off_managed_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An arbitrary server query must not create managed routing state."""
+    stored: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "omnigent.cli_auth.store_databricks_org_id",
+        lambda server, org_id: stored.append((server, org_id)),
+    )
+
+    resolved = cli_mod._resolve_server_url("https://example.com/service?o=123")
+
+    assert resolved.api_base == "https://example.com/service"
+    assert resolved.org_id == "123"
+    assert stored == []
 
 
 def test_workspace_url_expands_web_ui_path_to_api_mount(

--- a/tests/cli/test_login_databricks.py
+++ b/tests/cli/test_login_databricks.py
@@ -18,6 +18,7 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import click
 import httpx
 import pytest
 from click.testing import CliRunner
@@ -1299,6 +1300,31 @@ def test_resolve_server_url_does_not_store_selector_off_managed_mount(
     assert resolved.api_base == "https://example.com/service"
     assert resolved.org_id == "123"
     assert stored == []
+
+
+def test_resolve_server_url_reports_selector_persistence_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A routing selector must not be silently dropped when state is unwritable."""
+
+    def fail_to_store(_server: str, _org_id: str) -> None:
+        raise PermissionError("read-only data directory")
+
+    monkeypatch.setattr(
+        cli_mod,
+        "_workspace_api_server_url",
+        lambda _server: _WORKSPACE_API_URL,
+    )
+    monkeypatch.setattr(
+        "omnigent.cli_auth.store_databricks_org_id",
+        fail_to_store,
+    )
+
+    with pytest.raises(
+        click.ClickException,
+        match="Could not persist the workspace routing selector",
+    ):
+        cli_mod._resolve_server_url(f"{_WORKSPACE}/?o=2850744067564480")
 
 
 def test_workspace_url_expands_web_ui_path_to_api_mount(

--- a/tests/test_server_url.py
+++ b/tests/test_server_url.py
@@ -9,6 +9,8 @@ user-facing text or drop the selector from copy-pasteable URLs.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from omnigent.util.server_url import (
@@ -19,6 +21,15 @@ from omnigent.util.server_url import (
 )
 
 _WORKSPACE_API = "https://ws.databricks.com/api/2.0/omnigent"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_auth_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep remembered synthetic selectors out of other tests and user state."""
+    monkeypatch.setattr(
+        "omnigent.cli_auth._token_file_path",
+        lambda: tmp_path / "auth_tokens.json",
+    )
 
 
 def test_api_base_is_normalized() -> None:


### PR DESCRIPTION
## Related issue

Not publicly tracked.

## Summary

Managed workspace URLs can include a workspace selector in the query string. URL normalization correctly removes that query before constructing API paths, but commands that rebuild requests later—especially in child processes—can then lose the routing selector.

This change remembers an explicit selector beside the canonical managed API base and reuses it through the existing request-header path. Credential records are merged rather than replaced, and later login or token-refresh writes preserve the selector.

ELI5: the CLI still cleans the URL before using it, but now writes down which workspace the URL selected so every later request goes to the same place.

```text
managed URL with selector
          |
          v
canonical API base + remembered selector
          |
          v
CLI / host / runner / harness request headers
```

## Test Plan

- 121 focused URL, authentication, and export tests passed.
- 333 broader CLI, chat, host, diagnostics, and resume tests passed.
- Changed-file pre-commit checks passed, including formatting, linting, and type checking.
- Reproduced with an authenticated temporary managed session using a non-export command: the command failed before the change and succeeded after it.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used an authenticated temporary managed session and confirmed that routing works for a command other than export. Tests cover selector persistence, replacement of stale selectors, preservation across both credential record types and credential updates, generic request headers, and non-managed URLs.

## Changelog

Managed workspace URLs now route consistently across Omnigent commands.