### PR TITLE
Improve temporary session loading UI

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -52,7 +52,7 @@ import threading
 from collections.abc import Coroutine
 from typing import Any
 
-from playwright.async_api import Route, async_playwright, expect
+from playwright.async_api import Request, Route, async_playwright, expect
 
 # Stubbed host the composer auto-selects (the tunneled runner registers no
 # host). Keyed identically in the recent-workspaces localStorage seed.
@@ -637,6 +637,13 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
         page = await browser.new_page()
         try:
             create_bodies: list[dict[str, Any]] = []
+            temp_scoped_requests: list[str] = []
+
+            def capture_temp_scoped_request(request: Request) -> None:
+                if re.search(r"/v1/sessions/temp(?::|%3A)", request.url, re.IGNORECASE):
+                    temp_scoped_requests.append(request.url)
+
+            page.on("request", capture_temp_scoped_request)
             # A gate the create handler awaits before responding, so the POST
             # stays pending long enough to observe the temporary chat.
             release_create = asyncio.Event()
@@ -720,10 +727,43 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
             await expect(
                 page.get_by_test_id("message-bubble").get_by_text("set up the project", exact=True)
             ).to_be_visible()
+            await expect(
+                page.get_by_role("navigation", name="Conversation").get_by_text(
+                    "set up the project", exact=True
+                )
+            ).to_be_visible()
+            header = page.locator("header.chat-header")
+            for action_name in (
+                "Agent tools and policies",
+                "Chat view",
+                "Terminal view",
+                "Conversation actions",
+                "Share session",
+            ):
+                await expect(
+                    header.get_by_role("button", name=action_name, exact=True)
+                ).to_be_disabled()
+            await expect(
+                header.get_by_role("button", name="Collapse right panel", exact=True)
+            ).to_be_enabled()
+            workspace = page.get_by_role("complementary", name="Workspace")
+            await expect(workspace).to_be_visible()
+            for tab_name in ("Files", "Changes", "GitHub", "Agents"):
+                await expect(
+                    workspace.get_by_role("tab", name=re.compile(tab_name))
+                ).to_be_disabled()
+            await expect(workspace.get_by_role("button", name="Full screen")).to_be_disabled()
+            await expect(
+                workspace.get_by_role("separator", name="Resize panel")
+            ).to_have_attribute("aria-disabled", "true")
+            await expect(workspace.get_by_text("Starting workspace…", exact=True)).to_be_visible()
+            assert temp_scoped_requests == []
 
             # Release the create: the same chat hydrates onto the real id.
             release_create.set()
             await expect(page).to_have_url(f"{base_url}/c/{session_id}", timeout=30_000)
+            await expect(workspace.get_by_text("Starting workspace…", exact=True)).to_have_count(0)
+            await expect(workspace.get_by_role("tab", name=re.compile("Agents"))).to_be_enabled()
         finally:
             await browser.close()
 

