### PR TITLE
ci(deps): enforce and audit the seven-day dependency cooldown

### DIFF
--- a/.github/workflows/dependency-age-audit.yml
+++ b/.github/workflows/dependency-age-audit.yml
@@ -1,0 +1,57 @@
+name: Dependency Age Audit
+
+# Audits committed lockfiles for dependencies published inside the seven-day
+# supply-chain cooldown. The cooldown is applied only when a lockfile is
+# resolved (pnpm's minimumReleaseAge, uv's exclude-newer), and a frozen install
+# never re-checks it — so a too-new pin can still slip into the committed lock.
+# This reads the ages back out (uv.lock records them inline; npm ages come from
+# the registry) and fails if any pin is younger than the window.
+#
+# Scheduled, not a PR gate: the npm half makes ~1.7k registry lookups, so it is
+# run nightly (and on demand) rather than blocking every pull request. The
+# lint_dep_cooldown_policy pre-commit hook is the fast PR-time guard.
+
+on:
+  schedule:
+    # Daily at 08:00 UTC.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      max-age-days:
+        description: "Cooldown window in days"
+        default: "7"
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-age-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit dependency ages
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v3
+
+      # No project sync needed: the audit only reads the lockfiles and queries
+      # the public npm registry. PyYAML is the sole extra dependency (tomllib is
+      # stdlib on 3.12). Public npmjs is fast and carries accurate publish times.
+      - name: Run dependency age audit
+        run: |
+          uv run --no-project --with pyyaml \
+            python dev/lint/verify_dependency_ages.py \
+              --max-age-days "${{ github.event.inputs.max-age-days || '7' }}" \
+              --npm-registry https://registry.npmjs.org

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,17 @@ repos:
         files: \.(py|ya?ml|json|toml|sh)$
         exclude: (^|/)tests/|^openapi\.json$
 
+      # Guard the seven-day dependency-cooldown policy against silent regression:
+      # pnpm only honors minimumReleaseAge under top-level `settings:`, and uv
+      # needs exclude-newer + required-version. Offline config check; actual
+      # package ages are audited nightly by verify_dependency_ages.py.
+      - id: dep-cooldown-policy
+        name: dependency cooldown policy is effective
+        language: system
+        entry: .venv/bin/python dev/lint/lint_dep_cooldown_policy.py
+        pass_filenames: false
+        files: ^(pnpm-workspace\.yaml|uv\.toml)$
+
       - id: web-prettier
         name: web prettier
         language: system

