### PR TITLE
fix(codex-native): show MCP tool calls in chat

### DIFF
--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -2646,7 +2646,10 @@ async def _handle_event(
             # ``item/completed`` guard below remains the backstop for the
             # resume-backfill path, which replays only ``item/completed``.
             await _ensure_user_message_posted(client, route_session_id, params, forwarder_state)
-        elif isinstance(item, dict) and item.get("type") == "commandExecution":
+        elif isinstance(item, dict) and item.get("type") in {
+            "commandExecution",
+            "mcpToolCall",
+        }:
             call_id = await _post_tool_call_item(client, route_session_id, params, item)
             if call_id is not None:
                 forwarder_state.note_tool_call_posted(call_id)
@@ -5870,6 +5873,81 @@ def _web_search_tool_call(call_id: str, item: _JsonObject) -> _CodexToolCall | N
     )
 
 
+def _mcp_tool_call(call_id: str, item: _JsonObject) -> _CodexToolCall | None:
+    """Build a tool call from a Codex ``mcpToolCall`` item.
+
+    :param call_id: Codex item id, e.g. ``"exec-abc"``.
+    :param item: Codex ``mcpToolCall`` item, e.g. one naming a server,
+        tool, arguments, and MCP result content.
+    :returns: Normalized tool call, or ``None`` when required fields are
+        missing.
+    """
+    server = item.get("server")
+    tool = item.get("tool")
+    arguments = item.get("arguments")
+    if not isinstance(server, str) or not server:
+        _logger.warning("Codex mcpToolCall missing server: call_id=%s", call_id)
+        return None
+    if not isinstance(tool, str) or not tool:
+        _logger.warning("Codex mcpToolCall missing tool: call_id=%s server=%s", call_id, server)
+        return None
+    if not isinstance(arguments, dict):
+        _logger.warning(
+            "Codex mcpToolCall missing object arguments: call_id=%s server=%s tool=%s",
+            call_id,
+            server,
+            tool,
+        )
+        return None
+    return _CodexToolCall(
+        call_id=call_id,
+        name=f"{server}.{tool}",
+        arguments=arguments,
+        output=_mcp_tool_output_text(item),
+    )
+
+
+def _mcp_tool_output_text(item: _JsonObject) -> str:
+    """Extract display-safe text from a completed Codex MCP call."""
+    error = item.get("error")
+    if isinstance(error, str):
+        return error
+    if error is not None:
+        try:
+            return json.dumps(error, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(error)
+
+    result = item.get("result")
+    if not isinstance(result, dict):
+        status = item.get("status")
+        return f"status: {status}" if status not in {None, "completed"} else ""
+
+    content = result.get("content")
+    rendered: list[str] = []
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            text = block.get("text")
+            if block.get("type") == "text" and isinstance(text, str):
+                rendered.append(text)
+                continue
+            block_type = block.get("type")
+            if isinstance(block_type, str) and block_type:
+                rendered.append(f"[{block_type} content]")
+    if rendered:
+        return "\n".join(rendered)
+
+    structured = result.get("structuredContent")
+    if structured is not None:
+        try:
+            return json.dumps(structured, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(structured)
+    return ""
+
+
 def _image_view_tool_call(call_id: str, item: _JsonObject) -> _CodexToolCall | None:
     """
     Build a tool call from a Codex ``imageView`` item.
@@ -5935,14 +6013,12 @@ def _image_generation_tool_call(call_id: str, item: _JsonObject) -> _CodexToolCa
     )
 
 
-# Codex built-in tool item types this forwarder mirrors into Omnigent history.
-# ``mcpToolCall`` is intentionally absent: its event shape has not been
-# verified, so it is logged-but-skipped rather than mirrored with guessed
-# fields. Add it here once its real shape is captured.
+# Codex tool item types this forwarder mirrors into Omnigent history.
 _TOOL_ITEM_BUILDERS: dict[str, _ToolItemBuilder] = {
     "commandExecution": _command_execution_tool_call,
     "fileChange": _file_change_tool_call,
     "webSearch": _web_search_tool_call,
+    "mcpToolCall": _mcp_tool_call,
     "imageView": _image_view_tool_call,
     "imageGeneration": _image_generation_tool_call,
 }

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -6470,6 +6470,156 @@ def test_forwarder_posts_codex_web_search_tool_call() -> None:
     assert posted[1]["data"]["item_data"]["output"] == "python latest stable version"
 
 
+def test_forwarder_posts_codex_mcp_tool_call() -> None:
+    """A completed Codex ``mcpToolCall`` becomes a visible tool card."""
+    posted: list[dict[str, Any]] = []
+    asyncio.run(
+        _replay_completed_item(
+            {
+                "type": "mcpToolCall",
+                "id": "exec-123",
+                "server": "databricks-v2",
+                "tool": "execute_parameterized_sql",
+                "status": "completed",
+                "arguments": {
+                    "warehouse_id": "warehouse-123",
+                    "statement": "SELECT 1",
+                },
+                "result": {
+                    "content": [{"type": "text", "text": "Results:\n1"}],
+                    "structuredContent": None,
+                    "_meta": None,
+                },
+                "error": None,
+                "durationMs": 42,
+            },
+            _capture_handler(posted),
+        )
+    )
+
+    assert posted == [
+        {
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "function_call",
+                "item_data": {
+                    "agent": "codex-native-ui",
+                    "name": "databricks-v2.execute_parameterized_sql",
+                    "arguments": '{"warehouse_id": "warehouse-123", "statement": "SELECT 1"}',
+                    "call_id": "exec-123",
+                },
+                "response_id": "codex_turn_123",
+            },
+        },
+        {
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "function_call_output",
+                "item_data": {"call_id": "exec-123", "output": "Results:\n1"},
+                "response_id": "codex_turn_123",
+            },
+        },
+    ]
+
+
+def test_forwarder_posts_codex_mcp_call_at_start_then_result(tmp_path: Path) -> None:
+    """A running MCP call appears before its completed result arrives."""
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_123",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_123",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_123",
+        ),
+    )
+    posted: list[dict[str, Any]] = []
+    state = codex_native_forwarder._CodexForwarderState()
+    started_item = {
+        "type": "mcpToolCall",
+        "id": "exec-live",
+        "server": "databricks-v2",
+        "tool": "execute_parameterized_sql",
+        "status": "inProgress",
+        "arguments": {"statement": "SELECT sleep(10)"},
+        "result": None,
+        "error": None,
+    }
+
+    async def run() -> None:
+        """Replay MCP start and completion notifications."""
+        async with httpx.AsyncClient(
+            base_url="http://127.0.0.1:8000",
+            transport=httpx.MockTransport(_capture_handler(posted)),
+        ) as client:
+            for event in (
+                {
+                    "method": "item/started",
+                    "params": {
+                        "threadId": "thread_123",
+                        "turnId": "turn_123",
+                        "item": started_item,
+                    },
+                },
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": "thread_123",
+                        "turnId": "turn_123",
+                        "item": {
+                            **started_item,
+                            "status": "completed",
+                            "result": {"content": [{"type": "text", "text": "Results:\n10"}]},
+                        },
+                    },
+                },
+            ):
+                await codex_native_forwarder._handle_event(
+                    client,
+                    session_id="conv_123",
+                    bridge_dir=tmp_path,
+                    usage_coalescer=_usage_coalescer(client),
+                    elicitation_tracker=_elicitation_tracker(),
+                    event=event,
+                    forwarder_state=state,
+                )
+
+    asyncio.run(run())
+
+    assert [payload["data"]["item_type"] for payload in posted] == [
+        "function_call",
+        "function_call_output",
+    ]
+    assert posted[0]["data"]["item_data"]["call_id"] == "exec-live"
+    assert posted[1]["data"]["item_data"] == {
+        "call_id": "exec-live",
+        "output": "Results:\n10",
+    }
+
+
+def test_forwarder_surfaces_codex_mcp_error() -> None:
+    """A failed Codex MCP call preserves its structured error."""
+    posted: list[dict[str, Any]] = []
+    asyncio.run(
+        _replay_completed_item(
+            {
+                "type": "mcpToolCall",
+                "id": "exec-failed",
+                "server": "databricks-v2",
+                "tool": "execute_parameterized_sql",
+                "status": "failed",
+                "arguments": {"statement": "SELECT bad_column"},
+                "result": None,
+                "error": {"message": "column not found"},
+            },
+            _capture_handler(posted),
+        )
+    )
+
+    assert posted[1]["data"]["item_data"]["output"] == '{"message": "column not found"}'
+
+
 def test_forwarder_drops_codex_tool_item_missing_required_field(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A — maintainer fix from a live dogfood report.

## Summary

- Mirror Codex-native `mcpToolCall` items into the Omnigent transcript instead of logging and dropping them.
- Publish the call at `item/started` so long-running MCP work appears immediately, then attach its text, structured result, or error on completion.
- Keep non-text MCP content bounded to a type marker so binary payloads do not bloat persisted chat history.

ELI5: the terminal and chat read different event paths. This connects Codex MCP events to the chat path so both views show the same work.

```text
Codex mcpToolCall -> native forwarder -> function_call + output -> chat tool card
```

## Test Plan

- `uv run --frozen --group test python -m pytest -q tests/test_codex_native.py` — 253 passed.
- `uv run --frozen --group lint pyrefly check omnigent/harnesses/codex_native/forwarder.py` — 0 errors.
- Ran pre-commit on both changed files; formatting, Ruff, repository lint rules, and file hygiene passed. The project-wide Pyrefly hook was run separately on the changed production file because unrelated untracked scratch modules in the shared worktree fail the whole-project invocation.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The new tests replay the app-server `mcpToolCall` schema captured from the affected live session and assert both the immediate call card and completed result.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage includes completed calls, live start-before-result ordering, structured errors, and the existing shell-tool path.

## Changelog

Codex sessions now show MCP tool calls and results in chat while they run.
