### PR TITLE
fix(acp): attribute per-turn token usage to the model so it renders in the UI

### DIFF
--- a/omnigent/inner/acp_executor.py
+++ b/omnigent/inner/acp_executor.py
@@ -724,6 +724,12 @@ class AcpExecutor(Executor):
                 "ACP session/new response missing sessionId: " + json.dumps(resp)[:200]
             )
         self._session_id = session_id
+        # Capture the agent's advertised model from session/new's config options, so a
+        # turn's usage can name it. Agents that report the model here (e.g. jcode) would
+        # otherwise leave it unknown until a later config_option_update, leaving the
+        # server unable to attribute per-model token usage for the turn.
+        if isinstance(result, dict):
+            self._note_config_options(result.get("configOptions"))
         return self._session_id
 
     def _session_mcp_servers(self) -> list[_AcpJsonObject]:
@@ -1180,14 +1186,15 @@ class AcpExecutor(Executor):
         return self._context_window
 
     @staticmethod
-    def _usage_from_result(result: _AcpJsonObject) -> dict[str, int] | None:
+    def _usage_from_result(result: _AcpJsonObject) -> dict[str, Any] | None:
         """Map an agent's final ``result.usage`` to Omnigent's usage keys.
 
-        ACP does not standardize usage, but agents that report it (Goose, Devin)
-        use ``{totalTokens, inputTokens, outputTokens}`` plus an optional
-        ``cachedReadTokens``; Omnigent's ``TurnComplete.usage`` uses
-        ``{input_tokens, output_tokens, total_tokens, cache_read_input_tokens}``.
-        Absent → ``None`` (usage simply isn't shown for agents that don't report).
+        ACP does not standardize usage, but agents that report it (Goose, Devin,
+        jcode) use ``{totalTokens, inputTokens, outputTokens}`` plus optional
+        ``cachedReadTokens`` / ``cachedWriteTokens``; Omnigent's ``TurnComplete.usage``
+        uses ``{input_tokens, output_tokens, total_tokens, cache_read_input_tokens,
+        cache_creation_input_tokens}``. Absent → ``None`` (usage simply isn't shown for
+        agents that don't report).
 
         ``cachedReadTokens`` is kept as its own key rather than folded into
         ``input_tokens``: cache reads are real consumption but billed at a
@@ -1199,17 +1206,37 @@ class AcpExecutor(Executor):
         usage = result.get("usage")
         if not isinstance(usage, dict):
             return None
-        out: dict[str, int] = {}
+        out: dict[str, Any] = {}
         for acp_key, omni_key in (
             ("inputTokens", "input_tokens"),
             ("outputTokens", "output_tokens"),
             ("totalTokens", "total_tokens"),
             ("cachedReadTokens", "cache_read_input_tokens"),
+            ("cachedWriteTokens", "cache_creation_input_tokens"),
         ):
             value = usage.get(acp_key)
             if isinstance(value, int) and not isinstance(value, bool):
                 out[omni_key] = value
         return out or None
+
+    def _usage_with_active_model(self, result: _AcpJsonObject) -> dict[str, Any] | None:
+        """Usage from the result, tagged with the active model for cost attribution.
+
+        ACP ``result.usage`` carries token counts but no model id, so the server
+        cannot attribute a turn's tokens to a model — leaving its per-model usage
+        view (``usage_by_model``) empty and the counts unrendered in the UI. Stamp
+        the agent's active model (its ``model`` config option, captured at
+        ``session/new``) so the tokens are attributed, mirroring how codex stamps
+        ``usage["model"]``. The stamp is skipped when the model is unknown or the
+        agent already reported one on the result.
+
+        :param result: The ACP ``session/prompt`` result object.
+        :returns: The usage dict (with ``model`` when known), or ``None``.
+        """
+        usage = self._usage_from_result(result)
+        if usage is not None and self._active_model and "model" not in usage:
+            usage["model"] = self._active_model
+        return usage
 
     def _is_bridge_tool_call(self, name: str, update: _AcpJsonObject) -> bool:
         """True when this tool call reaches Omnigent through the MCP bridge.
@@ -1570,7 +1597,7 @@ class AcpExecutor(Executor):
                     yield ExecutorError(message=error_msg, retryable=True)
                     return
                 result = response.get("result", {}) if isinstance(response, dict) else {}
-                usage = self._usage_from_result(result) if isinstance(result, dict) else None
+                usage = self._usage_with_active_model(result) if isinstance(result, dict) else None
                 yield TurnComplete(response="".join(accumulated_text), usage=usage)
                 return
 

