### PR TITLE
refresh

### DIFF
--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -520,6 +520,7 @@ describe("TerminalSession", () => {
     clipboardEnabled = true,
     onClipboardRequest?: (text: string) => void,
     focusOnConnect = true,
+    onDbcertLogin?: (url: string) => void,
   ) {
     const states: ConnectionState[] = [];
     const container = document.createElement("div");
@@ -534,8 +535,21 @@ describe("TerminalSession", () => {
       clipboardEnabled,
       onClipboardRequest,
       focusOnConnect,
+      onDbcertLogin,
     );
     return { session, states, container, socket: FakeWebSocket.instances.at(-1)! };
+  }
+
+  /**
+   * Emit `text` as a binary pane frame, building the buffer from the global
+   * ArrayBuffer the source's `instanceof` check sees (see the binary-frame test
+   * below for why a TextEncoder's buffer fails that check under jsdom).
+   */
+  function emitPaneText(socket: FakeWebSocket, text: string): void {
+    const encoded = new TextEncoder().encode(text);
+    const data = new ArrayBuffer(encoded.byteLength);
+    new Uint8Array(data).set(encoded);
+    socket.emit("message", { data });
   }
 
   it("reports 'connected' and sends an initial resize on socket open", () => {
@@ -635,6 +649,50 @@ describe("TerminalSession", () => {
 
     socket.emit("message", { data: "text frame" });
     expect(onActivity).toHaveBeenCalledTimes(1); // unchanged — text ignored
+    session.dispose();
+  });
+
+  it("reports a dbcert login URL printed into the pane", () => {
+    // WHY: isaac's startup dbcert refresh prints an SSO URL whose own opener
+    // can't reach this browser, so the pane bytes are the only place the UI can
+    // learn about it.
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onDbcertLogin = vi.fn();
+    const { socket, session } = makeSession(
+      undefined,
+      undefined,
+      true,
+      undefined,
+      true,
+      onDbcertLogin,
+    );
+    const url =
+      "https://databricks.okta.com/oauth2/v1/authorize?client_id=0oa1&code_challenge=E9Me" +
+      "&code_challenge_method=S256&nonce=nQ3p" +
+      "&redirect_uri=http%3A%2F%2Flocalhost%3A4281%2Fv1%2Fdbcert%2Fcallback" +
+      "&response_type=code&scope=openid&state=hKFo";
+
+    emitPaneText(socket, `please open the following URL:\r\n\r\n\t${url}\r\n\r\n`);
+
+    expect(onDbcertLogin.mock.calls).toEqual([[url]]);
+    session.dispose();
+  });
+
+  it("stays silent on pane output with no dbcert login in it", () => {
+    vi.spyOn(performance, "now").mockReturnValue(10_000);
+    const onDbcertLogin = vi.fn();
+    const { socket, session } = makeSession(
+      undefined,
+      undefined,
+      true,
+      undefined,
+      true,
+      onDbcertLogin,
+    );
+
+    emitPaneText(socket, "$ ls -la\r\nhttps://github.com/omnigent-ai/omnigent \r\n");
+
+    expect(onDbcertLogin).not.toHaveBeenCalled();
     session.dispose();
   });
 

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -16,6 +16,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import { type FontWeight, type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { type CodeFont, codeFontFamilyForEditor, readCodeFont } from "@/lib/codeFontPreferences";
+import { createDbcertLoginWatcher } from "@/lib/dbcertLogin";
 
 // Card background colors derived from the app's CSS palette.
 // Light: --card: oklch(1.000 0 0) = pure white.
@@ -361,6 +362,12 @@ export function hadRecentTerminalInput(lastInputAt: number, now: number): boolea
 export type TerminalClipboardListener = (text: string) => void;
 
 /**
+ * Listener for a dbcert SSO login URL found in pane output. Called once per
+ * distinct URL; see lib/dbcertLogin.ts for why the UI opens it.
+ */
+export type TerminalDbcertLoginListener = (url: string) => void;
+
+/**
  * Ceiling on synthesized wheel reports for a single DOM wheel event, so a
  * page-mode or pathological delta can't flood the input channel.
  */
@@ -539,6 +546,8 @@ export class TerminalSession {
    * :param clipboardEnabled: Whether tmux copies may write the local clipboard.
    * :param onClipboardRequest: Receives validated tmux copy-mode text.
    * :param focusOnConnect: Whether to grab keyboard focus on WS-open.
+   * :param onDbcertLogin: Receives a dbcert SSO login URL printed into the
+   *     pane. Omit to skip the scan entirely.
    */
   constructor(
     container: HTMLElement,
@@ -550,6 +559,7 @@ export class TerminalSession {
     clipboardEnabled = true,
     onClipboardRequest?: TerminalClipboardListener,
     focusOnConnect = true,
+    onDbcertLogin?: TerminalDbcertLoginListener,
   ) {
     this.clipboardEnabled = clipboardEnabled;
     this.focusOnConnect = focusOnConnect;
@@ -631,6 +641,11 @@ export class TerminalSession {
       { signal },
     );
 
+    // dbcert login detection over the pane's own bytes, set up only when a
+    // listener was supplied so a surface that doesn't care pays nothing.
+    const dbcertDecoder = onDbcertLogin ? new TextDecoder() : null;
+    const watchDbcertLogin = onDbcertLogin ? createDbcertLoginWatcher(onDbcertLogin) : null;
+
     // Throttle activity notifications so rapid output (e.g. `yes`, large
     // `cat`) doesn't re-arm the 1.5 s idle timer on every WS frame.
     let lastActivityTs = 0;
@@ -640,6 +655,12 @@ export class TerminalSession {
         if (ev.data instanceof ArrayBuffer) {
           const bytes = new Uint8Array(ev.data);
           this.term.write(bytes);
+          // Decode a second time only when someone is listening. `stream: true`
+          // carries a multi-byte character split across frames, so the scan sees
+          // the same text the terminal renders.
+          if (watchDbcertLogin && dbcertDecoder) {
+            watchDbcertLogin(dbcertDecoder.decode(bytes, { stream: true }));
+          }
           const now = performance.now();
           if (now - lastActivityTs > 300) {
             lastActivityTs = now;

--- a/web/src/components/blocks/TerminalView.tsx
+++ b/web/src/components/blocks/TerminalView.tsx
@@ -14,6 +14,7 @@ import { useResolvedThemeMode } from "@/components/theme/useResolvedThemeMode";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { copyText } from "@/lib/clipboard";
+import { openDbcertLogin } from "@/lib/dbcertLogin";
 import { isDatabricksWorkspace, resolveWebSocketUrl } from "@/lib/host";
 import { subscribeCodeFont } from "@/lib/codeFontPreferences";
 import { resolveInitialAttachUrl, watchDirectUpgrade, withAttachParams } from "@/lib/terminals";
@@ -331,6 +332,33 @@ export function TerminalView({
     [copyTerminalText],
   );
 
+  // A dbcert login the agent's launcher printed into the pane. Opening it is the
+  // whole point (its own opener can't reach this browser — see lib/dbcertLogin),
+  // but terminal output carries no user gesture, so a popup blocker may refuse
+  // the tab. A refusal becomes a toast whose click supplies the gesture.
+  const notifyDbcertLogin = useCallback((url: string) => {
+    if (openDbcertLogin(url)) return;
+    toast("Finish signing in to dbcert", {
+      id: "dbcert-login",
+      description: (
+        <div className="flex flex-col gap-2">
+          <div>The agent is waiting on a dbcert login. Your browser blocked the tab.</div>
+          <div className="flex flex-wrap gap-2 pt-1">
+            <Button
+              type="button"
+              size="xs"
+              onClick={() => openDbcertLogin(url)}
+              componentId="diagnostics.terminal.dbcert_login"
+            >
+              Open dbcert login
+            </Button>
+          </div>
+        </div>
+      ),
+      duration: Infinity,
+    });
+  }, []);
+
   const notifyClipboardRequest = useCallback(
     (text: string) => {
       if (
@@ -584,6 +612,7 @@ export function TerminalView({
           !readOnly && activeRef.current,
           notifyClipboardRequest,
           focusOnConnectRef.current,
+          notifyDbcertLogin,
         );
         sessionRef.current = terminalSession;
         // Relay-connected with a direct URL on offer: negotiate the
@@ -616,6 +645,7 @@ export function TerminalView({
       notifyActivity,
       notifyInput,
       notifyClipboardRequest,
+      notifyDbcertLogin,
       disposeActiveSession,
     ],
   );

--- a/web/src/lib/dbcertLogin.test.ts
+++ b/web/src/lib/dbcertLogin.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createDbcertLoginWatcher,
+  extractDbcertLoginUrl,
+  isDbcertLoginUrl,
+  openDbcertLogin,
+} from "./dbcertLogin";
+
+/**
+ * A faithful authorize URL: the shape an OAuth2 client builds from dbcert's
+ * config, PKCE params and all.
+ */
+function authorizeUrl({
+  host = "databricks.okta.com",
+  port = 4280,
+  path = "/oauth2/v1/authorize",
+  callbackPath = "/v1/dbcert/callback",
+  state = "hKFo2SB1c2Vy",
+}: {
+  host?: string;
+  port?: number;
+  path?: string;
+  callbackPath?: string;
+  state?: string;
+} = {}): string {
+  const redirect = encodeURIComponent(`http://localhost:${port}${callbackPath}`);
+  return (
+    `https://${host}${path}?client_id=0oa1b2c3d4e5f6g7h8i9` +
+    `&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256` +
+    `&nonce=nQ3pAyEtM1&redirect_uri=${redirect}` +
+    `&response_type=code&scope=openid+profile+groups&state=${state}`
+  );
+}
+
+/**
+ * dbcert's prompt as it reaches a pane: its logger's timestamp prefix, the URL
+ * indented on its own line, and the OSC 8 hyperlink wrapper it adds whenever
+ * stderr is a terminal (so the URL appears twice).
+ */
+function dbcertPrompt(url: string): string {
+  return (
+    "Running dbcert to obtain a new certificate, please follow its instructions.\r\n" +
+    "2026/09/10 11:02:41 If the browser does not open automatically, " +
+    "please open the following URL:\r\n\r\n\t" +
+    `\x1b]8;;${url}\x1b\\${url}\x1b]8;;\x1b\\\r\n\r\n`
+  );
+}
+
+describe("isDbcertLoginUrl", () => {
+  it("accepts an authorize URL for each dbcert Okta environment", () => {
+    for (const host of [
+      "databricks.okta.com",
+      "regulated-databricks.okta-gov.com",
+      "corpengdatabricks.oktapreview.com",
+    ]) {
+      expect(isDbcertLoginUrl(authorizeUrl({ host }))).toBe(true);
+    }
+  });
+
+  it("accepts any loopback callback port", () => {
+    // dbcert moves its listener off the default port in some environments, so
+    // the port must not be part of the match.
+    expect(isDbcertLoginUrl(authorizeUrl({ port: 4281 }))).toBe(true);
+  });
+
+  it("rejects an Okta authorize URL redirecting somewhere other than dbcert", () => {
+    // Other tools' OAuth also lands on an Okta authorize endpoint; the callback
+    // path is what tells them apart.
+    expect(isDbcertLoginUrl(authorizeUrl({ callbackPath: "/callback", port: 8020 }))).toBe(false);
+  });
+
+  it("rejects a non-allowlisted host wearing the right query", () => {
+    expect(isDbcertLoginUrl(authorizeUrl({ host: "evil.example.com" }))).toBe(false);
+    expect(isDbcertLoginUrl(authorizeUrl({ host: "databricks.okta.com.evil.example" }))).toBe(
+      false,
+    );
+  });
+
+  it("rejects a different path on an allowlisted host", () => {
+    expect(isDbcertLoginUrl(authorizeUrl({ path: "/oauth2/v1/token" }))).toBe(false);
+  });
+
+  it("rejects http, missing redirect_uri, and unparseable input", () => {
+    expect(isDbcertLoginUrl(authorizeUrl().replace("https://", "http://"))).toBe(false);
+    expect(isDbcertLoginUrl("https://databricks.okta.com/oauth2/v1/authorize?client_id=x")).toBe(
+      false,
+    );
+    expect(isDbcertLoginUrl("not a url")).toBe(false);
+    expect(isDbcertLoginUrl("")).toBe(false);
+  });
+});
+
+describe("extractDbcertLoginUrl", () => {
+  it("pulls the URL out of dbcert's OSC 8 linkified prompt", () => {
+    const url = authorizeUrl();
+    expect(extractDbcertLoginUrl(dbcertPrompt(url))).toBe(url);
+  });
+
+  it("finds the URL when dbcert's stderr was not a terminal (no OSC 8 wrapper)", () => {
+    const url = authorizeUrl();
+    expect(extractDbcertLoginUrl(`please open the following URL:\r\n\r\n\t${url}\r\n\r\n`)).toBe(
+      url,
+    );
+  });
+
+  it("survives SGR colouring around the URL", () => {
+    const url = authorizeUrl();
+    expect(extractDbcertLoginUrl(`\x1b[36m${url}\x1b[0m\r\n`)).toBe(url);
+  });
+
+  it("returns the last URL when a redraw replays an older one", () => {
+    const stale = authorizeUrl({ state: "stale" });
+    const live = authorizeUrl({ state: "live" });
+    expect(extractDbcertLoginUrl(dbcertPrompt(stale) + dbcertPrompt(live))).toBe(live);
+  });
+
+  it("stays quiet for ordinary output and dbcert's other chatter", () => {
+    expect(extractDbcertLoginUrl("")).toBeNull();
+    expect(extractDbcertLoginUrl("Running dbcert to obtain a new certificate.\r\n")).toBeNull();
+    expect(extractDbcertLoginUrl("Successfully obtained new dbcert certificates.\r\n")).toBeNull();
+    expect(extractDbcertLoginUrl("https://github.com/omnigent-ai/omnigent/pull/1 \r\n")).toBeNull();
+  });
+
+  it("does not commit a URL truncated by a chunk boundary", () => {
+    const url = authorizeUrl();
+    const cut = url.slice(0, url.indexOf("&response_type"));
+    expect(cut).toContain("redirect_uri");
+    expect(extractDbcertLoginUrl(`following URL:\r\n\r\n\t${cut}`)).toBeNull();
+  });
+});
+
+describe("createDbcertLoginWatcher", () => {
+  it("reports a login URL once per distinct URL", () => {
+    const onLogin = vi.fn();
+    const watch = createDbcertLoginWatcher(onLogin);
+    const url = authorizeUrl();
+    watch(dbcertPrompt(url));
+    watch(dbcertPrompt(url));
+    expect(onLogin.mock.calls).toEqual([[url]]);
+  });
+
+  it("reassembles a URL split across frames", () => {
+    const onLogin = vi.fn();
+    const watch = createDbcertLoginWatcher(onLogin);
+    const url = authorizeUrl();
+    const text = dbcertPrompt(url);
+    const at = text.indexOf("&nonce");
+    watch(text.slice(0, at));
+    expect(onLogin).not.toHaveBeenCalled();
+    watch(text.slice(at));
+    expect(onLogin.mock.calls).toEqual([[url]]);
+  });
+
+  it("reports a second, different login", () => {
+    const onLogin = vi.fn();
+    const watch = createDbcertLoginWatcher(onLogin);
+    const first = authorizeUrl({ state: "first" });
+    const second = authorizeUrl({ state: "second" });
+    watch(dbcertPrompt(first));
+    watch(dbcertPrompt(second));
+    expect(onLogin.mock.calls).toEqual([[first], [second]]);
+  });
+
+  it("ignores empty chunks and plain output", () => {
+    const onLogin = vi.fn();
+    const watch = createDbcertLoginWatcher(onLogin);
+    watch("");
+    watch("$ ls -la\r\n");
+    expect(onLogin).not.toHaveBeenCalled();
+  });
+});
+
+describe("openDbcertLogin", () => {
+  const url = authorizeUrl();
+
+  it("opens the URL in a new tab with no handle back to this window", () => {
+    const open = vi.fn(() => ({}) as Window);
+    expect(openDbcertLogin(url, { open } as unknown as Window)).toBe(true);
+    expect(open).toHaveBeenCalledWith(url, "_blank", "noopener,noreferrer");
+  });
+
+  it("reports a popup-blocked open", () => {
+    const open = vi.fn(() => null);
+    expect(openDbcertLogin(url, { open } as unknown as Window)).toBe(false);
+  });
+});

--- a/web/src/lib/dbcertLogin.ts
+++ b/web/src/lib/dbcertLogin.ts
@@ -1,0 +1,183 @@
+// Auto-opening the dbcert SSO login an agent's terminal asks for.
+//
+// Databricks' ``isaac`` wrapper refreshes the short-lived dbcert credential
+// every agent needs before handing off to Claude/Codex. When that credential is
+// stale, its launcher runs ``dbcert``, which starts a loopback callback
+// listener, prints
+//
+//   If the browser does not open automatically, please open the following URL:
+//
+//       https://databricks.okta.com/oauth2/v1/authorize?...
+//
+// and tries to open that URL itself. Its opener is a local one (``open`` /
+// ``xdg-open``), so when the agent runs on a remote dev box there is no browser
+// to reach: the launch sits blocked on a login whose link is only visible as
+// text in the terminal pane. Since the pane's bytes already stream to this UI,
+// we scan them and open the link in the browser the user is actually looking at
+// — the same tab they would get by clicking it by hand.
+//
+// Detection is deliberately narrow. A match needs BOTH an allowlisted Okta
+// authorization endpoint AND a ``redirect_uri`` pointing at dbcert's own
+// ``/v1/dbcert/callback`` handler, so neither an unrelated Okta link an agent
+// happens to print nor a different OAuth flow can trigger an automatic tab.
+
+/**
+ * Okta authorization hosts dbcert is configured against, across its four
+ * environments (prod, prod-emergency, prod-aws-gov, dev). An authorize URL on
+ * any other host is not dbcert's, whatever its query string says.
+ */
+const DBCERT_OKTA_HOSTS = new Set([
+  "databricks.okta.com",
+  "regulated-databricks.okta-gov.com",
+  "corpengdatabricks.oktapreview.com",
+]);
+
+const OKTA_AUTHORIZE_PATH = "/oauth2/v1/authorize";
+
+/**
+ * dbcert's OAuth callback, served by the short-lived loopback listener it runs
+ * for the duration of a login. Its port varies by environment, so the match is
+ * on host and path only.
+ */
+const DBCERT_CALLBACK_PATH = "/v1/dbcert/callback";
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1"]);
+
+/**
+ * Candidate authorize URLs, with a required terminator after the match so a URL
+ * cut in half by a chunk boundary is never committed as if it were whole: a
+ * truncated authorize URL still parses and can still carry a valid
+ * ``redirect_uri``, and opening it would land the user on an Okta error. dbcert
+ * prints the URL followed by newlines, so a real one always brings its own
+ * terminator.
+ */
+const AUTHORIZE_URL = new RegExp(
+  String.raw`https?://[^\s'"\`<>)\]}]+\/oauth2\/v1\/authorize\?[^\s'"\`<>)\]}]+(?=[\s'"\`<>)\]}])`,
+  "gi",
+);
+
+/**
+ * How much recent output to keep for the scan. An Okta authorize URL carries
+ * PKCE, nonce, state and scopes, so it runs several hundred characters; the tail
+ * has to be able to hold a whole one plus whatever precedes it in the frame that
+ * split it.
+ */
+const TAIL_CHARS = 2048;
+
+/**
+ * ESC and BEL, built rather than written as escapes so the patterns below are
+ * assembled from a non-literal string: a control character inside a regex
+ * literal is a lint error, and the alternative would be suppressing it.
+ */
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+/** OSC (``ESC ]``) through either terminator: BEL or ST (``ESC \``). */
+const OSC_SEQUENCE = new RegExp(`${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)`, "g");
+/** CSI colour/style and cursor sequences. */
+const CSI_SEQUENCE = new RegExp(`${ESC}\\[[0-9;]*[a-zA-Z]`, "g");
+/** CSI private-mode sequences (``ESC [ ?``). */
+const CSI_PRIVATE_SEQUENCE = new RegExp(`${ESC}\\[\\?[0-9;]*[a-zA-Z]`, "g");
+
+/**
+ * Strip ANSI escapes before scanning.
+ *
+ * dbcert wraps the URL in an OSC 8 hyperlink whenever its stderr is a terminal —
+ * which it always is inside a pane — so the raw stream carries the URL twice:
+ * once inside ``ESC ] 8 ; ; <uri> ST`` and once as the visible text. Removing
+ * the OSC wrapper leaves the visible copy intact and stops the escape's ``ESC \``
+ * terminator being read as part of a URL. Both OSC terminators (BEL and ST) are
+ * handled.
+ */
+function stripAnsi(text: string): string {
+  return text.replace(OSC_SEQUENCE, "").replace(CSI_SEQUENCE, "").replace(CSI_PRIVATE_SEQUENCE, "");
+}
+
+/** Whether ``raw`` is dbcert's own loopback callback URL. */
+function isDbcertCallback(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return LOOPBACK_HOSTS.has(url.hostname) && url.pathname === DBCERT_CALLBACK_PATH;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether ``candidate`` is an Okta authorize URL for a dbcert login.
+ *
+ * :param candidate: A URL found in terminal output.
+ */
+export function isDbcertLoginUrl(candidate: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  if (!DBCERT_OKTA_HOSTS.has(url.hostname)) return false;
+  if (url.pathname !== OKTA_AUTHORIZE_PATH) return false;
+  const redirect = url.searchParams.get("redirect_uri");
+  return !!redirect && isDbcertCallback(redirect);
+}
+
+/**
+ * The dbcert login URL in a chunk of terminal output, or ``null``.
+ *
+ * Returns the LAST match: dbcert prints one URL per login, but a pane redraw can
+ * replay an older one, and the most recent belongs to the live listener.
+ *
+ * :param text: Raw (escape-bearing) terminal output.
+ */
+export function extractDbcertLoginUrl(text: string): string | null {
+  // Cheap gate before the scan: every dbcert authorize URL carries its callback
+  // path inside the percent-encoded `redirect_uri`, so the literal "dbcert" is
+  // always present. Ordinary agent output is not.
+  if (!text.includes("dbcert")) return null;
+  const clean = stripAnsi(text);
+  AUTHORIZE_URL.lastIndex = 0;
+  let found: string | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = AUTHORIZE_URL.exec(clean)) !== null) {
+    if (isDbcertLoginUrl(match[0])) found = match[0];
+  }
+  return found;
+}
+
+/**
+ * Open a dbcert login URL in a new tab.
+ *
+ * Returns whether the browser accepted it. There is no user gesture behind
+ * terminal output, so a popup blocker can refuse the tab and hand back null —
+ * callers must surface a refusal as something clickable rather than dropping it.
+ * In the desktop app this goes through the shell's external-link handling, which
+ * has no such restriction.
+ *
+ * :param url: The login URL to open.
+ * :param win: Window to open through; injectable for tests.
+ */
+export function openDbcertLogin(url: string, win: Window = window): boolean {
+  return win.open(url, "_blank", "noopener,noreferrer") !== null;
+}
+
+/**
+ * Build a watcher that reports each distinct dbcert login URL once.
+ *
+ * The returned function is fed raw terminal output as it arrives; it keeps a
+ * bounded tail so a URL split across frames is still found, and calls
+ * ``onLogin`` the first time each URL is seen.
+ *
+ * :param onLogin: Called with a newly seen login URL.
+ */
+export function createDbcertLoginWatcher(onLogin: (url: string) => void): (chunk: string) => void {
+  let tail = "";
+  let lastSeen: string | null = null;
+  return (chunk: string) => {
+    if (!chunk) return;
+    tail = (tail + chunk).slice(-TAIL_CHARS);
+    const url = extractDbcertLoginUrl(tail);
+    if (!url || url === lastSeen) return;
+    lastSeen = url;
+    onLogin(url);
+  };
+}


### PR DESCRIPTION
## Related issue

Closes #

<!-- No issue linked: I don't have one for this and didn't want to file one unprompted. Happy to open one and link it. -->

## Summary



- `vitest run src/lib/dbcertLogin.test.ts src/components/blocks/` — 331 passed (14 files), including 18 new detector/watcher/opener tests and 2 new `TerminalSession` wiring tests.
- `tsc -b` — clean.
- `oxlint --deny-warnings --report-unused-disable-directives .` — clean.
- `prettier --write` on the touched files.

The detector's fixtures are built from dbcert's real output shape: its logger's timestamp prefix, the URL indented on its own line, and the OSC 8 hyperlink wrapper it adds whenever stderr is a terminal (so the URL appears twice in the stream). Covered: each Okta environment host, any loopback callback port, SGR colouring, a redraw replaying an older URL, a URL split across two frames, a truncated URL, and rejection of a same-host authorize URL whose `redirect_uri` belongs to a different OAuth flow.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No recording: reproducing this end to end needs a genuinely stale dbcert credential on a remote box, which I couldn't stage. The behaviour is pinned by the unit tests above; the toast reuses the existing pattern in `TerminalView` (the clipboard-consent toast).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change

## Coverage notes

Not manually verified in the app for the reason in Demo. Worth a reviewer's eye on two judgement calls: opening a tab straight off terminal output (the allowlist plus the `redirect_uri` check are what keep that safe), and the popup-blocked fallback being a toast rather than something more persistent.

## Changelog

A dbcert sign-in an agent needs now opens automatically instead of waiting as a link in the terminal.

This pull request and its description were written by Isaac.
