### PR TITLE
feat(databricks-connect): wire the broker token into native Claude Code, opencode & the ucode bearer path

### DIFF
--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3113,6 +3113,23 @@ def _native_claude_config_from_entry(
 _BROKER_APIKEY_HELPER_TTL_MS = 900_000
 
 
+# A managed connect deployment can pin the gateway serving-endpoint model (e.g.
+# ``databricks-claude-sonnet-4-6``) so sessions default to a model the workspace
+# actually serves, rather than the bundled catalog default (which may name a
+# family the workspace has not deployed). Mirrors the opencode gateway env var.
+# Discovering the served model from the gateway is a follow-up cleanup.
+_DATABRICKS_GATEWAY_MODEL_ENV = "OMNIGENT_DATABRICKS_GATEWAY_MODEL"
+
+
+def _connect_broker_default_model() -> str:
+    """The model a managed connect session pins: the deployment override if set,
+    else the bundled Databricks Claude catalog default."""
+    pinned = os.environ.get(_DATABRICKS_GATEWAY_MODEL_ENV, "").strip()
+    if pinned:
+        return pinned
+    return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+
+
 def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
     """Gateway config for a managed host connected via the credential broker.
 
@@ -3160,7 +3177,7 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
             _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
         },
         api_key_helper=api_key_helper,
-        model=model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        model=_connect_broker_default_model(),
     )
 
 

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3107,6 +3107,63 @@ def _native_claude_config_from_entry(
     return None
 
 
+# Refresh cadence for the broker-backed apiKeyHelper on the managed connect
+# path. The broker vends a ~1h OAuth access token; re-mint well before expiry so
+# a long session never presents an expired bearer to the gateway.
+_BROKER_APIKEY_HELPER_TTL_MS = 900_000
+
+
+def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
+    """Gateway config for a managed host connected via the credential broker.
+
+    When the owner links Databricks through the connect flow, ``omnigent host``
+    writes a host-only ``[omnigent]`` ``~/.databrickscfg`` profile (workspace
+    host, no token), a broker sidecar, and exports ``DATABRICKS_CONFIG_PROFILE``
+    — but configures no ucode / spec / global-auth provider. Without this,
+    :func:`resolve_native_claude_config` finds nothing and native Claude Code
+    falls back to its own login, never reaching the owner's workspace gateway.
+
+    Bridge it: derive the gateway base URL from the profile's workspace host and
+    mint the bearer on demand from the broker
+    (:func:`omnigent.host.databricks_credential.broker_token_command`, which
+    re-fetches the server-refreshed token each call), so Claude Code auto-connects
+    to Databricks model serving as the owner and refreshes per the helper TTL.
+    Returns ``None`` off the managed connect path (profile is not the host connect
+    profile, or no broker sidecar is present).
+    """
+    from omnigent.host.databricks_credential import (
+        HOST_DATABRICKS_PROFILE,
+        broker_token_command,
+    )
+    from omnigent.inner.databricks_executor import _read_databrickscfg_host
+
+    # Gate on the on-disk [omnigent] profile + broker sidecar, NOT on the
+    # ``DATABRICKS_CONFIG_PROFILE`` env var: that var is deliberately stripped
+    # from the runner/terminal process (a set profile makes MCP WorkspaceClients
+    # prefer its cached OAuth over their own token), so keying off it misses the
+    # very process that builds the Claude terminal. The host-only profile +
+    # sidecar that ``configure_host_databricks`` writes are the reliable
+    # managed-connect signal and survive that strip. The host-only profile holds
+    # no token, so it can't reintroduce the MCP collision the strip prevents.
+    workspace_host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+    if not workspace_host:
+        return None
+    api_key_helper = broker_token_command(workspace_host)
+    if not api_key_helper:
+        return None  # no broker sidecar → not a managed connect host
+    workspace_host = workspace_host.rstrip("/")
+    return ClaudeNativeUcodeConfig(
+        env={
+            _UCODE_CLAUDE_BASE_URL_ENV: f"{workspace_host}/ai-gateway/anthropic",
+            _CLAUDE_CODE_API_KEY_HELPER_TTL_ENV: str(_BROKER_APIKEY_HELPER_TTL_MS),
+            _CLAUDE_CODE_USE_GATEWAY_ENV: "1",
+            _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
+        },
+        api_key_helper=api_key_helper,
+        model=model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+    )
+
+
 def resolve_native_claude_config(
     *,
     spec: AgentSpec | None,
@@ -3155,26 +3212,45 @@ def resolve_native_claude_config(
         entry = _resolve_provider_for_build(spec, harness_type="claude-sdk")
         if entry is not None:
             return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
-        return _ucode_config_for_profile(spec.executor.profile, refresh_models=refresh_models)
-
-    # 2. Spec-less (omnigent claude): explicit default wins first.
-    explicit = load_config()
-    entry = default_provider_for_harness(explicit, "claude-sdk")
-    if entry is not None:
-        return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
-    # A global databricks auth block → ucode.
-    global_auth = _load_global_auth()
-    if isinstance(global_auth, DatabricksAuth):
-        return _ucode_config_for_profile(global_auth.profile, refresh_models=refresh_models)
-    if global_auth is not None:
-        # A global api_key auth: let Claude's own login handle it (parity
-        # with the subscription path); the in-process harness would inject
-        # it, but the native CLI uses its configured account.
-        return None
-    # 3. Ambient detection (first run without configure).
-    entry = default_provider_for_harness(effective_config_with_detected(explicit), "claude-sdk")
-    if entry is not None:
-        return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
+        ucode_config = _ucode_config_for_profile(
+            spec.executor.profile, refresh_models=refresh_models
+        )
+        if ucode_config is not None:
+            return ucode_config
+        # The spec named no provider and no usable ucode profile — fall through to
+        # the managed-connect-host broker fallback (step 4) rather than giving up.
+    else:
+        # 2. Spec-less (omnigent claude): explicit default wins first.
+        explicit = load_config()
+        entry = default_provider_for_harness(explicit, "claude-sdk")
+        if entry is not None:
+            return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
+        # A global databricks auth block → ucode.
+        global_auth = _load_global_auth()
+        if isinstance(global_auth, DatabricksAuth):
+            return _ucode_config_for_profile(global_auth.profile, refresh_models=refresh_models)
+        if global_auth is not None:
+            # A global api_key auth: let Claude's own login handle it (parity
+            # with the subscription path); the in-process harness would inject
+            # it, but the native CLI uses its configured account.
+            return None
+        # 3. Ambient detection (first run without configure).
+        entry = default_provider_for_harness(
+            effective_config_with_detected(explicit), "claude-sdk"
+        )
+        if entry is not None:
+            return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
+    # 4. Managed connect host: no provider config, but the host linked Databricks
+    #    via the connect flow (host-only [omnigent] profile + broker sidecar).
+    #    Route Claude Code through the owner's gateway, minting via the broker.
+    broker_config = _connect_broker_claude_config()
+    if broker_config is not None:
+        log_info_once(
+            _logger,
+            "native-claude routing: managed connect host — Databricks AI gateway via the "
+            "credential broker (host-only [omnigent] profile + broker sidecar).",
+        )
+        return broker_config
     log_info_once(
         _logger,
         "native-claude routing: Claude CLI login (no provider configured for the Claude "

--- a/omnigent/harnesses/opencode_native/provider.py
+++ b/omnigent/harnesses/opencode_native/provider.py
@@ -41,6 +41,11 @@ DATABRICKS_GATEWAY_PROVIDER_ID = "databricks-gateway"
 DATABRICKS_GATEWAY_PROVIDER_NAME = "Databricks AI Gateway"
 # Endpoint that exposes the workspace's OpenAI-compatible chat completions.
 _SERVING_ENDPOINTS_PATH = "serving-endpoints"
+# Optional deployment default: a ``databricks-*`` serving-endpoint id used when a
+# session pins no compatible model. Unset falls back to the Databricks Claude
+# catalog. Set it in the runner env to steer every session at one endpoint
+# (e.g. ``databricks-kimi-k3``).
+DATABRICKS_GATEWAY_DEFAULT_MODEL_ENV_VAR = "OMNIGENT_DATABRICKS_GATEWAY_MODEL"
 
 
 @dataclass(frozen=True)
@@ -51,6 +56,9 @@ class OpenCodeGatewayResolution:
         ``"https://ws.cloud.databricks.com/serving-endpoints"``.
     :param api_key: Bearer token / API key for the gateway.
     :param model_id: The endpoint/model id, e.g. ``"databricks-claude-sonnet-4-6"``.
+    :param model_ids: Every serving-endpoint the gateway can route to, so opencode's
+        in-session model picker lists them all. ``model_id`` stays the pinned launch
+        default. Empty falls back to just ``model_id``.
     :param provider_id: opencode provider id, e.g. ``"databricks-gateway"``.
     :param provider_name: Human label for the opencode provider block.
     """
@@ -58,6 +66,7 @@ class OpenCodeGatewayResolution:
     base_url: str
     api_key: str
     model_id: str
+    model_ids: tuple[str, ...] = ()
     provider_id: str = DATABRICKS_GATEWAY_PROVIDER_ID
     provider_name: str = DATABRICKS_GATEWAY_PROVIDER_NAME
 
@@ -102,7 +111,9 @@ def build_opencode_provider_config(resolution: OpenCodeGatewayResolution) -> dic
                     "baseURL": resolution.base_url,
                     "apiKey": resolution.api_key,
                 },
