### PR TITLE
Add --project to omnigent import to file chats into a named project

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -6241,12 +6241,21 @@ class _SessionImportResult:
     is_flag=True,
     help="Replace a previously imported chat from the same harness session.",
 )
+@click.option(
+    "--project",
+    "project_name",
+    default=None,
+    metavar="NAME",
+    help="File the imported chat(s) into a project of this name, creating it if "
+    "one you own does not already exist.",
+)
 def import_session_command(
     harness: str,
     source_session_id: str | None,
     recent_session_count: int | None,
     server: str | None,
     force: bool,
+    project_name: str | None,
 ) -> None:
     """Import chats from supported local coding harnesses.
 
@@ -6265,6 +6274,7 @@ def import_session_command(
       omnigent import --harness qwen --session <session-id>
       omnigent import --harness claude --last 10
       omnigent import --harness claude --session <session-id> --force
+      omnigent import --harness claude --last 10 --project "Migrated chats"
     """
     import httpx
 
@@ -6337,6 +6347,7 @@ def import_session_command(
             "external_session_id": imported.external_session_id,
             "workspace": imported.workspace,
             "title": imported.native_title,
+            "project_name": project_name,
             "force": force,
             "items": [
                 {

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -134,6 +134,9 @@ class LocalImportRequest(BaseModel):
     source: ImportSource | Literal["all"]
     limit: int = Field(default=10, ge=1, le=100)
     session_id: str | None = Field(default=None, min_length=1, max_length=128)
+    # File every session in this batch into the caller's project of this name,
+    # find-or-created (same semantics as /imports project_name).
+    project_name: str | None = Field(default=None, max_length=100)
 
     @field_validator("session_id")
     @classmethod
@@ -547,6 +550,9 @@ def create_imports_router(
         counts["imported"] = 0
         counts["already_imported"] = 0
         counts["failed"] = 0
+        # Resolve the batch's target project once; every imported session in the
+        # batch is filed into it.
+        project_id = await _resolve_project(project_name=body.project_name, user_id=user_id)
         # Set by the stream to the count of sessions the host couldn't read (no
         # frame arrives for them); folded into ``failed`` after the loop.
         stats: dict[str, int] = {}
@@ -599,6 +605,7 @@ def create_imports_router(
                     workspace=workspace if isinstance(workspace, str) else None,
                     user_id=user_id,
                     native_title=native_title if isinstance(native_title, str) else None,
+                    project_id=project_id,
                     host_id=body.host_id,
                 )
             except (OmnigentError, ValueError):

--- a/omnigent/server/routes/imports.py
+++ b/omnigent/server/routes/imports.py
@@ -8,6 +8,7 @@ import json
 import logging
 import secrets
 import threading
+import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Literal, cast, get_args
@@ -85,7 +86,9 @@ class ImportSessionRequest(BaseModel):
 
     ``project_id`` files the imported session into a first-class project the
     caller owns, with the same ownership, default-fill, and mismatch-warning
-    semantics as ``POST /v1/sessions``.
+    semantics as ``POST /v1/sessions``. ``project_name`` is the by-name
+    alternative: the caller's project of that name, find-or-created; ignored
+    when ``project_id`` is set.
     """
 
     source: ImportSource
@@ -94,6 +97,7 @@ class ImportSessionRequest(BaseModel):
     title: str | None = Field(default=None, max_length=512)
     force: bool = False
     project_id: str | None = None
+    project_name: str | None = Field(default=None, max_length=100)
     items: list[ImportItemInput] = Field(min_length=1, max_length=_MAX_IMPORT_ITEMS)
 
     @field_validator("external_session_id")
@@ -403,6 +407,39 @@ def create_imports_router(
             raise
         return conversation.id, title
 
+    async def _resolve_project(*, project_name: str | None, user_id: str | None) -> str | None:
+        """Find, or create, a project of this name owned by the caller.
+
+        Returns the project id to file an imported session under, or ``None``
+        when there is no name to resolve, projects aren't available, or the
+        caller is unauthenticated (a project needs an owner). Names are unique
+        per owner but only via a store-side pre-check, so a concurrent create
+        can lose the race with ``ALREADY_EXISTS`` — that just means the project
+        now exists, so re-read and reuse it.
+        """
+        name = (project_name or "").strip()
+        if not name or project_store is None or user_id is None:
+            return None
+
+        def _find() -> str | None:
+            for proj in project_store.list(user_id=user_id):
+                if proj.name == name:
+                    return proj.id
+            return None
+
+        existing = await asyncio.to_thread(_find)
+        if existing is not None:
+            return existing
+        try:
+            created = await asyncio.to_thread(
+                project_store.create, uuid.uuid4().hex, name, user_id, None
+            )
+            return created.id
+        except OmnigentError as exc:
+            if exc.code != ErrorCode.ALREADY_EXISTS:
+                raise
+            return await asyncio.to_thread(_find)
+
     @router.post(
         "/imports",
         response_model=ImportSessionResponse,
@@ -441,6 +478,11 @@ def create_imports_router(
         if existing is not None:
             await conversation_store.delete_conversation(existing.id)
 
+        # An explicit project_id wins; otherwise file under the named project
+        # (find-or-created).
+        project_id = body.project_id or await _resolve_project(
+            project_name=body.project_name, user_id=user_id
+        )
         session_id, _title = await _persist_import(
             source=body.source,
             external_session_id=body.external_session_id,
@@ -448,7 +490,7 @@ def create_imports_router(
             workspace=body.workspace,
             user_id=user_id,
             native_title=body.title,
-            project_id=body.project_id,
+            project_id=project_id,
         )
 
         response.status_code = 201

--- a/tests/cli/test_import.py
+++ b/tests/cli/test_import.py
@@ -76,6 +76,7 @@ def test_import_command_loads_local_session_and_posts_normalized_items(tmp_path:
         "external_session_id": session_id,
         "workspace": "/repo",
         "title": None,
+        "project_name": None,
         "force": False,
         "items": [
             {
@@ -112,6 +113,37 @@ def test_import_command_sends_force_override(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert json.loads(route.calls.last.request.content)["force"] is True
     assert "conv_replaced" in result.output
+
+
+@respx.mock
+def test_import_command_sends_project_name(tmp_path: Path) -> None:
+    """--project asks the server to file the import into a named project."""
+    session_id = "a1b2c3d4-1234-5678-9abc-def012345680"
+    _write_claude_transcript(tmp_path, session_id, text="hello")
+    route = respx.post(f"{_BASE}/v1/imports").mock(
+        return_value=httpx.Response(
+            201,
+            json={"session_id": "conv_projected", "status": "imported", "item_count": 1},
+        )
+    )
+
+    with patch("omnigent.cli._resolve_attach_server", return_value=_BASE):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "import",
+                "--harness",
+                "claude",
+                "--session",
+                session_id,
+                "--project",
+                "Migrated chats",
+            ],
+            env={"HOME": str(tmp_path)},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(route.calls.last.request.content)["project_name"] == "Migrated chats"
 
 
 def test_import_command_rejects_cursor() -> None:

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -569,6 +569,74 @@ async def test_local_import_binds_session_to_importing_host(
     assert unbound.workspace is None
 
 
+async def test_local_import_files_batch_into_named_project(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``project_name`` on a host-mediated import files every session in the
+    batch into one find-or-created project."""
+    from fastapi import FastAPI
+
+    from omnigent.server.routes import imports as imports_module
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+
+    _seed_claude_agent(db_uri)
+    conversation_store = SqlAlchemyConversationStore(db_uri)
+    project_store = SqlAlchemyProjectStore(db_uri)
+
+    async def _fake_stream(**_kwargs: object):
+        for sid in ("host-proj-1", "host-proj-2"):
+            yield {
+                "external_session_id": sid,
+                "workspace": None,
+                "items": [_import_item()],
+                "title": sid,
+                "source": "claude",
+            }
+
+    monkeypatch.setattr(imports_module, "_stream_local_sessions_from_host", _fake_stream)
+    monkeypatch.setattr(imports_module, "require_user", lambda request, auth_provider: "user-test")
+
+    host_conn = SimpleNamespace(
+        host_id="host_0123456789abcdef0123456789abcdef", pending_import_local={}
+    )
+    host_registry = SimpleNamespace(get=lambda host_id: host_conn)
+    host_store = SimpleNamespace(get_host=lambda host_id: SimpleNamespace(user_id="user-test"))
+
+    app = FastAPI()
+    app.include_router(
+        imports_module.create_imports_router(
+            conversation_store,
+            SqlAlchemyAgentStore(db_uri),
+            project_store=project_store,
+            host_registry=host_registry,  # type: ignore[arg-type]
+            host_store=host_store,  # type: ignore[arg-type]
+        ),
+        prefix="/v1",
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.post(
+            "/v1/imports/local",
+            json={
+                "host_id": "host_0123456789abcdef0123456789abcdef",
+                "source": "claude",
+                "limit": 5,
+                "project_name": "Host batch",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["imported"] == 2
+    named = [p for p in project_store.list(user_id="user-test") if p.name == "Host batch"]
+    assert len(named) == 1
+    project_id = named[0].id
+    for sid in ("host-proj-1", "host-proj-2"):
+        conv = conversation_store.find_imported_conversation("claude", sid)
+        assert conv is not None and conv.project_id == project_id
+
+
 async def test_local_import_stream_emits_ndjson_session_then_done(
     db_uri: str,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/routes/test_imports.py
+++ b/tests/server/routes/test_imports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from types import SimpleNamespace
@@ -119,6 +120,101 @@ async def test_import_session_uses_native_title_when_supplied(
     )
     assert conversation is not None
     assert conversation.title == "My renamed thread"
+
+
+def _import_item(text: str = "hi") -> dict:
+    return {
+        "type": "message",
+        "response_id": "claude:turn-1",
+        "data": {"role": "user", "content": [{"type": "input_text", "text": text}]},
+    }
+
+
+@contextlib.asynccontextmanager
+async def _authed_imports_client(
+    db_uri: str, monkeypatch: pytest.MonkeyPatch, *, user_id: str = "user-test"
+):
+    """An imports-router client whose caller is a fixed authenticated user.
+
+    ``project_name`` needs an owner for the created project, so the shared
+    no-auth ``client`` fixture (user ``None``) can't exercise it — pin a user by
+    monkeypatching ``require_user`` and wire a real project store.
+    """
+    from fastapi import FastAPI
+
+    from omnigent.server.routes import imports as imports_module
+    from omnigent.stores.project_store.sqlalchemy_store import SqlAlchemyProjectStore
+
+    project_store = SqlAlchemyProjectStore(db_uri)
+    monkeypatch.setattr(imports_module, "require_user", lambda request, auth_provider: user_id)
+    app = FastAPI()
+    app.include_router(
+        imports_module.create_imports_router(
+            SqlAlchemyConversationStore(db_uri),
+            SqlAlchemyAgentStore(db_uri),
+            project_store=project_store,
+        ),
+        prefix="/v1",
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, project_store
+
+
+async def test_import_session_files_into_named_project(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``project_name`` find-or-creates a project and files the session into it;
+    a second import with the same name reuses that one project."""
+    _seed_claude_agent(db_uri)
+
+    def _body(sid: str) -> dict:
+        return {
+            "source": "claude",
+            "external_session_id": sid,
+            "project_name": "Imported chats",
+            "items": [_import_item()],
+        }
+
+    async with _authed_imports_client(db_uri, monkeypatch) as (client, project_store):
+        first = await client.post("/v1/imports", json=_body("named-proj-1"))
+        second = await client.post("/v1/imports", json=_body("named-proj-2"))
+    assert first.status_code == 201 and second.status_code == 201
+
+    store = SqlAlchemyConversationStore(db_uri)
+    project_id = store.get_conversation(first.json()["session_id"]).project_id
+    assert project_id is not None
+    # The second import reuses the project rather than creating a duplicate.
+    assert store.get_conversation(second.json()["session_id"]).project_id == project_id
+    project = project_store.get(project_id, user_id="user-test")
+    assert project is not None and project.name == "Imported chats"
+    assert [p.name for p in project_store.list(user_id="user-test")].count("Imported chats") == 1
+
+
+async def test_import_session_without_project_name_files_no_project(
+    db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``project_name`` imports with no project (old-client shape), and
+    an unknown extra field is ignored rather than 422'd (forward compatibility)."""
+    _seed_claude_agent(db_uri)
+    payload = {
+        "source": "claude",
+        "external_session_id": "no-project-1",
+        # A field a newer client might send; the server must ignore it, not 422.
+        "unknown_future_field": "ignored",
+        "items": [_import_item()],
+    }
+
+    async with _authed_imports_client(db_uri, monkeypatch) as (client, _project_store):
+        created = await client.post("/v1/imports", json=payload)
+    assert created.status_code == 201
+    conversation = SqlAlchemyConversationStore(db_uri).get_conversation(
+        created.json()["session_id"]
+    )
+    assert conversation is not None
+    assert conversation.project_id is None
 
 
 async def test_concurrent_identical_imports_return_one_session(


### PR DESCRIPTION
## Related issue

N/A — small additive feature.

## Summary

- Import can file chats into a named project across all three surfaces: `omnigent import --project NAME` (CLI), and `project_name` on `POST /v1/imports` and the host-mediated `POST /v1/imports/local` (+ `/imports/local/stream`).
- When set, the caller's project of that name is find-or-created and the imported chat(s) are filed into it. For a host-mediated batch the project is resolved once and every session in the batch lands in it.
- An explicit `project_id` still wins over `project_name`; omitting both imports with no project, exactly as before.
- The find-or-create tolerates the per-owner name-uniqueness race (a concurrent create losing with `ALREADY_EXISTS` re-reads the now-existing project).

Lets a bulk import land its chats grouped under a project instead of as a flat list, without a second organize step.

## Test Plan

```
uv run pytest tests/server/routes/test_imports.py tests/cli/test_import.py   # 36 passed
uv run ruff check .
uv run ruff format --check .
```

New tests: server route `/imports` find-or-create + dedupe (two imports, same name, one project) and the omitted-name path (no project, plus an unknown extra field ignored rather than 422'd); host-mediated `/imports/local` batch files both sessions into one named project; CLI `--project` sends `project_name` and the default sends `null`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A (CLI/API only). See Test Plan.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual: ran `omnigent import --harness claude --session <id> --project <name>` against a local server and confirmed over `GET /v1/sessions` and `/v1/projects` that the session was filed into the find-or-created project, that a second import with the same name reused the one project, and that omitting `--project` imported with no project.

Backward compatibility (both directions): `project_name` is an optional field on both request bodies. A new client against an old server has the unknown field ignored (the request models do not forbid extras), so the chat still imports, just unprojected. An old client against a new server sends no `project_name`, which resolves to no project. `project_name` is also a no-op when the caller is unauthenticated (a project needs an owner).

## Changelog

Import can file chats into a named project: `omnigent import --project <name>`, or `project_name` on the import APIs.
