### PR TITLE
fix(spec): contain instruction-file discovery within agent bundles

### DIFF
--- a/omnigent/spec/parser.py
+++ b/omnigent/spec/parser.py
@@ -2037,14 +2037,14 @@ def _read_contained_file(root: Path, value: str) -> str | None:
     """
     Read a bundle-relative file named by *value*, only if it stays in *root*.
 
-    The instruction-file reference comes from a spec field (``instructions:``)
-    that, for an uploaded bundle, is attacker-controlled. Resolving symlinks
-    and ``..`` and confirming the target is contained in *root* prevents a
-    crafted spec (e.g. ``instructions: ../../etc/passwd``) from reading files
+    The instruction-file reference comes from a spec field (``instructions:``
+    or ``prompt:``) or automatic context-file discovery in a bundle that may
+    be attacker-controlled. Resolving symlinks and ``..`` and confirming the
+    target is contained in *root* prevents a crafted spec
+    (e.g. ``instructions: ../../etc/passwd``) from reading files
     outside the bundle on the runner. A non-contained or non-existent path
-    returns ``None`` so the caller falls back to treating *value* as literal
-    instruction text — preserving the existing "missing file → inline text"
-    behavior for the CLI.
+    returns ``None`` so an explicit reference falls back to literal instruction
+    text, while automatic discovery skips it and tries the next context file.
 
     :param root: The bundle root directory the value is anchored to,
         e.g. ``Path("/tmp/agent-bundle")``.
@@ -2053,13 +2053,14 @@ def _read_contained_file(root: Path, value: str) -> str | None:
     :returns: The file contents if *value* names a file contained within
         *root*, else ``None``.
     """
-    candidate = root / value
     try:
-        resolved = candidate.resolve()
-        if resolved.is_relative_to(root.resolve()) and resolved.is_file():
-            return resolved.read_text()
+        root_prefix = os.path.join(os.path.realpath(root), "")
+        resolved = os.path.realpath(root / value)
+        if resolved.startswith(root_prefix):
+            candidate = Path(resolved)
+            if candidate.is_file():
+                return candidate.read_text()
     except OSError:
-        # Path too long or invalid characters — treat as inline text.
         pass
     return None
 
@@ -2069,12 +2070,11 @@ def _resolve_instructions(root: Path, raw_value: object) -> str | None:
     Resolve the instructions for an agent image.
 
     - If ``instructions`` is set in config.yaml and the value is
-      a path to an existing file relative to *root*, read that
-      file.
+      a path to an existing file contained in *root*, read that file.
     - If ``instructions`` is set but is not a file path, treat
       the value as inline text.
     - If ``instructions`` is not set, scan ``_CONTEXT_FILE_PRIORITY``
-      and return the first file found (first-wins, no merge).
+      and return the first file contained in *root* (first-wins, no merge).
 
     :param root: Path to the agent image directory.
     :param raw_value: The raw ``instructions`` value from
@@ -2095,12 +2095,9 @@ def _resolve_instructions(root: Path, raw_value: object) -> str | None:
         return text
     # Default: first-wins scan across known context files.
     for filename in _CONTEXT_FILE_PRIORITY:
-        candidate = root / filename
-        try:
-            if candidate.is_file():
-                return candidate.read_text()
-        except OSError:
-            pass
+        contained = _read_contained_file(root, filename)
+        if contained is not None:
+            return contained
     return None
 
 

--- a/tests/spec/test_parser.py
+++ b/tests/spec/test_parser.py
@@ -462,6 +462,74 @@ def test_parse_instructions_overrides_agents_md(agent_dir: Path) -> None:
     assert spec.instructions == "Inline wins."
 
 
