### PR TITLE
docs: change "common" to "unified" in README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### The open-source meta-harness for all your AI agents.
 
-Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
+Omnigent is an open-source **meta-harness** that gives you a unified orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
 
 [![PyPI version](https://img.shields.io/pypi/v/omnigent.svg)](https://pypi.org/project/omnigent/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/omnigent-ai/omnigent/blob/main/LICENSE)


### PR DESCRIPTION
## Summary

- Changes "common" to "unified" in the opening README description for tighter wording.

## Test Plan

- Visual review of `README.md` — no functional change.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Documentation / copy change
- [ ] New feature
- [ ] Breaking change

## Test coverage

- [x] Not applicable

### Coverage notes

Documentation-only change; no code modified.

---

This pull request and its description were written by Isaac.