--- a/tests/inner/test_acp_executor.py
+++ b/tests/inner/test_acp_executor.py
@@ -348,6 +348,71 @@ def test_usage_omits_absent_and_non_integer_fields() -> None:
     assert AcpExecutor._usage_from_result({}) is None
 
 
+def test_usage_maps_cached_writes_to_the_canonical_key() -> None:
+    """``cachedWriteTokens`` surfaces as ``cache_creation_input_tokens``.
+
+    Agents that report cache-creation tokens (e.g. jcode against a Databricks
+    gateway) had them silently dropped before, understating cost — cache writes
+    bill at ~1.25x the input rate.
+    """
+    usage = AcpExecutor._usage_from_result(
+        {
+            "usage": {
+                "inputTokens": 6216,
+                "outputTokens": 5,
+                "totalTokens": 6221,
+                "cachedReadTokens": 0,
+                "cachedWriteTokens": 128,
+            }
+        }
+    )
+    assert usage == {
+        "input_tokens": 6216,
+        "output_tokens": 5,
+        "total_tokens": 6221,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 128,
+    }
+
+
+def test_usage_with_active_model_tags_the_model() -> None:
+    """A turn's usage is stamped with the agent's active model.
+
+    ACP ``result.usage`` carries token counts but no model id, so the server
+    cannot attribute the tokens to a model — leaving its per-model usage view
+    (``usage_by_model``) empty and the UI showing no token counts for the ACP
+    (jcode / Devin / Grok) session. The active model comes from the agent's
+    ``model`` config option, captured at ``session/new``.
+
+    **What breaks if this fails**: token counts never render for any ACP harness.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._active_model = "system.ai.claude-haiku-4-5"
+    usage = ex._usage_with_active_model(
+        {"usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15}}
+    )
+    assert usage == {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "model": "system.ai.claude-haiku-4-5",
+    }
+
+
+def test_usage_with_active_model_skips_stamp_when_model_unknown() -> None:
+    """No active model → no ``model`` key (attribution simply stays absent)."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    assert ex._active_model is None
+    assert ex._usage_with_active_model({"usage": {"totalTokens": 15}}) == {"total_tokens": 15}
+
+
+def test_usage_with_active_model_is_none_when_no_usage_reported() -> None:
+    """No usage on the result → ``None`` (never a model-only dict)."""
+    ex = AcpExecutor(AcpAgentConfig(command="x"))
+    ex._active_model = "system.ai.claude-haiku-4-5"
+    assert ex._usage_with_active_model({}) is None
+
+
 def test_in_progress_tool_update_emits_nothing() -> None:
     ex = AcpExecutor(AcpAgentConfig(command="x"))
     ex._handle_session_update({"sessionUpdate": "tool_call", "toolCallId": "c3", "title": "t"})
@@ -1087,6 +1152,38 @@ def test_config_option_update_records_options_and_active_model() -> None:
     ex._handle_session_update(_model_option("swe-1-7-medium", "swe-1-7-medium", "gemini-3-1-pro"))
     assert ex._active_model == "swe-1-7-medium"
     assert "model" in ex._config_option_ids
+
+
+@pytest.mark.asyncio
+async def test_session_new_captures_advertised_model() -> None:
+    """A model advertised in ``session/new``'s config options sets ``_active_model``.
+
+    jcode (and others) report their model in the ``session/new`` result rather than
+    a later ``config_option_update``; capturing it at session creation is what lets
+    a turn's usage name the model, so the server can attribute per-model tokens.
+
+    **What breaks if this fails**: an ACP agent that only advertises its model in
+    ``session/new`` records no model → token counts don't render for the session.
+    """
+    ex = AcpExecutor(AcpAgentConfig(command="x", omnigent_mcp=False))
+
+    async def fake_rpc(method: str, params: dict, timeout: float | None = None) -> dict:
+        return {
+            "result": {
+                "sessionId": "s1",
+                "configOptions": [
+                    {
+                        "id": "model",
+                        "currentValue": "system.ai.claude-haiku-4-5",
+                        "options": [{"value": "system.ai.claude-haiku-4-5"}],
+                    }
+                ],
+            }
+        }
+
+    ex._rpc = fake_rpc  # type: ignore[assignment]
+    assert await ex._ensure_session() == "s1"
+    assert ex._active_model == "system.ai.claude-haiku-4-5"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Related issue

No filed issue — reported directly: a jcode (generic ACP) session ran fine but showed
**no token counts** in the web UI. Root-caused to a model-attribution gap that affects
every ACP harness (jcode, Devin, Grok, any `acp:<slug>`).

