### PR TITLE
fix(web): clear reply quotes when switching sessions

### DIFF
--- a/tests/e2e_ui/sessions/test_reply_quotes_session_switch.py
+++ b/tests/e2e_ui/sessions/test_reply_quotes_session_switch.py
@@ -1,0 +1,64 @@
+"""Reply quotes must not follow the composer into another session."""
+
+from pathlib import Path
+
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import seed_committed_turn
+
+
+def test_reply_quotes_clear_when_switching_sessions(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+    tmp_path: Path,
+) -> None:
+    base_url, session_a, session_b = seeded_session_pair
+    quoted_text = "This response belongs only to the original session."
+    seed_committed_turn(session_a, prompt="Original question", reply=quoted_text)
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(f"{base_url}/c/{session_b}")
+    composer = page.get_by_placeholder("Send a message…")
+    expect(composer).to_be_visible()
+    page.locator(f'a[href="/c/{session_a}"]').first.click()
+    assistant = page.locator('[data-role="assistant"]').get_by_text(quoted_text, exact=True)
+    expect(assistant).to_be_visible()
+
+    for _ in range(2):
+        assistant.evaluate("""element => {
+            const range = document.createRange();
+            range.selectNodeContents(element);
+            const selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+            document.dispatchEvent(new Event("selectionchange"));
+        }""")
+        page.get_by_role("button", name="Reply", exact=False).click()
+
+    remove_quote = page.get_by_role("button", name="Remove quote", exact=True)
+    expect(remove_quote).to_have_count(2)
+    composer.fill("Unsent draft in the original session")
+    expect(remove_quote).to_have_count(2)
+    page.screenshot(path=str(tmp_path / "reply-before-switch.png"))
+
+    page.locator(f'a[href="/c/{session_b}"]').first.click()
+    expect(page).to_have_url(f"{base_url}/c/{session_b}")
+    expect(composer).to_have_value("")
+    expect(remove_quote).to_have_count(0)
+    page.screenshot(path=str(tmp_path / "reply-after-switch.png"))
+
+    prompt = "A fresh prompt for the other session"
+    events_url = f"{base_url}/v1/sessions/{session_b}/events"
+    page.route(
+        events_url,
+        lambda route: route.fulfill(json={"queued": True, "item_id": "ci_reply_switch"}),
+    )
+    composer.fill(prompt)
+    with page.expect_request(events_url) as sent_request:
+        page.get_by_role("button", name="Send", exact=True).click()
+    assert sent_request.value.post_data_json["data"]["content"] == [
+        {"type": "input_text", "text": prompt}
+    ]
+
+    page.locator(f'a[href="/c/{session_a}"]').first.click()
+    expect(composer).to_have_value("Unsent draft in the original session")
+    expect(remove_quote).to_have_count(0)

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1491,7 +1491,13 @@ const MainAgentSurface = memo(function MainAgentSurfaceImpl({
 
   // Active reply quotes — each "Reply ↵" click appends; consumed by Composer.
   const [replyQuotes, setReplyQuotes] = useState<ReplyQuote[]>([]);
+  const [replyConversationId, setReplyConversationId] = useState(conversationId);
   const nextReplyQuoteId = useRef(0);
+
+  if (replyConversationId !== conversationId) {
+    setReplyConversationId(conversationId);
+    setReplyQuotes([]);
+  }
 
   // Ref forwarded to SelectionPopup to scope selection detection to the
   // conversation area, preventing selections in the composer from triggering


### PR DESCRIPTION
## Related issue

Closes #6869

## Summary

- Reply quotes currently survive sidebar navigation and can accidentally become part of a prompt sent to another session.
- Clear quotes when the active conversation changes, before rendering the next session's composer. Keep the existing per-session text draft behavior unchanged.
- Add a browser regression covering multiple quotes, cached-session navigation, quote-free outgoing content, and returning to the original draft.

## Test Plan

- Regression reproduced on the unfixed build: two quote chips remained after switching sessions.
- `OMNIGENT_WRAPPER_BYPASS=1 uv run --no-sync pytest tests/e2e_ui/sessions/test_reply_quotes_session_switch.py -q` — passed with the fix.
- `cd web && pnpm exec vitest run src/pages/ChatPage.composer.test.tsx` — 174 passed.
- `uv run --no-sync pre-commit run` — passed, including TypeScript and frontend lint.
- To verify manually: highlight an assistant response, click Reply, type a draft, and switch sessions using the sidebar. The destination should have no quote chips. Return to the original session: the text draft should remain, but the quotes should be cleared.

## Demo

Original session with two reply quotes and an unsent draft:

![Reply quotes before switching](https://raw.githubusercontent.com/yaoharry/omnigent/7990cec8459d98dead6f048c21a11e6fafa64157/reply-before-switch.png)

After switching to another session, the composer has no quotes:

![Clean composer after switching](https://raw.githubusercontent.com/yaoharry/omnigent/7990cec8459d98dead6f048c21a11e6fafa64157/reply-after-switch.png)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Playwright drives the real selection/reply and sidebar navigation flows against seeded sessions. The send acknowledgement is stubbed so the test can inspect the exact outgoing content without depending on model execution. Screenshots come from the passing browser run.

## Changelog

Reply quotes clear when switching sessions instead of carrying into another conversation.
