### PR TITLE
feat(databricks-connect): source harness gateway config from ucode (reuse read_ucode_state)

### DIFF
--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3129,6 +3129,28 @@ _BROKER_APIKEY_HELPER_TTL_MS = 900_000
 _DATABRICKS_GATEWAY_MODEL_ENV = "OMNIGENT_DATABRICKS_GATEWAY_MODEL"
 
 
+# Routing/model env keys the connect-broker path accepts from the *writable* ucode
+# ``state.json``. An explicit allowlist (mirroring the discipline of
+# ``_ucode_config_for_profile``), not a prefix match: it must exclude credential
+# keys — ``ANTHROPIC_API_KEY`` (raw key + the broker apiKeyHelper hard-fails
+# ``build_native_claude_terminal_env``) and ``ANTHROPIC_AUTH_TOKEN`` (would
+# override the helper) — and arbitrary process env.
+_CONNECT_BROKER_UCODE_ENV_ALLOWLIST = frozenset(
+    {
+        _UCODE_CLAUDE_BASE_URL_ENV,
+        _CLAUDE_CODE_USE_GATEWAY_ENV,
+        _CLAUDE_CODE_CUSTOM_HEADERS_ENV,
+        _ANTHROPIC_MODEL_ENV,
+        _ANTHROPIC_DEFAULT_FABLE_MODEL_ENV,
+        _ANTHROPIC_DEFAULT_OPUS_MODEL_ENV,
+        _ANTHROPIC_DEFAULT_SONNET_MODEL_ENV,
+        _ANTHROPIC_DEFAULT_HAIKU_MODEL_ENV,
+        _ANTHROPIC_CUSTOM_MODEL_OPTION_ENV,
+        _ANTHROPIC_CUSTOM_MODEL_OPTION_NAME_ENV,
+    }
+)
+
+
 def _connect_broker_default_model() -> str:
     """The model a managed connect session pins: the deployment override if set,
     else the bundled Databricks Claude catalog default."""
@@ -3206,16 +3228,18 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
         # host (mirrors the opencode guard); otherwise keep the profile-derived
         # route rather than forwarding the bearer to an unverified origin.
         if ucode_base_url and https_url_on_workspace_host(ucode_base_url, workspace_host):
-            # Forward only known gateway env keys from the writable state.json
-            # (ANTHROPIC_* / CLAUDE_CODE_*) — never PATH / NODE_OPTIONS / proxy
-            # vars — into the broker-authenticated process. The base-URL guard
-            # binds where the bearer goes; this bounds the rest of the environment.
+            # Adopt only the explicit routing/model keys from the writable
+            # state.json — never credential keys or arbitrary process env — then
+            # re-pin the base URL to the guarded value.
             allowed = {
                 k: v
                 for k, v in agent_state.env.items()
-                if k.startswith(("ANTHROPIC_", "CLAUDE_CODE_"))
+                if k in _CONNECT_BROKER_UCODE_ENV_ALLOWLIST
             }
             env = {**env, **allowed, _UCODE_CLAUDE_BASE_URL_ENV: ucode_base_url}
+            # The served model is adopted only alongside a trusted (guarded) base
+            # URL; a model with no/off-host URL falls back to the catalog default
+            # rather than trusting a half-validated state entry.
             if agent_state.model:
                 model = agent_state.model
         elif ucode_base_url:

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3206,7 +3206,16 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
         # host (mirrors the opencode guard); otherwise keep the profile-derived
         # route rather than forwarding the bearer to an unverified origin.
         if ucode_base_url and https_url_on_workspace_host(ucode_base_url, workspace_host):
-            env = {**env, **agent_state.env, _UCODE_CLAUDE_BASE_URL_ENV: ucode_base_url}
+            # Forward only known gateway env keys from the writable state.json
+            # (ANTHROPIC_* / CLAUDE_CODE_*) — never PATH / NODE_OPTIONS / proxy
+            # vars — into the broker-authenticated process. The base-URL guard
+            # binds where the bearer goes; this bounds the rest of the environment.
+            allowed = {
+                k: v
+                for k, v in agent_state.env.items()
+                if k.startswith(("ANTHROPIC_", "CLAUDE_CODE_"))
+            }
+            env = {**env, **allowed, _UCODE_CLAUDE_BASE_URL_ENV: ucode_base_url}
             if agent_state.model:
                 model = agent_state.model
         elif ucode_base_url:

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3159,6 +3159,7 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
     from omnigent.host.databricks_credential import (
         HOST_DATABRICKS_PROFILE,
         broker_token_command,
+        https_url_on_workspace_host,
     )
     from omnigent.inner.databricks_executor import _read_databrickscfg_host
 
@@ -3199,10 +3200,20 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
     agent_state = workspace_state.agent(_UCODE_CLAUDE_AGENT_NAME) if workspace_state else None
     if agent_state is not None:
         ucode_base_url = agent_state.env.get(_UCODE_CLAUDE_BASE_URL_ENV) or agent_state.base_url
-        if ucode_base_url:
+        # Security: state.json is writable, and the broker bearer (apiKeyHelper)
+        # is presented to whatever ANTHROPIC_BASE_URL resolves to. Only adopt
+        # ucode's env/model when its base URL is HTTPS on the connected workspace
+        # host (mirrors the opencode guard); otherwise keep the profile-derived
+        # route rather than forwarding the bearer to an unverified origin.
+        if ucode_base_url and https_url_on_workspace_host(ucode_base_url, workspace_host):
             env = {**env, **agent_state.env, _UCODE_CLAUDE_BASE_URL_ENV: ucode_base_url}
-        if agent_state.model:
-            model = agent_state.model
+            if agent_state.model:
+                model = agent_state.model
+        elif ucode_base_url:
+            _logger.warning(
+                "native-claude connect: ignoring ucode state base URL (not HTTPS on the "
+                "connected workspace host) — using the profile-derived gateway route.",
+            )
 
     env[_CLAUDE_CODE_API_KEY_HELPER_TTL_ENV] = str(_BROKER_APIKEY_HELPER_TTL_MS)
     return ClaudeNativeUcodeConfig(env=env, api_key_helper=api_key_helper, model=model)

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3177,16 +3177,35 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
     if not api_key_helper:
         return None  # no broker sidecar → not a managed connect host
     workspace_host = workspace_host.rstrip("/")
