### PR TITLE
feat(import): bind CLI-imported sessions to the local host

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6336,6 +6336,14 @@ def import_session_command(
         base_url = ensure_local_omnigent_server().url
     base_url = base_url.rstrip("/")
 
+    # If this machine is itself a host, bind the imported session to it so it
+    # resumes where the transcript came from. Read-only: never mints an identity
+    # on a machine that isn't already a host. Read from the effective config
+    # path so an OMNIGENT_CONFIG_HOME override is honored.
+    from omnigent.host.identity import load_host_identity_if_present
+
+    host_identity = load_host_identity_if_present(_effective_global_config_path())
+
     def _import_one(target: tuple[ImportSource, str]) -> _SessionImportResult:
         # Each target carries its own harness so an "all" batch can span them.
         current_source, sid = target
@@ -6346,7 +6354,7 @@ def import_session_command(
         except (OSError, TypeError, ValueError) as exc:
             return _SessionImportResult(sid, "load_error", message=str(exc), raw_exc=exc)
 
-        payload = {
+        payload: dict[str, object] = {
             "source": imported.source,
             "external_session_id": imported.external_session_id,
             "workspace": imported.workspace,
@@ -6361,6 +6369,8 @@ def import_session_command(
                 for item in imported.items
             ],
         }
+        if host_identity is not None:
+            payload["host_id"] = host_identity.host_id
         try:
             response = httpx.post(
                 f"{base_url}/v1/imports",

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -94,6 +94,10 @@ class ImportSessionRequest(BaseModel):
     title: str | None = Field(default=None, max_length=512)
     force: bool = False
     project_id: str | None = None
+    # The importing CLI's own host, so the session binds back to the machine
+    # the transcript came from and resumes there. Bound only alongside a
+    # workspace (the workspace-required-for-host check constraint).
+    host_id: str | None = None
     items: list[ImportItemInput] = Field(min_length=1, max_length=_MAX_IMPORT_ITEMS)
 
     @field_validator("external_session_id")
@@ -450,6 +454,7 @@ def create_imports_router(
             user_id=user_id,
             native_title=body.title,
             project_id=body.project_id,
+            host_id=body.host_id,
         )
 
         response.status_code = 201

--- a/openapi.json
+++ b/openapi.json
@@ -2663,6 +2663,17 @@
             "title": "Force",
             "type": "boolean"
           },
+          "host_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Host Id"
+          },
           "items": {
             "items": {
               "$ref": "#/components/schemas/ImportItemInput"

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -114,6 +114,65 @@ def test_import_command_sends_force_override(tmp_path: Path) -> None:
     assert "conv_replaced" in result.output
 
 
+@respx.mock
+def test_import_command_binds_local_host_when_configured(tmp_path: Path) -> None:
+    """A machine that is itself a host binds the imported session to it."""
+    from omnigent.host.identity import HostIdentity
+
+    session_id = "a1b2c3d4-1234-5678-9abc-def01234567a"
+    _write_claude_transcript(tmp_path, session_id, text="bind me")
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_bound", "status": "imported", "item_count": 1},
+        )
+    )
+
+    identity = HostIdentity(host_id="a1b2c3d4e5f67890abcdef1234567890", name="my-box")
+    with (
+        patch("omnigent.cli._resolve_attach_server", return_value=_BASE),
+        # The autouse _no_ambient_host fixture stubs this to None; re-patch so
+        # this machine looks like a configured host.
+        patch(
+            "omnigent.host.identity.load_host_identity_if_present",
+            return_value=identity,
+        ),
+    ):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--session", session_id],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content)["host_id"] == (
+        "a1b2c3d4e5f67890abcdef1234567890"
+    )
+
+
+@respx.mock
+def test_import_command_omits_host_id_when_not_a_host(tmp_path: Path) -> None:
+    """No host config means no host_id on the wire (unchanged behavior)."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def01234567b"
+    _write_claude_transcript(tmp_path, session_id, text="no host")
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_free", "status": "imported", "item_count": 1},
+        )
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            ["import", "--harness", "claude", "--session", session_id],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "host_id" not in json.loads(route.calls.last.request.content)
+
+
 def test_import_command_rejects_cursor() -> None:
     """The import command rejects sources without a supported adapter."""
     result = CliRunner().invoke(

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -131,6 +131,76 @@ async def test_import_dedupes_against_native_session(
     assert found.id == native.id
 
 
+async def test_import_binds_session_to_supplied_host(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """A CLI ``host_id`` binds the imported session to the origin machine.
+
+    The transcript's workspace lives on that host, so resume defaults there.
+    ``_persist_import`` binds only alongside a workspace (the check constraint).
+    """
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-host-1",
+        "workspace": "/repo",
+        "host_id": "a1b2c3d4e5f67890abcdef1234567890",
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "bind me"}],
+                },
+            }
+        ],
+    }
+
+    created = await client.post("/v1/imports", json=payload)
+    assert created.status_code == 201
+
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(
+        created.json()["session_id"]
+    )
+    assert conversation is not None
+    assert conversation.host_id == "a1b2c3d4e5f67890abcdef1234567890"
+    assert conversation.workspace == "/repo"
+
+
+async def test_import_host_id_without_workspace_stays_unbound(
+    client: httpx.AsyncClient,
+    db_uri: str,
+) -> None:
+    """No workspace means no host bind (the check constraint forbids it)."""
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "claude-host-2",
+        "host_id": "a1b2c3d4e5f67890abcdef1234567890",
+        "items": [
+            {
+                "type": "message",
+                "response_id": "claude:turn-1",
+                "data": {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "no workspace"}],
+                },
+            }
+        ],
+    }
+
+    created = await client.post("/v1/imports", json=payload)
+    assert created.status_code == 201
+
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(
+        created.json()["session_id"]
+    )
+    assert conversation is not None
+    assert conversation.host_id is None
+
+
 async def test_import_session_uses_native_title_when_supplied(
     client: httpx.AsyncClient,
     db_uri: str,


### PR DESCRIPTION
## Related issue

No tracking issue; small follow-on to host-bound import. Closes #

## Summary

- Running `omnigent import` on a machine that is itself a host now binds the imported session to that host, so resuming defaults to the machine the transcript (and its workspace) came from.
- The CLI reads its own host identity (read-only; never mints one) and sends `host_id` on the `/v1/imports` body. `ImportSessionRequest` accepts it and the route hands it to `_persist_import`, which already binds `host_id` alongside a workspace (the workspace-required-for-host check constraint) for the web `/imports/local` path. A machine that isn't a host sends nothing, so the wire is unchanged.

## Test Plan

- `pytest tests/cli/test_import.py tests/server/routes/test_imports.py` — 36 passed
- `ruff check` / `ruff format --check` — clean
- `pyrefly check omnigent/cli.py omnigent/server/routes/imports.py` — 0 errors

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

CLI test asserts `host_id` rides the wire when this machine is a host and is absent otherwise. Server tests assert an imported session binds to the supplied `host_id` alongside a workspace, and stays unbound when no workspace is present.

## Changelog

Chats imported with `omnigent import` now bind to the host you imported them from, so resume lands on that machine.
