### PR TITLE
fix(cursor-native): deliver final reply before completion

### DIFF
--- a/omnigent/harnesses/cursor_native/forwarder.py
+++ b/omnigent/harnesses/cursor_native/forwarder.py
@@ -929,6 +929,12 @@ async def forward_cursor_store_to_session(
     ) as client:
         while True:
             try:
+                # Snapshot completion before reading its transcript. A turn
+                # finishing during this poll must wait for the next read.
+                total_turn_ends = await asyncio.to_thread(
+                    cursor_native_status.count_turn_ends, bridge_dir
+                )
+                retrying_items = False
                 if store_path is None or not store_path.exists():
                     # On cold resume the runner pre-seeds the bridge state with
                     # the known store path (see ``preseed_resume_state``), so we
@@ -1102,6 +1108,7 @@ async def forward_cursor_store_to_session(
                                                 item.rowid,
                                                 failed_attempts,
                                             )
+                                            retrying_items = True
                                             break  # retry this item before any after it
                                         _logger.error(
                                             "cursor forwarder dropping item after %s "
@@ -1125,6 +1132,7 @@ async def forward_cursor_store_to_session(
                                             item.rowid,
                                             exc_info=True,
                                         )
+                                        retrying_items = True
                                         break
                             # Reached on a successful post, an ambiguous-delivery
                             # skip, a quarantine, or a non-posted sentinel row:
@@ -1171,10 +1179,7 @@ async def forward_cursor_store_to_session(
                 # supervisor restart never re-wakes the parent for a turn it
                 # already reported. Best-effort: a failed post leaves the count
                 # unadvanced so the next poll retries.
-                total_turn_ends = await asyncio.to_thread(
-                    cursor_native_status.count_turn_ends, bridge_dir
-                )
-                if total_turn_ends > await asyncio.to_thread(
+                if not retrying_items and total_turn_ends > await asyncio.to_thread(
                     cursor_native_status.read_posted_count, bridge_dir
                 ):
                     await _post_external_session_status(

--- a/omnigent/harnesses/cursor_native/usage.py
+++ b/omnigent/harnesses/cursor_native/usage.py
@@ -192,14 +192,6 @@ class _UsageAccumulator:
             self.model = model  # latest turn's model wins (mirrors a /model switch)
         return True
 
-    def seen_count(self) -> int:
-        """Distinct turns folded in so far (one per ``generation_id``).
-
-        Drives the forwarder's turn-completion wake edge: each newly-seen turn
-        posts one ``external_session_status: idle``.
-        """
-        return len(self.seen)
-
 
 def _read_usage_state(bridge_dir: Path) -> _UsageAccumulator:
     """Load the persisted accumulator, or a cold zero default."""
@@ -294,23 +286,16 @@ async def forward_cursor_usage_to_session(
     is persisted to ``bridge_dir`` so a supervisor restart resumes without
     re-counting. Never returns normally; cancel the task to stop it.
 
-    A newly-observed usage line means cursor-agent fired its ``stop`` hook — a
-    turn completed. On that edge we also POST ``external_session_status: idle``,
-    the only signal that reaches the parent inbox wake (the forwarder mirrors
-    only conversation items, and the PTY-activity watcher is suppressed for
-    cursor-native). Idle delivery is idempotent server-side.
+    Turn completion is forwarded separately by
+    :mod:`omnigent.harnesses.cursor_native.forwarder`, which can order the
+    terminal edge after transcript delivery. Usage must never post completion:
+    its independent poll can observe the stop-hook payload before the final
+    assistant message and wake a parent with empty output.
     """
     import httpx
 
-    from omnigent.native._native_post_delivery import post_external_session_status
-
     acc = _read_usage_state(bridge_dir)
     timeout = httpx.Timeout(_POST_TIMEOUT_S)
-    # Turns already woken this run. Seeded at 0 (not from persisted usage state):
-    # a restart re-posts one idle, which the server dedupes if already delivered
-    # — the safe direction. Seeding from persisted usage would permanently skip a
-    # wake whose idle POST crashed after the usage flush persisted.
-    idle_posted_turns = 0
     from omnigent.cli_auth import open_server_client
 
     async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
@@ -330,15 +315,6 @@ async def forward_cursor_usage_to_session(
                     # Persist only after a successful POST so a failed flush is
                     # retried (the unseen turns stay unseen until they land).
                     await asyncio.to_thread(_write_usage_state, bridge_dir, acc)
-                # Wake the parent once per newly-seen turn, after the usage flush
-                # so the inbox read sees up-to-date cost. A failed idle is retried
-                # next poll (the counter only advances on success).
-                seen_turns = acc.seen_count()
-                if seen_turns > idle_posted_turns:
-                    await post_external_session_status(
-                        client, session_id=session_id, status="idle"
-                    )
-                    idle_posted_turns = seen_turns
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/tests/e2e/test_cursor_native_subagent_tool_result_e2e.py
+++ b/tests/e2e/test_cursor_native_subagent_tool_result_e2e.py
@@ -1,0 +1,398 @@
+"""Real Cursor E2E for native sub-agent tool-result delivery.
+
+This is the reported ``sys_session_send`` journey, not a forwarder mock and
+not a top-level ``omnigent cursor`` smoke test:
+
+1. A deterministic mock parent calls ``sys_session_send`` for a
+   ``cursor-native`` child.
+2. The official, authenticated ``cursor-agent`` runs its real ``Shell`` and
+   ``Read`` tools in a temporary workspace.
+3. Cursor completes, waking the parent, which drains the result through the
+   real ``sys_read_inbox`` tool.
+
+The parent model is mocked only so dispatch and inbox draining are
+deterministic. The child is real Cursor using the ambient ``cursor-agent
+login``. A runner-only scheduling shim holds Cursor's real final message for
+one mirror read after its real stop marker exists. This deterministically
+creates the reported production ordering without faking either event::
+
+    transcript snapshot misses final reply
+    -> completion marker becomes visible
+    -> next transcript snapshot sees final reply
+
+On the completion-order bug, the child transcript eventually contains both
+probe values, but the parent inbox result is empty because ``idle`` was posted
+before the final reply. The fixed forwarder delivers the reply first.
+
+Opt in from a shell with an authenticated Cursor CLI::
+
+    OMNIGENT_E2E_CURSOR_NATIVE=1 \
+      .venv/bin/python -m pytest \
+      tests/e2e/test_cursor_native_subagent_tool_result_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.harnesses.cursor_native.bridge import bridge_dir_for_session_id, kill_session
+from tests.e2e.conftest import (
+    configure_mock_llm,
+    create_runner_bound_session,
+    poll_session_until_terminal,
+    register_inline_agent,
+    reset_mock_llm,
+    send_user_message_to_session,
+)
+from tests.e2e.helpers import POLL_INTERVAL_S
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get("OMNIGENT_E2E_CURSOR_NATIVE") != "1"
+        or shutil.which("cursor-agent") is None
+        or shutil.which("tmux") is None,
+        reason=(
+            "real cursor-native sub-agent e2e needs OMNIGENT_E2E_CURSOR_NATIVE=1, "
+            "an authenticated cursor-agent, and tmux"
+        ),
+    ),
+    pytest.mark.timeout(900, method="signal"),
+]
+
+_CHILD_TIMEOUT_S = 360.0
+_INBOX_TIMEOUT_S = 180.0
+_CURSOR_MODEL = "gpt-5.4-mini"
+_FINAL_REPLY_MARKER = "OMNI5700_CURSOR_FINAL_REPLY"
+_RACE_SHIM_SIGNAL = ".omni5700-cursor-race-observed"
+
+_RACE_SITECUSTOMIZE = r'''\
+"""Schedule the cursor-native transcript/completion race in the E2E runner."""
+
+import json
+import os
+import time
+from pathlib import Path
+
+
+if os.environ.get("OMNIGENT_E2E_CURSOR_RACE_SHIM") == "1" and os.environ.get(
+    "RUNNER_SERVER_URL"
+):
+    from omnigent.harnesses.cursor_native import forwarder
+    from omnigent.harnesses.cursor_native import status
+
+    _real_read_new_items = forwarder._read_new_items
+    _real_count_turn_ends = status.count_turn_ends
+    _final_reply_marker = os.environ["OMNIGENT_E2E_CURSOR_FINAL_REPLY_MARKER"]
+    _signal_path = Path(os.environ["OMNIGENT_E2E_CURSOR_RACE_SIGNAL"])
+    _bridge_dir = None
+    _final_reply_hidden_once = False
+    _completion_visible = False
+
+    def _controlled_count_turn_ends(bridge_dir):
+        global _bridge_dir
+        _bridge_dir = bridge_dir
+        if not _completion_visible:
+            return 0
+        return _real_count_turn_ends(bridge_dir)
+
+    def _controlled_read_new_items(store_path, last_rowid, agent_name):
+        global _completion_visible, _final_reply_hidden_once
+        items = _real_read_new_items(store_path, last_rowid, agent_name)
+        if _final_reply_hidden_once:
+            return items
+
+        for index, item in enumerate(items):
+            if item.item_type != "message" or _final_reply_marker not in json.dumps(
+                item.item_data
+            ):
+                continue
+            if _bridge_dir is None:
+                raise RuntimeError("cursor race shim did not observe a bridge directory")
+
+            deadline = time.monotonic() + 30.0
+            while _real_count_turn_ends(_bridge_dir) == 0:
+                if time.monotonic() >= deadline:
+                    raise RuntimeError("real Cursor stop marker did not arrive")
+                time.sleep(0.01)
+
+            # Do not return rows after the hidden reply: advancing their rowid
+            # would cause the real reply to be skipped on the next poll.
+            _completion_visible = True
+            _final_reply_hidden_once = True
+            _signal_path.write_text("real-final-reply-hidden-until-next-poll\n")
+            return items[:index]
+        return items
+
+    status.count_turn_ends = _controlled_count_turn_ends
+    forwarder._read_new_items = _controlled_read_new_items
+'''
+
+
+@pytest.fixture(scope="session")
+def cursor_runner_workspace(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Configure the native workspace and runner-only race scheduler.
+
+    The shared E2E runner inherits this environment when ``http_client`` starts
+    ``live_server``. Production runners already carry the setting; the generic
+    test fixture does not because most E2Es never launch a native terminal.
+
+    The ``sitecustomize`` shim loads only in the runner (identified by
+    ``RUNNER_SERVER_URL``). It waits for Cursor's real stop hook before hiding
+    the marked real assistant reply from exactly one transcript read.
+    """
+    workspace = tmp_path_factory.mktemp("cursor-native-subagent-workspace")
+    shim_dir = tmp_path_factory.mktemp("cursor-native-race-shim")
+    (shim_dir / "sitecustomize.py").write_text(_RACE_SITECUSTOMIZE, encoding="utf-8")
+    signal_path = workspace / _RACE_SHIM_SIGNAL
+    env_updates = {
+        "OMNIGENT_RUNNER_WORKSPACE": str(workspace),
+        "OMNIGENT_E2E_CURSOR_RACE_SHIM": "1",
+        "OMNIGENT_E2E_CURSOR_FINAL_REPLY_MARKER": _FINAL_REPLY_MARKER,
+        "OMNIGENT_E2E_CURSOR_RACE_SIGNAL": str(signal_path),
+        "PYTHONPATH": os.pathsep.join(
+            entry for entry in (str(shim_dir), os.environ.get("PYTHONPATH", "")) if entry
+        ),
+    }
+    prior = {key: os.environ.get(key) for key in env_updates}
+    os.environ.update(env_updates)
+    try:
+        yield workspace
+    finally:
+        for key, value in prior.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+@pytest.fixture
+def cursor_e2e_rig(
+    cursor_runner_workspace: Path,
+    http_client: httpx.Client,
+) -> tuple[httpx.Client, Path]:
+    """Start the shared server/runner only after its workspace is configured."""
+    return http_client, cursor_runner_workspace
+
+
+def _tool_call(name: str, arguments: dict[str, object], call_id: str) -> dict[str, object]:
+    """Build one deterministic mock Responses API tool call."""
+    return {"call_id": call_id, "name": name, "arguments": json.dumps(arguments)}
+
+
+def _session_items(client: httpx.Client, session_id: str) -> list[dict[str, object]]:
+    """Return a session's durable items in chronological order."""
+    response = client.get(
+        f"/v1/sessions/{session_id}/items",
+        params={"limit": 1000, "order": "asc"},
+    )
+    response.raise_for_status()
+    return response.json()["data"]
+
+
+def _wait_for_child(client: httpx.Client, parent_id: str) -> str:
+    """Wait for ``sys_session_send`` to create its cursor child."""
+    deadline = time.monotonic() + _CHILD_TIMEOUT_S
+    while time.monotonic() < deadline:
+        response = client.get(f"/v1/sessions/{parent_id}/child_sessions")
+        response.raise_for_status()
+        children = response.json().get("data", [])
+        if children:
+            child = children[0]
+            return str(child.get("session_id") or child["id"])
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"cursor child was not created for parent {parent_id}")
+
+
+def _wait_for_markers(
+    client: httpx.Client,
+    session_id: str,
+    markers: tuple[str, ...],
+    *,
+    timeout: float,
+) -> list[dict[str, object]]:
+    """Wait until every marker is present in a session's durable items."""
+    deadline = time.monotonic() + timeout
+    items: list[dict[str, object]] = []
+    while time.monotonic() < deadline:
+        items = _session_items(client, session_id)
+        blob = json.dumps(items)
+        if all(marker in blob for marker in markers):
+            return items
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(
+        f"markers {markers!r} did not appear in session {session_id}; "
+        f"last items={json.dumps(items, indent=2)}"
+    )
+
+
+def _wait_for_inbox_output(
+    client: httpx.Client,
+    parent_id: str,
+) -> tuple[list[object], list[dict[str, object]]]:
+    """Wait for the parent to execute ``sys_read_inbox`` and return its output."""
+    deadline = time.monotonic() + _INBOX_TIMEOUT_S
+    items: list[dict[str, object]] = []
+    while time.monotonic() < deadline:
+        items = _session_items(client, parent_id)
+        call_ids = {
+            item.get("call_id")
+            for item in items
+            if item.get("type") == "function_call" and item.get("name") == "sys_read_inbox"
+        }
+        outputs = [
+            item.get("output")
+            for item in items
+            if item.get("type") == "function_call_output" and item.get("call_id") in call_ids
+        ]
+        if outputs:
+            return outputs, items
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(
+        f"parent {parent_id} never drained sys_read_inbox; "
+        f"last items={json.dumps(items, indent=2)}"
+    )
+
+
+def test_real_cursor_tool_reply_reaches_parent_inbox(
+    cursor_e2e_rig: tuple[httpx.Client, Path],
+    live_runner_id: str,
+    mock_llm_server_url: str,
+) -> None:
+    """A real Cursor child's post-tool reply reaches its parent before completion."""
+    http_client, workspace = cursor_e2e_rig
+    nonce = uuid.uuid4().hex
+    shell_source = f"shell-{nonce}"
+    shell_result = shell_source[::-1]
+    read_result = f"read-{nonce}"
+    (workspace / "SHELL_PROBE.txt").write_text(shell_source, encoding="utf-8")
+    (workspace / "READ_PROBE.txt").write_text(read_result, encoding="utf-8")
+
+    child_task = (
+        "Use Cursor's Shell tool to run exactly: "
+        "python -c 'from pathlib import Path; "
+        'print(Path("SHELL_PROBE.txt").read_text().strip()[::-1])\'. '
+        "Then use Cursor's Read tool to read READ_PROBE.txt. After both tools "
+        f"finish, reply starting with exactly {_FINAL_REPLY_MARKER}, followed "
+        "by the Shell output and the complete Read output. Do not use the "
+        "final-reply marker before both tool calls finish and do not omit "
+        "either value."
+    )
+    suffix = nonce[:8]
+    parent_model = f"mock-cursor-parent-{suffix}"
+    mock_base_url = f"{mock_llm_server_url}/v1"
+    parent_name = register_inline_agent(
+        http_client,
+        name=f"cursor-parent-{suffix}",
+        harness="openai-agents",
+        model=parent_model,
+        profile="",
+        prompt="Dispatch the cursor sub-agent, then drain its inbox result when woken.",
+        mock_llm_base_url=mock_base_url,
+        extra_config={
+            "os_env": {
+                "type": "caller_process",
+                "cwd": str(workspace),
+                "sandbox": {"type": "none"},
+            },
+            "tools": {
+                "cursor": {
+                    "type": "agent",
+                    "description": "Real Cursor CLI coding sub-agent.",
+                    "executor": {"harness": "cursor-native", "model": _CURSOR_MODEL},
+                    "os_env": "inherit",
+                    "prompt": "Use the requested Cursor tools and report their exact outputs.",
+                }
+            },
+        },
+    )
+
+    reset_mock_llm(mock_llm_server_url)
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    _tool_call(
+                        "sys_session_send",
+                        {
+                            "agent": "cursor",
+                            "title": "cursor-tool-result",
+                            "args": {
+                                "purpose": "explore",
+                                "model": _CURSOR_MODEL,
+                                "input": child_task,
+                            },
+                        },
+                        "dispatch-cursor",
+                    )
+                ]
+            },
+            {"text": "Cursor dispatched; waiting for its inbox result."},
+            {"tool_calls": [_tool_call("sys_read_inbox", {}, "read-cursor-inbox")]},
+            {"text": "Cursor inbox drained."},
+        ],
+        key=parent_model,
+    )
+
+    parent_id = create_runner_bound_session(
+        http_client,
+        agent_name=parent_name,
+        runner_id=live_runner_id,
+    )
+    child_id: str | None = None
+    try:
+        dispatch_id = send_user_message_to_session(
+            http_client,
+            session_id=parent_id,
+            content="Dispatch cursor to run the Shell and Read probe task.",
+        )
+        poll_session_until_terminal(
+            http_client,
+            session_id=parent_id,
+            response_id=dispatch_id,
+            timeout=180,
+        )
+        child_id = _wait_for_child(http_client, parent_id)
+
+        # This proves the official Cursor child ran the task and its final reply
+        # eventually reached its own durable transcript. It passes even on the
+        # buggy ordering and makes an empty parent result diagnostic, not an
+        # ambiguous Cursor/auth/tool failure.
+        _wait_for_markers(
+            http_client,
+            child_id,
+            (_FINAL_REPLY_MARKER, shell_result, read_result),
+            timeout=_CHILD_TIMEOUT_S,
+        )
+        signal_path = workspace / _RACE_SHIM_SIGNAL
+        assert signal_path.read_text(encoding="utf-8").strip() == (
+            "real-final-reply-hidden-until-next-poll"
+        ), "runner race shim did not schedule the completion-order window"
+
+        inbox_outputs, parent_items = _wait_for_inbox_output(http_client, parent_id)
+        inbox_blob = json.dumps(inbox_outputs)
+        assert shell_result in inbox_blob and read_result in inbox_blob, (
+            "The real cursor-native child completed Shell and Read and its own "
+            "transcript contains both probe values, but sys_read_inbox received "
+            "an empty/stale completion payload. The forwarder posted child "
+            "completion before delivering the final reply.\n"
+            f"Expected Shell marker: {shell_result!r}\n"
+            f"Expected Read marker: {read_result!r}\n"
+            f"Inbox outputs: {json.dumps(inbox_outputs, indent=2)}\n"
+            f"Parent items: {json.dumps(parent_items, indent=2)}"
+        )
+    finally:
+        if child_id is not None:
+            with contextlib.suppress(OSError, RuntimeError):
+                kill_session(bridge_dir_for_session_id(child_id), timeout_s=5.0)
+        with contextlib.suppress(httpx.HTTPError):
+            http_client.delete(f"/v1/sessions/{parent_id}")

