### PR TITLE
fix(web): show every image in a multi-image user bubble

### DIFF
--- a/web/src/components/chat/chatBubbleParts.tsx
+++ b/web/src/components/chat/chatBubbleParts.tsx
@@ -662,9 +662,12 @@ function UserBubble({ bubble }: { bubble: Extract<Bubble, { kind: "user" }> }) {
               showAuthorBadge && author ? { backgroundColor: userColorTint(author) } : undefined
             }
           >
-            {/* Inline image previews — one non-wrapping strip. */}
+            {/* Inline image previews. Wrap rather than scroll horizontally:
+                a landscape image fills the bubble width, so a second one in a
+                non-wrapping strip would sit off-screen in the overflow and
+                look like it never rendered. */}
             {images.length > 0 && (
-              <div className="mb-1.5 flex gap-2 overflow-x-auto">
+              <div className="mb-1.5 flex flex-wrap gap-2">
                 {keyedAttachments(
                   images,
                   (img) => img.file_id ?? img.image_url ?? img.filename,


### PR DESCRIPTION
## Summary

A user message can carry several image attachments, but the chat bubble
rendered them into a single non-wrapping strip (`flex … overflow-x-auto`).
Each preview box is `max-w-full`, so a landscape screenshot filled the whole
640px bubble width and pushed any subsequent images into the horizontal-overflow
region — scrolled out of view. The message looked like only one image rendered
even though both were in the DOM.

I confirmed against a live session (`c6938ae0…`) that the underlying data and
render loop are correct — the user item held two `input_image` blocks and both
`<SessionImage>` elements were mounted; the second was simply clipped by the
overflow strip. It reproduces whenever the first image is wide enough to fill
the bubble (landscape screenshots always are), which is why it looked intermittent.

The fix swaps the horizontal-scroll strip for a wrapping one (`flex-wrap`), so
additional images fall onto their own row and stay visible. Each `SessionImage`
still reserves a fixed `h-64` box, so stacking is height-stable and doesn't
shove the transcript on decode.

## Test Plan

- `cd web && npm test` — full vitest suite: 7135 passed, 3 expected fail, 1 skipped.
- `cd web && npm run build` — tsc + vite build clean.
- Manual: open a session whose user message has two landscape screenshots; both
  now render (stacked) instead of one. Two small/portrait images sit side-by-side
  and wrap only when they don't fit.

## Demo

<!-- UI change: before = only the first (landscape) image visible; after = both images shown stacked. -->
_Before:_ only the first screenshot showed in the bubble.
_After:_ both screenshots render.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] UI / frontend change

## Test coverage

- [ ] Added/updated automated tests
- [x] Manual verification completed

## Coverage notes

Existing multi-image test (`ChatPage.userBubble.test.tsx`) asserts both images
mount in the DOM and still passes; the regression was layout-only (JSDOM has no
layout engine), so it's verified manually in the running app rather than with a
new unit test.

This pull request and its description were written by Isaac.
