### PR TITLE
Refresh host daemon when telemetry config changes

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3016,9 +3016,9 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
     but whose server tunnel is down (server restart, ungraceful death,
     flapping tunnel) is a zombie — the host reads ``offline`` and the
     caller would poll until timeout. And a daemon spawned under a
-    different server config (e.g. the user flipped
-    ``OMNIGENT_AUTH_ENABLED``) would silently keep its old auth
-    mode. In both cases we tear the unit down here and return
+    different process-start config (e.g. the user flipped
+    ``OMNIGENT_AUTH_ENABLED`` or enabled telemetry) would silently keep its
+    old environment. In both cases we tear the unit down here and return
     ``reuse=False`` so the caller spawns a fresh one — flagging
     ``config_changed`` for the auth-drift case so the caller can ask the
     user to re-run against the freshly-restarted server.
@@ -3044,26 +3044,27 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
         _terminate_host_unit(existing, reason="host identity changed")
         return _DaemonReuseDecision(reuse=False, config_changed=False)
 
-    if target != _LOCAL_DAEMON_MARKER:
-        # Remote / explicit ``--server`` mode: the daemon connects to a server
-        # we don't own and can't restart, so the config-signature / heal /
-        # "re-run" semantics below don't apply (auth posture is the remote's
-        # concern; its own reconnect loop covers transient tunnel drops). Keep
-        # the original PID-liveness reuse so a live daemon for the URL is
-        # reused as-is.
-        return _DaemonReuseDecision(reuse=True, config_changed=False)
-
     if not background:
         # Foreground host / legacy host.pid: keep prior behavior — a
         # live PID is reused as-is (don't kill the user's interactive
         # process or guess at an unstamped config).
         return _DaemonReuseDecision(reuse=True, config_changed=False)
 
-    # Config drift → the running server has the wrong auth source.
-    desired_sig = server_config_signature()
+    server_url = None if target == _LOCAL_DAEMON_MARKER else target
+    desired_sig = _host_daemon_config_signature(server_url=server_url)
     if existing.config_sig is not None and existing.config_sig != desired_sig:
-        _terminate_host_unit(existing, reason="config changed (auth)")
-        return _DaemonReuseDecision(reuse=False, config_changed=True)
+        _terminate_host_unit(existing, reason="host daemon config changed")
+        return _DaemonReuseDecision(
+            reuse=False,
+            config_changed=target == _LOCAL_DAEMON_MARKER,
+        )
+
+    if target != _LOCAL_DAEMON_MARKER:
+        # Remote / explicit ``--server`` mode: the daemon connects to a server
+        # we don't own and can't restart, so tunnel healing and local-server
+        # "re-run" semantics below don't apply. Its process-start signature was
+        # checked above; its reconnect loop covers transient tunnel drops.
+        return _DaemonReuseDecision(reuse=True, config_changed=False)
 
     # Tunnel health → don't reuse a zombie. Skip very young daemons (a
     # concurrent invocation may have just spawned one still connecting). This
@@ -3375,7 +3376,7 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
     _HOST_PID_PATH.parent.mkdir(parents=True, exist_ok=True)
     mode_args = ["--local"] if not server_url else ["--server", server_url]
     args = [sys.executable, "-m", "omnigent.host._daemon_entry", *mode_args]
-    config_sig = server_config_signature(include_features=not server_url)
+    config_sig = _host_daemon_config_signature(server_url=server_url)
     daemon_env = _build_host_daemon_env(server_url=server_url)
     daemon_env[DAEMON_CONFIG_SIG_ENV_VAR] = config_sig
     spawned = _spawn_host_daemon_process(args=args, env=daemon_env)
@@ -3393,6 +3394,29 @@ def _ensure_host_daemon(server_url: str | None) -> bool:
             spawned.log_path,
         )
     return decision.config_changed
+
+
+def _host_daemon_config_signature(*, server_url: str | None) -> str:
+    """Sign process-start configuration that must match a reused daemon."""
+    import hashlib
+
+    server_sig = server_config_signature(include_features=not server_url)
+    daemon_env = _build_host_daemon_env(server_url=server_url)
+    telemetry_env = {
+        key: value
+        for key, value in daemon_env.items()
+        if key == "OMNIGENT_TELEMETRY_ENABLED" or key.startswith(("OMNIGENT_OTEL_", "OTEL_"))
+    }
+    if not telemetry_env:
+        return server_sig
+    payload = json.dumps(
+        {
+            "runtime": telemetry_env,
+            "server": server_sig,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 def _build_host_daemon_env(

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -539,6 +539,40 @@ def test_ensure_host_daemon_respawns_on_config_drift(
     assert "args" in captured  # fresh daemon spawned
 
 
+def test_ensure_remote_host_daemon_respawns_when_telemetry_is_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A reused remote daemon must inherit newly enabled telemetry settings."""
+    captured: dict[str, object] = {}
+    _patch_daemon_spawn(monkeypatch, tmp_path, captured)
+    target = "https://server.example.com"
+    _write_daemon_registry_record(
+        tmp_path,
+        pid=4242,
+        target=target,
+        mode="server",
+        server_url=target,
+        log_path=str(tmp_path / "daemon.log"),
+        started_at=1_000_000,
+        config_sig=cli.server_config_signature(include_features=False),
+    )
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: True)
+    monkeypatch.setenv("OMNIGENT_TELEMETRY_ENABLED", "true")
+    monkeypatch.setenv("OTEL_PYTHON_METER_PROVIDER", "custom-provider")
+    torn_down: list[str] = []
+    monkeypatch.setattr(
+        cli, "_terminate_host_unit", lambda record, *, reason: torn_down.append(reason)
+    )
+
+    _ensure_host_daemon(target)
+
+    assert torn_down == ["host daemon config changed"]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["OMNIGENT_TELEMETRY_ENABLED"] == "true"
+    assert env["OTEL_PYTHON_METER_PROVIDER"] == "custom-provider"
+
+
 def test_ensure_host_daemon_heals_offline_tunnel(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Related issue

N/A — discovered while validating a downstream distribution's telemetry opt-in.

## Summary

Remote host daemons are long-lived and were reused solely by liveness. If a later CLI invocation enabled or changed telemetry, the existing daemon and every runner it spawned retained the old environment.

This change includes inherited `OTEL_*`, `OMNIGENT_OTEL_*`, and `OMNIGENT_TELEMETRY_ENABLED` values in the daemon's process-start signature. Background daemons are transparently replaced when those values change; foreground and legacy daemons remain untouched.

ELI5: when telemetry settings change, restart the background helper so it actually receives them.

```
CLI telemetry config changes
          |
          v
daemon signature differs
          |
          v
replace daemon -> new runners inherit config
```

## Test Plan

- `uv run pytest tests/cli/test_backend.py -q -k 'ensure_host_daemon or remote_host_daemon or build_host_daemon_env'` (20 passed)
- `uv run pre-commit run --files omnigent/cli.py tests/cli/test_backend.py` (formatting, lint, and type checks passed)
- Broader daemon lifecycle selection: 167 passed; one unrelated existing Databricks credential-profile test failed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

A regression test starts with a remote daemon stamped before telemetry was enabled, enables the master switch and custom meter provider, and verifies that the old daemon is replaced and the new process receives both variables.

## Changelog

Background remote hosts now refresh automatically when telemetry configuration changes.