### PR TITLE
Track PR reads and writes in compound shell commands

### DIFF
--- a/omnigent/runner/pr_observer.py
+++ b/omnigent/runner/pr_observer.py
@@ -42,10 +42,33 @@ def _result_parts(result: object, depth: int = 0) -> list[dict[str, object] | st
     if depth > 6:
         return []
     if isinstance(result, str):
-        try:
-            return _result_parts(json.loads(result), depth + 1)
-        except ValueError:
-            return [result]
+        # Compound shell output can interleave JSON responses, URL lines, and logs.
+        parts: list[dict[str, object] | str] = []
+        decoder = json.JSONDecoder()
+        index = 0
+        while index < len(result):
+            if result[index].isspace():
+                index += 1
+                continue
+            position = index
+            if result[index] in '{["':
+                try:
+                    value, position = decoder.raw_decode(result, index)
+                except ValueError as error:
+                    # Keep incomplete JSON together instead of re-parsing its nested lines.
+                    position = error.pos if isinstance(error, json.JSONDecodeError) else index
+                else:
+                    line_end = result.find("\n", position)
+                    if not result[position : line_end if line_end != -1 else len(result)].strip():
+                        parts.extend(_result_parts(value, depth + 1))
+                        index = position
+                        continue
+            end = result.find("\n", position)
+            if end == -1:
+                end = len(result)
+            parts.append(result[index:end])
+            index = end
+        return parts
     if isinstance(result, list):
         return [part for item in result[:100] for part in _result_parts(item, depth + 1)]
     if not isinstance(result, dict):
@@ -258,6 +281,11 @@ def _positional_target(tokens: list[str]) -> str | None:
         "--match-head-commit",
         "--branch",
         "--reason",
+        "--json",
+        "--jq",
+        "-q",
+        "--template",
+        "--color",
     }
     switches = {
         "--approve",
@@ -286,6 +314,9 @@ def _positional_target(tokens: list[str]) -> str | None:
         "--yes",
         "--web",
         "-w",
+        "--comments",
+        "--patch",
+        "--name-only",
     }
     index = 0
     while index < len(tokens):
@@ -311,6 +342,34 @@ def _target(repository: object, number: object, host: str = "github.com") -> Pul
             host, repository = parts[0], "/".join(parts[1:])
         return _reference(f"https://{host}/{repository}/pull/{number}")
     return None