--- a/dev/lint/lint_dep_cooldown_policy.py
+++ b/dev/lint/lint_dep_cooldown_policy.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Fail when the dependency-cooldown policy is missing or placed where the
+resolver silently ignores it.
+
+The scenario this guards: pnpm only honors `minimumReleaseAge` when it sits in
+the top-level `settings:` block of `pnpm-workspace.yaml`. Nested anywhere else
+it parses fine but is never read, so the seven-day cooldown is silently off and
+a freshly published (possibly compromised) version can be pinned. That is
+exactly the regression that landed once already — the setting existed but in a
+spot pnpm didn't look, so nothing enforced it.
+
+This is a cheap, offline config guard: it asserts the cooldown knobs are present
+AND effective on both ecosystems. It does NOT verify individual package ages —
+`verify_dependency_ages.py` does that against the registries.
+
+Checks:
+- pnpm-workspace.yaml `settings.minimumReleaseAge` >= 10080 (7 days, in minutes).
+- uv.toml `exclude-newer` present and >= 7 days (relative `P{n}D` form) or a
+  fixed date (accepted as-is).
+- uv.toml `required-version` present (so an old uv that can't honor the cooldown
+  fails loudly rather than resolving without it).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import tomllib
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKSPACE = REPO_ROOT / "pnpm-workspace.yaml"
+UV_TOML = REPO_ROOT / "uv.toml"
+
+# 7 days. pnpm expresses minimumReleaseAge in minutes; uv uses an ISO-8601 span.
+WEEK_MINUTES = 7 * 24 * 60
+
+
+def _check_pnpm(problems: list[str]) -> None:
+    if not WORKSPACE.exists():
+        problems.append(f"{WORKSPACE.name}: file not found")
+        return
+    workspace = yaml.safe_load(WORKSPACE.read_text()) or {}
+    settings = workspace.get("settings")
+    if not isinstance(settings, dict) or "minimumReleaseAge" not in settings:
+        # Catch the exact trap: the key nested somewhere the resolver ignores.
+        misplaced = "minimumReleaseAge" in WORKSPACE.read_text()
+        hint = (
+            " (found the key elsewhere in the file — it must live under the "
+            "top-level `settings:` block or pnpm ignores it)"
+            if misplaced
+            else ""
+        )
+        problems.append(
+            f"{WORKSPACE.name}: settings.minimumReleaseAge is missing{hint}"
+        )
+        return
+    value = settings["minimumReleaseAge"]
+    if not isinstance(value, int) or value < WEEK_MINUTES:
+        problems.append(
+            f"{WORKSPACE.name}: settings.minimumReleaseAge is {value!r}, "
+            f"expected an integer >= {WEEK_MINUTES} (7 days in minutes)"
+        )
+
+
+def _exclude_newer_ok(value: object) -> bool:
+    """Accept a fixed date, or a relative `P{n}D` / `P{n}W` span >= 7 days."""
+    if not isinstance(value, str):
+        return False
+    m = re.fullmatch(r"P(\d+)([DW])", value.strip())
+    if m:
+        days = int(m.group(1)) * (7 if m.group(2) == "W" else 1)
+        return days >= 7
+    # A fixed ISO date (e.g. "2026-01-01") or timestamp is a deliberate pin.
+    return bool(re.match(r"\d{4}-\d{2}-\d{2}", value.strip()))
+
+
+def _check_uv(problems: list[str]) -> None:
+    if not UV_TOML.exists():
+        problems.append(f"{UV_TOML.name}: file not found")
+        return
+    data = tomllib.loads(UV_TOML.read_text())
+    if "exclude-newer" not in data:
+        problems.append(f"{UV_TOML.name}: exclude-newer is missing")
+    elif not _exclude_newer_ok(data["exclude-newer"]):
+        problems.append(
+            f"{UV_TOML.name}: exclude-newer is {data['exclude-newer']!r}, "
+            "expected a span >= 7 days (e.g. \"P7D\") or a fixed date"
+        )
+    if "required-version" not in data:
+        problems.append(
+            f"{UV_TOML.name}: required-version is missing — without it an old uv "
+            "can resolve while ignoring the cooldown"
+        )
+
+
+def main() -> int:
+    problems: list[str] = []
+    _check_pnpm(problems)
+    _check_uv(problems)
+
+    if problems:
+        print(
+            "Dependency-cooldown policy is not effective. The seven-day supply-chain\n"
+            "cooldown must be configured where each resolver actually reads it:\n"
+        )
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/lint/verify_dependency_ages.py
+++ b/dev/lint/verify_dependency_ages.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Fail when a pinned dependency was published within the cooldown window.
+
+The config guard (`lint_dep_cooldown_policy.py`) proves the cooldown knobs are
+present, and each resolver applies them when it generates a lockfile. But
+resolution is the *only* moment the JS cooldown is applied — `--frozen-lockfile`
+installs trust the lock as-is and never re-check age. So a too-new version can
+still reach the committed lockfile: resolved while the policy was misconfigured,
+resolved by a machine with a stale config, or slipped in through a bypassed
+install. This audit closes that gap by reading the ages back out of the lockfiles
+and failing on anything younger than the window.
+
+Two ecosystems, two data sources:
+- Python (uv.lock): uv records `upload-time` for every package inline, so this
+  half is fully offline — no PyPI queries.
+- JS (pnpm-lock.yaml): the lock records no publish time, so we fetch each unique
+  package's registry metadata (`.time[version]`) once and read the age from it.
+
+Because the JS half hits the network over ~hundreds of packages, this is meant
+to run as a scheduled (nightly) job, not a per-PR blocking gate. Transient
+network failures are reported but do not fail the run unless `--strict` is given;
+a confirmed too-new package always fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import tomllib
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PNPM_LOCK = REPO_ROOT / "pnpm-lock.yaml"
+UV_LOCK = REPO_ROOT / "uv.lock"
+UV_TOML = REPO_ROOT / "uv.toml"
+
+DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org"
+DEFAULT_MAX_AGE_DAYS = 7
+# pnpm keys look like `name@version(peer@1)(peer@2)`; drop the peer suffix.
+_PNPM_PEER_SUFFIX = re.compile(r"\(.*\)$")
+_SEMVERISH = re.compile(r"^\d+\.\d+\.\d+")
+
+
+class Pinned:
+    __slots__ = ("ecosystem", "name", "version")
+
+    def __init__(self, ecosystem: str, name: str, version: str) -> None:
+        self.ecosystem = ecosystem
+        self.name = name
+        self.version = version
+
+    def __hash__(self) -> int:
+        return hash((self.ecosystem, self.name, self.version))
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Pinned) and (
+            self.ecosystem,
+            self.name,
+            self.version,
+        ) == (other.ecosystem, other.name, other.version)
+
+
+def _parse_iso(text: str) -> datetime | None:
+    try:
+        # uv/registry stamps end in 'Z'; normalize for fromisoformat.
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Lockfile parsing
+# --------------------------------------------------------------------------- #
+def parse_pnpm_lock() -> list[Pinned]:
+    """Extract (name, version) for every registry package in pnpm-lock.yaml."""
+    if not PNPM_LOCK.exists():
+        return []
+    data = yaml.safe_load(PNPM_LOCK.read_text()) or {}
+    pins: set[Pinned] = set()
+    for key in (data.get("packages") or {}):
+        spec = _PNPM_PEER_SUFFIX.sub("", key)
+        # Split off the version: name may be scoped (`@scope/pkg`), so the
+        # version is after the LAST '@'.
+        at = spec.rfind("@")
+        if at <= 0:
+            continue
+        name, version = spec[:at], spec[at + 1 :]
+        # Skip non-registry resolutions (tarball URLs, git, links, patches).
+        if "://" in version or not _SEMVERISH.match(version):
+            continue
+        pins.add(Pinned("npm", name, version))
+    return sorted(pins, key=lambda p: (p.name, p.version))
+
+
+def parse_uv_lock() -> list[tuple[Pinned, datetime | None]]:
+    """Extract (pin, publish_time) from uv.lock using its inline upload-time."""
+    if not UV_LOCK.exists():
+        return []
+    data = tomllib.loads(UV_LOCK.read_text())
+    out: list[tuple[Pinned, datetime | None]] = []
+    for pkg in data.get("package", []):
+        source = pkg.get("source") or {}
+        if "registry" not in source:
+            continue  # path/git/editable/virtual — not a registry release
+        name = pkg.get("name")
+        version = pkg.get("version")
+        if not name or not version:
+            continue
+        # Earliest upload across the sdist and wheels is the package's age.
+        times: list[datetime] = []
+        sdist = pkg.get("sdist") or {}
+        if isinstance(sdist, dict) and sdist.get("upload-time"):
+            t = _parse_iso(sdist["upload-time"])
+            if t:
+                times.append(t)
+        for wheel in pkg.get("wheels") or []:
+            if isinstance(wheel, dict) and wheel.get("upload-time"):
+                t = _parse_iso(wheel["upload-time"])
+                if t:
+                    times.append(t)
+        out.append((Pinned("pypi", name, version), min(times) if times else None))
+    return out
+
+
+def load_uv_exemptions() -> set[str]:
+    """Package names uv exempts from the cooldown (exclude-newer-package)."""
+    if not UV_TOML.exists():
+        return set()
+    data = tomllib.loads(UV_TOML.read_text())
+    exempt = data.get("exclude-newer-package") or {}
+    return {name.lower() for name in exempt}
+
+
+# --------------------------------------------------------------------------- #
+# npm registry lookups
+# --------------------------------------------------------------------------- #
+def _fetch_npm_times(name: str, registry: str, timeout: float) -> dict[str, str]:
+    # Scoped names must keep the '/' percent-encoded for the registry path.
+    encoded = urllib.parse.quote(name, safe="")
+    url = f"{registry.rstrip('/')}/{encoded}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        payload = json.load(resp)
+    times = payload.get("time")
+    return times if isinstance(times, dict) else {}
+
+
+def resolve_npm_ages(
+    pins: list[Pinned], registry: str, jobs: int, timeout: float
+) -> tuple[dict[Pinned, datetime | None], list[str]]:
+    """Map each npm pin to its publish time; collect names that couldn't be read."""
+    by_name: dict[str, list[Pinned]] = {}
+    for p in pins:
+        by_name.setdefault(p.name, []).append(p)
+
+    ages: dict[Pinned, datetime | None] = {}
+    unresolved: list[str] = []
+
+    def work(name: str) -> tuple[str, dict[str, str] | None]:
+        for attempt in range(3):
+            try:
+                return name, _fetch_npm_times(name, registry, timeout)
+            except (urllib.error.URLError, TimeoutError, ValueError):
+                if attempt == 2:
+                    return name, None
+        return name, None
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        for name, times in pool.map(work, by_name):
+            if times is None:
+                unresolved.append(name)
+                for p in by_name[name]:
+                    ages[p] = None
+                continue
+            for p in by_name[name]:
+                stamp = times.get(p.version)
+                ages[p] = _parse_iso(stamp) if stamp else None
+    return ages, unresolved
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-age-days", type=int, default=DEFAULT_MAX_AGE_DAYS)
+    parser.add_argument("--npm-registry", default=DEFAULT_NPM_REGISTRY)
+    parser.add_argument("--jobs", type=int, default=16)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat unresolved (network-failed) packages as failures",
+    )
+    args = parser.parse_args()
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=args.max_age_days)
+    violations: list[str] = []
+    unresolved: list[str] = []
+
+    # ---- Python (offline: ages come straight from uv.lock) ----
+    uv_exempt = load_uv_exemptions()
+    uv_pins = parse_uv_lock()
+    for pin, published in uv_pins:
+        if pin.name.lower() in uv_exempt:
+            continue
+        if published is None:
+            unresolved.append(f"pypi:{pin.name}@{pin.version} (no upload-time in uv.lock)")
+        elif published > cutoff:
+            age = (now - published).days
+            violations.append(
+                f"  pypi  {pin.name}@{pin.version} — published {published:%Y-%m-%d} "
+                f"({age}d ago, < {args.max_age_days}d)"
+            )
+
+    # ---- JS (fetch publish times from the npm registry) ----
+    npm_pins = parse_pnpm_lock()
+    npm_ages, npm_unresolved = resolve_npm_ages(
+        npm_pins, args.npm_registry, args.jobs, args.timeout
+    )
+    unresolved.extend(f"npm:{n} (registry lookup failed)" for n in npm_unresolved)
+    for pin in npm_pins:
+        published = npm_ages.get(pin)
+        if published is None:
+            if pin.name not in npm_unresolved:
+                unresolved.append(
+                    f"npm:{pin.name}@{pin.version} (version not in registry time map)"
+                )
+        elif published > cutoff:
+            age = (now - published).days
+            violations.append(
+                f"  npm   {pin.name}@{pin.version} — published {published:%Y-%m-%d} "
+                f"({age}d ago, < {args.max_age_days}d)"
+            )
+
+    print(
+        f"Dependency age audit: checked {len(uv_pins)} PyPI + {len(npm_pins)} npm "
+        f"pins against a {args.max_age_days}-day cooldown."
+    )
+
+    if violations:
+        print(f"\n{len(violations)} dependency(ies) newer than the cooldown window:\n")
+        print("\n".join(sorted(violations)))
+        print(
+            "\nThese should not be pinned yet. Regenerate the lockfile with the "
+            "cooldown active, or add a scoped exemption if the pin is intentional."
+        )
+
+    if unresolved:
+        print(f"\n{len(unresolved)} pin(s) could not be verified:")
+        print("\n".join(f"  - {u}" for u in sorted(unresolved)))
+
+    if violations:
+        return 1
+    if unresolved and args.strict:
+        print("\n--strict: failing because some pins could not be verified.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Related issue

N/A — Test / CI change (no issue required per the template).

## Summary

The seven-day supply-chain cooldown is applied **only at lockfile resolution**
(pnpm's `minimumReleaseAge`, uv's `exclude-newer`). Nothing verified it afterward,
and the pnpm setting had already regressed once by sitting where the resolver
silently ignored it (fixed in `c92738f8` by moving it to top-level `settings:`).
A `--frozen-lockfile` install never re-checks age, so a too-new pin can still
reach the committed lockfile.

This adds two guardrails:

- **`dev/lint/lint_dep_cooldown_policy.py`** — a fast, offline config guard wired
  as the `dep-cooldown-policy` pre-commit hook (so it runs locally on commit and
  in CI via the existing `pre-commit run --all-files` step). Asserts pnpm's
  `minimumReleaseAge` sits under top-level `settings:` at ≥ 7 days, and that
  `uv.toml` keeps `exclude-newer` + `required-version`. This catches the exact
  "silently ignored setting" regression at commit time.
- **`dev/lint/verify_dependency_ages.py` + `.github/workflows/dependency-age-audit.yml`**
  — a nightly audit that reads ages back out of the committed lockfiles and fails
  on any pin younger than the window. `uv.lock` is checked fully offline (it records
  `upload-time` inline); npm ages come from the registry `time` map. Scheduled
  daily (+ `workflow_dispatch`), **not** a PR gate; transient network failures are
  non-fatal unless `--strict`.

```
resolve (pnpm/uv)  ──►  lockfile  ──►  frozen install (no age re-check)
     ▲                     │
 cooldown applied here     └──► nightly audit re-derives age from lockfile ──► fail if < 7d
 (guarded by pre-commit config check)
```

## Test Plan

- `lint_dep_cooldown_policy.py`: passes on the current tree; fails (exit 1) when
  `minimumReleaseAge` is lowered below 10080 or moved out of `settings:`.
- `verify_dependency_ages.py`: parses all 1,945 npm + 287 uv pins; resolves scoped
  names; correctly fails on synthetic 2-day-old pins. Full audit of the current
  lockfiles reports **0 violations** (the Python half is offline via `uv.lock`
  `upload-time`).
- `ruff check` clean on both scripts; both YAML files parse; the `dep-cooldown-policy`
  hook runs green via `pre-commit run dep-cooldown-policy --all-files`.

To run the nightly audit on demand:
```
uv run --no-project --with pyyaml \
  python dev/lint/verify_dependency_ages.py --npm-registry https://registry.npmjs.org
```
(The scheduled workflow can only run once this lands on `main`.)

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Both scripts are self-contained lint/audit tools (matching the untested
`dev/lint/*` siblings). Verified manually: positive/negative runs of the policy
guard, synthetic-violation and full-lockfile runs of the age verifier, ruff and
YAML parse checks, and the pre-commit hook executing green. The nightly workflow
cannot execute until it exists on `main`.

This pull request and its description were written by Isaac.