### PR TITLE
fix(import): dedupe imports against native sessions by external id

### DIFF
--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -420,8 +420,7 @@ def create_imports_router(
         user_id = require_user(request, auth_provider)
         items = [item.to_item() for item in body.items]
         existing = await asyncio.to_thread(
-            conversation_store.find_imported_conversation,
-            body.source,
+            conversation_store.find_conversation_by_external_session_id,
             body.external_session_id,
         )
         if existing is not None:
@@ -433,8 +432,10 @@ def create_imports_router(
                 conversation_store,
             )
             if not body.force:
+                # Matches a prior import or a native run of the same session
+                # (both record the external id), so "exists", not "imported".
                 raise OmnigentError(
-                    f"This {body.source} session has already been imported as {existing.id}",
+                    f"This {body.source} session already exists as {existing.id}",
                     code=ErrorCode.CONFLICT,
                 )
 
@@ -539,8 +540,7 @@ def create_imports_router(
             # concrete harness — narrow off the request's ImportSource | "all".
             source = cast(ImportSource, source)
             existing = await asyncio.to_thread(
-                conversation_store.find_imported_conversation,
-                source,
+                conversation_store.find_conversation_by_external_session_id,
                 external_session_id,
             )
             if existing is not None:

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -467,14 +467,16 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
-    def find_imported_conversation(
+    def find_conversation_by_external_session_id(
         self,
-        source: str,
         external_session_id: str,
     ) -> Conversation | None:
-        """Find the original session imported from one external transcript.
+        """Find an existing conversation wrapping one external (harness) session id.
 
-        :param source: Import source key, e.g. ``"claude"``.
+        Both an imported transcript and a natively-run session record the
+        external id, so import dedup resolves against either through this one
+        lookup. When several rows share the id, the earliest-created wins.
+
         :param external_session_id: Source harness session id.
         :returns: The matching conversation, or ``None``.
         """

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
     text,
     update,
 )
-from sqlalchemy.orm import QueryableAttribute, Session, aliased, load_only
+from sqlalchemy.orm import QueryableAttribute, Session, load_only
 from sqlalchemy.sql.selectable import Subquery
 
 from omnigent._wrapper_labels import UI_MODE_LABEL_KEY, WRAPPER_LABEL_KEY
@@ -77,10 +77,7 @@ from omnigent.entities import (
     parse_item_data,
 )
 from omnigent.native.native_coding_agents import native_coding_agent_for_wrapper_label
-from omnigent.session_import.models import (
-    IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
-    IMPORT_SOURCE_LABEL_KEY,
-)
+from omnigent.session_import.models import IMPORT_SOURCE_LABEL_KEY
 from omnigent.stores.conversation_store import (
     _FORK_ONLY_DROPPED_LABEL_KEYS,
     _INSTANCE_SCOPED_LABEL_KEYS,
@@ -1097,38 +1094,32 @@ class SqlAlchemyConversationStore(ConversationStore):
             meta = self._get_meta(conversation_id)
             return _to_conversation(row, meta, _fetch_labels(session, conversation_id))
 
-    def find_imported_conversation(
+    def find_conversation_by_external_session_id(
         self,
-        source: str,
         external_session_id: str,
     ) -> Conversation | None:
-        """Find the original conversation carrying an import provenance pair."""
-        source_label = aliased(SqlConversationLabel)
-        external_label = aliased(SqlConversationLabel)
-        with self._conv_session("select_imported_conversation") as session:
-            conversation_id = session.execute(
-                select(SqlConversation.id)
-                .join(
-                    source_label,
-                    (source_label.workspace_id == SqlConversation.workspace_id)
-                    & (source_label.conversation_id == SqlConversation.id),
-                )
-                .join(
-                    external_label,
-                    (external_label.workspace_id == SqlConversation.workspace_id)
-                    & (external_label.conversation_id == SqlConversation.id),
-                )
-                .where(
-                    SqlConversation.workspace_id == current_workspace_id(),
-                    source_label.key == IMPORT_SOURCE_LABEL_KEY,
-                    source_label.value == source,
-                    external_label.key == IMPORT_EXTERNAL_SESSION_ID_LABEL_KEY,
-                    external_label.value == external_session_id,
-                )
-                .order_by(SqlConversation.created_at, SqlConversation.id)
-                .limit(1)
-            ).scalar_one_or_none()
-        return self.get_conversation(conversation_id) if conversation_id is not None else None
+        """Find an existing conversation wrapping one external (harness) session id.
+
+        Matches the ``external_session_id`` column, which both an imported
+        transcript and a natively-run session populate, so an import dedupes
+        against a prior import and against a native run of the same underlying
+        session alike. Returns the earliest-created match when more than one row
+        carries the id (the historical duplicate a fixed dedup should collapse).
+        """
+        with self._session("select_conversation_by_external_session_id") as session:
+            ids = list(
+                session.execute(
+                    select(SqlConversationMetadata.id).where(
+                        SqlConversationMetadata.workspace_id == current_workspace_id(),
+                        SqlConversationMetadata.external_session_id == external_session_id,
+                    )
+                ).scalars()
+            )
+        matches = sorted(
+            (c for c in (self.get_conversation(cid) for cid in ids) if c is not None),
+            key=lambda c: (c.created_at, c.id),
+        )
+        return matches[0] if matches else None
 
     def get_runner_ids(self, conversation_ids: list[str]) -> dict[str, str | None]:
         """

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -74,7 +74,7 @@ async def test_import_session_creates_normal_session_and_blocks_duplicate(
     assert created.json()["status"] == "imported"
     assert repeated.status_code == 409
     assert created.json()["session_id"] in repeated.text
-    assert "already been imported" in repeated.text
+    assert "already exists" in repeated.text
 
     session_id = created.json()["session_id"]
     conversation = SqlAlchemyConversationStore(db_uri).get_conversation(session_id)
@@ -87,6 +87,48 @@ async def test_import_session_creates_normal_session_and_blocks_duplicate(
     items = await client.get(f"/v1/sessions/{session_id}/items")
     assert items.status_code == 200
     assert [item["type"] for item in items.json()["data"]] == ["message", "message"]
+
+
+async def test_import_dedupes_against_native_session(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """Importing a session already run natively dedupes against the native row.
+
+    A native run records the harness session id on the metadata column but
+    carries no import-provenance labels. Dedup keys off that shared column, so
+    re-importing the same transcript must find the native session, not spawn a
+    duplicate.
+    """
+    agent_id = _seed_claude_agent(db_uri)
+    store = SqlAlchemyConversationStore(db_uri)
+    native = store.create_conversation(agent_id=agent_id, title="closing tickets")
+    store.set_external_session_id(native.id, "9d74df82-native")
+
+    resp = await client.post(
+        "/v1/imports",
+        json={
+            "source": "claude",
+            "external_session_id": "9d74df82-native",
+            "items": [
+                {
+                    "type": "message",
+                    "response_id": "claude:turn-1",
+                    "data": {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "hi"}],
+                    },
+                }
+            ],
+        },
+    )
+
+    assert resp.status_code == 409
+    assert native.id in resp.text
+    # Still exactly one row for the id: no duplicate was created.
+    found = store.find_conversation_by_external_session_id("9d74df82-native")
+    assert found is not None
+    assert found.id == native.id
 
 
 async def test_import_session_uses_native_title_when_supplied(
@@ -148,8 +190,8 @@ async def test_concurrent_identical_imports_return_one_session(
     )
 
     assert {first.status_code, second.status_code} == {201, 409}
-    imported = SqlAlchemyConversationStore(db_uri).find_imported_conversation(
-        "claude", "claude-concurrent-1"
+    imported = SqlAlchemyConversationStore(db_uri).find_conversation_by_external_session_id(
+        "claude-concurrent-1"
     )
     assert imported is not None
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3672,6 +3672,44 @@ def test_set_external_session_id_same_value_is_idempotent(
     assert fetched.external_session_id == "sid-1"
 
 
+def test_find_conversation_by_external_session_id_matches_column_without_labels(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The lookup keys off the metadata column, so a native run (no import
+    labels) is found — this is what lets an import dedupe against it."""
+    conv = conversation_store.create_conversation(title="native run")
+    conversation_store.set_external_session_id(conv.id, "sid-native")
+
+    found = conversation_store.find_conversation_by_external_session_id("sid-native")
+    assert found is not None
+    assert found.id == conv.id
+    assert conversation_store.find_conversation_by_external_session_id("sid-absent") is None
+
+
+def test_find_conversation_by_external_session_id_returns_earliest(
+    conversation_store: SqlAlchemyConversationStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When duplicates already exist for one id, the earliest-created wins.
+
+    ``created_at`` is integer seconds, so the two rows would otherwise tie and
+    fall back to the (random) id order; pin distinct stamps to assert the
+    created_at ordering itself.
+    """
+    import omnigent.stores.conversation_store.sqlalchemy_store as store_mod
+
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 1000)
+    first = conversation_store.create_conversation(title="first")
+    conversation_store.set_external_session_id(first.id, "sid-dupe")
+    monkeypatch.setattr(store_mod, "now_epoch", lambda: 2000)
+    second = conversation_store.create_conversation(title="second")
+    conversation_store.set_external_session_id(second.id, "sid-dupe")
+
+    found = conversation_store.find_conversation_by_external_session_id("sid-dupe")
+    assert found is not None
+    assert found.id == first.id
+
+
 def test_set_external_session_id_rejects_overwrite_with_different_value(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A. Found while diagnosing duplicate imported sessions on a live workspace (two conversations for one underlying harness session).

## Summary

- Import dedup only matched *prior imports* (via the `omnigent.import.*` provenance labels), so importing local history re-created a session that had already run natively through a coding-agent harness, leaving two conversations for the same underlying transcript.
- Both imports and native runs record the harness session id on the `external_session_id` metadata column, so dedup now resolves an existing session by that column and collapses onto a prior import or a native run alike.
- Renamed the store lookup `find_imported_conversation` to `find_conversation_by_external_session_id` (drops the now-unused `source` arg) and added a `(workspace_id, external_session_id, id)` index for it.

## Test Plan

- `uv run pytest tests/server/routes/test_imports.py tests/stores/test_conversation_store.py tests/db/test_migrations_sqlite_safe.py`: 264 passed, 1 skipped.
- New regression `test_import_dedupes_against_native_session`: a native run (external id on the column, no import labels) now blocks a later import of the same id instead of duplicating it.
- New store tests `test_find_conversation_by_external_session_id_matches_column_without_labels` and `..._returns_earliest`.
- `ruff check` / `ruff format --check` clean, `pyrefly check` 0 errors, migration chain round-trips on SQLite.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Store-level and route-level unit tests cover the new column-based lookup and the native-session dedup path; the migration is covered by the SQLite round-trip test.

## Changelog

Re-importing a coding-agent session that already exists (a prior import or a session run natively) no longer creates a duplicate.
