### PR TITLE
fix(codex-native): reconcile rejected steering across turn changes

### DIFF
--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -8,7 +8,9 @@ import binascii
 import json
 import logging
 import os
+import re
 from collections.abc import AsyncIterator, Mapping
+from dataclasses import replace
 from pathlib import Path
 from typing import cast
 
@@ -56,6 +58,8 @@ _logger = logging.getLogger(__name__)
 
 _NO_ACTIVE_TURN_ERROR_CODE = -32600
 _NO_ACTIVE_TURN_ERROR_MESSAGE = "no active turn to steer"
+_COMPACTION_WAIT_TIMEOUT_S = 60.0
+_COMPACTION_POLL_INTERVAL_S = 0.1
 
 
 def _is_no_active_turn_to_steer(error: CodexAppServerResponseError) -> bool:
@@ -65,6 +69,61 @@ def _is_no_active_turn_to_steer(error: CodexAppServerResponseError) -> bool:
         and error.message is not None
         and error.message.strip().casefold() == _NO_ACTIVE_TURN_ERROR_MESSAGE
     )
+
+
+def _replacement_turn_id(error: CodexAppServerResponseError, expected_turn_id: str) -> str | None:
+    """Read a replacement only from an explicit rejection of our expected turn."""
+    if error.code != _NO_ACTIVE_TURN_ERROR_CODE or error.message is None:
+        return None
+    match = re.fullmatch(
+        r"expected active turn id `([^`\s]+)` but found `([^`\s]+)`", error.message
+    )
+    if match is None or match[1] != expected_turn_id or match[2] == expected_turn_id:
+        return None
+    return match[2]
+
+
+def _is_compacting_turn(error: CodexAppServerResponseError) -> bool:
+    """Recognize Codex's structured rejection of steering during compaction."""
+    if error.code != _NO_ACTIVE_TURN_ERROR_CODE:
+        return False
+    payload = _json_object(error.error)
+    data = _json_object(payload.get("data")) if payload is not None else None
+    info = _json_object(data.get("codexErrorInfo")) if data is not None else None
+    not_steerable = _json_object(info.get("activeTurnNotSteerable")) if info is not None else None
+    return not_steerable is not None and not_steerable.get("turnKind") == "compact"
+
+
+def _read_recovery_state(
+    bridge_dir: Path, expected: CodexNativeBridgeState
+) -> CodexNativeBridgeState:
+    """Reject recovery after the session, thread, or app-server has changed."""
+    current = read_bridge_state(bridge_dir)
+    if current is None or (
+        current.session_id,
+        current.thread_id,
+        current.socket_path,
+    ) != (expected.session_id, expected.thread_id, expected.socket_path):
+        raise RuntimeError("Codex native bridge changed while recovering a rejected steer")
+    return current
+
+
+async def _wait_for_compaction(
+    bridge_dir: Path, expected: CodexNativeBridgeState
+) -> CodexNativeBridgeState:
+    """Hold rejected input until the forwarder observes compaction finishing."""
+    try:
+        async with asyncio.timeout(_COMPACTION_WAIT_TIMEOUT_S):
+            while True:
+                current = _read_recovery_state(bridge_dir, expected)
+                if current.active_turn_id != expected.active_turn_id:
+                    return current
+                await asyncio.sleep(_COMPACTION_POLL_INTERVAL_S)
+    except TimeoutError as exc:
+        raise RuntimeError(
+            "Codex is still compacting; this message was not delivered. "
+            "Wait for compaction to finish before retrying."
+        ) from exc
 
 
 async def _start_codex_turn(
@@ -144,7 +203,7 @@ async def _inject_codex_turn(
     input_items: list[dict[str, object]],
     settings_overrides: Mapping[str, object],
 ) -> None:
-    """Steer an active turn or start one, recovering one proven stale steer."""
+    """Steer or start a turn, retrying once only after a proven rejection."""
     if state.active_turn_id is None:
         await _start_codex_turn(
             client,
@@ -165,18 +224,22 @@ async def _inject_codex_turn(
         )
         return
     except CodexAppServerResponseError as error:
-        if not _is_no_active_turn_to_steer(error):
+        recovered_state = _read_recovery_state(bridge_dir, state)
+        replacement_turn_id = _replacement_turn_id(error, expected_turn_id)
+        if _is_no_active_turn_to_steer(error):
+            clear_active_turn_id_if_matches(bridge_dir, expected_turn_id)
+            recovered_state = _read_recovery_state(bridge_dir, state)
+        elif replacement_turn_id is not None:
+            if recovered_state.active_turn_id in (None, expected_turn_id):
+                recovered_state = replace(recovered_state, active_turn_id=replacement_turn_id)
+        elif _is_compacting_turn(error):
+            recovered_state = await _wait_for_compaction(bridge_dir, state)
+        else:
             raise
 
-    # Codex authoritatively says A ended. Clear A only if it is still the
-    # bridge's value; a concurrent turn/started(B) must survive this recovery.
-    clear_active_turn_id_if_matches(bridge_dir, expected_turn_id)
-    recovered_state = read_bridge_state(bridge_dir)
-    if recovered_state is None or recovered_state.session_id != state.session_id:
-        raise RuntimeError("Codex native bridge changed while recovering a stale turn")
     if recovered_state.active_turn_id is not None:
         _logger.info(
-            "Codex native stale steer raced with a newer turn; steering turn_id=%s",
+            "Codex native reconciled rejected steer; steering turn_id=%s",
             recovered_state.active_turn_id,
         )
         await _steer_codex_turn(

--- a/tests/e2e/test_codex_native_turn_desync_e2e.py
+++ b/tests/e2e/test_codex_native_turn_desync_e2e.py
@@ -1,0 +1,370 @@
+"""End-to-end: a web message must survive a codex-native active-turn-id desync.
+
+Production codex-native sessions fail user turns with::
+
+    turn surfaced to UI as failed for ... (harness=codex-native): {'code':
+    'runner_error', 'message': "inner executor error: Codex native executor
+    error: {'code': -32600, 'message': 'expected active turn id `A` but
+    found `B`'}"}
+
+The journey: the user has a codex-native session whose Codex thread is
+running a turn; the bridge's recorded ``active_turn_id`` has drifted from
+the turn Codex actually considers active (Codex rotated turns between the
+bridge write and the injection); the user sends a message from the web UI.
+``CodexNativeExecutor.run_turn`` steers with the stale recorded id, the
+app-server rejects it with the structured ``-32600 "expected active turn id
+`A` but found `B`"`` error, and ``_inject_codex_turn`` re-raises it (its
+stale-steer recovery only matches ``"no active turn to steer"``), so the
+user's turn dies in the web UI.
+
+Why fault-injection instead of driving the live TUI
+----------------------------------------------------
+The desync window is a narrow production race (the forwarder's bridge-state
+write racing the executor's read), not a state a scripted UI drive can hit
+deterministically, and this environment has no Codex credential or reachable
+model endpoint to run a real signed-in codex-native web session. So, like
+``test_host_codex_native_e2e.py::test_codex_native_stale_completed_turn_recovers_with_new_turn``
+does for the stale-*completed*-turn variant, this test recreates the proven
+desync state directly against **real** components: a real ``codex
+app-server`` (spawned from the ``codex`` CLI on PATH) whose model provider
+points at a local sink that never answers — keeping the started turn
+authoritatively *active* — and a real bridge state recording a different,
+stale turn id. The real ``CodexNativeExecutor`` then injects a user message
+over the real WebSocket JSON-RPC wire, exactly the production stack::
+
+    run_turn -> _inject_codex_turn -> _steer_codex_turn -> client.request
+
+While the bug is live the executor yields ``ExecutorError("Codex native
+executor error: {'code': -32600, 'message': 'expected active turn id ...
+but found ...'}")`` — the exact logged failure. After a fix the message
+must reach the turn Codex names as active (Codex's rejection is
+authoritative about it) and the user's turn must complete.
+
+Self-contained and offline: needs only the ``codex`` CLI on PATH — no
+login, no model access, no server. Run with::
+
+    .venv/bin/python -m pytest tests/e2e/test_codex_native_turn_desync_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent.harnesses.codex_native.app_server import (
+    CodexAppServerClient,
+    CodexAppServerResponseError,
+)
+from omnigent.harnesses.codex_native.bridge import (
+    CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    CodexNativeBridgeState,
+    read_bridge_state,
+    write_bridge_state,
+)
+from omnigent.inner.codex_native_executor import CodexNativeExecutor
+from omnigent.inner.executor import ExecutorError, TurnComplete
+
+# A well-formed UUIDv7-shaped turn id that is never the real active turn:
+# the bridge's stale record, standing in for the id the forwarder wrote
+# before Codex rotated turns.
+_STALE_TURN_ID = "01a00000-0000-7000-8000-000000000000"
+
+_APP_SERVER_CONNECT_TIMEOUT_S = 30.0
+# turn/start returns before the app-server registers the turn as
+# steerable, so the stale-steer precondition is polled until it draws
+# the structured desync rejection rather than "no active turn to steer".
+_TURN_STEERABLE_TIMEOUT_S = 15.0
+# connect() runs the ws handshake plus the initialize request with no
+# internal timeout; attaching while the app-server is still booting can
+# hang it, so every attempt is individually bounded and retried.
+_CONNECT_ATTEMPT_TIMEOUT_S = 10.0
+_RPC_TIMEOUT_S = 15.0
+
+
+def _free_port() -> int:
+    """
+    Allocate one free loopback TCP port.
+
+    :returns: A currently-unbound port number.
+    """
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+async def _sink_connection(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    """
+    Absorb a model-provider connection without ever responding.
+
+    Codex's model request hangs on this sink, so the turn it belongs to
+    stays *active* on the app-server for the whole test — the precondition
+    the stale steer needs to be rejected with the desync error rather than
+    "no active turn to steer".
+
+    :param reader: Connected stream reader.
+    :param writer: Connected stream writer.
+    """
+    try:
+        while await reader.read(65536):
+            pass
+    except Exception:
+        pass
+    finally:
+        writer.close()
+
+
+def _write_codex_home(home: Path, sink_port: int) -> None:
+    """
+    Seed a scratch ``CODEX_HOME`` whose model provider is the local sink.
+
+    :param home: Scratch CODEX_HOME directory.
+    :param sink_port: Loopback port of the never-answering sink server.
+    """
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "auth.json").write_text(json.dumps({"OPENAI_API_KEY": "sk-test-offline"}))
+    (home / "config.toml").write_text(
+        'model = "gpt-5.1-codex"\n'
+        'model_provider = "sink"\n'
+        "\n"
+        "[model_providers.sink]\n"
+        'name = "Sink"\n'
+        f'base_url = "http://127.0.0.1:{sink_port}/v1"\n'
+        'wire_api = "responses"\n'
+        'env_key = "OPENAI_API_KEY"\n'
+    )
+
+
+def _spawn_app_server(home: Path, ws_url: str, stderr_log: Path) -> subprocess.Popen[bytes]:
+    """
+    Spawn the real ``codex app-server`` listening on *ws_url*.
+
+    :param home: Scratch CODEX_HOME directory.
+    :param ws_url: Loopback WebSocket listen URL, e.g. ``"ws://127.0.0.1:9876"``.
+    :param stderr_log: File capturing the app-server's stderr for diagnostics.
+    :returns: The spawned app-server subprocess handle.
+    """
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(home)
+    env["OPENAI_API_KEY"] = "sk-test-offline"
+    # The sink must be dialed directly, never through a CI egress proxy.
+    env["NO_PROXY"] = "127.0.0.1,localhost," + env.get("NO_PROXY", "")
+    env["no_proxy"] = env["NO_PROXY"]
+    codex = shutil.which("codex")
+    assert codex is not None
+    with open(stderr_log, "wb") as log_fh:
+        return subprocess.Popen(
+            [codex, "app-server", "--listen", ws_url],
+            env=env,
+            cwd=str(home),
+            stdout=subprocess.DEVNULL,
+            stderr=log_fh,
+        )
+
+
+async def _connect_when_ready(
+    ws_url: str,
+    proc: subprocess.Popen[bytes],
+    stderr_log: Path,
+) -> CodexAppServerClient:
+    """
+    Connect (with the initialize handshake) once the app-server listens.
+
+    :param ws_url: App-server WebSocket URL.
+    :param proc: App-server subprocess, polled so a crash fails fast.
+    :param stderr_log: The app-server stderr log, quoted on failure.
+    :returns: A connected client.
+    """
+    deadline = asyncio.get_running_loop().time() + _APP_SERVER_CONNECT_TIMEOUT_S
+    while True:
+        if proc.poll() is not None:
+            pytest.fail(
+                "codex app-server exited before accepting connections: "
+                f"{stderr_log.read_text(errors='replace')[-2000:]}"
+            )
+        client = CodexAppServerClient(ws_url=ws_url, client_name="omnigent-desync-e2e")
+        try:
+            await asyncio.wait_for(client.connect(), _CONNECT_ATTEMPT_TIMEOUT_S)
+            return client
+        except (OSError, asyncio.TimeoutError):
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(client.close(), 5.0)
+            if asyncio.get_running_loop().time() > deadline:
+                pytest.fail(
+                    "codex app-server never accepted a connection: "
+                    f"{stderr_log.read_text(errors='replace')[-2000:]}"
+                )
+            await asyncio.sleep(0.1)
+
+
+async def _request(
+    client: CodexAppServerClient, method: str, params: dict[str, Any]
+) -> dict[str, Any]:
+    """
+    Issue one bounded driver RPC.
+
+    :param client: Connected app-server client.
+    :param method: JSON-RPC method, e.g. ``"turn/start"``.
+    :param params: JSON-RPC params.
+    :returns: The decoded response envelope.
+    """
+    return await asyncio.wait_for(client.request(method, params), _RPC_TIMEOUT_S)
+
+
+async def _collect_turn_events(executor: CodexNativeExecutor, text: str) -> list[Any]:
+    """
+    Run one executor turn for a web user message and collect its events.
+
+    :param executor: Native Codex executor under test.
+    :param text: User text to send, e.g. ``"follow up"``.
+    :returns: Events yielded by :meth:`CodexNativeExecutor.run_turn`.
+    """
+    events: list[Any] = []
+    async for event in executor.run_turn(
+        [{"role": "user", "content": [{"type": "input_text", "text": text}]}],
+        [],
+        "",
+    ):
+        events.append(event)
+    return events
+
+
+@pytest.mark.skipif(
+    shutil.which("codex") is None,
+    reason="codex-native turn-desync e2e needs the `codex` CLI on PATH",
+)
+@pytest.mark.timeout(120)
+async def test_web_message_survives_active_turn_id_desync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale bridge turn id must not fail the user's web message.
+
+    Recreates the production desync against a real codex app-server: Codex
+    is running turn B while the bridge records stale turn A. The web
+    message injected through the real executor must be delivered to the
+    turn Codex names as active — never surfaced to the UI as::
+
+        Codex native executor error: {'code': -32600, 'message':
+        'expected active turn id `A` but found `B`'}
+    """
+    # The executor only injects when no other Omnigent session owns the
+    # thread; this test is the owning session.
+    monkeypatch.delenv(CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR, raising=False)
+
+    sink_conns: list[asyncio.StreamWriter] = []
+
+    async def _sink(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        sink_conns.append(writer)
+        await _sink_connection(reader, writer)
+
+    sink_port = _free_port()
+    sink = await asyncio.start_server(_sink, "127.0.0.1", sink_port)
+    home = tmp_path / "codex-home"
+    _write_codex_home(home, sink_port)
+    ws_url = f"ws://127.0.0.1:{_free_port()}"
+    stderr_log = tmp_path / "app-server.stderr.log"
+    proc = _spawn_app_server(home, ws_url, stderr_log)
+    driver: CodexAppServerClient | None = None
+    try:
+        driver = await _connect_when_ready(ws_url, proc, stderr_log)
+
+        # Real thread + real turn B: Codex's authoritative active turn.
+        # Its model request hangs on the sink, so B stays active.
+        response = await _request(driver, "thread/start", {})
+        thread_id = response["result"]["thread"]["id"]
+        response = await _request(
+            driver,
+            "turn/start",
+            {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": "keep working"}],
+                "environments": [{"environmentId": "local", "cwd": str(tmp_path)}],
+            },
+        )
+        turn_b = response["result"]["turn"]["id"]
+        assert isinstance(turn_b, str) and turn_b
+        assert turn_b != _STALE_TURN_ID
+
+        # Precondition: Codex must consider B active and reject a stale
+        # steer with the structured desync error this bug is about. The
+        # app-server registers a started turn as steerable asynchronously
+        # after turn/start returns, so poll until the probe stops drawing
+        # the not-yet-registered "no active turn to steer".
+        deadline = asyncio.get_running_loop().time() + _TURN_STEERABLE_TIMEOUT_S
+        while True:
+            with pytest.raises(CodexAppServerResponseError) as rejection:
+                await _request(
+                    driver,
+                    "turn/steer",
+                    {
+                        "threadId": thread_id,
+                        "expectedTurnId": _STALE_TURN_ID,
+                        "input": [{"type": "text", "text": "probe"}],
+                    },
+                )
+            if "expected active turn id" in str(rejection.value):
+                break
+            if asyncio.get_running_loop().time() > deadline:
+                pytest.fail(
+                    "codex app-server never produced the desync rejection; "
+                    f"the started turn never became steerable: {rejection.value}"
+                )
+            await asyncio.sleep(0.05)
+
+        # The proven production desync state: Codex runs B, the bridge
+        # still records A (the forwarder's write raced the rotation).
+        bridge_dir = tmp_path / "bridge"
+        bridge_dir.mkdir()
+        write_bridge_state(
+            bridge_dir,
+            CodexNativeBridgeState(
+                session_id="conv_desync_e2e",
+                socket_path=ws_url,
+                thread_id=thread_id,
+                codex_home=str(home),
+                active_turn_id=_STALE_TURN_ID,
+            ),
+        )
+
+        # The user's web message, injected through the real executor —
+        # the exact production path (run_turn -> _inject_codex_turn ->
+        # _steer_codex_turn -> client.request).
+        executor = CodexNativeExecutor(bridge_dir=bridge_dir)
+        events = await _collect_turn_events(executor, "please also update the docs")
+
+        errors = [event for event in events if isinstance(event, ExecutorError)]
+        assert not errors, (
+            "web message died in the active-turn-id desync instead of being "
+            f"delivered to Codex's live turn: {errors[0].message!r}"
+        )
+        assert [type(event) for event in events] == [TurnComplete]
+
+        # The injection must have resynchronized onto the turn Codex named
+        # as active — steering B, never double-starting a new turn.
+        state = read_bridge_state(bridge_dir)
+        assert state is not None
+        assert state.active_turn_id == turn_b, (
+            "injection did not resync onto Codex's authoritative active turn: "
+            f"bridge records {state.active_turn_id!r}, codex runs {turn_b!r}"
+        )
+    finally:
+        if driver is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(driver.close(), 10.0)
+        proc.kill()
+        proc.wait()
+        for writer in sink_conns:
+            with contextlib.suppress(Exception):
+                writer.close()
+        sink.close()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(sink.wait_closed(), 5.0)

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -751,6 +753,231 @@ def test_stale_steer_recovery_preserves_and_steers_concurrent_new_turn(
     state = read_bridge_state(tmp_path)
     assert state is not None
     assert state.active_turn_id == "turn_b"
+
+
+@pytest.fixture
+def rejected_steer_client(monkeypatch: pytest.MonkeyPatch) -> type[_FakeCodexNativeClient]:
+    """Install a client that rejects the first steer and accepts a reconciled turn."""
+
+    class _RejectedSteerClient(_FakeCodexNativeClient):
+        requests = []
+        created = []
+        next_turn = 1
+        rejection = CodexAppServerResponseError(
+            {"code": -32600, "message": "expected active turn id `turn_a` but found `turn_b`"}
+        )
+        retry_error: Exception | None = None
+        on_rejection: Callable[[], None] = lambda: None
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            if method != "turn/steer":
+                return await super().request(method, params)
+            type(self).requests.append((method, params))
+            if sum(method == "turn/steer" for method, _params in type(self).requests) == 1:
+                type(self).on_rejection()
+                raise type(self).rejection
+            if type(self).retry_error is not None:
+                raise type(self).retry_error
+            return {"result": {"turnId": params["expectedTurnId"]}}
+
+    monkeypatch.setattr(
+        "omnigent.harnesses.codex_native.app_server.CodexAppServerClient", _RejectedSteerClient
+    )
+    return _RejectedSteerClient
+
+
+@pytest.mark.parametrize("enqueue", [False, True], ids=["run-turn", "live-message"])
+@pytest.mark.parametrize("bridge_turn", ["turn_a", "turn_c", None])
+def test_mismatched_turn_recovery_preserves_newer_bridge_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_steer_client: type[_FakeCodexNativeClient],
+    bridge_turn: str | None,
+    enqueue: bool,
+) -> None:
+    """Use the rejected RPC's turn only when the bridge has not advanced further."""
+    from omnigent.harnesses.codex_native.bridge import update_active_turn_id
+
+    _seed_bridge(tmp_path, active_turn_id="turn_a")
+    monkeypatch.setattr(
+        rejected_steer_client, "on_rejection", lambda: update_active_turn_id(tmp_path, bridge_turn)
+    )
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+    if enqueue:
+        assert asyncio.run(executor.enqueue_session_message("session", "follow up")) is True
+    else:
+        assert [type(event) for event in _collect_turn_events(executor, "follow up")] == [
+            TurnComplete
+        ]
+    expected_turn = "turn_b" if bridge_turn in (None, "turn_a") else bridge_turn
+    requests = rejected_steer_client.requests
+    assert len(requests) == 2
+    assert requests[0][1]["expectedTurnId"] == "turn_a"
+    assert requests[1][0] == "turn/steer"
+    assert requests[1][1]["expectedTurnId"] == expected_turn
+    assert requests[1][1]["input"] == [{"type": "text", "text": "follow up"}]
+    state = read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.active_turn_id == expected_turn
+
+
+@pytest.mark.parametrize("field", ["session_id", "thread_id", "socket_path"])
+def test_rejected_steer_does_not_follow_a_rotated_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_steer_client: type[_FakeCodexNativeClient],
+    field: str,
+) -> None:
+    """A clear, session rotation, or app-server replacement must not receive the old input."""
+    _seed_bridge(tmp_path, active_turn_id="turn_a")
+    original = read_bridge_state(tmp_path)
+    assert original is not None
+    rotated = replace(original, **{field: "different"})
+    monkeypatch.setattr(
+        rejected_steer_client, "on_rejection", lambda: write_bridge_state(tmp_path, rotated)
+    )
+
+    events = _collect_turn_events(CodexNativeExecutor(bridge_dir=tmp_path), "follow up")
+
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+    assert "bridge changed" in events[0].message
+    assert len(rejected_steer_client.requests) == 1
+    assert read_bridge_state(tmp_path) == rotated
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        {"code": -32600, "message": "expected active turn id `different` but found `turn_b`"},
+        {"code": -32600, "message": "expected active turn id `turn_a` but found `turn_a`"},
+        {"code": -32603, "message": "expected active turn id `turn_a` but found `turn_b`"},
+        {"code": -32600, "message": "cannot steer a compact turn"},
+        {
+            "code": -32600,
+            "data": {"codexErrorInfo": {"activeTurnNotSteerable": {"turnKind": "unknown"}}},
+        },
+    ],
+)
+def test_rejected_steer_requires_an_authoritative_recoverable_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_steer_client: type[_FakeCodexNativeClient],
+    error: dict[str, Any],
+) -> None:
+    """Malformed, unrelated and ambiguous errors do not authorize replaying input."""
+    _seed_bridge(tmp_path, active_turn_id="turn_a")
+    monkeypatch.setattr(rejected_steer_client, "rejection", CodexAppServerResponseError(error))
+
+    events = _collect_turn_events(CodexNativeExecutor(bridge_dir=tmp_path), "follow up")
+
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+    assert len(rejected_steer_client.requests) == 1
+    state = read_bridge_state(tmp_path)
+    assert state is not None and state.active_turn_id == "turn_a"
+
+
+def test_mismatched_turn_recovery_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_steer_client: type[_FakeCodexNativeClient],
+) -> None:
+    """A failed retry cannot start another retry or advance unconfirmed bridge state."""
+    _seed_bridge(tmp_path, active_turn_id="turn_a")
+    monkeypatch.setattr(
+        rejected_steer_client,
+        "retry_error",
+        CodexAppServerResponseError(
+            {"code": -32600, "message": "expected active turn id `turn_b` but found `turn_c`"}
+        ),
+    )
+
+    events = _collect_turn_events(CodexNativeExecutor(bridge_dir=tmp_path), "follow up")
+
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+    assert len(rejected_steer_client.requests) == 2
+    state = read_bridge_state(tmp_path)
+    assert state is not None and state.active_turn_id == "turn_a"
+
+
+def _compacting_error() -> CodexAppServerResponseError:
+    return CodexAppServerResponseError(
+        {
+            "code": -32600,
+            "message": "cannot steer a compact turn",
+            "data": {"codexErrorInfo": {"activeTurnNotSteerable": {"turnKind": "compact"}}},
+        }
+    )
+
+
+@pytest.mark.parametrize("enqueue", [False, True], ids=["run-turn", "live-message"])
+@pytest.mark.parametrize("next_turn", [None, "turn_b"])
+def test_compaction_holds_rejected_input_until_the_turn_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_steer_client: type[_FakeCodexNativeClient],
+    next_turn: str | None,
+    enqueue: bool,
+) -> None:
+    """Compaction may finish idle or start a newer turn; deliver the input once either way."""
+    from omnigent.harnesses.codex_native.bridge import update_active_turn_id
+
+    def finish_compaction() -> None:
+        asyncio.get_running_loop().call_soon(update_active_turn_id, tmp_path, next_turn)
+
+    _seed_bridge(tmp_path, active_turn_id="turn_compact")
+    monkeypatch.setattr(rejected_steer_client, "rejection", _compacting_error())
+    monkeypatch.setattr(rejected_steer_client, "on_rejection", finish_compaction)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    if enqueue:
+        assert asyncio.run(executor.enqueue_session_message("session", "follow up")) is True
+    else:
+        assert [type(event) for event in _collect_turn_events(executor, "follow up")] == [
+            TurnComplete
+        ]
+
+    requests = rejected_steer_client.requests
+    assert len(requests) == 2
+    assert requests[0][1]["expectedTurnId"] == "turn_compact"
+    assert requests[1][0] == ("turn/steer" if next_turn else "turn/start")
+    assert requests[1][1]["input"] == [{"type": "text", "text": "follow up"}]
+
+
+def test_compaction_wait_expires_without_delivering_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_steer_client: type[_FakeCodexNativeClient],
+) -> None:
+    """A wedged compaction yields a useful error without repeatedly submitting the prompt."""
+    _seed_bridge(tmp_path, active_turn_id="turn_compact")
+    monkeypatch.setattr(rejected_steer_client, "rejection", _compacting_error())
+    monkeypatch.setattr("omnigent.inner.codex_native_executor._COMPACTION_WAIT_TIMEOUT_S", 0)
+
+    events = _collect_turn_events(CodexNativeExecutor(bridge_dir=tmp_path), "follow up")
+
+    assert len(events) == 1 and isinstance(events[0], ExecutorError)
+    assert "still compacting" in events[0].message
+    assert len(rejected_steer_client.requests) == 1
+
+
+async def test_compaction_wait_can_be_cancelled_without_delivering_input(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_steer_client: type[_FakeCodexNativeClient],
+) -> None:
+    """Stopping while waiting for compaction does not inject the pending message later."""
+    _seed_bridge(tmp_path, active_turn_id="turn_compact")
+    rejected = asyncio.Event()
+    monkeypatch.setattr(rejected_steer_client, "rejection", _compacting_error())
+    monkeypatch.setattr(rejected_steer_client, "on_rejection", rejected.set)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+    pending = asyncio.create_task(executor.enqueue_session_message("session", "follow up"))
+    await asyncio.wait_for(rejected.wait(), timeout=1)
+    pending.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    assert len(rejected_steer_client.requests) == 1
 
 
 async def test_concurrent_steering_during_turn_start_is_not_dropped(


### PR DESCRIPTION
## Related issue

Follow-up to #5398. No separate issue filed.

## Summary

- Follow-up messages can fail when Codex replaces an active turn or rejects steering during compaction. Existing recovery only recognizes an idle thread.
- Reconcile an explicitly rejected turn ID, preserving newer bridge state. For structured compaction rejections, wait up to 60 seconds for the turn to change before retrying once.
- Recheck session/thread/app-server identity and propagate cancellation. Do not retry ambiguous transport errors, unknown errors, or a failed recovery attempt.

ELI5: if Codex says the message went to the wrong turn, deliver it to the right one once; if it is compacting, wait rather than repeatedly submit the message.

```text
steer rejected
  -> verify same session / thread / app-server
  -> reconcile turn ID OR wait for compaction
  -> one start/steer attempt
```

## Test Plan

- `uv run --no-sync pytest tests/inner/test_codex_native_executor.py -q`: 47 passed, including 21 added regression cases.
- `uv run --no-sync pytest tests/test_codex_native_bridge.py tests/test_codex_native_app_server.py -q`: 138 passed.
- `uv run --no-sync pyrefly check`: 0 errors.
- `uv run --no-sync pre-commit run`: passed on the staged changes.
- Coverage includes normal and live-message injection, lagging/newer/cleared bridge state, session/thread/server rotation, unrelated errors, retry bounds, compaction completion, compaction timeout, and cancellation.

Manual acceptance (not run): in a Codex-native session, start compaction in the terminal and send a follow-up from Omnigent. It should be delivered once after compaction completes. Cancelling while it waits must not deliver it later. A compaction lasting over 60 seconds should return the explicit wait-and-retry message.

## Demo

N/A — backend-only change; reproducible automated evidence is listed in Test Plan.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Deterministic app-server doubles exercise both executor entry points; real bridge files exercise state changes. No live model or authenticated UI testing was performed. Existing bridge/app-server tests also pass.

## Changelog

Codex-native follow-ups recover from rejected turn changes and wait for compaction before retrying.

## Issues

Resolves [OMNI-7117](https://linear.app/omnigent/issue/OMNI-7117/omnigent-codex-native-turn-injection-desynchronizes-active-turn-ids)
