### PR TITLE
Fix predictive text lingering after composer send

### DIFF
--- a/tests/e2e_ui/chat/test_composer_native_prediction.py
+++ b/tests/e2e_ui/chat/test_composer_native_prediction.py
@@ -1,0 +1,41 @@
+"""Sending must dismiss native prediction before clearing the composer."""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import Page, expect
+
+_QUEUED_PLACEHOLDER = "Send a follow-up (queued) — Esc to stop"
+
+
+def _publish_running(base_url: str, session_id: str) -> None:
+    response = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_session_status",
+            "data": {"status": "running", "response_id": "resp_native_prediction"},
+        },
+        timeout=10.0,
+    )
+    response.raise_for_status()
+
+
+def test_submit_button_resets_native_text_input_when_send_moves_focus(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Clear and end the textarea's native input session after sending."""
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = page.get_by_label("Message the agent")
+    expect(composer).to_be_visible(timeout=30_000)
+
+    _publish_running(base_url, session_id)
+    expect(composer).to_have_attribute("placeholder", _QUEUED_PLACEHOLDER, timeout=15_000)
+
+    composer.fill("disabled")
+    page.get_by_role("button", name="Send").focus()
+    composer.evaluate("textarea => textarea.form?.requestSubmit()")
+    expect(composer).to_have_value("")
+    expect(composer).not_to_be_focused()
+    expect(composer).to_have_attribute("placeholder", _QUEUED_PLACEHOLDER)

--- a/web/src/pages/ChatPage.composer.test.tsx
+++ b/web/src/pages/ChatPage.composer.test.tsx
@@ -1923,6 +1923,41 @@ describe("Composer placeholder", () => {
     expect(textarea().placeholder).toMatch(/send a follow-up/i);
   });
 
+  it("resets the native text input when the Send button moves focus first", () => {
+    const props = composerProps({ status: "streaming", isWorking: true });
+    render(<Composer {...props} />);
+    const ta = textarea();
+
+    ta.focus();
+    fireEvent.change(ta, { target: { value: "disabled" } });
+    fireEvent.blur(ta);
+    const focusSpy = vi.spyOn(ta, "focus");
+    const blurSpy = vi.spyOn(ta, "blur");
+    fireEvent.submit(ta.closest("form")!);
+
+    expect(props.onSend).toHaveBeenCalledWith("disabled", undefined);
+    expect(focusSpy).toHaveBeenCalledOnce();
+    expect(blurSpy).toHaveBeenCalledOnce();
+    expect(ta).toHaveValue("");
+    expect(ta).not.toHaveFocus();
+    expect(ta.placeholder).toMatch(/send a follow-up/i);
+  });
+
+  it("keeps the native input focused after a keyboard send", () => {
+    const props = composerProps({ status: "streaming", isWorking: true });
+    render(<Composer {...props} />);
+    const ta = textarea();
+
+    ta.focus();
+    fireEvent.change(ta, { target: { value: "disabled" } });
+    fireEvent.keyDown(ta, { key: "Enter" });
+
+    expect(props.onSend).toHaveBeenCalledWith("disabled", undefined);
+    expect(ta).toHaveValue("");
+    expect(ta).toHaveFocus();
+    expect(ta.placeholder).toMatch(/send a follow-up/i);
+  });
+
   it("unreachable (host offline / local-stranded): composer is blocked", () => {
     // A message can't wake it, so the textarea is disabled and the banner
     // below is the only affordance.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3158,7 +3158,21 @@ function ComposerImpl({
     dirtyRef.current = true;
   };
 
-  const submit = () => {
+  const clearComposerAfterSend = (resetNativeInputSession: boolean) => {
+    const textarea = textareaRef.current;
+    if (resetNativeInputSession && textarea !== null) {
+      // End the emptied text-input session so native keyboards drop predictions.
+      textarea.focus({ preventScroll: true });
+      textarea.value = "";
+      textarea.setSelectionRange(0, 0);
+      textarea.blur();
+    }
+    setValue("");
+  };
+
+  const submit = ({
+    resetNativeInputSession = false,
+  }: { resetNativeInputSession?: boolean } = {}) => {
     const trimmed = value.trim();
     // Allow send if there's text, attached files, OR "@"-tagged paths.
     if (
@@ -3258,7 +3272,7 @@ function ComposerImpl({
     if (trimmed) appendEntry(trimmed);
     onSend(messageText, files.length > 0 ? files : undefined);
     dirtyRef.current = true;
-    setValue("");
+    clearComposerAfterSend(resetNativeInputSession);
     setFiles([]);
     setAttachmentError(null);
     setMentionedItems([]);
@@ -3272,7 +3286,7 @@ function ComposerImpl({
       onStop();
       return;
     }
-    submit();
+    submit({ resetNativeInputSession: true });
   };
 
   const applyRecall = (ta: HTMLTextAreaElement, recalled: string) => {


### PR DESCRIPTION
## Related issue

[OMNI-6120](https://linear.app/omnigent/issue/OMNI-6120/queued-follow-up-prompt-overlaps-composer-text)

## Summary

- End the native textarea editing session after a successful submit-button send by focusing it, clearing its DOM value and caret, then blurring it. This makes UIKit discard lingering inline prediction; keyboard sends keep their existing focus behavior.
- Preserve the existing placeholder contract: only local `streaming` state shows `Send a follow-up (queued)`.

ELI5: tapping Send briefly gives the emptied input back to the phone, then closes it cleanly, so its gray predicted word cannot remain over the next prompt.

```text
submit-button Send -> focus textarea -> clear DOM value/caret -> blur -> clear React value
```

## Test Plan

- `pnpm --dir web exec vitest run src/pages/ChatPage.composer.test.tsx` — 184 passed.
- `uv run --no-sync pytest tests/e2e_ui/chat/test_composer_native_prediction.py tests/e2e_ui/chat/test_escape_interrupts_working_session.py 'tests/e2e_ui/chat/test_stop_button_interrupts_turn.py::test_composer_interrupts_running_turn[chromium-escape-after-reload-hermes]' -q -p no:randomly --ui-skip-build` — 3 passed.
- `pnpm --dir web type-check` — passed.
- Targeted Prettier, Oxlint, and Ruff checks — passed.
- Manual iOS Simulator A/B — focus → clear → blur removes the lingering prediction. A follow-up commit that retained only synchronous DOM/caret clearing did not; it was removed from the PR.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before:
<img width="603" height="1311" alt="text overlap on ios" src="https://github.com/user-attachments/assets/d307a7fb-61c6-4812-87f7-19c60c79f648" />

After:
<img width="412" height="274" alt="Screenshot 2026-09-10 at 1 34 45 PM" src="https://github.com/user-attachments/assets/7ac9727c-486a-4d01-bb49-94d93ed5d4df" />

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Component coverage verifies submit-button native reset and keyboard-send focus preservation. Playwright covers the browser-side reset sequence and protects the original idle-placeholder behavior; the reporter verified UIKit prediction dismissal manually.

## Changelog

Native predictive text no longer lingers over the composer after sending.
