### PR TITLE
fix(claude-native): honor managed model picker

### DIFF
--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -1229,6 +1229,7 @@ def claude_catalog_fingerprint(claude_config: ClaudeNativeUcodeConfig | None) ->
     """
     from omnigent.claude_launcher import resolve_claude_launch
     from omnigent.models.model_catalog_store import binary_identity, fingerprint_of
+    from omnigent.onboarding.ambient import claude_managed_model_picker
 
     command, _ = resolve_claude_launch("claude", [])
     ambient_gateway = os.environ.get(_UCODE_CLAUDE_BASE_URL_ENV) if claude_config is None else None
@@ -1239,6 +1240,7 @@ def claude_catalog_fingerprint(claude_config: ClaudeNativeUcodeConfig | None) ->
         claude_config.model if claude_config is not None else None,
         binary_identity(command),
         ambient_gateway,
+        claude_managed_model_picker() if claude_config is None else None,
     )
 
 
@@ -1261,10 +1263,16 @@ async def claude_model_catalog(
     :param claude_config: The resolved launch config, or ``None``.
     :returns: Catalog rows, or ``None`` when the probe failed.
     """
+    from omnigent.onboarding.ambient import claude_managed_model_picker
+
+    managed_picker = claude_managed_model_picker() if claude_config is None else ()
+    managed_rows: list[dict[str, object]] = [
+        {"id": model, "model": model, "displayName": label} for model, label in managed_picker
+    ]
     probe = await probe_claude_model_options(claude_config)
     if probe is None:
-        return None
-    rows = list(probe.alias_rows)
+        return managed_rows or None
+    rows = managed_rows or list(probe.alias_rows)
     _non_canonical = (
         claude_config is not None and not _serves_canonical_anthropic_ids(claude_config)
     ) or (claude_config is None and _ambient_env_is_non_anthropic_gateway())