+@pytest.mark.parametrize("instruction_key", ["instructions", "prompt", None])
+@pytest.mark.parametrize("filename", ["AGENTS.md", "CLAUDE.md", ".cursorrules"])
+def test_parse_instructions_rejects_symlink_escape(
+    tmp_path: Path, instruction_key: str | None, filename: str
+) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET RUNNER FILE")
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / filename).symlink_to(secret)
+    config = {"spec_version": 1, "name": "test-agent"}
+    if instruction_key is not None:
+        config[instruction_key] = filename
+    (bundle / "config.yaml").write_text(yaml.dump(config))
+
+    spec = parse(bundle)
+
+    assert spec.instructions == (filename if instruction_key is not None else None)
+
+
+@pytest.mark.parametrize("instruction_key", ["instructions", "prompt"])
+def test_parse_instructions_rejects_sibling_prefix(tmp_path: Path, instruction_key: str) -> None:
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    sibling = tmp_path / "bundle-other"
+    sibling.mkdir()
+    secret = sibling / "secret.txt"
+    secret.write_text("TOP SECRET RUNNER FILE")
+    config = {"spec_version": 1, instruction_key: str(secret)}
+    (bundle / "config.yaml").write_text(yaml.dump(config))
+
+    assert parse(bundle).instructions == str(secret)
+
+
+@pytest.mark.parametrize("root_kind", ["direct", "relative", "symlink"])
+@pytest.mark.parametrize("reference_kind", ["nested", "absolute", "symlink"])
+@pytest.mark.parametrize("instruction_key", ["instructions", "prompt"])
+def test_parse_instructions_reads_contained_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    root_kind: str,
+    reference_kind: str,
+    instruction_key: str,
+) -> None:
+    bundle = tmp_path / "bundle"
+    prompt_dir = bundle / "prompts"
+    prompt_dir.mkdir(parents=True)
+    prompt_file = prompt_dir / "system.md"
+    prompt_file.write_text("Contained instructions.")
+    reference = "prompts/system.md"
+    if reference_kind == "absolute":
+        reference = str(prompt_file)
+    elif reference_kind == "symlink":
+        (bundle / "linked.md").symlink_to(prompt_file)
+        reference = "linked.md"
+    config = {"spec_version": 1, instruction_key: reference}
+    (bundle / "config.yaml").write_text(yaml.dump(config))
+    root = bundle
+    if root_kind == "relative":
+        monkeypatch.chdir(tmp_path)
+        root = Path("bundle")
+    elif root_kind == "symlink":
+        root = tmp_path / "bundle-alias"
+        root.symlink_to(bundle, target_is_directory=True)
+
+    assert parse(root).instructions == "Contained instructions."
+
+
 def test_parse_instructions_file_overrides_agents_md(agent_dir: Path) -> None:
     """instructions pointing to a file takes precedence over AGENTS.md."""
     (agent_dir / "AGENTS.md").write_text("Fallback instructions.")
@@ -554,6 +622,25 @@ def test_auto_detect_none_when_no_context_files(agent_dir: Path) -> None:
     """No context files present → instructions is None."""
     spec = parse(agent_dir)
     assert spec.instructions is None
+
+
+def test_auto_detect_skips_escaping_context_file(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET RUNNER FILE")
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    (bundle / "config.yaml").write_text(yaml.dump({"spec_version": 1}))
+    (bundle / "AGENTS.md").symlink_to(secret)
+    (bundle / "CLAUDE.md").write_text("Safe fallback.")
+
+    assert parse(bundle).instructions == "Safe fallback."
+
+
+def test_auto_detect_empty_context_file_keeps_priority(agent_dir: Path) -> None:
+    (agent_dir / "AGENTS.md").write_text("")
+    (agent_dir / "CLAUDE.md").write_text("Lower priority.")
+
+    assert parse(agent_dir).instructions == ""
 
 
 def test_parse_skill(agent_dir: Path) -> None:


### PR DESCRIPTION
## Related issue

Targets CodeQL path-injection alerts [59](https://github.com/omnigent-ai/omnigent/security/code-scanning/59), [60](https://github.com/omnigent-ai/omnigent/security/code-scanning/60), and [61](https://github.com/omnigent-ai/omnigent/security/code-scanning/61). These are security alert IDs, not issue numbers. CodeQL confirmation is pending analysis of this PR's head.

## Summary

- Automatic `AGENTS.md`, `CLAUDE.md`, and `.cursorrules` discovery bypassed the containment check used by explicit instruction references, allowing external symlinks to supply instruction content.
- Route automatic discovery through the same helper as `instructions` / `prompt`. Normalize both paths with `os.path.realpath`, then require the candidate to start with the bundle root plus a directory separator before inspecting or reading it.
- Preserve inline fallback for rejected explicit references, safe internal symlinks and absolute references, first-wins discovery, and empty-file priority. Unsafe automatic candidates are skipped so a safe lower-priority file can still win.

**ELI5:** An agent may read instructions inside its own folder, but an instruction file cannot point outside that folder to read another file.

```text
explicit instructions / prompt ----+
                                   +--> normalize paths --> inside bundle? --> read
automatic context-file discovery --+                            |
                                                               no
                                          explicit: keep literal text
                                          automatic: try next filename
```

## Test Plan

- Before the production fix, the new regressions fail in four cases: all three automatically discovered filenames symlinked outside the bundle, plus an unsafe `AGENTS.md` masking a safe `CLAUDE.md` (4 failed, 42 passed).
- `.venv/bin/python -m pytest -q tests/spec tests/runtime/test_agent_cache.py --tb=short` — **688 passed**.
- `.venv/bin/pre-commit run --files omnigent/spec/parser.py tests/spec/test_parser.py` — all applicable hooks pass, including Ruff and Pyrefly.
- `git diff --check` — clean.
- Focused reproduction: `.venv/bin/python -m pytest -q tests/spec/test_parser.py -k 'instructions or prompt_alias or auto_detect' --tb=short`.

## Demo

N/A — non-visual parser/security change. Filesystem regression evidence is in Test Plan.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests use real temporary files and symlinks through `parse()`. Coverage includes explicit fields and automatic discovery, sibling-prefix escapes, safe nested/absolute/internal-symlink references, direct/relative/symlinked roots, safe fallback, and empty-file priority. Local validation ran on macOS; CI and CodeQL results remain pending. This check does not claim protection against concurrent filesystem mutation between validation and reading.

## Changelog

Agent instruction-file discovery no longer follows symlinks outside the agent bundle.