--- a/tests/test_cursor_native_status.py
+++ b/tests/test_cursor_native_status.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sqlite3
 from pathlib import Path
 
+import httpx
 import pytest
 
 from omnigent.harnesses.cursor_native import forwarder as fwd
@@ -228,3 +230,78 @@ async def test_idle_restart_safe_does_not_rewake(tmp_path: Path, monkeypatch) ->
         await asyncio.gather(task, return_exceptions=True)
     assert recorder.statuses == []
     assert status.read_posted_count(bridge) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("race", ["finishes_after_read", "rejected_item", "connection_error"])
+async def test_completion_waits_for_final_reply(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, race: str
+) -> None:
+    """The parent's completion must follow delivery of the child's final reply."""
+    bridge = tmp_path / "bridge"
+    store = tmp_path / "store.db"
+    with sqlite3.connect(store) as db:
+        db.execute("CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB)")
+
+    def finish_turn() -> None:
+        reply = {"role": "assistant", "content": [{"type": "text", "text": "pwd: /workspace"}]}
+        with sqlite3.connect(store) as db:
+            db.execute("INSERT INTO blobs VALUES (?, ?)", ("reply", json.dumps(reply)))
+        status.record_turn_end(bridge)
+
+    if race != "finishes_after_read":
+        finish_turn()
+    read_items = fwd._read_new_items
+    first_read = True
+
+    def read_then_finish(*args):
+        nonlocal first_read
+        items = read_items(*args)
+        if first_read and race == "finishes_after_read":
+            finish_turn()
+        first_read = False
+        return items
+
+    delivered: list[str] = []
+    attempts = 0
+
+    async def post_item(client, *, session_id, item):
+        nonlocal attempts
+        attempts += 1
+        if race == "rejected_item" and attempts == 1:
+            response = httpx.Response(503, request=httpx.Request("POST", "http://test/events"))
+            response.raise_for_status()
+        if race == "connection_error" and attempts == 1:
+            raise httpx.ConnectError("connection refused")
+        delivered.append(item.item_data["content"][0]["text"])
+
+    async def post_status(client, *, session_id, status):
+        delivered.append(status)
+
+    async def ignore_patch(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(fwd, "_discover_store", lambda *args: store)
+    monkeypatch.setattr(fwd, "_read_new_items", read_then_finish)
+    monkeypatch.setattr(fwd, "_read_last_used_model", lambda path: None)
+    monkeypatch.setattr(fwd, "_patch_external_session_id", ignore_patch)
+    monkeypatch.setattr(fwd, "_post_conversation_item", post_item)
+    monkeypatch.setattr(fwd, "_post_external_session_status", post_status)
+    task = asyncio.create_task(
+        fwd.forward_cursor_store_to_session(
+            base_url="http://test",
+            headers={},
+            session_id="child",
+            bridge_dir=bridge,
+            agent_name="cursor-native-ui",
+            workspace=str(tmp_path),
+            launch_epoch_ms=1000,
+            poll_interval_s=0.001,
+        )
+    )
+    try:
+        await _wait_until(lambda: status.read_posted_count(bridge) == 1)
+        assert delivered == ["pwd: /workspace", "idle"]
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)