-                "models": {resolution.model_id: {"name": resolution.model_id}},
+                "models": {
+                    mid: {"name": mid} for mid in (resolution.model_ids or (resolution.model_id,))
+                },
             }
         },
     }
@@ -314,14 +325,54 @@ def resolve_databricks_gateway(
 
     resolved_model = _gateway_endpoint_for_model(model_id)
     if resolved_model is None:
+        resolved_model = _gateway_endpoint_for_model(
+            os.environ.get(DATABRICKS_GATEWAY_DEFAULT_MODEL_ENV_VAR)
+        )
+    if resolved_model is None:
         resolved_model = model_catalog.resolve_catalog_model(
             "databricks", family="claude"
         ).model_id
+    # List every chat serving-endpoint so opencode's picker offers them all,
+    # with the pinned default first. Best-effort: a failure leaves just the
+    # default (dict.fromkeys de-dupes if the default is also discovered).
+    model_ids = tuple(dict.fromkeys((resolved_model, *_list_gateway_models(config))))
     return OpenCodeGatewayResolution(
         base_url=f"{host}/{_SERVING_ENDPOINTS_PATH}",
         api_key=token,
         model_id=resolved_model,
+        model_ids=model_ids,
     )
+
+
+def _list_gateway_models(config: object) -> tuple[str, ...]:
+    """
+    List the workspace's chat-capable ``databricks-*`` serving endpoints.
+
+    Reuses the already-authenticated SDK *config* so it shares the gateway's
+    auth. Best-effort: any failure (SDK absent, list denied) returns ``()`` and
+    the caller falls back to the single pinned model. Embedding/rerank endpoints
+    are dropped so the model picker only lists chat models.
+
+    :param config: A ``databricks.sdk.core.Config`` for the gateway workspace.
+    :returns: Endpoint names, e.g. ``("databricks-kimi-k3", ...)``.
+    """
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        client = WorkspaceClient(config=config)
+        ids: list[str] = []
+        for endpoint in client.serving_endpoints.list():
+            name = getattr(endpoint, "name", "") or ""
+            if not name.startswith("databricks-"):
+                continue
+            task = (getattr(endpoint, "task", "") or "").lower()
+            if "embed" in task or "rerank" in task:
+                continue
+            ids.append(name)
+        return tuple(ids)
+    except Exception as exc:  # noqa: BLE001 - SDK absent / list denied / bad shape.
+        _logger.info("opencode Databricks gateway model list failed: %r", exc)
+        return ()
 
 
 def _gateway_endpoint_for_model(model_id: str | None) -> str | None:

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -284,6 +284,18 @@ def databricks_bearer_token_command(
         run only when the profile above yields an empty token.
     :returns: Shell command that prints a bearer token on stdout.
     """
+    # In a managed connect sandbox the owner's workspace profile is host-only
+    # (its bearer lives in the credential broker, not on disk), so
+    # ``databricks auth token`` finds no OAuth cache and yields nothing. When the
+    # caller named no other fallback and *host* is that connected workspace,
+    # default it to the broker fetch so the harness re-mints per use as them.
+    if fallback_command is None:
+        try:
+            from omnigent.host.databricks_credential import broker_token_command
+
+            fallback_command = broker_token_command(host)
+        except Exception:  # noqa: BLE001 - best-effort; no sidecar ⇒ no fallback.
+            pass
     selector = (
         f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
     )

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1737,16 +1737,19 @@ def _opencode_native_profile_from_spec(
     Resolve the Databricks profile from a resolved agent spec, if any.
 
     :param agent_spec: Optional resolved agent spec.
-    :returns: The spec's ``executor.config.profile``, or ``None``.
+    :returns: The spec's ``executor.config.profile``, else the ambient
+        ``DATABRICKS_CONFIG_PROFILE`` (set by the host when the owner linked
+        Databricks), or ``None``.
     """
+    env_profile = os.environ.get("DATABRICKS_CONFIG_PROFILE") or None
     if agent_spec is None:
-        return None
+        return env_profile
     try:
         spec = agent_spec.spec if isinstance(agent_spec, ResolvedSpec) else agent_spec
         profile = spec.executor.config.get("profile")
-        return str(profile) if profile else None
+        return str(profile) if profile else env_profile
     except Exception:  # noqa: BLE001 - profile resolution is best effort.
-        return None
+        return env_profile
 
 
 def _opencode_native_mcp_servers_from_spec(

--- a/tests/inner/test_databricks_auth_command.py
+++ b/tests/inner/test_databricks_auth_command.py
@@ -253,3 +253,67 @@ def test_without_a_recorded_command_an_unauthenticated_profile_stays_empty(
         )
         == ""
     )
+
+
+def _write_broker_sidecar(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, workspace_host: str):
+    """Point the config file at *tmp_path* and drop a broker sidecar for *workspace_host*."""
+    from omnigent.host import databricks_credential as dc
+
+    cfg_path = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    assert dc._write_sidecar(
+        cfg_path, "https://omni.example", "host-1", "host-tok", workspace_host
+    )
+
+
+def test_the_broker_sidecar_becomes_the_fallback_for_the_connected_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """In a connect sandbox, the host-only profile delegates its mint to the broker."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    _write_broker_sidecar(monkeypatch, tmp_path, "https://example.databricks.com")
+    command = databricks_bearer_token_command("https://example.databricks.com", "omnigent")
+    assert "python3 -m omnigent.host.databricks_credential token" in command
+
+
+def test_the_broker_sidecar_is_ignored_for_a_different_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A gateway pinned to a spec's own workspace must not borrow the broker token."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    _write_broker_sidecar(monkeypatch, tmp_path, "https://connected.databricks.com")
+    command = databricks_bearer_token_command("https://other.databricks.com", "myprofile")
+    assert "omnigent.host.databricks_credential" not in command
+
+
+def test_an_explicit_fallback_is_not_overridden_by_the_broker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A caller-supplied fallback (e.g. ucode's) wins over the broker default."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    _write_broker_sidecar(monkeypatch, tmp_path, "https://example.databricks.com")
+    command = databricks_bearer_token_command(
+        "https://example.databricks.com", "omnigent", fallback_command="ucode-token"
+    )
+    assert "omnigent.host.databricks_credential" not in command
+    assert "ucode-token" in command
+
+
+def test_no_sidecar_leaves_the_command_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Non-regression: with NO broker sidecar (a normal user with their own
+    Databricks profile, not a managed connect sandbox), the broker fallback adds
+    nothing — the command has no broker reference and no eval-fallback clause,
+    i.e. it is identical to the pre-change behaviour."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(tmp_path / ".databrickscfg"))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    cmd = databricks_bearer_token_command("https://example.databricks.com", "myprofile")
+    assert "omnigent.host.databricks_credential" not in cmd
+    # The eval-fallback clause is emitted ONLY when a fallback command is set.
+    assert "eval" not in cmd

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -10994,6 +10994,29 @@ def test_resolve_native_claude_config_connect_broker_fallback(
     assert config.model == "catalog-databricks-claude-default"
 
 
+def test_connect_fallback_pins_deployment_gateway_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deployment can pin the served gateway model via
+    OMNIGENT_DATABRICKS_GATEWAY_MODEL so managed sessions default to a model the
+    workspace actually serves, rather than the bundled catalog default."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "databricks-claude-sonnet-4-6")
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    # The deployment override wins over the (stubbed) catalog default.
+    assert config.model == "databricks-claude-sonnet-4-6"
+
+
 def test_resolve_native_claude_config_declines_without_broker_sidecar(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -10954,3 +10954,121 @@ async def test_claude_model_catalog_keeps_canonical_ids_without_ambient_gateway(
     # Both canonical models should be present
     assert [row["id"] for row in rows] == ["sonnet", "opus"]
     assert rows[1]["isDefault"] is True
+
+
+def _isolate_to_connect_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the spec-less resolution reach the connect-broker fallback: no explicit
+    default, no global auth, no ambient-detected provider."""
+    monkeypatch.setattr(
+        "omnigent.onboarding.provider_config.default_provider_for_harness",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr("omnigent.runtime.workflow._load_global_auth", lambda: None)
+    monkeypatch.setattr(
+        "omnigent.onboarding.detected.effective_config_with_detected", lambda cfg: cfg
+    )
+
+
+def test_resolve_native_claude_config_connect_broker_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A managed connect host (host-only [omnigent] profile + broker sidecar) routes
+    native Claude Code through the workspace gateway with a broker-minted apiKeyHelper."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/ai-gateway/anthropic"
+    assert config.env["CLAUDE_CODE_USE_GATEWAY"] == "1"
+    assert config.api_key_helper is not None
+    assert "omnigent.host.databricks_credential token" in config.api_key_helper
+    # Model comes from the catalog default (stubbed by _stub_catalog_default).
+    assert config.model == "catalog-databricks-claude-default"
+
+
+def test_resolve_native_claude_config_declines_without_broker_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A host-only profile with NO broker sidecar is not a managed connect host: the
+    fallback declines and Claude Code uses its own login (returns None)."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")  # profile but no sidecar
+
+    assert claude_native.resolve_native_claude_config(spec=None, refresh_models=False) is None
+
+
+def test_configured_provider_wins_over_connect_broker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ordering non-regression: the connect-broker fallback is the LAST resort. A
+    configured provider (spec / explicit default / global auth / ambient) wins even
+    when a broker sidecar is present, so a normal Claude harness is never overridden."""
+    sentinel = claude_native.ClaudeNativeUcodeConfig(env={"MARK": "configured-provider"})
+    # Step-2 explicit-default returns an entry → its config is used, short-circuiting.
+    monkeypatch.setattr(
+        "omnigent.onboarding.provider_config.default_provider_for_harness",
+        lambda cfg, harness: object(),
+    )
+    monkeypatch.setattr(
+        claude_native,
+        "_native_claude_config_from_entry",
+        lambda entry, *, refresh_models: sentinel,
+    )
+    # A broker sidecar IS present, but must be ignored (a provider is configured).
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "tok", "https://ws.example")
+
+    result = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+    assert result is sentinel  # configured provider wins; broker fallback not consulted
+
+
+def test_resolve_native_claude_config_spec_path_reaches_connect_broker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The runner resolves with a spec (spec is not None). When that spec names no
+    provider and no usable ucode profile, resolution must still fall through to the
+    managed-connect-host broker fallback — not return None (which leaves Claude Code
+    'not logged in' on the real product path)."""
+    from types import SimpleNamespace
+
+    # Spec routes to no provider and carries no ucode profile.
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build", lambda spec, harness_type: None
+    )
+    monkeypatch.setattr(
+        claude_native, "_ucode_config_for_profile", lambda profile, *, refresh_models: None
+    )
+    spec = SimpleNamespace(executor=SimpleNamespace(profile=None))
+
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    config = claude_native.resolve_native_claude_config(spec=spec, refresh_models=False)
+    assert config is not None
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/ai-gateway/anthropic"
+    assert (
+        config.api_key_helper
+        and "omnigent.host.databricks_credential token" in config.api_key_helper
+    )

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -154,7 +154,13 @@ def test_resolve_gateway_none_when_sdk_absent(monkeypatch: pytest.MonkeyPatch) -
     assert resolve_databricks_gateway("oss") is None
 
 
-def _install_fake_sdk(monkeypatch: pytest.MonkeyPatch, *, host: str, token: str | None) -> None:
+def _install_fake_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    host: str,
+    token: str | None,
+    endpoints: list[tuple[str, str]] | None = None,
+) -> None:
     fake = types.ModuleType("databricks.sdk.core")
 
     class _Config:
