### PR TITLE
fix(web): reconcile mobile terminal IME edits and caret movement

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -61,6 +61,9 @@ ________________
 
 This Software contains code from the following open source projects, licensed under the MIT license (https://opensource.org/license/mit):
 
+Dinotty - https://github.com/xichan96/dinotty
+Copyright (c) 2026 ChenXi.
+
 pyyaml - https://pypi.org/project/pyyaml/
 Copyright (c) 2017-2021 Ingy döt Net. Copyright (c) 2006-2016 Kirill Simonov.
 

--- a/web/src/components/blocks/TerminalImeInput.ts
+++ b/web/src/components/blocks/TerminalImeInput.ts
@@ -1,0 +1,252 @@
+import type { Terminal } from "@xterm/xterm";
+import {
+  normalizeTerminalTextareaSelection,
+  terminalTextareaEdit,
+  type TerminalTextareaSnapshot,
+} from "./terminalTextareaEdit";
+
+interface PendingEdit {
+  kind: "key" | "input" | "composition";
+  before: TerminalTextareaSnapshot;
+  data: string | null;
+  after: TerminalTextareaSnapshot | null;
+  settled: boolean;
+}
+
+const EDIT_INPUT_TYPES = new Set([
+  "insertText",
+  "insertReplacementText",
+  "deleteContentBackward",
+  "deleteContentForward",
+  "deleteWordBackward",
+  "deleteWordForward",
+]);
+
+/** Reconcile mobile DOM edits without treating the IME's caret as the line end. */
+export class TerminalImeInput {
+  private readonly term: Terminal;
+  private readonly listeners = new AbortController();
+  private readonly keyListener: { dispose: () => void };
+  private pending: PendingEdit | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private nativeKey = false;
+  private pasting = false;
+  private composing = false;
+  private forwarding = false;
+
+  constructor(term: Terminal) {
+    this.term = term;
+    const { signal } = this.listeners;
+    const textarea = term.textarea;
+    const root = term.element;
+    // Root capture runs before xterm's textarea-capture input handler.
+    root?.addEventListener("beforeinput", this.beforeInput, { capture: true, signal });
+    root?.addEventListener("input", this.input, { capture: true, signal });
+    root?.addEventListener("paste", this.paste, { capture: true, signal });
+    root?.addEventListener("blur", this.blur, { capture: true, signal });
+    textarea?.addEventListener("compositionstart", this.compositionStart, { signal });
+    textarea?.addEventListener("compositionend", this.compositionEnd, { signal });
+    this.keyListener = term.onKey(() => {
+      // xterm finalizes its composition before raising onKey for the next key.
+      if (!this.composing) this.flush(true, this.pending?.after ?? undefined);
+    });
+  }
+
+  get isComposing(): boolean {
+    return this.composing;
+  }
+
+  private get enabled(): boolean {
+    return navigator.maxTouchPoints > 0 && !this.term.options.screenReaderMode;
+  }
+
+  private snapshot(): TerminalTextareaSnapshot {
+    const textarea = this.term.textarea!;
+    return {
+      value: textarea.value,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+    };
+  }
+
+  /** Return false only when the browser IME owns this keyboard event. */
+  handleKeyEvent(event: KeyboardEvent): boolean {
+    if (!this.enabled) return true;
+    if (this.composing || event.isComposing) return false;
+    const processing = event.keyCode === 229 || event.key === "Process";
+    if (processing) {
+      this.nativeKey = false;
+      if (event.type === "keydown" && !this.pending) this.start("key");
+      if (event.type === "keyup" && this.pending?.kind === "key") this.flush(false);
+      return false;
+    }
+    if (event.type === "keyup") {
+      this.nativeKey = false;
+      if (this.pending?.kind === "key") {
+        this.flush(false);
+        return false;
+      }
+    } else if (event.type === "keydown") {
+      if (this.pending?.kind !== "composition") this.flush();
+      else this.pending.after = this.snapshot();
+      this.nativeKey = true;
+    }
+    return true;
+  }
+
+  /** Native composition still renders preedit, but its end-of-line diff is not sent. */
+  consumeData(data: string): boolean {
+    if (this.forwarding || !this.enabled || this.pending?.kind !== "composition" || this.pasting)
+      return false;
+    // Terminal replies and explicit soft keys are not IME commit text.
+    const code = data.charCodeAt(0);
+    if (data.startsWith("\x1b") || (data.length === 1 && (code < 32 || code === 127))) return false;
+    return true;
+  }
+
+  beforeSoftKey(): boolean {
+    if (!this.enabled) return true;
+    if (this.composing) return false;
+    this.flush(true, this.snapshot(), true);
+    return true;
+  }
+
+  private send(data: string): void {
+    this.forwarding = true;
+    try {
+      // Keep xterm's scroll, selection, input-disable and activity semantics.
+      this.term.input(data, true);
+    } finally {
+      this.forwarding = false;
+    }
+  }
+
+  private start(kind: PendingEdit["kind"]): void {
+    this.pending = {
+      kind,
+      before: this.snapshot(),
+      data: null,
+      after: null,
+      settled: false,
+    };
+    if (kind !== "composition") this.schedule(80);
+  }
+
+  private schedule(delay: number): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.flush();
+    }, delay);
+  }
+
+  private flush(clearEmpty = true, observed = this.snapshot(), keepComposition = false): void {
+    if (this.composing) return;
+    const pending = this.pending;
+    if (!pending || !this.enabled) {
+      this.clear();
+      return;
+    }
+    if (pending.settled) {
+      if (!keepComposition) this.clear();
+      return;
+    }
+    const after = normalizeTerminalTextareaSelection(pending.before, observed, pending.data);
+    const data = terminalTextareaEdit(
+      pending.before,
+      after,
+      this.term.modes.applicationCursorKeysMode,
+    );
+    if (!data && !clearEmpty) return;
+    if (keepComposition && pending.kind === "composition") pending.settled = true;
+    else this.clear();
+    if (
+      after.selectionStart !== observed.selectionStart ||
+      after.selectionEnd !== observed.selectionEnd
+    ) {
+      this.term.textarea!.setSelectionRange(after.selectionStart, after.selectionEnd);
+    }
+    if (data) this.send(data);
+  }
+
+  private clear(): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = null;
+    this.pending = null;
+  }
+
+  private compositionStart = (): void => {
+    if (this.enabled) {
+      this.flush();
+      this.start("composition");
+    }
+    this.nativeKey = false;
+    this.composing = true;
+  };
+
+  private compositionEnd = (event: CompositionEvent): void => {
+    this.composing = false;
+    if (this.pending?.kind === "composition") {
+      this.pending.data = event.data;
+      this.pending.after = this.snapshot();
+      // Registered after xterm's compositionend, so its final callback runs first.
+      this.schedule(0);
+    }
+  };
+
+  private beforeInput = (event: InputEvent): void => {
+    if (event.target !== this.term.textarea || !this.enabled || this.composing || event.isComposing)
+      return;
+    if (!EDIT_INPUT_TYPES.has(event.inputType)) return;
+    if (this.nativeKey && event.inputType === "insertText") return;
+    if (!this.pending) this.start("input");
+  };
+
+  private input = (event: InputEvent): void => {
+    if (event.target !== this.term.textarea || !this.enabled) return;
+    if (this.pending) {
+      event.stopPropagation();
+      this.pending.data = event.data;
+      this.pending.after = this.snapshot();
+      if (!this.composing && this.pending.kind !== "composition") {
+        this.schedule(this.pending.kind === "key" ? 80 : 0);
+      }
+      return;
+    }
+    if (!this.nativeKey && !event.isComposing && event.inputType === "insertText" && event.data) {
+      // Some keyboards emit neither keydown nor beforeinput for committed symbols.
+      event.stopPropagation();
+      this.send(event.data);
+    }
+  };
+
+  private paste = (): void => {
+    if (!this.enabled) return;
+    this.flush(true, this.snapshot(), true);
+    if (this.pending) this.pending.settled = true;
+    this.pasting = true;
+    queueMicrotask(() => {
+      this.pasting = false;
+    });
+  };
+
+  private blur = (event: FocusEvent): void => {
+    if (event.target !== this.term.textarea || !this.enabled) return;
+    this.nativeKey = false;
+    if (this.composing) {
+      this.composing = false;
+      if (this.pending) this.pending.settled = true;
+      this.schedule(0);
+      return;
+    }
+    // xterm clears the textarea in its blur listener; settle before that happens.
+    this.flush(true, this.snapshot(), true);
+  };
+
+  dispose(): void {
+    this.listeners.abort();
+    this.keyListener.dispose();
+    this.clear();
+    this.composing = false;
+  }
+}

