### PR TITLE
fix(web): restore Goal marker after runner reconnect

### DIFF
--- a/tests/e2e_ui/chat/test_codex_goal_mode.py
+++ b/tests/e2e_ui/chat/test_codex_goal_mode.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
+import re
 from urllib.parse import urlparse
 
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Page, Route, expect
 
-from tests.e2e_ui.conftest import MockedCodexNativeSession
+from tests.e2e_ui.conftest import MockedCodexNativeSession, fetch_with_retry
 from tests.e2e_ui.messages.test_message_render_parity import (
     _ASSISTANT,
     _WORKING,
@@ -47,6 +49,23 @@ def test_codex_goal_mode_processes_first_message_with_untrusted_hooks(
 ) -> None:
     """Bypass hook review, then exercise goal controls through the real UI path."""
     session = mocked_native_codex_session
+    runner_online = {"value": True}
+
+    def _patch_health(route: Route) -> None:
+        response = fetch_with_retry(route)
+        payload = response.json()
+        live = {"runner_online": runner_online["value"], "host_online": True}
+        if isinstance(payload.get("sessions"), dict):
+            payload["sessions"][session.session_id] = live
+        if isinstance(payload.get("session"), dict):
+            payload["session"] = {**payload["session"], **live}
+        route.fulfill(
+            status=200,
+            headers={**response.headers, "content-type": "application/json"},
+            body=json.dumps(payload),
+        )
+
+    page.route(re.compile(r"/health(\?|$)"), _patch_health)
     page.goto(f"{session.base_url}/c/{session.session_id}")
 
     _open_terminal_view(page)
@@ -96,6 +115,15 @@ def test_codex_goal_mode_processes_first_message_with_untrusted_hooks(
     expect(current_goal).to_contain_text("active", timeout=30_000)
     expect(page.get_by_test_id("composer-goal-mode")).to_contain_text("Goal active")
     expect(page.get_by_test_id("goal-pause")).to_be_visible()
+
+    runner_online["value"] = False
+    expect(page.get_by_test_id("composer-goal-mode")).to_have_count(0, timeout=30_000)
+    with page.expect_response(_goal_response(session.session_id, "GET"), timeout=30_000):
+        runner_online["value"] = True
+        page.wait_for_timeout(12_000)
+    expect(page.get_by_test_id("composer-goal-mode")).to_contain_text(
+        "Goal active", timeout=30_000
+    )
 
     with page.expect_response(_goal_response(session.session_id, "DELETE")):
         page.get_by_test_id("goal-clear").click()

--- a/web/src/components/goal/useGoalState.test.tsx
+++ b/web/src/components/goal/useGoalState.test.tsx
@@ -48,4 +48,19 @@ describe("useGoalState", () => {
     rerender({ enabled: false });
     expect(result.current.goal).toBeNull();
   });
+
+  it("reloads the goal when a session becomes reachable again", async () => {
+    mockGetGoal.mockResolvedValueOnce({ goal: GOAL });
+
+    const { result, rerender } = renderHook(({ reachable }) => useGoalState("conv", reachable), {
+      initialProps: { reachable: false },
+    });
+    expect(mockGetGoal).not.toHaveBeenCalled();
+
+    rerender({ reachable: true });
+
+    await waitFor(() => expect(result.current.goal).toEqual(GOAL));
+    expect(mockGetGoal).toHaveBeenCalledTimes(1);
+    expect(mockGetGoal).toHaveBeenCalledWith("conv");
+  });
 });

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -3,6 +3,7 @@ import type * as UseSessionModule from "@/hooks/useSession";
 import type * as UseHostsModule from "@/hooks/useHosts";
 import type * as RunnerHealthProviderModule from "@/hooks/RunnerHealthProvider";
 import type * as AgentLabelsModule from "@/lib/agentLabels";
+import type * as GoalApiModule from "@/lib/goalApi";
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactElement } from "react";
@@ -55,7 +56,12 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
     copilot: "Copilot",
   }),
 }));
+vi.mock("@/lib/goalApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof GoalApiModule>()),
+  getGoal: vi.fn(),
+}));
 import type { ElicitationBlock } from "@/lib/blocks";
+import { getGoal } from "@/lib/goalApi";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Composer, isSubagentRoutingEligible, shouldQueueSend } from "./ChatPage";
 import type { Session } from "@/lib/types";