@@ -166,9 +172,24 @@ def _install_fake_sdk(monkeypatch: pytest.MonkeyPatch, *, host: str, token: str 
             return {"Authorization": f"Bearer {token}"} if token else {}
 
     fake.Config = _Config  # type: ignore[attr-defined]
+    sdk = types.ModuleType("databricks.sdk")
+    # Only expose WorkspaceClient (used for serving-endpoint discovery) when the
+    # test supplies endpoints; otherwise the import fails and discovery no-ops.
+    if endpoints is not None:
+
+        class _WorkspaceClient:
+            def __init__(self, *, config: object) -> None:
+                self._config = config
+
+            @property
+            def serving_endpoints(self) -> object:
+                eps = [types.SimpleNamespace(name=n, task=t) for n, t in endpoints]
+                return types.SimpleNamespace(list=lambda: eps)
+
+        sdk.WorkspaceClient = _WorkspaceClient  # type: ignore[attr-defined]
     # Ensure parent packages resolve for the dotted import.
     monkeypatch.setitem(sys.modules, "databricks", types.ModuleType("databricks"))
-    monkeypatch.setitem(sys.modules, "databricks.sdk", types.ModuleType("databricks.sdk"))
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk)
     monkeypatch.setitem(sys.modules, "databricks.sdk.core", fake)
 
 
