### PR TITLE
Retain inactive Codex bridges for 7 days

### DIFF
--- a/omnigent/harnesses/codex_native/bridge.py
+++ b/omnigent/harnesses/codex_native/bridge.py
@@ -8,8 +8,10 @@ import json
 import os
 import re
 import secrets
+import stat
 import sys
 import tempfile
+import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
@@ -55,6 +57,7 @@ _MCP_CONFIG_FILE = "bridge.json"
 # whereas ``state.json`` mutates on every turn/thread change.
 _POLICY_HOOK_FILE = "policy_hook.json"
 _BRIDGE_ROOT = Path.home() / ".omnigent" / "codex-native"
+_ORPHAN_RETENTION_SECONDS = 7 * 24 * 60 * 60
 
 
 def bridge_root() -> Path:
@@ -149,16 +152,68 @@ def prepare_bridge_dir(bridge_id: str) -> Path:
 
 def prune_orphaned_bridge_dirs() -> int:
     """
-    Remove codex-native bridge dirs whose owner process is provably dead.
+    Remove inactive codex-native bridge dirs whose owner is provably dead.
 
-    Delegates to the shared sweep against this harness's bridge root; the
-    runner calls it (via ``native_bridge_common.reap_orphaned_native_bridge_dirs``)
-    at startup to reclaim dirs leaked by a prior runner that died without
-    running the explicit delete path.
+    A runner restart is a normal Codex resume boundary, so owner death alone
+    cannot imply that the local rollout is disposable. Keep the whole bridge
+    for 7 days after its latest bridge preparation or rollout activity, then
+    remove it intact.
+    Explicit session deletion remains immediate. The runner calls this via
+    ``native_bridge_common.reap_orphaned_native_bridge_dirs`` at startup.
 
-    :returns: The number of orphaned bridge dirs removed.
+    :returns: The number of orphaned bridge dirs pruned.
     """
-    return native_bridge_common.prune_orphaned_dirs(bridge_root())
+    return native_bridge_common.prune_orphaned_dirs(
+        bridge_root(),
+        should_prune=_codex_orphan_retention_expired,
+    )
+
+
+def _codex_orphan_retention_expired(bridge_dir: Path) -> bool:
+    """Return whether a dead-owner Codex bridge has been inactive for 7 days."""
+    activity_cutoff = time.time() - _ORPHAN_RETENTION_SECONDS
+    owner_marker = bridge_dir / native_bridge_common.OWNER_PID_FILENAME
+    try:
+        if owner_marker.stat().st_mtime > activity_cutoff:
+            return False
+    except OSError:
+        return False
+
+    sessions_dir = bridge_dir / "codex-home" / "sessions"
+    try:
+        sessions_mode = sessions_dir.stat().st_mode
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    if not stat.S_ISDIR(sessions_mode):
+        return False
+
+    scan_failed = False
+
+    def _record_scan_failure(_error: OSError) -> None:
+        nonlocal scan_failed
+        scan_failed = True
+
+    try:
+        for directory, _subdirs, filenames in os.walk(
+            sessions_dir,
+            onerror=_record_scan_failure,
+        ):
+            for filename in filenames:
+                if not filename.startswith("rollout-") or not filename.endswith(".jsonl"):
+                    continue
+                rollout = Path(directory) / filename
+                try:
+                    if rollout.stat().st_mtime > activity_cutoff:
+                        return False
+                except FileNotFoundError:
+                    continue
+                except OSError:
+                    return False
+    except OSError:
+        return False
+    return not scan_failed
 
 
 def write_mcp_bridge_config(bridge_dir: Path) -> None:

--- a/omnigent/native/native_bridge_common.py
+++ b/omnigent/native/native_bridge_common.py
@@ -2,14 +2,15 @@
 
 Each native coding-agent harness (claude / codex / antigravity / opencode /
 pi) keeps a per-session bridge directory under its own bridge root holding the
-``bridge.json`` token, MCP/policy config, and ``permission_hook.json``. When a
-launcher crashes or a session is abandoned, that directory is left behind and
-accumulates — each one holds bearer-token / auth material.
+``bridge.json`` token, MCP/policy config, and hook state. Some harnesses also
+co-locate persistent resume state there. When a launcher crashes or a session
+is abandoned, disposable bridge material must be reclaimed without deleting
+state the native runtime needs to resume.
 
