### PR TITLE
test: make pytest pass on a developer macOS checkout (#4279)

### DIFF
--- a/tests/inner/conftest.py
+++ b/tests/inner/conftest.py
@@ -12,14 +12,35 @@ import json
 import logging
 import os
 import pathlib
+import shutil
 import sys
+import tempfile
 import time
+from collections.abc import Iterator
 from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
 
 from tests import _model_pools
+
+
+@pytest.fixture
+def short_tmp_parent() -> Iterator[pathlib.Path]:
+    """A short-pathed temp dir under ``/tmp`` for Unix-socket-binding tests.
+
+    macOS caps an ``AF_UNIX`` path at ~103 bytes and its ``$TMPDIR`` is already
+    ~48 bytes, so pytest's ``tmp_path`` (which embeds the test name) overflows
+    before a socket filename is appended (issue #4279). Tests that bind a real
+    Unix socket — the private tmux server, the egress proxy — must place it
+    under a short parent. Production sockets already live under a short
+    ``$TMPDIR/omnigent-...`` path, so this is a test-path artifact only.
+    """
+    parent = pathlib.Path(tempfile.mkdtemp(prefix="omni-inner-", dir="/tmp"))
+    try:
+        yield parent
+    finally:
+        shutil.rmtree(parent, ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/inner/egress/test_proxy.py
+++ b/tests/inner/egress/test_proxy.py
@@ -51,13 +51,14 @@ async def test_proxy_start_stop_tcp(
 
 
 @pytest.mark.asyncio
-async def test_proxy_start_unix(ca_paths: tuple[Path, Path, Path], tmp_path: Path) -> None:
+async def test_proxy_start_unix(ca_paths: tuple[Path, Path, Path], short_tmp_parent: Path) -> None:
     """Proxy can listen on a Unix socket."""
     cert_path, key_path, _ = ca_paths
     rules = parse_rules(["GET example.com/**"])
     proxy = EgressProxy(rules, cert_path, key_path)
 
-    sock_path = tmp_path / "test.sock"
+    # short_tmp_parent (not tmp_path): the AF_UNIX path cap overflows on macOS.
+    sock_path = short_tmp_parent / "test.sock"
     await proxy.start_unix(sock_path)
 
     # Socket file is created

--- a/tests/inner/test_bwrap_sandbox.py
+++ b/tests/inner/test_bwrap_sandbox.py
@@ -55,6 +55,15 @@ from omnigent.inner.sandbox import SandboxPolicy, with_denied_unix_sockets
 
 BWRAP_AVAILABLE = shutil.which("bwrap") is not None
 
+# Skip anything that reaches real bwrap resolution/execution when bwrap is not
+# available (macOS, Windows, or a bwrap-less Linux box) — the backend hard-errors
+# off Linux by design. Defined here at module top so it can decorate tests
+# throughout the file, including the resolver tests below (issue #4279: it was
+# previously defined *after* those tests, so it never gated them).
+pytestmark_bwrap = pytest.mark.skipif(
+    not BWRAP_AVAILABLE, reason="bwrap not installed on this host"
+)
+
 
 # ---------------------------------------------------------------------------
 # Test helpers
@@ -248,6 +257,7 @@ def _repo_root() -> Path:
 # ---------------------------------------------------------------------------
 
 
+@pytestmark_bwrap
 def test_resolve_default_keeps_cwd_read_only() -> None:
     """
     ``write_paths`` omitted (the common case) leaves ``write_roots``
@@ -275,6 +285,7 @@ def test_resolve_default_keeps_cwd_read_only() -> None:
     assert policy.read_roots is None  # No spec-supplied read_paths.
 
 
+@pytestmark_bwrap
 def test_resolve_write_paths_dot_makes_cwd_writable() -> None:
     """
     Setting ``write_paths: ["."]`` flips cwd to writable. This is the
@@ -291,6 +302,7 @@ def test_resolve_write_paths_dot_makes_cwd_writable() -> None:
     assert policy.write_roots == [Path.cwd().resolve(strict=False)]
 
 
+@pytestmark_bwrap
 def test_resolve_default_cwd_allow_hidden_is_dot_venv() -> None:
     """
     ``cwd_allow_hidden=None`` in the spec resolves to the documented
@@ -312,6 +324,7 @@ def test_resolve_default_cwd_allow_hidden_is_dot_venv() -> None:
     )
 
 
+@pytestmark_bwrap
 def test_resolve_explicit_cwd_allow_hidden_overrides_default() -> None:
     """
     An explicit ``cwd_allow_hidden`` in the spec replaces the default
@@ -1675,11 +1688,6 @@ def test_s5_read_paths_dedup_skips_paths_under_cwd(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Seccomp profile (real bwrap subprocess required)
 # ---------------------------------------------------------------------------
-
-
-pytestmark_bwrap = pytest.mark.skipif(
-    not BWRAP_AVAILABLE, reason="bwrap not installed on this host"
-)
 
 
 @pytestmark_bwrap

--- a/tests/inner/test_claude_router_hook.py
+++ b/tests/inner/test_claude_router_hook.py
@@ -12,6 +12,27 @@ from omnigent.inner.hook_scripts import claude_router_hook, subagent_router
 from omnigent.models.claude_model_vocabulary import claude_model_alias
 from tests.inner.conftest import advertise_relay_tools, advertise_router
 
+# Gateway model pins that alias resolution reads from the ambient environment.
+_ANTHROPIC_DEFAULT_MODEL_VARS = (
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_anthropic_default_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear ambient ``ANTHROPIC_DEFAULT_*_MODEL`` pins for every test here.
+
+    ``alias_pins()`` falls back to ``os.environ`` and ``claude_model_alias``
+    returns ``None`` on a *mismatched* pin, so any developer whose shell pins
+    these vars (anyone driving Claude through a gateway) gets no translation and
+    these tests fail spuriously (issue #4279). Tests that need a specific pin set
+    it explicitly after this autouse fixture has cleared the ambient value.
+    """
+    for var in _ANTHROPIC_DEFAULT_MODEL_VARS:
+        monkeypatch.delenv(var, raising=False)
+
 
 def _payload(
     *,

--- a/tests/inner/test_seccomp.py
+++ b/tests/inner/test_seccomp.py
@@ -224,6 +224,12 @@ def _run_in_child(probe: str) -> int:
     :param probe: Python source to run in the child.
     :returns: The child's exit code.
     """
+    # seccomp (prctl/seccomp_load) and os.fork() are Linux-only; off Linux the
+    # child dies with "dlsym(prctl): symbol not found" (macOS) or os.fork raises
+    # (Windows). Skip here so every real-filter test that forks a child is gated
+    # in one place (issue #4279), rather than each carrying its own marker.
+    if sys.platform != "linux":
+        pytest.skip("seccomp filter tests require Linux (prctl/seccomp_load + os.fork)")
     pid = os.fork()
     if pid == 0:
         os.execvp(sys.executable, [sys.executable, "-c", probe])
@@ -314,6 +320,10 @@ def test_apply_baseline_denylist_does_not_break_subprocess_basics() -> None:
     )
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="references socket.AF_NETLINK (Linux-only) while building the probe",
+)
 def test_arg_filter_blocks_socket_family_only() -> None:
     """
     ``SCMP_CMP_EQ`` on ``socket(domain, ...)`` returns ``EPERM`` for

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -452,7 +452,9 @@ async def test_is_alive_true_when_pane_live(
 
 @pytest.mark.skipif(shutil.which("tmux") is None, reason="requires a real tmux binary")
 @pytest.mark.asyncio
-async def test_server_survives_inner_process_exit_real_tmux(tmp_path: Path) -> None:
+async def test_server_survives_inner_process_exit_real_tmux(
+    tmp_path: Path, short_tmp_parent: Path
+) -> None:
     """
     The private tmux server outlives an inner-process exit (issue #540).
 
@@ -468,7 +470,9 @@ async def test_server_survives_inner_process_exit_real_tmux(tmp_path: Path) -> N
     instance = TerminalInstance(
         name="bash",
         session_key="s1",
-        socket_path=tmp_path / "tmux.sock",
+        # short_tmp_parent (not tmp_path): tmux's AF_UNIX socket path overflows
+        # the macOS 103-byte cap when it embeds pytest's long tmp_path (#4279).
+        socket_path=short_tmp_parent / "tmux.sock",
         private_dir=tmp_path,
         command="sh",
         args=["-c", "exit 0"],

--- a/tests/runner/test_app_sessions_native_events_options.py
+++ b/tests/runner/test_app_sessions_native_events_options.py
@@ -30,6 +30,22 @@ from tests.runner.conftest import (
 from tests.runner.helpers import NullServerClient
 
 
+@pytest.fixture(autouse=True)
+def _isolate_anthropic_default_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear ambient ``ANTHROPIC_DEFAULT_*_MODEL`` gateway pins (#4279).
+
+    claude-native model resolution reads these from ``os.environ``; a developer
+    whose shell pins them (anyone driving Claude through a gateway) otherwise
+    gets a different model-change verdict and these tests fail spuriously.
+    """
+    for var in (
+        "ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "effort_value",

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -156,6 +156,11 @@ async def test_create_session_threads_workspace_to_pi_cwd(
 ) -> None:
     """Pi pre-spawn receives the session workspace, not the bundle dir."""
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
+    # Isolate $HOME too: ambient provider detection reads ~/.databrickscfg,
+    # which on a multi-profile Databricks dev box otherwise 400s the create
+    # with "match <host>; use --profile" (issue #4279).
+    monkeypatch.setenv("HOME", str(tmp_path / "config-home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "config-home"))
     session_id = "18f39ab73f49285e4dab0c80ff7b8455"
     runner_workspace = tmp_path / "runner-workspace"
     runner_workspace.mkdir()

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -229,6 +229,11 @@ async def test_create_session_threads_runner_workspace_to_pi_cwd_when_session_wo
 ) -> None:
     """Pi pre-spawn falls back to runner workspace when session workspace is empty."""
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path / "config-home"))
+    # Isolate $HOME too: ambient provider detection reads ~/.databrickscfg,
+    # which on a multi-profile Databricks dev box otherwise 400s the create
+    # with "match <host>; use --profile" (issue #4279).
+    monkeypatch.setenv("HOME", str(tmp_path / "config-home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "config-home"))
     session_id = "3f1d20a97a7d0ba93e02cf17aeb92367"
     runner_workspace = tmp_path / "runner-workspace"
     runner_workspace.mkdir()

--- a/tests/runtime/test_openai_agents_sdk_spawn_env.py
+++ b/tests/runtime/test_openai_agents_sdk_spawn_env.py
@@ -37,11 +37,19 @@ def _isolate_global_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     this file so tests that don't explicitly set up a global config are
     not affected by the developer's real ``~/.omnigent/config.yaml``.
 
+    Also redirect ``$HOME`` (and ``$USERPROFILE`` on Windows) to that temp
+    dir: ambient provider detection reads ``~/.codex/config.toml`` and
+    ``~/.databrickscfg``, which live under HOME, not OMNIGENT_CONFIG_HOME. On
+    a Databricks developer machine those otherwise pin a provider and break
+    these tests (issue #4279).
+
     Tests that need a specific global config write their own config.yaml
     into a separate temp dir and set OMNIGENT_CONFIG_HOME themselves —
     that setenv call wins because monkeypatch applies in call order.
     """
     monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
 
 def _make_spec(

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -83,6 +83,25 @@ def _clear_ambient_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_ambient_provider_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Isolate host state ambient provider detection reads (issue #4279).
+
+    Two ambient sources leak past ``$OMNIGENT_CONFIG_HOME``:
+
+    - ``~/.codex/config.toml`` and ``~/.databrickscfg`` live under ``$HOME``
+      (``$USERPROFILE`` on Windows), so redirect it to an empty temp dir.
+    - On macOS ``_claude_login_detected()`` falls back to ``claude auth status``,
+      which reads the **Keychain** — no ``$HOME`` override can hide it. A
+      signed-in Mac would inject a ``subscription`` provider that outranks the
+      test's own configured entry, so stub it to "not logged in". Tests that
+      exercise a detected login can still override this in call order.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setattr("omnigent.onboarding.ambient._claude_login_detected", lambda: False)
+
+
 @pytest.fixture
 def config_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     """

--- a/tests/runtime/test_provider_spawn_env.py
+++ b/tests/runtime/test_provider_spawn_env.py
@@ -60,16 +60,28 @@ _CATALOG_DEFAULTS = {
 @pytest.fixture(autouse=True)
 def _clear_ambient_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     """
-    Clear ambient vendor keys so they cannot leak into the spawn env.
+    Clear ambient vendor keys and gateway routing so they cannot leak into
+    the spawn env.
 
     The coding-agent process may have ``ANTHROPIC_API_KEY`` /
-    ``OPENAI_API_KEY`` / ``DATABRICKS_TOKEN`` set; clearing them keeps the
-    tests deterministic (the provider path resolves keys from the config
-    file, not the ambient environment).
+    ``OPENAI_API_KEY`` / ``DATABRICKS_TOKEN`` set; a gateway-driven shell also
+    exports ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_MODEL`` /
+    ``ANTHROPIC_CUSTOM_HEADERS``. Detection folds those routing vars into the
+    detected anthropic entry, which would redirect the "routes to
+    api.anthropic.com" assertions at the developer's own gateway (issue #4279).
+    Clearing them keeps the tests deterministic (the provider path resolves
+    from the config file, not the ambient environment).
 
     :param monkeypatch: Pytest monkeypatch fixture.
     """
-    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "DATABRICKS_TOKEN"):
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "DATABRICKS_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_CUSTOM_HEADERS",
+    ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr(
         "omnigent.runtime.workflow._resolve_catalog_default_model",


### PR DESCRIPTION
## Related issue

Closes #4279

## Summary

Twenty tests fail on a Databricks developer's macOS checkout but pass in Linux
CI. None are product bugs — they are four classes of **test-isolation /
platform-gating** gaps that make local `pytest` an unreliable signal (a
contributor sees a red suite they didn't cause, and real regressions hide in
the noise). This lands fixes for all four classes.

- **Class 1 — Linux-only tests with no platform gate.** Move the
  `pytestmark_bwrap` skip *above* the resolver tests in `test_bwrap_sandbox.py`
  (it was defined ~1400 lines below them, so it never gated them); gate the
  forked-BPF tests in `test_seccomp.py` from one place inside `_run_in_child`,
  plus a dedicated skip for the one test that references `socket.AF_NETLINK` at
  build time. The "negative" siblings (`test_resolve_raises_on_non_linux`) stay
  ungated — those are what cover macOS.
- **Class 2 — AF_UNIX 103-byte path cap on macOS.** Add a shared
  `short_tmp_parent` fixture under `/tmp` in `tests/inner/conftest.py` and use
  it for the real-tmux and unix-socket tests, whose `tmp_path`-based sockets
  overflow the cap. Production sockets already live under a short path.
- **Class 3 — ambient `ANTHROPIC_DEFAULT_*_MODEL` pins.** Autouse fixtures clear
  the gateway pins so a developer's shell (anyone driving Claude through a
  gateway) doesn't defeat alias translation.
- **Class 4 — host state outside `OMNIGENT_CONFIG_HOME`.** Isolate
  `HOME`/`USERPROFILE` (for `~/.codex/config.toml` and `~/.databrickscfg`) and
  stub the macOS Keychain `claude auth status` fallback that no `HOME` override
  can hide.

This **adopts the two stalled community PRs** that solved this —
**#4363** (classes 1 & 3) and **#4369** (classes 2 & 4) by @abhay-codes07 —
rebased onto current `main` (which had moved ~540 commits, including the #6721
module refactor), with their commits and authorship preserved. A follow-up
commit closes two leaks of the same family that surface **only once those fixes
are in place** and **only on a fully gateway-pinned box**: the
`ANTHROPIC_BASE_URL` / `ANTHROPIC_MODEL` / `ANTHROPIC_CUSTOM_HEADERS` redirect in
`test_provider_spawn_env.py`, and the uncovered `...when_session_workspace_missing`
sibling in `test_app_sessions_native_terminals_runtime.py`.

The related latent-leak follow-up (@josuediazflores's **#4478**) already merged
and is not re-included here.

**ELI5:** CI runs on clean Linux. A Databricks laptop is macOS with a `claude`
login, gateway env pins, a `~/.codex/config.toml`, and a big `~/.databrickscfg`.
The tests never told those apart, so they broke locally in ways CI can't see.
These changes teach the tests to skip what can't run off Linux and to ignore the
developer's ambient credentials — without weakening what they assert on CI.

## Test Plan

Verified on **macOS 26.5.2 (arm64)** — a machine carrying the exact triggering
state: all three `ANTHROPIC_DEFAULT_*_MODEL` pins, `ANTHROPIC_BASE_URL`,
`~/.codex/config.toml` (300 lines), a 23-profile `~/.databrickscfg`, and a
signed-in `claude` CLI.

Baseline on `origin/main` (same machine + env) — the documented failures
reproduce: **6 failed** across the classes 1–3 representative tests, **4 failed**
across the class-4 + native-events tests.

With this branch, the affected files run green:

```
uv run python -m pytest -n auto \
  tests/inner/test_bwrap_sandbox.py tests/inner/test_seccomp.py \
  tests/inner/egress/test_proxy.py tests/inner/test_terminal.py \
  tests/inner/test_claude_router_hook.py \
  tests/runtime/test_openai_agents_sdk_spawn_env.py \
  tests/runtime/test_provider_spawn_env.py \
  tests/runner/test_app_sessions_native_events_options.py \
  tests/runner/test_app_sessions_native_terminals_runtime.py
# 463 passed, 18 skipped, 1 failed
```

The skips are the platform-gated Linux-only tests (bwrap/seccomp), which still
execute on Linux CI.

**The one remaining failure is out of scope and pre-existing on `main`:**
`test_app_sessions_native_events_options.py::test_events_compact_on_codex_native_returns_503_when_no_terminal`.
It survives full `HOME` + env isolation (fails on pristine `main` with an empty
`HOME`) because the codex-native path now auto-creates a terminal on `/compact`
and returns 200 where the test expects 503. It has no `sys.platform` branch and
belongs to the pre-existing codex-native family called out in the issue's scope
note — to be filed/fixed separately, not here.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Test-only change — no product code touched. Manually verified with the
baseline→fix comparison above on a real macOS Databricks developer machine that
carries all four classes' triggering state: the affected files go from the
documented failures to green (excluding the one out-of-scope, pre-existing
codex-native failure). The newly-gated Linux-only tests still run on Linux CI,
so coverage there is unchanged.

This pull request and its description were written by Isaac.