@@ -192,6 +213,69 @@ def test_resolve_gateway_defaults_non_gateway_model(monkeypatch: pytest.MonkeyPa
 def test_resolve_gateway_none_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token=None)
     assert resolve_databricks_gateway("oss") is None
+
+
+def test_resolve_gateway_lists_all_chat_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Discovery lists every chat serving-endpoint (pinned default first, embeddings
+    # dropped) so opencode's in-session picker offers them all.
+    _install_fake_sdk(
+        monkeypatch,
+        host="https://ws.databricks.com",
+        token="t",
+        endpoints=[
+            ("databricks-kimi-k3", "llm/v1/chat"),
+            ("databricks-claude-sonnet-4-6", "llm/v1/chat"),
+            ("databricks-gte-large-en", "llm/v1/embeddings"),
+            ("some-other-endpoint", "llm/v1/chat"),
+        ],
+    )
+    res = resolve_databricks_gateway("oss", model_id="databricks-claude-sonnet-4-6")
+    assert res is not None
+    # pinned default first, embeddings + non-databricks dropped, de-duped
+    assert res.model_ids == ("databricks-claude-sonnet-4-6", "databricks-kimi-k3")
+    cfg = build_opencode_provider_config(res)
+    models = cfg["provider"]["databricks-gateway"]["models"]  # type: ignore[index]
+    assert set(models) == {"databricks-claude-sonnet-4-6", "databricks-kimi-k3"}
+
+
+def test_resolve_gateway_single_model_when_discovery_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No WorkspaceClient (endpoints=None) -> discovery no-ops, just the pinned model.
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    res = resolve_databricks_gateway("oss", model_id="databricks-kimi-k3")
+    assert res is not None
+    assert res.model_ids == ("databricks-kimi-k3",)
+
+
+def test_resolve_gateway_env_default_applies(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No session model pinned -> the deployment env default steers the endpoint.
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "databricks-kimi-k3")
+    res = resolve_databricks_gateway("oss")
+    assert res is not None
+    assert res.model_id == "databricks-kimi-k3"
+
+
+def test_resolve_gateway_session_model_beats_env_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "databricks-kimi-k3")
+    res = resolve_databricks_gateway("oss", model_id="databricks-gpt-5-5")
+    assert res is not None
+    assert res.model_id == "databricks-gpt-5-5"
+
+
+def test_resolve_gateway_env_default_ignored_when_not_gateway_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A non ``databricks-*`` env value is not a routable endpoint -> catalog wins.
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "kimi-k3")
+    res = resolve_databricks_gateway("oss")
+    assert res is not None
+    assert res.model_id == "catalog-databricks-claude-default"
 
 
 def test_build_mcp_block_stdio_and_http() -> None:


