### PR TITLE
fix(cursor): cancel obsolete native approval tasks

### DIFF
--- a/docs/cursor-native-elicitation.md
+++ b/docs/cursor-native-elicitation.md
@@ -14,6 +14,11 @@ stays the source of truth — Omnigent never modifies cursor's JS bundle and nev
 the TUI prompt. The failure mode is benign: if detection ever breaks, the embedded TUI prompt
 still works and the user answers there.
 
+Pending verdict requests belong to the transcript supervisor. When a call resolves
+in the terminal, its parked request is cancelled before clearing the web card.
+When the supervisor stops, it cancels and joins every remaining verdict task before
+closing its HTTP client, so a late web answer cannot start typing into a retired terminal.
+
 One exception: a session the *caller* launched with `--yolo` / `--force` / `-f` has already
 declared it wants no approvals, and a card mirrored to a piloted parent is a stall nobody can
 click. Those sessions answer lingering gates in the pane instead — see

--- a/omnigent/harnesses/cursor_native/permissions.py
+++ b/omnigent/harnesses/cursor_native/permissions.py
@@ -43,6 +43,8 @@ import hashlib
 import json
 import logging
 import re
+from collections.abc import AsyncIterator, Collection
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -146,7 +148,7 @@ async def _send_cursor_keys(bridge_dir: Path, session_id: str, *keys: str) -> bo
             await asyncio.sleep(_KEY_ENTER_SETTLE_S)
         try:
             await asyncio.to_thread(send_cursor_pane_keys, bridge_dir, key)
-        except RuntimeError:
+        except (RuntimeError, OSError):
             _logger.exception(
                 "failed to send cursor keystroke %r (of %r); session=%s", key, keys, session_id
             )