--- a/omnigent/onboarding/ambient.py
+++ b/omnigent/onboarding/ambient.py
@@ -538,6 +538,35 @@ def claude_managed_gateway(
     return None, False
 
 
+def claude_managed_model_picker(
+    paths: tuple[Path, ...] | None = None,
+) -> tuple[tuple[str, str], ...]:
+    """Read a replacement model picker from Claude Code's managed settings."""
+    for path in CLAUDE_CODE_MANAGED_SETTINGS_PATHS if paths is None else paths:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        picker = payload.get("modelPicker")
+        if not isinstance(picker, dict) or picker.get("replaceBuiltInOptions") is not True:
+            return ()
+        options = picker.get("options")
+        if not isinstance(options, list):
+            return ()
+        return tuple(
+            (model.strip(), label.strip())
+            for option in options
+            if isinstance(option, dict)
+            and isinstance((model := option.get("model")), str)
+            and model.strip()
+            and isinstance((label := option.get("label", model)), str)
+            and label.strip()
+        )
+    return ()
+
+
 def claude_managed_gateway_display_name(paths: tuple[Path, ...] | None = None) -> str | None:
     """A human label for the managed-settings credential, when one is delivered.
 

--- a/tests/onboarding/test_ambient.py
+++ b/tests/onboarding/test_ambient.py
@@ -13,6 +13,9 @@ count, so a wrong field turns the test red.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from omnigent.onboarding import ambient
@@ -990,3 +993,25 @@ def test_claude_managed_gateway_first_readable_file_decides(clean_env, monkeypat
     low.write_text(json.dumps(_ISAAC_CLAUDE_SETTINGS))
     monkeypatch.setattr(ambient, "CLAUDE_CODE_MANAGED_SETTINGS_PATHS", (high, low))
     assert ambient.claude_managed_gateway() == (None, False)
+
+
+def test_claude_managed_model_picker_reads_replacement_options(tmp_path: Path) -> None:
+    path = tmp_path / "managed-settings.json"
+    path.write_text(
+        json.dumps(
+            {
+                "modelPicker": {
+                    "options": [
+                        {"model": "gateway-opus", "label": "Opus"},
+                        {"model": "gateway-sonnet", "label": "Sonnet"},
+                    ],
+                    "replaceBuiltInOptions": True,
+                }
+            }
+        )
+    )
+
+    assert ambient.claude_managed_model_picker((path,)) == (
+        ("gateway-opus", "Opus"),
+        ("gateway-sonnet", "Sonnet"),
+    )

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -10308,6 +10308,54 @@ async def test_claude_model_catalog_marks_the_enumerated_default(
     assert rows[1]["isDefault"] is True
 
 
+async def test_claude_model_catalog_honors_managed_replacement_picker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Managed replacement rows override Claude's headless alias output."""
+
+    async def _fake_probe(config: object) -> claude_native.ClaudeModelProbe:
+        del config
+        return claude_native.ClaudeModelProbe(
+            alias_rows=[{"id": "fable", "model": "fable", "displayName": "fable"}],
+            default_model="gateway-opus",
+            default_label="Opus",
+        )
+
+    monkeypatch.setattr(claude_native, "probe_claude_model_options", _fake_probe)
+    monkeypatch.setattr(
+        "omnigent.onboarding.ambient.claude_managed_model_picker",
+        lambda: (("gateway-opus", "Opus"), ("gateway-sonnet", "Sonnet")),
+    )
+
+    assert await claude_native.claude_model_catalog(None) == [
+        {
+            "id": "gateway-opus",
+            "model": "gateway-opus",
+            "displayName": "Opus",
+            "isDefault": True,
+        },
+        {"id": "gateway-sonnet", "model": "gateway-sonnet", "displayName": "Sonnet"},
+    ]
+
+
+async def test_claude_model_catalog_keeps_managed_picker_when_probe_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _failed_probe(config: object) -> None:
+        del config
+        return
+
+    monkeypatch.setattr(claude_native, "probe_claude_model_options", _failed_probe)
+    monkeypatch.setattr(
+        "omnigent.onboarding.ambient.claude_managed_model_picker",
+        lambda: (("gateway-opus", "Opus"),),
+    )
+
+    assert await claude_native.claude_model_catalog(None) == [
+        {"id": "gateway-opus", "model": "gateway-opus", "displayName": "Opus"}
+    ]
+
+
 async def test_claude_model_catalog_appends_an_off_list_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A — compatibility fix for managed Claude Code settings.

## Summary

Isaac now uses Claude Code's `modelPicker` setting to curate the gateway-backed models without restricting explicit model selection. Claude's interactive picker honors that setting, but its headless `/model` output does not. Omnigent currently builds its web picker from that headless output, so unsupported aliases such as `fable[1m]` can still appear in the Omnigent UI.

This change reads a managed replacement picker and uses those rows as the authoritative Omnigent catalog. It applies only when `replaceBuiltInOptions` is explicitly true. Other Claude configurations keep the existing harness-probe behavior.

ELI5: Isaac writes the approved menu, but Omnigent was asking a different Claude command for the menu. Omnigent now reads Isaac's menu when one is present.

```text
/etc/claude-code/managed-settings.json
                 |
                 | modelPicker + replaceBuiltInOptions=true
                 v
       Omnigent host model catalog
                 |
                 v
        Omnigent web model picker
```

The managed picker is included in the catalog fingerprint, so changing the settings invalidates the cached catalog. If Claude's probe fails, the managed rows remain available.

## Test Plan

- Added parser coverage for managed replacement picker options.
- Added catalog coverage proving managed rows replace headless aliases.
- Added coverage proving managed rows survive a failed Claude probe.
- Ran focused tests:
  - `.venv/bin/pytest -p no:rerunfailures -q tests/onboarding/test_ambient.py tests/test_claude_native.py -k 'managed_model_picker or managed_replacement_picker or keeps_managed_picker'`
- Ran pre-commit on all changed files.
- Manually called the real `claude_model_catalog(None)` against settings generated by `USE_DBEXEC=0 devtools/ai/bin/isaac omni`.

Before:

```text
Sonnet, Opus, Haiku, fable[1m]
```

After:

```text
Opus, Sonnet, Haiku
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The Test Plan includes the real before/after model catalog consumed by the web UI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification used the real Claude Code binary and the real managed settings written by the Isaac PR. The resulting catalog is the backend payload used by Omnigent's host model-options endpoint.

## Changelog

Omnigent now honors Claude Code's managed model picker instead of showing unsupported model aliases.