-To reap those, every bridge dir carries an ``owner.pid`` marker naming the
-process that prepared it. The marker is refreshed on every turn's bridge prep,
-so it always names the *current* runner; a periodic startup sweep removes dirs
-whose owner is provably dead while leaving live and unmarked dirs untouched.
+Every bridge dir carries an ``owner.pid`` marker naming the process that
+prepared it. The marker is refreshed on every turn's bridge prep. The sweep
+considers dirs whose owner is provably dead while leaving live and unmarked
+dirs alone; harnesses may apply an additional retention policy.
 
 This module factors the marker write and the per-root sweep so all five
 harnesses share one implementation (the per-harness modules only supply their
@@ -26,6 +27,7 @@ import importlib
 import logging
 import os
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 
 _logger = logging.getLogger(__name__)
@@ -49,14 +51,20 @@ def write_owner_pid_marker(bridge_dir: Path) -> None:
         (bridge_dir / OWNER_PID_FILENAME).write_text(str(os.getpid()), encoding="utf-8")
 
 
-def prune_orphaned_dirs(bridge_root: Path) -> int:
+def prune_orphaned_dirs(
+    bridge_root: Path,
+    *,
+    should_prune: Callable[[Path], bool] | None = None,
+) -> int:
     """
     Remove per-session bridge dirs under *bridge_root* whose owner is dead.
 
     The in-run analog of the terminal/process orphan sweeps: scans
-    *bridge_root* and rmtrees each immediate child dir whose ``owner.pid``
-    marker names a process that no longer exists. Conservative in the
-    dangerous direction — a reused/foreign pid reads as alive and is left.
+    *bridge_root* and removes each immediate child dir whose ``owner.pid``
+    marker names a process that no longer exists. A harness may provide an
+    additional eligibility predicate, such as a minimum inactivity period.
+    Conservative in the dangerous direction — a reused/foreign pid reads as
+    alive and is left.
     The check-then-rmtree race (a pid reused between the liveness read and
     the removal) is accepted: it is benign because a live session refreshes
     its marker every turn, so only genuinely orphaned dirs reach removal.
@@ -67,6 +75,9 @@ def prune_orphaned_dirs(bridge_root: Path) -> int:
 
     :param bridge_root: The harness's bridge root, e.g.
         ``~/.omnigent/codex-native``.
+    :param should_prune: Optional harness-specific eligibility predicate called
+        only after the owner is proven dead. ``None`` removes every dead-owner
+        directory.
     :returns: The number of orphaned bridge dirs removed.
     """
     if not bridge_root.exists():
@@ -84,11 +95,14 @@ def prune_orphaned_dirs(bridge_root: Path) -> int:
             continue
         if _process_alive(pid):
             continue
-        # Accepted residual race: the owner pid could in principle be reused
-        # by a new live process between this check and the rmtree below. The
-        # window is tiny and benign here — a live session refreshes its
-        # owner.pid every turn, so its dir always reads as live at check time
-        # and only a genuinely orphaned dir reaches this point.
+        if should_prune is not None:
+            try:
+                eligible = should_prune(entry)
+            except Exception:
+                _logger.exception("Error checking orphaned bridge dir %s", entry)
+                continue
+            if not eligible:
+                continue
         shutil.rmtree(entry, ignore_errors=True)
         pruned += 1
     return pruned

--- a/tests/e2e/test_codex_native_dir_gc_e2e.py
+++ b/tests/e2e/test_codex_native_dir_gc_e2e.py
@@ -1,19 +1,16 @@
-"""E2E regression test for unbounded ``~/.omnigent`` growth from orphaned dirs.
+"""E2E regression test for Codex bridge retention after unclean death.
 
 Per-session codex-native directories under ``~/.omnigent/codex-native/`` are
-created when a host-bound ``codex-native-ui`` session launches, but the only
-cleanup path is the runner-side ``_delete_native_bridge_dirs`` invoked on a
-clean session delete. A session whose host/runner dies uncleanly (crash,
-SIGKILL, host restart mid-run) leaves its directory behind forever — nothing
-reaps orphaned dirs on host restart or on any periodic sweep, so the tree
-grows without bound (28 GB / 273 dirs observed on one developer host).
+created when a host-bound ``codex-native-ui`` session launches. A session whose
+host/runner dies uncleanly leaves bridge credentials, sockets, and hook state
+behind alongside the ``codex-home`` rollout that Codex needs to resume the
+original thread. Host restart must retain recent bridges, then reclaim the
+whole directory after 7 days of inactivity.
 
 This test drives the real user journey: connect a host, create a
 codex-native session on it (the per-session dir appears), kill the host
-daemon and its runner uncleanly, restart the host, and assert the orphaned
-per-session directory is reclaimed within a grace period. On the current
-build the directory survives forever, so this test FAILS until a dead-owner
-reaper / retention GC lands.
+daemon and its runner uncleanly, restart the host to verify the recent bridge
+survives intact, then age its activity and restart again to verify expiration.
 
 Run::
 
@@ -35,27 +32,34 @@ import httpx
 import psutil
 import pytest
 
-from omnigent.harnesses.codex_native.bridge import bridge_dir_for_bridge_id
+from omnigent.harnesses.codex_native import bridge as codex_native_bridge
 from omnigent.native.native_coding_agents import CODEX_NATIVE_AGENT_NAME
 from tests._helpers.compat import apply_runner_env, compat_runner_cwd, runner_executable
 from tests.e2e.helpers import POLL_INTERVAL_S
 
-# How long the harness gets to reclaim an orphaned per-session dir after the
-# host restarts. Generous so a slow startup sweep still passes; the bug is
-# that no sweep exists at all, so today the dir survives indefinitely.
+# How long the host gets to reclaim an expired bridge after restart.
 _GC_GRACE_S = 90.0
 
 
-def _spawn_host_daemon(*, log_path: Path, live_server: str) -> subprocess.Popen[bytes]:
+def _spawn_host_daemon(
+    *,
+    home_dir: Path,
+    log_path: Path,
+    live_server: str,
+) -> subprocess.Popen[bytes]:
     """
     Spawn an ``omnigent host`` daemon bound to the test server.
 
+    :param home_dir: Isolated home containing only this test's bridge state.
     :param log_path: File that captures the daemon's stderr.
     :param live_server: Test server base URL.
     :returns: The spawned daemon subprocess handle.
     """
     repo_root = Path(__file__).resolve().parents[2]
     env = os.environ.copy()
+    codex_home_source = env.get("CODEX_HOME") or str(Path.home() / ".codex")
+    env["HOME"] = str(home_dir)
+    env["CODEX_HOME"] = codex_home_source
     env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
     with open(log_path, "w") as log_fh:
         return subprocess.Popen(
@@ -68,9 +72,29 @@ def _spawn_host_daemon(*, log_path: Path, live_server: str) -> subprocess.Popen[
             ],
             env=apply_runner_env(env),
             cwd=compat_runner_cwd(),
-            stdout=subprocess.DEVNULL,
+            stdout=log_fh,
             stderr=log_fh,
         )
+
+
+def _wait_for_host_connection(
+    proc: subprocess.Popen[bytes],
+    log_path: Path,
+    timeout: float = 45.0,
+) -> None:
+    """Wait until this daemon logs that its own tunnel connected."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise AssertionError(
+                f"Host daemon exited with {proc.returncode}:\n"
+                f"{log_path.read_text(encoding='utf-8', errors='replace')}"
+            )
+        with contextlib.suppress(OSError):
+            if "✓ Connected as" in log_path.read_text(encoding="utf-8"):
+                return
+        time.sleep(POLL_INTERVAL_S)
+    raise AssertionError(f"Host daemon did not connect within {timeout}s")
 
 
 def _online_host_id(client: httpx.Client, timeout: float = 45.0) -> str:
@@ -138,39 +162,60 @@ def _kill_tree_uncleanly(proc: subprocess.Popen[bytes]) -> None:
             straggler.kill()
 
 
+def _expire_codex_bridge_activity(bridge_dir: Path) -> None:
+    """Age bridge preparation and rollout activity beyond Codex retention."""
+    expired_at = time.time() - codex_native_bridge._ORPHAN_RETENTION_SECONDS - 60
+    activity_paths = [bridge_dir / "owner.pid"]
+    sessions_dir = bridge_dir / "codex-home" / "sessions"
+    if sessions_dir.is_dir():
+        activity_paths.extend(sessions_dir.rglob("rollout-*.jsonl"))
+    for activity_path in activity_paths:
+        if activity_path.exists():
+            os.utime(activity_path, (expired_at, expired_at))
+
+
 @pytest.mark.skipif(
     os.environ.get("OMNIGENT_E2E_CODEX_NATIVE") != "1" or shutil.which("codex") is None,
     reason=(
         "codex-native dir GC e2e needs `codex` on PATH and OMNIGENT_E2E_CODEX_NATIVE=1 to run"
     ),
 )
-def test_orphaned_codex_native_dir_is_reclaimed_after_host_restart(
+def test_host_restart_retains_recent_codex_bridge_then_reclaims_it(
     live_server: str,
     http_client: httpx.Client,
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """
-    A codex-native session dir orphaned by an unclean death gets reclaimed.
+    An unclean host death retains recent state and later reclaims it whole.
 
     Journey: connect host -> create a codex-native session (its per-session
     dir appears under ``~/.omnigent/codex-native/``) -> SIGKILL the host
-    daemon and its runner tree (crash) -> restart the host -> the orphaned
-    per-session dir must be garbage-collected within a grace period.
-
-    Today nothing reclaims it (cleanup only runs on clean session delete,
-    inside the now-dead runner), so this test fails until a dead-owner
-    reaper runs on host restart.
+    daemon and its runner tree (crash) -> restart the host -> the recent bridge
+    remains intact -> crash again, age it past retention, and restart -> the
+    old bridge is removed wholesale.
     """
     workspace = tmp_path / "codex_ws"
     workspace.mkdir()
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setattr(
+        codex_native_bridge,
+        "_BRIDGE_ROOT",
+        home_dir / ".omnigent" / "codex-native",
+    )
 
+    daemon_a_log = tmp_path / "host-daemon-a.log"
     daemon = _spawn_host_daemon(
-        log_path=tmp_path / "host-daemon-a.log",
+        home_dir=home_dir,
+        log_path=daemon_a_log,
         live_server=live_server,
     )
     session_id: str | None = None
     daemon_b: subprocess.Popen[bytes] | None = None
+    daemon_c: subprocess.Popen[bytes] | None = None
     try:
+        _wait_for_host_connection(daemon, daemon_a_log)
         host_id = _online_host_id(http_client)
         agent_id = _codex_native_agent_id(http_client)
 
@@ -189,7 +234,7 @@ def test_orphaned_codex_native_dir_is_reclaimed_after_host_restart(
         # The runner prepares the per-session bridge dir (keyed on the
         # session id unless rotated — a fresh session is un-rotated) under
         # ~/.omnigent/codex-native/<sha256(session_id)[:32]>.
-        session_dir = bridge_dir_for_bridge_id(session_id)
+        session_dir = codex_native_bridge.bridge_dir_for_bridge_id(session_id)
         deadline = time.monotonic() + 120.0
         while time.monotonic() < deadline and not session_dir.is_dir():
             time.sleep(POLL_INTERVAL_S)
@@ -197,6 +242,12 @@ def test_orphaned_codex_native_dir_is_reclaimed_after_host_restart(
             f"per-session codex-native dir {session_dir} never appeared — "
             "cannot exercise the GC journey"
         )
+        codex_home = session_dir / "codex-home"
+        codex_home.mkdir(parents=True, exist_ok=True)
+        persistent_sentinel = codex_home / "transcript-preserved.txt"
+        persistent_sentinel.write_text("keep", encoding="utf-8")
+        stale_runtime = session_dir / "stale-runtime.txt"
+        stale_runtime.write_text("keep-until-expiry", encoding="utf-8")
 
         # Unclean death: crash the host daemon and every runner it spawned.
         # No session delete, no graceful shutdown — the orphan scenario.
@@ -205,25 +256,47 @@ def test_orphaned_codex_native_dir_is_reclaimed_after_host_restart(
             "sanity: the crash itself must not remove the dir (nothing ran cleanup)"
         )
 
-        # Host restart after the crash — the moment a dead-owner reaper /
-        # startup GC pass should notice the orphaned dir and reclaim it.
+        # A normal replacement-runner boundary is recent activity, so the
+        # first restart must retain both persistent and runtime bridge state.
+        daemon_b_log = tmp_path / "host-daemon-b.log"
         daemon_b = _spawn_host_daemon(
-            log_path=tmp_path / "host-daemon-b.log",
+            home_dir=home_dir,
+            log_path=daemon_b_log,
             live_server=live_server,
         )
+        _wait_for_host_connection(daemon_b, daemon_b_log)
         _online_host_id(http_client)
+        assert persistent_sentinel.read_text(encoding="utf-8") == "keep"
+        assert stale_runtime.read_text(encoding="utf-8") == "keep-until-expiry"
 
+        # Once the whole bridge is inactive beyond retention, the next host
+        # restart should remove it. The session may immediately relaunch and
+        # recreate an empty bridge, so sentinel removal proves the old tree was
+        # reclaimed rather than requiring the directory to stay absent.
+        _kill_tree_uncleanly(daemon_b)
+        assert session_dir.is_dir()
+        _expire_codex_bridge_activity(session_dir)
+        daemon_c_log = tmp_path / "host-daemon-c.log"
+        daemon_c = _spawn_host_daemon(
+            home_dir=home_dir,
+            log_path=daemon_c_log,
+            live_server=live_server,
+        )
+        _wait_for_host_connection(daemon_c, daemon_c_log)
+        _online_host_id(http_client)
         gc_deadline = time.monotonic() + _GC_GRACE_S
-        while time.monotonic() < gc_deadline and session_dir.is_dir():
+        while time.monotonic() < gc_deadline and persistent_sentinel.exists():
             time.sleep(1.0)
 
-        assert not session_dir.is_dir(), (
-            f"orphaned per-session dir {session_dir} for crashed session "
-            f"{session_id} was not garbage-collected within {_GC_GRACE_S:.0f}s "
-            "of the host restarting — ~/.omnigent grows without bound"
+        assert not persistent_sentinel.exists(), (
+            f"expired bridge for crashed session {session_id} was not "
+            f"reclaimed within {_GC_GRACE_S:.0f}s of the host restarting"
+        )
+        assert not stale_runtime.exists(), (
+            "whole-directory expiration must remove runtime state with the transcript"
         )
     finally:
-        for proc in (daemon, daemon_b):
+        for proc in (daemon, daemon_b, daemon_c):
             if proc is not None and proc.poll() is None:
                 _kill_tree_uncleanly(proc)
         # Best-effort server-side delete so the test leaves no session rows
@@ -231,4 +304,7 @@ def test_orphaned_codex_native_dir_is_reclaimed_after_host_restart(
         if session_id is not None:
             with contextlib.suppress(httpx.HTTPError):
                 http_client.delete(f"/v1/sessions/{session_id}", timeout=30.0)
-            shutil.rmtree(bridge_dir_for_bridge_id(session_id), ignore_errors=True)
+            shutil.rmtree(
+                codex_native_bridge.bridge_dir_for_bridge_id(session_id),
+                ignore_errors=True,
+            )

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 from pathlib import Path
 
@@ -494,37 +495,193 @@ def test_prepare_bridge_dir_writes_owner_pid_marker(
     assert (bridge_dir / "owner.pid").read_text(encoding="utf-8").strip() == str(os.getpid())
 
 
-def test_prune_orphaned_bridge_dirs_only_removes_dead_owners(
+def test_prune_orphaned_bridge_dirs_retains_recent_dead_owner_bridge(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Prune removes only provably-dead-owner dirs; live and unmarked survive."""
-    import os
-    import subprocess
-    import sys
-
-    from omnigent.harnesses.codex_native.bridge import prune_orphaned_bridge_dirs
-
+    """Recent dead-owner bridges remain fully intact during the grace period."""
     root = tmp_path / "codex-native"
     root.mkdir(parents=True)
     monkeypatch.setattr("omnigent.harnesses.codex_native.bridge._BRIDGE_ROOT", root)
+    monkeypatch.setattr("omnigent.inner.terminal._process_alive", lambda _pid: False)
+    now = 2_000_000_000.0
+    monkeypatch.setattr(codex_native_bridge.time, "time", lambda: now)
 
-    dead = subprocess.Popen([sys.executable, "-c", "pass"])
-    dead.wait()
     dead_dir = root / "deadowner"
     dead_dir.mkdir()
-    (dead_dir / "owner.pid").write_text(str(dead.pid), encoding="utf-8")
+    owner_marker = dead_dir / "owner.pid"
+    owner_marker.write_text("999999", encoding="utf-8")
+    rollout = (
+        dead_dir
+        / "codex-home"
+        / "sessions"
+        / "2026"
+        / "09"
+        / "09"
+        / "rollout-2026-09-09T00-00-00-thread.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    rollout.write_text('{"type":"session_meta"}\n', encoding="utf-8")
+    bridge_config = dead_dir / "bridge.json"
+    bridge_config.write_text("secret", encoding="utf-8")
+    policy_config = dead_dir / "policy_hook.json"
+    policy_config.write_text("secret", encoding="utf-8")
+    ephemeral_dir = dead_dir / "mcp-runtime"
+    ephemeral_dir.mkdir()
+    runtime_token = ephemeral_dir / "token"
+    runtime_token.write_text("secret", encoding="utf-8")
+    os.utime(owner_marker, (now - 60, now - 60))
+
+    def _unexpected_walk(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("recent owner activity should skip rollout scanning")
+
+    monkeypatch.setattr(codex_native_bridge.os, "walk", _unexpected_walk)
+
+    assert codex_native_bridge.prune_orphaned_bridge_dirs() == 0
+    assert owner_marker.read_text(encoding="utf-8") == "999999"
+    assert rollout.read_text(encoding="utf-8") == '{"type":"session_meta"}\n'
+    assert bridge_config.read_text(encoding="utf-8") == "secret"
+    assert policy_config.read_text(encoding="utf-8") == "secret"
+    assert runtime_token.read_text(encoding="utf-8") == "secret"
+
+
+def test_prune_orphaned_bridge_dirs_removes_expired_bridge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead-owner bridge inactive for 7 days is removed wholesale."""
+    root = tmp_path / "codex-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("omnigent.harnesses.codex_native.bridge._BRIDGE_ROOT", root)
+    monkeypatch.setattr("omnigent.inner.terminal._process_alive", lambda _pid: False)
+    now = 2_000_000_000.0
+    monkeypatch.setattr(codex_native_bridge.time, "time", lambda: now)
+
+    dead_dir = root / "deadowner"
+    rollout = (
+        dead_dir
+        / "codex-home"
+        / "sessions"
+        / "2026"
+        / "09"
+        / "09"
+        / "rollout-2026-09-09T00-00-00-thread.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    rollout.write_text('{"type":"session_meta"}\n', encoding="utf-8")
+    unrelated_jsonl = rollout.parent / "metadata.jsonl"
+    unrelated_jsonl.write_text('{"recent":true}\n', encoding="utf-8")
+    owner_marker = dead_dir / "owner.pid"
+    owner_marker.write_text("999999", encoding="utf-8")
+    (dead_dir / "bridge.json").write_text("secret", encoding="utf-8")
+    expired_at = now - codex_native_bridge._ORPHAN_RETENTION_SECONDS
+    for activity_path in (owner_marker, rollout):
+        os.utime(activity_path, (expired_at, expired_at))
+    os.utime(unrelated_jsonl, (now - 60, now - 60))
+
+    assert codex_native_bridge.prune_orphaned_bridge_dirs() == 1
+    assert not dead_dir.exists()
+
+
+def test_prune_orphaned_bridge_dirs_uses_latest_rollout_activity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recent rollout keeps a bridge whose launch and owner marker are old."""
+    root = tmp_path / "codex-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("omnigent.harnesses.codex_native.bridge._BRIDGE_ROOT", root)
+    monkeypatch.setattr("omnigent.inner.terminal._process_alive", lambda _pid: False)
+    now = 2_000_000_000.0
+    monkeypatch.setattr(codex_native_bridge.time, "time", lambda: now)
+
+    dead_dir = root / "deadowner"
+    rollout = (
+        dead_dir
+        / "codex-home"
+        / "sessions"
+        / "2026"
+        / "09"
+        / "09"
+        / "rollout-2026-09-09T00-00-00-thread.jsonl"
+    )
+    rollout.parent.mkdir(parents=True)
+    rollout.write_text('{"type":"session_meta"}\n', encoding="utf-8")
+    owner_marker = dead_dir / "owner.pid"
+    owner_marker.write_text("999999", encoding="utf-8")
+    expired_at = now - codex_native_bridge._ORPHAN_RETENTION_SECONDS - 1
+    os.utime(owner_marker, (expired_at, expired_at))
+    os.utime(rollout, (now - 60, now - 60))
+
+    assert codex_native_bridge.prune_orphaned_bridge_dirs() == 0
+    assert dead_dir.exists()
+    assert rollout.exists()
+
+
+def test_prune_orphaned_bridge_dirs_retains_bridge_when_rollout_scan_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An incomplete rollout scan fails closed instead of deleting the bridge."""
+    root = tmp_path / "codex-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("omnigent.harnesses.codex_native.bridge._BRIDGE_ROOT", root)
+    monkeypatch.setattr("omnigent.inner.terminal._process_alive", lambda _pid: False)
+    now = 2_000_000_000.0
+    monkeypatch.setattr(codex_native_bridge.time, "time", lambda: now)
+
+    dead_dir = root / "deadowner"
+    sessions_dir = dead_dir / "codex-home" / "sessions"
+    sessions_dir.mkdir(parents=True)
+    owner_marker = dead_dir / "owner.pid"
+    owner_marker.write_text("999999", encoding="utf-8")
+    expired_at = now - codex_native_bridge._ORPHAN_RETENTION_SECONDS - 1
+    os.utime(owner_marker, (expired_at, expired_at))
+
+    def _failed_walk(
+        _root: Path,
+        *,
+        onerror: object,
+    ) -> list[tuple[str, list[str], list[str]]]:
+        assert callable(onerror)
+        onerror(PermissionError("rollout directory unreadable"))
+        return []
+
+    monkeypatch.setattr(codex_native_bridge.os, "walk", _failed_walk)
+
+    assert codex_native_bridge.prune_orphaned_bridge_dirs() == 0
+    assert dead_dir.exists()
+
+
+def test_prune_orphaned_bridge_dirs_keeps_live_and_unmarked_bridges(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live-owner and unmarked bridges remain even when old."""
+    root = tmp_path / "codex-native"
+    root.mkdir(parents=True)
+    monkeypatch.setattr("omnigent.harnesses.codex_native.bridge._BRIDGE_ROOT", root)
+    monkeypatch.setattr("omnigent.inner.terminal._process_alive", lambda pid: pid == os.getpid())
+    now = 2_000_000_000.0
+    monkeypatch.setattr(codex_native_bridge.time, "time", lambda: now)
+    expired_at = now - codex_native_bridge._ORPHAN_RETENTION_SECONDS - 1
+
+    dead_dir = root / "deadowner"
+    dead_dir.mkdir()
+    dead_marker = dead_dir / "owner.pid"
+    dead_marker.write_text("999999", encoding="utf-8")
+    os.utime(dead_marker, (expired_at, expired_at))
 
     live_dir = root / "liveowner"
     live_dir.mkdir()
-    (live_dir / "owner.pid").write_text(str(os.getpid()), encoding="utf-8")
+    live_marker = live_dir / "owner.pid"
+    live_marker.write_text(str(os.getpid()), encoding="utf-8")
+    os.utime(live_marker, (expired_at, expired_at))
 
     unmarked_dir = root / "unmarked"
     unmarked_dir.mkdir()
 
-    pruned = prune_orphaned_bridge_dirs()
-
-    assert pruned == 1
+    assert codex_native_bridge.prune_orphaned_bridge_dirs() == 1
     assert not dead_dir.exists()
     assert live_dir.exists()
     assert unmarked_dir.exists()

--- a/tests/test_native_bridge_common.py
+++ b/tests/test_native_bridge_common.py
@@ -75,6 +75,31 @@ def test_prune_missing_root_returns_zero(tmp_path: Path) -> None:
     assert native_bridge_common.prune_orphaned_dirs(tmp_path / "never-created") == 0
 
 
+def test_prune_retains_entry_when_eligibility_check_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing retention check keeps that dir and does not stop the sweep."""
+    root = tmp_path / "bridge-root"
+    failing_dir = root / "failing"
+    eligible_dir = root / "eligible"
+    for bridge_dir in (failing_dir, eligible_dir):
+        bridge_dir.mkdir(parents=True)
+        (bridge_dir / native_bridge_common.OWNER_PID_FILENAME).write_text(
+            "999999", encoding="utf-8"
+        )
+    monkeypatch.setattr("omnigent.inner.terminal._process_alive", lambda _pid: False)
+
+    def _should_prune(bridge_dir: Path) -> bool:
+        if bridge_dir == failing_dir:
+            raise OSError("unreadable activity timestamp")
+        return True
+
+    assert native_bridge_common.prune_orphaned_dirs(root, should_prune=_should_prune) == 1
+    assert failing_dir.exists()
+    assert not eligible_dir.exists()
+
+
 def test_reap_invokes_prune_for_every_native_agent(monkeypatch: pytest.MonkeyPatch) -> None:
     """The dynamic sweep calls each native agent's module-level prune once."""
     agents = (


### PR DESCRIPTION
## Related issue

Closes [OMNI-6996](https://linear.app/omnigent/issue/OMNI-6996/codex-transcript-is-getting-wiped)

## Summary

- Stop treating a dead Codex runner as proof that its local transcript is disposable. Replacement runners and host restarts are normal resume boundaries, but the orphan sweep previously deleted the per-session `codex-home` before the replacement could read it.
- Retain the entire dead-owner Codex bridge for 7 days after its latest bridge preparation or rollout activity. Live-owner and unmarked directories remain untouched; once retention expires, cleanup keeps the existing whole-directory deletion behavior.
- Use the owner marker as a fast path for recently prepared bridges, then inspect only Codex `rollout-*.jsonl` files when the marker is old. Timestamp and scan failures retain the directory rather than risking destructive cleanup.
- Keep explicit session deletion immediate and unchanged.

**ELI5:** a stopped runner is not an abandoned session. Keep its local notebook for 7 days, then delete the whole folder.

```text
live owner                        -> never purge
dead owner, recent preparation   -> retain without scanning
dead owner, recent rollout       -> retain
dead owner, inactive >= 7 days   -> delete entire bridge
explicit session deletion        -> delete immediately
```

The tradeoff is that transient bridge credentials and runtime files are retained with the transcript for up to 7 days. This first fix intentionally keeps the retention period fixed rather than adding configuration or synchronization machinery. A separate follow-up will make the server transcript the source of truth for cold resume, while keeping valid local Codex state as a fast fallback.

## Test Plan

- `.venv/bin/pytest -q tests/test_codex_native_bridge.py tests/test_native_bridge_common.py tests/e2e/test_codex_native_dir_gc_e2e.py` with a disposable `HOME` — 41 passed, 1 opt-in E2E skipped.
- `OMNIGENT_E2E_CODEX_NATIVE=1 .venv/bin/python -m pytest tests/e2e/test_codex_native_dir_gc_e2e.py -vv -s` with an isolated outer `HOME`, mock LLM, and parent runner variables removed — 1 passed.
- `uv run pre-commit run --files omnigent/harnesses/codex_native/bridge.py omnigent/native/native_bridge_common.py tests/test_codex_native_bridge.py tests/test_native_bridge_common.py tests/e2e/test_codex_native_dir_gc_e2e.py` — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression coverage verifies the recent-owner fast path, recent rollout retention, deletion at the exact 7-day boundary, exact rollout filename filtering, fail-closed timestamp scanning, live/unmarked preservation, and the real host-restart lifecycle in an isolated home directory.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The live host-restart E2E is opt-in and requires `OMNIGENT_E2E_CODEX_NATIVE=1` and `codex` on `PATH`. It passed locally against a disposable outer `HOME` and creates another isolated host `HOME` internally, so neither the reaper nor test cleanup can target real Codex sessions. Deterministic unit coverage exercises the same retention boundaries.

## Changelog

Codex sessions retain their local transcripts across runner and host restarts, with inactive bridge directories cleaned up after 7 days.

