### PR TITLE
Harden Claude child history forwarding

### DIFF
--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -67,7 +67,9 @@ _HOOKS_FILE = "hooks.jsonl"
 # Keep child-history requests below the server's 10 MiB API ceiling to bound
 # per-request latency and retry cost while still accommodating large events.
 MAX_SUBAGENT_EVENT_BATCH_BYTES = 5 * 1024 * 1024
-_TRUNCATABLE_SUBAGENT_FIELDS = frozenset({"arguments", "content", "output", "text"})
+_TRUNCATABLE_SUBAGENT_FIELDS = frozenset(
+    {"arguments", "content", "input", "output", "stderr", "stdout", "text"}
+)
 
 # Cap on the ``persisted_seqs`` history kept in the durable compaction
 # state. Each entry is one completed compaction boundary; a session sees
@@ -776,6 +778,10 @@ class _PostRetryTracker:
         if remaining <= 0:
             return None
         return remaining
+
+    def has_retry_state(self, key: str) -> bool:
+        """Return whether ``key`` has a recorded failure awaiting retry."""
+        return key in self._entries
 
     def clear(self, key: str) -> None:
         """
@@ -1793,6 +1799,9 @@ async def _forward_one_subagent(
             f"subagent_item:{entry.child_conversation_id}:{pending.item.source_id}"
             for pending in batch
         ]
+        retry_individually = any(
+            item_retry_tracker.has_retry_state(item_key) for item_key in item_retry_keys
+        )
         if item_retry_tracker.retry_delay_s(retry_key) is not None or any(
             item_retry_tracker.retry_delay_s(item_key) is not None for item_key in item_retry_keys
         ):
@@ -1831,7 +1840,7 @@ async def _forward_one_subagent(
                 last_activity_ts=now,
                 delivery_error=_SUBAGENT_DROPPED_ITEM_REASON,
             )
-        else:
+        elif not retry_individually:
             try:
                 await _post_external_conversation_items(
                     client,
@@ -1899,72 +1908,74 @@ async def _forward_one_subagent(
                         _http_status_for_log(exc),
                         extra={"session_id": parent_session_id},
                     )
-                    for pending_item, item_retry_key in zip(batch, item_retry_keys, strict=True):
-                        item = pending_item.item
-                        try:
-                            await _post_external_conversation_item(
-                                client,
-                                session_id=entry.child_conversation_id,
-                                item=item,
-                            )
-                        except httpx.HTTPError as item_exc:
-                            item_decision = item_retry_tracker.record_failure(
-                                item_retry_key, item_exc
-                            )
-                            if not item_decision.exhausted:
-                                stop_after_batch = True
-                                _logger.warning(
-                                    "Failed to re-drive claude-native sub-agent transcript "
-                                    "item; child=%s source_id=%s attempt=%s "
-                                    "next_retry_s=%.3f http_status=%s",
-                                    entry.child_conversation_id,
-                                    item.source_id,
-                                    item_decision.attempts,
-                                    item_decision.delay_s,
-                                    _http_status_for_log(item_exc),
-                                    exc_info=True,
-                                    extra={"session_id": parent_session_id},
-                                )
-                                break
-                            _logger.error(
-                                "Dropping claude-native sub-agent transcript item after "
-                                "individual rejection; child=%s source_id=%s http_status=%s",
-                                entry.child_conversation_id,
-                                item.source_id,
-                                _http_status_for_log(item_exc),
-                                extra={"session_id": parent_session_id},
-                            )
-                            append_dead_letter(
-                                bridge_dir,
-                                session_id=entry.child_conversation_id,
-                                event_type="external_conversation_item",
-                                payload={
-                                    "source_id": item.source_id,
-                                    "item_type": item.item_type,
-                                    "item_data": item.data,
-                                    "response_id": item.response_id,
-                                },
-                                reason="permanent HTTP failure after retries",
-                                delivered_ambiguous=False,
-                                http_status=_http_status_for_log(item_exc),
-                            )
-                            new_entry = replace(
-                                new_entry,
-                                last_activity_ts=now,
-                                delivery_error=_SUBAGENT_DROPPED_ITEM_REASON,
-                            )
-                        else:
-                            item_retry_tracker.clear(item_retry_key)
-                            delivered = True
-                        completed_items.append(pending_item)
+                    retry_individually = True
             else:
                 completed_items.extend(batch)
                 delivered = True
-        item_retry_tracker.clear(retry_key)
-        completed_source_ids = {pending.item.source_id for pending in completed_items}
-        for pending_item, item_retry_key in zip(batch, item_retry_keys, strict=True):
-            if pending_item.item.source_id in completed_source_ids:
-                item_retry_tracker.clear(item_retry_key)
+                item_retry_tracker.clear(retry_key)
+        if retry_individually and drop_reason is None:
+            for pending_item, item_retry_key in zip(batch, item_retry_keys, strict=True):
+                item = pending_item.item
+                try:
+                    await _post_external_conversation_item(
+                        client,
+                        session_id=entry.child_conversation_id,
+                        item=item,
+                    )
+                except httpx.HTTPError as item_exc:
+                    item_decision = item_retry_tracker.record_failure(item_retry_key, item_exc)
+                    if not item_decision.exhausted:
+                        stop_after_batch = True
+                        _logger.warning(
+                            "Failed to re-drive claude-native sub-agent transcript "
+                            "item; child=%s source_id=%s attempt=%s "
+                            "next_retry_s=%.3f http_status=%s",
+                            entry.child_conversation_id,
+                            item.source_id,
+                            item_decision.attempts,
+                            item_decision.delay_s,
+                            _http_status_for_log(item_exc),
+                            exc_info=True,
+                            extra={"session_id": parent_session_id},
+                        )
+                        break
+                    _logger.error(
+                        "Dropping claude-native sub-agent transcript item after "
+                        "individual delivery retries; child=%s source_id=%s http_status=%s",
+                        entry.child_conversation_id,
+                        item.source_id,
+                        _http_status_for_log(item_exc),
+                        extra={"session_id": parent_session_id},
+                    )
+                    if _is_permanent_http_error(item_exc):
+                        dead_letter_reason = "permanent HTTP failure after retries"
+                    elif _is_subagent_delivery_not_confirmed(item_exc):
+                        dead_letter_reason = "delivery not confirmed after retries"
+                    else:
+                        dead_letter_reason = "transient HTTP failure after retries"
+                    append_dead_letter(
+                        bridge_dir,
+                        session_id=entry.child_conversation_id,
+                        event_type="external_conversation_item",
+                        payload={
+                            "source_id": item.source_id,
+                            "item_type": item.item_type,
+                            "item_data": item.data,
+                            "response_id": item.response_id,
+                        },
+                        reason=dead_letter_reason,
+                        delivered_ambiguous=False,
+                        http_status=_http_status_for_log(item_exc),
+                    )
+                    new_entry = replace(
+                        new_entry,
+                        last_activity_ts=now,
+                        delivery_error=_SUBAGENT_DROPPED_ITEM_REASON,
+                    )
+                else:
+                    item_retry_tracker.clear(item_retry_key)
+                    delivered = True
+                completed_items.append(pending_item)
         had_item = had_item or delivered
         for pending_item in completed_items:
             source_id = pending_item.item.source_id

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -3794,7 +3794,8 @@ async def _cancel_subagent_forward_task(
     try:
         await task
     except asyncio.CancelledError:
-        pass
+        # Cancellation is expected after task.cancel().
+        return
     except Exception:
         _logger.exception("Claude child-history worker failed during cleanup")
 

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -67,6 +67,7 @@ _HOOKS_FILE = "hooks.jsonl"
 # Keep child-history requests below the server's 10 MiB API ceiling to bound
 # per-request latency and retry cost while still accommodating large events.
 MAX_SUBAGENT_EVENT_BATCH_BYTES = 5 * 1024 * 1024
+_TRUNCATABLE_SUBAGENT_FIELDS = frozenset({"arguments", "content", "output", "text"})
 
 # Cap on the ``persisted_seqs`` history kept in the durable compaction
 # state. Each entry is one completed compaction boundary; a session sees
@@ -1166,17 +1167,20 @@ async def forward_claude_transcript_to_session(
                                 _read_subagent_forward_state, bridge_dir
                             )
                             subagent_task = asyncio.create_task(
-                                _forward_available_subagents(
-                                    client=subagent_client,
-                                    parent_session_id=current_session_id,
-                                    bridge_dir=bridge_dir,
-                                    transcript_path=transcript_path,
-                                    state=subagent_state,
-                                    agent_name=agent_name,
-                                    start_retry_tracker=subagent_start_retries,
-                                    item_retry_tracker=subagent_item_retries,
-                                    status_retry_tracker=subagent_status_retries,
-                                    batch_capability=session_event_batch_capability,
+                                asyncio.wait_for(
+                                    _forward_available_subagents(
+                                        client=subagent_client,
+                                        parent_session_id=current_session_id,
+                                        bridge_dir=bridge_dir,
+                                        transcript_path=transcript_path,
+                                        state=subagent_state,
+                                        agent_name=agent_name,
+                                        start_retry_tracker=subagent_start_retries,
+                                        item_retry_tracker=subagent_item_retries,
+                                        status_retry_tracker=subagent_status_retries,
+                                        batch_capability=session_event_batch_capability,
+                                    ),
+                                    timeout=_FORWARD_LOOP_STALL_DEADLINE_S,
                                 ),
                                 name=f"claude-child-history-{current_session_id}",
                             )
@@ -1509,7 +1513,7 @@ def _encoded_subagent_batch(items: Sequence[_PendingSubagentItem]) -> bytes:
 
 
 def _string_paths(value: object, path: tuple[str | int, ...] = ()) -> list[tuple[str | int, ...]]:
-    """Find truncatable strings in a transcript item's data payload."""
+    """Find free-text strings that are safe to truncate in an item payload."""
     paths: list[tuple[str | int, ...]] = []
     if isinstance(value, dict):
         for key, child in value.items():
