### PR TITLE
fix(codex-native): apply the persisted reasoning effort at launch and on dispatch

### DIFF
--- a/omnigent/harness_capabilities.py
+++ b/omnigent/harness_capabilities.py
@@ -58,6 +58,9 @@ class EffortFamily(str, Enum):
     GEMINI = "gemini"
     COPILOT = "copilot"
     PI = "pi"
+    # The real codex process is the per-model authority on reasoning levels
+    # (Sol reaches ``ultra``); the SDK codex wire caps at ``xhigh``.
+    CODEX_NATIVE = "codex-native"
 
 
 class ModelFamily(str, Enum):

--- a/omnigent/harness_plugins.py
+++ b/omnigent/harness_plugins.py
@@ -351,7 +351,7 @@ _BUILTIN_CAPABILITIES: dict[str, HarnessCapabilities] = {
         _IM.NATIVE_TUI,
         _EL.JSONRPC,
         _RS.WARM_REATTACH,
-        _EF.OPENAI,
+        _EF.CODEX_NATIVE,
         _MF.GPT,
         _AU.OMNIGENT_CREDENTIAL,
         subagents=True,

--- a/omnigent/harnesses/codex_native/app_server.py
+++ b/omnigent/harnesses/codex_native/app_server.py
@@ -3403,6 +3403,43 @@ async def preload_codex_thread_for_resume(
         await client.close()
 
 
+async def apply_codex_thread_effort(
+    transport: str,
+    thread_id: str,
+    effort: str,
+    *,
+    model: str | None = None,
+) -> None:
+    """
+    Set a loaded thread's reasoning effort via ``thread/settings/update``.
+
+    A resumed thread takes its effort from the rollout, not ``config.toml``.
+    After a runner restart the rollout is the cold-resume synthesis (no effort
+    recorded), and a forked clone's rollout carries the SOURCE's effort, so the
+    thread — and the TUI footer — would sit at the wrong level until a web turn
+    re-applied the session's effort. This is that re-application, run once the
+    thread has started.
+
+    :param transport: App-server transport, e.g. ``"ws://127.0.0.1:9876"``.
+    :param thread_id: Loaded Codex thread id, e.g. ``"019e96aa-..."``.
+    :param effort: Session-persisted effort, e.g. ``"ultra"``.
+    :param model: Model the thread runs, or ``None``; the effort is clamped to
+        a level that model accepts.
+    :raises Exception: If the app-server rejects the update.
+    """
+    from omnigent.util.reasoning_effort import clamp_effort_for_model
+
+    client = client_for_transport(transport, client_name="omnigent-codex-native-effort")
+    await client.connect()
+    try:
+        await client.request(
+            "thread/settings/update",
+            {"threadId": thread_id, "effort": clamp_effort_for_model(effort, model)},
+        )
+    finally:
+        await client.close()
+
+
 def codex_terminal_env(app_server: CodexNativeAppServer) -> dict[str, str]:
     """
     Build terminal env overrides for the native Codex TUI.

--- a/omnigent/harnesses/codex_native/app_server.py
+++ b/omnigent/harnesses/codex_native/app_server.py
@@ -309,15 +309,7 @@ def _pin_codex_config_model(codex_home: Path, model: str) -> None:
     from omnigent.util.reasoning_effort import clamp_effort_for_model
 
     config_path = codex_home / "config.toml"
-    # Same symlink-materialization dance as the MCP injection: never edit
-    # the user's real config.toml through the link.
-    if config_path.is_symlink():
-        target = config_path.resolve()
-        config_path.unlink()
-        if target.is_file():
-            import shutil
-
-            shutil.copy2(target, config_path)
+    _materialize_config_symlink(config_path)
     existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
     pin_line = f"model = {json.dumps(model)}"
     lines = existing.splitlines()
@@ -340,6 +332,62 @@ def _pin_codex_config_model(codex_home: Path, model: str) -> None:
     if not replaced:
         lines.insert(0, pin_line)
     config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _pin_codex_config_effort(codex_home: Path, effort: str, model: str | None) -> None:
+    """
+    Write *effort* as the top-level ``model_reasoning_effort`` in the session config.
+
+    Like the model line, the copied ``model_reasoning_effort`` is whatever the
+    user last ran — NOT this session's persisted effort. Both the app-server
+    and the ``--remote`` TUI read this file when the thread is created, so
+    without the seed a session created or forked with an explicit effort runs
+    (and its TUI footer reports) the shared default until a web turn re-applies
+    it via ``thread/settings/update``. An in-TUI ``/effort`` later overwrites
+    the same line, so user switches still win.
+
+    :param codex_home: Private per-session ``CODEX_HOME`` directory.
+    :param effort: Validated effort to pin, e.g. ``"ultra"``.
+    :param model: Pinned model id, or ``None``; the effort is clamped to a
+        level that model accepts (GLM has no ``xhigh``).
+    """
+    from omnigent.util.reasoning_effort import clamp_effort_for_model
+
+    config_path = codex_home / "config.toml"
+    _materialize_config_symlink(config_path)
+    existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    pin_line = f"model_reasoning_effort = {json.dumps(clamp_effort_for_model(effort, model))}"
+    lines = existing.splitlines()
+    replaced = False
+    for i, line in enumerate(lines):
+        if line.startswith("["):
+            break
+        if re.match(r"^model_reasoning_effort\s*=", line):
+            lines[i] = pin_line
+            replaced = True
+            break
+    if not replaced:
+        lines.insert(0, pin_line)
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _materialize_config_symlink(config_path: Path) -> None:
+    """
+    Replace a symlinked session ``config.toml`` with a private copy.
+
+    Same dance as the MCP injection: never edit the user's real config.toml
+    through the link.
+
+    :param config_path: The session config path, e.g. ``CODEX_HOME/config.toml``.
+    """
+    if not config_path.is_symlink():
+        return
+    target = config_path.resolve()
+    config_path.unlink()
+    if target.is_file():
+        import shutil
+
+        shutil.copy2(target, config_path)
 
 
 def _sync_codex_developer_instructions(
@@ -1258,6 +1306,9 @@ class CodexNativeAppServer:
         per-session ``config.toml`` at start, or ``None``. Keeps the
         forwarder's config.toml model mirror (and the cost gate's hook
         read) consistent with what the session was launched to run.
+    :param pinned_effort: Session-persisted reasoning effort written as
+        ``model_reasoning_effort`` into the per-session ``config.toml`` at
+        start, or ``None`` to keep the copied config's value.
     :param trust_project: Whether to trust :attr:`cwd` in the private
         session config before startup. Runner-owned headless sessions set
         this because nobody can answer Codex's project-trust TUI prompt.
@@ -1295,6 +1346,7 @@ class CodexNativeAppServer:
     policy_hook_disabled_reason: str | None = None
     policy_notice_pending: bool = False
     pinned_model: str | None = None
+    pinned_effort: str | None = None
     process_registry_tag: str | None = None
     process_owner_lock: CodexNativeProcessOwnerLock | None = None
     codex_cli_version: tuple[int, int, int] | None = None
@@ -1385,6 +1437,8 @@ class CodexNativeAppServer:
                     self.pinned_model,
                     model_migration_target,
                 )
+        if self.pinned_effort:
+            _pin_codex_config_effort(self.codex_home, self.pinned_effort, self.pinned_model)
         _sync_codex_developer_instructions(
             self.codex_home,
             self.developer_instructions,
@@ -2383,6 +2437,7 @@ def build_codex_native_server(
     bypass_sandbox: bool = False,
     trust_project: bool = False,
     trust_all_hooks: bool = False,
+    reasoning_effort: str | None = None,
 ) -> CodexNativeAppServer:
     """
     Build a configured native Codex app-server process wrapper.
@@ -2427,6 +2482,10 @@ def build_codex_native_server(
         startup hook-review screen on a persistent ``resume`` attach (see
         :func:`trust_all_codex_hooks`). Interactive CLI sessions leave it
         disabled so a human reviews their own new or changed hooks.
+    :param reasoning_effort: Session-persisted reasoning effort to pin into
+        the private ``config.toml`` at start (see
+        :func:`_pin_codex_config_effort`), e.g. ``"ultra"``. ``None`` keeps
+        the copied config's value.
     :returns: Configured app-server process wrapper.
     :raises ImportError: If no Codex CLI is available.
     :raises OSError: If Databricks routing was requested but no
@@ -2488,6 +2547,7 @@ def build_codex_native_server(
         ap_auth_headers=ap_auth_headers,
         python_executable=python_executable,
         pinned_model=pinned_model,
+        pinned_effort=reasoning_effort,
         trust_project=trust_project,
         trust_all_hooks=trust_all_hooks,
     )

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -458,6 +458,10 @@ class _CodexNativeLaunchConfig:
         still has work to do. False on a session something already routed —
         a web create that pinned the model before the pane launched — so the
         ``UserPromptSubmit`` hook is never registered and no prompt is held.
+    :param reasoning_effort: Persisted per-session effort, e.g. ``"ultra"``,
+        pinned into the private ``config.toml`` at launch so the thread (and
+        the TUI footer) start at it instead of the shared config's default.
+        ``None`` leaves Codex's configured effort in place.
     """
 
     workspace: Path
@@ -472,6 +476,7 @@ class _CodexNativeLaunchConfig:
     auto_harness: bool = False
     routing_enabled: bool = False
     turn_routing: bool = False
+    reasoning_effort: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1004,6 +1009,22 @@ async def _codex_native_launch_config(
         not isinstance(external_session_id, str) or not external_session_id
     ):
         raise RuntimeError(f"Invalid external_session_id for Codex session {session_id!r}.")
+    from omnigent.util.reasoning_effort import CODEX_NATIVE_EFFORTS, validate_effort
+
+    reasoning_effort = snapshot.get("reasoning_effort")
+    if reasoning_effort is not None:
+        try:
+            reasoning_effort = validate_effort(reasoning_effort, "codex", CODEX_NATIVE_EFFORTS)
+        except ValueError:
+            # An effort codex cannot take must not sink the launch: keep the
+            # configured default, as the per-turn override does.
+            _logger.warning(
+                "Ignoring unsupported reasoning_effort %r for Codex session %s",
+                reasoning_effort,
+                session_id,
+                extra={"session_id": session_id},
+            )
+            reasoning_effort = None
     # The session's stored workspace is the worktree path for worktree
     # sessions (set by _create_session_worktree), or the repo root
     # otherwise. Use it as the Codex terminal cwd so worktree sessions
@@ -1063,6 +1084,7 @@ async def _codex_native_launch_config(
         auto_harness=routing_class.auto_harness,
         routing_enabled=routing_class.routing_enabled,
         turn_routing=routing_class.turn_routing,
+        reasoning_effort=reasoning_effort,
     )
 
 
@@ -4276,6 +4298,7 @@ async def _auto_create_codex_terminal(
         ap_auth_headers=policy_headers,
         bypass_sandbox=launch_config.bypass_sandbox,
         developer_instructions=_codex_developer_instructions,
+        reasoning_effort=launch_config.reasoning_effort,
         # Codex can show project-trust and legacy-model migration prompts before
         # creating a thread. This TUI runs detached for the web UI, so persist
         # the runner-owned acknowledgements in the private session config.

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -3886,6 +3886,7 @@ async def _auto_create_codex_terminal(
         _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION,
         CodexAppServerClient,
         CodexAppServerResponseError,
+        apply_codex_thread_effort,
         build_codex_native_server,
         build_codex_remote_args,
         codex_session_meta_model_provider,
@@ -4406,6 +4407,25 @@ async def _auto_create_codex_terminal(
                     cwd=workspace,
                 ),
             )
+            if launch_config.reasoning_effort:
+                # A resumed thread runs the rollout's effort, not the config pin.
+                try:
+                    await apply_codex_thread_effort(
+                        codex_ws_url,
+                        launch_config.external_session_id,
+                        launch_config.reasoning_effort,
+                        model=_codex_launch.model,
+                    )
+                except Exception:  # noqa: BLE001 — a failed update must not sink the launch
+                    _logger.warning(
+                        "codex-native: could not apply reasoning effort %r to resumed thread "
+                        "%s for session %s; the next web turn re-applies it",
+                        launch_config.reasoning_effort,
+                        launch_config.external_session_id,
+                        session_id,
+                        exc_info=True,
+                        extra={"session_id": session_id},
+                    )
     if launch_config.external_session_id is None:
         try:
             # Connect the listener BEFORE launching the TUI so it observes the

--- a/omnigent/util/reasoning_effort.py
+++ b/omnigent/util/reasoning_effort.py
@@ -143,6 +143,7 @@ def efforts_for_harness(harness: str | None) -> frozenset[str] | None:
         EffortFamily.GEMINI: GEMINI_EFFORTS,
         EffortFamily.COPILOT: COPILOT_EFFORTS,
         EffortFamily.PI: PI_EFFORTS,
+        EffortFamily.CODEX_NATIVE: CODEX_NATIVE_EFFORTS,
     }.get(capabilities.effort, frozenset())
 
 

--- a/tests/runner/test_app_sessions_native_workflow_messages.py
+++ b/tests/runner/test_app_sessions_native_workflow_messages.py
@@ -947,6 +947,63 @@ async def test_forwarded_reasoning_effort_reaches_the_harness() -> None:
 
 
 @pytest.mark.asyncio
+async def test_forwarded_reasoning_effort_keeps_codex_native_full_ladder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A codex-native turn keeps Sol's ``ultra``; the SDK codex cap must not filter it.
+
+    The runner filters the turn's effort through the declared effort family of
+    the harness the session's spec resolves to. codex-native used to share the
+    SDK codex family (capped at ``xhigh``), so a session created or forked at
+    ``ultra`` had its effort dropped here and Codex ran its default.
+    """
+    # A native turn also nudges the tool relay, which waits 30s for a bridge
+    # server-info file no fake harness ever writes.
+    monkeypatch.setattr(claude_native_bridge, "post_tools_changed", lambda _bridge_dir: None)
+    hc = _ScriptedHarnessClient(
+        [
+            _sse({"type": "response.created", "response": {"id": "resp_1"}}),
+            _sse({"type": "response.completed", "response": {"id": "resp_1"}}),
+        ]
+    )
+    pm = _FakeProcessManager(hc)
+    spec = AgentSpec(spec_version=1, name="t", executor=ExecutorSpec(type="codex-native"))
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return spec
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    session = "ee1f2b3c4d5e6f708192a3b4c5d6e7f9"
+
+    async with _runner_client(app) as client:
+        resp = await client.post(
+            f"/v1/sessions/{session}/events",
+            json={
+                "type": "message",
+                "role": "user",
+                "agent_id": "agent",
+                "model": "test-agent",
+                "content": [{"type": "input_text", "text": "hi"}],
+                "harness": "codex-native",
+                "reasoning": {"effort": "ultra"},
+            },
+        )
+        assert resp.status_code == 202
+        for _ in range(200):
+            if hc.posted_bodies:
+                break
+            await asyncio.sleep(0.01)
+
+    assert hc.posted_bodies, "harness never received a turn"
+    assert hc.posted_bodies[0].get("reasoning") == {"effort": "ultra"}
+
+
+@pytest.mark.asyncio
 async def test_buffered_continuation_skips_transient_idle() -> None:
     """End-of-turn `idle` is suppressed when a buffered message will start a new turn."""
     import asyncio as _aio

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -1233,6 +1233,38 @@ args = []
     }
 
 
+async def test_start_pins_reasoning_effort_in_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Startup seeds ``model_reasoning_effort`` from the session's persisted effort.
+
+    The private config is a copy of the user's shared one, whose effort line is
+    whatever the user last ran. Both the app-server and the ``--remote`` TUI
+    read it at thread creation, so a session created or forked at ``ultra``
+    otherwise starts (and reports in the TUI footer) that stale level.
+    """
+    real_codex_home = tmp_path / "real-codex-home"
+    real_codex_home.mkdir()
+    original = 'model_reasoning_effort = "medium"\n'
+    (real_codex_home / "config.toml").write_text(original, encoding="utf-8")
+    codex_home = tmp_path / "codex-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(real_codex_home))
+    _disable_codex_startup_rpc(monkeypatch)
+
+    server = _test_app_server(tmp_path, codex_home, tmp_path / "bridge", workspace)
+    server.pinned_effort = "ultra"
+    await server.start()
+    await server.close()
+
+    rendered = (codex_home / "config.toml").read_text(encoding="utf-8")
+    assert tomllib.loads(rendered)["model_reasoning_effort"] == "ultra"
+    assert rendered.count("model_reasoning_effort") == 1
+    assert (real_codex_home / "config.toml").read_text(encoding="utf-8") == original
+
+
 async def test_start_writes_fresh_mcp_config_without_leading_blanks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2151,6 +2183,48 @@ class TestPinCodexConfigModel:
         assert read_codex_config_model(bridge_dir) == "databricks-gpt-5-4-mini"
 
 
+class TestPinCodexConfigEffort:
+    """_pin_codex_config_effort seeds the per-session config.toml effort."""
+
+    def test_replaces_top_level_effort_only(self, tmp_path: Path) -> None:
+        """The copied effort line is replaced; model and table-scoped keys survive."""
+        from omnigent.harnesses.codex_native.app_server import _pin_codex_config_effort
+
+        config = tmp_path / "config.toml"
+        config.write_text(
+            'model = "gpt-5.5"\n'
+            'model_reasoning_effort = "medium"\n'
+            "[profiles.default]\n"
+            'model_reasoning_effort = "table-scoped-stays"\n',
+            encoding="utf-8",
+        )
+        _pin_codex_config_effort(tmp_path, "ultra", "gpt-5.5")
+        lines = config.read_text(encoding="utf-8").splitlines()
+        assert lines[:2] == ['model = "gpt-5.5"', 'model_reasoning_effort = "ultra"']
+        assert 'model_reasoning_effort = "table-scoped-stays"' in lines
+        assert "medium" not in "\n".join(lines)
+
+    def test_inserts_effort_when_absent(self, tmp_path: Path) -> None:
+        """A config with no top-level effort gains one before the first table."""
+        from omnigent.harnesses.codex_native.app_server import _pin_codex_config_effort
+
+        config = tmp_path / "config.toml"
+        config.write_text("[profiles.default]\nx = 1\n", encoding="utf-8")
+        _pin_codex_config_effort(tmp_path, "high", None)
+        lines = config.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == 'model_reasoning_effort = "high"'
+        assert "[profiles.default]" in lines
+
+    def test_clamps_to_the_pinned_models_ladder(self, tmp_path: Path) -> None:
+        """A level the pinned model rejects is coerced so the first turn cannot 400."""
+        from omnigent.harnesses.codex_native.app_server import _pin_codex_config_effort
+
+        _pin_codex_config_effort(tmp_path, "ultra", "glm-5-2")
+        assert (tmp_path / "config.toml").read_text(encoding="utf-8") == (
+            'model_reasoning_effort = "medium"\n'
+        )
+
+
 # --- Subagent-routing hook trust ---------------------------------------
 #
 # Empirically (codex-cli 0.145.0) ``--dangerously-bypass-hook-trust`` does
@@ -2474,6 +2548,38 @@ async def test_codex_native_launch_config_reads_the_auto_harness_flag(
         config = await _codex_native_launch_config(session_id="conv_abc", server_client=client)
 
     assert config.auto_harness is expected
+
+
+@pytest.mark.parametrize(
+    ("persisted", "expected"),
+    [("ultra", "ultra"), ("bogus", None), (None, None)],
+    ids=["ultra", "unsupported", "unset"],
+)
+async def test_codex_native_launch_config_reads_reasoning_effort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    persisted: str | None,
+    expected: str | None,
+) -> None:
+    """The persisted effort reaches the launch; an unsupported one is dropped, not fatal."""
+    import httpx
+
+    from omnigent.runner.native.orchestration import _codex_native_launch_config
+
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://127.0.0.1:9999")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"workspace": str(tmp_path), "labels": {}, "reasoning_effort": persisted},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://runner"
+    ) as client:
+        config = await _codex_native_launch_config(session_id="conv_abc", server_client=client)
+
+    assert config.reasoning_effort == expected
 
 
 async def test_probe_codex_model_options_uses_launch_config_and_marks_default(

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -2582,6 +2582,51 @@ async def test_codex_native_launch_config_reads_reasoning_effort(
     assert config.reasoning_effort == expected
 
 
+@pytest.mark.parametrize(
+    ("model", "expected_effort"),
+    [("gpt-5.6-sol", "ultra"), (None, "ultra"), ("glm-5-2", "medium")],
+    ids=["sol", "no-model", "clamped"],
+)
+async def test_apply_codex_thread_effort_updates_the_loaded_thread(
+    monkeypatch: pytest.MonkeyPatch, model: str | None, expected_effort: str
+) -> None:
+    """
+    The persisted effort reaches a resumed thread via ``thread/settings/update``.
+
+    A resumed thread runs the rollout's recorded effort — none after a runner
+    restart rebuilt the rollout, the source's on a forked clone — so the launch
+    re-applies the session's effort (clamped to the model's ladder) once the
+    thread has started, instead of leaving the TUI at ``default`` until a web
+    turn happens to send one.
+    """
+    from omnigent.harnesses.codex_native import app_server as codex_native_app_server
+
+    requests: list[tuple[str, dict[str, object]]] = []
+
+    class _FakeClient:
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            assert ws_url == "ws://127.0.0.1:9876"
+            assert client_name == "omnigent-codex-native-effort"
+
+        async def connect(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+        async def request(self, method: str, params: dict[str, object]) -> dict[str, object]:
+            requests.append((method, params))
+            return {"result": {}}
+
+    monkeypatch.setattr(codex_native_app_server, "CodexAppServerClient", _FakeClient)
+    await codex_native_app_server.apply_codex_thread_effort(
+        "ws://127.0.0.1:9876", "thread_abc", "ultra", model=model
+    )
+    assert requests == [
+        ("thread/settings/update", {"threadId": "thread_abc", "effort": expected_effort})
+    ]
+
+
 async def test_probe_codex_model_options_uses_launch_config_and_marks_default(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_reasoning_effort.py
+++ b/tests/test_reasoning_effort.py
@@ -245,6 +245,11 @@ def test_efforts_for_harness_distinguishes_unsupported_from_unknown() -> None:
     # pi declares its own family, so it resolves to a real vocabulary.
     assert efforts_for_harness("pi") == PI_EFFORTS
     assert efforts_for_harness("pi-native") == PI_EFFORTS
+    # codex-native drives the real codex process, which takes Sol's max/ultra;
+    # sharing the SDK codex family (capped at xhigh) dropped a session created
+    # at ultra to Codex's default before its first turn.
+    assert efforts_for_harness("codex-native") == CODEX_NATIVE_EFFORTS
+    assert efforts_for_harness("codex") == CODEX_EFFORTS
     # Known, but declared EffortFamily.NONE.
     assert efforts_for_harness("opencode-native") == frozenset()
     # Not in the registry at all — unclassifiable, not unsupported.


### PR DESCRIPTION
## Related issue

Closes #

## Summary

A codex-native session created from the new-session composer at `GPT-5.6-Sol ultra` (or a fork inheriting that pick) ran at Codex's default effort and its TUI footer read `gpt-5.6-sol default`, while the composer chip claimed `ultra`. A runner or host restart put a session that *was* on the right effort back to `default` the same way. Live `/effort` changes on an existing session were fine.

**ELI5:** three places each assumed someone else had applied the effort. The runner checks each turn's effort against a per-harness allow-list before handing it to Codex, and codex-native was on the SDK codex list (tops out at `xhigh`), so `ultra`/`max` were quietly thrown away. The launch pinned the *model* into the session's private Codex config but never the *effort*. And a *resumed* thread takes its effort from the rollout file rather than the config at all, so after a restart (where the relaunched runner's startup reap deletes the session's Codex home and the rollout is rebuilt from Omnigent items with no effort in it) or on a fork with a different pick (the clone carries the source's rollout), Codex came up on the rollout's level.

Three fixes:

- **Dispatch filter (create/fork root cause).** `codex-native` now declares its own `EffortFamily.CODEX_NATIVE`, mapped to `CODEX_NATIVE_EFFORTS` (the real codex process is the per-model authority on reasoning levels; Sol reaches `ultra`). The runner no longer logs `dropping reasoning effort 'ultra' — harness codex-native accepts none…xhigh` and the executor's `thread/settings/update` carries the level. The SDK `codex` harness keeps the OpenAI ladder.
- **Launch pin (fresh threads).** The persisted `reasoning_effort` is threaded through the codex-native launch config and written as `model_reasoning_effort` into the private `config.toml` next to the existing model pin (clamped to the pinned model's ladder), so a fresh thread — and the `--remote` TUI footer — start at the picked level before any web turn.
- **Resumed threads (restart / fork root cause).** Once the app-server has loaded a known thread (after the resume preload, before the TUI attaches), the launch sends the session's persisted effort over `thread/settings/update` — the RPC the web `/effort` path already uses — clamped to the launch model's ladder. A failure is logged and the next web turn still re-applies it.

```
composer "ultra" ─► server persists reasoning_effort=ultra ─► runner
   fresh launch:   config.toml  model="gpt-5.6-sol" + model_reasoning_effort="ultra"          (new)
   resumed launch: thread/resume ─► thread/settings/update{effort:"ultra"} ─► TUI attaches   (new)
   each turn:      efforts_for_harness("codex-native") ⊇ {ultra} ─► thread/settings/update    (was dropped)
```

Not changed here: the runner-startup reap still deletes a restarting session's Codex home (the cold-resume rebuild is lossy beyond effort); that is a separate design question.

## Test Plan

Unit (all green; each new test is red on `main`):

- `tests/test_reasoning_effort.py` — `efforts_for_harness("codex-native")` resolves to the full codex ladder, `codex` stays capped.
- `tests/runner/test_app_sessions_native_workflow_messages.py::test_forwarded_reasoning_effort_keeps_codex_native_full_ladder` — a codex-native turn at `ultra` reaches the harness body (fails on `main` with the "dropping reasoning effort" warning).
- `tests/test_codex_native_app_server.py` — `TestPinCodexConfigEffort` (replace / insert / clamp), `test_start_pins_reasoning_effort_in_config`, `test_codex_native_launch_config_reads_reasoning_effort[ultra|unsupported|unset]`, `test_apply_codex_thread_effort_updates_the_loaded_thread[sol|no-model|clamped]`.
- Regression: `tests/test_codex_native_app_server.py`, `tests/test_harness_capabilities.py`, `tests/inner/test_codex_native_executor.py`, `tests/runner/test_app_sessions_native_terminals_autocreate.py`, `tests/runner/test_app_sessions_native_workflow_messages.py`, `tests/runner/test_runner_dispatch.py` — 561 passed. Ruff (repo-pinned 0.15.16) clean; pyrefly 1.1.1 reports only the 21 errors that file already has on `main`.

Live, sandboxed `omnigent server` + `omnigent host` (real codex-cli 0.152.1, Databricks provider, model `gpt-5.6-sol`), driven through the REST calls the SPA makes, TUI truth read from the tmux pane footer before any web turn:

| flow | unmodified `main` | this branch |
|---|---|---|
| create at `ultra`, footer before/after first turn | `default` / `default`; runner log: `dropping reasoning effort 'ultra'` | `ultra` / `ultra`; no drop logged |
| private `config.toml` pin | `model = "gpt-5.6-sol"` only | `model_reasoning_effort = "ultra"` + model |
| kill the runner, `retry_session`, footer over the next 60 s with no turn | `default` for the whole minute (rollout rebuilt without effort) | `ultra` from first paint |
| fork inheriting `ultra` → bind host → turn | — | `ultra` from first paint; reply arrives; effort stays `ultra` |
| fork overriding to `high`, footer before any turn | — | `high` from first paint (was the source's `ultra` until the first turn) |

Manual check for reviewers: New session → Codex → gear → GPT-5.6-Sol + Ultra → send "hi". Open the terminal view: the footer must read `gpt-5.6-sol ultra`. Then restart the host (or kill the session's runner and hit Retry): the footer must come back reading `ultra` without sending anything. Fork that session (Clone) picking Medium: the clone's footer must read `medium` before its first message.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the live before/after matrix above against a real codex TUI; the unit tests pin the three code paths (dispatch filter vocabulary, launch-time config pin, resumed-thread settings update) hermetically.

## Changelog

Codex sessions created, forked, or resumed after a runner restart at a picked reasoning effort (including Sol's `ultra`/`max`) now run at that effort instead of Codex's default.
