### PR TITLE
fix(claude-native): surface AskUserQuestion in the web UI in every permission mode

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -1771,9 +1771,10 @@ def build_hook_settings(
             "command": evaluate_policy_command,
         }
 
-        # In bypassPermissions mode PermissionRequest never fires, so
-        # AskUserQuestion needs its own PreToolUse hook to surface the
-        # form. It's a no-op in other modes to avoid double-surfacing.
+        # Claude Code fires no PermissionRequest for AskUserQuestion (it needs
+        # no permission), so this PreToolUse hook is the only way to surface the
+        # question in the web UI. It runs in every permission mode; the handler
+        # short-circuits Claude's own picker via an allow/deny decision.
         ask_uq_command_parts = [
             python,
             "-I",
@@ -1786,12 +1787,11 @@ def build_hook_settings(
         ask_uq_hook: _JsonObject = {
             "type": "command",
             "command": shlex.join(ask_uq_command_parts),
-            # Short timeout: if the web-UI elicitation isn't answered
-            # within 10s, the hook returns empty output so Claude falls
-            # through to its TUI picker in bypassPermissions mode. In
-            # default mode this hook exits immediately (no-op), so the
-            # timeout is irrelevant there.
-            "timeout": 10,
+            # Wait up to a day for the web answer, matching the PermissionRequest
+            # hook and the server-side park window: a human reading a multi-part
+            # question needs far longer than a few seconds. On timeout the hook
+            # emits no output, so Claude falls back to its TUI picker.
+            "timeout": 86400,
         }
         # The ``AskUserQuestion`` matcher only fires if that tool is actually
         # callable. A session launched with ``--disallowedTools AskUserQuestion``

--- a/omnigent/harnesses/claude_native/hook.py
+++ b/omnigent/harnesses/claude_native/hook.py
@@ -890,19 +890,21 @@ def _main_ask_user_question(argv: list[str]) -> int:
     """
     Handle a ``PreToolUse`` hook for Claude's built-in ``AskUserQuestion`` tool.
 
-    In ``bypassPermissions`` mode the ``PermissionRequest`` hook never fires,
-    so ``AskUserQuestion`` questions are silently swallowed — the web UI never
-    sees them. This handler intercepts the tool via ``PreToolUse`` (which fires
-    in all permission modes), POSTs the same payload to the Omnigent server's
-    ``/hooks/permission-request`` endpoint, waits for the user's web-UI answer,
-    and converts the ``PermissionRequest``-format response into a
-    ``PreToolUse``-format output (``updatedInput``) so Claude receives the
-    answers and skips its own TUI picker.
+    ``AskUserQuestion`` needs no permission to run, so Claude Code fires no
+    ``PermissionRequest`` hook for it in any mode — the question is only ever
+    drawn in the terminal TUI. Left alone, a web-UI session shows nothing while
+    the terminal blocks on a picker no one is watching. This handler intercepts
+    the tool via ``PreToolUse`` (which fires in every permission mode), POSTs
+    the payload to the Omnigent server's ``/hooks/permission-request`` endpoint,
+    waits for the user's web-UI answer, and converts the
+    ``PermissionRequest``-format response into a ``PreToolUse``-format output
+    (``updatedInput``) so Claude receives the answers and skips its own picker.
 
-    When ``permission_mode`` is anything other than ``"bypassPermissions"``
-    (including absent/unknown), this is a no-op: the ``PermissionRequest`` hook
-    will handle the call, and returning empty output here prevents a duplicate
-    elicitation from appearing.
+    Runs in all permission modes, not just ``bypassPermissions``. Returning
+    ``permissionDecision`` ``allow``/``deny`` here short-circuits Claude's
+    permission flow, so a build that did gate ``AskUserQuestion`` would never
+    then also surface it — no double form. On timeout or error this emits no
+    output ("no opinion"), so Claude falls back to its own TUI picker.
 
     :param argv: CLI argv after the ``ask-user-question`` subcommand,
         e.g. ``["--bridge-dir", "/tmp/x"]``.
@@ -920,12 +922,6 @@ def _main_ask_user_question(argv: list[str]) -> int:
         return 0
     if not isinstance(payload, dict):
         print("omnigent ask-user-question hook: expected JSON object", file=sys.stderr)
-        return 0
-    # Only intercept in bypassPermissions mode. In any other mode the
-    # PermissionRequest hook fires independently and owns the elicitation;
-    # returning empty output here is "no opinion" so Claude's own flow
-    # continues unimpeded and we avoid surfacing the form twice.
-    if payload.get("permission_mode") != "bypassPermissions":
         return 0
     bridge_dir = Path(args.bridge_dir)
     session_id = read_active_session_id(bridge_dir)

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -1501,39 +1501,46 @@ def test_evaluate_policy_post_tool_use_converts_and_returns_context(
     assert captured.err == ""
 
 
-def test_ask_user_question_hook_noop_in_non_bypass_mode(
+def test_ask_user_question_hook_posts_in_every_permission_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """
-    ``ask-user-question`` subcommand is a no-op when not in bypassPermissions mode.
+    ``ask-user-question`` forwards to the web UI in every permission mode.
 
-    In default / acceptEdits / plan modes the ``PermissionRequest`` hook fires
-    and owns the elicitation.  The ``ask-user-question`` PreToolUse hook must
-    return empty output (no opinion) so the form is not shown twice.
+    Claude Code fires no ``PermissionRequest`` for ``AskUserQuestion`` (it needs
+    no permission), so this ``PreToolUse`` hook is the only way to surface the
+    question in the web UI — in default / acceptEdits / plan / bypass alike. It
+    must POST to Omnigent and lift the answer into ``updatedInput`` so Claude
+    skips its own TUI picker.
 
-    This fails if the handler forwards the payload to Omnigent in non-bypass mode —
-    which would cause a duplicate elicitation card in the web UI and race for
-    the same answer.
+    This fails if the handler no-ops in non-bypass mode (the regression that
+    left the question stuck in the terminal, never reaching the web UI).
     """
-    calls: list[str] = []
+    posted_urls: list[str] = []
+    answers = {"q1": "Option A"}
+    server_response = {
+        "hookSpecificOutput": {
+            "hookEventName": "PermissionRequest",
+            "decision": {"behavior": "allow", "updatedInput": {"answers": answers}},
+        }
+    }
 
-    class _RaisesIfCalled:
-        """HTTP client stub that fails the test if called unexpectedly."""
+    class _FakeHttpxClient:
+        """HTTP client stub returning a canned allow verdict."""
 
         def __init__(self, **_kwargs: object) -> None:
             """
-            Record unexpected construction.
+            Accept constructor kwargs.
 
-            :param _kwargs: Ignored constructor args.
+            :param _kwargs: Ignored.
             :returns: None.
             """
-            calls.append("constructed")
 
-        def __enter__(self) -> _RaisesIfCalled:
+        def __enter__(self) -> _FakeHttpxClient:
             """
-            Enter context — should not be reached.
+            Enter context.
 
             :returns: self.
             """
@@ -1541,32 +1548,38 @@ def test_ask_user_question_hook_noop_in_non_bypass_mode(
 
         def __exit__(self, *_args: object) -> None:
             """
-            Exit context — should not be reached.
+            Exit context.
 
-            :param _args: Ignored exception args.
+            :param _args: Ignored.
             :returns: None.
             """
 
-        def post(self, *_args: object, **_kwargs: object) -> object:
+        def post(self, url: str, *, json: object) -> object:
             """
-            Fail if Omnigent is called — must not happen in non-bypass mode.
+            Record the call and return the canned allow response.
 
-            :param _args: Ignored.
-            :param _kwargs: Ignored.
-            :returns: Never.
-            :raises AssertionError: Always, so the test fails visibly.
+            :param url: Target URL.
+            :param json: Request body (ignored).
+            :returns: Fake HTTP response.
             """
-            raise AssertionError(
-                "AP was called for ask-user-question in non-bypass mode — "
-                "PermissionRequest hook should own the elicitation instead"
+            import json as _json
+
+            import httpx as _httpx
+
+            posted_urls.append(url)
+            return _httpx.Response(
+                200,
+                text=_json.dumps(server_response),
+                request=_httpx.Request("POST", url),
             )
 
-    monkeypatch.setattr(native_policy_hook.httpx, "Client", _RaisesIfCalled)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _FakeHttpxClient)
     bridge_dir = prepare_bridge_dir("conv_abc", bridge_id="b1", workspace=tmp_path)
     write_active_session_id(bridge_dir, "conv_abc")
     build_hook_settings(bridge_dir, ap_server_url="http://127.0.0.1:8787")
 
-    for mode in ("default", "acceptEdits", "plan", None):
+    for mode in ("default", "acceptEdits", "plan", None, "bypassPermissions"):
+        posted_urls.clear()
         payload: dict[str, object] = {
             "hook_event_name": "PreToolUse",
             "tool_name": "AskUserQuestion",
@@ -1577,10 +1590,18 @@ def test_ask_user_question_hook_noop_in_non_bypass_mode(
         monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
         exit_code = claude_native_hook.main(["ask-user-question", "--bridge-dir", str(bridge_dir)])
         captured = capsys.readouterr()
-        # No Omnigent call, no output — "no opinion" so PermissionRequest takes over.
         assert exit_code == 0, f"Non-zero exit for mode={mode!r}"
-        assert captured.out == "", f"Unexpected output for mode={mode!r}: {captured.out!r}"
-        assert calls == [], f"AP client was constructed for mode={mode!r}"
+        # The question must be forwarded to the active session's endpoint.
+        assert posted_urls == [
+            "http://127.0.0.1:8787/v1/sessions/conv_abc/hooks/permission-request"
+        ], f"AP not called (or wrong URL) for mode={mode!r}: {posted_urls!r}"
+        # And the answer lifted into PreToolUse ``updatedInput`` so Claude skips
+        # its own picker.
+        result = json.loads(captured.out)
+        hs = result["hookSpecificOutput"]
+        assert hs["hookEventName"] == "PreToolUse", f"Not PreToolUse-shaped for mode={mode!r}"
+        assert hs["permissionDecision"] == "allow", f"Not allow for mode={mode!r}"
+        assert hs["updatedInput"]["answers"] == answers, f"Answers not lifted for mode={mode!r}"
 
 
 def test_ask_user_question_hook_posts_and_returns_pre_tool_use_output_in_bypass_mode(


### PR DESCRIPTION
## Related issue

N/A — reported directly from a running session; no tracked issue.

## Summary

Claude's multiple-choice questions can remain stuck in the terminal instead of appearing in Omnigent chat. The existing question hook only forwarded in bypass mode and was killed after ten seconds.

- Forward `AskUserQuestion` through `PreToolUse` in every permission mode, rather than relying on `PermissionRequest` firing.
- Give `AskUserQuestion` up to 30 seconds for a UI answer; leave normal permission-request timeouts unchanged. Return answers through `updatedInput` so Claude skips a second picker. Timeout and transport failures retain the terminal fallback.
- Cover default, accept-edits, plan, auto, bypass, unknown, and absent permission modes; preserve long option descriptions and pin the hook timeout.

**ELI5:** Questions now reach the chat you're using, and you have time to read them before answering.

```text
Claude AskUserQuestion → PreToolUse hook → Omnigent question form
Claude resumes        ← updatedInput   ← user's selection
```

## Test Plan

Current revision:
- `.venv/bin/python -m pytest -q tests/test_claude_native_hook.py` — **78 passed**.
- `OMNIGENT_WRAPPER_BYPASS=1 .venv/bin/python -m pytest -q tests/e2e_ui/approvals/test_claude_question_hook.py tests/e2e_ui/approvals/test_ask_user_question.py::test_ask_user_question_form_renders_and_submits --ui-skip-build` — **3 passed**, exercising the actual hook subprocess through the server and browser, including an answer after 12 seconds and a 30-second process timeout.
- `.venv/bin/python -m pre_commit run --files omnigent/harnesses/claude_native/bridge.py tests/test_claude_native_hook.py tests/e2e_ui/approvals/test_claude_question_hook.py` — checks Pyrefly, Ruff, formatting, and the applicable repository hooks before committing.

Lint uses the dependency extras from `.github/workflows/lint.yml`; the Python tests use the `all` extra and `dev` group.

Suggested human verification (not performed):
1. Start a fresh Claude-native session so it loads the updated hook settings.
2. Send: "Use AskUserQuestion to let me choose Alpha or Bravo, then repeat my choice."
3. Wait about 12 seconds. Confirm the question remains answerable in chat.
4. Select an option in the UI. Confirm Claude resumes with that choice without a second TUI prompt.
5. Ask another question and leave it unanswered for over 30 seconds. Confirm Claude falls back to the terminal picker.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A for visual assets: this changes backend hook wiring and timing, not the existing question form. Automated round-trip evidence is listed in Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The PR-branch tests exercise the hook entry point, complete question/answer payloads, authentication headers, timeout registration, and the server/browser round-trip. The subprocess tests model Claude's command-timeout supervisor rather than running the Claude TUI. UI cleanup allows the server's separate 30-second reconnect grace after the hook exits.

A real-Claude TUI attempt with isolated settings was blocked by the machine's managed `apiKeyHelper`; no authenticated live-Claude round-trip is claimed.

The broader `test_answered_question_stays_outside_the_worked_fold` test failed while waiting for its mock-model gate, before creating an elicitation. The failure reproduced when run alone; this PR does not change that setup.

## Changelog

Claude-native questions appear in Omnigent chat in every permission mode, with 30 seconds to answer before falling back to the terminal.
