### PR TITLE
docs: add "of" to README tagline for natural phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # <img src="https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg" alt="" height="38" valign="middle" /> Omnigent
 
-### The open-source meta-harness for all your AI agents.
+### The open-source meta-harness for all of your AI agents.
 
 Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
 


### PR DESCRIPTION
## Summary

- Adds "of" to the tagline: "for all your AI agents" → "for all of your AI agents".

## Test Plan

- Visual review of `README.md` — no functional change.

## Demo

N/A

## Type of change

- [ ] Bug fix
- [x] Documentation / copy change
- [ ] New feature
- [ ] Breaking change

## Test coverage

- [x] Not applicable

### Coverage notes

Documentation-only change; no code modified.

---

This pull request and its description were written by Isaac.