@@ -798,6 +800,31 @@ async def _yolo_auto_accept(
     return _YoloAccept.SENT
 
 
+async def _cancel_cursor_elicitation_tasks(tasks: Collection[asyncio.Task[None]]) -> None:
+    pending = tuple(tasks)
+    for task in pending:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _report_cursor_elicitation_result(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None:
+        _logger.error("cursor elicitation task failed: %s", task.get_name(), exc_info=error)
+
+
+@asynccontextmanager
+async def _cursor_elicitation_tasks() -> AsyncIterator[set[asyncio.Task[None]]]:
+    tasks: set[asyncio.Task[None]] = set()
+    try:
+        yield tasks
+    finally:
+        await _cancel_cursor_elicitation_tasks(tasks)
+
+
 async def supervise_cursor_transcript_elicitations(
     *,
     base_url: str,
@@ -864,7 +891,10 @@ async def supervise_cursor_transcript_elicitations(
     timeout = httpx.Timeout(_POST_TIMEOUT_S, connect=10.0)
     from omnigent.cli_auth import open_server_client
 
-    async with open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client:
+    async with (
+        open_server_client(base_url, headers=headers, auth=auth, timeout=timeout) as client,
+        _cursor_elicitation_tasks() as pending_tasks,
+    ):
         while True:
             try:
                 if store_path is None or not store_path.exists():
@@ -884,6 +914,7 @@ async def supervise_cursor_transcript_elicitations(
                     entry = active.pop(tool_call_id)
                     task = entry["task"]
                     if isinstance(task, asyncio.Task) and not task.done():
+                        await _cancel_cursor_elicitation_tasks((task,))
                         await _post_external_elicitation_resolved(
                             client, session_id, str(entry["elicitation_id"])
                         )
@@ -961,6 +992,9 @@ async def supervise_cursor_transcript_elicitations(
                             elicitation_id=elicitation_id,
                         )
                     task = asyncio.create_task(coro, name=f"cursor-approval-{elicitation_id}")
+                    pending_tasks.add(task)
+                    task.add_done_callback(pending_tasks.discard)
+                    task.add_done_callback(_report_cursor_elicitation_result)
                     active[call.tool_call_id] = {
                         "elicitation_id": elicitation_id,
                         "task": task,

--- a/tests/test_cursor_native_permissions.py
+++ b/tests/test_cursor_native_permissions.py
@@ -626,6 +626,97 @@ def _hook_posts(posts: list[tuple[str, dict]]) -> list[tuple[str, dict]]:
     return [(u, j) for u, j in posts if "hooks/cursor-permission-request" in u]
 
 
+@pytest.mark.parametrize("resolved_in_terminal", [False, True])
+@pytest.mark.parametrize("tool_name", ["Shell", "AskQuestion"])
+async def test_supervisor_cancels_obsolete_verdict_before_it_can_send_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    resolved_in_terminal: bool,
+    tool_name: str,
+) -> None:
+    pending = [CursorPendingToolCall("call_cleanup", tool_name, {})]
+    posts, sent = _install_supervisor_fakes(
+        monkeypatch, tmp_path, pending=pending, pane=_IDLE_PANE
+    )
+    parked = asyncio.Event()
+    cancelled = asyncio.Event()
+    late_verdict = asyncio.Event()
+    verdict_tasks: list[asyncio.Task] = []
+
+    async def park(*_args, **_kwargs):
+        current = asyncio.current_task()
+        assert current is not None
+        verdict_tasks.append(current)
+        parked.set()
+        try:
+            await late_verdict.wait()
+            return {"action": "accept"}
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    monkeypatch.setattr(cnp, "_park_cursor_elicitation", park)
+    supervisor = _start_supervisor(
+        tmp_path, session_id="conv_cleanup", auto_accept_approvals=False
+    )
+    try:
+        await asyncio.wait_for(parked.wait(), timeout=2)
+        if resolved_in_terminal:
+            pending.clear()
+            assert await _wait_for(
+                lambda: any(
+                    body.get("type") == "external_elicitation_resolved" for _, body in posts
+                )
+            )
+        else:
+            await _stop(supervisor)
+        assert cancelled.is_set()
+        assert all(task.cancelled() for task in verdict_tasks)
+        late_verdict.set()
+        await asyncio.sleep(0)
+        assert sent == []
+    finally:
+        await _stop(supervisor)
+
+
+async def test_supervisor_observes_verdict_failure_without_restarting_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _install_supervisor_fakes(monkeypatch, tmp_path, pending=[_SHELL_CALL], pane=_IDLE_PANE)
+    failures: list[str] = []
+
+    async def fail(*_args, **_kwargs):
+        failures.append("failed")
+        raise ValueError("invalid verdict")
+
+    monkeypatch.setattr(cnp, "_park_cursor_elicitation", fail)
+    supervisor = _start_supervisor(
+        tmp_path, session_id="conv_failed_verdict", auto_accept_approvals=False
+    )
+    try:
+        assert await _wait_for(lambda: "cursor elicitation task failed" in caplog.text)
+        assert "invalid verdict" in caplog.text
+        assert not supervisor.done()
+        assert failures == ["failed"]
+    finally:
+        await _stop(supervisor)
+
+
+@pytest.mark.parametrize("error", [OSError(24, "Too many open files"), RuntimeError("gone")])
+async def test_send_keys_stops_sequence_when_terminal_command_cannot_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, error: Exception
+) -> None:
+    attempts: list[str] = []
+
+    def fail(_bridge: Path, key: str) -> None:
+        attempts.append(key)
+        raise error
+
+    monkeypatch.setattr(cnp, "send_cursor_pane_keys", fail)
+    assert not await cnp._send_cursor_keys(tmp_path, "conv_keys", "Escape", "Enter")
+    assert attempts == ["Escape"]
+
+
 async def test_supervise_transcript_yolo_auto_accepts_without_card(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Related issue

Dashboard triage: Cursor verdict tasks outlive their terminal/supervisor and attempt keystrokes against missing tmux sockets.

## Summary

- Own parked approval/question tasks for the supervisor lifetime; cancel and join them before closing the HTTP client, and when a transcript call resolves locally.
- Observe background failures once without replaying verdicts, and stop a key sequence when tmux cannot spawn because of an OS error.
- ELI5: a late answer must not type into a terminal whose approval is already gone.

```text
pending call -> parked verdict task -> approved answer -> keys
                      |
             resolved / supervisor stops
                      v
                cancel + join
```

## Test Plan

- `uv run --offline pytest tests/test_cursor_native_permissions.py tests/test_cursor_native_bridge.py -q`: 90 passed.
- Pyrefly: 0 errors. Pre-commit passed for all changed files.
- Regression coverage: approval and question tasks cancelled on local resolution/shutdown; late verdict cannot deliver keys; task errors are observed; spawn errors stop multi-key delivery.
- Manual verification: start a Cursor session with an approval pending, answer in its terminal, then verify the web card clears without sending a second verdict. Stop a session with a pending approval and verify no later keystroke/task exception appears in its runner log.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — backend task-lifecycle change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Local tests fake the external store, HTTP and tmux boundaries. A live Cursor session was not exercised. This fixes task ownership and error handling, not the underlying host resource exhaustion.

## Changelog

Cursor stops waiting for obsolete approval answers when their call resolves or the session supervisor shuts down.
