### PR TITLE
fix(web): recover chat status from missed SSE events

### DIFF
--- a/tests/e2e_ui/chat/test_working_indicator_snapshot_reconcile.py
+++ b/tests/e2e_ui/chat/test_working_indicator_snapshot_reconcile.py
@@ -1,0 +1,110 @@
+"""E2E coverage for recovering a missed session-status event."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_WORKING = '[data-testid="working-indicator"]'
+_HEARTBEAT_INTERVAL_MS = 10_000
+
+
+def _publish_status(base_url: str, session_id: str, status: str) -> None:
+    """Publish a durable status edge through the native-harness event route."""
+    response = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": {"status": status}},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+
+
+def _snapshot_status(base_url: str, session_id: str) -> str:
+    """Read the status exposed by the slim session snapshot."""
+    response = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    response.raise_for_status()
+    return str(response.json()["status"])
+
+
+def _install_heartbeat_only_stream(page: Page, session_id: str) -> None:
+    """Replace this session's stream with a live heartbeat-only transport."""
+    script = """
+        (() => {
+          const sessionId = __SESSION_ID__;
+          const heartbeatInterval = __HEARTBEAT_INTERVAL__;
+          const originalFetch = window.fetch.bind(window);
+          window.__statusGapStreamOpens = 0;
+          window.__statusGapHeartbeats = 0;
+          window.fetch = (input, init) => {
+            const url = typeof input === "string" ? input : input.url;
+            const streamPath = `/v1/sessions/${sessionId}/stream`;
+            if (new URL(url, window.location.origin).pathname !== streamPath) {
+              return originalFetch(input, init);
+            }
+
+            window.__statusGapStreamOpens += 1;
+            let heartbeatTimer;
+            const body = new ReadableStream({
+              start(controller) {
+                const sendHeartbeat = () => {
+                  const frame = "event: session.heartbeat\\ndata: {}\\n\\n";
+                  controller.enqueue(new TextEncoder().encode(frame));
+                  window.__statusGapHeartbeats += 1;
+                };
+                sendHeartbeat();
+                heartbeatTimer = window.setInterval(sendHeartbeat, heartbeatInterval);
+              },
+              cancel() {
+                window.clearInterval(heartbeatTimer);
+              },
+            });
+            return Promise.resolve(new Response(body, {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            }));
+          };
+        })()
+        """
+    page.add_init_script(
+        script.replace("__SESSION_ID__", json.dumps(session_id)).replace(
+            "__HEARTBEAT_INTERVAL__", str(_HEARTBEAT_INTERVAL_MS)
+        )
+    )
+
+
+def test_snapshot_idle_clears_working_on_heartbeat_only_stream(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A visible chat recovers when its stream misses the terminal status edge."""
+    base_url, session_id = seeded_session
+    _publish_status(base_url, session_id, "running")
+    assert _snapshot_status(base_url, session_id) == "running"
+
+    page.clock.install()
+    _install_heartbeat_only_stream(page, session_id)
+    page.goto(f"{base_url}/c/{session_id}")
+
+    working = page.locator(_WORKING)
+    expect(working).to_be_visible(timeout=15_000)
+    page.wait_for_function("window.__statusGapHeartbeats > 0")
+
+    # The server reaches idle, but this tab's healthy stream never receives
+    # that lifecycle event. Only snapshot reconciliation can clear the UI.
+    _publish_status(base_url, session_id, "idle")
+    assert _snapshot_status(base_url, session_id) == "idle"
+    expect(working).to_be_visible()
+
+    # Heartbeats keep the transport healthy, and the missing idle edge leaves
+    # the stale indicator untouched before the reconciliation interval.
+    page.clock.run_for("00:50")
+    expect(working).to_be_visible()
+    assert page.evaluate("window.__statusGapStreamOpens") == 1
+
+    page.clock.run_for("00:10")
+
+    expect(working).to_have_count(0, timeout=15_000)
+    assert page.evaluate("window.__statusGapStreamOpens") == 1
+    assert page.evaluate("window.__statusGapHeartbeats") >= 6

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -1071,6 +1071,8 @@ export interface GetSessionSlimOptions {
    * refresh pierces stale server-side capability caches.
    */
   refreshState?: boolean;
+  /** Cancel this request when the owning operation ends or times out. */
+  signal?: AbortSignal;
 }
 
 export async function getSessionSlim(
@@ -1084,6 +1086,7 @@ export async function getSessionSlim(
   if (options.refreshState === true) params.set("refresh_state", "true");
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(sessionId)}?${params.toString()}`,
+    { signal: options.signal },
   );
   return sessionFromWire(await readJsonOrThrow<SessionResponseWire>(res));
 }

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -57,6 +57,7 @@ import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
   ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS,
+  ACTIVE_SESSION_STATUS_RECONCILE_TIMEOUT_MS,
   beginLocalConversation,
   consumePendingInitialPrompt,
   handleSessionEvent,
@@ -9494,6 +9495,180 @@ describe("chatStore — startStreamPump reconnect loop", () => {
       responseId: "resp_new",
       state: "streaming",
     });
+
+    controller.abort();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("discards a stale snapshot after a same-value live status event", async () => {
+    seedSession("conv_same_status_race", []);
+    const sink = pushableStream();
+    let resolveSnapshot: ((response: Response) => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_same_status_race/stream") {
+        init?.signal?.addEventListener("abort", () =>
+          sink.error(new DOMException("aborted", "AbortError")),
+        );
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      if (
+        url.startsWith("/v1/sessions/conv_same_status_race?") &&
+        (init?.method ?? "GET") === "GET"
+      ) {
+        return new Promise<Response>((resolve) => {
+          resolveSnapshot = resolve;
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    const bound = bindConversationForTest("conv_same_status_race", {
+      abortController: controller,
+      sessionStatus: "idle",
+      status: "idle",
+      activeResponse: null,
+    });
+    const loop = startStreamPump("conv_same_status_race", controller, bound.set, bound.get);
+    await drainAsync();
+
+    await advanceWithHeartbeats(sink, ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS);
+    expect(resolveSnapshot).not.toBeNull();
+
+    // This live terminal edge is value-equal locally, but it proves that the
+    // earlier running snapshot resolving below is stale.
+    sink.push(
+      sse("session.status", {
+        conversation_id: "conv_same_status_race",
+        status: "idle",
+      }),
+    );
+    await drainAsync();
+    expect(bound.get().sessionStatus).toBe("idle");
+
+    resolveSnapshot!(
+      mockResponse({
+        id: "conv_same_status_race",
+        agent_id: "agent_xyz",
+        status: "running",
+        active_response_id: "resp_stale",
+        created_at: 0,
+        items: [],
+        labels: {},
+      }),
+    );
+    await drainAsync();
+
+    expect(bound.get().sessionStatus).toBe("idle");
+    expect(bound.get().status).toBe("idle");
+    expect(bound.get().activeResponse).toBeNull();
+
+    controller.abort();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("does not join an older shared session query", async () => {
+    seedSession("conv_independent_snapshot", []);
+    let resolveSharedQuery: ((value: unknown) => void) | null = null;
+    const sharedQuery = client.fetchQuery<unknown>({
+      queryKey: ["session", "conv_independent_snapshot"],
+      queryFn: () =>
+        new Promise<unknown>((resolve) => {
+          resolveSharedQuery = resolve;
+        }),
+    });
+    await drainAsync();
+
+    const sink = pushableStream();
+    let snapshotFetches = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_independent_snapshot/stream") {
+        init?.signal?.addEventListener("abort", () =>
+          sink.error(new DOMException("aborted", "AbortError")),
+        );
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      if (
+        url.startsWith("/v1/sessions/conv_independent_snapshot?") &&
+        (init?.method ?? "GET") === "GET"
+      ) {
+        snapshotFetches += 1;
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    const bound = bindConversationForTest("conv_independent_snapshot", {
+      abortController: controller,
+      sessionStatus: "running",
+    });
+    const loop = startStreamPump("conv_independent_snapshot", controller, bound.set, bound.get);
+    await drainAsync();
+
+    await advanceWithHeartbeats(sink, ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS);
+    await drainAsync();
+
+    expect(snapshotFetches).toBe(1);
+    expect(bound.get().sessionStatus).toBe("idle");
+
+    resolveSharedQuery!({ source: "older request" });
+    await sharedQuery;
+    controller.abort();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("retries after a status snapshot request times out", async () => {
+    seedSession("conv_status_timeout", []);
+    const sink = pushableStream();
+    let snapshotFetches = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_status_timeout/stream") {
+        init?.signal?.addEventListener("abort", () =>
+          sink.error(new DOMException("aborted", "AbortError")),
+        );
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      if (
+        url.startsWith("/v1/sessions/conv_status_timeout?") &&
+        (init?.method ?? "GET") === "GET"
+      ) {
+        snapshotFetches += 1;
+        if (snapshotFetches === 1) {
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        }
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    const bound = bindConversationForTest("conv_status_timeout", {
+      abortController: controller,
+      sessionStatus: "running",
+    });
+    const loop = startStreamPump("conv_status_timeout", controller, bound.set, bound.get);
+    await drainAsync();
+
+    await advanceWithHeartbeats(sink, ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS);
+    expect(snapshotFetches).toBe(1);
+
+    await advanceWithHeartbeats(sink, ACTIVE_SESSION_STATUS_RECONCILE_TIMEOUT_MS);
+    await advanceWithHeartbeats(
+      sink,
+      ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS - ACTIVE_SESSION_STATUS_RECONCILE_TIMEOUT_MS,
+    );
+    await drainAsync();
+
+    expect(snapshotFetches).toBe(2);
+    expect(bound.get().sessionStatus).toBe("idle");
 
     controller.abort();
     await drainAsync(2);

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -56,6 +56,7 @@ import type { TerminalInfo } from "@/hooks/useTerminals";
 import { terminalsQueryKey } from "@/hooks/useTerminals";
 import { type ChildSessionInfo, childSessionsQueryKey } from "@/hooks/useChildSessions";
 import {
+  ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS,
   beginLocalConversation,
   consumePendingInitialPrompt,
   handleSessionEvent,
@@ -8964,6 +8965,16 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     return sinks;
   }
 
+  async function advanceWithHeartbeats(sink: StreamSink, durationMs: number): Promise<void> {
+    /* oxlint-disable no-await-in-loop */
+    for (let elapsed = 0; elapsed < durationMs; elapsed += 15_000) {
+      sink.push(sse("session.heartbeat", {}));
+      await drainAsync(2);
+      await vi.advanceTimersByTimeAsync(15_000);
+    }
+    /* oxlint-enable no-await-in-loop */
+  }
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -9372,6 +9383,119 @@ describe("chatStore — startStreamPump reconnect loop", () => {
 
     sinks[0]!.push("data: [DONE]\n\n");
     sinks[0]!.close();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("reconciles status when a heartbeat-only stream misses the idle event", async () => {
+    seedSession("conv_heartbeat_gap", []);
+    const sink = pushableStream();
+    let streamOpens = 0;
+    let snapshotFetches = 0;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_heartbeat_gap/stream") {
+        streamOpens += 1;
+        init?.signal?.addEventListener("abort", () =>
+          sink.error(new DOMException("aborted", "AbortError")),
+        );
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      if (url.startsWith("/v1/sessions/conv_heartbeat_gap?") && (init?.method ?? "GET") === "GET") {
+        snapshotFetches += 1;
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    const bound = bindConversationForTest("conv_heartbeat_gap", {
+      abortController: controller,
+      sessionStatus: "running",
+      status: "idle",
+      activeResponse: {
+        responseId: "resp_done",
+        state: "completed",
+        error: null,
+        completedAt: Date.now(),
+      },
+    });
+
+    const loop = startStreamPump("conv_heartbeat_gap", controller, bound.set, bound.get);
+    await drainAsync();
+    expect(streamOpens).toBe(1);
+
+    // The transport stays byte-active while the real idle edge is absent.
+    await advanceWithHeartbeats(sink, ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS);
+    await drainAsync();
+
+    expect(streamOpens).toBe(1);
+    expect(snapshotFetches).toBe(1);
+    expect(bound.get().sessionStatus).toBe("idle");
+    expect(useChatStore.getState().sessionStatus).toBe("idle");
+
+    controller.abort();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("keeps a live status event that arrives during snapshot reconciliation", async () => {
+    seedSession("conv_status_race", []);
+    const sink = pushableStream();
+    let resolveSnapshot: ((response: Response) => void) | null = null;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_status_race/stream") {
+        init?.signal?.addEventListener("abort", () =>
+          sink.error(new DOMException("aborted", "AbortError")),
+        );
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      if (url.startsWith("/v1/sessions/conv_status_race?") && (init?.method ?? "GET") === "GET") {
+        return new Promise<Response>((resolve) => {
+          resolveSnapshot = resolve;
+        });
+      }
+      return defaultFetchHandler(input, init);
+    });
+    const controller = new AbortController();
+    const bound = bindConversationForTest("conv_status_race", {
+      abortController: controller,
+      sessionStatus: "idle",
+    });
+    const loop = startStreamPump("conv_status_race", controller, bound.set, bound.get);
+    await drainAsync();
+
+    await advanceWithHeartbeats(sink, ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS);
+    expect(resolveSnapshot).not.toBeNull();
+
+    sink.push(
+      sse("session.status", {
+        conversation_id: "conv_status_race",
+        status: "running",
+        response_id: "resp_new",
+      }),
+    );
+    await drainAsync();
+    expect(bound.get().sessionStatus).toBe("running");
+
+    resolveSnapshot!(
+      mockResponse({
+        id: "conv_status_race",
+        agent_id: "agent_xyz",
+        status: "idle",
+        created_at: 0,
+        items: [],
+        labels: {},
+      }),
+    );
+    await drainAsync();
+
+    expect(bound.get().sessionStatus).toBe("running");
+    expect(bound.get().activeResponse).toMatchObject({
+      responseId: "resp_new",
+      state: "streaming",
+    });
+
+    controller.abort();
     await drainAsync(2);
     await loop;
   });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1107,6 +1107,11 @@ export interface ChatState extends ConversationState, AppChatState, ChatActions 
 
 let queryClient: QueryClient | null = null;
 
+// Any semantic stream event makes a snapshot already in flight potentially
+// stale. Heartbeats are filtered before this revision is bumped.
+const streamEventRevisions = new Map<string, number>();
+conversationRegistry.subscribeDisposed((id) => streamEventRevisions.delete(id));
+
 /**
  * Evict a conversation from the live registry.
  *
@@ -1401,6 +1406,7 @@ const WORKSPACE_INVALIDATION_DEBOUNCE_MS = 750;
 const STREAM_RECONNECT_BASE_MS = 250;
 const STREAM_RECONNECT_MAX_MS = 5_000;
 export const ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS = 60_000;
+export const ACTIVE_SESSION_STATUS_RECONCILE_TIMEOUT_MS = 15_000;
 // A reverse proxy serves 404 for the stream route for the ~10-60s a backend
 // container takes to restart (upgrade, config change, re-seed bounce), so a
 // 404 mid-restart must not be treated as permanent. Bound the retries instead
@@ -3995,10 +4001,9 @@ function reconnectStatusPatch(session: Session, s: ChatState): Partial<ChatState
 /**
  * Reconcile the visible conversation's lifecycle from its persisted snapshot.
  *
- * A stream can keep receiving heartbeats while missing a real lifecycle event.
- * The byte-stall guard cannot detect that semantic gap, so periodically re-read
- * durable status while the stream remains open. If a live event changes the
- * entry during the fetch, discard the older snapshot.
+ * A stream pump can keep receiving heartbeats while missing a lifecycle event.
+ * Periodically re-read durable status, discarding a snapshot if any semantic
+ * stream event arrives during the fetch.
  */
 async function reconcileActiveSessionStatus(
   id: string,
@@ -4015,16 +4020,24 @@ async function reconcileActiveSessionStatus(
     return;
   }
   const stateBeforeFetch = get();
+  const revisionBeforeFetch = streamEventRevisions.get(id) ?? 0;
+  const snapshotController = new AbortController();
+  const abortSnapshot = () => snapshotController.abort();
+  controller.signal.addEventListener("abort", abortSnapshot, { once: true });
+  const snapshotTimeout = window.setTimeout(
+    abortSnapshot,
+    ACTIVE_SESSION_STATUS_RECONCILE_TIMEOUT_MS,
+  );
   let session: Session;
   try {
-    session = await queryClient.fetchQuery({
-      queryKey: ["session", id],
-      queryFn: () => getSessionSlim(id),
-      staleTime: 0,
-      retry: false,
-    });
+    // This read must not join the shared React Query request: an older request
+    // could have started before the live event this reconciliation follows.
+    session = await getSessionSlim(id, { signal: snapshotController.signal });
   } catch {
     return;
+  } finally {
+    window.clearTimeout(snapshotTimeout);
+    controller.signal.removeEventListener("abort", abortSnapshot);
   }
   const current = get();
   if (
@@ -4032,6 +4045,7 @@ async function reconcileActiveSessionStatus(
     isConversationDisposed(id) ||
     conversationRegistry.getActive()?.id !== id ||
     get().abortController !== controller ||
+    (streamEventRevisions.get(id) ?? 0) !== revisionBeforeFetch ||
     current.sessionStatus !== stateBeforeFetch.sessionStatus ||
     current.status !== stateBeforeFetch.status ||
     current.activeResponse !== stateBeforeFetch.activeResponse ||
@@ -6610,6 +6624,9 @@ async function* tapSessionEvents(
   onElicitationResolved?: (elicitationId: string) => void,
 ): AsyncIterable<StreamEvent> {
   for await (const event of events) {
+    if (!isConversationDisposed(conversationId)) {
+      streamEventRevisions.set(conversationId, (streamEventRevisions.get(conversationId) ?? 0) + 1);
+    }
     handleSessionEvent(event, conversationId);
     if (event.type === "elicitation_resolved") {
       onElicitationResolved?.(event.elicitationId);

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -1400,6 +1400,7 @@ const WORKSPACE_INVALIDATION_DEBOUNCE_MS = 750;
 // instantly.
 const STREAM_RECONNECT_BASE_MS = 250;
 const STREAM_RECONNECT_MAX_MS = 5_000;
+export const ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS = 60_000;
 // A reverse proxy serves 404 for the stream route for the ~10-60s a backend
 // container takes to restart (upgrade, config change, re-seed bounce), so a
 // 404 mid-restart must not be treated as permanent. Bound the retries instead
@@ -3992,6 +3993,62 @@ function reconnectStatusPatch(session: Session, s: ChatState): Partial<ChatState
 }
 
 /**
+ * Reconcile the visible conversation's lifecycle from its persisted snapshot.
+ *
+ * A stream can keep receiving heartbeats while missing a real lifecycle event.
+ * The byte-stall guard cannot detect that semantic gap, so periodically re-read
+ * durable status while the stream remains open. If a live event changes the
+ * entry during the fetch, discard the older snapshot.
+ */
+async function reconcileActiveSessionStatus(
+  id: string,
+  controller: AbortController,
+  set: Setter,
+  get: Getter,
+): Promise<void> {
+  if (
+    queryClient === null ||
+    controller.signal.aborted ||
+    conversationRegistry.getActive()?.id !== id ||
+    get().abortController !== controller
+  ) {
+    return;
+  }
+  const stateBeforeFetch = get();
+  let session: Session;
+  try {
+    session = await queryClient.fetchQuery({
+      queryKey: ["session", id],
+      queryFn: () => getSessionSlim(id),
+      staleTime: 0,
+      retry: false,
+    });
+  } catch {
+    return;
+  }
+  const current = get();
+  if (
+    controller.signal.aborted ||
+    isConversationDisposed(id) ||
+    conversationRegistry.getActive()?.id !== id ||
+    get().abortController !== controller ||
+    current.sessionStatus !== stateBeforeFetch.sessionStatus ||
+    current.status !== stateBeforeFetch.status ||
+    current.activeResponse !== stateBeforeFetch.activeResponse ||
+    current.backgroundTaskCount !== stateBeforeFetch.backgroundTaskCount ||
+    current.backgroundTasks !== stateBeforeFetch.backgroundTasks ||
+    current.mcpStartup !== stateBeforeFetch.mcpStartup ||
+    current.contextWindow !== stateBeforeFetch.contextWindow ||
+    current.tokensUsed !== stateBeforeFetch.tokensUsed ||
+    current.sessionCostUsd !== stateBeforeFetch.sessionCostUsd ||
+    current.sessionUsageByModel !== stateBeforeFetch.sessionUsageByModel
+  ) {
+    return;
+  }
+  set((s) => reconnectStatusPatch(session, s));
+}
+
+/**
  * Reconcile rendered ApprovalCards against a reconnect snapshot's
  * pending-elicitation list.
  *
@@ -4466,6 +4523,17 @@ export async function startStreamPump(
   get: Getter,
 ): Promise<void> {
   let failedOpens = 0;
+  let statusReconcileInFlight = false;
+  const statusReconcileTimer =
+    typeof window === "undefined"
+      ? null
+      : window.setInterval(() => {
+          if (statusReconcileInFlight) return;
+          statusReconcileInFlight = true;
+          void reconcileActiveSessionStatus(id, controller, set, get).finally(() => {
+            statusReconcileInFlight = false;
+          });
+        }, ACTIVE_SESSION_STATUS_RECONCILE_INTERVAL_MS);
   // Consecutive 404s only — reset on any non-404 outcome (success or a
   // different-status failure), so a 404 has to persist across attempts to
   // count toward the cap below.
@@ -4634,6 +4702,7 @@ export async function startStreamPump(
       }
     }
   } finally {
+    if (statusReconcileTimer !== null) window.clearInterval(statusReconcileTimer);
     if (get().abortController === controller) {
       set({ abortController: null });
     }


### PR DESCRIPTION
## Related issue

N/A — diagnosed from session `a9bfe779542c4214b0675da8a19e8739`.

## Summary

- ELI5: the live chat connection could say “I’m healthy” via heartbeats while silently missing the event that says the agent finished. The chat now periodically checks the persisted session status while it is visible, so “Working…” cannot remain stuck indefinitely.
- Reconcile the active conversation from the slim session snapshot every 60 seconds without reconnecting its stream.
- Discard a polled snapshot when any semantic stream event arrives during the fetch, including value-equal lifecycle edges.
- Use an independent, abortable snapshot request with a 15-second timeout so query deduplication or a hung fetch cannot apply stale state or disable future reconciliation.

```mermaid
flowchart LR
    A[Agent finishes] --> B[Persist idle status]
    A -. missed SSE event .-> C[Chat still shows Working]
    B --> D[Active-chat snapshot reconcile]
    D --> E[Chat settles to idle]
```

## Test Plan

- `cd web && pnpm exec vitest run src/store/chatStore.test.ts` — 408 tests passed.
- `cd web && pnpm exec vitest run src/lib/sessionsApi.test.ts` — 55 tests passed.
- `cd web && pnpm run lint`
- `cd web && pnpm run type-check`
- `cd web && pnpm run format:check`
- `cd web && pnpm run build` — passed with existing CSS and chunk-size warnings.
- `.venv/bin/pre-commit run --all-files`
- `uv run --no-sync pytest tests/e2e_ui/chat/test_working_indicator_snapshot_reconcile.py -v` — 1 passed.

The regression test keeps an eventless stream alive with 15-second heartbeats, verifies it never reconnects, and confirms the persisted idle snapshot clears the stale running state. Additional tests verify that value-changing and value-equal live events win over a stale snapshot, reconciliation never joins an older shared query, and a timed-out request is retried on the next interval.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

This changes lifecycle synchronization rather than layout or styling; the deterministic heartbeat-only stream reproduction above covers the visible behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit coverage reproduces both a missed idle event on a heartbeat-active stream and the snapshot/live-event race. Browser coverage verifies the rendered indicator remains stale before the 60-second reconciliation boundary, then clears from the persisted idle snapshot without a stream reconnect.

## Changelog

Chat no longer stays on “Working…” after the agent has finished.