@@ -344,6 +350,42 @@ describe("Composer Codex goal control", () => {
     fireEvent.click(screen.getByTestId("goal-start"));
 
     expect(onSend).toHaveBeenCalledWith("/goal Finish the implementation and pass tests");
+  });
+});
+
+describe("Composer native goal state", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("loads the goal when a detached runner reconnects", async () => {
+    const mockGetGoal = vi.mocked(getGoal);
+    mockGetGoal.mockResolvedValueOnce({
+      goal: {
+        objective: "Finish the implementation",
+        status: "active",
+        tokenBudget: null,
+        tokensUsed: 0,
+        timeUsedSeconds: 0,
+        createdAt: null,
+        updatedAt: null,
+      },
+    });
+    useChatStore.setState({ conversationId: "conv_goal" });
+
+    const { rerender } = renderWithTooltips(
+      <Composer {...composerProps({ showGoalControl: true, runnerOnline: false })} />,
+    );
+    expect(mockGetGoal).not.toHaveBeenCalled();
+
+    rerender(
+      <TooltipProvider>
+        <Composer {...composerProps({ showGoalControl: true, runnerOnline: true })} />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => expect(mockGetGoal).toHaveBeenCalledWith("conv_goal"));
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -2674,7 +2674,10 @@ function ComposerImpl({
   // No server session behind a temp id — gate goal/workspace fetches on it so
   // the create window issues no `/v1/sessions/temp:*` requests.
   const composerSessionId = isTempConvId(conversationId) ? null : conversationId;
-  const { goal, setGoal: setGoalState } = useGoalState(composerSessionId, showGoalControl);
+  const { goal, setGoal: setGoalState } = useGoalState(
+    composerSessionId,
+    showGoalControl && !unreachable,
+  );
   // "@"-file-mention is scoped to the native coding-agent harnesses: their
   // vendor CLIs run in the workspace and read an on-disk file from an
   // attachment marker the executor already emits. In-process SDK sessions

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1771,6 +1771,7 @@ const MainAgentSurface = memo(function MainAgentSurfaceImpl({
             showClaudePermissionMode={showClaudePermissionMode}
             showCodexApprovalMode={showCodexApprovalMode}
             showGoalControl={showGoalControl}
+            runnerOnline={runnerOnline}
             showClaudeGoalControl={showClaudeGoalControl}
             showPollyCodexGoalControl={showPollyCodexGoalControl}
             isTerminalFirst={isTerminalFirst}
@@ -1896,6 +1897,8 @@ interface ComposerProps {
   showCodexApprovalMode?: boolean;
   /** Show the session Goal control. */
   showGoalControl?: boolean;
+  /** Whether the active session's runner tunnel is connected. */
+  runnerOnline?: boolean;
   /** Show Polly's Claude SDK command-backed Goal control. */
   showClaudeGoalControl?: boolean;
   /** Show Polly's Codex command-backed Goal control. */
@@ -2535,6 +2538,7 @@ function ComposerImpl({
   showClaudePermissionMode = false,
   showCodexApprovalMode = false,
   showGoalControl = false,
+  runnerOnline,
   showClaudeGoalControl = false,
   showPollyCodexGoalControl = false,
   isTerminalFirst = false,
@@ -2676,7 +2680,7 @@ function ComposerImpl({
   const composerSessionId = isTempConvId(conversationId) ? null : conversationId;
   const { goal, setGoal: setGoalState } = useGoalState(
     composerSessionId,
-    showGoalControl && !unreachable,
+    showGoalControl && runnerOnline === true,
   );
   // "@"-file-mention is scoped to the native coding-agent harnesses: their
   // vendor CLIs run in the workspace and read an on-disk file from an


### PR DESCRIPTION
## Related issue

Addresses [OMNI-6426](https://linear.app/omnigent/issue/OMNI-6426/restore-native-goal-markers-after-reattach-and-server-restart).

Supersedes #6630 with the bug-only fix; this intentionally does not add session-list Goal state or sidebar/chat-frame UI.

## Summary

The composer used to read native Codex Goal state once when the session opened. If that read occurred while the runner was detached, the empty result remained after reconnection. Gate the read on strict runner-online state so the existing Goal hook reloads from Codex when any detached state reattaches.

## Test Plan

- `npm --prefix web test -- --run src/components/goal/useGoalState.test.tsx`
- `npm --prefix web test -- --run src/pages/ChatPage.composer.test.tsx`
- `npm --prefix web run type-check`
- `uv run pre-commit run --files web/src/pages/ChatPage.tsx web/src/components/goal/useGoalState.test.tsx`

The unit regression tests cover the strict offline-to-online boundary. The Codex Goal Playwright test now drives the same runner-health transition and verifies the visible Goal marker disappears while detached and returns after reconnect.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The focused hook and Composer tests cover the reachability transition, and the updated Playwright test covers the visible native Goal marker across detach and reconnect.

## Changelog

Native Codex Goal markers return after the runner reconnects.
