### PR TITLE
fix(server): stop warning when a project session picks a different workspace

### DIFF
--- a/omnigent/server/routes/_session_create_validation.py
+++ b/omnigent/server/routes/_session_create_validation.py
@@ -10,11 +10,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import ntpath
 import os
-import posixpath
 from dataclasses import dataclass
-from pathlib import PurePosixPath, PureWindowsPath
 from typing import Any
 
 from pydantic import ValidationError
@@ -51,19 +48,6 @@ def _strict_project_create_enabled() -> bool:
         "yes",
         "on",
     }
-
-
-def _workspace_within(candidate: str, root: str) -> bool:
-    """Return whether normalized *candidate* is lexically inside *root*."""
-    try:
-        windows = "\\" in candidate or "\\" in root
-        path_module = ntpath if windows else posixpath
-        path_type = PureWindowsPath if windows else PurePosixPath
-        candidate_path = path_type(path_module.normpath(candidate))
-        root_path = path_type(path_module.normpath(root))
-        return candidate_path.is_relative_to(root_path)
-    except (TypeError, ValueError):
-        return False
 
 
 async def resolve_project_session_create(
@@ -137,20 +121,6 @@ async def resolve_project_session_create(
             {
                 "code": "project_agent_mismatch",
                 "message": "Explicit agent_id differs from the project's pinned agent",
-            }
-        )
-
-    explicit_workspace = getattr(body, "workspace", None) if "workspace" in fields_set else None
-    configured_workspace = config.get("workspace")
-    if (
-        isinstance(explicit_workspace, str)
-        and isinstance(configured_workspace, str)
-        and not _workspace_within(explicit_workspace, configured_workspace)
-    ):
-        warnings.append(
-            {
-                "code": "project_workspace_mismatch",
-                "message": "Explicit workspace is outside the project's configured workspace root",
             }
         )
 

--- a/tests/server/routes/test_session_create_project_consistency.py
+++ b/tests/server/routes/test_session_create_project_consistency.py
@@ -152,9 +152,11 @@ async def test_unknown_and_unowned_project_are_404(
         assert "Project not found" in response.text
 
 
-async def test_workspace_mismatch_warns_and_strict_mode_escalates(
+async def test_workspace_outside_configured_root_is_allowed_silently(
     project_create_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A per-session working directory outside the project root is a deliberate
+    choice, not a mismatch — no warning, and strict mode does not reject it."""
     project_id = await _project(
         project_create_client,
         {"agent_id": CUSTOM_AGENT_ID, "workspace": "/work/project"},
@@ -166,11 +168,14 @@ async def test_workspace_mismatch_warns_and_strict_mode_escalates(
     }
     response = await project_create_client.post("/v1/sessions", json=payload, headers=_headers())
     assert response.status_code == 201, response.text
-    assert response.json()["warnings"][0]["code"] == "project_workspace_mismatch"
+    assert "warnings" not in response.json()
 
+    # Strict mode still gates other mismatches (e.g. agent), but a differing
+    # workspace no longer produces a warning to escalate.
     monkeypatch.setenv("OMNIGENT_STRICT_PROJECT_SESSION_CREATE", "1")
     response = await project_create_client.post("/v1/sessions", json=payload, headers=_headers())
-    assert response.status_code == 400
+    assert response.status_code == 201, response.text
+    assert "warnings" not in response.json()
 
 
 async def test_builtin_agent_mismatch_warning_surfaces(
@@ -430,7 +435,7 @@ async def test_explicit_null_workspace_is_not_defaulted(
     assert response.json()["workspace"] is None
 
 
-async def test_git_default_fill_and_workspace_parent_traversal_warning(db_uri: str) -> None:
+async def test_git_default_fill_with_differing_workspace_emits_no_warning(db_uri: str) -> None:
     project_store = SqlAlchemyProjectStore(db_uri)
     project = project_store.create(
         "487b7cb7ac30abf4debfaa578d052ec6",
@@ -446,14 +451,16 @@ async def test_git_default_fill_and_workspace_parent_traversal_warning(db_uri: s
         body=ProjectSessionCreateRequest(
             project_id=project.id,
             host_id="host_abc",
-            workspace="/work/project/../other",
+            workspace="/work/other",
         ),
         user_id=ALICE,
         project_store=project_store,
     )
+    # The omitted git block is default-filled from config; an explicit workspace
+    # outside the project root is a deliberate choice and emits no warning.
     assert resolved.body.git is not None
     assert resolved.body.git.branch_name == "feature/project"
-    assert resolved.warnings[0]["code"] == "project_workspace_mismatch"
+    assert resolved.warnings == ()
 
 
 async def test_multipart_create_defaults_workspace_and_files_atomically(


### PR DESCRIPTION
## Summary

Starting a session from a working directory **outside** a project's configured `workspace` root surfaced a `project_workspace_mismatch` warning toast on **every** create (e.g. starting from `omnigent-internal` when the project points elsewhere).

The web composer only ever sends an *explicit* workspace when the user **deliberately** picks one that differs from the project config (the `workspaceFromProjectConfig` guard omits it otherwise). So this warning fired *by construction* on an intentional per-session choice and read as a spurious error for something the user just did on purpose.

This PR **deletes the workspace-within-root detection entirely** in `resolve_project_session_create`:
- the branch that appended the `project_workspace_mismatch` warning,
- the `_workspace_within` helper, and
- its now-unused path imports (`ntpath`, `posixpath`, `PurePosixPath`, `PureWindowsPath`).

Picking a per-session working directory is a supported choice, not a misconfiguration. The `project_agent_mismatch` warning (and its `OMNIGENT_STRICT_PROJECT_SESSION_CREATE` strict-mode escalation) is untouched — picking an agent that contradicts the project's pin is a more plausible mistake and remains flagged.

## Test Plan

- Updated `tests/server/routes/test_session_create_project_consistency.py`:
  - `test_workspace_mismatch_warns_and_strict_mode_escalates` → `test_workspace_outside_configured_root_is_allowed_silently`: a differing workspace returns 201 with no `warnings`, and strict mode no longer rejects it.
  - `test_git_default_fill_and_workspace_parent_traversal_warning` → `test_git_default_fill_with_differing_workspace_emits_no_warning`: keeps the git default-fill coverage, asserts `resolved.warnings == ()`.
- `pytest tests/server/routes/test_session_create_project_consistency.py` — **28 passed**.
- `ruff format --check` and `ruff check` clean; pre-commit hooks green on commit.
- Manual: open a project with a configured workspace, start a new session in a different directory (e.g. `omnigent-internal`) → session creates with **no** "Explicit workspace is outside..." toast. Agent-mismatch toast still appears when picking a non-pinned agent.

## Demo

N/A — no UI code changed; this removes a server-emitted warning. Verified via the manual behavior check above.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test coverage

- [x] Unit tests added/updated
- [x] Manual verification completed

## Coverage notes

Backend-only change to warning emission. Covered by the two updated tests in `test_session_create_project_consistency.py`; manually verified the toast no longer appears and that the agent-mismatch warning is unaffected.

This pull request and its description were written by Isaac.
