### PR TITLE
fix(terminals): pin the web terminal's TERM so a pane TUI never sees "dumb"

### DIFF
--- a/omnigent/terminals/control_bridge.py
+++ b/omnigent/terminals/control_bridge.py
@@ -43,6 +43,7 @@ import base64
 import contextlib
 import json
 import logging
+import os
 import re
 import shutil
 from collections.abc import Callable
@@ -95,6 +96,13 @@ _CONTROL_READ_CHUNK: Final[int] = 256 * 1024
 # doesn't enforce a line limit, but the 64 KiB default would still bound a
 # single read; raise it so a large burst can be pulled in one wakeup.
 _CONTROL_STDOUT_BUFFER_LIMIT: Final[int] = 16 * 1024 * 1024
+
+# Terminal type declared for the control-mode attach client. The real renderer
+# is the browser's xterm.js, an xterm-256color-class emulator, so this is
+# accurate rather than a guess. tmux exposes it as ``#{client_termname}``, and a
+# pane TUI (e.g. Codex) trusts that over its own $TERM; without pinning it the
+# client inherits the runner's TERM, which can be a non-interactive ``dumb``.
+_WEB_TERMINAL_TERM: Final[str] = "xterm-256color"
 
 # When the control reader ends with a send backlog still queued (a
 # burst-then-exit program), how long to let the forwarder finish draining that
@@ -551,6 +559,10 @@ async def bridge_tmux_control_to_websocket(
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            # Pin the client's TERM so a leaked ``dumb`` from the runner env
+            # can't reach a pane TUI via ``#{client_termname}`` (see
+            # _WEB_TERMINAL_TERM).
+            env={**os.environ, "TERM": _WEB_TERMINAL_TERM},
             # Raise the stdout StreamReader buffer above the 64 KiB default so a
             # single ``read`` can pull a whole output burst (see
             # _CONTROL_STDOUT_BUFFER_LIMIT).

--- a/tests/terminals/test_control_bridge.py
+++ b/tests/terminals/test_control_bridge.py
@@ -846,3 +846,53 @@ async def test_control_bridge_read_only_drops_input() -> None:
     assert ws.sent_text == []
 
     await _kill_and_join(sock, task)
+
+
+@pytest.mark.skipif(not _HAS_TMUX, reason="tmux not installed")
+@pytest.mark.asyncio
+async def test_control_attach_pins_client_term_over_inherited_dumb(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The control client reports a real TERM even when the runner env is ``dumb``.
+
+    A pane TUI (e.g. Codex) reads the attached client's ``#{client_termname}``
+    over its own $TERM and refuses to start when it sees ``dumb``. A runner
+    launched non-interactively can inherit ``TERM=dumb``, so the bridge must pin
+    a real terminal type on the attach regardless of the inherited value.
+    """
+    tmux = shutil.which("tmux")
+    assert tmux
+    # Simulate a runner whose environment carries a non-interactive ``dumb``.
+    monkeypatch.setenv("TERM", "dumb")
+
+    sock, target = await _new_private_tmux("sleep 30")
+    ws = _FakeWebSocket(inbound=[])
+    task = asyncio.create_task(
+        bridge_tmux_control_to_websocket(
+            ws, socket_path=str(sock), tmux_target=target, read_only=False
+        )
+    )
+    try:
+        termname = ""
+        for _ in range(50):
+            proc = await asyncio.create_subprocess_exec(
+                tmux,
+                "-S",
+                str(sock),
+                "list-clients",
+                "-F",
+                "#{client_termname}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            out, _ = await proc.communicate()
+            termname = out.decode().strip()
+            if termname:
+                break
+            await asyncio.sleep(0.1)
+        assert termname == "xterm-256color", (
+            f"attached control client reported TERM {termname!r}; a leaked "
+            "'dumb' makes a pane TUI (Codex) refuse to start"
+        )
+    finally:
+        await _kill_and_join(sock, task)


### PR DESCRIPTION
## Related issue

No tracked issue — found while root-causing the recurring "Codex terminal crashing" reports (most recently Sid; earlier Samraj and Kasey hit the same `Codex native thread never started` timeout) from the Omnigent debug logs. Happy to file a tracking issue if preferred.

Closes #

## Summary

- Web-driven Codex sessions intermittently sat for ~30s, failed with `Codex native thread never started (startup timed out)`, and the terminal then vanished — experienced as the terminal "crashing".
- Root cause: the browser↔tmux control-mode client (`tmux -C attach` in `control_bridge.py`) was spawned inheriting the runner's environment. A runner launched non-interactively can carry `TERM=dumb`; tmux exposes that as the attached client's `#{client_termname}`. A pane TUI like Codex trusts the attached client's termname over its own `$TERM` (it does this whenever `TERM_PROGRAM=tmux`, which tmux sets), so it printed `WARNING: TERM is set to "dumb" … Continue anyway? [y/N]` and blocked on a keypress a web session cannot send. No thread was created, `wait_for_thread_started` timed out after 30s, and the abandoned TUI's tmux server was later reaped.
- It was intermittent because Codex probes the terminal once at startup: the failure only happened when the browser was attached at the instant Codex booted (which is most of the time when you open a session and watch it).
- Fix: pin the control client's `TERM` to `xterm-256color`. The real renderer is the browser's xterm.js (an xterm-256color-class emulator), so this is accurate rather than a guess, and no inherited `dumb` can reach the pane. This matches the `TERM` the sandbox terminal launchers already hardcode.

ELI5: Codex asks tmux "what kind of screen is watching me?" The watcher is the browser, but we never told tmux what it was, so tmux handed back a junk label ("dumb") the machine happened to have. Codex saw "dumb", stopped to ask "are you sure?", and nobody could answer. Now we hand tmux the right label.

```
runner env TERM=dumb
  └─ tmux -C attach (no env override)  ──►  #{client_termname} = "dumb"
       └─ Codex in the pane reads the client termname (TERM_PROGRAM=tmux)
            └─ "TERM is set to dumb… Continue anyway?" ──► blocks ──► 30s timeout ──► terminal reaped

after: tmux -C attach with TERM=xterm-256color ──► client_termname = "xterm-256color" ──► Codex starts normally
```

## Test Plan

- New regression test `test_control_attach_pins_client_term_over_inherited_dumb` drives the real control bridge against a private tmux with `TERM=dumb` in the environment and asserts the attached client reports `xterm-256color`. Verified it **fails without the fix** (reports `dumb`, matching the incident) and **passes with it**.
- Full suite green: `tests/terminals/test_control_bridge.py` — 21 passed, 1 skipped.

```
.venv/bin/python -m pytest tests/terminals/test_control_bridge.py -q
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification reproduced the tmux signal Codex actually reads: a `tmux -C attach` client spawned with `TERM=dumb` reports `#{client_termname}=dumb`, unset reports `unknown`, and `xterm-256color` reports `xterm-256color`; Codex maps `dumb` to the "Continue anyway?" gate. The new unit test asserts that exact client-termname value before/after the change (fails without the fix), which is the decisive link between the change and the user-visible hang. A full browser+Codex end-to-end repro additionally requires a runner launched with `TERM=dumb`.

## Changelog

Fix intermittent Codex web-terminal hangs caused by a `dumb` TERM leaking to the embedded terminal.
