### PR TITLE
fix(server): keep runner liveness across a server recycle

### DIFF
--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -345,12 +345,15 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-ui-server-logs-${{ github.run_id }}-shard${{ matrix.shard_id }}
-          # server.log + runner.log from the live_server fixture's tmp dir,
-          # plus the native bridge dirs and the Claude / Codex transcripts
-          # staged above -- all needed to triage a native render-parity failure.
+          # server.log + runner.log from the live_server and mocked-Codex
+          # fixtures' tmp dirs, plus the native bridge dirs and the Claude /
+          # Codex transcripts staged above -- all needed to triage a native
+          # render-parity or restart failure.
           path: |
             /tmp/pytest-of-runner/**/e2e_ui_server*/server.log
             /tmp/pytest-of-runner/**/e2e_ui_server*/runner.log
+            /tmp/pytest-of-runner/**/e2e_ui_mocked_codex_server*/server.log
+            /tmp/pytest-of-runner/**/e2e_ui_mocked_codex_server*/runner.log
             /tmp/omnigent-*/claude-native/**
             /tmp/claude-home-dump/**
             /tmp/codex-home-dump/**

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -2857,9 +2857,11 @@ def create_app(
             )
             return
         runner_session_initializer.invalidate_runner(runner_id)
-        # Graceful disconnect: clear the persisted liveness stamp so other
-        # replicas flip offline immediately rather than after the TTL.
-        session_live_state.clear_runner_liveness(runner_id)
+        # Graceful disconnect: clear the persisted liveness stamp so other replicas
+        # flip offline at once. Not on our own shutdown: the runner is alive and
+        # re-tunnels to the replacement, which must not settle its turns to idle.
+        if not shutdown_state.server_shutting_down():
+            session_live_state.clear_runner_liveness(runner_id)
 
         # Replace any pending timer so a rapid drop-reconnect-drop gives
         # each outage a full grace window.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6972,9 +6972,13 @@ def _ensure_runner_relay(
             extra={"session_id": session_id},
         )
     # A session bound to an already-connected runner has no ``runner_last_seen``
-    # until the tunnel's next ping; stamp it now so a server recycle inside that
-    # window cannot read the fresh binding as an orphaned runner.
-    session_live_state.touch_runner_liveness([runner_id])
+    # until the next ping; stamp it now so a recycle in that window cannot read
+    # it as orphaned. Registered tunnels only: a mid-rebind drop must not re-stamp.
+    from omnigent.runtime import get_runner_router
+
+    runner_router = get_runner_router()
+    if runner_router is None or runner_router.runner_is_online(runner_id):
+        session_live_state.touch_runner_liveness([runner_id])
     ready = asyncio.Event()
     # Runtime callers always supply a store. ``None`` is retained for
     # heartbeat-only relay readiness tests that never emit persistable frames.

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6971,14 +6971,6 @@ def _ensure_runner_relay(
             runner_id,
             extra={"session_id": session_id},
         )
-    # A session bound to an already-connected runner has no ``runner_last_seen``
-    # until the next ping; stamp it now so a recycle in that window cannot read
-    # it as orphaned. Registered tunnels only: a mid-rebind drop must not re-stamp.
-    from omnigent.runtime import get_runner_router
-
-    runner_router = get_runner_router()
-    if runner_router is None or runner_router.runner_is_online(runner_id):
-        session_live_state.touch_runner_liveness([runner_id])
     ready = asyncio.Event()
     # Runtime callers always supply a store. ``None`` is retained for
     # heartbeat-only relay readiness tests that never emit persistable frames.
@@ -7067,6 +7059,11 @@ async def _ensure_runner_relay_ready_impl(
             "Timed out waiting for runner stream relay to subscribe",
             code=ErrorCode.RUNNER_UNAVAILABLE,
         ) from exc
+    # The runner just acknowledged this session's stream. A session bound after
+    # the tunnel connected has no ``runner_last_seen`` until the next ping; stamp
+    # it here so a server recycle in that window cannot read it as orphaned.
+    if runner_id is not None:
+        session_live_state.touch_runner_liveness([runner_id])
     return handle
 
 

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -6971,6 +6971,10 @@ def _ensure_runner_relay(
             runner_id,
             extra={"session_id": session_id},
         )
+    # A session bound to an already-connected runner has no ``runner_last_seen``
+    # until the tunnel's next ping; stamp it now so a server recycle inside that
+    # window cannot read the fresh binding as an orphaned runner.
+    session_live_state.touch_runner_liveness([runner_id])
     ready = asyncio.Event()
     # Runtime callers always supply a store. ``None`` is retained for
     # heartbeat-only relay readiness tests that never emit persistable frames.

--- a/tests/e2e/test_orphaned_running_session_stop.py
+++ b/tests/e2e/test_orphaned_running_session_stop.py
@@ -7,11 +7,13 @@ pokes, no hand-written session rows):
 1. **Orphaned "running" after a server restart.** A runner-bound session with
    an in-flight turn persists ``live_status="running"`` on its conversation
    row. When the server is shut down and a replacement server comes up on the
-   same database, the replacement has no startup reconciliation and no live
-   status cache, so it falls back to the stale persisted ``running`` value.
-   ``omnigent host status --sessions`` (which reads ``GET /v1/sessions``)
-   therefore keeps reporting the session as ``running`` even though its runner
-   is gone.
+   same database, the replacement has no live status cache, so it falls back
+   to the persisted ``running`` value. A server recycle also leaves the
+   runner's liveness lease (``runner_last_seen``) in place, because the
+   replacement cannot tell a dead runner from one still reconnecting; once
+   that lease lapses (``RUNNER_LIVENESS_TTL_S``), ``omnigent host status
+   --sessions`` (which reads ``GET /v1/sessions``) must stop reporting the
+   runner-less session as ``running``.
 
 2. **``stop-session`` falsely succeeds.** ``omnigent host stop-session`` POSTs
    a ``stop_session`` event to ``POST /v1/sessions/{id}/events``. On the
@@ -52,6 +54,7 @@ import yaml
 
 from omnigent.db.enum_codecs import SESSION_LIVE_STATUS
 from omnigent.runner.identity import token_bound_runner_id
+from omnigent.stores.conversation_store import RUNNER_LIVENESS_TTL_S
 from tests._helpers.compat import (
     apply_runner_env,
     apply_server_env,
@@ -299,6 +302,28 @@ def _persisted_live_status(db_path: Path, session_id: str) -> int | None:
     return None if row is None else row[0]
 
 
+def _expire_runner_lease(db_path: Path, runner_id: str) -> None:
+    """Age *runner_id*'s liveness lease past :data:`RUNNER_LIVENESS_TTL_S`.
+
+    A server recycle keeps the runner's ``runner_last_seen`` stamp so a
+    replacement does not mistake a reconnecting runner for a dead one. A runner
+    that never comes back is only recognised as gone once that lease lapses;
+    backdating the stamp stands in for waiting out the TTL.
+
+    :param db_path: The shared sqlite database path.
+    :param runner_id: Runner id whose sessions' lease should lapse.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "UPDATE omnigent_conversation_metadata SET runner_last_seen = ? WHERE runner_id = ?",
+            (int(time.time()) - RUNNER_LIVENESS_TTL_S - 1, runner_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _runner_online(client: httpx.Client, runner_id: str) -> bool:
     """Return whether *runner_id* has a live tunnel on the server.
 
@@ -324,8 +349,9 @@ def test_runner_less_session_remains_running_after_shutdown_and_stop(
     shut the server down, start a replacement on the same DB — then asserts the
     two post-fix expectations the CLI relies on:
 
-    * Facet 1: the replacement server must not report the runner-less session
-      as ``running`` in ``GET /v1/sessions``.
+    * Facet 1: once the dead runner's liveness lease has lapsed, the replacement
+      server must not report the runner-less session as ``running`` in
+      ``GET /v1/sessions``.
     * Facet 2: ``stop_session`` must not report success (``2xx``) while leaving
       the session ``running``.
     """
@@ -455,6 +481,9 @@ def test_runner_less_session_remains_running_after_shutdown_and_stop(
             tunnel_token=tunnel_token,
         )
         client_b = httpx.Client(base_url=base_b, timeout=30.0, trust_env=False)
+        # The runner is gone for good, but the replacement honours its liveness
+        # lease until the TTL lapses (a reconnecting runner looks identical).
+        _expire_runner_lease(db_path, runner_id)
 
         # ── 6. Observe what the CLI observes on the replacement server. ────
         item_b = _list_session(client_b, session_id)

--- a/tests/e2e/test_orphaned_running_session_stop.py
+++ b/tests/e2e/test_orphaned_running_session_stop.py
@@ -482,7 +482,13 @@ def test_runner_less_session_remains_running_after_shutdown_and_stop(
         )
         client_b = httpx.Client(base_url=base_b, timeout=30.0, trust_env=False)
         # The runner is gone for good, but the replacement honours its liveness
-        # lease until the TTL lapses (a reconnecting runner looks identical).
+        # lease until the TTL lapses (a reconnecting runner looks identical), so
+        # the shutdown must have left the lease in place and the row running.
+        item_leased = _list_session(client_b, session_id)
+        assert item_leased is not None and item_leased.get("status") == "running", (
+            "Precondition failed: the replacement settled the session before the "
+            f"runner's liveness lease lapsed (item={item_leased!r})"
+        )
         _expire_runner_lease(db_path, runner_id)
 
         # ── 6. Observe what the CLI observes on the replacement server. ────

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -1768,6 +1768,7 @@ async def test_server_initiated_close_keeps_runner_liveness_stamp(
     ap_client = tunnel_three_layer_stack.ap_client
     ap_app = tunnel_three_layer_stack.ap_app
 
+    shutdown_state.reset_for_tests()
     monkeypatch.setattr("omnigent.server.routes.sessions.RUNNER_DISCONNECT_GRACE_S", 0.4)
     _stub_connect_hook_for_pumpless_ws(ap_app, monkeypatch)
 
@@ -1823,8 +1824,8 @@ async def test_patch_rebind_stamps_runner_liveness(
     and the ping loop refreshes them every 30s. A session bound in between
     would carry no stamp until that next ping, so a server recycle inside the
     window would let the replacement replica's orphan backstop settle its
-    turn to ``idle``. Starting the relay is the moment the session begins
-    riding a live tunnel, so it stamps too.
+    turn to ``idle``. The runner acknowledging the session's relay stream is
+    the moment it provably rides a live tunnel, so that stamps too.
     """
     ap_client = tunnel_three_layer_stack.ap_client
 

--- a/tests/server/integration/test_sessions_tunnel_three_layer.py
+++ b/tests/server/integration/test_sessions_tunnel_three_layer.py
@@ -37,6 +37,7 @@ import contextlib
 import io
 import json
 import tarfile
+import threading
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -1728,3 +1729,125 @@ async def test_on_runner_disconnect_spares_idle_sessions_and_labels_interrupted_
             await communicator.wait(timeout=2.0)
         for session_id in session_ids:
             sessions_module._session_status_cache.pop(session_id, None)
+
+
+def _drain_session_live_state() -> None:
+    """Block until every live-state write queued so far has run."""
+    from omnigent.server import session_live_state
+
+    drained = threading.Event()
+    session_live_state.submit("test-drain", drained.set)
+    assert drained.wait(5.0), "session live-state worker did not drain"
+
+
+def _runner_last_seen(session_id: str) -> int | None:
+    """Read the session's persisted ``runner_last_seen`` stamp."""
+    from omnigent.runtime import get_conversation_store
+
+    connectivity = get_conversation_store().get_session_connectivity([session_id])
+    return connectivity[session_id].runner_last_seen
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_isolated_session_status_cache")
+async def test_server_initiated_close_keeps_runner_liveness_stamp(
+    tunnel_three_layer_stack: _TunnelStack,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tunnel THIS server closed (code 1012) leaves ``runner_last_seen`` intact.
+
+    A genuine drop clears the stamp so other replicas flip the runner offline
+    at once. A server closing tunnels on its own way down must not: the runner
+    is alive and re-tunnels to the replacement replica, whose orphan backstop
+    would read a cleared stamp as a dead runner and settle the runner's
+    mid-turn sessions to ``idle`` before it reconnects.
+    """
+    from omnigent.runtime import get_conversation_store
+    from omnigent.server import shutdown_state
+
+    ap_client = tunnel_three_layer_stack.ap_client
+    ap_app = tunnel_three_layer_stack.ap_app
+
+    monkeypatch.setattr("omnigent.server.routes.sessions.RUNNER_DISCONNECT_GRACE_S", 0.4)
+    _stub_connect_hook_for_pumpless_ws(ap_app, monkeypatch)
+
+    create_resp = await ap_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _build_harness_agent_bundle(),
+                "application/gzip",
+            ),
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    session_id = create_resp.json()["session_id"]
+    runner_id = "runner-server-close-stamp"
+    get_conversation_store().replace_runner_id(session_id, runner_id)
+
+    try:
+        # Baseline: a genuine drop clears the stamp the connect hook wrote.
+        communicator = await _connect_runner_tunnel(ap_app, runner_id)
+        await _send_hello_and_wait(communicator, ap_app, runner_id, harnesses=[_TEST_HARNESS_NAME])
+        _drain_session_live_state()
+        assert _runner_last_seen(session_id) is not None
+        await communicator.send_input({"type": "websocket.disconnect", "code": 1006})
+        await communicator.wait(timeout=2.0)
+        _drain_session_live_state()
+        assert _runner_last_seen(session_id) is None
+
+        # Server-initiated close: the reconnect re-stamps and the close keeps it.
+        communicator = await _connect_runner_tunnel(ap_app, runner_id)
+        await _send_hello_and_wait(communicator, ap_app, runner_id, harnesses=[_TEST_HARNESS_NAME])
+        _drain_session_live_state()
+        assert _runner_last_seen(session_id) is not None
+        await communicator.send_input({"type": "websocket.disconnect", "code": 1012})
+        await communicator.wait(timeout=2.0)
+        assert shutdown_state.server_shutting_down(), "a 1012 close did not mark server shutdown"
+        _drain_session_live_state()
+        assert _runner_last_seen(session_id) is not None
+    finally:
+        shutdown_state.reset_for_tests()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_isolated_session_status_cache")
+async def test_patch_rebind_stamps_runner_liveness(
+    tunnel_three_layer_stack: _TunnelStack,
+) -> None:
+    """Binding a session to an already-connected runner stamps ``runner_last_seen``.
+
+    The connect hook stamps only the sessions bound when the tunnel opened,
+    and the ping loop refreshes them every 30s. A session bound in between
+    would carry no stamp until that next ping, so a server recycle inside the
+    window would let the replacement replica's orphan backstop settle its
+    turn to ``idle``. Starting the relay is the moment the session begins
+    riding a live tunnel, so it stamps too.
+    """
+    ap_client = tunnel_three_layer_stack.ap_client
+
+    create_resp = await ap_client.post(
+        "/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _build_harness_agent_bundle(),
+                "application/gzip",
+            ),
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    session_id = create_resp.json()["session_id"]
+    assert _runner_last_seen(session_id) is None
+
+    patch_resp = await ap_client.patch(
+        f"/v1/sessions/{session_id}",
+        json={"runner_id": _RUNNER_ID},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+
+    _drain_session_live_state()
+    assert _runner_last_seen(session_id) is not None


### PR DESCRIPTION
## Related issue

No GitHub issue. Reported as CI flakiness of `tests/e2e_ui/chat/test_codex_working_indicator_restart.py` (added in #6669 for Linear OMNI-6717); that test is a real failure, not a flake.

## Summary

**User-visible symptom:** after a server restart (deploy, App recycle) a Codex session mid-turn lost its Working indicator and read `idle` while the runner was still executing the turn (OMNI-6717). Behavioral evidence for the fix is the two new integration tests below, both of which fail on `main`.

`test_codex_working_indicator_restart` failed in 39 of the 56 red E2E UI runs since #6669 merged, always with `assert snapshot["status"] == "running"` → `'idle'` right after the server restart. Root cause is a server bug that #6669's persisted-status fallback could not survive:

- On its own shutdown, `_on_runner_disconnect` cleared `runner_last_seen` for every session on the dropped runner. The failed-marking on that path is already guarded by `shutdown_state.server_shutting_down()`; the liveness clear was not.
- The replacement server's session-list orphan backstop treats a NULL stamp as stale. With no tunnel yet (the runner re-tunnels on a 0.5s→10s backoff) it settled the still-running row to `idle` and cached that, so the snapshot never reached the persisted `running`. The browser sidebar's `sessions/updates` reconnect issues exactly that list request, which is why the outcome was a race.
- A session bound to an already-connected runner had no stamp at all until the tunnel's next 30s ping, so short-lived sessions hit the same path even without the clear.

Changes:

- `omnigent/server/app.py`: skip `clear_runner_liveness` when the server is shutting down.
- `omnigent/server/routes/_sessions/orchestration.py`: `_ensure_runner_relay_ready` stamps `runner_last_seen` once the runner acknowledges a newly started relay stream (covers PATCH rebinds and message-driven relay starts). Stamping on the ready ack rather than at relay creation needs no router check, and the connect hook's per-session fan-out does not re-stamp (it already stamps once).
- `.github/workflows/e2e-ui.yml`: also upload the mocked-Codex fixture's `server.log`/`runner.log` on failure. The existing glob (`e2e_ui_server*`) never matched its `e2e_ui_mocked_codex_server*` temp dir, so the logs that would have explained this were never captured.

**Trade-off, called out deliberately:** a replacement server cannot tell a runner that died together with the old server from one that is mid-reconnect. Preserving the lease means a genuinely dead runner's sessions keep reading `running` until the lease lapses (`RUNNER_LIVENESS_TTL_S`, at most 90s after its last heartbeat), after which the existing lazy orphan backstop settles them exactly as before. `tests/e2e/test_orphaned_running_session_stop.py` encoded the old instant-settle expectation; it now expires the dead runner's lease (backdating `runner_last_seen`) before asserting its two facets, and its docstrings describe the lease. hzub's #6954 and the parallel #6955 hit the same test for the same reason.

**ELI5:** the runner is alive during a deploy, but the old server erased the "last seen" note on its way out, and the new server read the missing note as "runner died" and stopped the spinner. Keep the note, and write it as soon as a session joins a live runner.

```mermaid
sequenceDiagram
    participant Old as old server
    participant DB
    participant New as new server
    participant Web as browser sidebar
    participant Runner
    Old->>DB: (before) clear runner_last_seen on SIGTERM
    Web->>New: GET /v1/sessions (include_liveness)
    New->>DB: (before) stamp NULL + no tunnel → settle running→idle
    Runner->>New: tunnel reconnects (0.5–10s later)
    Web->>New: GET /v1/sessions/{id} → idle (bug)
    Note over Old,DB: (after) stamp kept on shutdown, written at bind
    Note over New,DB: (after) stamp fresh → row left running
```

## Test Plan

- New integration tests in `tests/server/integration/test_sessions_tunnel_three_layer.py` (both fail on `main`, pass here):
  - `test_server_initiated_close_keeps_runner_liveness_stamp`: a 1006 drop still clears the stamp; a 1012 (server-initiated) close keeps it.
  - `test_patch_rebind_stamps_runner_liveness`: `PATCH /v1/sessions/{id}` with `runner_id` stamps `runner_last_seen` once the relay is acknowledged.
- `tests/e2e/test_orphaned_running_session_stop.py` now also asserts the replacement still reads `running` while the dead runner's lease is honored (proving the shutdown preserved it end to end) before expiring the lease and checking both facets.
- Ran `tests/server/integration/test_sessions_tunnel_three_layer.py`, `tests/server/test_app.py`, `tests/server/integration/test_runner_tunnel_route.py`, `tests/server/routes/test_sessions_snapshot.py`, `tests/server/routes/test_ensure_runner_connected.py`, `tests/server/routes/test_orphaned_running_session_reconcile.py`, `tests/server/test_session_live_state.py`: all green.
- Process-level reproduction with a real `omnigent server` + `omnigent.runner._entry`, no Codex and no browser: bind a session, post `external_session_status: running`, SIGSTOP the runner, SIGTERM the server, start a new server, `GET /v1/sessions` before SIGCONT, then read the snapshot.

  Before (main):
  ```
  post-SIGTERM db row  : live_status=2 runner_last_seen=None
  list (pre-runner)    : status=idle
  post-restart snapshot: {'status': 'idle', 'runner_online': True}
  ```
  After (this branch):
  ```
  post-SIGTERM db row  : live_status=2 runner_last_seen=1789053562
  list (pre-runner)    : status=running
  post-restart snapshot: {'status': 'running', 'runner_online': True}
  ```
- `tests/e2e/test_orphaned_running_session_stop.py` (updated) passes locally against this branch with real server + runner subprocesses.
- `tests/e2e_ui/chat/test_codex_working_indicator_restart.py` should now pass deterministically in CI; watch the E2E UI Tests run on this PR.
- The first CI attempt's `Integration (openai-agents)` failure was cross-worker mock-LLM contamination (the `compute` round-trip test received the sibling `sys_terminal_launch` script from the shared mock at the same second); the rerun passed with no code change.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the process-level restart reproduction described in the Test Plan (real server and runner processes, deterministic ordering via SIGSTOP). The existing `tests/e2e_ui/chat/test_codex_working_indicator_restart.py` exercises the same restart with the browser open and is the end-to-end regression test for this fix.

## Changelog

A server restart no longer drops the Working indicator or marks a session idle while its runner is still mid-turn.
