### PR TITLE
fix(codex-native): rewrite the effort pin's config line in place

### DIFF
--- a/omnigent/harnesses/codex_native/app_server.py
+++ b/omnigent/harnesses/codex_native/app_server.py
@@ -356,13 +356,22 @@ def _pin_codex_config_effort(codex_home: Path, effort: str, model: str | None) -
     config_path = codex_home / "config.toml"
     _materialize_config_symlink(config_path)
     existing = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
-    pin_line = f"model_reasoning_effort = {json.dumps(clamp_effort_for_model(effort, model))}"
+    clamped = clamp_effort_for_model(effort, model) or effort
+    pin_line = f"model_reasoning_effort = {json.dumps(clamped)}"
     lines = existing.splitlines()
     replaced = False
     for i, line in enumerate(lines):
         if line.startswith("["):
             break
-        if re.match(r"^model_reasoning_effort\s*=", line):
+        # Rewrite the value in place so the line's indentation and trailing
+        # comment survive, as the model pin's clamp does; a value the regex
+        # cannot parse (e.g. single-quoted) is replaced wholesale.
+        effort_match = _EFFORT_KEY_RE.match(line)
+        if effort_match:
+            lines[i] = f"{effort_match.group(1)}{clamped}{effort_match.group(3)}"
+            replaced = True
+            break
+        if re.match(r"^\s*model_reasoning_effort\s*=", line):
             lines[i] = pin_line
             replaced = True
             break

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -2204,6 +2204,38 @@ class TestPinCodexConfigEffort:
         assert 'model_reasoning_effort = "table-scoped-stays"' in lines
         assert "medium" not in "\n".join(lines)
 
+    @pytest.mark.parametrize(
+        ("existing", "expected"),
+        [
+            (
+                '  model_reasoning_effort = "medium"  # user default',
+                '  model_reasoning_effort = "ultra"  # user default',
+            ),
+            ("model_reasoning_effort = 'medium'", 'model_reasoning_effort = "ultra"'),
+        ],
+        ids=["indented-with-comment", "single-quoted"],
+    )
+    def test_rewrites_the_existing_line_in_place(
+        self, tmp_path: Path, existing: str, expected: str
+    ) -> None:
+        """An indented key keeps its indent and comment; an unparsable value is replaced whole.
+
+        Missing the indented spelling would insert a second top-level key, which
+        codex rejects as invalid TOML — the same regex the model pin uses to clamp
+        this line already tolerates it.
+        """
+        from omnigent.harnesses.codex_native.app_server import _pin_codex_config_effort
+
+        config = tmp_path / "config.toml"
+        config.write_text(f"{existing}\n[profiles.default]\nx = 1\n", encoding="utf-8")
+        _pin_codex_config_effort(tmp_path, "ultra", "gpt-5.6-sol")
+        lines = config.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == expected
+        assert sum("model_reasoning_effort" in line for line in lines) == 1
+        assert (
+            tomllib.loads(config.read_text(encoding="utf-8"))["model_reasoning_effort"] == "ultra"
+        )
+
     def test_inserts_effort_when_absent(self, tmp_path: Path) -> None:
         """A config with no top-level effort gains one before the first table."""
         from omnigent.harnesses.codex_native.app_server import _pin_codex_config_effort


### PR DESCRIPTION
## Related issue

Follow-up to #6860 (Polly review note on the effort pin's line parser).

## Summary

`_pin_codex_config_effort` (added in #6860) seeds `model_reasoning_effort` into the session's private `config.toml`, but its line matcher only recognised an **unindented** key. An indented top-level key in the copied user config was therefore not replaced, and a second `model_reasoning_effort` was inserted, which codex rejects as invalid TOML. A replaced line also dropped any trailing inline comment.

**ELI5:** the model pin next door already has a regex (`_EFFORT_KEY_RE`) that tolerates leading whitespace and a trailing comment, and uses it to clamp this very line. The effort pin now reuses it to rewrite just the value in place, so indentation and comment survive, and falls back to replacing the whole line when the value is not double-quoted (e.g. `'medium'`), so no config shape can end up with two keys.

## Test Plan

- `tests/test_codex_native_app_server.py::TestPinCodexConfigEffort::test_rewrites_the_existing_line_in_place[indented-with-comment|single-quoted]` — the indented case is red on `main` (a second key is inserted); the single-quoted case pins the fallback.
- `TestPinCodexConfigEffort` + `test_start_pins_reasoning_effort_in_config` + `test_apply_codex_thread_effort_*` — 13 passed. Ruff (0.15.16) and pyrefly (1.1.1) clean on the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

N/A — the parametrized unit test covers both the in-place rewrite and the wholesale fallback.

## Changelog

Codex sessions whose copied config indents its `model_reasoning_effort` line no longer get a duplicate key when the picked effort is pinned at launch.