+
+
+def _command_target(tokens: list[str]) -> PullRequestRef | None:
+    host = _flag(tokens, "--hostname") or "github.com"
+    if tokens[0] == "api":
+        endpoint = (_api_endpoint(tokens[1:]) or "").split("?", 1)[0]
+        match = re.match(r"/?repos/([^/]+/[^/]+)/pulls/([1-9][0-9]*)(?:/|$)", endpoint)
+        return _target(match[1], match[2], host) if match else None
+    if tokens[0] == "pr" and len(tokens) > 1 and tokens[1] != "create":
+        target = _positional_target(tokens[2:])
+        if ref := _reference(target):
+            return ref
+        if target and target.isdigit():
+            return _target(_flag(tokens, "--repo", "-R"), target, host)
+    return None
+
+
+def _content_only(tokens: list[str]) -> bool:
+    fields = _flag(tokens, "--json")
+    return (
+        tokens[:2] == ["pr", "diff"]
+        or _flag(tokens, "--jq", "-q") in {".body", ".[].body"}
+        or (
+            tokens[0] == "pr"
+            and fields is not None
+            and set(fields.split(",")) <= {"body", "title"}
+        )
+    )
 
 
 def _mcp_prs(
@@ -373,34 +432,16 @@ def extract_prs(
             return [], False
         # Mixed reads/writes still associate PRs, but cannot establish creation.
         created = all(_creates_pr(tokens) for tokens in commands)
-        for tokens in commands:
-            if tokens[0] == "pr" and len(tokens) > 1 and tokens[1] != "create":
-                target = _positional_target(tokens[2:])
-                ref = _reference(target)
-                if ref is None and target and target.isdigit():
-                    ref = _target(
-                        _flag(tokens, "--repo", "-R"),
-                        target,
-                        _flag(tokens, "--hostname") or "github.com",
-                    )
-                if ref:
+        references = [ref for tokens in commands if (ref := _command_target(tokens))]
+        if len(commands) > 1 or not _content_only(commands[0]):
+            for obj in _objects(result):
+                if ref := _reference(obj.get("html_url", obj.get("url"))):
                     references.append(ref)
-        for obj in _objects(result):
-            if ref := _reference(obj.get("html_url", obj.get("url"))):
-                references.append(ref)
-        # Standalone URL lines are gh's own operation results. URLs embedded in
-        # rendered bodies/diffs (pr view, pr diff) can name unrelated PRs, so
-        # they count only when the output is otherwise unattributed and names
-        # exactly one PR.
-        references.extend(ref for line in text.splitlines() if (ref := _reference(line.strip())))
-        if not references:
-            embedded = {
-                ref.url: ref
-                for url in re.findall(r"https://[^\s<>\"'`]+", text)
-                if (ref := _reference(url))
-            }
-            if len(embedded) == 1:
-                references.extend(embedded.values())
+            # A single operation's known identity makes rendered body links redundant.
+            if len(commands) > 1 or not references:
+                for line in text.splitlines():
+                    if len(line.split()) == 1 and (ref := _reference(line.strip())):
+                        references.append(ref)
     else:
         name = tool_name.rsplit("__", 1)[-1].removeprefix("github_")
         if name == "write_api_call":

--- a/omnigent/runner/pr_observer.py
+++ b/omnigent/runner/pr_observer.py
@@ -17,17 +17,6 @@ from omnigent.policies.builtins._shell import (
 from omnigent.runner.session_prs import PullRequestRef, SessionPrRegistry, observation_key
 
 _logger = logging.getLogger(__name__)
-_PR_ACTIONS = {
-    "create",
-    "edit",
-    "review",
-    "checkout",
-    "merge",
-    "ready",
-    "reopen",
-    "close",
-    "comment",
-}
 _MCP_ACTIONS = {
     "create_pull_request",
     "update_pull_request",
@@ -229,6 +218,18 @@ def _api_endpoint(tokens: list[str]) -> str | None:
     return None
 
 
+def _creates_pr(tokens: list[str]) -> bool:
+    if tokens[:2] == ["pr", "create"]:
+        return True
+    if tokens[0] != "api":
+        return False
+    method = _flag(tokens, "--method", "-X")
+    if method is None:
+        method = "POST" if _flag(tokens, "--field", "--raw-field", "-f", "-F") else "GET"
+    endpoint = (_api_endpoint(tokens[1:]) or "").split("?", 1)[0]
+    return method == "POST" and re.fullmatch(r"/?repos/[^/]+/[^/]+/pulls/?", endpoint) is not None
+
+
 def _positional_target(tokens: list[str]) -> str | None:
     # Unknown flags are deliberately ambiguous; output URLs can still identify the PR.
     values = {
@@ -361,72 +362,35 @@ def extract_prs(
         command = arguments.get("command", arguments.get("cmd"))
         if not isinstance(command, str) or len(command) > 100_000:
             return [], False
-        # Only PR/API clauses participate in PR evidence and ambiguity checks.
+        # Unrelated setup commands do not affect PR associations.
         commands = [
             tokens for tokens in _gh_commands(command) if tokens and tokens[0] in {"pr", "api"}
         ]
+        if not commands:
+            return [], False
         text = _output_text(result)
         if re.search(r"\[exit code: [1-9]|Process exited with code [1-9]", text):
             return [], False
-        actions = [tokens[1] for tokens in commands if len(tokens) > 1 and tokens[0] == "pr"]
-        # A combined output cannot establish which conditional command produced a URL.
-        if any(action not in _PR_ACTIONS for action in actions) or (
-            len(commands) > 1 and len(actions) != len(commands)
-        ):
-            return [], False
-        created = bool(actions) and all(action == "create" for action in actions)
+        for obj in _objects(result):
+            if ref := _reference(obj.get("html_url", obj.get("url"))):
+                references.append(ref)
+        for url in re.findall(r"https://[^\s<>\"'`]+", text):
+            if ref := _reference(url):
+                references.append(ref)
+        # Mixed reads/writes still associate PRs, but cannot establish creation.
+        created = all(_creates_pr(tokens) for tokens in commands)
         for tokens in commands:
-            if tokens and tokens[0] == "pr":
-                index = 0
-                if len(tokens) <= index + 1 or tokens[index + 1] not in _PR_ACTIONS:
-                    continue
-                action = tokens[index + 1]
-                # Standalone URLs are gh's operation result, not links embedded in a body.
-                for line in text.splitlines():
-                    ref = _reference(line.strip())
-                    if ref:
-                        references.append(ref)
-                if action != "create":
-                    target = _positional_target(tokens[index + 2 :])
-                    ref = _reference(target)
-                    if ref is None and target and target.isdigit():
-                        ref = _target(
-                            _flag(tokens, "--repo", "-R"),
-                            target,
-                            _flag(tokens, "--hostname") or "github.com",
-                        )
-                    if ref:
-                        references.append(ref)
-            elif tokens and tokens[0] == "api":
-                method = _flag(tokens, "--method", "-X")
-                writes = method in {"POST", "PATCH", "PUT"} or (
-                    method is None and _flag(tokens, "--field", "--raw-field", "-f", "-F")
-                )
-                if not writes:
-                    continue
-                for obj in _objects(result):
-                    if ref := _reference(obj.get("html_url", obj.get("url"))):
-                        references.append(ref)
-                endpoint = _api_endpoint(tokens[1:])
-                pr_endpoint = re.fullmatch(
-                    r"/?repos/([^/]+/[^/]+)/pulls(?:/([1-9][0-9]*))?/?",
-                    (endpoint or "").split("?", 1)[0],
-                )
-                created = bool(pr_endpoint and pr_endpoint[2] is None and method in {None, "POST"})
-                # A direct URL projection omits the JSON envelope. Body/list projections
-                # can contain unrelated PR links and are not association evidence.
-                if pr_endpoint and _flag(tokens, "--jq", "-q") in {".html_url", ".url"}:
-                    projected = {
-                        ref.url: ref
-                        for line in text.splitlines()
-                        if (ref := _reference(line.strip()))
-                    }
-                    if len(projected) == 1:
-                        ref = next(iter(projected.values()))
-                        if ref.repository == pr_endpoint[1].lower() and (
-                            pr_endpoint[2] is None or ref.number == int(pr_endpoint[2])
-                        ):
-                            references.append(ref)
+            if tokens[0] == "pr" and len(tokens) > 1 and tokens[1] != "create":
+                target = _positional_target(tokens[2:])
+                ref = _reference(target)
+                if ref is None and target and target.isdigit():
+                    ref = _target(
+                        _flag(tokens, "--repo", "-R"),
+                        target,
+                        _flag(tokens, "--hostname") or "github.com",
+                    )
+                if ref:
+                    references.append(ref)
     else:
         name = tool_name.rsplit("__", 1)[-1].removeprefix("github_")
         if name == "write_api_call":

--- a/omnigent/runner/pr_observer.py
+++ b/omnigent/runner/pr_observer.py
@@ -361,7 +361,10 @@ def extract_prs(
         command = arguments.get("command", arguments.get("cmd"))
         if not isinstance(command, str) or len(command) > 100_000:
             return [], False
-        commands = _gh_commands(command)
+        # Only PR/API clauses participate in PR evidence and ambiguity checks.
+        commands = [
+            tokens for tokens in _gh_commands(command) if tokens and tokens[0] in {"pr", "api"}
+        ]
         text = _output_text(result)
         if re.search(r"\[exit code: [1-9]|Process exited with code [1-9]", text):
             return [], False

--- a/omnigent/runner/pr_observer.py
+++ b/omnigent/runner/pr_observer.py
@@ -371,12 +371,6 @@ def extract_prs(
         text = _output_text(result)
         if re.search(r"\[exit code: [1-9]|Process exited with code [1-9]", text):
             return [], False
-        for obj in _objects(result):
-            if ref := _reference(obj.get("html_url", obj.get("url"))):
-                references.append(ref)
-        for url in re.findall(r"https://[^\s<>\"'`]+", text):
-            if ref := _reference(url):
-                references.append(ref)
         # Mixed reads/writes still associate PRs, but cannot establish creation.
         created = all(_creates_pr(tokens) for tokens in commands)
         for tokens in commands:
@@ -391,6 +385,22 @@ def extract_prs(
                     )
                 if ref:
                     references.append(ref)
+        for obj in _objects(result):
+            if ref := _reference(obj.get("html_url", obj.get("url"))):
+                references.append(ref)
+        # Standalone URL lines are gh's own operation results. URLs embedded in
+        # rendered bodies/diffs (pr view, pr diff) can name unrelated PRs, so
+        # they count only when the output is otherwise unattributed and names
+        # exactly one PR.
+        references.extend(ref for line in text.splitlines() if (ref := _reference(line.strip())))
+        if not references:
+            embedded = {
+                ref.url: ref
+                for url in re.findall(r"https://[^\s<>\"'`]+", text)
+                if (ref := _reference(url))
+            }
+            if len(embedded) == 1:
+                references.extend(embedded.values())
     else:
         name = tool_name.rsplit("__", 1)[-1].removeprefix("github_")
         if name == "write_api_call":

--- a/tests/e2e/test_session_pr_tracking_e2e.py
+++ b/tests/e2e/test_session_pr_tracking_e2e.py
@@ -44,6 +44,10 @@ async def test_native_session_tracks_prs_across_repositories(
         "args[args.index('-R') + 1].removeprefix('github.com/'))\n"
         "url = f'https://github.com/{repo}/pull/42'\n"
         "if args[:2] == ['pr', 'create'] or args[0] == 'api': print(url)\n"
+        "elif args[:2] == ['pr', 'view'] and '--comments' in args:\n"
+        "    print('Supersedes https://github.com/unrelated/repo/pull/7')\n"
+        "    print('https://github.com/unrelated/repo/pull/7')\n"
+        "    print('View this pull request on GitHub: ' + url)\n"
         "elif args[:2] == ['pr', 'view']: "
         "print(json.dumps({'number': 42, 'url': url, 'title': repo, 'state': 'OPEN'}))\n"
         "elif args[:2] == ['pr', 'diff']: print('patch for ' + repo)\n"
@@ -88,6 +92,10 @@ async def test_native_session_tracks_prs_across_repositories(
         )
         mixed_output = subprocess.check_output(
             ["/bin/sh", "-c", mixed_command], text=True, cwd=workspace
+        )
+        view_command = "gh pr view 42 -R example/one --comments"
+        view_output = subprocess.check_output(
+            ["/bin/sh", "-c", view_command], text=True, cwd=workspace
         )
         payloads = [
             {
@@ -135,6 +143,11 @@ async def test_native_session_tracks_prs_across_repositories(
                         "Next steps:\n  • Assign reviewers\n  • Monitor CI checks\n"
                     }
                 ),
+            },
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": view_command},
+                "tool_response": {"stdout": view_output, "exit_code": 0},
             },
             {
                 "tool_name": "Bash",

--- a/tests/e2e/test_session_pr_tracking_e2e.py
+++ b/tests/e2e/test_session_pr_tracking_e2e.py
@@ -38,6 +38,7 @@ async def test_native_session_tracks_prs_across_repositories(
         f"#!{sys.executable}\n"
         "import json, sys\n"
         "args = sys.argv[1:]\n"
+        "if args[0] not in {'pr', 'api'}: sys.exit(0)\n"
         "repo = (args[1].strip('/').removeprefix('repos/').removesuffix('/pulls')\n"
         "        if args[0] == 'api' else "
         "args[args.index('-R') + 1].removeprefix('github.com/'))\n"
@@ -63,9 +64,15 @@ async def test_native_session_tracks_prs_across_repositories(
     hook = hook_settings(bridge_dir, sys.executable, f"omnigent.harnesses.{harness}.hook")
     command = shlex.split(str(hook["command"]))
     try:
-        shell_command = "gh pr create -R example/one"
-        output = subprocess.check_output(shlex.split(shell_command), text=True, cwd=workspace)
+        shell_command = (
+            "gh auth switch --user example-user; gh repo set-default example/one && "
+            "gh pr create -R example/one; gh config set pager cat"
+        )
+        output = subprocess.check_output(
+            ["/bin/sh", "-c", shell_command], text=True, cwd=workspace
+        )
         rest_command = (
+            "gh auth switch --user example-user; "
             "printf 'HEAD SHA: fixture\\n' && gh api /repos/example/three/pulls \\\n"
             "  --method POST \\\n"
             "  --field title='fixture PR' \\\n"

--- a/tests/e2e/test_session_pr_tracking_e2e.py
+++ b/tests/e2e/test_session_pr_tracking_e2e.py
@@ -39,7 +39,7 @@ async def test_native_session_tracks_prs_across_repositories(
         "import json, sys\n"
         "args = sys.argv[1:]\n"
         "if args[0] not in {'pr', 'api'}: sys.exit(0)\n"
-        "repo = (args[1].strip('/').removeprefix('repos/').removesuffix('/pulls')\n"
+        "repo = ('/'.join(args[1].strip('/').split('/')[1:3])\n"
         "        if args[0] == 'api' else "
         "args[args.index('-R') + 1].removeprefix('github.com/'))\n"
         "url = f'https://github.com/{repo}/pull/42'\n"
@@ -81,6 +81,13 @@ async def test_native_session_tracks_prs_across_repositories(
         )
         rest_output = subprocess.check_output(
             ["/bin/sh", "-c", rest_command], text=True, cwd=workspace
+        )
+        mixed_command = (
+            "gh api /repos/example/five/issues/42/comments -f body=fixture; "
+            "gh pr view 42 -R example/one --json url"
+        )
+        mixed_output = subprocess.check_output(
+            ["/bin/sh", "-c", mixed_command], text=True, cwd=workspace
         )
         payloads = [
             {
@@ -129,6 +136,11 @@ async def test_native_session_tracks_prs_across_repositories(
                     }
                 ),
             },
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": mixed_command},
+                "tool_response": {"stdout": mixed_output, "exit_code": 0},
+            },
         ]
         for index, payload in enumerate(payloads):
             payload.update(
@@ -147,6 +159,29 @@ async def test_native_session_tracks_prs_across_repositories(
                 )
                 assert completed.returncode == 0, completed.stderr
                 assert completed.stdout == ""
+        registry = SessionPrRegistry("conv_owned")
+        entries = registry.list()
+        assert len(entries) == 5
+        assert {entry.repository: entry.relationship for entry in entries} == {
+            "example/one": "created",
+            "example/two": "created",
+            "example/three": "created",
+            "example/four": "created",
+            "example/five": "worked_on",
+        }
+        registry.remove("https://github.com/example/five/pull/42")
+        # A new observation, as well as hook replay, must respect explicit unlinking.
+        for call_id in (payloads[-1]["tool_use_id"], "new-comment"):
+            completed = await asyncio.to_thread(
+                subprocess.run,
+                command,
+                input=json.dumps({**payloads[-1], "tool_use_id": call_id}),
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+            assert completed.returncode == 0, completed.stderr
+            assert completed.stdout == ""
         info = json.loads((bridge_dir / "tool_relay.json").read_text())
         async with httpx.AsyncClient() as client:
             denied = await client.post(info["url"] + "/hook/observe-tool", json=payloads[0])

--- a/tests/e2e_ui/github/test_pr_tracking_after_gh_auth_switch.py
+++ b/tests/e2e_ui/github/test_pr_tracking_after_gh_auth_switch.py
@@ -36,6 +36,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from tests.e2e_ui.conftest import (
+    _ensure_runner_online,
     configure_mock_llm,
     open_right_rail,
     set_fallback_mock_llm,
@@ -112,9 +113,29 @@ def _git(*args: str) -> None:
 
 
 @pytest.fixture
-def pr_probe_session(
+def pr_probe_runner_id(
     live_server: str,
     runner_id: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[str]:
+    """Recover the shared runner after an earlier crash test in the shard."""
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    try:
+        yield runner_id
+    finally:
+        if respawned is not None:
+            respawned.terminate()
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)
+
+
+@pytest.fixture
+def pr_probe_session(
+    live_server: str,
+    pr_probe_runner_id: str,
     mock_llm_server_url: str,
 ) -> Iterator[tuple[str, str, str, Path, Path]]:
     """An isolated runner-bound session whose workspace can run the commands.
@@ -165,7 +186,7 @@ def pr_probe_session(
     try:
         httpx.patch(
             f"{live_server}/v1/sessions/{session_id}",
-            json={"runner_id": runner_id},
+            json={"runner_id": pr_probe_runner_id},
             timeout=10.0,
         ).raise_for_status()
         yield (live_server, session_id, model, stub, worktree)

--- a/tests/e2e_ui/github/test_pr_tracking_after_gh_auth_switch.py
+++ b/tests/e2e_ui/github/test_pr_tracking_after_gh_auth_switch.py
@@ -1,0 +1,226 @@
+"""A PR created after a same-call ``gh auth switch`` is still tracked.
+
+Session PR tracking observes completed shell calls on the runner
+(``omnigent/runner/pr_observer.py``) and surfaces created PRs in the web UI:
+the composer status line's ``#<pr>`` link and the workspace rail's GitHub
+tab. Reported bug: when the successful ``gh pr create`` call also contains
+an unrelated ``gh auth switch`` (with or without an intervening ``git
+push``), the observer's mixed-operation guard rejects the whole call and
+the created PR is never associated with the session.
+
+These tests drive the real journey end to end — a live server + runner
+executes the agent's shell command for real (a PATH-stubbed ``gh`` prints
+gh's canonical PR-create success output, so no GitHub access is needed; the
+observer only ever sees the command string and its output) — and assert the
+*correct* behavior: the created PR appears in the UI. The two
+``auth-switch`` shapes fail on the affected build; the control shape
+passes, isolating the failure to the mixed-operation guard rather than the
+tracking pipeline.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import (
+    configure_mock_llm,
+    open_right_rail,
+    set_fallback_mock_llm,
+)
+
+_PR_URL = "https://github.com/example/project/pull/42"
+_COMPOSER = "Send a message…"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_WORKING = '[data-testid="working-indicator"]'
+
+# The per-fixture model gives each test an isolated mock-LLM queue.
+_AGENT_YAML = """\
+name: {name}
+prompt: |
+  You are a deterministic test assistant. When asked to open a pull request
+  you run a shell command that creates it, then confirm.
+
+executor:
+  model: {model}
+  harness: openai-agents
+
+os_env:
+  type: caller_process
+  cwd: {cwd}
+  sandbox:
+    type: none
+"""
+
+# Stands in for the real gh CLI on PATH: prints gh's canonical PR-create
+# success output (the standalone PR URL) and succeeds for setup subcommands
+# such as ``auth switch``, exactly what a real successful call shows.
+_GH_STUB = f"""\
+#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo "{_PR_URL}"
+fi
+exit 0
+"""
+
+# The reported failing command shapes, plus the same command without the
+# unrelated ``gh auth switch`` as the pipeline control. The leading PATH
+# export only makes the stubbed gh resolvable; it adds no gh clause.
+_PR_CREATE = "gh pr create --title 'Example' --body 'Example'"
+_COMMANDS = {
+    "control-pr-create-alone": 'export PATH="{stub}:$PATH"; cd {worktree} && ' + _PR_CREATE,
+    "auth-switch-then-pr-create": (
+        'export PATH="{stub}:$PATH"; gh auth switch --user example-user 2>/dev/null; '
+        "cd {worktree} && " + _PR_CREATE
+    ),
+    "auth-switch-push-then-pr-create": (
+        'export PATH="{stub}:$PATH"; gh auth switch --user example-user 2>/dev/null; '
+        "cd {worktree} && git push -u origin topic && " + _PR_CREATE
+    ),
+}
+
+
+def _agent_bundle(name: str, model: str, cwd: str) -> bytes:
+    """Gzip-tar the agent YAML for multipart upload."""
+    yaml_text = _AGENT_YAML.format(name=name, model=model, cwd=cwd)
+    buf = io.BytesIO()
+    with (
+        gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz,
+        tarfile.open(fileobj=gz, mode="w") as tar,
+    ):
+        data = yaml_text.encode()
+        info = tarfile.TarInfo(name=f"{name}.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _git(*args: str) -> None:
+    subprocess.run(["git", *args], check=True, capture_output=True)
+
+
+@pytest.fixture
+def pr_probe_session(
+    live_server: str,
+    runner_id: str,
+    mock_llm_server_url: str,
+) -> Iterator[tuple[str, str, str, Path, Path]]:
+    """An isolated runner-bound session whose workspace can run the commands.
+
+    The workspace holds a ``stub-bin/gh`` for PATH and a ``worktree`` git
+    repo on branch ``topic`` with a local bare ``origin``, so the push
+    shape runs offline.
+    """
+    ws = Path(tempfile.mkdtemp(prefix="omnigent-e2e-pr-auth-switch-"))
+    stub = ws / "stub-bin"
+    stub.mkdir()
+    (stub / "gh").write_text(_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    worktree = ws / "worktree"
+    _git("init", "-q", "-b", "topic", str(worktree))
+    _git(
+        "-C",
+        str(worktree),
+        "-c",
+        "user.email=e2e@example.com",
+        "-c",
+        "user.name=e2e",
+        "commit",
+        "--allow-empty",
+        "-q",
+        "-m",
+        "init",
+    )
+    _git("init", "-q", "--bare", str(ws / "origin.git"))
+    _git("-C", str(worktree), "remote", "add", "origin", str(ws / "origin.git"))
+
+    name = f"pr_track_probe_{uuid.uuid4().hex[:8]}"
+    model = f"pr-track-probe-{uuid.uuid4().hex[:8]}"
+    create_resp = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _agent_bundle(name, model, str(ws)),
+                "application/gzip",
+            )
+        },
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+    try:
+        httpx.patch(
+            f"{live_server}/v1/sessions/{session_id}",
+            json={"runner_id": runner_id},
+            timeout=10.0,
+        ).raise_for_status()
+        yield (live_server, session_id, model, stub, worktree)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        shutil.rmtree(ws, ignore_errors=True)
+
+
+@pytest.mark.parametrize("shape", list(_COMMANDS), ids=list(_COMMANDS))
+def test_created_pr_is_tracked(
+    page: Page,
+    pr_probe_session: tuple[str, str, str, Path, Path],
+    mock_llm_server_url: str,
+    shape: str,
+) -> None:
+    """A successful ``gh pr create`` associates its PR with the session."""
+    base_url, session_id, model, stub, worktree = pr_probe_session
+    command = _COMMANDS[shape].format(stub=stub, worktree=worktree)
+    # Configure both responses together because reconfiguring a queue resets it.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_create_pr",
+                        "name": "sys_os_shell",
+                        "arguments": json.dumps({"command": command}),
+                    }
+                ]
+            },
+            {"text": "Opened the pull request."},
+        ],
+        key=model,
+    )
+    set_fallback_mock_llm(mock_llm_server_url, model, "Done.")
+
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill("Open a pull request for this change.")
+    page.get_by_role("button", name="Send", exact=True).click()
+    expect(page.locator(_ASSISTANT).last).to_contain_text(
+        "Opened the pull request.", timeout=60_000
+    )
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+
+    # A fresh load reads the tracked-PR state the way a returning user does.
+    page.reload()
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name="GitHub").click()
+    # The created PR must be associated with the session: the GitHub tab's
+    # session-PR picker names it, and the composer status line links it.
+    picker = rail.get_by_role("combobox", name="Session pull request")
+    expect(picker).to_have_text("example/project #42", timeout=30_000)
+    expect(page.get_by_test_id("composer-pr-link")).to_have_accessible_name("#42")

--- a/tests/runner/test_session_prs.py
+++ b/tests/runner/test_session_prs.py
@@ -255,6 +255,120 @@ def test_mixed_operations_do_not_claim_creation() -> None:
     assert not created
 
 
+@pytest.mark.parametrize("tool_name", ["Bash", "exec_command"])
+@pytest.mark.parametrize("structured", [False, True])
+def test_auth_switch_before_creating_two_prs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tool_name: str, structured: bool
+) -> None:
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+    for index, url in enumerate((A, B)):
+        push = "git push -u origin topic && " if index else ""
+        command = (
+            "gh auth switch --user example-user 2>/dev/null; cd /worktree && "
+            + push
+            + '''gh pr create \\
+  --title 'README wording' \\
+  --body "$(cat <<'EOF'
+## Summary
+Update `README.md` wording.
+EOF
+)"'''
+        )
+        stdout = (
+            "remote: https://github.com/example/two/pull/new/topic\nPushed topic\n"
+            if index
+            else ""
+        ) + url
+        result = (
+            {
+                "stdout": stdout,
+                "stderr": "Shell cwd was reset to /workspace",
+                "interrupted": False,
+                "gitOperation": {"pr": {"number": 42, "url": url, "action": "created"}},
+            }
+            if structured
+            else {"content": stdout + "\nShell cwd was reset to /workspace", "is_error": False}
+        )
+        observe_hook(
+            "conv_auth_switch",
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": tool_name,
+                "tool_input": {"command": command},
+                "tool_response": result,
+                "tool_use_id": f"create-{index}",
+            },
+        )
+    entries = SessionPrRegistry("conv_auth_switch").list()
+    assert {entry.url for entry in entries} == {A, B}
+    assert all(entry.relationship == "created" for entry in entries)
+
+
+@pytest.mark.parametrize(
+    "command,result,urls,created",
+    [
+        ("gh auth status; gh pr create", A, [A], True),
+        ("gh auth setup-git && gh pr edit 42 -R example/one", "Updated", [A], False),
+        (
+            "gh auth switch --user example-user; "
+            "gh api repos/example/one/pulls -X POST --jq .html_url",
+            A,
+            [A],
+            True,
+        ),
+        ("gh auth status", A, [], False),
+        ("gh auth switch --user example-user; gh pr list", A, [], False),
+        ("gh auth switch --user example-user; gh pr view; gh pr create", A, [], False),
+        (
+            "gh auth switch --user example-user; gh api repos/example/one/pulls/42; gh pr create",
+            A,
+            [],
+            False,
+        ),
+        ("gh auth switch --user example-user; gh pr create || true", A, [], False),
+        (
+            "gh auth switch --user example-user; gh pr create",
+            {"stdout": A, "exit_code": 1},
+            [],
+            False,
+        ),
+        (
+            "gh auth switch --user example-user; gh pr create",
+            {"stdout": A, "backgroundTaskId": "pending"},
+            [],
+            False,
+        ),
+    ],
+)
+def test_auth_commands_do_not_supply_pr_evidence(
+    command: str, result: object, urls: list[str], created: bool
+) -> None:
+    refs, was_created = extract_prs("Bash", {"command": command}, result)
+    assert [ref.url for ref in refs] == urls
+    assert was_created is created
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        "gh repo set-default example/one",
+        "gh config set pager cat",
+        "gh arbitrary-extension --option value",
+        "git push -u origin topic",
+        "printf '%s' 'gh pr list'",
+    ],
+)
+@pytest.mark.parametrize("before", [False, True])
+@pytest.mark.parametrize(
+    "write", ["gh pr create", "gh api repos/example/one/pulls -X POST --jq .html_url"]
+)
+def test_unrelated_commands_do_not_hide_pr_write(other: str, before: bool, write: str) -> None:
+    command = f"{other}; {write}" if before else f"{write}; {other}"
+    refs, created = extract_prs("Bash", {"command": command}, {"stdout": A, "exit_code": 0})
+    assert [ref.url for ref in refs] == [A]
+    assert created
+
+
 def test_rest_proxy_wrapper() -> None:
     refs, created = extract_prs(
         "mcp__custom__github_write_api_call",

--- a/tests/runner/test_session_prs.py
+++ b/tests/runner/test_session_prs.py
@@ -122,8 +122,8 @@ def test_reference_accepts_dns_hostname(host: str) -> None:
         ("Bash", {"command": "gh pr create"}, {"stdout": A, "exit_code": 1}, []),
         ("Bash", {"command": "gh pr create"}, A + "\n[exit code: 1]", []),
         ("Bash", {"command": f"echo '{A}'"}, A, []),
-        ("Bash", {"command": "gh pr list"}, A + "\n" + B, []),
-        ("Bash", {"command": "gh pr view 42"}, A, []),
+        ("Bash", {"command": "gh pr list"}, A + "\n" + B, [A, B]),
+        ("Bash", {"command": "gh pr view 42"}, A, [A]),
         (
             "mcp__custom__create_pull_request",
             {"owner": "example", "repo": "one"},
@@ -317,12 +317,12 @@ EOF
             True,
         ),
         ("gh auth status", A, [], False),
-        ("gh auth switch --user example-user; gh pr list", A, [], False),
-        ("gh auth switch --user example-user; gh pr view; gh pr create", A, [], False),
+        ("gh auth switch --user example-user; gh pr list", A, [A], False),
+        ("gh auth switch --user example-user; gh pr view; gh pr create", A, [A], False),
         (
             "gh auth switch --user example-user; gh api repos/example/one/pulls/42; gh pr create",
             A,
-            [],
+            [A],
             False,
         ),
         ("gh auth switch --user example-user; gh pr create || true", A, [], False),
@@ -595,13 +595,70 @@ def test_background_or_interrupted_shell_does_not_attach_target(result: dict) ->
     assert refs == []
 
 
-def test_read_api_output_is_not_attributed_to_later_create() -> None:
-    refs, _ = extract_prs(
+@pytest.mark.parametrize(
+    "commands,created",
+    [
+        (["gh api repos/example/one/pulls/42 --jq .html_url", "gh pr create"], False),
+        (["gh pr view 42 --repo example/one", "gh pr create"], False),
+        (["gh api repos/example/one/pulls -X POST", "gh pr edit 42"], False),
+        (
+            ["gh api repos/example/one/pulls -X POST", "gh api repos/example/two/pulls/42"],
+            False,
+        ),
+        (
+            ["gh api repos/example/one/pulls -X POST", "gh api repos/example/two/pulls -X POST"],
+            True,
+        ),
+        (["gh api repos/example/one/pulls -X POST", "gh pr create"], True),
+    ],
+)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_combined_operations_keep_prs_without_misattributing_creation(
+    commands: list[str], created: bool, reverse: bool
+) -> None:
+    refs, was_created = extract_prs(
         "Bash",
-        {"command": "gh api repos/example/one/pulls/42 --jq .html_url; gh pr create"},
+        {"command": "; ".join(reversed(commands) if reverse else commands)},
         A + "\n" + B,
     )
-    assert refs == []
+    assert {ref.url for ref in refs} == {A, B}
+    assert was_created is created
+
+
+@pytest.mark.parametrize(
+    "result,urls",
+    [
+        ({"html_url": A + "#issuecomment-123", "body": B}, [A]),
+        ({"stdout": json.dumps({"html_url": A + "#issuecomment-123", "body": B})}, [A]),
+        (A + "#issuecomment-123", [A]),
+        (f"Comment posted: [view]({A}#issuecomment-123)", [A]),
+        ({"body": B}, []),
+        ({"html_url": A.replace("/pull/", "/issues/") + "#issuecomment-123"}, []),
+        ({"stdout": A, "exit_code": 1}, []),
+        ({"stdout": A, "interrupted": True}, []),
+        ({"stdout": A, "backgroundTaskId": "pending"}, []),
+    ],
+)
+def test_rest_comment_tracks_pr_identity(result: object, urls: list[str]) -> None:
+    refs, created = extract_prs(
+        "Bash",
+        {"command": f"gh api repos/example/one/issues/42/comments -f body='{B}'"},
+        result,
+    )
+    assert [ref.url for ref in refs] == urls
+    assert not created
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["gh pr view 42 --json url,body", "gh api repos/example/one/pulls/42"],
+)
+def test_pr_reads_use_structured_identity(command: str) -> None:
+    refs, created = extract_prs(
+        "Bash", {"command": command}, {"stdout": json.dumps({"url": A, "body": B})}
+    )
+    assert [ref.url for ref in refs] == [A]
+    assert not created
 
 
 @pytest.mark.parametrize("envelope", [False, True])
@@ -633,16 +690,15 @@ def test_rest_create_with_jq_and_multiline_shell(envelope: bool) -> None:
             True,
         ),
         ("gh api /repos/example/one/pulls/42 -X PATCH --jq .html_url", A, [A], False),
-        ("gh api /repos/example/one/pulls/42 --jq .html_url", A, [], False),
-        ("gh api /repos/example/one/pulls -X GET -f title=test --jq .html_url", A, [], False),
-        ("gh api /repos/example/one/pulls -X POST --jq .body", B, [], False),
-        ("gh api /repos/example/one/pulls -X POST --jq .html_url", B, [], False),
-        ("gh api /repos/example/one/pulls/99 -X PATCH --jq .html_url", A, [], False),
+        ("gh api /repos/example/one/pulls/42 --jq .html_url", A, [A], False),
+        ("gh api /repos/example/one/pulls -X GET -f title=test --jq .html_url", A, [A], False),
+        ("gh api /repos/example/one/pulls --jq '.[].html_url'", A + "\n" + B, [A, B], False),
+        ("gh api /repos/example/one/pulls/99 -X PATCH --jq .html_url", A, [A], False),
         (
             "gh api --input /repos/example/one/pulls -X POST "
             "/repos/example/one/issues --jq .html_url",
             A,
-            [],
+            [A],
             False,
         ),
         (
@@ -660,8 +716,9 @@ def test_rest_url_projection(command: str, result: object, urls: list[str], crea
         assert was_created is created
 
 
-@pytest.mark.parametrize("quote,urls", [('"', [A]), ("'", [])])
-def test_shell_continuation_respects_quoting(quote: str, urls: list[str]) -> None:
+@pytest.mark.parametrize("quote,created", [('"', True), ("'", False)])
+def test_shell_continuation_respects_quoting(quote: str, created: bool) -> None:
     command = f"gh api {quote}/repos/example/one/pul\\\nls{quote} -X POST --jq .html_url"
-    refs, _ = extract_prs("Bash", {"command": command}, A)
-    assert [pr.url for pr in refs] == urls
+    refs, was_created = extract_prs("Bash", {"command": command}, A)
+    assert [pr.url for pr in refs] == [A]
+    assert was_created is created

--- a/tests/runner/test_session_prs.py
+++ b/tests/runner/test_session_prs.py
@@ -661,6 +661,24 @@ def test_pr_reads_use_structured_identity(command: str) -> None:
     assert not created
 
 
+@pytest.mark.parametrize(
+    "result,urls",
+    [
+        # Rendered output naming several PRs (a body linking another PR plus the
+        # view footer) cannot say which one the call was about.
+        (f"Fix typo\n\nSupersedes {B}.\nView this pull request on GitHub: {A}", []),
+        # A single embedded URL is unambiguous, as in comment confirmations.
+        (f"posted: [view]({A}#issuecomment-9)", [A]),
+        # A standalone result line stays authoritative over embedded prose links.
+        (f"See {B} for background\n{A}", [A]),
+    ],
+)
+def test_embedded_urls_associate_only_when_unambiguous(result: str, urls: list[str]) -> None:
+    refs, created = extract_prs("Bash", {"command": "gh pr view 42"}, result)
+    assert [ref.url for ref in refs] == urls
+    assert not created
+
+
 @pytest.mark.parametrize("envelope", [False, True])
 def test_rest_create_with_jq_and_multiline_shell(envelope: bool) -> None:
     url = "https://github.com/example/project-dev/pull/123"

--- a/tests/runner/test_session_prs.py
+++ b/tests/runner/test_session_prs.py
@@ -631,7 +631,7 @@ def test_combined_operations_keep_prs_without_misattributing_creation(
         ({"html_url": A + "#issuecomment-123", "body": B}, [A]),
         ({"stdout": json.dumps({"html_url": A + "#issuecomment-123", "body": B})}, [A]),
         (A + "#issuecomment-123", [A]),
-        (f"Comment posted: [view]({A}#issuecomment-123)", [A]),
+        (f"Comment posted: [view]({A}#issuecomment-123)", []),
         ({"body": B}, []),
         ({"html_url": A.replace("/pull/", "/issues/") + "#issuecomment-123"}, []),
         ({"stdout": A, "exit_code": 1}, []),
@@ -664,19 +664,102 @@ def test_pr_reads_use_structured_identity(command: str) -> None:
 @pytest.mark.parametrize(
     "result,urls",
     [
-        # Rendered output naming several PRs (a body linking another PR plus the
-        # view footer) cannot say which one the call was about.
         (f"Fix typo\n\nSupersedes {B}.\nView this pull request on GitHub: {A}", []),
-        # A single embedded URL is unambiguous, as in comment confirmations.
-        (f"posted: [view]({A}#issuecomment-9)", [A]),
-        # A standalone result line stays authoritative over embedded prose links.
+        (f"posted: [view]({A}#issuecomment-9)", []),
         (f"See {B} for background\n{A}", [A]),
     ],
 )
-def test_embedded_urls_associate_only_when_unambiguous(result: str, urls: list[str]) -> None:
+def test_rendered_output_requires_complete_url_line(result: str, urls: list[str]) -> None:
     refs, created = extract_prs("Bash", {"command": "gh pr view 42"}, result)
     assert [ref.url for ref in refs] == urls
     assert not created
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh pr view 42 -R example/one",
+        f"gh pr view {A} --comments",
+        "gh auth status; gh pr view --comments -R example/one 42; gh config set pager cat",
+        "gh pr view --json body -q .body 42 -R example/one",
+        "gh pr diff --color never 42 -R example/one",
+        "gh api repos/example/one/pulls/42 --jq .body",
+        "gh api repos/example/one/pulls/42/reviews",
+    ],
+)
+def test_known_target_excludes_prs_mentioned_in_output(command: str) -> None:
+    refs, created = extract_prs(
+        "Bash",
+        {"command": command},
+        {"stdout": f"Supersedes {B}\n{B}\nView this pull request on GitHub: {A}"},
+    )
+    assert [ref.url for ref in refs] == [A]
+    assert not created
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh pr diff",
+        "gh pr diff 42",
+        "gh api repos/example/one/pulls -X POST --jq .body",
+        "gh api repos/example/one/pulls --jq '.[].body'",
+        "gh api repos/example/one/issues/42/comments --jq .body",
+        "gh pr view 42 --json body --jq .body",
+        "gh pr list --json body --jq '.[] | .body'",
+    ],
+)
+@pytest.mark.parametrize("output", [B, json.dumps({"url": B})])
+def test_content_only_output_does_not_supply_pr_identity(command: str, output: str) -> None:
+    refs, _ = extract_prs("Bash", {"command": command}, {"stdout": output})
+    assert refs == []
+
+
+def test_single_operation_prefers_structured_identity_over_text() -> None:
+    refs, created = extract_prs(
+        "Bash",
+        {"command": "gh pr create"},
+        {"structuredContent": {"html_url": A}, "stdout": B},
+    )
+    assert [ref.url for ref in refs] == [A]
+    assert created
+
+
+def test_plain_text_fallback_accepts_only_complete_url_lines() -> None:
+    refs, _ = extract_prs(
+        "Bash",
+        {"command": "gh pr view 42; gh pr create"},
+        {
+            "stdout": (
+                f"Supersedes {A}\n+{A}\n[view]({A})\n"
+                f'42{A}\n"{A}" is mentioned\n{A}#comment is mentioned\n{B}\n'
+            )
+        },
+    )
+    assert [ref.url for ref in refs] == [B]
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("second_json", [False, True])
+def test_compound_output_preserves_json_identities_and_url_lines(
+    reverse: bool, second_json: bool
+) -> None:
+    other = "https://github.com/unrelated/repo/pull/7"
+    commands = ["gh api repos/example/one/pulls -X POST", "gh pr create -R example/two"]
+    outputs = [json.dumps({"html_url": A, "body": other}, indent=2), B]
+    if second_json:
+        commands[1] = "gh api repos/example/two/pulls -X POST"
+        outputs[1] = json.dumps({"html_url": B, "body": other})
+    if reverse:
+        commands.reverse()
+        outputs.reverse()
+    refs, created = extract_prs(
+        "Bash",
+        {"command": "; ".join(commands)},
+        {"stdout": "Preparing PRs\n" + "\n".join(outputs) + "\nShell cwd was reset"},
+    )
+    assert {ref.url for ref in refs} == {A, B}
+    assert created
 
 
 @pytest.mark.parametrize("envelope", [False, True])
@@ -711,7 +794,12 @@ def test_rest_create_with_jq_and_multiline_shell(envelope: bool) -> None:
         ("gh api /repos/example/one/pulls/42 --jq .html_url", A, [A], False),
         ("gh api /repos/example/one/pulls -X GET -f title=test --jq .html_url", A, [A], False),
         ("gh api /repos/example/one/pulls --jq '.[].html_url'", A + "\n" + B, [A, B], False),
-        ("gh api /repos/example/one/pulls/99 -X PATCH --jq .html_url", A, [A], False),
+        (
+            "gh api /repos/example/one/pulls/99 -X PATCH --jq .body",
+            A,
+            [A.replace("/42", "/99")],
+            False,
+        ),
         (
             "gh api --input /repos/example/one/pulls -X POST "
             "/repos/example/one/issues --jq .html_url",


### PR DESCRIPTION
## Related issue

Closes #6947

## Summary

Session PR tracking drops successful GitHub operations when setup commands or mixed PR/API operations share a shell call. For example, `gh auth switch ...; gh pr create ...` missed both PRs in the reported session, and combining an API read with PR creation dropped both results.

Inspect parsed `gh pr` and `gh api` clauses independently of unrelated setup commands. Track PRs read, created, edited, or commented on using explicit command targets and structured `html_url`/`url` fields. Decode JSON responses interleaved with logs or other results so mixed calls retain their identities without scanning JSON bodies.

For a single operation with an identified PR, use that identity without scraping rendered text. Standalone diffs and direct body-only projections do not supply additional identities. Remaining shell output contributes only complete canonical PR URL lines, including multiple result URLs. This keeps links embedded in descriptions, prose, and changed diff lines from becoming session associations.

The panel records PRs the session interacted with. Mixed operations are marked `worked_on`; `created` applies when every detected PR/API clause creates a PR. Repeated observations remain idempotent, creation labels survive later interactions, and explicit unlinking prevents automatic reattachment.

```text
Successful gh pr/api call → command targets + structured URLs + URL result lines → session PRs
```

The browser fixture also recovers the shared runner before binding its session, using the existing recovery helper. This lets it run after tests that intentionally stop the runner; any replacement runner is cleaned up at teardown.

## Test Plan

- Before the fixture recovery update, 226 tests passed: `.venv/bin/python -m pytest tests/runner/test_session_prs.py tests/runner/test_session_pr_resources.py tests/e2e/test_session_pr_tracking_e2e.py tests/e2e_ui/github/test_pr_tracking_after_gh_auth_switch.py -q --tb=short`.
- Replayed both reported tool completions: PRs #6945 and #6946 are detected as created using either structured responses or transcript result envelopes.
- Regression tests cover arbitrary setup commands, heredoc bodies, REST comments, PR reads, multiple URLs, mixed operations in either order, and failed/background/interrupted calls.
- Added coverage for description links, standalone diffs, body projections, complete URL lines, and mixed JSON/text results whose JSON bodies reference unrelated PRs.
- Native Claude/Codex hook subprocess tests cover authenticated relay delivery, replay deduplication, preserved creation labels, description-link exclusion, unlinking followed by replay and a new interaction, and host reads after the relay closes.
- Browser tests verify that creation with account switching, with and without an intervening push, appears in the PR selector and composer. These use a real server/runner, a mock LLM, and an offline GitHub CLI fixture.
- Reproduced the CI setup failure with the disposable runner offline: session binding returned HTTP 400 (`runner is not registered`). After fixture recovery, all 3 browser scenarios passed with the runner stopped before each case, and all 3 passed in a normal run: `.venv/bin/python -m pytest tests/e2e_ui/github/test_pr_tracking_after_gh_auth_switch.py --ui-skip-build -q --tb=short`.
- Pre-commit passed, including formatting, lint, and Python type checking for the detection changes. Formatting and lint passed again for the test-only fixture update.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — backend detection change; reproduction and validation are in Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Fixtures use synthetic repositories and accounts. Native hook tests execute real hook subprocesses against an authenticated relay with a stubbed GitHub CLI; live vendor agents are not launched.

Bare links in unstructured output can still be ambiguous, especially when commands share stdout. A bare PR URL printed by a body can be indistinguishable from a PR result; this remains best effort without per-command output capture. Existing exclusion of `||` conditionals remains unchanged.

For manual verification, run `omnidev` from this branch and start a fresh session. Choose a PR whose description links another PR, then ask the agent to run `gh pr view <number> -R <owner>/<repo> --comments` and `gh pr diff <number> -R <owner>/<repo>`. Only the selected PR should appear. Next run `gh auth status; gh api repos/<other-owner>/<other-repo>/pulls/<number> --jq .html_url`; that PR should also appear. Unlink it and repeat the API read; it should stay hidden.

## Changelog

Sessions now track PR reads and writes across compound GitHub CLI commands while avoiding incidental links in descriptions and diffs.