### PR DESCRIPTION
## Related issue

Follows **#6382** (per-user Databricks Connect — **merged**), which delivered the connector + broker + the standalone command to mint a per-user Databricks token inside a sandbox. Together with the merged connector, this PR **supersedes #5203** — Luka's opencode work is ported here, so #5203 can be closed.

## Summary

#6382 delivers the connector + the standalone token command. **This PR wires that command into the harnesses** so a linked workspace "just works" for model serving.

- **Generic bearer command** (`omnigent/inner/databricks_executor.py`) — in a managed connect sandbox the profile is host-only, so `databricks_bearer_token_command` defaults to the broker fetch (`broker_token_command`); **codex / claude (ucode) / pi** re-mint per use as the owner instead of reading a static token. *(This is the shared consumer that #6382's command was designed for.)*
- **Native Claude Code** (`harnesses/claude_native/main.py`) — `resolve_native_claude_config` gains a last-resort managed-connect-host fallback that routes Claude Code through the owner's workspace AI gateway (`ANTHROPIC_BASE_URL` + `CLAUDE_CODE_USE_GATEWAY`) with a broker-minted `apiKeyHelper`. Reached from **both** the spec-driven (runner / web chat) and spec-less (`omnigent claude`) paths — the earlier version only handled spec-less, so the real product path fell through to `None` ("Not logged in"). The pinned model honors **`OMNIGENT_DATABRICKS_GATEWAY_MODEL`** so a deployment can default sessions to a model the workspace actually serves, instead of a bundled catalog default it may not have deployed.
- **opencode** (`harnesses/opencode_native/provider.py`, `runner/native/orchestration.py`) — resolve the gateway profile from `DATABRICKS_CONFIG_PROFILE`; list all chat-capable `databricks-*` serving endpoints in the model picker; and make the gateway default model configurable via `OMNIGENT_DATABRICKS_GATEWAY_MODEL`. *(Ported from Luka's #5203 opencode commits onto main's `opencode_native` package.)*

> Full served-model **discovery** from the gateway (so no env var is needed) is deferred to the planned holistic gateway-setup cleanup across harnesses.

## Test Plan

- **Unit** (`uv run --group test pytest`): `tests/inner/test_databricks_auth_command.py` (broker backstop), `tests/test_claude_native.py` (connect-broker fallback on both paths, spec-path regression, the `OMNIGENT_DATABRICKS_GATEWAY_MODEL` override, declines-without-sidecar), `tests/test_opencode_native_provider.py` (endpoint listing, configurable default, session-model priority) — 440 pass with a clean env.
- **Live** (agent_sandbox pod, local server with #6382's connector): a runner-launched Claude Code session came up on the Databricks gateway (process env carried `ANTHROPIC_BASE_URL=…/ai-gateway/anthropic`, `CLAUDE_CODE_USE_GATEWAY=1`, and the broker `apiKeyHelper`), and a real coding turn **cloned a private GitHub repo (GitHub broker) and ran inference through the Databricks gateway (Databricks broker) in one turn** — both per-user tokens off a single launch token. Token refresh verified by forcing expiry (mint rotated, serving continued).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified end-to-end in an agent_sandbox pod against a live Databricks workspace (see Test Plan): the runner-launched Claude Code connected through the gateway with a broker-minted key and completed a coding turn using both the Databricks and GitHub per-user tokens; token refresh was exercised by forcing expiry. Unit tests cover the resolution logic on both paths, the ucode bearer fallback, the gateway-model override, and the opencode endpoint listing / configurable default.

## Changelog

Native Claude Code, opencode, and the codex/pi bearer path now automatically use a connected user's per-user Databricks token (via the credential broker) when running in a managed sandbox, so a linked workspace works for model serving without a static token on disk.

---
This pull request and its description were written by Isaac.