--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -734,6 +734,7 @@ async def _drive_send_busy_spinner(base_url: str, session_id: str) -> None:
             ).to_be_visible()
             header = page.locator("header.chat-header")
             for action_name in (
+                "Add to project",
                 "Agent tools and policies",
                 "Chat view",
                 "Terminal view",

--- a/web/src/shell/AppShell.test.tsx
+++ b/web/src/shell/AppShell.test.tsx
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ServerInfo } from "@/lib/capabilities";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
+import { clearOptimisticTitles, recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 import { writeWorkspacePanelDefault } from "@/lib/workspacePanelPreferences";
 
@@ -554,6 +555,7 @@ beforeEach(() => {
   // choice carries across sessions. Clear it so a stored preference from one
   // test can't change another test's default scope.
   localStorage.clear();
+  clearOptimisticTitles();
   // Reset terminal-first startup signals so one test's terminalPending /
   // failed status can't leak into another's terminalStartingUp.
   useChatStore.setState({
@@ -580,12 +582,26 @@ describe("AppShell header", () => {
     expect(screen.queryByTestId("execution-logs-card")).toBeNull();
   });
 
-  it("does not expose conversation actions for a provisional temp row", () => {
+  it("shows only disabled conversation actions for a provisional temp row", () => {
     mockConversations([{ id: "temp:12345678", permission_level: null, provisional: true }]);
     renderShell("/c/temp:12345678");
 
-    expect(screen.queryByRole("button", { name: "Conversation actions" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Conversation actions" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Share session" })).toBeDisabled();
+    expect(screen.getByTestId("fork-probe")).toHaveAttribute("data-can-fork", "false");
+  });
+
+  it("shows the optimistic title when the temp row is absent from the shell list cache", () => {
+    recordOptimisticTitle("temp:12345678", "Inspect the workspace");
+    mockConversations([]);
+
+    renderShell("/c/temp:12345678");
+
+    expect(screen.getByText("Inspect the workspace")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Conversation actions" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Share session" })).toBeDisabled();
+    expect(screen.queryByTestId("agent-info-trigger")).toBeNull();
+    expect(screen.queryByTestId("session-actions-menu")).toBeNull();
     expect(screen.getByTestId("fork-probe")).toHaveAttribute("data-can-fork", "false");
   });
 
@@ -2646,6 +2662,20 @@ describe("Extension pages own the header", () => {
 });
 
 describe("Right workspace card visibility", () => {
+  it("mounts an expandable pending card for a temporary session", () => {
+    writeSessionWorkspaceState("temp:12345678", { open: true });
+    mockConversations([{ id: "temp:12345678", permission_level: null, provisional: true }]);
+
+    renderShell("/c/temp:12345678");
+
+    expect(screen.getByRole("complementary", { name: "Workspace" })).toBeInTheDocument();
+    expect(screen.getByText("Starting workspace…")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Collapse right panel" }));
+    expect(screen.queryByRole("complementary", { name: "Workspace" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Expand right panel" }));
+    expect(screen.getByRole("complementary", { name: "Workspace" })).toBeInTheDocument();
+  });
+
   it("reserves the visible pane width plus its two desktop margins from the header", () => {
     useEnvironmentMock.mockReturnValue({
       data: { available: false, root: null, home: null },

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -20,6 +20,7 @@ import { useIdleNotifications } from "@/hooks/useIdleNotifications";
 import { useSeedReadState } from "@/hooks/useUnseenConversations";
 import { useIOSViewportLock } from "@/hooks/useIOSViewportLock";
 import { readFilesPanelPreferences, writeFilesPanelPreferences } from "@/lib/filesPanelPreferences";
+import { useOptimisticTitle } from "@/lib/optimisticTitles";
 import { derivePermissionLevel, isEditorLevel, isOwnerLevel } from "@/lib/permissionsApi";
 import {
   isAndroidShell,
@@ -227,6 +228,7 @@ export function AppShell() {
   // of the raw route id so none of them fetch `/v1/sessions/temp:*` during the
   // create window (or on a stale temp reload, before ChatPage redirects).
   const serverConversationId = isTempConvId(conversationId) ? undefined : conversationId;
+  const pendingConversation = conversationId != null && serverConversationId == null;
   const [fileViewerCommentsOpen, setFileViewerCommentsOpen] = useState(false);
   const [rightRailTab, setRightRailTab] = useState<RightRailTab>(() =>
     conversationId ? (readSessionWorkspaceState(conversationId).rightRailTab ?? "files") : "files",
@@ -425,6 +427,7 @@ export function AppShell() {
 
   const debugMode = useDebugMode();
   const { data: conversationsData, isLoading: conversationsLoading } = useConversations("", true);
+  const optimisticConversationTitle = useOptimisticTitle(conversationId ?? "");
   // Surface sessions needing attention as OS notifications + a dock badge.
   // Mounted here (inside the Router) so it can navigate on click and knows
   // the active conversation id, which suppresses the notification/badge for
@@ -442,11 +445,15 @@ export function AppShell() {
   useSeedReadState(allConversations);
   const activeConv = useMemo(() => {
     if (!serverConversationId) return null;
-    return (
-      conversationsData?.pages.flatMap((p) => p.data).find((c) => c.id === serverConversationId) ??
-      null
-    );
-  }, [serverConversationId, conversationsData]);
+    return allConversations?.find((c) => c.id === serverConversationId) ?? null;
+  }, [serverConversationId, allConversations]);
+  // A temporary row is display-only: it can supply optimistic breadcrumb
+  // text, but must not participate in permissions, actions, or server hooks.
+  const provisionalConv = useMemo(() => {
+    if (!conversationId || !isTempConvId(conversationId)) return null;
+    const row = allConversations?.find((c) => c.id === conversationId);
+    return row?.provisional === true ? row : null;
+  }, [conversationId, allConversations]);
   // Single-conversation snapshot (shared cache with chatStore.bindStream).
   // For sub-agent (child) sessions the sidebar list omits the row, so this
   // is the only path through which the UI learns the user's permission
@@ -524,11 +531,14 @@ export function AppShell() {
   // the snapshot, so a parent outside the loaded window shows no folder.
   const { session: parentSession } = useSession(activeSession?.parentSessionId);
   const { data: projectSummaries } = useProjects();
-  const breadcrumbConv = isChildSession ? parentConv : activeConv;
+  const breadcrumbConv = isChildSession ? parentConv : (activeConv ?? provisionalConv);
   const headerConversationTitle =
     breadcrumbConv?.title ||
     (isChildSession ? parentSession?.title : activeSession?.title) ||
     (breadcrumbConv ? conversationDisplayLabel(breadcrumbConv) : null) ||
+    (isTempConvId(conversationId)
+      ? (optimisticConversationTitle ?? UNTITLED_CONVERSATION_LABEL)
+      : null) ||
     (isChildSession ? UNTITLED_CONVERSATION_LABEL : null);
   const headerProjectSummary =
     breadcrumbConv?.project_id != null
@@ -612,7 +622,8 @@ export function AppShell() {
     (isKnownTopLevel || isChildSession) &&
     (permissionLevel === null || permissionLevel >= 1);
   // Agent tools/policies exist to show.
-  const hasAgentInfo = !!conversationId && agentHasInfo(boundAgent, conversationId);
+  const hasAgentInfo =
+    serverConversationId != null && agentHasInfo(boundAgent, serverConversationId);
   // Whether the mobile three-dot menu has any entry to offer.
   const hasHeaderMenu = canShare || hasAgentInfo;
   // The live snapshot is authoritative; the sidebar row is only a fallback
@@ -1865,7 +1876,7 @@ export function AppShell() {
     [canClone],
   );
   const workspacePanelVisible = Boolean(
-    serverConversationId &&
+    conversationId &&
     hasRailContent &&
     rightPanelOpen &&
     (terminalFirst || !panelOpen) &&
@@ -2031,6 +2042,7 @@ export function AppShell() {
                     hasRailContent={hasRailContent}
                     rightPanelOpen={rightPanelOpen}
                     onToggleRightPanel={toggleRightPanel}
+                    pending={pendingConversation}
                     mobileMenu={{
                       fileViewerOpen,
                       panelOpen,
@@ -2092,9 +2104,10 @@ export function AppShell() {
               rectangle (e.g. a no-filesystem agent with no terminals).
               Sits inside the group so the header overlay spans it; the
               push panels below sit outside the group. */}
-                {serverConversationId && workspacePanelVisible && (
+                {conversationId && workspacePanelVisible && (
                   <WorkspacePanel
-                    conversationId={serverConversationId}
+                    conversationId={conversationId}
+                    pending={pendingConversation}
                     width={inlinePanelWidth}
                     inert={inlinePanelWidth === 0}
                     handleProps={inlinePanelHandleProps}

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -184,6 +184,7 @@ describe("ChatHeader — pending session presentation", () => {
       pending: true,
     });
 
+    expect(screen.getByRole("button", { name: "Add to project" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Agent tools and policies" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Chat view" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Terminal view" })).toBeDisabled();

--- a/web/src/shell/ChatHeader.test.tsx
+++ b/web/src/shell/ChatHeader.test.tsx
@@ -79,6 +79,7 @@ function renderHeader(props: {
   hasAgentInfo?: boolean;
   hasRailContent?: boolean;
   showFilesPanel?: boolean;
+  pending?: boolean;
   mobileMenu?: typeof mobileMenu;
   onOpenSidebar?: (peek?: boolean) => void;
   onFork?: () => void;
@@ -116,6 +117,7 @@ function renderHeader(props: {
             hasRailContent={props.hasRailContent ?? true}
             rightPanelOpen={false}
             onToggleRightPanel={() => {}}
+            pending={props.pending}
             mobileMenu={props.mobileMenu ?? mobileMenu}
           />
         </TooltipProvider>
@@ -170,6 +172,37 @@ describe("ChatHeader — deployed Share presentation", () => {
       "share-button-glassy",
     );
     expect(share.querySelector(".lucide-user-plus")).not.toBeNull();
+  });
+});
+
+describe("ChatHeader — pending session presentation", () => {
+  it("shows the full desktop control shell disabled while Workspace remains available", () => {
+    renderHeader({
+      sidebarOpen: true,
+      conversationId: "temp:12345678",
+      conversationTitle: "Inspect the workspace",
+      pending: true,
+    });
+
+    expect(screen.getByRole("button", { name: "Agent tools and policies" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Chat view" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Terminal view" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Conversation actions" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Share session" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Expand right panel" })).toBeEnabled();
+  });
+
+  it("collapses pending controls into one disabled mobile actions button", () => {
+    isMobileMock.mockReturnValue(true);
+    renderHeader({
+      sidebarOpen: true,
+      conversationId: "temp:12345678",
+      conversationTitle: "Inspect the workspace",
+      pending: true,
+    });
+
+    expect(screen.getByRole("button", { name: "Session actions" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Share session" })).toBeNull();
   });
 });
 

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -6,6 +6,7 @@ import {
   GitForkIcon,
   InfoIcon,
   ListIcon,
+  MessagesSquareIcon,
   PanelLeftIcon,
   PanelRightCloseIcon,
   PanelRightIcon,
@@ -180,8 +181,99 @@ interface ChatHeaderProps {
   rightPanelOpen: boolean;
   /** Toggle the right workspace panel. */
   onToggleRightPanel: () => void;
+  /** Show dependency-free disabled chrome while the server session is pending. */
+  pending?: boolean;
   /** Gating + handlers for the mobile session-menu FAB. */
   mobileMenu: MobileSessionMenuProps;
+}
+
+const PENDING_ACTION_TITLE = "Available when the session starts";
+
+function PendingHeaderActions({ isMobile }: { isMobile: boolean }) {
+  if (isMobile) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Session actions"
+        title={PENDING_ACTION_TITLE}
+        disabled
+        className="text-muted-foreground md:hidden max-md:size-11 max-md:rounded-full"
+      >
+        <EllipsisVerticalIcon className="size-4 max-md:size-5" />
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label="Agent tools and policies"
+        title={PENDING_ACTION_TITLE}
+        disabled
+        className="hidden border-none text-muted-foreground md:inline-flex"
+      >
+        <InfoIcon className="size-4" />
+      </Button>
+      <div
+        role="group"
+        aria-label="Switch between chat and terminal"
+        aria-disabled="true"
+        title={PENDING_ACTION_TITLE}
+        className="hidden items-center gap-0.5 rounded-[var(--radius-lg)] bg-muted/60 p-0.5 md:flex"
+      >
+        <Button
+          type="button"
+          variant="secondary"
+          size="icon-xs"
+          aria-label="Chat view"
+          aria-pressed="true"
+          disabled
+          className="border-none bg-background text-foreground shadow-sm"
+        >
+          <MessagesSquareIcon className="size-3.5" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Terminal view"
+          aria-pressed="false"
+          disabled
+          className="border-none text-muted-foreground"
+        >
+          <TerminalIcon className="size-3.5" />
+        </Button>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label="Conversation actions"
+        title={PENDING_ACTION_TITLE}
+        disabled
+        className="hidden border-none text-muted-foreground md:inline-flex"
+      >
+        <EllipsisVerticalIcon className="size-3.5" />
+      </Button>
+      <Button
+        type="button"
+        aria-label="Share session"
+        title={PENDING_ACTION_TITLE}
+        disabled
+        className="share-button-glassy hidden h-6 gap-1 rounded-[6px] px-2 text-ui font-normal text-white md:inline-flex"
+      >
+        <span className="flex size-4 shrink-0 items-center justify-center">
+          <UserPlusIcon />
+        </span>
+        Share
+      </Button>
+    </>
+  );
 }
 
 /**
@@ -232,6 +324,7 @@ export function ChatHeader({
   hasRailContent,
   rightPanelOpen,
   onToggleRightPanel,
+  pending = false,
   mobileMenu,
 }: ChatHeaderProps) {
   // Dwell on the toggle for 400ms to peek the sidebar; leaving before then cancels
@@ -278,6 +371,7 @@ export function ChatHeader({
   // inline in main and no drawer is mounted.
   const workspaceItems =
     conversationId &&
+    !pending &&
     !mobileMenu.fileViewerOpen &&
     (!mobileMenu.panelOpen || mobileMenu.terminalFirst) &&
     !mobileMenu.executionLogsOpen &&
@@ -372,27 +466,29 @@ export function ChatHeader({
         )}
       </>
     ) : null;
+  const showShare = !pending && canShare;
   // Session actions (pin/share/rename/project/archive/delete). Desktop hangs
   // them off the breadcrumb title; mobile puts the kebab in the right-hand
   // control cluster instead — the native iOS/Android shells hide the
   // breadcrumb entirely (their own chrome names the session), so a
   // title-adjacent trigger would be unreachable there.
-  const conversationMenu = actionConversation ? (
-    <HeaderConversationMenu
-      conversation={actionConversation}
-      currentProject={projectName}
-      canShare={canShare}
-      canFork={canFork}
-      shareDisabled={shareDisabled}
-      shareDisabledReason={shareDisabledReason}
-      onShare={onShare}
-      onFork={onFork}
-      hasAgentInfo={isMobile && hasAgentInfo}
-      onAgentInfo={onAgentInfo}
-      viewItems={isMobile ? <ViewModeMenuItems /> : null}
-      workspaceItems={isMobile ? workspaceItems : null}
-    />
-  ) : null;
+  const conversationMenu =
+    !pending && actionConversation ? (
+      <HeaderConversationMenu
+        conversation={actionConversation}
+        currentProject={projectName}
+        canShare={canShare}
+        canFork={canFork}
+        shareDisabled={shareDisabled}
+        shareDisabledReason={shareDisabledReason}
+        onShare={onShare}
+        onFork={onFork}
+        hasAgentInfo={isMobile && hasAgentInfo}
+        onAgentInfo={onAgentInfo}
+        viewItems={isMobile ? <ViewModeMenuItems /> : null}
+        workspaceItems={isMobile ? workspaceItems : null}
+      />
+    ) : null;
   // Slack-style "Move to…" shortcut on the breadcrumb's folder tag: click it to
   // file/move/unfile the session without opening the kebab. Desktop-only (the
   // tag is hidden on mobile; the mobile menu keeps its own move item) and only
@@ -400,7 +496,7 @@ export function ChatHeader({
   // the title keeps its back-to-parent role. `null` falls back to the static
   // folder icon in the breadcrumb.
   const projectTag =
-    !isMobile && actionConversation && !isChildSession ? (
+    !pending && !isMobile && actionConversation && !isChildSession ? (
       <HeaderProjectTag
         conversationId={actionConversation.id}
         projectName={projectName}
@@ -412,7 +508,7 @@ export function ChatHeader({
   // back-to-parent link (titleLinkTo wins over titleSlot in the breadcrumb),
   // and mobile keeps the Rename item in the kebab.
   const titleSlot =
-    !isMobile && actionConversation && !isChildSession ? (
+    !pending && !isMobile && actionConversation && !isChildSession ? (
       <HeaderTitle
         conversationId={actionConversation.id}
         title={conversationTitle ?? UNTITLED_CONVERSATION_LABEL}
@@ -527,13 +623,16 @@ export function ChatHeader({
         {/* Desktop (md+) action buttons. On mobile these collapse into
             the three-dot "Session actions" menu below. Fork is also
             available from the session menus and assistant messages. */}
+        {pending && <PendingHeaderActions isMobile={isMobile} />}
         {/* Agent info: tools & policies for the bound agent. Desktop-only
             popover; self-hides when the agent has neither configured. */}
-        {conversationId && <AgentInfoButton agent={boundAgent} sessionId={conversationId} />}
+        {!pending && conversationId && (
+          <AgentInfoButton agent={boundAgent} sessionId={conversationId} />
+        )}
         {/* Chat/Terminal switcher for terminal-first sessions — self-gates to
             null otherwise. Renders on every shell, iOS included. */}
-        {conversationId && <ViewModeToggle />}
-        {!actionConversation && canFork && (
+        {!pending && conversationId && <ViewModeToggle />}
+        {!pending && !actionConversation && canFork && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -558,7 +657,8 @@ export function ChatHeader({
         {/* Fallback mobile kebab for sessions with no owner-managed menu.
             It carries Fork, Share, Agent info, and the workspace-rail entries
             so a phone still needs only one trigger. */}
-        {(hasHeaderMenu || workspaceItems || canFork || (isMobile && mobileMenu.terminalFirst)) &&
+        {!pending &&
+          (hasHeaderMenu || workspaceItems || canFork || (isMobile && mobileMenu.terminalFirst)) &&
           (!actionConversation || !isMobile) && (
             // Non-modal on mobile: modal mode's body-wide pointer-events:none
             // makes the menu the sole touch target, so touch-target adjustment
@@ -624,7 +724,7 @@ export function ChatHeader({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-        {canShare && shareDisabled && shareDisabledReason ? (
+        {showShare && shareDisabled && shareDisabledReason ? (
           <Tooltip>
             <TooltipTrigger asChild>
               {/* Disabled buttons don't receive pointer events, so the wrapper
@@ -652,7 +752,7 @@ export function ChatHeader({
             </TooltipTrigger>
             <TooltipContent side="bottom">{shareDisabledReason}</TooltipContent>
           </Tooltip>
-        ) : canShare ? (
+        ) : showShare ? (
           <Button
             type="button"
             aria-label="Share session"

--- a/web/src/shell/ChatHeader.tsx
+++ b/web/src/shell/ChatHeader.tsx
@@ -2,6 +2,7 @@ import {
   BotIcon,
   EllipsisVerticalIcon,
   FileIcon,
+  FolderPlusIcon,
   GitCompareIcon,
   GitForkIcon,
   InfoIcon,
@@ -496,7 +497,22 @@ export function ChatHeader({
   // the title keeps its back-to-parent role. `null` falls back to the static
   // folder icon in the breadcrumb.
   const projectTag =
-    !pending && !isMobile && actionConversation && !isChildSession ? (
+    pending && !isMobile && !projectName ? (
+      <div className="hidden min-w-0 shrink-0 items-center gap-1.5 text-ui md:flex">
+        <button
+          type="button"
+          aria-label="Add to project"
+          title={PENDING_ACTION_TITLE}
+          disabled
+          className="breadcrumb-folder flex shrink-0 items-center text-muted-foreground opacity-30"
+        >
+          <FolderPlusIcon className="size-4" />
+        </button>
+        <span aria-hidden className="shrink-0 text-muted-foreground opacity-40">
+          /
+        </span>
+      </div>
+    ) : !pending && !isMobile && actionConversation && !isChildSession ? (
       <HeaderProjectTag
         conversationId={actionConversation.id}
         projectName={projectName}

--- a/web/src/shell/WorkspacePanel.test.tsx
+++ b/web/src/shell/WorkspacePanel.test.tsx
@@ -90,6 +90,7 @@ function renderWorkspace(
     selectedTerminalKey?: string | null;
     maximized?: boolean;
     liveness?: SessionLiveness;
+    pending?: boolean;
   } = {},
 ) {
   const openFileViewer = vi.fn();
@@ -103,7 +104,13 @@ function renderWorkspace(
       <WorkspacePanel
         conversationId="conv_ws"
         width={360}
-        handleProps={{ tabIndex: 0 }}
+        handleProps={{
+          tabIndex: 0,
+          role: "separator",
+          "aria-label": "Resize panel",
+          onMouseDown: vi.fn(),
+          onKeyDown: vi.fn(),
+        }}
         rightRailTab={overrides.rightRailTab ?? "files"}
         onRightRailTabChange={onRightRailTabChange}
         showFilesPanel
@@ -131,6 +138,7 @@ function renderWorkspace(
         filesPanelShowHidden={false}
         onShowHiddenChange={vi.fn()}
         liveness={overrides.liveness}
+        pending={overrides.pending}
       />
     </TooltipProvider>,
   );
@@ -165,6 +173,29 @@ describe("WorkspacePanel surface presentation", () => {
     expect(filesTab).not.toHaveAttribute("title");
     expect(changesTab).not.toHaveAttribute("title");
     expect(agentsTab).not.toHaveAttribute("title");
+  });
+
+  it("shows inert workspace chrome while a temporary session is pending", () => {
+    renderWorkspace({ pending: true });
+
+    for (const name of ["Files", "Changes", "GitHub", "Agents"]) {
+      expect(screen.getByRole("tab", { name: new RegExp(name) })).toBeDisabled();
+    }
+    expect(screen.getByText("Starting workspace…")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open new" })).toBeNull();
+    expect(screen.queryByTestId("files-panel-stub")).toBeNull();
+    expect(screen.queryByTestId("file-viewer-stub")).toBeNull();
+    expect(screen.queryByTestId("subagents-stub")).toBeNull();
+    expect(useCreateTerminalMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Full screen" })).toBeDisabled();
+    expect(screen.getByRole("separator", { name: "Resize panel" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(screen.getByRole("separator", { name: "Resize panel" })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
   });
 
   it("has no static Shells nav tab — shells open only as closable soft tabs", () => {

--- a/web/src/shell/WorkspacePanel.tsx
+++ b/web/src/shell/WorkspacePanel.tsx
@@ -36,6 +36,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { BrowserPane } from "@/components/BrowserPane/BrowserPane";
 import { useBrowserTabs } from "@/hooks/useBrowserTabs";
@@ -564,6 +565,8 @@ function RailTerminalView({
 interface WorkspacePanelProps {
   /** Active session id — panels read the workspace against it. */
   conversationId: string;
+  /** Show inert panel chrome while the server session id is still pending. */
+  pending?: boolean;
   /** Current rail width (px), driven by the resize handle. */
   width: number;
   /** Whether the panel is closed/collapsed (hides it from keyboard nav + assistive tech). */
@@ -676,6 +679,7 @@ interface WorkspacePanelProps {
  */
 function WorkspacePanelImpl({
   conversationId,
+  pending = false,
   width,
   handleProps,
   inert,
@@ -745,6 +749,25 @@ function WorkspacePanelImpl({
     },
     [terminals],
   );
+  const showOpenTabs =
+    !pending &&
+    (openFiles.length > 0 ||
+      openTerminals.length > 0 ||
+      (showBrowserTab && browsers.tabs.length > 0));
+  const showEmptyNewTab =
+    !pending &&
+    openFiles.length === 0 &&
+    openTerminals.length === 0 &&
+    (!showBrowserTab || browsers.tabs.length === 0);
+  const effectiveHandleProps = pending
+    ? {
+        ...handleProps,
+        onMouseDown: undefined,
+        onKeyDown: undefined,
+        "aria-disabled": true,
+        tabIndex: -1,
+      }
+    : handleProps;
   return (
     <aside
       aria-label="Workspace"
@@ -784,8 +807,11 @@ function WorkspacePanelImpl({
       {/* Left-edge horizontal resize handle — suppressed while maximized. */}
       {!maximized && (
         <div
-          {...handleProps}
-          className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+          {...effectiveHandleProps}
+          className={cn(
+            "absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors",
+            pending && "cursor-default hover:bg-transparent active:bg-transparent",
+          )}
         />
       )}
       {/* Tab strip, in display order Files · Changes · Agents.
@@ -815,11 +841,13 @@ function WorkspacePanelImpl({
           // content slot below): a sticky selection whose terminal is gone shows
           // the fallback nav view, so its nav tab must highlight, not "__tab__".
           value={
-            selectedFilePath !== null ||
-            (browserSelected && browsers.selected !== null) ||
-            (selectedTerminalKey !== null && openTerminals.includes(selectedTerminalKey))
-              ? "__tab__"
-              : rightRailTab
+            pending
+              ? "__pending__"
+              : selectedFilePath !== null ||
+                  (browserSelected && browsers.selected !== null) ||
+                  (selectedTerminalKey !== null && openTerminals.includes(selectedTerminalKey))
+                ? "__tab__"
+                : rightRailTab
           }
           onValueChange={(value) => {
             if (value === "browser") browsers.select(null);
@@ -828,11 +856,12 @@ function WorkspacePanelImpl({
           componentId="chat.right_rail.tabs"
         >
           <TabsList variant="pill" className="gap-1">
-            {showFilesPanel && (
+            {(pending || showFilesPanel) && (
               <WorkspaceTabTooltip label="Files">
                 <TabsTrigger
                   value="files"
                   aria-label="Files"
+                  disabled={pending}
                   className="size-6 shrink-0 p-0 hover:border-1 hover:border-muted rounded-md!"
                 >
                   <FolderTreeIcon />
@@ -840,11 +869,12 @@ function WorkspacePanelImpl({
                 </TabsTrigger>
               </WorkspaceTabTooltip>
             )}
-            {showFilesPanel && (
+            {(pending || showFilesPanel) && (
               <WorkspaceTabTooltip label="Changes">
                 <TabsTrigger
                   value="changes"
                   aria-label={changedCount > 0 ? `Changes ${changedCount} changed` : "Changes"}
+                  disabled={pending}
                   className="size-6 shrink-0 p-0 hover:border-1 hover:border-muted rounded-md!"
                 >
                   <FileDiffIcon />
@@ -853,11 +883,12 @@ function WorkspacePanelImpl({
                 </TabsTrigger>
               </WorkspaceTabTooltip>
             )}
-            {showGithubTab && (
+            {(pending || showGithubTab) && (
               <WorkspaceTabTooltip label="GitHub">
                 <TabsTrigger
                   value="github"
                   aria-label="GitHub"
+                  disabled={pending}
                   className="size-6 shrink-0 p-0 hover:border-1 hover:border-muted rounded-md!"
                 >
                   <GithubMono size={16} />
@@ -868,6 +899,7 @@ function WorkspacePanelImpl({
             <WorkspaceTabTooltip label="Agents">
               <TabsTrigger
                 value="subagents"
+                disabled={pending}
                 aria-label={
                   subagentsWorking > 0
                     ? `Agents ${subagentsWorking}/${agentCount}`
@@ -893,6 +925,7 @@ function WorkspacePanelImpl({
                 <TabsTrigger
                   value="browser"
                   aria-label="Browser"
+                  disabled={pending}
                   className="size-6 shrink-0 p-0 hover:border-1 hover:border-muted rounded-md!"
                 >
                   <GlobeIcon />
@@ -906,9 +939,7 @@ function WorkspacePanelImpl({
                 Pinned (outside the scrolling file-tabs region), so it stays put
                 at every rail width while the tabs scroll past it. */}
         <div aria-hidden className="mx-[8px] h-[14px] w-px shrink-0 self-center bg-border-strong" />
-        {(openFiles.length > 0 ||
-          openTerminals.length > 0 ||
-          (showBrowserTab && browsers.tabs.length > 0)) && (
+        {showOpenTabs && (
           <>
             {/* Open-tabs region (file tabs + shell tabs) — the horizontal
                 scroller. It sizes to its content and shrinks+scrolls only when
@@ -993,18 +1024,16 @@ function WorkspacePanelImpl({
             after the nav tabs (next to Shells); once tabs exist it moves into
             the open-tabs region to trail the last tab (see above). Self-gates
             to nothing when the agent has no terminal access. */}
-        {openFiles.length === 0 &&
-          openTerminals.length === 0 &&
-          (!showBrowserTab || browsers.tabs.length === 0) && (
-            <NewTabMenu
-              conversationId={conversationId}
-              onOpenBrowser={addBrowser}
-              onOpenTerminal={openTerminalTab}
-              onCreateStart={onShellCreateStart}
-              onCreateError={onShellCreateFailed}
-              liveness={liveness}
-            />
-          )}
+        {showEmptyNewTab && (
+          <NewTabMenu
+            conversationId={conversationId}
+            onOpenBrowser={addBrowser}
+            onOpenTerminal={openTerminalTab}
+            onCreateStart={onShellCreateStart}
+            onCreateError={onShellCreateFailed}
+            liveness={liveness}
+          />
+        )}
         {/* Maximize/minimize toggle, pinned to the rightmost edge via ml-auto,
             which absorbs the free space before it. When open tabs exist their
             ≥500px flex-1 region absorbs the space instead, so the button still
@@ -1019,6 +1048,7 @@ function WorkspacePanelImpl({
             aria-label={maximized ? "Exit full screen" : "Full screen"}
             aria-pressed={maximized}
             onClick={onToggleMaximized}
+            disabled={pending}
             size="icon-xs"
             className="flex size-6"
           >
@@ -1031,7 +1061,12 @@ function WorkspacePanelImpl({
           (tree vs changed-only list); Subagents lists the root's children +
           a "main" link back to the parent. */}
       <div data-workspace-panel-content className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {selectedTerminalKey !== null && openTerminals.includes(selectedTerminalKey) ? (
+        {pending ? (
+          <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-2 text-muted-foreground">
+            <Spinner />
+            <span className="text-ui">Starting workspace…</span>
+          </div>
+        ) : selectedTerminalKey !== null && openTerminals.includes(selectedTerminalKey) ? (
           // Show the selected shell's xterm only while its terminal is actually
           // present. The selection is sticky (AppShell never prunes it off the
           // list), so during a transient terminals-list churn this falls back to


### PR DESCRIPTION
## Related issue

N/A — no linked issue.

## Summary

- Render temporary sessions as a complete conversation shell using the optimistic title and visible-but-disabled header controls.
- Keep the Workspace panel available with inert loading chrome while preventing `temp:*` IDs from reaching session APIs.

ELI5: the conversation room appears immediately while its server key is being cut; controls are visible but locked until the real ID arrives.

```text
Landing submit → temp:* shell (optimistic + inert) → real ID → live session UI
```

## Test Plan

- `cd web && pnpm exec vitest run src/shell/AppShell.test.tsx src/shell/ChatHeader.test.tsx src/shell/WorkspacePanel.test.tsx` — 210 passed.
- `.venv/bin/pytest tests/e2e_ui/start_session/test_start_session.py::test_start_session_navigates_while_create_is_pending -q` — 1 passed.
- `.venv/bin/pre-commit run --files ...` — all applicable hooks passed.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

https://github.com/user-attachments/assets/ec33ae78-402c-47ef-90b3-6235a7d31b0f

The held-create Playwright scenario verifies the optimistic header, disabled controls, inert Workspace panel, absence of temp-scoped API requests, and transition to the real session.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The E2E test holds session creation at the HTTP boundary to exercise the complete temporary-ID state, then releases it to verify hydration.

## Changelog

New sessions now display their conversation header and Workspace shell while waiting for the server session ID.