--- a/web/src/components/blocks/TerminalSession.test.ts
+++ b/web/src/components/blocks/TerminalSession.test.ts
@@ -760,4 +760,482 @@ describe("TerminalSession", () => {
     expect(observer.observed).toContain(container);
     session.dispose();
   });
+  describe("mobile IME input", () => {
+    function enableTouchInput(): () => void {
+      if ("maxTouchPoints" in navigator) {
+        const spy = vi.spyOn(navigator, "maxTouchPoints", "get").mockReturnValue(1);
+        return () => spy.mockRestore();
+      }
+
+      Object.defineProperty(navigator, "maxTouchPoints", {
+        configurable: true,
+        value: 1,
+      });
+      return () => {
+        Reflect.deleteProperty(navigator, "maxTouchPoints");
+      };
+    }
+
+    function terminalTextarea(container: HTMLElement): HTMLTextAreaElement {
+      const textarea = container.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
+      if (!textarea) throw new Error("xterm helper textarea was not mounted");
+      return textarea;
+    }
+
+    function processKey(type: "keydown" | "keyup"): KeyboardEvent {
+      return new KeyboardEvent(type, {
+        key: "Process",
+        keyCode: 229,
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      });
+    }
+
+    function setTextareaState(
+      textarea: HTMLTextAreaElement,
+      value: string,
+      selectionStart: number,
+      selectionEnd = selectionStart,
+    ): void {
+      textarea.value = value;
+      textarea.setSelectionRange(selectionStart, selectionEnd);
+    }
+
+    function inputEvent(inputType: string, data: string, composed = true): InputEvent {
+      return new InputEvent("input", {
+        inputType,
+        data,
+        bubbles: true,
+        cancelable: true,
+        composed,
+      });
+    }
+
+    function sentInput(socket: FakeWebSocket): string[] {
+      const decoder = new TextDecoder();
+      return socket.sent
+        .filter((frame): frame is Uint8Array => typeof frame !== "string")
+        .map((frame) => decoder.decode(frame));
+    }
+
+    it("reconciles auto-pairs and a following Chinese composition", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+
+        textarea.dispatchEvent(processKey("keydown"));
+        setTextareaState(textarea, "()", 1);
+        textarea.dispatchEvent(inputEvent("insertText", "("));
+        textarea.dispatchEvent(processKey("keyup"));
+
+        expect(sentInput(socket)).toEqual([`()\x1b[D`]);
+
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionstart", {
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        setTextareaState(textarea, "(ni)", 3);
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionupdate", {
+            data: "ni",
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(80);
+        expect(sentInput(socket)).toEqual([`()\x1b[D`]);
+
+        setTextareaState(textarea, "(你)", 2);
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionend", {
+            data: "你",
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        textarea.dispatchEvent(inputEvent("insertCompositionText", "你"));
+        await vi.advanceTimersByTimeAsync(80);
+
+        expect(sentInput(socket)).toEqual([`()\x1b[D`, "你"]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it.each(["key", "composition"])(
+      "commits a pending %s edit before blur clears the textarea",
+      async (kind) => {
+        vi.useFakeTimers();
+        const restoreTouchInput = enableTouchInput();
+        const { container, session, socket } = makeSession();
+        try {
+          socket.open();
+          socket.sent = [];
+          const textarea = terminalTextarea(container);
+          setTextareaState(textarea, "abc", 3);
+          textarea.dispatchEvent(
+            kind === "key"
+              ? processKey("keydown")
+              : new CompositionEvent("compositionstart", { bubbles: true }),
+          );
+          setTextareaState(textarea, "abc，", 4);
+          if (kind === "composition") {
+            textarea.dispatchEvent(
+              new CompositionEvent("compositionend", { data: "，", bubbles: true }),
+            );
+          }
+          textarea.dispatchEvent(
+            inputEvent(kind === "key" ? "insertText" : "insertCompositionText", "，"),
+          );
+          textarea.blur();
+          await vi.advanceTimersByTimeAsync(80);
+          expect(sentInput(socket)).toEqual(["，"]);
+        } finally {
+          session.dispose();
+          restoreTouchInput();
+          vi.useRealTimers();
+        }
+      },
+    );
+
+    it.each([
+      [true, false],
+      [false, false],
+      [true, true],
+    ])(
+      "honors scrollOnUserInput=%s and disableStdin=%s for IME commits",
+      async (scroll, disabled) => {
+        const restoreTouchInput = enableTouchInput();
+        const onInput = vi.fn();
+        const { container, session, socket } = makeSession(undefined, onInput);
+        try {
+          socket.open();
+          socket.sent = [];
+          const term = (session as unknown as { term: Terminal }).term;
+          await new Promise<void>((resolve) => {
+            term.write("row\r\n".repeat(50), resolve);
+          });
+          const core = (
+            term as unknown as {
+              _core: { buffer: { ydisp: number }; scrollToBottom: (instant?: boolean) => void };
+            }
+          )["_core"];
+          // jsdom has no measured viewport; observe the core's reveal request.
+          core.buffer.ydisp = 0;
+          const reveal = vi.spyOn(core, "scrollToBottom");
+          term.options.scrollOnUserInput = scroll;
+          term.options.disableStdin = disabled;
+          expect(term.buffer.active.baseY).toBeGreaterThan(0);
+          expect(term.buffer.active.viewportY).toBe(0);
+          const textarea = terminalTextarea(container);
+          textarea.dispatchEvent(processKey("keydown"));
+          setTextareaState(textarea, "，", 1);
+          textarea.dispatchEvent(inputEvent("insertText", "，"));
+          textarea.dispatchEvent(processKey("keyup"));
+          expect(sentInput(socket)).toEqual(disabled ? [] : ["，"]);
+          expect(onInput).toHaveBeenCalledTimes(disabled ? 0 : 1);
+          expect(reveal).toHaveBeenCalledTimes(scroll && !disabled ? 1 : 0);
+        } finally {
+          session.dispose();
+          restoreTouchInput();
+        }
+      },
+    );
+
+    it("does not append a selected candidate when its replacement leaves the DOM unchanged", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+        setTextareaState(textarea, "abc", 1, 3);
+        textarea.dispatchEvent(processKey("keydown"));
+        setTextareaState(textarea, "abc", 3);
+        textarea.dispatchEvent(inputEvent("insertReplacementText", "bc"));
+        textarea.dispatchEvent(processKey("keyup"));
+        await vi.advanceTimersByTimeAsync(80);
+        expect(sentInput(socket)).toEqual([]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it("renders preedit and commits once when composing input arrives before compositionend", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+        textarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+        setTextareaState(textarea, "ni", 2);
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionupdate", { data: "ni", bubbles: true }),
+        );
+        textarea.dispatchEvent(
+          new InputEvent("input", {
+            inputType: "insertCompositionText",
+            data: "ni",
+            isComposing: true,
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(20);
+        const preedit = container.querySelector(".composition-view");
+        expect(preedit).toHaveTextContent("ni");
+        expect(preedit).toHaveClass("active");
+        expect(sentInput(socket)).toEqual([]);
+        setTextareaState(textarea, "你", 1);
+        textarea.dispatchEvent(
+          new InputEvent("input", {
+            inputType: "insertCompositionText",
+            data: "你",
+            isComposing: true,
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionend", { data: "你", bubbles: true }),
+        );
+        await vi.advanceTimersByTimeAsync(80);
+        expect(sentInput(socket)).toEqual(["你"]);
+        expect(preedit).not.toHaveClass("active");
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it("reconciles a selected Unicode tail replacement", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+
+        textarea.dispatchEvent(processKey("keydown"));
+        setTextareaState(textarea, "A😀B", 4);
+        textarea.dispatchEvent(inputEvent("insertText", "A😀B"));
+        textarea.dispatchEvent(processKey("keyup"));
+        expect(sentInput(socket)).toEqual(["A😀B"]);
+
+        socket.sent = [];
+        setTextareaState(textarea, "A😀B", 1, 4);
+        textarea.dispatchEvent(
+          new InputEvent("beforeinput", {
+            inputType: "insertReplacementText",
+            data: "你",
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+          }),
+        );
+        setTextareaState(textarea, "A你", 2);
+        textarea.dispatchEvent(inputEvent("insertReplacementText", "你"));
+        await vi.advanceTimersByTimeAsync(80);
+
+        expect(sentInput(socket)).toEqual(["\x7f\x7f你"]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it("sends a completed composition before an immediate Enter", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionstart", {
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        setTextareaState(textarea, "ni", 2);
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionupdate", {
+            data: "ni",
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+
+        setTextareaState(textarea, "你", 1);
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionend", {
+            data: "你",
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        textarea.dispatchEvent(inputEvent("insertCompositionText", "你"));
+        textarea.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            code: "Enter",
+            keyCode: 13,
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+          }),
+        );
+        textarea.dispatchEvent(
+          new KeyboardEvent("keyup", {
+            key: "Enter",
+            code: "Enter",
+            keyCode: 13,
+            bubbles: true,
+            cancelable: true,
+            composed: true,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(80);
+
+        expect(sentInput(socket)).toEqual(["你", "\r"]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it("ignores a late 229 key after compositionend", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionstart", {
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        setTextareaState(textarea, "ni", 2);
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionupdate", {
+            data: "ni",
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+
+        setTextareaState(textarea, "你", 1);
+        textarea.dispatchEvent(
+          new CompositionEvent("compositionend", {
+            data: "你",
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        textarea.dispatchEvent(inputEvent("insertCompositionText", "你"));
+        textarea.dispatchEvent(processKey("keydown"));
+        textarea.dispatchEvent(processKey("keyup"));
+        await vi.advanceTimersByTimeAsync(80);
+
+        expect(sentInput(socket)).toEqual(["你"]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it("commits a 229 edit after 80ms when keyup is missing", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+
+        textarea.dispatchEvent(processKey("keydown"));
+        setTextareaState(textarea, "，", 1);
+        textarea.dispatchEvent(inputEvent("insertText", "，"));
+
+        await vi.advanceTimersByTimeAsync(79);
+        expect(sentInput(socket)).toEqual([]);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(sentInput(socket)).toEqual(["，"]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it("cancels a pending 229 commit when the session is disposed", async () => {
+      vi.useFakeTimers();
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+
+        textarea.dispatchEvent(processKey("keydown"));
+        setTextareaState(textarea, "。", 1);
+        textarea.dispatchEvent(inputEvent("insertText", "。"));
+        session.dispose();
+        await vi.advanceTimersByTimeAsync(80);
+
+        expect(sentInput(socket)).toEqual([]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+        vi.useRealTimers();
+      }
+    });
+
+    it("sends every repeated input-only punctuation mark exactly once", () => {
+      const restoreTouchInput = enableTouchInput();
+      const { container, session, socket } = makeSession();
+      try {
+        socket.open();
+        socket.sent = [];
+        const textarea = terminalTextarea(container);
+
+        setTextareaState(textarea, "！", 1);
+        textarea.dispatchEvent(inputEvent("insertText", "！"));
+        setTextareaState(textarea, "！！", 2);
+        textarea.dispatchEvent(inputEvent("insertText", "！"));
+
+        expect(sentInput(socket)).toEqual(["！", "！"]);
+      } finally {
+        session.dispose();
+        restoreTouchInput();
+      }
+    });
+  });
 });

--- a/web/src/components/blocks/TerminalSession.ts
+++ b/web/src/components/blocks/TerminalSession.ts
@@ -15,6 +15,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { type FontWeight, type ITheme, Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import { TerminalImeInput } from "./TerminalImeInput";
 import { type CodeFont, codeFontFamilyForEditor, readCodeFont } from "@/lib/codeFontPreferences";
 
 // Card background colors derived from the app's CSS palette.
@@ -522,6 +523,7 @@ export class TerminalSession {
   private lastSentSize: { cols: number; rows: number } | null = null;
   /** Fractional wheel lines carried across events (see {@link wheelReportPayload}). */
   private wheelPartialLines = 0;
+  private readonly imeInput: TerminalImeInput;
 
   /**
    * Construct, attach to the DOM, and open the WebSocket.
@@ -670,16 +672,22 @@ export class TerminalSession {
       { signal },
     );
 
-    this.dataDispose = this.term.onData((d) => {
+    const sendInput = (d: string) => {
       onInput?.();
       // Stamp before the readyState guard so clipboard trust still reflects
       // local input during a momentary WebSocket hiccup.
       this.lastUserInputAt = performance.now();
       if (this.ws.readyState !== WebSocket.OPEN) return;
       this.ws.send(INPUT_ENCODER.encode(d));
+    };
+    this.imeInput = new TerminalImeInput(this.term);
+    this.dataDispose = this.term.onData((d) => {
+      if (!this.imeInput.consumeData(d)) sendInput(d);
     });
 
     this.term.attachCustomKeyEventHandler((e) => {
+      if (!this.imeInput.handleKeyEvent(e)) return false;
+      if (this.imeInput.isComposing) return true;
       const payload = terminalKeyEventPayload(e);
       if (payload === null) return true;
       // xterm invokes this handler for keydown, keypress, and keyup.
@@ -687,6 +695,7 @@ export class TerminalSession {
       // the CSI-u sequence once, on keydown.
       if (e.type === "keydown") {
         e.preventDefault();
+        if (!this.imeInput.beforeSoftKey()) return false;
         onInput?.();
         this.lastUserInputAt = performance.now();
         if (this.ws.readyState === WebSocket.OPEN) {
@@ -777,6 +786,7 @@ export class TerminalSession {
     this.disposed = true;
     this.listenerCtl.abort();
     this.resizeObserver.disconnect();
+    this.imeInput.dispose();
     this.dataDispose.dispose();
     this.osc52Dispose.dispose();
     try {

--- a/web/src/components/blocks/terminalTextareaEdit.test.ts
+++ b/web/src/components/blocks/terminalTextareaEdit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeTerminalTextareaSelection,
+  terminalTextareaEdit,
+  type TerminalTextareaSnapshot,
+} from "./terminalTextareaEdit";
+
+const snapshot = (
+  value: string,
+  selectionStart: number,
+  selectionEnd = selectionStart,
+): TerminalTextareaSnapshot => ({ value, selectionStart, selectionEnd });
+
+describe("terminalTextareaEdit", () => {
+  it("inserts an auto-completed pair and leaves the terminal cursor inside it", () => {
+    expect(terminalTextareaEdit(snapshot("", 0), snapshot("()", 1))).toBe(`()\x1b[D`);
+  });
+
+  it("inserts Chinese text at the cursor without rewriting the surrounding pair", () => {
+    expect(terminalTextareaEdit(snapshot("()", 1), snapshot("(中文)", 3))).toBe("中文");
+  });
+
+  it("replaces only the changed middle range", () => {
+    expect(terminalTextareaEdit(snapshot("你好世界", 4), snapshot("您好世界", 1))).toBe(
+      `\x1b[D\x1b[D\x1b[D\x7f您`,
+    );
+  });
+
+  it("moves the cursor when the value is unchanged", () => {
+    expect(terminalTextareaEdit(snapshot("abc", 3), snapshot("abc", 1))).toBe(`\x1b[D\x1b[D`);
+    expect(terminalTextareaEdit(snapshot("abc", 1), snapshot("abc", 3))).toBe(`\x1b[C\x1b[C`);
+  });
+
+  it("uses application cursor sequences when requested", () => {
+    expect(terminalTextareaEdit(snapshot("abc", 3), snapshot("abc", 1), true)).toBe(`\x1bOD\x1bOD`);
+    expect(terminalTextareaEdit(snapshot("abc", 1), snapshot("abc", 3), true)).toBe(`\x1bOC\x1bOC`);
+  });
+
+  it("counts supplementary Unicode characters as one terminal position", () => {
+    expect(terminalTextareaEdit(snapshot("A😀B", 4), snapshot("A😀B", 1))).toBe(`\x1b[D\x1b[D`);
+    expect(terminalTextareaEdit(snapshot("A😀B", 3), snapshot("AB", 1))).toBe("\x7f");
+  });
+});
+
+describe("normalizeTerminalTextareaSelection", () => {
+  it("advances a stale collapsed selection past inserted input data", () => {
+    expect(normalizeTerminalTextareaSelection(snapshot("a", 1), snapshot("a()", 1), "()")).toEqual(
+      snapshot("a()", 3),
+    );
+  });
+
+  it("preserves selections and edits that do not exactly insert the input data", () => {
+    const range = snapshot("a()", 1, 3);
+    expect(normalizeTerminalTextareaSelection(snapshot("a", 1), range, "()")).toBe(range);
+
+    const replacement = snapshot("ab", 2);
+    expect(normalizeTerminalTextareaSelection(snapshot("a", 1), replacement, "()")).toBe(
+      replacement,
+    );
+  });
+});

--- a/web/src/components/blocks/terminalTextareaEdit.ts
+++ b/web/src/components/blocks/terminalTextareaEdit.ts
@@ -1,0 +1,111 @@
+/*!
+ * This helper is adapted from Dinotty's terminalInputCore.ts.
+ *
+ * MIT License
+ * Copyright (c) 2026 ChenXi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+export interface TerminalTextareaSnapshot {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+function codePointOffset(value: string, utf16Offset: number): number {
+  return Array.from(value.slice(0, Math.max(0, utf16Offset))).length;
+}
+
+function moveTerminalCursor(from: number, to: number, applicationCursor: boolean): string {
+  if (from === to) return "";
+
+  const direction = to < from ? "D" : "C";
+  const sequence = `\x1b${applicationCursor ? "O" : "["}${direction}`;
+  return sequence.repeat(Math.abs(to - from));
+}
+
+export function normalizeTerminalTextareaSelection(
+  before: TerminalTextareaSnapshot,
+  after: TerminalTextareaSnapshot,
+  inputData: string | null,
+): TerminalTextareaSnapshot {
+  if (!inputData || after.selectionStart !== after.selectionEnd) return after;
+
+  const insertionStart = after.selectionEnd;
+  const insertionEnd = insertionStart + inputData.length;
+  const insertedAtSelection = after.value.slice(insertionStart, insertionEnd) === inputData;
+  const valueWithoutInsertion =
+    after.value.slice(0, insertionStart) + after.value.slice(insertionEnd);
+
+  return insertedAtSelection && valueWithoutInsertion === before.value
+    ? {
+        ...after,
+        selectionStart: insertionEnd,
+        selectionEnd: insertionEnd,
+      }
+    : after;
+}
+
+export function terminalTextareaEdit(
+  before: TerminalTextareaSnapshot,
+  after: TerminalTextareaSnapshot,
+  applicationCursor = false,
+): string {
+  const cursorBefore = codePointOffset(before.value, before.selectionEnd);
+  const desiredCursor = codePointOffset(after.value, after.selectionEnd);
+
+  if (before.value === after.value) {
+    return moveTerminalCursor(cursorBefore, desiredCursor, applicationCursor);
+  }
+
+  const oldText = Array.from(before.value);
+  const newText = Array.from(after.value);
+  let commonPrefixLength = 0;
+  while (
+    commonPrefixLength < oldText.length &&
+    commonPrefixLength < newText.length &&
+    oldText[commonPrefixLength] === newText[commonPrefixLength]
+  ) {
+    commonPrefixLength += 1;
+  }
+
+  let commonSuffixLength = 0;
+  while (
+    commonSuffixLength < oldText.length - commonPrefixLength &&
+    commonSuffixLength < newText.length - commonPrefixLength &&
+    oldText[oldText.length - 1 - commonSuffixLength] ===
+      newText[newText.length - 1 - commonSuffixLength]
+  ) {
+    commonSuffixLength += 1;
+  }
+
+  const oldEditEnd = oldText.length - commonSuffixLength;
+  const insertedText = newText
+    .slice(commonPrefixLength, newText.length - commonSuffixLength)
+    .join("");
+  const cursorAfterEdit = commonPrefixLength + Array.from(insertedText).length;
+
+  return [
+    moveTerminalCursor(cursorBefore, oldEditEnd, applicationCursor),
+    "\x7f".repeat(oldEditEnd - commonPrefixLength),
+    insertedText,
+    moveTerminalCursor(cursorAfterEdit, desiredCursor, applicationCursor),
+  ].join("");
+}


### PR DESCRIPTION
## Related issue

Closes #6909

## Summary

- Reconcile touch IME edits from textarea text and selection so automatic pairs and candidate replacements reach the terminal in the correct order.
- Preserve native preedit, suppress intermediate composition output, settle committed edits before subsequent keys or blur, and dispose pending work with the session.
- Keep output on xterm's native input path and retain Dinotty's MIT attribution for the adapted edit helper.

ELI5: when the phone keyboard puts its cursor between brackets, the terminal now moves its cursor there too.

```text
textarea text + selection → minimal edit → xterm input → terminal WebSocket
unconfirmed composition  → native preedit only
```

## Test Plan

- 124 tests passed across TerminalSession, terminalTextareaEdit, TerminalView, MainTerminalView and TerminalsPanel.
- Full TypeScript check, production build and applicable pre-commit hooks passed.
- Real Chromium/xterm replay against upstream and this patch: upstream produces `())`; patched terminal produces `(你)` without preedit leakage.
- Reporter confirmed the deployed implementation resolves the original mobile input problem.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

![Before and after: controlled browser event replay](https://raw.githubusercontent.com/pandalaohe/omnigent/evidence/mobile-terminal-ime-20260910/ime-before-after.png)

The screenshot uses the real TerminalSession and xterm with a synthetic WebSocket sink. It is not a recording of a physical phone keyboard.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests drive actual xterm textarea events and inspect transmitted bytes for pairing, composition settlement/cancellation, repeated punctuation, replacements, missing or late key events, paste ordering, blur and disposal. Desktop composition and screen-reader fallback remain covered. Browser replay and reporter acceptance complement these tests; the exact mobile keyboard/version and a full iOS/Android matrix were not recorded. Hardware dead keys and mid-composition screen-reader setting changes are not claimed as verified.

## Changelog

Mobile terminal input preserves Chinese candidates and automatic punctuation pairs.
