### PR TITLE
feat(databricks-connect): source harness gateway config from ucode (no wrapper)

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -397,6 +397,23 @@ RUN pip install --no-cache-dir /build /build/sdks/python-client /build/sdks/ui \
 # are sourced after that reset, so this puts the venv back in front.
 RUN echo 'export PATH="/opt/venv/bin:${PATH}"' > /etc/profile.d/omnigent-venv.sh
 
+# ── Databricks AI Gateway via ucode (github.com/databricks/ucode) ──────────────
+# ucode owns the coding-agent gateway config shape and served-model discovery. In
+# a managed connect sandbox, `omnigent host` runs `ucode configure` at boot to
+# GENERATE each harness's gateway config; the harness launch paths read it and
+# omnigent launches the harness itself, bridge intact (no PATH wrapper). Installed
+# in an isolated venv so its deps can't clash with /opt/venv, and pinned like every
+# other externally-fetched CLI here. If ucode is absent or configure fails, the
+# harness falls back to omnigent's hand-built gateway config, so this is optional.
+# UCODE_REF must point at a revision carrying databricks/ucode#531 + #532 (the
+# DATABRICKS_BEARER_COMMAND hook and per-request Pi auth); repin to the upstream
+# merge commit once those land.
+ARG UCODE_REF=c1cc383
+RUN python3 -m venv /opt/ucode-venv \
+ && /opt/ucode-venv/bin/pip install --no-cache-dir \
+      "ucode @ git+https://github.com/dhruv0811/ucode@${UCODE_REF}" \
+ && ln -sf /opt/ucode-venv/bin/ucode /usr/local/bin/ucode
+
 # Optional extra harness CLIs, off by default: space-separated harness names
 # with optional @version pins, or npm:<pkg-spec> — see install-harness-cli.sh
 # and deploy/docker/README.md. Kept at the end of the stage so script churn

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3130,6 +3130,31 @@ def _connect_broker_default_model() -> str:
     return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
 
 