-    return ClaudeNativeUcodeConfig(
-        env={
-            _UCODE_CLAUDE_BASE_URL_ENV: f"{workspace_host}/ai-gateway/anthropic",
-            _CLAUDE_CODE_API_KEY_HELPER_TTL_ENV: str(_BROKER_APIKEY_HELPER_TTL_MS),
-            _CLAUDE_CODE_USE_GATEWAY_ENV: "1",
-            _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
-        },
-        api_key_helper=api_key_helper,
-        model=_connect_broker_default_model(),
-    )
+
+    # Prefer the gateway config ucode generated at host boot (see
+    # ``omnigent.onboarding.ucode_setup.configure_ucode_for_sandbox``): ucode owns
+    # the base URL/route, coding-agent headers, and the discovered served model.
+    # We still mint the bearer through our own broker ``apiKeyHelper`` and launch
+    # Claude Code ourselves (bridge intact), so this consumes ucode's config
+    # without ucode launching or authenticating the binary. Fall back to a
+    # hand-built config when ucode wrote nothing usable (configure still running,
+    # skipped, or absent).
+    env = {
+        _UCODE_CLAUDE_BASE_URL_ENV: f"{workspace_host}/ai-gateway/anthropic",
+        _CLAUDE_CODE_USE_GATEWAY_ENV: "1",
+        _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
+    }
+    model = _connect_broker_default_model()
+
+    from omnigent.onboarding.ucode_state import read_ucode_state
+
+    workspace_state = read_ucode_state(workspace_host)
+    agent_state = workspace_state.agent(_UCODE_CLAUDE_AGENT_NAME) if workspace_state else None
+    if agent_state is not None:
+        ucode_base_url = agent_state.env.get(_UCODE_CLAUDE_BASE_URL_ENV) or agent_state.base_url
+        if ucode_base_url:
+            env = {**env, **agent_state.env, _UCODE_CLAUDE_BASE_URL_ENV: ucode_base_url}
+        if agent_state.model:
+            model = agent_state.model
+
+    env[_CLAUDE_CODE_API_KEY_HELPER_TTL_ENV] = str(_BROKER_APIKEY_HELPER_TTL_MS)
+    return ClaudeNativeUcodeConfig(env=env, api_key_helper=api_key_helper, model=model)
 
 
 def resolve_native_claude_config(

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3115,6 +3115,63 @@ def _native_claude_config_from_entry(
     return None
 
 
+# Refresh cadence for the broker-backed apiKeyHelper on the managed connect
+# path. The broker vends a ~1h OAuth access token; re-mint well before expiry so
+# a long session never presents an expired bearer to the gateway.
+_BROKER_APIKEY_HELPER_TTL_MS = 900_000
+
+
+def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
+    """Gateway config for a managed host connected via the credential broker.
+
+    When the owner links Databricks through the connect flow, ``omnigent host``
+    writes a host-only ``[omnigent]`` ``~/.databrickscfg`` profile (workspace
+    host, no token), a broker sidecar, and exports ``DATABRICKS_CONFIG_PROFILE``
+    — but configures no ucode / spec / global-auth provider. Without this,
+    :func:`resolve_native_claude_config` finds nothing and native Claude Code
+    falls back to its own login, never reaching the owner's workspace gateway.
+
+    Bridge it: derive the gateway base URL from the profile's workspace host and
+    mint the bearer on demand from the broker
+    (:func:`omnigent.host.databricks_credential.broker_token_command`, which
+    re-fetches the server-refreshed token each call), so Claude Code auto-connects
+    to Databricks model serving as the owner and refreshes per the helper TTL.
+    Returns ``None`` off the managed connect path (profile is not the host connect
+    profile, or no broker sidecar is present).
+    """
+    from omnigent.host.databricks_credential import (
+        HOST_DATABRICKS_PROFILE,
+        broker_token_command,
+    )
+    from omnigent.inner.databricks_executor import _read_databrickscfg_host
+
+    # Gate on the on-disk [omnigent] profile + broker sidecar, NOT on the
+    # ``DATABRICKS_CONFIG_PROFILE`` env var: that var is deliberately stripped
+    # from the runner/terminal process (a set profile makes MCP WorkspaceClients
+    # prefer its cached OAuth over their own token), so keying off it misses the
+    # very process that builds the Claude terminal. The host-only profile +
+    # sidecar that ``configure_host_databricks`` writes are the reliable
+    # managed-connect signal and survive that strip. The host-only profile holds
+    # no token, so it can't reintroduce the MCP collision the strip prevents.
+    workspace_host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+    if not workspace_host:
+        return None
+    api_key_helper = broker_token_command(workspace_host)
+    if not api_key_helper:
+        return None  # no broker sidecar → not a managed connect host
+    workspace_host = workspace_host.rstrip("/")
+    return ClaudeNativeUcodeConfig(
+        env={
+            _UCODE_CLAUDE_BASE_URL_ENV: f"{workspace_host}/ai-gateway/anthropic",
+            _CLAUDE_CODE_API_KEY_HELPER_TTL_ENV: str(_BROKER_APIKEY_HELPER_TTL_MS),
+            _CLAUDE_CODE_USE_GATEWAY_ENV: "1",
+            _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
+        },
+        api_key_helper=api_key_helper,
+        model=model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+    )
+
+
 def resolve_native_claude_config(
     *,
     spec: AgentSpec | None,
@@ -3163,26 +3220,45 @@ def resolve_native_claude_config(
         entry = _resolve_provider_for_build(spec, harness_type="claude-sdk")
         if entry is not None:
             return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
-        return _ucode_config_for_profile(spec.executor.profile, refresh_models=refresh_models)
-
-    # 2. Spec-less (omnigent claude): explicit default wins first.
-    explicit = load_config()
-    entry = default_provider_for_harness(explicit, "claude-sdk")
-    if entry is not None:
-        return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
-    # A global databricks auth block → ucode.
-    global_auth = _load_global_auth()
-    if isinstance(global_auth, DatabricksAuth):
-        return _ucode_config_for_profile(global_auth.profile, refresh_models=refresh_models)
-    if global_auth is not None:
-        # A global api_key auth: let Claude's own login handle it (parity
-        # with the subscription path); the in-process harness would inject
-        # it, but the native CLI uses its configured account.
-        return None
-    # 3. Ambient detection (first run without configure).
-    entry = default_provider_for_harness(effective_config_with_detected(explicit), "claude-sdk")
-    if entry is not None:
-        return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
+        ucode_config = _ucode_config_for_profile(
+            spec.executor.profile, refresh_models=refresh_models
+        )
+        if ucode_config is not None:
+            return ucode_config
+        # The spec named no provider and no usable ucode profile — fall through to
+        # the managed-connect-host broker fallback (step 4) rather than giving up.
+    else:
+        # 2. Spec-less (omnigent claude): explicit default wins first.
+        explicit = load_config()
+        entry = default_provider_for_harness(explicit, "claude-sdk")
+        if entry is not None:
+            return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
+        # A global databricks auth block → ucode.
+        global_auth = _load_global_auth()
+        if isinstance(global_auth, DatabricksAuth):
+            return _ucode_config_for_profile(global_auth.profile, refresh_models=refresh_models)
+        if global_auth is not None:
+            # A global api_key auth: let Claude's own login handle it (parity
+            # with the subscription path); the in-process harness would inject
+            # it, but the native CLI uses its configured account.
+            return None
+        # 3. Ambient detection (first run without configure).
+        entry = default_provider_for_harness(
+            effective_config_with_detected(explicit), "claude-sdk"
+        )
+        if entry is not None:
+            return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
+    # 4. Managed connect host: no provider config, but the host linked Databricks
+    #    via the connect flow (host-only [omnigent] profile + broker sidecar).
+    #    Route Claude Code through the owner's gateway, minting via the broker.
+    broker_config = _connect_broker_claude_config()
+    if broker_config is not None:
+        log_info_once(
+            _logger,
+            "native-claude routing: managed connect host — Databricks AI gateway via the "
+            "credential broker (host-only [omnigent] profile + broker sidecar).",
+        )
+        return broker_config
     log_info_once(
         _logger,
         "native-claude routing: Claude CLI login (no provider configured for the Claude "

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3240,6 +3240,7 @@ def resolve_native_claude_config(
         only need the routing shape pass ``False`` to stay network-free.
     :returns: The launch config, or ``None`` to use Claude's own login.
     """
+    from omnigent.host.databricks_credential import api_key_auth_precludes_broker
     from omnigent.onboarding.detected import effective_config_with_detected
     from omnigent.onboarding.provider_config import (
         default_provider_for_harness,
@@ -3286,15 +3287,20 @@ def resolve_native_claude_config(
             return _native_claude_config_from_entry(entry, refresh_models=refresh_models)
     # 4. Managed connect host: no provider config, but the host linked Databricks
     #    via the connect flow (host-only [omnigent] profile + broker sidecar).
-    #    Route Claude Code through the owner's gateway, minting via the broker.
-    broker_config = _connect_broker_claude_config()
-    if broker_config is not None:
-        log_info_once(
-            _logger,
-            "native-claude routing: managed connect host — Databricks AI gateway via the "
-            "credential broker (host-only [omnigent] profile + broker sidecar).",
-        )
-        return broker_config
+    #    Route Claude Code through the owner's gateway, minting via the broker —
+    #    unless an explicit API key (spec-level or global) is configured, which
+    #    Claude's own login threads and must not be silently rerouted (the
+    #    spec-less branch returns None above for the same reason; this covers the
+    #    spec branch, where _resolve_provider_for_build also returns None for it).
+    if not api_key_auth_precludes_broker(spec):
+        broker_config = _connect_broker_claude_config()
+        if broker_config is not None:
+            log_info_once(
+                _logger,
+                "native-claude routing: managed connect host — Databricks AI gateway via the "
+                "credential broker (host-only [omnigent] profile + broker sidecar).",
+            )
+            return broker_config
     log_info_once(
         _logger,
         "native-claude routing: Claude CLI login (no provider configured for the Claude "

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -3121,6 +3121,23 @@ def _native_claude_config_from_entry(
 _BROKER_APIKEY_HELPER_TTL_MS = 900_000
 
 
+# A managed connect deployment can pin the gateway serving-endpoint model (e.g.
+# ``databricks-claude-sonnet-4-6``) so sessions default to a model the workspace
+# actually serves, rather than the bundled catalog default (which may name a
+# family the workspace has not deployed). Mirrors the opencode gateway env var.
+# Discovering the served model from the gateway is a follow-up cleanup.
+_DATABRICKS_GATEWAY_MODEL_ENV = "OMNIGENT_DATABRICKS_GATEWAY_MODEL"
+
+
+def _connect_broker_default_model() -> str:
+    """The model a managed connect session pins: the deployment override if set,
+    else the bundled Databricks Claude catalog default."""
+    pinned = os.environ.get(_DATABRICKS_GATEWAY_MODEL_ENV, "").strip()
+    if pinned:
+        return pinned
+    return model_catalog.resolve_catalog_model("databricks", family="claude").model_id
+
+
 def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
     """Gateway config for a managed host connected via the credential broker.
 
@@ -3168,7 +3185,7 @@ def _connect_broker_claude_config() -> ClaudeNativeUcodeConfig | None:
             _CLAUDE_CODE_CUSTOM_HEADERS_ENV: _DATABRICKS_CODING_AGENT_HEADER,
         },
         api_key_helper=api_key_helper,
-        model=model_catalog.resolve_catalog_model("databricks", family="claude").model_id,
+        model=_connect_broker_default_model(),
     )
 
 

--- a/omnigent/harnesses/codex_native/app_server.py
+++ b/omnigent/harnesses/codex_native/app_server.py
@@ -3165,13 +3165,17 @@ def resolve_native_codex_launch(
             summary=f"Codex config.toml provider {provider_id!r} (ambient fallback)",
         )
 
-    if entry is None:
+    from omnigent.host.databricks_credential import api_key_auth_precludes_broker
+
+    if entry is None and not api_key_auth_precludes_broker(spec):
         # Managed connect host: no spec/global/ambient provider, but the owner
         # linked Databricks via the connect flow (host-only [omnigent] profile +
         # broker sidecar). Route Codex through the workspace gateway, minting the
         # bearer via the broker — the Codex counterpart to
         # _connect_broker_claude_config. ucode configure (host boot) populated
-        # ucode state, so the model resolves to a served id.
+        # ucode state, so the model resolves to a served id. An explicit spec
+        # ApiKeyAuth resolves to None above too, but Codex threads that key
+        # itself, so it must not be rerouted through the owner's gateway.
         from omnigent.host.databricks_credential import (
             HOST_DATABRICKS_PROFILE,
             broker_token_command,

--- a/omnigent/harnesses/codex_native/app_server.py
+++ b/omnigent/harnesses/codex_native/app_server.py
@@ -3166,6 +3166,43 @@ def resolve_native_codex_launch(
         )
 
     if entry is None:
+        # Managed connect host: no spec/global/ambient provider, but the owner
+        # linked Databricks via the connect flow (host-only [omnigent] profile +
+        # broker sidecar). Route Codex through the workspace gateway, minting the
+        # bearer via the broker — the Codex counterpart to
+        # _connect_broker_claude_config. ucode configure (host boot) populated
+        # ucode state, so the model resolves to a served id.
+        from omnigent.host.databricks_credential import (
+            HOST_DATABRICKS_PROFILE,
+            broker_token_command,
+        )
+        from omnigent.inner.databricks_executor import _read_databrickscfg_host
+
+        connect_host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+        if connect_host and broker_token_command(connect_host.rstrip("/")):
+            connect_host = connect_host.rstrip("/")
+            resolved_model = _resolve_databricks_codex_model(
+                connect_host, HOST_DATABRICKS_PROFILE, model
+            )
+            log_info_once(
+                _logger,
+                "native-codex routing: managed connect host — Databricks AI gateway "
+                "via the credential broker (host-only [omnigent] profile + sidecar).",
+            )
+            return NativeCodexLaunch(
+                config_overrides=_databricks_codex_config_overrides(
+                    model=resolved_model,
+                    base_url=_databricks_codex_base_url(connect_host),
+                    auth_command=_databricks_codex_auth_command(
+                        connect_host, HOST_DATABRICKS_PROFILE
+                    ),
+                ),
+                model=resolved_model,
+                profile=None,
+                summary="Databricks AI gateway (managed connect host, broker-minted)",
+            )
+
+    if entry is None:
         log_info_once(
             _logger,
             "native-codex routing: Codex CLI login (no provider configured for the Codex "

--- a/omnigent/harnesses/opencode_native/provider.py
+++ b/omnigent/harnesses/opencode_native/provider.py
@@ -647,16 +647,14 @@ def _configure_opencode_on_demand() -> None:
             argv = build_ucode_configure_command_for_profile(
                 find_ucode_command(), profile=HOST_DATABRICKS_PROFILE, agents=["opencode"]
             )
-            subprocess.run(
-                argv,
-                capture_output=True,
-                timeout=120,
-                env={
-                    **os.environ,
-                    "DATABRICKS_BEARER_COMMAND": bearer_command,
-                    "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,
-                },
-            )
+            configure_env = {
+                **os.environ,
+                "DATABRICKS_BEARER_COMMAND": bearer_command,
+                "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,
+            }
+            # ucode has no use for the host's launch token; don't hand it over.
+            configure_env.pop("OMNIGENT_HOST_TOKEN", None)
+            subprocess.run(argv, capture_output=True, timeout=120, env=configure_env)
     except Exception:  # noqa: BLE001 - best-effort; the caller declines if config is still absent.
         _logger.info("opencode on-demand ucode configure failed", exc_info=True)
 

--- a/omnigent/harnesses/opencode_native/provider.py
+++ b/omnigent/harnesses/opencode_native/provider.py
@@ -630,26 +630,33 @@ def _configure_opencode_on_demand() -> None:
     from omnigent.onboarding.ucode_setup import (
         build_ucode_configure_command_for_profile,
         find_ucode_command,
+        ucode_configure_lock,
     )
 
     host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
     bearer_command = broker_token_command(host.rstrip("/")) if host else None
     if not bearer_command:
         return
+    ucode_config = Path.home() / ".ucode" / "opencode-xdg" / "opencode" / "opencode.json"
     try:
-        argv = build_ucode_configure_command_for_profile(
-            find_ucode_command(), profile=HOST_DATABRICKS_PROFILE, agents=["opencode"]
-        )
-        subprocess.run(
-            argv,
-            capture_output=True,
-            timeout=120,
-            env={
-                **os.environ,
-                "DATABRICKS_BEARER_COMMAND": bearer_command,
-                "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,
-            },
-        )
+        with ucode_configure_lock():
+            # The boot-time all-agent configure may have written opencode's config
+            # while we waited for the lock — skip a redundant run if so.
+            if ucode_config.exists():
+                return
+            argv = build_ucode_configure_command_for_profile(
+                find_ucode_command(), profile=HOST_DATABRICKS_PROFILE, agents=["opencode"]
+            )
+            subprocess.run(
+                argv,
+                capture_output=True,
+                timeout=120,
+                env={
+                    **os.environ,
+                    "DATABRICKS_BEARER_COMMAND": bearer_command,
+                    "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,
+                },
+            )
     except Exception:  # noqa: BLE001 - best-effort; the caller declines if config is still absent.
         _logger.info("opencode on-demand ucode configure failed", exc_info=True)
 
@@ -663,11 +670,8 @@ def _provider_base_urls_match_host(config: Mapping[str, object], workspace_host:
     origin must not be trusted. Requires at least one base URL (a provider block
     with none is not a usable gateway target).
     """
-    from urllib.parse import urlsplit
+    from omnigent.host.databricks_credential import https_url_on_workspace_host
 
-    expected = urlsplit(
-        workspace_host if "://" in workspace_host else f"https://{workspace_host}"
-    ).netloc
     providers = config.get("provider")
     if not isinstance(providers, Mapping):
         return False
@@ -678,8 +682,7 @@ def _provider_base_urls_match_host(config: Mapping[str, object], workspace_host:
         if not isinstance(base_url, str) or not base_url:
             continue
         saw_url = True
-        parts = urlsplit(base_url)
-        if parts.scheme != "https" or parts.netloc != expected:
+        if not https_url_on_workspace_host(base_url, workspace_host):
             return False
     return saw_url
 
@@ -724,9 +727,15 @@ def managed_connect_opencode_config(xdg_config_home: Path) -> dict[str, object] 
         _configure_opencode_on_demand()
     try:
         config = json.loads(ucode_config.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        _logger.info("opencode managed config: unreadable ucode config %s: %r", ucode_config, exc)
         return None
     if not isinstance(config, dict) or "provider" not in config:
+        _logger.info(
+            "opencode managed config: ucode did not configure opencode (no provider block in %s); "
+            "opencode falls back to its own login.",
+            ucode_config,
+        )
         return None  # ucode did not configure opencode (e.g. not in --agents)
     # Security: the config on disk carries the provider base URL, and we forward a
     # freshly-minted broker bearer to it. A stale config (left from a previous
@@ -745,7 +754,13 @@ def managed_connect_opencode_config(xdg_config_home: Path) -> dict[str, object] 
     ucode_plugin = ucode_config_dir / "plugin" / "ucode-auth.js"
     try:
         plugin_src = ucode_plugin.read_text(encoding="utf-8")
-    except OSError:
+    except OSError as exc:
+        _logger.info(
+            "opencode managed config: provider block present but the refresh plugin %s is "
+            "unreadable (%r); declining so no static bearer is used.",
+            ucode_plugin,
+            exc,
+        )
         return None  # provider block without the refresh plugin is not usable
     session_plugin_dir = xdg_config_home / "opencode" / "plugin"
     session_plugin_dir.mkdir(mode=0o700, parents=True, exist_ok=True)

--- a/omnigent/harnesses/opencode_native/provider.py
+++ b/omnigent/harnesses/opencode_native/provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
 import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -618,3 +619,93 @@ def maybe_merge_user_provider_config(config: dict[str, object]) -> dict[str, obj
     result.setdefault("$schema", "https://opencode.ai/config.json")
 
     return result
+
+
+def _configure_opencode_on_demand() -> None:
+    """Run ``ucode configure --agents opencode`` for the connect profile, minting
+    via the broker. Used when the background boot configure has not yet written
+    opencode's config at launch time. Best-effort and quiet."""
+    from omnigent.host.databricks_credential import HOST_DATABRICKS_PROFILE, broker_token_command
+    from omnigent.inner.databricks_executor import _read_databrickscfg_host
+    from omnigent.onboarding.ucode_setup import (
+        build_ucode_configure_command_for_profile,
+        find_ucode_command,
+    )
+
+    host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+    bearer_command = broker_token_command(host.rstrip("/")) if host else None
+    if not bearer_command:
+        return
+    try:
+        argv = build_ucode_configure_command_for_profile(
+            find_ucode_command(), profile=HOST_DATABRICKS_PROFILE, agents=["opencode"]
+        )
+        subprocess.run(
+            argv,
+            capture_output=True,
+            timeout=120,
+            env={
+                **os.environ,
+                "DATABRICKS_BEARER_COMMAND": bearer_command,
+                "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,
+            },
+        )
+    except Exception:  # noqa: BLE001 - best-effort; the caller declines if config is still absent.
+        _logger.info("opencode on-demand ucode configure failed", exc_info=True)
+
+
+def managed_connect_opencode_config(xdg_config_home: Path) -> dict[str, object] | None:
+    """Consume ucode's generated opencode config on a managed connect host.
+
+    The opencode counterpart to Claude reading ``read_ucode_state``: on a managed
+    connect host, ``ucode configure --agents opencode`` (run at host boot) writes
+    ``~/.config/opencode/opencode.json`` (provider block + served-model selectors)
+    and a ``plugin/ucode-auth.js`` that mints a fresh Databricks token per request
+    via ``ucode auth-token`` (→ the broker). omnigent isolates opencode to a
+    per-session ``XDG_CONFIG_HOME``, so this reuses ucode's output: it returns
+    ucode's config (to seed the session ``opencode.json``) after copying the auth
+    plugin into the session plugin dir and pointing ``plugin`` at the copy.
+
+    Reuse over reinvention — the same ucode artifact serves OSS connect sandboxes
+    here, lakebox (via ``ucode opencode``), and ucode's own users; refresh comes
+    from ucode's plugin, not a static omnigent-minted token.
+
+    Returns ``None`` off a managed connect host (no broker sidecar) or when ucode
+    did not generate an opencode config — so laptop and non-connect launches are
+    untouched. The caller must also forward ``DATABRICKS_BEARER_COMMAND`` into the
+    opencode process env so the plugin's ``ucode auth-token`` can mint.
+    """
+    from omnigent.host.databricks_credential import _read_sidecar, _sidecar_path
+
+    if _read_sidecar(_sidecar_path()) is None:
+        return None  # not a managed connect host
+
+    # ucode writes opencode's config into its own XDG root, not ~/.config/opencode.
+    ucode_config_dir = Path.home() / ".ucode" / "opencode-xdg" / "opencode"
+    ucode_config = ucode_config_dir / "opencode.json"
+    if not ucode_config.exists():
+        # The boot-time configure_ucode_for_sandbox runs in the background and may
+        # not have written opencode's config yet when this launch resolves. Unlike
+        # claude/codex/pi, opencode has no working hand-built fallback on the
+        # connect path, so configure it on demand here (a few seconds, off the
+        # runner's dial-back path). Best-effort; a failure just declines below.
+        _configure_opencode_on_demand()
+    try:
+        config = json.loads(ucode_config.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(config, dict) or "provider" not in config:
+        return None  # ucode did not configure opencode (e.g. not in --agents)
+
+    ucode_plugin = ucode_config_dir / "plugin" / "ucode-auth.js"
+    try:
+        plugin_src = ucode_plugin.read_text(encoding="utf-8")
+    except OSError:
+        return None  # provider block without the refresh plugin is not usable
+    session_plugin_dir = xdg_config_home / "opencode" / "plugin"
+    session_plugin_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    session_plugin = session_plugin_dir / "ucode-auth.js"
+    session_plugin.write_text(plugin_src, encoding="utf-8")
+    # Point at the session copy; the caller appends its own policy plugin.
+    config["plugin"] = [str(session_plugin)]
+    return config

--- a/omnigent/harnesses/opencode_native/provider.py
+++ b/omnigent/harnesses/opencode_native/provider.py
@@ -41,6 +41,11 @@ DATABRICKS_GATEWAY_PROVIDER_ID = "databricks-gateway"
 DATABRICKS_GATEWAY_PROVIDER_NAME = "Databricks AI Gateway"
 # Endpoint that exposes the workspace's OpenAI-compatible chat completions.
 _SERVING_ENDPOINTS_PATH = "serving-endpoints"
+# Optional deployment default: a ``databricks-*`` serving-endpoint id used when a
+# session pins no compatible model. Unset falls back to the Databricks Claude
+# catalog. Set it in the runner env to steer every session at one endpoint
+# (e.g. ``databricks-kimi-k3``).
+DATABRICKS_GATEWAY_DEFAULT_MODEL_ENV_VAR = "OMNIGENT_DATABRICKS_GATEWAY_MODEL"
 
 
 @dataclass(frozen=True)
@@ -51,6 +56,9 @@ class OpenCodeGatewayResolution:
         ``"https://ws.cloud.databricks.com/serving-endpoints"``.
     :param api_key: Bearer token / API key for the gateway.
     :param model_id: The endpoint/model id, e.g. ``"databricks-claude-sonnet-4-6"``.
+    :param model_ids: Every serving-endpoint the gateway can route to, so opencode's
+        in-session model picker lists them all. ``model_id`` stays the pinned launch
+        default. Empty falls back to just ``model_id``.
     :param provider_id: opencode provider id, e.g. ``"databricks-gateway"``.
     :param provider_name: Human label for the opencode provider block.
     """
@@ -58,6 +66,7 @@ class OpenCodeGatewayResolution:
     base_url: str
     api_key: str
     model_id: str
+    model_ids: tuple[str, ...] = ()
     provider_id: str = DATABRICKS_GATEWAY_PROVIDER_ID
     provider_name: str = DATABRICKS_GATEWAY_PROVIDER_NAME
 
@@ -102,7 +111,9 @@ def build_opencode_provider_config(resolution: OpenCodeGatewayResolution) -> dic
                     "baseURL": resolution.base_url,
                     "apiKey": resolution.api_key,
                 },
-                "models": {resolution.model_id: {"name": resolution.model_id}},
+                "models": {
+                    mid: {"name": mid} for mid in (resolution.model_ids or (resolution.model_id,))
+                },
             }
         },
     }
@@ -314,14 +325,54 @@ def resolve_databricks_gateway(
 
     resolved_model = _gateway_endpoint_for_model(model_id)
     if resolved_model is None:
+        resolved_model = _gateway_endpoint_for_model(
+            os.environ.get(DATABRICKS_GATEWAY_DEFAULT_MODEL_ENV_VAR)
+        )
+    if resolved_model is None:
         resolved_model = model_catalog.resolve_catalog_model(
             "databricks", family="claude"
         ).model_id
+    # List every chat serving-endpoint so opencode's picker offers them all,
+    # with the pinned default first. Best-effort: a failure leaves just the
+    # default (dict.fromkeys de-dupes if the default is also discovered).
+    model_ids = tuple(dict.fromkeys((resolved_model, *_list_gateway_models(config))))
     return OpenCodeGatewayResolution(
         base_url=f"{host}/{_SERVING_ENDPOINTS_PATH}",
         api_key=token,
         model_id=resolved_model,
+        model_ids=model_ids,
     )
+
+
+def _list_gateway_models(config: object) -> tuple[str, ...]:
+    """
+    List the workspace's chat-capable ``databricks-*`` serving endpoints.
+
+    Reuses the already-authenticated SDK *config* so it shares the gateway's
+    auth. Best-effort: any failure (SDK absent, list denied) returns ``()`` and
+    the caller falls back to the single pinned model. Embedding/rerank endpoints
+    are dropped so the model picker only lists chat models.
+
+    :param config: A ``databricks.sdk.core.Config`` for the gateway workspace.
+    :returns: Endpoint names, e.g. ``("databricks-kimi-k3", ...)``.
+    """
+    try:
+        from databricks.sdk import WorkspaceClient
+
+        client = WorkspaceClient(config=config)
+        ids: list[str] = []
+        for endpoint in client.serving_endpoints.list():
+            name = getattr(endpoint, "name", "") or ""
+            if not name.startswith("databricks-"):
+                continue
+            task = (getattr(endpoint, "task", "") or "").lower()
+            if "embed" in task or "rerank" in task:
+                continue
+            ids.append(name)
+        return tuple(ids)
+    except Exception as exc:  # noqa: BLE001 - SDK absent / list denied / bad shape.
+        _logger.info("opencode Databricks gateway model list failed: %r", exc)
+        return ()
 
 
 def _gateway_endpoint_for_model(model_id: str | None) -> str | None:

--- a/omnigent/harnesses/opencode_native/provider.py
+++ b/omnigent/harnesses/opencode_native/provider.py
@@ -654,6 +654,36 @@ def _configure_opencode_on_demand() -> None:
         _logger.info("opencode on-demand ucode configure failed", exc_info=True)
 
 
+def _provider_base_urls_match_host(config: Mapping[str, object], workspace_host: str) -> bool:
+    """True when every opencode provider base URL is HTTPS and shares
+    *workspace_host*'s network location.
+
+    Guards the managed-connect path: a broker bearer is forwarded to whatever
+    ``provider.<id>.options.baseURL`` the on-disk config names, so a stale/other
+    origin must not be trusted. Requires at least one base URL (a provider block
+    with none is not a usable gateway target).
+    """
+    from urllib.parse import urlsplit
+
+    expected = urlsplit(
+        workspace_host if "://" in workspace_host else f"https://{workspace_host}"
+    ).netloc
+    providers = config.get("provider")
+    if not isinstance(providers, Mapping):
+        return False
+    saw_url = False
+    for provider in providers.values():
+        options = provider.get("options") if isinstance(provider, Mapping) else None
+        base_url = options.get("baseURL") if isinstance(options, Mapping) else None
+        if not isinstance(base_url, str) or not base_url:
+            continue
+        saw_url = True
+        parts = urlsplit(base_url)
+        if parts.scheme != "https" or parts.netloc != expected:
+            return False
+    return saw_url
+
+
 def managed_connect_opencode_config(xdg_config_home: Path) -> dict[str, object] | None:
     """Consume ucode's generated opencode config on a managed connect host.
 
@@ -677,8 +707,10 @@ def managed_connect_opencode_config(xdg_config_home: Path) -> dict[str, object] 
     """
     from omnigent.host.databricks_credential import _read_sidecar, _sidecar_path
 
-    if _read_sidecar(_sidecar_path()) is None:
+    sidecar = _read_sidecar(_sidecar_path())
+    if sidecar is None:
         return None  # not a managed connect host
+    workspace_host = sidecar["workspace_host"].rstrip("/")
 
     # ucode writes opencode's config into its own XDG root, not ~/.config/opencode.
     ucode_config_dir = Path.home() / ".ucode" / "opencode-xdg" / "opencode"
@@ -696,6 +728,19 @@ def managed_connect_opencode_config(xdg_config_home: Path) -> dict[str, object] 
         return None
     if not isinstance(config, dict) or "provider" not in config:
         return None  # ucode did not configure opencode (e.g. not in --agents)
+    # Security: the config on disk carries the provider base URL, and we forward a
+    # freshly-minted broker bearer to it. A stale config (left from a previous
+    # workspace connection) or a locally-modified file could aim that bearer at a
+    # different origin. Only trust it when every provider base URL is HTTPS and
+    # targets the sidecar's current workspace host.
+    if not _provider_base_urls_match_host(config, workspace_host):
+        _logger.warning(
+            "opencode managed config: provider base URL is not HTTPS on the connected "
+            "workspace host %r — declining so the broker bearer is not forwarded to an "
+            "unverified origin.",
+            workspace_host,
+        )
+        return None
 
     ucode_plugin = ucode_config_dir / "plugin" / "ucode-auth.js"
     try:

--- a/omnigent/harnesses/pi_native/credentials.py
+++ b/omnigent/harnesses/pi_native/credentials.py
@@ -1253,9 +1253,16 @@ def resolve_pi_native_provider(
         # no longer shadows it.
         entry = default_provider_for_harness(config, PI_SURFACE)
         if entry is None:
-            broker_resolved = _connect_broker_pi_provider(model=model)
-            if broker_resolved is not None:
-                return broker_resolved
+            # A global ApiKeyAuth means "use Pi's own login", not "route Pi
+            # through the owner's gateway" — so don't let the managed-connect
+            # broker fallback hijack an explicit key. (Pi has no spec here, so
+            # only the global auth block can carry that intent.)
+            from omnigent.host.databricks_credential import api_key_auth_precludes_broker
+
+            if not api_key_auth_precludes_broker(None):
+                broker_resolved = _connect_broker_pi_provider(model=model)
+                if broker_resolved is not None:
+                    return broker_resolved
             _LOGGER.info(
                 "pi-native: no omnigent-configured provider for the pi/anthropic/openai "
                 "surface; Pi will use its own login."

--- a/omnigent/harnesses/pi_native/credentials.py
+++ b/omnigent/harnesses/pi_native/credentials.py
@@ -547,6 +547,47 @@ def _databricks_pi_provider(entry: ProviderEntry, *, model: str | None) -> PiPro
     )
 
 
+def _connect_broker_pi_provider(*, model: str | None) -> PiProviderConfig | None:
+    """Pi provider for a managed connect host, or ``None`` when not one.
+
+    The Pi counterpart to ``_connect_broker_claude_config``: when the owner linked
+    Databricks via the connect flow (host-only ``[omnigent]`` profile + broker
+    sidecar) but configured no omnigent provider, route Pi through the workspace
+    gateway with a broker-minted ``!command`` apiKey. ``ucode configure`` (host
+    boot) populated ucode state, so the model resolves to a served id rather than
+    the legacy bundled-catalog default.
+    """
+    from omnigent.host.databricks_credential import (
+        HOST_DATABRICKS_PROFILE,
+        broker_token_command,
+    )
+    from omnigent.inner.databricks_executor import _read_databrickscfg_host
+    from omnigent.onboarding.provider_config import ProviderEntry
+    from omnigent.onboarding.ucode_state import read_ucode_state
+
+    host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+    if not host or not broker_token_command(host.rstrip("/")):
+        return None  # not a managed connect host
+    host = host.rstrip("/")
+    served_model = model
+    if served_model is None:
+        workspace_state = read_ucode_state(host)
+        agent_state = workspace_state.agent("claude") if workspace_state else None
+        served_model = agent_state.model if agent_state else None
+    entry = ProviderEntry(name="databricks", kind=DATABRICKS_KIND, profile=HOST_DATABRICKS_PROFILE)
+    resolved = _databricks_pi_provider(entry, model=served_model)
+    if resolved is not None and resolved.credential_warning:
+        # The host-only [omnigent] profile deliberately carries no token — the
+        # bearer is minted from the broker by the !command apiKey at request time —
+        # so _databricks_pi_provider's live-credential probe is expected to fail
+        # here. Drop its "login expired" warning so it doesn't surface as a false
+        # error banner on a session that authenticates fine through the broker.
+        import dataclasses
+
+        resolved = dataclasses.replace(resolved, credential_warning=None)
+    return resolved
+
+
 def _databricks_credential_warning(profile: str | None) -> str:
     """User-facing notice for an unresolvable Databricks profile.
 
@@ -1212,6 +1253,9 @@ def resolve_pi_native_provider(
         # no longer shadows it.
         entry = default_provider_for_harness(config, PI_SURFACE)
         if entry is None:
+            broker_resolved = _connect_broker_pi_provider(model=model)
+            if broker_resolved is not None:
+                return broker_resolved
             _LOGGER.info(
                 "pi-native: no omnigent-configured provider for the pi/anthropic/openai "
                 "surface; Pi will use its own login."

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4195,7 +4195,7 @@ def _generate_ucode_configs() -> None:
     background, best-effort populate of ``~/.ucode/state.json``), which the
     managed lakebox launcher shares with ``use_pat=True`` against its injected PAT.
 
-    Configures opencode too (``_CONNECT_AGENT_NAMES``), overlapping host boot, so
+    Configures opencode too (alongside claude/codex/pi), overlapping host boot, so
     the runner never has to fall back to a synchronous on-demand ``ucode
     configure`` when opencode first launches — the slow path for opencode startup.
     """
@@ -4204,7 +4204,7 @@ def _generate_ucode_configs() -> None:
         broker_token_command,
     )
     from omnigent.inner.databricks_executor import _read_databrickscfg_host
-    from omnigent.onboarding.ucode_setup import _CONNECT_AGENT_NAMES, configure_ucode_for_sandbox
+    from omnigent.onboarding.ucode_setup import configure_ucode_for_sandbox
 
     workspace = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
     if not workspace:
@@ -4212,9 +4212,12 @@ def _generate_ucode_configs() -> None:
     bearer_command = broker_token_command(workspace)
     if not bearer_command:
         return  # no broker sidecar → not a managed connect host
+    # opencode is included here (unlike lakebox's claude/codex/pi ``--use-pat``
+    # wrappers) so its config is ready at first launch instead of forcing a
+    # synchronous on-demand ``ucode configure`` on the runner.
     configure_ucode_for_sandbox(
         HOST_DATABRICKS_PROFILE,
-        agents=_CONNECT_AGENT_NAMES,
+        agents=("claude", "codex", "pi", "opencode"),
         extra_env={
             "DATABRICKS_BEARER_COMMAND": bearer_command,
             "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4184,6 +4184,39 @@ class HostProcess:
             await self._handle_import_local(ws, frame)
 
 
+def _generate_ucode_configs() -> None:
+    """At host boot, have ucode generate the harnesses' gateway config (OSS connect).
+
+    The OSS managed-connect gate: only when the host-only ``[omnigent]`` profile +
+    broker sidecar are present (the owner linked Databricks via the connect flow)
+    do we drive ucode, passing the broker command in the configure env so ucode
+    mints per request and nothing lands on disk. The reusable run lives in
+    :func:`omnigent.onboarding.ucode_setup.configure_ucode_for_sandbox` (a
+    background, best-effort populate of ``~/.ucode/state.json``), which the
+    managed lakebox launcher shares with ``use_pat=True`` against its injected PAT.
+    """
+    from omnigent.host.databricks_credential import (
+        HOST_DATABRICKS_PROFILE,
+        broker_token_command,
+    )
+    from omnigent.inner.databricks_executor import _read_databrickscfg_host
+    from omnigent.onboarding.ucode_setup import configure_ucode_for_sandbox
+
+    workspace = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+    if not workspace:
+        return
+    bearer_command = broker_token_command(workspace)
+    if not bearer_command:
+        return  # no broker sidecar → not a managed connect host
+    configure_ucode_for_sandbox(
+        HOST_DATABRICKS_PROFILE,
+        extra_env={
+            "DATABRICKS_BEARER_COMMAND": bearer_command,
+            "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,
+        },
+    )
+
+
 def run_host_process(
     server_url: str,
     config_path: Path | None = None,
@@ -4286,6 +4319,7 @@ def run_host_process(
     from omnigent.host.databricks_credential import configure_host_databricks
 
     configure_host_databricks(server_url, identity.host_id)
+    _generate_ucode_configs()
 
     if lifecycle_lock is None and daemon_target is not None:
         lifecycle_lock = DaemonLifecycleLock.for_target(daemon_target)

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -4194,13 +4194,17 @@ def _generate_ucode_configs() -> None:
     :func:`omnigent.onboarding.ucode_setup.configure_ucode_for_sandbox` (a
     background, best-effort populate of ``~/.ucode/state.json``), which the
     managed lakebox launcher shares with ``use_pat=True`` against its injected PAT.
+
+    Configures opencode too (``_CONNECT_AGENT_NAMES``), overlapping host boot, so
+    the runner never has to fall back to a synchronous on-demand ``ucode
+    configure`` when opencode first launches — the slow path for opencode startup.
     """
     from omnigent.host.databricks_credential import (
         HOST_DATABRICKS_PROFILE,
         broker_token_command,
     )
     from omnigent.inner.databricks_executor import _read_databrickscfg_host
-    from omnigent.onboarding.ucode_setup import configure_ucode_for_sandbox
+    from omnigent.onboarding.ucode_setup import _CONNECT_AGENT_NAMES, configure_ucode_for_sandbox
 
     workspace = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
     if not workspace:
@@ -4210,6 +4214,7 @@ def _generate_ucode_configs() -> None:
         return  # no broker sidecar → not a managed connect host
     configure_ucode_for_sandbox(
         HOST_DATABRICKS_PROFILE,
+        agents=_CONNECT_AGENT_NAMES,
         extra_env={
             "DATABRICKS_BEARER_COMMAND": bearer_command,
             "DATABRICKS_CONFIG_PROFILE": HOST_DATABRICKS_PROFILE,

--- a/omnigent/host/databricks_credential.py
+++ b/omnigent/host/databricks_credential.py
@@ -211,6 +211,28 @@ def broker_token_command(host: str, cfg_path: Path | None = None) -> str | None:
     return f"python3 -m {module} token --coords {shlex.quote(str(path))}"
 
 
+def https_url_on_workspace_host(url: str, workspace_host: str) -> bool:
+    """True when *url* is HTTPS and shares *workspace_host*'s network location.
+
+    The managed-connect harnesses forward a broker-minted bearer to a base URL
+    that ultimately comes from a writable on-disk file (ucode ``state.json`` or
+    the generated opencode config). Bind that destination to the sidecar/profile
+    workspace so a stale or tampered file can't aim the bearer at another origin.
+    A scheme-less *workspace_host* is treated as HTTPS.
+    """
+    from urllib.parse import urlsplit
+
+    if not url:
+        return False
+    expected = urlsplit(
+        workspace_host if "://" in workspace_host else f"https://{workspace_host}"
+    ).netloc
+    if not expected:
+        return False
+    parts = urlsplit(url)
+    return parts.scheme == "https" and parts.netloc == expected
+
+
 def api_key_auth_precludes_broker(spec: AgentSpec | None) -> bool:
     """True when an explicit ``ApiKeyAuth`` is configured, so the managed-connect
     broker fallback must not reroute it through the owner's Databricks gateway.
@@ -297,7 +319,13 @@ def main(argv: list[str] | None = None) -> int:
     resolved = fetch_broker_bearer(coords["server"], coords["host_id"], coords["host_token"])
     if resolved is None:
         return 0
-    _workspace_host, bearer = resolved
+    refreshed_host, bearer = resolved
+    # The harness's gateway base URL is pinned to the sidecar's workspace. If the
+    # owner has since reconnected to a different workspace, the broker now vends
+    # that workspace's bearer — emitting it would present a token to the pinned
+    # (now-wrong) origin. Withhold it so auth fails cleanly instead.
+    if refreshed_host.rstrip("/") != coords["workspace_host"].rstrip("/"):
+        return 0
     sys.stdout.write(bearer + "\n")
     return 0
 

--- a/omnigent/host/databricks_credential.py
+++ b/omnigent/host/databricks_credential.py
@@ -244,17 +244,25 @@ def api_key_auth_precludes_broker(spec: AgentSpec | None) -> bool:
     silently ignore the user's key, so claude/codex/pi gate their broker fallback
     on ``not api_key_auth_precludes_broker(...)``.
 
-    With a *spec*, its own ``executor.auth`` is authoritative (the resolver that
-    already ran consulted the global block for it). Without one (pi resolves off
-    machine config), the global ``auth:`` block carries the only key intent.
+    Precedence: a spec's own ``executor.auth`` wins; when the spec declares no
+    auth of its own (or there is no spec, e.g. pi resolving off machine config)
+    the global ``auth:`` block carries the key intent. A **global** ``ApiKeyAuth``
+    must also preclude the broker — the shared resolver returns ``None`` for it,
+    which would otherwise fall through to the broker fallback and silently reroute
+    the configured key.
     """
     from omnigent.spec.types import ApiKeyAuth
 
-    if spec is not None:
-        return isinstance(getattr(spec.executor, "auth", None), ApiKeyAuth)
-    from omnigent.runtime.workflow import _load_global_auth
+    # A spec's own explicit ApiKeyAuth precludes the broker outright.
+    if spec is not None and isinstance(getattr(spec.executor, "auth", None), ApiKeyAuth):
+        return True
+    # No spec, or a spec that declares no auth of its own → consult the global
+    # ``auth:`` block, which is the only remaining place a key intent can live.
+    if spec is None or getattr(spec.executor, "auth", None) is None:
+        from omnigent.runtime.workflow import _load_global_auth
 
-    return isinstance(_load_global_auth(), ApiKeyAuth)
+        return isinstance(_load_global_auth(), ApiKeyAuth)
+    return False
 
 
 def configure_host_databricks(server_url: str, host_id: str) -> bool:

--- a/omnigent/host/databricks_credential.py
+++ b/omnigent/host/databricks_credential.py
@@ -40,10 +40,14 @@ import os
 import shlex
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import httpx
 
 from omnigent.host.identity import HOST_TOKEN_ENV_VAR, MANAGED_HOST_TOKEN_HEADER
+
+if TYPE_CHECKING:
+    from omnigent.spec.types import AgentSpec
 
 _logger = logging.getLogger(__name__)
 
@@ -205,6 +209,30 @@ def broker_token_command(host: str, cfg_path: Path | None = None) -> str | None:
         return None
     module = "omnigent.host.databricks_credential"
     return f"python3 -m {module} token --coords {shlex.quote(str(path))}"
+
+
+def api_key_auth_precludes_broker(spec: AgentSpec | None) -> bool:
+    """True when an explicit ``ApiKeyAuth`` is configured, so the managed-connect
+    broker fallback must not reroute it through the owner's Databricks gateway.
+
+    The broker fallback is a last resort for a host with **no** credential intent
+    at all. An explicit API key resolves to ``None`` in the shared provider
+    resolver on purpose: the claude-sdk / openai builders and the native CLIs
+    thread the bare key themselves. Rerouting it through the owner's gateway would
+    silently ignore the user's key, so claude/codex/pi gate their broker fallback
+    on ``not api_key_auth_precludes_broker(...)``.
+
+    With a *spec*, its own ``executor.auth`` is authoritative (the resolver that
+    already ran consulted the global block for it). Without one (pi resolves off
+    machine config), the global ``auth:`` block carries the only key intent.
+    """
+    from omnigent.spec.types import ApiKeyAuth
+
+    if spec is not None:
+        return isinstance(getattr(spec.executor, "auth", None), ApiKeyAuth)
+    from omnigent.runtime.workflow import _load_global_auth
+
+    return isinstance(_load_global_auth(), ApiKeyAuth)
 
 
 def configure_host_databricks(server_url: str, host_id: str) -> bool:

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -284,6 +284,18 @@ def databricks_bearer_token_command(
         run only when the profile above yields an empty token.
     :returns: Shell command that prints a bearer token on stdout.
     """
+    # In a managed connect sandbox the owner's workspace profile is host-only
+    # (its bearer lives in the credential broker, not on disk), so
+    # ``databricks auth token`` finds no OAuth cache and yields nothing. When the
+    # caller named no other fallback and *host* is that connected workspace,
+    # default it to the broker fetch so the harness re-mints per use as them.
+    if fallback_command is None:
+        try:
+            from omnigent.host.databricks_credential import broker_token_command
+
+            fallback_command = broker_token_command(host)
+        except Exception:  # noqa: BLE001 - best-effort; no sidecar ⇒ no fallback.
+            pass
     selector = (
         f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
     )

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -294,8 +294,8 @@ def databricks_bearer_token_command(
             from omnigent.host.databricks_credential import broker_token_command
 
             fallback_command = broker_token_command(host)
-        except Exception:  # noqa: BLE001 - best-effort; no sidecar ⇒ no fallback.
-            pass
+        except Exception as exc:  # noqa: BLE001 - best-effort; no sidecar ⇒ no fallback.
+            logger.info("databricks bearer: broker fallback lookup failed: %r", exc)
     selector = (
         f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
     )

--- a/omnigent/inner/databricks_executor.py
+++ b/omnigent/inner/databricks_executor.py
@@ -286,16 +286,21 @@ def databricks_bearer_token_command(
     """
     # In a managed connect sandbox the owner's workspace profile is host-only
     # (its bearer lives in the credential broker, not on disk), so
-    # ``databricks auth token`` finds no OAuth cache and yields nothing. When the
-    # caller named no other fallback and *host* is that connected workspace,
-    # default it to the broker fetch so the harness re-mints per use as them.
+    # ``databricks auth token`` finds no OAuth cache and yields nothing. Default
+    # ONLY that connect profile to the broker fetch. Gate on the profile, not
+    # just the host: a *different* credential-less profile that happens to share
+    # the connected workspace host must not silently mint as the owner (distinct
+    # profiles on one host can be different users/service principals).
     if fallback_command is None:
-        try:
-            from omnigent.host.databricks_credential import broker_token_command
+        from omnigent.host.databricks_credential import HOST_DATABRICKS_PROFILE
 
-            fallback_command = broker_token_command(host)
-        except Exception as exc:  # noqa: BLE001 - best-effort; no sidecar ⇒ no fallback.
-            logger.info("databricks bearer: broker fallback lookup failed: %r", exc)
+        if profile == HOST_DATABRICKS_PROFILE:
+            try:
+                from omnigent.host.databricks_credential import broker_token_command
+
+                fallback_command = broker_token_command(host)
+            except Exception as exc:  # noqa: BLE001 - best-effort; no sidecar ⇒ no fallback.
+                logger.info("databricks bearer: broker fallback lookup failed: %r", exc)
     selector = (
         f"--profile {json.dumps(profile)}" if profile else f"--host {json.dumps(host.rstrip('/'))}"
     )

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -268,8 +268,8 @@ def configure_ucode_for_sandbox(
     from ``omnigent host`` boot with the broker command in ``extra_env``) and the
     lakebox launcher (``use_pat=True`` against its injected PAT).
 
-    ponytail: fire-and-forget per boot, no resume-skip; configure is idempotent
-    and cheap to repeat. Add a marker gate if warm-resume latency matters.
+    Fire-and-forget per boot (no resume-skip): configure is idempotent and cheap
+    to repeat, and concurrent runs are serialized by :func:`ucode_configure_lock`.
     """
     try:
         ucode_command = find_ucode_command()

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import shutil
 import subprocess
 import threading
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platforms have no flock
+    fcntl = None  # type: ignore[assignment]
 
 import click
 
@@ -21,12 +28,6 @@ _logger = logging.getLogger(__name__)
 _SANDBOX_CONFIGURE_TIMEOUT_S = 120
 
 _UCODE_AGENT_NAMES: tuple[str, ...] = ("claude", "codex", "pi")
-# The OSS managed-connect flow (``omnigent host`` boot) also configures opencode,
-# so its config is ready at first launch instead of forcing a synchronous
-# on-demand ``ucode configure`` on the runner's event loop. Kept off
-# ``_UCODE_AGENT_NAMES`` so lakebox's own ``--use-pat`` claude/codex/pi wrappers,
-# which don't ship opencode, are unaffected.
-_CONNECT_AGENT_NAMES: tuple[str, ...] = (*_UCODE_AGENT_NAMES, "opencode")
 # Pin ucode to a fixed commit so setup is reproducible, rather than tracking
 # ucode's ``main`` HEAD (a mutable ref that can move under us between runs and
 # break setup unexpectedly). A full SHA is immutable, so uvx caches the built
@@ -169,6 +170,46 @@ def find_ucode_command() -> list[str]:
     return [ucode]
 
 
+# Lock file shared by every sandbox ``ucode configure`` run, so they serialize
+# their writes to ``~/.ucode/state.json``.
+_CONFIGURE_LOCK_PATH = Path.home() / ".ucode" / ".omnigent-configure.lock"
+
+
+@contextlib.contextmanager
+def ucode_configure_lock() -> Iterator[None]:
+    """Serialize concurrent ``ucode configure`` runs across processes and threads.
+
+    At managed-connect boot the host runs ``ucode configure`` for all agents in a
+    daemon thread; independently, opencode's launch can run a second
+    ``ucode configure --agents opencode`` on demand. Both write
+    ``~/.ucode/state.json``, so overlapping runs can interleave and drop an agent's
+    entry or leave torn JSON. An advisory ``flock`` on a shared lock file
+    serializes them (and concurrent host starts). Best-effort: if the lock file
+    can't be created or the platform has no ``flock``, run unserialized rather than
+    block the launch.
+    """
+    if fcntl is None:
+        yield  # non-POSIX platform, no flock — degrade to unserialized
+        return
+    try:
+        _CONFIGURE_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(_CONFIGURE_LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o600)
+    except OSError:
+        yield  # can't create the lock file — degrade to unserialized
+        return
+    locked = False
+    try:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            locked = True
+        yield
+    finally:
+        if locked:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def build_ucode_configure_command_for_profile(
     ucode_command: Sequence[str],
     *,
@@ -241,9 +282,10 @@ def configure_ucode_for_sandbox(
 
     def _run() -> None:
         try:
-            result = subprocess.run(
-                argv, capture_output=True, timeout=_SANDBOX_CONFIGURE_TIMEOUT_S, env=env
-            )
+            with ucode_configure_lock():
+                result = subprocess.run(
+                    argv, capture_output=True, timeout=_SANDBOX_CONFIGURE_TIMEOUT_S, env=env
+                )
         except (OSError, subprocess.SubprocessError) as exc:
             # A failed/timed-out configure silently forces the harness hand-built
             # fallback; log it (with the exception) so the field isn't blind.

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -279,6 +279,9 @@ def configure_ucode_for_sandbox(
         ucode_command, profile=profile, agents=agents, use_pat=use_pat
     )
     env = {**os.environ, **(extra_env or {})}
+    # ucode has no use for the host's launch token; don't hand it to the external
+    # tool (it mints via DATABRICKS_BEARER_COMMAND, passed in extra_env).
+    env.pop("OMNIGENT_HOST_TOKEN", None)
 
     def _run() -> None:
         try:
@@ -288,15 +291,14 @@ def configure_ucode_for_sandbox(
                 )
         except (OSError, subprocess.SubprocessError) as exc:
             # A failed/timed-out configure silently forces the harness hand-built
-            # fallback; log it (with the exception) so the field isn't blind.
-            _logger.info("ucode: sandbox configure failed (profile=%s): %r", profile, exc)
+            # fallback; log at WARNING so the field isn't blind.
+            _logger.warning("ucode: sandbox configure failed (profile=%s): %r", profile, exc)
             return
         if result.returncode != 0:
-            _logger.info(
-                "ucode: sandbox configure exit=%s (profile=%s): %s",
-                result.returncode,
-                profile,
-                result.stderr.decode("utf-8", "replace")[-500:].strip(),
+            # Log the returncode, not ucode's stderr body — stderr could echo a
+            # secret, and the code is enough to flag the fallback was taken.
+            _logger.warning(
+                "ucode: sandbox configure exit=%s (profile=%s)", result.returncode, profile
             )
         else:
             _logger.info("ucode: sandbox configure ok (profile=%s)", profile)

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
+import logging
+import os
 import shutil
 import subprocess
+import threading
 from collections.abc import Sequence
 
 import click
 
 from omnigent.onboarding.databricks_config import normalize_workspace_url
 from omnigent.onboarding.ucode_state import read_ucode_state
+
+_logger = logging.getLogger(__name__)
+
+# Sandbox configure is best-effort and off the host's dial-back path; bound it so
+# a hung ucode can't leak a thread for the life of the host.
+_SANDBOX_CONFIGURE_TIMEOUT_S = 120
 
 _UCODE_AGENT_NAMES: tuple[str, ...] = ("claude", "codex", "pi")
 # Pin ucode to a fixed commit so setup is reproducible, rather than tracking
@@ -152,3 +161,84 @@ def find_ucode_command() -> list[str]:
             "  uv tool install uv  # provides uvx"
         )
     return [ucode]
+
+
+def build_ucode_configure_command_for_profile(
+    ucode_command: Sequence[str],
+    *,
+    profile: str,
+    agents: Sequence[str] = _UCODE_AGENT_NAMES,
+    use_pat: bool = False,
+) -> list[str]:
+    """Build a non-interactive ``ucode configure`` against an injected profile.
+
+    The sandbox counterpart to :func:`build_ucode_configure_command`: that one
+    takes ``--workspaces`` and drives an interactive OAuth login, which a headless
+    managed sandbox can't do. Here the workspace is already present as a
+    ``~/.databrickscfg`` profile, so ucode authenticates from it: ``use_pat``
+    reads the profile's PAT (the lakebox control plane injects one), otherwise the
+    caller exports ``DATABRICKS_BEARER_COMMAND`` so the credential broker mints per
+    request (the OSS connect flow, nothing on disk). ``--skip-validate`` /
+    ``--skip-upgrade`` keep host bring-up fast (no gateway round-trip or
+    self-update mid-launch).
+    """
+    argv = [
+        *ucode_command,
+        "configure",
+        "--profiles",
+        profile,
+        "--agents",
+        ",".join(agents),
+        "--skip-validate",
+        "--skip-upgrade",
+    ]
+    if use_pat:
+        argv.append("--use-pat")
+    return argv
+
+
+def configure_ucode_for_sandbox(
+    profile: str,
+    *,
+    agents: Sequence[str] = _UCODE_AGENT_NAMES,
+    use_pat: bool = False,
+    extra_env: dict[str, str] | None = None,
+) -> None:
+    """Populate ``~/.ucode/state.json`` at managed-sandbox host boot, in the background.
+
+    Runs ``ucode configure`` for the coding harnesses against an injected profile
+    so the harness launch paths (which already call
+    :func:`omnigent.onboarding.ucode_state.read_ucode_state`) pick up the
+    workspace's base URLs and served models. A daemon thread keeps it off
+    ``omnigent host``'s dial-back path, where a synchronous multi-second run would
+    delay the runner connect; the harness launch falls back to its own hand-built
+    gateway config until ``state.json`` exists, so the eventual-consistency window
+    is safe. Best-effort: when ucode isn't available (a non-managed image) it
+    no-ops rather than raising.
+
+    Shared by both managed-sandbox callers: the OSS connect flow (this runs it
+    from ``omnigent host`` boot with the broker command in ``extra_env``) and the
+    lakebox launcher (``use_pat=True`` against its injected PAT).
+
+    ponytail: fire-and-forget per boot, no resume-skip; configure is idempotent
+    and cheap to repeat. Add a marker gate if warm-resume latency matters.
+    """
+    try:
+        ucode_command = find_ucode_command()
+    except click.ClickException:
+        return  # neither uvx nor ucode present → not a managed-sandbox image
+    argv = build_ucode_configure_command_for_profile(
+        ucode_command, profile=profile, agents=agents, use_pat=use_pat
+    )
+    env = {**os.environ, **(extra_env or {})}
+
+    def _run() -> None:
+        try:
+            result = subprocess.run(
+                argv, capture_output=True, timeout=_SANDBOX_CONFIGURE_TIMEOUT_S, env=env
+            )
+        except (OSError, subprocess.SubprocessError):
+            return
+        _logger.info("ucode: sandbox configure exit=%s (profile=%s)", result.returncode, profile)
+
+    threading.Thread(target=_run, name="ucode-configure", daemon=True).start()

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -21,6 +21,12 @@ _logger = logging.getLogger(__name__)
 _SANDBOX_CONFIGURE_TIMEOUT_S = 120
 
 _UCODE_AGENT_NAMES: tuple[str, ...] = ("claude", "codex", "pi")
+# The OSS managed-connect flow (``omnigent host`` boot) also configures opencode,
+# so its config is ready at first launch instead of forcing a synchronous
+# on-demand ``ucode configure`` on the runner's event loop. Kept off
+# ``_UCODE_AGENT_NAMES`` so lakebox's own ``--use-pat`` claude/codex/pi wrappers,
+# which don't ship opencode, are unaffected.
+_CONNECT_AGENT_NAMES: tuple[str, ...] = (*_UCODE_AGENT_NAMES, "opencode")
 # Pin ucode to a fixed commit so setup is reproducible, rather than tracking
 # ucode's ``main`` HEAD (a mutable ref that can move under us between runs and
 # break setup unexpectedly). A full SHA is immutable, so uvx caches the built
@@ -238,8 +244,19 @@ def configure_ucode_for_sandbox(
             result = subprocess.run(
                 argv, capture_output=True, timeout=_SANDBOX_CONFIGURE_TIMEOUT_S, env=env
             )
-        except (OSError, subprocess.SubprocessError):
+        except (OSError, subprocess.SubprocessError) as exc:
+            # A failed/timed-out configure silently forces the harness hand-built
+            # fallback; log it (with the exception) so the field isn't blind.
+            _logger.info("ucode: sandbox configure failed (profile=%s): %r", profile, exc)
             return
-        _logger.info("ucode: sandbox configure exit=%s (profile=%s)", result.returncode, profile)
+        if result.returncode != 0:
+            _logger.info(
+                "ucode: sandbox configure exit=%s (profile=%s): %s",
+                result.returncode,
+                profile,
+                result.stderr.decode("utf-8", "replace")[-500:].strip(),
+            )
+        else:
+            _logger.info("ucode: sandbox configure ok (profile=%s)", profile)
 
     threading.Thread(target=_run, name="ucode-configure", daemon=True).start()

--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -191,6 +191,7 @@ def build_ucode_configure_command_for_profile(
         ",".join(agents),
         "--skip-validate",
         "--skip-upgrade",
+        "--skip-unavailable",
     ]
     if use_pat:
         argv.append("--use-pat")

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1288,12 +1288,14 @@ async def _auto_create_opencode_terminal(
     config: dict[str, object] = {}
     xdg_config_home = xdg_config_home_for_bridge_dir(bridge_dir)
     managed_opencode_broker_cmd: str | None = None
-    # A spec/CLI-selected Databricks gateway wins first (an explicit ``--model`` or
-    # a spec naming a profile), exactly as claude/codex/pi resolve the spec
-    # provider before their broker fallback. ``resolve_databricks_gateway`` returns
-    # None when no profile is selected (the bare managed-connect host), so the
-    # ucode-config path below is the genuine last resort — it never overrides an
-    # explicit selection.
+    # A spec/CLI-selected Databricks gateway wins first (an explicit ``--model``
+    # that names a gateway endpoint, or a spec profile), exactly as claude/codex/pi
+    # resolve the spec provider before their broker fallback.
+    # ``resolve_databricks_gateway`` returns None when no profile is selected (the
+    # bare managed-connect host); the ucode-config path below is then the last
+    # resort. On that bare host it adopts ucode's pinned served model — replacing an
+    # unrecognized explicit ``--model`` (logged below), since the workspace gateway
+    # is the only working provider there.
     gateway = resolve_databricks_gateway(
         _opencode_native_profile_from_spec(agent_spec), model_id=model_override
     )
@@ -1333,6 +1335,14 @@ async def _auto_create_opencode_terminal(
                 config = managed_config
                 pinned = config.get("model")
                 if isinstance(pinned, str):
+                    if model_override and model_override != pinned:
+                        _logger.info(
+                            "opencode managed connect: replacing requested model %r with the "
+                            "ucode-pinned served model %r (the workspace gateway is the only "
+                            "provider on this host).",
+                            model_override,
+                            pinned,
+                        )
                     model_override = pinned
             else:
                 _logger.warning(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1318,16 +1318,25 @@ async def _auto_create_opencode_terminal(
             pinned = config.get("model")
             if isinstance(pinned, str):
                 model_override = pinned
+            # Derive the broker command from the SAME sidecar the config gated on
+            # (not a separate profile read), so the two can't disagree. The auth
+            # plugin needs it to mint per request; log if it's somehow absent.
             from omnigent.host.databricks_credential import (
-                HOST_DATABRICKS_PROFILE,
+                _read_sidecar,
+                _sidecar_path,
                 broker_token_command,
             )
-            from omnigent.inner.databricks_executor import _read_databrickscfg_host
 
-            _oc_host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+            _oc_sidecar = _read_sidecar(_sidecar_path())
             managed_opencode_broker_cmd = (
-                broker_token_command(_oc_host.rstrip("/")) if _oc_host else None
+                broker_token_command(_oc_sidecar["workspace_host"]) if _oc_sidecar else None
             )
+            if not managed_opencode_broker_cmd:
+                _logger.warning(
+                    "opencode managed connect: ucode config resolved but no broker command "
+                    "(sidecar missing/mismatched); the auth plugin cannot mint, so opencode "
+                    "will fall back to its own login."
+                )
         elif model_override:
             # No custom provider, but a model is pinned (``omni opencode --model``
             # or the ``omni setup`` OpenCode default): write opencode's default

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1314,13 +1314,11 @@ async def _auto_create_opencode_terminal(
         # the runner's event loop. None off a managed connect host.
         managed_config = await asyncio.to_thread(managed_connect_opencode_config, xdg_config_home)
         if managed_config:
-            config = managed_config
-            pinned = config.get("model")
-            if isinstance(pinned, str):
-                model_override = pinned
-            # Derive the broker command from the SAME sidecar the config gated on
-            # (not a separate profile read), so the two can't disagree. The auth
-            # plugin needs it to mint per request; log if it's somehow absent.
+            # The auth plugin needs the broker command to mint per request; derive
+            # it from the SAME sidecar the config gated on (not a separate profile
+            # read), so the two can't disagree. Only adopt the managed config when
+            # the command resolves — a provider block with no mint command can't
+            # authenticate, so without it leave opencode on its own login instead.
             from omnigent.host.databricks_credential import (
                 _read_sidecar,
                 _sidecar_path,
@@ -1331,13 +1329,17 @@ async def _auto_create_opencode_terminal(
             managed_opencode_broker_cmd = (
                 broker_token_command(_oc_sidecar["workspace_host"]) if _oc_sidecar else None
             )
-            if not managed_opencode_broker_cmd:
+            if managed_opencode_broker_cmd:
+                config = managed_config
+                pinned = config.get("model")
+                if isinstance(pinned, str):
+                    model_override = pinned
+            else:
                 _logger.warning(
                     "opencode managed connect: ucode config resolved but no broker command "
-                    "(sidecar missing/mismatched); the auth plugin cannot mint, so opencode "
-                    "will fall back to its own login."
+                    "(sidecar missing/mismatched); leaving opencode on its own login."
                 )
-        elif model_override:
+        if not config and model_override:
             # No custom provider, but a model is pinned (``omni opencode --model``
             # or the ``omni setup`` OpenCode default): write opencode's default
             # model so the native TUI and first turn use it instead of

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1737,16 +1737,19 @@ def _opencode_native_profile_from_spec(
     Resolve the Databricks profile from a resolved agent spec, if any.
 
     :param agent_spec: Optional resolved agent spec.
-    :returns: The spec's ``executor.config.profile``, or ``None``.
+    :returns: The spec's ``executor.config.profile``, else the ambient
+        ``DATABRICKS_CONFIG_PROFILE`` (set by the host when the owner linked
+        Databricks), or ``None``.
     """
+    env_profile = os.environ.get("DATABRICKS_CONFIG_PROFILE") or None
     if agent_spec is None:
-        return None
+        return env_profile
     try:
         spec = agent_spec.spec if isinstance(agent_spec, ResolvedSpec) else agent_spec
         profile = spec.executor.config.get("profile")
-        return str(profile) if profile else None
+        return str(profile) if profile else env_profile
     except Exception:  # noqa: BLE001 - profile resolution is best effort.
-        return None
+        return env_profile
 
 
 def _opencode_native_mcp_servers_from_spec(

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1277,6 +1277,7 @@ async def _auto_create_opencode_terminal(
         build_opencode_model_default_config,
         build_opencode_omnigent_mcp_server,
         build_opencode_provider_config,
+        managed_connect_opencode_config,
         maybe_merge_user_provider_config,
         resolve_databricks_gateway,
         write_opencode_provider_config,
@@ -1285,8 +1286,34 @@ async def _auto_create_opencode_terminal(
     # Accumulate the synthesized opencode.json: provider/model (Databricks
     # gateway or a pinned default) + the agent's MCP servers + force-ask.
     config: dict[str, object] = {}
-    gateway = resolve_databricks_gateway(
-        _opencode_native_profile_from_spec(agent_spec), model_id=model_override
+    xdg_config_home = xdg_config_home_for_bridge_dir(bridge_dir)
+    # Managed connect host: reuse ucode's generated opencode config (provider block
+    # + served model + refreshing auth plugin), the same artifact lakebox and ucode
+    # itself use. The plugin mints per request via ``ucode auth-token`` → the broker
+    # command forwarded into the opencode env below, so no static omnigent-minted
+    # token. None off a connect host, so the gateway/default path below is unchanged.
+    managed_opencode_broker_cmd: str | None = None
+    config = managed_connect_opencode_config(xdg_config_home) or {}
+    if config:
+        pinned = config.get("model")
+        if isinstance(pinned, str):
+            model_override = pinned
+        from omnigent.host.databricks_credential import (
+            HOST_DATABRICKS_PROFILE,
+            broker_token_command,
+        )
+        from omnigent.inner.databricks_executor import _read_databrickscfg_host
+
+        _oc_host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+        managed_opencode_broker_cmd = (
+            broker_token_command(_oc_host.rstrip("/")) if _oc_host else None
+        )
+    gateway = (
+        None
+        if config
+        else resolve_databricks_gateway(
+            _opencode_native_profile_from_spec(agent_spec), model_id=model_override
+        )
     )
     if gateway is not None:
         # Pin the per-prompt model to the synthesized provider/endpoint id, and
@@ -1294,7 +1321,7 @@ async def _auto_create_opencode_terminal(
         model_override = gateway.qualified_model
         config = dict(build_opencode_provider_config(gateway))
         config["model"] = model_override
-    elif model_override:
+    elif not config and model_override:
         # No custom provider, but a model is pinned (``omni opencode --model`` or
         # the ``omni setup`` OpenCode default): write opencode's default model so
         # the native TUI and the first turn use it instead of ``opencode/big-pickle``.
@@ -1327,11 +1354,18 @@ async def _auto_create_opencode_terminal(
     # PostToolUse hooks); coordinates come from the OMNIGENT_* env stamped on
     # the server below. Only wired when there's a server to evaluate against.
     policy_env: dict[str, str] = {}
+    if managed_opencode_broker_cmd:
+        # ucode's auth plugin runs ``ucode auth-token`` → get_databricks_token,
+        # which mints from this broker command (databricks/ucode#531).
+        policy_env["DATABRICKS_BEARER_COMMAND"] = managed_opencode_broker_cmd
     runner_server_url = os.environ.get("RUNNER_SERVER_URL")
     if server_client is not None and runner_server_url:
         plugin_path = write_opencode_policy_plugin(bridge_dir)
         config.setdefault("$schema", "https://opencode.ai/config.json")
-        config["plugin"] = [str(plugin_path)]
+        existing_plugins = config.get("plugin")
+        config["plugin"] = ([*existing_plugins] if isinstance(existing_plugins, list) else []) + [
+            str(plugin_path)
+        ]
         policy_env["OMNIGENT_POLICY_URL"] = runner_server_url
         policy_env["OMNIGENT_SESSION_ID"] = session_id
         # Point the plugin at tool_relay.json so it can pick up relay

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -1287,33 +1287,15 @@ async def _auto_create_opencode_terminal(
     # gateway or a pinned default) + the agent's MCP servers + force-ask.
     config: dict[str, object] = {}
     xdg_config_home = xdg_config_home_for_bridge_dir(bridge_dir)
-    # Managed connect host: reuse ucode's generated opencode config (provider block
-    # + served model + refreshing auth plugin), the same artifact lakebox and ucode
-    # itself use. The plugin mints per request via ``ucode auth-token`` → the broker
-    # command forwarded into the opencode env below, so no static omnigent-minted
-    # token. None off a connect host, so the gateway/default path below is unchanged.
     managed_opencode_broker_cmd: str | None = None
-    config = managed_connect_opencode_config(xdg_config_home) or {}
-    if config:
-        pinned = config.get("model")
-        if isinstance(pinned, str):
-            model_override = pinned
-        from omnigent.host.databricks_credential import (
-            HOST_DATABRICKS_PROFILE,
-            broker_token_command,
-        )
-        from omnigent.inner.databricks_executor import _read_databrickscfg_host
-
-        _oc_host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
-        managed_opencode_broker_cmd = (
-            broker_token_command(_oc_host.rstrip("/")) if _oc_host else None
-        )
-    gateway = (
-        None
-        if config
-        else resolve_databricks_gateway(
-            _opencode_native_profile_from_spec(agent_spec), model_id=model_override
-        )
+    # A spec/CLI-selected Databricks gateway wins first (an explicit ``--model`` or
+    # a spec naming a profile), exactly as claude/codex/pi resolve the spec
+    # provider before their broker fallback. ``resolve_databricks_gateway`` returns
+    # None when no profile is selected (the bare managed-connect host), so the
+    # ucode-config path below is the genuine last resort — it never overrides an
+    # explicit selection.
+    gateway = resolve_databricks_gateway(
+        _opencode_native_profile_from_spec(agent_spec), model_id=model_override
     )
     if gateway is not None:
         # Pin the per-prompt model to the synthesized provider/endpoint id, and
@@ -1321,13 +1303,39 @@ async def _auto_create_opencode_terminal(
         model_override = gateway.qualified_model
         config = dict(build_opencode_provider_config(gateway))
         config["model"] = model_override
-    elif not config and model_override:
-        # No custom provider, but a model is pinned (``omni opencode --model`` or
-        # the ``omni setup`` OpenCode default): write opencode's default model so
-        # the native TUI and the first turn use it instead of ``opencode/big-pickle``.
-        # OpenCode resolves the provider from the model-id prefix against its own
-        # auth.json, so no provider block is needed.
-        config = dict(build_opencode_model_default_config(model_override))
+    else:
+        # Managed connect host (last resort): reuse ucode's generated opencode
+        # config (provider block + served model + refreshing auth plugin), the
+        # same artifact lakebox and ucode itself use. The plugin mints per request
+        # via ``ucode auth-token`` → the broker command forwarded into the opencode
+        # env below, so no static omnigent-minted token. Offloaded to a thread: on
+        # the first launch (before the host-boot configure has written opencode's
+        # config) it may run a ``ucode configure`` subprocess, which must not block
+        # the runner's event loop. None off a managed connect host.
+        managed_config = await asyncio.to_thread(managed_connect_opencode_config, xdg_config_home)
+        if managed_config:
+            config = managed_config
+            pinned = config.get("model")
+            if isinstance(pinned, str):
+                model_override = pinned
+            from omnigent.host.databricks_credential import (
+                HOST_DATABRICKS_PROFILE,
+                broker_token_command,
+            )
+            from omnigent.inner.databricks_executor import _read_databrickscfg_host
+
+            _oc_host = _read_databrickscfg_host(HOST_DATABRICKS_PROFILE)
+            managed_opencode_broker_cmd = (
+                broker_token_command(_oc_host.rstrip("/")) if _oc_host else None
+            )
+        elif model_override:
+            # No custom provider, but a model is pinned (``omni opencode --model``
+            # or the ``omni setup`` OpenCode default): write opencode's default
+            # model so the native TUI and first turn use it instead of
+            # ``opencode/big-pickle``. OpenCode resolves the provider from the
+            # model-id prefix against its own auth.json, so no provider block is
+            # needed.
+            config = dict(build_opencode_model_default_config(model_override))
 
     # Build opencode's ``mcp`` block: the Omnigent builtin-tool relay (so the
     # model can call sys_*/load_skill/web_fetch — the real "connects to Omnigent

--- a/tests/host/test_databricks_credential.py
+++ b/tests/host/test_databricks_credential.py
@@ -246,6 +246,39 @@ def test_main_ignores_unknown_operation(
     assert capsys.readouterr().out == ""
 
 
+def test_main_withholds_token_when_broker_workspace_changed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Reconnect edge: the sidecar pins workspace A, but the owner has since
+    reconnected to workspace B, so the broker now vends B's bearer. main() must
+    withhold it rather than present B's token to the A-pinned gateway base URL."""
+    _connected(monkeypatch)  # sidecar pinned to https://ws.example
+    assert dc.configure_host_databricks("https://omni.example", "h") is True
+    _patch_get(
+        monkeypatch,
+        _Resp(
+            200,
+            {"connected": True, "token": "dbx-tok-B", "workspace_host": "https://ws-b.example"},
+        ),
+    )
+    capsys.readouterr()  # discard configure-time log output
+    assert dc.main(["token"]) == 0
+    assert capsys.readouterr().out == ""  # withheld: workspace mismatch
+
+
+def test_https_url_on_workspace_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only HTTPS URLs on the workspace host's netloc are accepted; other schemes,
+    other hosts, and empty inputs are refused. A scheme-less workspace host is
+    treated as HTTPS."""
+    ok = dc.https_url_on_workspace_host
+    assert ok("https://ws.example/ai-gateway/anthropic", "https://ws.example") is True
+    assert ok("https://ws.example/x", "ws.example") is True  # scheme-less host
+    assert ok("http://ws.example/x", "https://ws.example") is False  # not HTTPS
+    assert ok("https://evil.example/x", "https://ws.example") is False  # other host
+    assert ok("", "https://ws.example") is False
+    assert ok("https://ws.example/x", "") is False
+
+
 def test_api_key_auth_precludes_broker(monkeypatch: pytest.MonkeyPatch) -> None:
     """Only an explicit ApiKeyAuth suppresses the managed-connect broker fallback.
 

--- a/tests/host/test_databricks_credential.py
+++ b/tests/host/test_databricks_credential.py
@@ -280,11 +280,10 @@ def test_https_url_on_workspace_host(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_api_key_auth_precludes_broker(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Only an explicit ApiKeyAuth suppresses the managed-connect broker fallback.
-
-    A spec's own ``executor.auth`` is authoritative (the resolver already consulted
-    the global block for it); a spec-less launch (pi) falls back to the global
-    ``auth:`` block. A Databricks profile or no auth at all lets the broker run.
+    """An explicit ApiKeyAuth — spec-level OR the global ``auth:`` block — suppresses
+    the managed-connect broker fallback. A spec's own explicit key wins; when the
+    spec declares no auth (or there is no spec, e.g. pi), the global block decides.
+    A DatabricksAuth or no key anywhere lets the broker run.
     """
     from types import SimpleNamespace
 
@@ -293,18 +292,21 @@ def test_api_key_auth_precludes_broker(monkeypatch: pytest.MonkeyPatch) -> None:
     key_spec = SimpleNamespace(executor=SimpleNamespace(auth=ApiKeyAuth(api_key="sk-x")))
     dbx_spec = SimpleNamespace(executor=SimpleNamespace(auth=DatabricksAuth(profile="p")))
     bare_spec = SimpleNamespace(executor=SimpleNamespace(auth=None))
+
+    # No global auth configured: only a spec-level key precludes.
+    monkeypatch.setattr("omnigent.runtime.workflow._load_global_auth", lambda: None)
     assert dc.api_key_auth_precludes_broker(key_spec) is True
     assert dc.api_key_auth_precludes_broker(dbx_spec) is False
     assert dc.api_key_auth_precludes_broker(bare_spec) is False
+    assert dc.api_key_auth_precludes_broker(None) is False
 
-    # Spec-less (pi): the global auth block carries the only key intent.
+    # A GLOBAL ApiKeyAuth must also preclude the broker — including in the spec
+    # branch when the spec declares no auth of its own (the reroute bug this guards).
     monkeypatch.setattr(
         "omnigent.runtime.workflow._load_global_auth", lambda: ApiKeyAuth(api_key="sk-g")
     )
     assert dc.api_key_auth_precludes_broker(None) is True
-    monkeypatch.setattr(
-        "omnigent.runtime.workflow._load_global_auth", lambda: DatabricksAuth(profile="p")
-    )
-    assert dc.api_key_auth_precludes_broker(None) is False
-    monkeypatch.setattr("omnigent.runtime.workflow._load_global_auth", lambda: None)
-    assert dc.api_key_auth_precludes_broker(None) is False
+    assert dc.api_key_auth_precludes_broker(bare_spec) is True
+    # A spec-level DatabricksAuth is authoritative and is not a key, so the broker
+    # still runs even when a global key exists.
+    assert dc.api_key_auth_precludes_broker(dbx_spec) is False

--- a/tests/host/test_databricks_credential.py
+++ b/tests/host/test_databricks_credential.py
@@ -244,3 +244,34 @@ def test_main_ignores_unknown_operation(
     capsys.readouterr()  # discard configure-time log output
     assert dc.main(["store"]) == 0
     assert capsys.readouterr().out == ""
+
+
+def test_api_key_auth_precludes_broker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only an explicit ApiKeyAuth suppresses the managed-connect broker fallback.
+
+    A spec's own ``executor.auth`` is authoritative (the resolver already consulted
+    the global block for it); a spec-less launch (pi) falls back to the global
+    ``auth:`` block. A Databricks profile or no auth at all lets the broker run.
+    """
+    from types import SimpleNamespace
+
+    from omnigent.spec.types import ApiKeyAuth, DatabricksAuth
+
+    key_spec = SimpleNamespace(executor=SimpleNamespace(auth=ApiKeyAuth(api_key="sk-x")))
+    dbx_spec = SimpleNamespace(executor=SimpleNamespace(auth=DatabricksAuth(profile="p")))
+    bare_spec = SimpleNamespace(executor=SimpleNamespace(auth=None))
+    assert dc.api_key_auth_precludes_broker(key_spec) is True
+    assert dc.api_key_auth_precludes_broker(dbx_spec) is False
+    assert dc.api_key_auth_precludes_broker(bare_spec) is False
+
+    # Spec-less (pi): the global auth block carries the only key intent.
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._load_global_auth", lambda: ApiKeyAuth(api_key="sk-g")
+    )
+    assert dc.api_key_auth_precludes_broker(None) is True
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._load_global_auth", lambda: DatabricksAuth(profile="p")
+    )
+    assert dc.api_key_auth_precludes_broker(None) is False
+    monkeypatch.setattr("omnigent.runtime.workflow._load_global_auth", lambda: None)
+    assert dc.api_key_auth_precludes_broker(None) is False

--- a/tests/inner/test_databricks_auth_command.py
+++ b/tests/inner/test_databricks_auth_command.py
@@ -253,3 +253,67 @@ def test_without_a_recorded_command_an_unauthenticated_profile_stays_empty(
         )
         == ""
     )
+
+
+def _write_broker_sidecar(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, workspace_host: str):
+    """Point the config file at *tmp_path* and drop a broker sidecar for *workspace_host*."""
+    from omnigent.host import databricks_credential as dc
+
+    cfg_path = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    assert dc._write_sidecar(
+        cfg_path, "https://omni.example", "host-1", "host-tok", workspace_host
+    )
+
+
+def test_the_broker_sidecar_becomes_the_fallback_for_the_connected_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """In a connect sandbox, the host-only profile delegates its mint to the broker."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    _write_broker_sidecar(monkeypatch, tmp_path, "https://example.databricks.com")
+    command = databricks_bearer_token_command("https://example.databricks.com", "omnigent")
+    assert "python3 -m omnigent.host.databricks_credential token" in command
+
+
+def test_the_broker_sidecar_is_ignored_for_a_different_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A gateway pinned to a spec's own workspace must not borrow the broker token."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    _write_broker_sidecar(monkeypatch, tmp_path, "https://connected.databricks.com")
+    command = databricks_bearer_token_command("https://other.databricks.com", "myprofile")
+    assert "omnigent.host.databricks_credential" not in command
+
+
+def test_an_explicit_fallback_is_not_overridden_by_the_broker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A caller-supplied fallback (e.g. ucode's) wins over the broker default."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    _write_broker_sidecar(monkeypatch, tmp_path, "https://example.databricks.com")
+    command = databricks_bearer_token_command(
+        "https://example.databricks.com", "omnigent", fallback_command="ucode-token"
+    )
+    assert "omnigent.host.databricks_credential" not in command
+    assert "ucode-token" in command
+
+
+def test_no_sidecar_leaves_the_command_unchanged(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Non-regression: with NO broker sidecar (a normal user with their own
+    Databricks profile, not a managed connect sandbox), the broker fallback adds
+    nothing — the command has no broker reference and no eval-fallback clause,
+    i.e. it is identical to the pre-change behaviour."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(tmp_path / ".databrickscfg"))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    cmd = databricks_bearer_token_command("https://example.databricks.com", "myprofile")
+    assert "omnigent.host.databricks_credential" not in cmd
+    # The eval-fallback clause is emitted ONLY when a fallback command is set.
+    assert "eval" not in cmd

--- a/tests/inner/test_databricks_auth_command.py
+++ b/tests/inner/test_databricks_auth_command.py
@@ -288,6 +288,21 @@ def test_the_broker_sidecar_is_ignored_for_a_different_workspace(
     assert "omnigent.host.databricks_credential" not in command
 
 
+def test_the_broker_is_ignored_for_a_different_profile_on_the_connected_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Identity boundary: only the host-only connect profile (HOST_DATABRICKS_PROFILE)
+    borrows the owner's broker bearer. A different, credential-less profile that
+    happens to share the connected workspace host must NOT silently mint as the
+    owner — distinct profiles on one host can be different users/service principals."""
+    from omnigent.inner.databricks_executor import databricks_bearer_token_command
+
+    _write_broker_sidecar(monkeypatch, tmp_path, "https://example.databricks.com")
+    # Same connected workspace host as the sidecar, but NOT the connect profile.
+    command = databricks_bearer_token_command("https://example.databricks.com", "someone-else")
+    assert "omnigent.host.databricks_credential" not in command
+
+
 def test_an_explicit_fallback_is_not_overridden_by_the_broker(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/onboarding/test_ucode_setup.py
+++ b/tests/onboarding/test_ucode_setup.py
@@ -232,3 +232,31 @@ def test_build_ucode_configure_command_normalizes_pasted_url() -> None:
         "claude",
         "--enable-fable",
     ]
+
+
+def test_build_ucode_configure_command_for_profile_broker_mode() -> None:
+    from omnigent.onboarding.ucode_setup import build_ucode_configure_command_for_profile
+
+    argv = build_ucode_configure_command_for_profile(["ucode"], profile="omnigent")
+    assert argv == [
+        "ucode",
+        "configure",
+        "--profiles",
+        "omnigent",
+        "--agents",
+        "claude,codex,pi",
+        "--skip-validate",
+        "--skip-upgrade",
+    ]
+    # broker mode: no --use-pat (the caller supplies DATABRICKS_BEARER_COMMAND)
+    assert "--use-pat" not in argv
+
+
+def test_build_ucode_configure_command_for_profile_pat_mode() -> None:
+    from omnigent.onboarding.ucode_setup import build_ucode_configure_command_for_profile
+
+    argv = build_ucode_configure_command_for_profile(
+        ["ucode"], profile="DEFAULT", agents=["claude"], use_pat=True
+    )
+    assert argv[-1] == "--use-pat"  # lakebox authenticates from the injected profile PAT
+    assert "claude" in argv[argv.index("--agents") + 1]

--- a/tests/onboarding/test_ucode_setup.py
+++ b/tests/onboarding/test_ucode_setup.py
@@ -237,7 +237,9 @@ def test_build_ucode_configure_command_normalizes_pasted_url() -> None:
 def test_build_ucode_configure_command_for_profile_broker_mode() -> None:
     from omnigent.onboarding.ucode_setup import build_ucode_configure_command_for_profile
 
-    argv = build_ucode_configure_command_for_profile(["ucode"], profile="omnigent")
+    argv = build_ucode_configure_command_for_profile(
+        ["ucode"], profile="omnigent", agents=["claude", "codex", "pi"]
+    )
     assert argv == [
         "ucode",
         "configure",
@@ -247,6 +249,7 @@ def test_build_ucode_configure_command_for_profile_broker_mode() -> None:
         "claude,codex,pi",
         "--skip-validate",
         "--skip-upgrade",
+        "--skip-unavailable",
     ]
     # broker mode: no --use-pat (the caller supplies DATABRICKS_BEARER_COMMAND)
     assert "--use-pat" not in argv

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -11080,6 +11080,47 @@ def test_connect_fallback_prefers_ucode_state(
     assert "omnigent.host.databricks_credential token" in config.api_key_helper
 
 
+def test_connect_fallback_rejects_ucode_base_url_off_workspace_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Security: state.json is writable and the broker bearer is presented to
+    whatever ANTHROPIC_BASE_URL resolves to. A ucode base URL that is not HTTPS on
+    the connected workspace host (a stale/tampered file) is ignored — the config
+    keeps the profile-derived gateway route rather than forwarding the bearer to an
+    unverified origin."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    # ucode state points the base URL at a DIFFERENT origin (and the model it
+    # would otherwise adopt). Must be refused.
+    state = UcodeWorkspaceState(
+        workspace_url="https://ws.example",
+        agents={
+            "claude": UcodeAgentState(
+                model="system.ai.claude-sonnet-4-6",
+                env={"ANTHROPIC_BASE_URL": "https://evil.example/anthropic"},
+            )
+        },
+    )
+    monkeypatch.setattr("omnigent.onboarding.ucode_state.read_ucode_state", lambda url: state)
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    # The profile-derived route wins; the off-host base URL is not adopted.
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/ai-gateway/anthropic"
+    # And its paired model is not adopted either (falls back to the catalog default).
+    assert config.model != "system.ai.claude-sonnet-4-6"
+    assert config.api_key_helper is not None
+
+
 def test_connect_fallback_pins_deployment_gateway_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -11189,6 +11189,81 @@ def test_configured_provider_wins_over_connect_broker(
     assert result is sentinel  # configured provider wins; broker fallback not consulted
 
 
+def test_configured_provider_wins_over_connect_broker_spec_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ordering in the SPEC branch (not just spec-less): when a spec resolves to a
+    provider, its config wins over the connect-broker fallback even with a broker
+    sidecar present — the broker is a last resort in the spec path too."""
+    from types import SimpleNamespace
+
+    sentinel = claude_native.ClaudeNativeUcodeConfig(env={"MARK": "spec-provider"})
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build",
+        lambda spec, harness_type: object(),  # spec resolves to a provider entry
+    )
+    monkeypatch.setattr(
+        claude_native,
+        "_native_claude_config_from_entry",
+        lambda entry, *, refresh_models: sentinel,
+    )
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "tok", "https://ws.example")
+
+    spec = SimpleNamespace(executor=SimpleNamespace(profile=None, auth=None))
+    result = claude_native.resolve_native_claude_config(spec=spec, refresh_models=False)
+    assert result is sentinel  # spec provider wins; broker fallback not consulted
+
+
+def test_connect_fallback_drops_credential_env_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The connect-broker path adopts only allowlisted routing keys from the writable
+    state.json. Credential keys — ANTHROPIC_API_KEY (which would hard-fail the
+    terminal-env build alongside the apiKeyHelper) and ANTHROPIC_AUTH_TOKEN (which
+    would override the helper) — and arbitrary process env (PATH) are dropped."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    state = UcodeWorkspaceState(
+        workspace_url="https://ws.example",
+        agents={
+            "claude": UcodeAgentState(
+                model="system.ai.claude-sonnet-4-6",
+                env={
+                    "ANTHROPIC_BASE_URL": "https://ws.example/serving-endpoints/anthropic",
+                    "ANTHROPIC_API_KEY": "must-not-leak",
+                    "ANTHROPIC_AUTH_TOKEN": "must-not-leak",
+                    "PATH": "/evil/bin",
+                },
+            )
+        },
+    )
+    monkeypatch.setattr("omnigent.onboarding.ucode_state.read_ucode_state", lambda url: state)
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    assert "ANTHROPIC_API_KEY" not in config.env
+    assert "ANTHROPIC_AUTH_TOKEN" not in config.env
+    assert "PATH" not in config.env
+    # The allowlisted routing key (the guarded base URL) is kept, and the bearer
+    # still reaches Claude Code via the broker helper, not a raw key.
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/serving-endpoints/anthropic"
+    assert config.api_key_helper is not None
+
+
 def test_resolve_native_claude_config_spec_path_reaches_connect_broker(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -11002,3 +11002,121 @@ async def test_claude_model_catalog_keeps_canonical_ids_without_ambient_gateway(
     # Both canonical models should be present
     assert [row["id"] for row in rows] == ["sonnet", "opus"]
     assert rows[1]["isDefault"] is True
+
+
+def _isolate_to_connect_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the spec-less resolution reach the connect-broker fallback: no explicit
+    default, no global auth, no ambient-detected provider."""
+    monkeypatch.setattr(
+        "omnigent.onboarding.provider_config.default_provider_for_harness",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr("omnigent.runtime.workflow._load_global_auth", lambda: None)
+    monkeypatch.setattr(
+        "omnigent.onboarding.detected.effective_config_with_detected", lambda cfg: cfg
+    )
+
+
+def test_resolve_native_claude_config_connect_broker_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A managed connect host (host-only [omnigent] profile + broker sidecar) routes
+    native Claude Code through the workspace gateway with a broker-minted apiKeyHelper."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/ai-gateway/anthropic"
+    assert config.env["CLAUDE_CODE_USE_GATEWAY"] == "1"
+    assert config.api_key_helper is not None
+    assert "omnigent.host.databricks_credential token" in config.api_key_helper
+    # Model comes from the catalog default (stubbed by _stub_catalog_default).
+    assert config.model == "catalog-databricks-claude-default"
+
+
+def test_resolve_native_claude_config_declines_without_broker_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A host-only profile with NO broker sidecar is not a managed connect host: the
+    fallback declines and Claude Code uses its own login (returns None)."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")  # profile but no sidecar
+
+    assert claude_native.resolve_native_claude_config(spec=None, refresh_models=False) is None
+
+
+def test_configured_provider_wins_over_connect_broker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ordering non-regression: the connect-broker fallback is the LAST resort. A
+    configured provider (spec / explicit default / global auth / ambient) wins even
+    when a broker sidecar is present, so a normal Claude harness is never overridden."""
+    sentinel = claude_native.ClaudeNativeUcodeConfig(env={"MARK": "configured-provider"})
+    # Step-2 explicit-default returns an entry → its config is used, short-circuiting.
+    monkeypatch.setattr(
+        "omnigent.onboarding.provider_config.default_provider_for_harness",
+        lambda cfg, harness: object(),
+    )
+    monkeypatch.setattr(
+        claude_native,
+        "_native_claude_config_from_entry",
+        lambda entry, *, refresh_models: sentinel,
+    )
+    # A broker sidecar IS present, but must be ignored (a provider is configured).
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "tok", "https://ws.example")
+
+    result = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+    assert result is sentinel  # configured provider wins; broker fallback not consulted
+
+
+def test_resolve_native_claude_config_spec_path_reaches_connect_broker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The runner resolves with a spec (spec is not None). When that spec names no
+    provider and no usable ucode profile, resolution must still fall through to the
+    managed-connect-host broker fallback — not return None (which leaves Claude Code
+    'not logged in' on the real product path)."""
+    from types import SimpleNamespace
+
+    # Spec routes to no provider and carries no ucode profile.
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build", lambda spec, harness_type: None
+    )
+    monkeypatch.setattr(
+        claude_native, "_ucode_config_for_profile", lambda profile, *, refresh_models: None
+    )
+    spec = SimpleNamespace(executor=SimpleNamespace(profile=None))
+
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    config = claude_native.resolve_native_claude_config(spec=spec, refresh_models=False)
+    assert config is not None
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/ai-gateway/anthropic"
+    assert (
+        config.api_key_helper
+        and "omnigent.host.databricks_credential token" in config.api_key_helper
+    )

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -11042,6 +11042,44 @@ def test_resolve_native_claude_config_connect_broker_fallback(
     assert config.model == "catalog-databricks-claude-default"
 
 
+def test_connect_fallback_prefers_ucode_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ucode has populated ~/.ucode/state.json for the connected workspace,
+    the managed-connect config uses ucode's base URL and discovered served model,
+    while still minting the bearer through our own broker apiKeyHelper."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+    from omnigent.onboarding.ucode_state import UcodeAgentState, UcodeWorkspaceState
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    state = UcodeWorkspaceState(
+        workspace_url="https://ws.example",
+        agents={
+            "claude": UcodeAgentState(
+                model="system.ai.claude-sonnet-4-6",
+                env={"ANTHROPIC_BASE_URL": "https://ws.example/serving-endpoints/anthropic"},
+            )
+        },
+    )
+    monkeypatch.setattr("omnigent.onboarding.ucode_state.read_ucode_state", lambda url: state)
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    # ucode's base URL + discovered model win over the hand-built defaults.
+    assert config.env["ANTHROPIC_BASE_URL"] == "https://ws.example/serving-endpoints/anthropic"
+    assert config.model == "system.ai.claude-sonnet-4-6"
+    # But the bearer is still our own broker command, not ucode's.
+    assert config.api_key_helper is not None
+    assert "omnigent.host.databricks_credential token" in config.api_key_helper
+
+
 def test_connect_fallback_pins_deployment_gateway_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -11181,3 +11181,35 @@ def test_resolve_native_claude_config_spec_path_reaches_connect_broker(
         config.api_key_helper
         and "omnigent.host.databricks_credential token" in config.api_key_helper
     )
+
+
+def test_resolve_native_claude_config_spec_api_key_auth_skips_connect_broker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A spec that explicitly configures an API key must NOT be rerouted through
+    the owner's Databricks gateway on a managed connect host — Claude Code threads
+    that key itself. Even with a broker sidecar present, resolution returns None
+    (Claude's own login), not the broker config."""
+    from types import SimpleNamespace
+
+    from omnigent.spec.types import ApiKeyAuth
+
+    # The shared resolver returns None for an explicit ApiKeyAuth (it leaves bare
+    # keys to Claude's own login), which previously fell through to the broker.
+    monkeypatch.setattr(
+        "omnigent.runtime.workflow._resolve_provider_for_build", lambda spec, harness_type: None
+    )
+    monkeypatch.setattr(
+        claude_native, "_ucode_config_for_profile", lambda profile, *, refresh_models: None
+    )
+    spec = SimpleNamespace(executor=SimpleNamespace(profile=None, auth=ApiKeyAuth(api_key="sk-x")))
+
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    assert claude_native.resolve_native_claude_config(spec=spec, refresh_models=False) is None

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -11042,6 +11042,29 @@ def test_resolve_native_claude_config_connect_broker_fallback(
     assert config.model == "catalog-databricks-claude-default"
 
 
+def test_connect_fallback_pins_deployment_gateway_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deployment can pin the served gateway model via
+    OMNIGENT_DATABRICKS_GATEWAY_MODEL so managed sessions default to a model the
+    workspace actually serves, rather than the bundled catalog default."""
+    _isolate_to_connect_fallback(monkeypatch)
+    from omnigent.host import databricks_credential as dc
+
+    cfg = tmp_path / ".databrickscfg"
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "databricks-claude-sonnet-4-6")
+    dc._write_profile(cfg, "https://ws.example")
+    dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
+
+    config = claude_native.resolve_native_claude_config(spec=None, refresh_models=False)
+
+    assert config is not None
+    # The deployment override wins over the (stubbed) catalog default.
+    assert config.model == "databricks-claude-sonnet-4-6"
+
+
 def test_resolve_native_claude_config_declines_without_broker_sidecar(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -11300,6 +11300,71 @@ def test_resolve_native_codex_launch_databricks_provider_sets_summary(
     assert launch.summary == "Databricks ucode profile 'my-profile'"
 
 
+def test_resolve_native_codex_launch_connect_broker_managed_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No configured provider, but a managed connect host (host-only [omnigent]
+    profile + broker sidecar) routes Codex through the gateway with broker auth."""
+    from omnigent.inner import databricks_executor
+    from omnigent.onboarding import ambient, detected, provider_config
+    from omnigent.runtime import workflow
+
+    # Everything unconfigured, so resolution reaches the last-resort branch.
+    monkeypatch.setattr(provider_config, "load_config", dict)
+    monkeypatch.setattr(ambient, "codex_config_detection", lambda: None)
+    monkeypatch.setattr(detected, "dismissed_detection_names", lambda cfg: frozenset())
+    monkeypatch.setattr(detected, "effective_config_with_detected", lambda cfg: {})
+    monkeypatch.setattr(provider_config, "default_provider_for_harness", lambda cfg, harness: None)
+    monkeypatch.setattr(workflow, "_load_global_auth", lambda: None)
+    # Managed connect signal: [omnigent] profile host + broker sidecar present.
+    monkeypatch.setattr(
+        databricks_executor, "_read_databrickscfg_host", lambda profile: "https://ws.example"
+    )
+    monkeypatch.setattr(
+        "omnigent.host.databricks_credential.broker_token_command",
+        lambda host, *a, **k: "python3 -m omnigent.host.databricks_credential token --coords /x",
+    )
+    monkeypatch.setattr(
+        codex_native_app_server,
+        "_resolve_databricks_codex_model",
+        lambda host, profile, model: "system.ai.gpt-6-astra",
+    )
+
+    launch = codex_native_app_server.resolve_native_codex_launch(model=None)
+
+    assert launch.profile is None
+    assert launch.model == "system.ai.gpt-6-astra"  # ucode-served model
+    assert launch.config_overrides  # gateway provider table (base_url + broker auth)
+    assert "managed connect host" in launch.summary
+
+
+def test_resolve_native_codex_launch_no_broker_sidecar_falls_back_to_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No broker sidecar (e.g. a laptop) → connect-broker branch is skipped and
+    Codex falls back to CLI login, so non-sandbox auth is untouched."""
+    from omnigent.inner import databricks_executor
+    from omnigent.onboarding import ambient, detected, provider_config
+    from omnigent.runtime import workflow
+
+    monkeypatch.setattr(provider_config, "load_config", dict)
+    monkeypatch.setattr(ambient, "codex_config_detection", lambda: None)
+    monkeypatch.setattr(detected, "dismissed_detection_names", lambda cfg: frozenset())
+    monkeypatch.setattr(detected, "effective_config_with_detected", lambda cfg: {})
+    monkeypatch.setattr(provider_config, "default_provider_for_harness", lambda cfg, harness: None)
+    monkeypatch.setattr(workflow, "_load_global_auth", lambda: None)
+    monkeypatch.setattr(
+        databricks_executor, "_read_databrickscfg_host", lambda profile: "https://ws.example"
+    )
+    monkeypatch.setattr(
+        "omnigent.host.databricks_credential.broker_token_command", lambda host, *a, **k: None
+    )
+
+    launch = codex_native_app_server.resolve_native_codex_launch(model=None)
+
+    assert "no provider configured" in launch.summary  # CLI-login fallback, not the gateway
+
+
 def test_codex_discover_thread_and_forward_writes_routing_summary_on_timeout(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -154,7 +154,13 @@ def test_resolve_gateway_none_when_sdk_absent(monkeypatch: pytest.MonkeyPatch) -
     assert resolve_databricks_gateway("oss") is None
 
 
-def _install_fake_sdk(monkeypatch: pytest.MonkeyPatch, *, host: str, token: str | None) -> None:
+def _install_fake_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    host: str,
+    token: str | None,
+    endpoints: list[tuple[str, str]] | None = None,
+) -> None:
     fake = types.ModuleType("databricks.sdk.core")
 
     class _Config:
@@ -166,9 +172,24 @@ def _install_fake_sdk(monkeypatch: pytest.MonkeyPatch, *, host: str, token: str 
             return {"Authorization": f"Bearer {token}"} if token else {}
 
     fake.Config = _Config  # type: ignore[attr-defined]
+    sdk = types.ModuleType("databricks.sdk")
+    # Only expose WorkspaceClient (used for serving-endpoint discovery) when the
+    # test supplies endpoints; otherwise the import fails and discovery no-ops.
+    if endpoints is not None:
+
+        class _WorkspaceClient:
+            def __init__(self, *, config: object) -> None:
+                self._config = config
+
+            @property
+            def serving_endpoints(self) -> object:
+                eps = [types.SimpleNamespace(name=n, task=t) for n, t in endpoints]
+                return types.SimpleNamespace(list=lambda: eps)
+
+        sdk.WorkspaceClient = _WorkspaceClient  # type: ignore[attr-defined]
     # Ensure parent packages resolve for the dotted import.
     monkeypatch.setitem(sys.modules, "databricks", types.ModuleType("databricks"))
-    monkeypatch.setitem(sys.modules, "databricks.sdk", types.ModuleType("databricks.sdk"))
+    monkeypatch.setitem(sys.modules, "databricks.sdk", sdk)
     monkeypatch.setitem(sys.modules, "databricks.sdk.core", fake)
 
 
@@ -192,6 +213,69 @@ def test_resolve_gateway_defaults_non_gateway_model(monkeypatch: pytest.MonkeyPa
 def test_resolve_gateway_none_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token=None)
     assert resolve_databricks_gateway("oss") is None
+
+
+def test_resolve_gateway_lists_all_chat_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Discovery lists every chat serving-endpoint (pinned default first, embeddings
+    # dropped) so opencode's in-session picker offers them all.
+    _install_fake_sdk(
+        monkeypatch,
+        host="https://ws.databricks.com",
+        token="t",
+        endpoints=[
+            ("databricks-kimi-k3", "llm/v1/chat"),
+            ("databricks-claude-sonnet-4-6", "llm/v1/chat"),
+            ("databricks-gte-large-en", "llm/v1/embeddings"),
+            ("some-other-endpoint", "llm/v1/chat"),
+        ],
+    )
+    res = resolve_databricks_gateway("oss", model_id="databricks-claude-sonnet-4-6")
+    assert res is not None
+    # pinned default first, embeddings + non-databricks dropped, de-duped
+    assert res.model_ids == ("databricks-claude-sonnet-4-6", "databricks-kimi-k3")
+    cfg = build_opencode_provider_config(res)
+    models = cfg["provider"]["databricks-gateway"]["models"]  # type: ignore[index]
+    assert set(models) == {"databricks-claude-sonnet-4-6", "databricks-kimi-k3"}
+
+
+def test_resolve_gateway_single_model_when_discovery_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No WorkspaceClient (endpoints=None) -> discovery no-ops, just the pinned model.
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    res = resolve_databricks_gateway("oss", model_id="databricks-kimi-k3")
+    assert res is not None
+    assert res.model_ids == ("databricks-kimi-k3",)
+
+
+def test_resolve_gateway_env_default_applies(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No session model pinned -> the deployment env default steers the endpoint.
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "databricks-kimi-k3")
+    res = resolve_databricks_gateway("oss")
+    assert res is not None
+    assert res.model_id == "databricks-kimi-k3"
+
+
+def test_resolve_gateway_session_model_beats_env_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "databricks-kimi-k3")
+    res = resolve_databricks_gateway("oss", model_id="databricks-gpt-5-5")
+    assert res is not None
+    assert res.model_id == "databricks-gpt-5-5"
+
+
+def test_resolve_gateway_env_default_ignored_when_not_gateway_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A non ``databricks-*`` env value is not a routable endpoint -> catalog wins.
+    _install_fake_sdk(monkeypatch, host="https://ws.databricks.com", token="t")
+    monkeypatch.setenv("OMNIGENT_DATABRICKS_GATEWAY_MODEL", "kimi-k3")
+    res = resolve_databricks_gateway("oss")
+    assert res is not None
+    assert res.model_id == "catalog-databricks-claude-default"
 
 
 def test_build_mcp_block_stdio_and_http() -> None:

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -18,6 +18,7 @@ from omnigent.harnesses.opencode_native.provider import (
     build_opencode_model_default_config,
     build_opencode_omnigent_mcp_server,
     build_opencode_provider_config,
+    managed_connect_opencode_config,
     maybe_merge_user_provider_config,
     resolve_databricks_gateway,
     write_opencode_provider_config,
@@ -750,8 +751,6 @@ def test_managed_connect_opencode_config_consumes_ucode(
     """On a managed connect host, opencode reuses ucode's generated config
     (provider block + system.ai model) and its refreshing auth plugin, copied into
     the per-session XDG dir."""
-    import omnigent.harnesses.opencode_native.provider as prov
-
     monkeypatch.setenv("HOME", str(tmp_path))
     # ucode's generated opencode config + auth plugin (its own XDG root).
     ucode_dir = tmp_path / ".ucode" / "opencode-xdg" / "opencode"
@@ -778,7 +777,7 @@ def test_managed_connect_opencode_config_consumes_ucode(
     )
 
     session_xdg = tmp_path / "session-xdg"
-    config = prov.managed_connect_opencode_config(session_xdg)
+    config = managed_connect_opencode_config(session_xdg)
 
     assert config is not None
     assert config["model"] == "databricks-anthropic/system.ai.claude-opus-4-8"  # system.ai
@@ -794,10 +793,8 @@ def test_managed_connect_opencode_config_none_without_sidecar(
 ) -> None:
     """No broker sidecar (e.g. a laptop) → None, so opencode's normal launch is
     untouched off a managed sandbox."""
-    import omnigent.harnesses.opencode_native.provider as prov
-
     monkeypatch.setattr("omnigent.host.databricks_credential._read_sidecar", lambda path: None)
-    assert prov.managed_connect_opencode_config(Path("/tmp/unused-xdg")) is None
+    assert managed_connect_opencode_config(Path("/tmp/unused-xdg")) is None
 
 
 @pytest.mark.parametrize("bad_url", ["https://evil.example/x", "http://ws/x"])
@@ -808,8 +805,6 @@ def test_managed_connect_opencode_config_rejects_untrusted_base_url(
     workspace host (a stale file from a prior connection, or a tampered one) is
     refused, so the freshly-minted broker bearer is never forwarded to an
     unverified origin."""
-    import omnigent.harnesses.opencode_native.provider as prov
-
     monkeypatch.setenv("HOME", str(tmp_path))
     ucode_dir = tmp_path / ".ucode" / "opencode-xdg" / "opencode"
     (ucode_dir / "plugin").mkdir(parents=True)
@@ -832,4 +827,4 @@ def test_managed_connect_opencode_config_rejects_untrusted_base_url(
         },
     )
 
-    assert prov.managed_connect_opencode_config(tmp_path / "session-xdg") is None
+    assert managed_connect_opencode_config(tmp_path / "session-xdg") is None

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -769,7 +769,12 @@ def test_managed_connect_opencode_config_consumes_ucode(
     # already exists, so no on-demand configure is triggered.
     monkeypatch.setattr(
         "omnigent.host.databricks_credential._read_sidecar",
-        lambda path: {"server": "s", "host_id": "h", "host_token": "t", "workspace_host": "https://ws"},
+        lambda path: {
+            "server": "s",
+            "host_id": "h",
+            "host_token": "t",
+            "workspace_host": "https://ws",
+        },
     )
 
     session_xdg = tmp_path / "session-xdg"
@@ -793,3 +798,38 @@ def test_managed_connect_opencode_config_none_without_sidecar(
 
     monkeypatch.setattr("omnigent.host.databricks_credential._read_sidecar", lambda path: None)
     assert prov.managed_connect_opencode_config(Path("/tmp/unused-xdg")) is None
+
+
+@pytest.mark.parametrize("bad_url", ["https://evil.example/x", "http://ws/x"])
+def test_managed_connect_opencode_config_rejects_untrusted_base_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad_url: str
+) -> None:
+    """A ucode config whose provider baseURL is not HTTPS on the sidecar's
+    workspace host (a stale file from a prior connection, or a tampered one) is
+    refused, so the freshly-minted broker bearer is never forwarded to an
+    unverified origin."""
+    import omnigent.harnesses.opencode_native.provider as prov
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ucode_dir = tmp_path / ".ucode" / "opencode-xdg" / "opencode"
+    (ucode_dir / "plugin").mkdir(parents=True)
+    (ucode_dir / "opencode.json").write_text(
+        json.dumps(
+            {
+                "model": "databricks-anthropic/system.ai.claude-opus-4-8",
+                "provider": {"databricks-anthropic": {"options": {"baseURL": bad_url}}},
+            }
+        )
+    )
+    (ucode_dir / "plugin" / "ucode-auth.js").write_text("// ucode auth plugin\n")
+    monkeypatch.setattr(
+        "omnigent.host.databricks_credential._read_sidecar",
+        lambda path: {
+            "server": "s",
+            "host_id": "h",
+            "host_token": "t",
+            "workspace_host": "https://ws",  # bad_url points elsewhere / non-HTTPS
+        },
+    )
+
+    assert prov.managed_connect_opencode_config(tmp_path / "session-xdg") is None

--- a/tests/test_opencode_native_provider.py
+++ b/tests/test_opencode_native_provider.py
@@ -742,3 +742,54 @@ def test_mcp_progress_heartbeat_lifecycle() -> None:
         assert len(written_messages) == count_at_exit
     finally:
         bridge_mod._write_jsonrpc = orig_write
+
+
+def test_managed_connect_opencode_config_consumes_ucode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a managed connect host, opencode reuses ucode's generated config
+    (provider block + system.ai model) and its refreshing auth plugin, copied into
+    the per-session XDG dir."""
+    import omnigent.harnesses.opencode_native.provider as prov
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # ucode's generated opencode config + auth plugin (its own XDG root).
+    ucode_dir = tmp_path / ".ucode" / "opencode-xdg" / "opencode"
+    (ucode_dir / "plugin").mkdir(parents=True)
+    (ucode_dir / "opencode.json").write_text(
+        json.dumps(
+            {
+                "model": "databricks-anthropic/system.ai.claude-opus-4-8",
+                "provider": {"databricks-anthropic": {"options": {"baseURL": "https://ws/x"}}},
+            }
+        )
+    )
+    (ucode_dir / "plugin" / "ucode-auth.js").write_text("// ucode auth plugin\n")
+    # A managed connect host (broker sidecar present) — and the ucode config
+    # already exists, so no on-demand configure is triggered.
+    monkeypatch.setattr(
+        "omnigent.host.databricks_credential._read_sidecar",
+        lambda path: {"server": "s", "host_id": "h", "host_token": "t", "workspace_host": "https://ws"},
+    )
+
+    session_xdg = tmp_path / "session-xdg"
+    config = prov.managed_connect_opencode_config(session_xdg)
+
+    assert config is not None
+    assert config["model"] == "databricks-anthropic/system.ai.claude-opus-4-8"  # system.ai
+    assert "databricks-anthropic" in config["provider"]
+    # auth plugin copied into the session dir and registered.
+    session_plugin = session_xdg / "opencode" / "plugin" / "ucode-auth.js"
+    assert session_plugin.exists()
+    assert config["plugin"] == [str(session_plugin)]
+
+
+def test_managed_connect_opencode_config_none_without_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No broker sidecar (e.g. a laptop) → None, so opencode's normal launch is
+    untouched off a managed sandbox."""
+    import omnigent.harnesses.opencode_native.provider as prov
+
+    monkeypatch.setattr("omnigent.host.databricks_credential._read_sidecar", lambda path: None)
+    assert prov.managed_connect_opencode_config(Path("/tmp/unused-xdg")) is None

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -2266,3 +2266,56 @@ def test_cli_config_pi_provider_discovery_failure_falls_back_to_catalog_default(
     assert provider.model == "catalog-databricks-claude-default", (
         f"discovery failure must fall back to catalog default; got {provider.model!r}"
     )
+
+
+def test_connect_broker_managed_host_resolves_without_configured_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A managed connect host with no configured provider still resolves a Pi
+    Databricks provider via the broker (the connect-broker fallback).
+
+    No omnigent provider is configured, so ``default_provider_for_harness``
+    returns None; the host-only ``[omnigent]`` profile + broker sidecar then route
+    Pi through the gateway with a broker ``!command`` apiKey and the ucode-served
+    model. The live-credential probe fails on the token-less profile, but that
+    warning is suppressed (the broker mints per request).
+    """
+    from types import SimpleNamespace
+
+    from omnigent.inner import databricks_executor
+
+    monkeypatch.setattr(
+        databricks_executor, "_read_databrickscfg_host", lambda profile: "https://ws.example"
+    )
+    monkeypatch.setattr(
+        "omnigent.host.databricks_credential.broker_token_command",
+        lambda host, *a, **k: "python3 -m omnigent.host.databricks_credential token --coords /x",
+    )
+    monkeypatch.setattr(
+        "omnigent.onboarding.ucode_state.read_ucode_state",
+        lambda host: SimpleNamespace(
+            agent=lambda name: SimpleNamespace(model="system.ai.claude-sonnet-4-6")
+        ),
+    )
+
+    provider = creds.resolve_pi_native_provider(config_loader=lambda: {"providers": {}})
+
+    assert provider is not None
+    assert provider.base_url == "https://ws.example/ai-gateway/anthropic"
+    assert provider.model == "system.ai.claude-sonnet-4-6"  # ucode-served, not legacy catalog
+    assert provider.api_key.startswith("!")  # broker command, minted per request
+    assert provider.credential_warning is None  # false "expired" warning suppressed
+
+
+def test_connect_broker_skipped_without_sidecar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No broker sidecar (e.g. a laptop) → connect-broker branch no-ops → None,
+    so non-sandbox auth is untouched."""
+    from omnigent.inner import databricks_executor
+
+    monkeypatch.setattr(
+        databricks_executor, "_read_databrickscfg_host", lambda profile: "https://ws.example"
+    )
+    monkeypatch.setattr(
+        "omnigent.host.databricks_credential.broker_token_command", lambda host, *a, **k: None
+    )
+    assert creds.resolve_pi_native_provider(config_loader=lambda: {"providers": {}}) is None


### PR DESCRIPTION
## Summary

Wires managed-sandbox coding harnesses (Claude Code, Codex, Pi) to a connected user's Databricks AI Gateway, by having **[`ucode`](https://github.com/databricks/ucode) generate each harness's gateway config, which omnigent then consumes** — omnigent keeps launching the harness itself (runner/harness bridge intact); ucode only writes the config, it never launches the agent.

Follows the merged connector #6382 (per-user OAuth broker). **Supersedes and replaces the closed #6889 + #6900** — this is a reuse-first rebuild: it drops #6900's PATH-wrapper approach (which broke the runner bridge and recursed on `ucode configure`, confirmed in the lab and by review) and reuses omnigent's existing ucode infra instead of the parallel module #6900 added.

### The key realization
omnigent already has the ucode integration: `ucode_setup` drives `ucode configure`, and `ucode_state.read_ucode_state` reads per-agent base URL / served model from `~/.ucode/state.json` — which `claude_native` and `codex_native` **already consume**. The only missing piece on the OSS connect-broker path was that nothing ran `ucode configure` there to populate `state.json`. So all three harnesses already work this way in the managed lakebox↔omnigent setup; this brings the same to the OSS connect flow.

### Changes
- **`ucode_setup.py`** — `build_ucode_configure_command_for_profile()` + a background `configure_ucode_for_sandbox()`: the non-interactive profile/broker counterpart to the existing interactive `--workspaces` flow. Reuses `find_ucode_command()` (pinned `uvx`). **Two token modes, one helper**: broker (caller exports `DATABRICKS_BEARER_COMMAND`, nothing on disk) and `--use-pat` (lakebox's injected PAT), so the managed lakebox launcher can converge on this helper on the next OSS→managed sync.
- **`connect.py`** — at host boot, the OSS managed-connect gate (host-only `[omnigent]` profile + broker sidecar) runs it in the **background**, so it never delays the runner's dial-back.
- **`claude_native`** — the connect-broker fallback prefers ucode's generated base URL + served model via `read_ucode_state` (fixing the legacy-model default), while still minting the bearer through omnigent's own broker `apiKeyHelper`. Falls back to the hand-built config when `state.json` isn't ready or ucode is absent.
- Carries forward #6889's still-valid harness wiring (the codex/pi broker-bearer fallback in `databricks_executor`, opencode gateway model listing, orchestration).

codex/pi already consume their ucode-generated config (codex via `read_ucode_state` + config overrides, pi via its own `models.json`), so populating `state.json` wires them too. No PATH wrapper, no parallel module, no Dockerfile wrapper.

## Test Plan

- **Unit** (`uv run --group test pytest`): `tests/onboarding/test_ucode_setup.py` (profile builder, both token modes), `tests/test_claude_native.py` (connect-broker fallback + a new `test_connect_fallback_prefers_ucode_state`: ucode's base URL/model win, broker apiKeyHelper retained), `tests/inner/test_databricks_auth_command.py`, `tests/test_opencode_native_provider.py` — pass with a clean env. ruff clean.
- **Lab (pending, Mac K8s):** stand up the agent_sandbox connect lab, connect Databricks, and drive a runner turn per harness to confirm each routes through the gateway once `ucode configure` has populated `state.json`. (The claude gateway turn was proven end-to-end in the lab on the prior approach; this re-verifies through `read_ucode_state`.)

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the profile-mode configure builder (both token modes) and the claude connect-broker config sourcing (prefer ucode's `read_ucode_state`, fall back to hand-built). The end-to-end runner turn per harness through the gateway is verified in the agent_sandbox lab (pending, Mac), since it exercises real ucode + the agent binaries.

## Changelog

Native coding harnesses in a managed sandbox now get their Databricks AI Gateway configuration (base URL, headers, served model) from ucode, while omnigent launches the harness, so a connected workspace works without omnigent re-implementing per-harness gateway config.

---
This pull request and its description were written by Isaac.