## Summary

<img width="363" height="503" alt="Screenshot 2026-09-09 at 3 22 13 PM" src="https://github.com/user-attachments/assets/6a4f3d59-4ed3-4ff4-ba0c-94af2eebc425" />


An ACP session showed no token counts in the agent-info popover even when the agent
reported usage. The popover renders the server's per-model usage view (`usage_by_model`),
which `_accumulate_session_usage` writes **only when it can attribute the turn's tokens to
a model** (`if llm_model:`). `llm_model` is resolved from `usage.model` first — but:

- ACP's `result.usage` carries token counts and **no model id**, and `_usage_from_result`
  mapped only the token keys (so `usage.model` was never set);
- `reported_model` is **claude-native-only** (set via the `external_model_change` event; the
  ACP path never emits it);
- `model_override` is set only on a manual `/model` switch;
- the seeded ACP picker agent has no spec `llm.model`.

So `llm_model` stayed empty, `by_model` was never written, and the popover had nothing to
render. (The *aggregate* token totals were recorded — it's the per-model view the UI shows
that stayed blank.)

**Fix.** Stamp the turn's usage with the agent's active model:

1. **Capture the model at `session/new`.** Process the agent's `model` config option from the
   `session/new` result into `_active_model`. jcode advertises its model there rather than in a
   later `config_option_update`, so without this it stayed unknown.
2. **Tag the usage.** New `_usage_with_active_model` stamps `usage["model"] = _active_model`,
   mirroring exactly how `codex_executor` stamps `usage["model"]`. It then flows through the
   existing scaffold → `_accumulate_session_usage` path to populate `usage_by_model`.

No UI change — the popover already renders `usage_by_model`; it just had nothing to render.
This fixes token display for **every** ACP harness at once. (Builtin Devin has the identical
gap, so it wouldn't reliably show per-model tokens either unless a model was manually picked.)

Also **stop dropping `cachedWriteTokens`**: `_usage_from_result` mapped `cachedReadTokens` but
not `cachedWriteTokens` (cache creation), understating cost on cache-heavy turns (cache writes
bill ~1.25x input) for any ACP agent that reports it.

**Out of scope:** cost in **dollars** still won't render for Databricks `system.ai.*` models —
that needs model pricing wired into the catalog path (separate follow-up, #4704). This PR is
about token counts.

## Test Plan

- `pytest tests/inner/test_acp_executor.py` → **111 passed** (5 new):
  - `..._usage_maps_cached_writes_to_the_canonical_key` — `cachedWriteTokens` →
    `cache_creation_input_tokens`.
  - `..._usage_with_active_model_tags_the_model` — usage is stamped with `_active_model`.
  - `..._usage_with_active_model_skips_stamp_when_model_unknown` — no model → no `model` key.
  - `..._usage_with_active_model_is_none_when_no_usage_reported` — no usage → `None`.
  - `..._session_new_captures_advertised_model` — the model in `session/new`'s config options
    sets `_active_model` (mocked `_rpc`).
- `pytest tests/runtime/test_acp_spawn_env.py tests/test_acp_cli_harnesses.py` → **42 passed**.
- `pre-commit` (ruff format, ruff check, pyrefly) clean on the changed files; `uv.lock` untouched.

## Demo

N/A — no frontend change. The agent-info popover already renders `usage_by_model`; this makes
the server populate it for ACP sessions. The executor half (config-option capture + usage
stamping) is unit-tested; it reaches the popover through the same scaffold → accumulation path
that already works for codex (which stamps `usage["model"]` identically). End-to-end UI
confirmation — a live ACP turn showing a token row in the popover — needs a deployed
server/runner (same limitation as prior ACP PRs).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification was of the diagnosis and the emitted shape, not the deployed UI: against a
live `jcode acp` (v0.84.0) routed through a Databricks gateway, the ACP `result.usage` was
confirmed to carry token counts but no model id, and the session's config option to carry the
model (`system.ai.claude-haiku-4-5`) — exactly the inputs this fix reads. The stamped
`usage["model"]` then follows the same `TurnComplete.usage` → `ctx.provider_usage` →
`_accumulate_session_usage` (`usage.model` branch) → `usage_by_model` path already exercised by
codex. What is **not** automated is the final browser check (a token row appearing in the
popover for a live ACP turn), which needs a deployed server + a live harness.

## Changelog

Token counts now show in the UI for ACP-based harness sessions (jcode, Devin, Grok, and any
`acp:<slug>` agent), attributed to the model the agent reports.
