### PR TITLE
fix(codex-native): keep working indicator across server restart

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2858,8 +2858,14 @@ def create_app(
             return
         runner_session_initializer.invalidate_runner(runner_id)
         # Graceful disconnect: clear the persisted liveness stamp so other
-        # replicas flip offline immediately rather than after the TTL.
-        session_live_state.clear_runner_liveness(runner_id)
+        # replicas flip offline immediately rather than after the TTL. Skip
+        # this when the loss is our own shutdown: the runner survives and
+        # re-adopts on the replacement server, but a NULLed stamp makes that
+        # server read its still-running sessions as orphaned and settle them
+        # to idle before the tunnel reconnects. Leaving the stamp fresh keeps
+        # the runner within the liveness TTL across the restart.
+        if not shutdown_state.server_shutting_down():
+            session_live_state.clear_runner_liveness(runner_id)
 
         # Replace any pending timer so a rapid drop-reconnect-drop gives
         # each outage a full grace window.

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -1278,7 +1278,16 @@ def register_core_routes(
         # here and never reaches the probe. Only stamp-stale candidates fall
         # through to liveness_lookup, which additionally rules out a runner
         # whose tunnel is live on THIS replica before we settle.
-        if liveness_lookup is not None:
+        # Hold the reaper off right after this process started: a server
+        # recycle keeps its runners, which re-register within seconds. A poll
+        # landing before a runner's tunnel is back would otherwise read its
+        # still-running session as orphaned (no live tunnel here, and its
+        # runner_last_seen was NULLed on the old process's shutdown or not yet
+        # re-stamped) and settle it to idle — the turn then reads idle even
+        # after the runner reconnects. See shutdown_state.server_recently_started.
+        from omnigent.server import shutdown_state
+
+        if liveness_lookup is not None and not shutdown_state.server_recently_started():
             orphan_suspects = [
                 conv
                 for conv in page.data

--- a/omnigent/server/shutdown_state.py
+++ b/omnigent/server/shutdown_state.py
@@ -37,6 +37,18 @@ import time
 # the only peer that sends it.
 SERVER_INITIATED_CLOSE_CODES: frozenset[int] = frozenset({1012})
 
+# How long after process start a runner that has not yet reconnected its
+# tunnel counts as "still reconnecting" rather than orphaned. A server
+# recycle (rolling deploy, App restart) leaves its runners intact; they
+# re-register within seconds, but a session-list poll landing in that gap
+# would otherwise read a still-running session as orphaned and settle it to
+# idle before the tunnel is back. Comfortably covers a reconnect while
+# staying well under the runner liveness TTL. Symmetric with
+# :data:`SHUTDOWN_WINDOW_S`.
+STARTUP_WINDOW_S: float = 30.0
+
+_process_started_at: float = time.monotonic()
+
 # How long a mark counts as "still shutting down". Platform termination
 # graces are far shorter (Databricks Apps: 15s; Kubernetes default: 30s),
 # and the reconciliation deadlines this suppresses fire ~10s after the drop.
@@ -82,9 +94,27 @@ def server_shutting_down(now: float | None = None) -> bool:
     return current - _marked_at < SHUTDOWN_WINDOW_S
 
 
+def server_recently_started(now: float | None = None) -> bool:
+    """
+    Return whether this process started within :data:`STARTUP_WINDOW_S`.
+
+    Used to hold off the orphaned-``running`` reaper right after start: a
+    server recycle keeps its runners, which re-register within seconds, so a
+    running session whose runner has not reconnected *yet* is presumed
+    reconnecting rather than dead during this window.
+
+    :param now: Monotonic clock reading to measure against; defaults to
+        :func:`time.monotonic`.
+    :returns: ``True`` while still inside the startup window.
+    """
+    current = time.monotonic() if now is None else now
+    return current - _process_started_at < STARTUP_WINDOW_S
+
+
 def reset_for_tests() -> None:
     """
-    Clear the shutdown mark (test isolation).
+    Clear the shutdown mark and reset the startup clock (test isolation).
     """
-    global _marked_at
+    global _marked_at, _process_started_at
     _marked_at = None
+    _process_started_at = time.monotonic()

--- a/tests/server/routes/test_orphaned_running_session_reconcile.py
+++ b/tests/server/routes/test_orphaned_running_session_reconcile.py
@@ -122,9 +122,15 @@ def test_reconcile_is_conditional_and_marks_scheduled_run_incomplete(
 async def test_list_reconciles_orphaned_running_session(
     client: httpx.AsyncClient,
     db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A persisted-running session whose runner is confirmed gone reads
     "idle" in the list, not a phantom "running"."""
+    # Exercise the steady-state reaper, past the post-start grace that holds
+    # it off while recycled runners reconnect.
+    from omnigent.server import shutdown_state
+
+    monkeypatch.setattr(shutdown_state, "server_recently_started", lambda now=None: False)
     session_id = _seed_running_session(db_uri, runner_fresh=False)
 
     resp = await client.get("/v1/sessions")
@@ -136,10 +142,16 @@ async def test_list_reconciles_orphaned_running_session(
 async def test_list_leaves_running_session_with_fresh_runner(
     client: httpx.AsyncClient,
     db_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A running session whose runner is fresh (alive on another replica
     within the grace window) is left running — the reconciliation must not
     fire while the runner could still be executing the turn."""
+    # Past the post-start grace, so this isolates the fresh-runner guard
+    # rather than passing only because the reaper is held off after start.
+    from omnigent.server import shutdown_state
+
+    monkeypatch.setattr(shutdown_state, "server_recently_started", lambda now=None: False)
     session_id = _seed_running_session(db_uri, runner_fresh=True)
 
     resp = await client.get("/v1/sessions")

--- a/tests/server/test_shutdown_state.py
+++ b/tests/server/test_shutdown_state.py
@@ -37,3 +37,10 @@ def test_only_a_server_initiated_close_code_marks_shutdown(
 ) -> None:
     assert shutdown_state.note_tunnel_close_code(code) is expected
     assert shutdown_state.server_shutting_down() is expected
+
+
+def test_freshly_started_process_is_within_the_startup_window_then_leaves_it() -> None:
+    # reset_for_tests() stamps the start clock to now, so we are inside it.
+    assert shutdown_state.server_recently_started() is True
+    past = time.monotonic() + shutdown_state.STARTUP_WINDOW_S
+    assert shutdown_state.server_recently_started(now=past) is False


### PR DESCRIPTION
## Related issue

<!-- Bug fix; no tracking issue. -->

## Summary

- A native Codex session that reads **Working** while a tool call runs (e.g. a long `exec_command`) flipped to **idle** when the Omnigent server restarted under it (App recycle / rolling deploy) — even though the runner, Codex app-server, and its long-running shell all survive. The chat then showed the turn as finished mid-work.
- **Root cause:** the orphaned-`running` reaper in the session-list endpoint settled the still-running row to idle during the restart window. On the old process's shutdown the runner tunnel closes and `_on_runner_disconnect` NULLs `runner_last_seen`; the replacement server then sees a running session whose runner has no live tunnel and no fresh heartbeat, mistakes it for an orphan, and settles it — *before* the runner's tunnel reconnects. Status is derived from the persisted `live_status` (the in-memory cache is empty after a recycle), so the reaped `idle` sticks; the runner's own active-turn probe also reports idle because the Responses-API sub-request that dispatched the tool call has already completed while Codex runs the shell locally.
- **Fix (two guards, symmetric with the existing shutdown-aware relay path):**
  1. Don't clear runner liveness when the disconnect is our own shutdown — the runner survives and re-adopts on the replacement server, so leaving the stamp fresh keeps it within the liveness TTL across the restart.
  2. Hold the reaper off during a short post-start window (`server_recently_started`, 30s) — a recycled server's runners re-register within seconds, so a running session whose tunnel isn't back yet is presumed reconnecting, not dead. The lazy-on-read backstop still fires once the window passes.

### ELI5

When the server restarts, the still-alive worker takes a few seconds to knock on the door again. The bouncer used to declare "nobody's working here" during those seconds and stop the spinner. Now the bouncer waits a moment for known workers to knock back before declaring anyone gone, and a server going down no longer erases its workers' "I'm alive" stamp.

## Test Plan

- Reproduced the flake locally by looping `tests/e2e_ui/chat/test_codex_working_indicator_restart.py` (built the codex-parity sidecar, real `codex` app-server): failed ~1 in 5 with `AssertionError: assert 'idle' == 'running'`.
- Instrumented the DB `live_status` and the reaper to confirm the exact path: DB was `2` (running) before restart and `1` (idle) after, written by `settle_orphaned_live_status` via the list-endpoint reaper.
- After the fix, looped the same test **30×**: 29 pass, **0** recurrences of the `idle == running` status assertion. The single failure was an unrelated `view-mode-toggle` page-load flake at test start (`test_message_render_parity.py:78`), not this bug.
- `uv run --group lint pre-commit run --files <changed>` — ruff, pyrefly, and repo hooks pass.
- Unit tests: `uv run pytest tests/server/test_shutdown_state.py tests/server/routes/test_orphaned_running_session_reconcile.py` — 13 pass.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

`test_codex_working_indicator_survives_server_restart` is the existing E2E that exercises this path (verified de-flaked by the 30× loop). Added a unit test for `server_recently_started` and updated the orphan-reconcile list tests to exercise the steady-state reaper past the new post-start grace so they still assert the settle/leave-running behavior.

## Changelog

Native Codex sessions keep the Working indicator across an Omnigent server restart instead of showing a mid-work turn as finished.

This pull request and its description were written by Isaac.
