### PR TITLE
fix(claude-native): surface transcript observer failures

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -94,6 +94,7 @@ _CONFIG_FILE = "bridge.json"
 _SERVER_FILE = "server.json"
 _STATE_FILE = "state.json"
 _HOOKS_FILE = "hooks.jsonl"
+OBSERVER_HOOK_STDERR_FILE = "observer_hook.stderr"
 _RECENT_LOCAL_COMMAND_LINE_LIMIT = 200
 _RECENT_LOCAL_COMMAND_WINDOW_S = 10.0
 _FORKED_FROM_LINE_LIMIT = 200
@@ -1189,6 +1190,7 @@ def prepare_bridge_dir(
         _SERVER_FILE,
         _STATE_FILE,
         _HOOKS_FILE,
+        OBSERVER_HOOK_STDERR_FILE,
         _TOOL_RELAY_FILE,
         _TMUX_FILE,
     ):
@@ -1603,7 +1605,10 @@ def build_hook_settings(
         "--bridge-dir",
         str(bridge_dir),
     ]
-    command = shlex.join(command_parts)
+    # Claude owns command-hook stderr, so it does not reach the runner logs.
+    # Persist it for the forwarder to relay with the Omnigent session id.
+    observer_stderr = shlex.quote(str(bridge_dir / OBSERVER_HOOK_STDERR_FILE))
+    command = f"{shlex.join(command_parts)} 2>> {observer_stderr}"
     hook = {"type": "command", "command": command}
     session_start_hook = {
         "type": "command",

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -20,6 +20,7 @@ import httpx
 from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.harnesses.claude_native.bridge import (
     BRIDGE_ID_LABEL_KEY,
+    OBSERVER_HOOK_STDERR_FILE,
     ClaudeHookRecord,
     ClaudeMessageDelta,
     ClaudeTranscriptItem,
@@ -63,6 +64,7 @@ _SUBAGENT_STATE_FILE = "subagent_forwarder.json"
 _DELTA_STATE_FILE = "message_deltas_forwarder.json"
 _COMPACTION_STATE_FILE = "compaction_forwarder.json"
 _HOOKS_FILE = "hooks.jsonl"
+_INVOCATION_SETTINGS_FILE = "claude-settings.json"
 
 # Keep child-history requests below the server's 10 MiB API ceiling to bound
 # per-request latency and retry cost while still accommodating large events.
@@ -105,6 +107,8 @@ def _subagent_id_from_meta_path(meta_path: Path) -> str:
 
 
 _DEFAULT_POLL_INTERVAL_S = 0.25
+_TRANSCRIPT_DISCOVERY_WARNING_S = 30.0
+_OBSERVER_HOOK_STDERR_READ_BYTES = 64 * 1024
 # Minimum spacing between permission-mode pane reads. Unlike the model mirror
 # (which reads a JSON file), this spawns a ``tmux capture-pane`` subprocess, so
 # it runs well below the poll interval; a mode switch is a human action and 2s
@@ -173,6 +177,106 @@ _HOOK_EVENT_TO_STATUS: dict[str, str] = {
 }
 
 _logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _TranscriptDiscoveryDiagnostics:
+    """One-shot logging state while waiting for Claude's transcript path."""
+
+    started_at: float
+    warning_logged: bool = False
+    discovery_logged: bool = False
+
+
+def _diagnostic_file_size(path: Path) -> int | None:
+    """Return a diagnostic file's size, or ``None`` when it is unavailable."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return None
+
+
+def _last_observer_hook_name(bridge_dir: Path) -> str | None:
+    """Return the last recorded observer hook name for diagnostics."""
+    try:
+        state = json.loads((bridge_dir / "state.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    value = state.get("last_hook_event_name") if isinstance(state, dict) else None
+    return value if isinstance(value, str) and value else None
+
+
+def _observe_transcript_discovery(
+    *,
+    bridge_dir: Path,
+    session_id: str,
+    transcript_path: Path | None,
+    diagnostics: _TranscriptDiscoveryDiagnostics,
+    now: float | None = None,
+) -> None:
+    """Log transcript discovery, or one actionable error when it never occurs."""
+    elapsed_s = (time.monotonic() if now is None else now) - diagnostics.started_at
+    if transcript_path is not None:
+        if not diagnostics.discovery_logged:
+            _logger.info(
+                "Claude transcript path discovered; forwarding can start after %.1fs; session=%s",
+                max(0.0, elapsed_s),
+                session_id,
+                extra={"session_id": session_id},
+            )
+            diagnostics.discovery_logged = True
+        return
+    if diagnostics.warning_logged or elapsed_s < _TRANSCRIPT_DISCOVERY_WARNING_S:
+        return
+
+    hooks_size = _diagnostic_file_size(bridge_dir / _HOOKS_FILE)
+    stderr_size = _diagnostic_file_size(bridge_dir / OBSERVER_HOOK_STDERR_FILE)
+    settings_present = (bridge_dir / _INVOCATION_SETTINGS_FILE).is_file()
+    _logger.error(
+        "Claude transcript forwarding has not started: no observer hook reported a "
+        "transcript path after %.0fs; session=%s last_hook=%s hooks_bytes=%s "
+        "observer_stderr_bytes=%s hook_settings=%s",
+        max(0.0, elapsed_s),
+        session_id,
+        _last_observer_hook_name(bridge_dir) or "none",
+        hooks_size if hooks_size is not None else "missing",
+        stderr_size if stderr_size is not None else "missing",
+        "present" if settings_present else "missing",
+        extra={"session_id": session_id},
+    )
+    diagnostics.warning_logged = True
+
+
+def _log_new_observer_hook_stderr(
+    *,
+    bridge_dir: Path,
+    session_id: str,
+    byte_offset: int,
+) -> int:
+    """Relay newly captured observer-hook stderr into session-scoped runner logs."""
+    path = bridge_dir / OBSERVER_HOOK_STDERR_FILE
+    try:
+        size = path.stat().st_size
+        if size < byte_offset:
+            byte_offset = 0
+        if size == byte_offset:
+            return byte_offset
+        with path.open("rb") as handle:
+            handle.seek(byte_offset)
+            raw = handle.read(_OBSERVER_HOOK_STDERR_READ_BYTES)
+            new_offset = handle.tell()
+    except OSError:
+        return byte_offset
+
+    output = raw.decode("utf-8", errors="replace").strip()
+    if output:
+        _logger.error(
+            "Claude observer hook wrote to stderr; session=%s stderr=%s",
+            session_id,
+            output,
+            extra={"session_id": session_id},
+        )
+    return new_offset
 
 
 @dataclass
@@ -949,6 +1053,8 @@ async def forward_claude_transcript_to_session(
     task_statuses: dict[str, str] = {}
     task_order: list[str] = []
     subagent_task: asyncio.Task[SubagentForwardState] | None = None
+    observer_stderr_offset = 0
+    transcript_diagnostics = _TranscriptDiscoveryDiagnostics(started_at=time.monotonic())
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
     from omnigent.cli_auth import open_server_client
 
@@ -976,6 +1082,11 @@ async def forward_claude_transcript_to_session(
                     subagent_task = None
                 async with _forward_progress_timeout(client, _FORWARD_LOOP_STALL_DEADLINE_S):
                     current_session_id = read_active_session_id(bridge_dir) or session_id
+                    observer_stderr_offset = _log_new_observer_hook_stderr(
+                        bridge_dir=bridge_dir,
+                        session_id=current_session_id,
+                        byte_offset=observer_stderr_offset,
+                    )
                     if hook_state is None:
                         hook_state = await _ensure_hook_state(
                             bridge_dir,
@@ -1028,6 +1139,9 @@ async def forward_claude_transcript_to_session(
                         task_subjects = {}
                         task_statuses = {}
                         task_order = []
+                        transcript_diagnostics = _TranscriptDiscoveryDiagnostics(
+                            started_at=time.monotonic()
+                        )
                         # A rotated session is a fresh dedupe context — reseed
                         # so the new session's first model observation doesn't
                         # post against the prior session's baseline.
@@ -1068,6 +1182,9 @@ async def forward_claude_transcript_to_session(
                         task_subjects = {}
                         task_statuses = {}
                         task_order = []
+                        transcript_diagnostics = _TranscriptDiscoveryDiagnostics(
+                            started_at=time.monotonic()
+                        )
                         # A rotated session is a fresh dedupe context — reseed
                         # so the new session's first model observation doesn't
                         # post against the prior session's baseline.
@@ -1088,6 +1205,12 @@ async def forward_claude_transcript_to_session(
                     # context.json (one stat when nothing changed).
                     status_raw_sig = sync_raw_status_context(bridge_dir, status_raw_sig)
                     transcript_path = read_transcript_path(bridge_dir)
+                    _observe_transcript_discovery(
+                        bridge_dir=bridge_dir,
+                        session_id=current_session_id,
+                        transcript_path=transcript_path,
+                        diagnostics=transcript_diagnostics,
+                    )
                     if transcript_path is not None:
                         state = await _ensure_state_for_transcript(
                             bridge_dir=bridge_dir,

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -269,6 +269,100 @@ async def _wait_for_json_state(
     raise AssertionError(f"{path} did not reach expected state; last={last_payload!r}")
 
 
+def test_observer_hook_stderr_is_logged_incrementally(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Hook process errors reach the session-scoped runner log exactly once."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    stderr_path = bridge_dir / forwarder.OBSERVER_HOOK_STDERR_FILE
+    stderr_path.write_text("ModuleNotFoundError: No module named 'omnigent'\n", encoding="utf-8")
+    caplog.set_level(logging.ERROR, logger=forwarder.__name__)
+
+    offset = forwarder._log_new_observer_hook_stderr(
+        bridge_dir=bridge_dir,
+        session_id="conv_abc",
+        byte_offset=0,
+    )
+    assert offset == stderr_path.stat().st_size
+    assert "No module named 'omnigent'" in caplog.text
+    assert caplog.records[-1].session_id == "conv_abc"
+
+    with stderr_path.open("a", encoding="utf-8") as handle:
+        handle.write("PermissionError: bridge directory is not writable\n")
+    offset = forwarder._log_new_observer_hook_stderr(
+        bridge_dir=bridge_dir,
+        session_id="conv_abc",
+        byte_offset=offset,
+    )
+    assert offset == stderr_path.stat().st_size
+    assert caplog.text.count("No module named 'omnigent'") == 1
+    assert caplog.text.count("bridge directory is not writable") == 1
+
+    record_count = len(caplog.records)
+    assert (
+        forwarder._log_new_observer_hook_stderr(
+            bridge_dir=bridge_dir,
+            session_id="conv_abc",
+            byte_offset=offset,
+        )
+        == offset
+    )
+    assert len(caplog.records) == record_count
+
+
+def test_missing_transcript_logs_actionable_snapshot_once(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A silent observer failure becomes a bounded, session-scoped error."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir()
+    record_hook_event(bridge_dir, {"hook_event_name": "UserPromptSubmit"})
+    (bridge_dir / "claude-settings.json").write_text("{}", encoding="utf-8")
+    diagnostics = forwarder._TranscriptDiscoveryDiagnostics(started_at=100.0)
+    warning_at = diagnostics.started_at + forwarder._TRANSCRIPT_DISCOVERY_WARNING_S
+    caplog.set_level(logging.INFO, logger=forwarder.__name__)
+
+    forwarder._observe_transcript_discovery(
+        bridge_dir=bridge_dir,
+        session_id="conv_abc",
+        transcript_path=None,
+        diagnostics=diagnostics,
+        now=warning_at - 0.1,
+    )
+    assert "has not started" not in caplog.text
+
+    for now in (warning_at, warning_at + 30.0):
+        forwarder._observe_transcript_discovery(
+            bridge_dir=bridge_dir,
+            session_id="conv_abc",
+            transcript_path=None,
+            diagnostics=diagnostics,
+            now=now,
+        )
+
+    failures = [record for record in caplog.records if "has not started" in record.getMessage()]
+    assert len(failures) == 1
+    assert failures[0].session_id == "conv_abc"
+    assert "last_hook=UserPromptSubmit" in failures[0].getMessage()
+    assert "observer_stderr_bytes=missing" in failures[0].getMessage()
+    assert "hook_settings=present" in failures[0].getMessage()
+
+    transcript_path = tmp_path / "claude-session.jsonl"
+    for now in (warning_at + 31.0, warning_at + 32.0):
+        forwarder._observe_transcript_discovery(
+            bridge_dir=bridge_dir,
+            session_id="conv_abc",
+            transcript_path=transcript_path,
+            diagnostics=diagnostics,
+            now=now,
+        )
+    discoveries = [record for record in caplog.records if "path discovered" in record.getMessage()]
+    assert len(discoveries) == 1
+
+
 @pytest.mark.asyncio
 async def test_clear_hook_rotates_active_session_without_reprocessing(
     tmp_path: Path,

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -13,6 +14,7 @@ import pytest
 
 from omnigent.harnesses.claude_native import hook as claude_native_hook
 from omnigent.harnesses.claude_native.bridge import (
+    OBSERVER_HOOK_STDERR_FILE,
     ClaudeNativeHookInterpreterMismatchError,
     build_hook_settings,
     prepare_bridge_dir,
@@ -1123,6 +1125,22 @@ def test_build_hook_settings_registers_policy_hooks_when_omnigent_server_url_set
     )
     # The forwarder's status hook must survive (the policy hook is appended).
     assert any("evaluate-policy" not in cmd for cmd in user_prompt_cmds)
+
+
+def test_build_hook_settings_captures_observer_stderr(tmp_path: Path) -> None:
+    """Observer process failures are persisted where the forwarder can log them."""
+    bridge_dir = prepare_bridge_dir("conv_abc", workspace=tmp_path)
+
+    settings = build_hook_settings(
+        bridge_dir,
+        python_executable="/venv/bin/python",
+    )
+
+    expected_redirection = f"2>> {shlex.quote(str(bridge_dir / OBSERVER_HOOK_STDERR_FILE))}"
+    hooks = settings["hooks"]
+    for event_name in ("SessionStart", "UserPromptSubmit", "Stop", "StopFailure"):
+        command = hooks[event_name][0]["hooks"][0]["command"]
+        assert command.endswith(expected_redirection)
 
 
 def test_build_hook_settings_registers_message_display_hook(


### PR DESCRIPTION
## Related issue

Related to https://linear.app/omnigent/issue/OMNI-6869/web-ui-is-running-behind-tui

## Summary

- Capture Claude observer-hook stderr in the owner-only bridge directory and relay new output into session-scoped runner logs/Logfood.
- Log successful transcript discovery, or one actionable error after 30 seconds with the last observed hook and diagnostic-file state.
- Clear stale observer diagnostics when preparing a fresh bridge.

ELI5: Claude tells Omnigent where its conversation file lives through a hook. If that messenger fails, its error now reaches our logs; if no file location arrives within 30 seconds, the forwarder raises a clear alarm instead of silently polling forever.

```text
Claude observer hook ──stderr──> bridge file ──> runner logs / Logfood
         │
         └──transcript path──> forwarder
                 └──missing for 30s──> one session-scoped error
```

## Test Plan

- `uv run --no-sync pytest tests/test_claude_native_hook.py tests/test_claude_native_forwarder.py` — 237 passed.
- `uv run --no-sync pre-commit run --all-files` — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests cover stderr relay and cursoring, the bounded missing-transcript alarm, recovery logging, and generated hook redirection.

## Changelog

Claude-native transcript observer failures now appear in session-scoped logs.
