### PR TITLE
feat(sandbox): add tolerations support to the kubernetes provider

### DIFF
--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -600,6 +600,7 @@ def build_job_manifest(
     resources: dict[str, object] | None = None,
     pvc_mounts: Sequence[Mapping[str, object]] | None = None,
     secret_mounts: Sequence[Mapping[str, object]] | None = None,
+    tolerations: Sequence[Mapping[str, object]] | None = None,
     agent_name: str | None = None,
     backoff_limit: int = _JOB_BACKOFF_LIMIT,
     active_deadline_seconds: int = _JOB_ACTIVE_DEADLINE_S,
@@ -673,6 +674,10 @@ def build_job_manifest(
       the Pod onto a sandboxed container runtime the cluster provides via a
       ``RuntimeClass`` object (e.g. Kata Containers micro-VMs, gVisor). Unset
       keeps the cluster's default runtime — today's behaviour exactly.
+    - Operator *tolerations* become ``spec.tolerations`` verbatim, letting the
+      Pod land on a tainted NodePool dedicated to sandboxes. A toleration only
+      permits scheduling there — pair it with *node_selector* to also pin the
+      Pod to that pool, or it may just as well land anywhere else untainted.
 
     :param job_name: DNS-label-safe Job name (see :func:`_new_pod_name`).
     :param namespace: Namespace the Job is created in.
@@ -707,6 +712,10 @@ def build_job_manifest(
     :param secret_mounts: Normalized Secret mounts (``{secret_name,
         mount_path}``) added as read-only ``secret`` volumes on the host
         container only, or ``None``.
+    :param tolerations: Normalized Toleration entries (``{key?, operator?,
+        value?, effect?, tolerationSeconds?}``) added to ``spec.tolerations``
+        verbatim, or ``None`` for none. Permits scheduling onto a tainted
+        NodePool; it does not by itself attract the Pod there.
     :param agent_name: Server-resolved built-in agent name the session runs,
         added as the ``omnigent.ai/agent`` classifier label. Stamped verbatim
         when it is already a valid label value, otherwise omitted (extending the
@@ -901,6 +910,10 @@ def build_job_manifest(
         # Opt-in only: an absent key (not an explicit None/null) keeps the
         # manifest byte-compatible with pre-runtime_class deployments.
         pod_spec["runtimeClassName"] = runtime_class
+    if tolerations:
+        # Opt-in only, same rationale as runtime_class above: an absent key
+        # keeps the manifest byte-compatible with pre-tolerations deployments.
+        pod_spec["tolerations"] = list(tolerations)
     return {
         "apiVersion": "batch/v1",
         "kind": "Job",
@@ -1141,6 +1154,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         resources: dict[str, object] | None = None,
         pvc_mounts: Sequence[Mapping[str, object]] | None = None,
         secret_mounts: Sequence[Mapping[str, object]] | None = None,
+        tolerations: Sequence[Mapping[str, object]] | None = None,
         pod_ready_timeout_s: int | None = None,
         runtime_class: str | None = None,
         home_size_limit: str | None = _HOME_SIZE_LIMIT_DEFAULT,
@@ -1169,6 +1183,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         self._resources = resources
         self._pvc_mounts = list(pvc_mounts) if pvc_mounts else None
         self._secret_mounts = list(secret_mounts) if secret_mounts else None
+        self._tolerations = list(tolerations) if tolerations else None
         self._pod_ready_timeout_s = pod_ready_timeout_s
         self._runtime_class = runtime_class
         self._home_size_limit = home_size_limit
@@ -1462,6 +1477,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                     resources=self._resources,
                     pvc_mounts=self._pvc_mounts,
                     secret_mounts=self._secret_mounts,
+                    tolerations=self._tolerations,
                     agent_name=agent_name,
                     runtime_class=self._runtime_class,
                     home_size_limit=self._home_size_limit,

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1367,6 +1367,7 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
                     "secret_name",
                     "service_account",
                     "node_selector",
+                    "tolerations",
                     "kubeconfig",
                     "in_cluster",
                     "resources",
@@ -1389,6 +1390,7 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
             secret_name=_parse_provider_string(raw, "kubernetes", "secret_name"),
             service_account=_parse_provider_string(raw, "kubernetes", "service_account"),
             node_selector=_parse_provider_str_mapping(raw, "kubernetes", "node_selector"),
+            tolerations=_parse_kubernetes_tolerations(raw),
             kubeconfig=_parse_provider_string(raw, "kubernetes", "kubeconfig"),
             in_cluster=_parse_provider_bool(raw, "kubernetes", "in_cluster"),
             resources=_parse_kubernetes_resources(raw),
@@ -2538,6 +2540,116 @@ def _validate_kubernetes_identifiers(
             )
 
 
+# Kubernetes Toleration ``operator`` / ``effect`` enums for parse-time
+# validation of ``sandbox.kubernetes.tolerations`` entries.
+_K8S_TOLERATION_OPERATORS: frozenset[str] = frozenset({"Exists", "Equal"})
+_K8S_TOLERATION_EFFECTS: frozenset[str] = frozenset(
+    {"NoSchedule", "PreferNoSchedule", "NoExecute"}
+)
+
+
+def _parse_kubernetes_tolerations(raw: dict[str, object]) -> list[dict[str, object]] | None:
+    """
+    Extract and validate the optional ``sandbox.kubernetes.tolerations`` list.
+
+    Each entry is a Kubernetes Toleration — ``{key?, operator?, value?,
+    effect?, tolerationSeconds?}`` — added to every runner Pod's
+    ``spec.tolerations`` verbatim. Lets an operator dedicate a tainted
+    NodePool to sandbox Pods (pair with ``node_selector`` to also pin them
+    there — a toleration alone only permits scheduling, it does not attract
+    it). Validated at parse time so a malformed entry fails server startup
+    instead of the first managed launch.
+
+    :param raw: The raw ``sandbox`` mapping.
+    :returns: Normalized entries, or ``None`` when omitted or empty.
+    :raises ValueError: When the list or any entry has the wrong shape, or
+        combines fields Kubernetes itself would reject (an ``Exists``
+        operator with a ``value``, an empty ``key`` with an operator other
+        than ``Exists``, or a ``tolerationSeconds`` without ``effect:
+        NoExecute``).
+    """
+    section = _parse_provider_section(raw, "kubernetes")
+    if section is None:
+        return None
+    value = section.get("tolerations")
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(
+            "server config 'sandbox.kubernetes.tolerations' must be a list of "
+            "{key?, operator?, value?, effect?, tolerationSeconds?} entries"
+        )
+    normalized: list[dict[str, object]] = []
+    for i, entry in enumerate(value):
+        path_prefix = f"sandbox.kubernetes.tolerations[{i}]"
+        if not isinstance(entry, dict):
+            raise ValueError(f"server config '{path_prefix}' must be a mapping")
+        _reject_unknown_keys(
+            entry, {"key", "operator", "value", "effect", "tolerationSeconds"}, path_prefix
+        )
+        key = entry.get("key")
+        if key is not None and (not isinstance(key, str) or not key.strip()):
+            raise ValueError(f"server config '{path_prefix}.key' must be a non-empty string")
+        if key is not None and not _validate_label_key(key.strip()):
+            raise ValueError(
+                f"server config '{path_prefix}.key' is not a valid Kubernetes label key: {key!r}"
+            )
+        operator = entry.get("operator", "Equal")
+        if not isinstance(operator, str) or operator not in _K8S_TOLERATION_OPERATORS:
+            raise ValueError(
+                f"server config '{path_prefix}.operator' must be one of: "
+                f"{', '.join(sorted(_K8S_TOLERATION_OPERATORS))} (got {operator!r})"
+            )
+        if key is None and operator != "Exists":
+            raise ValueError(
+                f"server config '{path_prefix}' omits 'key' but sets operator "
+                f"{operator!r} — an empty key only pairs with 'Exists' "
+                "(Kubernetes' 'tolerate everything' form)"
+            )
+        entry_value = entry.get("value")
+        if entry_value is not None and not isinstance(entry_value, str):
+            raise ValueError(f"server config '{path_prefix}.value' must be a string")
+        if entry_value and (len(entry_value) > 63 or not _K8S_LABEL_SEGMENT_RE.match(entry_value)):
+            raise ValueError(
+                f"server config '{path_prefix}.value' is not a valid Kubernetes "
+                f"label value: {entry_value!r}"
+            )
+        if operator == "Exists" and entry_value:
+            raise ValueError(
+                f"server config '{path_prefix}.value' is not allowed with operator 'Exists'"
+            )
+        effect = entry.get("effect")
+        if effect is not None and (
+            not isinstance(effect, str) or effect not in _K8S_TOLERATION_EFFECTS
+        ):
+            raise ValueError(
+                f"server config '{path_prefix}.effect' must be one of: "
+                f"{', '.join(sorted(_K8S_TOLERATION_EFFECTS))} (got {effect!r})"
+            )
+        toleration_seconds = entry.get("tolerationSeconds")
+        if toleration_seconds is not None:
+            if not isinstance(toleration_seconds, int) or isinstance(toleration_seconds, bool):
+                raise ValueError(
+                    f"server config '{path_prefix}.tolerationSeconds' must be an integer"
+                )
+            if effect != "NoExecute":
+                raise ValueError(
+                    f"server config '{path_prefix}.tolerationSeconds' only applies "
+                    "with effect 'NoExecute'"
+                )
+        normalized_entry: dict[str, object] = {"operator": operator}
+        if key is not None:
+            normalized_entry["key"] = key.strip()
+        if entry_value:
+            normalized_entry["value"] = entry_value
+        if effect is not None:
+            normalized_entry["effect"] = effect
+        if toleration_seconds is not None:
+            normalized_entry["tolerationSeconds"] = toleration_seconds
+        normalized.append(normalized_entry)
+    return normalized or None
+
+
 def _parse_kubernetes_resources(raw: dict[str, object]) -> dict[str, object] | None:
     """
     Extract and validate the optional ``sandbox.kubernetes.resources`` block.
@@ -2878,6 +2990,7 @@ def _kubernetes_launcher_factory(
     secret_name: str | None,
     service_account: str | None,
     node_selector: dict[str, str] | None,
+    tolerations: list[dict[str, object]] | None,
     kubeconfig: str | None,
     in_cluster: bool | None,
     resources: dict[str, object] | None,
@@ -2905,6 +3018,10 @@ def _kubernetes_launcher_factory(
     :param node_selector: Extra node selector labels merged with a default
         ``kubernetes.io/arch: amd64`` (an entry for that key overrides it),
         or ``None``.
+    :param tolerations: Normalized Toleration entries added to every runner
+        Pod's ``spec.tolerations`` verbatim, or ``None``. Permits scheduling
+        onto a tainted NodePool; pair with *node_selector* to also pin the
+        Pod there.
     :param kubeconfig: Explicit kubeconfig path for the out-of-cluster fallback,
         or ``None``.
     :param in_cluster: Force the cluster-config source, or ``None`` to try
@@ -2944,6 +3061,7 @@ def _kubernetes_launcher_factory(
             secret_name=secret_name,
             service_account=service_account,
             node_selector=node_selector,
+            tolerations=tolerations,
             kubeconfig=kubeconfig,
             in_cluster=in_cluster,
             resources=resources,

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -290,6 +290,27 @@ def test_build_job_manifest_node_selector_can_override_arch() -> None:
     assert selector["disktype"] == "ssd"
 
 
+def test_build_job_manifest_omits_tolerations_by_default() -> None:
+    """No tolerations → no tolerations key: byte-compatible with pre-tolerations manifests."""
+    manifest = build_job_manifest(**_MANIFEST_KW)
+    assert "tolerations" not in _pod_spec(manifest)
+
+
+def test_build_job_manifest_tolerations_land_on_the_pod_spec_verbatim() -> None:
+    """Normalized toleration entries reach spec.tolerations verbatim."""
+    tolerations = [
+        {
+            "key": "sei.io/node-role",
+            "operator": "Equal",
+            "value": "omnigent-sandbox",
+            "effect": "NoSchedule",
+        },
+        {"operator": "Exists"},
+    ]
+    manifest = build_job_manifest(**{**_MANIFEST_KW, "tolerations": tolerations})
+    assert _pod_spec(manifest)["tolerations"] == tolerations
+
+
 def test_build_job_manifest_omits_runtime_class_by_default() -> None:
     """No runtime_class → no runtimeClassName key: the cluster default runtime."""
     manifest = build_job_manifest(**_MANIFEST_KW)
@@ -856,6 +877,38 @@ def test_launch_host_threads_pvc_mounts_into_the_job(
         "name": "pvc-0",
         "persistentVolumeClaim": {"claimName": "omnigent-datasets", "readOnly": True},
     } in pod_spec["volumes"]
+
+
+def test_launch_host_threads_tolerations_into_the_job(
+    fake_clients: tuple[_FakeCore, _FakeBatch],
+) -> None:
+    """A launcher built with tolerations creates Jobs whose Pod spec carries them."""
+    core, batch = fake_clients
+    _setup_pod_discovery(core)
+    tolerations = [
+        {
+            "key": "sei.io/node-role",
+            "operator": "Equal",
+            "value": "omnigent-sandbox",
+            "effect": "NoSchedule",
+        }
+    ]
+    launcher = KubernetesSandboxLauncher(
+        in_cluster=True,
+        namespace="omnigent-sandboxes",
+        secret_name="omnigent-creds",
+        env=(),
+        tolerations=tolerations,
+    )
+    launcher.start_host(
+        "omnigent-job-1",
+        token=_TOKEN,
+        host_id="host_1",
+        host_name="managed-1",
+        server_url="http://srv.example.com",
+    )
+    pod_spec = batch.created_jobs[0]["spec"]["template"]["spec"]
+    assert pod_spec["tolerations"] == tolerations
 
 
 @pytest.mark.parametrize(

--- a/tests/server/helpers.py
+++ b/tests/server/helpers.py
@@ -224,6 +224,7 @@ class FakeSandboxLauncher(SandboxLauncher):
         self.resources: dict[str, object] | None = None
         self.pvc_mounts: list[dict[str, object]] | None = None
         self.secret_mounts: list[dict[str, object]] | None = None
+        self.tolerations: list[dict[str, object]] | None = None
         self.pod_ready_timeout_s: int | None = None
         self.runtime_class: str | None = None
         self.home_size_limit: str | None = None
@@ -604,8 +605,8 @@ def install_fake_kubernetes_launcher(
     The managed flow constructs ``KubernetesSandboxLauncher(image=…, env=…,
     namespace=…, secret_name=…, service_account=…, node_selector=…,
     kubeconfig=…, in_cluster=…, resources=…, pvc_mounts=…, secret_mounts=…,
-    pod_ready_timeout_s=…, runtime_class=…, home_size_limit=…)``; the shim records those
-    constructor args on the
+    tolerations=…, pod_ready_timeout_s=…, runtime_class=…, home_size_limit=…)``;
+    the shim records those constructor args on the
     fake and hands it back, so production code runs unmodified against it.
 
     :param monkeypatch: The test's ``pytest.MonkeyPatch``.
@@ -626,6 +627,7 @@ def install_fake_kubernetes_launcher(
         resources: dict[str, object] | None = None,
         pvc_mounts: list[dict[str, object]] | None = None,
         secret_mounts: list[dict[str, object]] | None = None,
+        tolerations: list[dict[str, object]] | None = None,
         pod_ready_timeout_s: int | None = None,
         runtime_class: str | None = None,
         home_size_limit: str | None = None,
@@ -642,6 +644,7 @@ def install_fake_kubernetes_launcher(
         fake.resources = resources
         fake.pvc_mounts = pvc_mounts
         fake.secret_mounts = secret_mounts
+        fake.tolerations = tolerations
         fake.pod_ready_timeout_s = pod_ready_timeout_s
         fake.runtime_class = runtime_class
         fake.home_size_limit = home_size_limit

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -1056,6 +1056,111 @@ def test_parse_kubernetes_without_pvc_mounts_is_none(monkeypatch: pytest.MonkeyP
     assert fake.pvc_mounts is None
 
 
+def test_parse_kubernetes_tolerations_normalizes_and_reaches_launcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """tolerations parse into normalized entries (operator defaults 'Equal') on the launcher."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {
+                "tolerations": [
+                    {
+                        "key": "sei.io/node-role",
+                        "value": "omnigent-sandbox",
+                        "effect": "NoSchedule",
+                    },
+                    {"operator": "Exists", "effect": "NoExecute", "tolerationSeconds": 300},
+                ]
+            },
+        }
+    )
+    assert cfg is not None
+    cfg = cfg.default
+    fake = FakeSandboxLauncher()
+    install_fake_kubernetes_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.tolerations == [
+        {
+            "key": "sei.io/node-role",
+            "operator": "Equal",
+            "value": "omnigent-sandbox",
+            "effect": "NoSchedule",
+        },
+        {"operator": "Exists", "effect": "NoExecute", "tolerationSeconds": 300},
+    ]
+
+
+def test_parse_kubernetes_without_tolerations_is_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitted (or empty) tolerations reach the launcher as None — no tolerations added."""
+    cfg = parse_sandbox_config(
+        {
+            "provider": "kubernetes",
+            "server_url": "http://s.svc.cluster.local",
+            "kubernetes": {"tolerations": []},
+        }
+    )
+    assert cfg is not None
+    cfg = cfg.default
+    fake = FakeSandboxLauncher()
+    install_fake_kubernetes_launcher(monkeypatch, fake)
+    assert cfg.launcher_factory() is fake
+    assert fake.tolerations is None
+
+
+@pytest.mark.parametrize(
+    ("tolerations", "expected_fragment"),
+    [
+        # Wrong container shapes.
+        ("sei.io/node-role", "must be a list"),
+        ([["sei.io/node-role"]], "must be a mapping"),
+        ([{"bogus": "x"}], "unknown key"),
+        # key/value field shape.
+        ([{"key": "", "operator": "Equal"}], "key.*must be a non-empty string"),
+        ([{"key": "k", "value": 123}], "value.*must be a string"),
+        # key/value Kubernetes label format.
+        ([{"key": "sei.io/node role", "operator": "Exists"}], "not a valid Kubernetes label key"),
+        (
+            [{"key": "k", "operator": "Equal", "value": "x" * 64}],
+            "not a valid Kubernetes label value",
+        ),
+        # operator/effect given the wrong Python type outright (a config typo
+        # nesting a mapping/list under a scalar field) must still fail as
+        # ValueError, not escape as an unhandled TypeError from the `in`
+        # membership test against an unhashable value.
+        ([{"operator": {"nested": "mapping"}}], "operator.*must be one of"),
+        ([{"key": "k", "effect": ["NoSchedule"]}], "effect.*must be one of"),
+        # key/operator combinations Kubernetes itself would reject.
+        ([{"operator": "Equal"}], "only pairs with 'Exists'"),
+        ([{"key": "sei.io/x", "operator": "Maybe"}], "operator.*must be one of"),
+        ([{"operator": "Exists", "value": "x"}], "not allowed with operator 'Exists'"),
+        # effect / tolerationSeconds combinations.
+        ([{"key": "sei.io/x", "effect": "Sometimes"}], "effect.*must be one of"),
+        (
+            [{"key": "sei.io/x", "effect": "NoSchedule", "tolerationSeconds": 60}],
+            "only applies with effect 'NoExecute'",
+        ),
+        (
+            [{"key": "sei.io/x", "tolerationSeconds": "60"}],
+            "tolerationSeconds.*must be an integer",
+        ),
+    ],
+)
+def test_parse_kubernetes_tolerations_invalid_fails_loud(
+    tolerations: object, expected_fragment: str
+) -> None:
+    """An operator typo in tolerations fails at parse (server startup), not at launch."""
+    with pytest.raises(ValueError, match=expected_fragment):
+        parse_sandbox_config(
+            {
+                "provider": "kubernetes",
+                "server_url": "http://s.svc.cluster.local",
+                "kubernetes": {"tolerations": tolerations},
+            }
+        )
+
+
 @pytest.mark.parametrize(
     ("pvc_mounts", "expected_fragment"),
     [


### PR DESCRIPTION
## Related issue

Closes #6880

## Summary

- `sandbox.kubernetes.node_selector` attracts sandbox Pods to a labeled node pool, but the provider has no way to set `tolerations`, so a `NoSchedule` taint on that pool makes every sandbox Pod unschedulable — operators can't fully dedicate a pool.
- Adds `sandbox.kubernetes.tolerations`, mirroring `node_selector`'s existing path exactly: parsed and validated at server startup, threaded through `KubernetesSandboxLauncher`, added verbatim to the Job's Pod spec (`spec.tolerations`) when set.

## Test Plan

- `uv run --group lint ruff check` / `ruff format --check` — clean on every touched file.
- `uv run --group lint pyrefly check` — 0 errors on both touched source files.
- `uv run --group test pytest tests/server/test_managed_hosts.py tests/onboarding/sandboxes/test_kubernetes.py` — 414 passed (20 new, 0 regressions).
- `uv run --group lint pre-commit run --files <changed files>` — ruff hooks pass; the `pyrefly` hook reports 23 pre-existing errors in `omnigent/runtime/telemetry.py` (missing optional `opentelemetry` extras in this venv) that reproduce identically on `origin/main` with this diff stashed out — unrelated to this change.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

New tests mirror the existing `node_selector`/`pvc_mounts` shapes: `build_job_manifest` and `KubernetesSandboxLauncher` Pod-spec tests, plus parse-time validation tests covering every Toleration field combination the Kubernetes API server itself enforces (`Exists` + `value`, empty `key` + non-`Exists` operator, `tolerationSeconds` without `effect: NoExecute`, and `key`/`value` Kubernetes label-format checks matching `node_selector`'s existing validation).

## Changelog

Added `sandbox.kubernetes.tolerations` to the kubernetes sandbox provider, so operators can dedicate a tainted node pool to sandbox Pods.
