### PR TITLE
docs(readme): add "coding" to tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # <img src="https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg" alt="" height="38" valign="middle" /> Omnigent
 
-### The open-source meta-harness for all your AI agents.
+### The open-source meta-harness for all your AI coding agents.
 
 Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
 


### PR DESCRIPTION
## Summary
- Adds "coding" to the README tagline ("The open-source meta-harness for all your AI coding agents.") as a test PR.

## Test Plan
- N/A — single-word README edit, no functional change.

## Demo
N/A

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation / non-breaking change

## Test coverage
- [x] Not applicable

## Coverage notes
Single-word documentation change only.

This pull request and its description were written by Isaac.