--- a/tests/test_cursor_native_usage.py
+++ b/tests/test_cursor_native_usage.py
@@ -288,17 +288,8 @@ async def _run_loop_until(
 
 
 def _usage_posts(client: _CtxRecordingClient) -> list[tuple[str, dict]]:
-    """Only the ``external_session_usage`` POSTs (excludes the idle wake edges)."""
+    """Return the ``external_session_usage`` POSTs."""
     return [(u, b) for (u, b) in client.posts if b.get("type") == "external_session_usage"]
-
-
-def _idle_posts(client: _CtxRecordingClient) -> list[tuple[str, dict]]:
-    """Only the ``external_session_status: idle`` turn-end wake POSTs."""
-    return [
-        (u, b)
-        for (u, b) in client.posts
-        if b.get("type") == "external_session_status" and b.get("data", {}).get("status") == "idle"
-    ]
 
 
 @pytest.mark.asyncio
@@ -330,15 +321,15 @@ class TestForwardLoop:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         usage.record_usage_payload(tmp_path, _TURN1)
-        # Gate on the idle POST: it is the LAST side effect of processing turn 1
-        # (usage POST, then the state write, then idle), so once it lands both
-        # assertions below read fully-settled state instead of racing the write.
-        client = await _run_loop_until(monkeypatch, tmp_path, _idle_posts)
+        client = await _run_loop_until(
+            monkeypatch,
+            tmp_path,
+            lambda c: _usage_posts(c) and usage._read_usage_state(tmp_path).seen == {"g1"},
+        )
         # Let several more polls run; with no new turns there must be no 2nd
-        # usage POST and no further idle edge.
+        # usage POST.
         await asyncio.sleep(0.1)
         assert len(_usage_posts(client)) == 1
-        assert len(_idle_posts(client)) == 1
 
     async def test_new_turn_triggers_followup_post(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -355,61 +346,14 @@ class TestForwardLoop:
         _, body = _usage_posts(client)[-1]
         assert body["data"]["cumulative_output_tokens"] == 5 + 120
 
-    async def test_completed_turn_posts_idle_wake_edge(
+    async def test_never_posts_completion_status(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A completed cursor turn posts external_session_status: idle.
-
-        This is the edge the runner turns into a parent-inbox wake for a cursor
-        sub-agent. Without it, a cursor child finishes with its review only in
-        its own transcript and the parent orchestrator is never woken.
-        """
+        """Usage cannot wake a parent before transcript delivery catches up."""
         usage.record_usage_payload(tmp_path, _TURN1)
-        client = await _run_loop_until(monkeypatch, tmp_path, _idle_posts)
-        url, body = _idle_posts(client)[0]
-        assert url == "/v1/sessions/conv_1/events"
-        assert body == {"type": "external_session_status", "data": {"status": "idle"}}
-
-    async def test_idle_posted_once_per_turn(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Each completed turn wakes the parent exactly once within a run."""
-        usage.record_usage_payload(tmp_path, _TURN1)
-        client = _CtxRecordingClient()
-        await _run_loop_until(monkeypatch, tmp_path, _idle_posts, client=client)
-        await asyncio.sleep(0.1)  # extra polls: turn 1 must not re-wake
-        assert len(_idle_posts(client)) == 1
-        # A second turn yields exactly one more idle edge.
-        usage.record_usage_payload(tmp_path, _TURN2)
-        await _run_loop_until(
-            monkeypatch, tmp_path, lambda c: len(_idle_posts(c)) >= 2, client=client
-        )
+        client = await _run_loop_until(monkeypatch, tmp_path, _usage_posts)
         await asyncio.sleep(0.1)
-        assert len(_idle_posts(client)) == 2
-
-    async def test_restart_reposts_idle_for_dedup_not_skip(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A restart re-posts idle (server dedupes) rather than risk skipping a wake.
-
-        The idle counter is NOT seeded from persisted usage: if it were, a wake
-        whose idle POST crashed after the usage flush persisted would be skipped
-        forever. Seeding at 0 makes a restart re-post at most one idle, which the
-        server treats as an already-delivered no-op.
-        """
-        # First run: turn 1 usage persisted.
-        usage.record_usage_payload(tmp_path, _TURN1)
-        first = _CtxRecordingClient()
-        await _run_loop_until(monkeypatch, tmp_path, _idle_posts, client=first)
-        assert usage._read_usage_state(tmp_path).seen == {"g1"}
-
-        # Fresh loop (simulated restart) over the SAME bridge dir, no new turns:
-        # idle is re-posted so a lost pre-crash wake still lands.
-        second = _CtxRecordingClient()
-        await _run_loop_until(monkeypatch, tmp_path, _idle_posts, client=second)
-        await asyncio.sleep(0.1)
-        # Exactly one re-post — the single already-seen turn, not a loop.
-        assert len(_idle_posts(second)) == 1
+        assert [body["type"] for _, body in client.posts] == ["external_session_usage"]
 
     async def test_failed_post_is_not_persisted(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Related issue

Closes #5677.

Supersedes and ports the fix from community PR #6520 after the cursor-native module refactor. Credit for the original diagnosis and patch goes to @josuediazflores; the commit retains their co-authorship.

## Summary

Cursor can finish a turn between the transcript and stop-marker reads. Completion then reaches the parent before the final reply is mirrored, so `sys_read_inbox` reports that the sub-agent produced no output.

This makes the transcript forwarder the single completion authority: it snapshots stop markers before reading the transcript, waits through transcript-delivery retries, and posts completion only after the final reply. The independent usage poller no longer posts a duplicate `idle`; that stale path could win the race and permanently deliver an empty result before the ordered forwarder ran.

ELI5: deliver the child's answer before telling its parent that the answer is ready, and have only one component ring that bell.

```text
Read stop markers -> read transcript -> deliver items -> notify parent
                                          |
                                     retry needed
                                          |
                                     next poll
```

## Test Plan

- Real-Cursor A/B using the byte-identical E2E test:
  - unchanged `origin/main` (`55a135325`): **failed** in 44.77s; authenticated Cursor completed real `Shell` and `Read` calls and its child transcript contained both nonce probe values, while the parent's real `sys_read_inbox` returned `produced no output`.
  - this branch: **passed** in 45.48s with both probe values delivered through the parent inbox.
- `python -m pytest tests/test_cursor_native_status.py tests/test_cursor_native_forwarder.py tests/test_cursor_native_permissions.py tests/test_cursor_native_usage.py -q` — 163 passed.
- `uvx pre-commit run --files omnigent/harnesses/cursor_native/usage.py tests/test_cursor_native_usage.py tests/e2e/test_cursor_native_subagent_tool_result_e2e.py` — all hooks passed.

The opt-in E2E launches an actual authenticated `cursor-agent` as a `cursor-native` child through `sys_session_send`, requires it to use Cursor's real `Shell` and `Read` tools, and drains the result with the real `sys_read_inbox`. A runner-only timing shim waits for Cursor's real final reply and real stop marker, then schedules the reported production observation order; it does not fake either event.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The deterministic unit tests cover transcript/completion ordering, rejected or unreachable transcript delivery, and the rule that usage forwarding never emits completion. The gated E2E covers the original nested-agent path with authenticated Cursor and real shell/file tool calls; its controlled scheduling makes the regression fail reliably on unchanged main instead of depending on a sub-second poll race.

## Changelog

Cursor sub-agents now return their final response after using shell or file tools instead of sometimes producing empty output.