+def _ucode_generated_claude_env(workspace_host: str) -> dict[str, str] | None:
+    """The Claude gateway env ucode generated at host boot, or ``None``.
+
+    ``ucode configure`` (run once at host boot) writes ``ucode-settings.json``
+    with the workspace gateway env — base URL/route, coding-agent headers, and a
+    discovered served model. We read it so ucode owns the config shape and model
+    selection; the caller supplies our own broker ``apiKeyHelper`` and launches
+    Claude Code itself (bridge intact). Returns ``None`` when the file is absent,
+    malformed, or points at a different workspace than the connected one (a stale
+    config we must not trust).
+    """
+    settings_path = Path.home() / ".claude" / "ucode-settings.json"
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    env = data.get("env") if isinstance(data, dict) else None
+    if not isinstance(env, dict):
+        return None
+    base_url = env.get(_UCODE_CLAUDE_BASE_URL_ENV)
+    if not isinstance(base_url, str) or workspace_host.rstrip("/") not in base_url:
+        return None  # absent, or generated for a different workspace
+    return {str(k): str(v) for k, v in env.items() if isinstance(v, (str, int))}
+
+
 def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
     """Gateway config for a managed host connected via the credential broker.
 
@@ -3169,15 +3194,24 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
     if not api_key_helper:
         return None  # no broker sidecar → not a managed connect host
     workspace_host = workspace_host.rstrip("/")
-    return ClaudeNativeUcodeConfig(
-        env={
+    # Prefer the gateway config ucode generated at host boot: it owns the config
+    # shape (base URL/route, coding-agent headers) and served-model discovery. We
+    # still mint the bearer through our own broker command (bridge-launched by the
+    # runner as usual), so this consumes ucode's config without ucode launching or
+    # authenticating the binary. Falls back to a hand-built config when ucode wrote
+    # nothing usable (configure skipped/failed, or ucode absent).
+    env = _ucode_generated_claude_env(workspace_host)
+    if env is None:
+        env = {
             _UCODE_CLAUDE_BASE_URL_ENV: f"{workspace_host}/ai-gateway/anthropic",
-            _CLAUDE_CODE_API_KEY_HELPER_TTL_ENV: str(_BROKER_APIKEY_HELPER_TTL_MS),
             _CLAUDE_CODE_USE_GATEWAY_ENV: "1",
             _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
-        },
+        }
+    env[_CLAUDE_CODE_API_KEY_HELPER_TTL_ENV] = str(_BROKER_APIKEY_HELPER_TTL_MS)
+    return ClaudeNativeUcodeConfig(
+        env=env,
         api_key_helper=api_key_helper,
-        model=_connect_broker_default_model(),
+        model=env.get("ANTHROPIC_MODEL") or _connect_broker_default_model(),
     )
 
 

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4184,6 +4184,66 @@ class HostProcess:
             await self._handle_import_local(ws, frame)
 
 
+_UCODE_CONFIGURED_HARNESSES = ("claude", "codex", "pi")
+
+
+def _generate_ucode_configs() -> None:
+    """Generate the harnesses' gateway configs via ``ucode`` at host boot.
+
+    ``ucode configure`` writes each harness's gateway config (e.g.
+    ``~/.claude/ucode-settings.json``) — base URL/route, coding-agent headers, and
+    a discovered served model — which the harness launch paths then read, so ucode
+    owns the config shape and model selection while omnigent still launches the
+    harness itself (bridge intact). Runs off the hot path, before the host
+    connects, so it never delays the runner's connect.
+
+    Best-effort and self-gating: only on a managed connect host (a broker sidecar
+    exists) with ``ucode`` installed (the managed-sandbox image). ``ucode
+    configure`` authenticates to the gateway through the broker, set in the
+    subprocess env only — it is not exported to the runner, which mints its own
+    per-request bearer. There is no PATH wrapper, so configure's internal
+    ``<agent> mcp`` calls hit the real binary (no re-entry).
+    """
+    from omnigent.host.databricks_credential import (
+        HOST_DATABRICKS_PROFILE,
+        broker_token_command,
+    )
+    from omnigent.inner.databricks_executor import _read_databrickscfg_host
+
+    workspace = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+    if not workspace:
+        return
+    bearer_command = broker_token_command(workspace)
+    if not bearer_command:
+        return  # no broker sidecar → not a managed connect host
+    env = {
+        **os.environ,
+        "DATABRICKS_BEARER_COMMAND": bearer_command,
+        "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,
+    }
+    for agent in _UCODE_CONFIGURED_HARNESSES:
+        try:
+            subprocess.run(
+                [
+                    "ucode",
+                    "configure",
+                    "--profiles",
+                    HOST_DATABRICKS_PROFILE,
+                    "--agents",
+                    agent,
+                    "--skip-validate",
+                    "--skip-upgrade",
+                ],
+                capture_output=True,
+                timeout=120,
+                env=env,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return  # ucode absent (not a managed-sandbox image) or unrunnable
+        else:
+            _logger.info("ucode: generated %s gateway config", agent)
+
+
 def run_host_process(
     server_url: str,
     config_path: Path | None = None,
@@ -4286,6 +4346,12 @@ def run_host_process(
     from omnigent.host.databricks_credential import configure_host_databricks
 
     configure_host_databricks(server_url, identity.host_id)
+
+    # Generate the harnesses' gateway configs via ucode now, before the host
+    # connects (off the runner's critical path). The harness launch paths read
+    # these; omnigent still launches each harness with its bridge. No-op outside a
+    # managed connect sandbox. See :func:`_generate_ucode_configs`.
+    _generate_ucode_configs()
 
     if lifecycle_lock is None and daemon_target is not None:
         lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -10994,6 +10994,42 @@ def test_resolve_native_claude_config_connect_broker_fallback(
     assert config.model == "catalog-databricks-claude-default"
 
 
+def test_connect_broker_prefers_ucode_generated_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ucode has generated ~/.claude/ucode-settings.json for the connected
+    workspace, the managed-connect config uses ucode's base URL/headers and its
+    discovered served model — while keeping omnigent's own broker apiKeyHelper."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    (home / ".claude" / "ucode-settings.json").write_text(
+        '{"apiKeyHelper": "ucode auth-token --host https://ws.example",'
+        ' "env": {"ANTHROPIC_BASE_URL": "https://ws.example/serving-endpoints/anthropic",'
+        ' "ANTHROPIC_MODEL": "system.ai.claude-sonnet-4-6",'
+        ' "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true"}}'
+    )
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    # ucode's base URL/route and discovered served model win over the hand-built default.
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/serving-endpoints/anthropic"
+    assert config.model == "system.ai.claude-sonnet-4-6"
+    # But the bearer is still minted through our own broker command, not ucode's.
+    assert config.api_key_helper is not None
+    assert "omnigent.host.databricks_credential token" in config.api_key_helper
+
+
 def test_connect_fallback_pins_deployment_gateway_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Wires managed-sandbox coding harnesses to a user's Databricks AI Gateway by having **[`ucode`](https://github.com/databricks/ucode) generate each harness's gateway config, which omnigent then consumes while launching the harness itself** — so ucode owns the config shape + served-model discovery, and omnigent keeps its runner/harness bridge intact.

> Supersedes this PR's earlier **PATH-wrapper** approach. The lab + Polly review proved the wrapper is incompatible with omnigent's runner: dispatching through `ucode <agent>` discards omnigent's harness bridge (the runner proxies the harness's HTTP stream → *"Harness stream connection error"*), and `ucode configure` probing the wrapped binary recurses (Polly **B3/B5**, both reproduced live). This "config source" design has none of those failure modes.

Stacked on **#6889** (per-user Databricks Connect harness wiring); this PR is the ucode-config-source delta on top of it.

### How it works
- **Boot-generate (off the hot path):** `_generate_ucode_configs()` runs `ucode configure` once per harness at host startup, *before* the host connects, to generate each harness's gateway config (e.g. `~/.claude/ucode-settings.json`). With **no PATH wrapper**, configure's internal `<agent> mcp` calls hit the real binary — no recursion. It authenticates to the gateway through the broker, set in the subprocess env only (never exported to the runner).
- **Consume, don't dispatch:** `_connect_broker_claude_config` prefers the config ucode generated — its base URL/route, coding-agent headers, and discovered served model — while still minting the bearer through omnigent's own broker `apiKeyHelper` and **launching Claude Code itself (bridge intact)**. Falls back to the hand-built config when ucode wrote nothing usable, and ignores a config generated for a different workspace.
- **No wrapper.** ucode is installed in an isolated venv, pinned (addresses the earlier B1/B2/supply-chain findings). The harness binaries stay unwrapped, so omnigent's bridged launch is unchanged.

### Scope
Claude Code is the proven template here; codex / pi / opencode get the same "read ucode's generated config" treatment (each reads its own generated config file) — landing incrementally on this branch.

## Test Plan

- **Unit** (`uv run --group test pytest tests/test_claude_native.py`): connect-broker fallback, spec-path, declines-without-sidecar, and a new `test_connect_broker_prefers_ucode_generated_config` (ucode's base URL + served model win; omnigent's broker `apiKeyHelper` retained) — pass with a clean env.
- **Live (agent_sandbox pod, :8098, ucode = main + databricks/ucode#531/#532):** a runner-driven turn completed end-to-end through the Databricks gateway — *"ucode via omnigent works."* Confirmed on the pod: `ucode configure` generated `~/.claude/ucode-settings.json` at boot (no wrapper, no recursion); claude was launched by **omnigent** with its `--mcp-config` bridge under tmux (not `ucode <agent>`); the broker `apiKeyHelper` authed to the gateway (no 401). The runner connects promptly (the wrapper's connect-stall is gone). Also verified by the author's own manual test.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the claude config-source logic (prefer ucode's config, fall back to hand-built, reject a foreign-workspace config). The end-to-end runner turn through the gateway was verified manually in the agent_sandbox lab (see Test Plan); codex/pi/opencode paths will add their own coverage as they land.

## Changelog

Native coding harnesses in a managed sandbox now get their Databricks AI Gateway configuration from ucode (base URL, headers, served model), while omnigent launches the harness, so a connected workspace "just works" without omnigent re-implementing per-harness gateway config.

---
This pull request and its description were written by Isaac.