@@ -1520,7 +1524,9 @@ def _string_paths(value: object, path: tuple[str | int, ...] = ()) -> list[tuple
         for index, child in enumerate(value):
             paths.extend(_string_paths(child, (*path, index)))
     elif isinstance(value, str):
-        paths.append(path)
+        field_name = next((part for part in reversed(path) if isinstance(part, str)), None)
+        if field_name in _TRUNCATABLE_SUBAGENT_FIELDS:
+            paths.append(path)
     return paths
 
 
@@ -1782,12 +1788,14 @@ async def _forward_one_subagent(
     now = time.time()
     had_item = False
     for batch in batches:
-        batch_ids = [pending_item.item.source_id for pending_item in batch]
-        retry_key = (
-            f"subagent_batch:{entry.child_conversation_id}:"
-            f"{hashlib.sha256(chr(0).join(batch_ids).encode()).hexdigest()[:16]}"
-        )
-        if item_retry_tracker.retry_delay_s(retry_key) is not None:
+        retry_key = f"subagent_batch:{entry.child_conversation_id}:{batch[0].item.source_id}"
+        item_retry_keys = [
+            f"subagent_item:{entry.child_conversation_id}:{pending.item.source_id}"
+            for pending in batch
+        ]
+        if item_retry_tracker.retry_delay_s(retry_key) is not None or any(
+            item_retry_tracker.retry_delay_s(item_key) is not None for item_key in item_retry_keys
+        ):
             break
         drop_reason = batch[0].drop_reason if len(batch) == 1 else None
         completed_items: list[_PendingSubagentItem] = []
@@ -1891,7 +1899,7 @@ async def _forward_one_subagent(
                         _http_status_for_log(exc),
                         extra={"session_id": parent_session_id},
                     )
-                    for pending_item in batch:
+                    for pending_item, item_retry_key in zip(batch, item_retry_keys, strict=True):
                         item = pending_item.item
                         try:
                             await _post_external_conversation_item(
@@ -1900,16 +1908,19 @@ async def _forward_one_subagent(
                                 item=item,
                             )
                         except httpx.HTTPError as item_exc:
-                            if not (
-                                _is_permanent_http_error(item_exc)
-                                or _is_subagent_delivery_not_confirmed(item_exc)
-                            ):
+                            item_decision = item_retry_tracker.record_failure(
+                                item_retry_key, item_exc
+                            )
+                            if not item_decision.exhausted:
                                 stop_after_batch = True
                                 _logger.warning(
                                     "Failed to re-drive claude-native sub-agent transcript "
-                                    "item; child=%s source_id=%s http_status=%s",
+                                    "item; child=%s source_id=%s attempt=%s "
+                                    "next_retry_s=%.3f http_status=%s",
                                     entry.child_conversation_id,
                                     item.source_id,
+                                    item_decision.attempts,
+                                    item_decision.delay_s,
                                     _http_status_for_log(item_exc),
                                     exc_info=True,
                                     extra={"session_id": parent_session_id},
@@ -1943,12 +1954,17 @@ async def _forward_one_subagent(
                                 delivery_error=_SUBAGENT_DROPPED_ITEM_REASON,
                             )
                         else:
+                            item_retry_tracker.clear(item_retry_key)
                             delivered = True
                         completed_items.append(pending_item)
             else:
                 completed_items.extend(batch)
                 delivered = True
         item_retry_tracker.clear(retry_key)
+        completed_source_ids = {pending.item.source_id for pending in completed_items}
+        for pending_item, item_retry_key in zip(batch, item_retry_keys, strict=True):
+            if pending_item.item.source_id in completed_source_ids:
+                item_retry_tracker.clear(item_retry_key)
         had_item = had_item or delivered
         for pending_item in completed_items:
             source_id = pending_item.item.source_id
@@ -3771,12 +3787,16 @@ async def _ensure_state_for_transcript(
 async def _cancel_subagent_forward_task(
     task: asyncio.Task[SubagentForwardState] | None,
 ) -> None:
-    """Cancel and drain the independent child-history worker."""
+    """Cancel and best-effort drain the independent child-history worker."""
     if task is None:
         return
     task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
+    try:
         await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        _logger.exception("Claude child-history worker failed during cleanup")
 
 
 def _promote_pending_settle(

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5863,6 +5863,36 @@ def test_oversized_subagent_item_does_not_truncate_identifiers() -> None:
     assert fitted.item.data["name"] == name
 
 
+@pytest.mark.parametrize(
+    ("field_name", "kind"),
+    [("input", "input"), ("stdout", "output"), ("stderr", "output")],
+)
+def test_oversized_subagent_terminal_text_is_truncated(
+    monkeypatch: pytest.MonkeyPatch,
+    field_name: str,
+    kind: str,
+) -> None:
+    """Large terminal commands and output are shrunk instead of dropped."""
+    monkeypatch.setattr(forwarder, "MAX_SUBAGENT_EVENT_BATCH_BYTES", 1024)
+    entry = forwarder._PendingSubagentItem(
+        item=ClaudeTranscriptItem(
+            source_id=f"oversized-terminal-{field_name}",
+            item_type="terminal_command",
+            data={"kind": kind, field_name: "x" * 2048},
+            response_id="resp-terminal",
+        )
+    )
+
+    fitted = forwarder._fit_subagent_item(entry)
+
+    assert fitted.drop_reason is None
+    assert fitted.item.data["kind"] == kind
+    terminal_text = fitted.item.data[field_name]
+    assert isinstance(terminal_text, str)
+    assert "content truncated by omnigent" in terminal_text
+    assert len(forwarder._encoded_subagent_batch([fitted])) <= 1024
+
+
 def test_subagent_batch_partitioning_encodes_items_linearly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -6306,14 +6336,23 @@ async def test_individual_redrive_honors_not_confirmed_retry_budget(
         bridge_dir,
         forwarder.SubagentForwardState(subagents={"retry": entry}),
     )
+    batch_attempts = 0
     individual_attempts = 0
+    forward_successes = 0
+
+    def note_forward_success() -> None:
+        nonlocal forward_successes
+        forward_successes += 1
+
+    monkeypatch.setattr(forwarder, "_note_forward_success", note_forward_success)
 
     def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal individual_attempts
+        nonlocal batch_attempts, individual_attempts
         body = json.loads(request.content.decode("utf-8"))
         if isinstance(body, list):
-            return httpx.Response(400, json={"error": "reject batch"})
-        individual_attempts += 1
+            batch_attempts += 1
+        else:
+            individual_attempts += 1
         return httpx.Response(
             503,
             json={"error": "subagent_delivery_not_confirmed"},
@@ -6327,7 +6366,7 @@ async def test_individual_redrive_honors_not_confirmed_retry_budget(
     async with httpx.AsyncClient(
         transport=httpx.MockTransport(handler), base_url="http://ap"
     ) as client:
-        for _ in range(2):
+        for _ in range(3):
             await forwarder._forward_one_subagent(
                 client=client,
                 parent_session_id="conv_parent",
@@ -6341,13 +6380,16 @@ async def test_individual_redrive_honors_not_confirmed_retry_budget(
                 batch_capability=forwarder._SessionEventBatchCapability(),
             )
 
+    assert batch_attempts == 2
     assert individual_attempts == 2
+    assert forward_successes == 0
     assert checkpoint.state.subagents["retry"].byte_offset == 10
     dead_letters = [
         json.loads(line)
         for line in (bridge_dir / "dead_letter.jsonl").read_text("utf-8").splitlines()
     ]
     assert [record["payload"]["source_id"] for record in dead_letters] == [item.source_id]
+    assert dead_letters[0]["reason"] == "delivery not confirmed after retries"
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -5845,6 +5845,24 @@ def test_subagent_batches_obey_count_and_exact_byte_limits() -> None:
         )
 
 
+def test_oversized_subagent_item_does_not_truncate_identifiers() -> None:
+    """Batch fitting never rewrites schema-significant identifier fields."""
+    name = "n" * forwarder.MAX_SUBAGENT_EVENT_BATCH_BYTES
+    entry = forwarder._PendingSubagentItem(
+        item=ClaudeTranscriptItem(
+            source_id="oversized-name",
+            item_type="function_call",
+            data={"agent": "claude", "name": name, "arguments": "{}", "call_id": "call-1"},
+            response_id="resp-name",
+        )
+    )
+
+    fitted = forwarder._fit_subagent_item(entry)
+
+    assert fitted.drop_reason is not None
+    assert fitted.item.data["name"] == name
+
+
 def test_subagent_batch_partitioning_encodes_items_linearly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -6249,6 +6267,195 @@ async def test_permanent_batch_failure_redrives_items_individually(
         for line in (bridge_dir / "dead_letter.jsonl").read_text("utf-8").splitlines()
     ]
     assert [record["payload"]["source_id"] for record in dead_letters] == ["poison"]
+
+
+@pytest.mark.asyncio
+async def test_individual_redrive_honors_not_confirmed_retry_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fallback item is retried before a not-confirmed 503 is dead-lettered."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    subagents_dir = tmp_path / "subagents"
+    subagents_dir.mkdir()
+    (subagents_dir / "agent-retry.jsonl").write_text("{}\n", encoding="utf-8")
+    item = ClaudeTranscriptItem(
+        source_id="retry-not-confirmed",
+        item_type="message",
+        data={"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+        response_id="resp-retry",
+    )
+    read_result = TranscriptReadResult(
+        line_cursor=1,
+        byte_offset=10,
+        current_response_id=None,
+        items=[item],
+        record_items=(TranscriptRecordItems(next_byte_offset=10, items=(item,)),),
+    )
+    monkeypatch.setattr(
+        forwarder,
+        "read_transcript_items_from_offset",
+        lambda *args, **kwargs: read_result,
+    )
+    entry = forwarder.SubagentEntry(
+        subagent_id="retry",
+        child_conversation_id="conv_child_retry",
+    )
+    checkpoint = forwarder._SubagentStateCheckpoint(
+        bridge_dir,
+        forwarder.SubagentForwardState(subagents={"retry": entry}),
+    )
+    individual_attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal individual_attempts
+        body = json.loads(request.content.decode("utf-8"))
+        if isinstance(body, list):
+            return httpx.Response(400, json={"error": "reject batch"})
+        individual_attempts += 1
+        return httpx.Response(
+            503,
+            json={"error": "subagent_delivery_not_confirmed"},
+        )
+
+    retry_tracker = forwarder._PostRetryTracker(
+        base_delay_s=0.0,
+        max_permanent_attempts=1,
+        max_not_confirmed_attempts=2,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        for _ in range(2):
+            await forwarder._forward_one_subagent(
+                client=client,
+                parent_session_id="conv_parent",
+                bridge_dir=bridge_dir,
+                subagents_dir=subagents_dir,
+                entry=checkpoint.state.subagents["retry"],
+                agent_name="claude-native-ui",
+                checkpoint=checkpoint,
+                item_retry_tracker=retry_tracker,
+                status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+                batch_capability=forwarder._SessionEventBatchCapability(),
+            )
+
+    assert individual_attempts == 2
+    assert checkpoint.state.subagents["retry"].byte_offset == 10
+    dead_letters = [
+        json.loads(line)
+        for line in (bridge_dir / "dead_letter.jsonl").read_text("utf-8").splitlines()
+    ]
+    assert [record["payload"]["source_id"] for record in dead_letters] == [item.source_id]
+
+
+@pytest.mark.asyncio
+async def test_subagent_batch_backoff_survives_new_tail_items(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Appending later items cannot reset backoff for the failing head item."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    subagents_dir = tmp_path / "subagents"
+    subagents_dir.mkdir()
+    (subagents_dir / "agent-backoff.jsonl").write_text("{}\n", encoding="utf-8")
+
+    def transcript_item(source_id: str) -> ClaudeTranscriptItem:
+        return ClaudeTranscriptItem(
+            source_id=source_id,
+            item_type="message",
+            data={"role": "assistant", "content": [{"type": "text", "text": source_id}]},
+            response_id="resp-backoff",
+        )
+
+    first = transcript_item("first")
+    second = transcript_item("second")
+    current_result = TranscriptReadResult(
+        line_cursor=1,
+        byte_offset=10,
+        current_response_id=None,
+        items=[first],
+        record_items=(TranscriptRecordItems(next_byte_offset=10, items=(first,)),),
+    )
+    monkeypatch.setattr(
+        forwarder,
+        "read_transcript_items_from_offset",
+        lambda *args, **kwargs: current_result,
+    )
+    entry = forwarder.SubagentEntry(
+        subagent_id="backoff",
+        child_conversation_id="conv_child_backoff",
+    )
+    checkpoint = forwarder._SubagentStateCheckpoint(
+        bridge_dir,
+        forwarder.SubagentForwardState(subagents={"backoff": entry}),
+    )
+    requests = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(502, text="unavailable")
+
+    retry_tracker = forwarder._PostRetryTracker(base_delay_s=60.0)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        await forwarder._forward_one_subagent(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            subagents_dir=subagents_dir,
+            entry=entry,
+            agent_name="claude-native-ui",
+            checkpoint=checkpoint,
+            item_retry_tracker=retry_tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            batch_capability=forwarder._SessionEventBatchCapability(),
+        )
+        current_result = TranscriptReadResult(
+            line_cursor=2,
+            byte_offset=20,
+            current_response_id=None,
+            items=[first, second],
+            record_items=(
+                TranscriptRecordItems(next_byte_offset=10, items=(first,)),
+                TranscriptRecordItems(next_byte_offset=20, items=(second,)),
+            ),
+        )
+        await forwarder._forward_one_subagent(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=bridge_dir,
+            subagents_dir=subagents_dir,
+            entry=entry,
+            agent_name="claude-native-ui",
+            checkpoint=checkpoint,
+            item_retry_tracker=retry_tracker,
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            batch_capability=forwarder._SessionEventBatchCapability(),
+        )
+
+    assert requests == 1
+
+
+@pytest.mark.asyncio
+async def test_subagent_cleanup_swallows_finished_worker_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Rotation cleanup cannot re-raise an already-finished worker error."""
+
+    async def fail() -> forwarder.SubagentForwardState:
+        raise RuntimeError("worker failed")
+
+    task = asyncio.create_task(fail())
+    await asyncio.sleep(0)
+
+    await forwarder._cancel_subagent_forward_task(task)
+
+    assert "worker failed during cleanup" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

Follow-up to #6792 and review feedback on [Universe PR #2580672](https://github.com/databricks-eng/universe/pull/2580672).

## Summary

Hardens Claude child-history forwarding under retries, oversized events, and stalled workers:

- Keep retry identity stable as new tail events arrive and apply bounded per-item retries during compatibility fallback.
- Truncate only known free-text fields, preserving identifiers and structural metadata.
- Bound detached child workers with the existing 300-second stall deadline and safely log terminal cleanup failures.

```text
pending events -> size-bounded batch -> batch retry
                                      -> legacy per-item retry
child worker   -> 300s deadline       -> safe cleanup
```

ELI5: child-agent history now retries the same work consistently, avoids damaging IDs when shrinking huge messages, and cannot hang forever in the background.

## Test Plan

- `uv run pytest tests/test_claude_native_forwarder.py` (174 passed)
- `.venv/bin/pre-commit run --files omnigent/harnesses/claude_native/forwarder.py tests/test_claude_native_forwarder.py`

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Added focused regression coverage for safe truncation, bounded individual retries, stable batch backoff, and failed-worker cleanup.

## Changelog

Claude child-agent history forwarding is more reliable when requests fail, events are very large, or a worker stalls.