### PR TITLE
fix(server): preserve running status across server restarts

### DIFF
--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2107,9 +2107,9 @@ def create_app(
             if tunnel_registry.get(conn.runner_id) is not None:
                 return True
             # Another replica may hold the tunnel: it stamps
-            # ``runner_last_seen`` on connect + a periodic sweep, and
-            # clears it on graceful disconnect; an ungraceful death goes
-            # stale and self-corrects after the TTL.
+            # ``runner_last_seen`` on connect + a periodic sweep. Genuine
+            # runner disconnects clear it; crashes and server recycles rely
+            # on the TTL so a replacement can adopt a reconnecting runner.
             return runner_seen_is_fresh(conn.runner_last_seen, now=liveness_now)
 
         # Resolve host liveness for every bound host in one query, so

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2833,8 +2833,10 @@ def create_app(
         (``RUNNER_DISCONNECT_GRACE_S``): transient drops re-register
         well inside it and the timer's live-tunnel re-check turns them
         into no-ops, so routine recycles never flap sessions to failed.
-        Runner invalidation and liveness clearing stay immediate so
-        reconnect re-initialization still happens.
+        Runner invalidation stays immediate so reconnect re-initialization
+        still happens. Liveness clearing is skipped when this server closed
+        the tunnel itself: the surviving stamp gives its replacement time to
+        adopt the runner without treating the turn as orphaned.
 
         :param runner_id: The disconnected runner's id.
         """
@@ -2857,9 +2859,16 @@ def create_app(
             )
             return
         runner_session_initializer.invalidate_runner(runner_id)
-        # Graceful disconnect: clear the persisted liveness stamp so other
-        # replicas flip offline immediately rather than after the TTL.
-        session_live_state.clear_runner_liveness(runner_id)
+        # A server recycle closes a healthy runner's tunnel. Preserve the
+        # lease so the replacement does not classify it as orphaned while it
+        # reconnects. Genuine runner disconnects still flip offline at once.
+        if shutdown_state.server_shutting_down():
+            _logger.info(
+                "Runner %s tunnel closed during server shutdown; preserving liveness lease",
+                runner_id,
+            )
+        else:
+            session_live_state.clear_runner_liveness(runner_id)
 
         # Replace any pending timer so a rapid drop-reconnect-drop gives
         # each outage a full grace window.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6971,6 +6971,9 @@ def _ensure_runner_relay(
             runner_id,
             extra={"session_id": session_id},
         )
+    # A binding created after tunnel connect misses the connect-time stamp
+    # until the next sweep. Stamp now so a restart cannot orphan it.
+    session_live_state.touch_runner_liveness([runner_id])
     ready = asyncio.Event()
     # Runtime callers always supply a store. ``None`` is retained for
     # heartbeat-only relay readiness tests that never emit persistable frames.

--- a/omnigent/server/session_live_state.py
+++ b/omnigent/server/session_live_state.py
@@ -298,11 +298,11 @@ def touch_runner_liveness(runner_ids: list[str]) -> None:
 
 def clear_runner_liveness(runner_id: str) -> None:
     """
-    Clear ``runner_last_seen`` for a gracefully-disconnected runner.
+    Clear ``runner_last_seen`` for a genuine runner disconnect.
 
     Flips the sidebar offline immediately instead of waiting out the
-    freshness TTL. An ungraceful death (host / replica crash) never
-    reaches this — the TTL self-corrects it.
+    freshness TTL. Server shutdowns preserve the lease so a replacement
+    can adopt the runner; crashes rely on the TTL to self-correct.
 
     :param runner_id: The disconnected runner's id.
     """

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1303,9 +1303,9 @@ class ConversationStore(ABC):
         """
         Clear ``runner_last_seen`` for every session bound to a runner.
 
-        Called on a graceful tunnel disconnect so the sidebar flips
-        offline immediately instead of waiting out
-        :data:`RUNNER_LIVENESS_TTL_S`. Must NOT bump ``updated_at``.
+        Called on a genuine runner disconnect so the sidebar flips offline
+        immediately instead of waiting out :data:`RUNNER_LIVENESS_TTL_S`.
+        Server shutdowns preserve the lease. Must NOT bump ``updated_at``.
 
         :param runner_id: The disconnected runner's id.
         """

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -1649,6 +1649,44 @@ async def test_server_initiated_close_never_fails_the_turn(
         sessions_module._session_status_cache.pop(session_id, None)
 
 
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_isolated_session_status_cache")
+async def test_binding_to_connected_runner_stamps_liveness(
+    tunnel_three_layer_stack: _TunnelStack,
+) -> None:
+    """A session riding an existing tunnel gets a liveness lease immediately."""
+    from omnigent.runtime import get_conversation_store
+    from omnigent.server import session_live_state
+
+    ap_client = tunnel_three_layer_stack.ap_client
+    create_resp = await ap_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _build_harness_agent_bundle(),
+                "application/gzip",
+            ),
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    session_id = create_resp.json()["session_id"]
+    store = get_conversation_store()
+    assert store.get_session_connectivity([session_id])[session_id].runner_last_seen is None
+
+    patch_resp = await ap_client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"runner_id": _RUNNER_ID},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+
+    writes_drained = threading.Event()
+    session_live_state.submit("test_barrier", writes_drained.set)
+    assert await asyncio.to_thread(writes_drained.wait, 10.0)
+    assert store.get_session_connectivity([session_id])[session_id].runner_last_seen is not None
+
+
 # TODO: factor ``FakeProcessManager`` and ``_build_harness_agent_bundle``
 # out of ``test_sessions_three_layer.py`` + this file into a shared
 # ``_three_layer_helpers.py`` module once a third caller arrives. Kept

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -37,6 +37,8 @@ import contextlib
 import io
 import json
 import tarfile
+import threading
+import time
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -1574,12 +1576,13 @@ async def test_server_initiated_close_never_fails_the_turn(
 
     A deploy shuts the server down: uvicorn closes every runner tunnel with
     close code 1012 and stops listening, so no runner can re-register inside
-    the grace even though all of them are alive. The grace timer must read
-    that close as the server's own shutdown and skip the offline-marking —
-    no ``failed`` status, no ``runner_disconnected`` labels.
+    the grace even though all of them are alive. The disconnect path must
+    preserve both the turn and the runner's durable liveness lease. Otherwise
+    a cold replacement server can mistake the reconnecting turn for an orphan
+    and persist ``idle`` before the runner arrives.
     """
     from omnigent.runtime import get_conversation_store
-    from omnigent.server import shutdown_state
+    from omnigent.server import session_live_state, shutdown_state
     from omnigent.server.routes import sessions as sessions_module
 
     ap_client = tunnel_three_layer_stack.ap_client
@@ -1605,6 +1608,8 @@ async def test_server_initiated_close_never_fails_the_turn(
     runner_id = "runner-server-close"
     store = get_conversation_store()
     store.replace_runner_id(session_id, runner_id)
+    store.set_session_live_status(session_id, "running")
+    store.touch_runner_liveness([runner_id], int(time.time()))
 
     communicator = await _connect_runner_tunnel(ap_app, runner_id)
     await _send_hello_and_wait(communicator, ap_app, runner_id, harnesses=[_TEST_HARNESS_NAME])
@@ -1620,6 +1625,25 @@ async def test_server_initiated_close_never_fails_the_turn(
         conv = store.get_conversation(session_id)
         assert conv is not None
         assert sessions_module._last_task_error_from_labels(conv.labels) is None
+
+        # Drain live-state writes queued by the disconnect hook before reading
+        # the row. This makes the lease assertion deterministic on loaded CI.
+        writes_drained = threading.Event()
+        session_live_state.submit("test_barrier", writes_drained.set)
+        assert await asyncio.to_thread(writes_drained.wait, 10.0)
+
+        restarted = store.get_conversation(session_id)
+        assert restarted is not None
+        assert restarted.runner_last_seen is not None
+
+        # Model the replacement process: its relay cache starts empty and its
+        # runner tunnel may not have reconnected before the sidebar's first
+        # list request. The preserved lease must keep durable running status.
+        sessions_module._session_status_cache.pop(session_id, None)
+        listed = await ap_client.get("/v1/sessions")
+        assert listed.status_code == 200
+        item = next(item for item in listed.json()["data"] if item["id"] == session_id)
+        assert item["status"] == "running"
     finally:
         shutdown_state.reset_for_tests()
         sessions_module._session_status_cache.pop(session_id, None)


### PR DESCRIPTION
## Related issue

Follow-up to #6879 and the CI flakiness report for `test_codex_working_indicator_restart.py`.

## Summary

- Preserve a runner's durable liveness lease when the server itself closes its tunnel during shutdown.
- Stamp liveness when a session binds to an already-connected runner instead of waiting for the next 30-second sweep.
- Prevent a replacement server from reconciling an active turn to `idle` before the runner reconnects.
- Strengthen the tunnel integration test to exercise a cold replacement server's first session-list request.

ELI5: during a deploy, the old server was erasing the runner's "I am alive" timestamp as it shut down. A newly bound session could also be missing that timestamp until the next heartbeat. If the new server listed sessions before the runner reconnected, it concluded the active turn was abandoned. This writes the timestamp at bind time and preserves it through shutdown so the new server gives the runner time to reconnect.

```text
session binds to live runner --> stamp runner_last_seen
                              |
server shutdown (1012)        |
        |
        v
runner tunnel closes --> preserve runner_last_seen lease
                              |
                              v
replacement lists sessions --> fresh lease --> keep status running
                              |
                              v
                       runner reconnects
```

## Test Plan

- Ran both strengthened regression tests five consecutive times; all ten test executions passed.
- Causal controls: removing only the shutdown guard made the restart test fail because `runner_last_seen` was cleared. Before adding the bind-time stamp, the new binding test failed because `runner_last_seen` remained `None`. Each test passes with its corresponding guard.
- `.venv/bin/pytest -q tests/server/integration/test_runner_tunnel_route.py tests/server/integration/test_sessions_tunnel_three_layer.py tests/server/routes/test_orphaned_running_session_reconcile.py tests/server/test_app.py` — 106 passed.
- `.venv/bin/pre-commit run --all-files` — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression tests cover both ways the lease was lost: binding between heartbeat sweeps and a server-initiated tunnel close. They drain queued writes, clear the replacement server's in-memory status cache, and verify that the durable session remains `running`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The integration tests cover lease creation, shutdown preservation, and the resulting session-list status during the reconnect window.

## Changelog

Active chats no longer briefly become idle when the Omnigent server restarts.
