### PR TITLE
fix(claude-native): keep permission approvals answerable across the 5-minute request cap and idle reaper

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -45,7 +45,7 @@ import tempfile
 import threading
 import time
 import urllib.parse
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterator, Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from http import HTTPStatus
@@ -117,10 +117,13 @@ _BRIDGE_ROOT = _BRIDGE_ROOT_PARENT / "claude-native"
 # it (see ``native_bridge_common.prune_orphaned_dirs``).
 _APPROVAL_WAIT_DIR_NAME = "approval-waits"
 _APPROVAL_WAIT_ROOT = _BRIDGE_ROOT / _APPROVAL_WAIT_DIR_NAME
+# A parked hook re-touches its marker this often for as long as its POST is
+# held, so the marker stays fresh whether or not a gateway ever severs the poll
+# (a direct server holds one POST for the whole wait).
+APPROVAL_WAIT_MARKER_REFRESH_S = 60.0
 # A marker touched more recently than this means a hook is still waiting.
-# Above one full long-poll (the Databricks front door caps a request at 300s)
-# plus a retry backoff, so a marker refreshed once per POST attempt never
-# reads stale while the hook is alive.
+# Several refresh intervals of slack, so a hook that is slow to wake never
+# reads stale; a hook killed mid-wait leaves a marker that expires on its own.
 APPROVAL_WAIT_MARKER_TTL_S = 420.0
 _CONFIG_FILE = "bridge.json"
 _SERVER_FILE = "server.json"
@@ -1207,9 +1210,23 @@ def bridge_dir_for_conversation_id(conversation_id: str) -> Path:
     return bridge_dir_for_bridge_id(conversation_id)
 
 
+def _approval_wait_digest(session_id: str) -> str:
+    """
+    Return the filename stem shared by every marker for one session.
+
+    :param session_id: Omnigent session id, e.g. ``"conv_abc123"``.
+    :returns: Hex digest prefix, e.g. ``"3f0e..."`` (32 chars).
+    """
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
+
+
 def approval_wait_marker_path(session_id: str, *, bridge_dir: Path | None = None) -> Path:
     """
     Return the marker path a parked permission hook keeps fresh.
+
+    One marker per hook process: concurrent prompts on one session (a
+    permission request and an AskUserQuestion, or parallel tool calls) each
+    own a file, so the first to finish never clears another's evidence.
 
     :param session_id: Omnigent session id whose verdict a hook is waiting
         on, e.g. ``"conv_abc123"``.
@@ -1221,22 +1238,23 @@ def approval_wait_marker_path(session_id: str, *, bridge_dir: Path | None = None
         computed root could — and a marker written where the reaper never looks
         would fail silently. ``None`` uses this process's own root, which is
         the runner side including the pane reaper.
-    :returns: Absolute marker path under ``<temp root>/approval-waits``.
+    :returns: Absolute marker path under ``<temp root>/approval-waits``, e.g.
+        ``.../approval-waits/<digest>.<pid>.wait``.
     """
     root = (
         bridge_dir.parent / _APPROVAL_WAIT_DIR_NAME
         if bridge_dir is not None
         else _APPROVAL_WAIT_ROOT
     )
-    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
-    return root / f"{digest}.wait"
+    return root / f"{_approval_wait_digest(session_id)}.{os.getpid()}.wait"
 
 
 def touch_approval_wait_marker(marker: Path) -> None:
     """
     Stamp an approval-wait marker with the current time.
 
-    Refreshed once per hook POST attempt so the idle pane reaper can tell a
+    Refreshed on a timer for the life of a hook's wait (see
+    :func:`hold_approval_wait_marker`) so the idle pane reaper can tell a
     pane parked on a permission prompt — which emits no output and reports no
     active turn — from an abandoned one. The root is created and validated by
     :func:`prepare_bridge_dir` in the runner, so this only writes inside an
@@ -1271,17 +1289,66 @@ def approval_wait_is_fresh(session_id: str) -> bool:
     """
     Whether a permission hook is parked on this session's verdict right now.
 
+    Scans every hook's marker for the session; a stale one (a hook killed
+    mid-wait) is removed on the way so they never accumulate.
+
     :param session_id: Omnigent session id to check, e.g.
         ``"conv_abc123"``.
-    :returns: ``True`` when the marker was touched within
-        :data:`APPROVAL_WAIT_MARKER_TTL_S`; ``False`` when it is missing,
-        stale, or unreadable.
+    :returns: ``True`` when any marker was touched within
+        :data:`APPROVAL_WAIT_MARKER_TTL_S`; ``False`` when none exists, all
+        are stale, or the root is unreadable.
     """
     try:
-        touched_at = approval_wait_marker_path(session_id).stat().st_mtime
+        markers = list(_APPROVAL_WAIT_ROOT.glob(f"{_approval_wait_digest(session_id)}.*.wait"))
     except OSError:
         return False
-    return time.time() - touched_at < APPROVAL_WAIT_MARKER_TTL_S
+    now = time.time()
+    fresh = False
+    for marker in markers:
+        try:
+            touched_at = marker.stat().st_mtime
+        except OSError:
+            continue
+        if now - touched_at < APPROVAL_WAIT_MARKER_TTL_S:
+            fresh = True
+        else:
+            clear_approval_wait_marker(marker)
+    return fresh
+
+
+@contextlib.contextmanager
+def hold_approval_wait_marker(marker: Path) -> Iterator[None]:
+    """
+    Keep *marker* fresh for the duration of the block, then remove it.
+
+    Touches the marker at once and again every
+    :data:`APPROVAL_WAIT_MARKER_REFRESH_S` on a daemon thread, so a hook
+    blocked in one long POST (a direct server holds the poll for the whole
+    wait) reads as parked exactly like one a gateway severs every few
+    minutes. The refresher is stopped before the marker is cleared so a late
+    touch cannot resurrect it; a hook killed mid-wait takes the thread with
+    it and its marker simply expires.
+
+    :param marker: Marker path from :func:`approval_wait_marker_path`.
+    :returns: ``None`` for the duration of the block.
+    """
+    stop = threading.Event()
+
+    def _refresh() -> None:
+        while not stop.wait(APPROVAL_WAIT_MARKER_REFRESH_S):
+            touch_approval_wait_marker(marker)
+
+    touch_approval_wait_marker(marker)
+    refresher = threading.Thread(
+        target=_refresh, name="omnigent-approval-wait-marker", daemon=True
+    )
+    refresher.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        refresher.join(timeout=5.0)
+        clear_approval_wait_marker(marker)
 
 
 def build_claude_native_spawn_env(

--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -109,6 +109,19 @@ DEFAULT_BRIDGE_PORT_POOL: tuple[int, ...] = tuple(range(28700, 28716))
 _TRUSTED_PARENT = Path(tempfile.gettempdir())
 _BRIDGE_ROOT_PARENT = _TRUSTED_PARENT / f"omnigent-{stable_user_id()}"
 _BRIDGE_ROOT = _BRIDGE_ROOT_PARENT / "claude-native"
+# Markers for permission hooks parked on a verdict, keyed by SESSION id: the
+# idle pane reaper's busy check holds a pane's conversation id, and resolving
+# that to a bridge id needs a session-label fetch no per-scan check can afford.
+# Inside the bridge root so it inherits the same owner-only validation; it
+# carries no ``owner.pid``, which is exactly what makes the orphan pruner skip
+# it (see ``native_bridge_common.prune_orphaned_dirs``).
+_APPROVAL_WAIT_DIR_NAME = "approval-waits"
+_APPROVAL_WAIT_ROOT = _BRIDGE_ROOT / _APPROVAL_WAIT_DIR_NAME
+# A marker touched more recently than this means a hook is still waiting.
+# Above one full long-poll (the Databricks front door caps a request at 300s)
+# plus a retry backoff, so a marker refreshed once per POST attempt never
+# reads stale while the hook is alive.
+APPROVAL_WAIT_MARKER_TTL_S = 420.0
 _CONFIG_FILE = "bridge.json"
 _SERVER_FILE = "server.json"
 _STATE_FILE = "state.json"
@@ -1194,6 +1207,83 @@ def bridge_dir_for_conversation_id(conversation_id: str) -> Path:
     return bridge_dir_for_bridge_id(conversation_id)
 
 
+def approval_wait_marker_path(session_id: str, *, bridge_dir: Path | None = None) -> Path:
+    """
+    Return the marker path a parked permission hook keeps fresh.
+
+    :param session_id: Omnigent session id whose verdict a hook is waiting
+        on, e.g. ``"conv_abc123"``.
+    :param bridge_dir: The caller's own bridge directory, e.g.
+        ``/tmp/omnigent-501/claude-native/<digest>``. When given, the marker
+        root is derived from it instead of from this process's own temp root: a
+        hook subprocess is *told* its bridge dir, so deriving from it cannot
+        disagree with the runner about ``$TMPDIR`` the way an independently
+        computed root could — and a marker written where the reaper never looks
+        would fail silently. ``None`` uses this process's own root, which is
+        the runner side including the pane reaper.
+    :returns: Absolute marker path under ``<temp root>/approval-waits``.
+    """
+    root = (
+        bridge_dir.parent / _APPROVAL_WAIT_DIR_NAME
+        if bridge_dir is not None
+        else _APPROVAL_WAIT_ROOT
+    )
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:32]
+    return root / f"{digest}.wait"
+
+
+def touch_approval_wait_marker(marker: Path) -> None:
+    """
+    Stamp an approval-wait marker with the current time.
+
+    Refreshed once per hook POST attempt so the idle pane reaper can tell a
+    pane parked on a permission prompt — which emits no output and reports no
+    active turn — from an abandoned one. The root is created and validated by
+    :func:`prepare_bridge_dir` in the runner, so this only writes inside an
+    already-trusted directory. Best-effort: a marker that cannot be written
+    only costs the pre-existing reap behavior.
+
+    :param marker: Marker path from :func:`approval_wait_marker_path`.
+    :returns: None.
+    """
+    try:
+        marker.touch()
+    except OSError:
+        _logger.debug("Could not touch approval-wait marker", exc_info=True)
+
+
+def clear_approval_wait_marker(marker: Path) -> None:
+    """
+    Remove an approval-wait marker.
+
+    Called when the hook stops waiting (verdict, rejection, give-up, or a
+    signal that kills it mid-wait) so the pane returns to normal idle
+    accounting at once rather than after :data:`APPROVAL_WAIT_MARKER_TTL_S`.
+
+    :param marker: Marker path from :func:`approval_wait_marker_path`.
+    :returns: None.
+    """
+    with contextlib.suppress(OSError):
+        marker.unlink(missing_ok=True)
+
+
+def approval_wait_is_fresh(session_id: str) -> bool:
+    """
+    Whether a permission hook is parked on this session's verdict right now.
+
+    :param session_id: Omnigent session id to check, e.g.
+        ``"conv_abc123"``.
+    :returns: ``True`` when the marker was touched within
+        :data:`APPROVAL_WAIT_MARKER_TTL_S`; ``False`` when it is missing,
+        stale, or unreadable.
+    """
+    try:
+        touched_at = approval_wait_marker_path(session_id).stat().st_mtime
+    except OSError:
+        return False
+    return time.time() - touched_at < APPROVAL_WAIT_MARKER_TTL_S
+
+
 def build_claude_native_spawn_env(
     conversation_id: str,
     *,
@@ -1282,6 +1372,11 @@ def prepare_bridge_dir(
     resolved_bridge_id = bridge_id or conversation_id
     bridge_dir = bridge_dir_for_bridge_id(resolved_bridge_id)
     _ensure_secure_dir(bridge_dir)
+    # A parked permission hook only touches files in this root, so the runner
+    # owns creating and validating it before any hook can fire. Derived from the
+    # bridge dir just validated rather than read from the module global, so it
+    # lands in the same tree the caller asked for.
+    _ensure_secure_dir(bridge_dir.parent / _APPROVAL_WAIT_DIR_NAME)
     config = _read_json_file(bridge_dir / _CONFIG_FILE)
     token = config.get("token") if isinstance(config, dict) else None
     if not isinstance(token, str) or not token:

--- a/omnigent/harnesses/claude_native/hook.py
+++ b/omnigent/harnesses/claude_native/hook.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING
 
 from omnigent.harnesses.claude_native.bridge import (
     BRIDGE_ID_LABEL_KEY,
+    approval_wait_marker_path,
+    clear_approval_wait_marker,
     read_active_session_id,
     read_bridge_id,
     read_claude_session_id,
@@ -22,6 +24,7 @@ from omnigent.harnesses.claude_native.bridge import (
     read_permission_hook_config,
     read_seen_claude_session_ids,
     record_hook_event,
+    touch_approval_wait_marker,
     transcript_has_forked_from_marker,
     transcript_has_recent_local_command,
     url_component,
@@ -662,6 +665,7 @@ def _post_hook_with_reattach(
     payload: dict[str, object],
     hook_label: str,
     reauth: Callable[[], dict[str, str] | None] | None = None,
+    wait_marker: Path | None = None,
 ) -> httpx.Response | None:
     """
     POST one permission-style hook payload, surviving severed long-polls.
@@ -732,6 +736,10 @@ def _post_hook_with_reattach(
         or returns ``401`` — i.e. the one-shot ``ap_auth_headers`` token lapsed.
         Called at most once; new headers trigger an immediate retry with them.
         ``None`` keeps the legacy behavior.
+    :param wait_marker: Approval-wait marker kept fresh for the life of the
+        wait, from :func:`approval_wait_marker_path`, so the idle pane reaper
+        spares a pane parked on this prompt. ``None`` skips the marker
+        (non-approval callers).
     :returns: The successful (2xx) response, or ``None`` when rejected
         or out of budget — callers fail-ask as before.
     """
@@ -751,94 +759,104 @@ def _post_hook_with_reattach(
     deadline = time.monotonic() + _PERMISSION_TIMEOUT_S
     reauthed = False
     consecutive_hard_failures = 0
-    while True:
-        attempt_started = time.monotonic()
-        try:
-            with httpx.Client(headers=headers, timeout=timeout) as client:
-                resp = client.post(url, json=body)
-                if (
-                    reauth is not None
-                    and not reauthed
-                    and _is_login_redirect_or_unauthorized(resp)
-                ):
-                    # One-shot ``ap_auth_headers`` token lapsed (~1h OAuth
-                    # lifetime): re-mint and retry once rather than fail-asking
-                    # into a terminal prompt no one watches. Mirrors the
-                    # evaluate-policy hook and ``_RunnerDatabricksAuth``.
-                    refreshed = reauth()
-                    if refreshed:
-                        headers = refreshed
-                        reauthed = True
-                        print(
-                            f"omnigent {hook_label} hook: Omnigent auth expired "
-                            "(login redirect/401); re-minted token and retrying",
-                            file=sys.stderr,
-                        )
-                        continue
-                resp.raise_for_status()
-                return resp
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code < 500:
+    try:
+        while True:
+            attempt_started = time.monotonic()
+            if wait_marker is not None:
+                # Refreshed per attempt: a pane parked on this prompt makes no
+                # output, so without it the idle reaper kills the prompt.
+                touch_approval_wait_marker(wait_marker)
+            try:
+                with httpx.Client(headers=headers, timeout=timeout) as client:
+                    resp = client.post(url, json=body)
+                    if (
+                        reauth is not None
+                        and not reauthed
+                        and _is_login_redirect_or_unauthorized(resp)
+                    ):
+                        # One-shot ``ap_auth_headers`` token lapsed (~1h OAuth
+                        # lifetime): re-mint and retry once rather than fail-asking
+                        # into a terminal prompt no one watches. Mirrors the
+                        # evaluate-policy hook and ``_RunnerDatabricksAuth``.
+                        refreshed = reauth()
+                        if refreshed:
+                            headers = refreshed
+                            reauthed = True
+                            print(
+                                f"omnigent {hook_label} hook: Omnigent auth expired "
+                                "(login redirect/401); re-minted token and retrying",
+                                file=sys.stderr,
+                            )
+                            continue
+                    resp.raise_for_status()
+                    return resp
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code < 500:
+                    print(
+                        f"omnigent {hook_label} hook: Omnigent request rejected: {exc}",
+                        file=sys.stderr,
+                    )
+                    return None
+                # A fast 5xx is a sick server (the spin). One that arrives only
+                # after the poll was held past the floor is a gateway timing out
+                # an idle long-poll (a 504 at 300s) — a held-poll sever.
+                held_s = time.monotonic() - attempt_started
+                is_hard_failure = held_s < _PERMISSION_HELD_POLL_FLOOR_S
+                kind = "sick" if is_hard_failure else "held-poll severed by gateway"
                 print(
-                    f"omnigent {hook_label} hook: Omnigent request rejected: {exc}",
+                    f"omnigent {hook_label} hook: Omnigent request failed "
+                    f"({kind}); retrying: {exc}",
+                    file=sys.stderr,
+                )
+            except httpx.HTTPError as exc:
+                # Classify by HOW it failed, not by elapsed time (a proxy severs a
+                # legitimately-held poll in seconds-to-minutes, so wall-clock can't
+                # tell it from a down server — #1782 Polly review).
+                never_connected = isinstance(exc, _never_connected_errors())
+                held_s = time.monotonic() - attempt_started
+                # Hard failure iff the server was never reached, OR an established
+                # connection dropped so fast it's a flap rather than a parked poll.
+                is_hard_failure = never_connected or held_s < _PERMISSION_HELD_POLL_FLOOR_S
+                kind = (
+                    "unreachable"
+                    if never_connected
+                    else ("flapping" if is_hard_failure else "held-poll severed")
+                )
+                print(
+                    f"omnigent {hook_label} hook: Omnigent request failed "
+                    f"({kind}); retrying: {exc}",
+                    file=sys.stderr,
+                )
+            if is_hard_failure:
+                consecutive_hard_failures += 1
+            else:
+                # A proxy severed a genuinely-held poll — the re-park mechanism
+                # working as intended. Reset so a slow human is never capped, and
+                # re-POST promptly so the same id re-parks inside the server's
+                # re-park grace instead of letting the card clear between polls.
+                consecutive_hard_failures = 0
+                backoff_s = _PERMISSION_RETRY_INITIAL_BACKOFF_S
+            if consecutive_hard_failures >= _PERMISSION_MAX_CONSECUTIVE_FAILURES:
+                print(
+                    f"omnigent {hook_label} hook: giving up after "
+                    f"{consecutive_hard_failures} consecutive hard failures "
+                    "(server unreachable/sick) — failing ask",
                     file=sys.stderr,
                 )
                 return None
-            # A fast 5xx is a sick server (the spin). One that arrives only
-            # after the poll was held past the floor is a gateway timing out
-            # an idle long-poll (a 504 at 300s) — a held-poll sever.
-            held_s = time.monotonic() - attempt_started
-            is_hard_failure = held_s < _PERMISSION_HELD_POLL_FLOOR_S
-            kind = "sick" if is_hard_failure else "held-poll severed by gateway"
-            print(
-                f"omnigent {hook_label} hook: Omnigent request failed ({kind}); retrying: {exc}",
-                file=sys.stderr,
-            )
-        except httpx.HTTPError as exc:
-            # Classify by HOW it failed, not by elapsed time (a proxy severs a
-            # legitimately-held poll in seconds-to-minutes, so wall-clock can't
-            # tell it from a down server — #1782 Polly review).
-            never_connected = isinstance(exc, _never_connected_errors())
-            held_s = time.monotonic() - attempt_started
-            # Hard failure iff the server was never reached, OR an established
-            # connection dropped so fast it's a flap rather than a parked poll.
-            is_hard_failure = never_connected or held_s < _PERMISSION_HELD_POLL_FLOOR_S
-            kind = (
-                "unreachable"
-                if never_connected
-                else ("flapping" if is_hard_failure else "held-poll severed")
-            )
-            print(
-                f"omnigent {hook_label} hook: Omnigent request failed ({kind}); retrying: {exc}",
-                file=sys.stderr,
-            )
-        if is_hard_failure:
-            consecutive_hard_failures += 1
-        else:
-            # A proxy severed a genuinely-held poll — the re-park mechanism
-            # working as intended. Reset so a slow human is never capped, and
-            # re-POST promptly so the same id re-parks inside the server's
-            # re-park grace instead of letting the card clear between polls.
-            consecutive_hard_failures = 0
-            backoff_s = _PERMISSION_RETRY_INITIAL_BACKOFF_S
-        if consecutive_hard_failures >= _PERMISSION_MAX_CONSECUTIVE_FAILURES:
-            print(
-                f"omnigent {hook_label} hook: giving up after "
-                f"{consecutive_hard_failures} consecutive hard failures "
-                "(server unreachable/sick) — failing ask",
-                file=sys.stderr,
-            )
-            return None
-        # Two-line backoff; not worth a retry lib in this dependency-light hook.
-        time.sleep(backoff_s)
-        backoff_s = min(backoff_s * 2, _PERMISSION_RETRY_MAX_BACKOFF_S)
-        if time.monotonic() >= deadline:
-            print(
-                f"omnigent {hook_label} hook: retry budget exhausted "
-                f"({_PERMISSION_TIMEOUT_S:.0f}s) — failing ask",
-                file=sys.stderr,
-            )
-            return None
+            # Two-line backoff; not worth a retry lib in this dependency-light hook.
+            time.sleep(backoff_s)
+            backoff_s = min(backoff_s * 2, _PERMISSION_RETRY_MAX_BACKOFF_S)
+            if time.monotonic() >= deadline:
+                print(
+                    f"omnigent {hook_label} hook: retry budget exhausted "
+                    f"({_PERMISSION_TIMEOUT_S:.0f}s) — failing ask",
+                    file=sys.stderr,
+                )
+                return None
+    finally:
+        if wait_marker is not None:
+            clear_approval_wait_marker(wait_marker)
 
 
 def _main_permission_request(argv: list[str]) -> int:
@@ -895,6 +913,7 @@ def _main_permission_request(argv: list[str]) -> int:
         payload,
         "claude permission",
         reauth=policy_hook_reauth(ap_server_url, headers),
+        wait_marker=approval_wait_marker_path(session_id, bridge_dir=bridge_dir),
     )
     if resp is None:
         return 0
@@ -975,6 +994,7 @@ def _main_ask_user_question(argv: list[str]) -> int:
         payload,
         "ask-user-question",
         reauth=policy_hook_reauth(ap_server_url, headers),
+        wait_marker=approval_wait_marker_path(session_id, bridge_dir=bridge_dir),
     )
     if resp is None or not resp.content:
         return 0

--- a/omnigent/harnesses/claude_native/hook.py
+++ b/omnigent/harnesses/claude_native/hook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import math
 import os
@@ -16,7 +17,7 @@ from typing import TYPE_CHECKING
 from omnigent.harnesses.claude_native.bridge import (
     BRIDGE_ID_LABEL_KEY,
     approval_wait_marker_path,
-    clear_approval_wait_marker,
+    hold_approval_wait_marker,
     read_active_session_id,
     read_bridge_id,
     read_claude_session_id,
@@ -24,7 +25,6 @@ from omnigent.harnesses.claude_native.bridge import (
     read_permission_hook_config,
     read_seen_claude_session_ids,
     record_hook_event,
-    touch_approval_wait_marker,
     transcript_has_forked_from_marker,
     transcript_has_recent_local_command,
     url_component,
@@ -707,19 +707,23 @@ def _post_hook_with_reattach(
 
     Residual limitation (by design): a *sick* backend behind a proxy/LB that
     accepts the connection and then silently severs it after its upstream
-    timeout (>= the floor) is indistinguishable at the transport layer from a
-    proxy severing a genuinely-parked human poll — both surface as an
-    established-then-severed error after N seconds, and the server holds the
+    timeout (>= the floor) — or whose proxy answers that timeout with a 5xx —
+    is indistinguishable at the transport layer from a proxy severing a
+    genuinely-parked human poll — both surface as an established-then-severed
+    error (or a late gateway 5xx) after N seconds, and the server holds the
     POST silently with no client-visible "parked" ack. So this case resets the
     counter and is NOT caught by the consecutive-hard-failure cap; it is bounded
     only by the absolute :data:`_PERMISSION_TIMEOUT_S` ceiling below (the same
     day-long human-answer window). That is the tightest safe client-side bound:
-    capping it sooner would necessarily cap a real slow human on the same
-    topology. The blast radius is limited — this loop only re-POSTs over HTTP
-    from one hook process (it does not itself respawn harness/tool
-    subprocesses), and the host-side orphan reaper (#1782 Bug A) reclaims any
-    subprocesses a re-driven turn does spawn — so the worst case is one hook
-    slow-retrying for up to a day, not the original zombie pileup.
+    capping it sooner — or raising the floor for 5xx above the 10s shared with
+    torn connections — would necessarily cap a real slow human behind any
+    gateway that answers sooner than the floor, which is the very wedge this
+    loop exists to prevent. The blast radius is limited — this loop only
+    re-POSTs over HTTP from one hook process (it does not itself respawn
+    harness/tool subprocesses), and the host-side orphan reaper (#1782 Bug A)
+    reclaims any subprocesses a re-driven turn does spawn — so the worst case is
+    one hook re-POSTing once per proxy timeout for up to a day, which also
+    keeps the card alive until the server recovers.
 
     The absolute :data:`_PERMISSION_TIMEOUT_S` ceiling bounds the total wait on
     every path, matching the day-long human-answer window.
@@ -734,12 +738,15 @@ def _post_hook_with_reattach(
     :param reauth: Optional callable that re-mints fresh auth headers when the
         server bounces the POST to its OAuth login flow (Apps 302→``/oidc/``)
         or returns ``401`` — i.e. the one-shot ``ap_auth_headers`` token lapsed.
-        Called at most once; new headers trigger an immediate retry with them.
-        ``None`` keeps the legacy behavior.
-    :param wait_marker: Approval-wait marker kept fresh for the life of the
-        wait, from :func:`approval_wait_marker_path`, so the idle pane reaper
-        spares a pane parked on this prompt. ``None`` skips the marker
-        (non-approval callers).
+        Called at most once per accepted poll: new headers trigger an immediate
+        retry, and a poll the server then held past the floor re-arms it, so a
+        wait longer than the token lifetime survives every lapse while two
+        rejections in a row still fail-ask. ``None`` keeps the legacy behavior.
+    :param wait_marker: Approval-wait marker held fresh for the life of the
+        wait (see :func:`hold_approval_wait_marker`), from
+        :func:`approval_wait_marker_path`, so the idle pane reaper spares a
+        pane parked on this prompt. ``None`` skips the marker (non-approval
+        callers).
     :returns: The successful (2xx) response, or ``None`` when rejected
         or out of budget — callers fail-ask as before.
     """
@@ -759,13 +766,14 @@ def _post_hook_with_reattach(
     deadline = time.monotonic() + _PERMISSION_TIMEOUT_S
     reauthed = False
     consecutive_hard_failures = 0
-    try:
+    marker_scope = (
+        hold_approval_wait_marker(wait_marker)
+        if wait_marker is not None
+        else contextlib.nullcontext()
+    )
+    with marker_scope:
         while True:
             attempt_started = time.monotonic()
-            if wait_marker is not None:
-                # Refreshed per attempt: a pane parked on this prompt makes no
-                # output, so without it the idle reaper kills the prompt.
-                touch_approval_wait_marker(wait_marker)
             try:
                 with httpx.Client(headers=headers, timeout=timeout) as client:
                     resp = client.post(url, json=body)
@@ -836,6 +844,10 @@ def _post_hook_with_reattach(
                 # re-park grace instead of letting the card clear between polls.
                 consecutive_hard_failures = 0
                 backoff_s = _PERMISSION_RETRY_INITIAL_BACKOFF_S
+                # The held poll proves this token was accepted, so the one-shot
+                # re-mint is armed again: a wait longer than the token lifetime
+                # lapses once an hour, and each lapse must be re-mintable.
+                reauthed = False
             if consecutive_hard_failures >= _PERMISSION_MAX_CONSECUTIVE_FAILURES:
                 print(
                     f"omnigent {hook_label} hook: giving up after "
@@ -854,9 +866,6 @@ def _post_hook_with_reattach(
                     file=sys.stderr,
                 )
                 return None
-    finally:
-        if wait_marker is not None:
-            clear_approval_wait_marker(wait_marker)
 
 
 def _main_permission_request(argv: list[str]) -> int:

--- a/omnigent/harnesses/claude_native/hook.py
+++ b/omnigent/harnesses/claude_native/hook.py
@@ -50,8 +50,9 @@ if TYPE_CHECKING:
 # respawning harness/tool subprocesses) every ≤30s for 24h — the spin-loop half
 # of the zombie pileup.
 _PERMISSION_TIMEOUT_S = 86400.0
-# First retry must land inside the server's re-park grace (proxies
-# sever idle long-polls); later retries back off.
+# Every retry after a held-poll sever must land inside the server's
+# re-park grace (proxies sever idle long-polls); only hard failures
+# back off.
 _PERMISSION_RETRY_INITIAL_BACKOFF_S = 1.0
 _PERMISSION_RETRY_MAX_BACKOFF_S = 30.0
 # Fail unreachable-server connects fast into the backoff loop instead
@@ -680,18 +681,23 @@ def _post_hook_with_reattach(
 
     Failure classification:
 
-    * **Hard failure → count toward the cap.** A 5xx, or a connection that
-      never established (:func:`_never_connected_errors`), or an established
-      connection that dropped in under :data:`_PERMISSION_HELD_POLL_FLOOR_S`
-      (a flapping/crash-looping server). This is the spin.
-    * **Held-poll sever → reset the counter.** An established connection that
-      dropped mid-poll after being held ≥ the floor. That is a proxy severing
-      an idle long-poll — the re-park mechanism working as intended — so it
-      must NOT count, or a legitimately-parked human approval behind a
-      severing proxy would be capped after a handful of severs. Classifying by
-      *how the request failed* (established-then-severed vs never-connected),
-      not by elapsed wall-clock, is what makes "a slow human is never capped"
-      hold even when the proxy severs every 30-60s.
+    * **Hard failure → count toward the cap.** A 5xx returned in under
+      :data:`_PERMISSION_HELD_POLL_FLOOR_S`, or a connection that never
+      established (:func:`_never_connected_errors`), or an established
+      connection that dropped in under the floor (a flapping/crash-looping
+      server). This is the spin.
+    * **Held-poll sever → reset the counter and the backoff.** An established
+      connection that dropped mid-poll after being held ≥ the floor, or a
+      gateway 5xx (the Databricks front door answers an idle long-poll with
+      504 after 300s) that arrived after the poll was held ≥ the floor. Either
+      is a proxy severing an idle long-poll — the re-park mechanism working as
+      intended — so it must NOT count, or a legitimately-parked human approval
+      behind a severing proxy would be capped after a handful of severs.
+      Classifying by *how the request failed* (established-then-severed vs
+      never-connected), not by elapsed wall-clock alone, is what makes "a slow
+      human is never capped" hold even when the proxy severs every 30-60s. The
+      backoff resets too, so the re-POST re-parks the same id inside the
+      server's re-park grace and the approval card never clears between polls.
 
     A hard 4xx is final (bad request won't succeed on retry).
 
@@ -778,10 +784,14 @@ def _post_hook_with_reattach(
                     file=sys.stderr,
                 )
                 return None
-            # 5xx: server responded but is sick — a hard failure (the spin).
-            is_hard_failure = True
+            # A fast 5xx is a sick server (the spin). One that arrives only
+            # after the poll was held past the floor is a gateway timing out
+            # an idle long-poll (a 504 at 300s) — a held-poll sever.
+            held_s = time.monotonic() - attempt_started
+            is_hard_failure = held_s < _PERMISSION_HELD_POLL_FLOOR_S
+            kind = "sick" if is_hard_failure else "held-poll severed by gateway"
             print(
-                f"omnigent {hook_label} hook: Omnigent request failed; retrying: {exc}",
+                f"omnigent {hook_label} hook: Omnigent request failed ({kind}); retrying: {exc}",
                 file=sys.stderr,
             )
         except httpx.HTTPError as exc:
@@ -806,8 +816,11 @@ def _post_hook_with_reattach(
             consecutive_hard_failures += 1
         else:
             # A proxy severed a genuinely-held poll — the re-park mechanism
-            # working as intended. Reset so a slow human is never capped.
+            # working as intended. Reset so a slow human is never capped, and
+            # re-POST promptly so the same id re-parks inside the server's
+            # re-park grace instead of letting the card clear between polls.
             consecutive_hard_failures = 0
+            backoff_s = _PERMISSION_RETRY_INITIAL_BACKOFF_S
         if consecutive_hard_failures >= _PERMISSION_MAX_CONSECUTIVE_FAILURES:
             print(
                 f"omnigent {hook_label} hook: giving up after "

--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -124,6 +124,10 @@ _CODEX_ELICITATION_CONNECT_TIMEOUT_SECONDS = 30.0
 # idle long-polls); later retries back off.
 _CODEX_ELICITATION_RETRY_INITIAL_BACKOFF_SECONDS = 1.0
 _CODEX_ELICITATION_RETRY_MAX_BACKOFF_SECONDS = 30.0
+# A POST held at least this long before failing was severed by the gateway at
+# its request cap, not refused by a sick server, so its retry must not back off
+# — see the backoff reset in :func:`_post_codex_elicitation_request`.
+_CODEX_ELICITATION_HELD_POLL_FLOOR_SECONDS = 10.0
 _CODEX_MCP_ELICITATION_REQUEST_METHOD = "mcpServer/elicitation/request"
 # Per-server MCP startup progress (issue #2058). Codex runs an MCP
 # startup round when a thread starts, but delivers the per-server
@@ -3940,6 +3944,7 @@ async def _post_codex_elicitation_request(
     backoff_s = _CODEX_ELICITATION_RETRY_INITIAL_BACKOFF_SECONDS
     while True:
         response: httpx.Response | None = None
+        attempt_started = loop.time()
         try:
             response = await client.post(url, json=event, timeout=timeout)
         except httpx.HTTPError:
@@ -3948,6 +3953,7 @@ async def _post_codex_elicitation_request(
                 event.get("method"),
                 exc_info=True,
             )
+        held_s = loop.time() - attempt_started
         if response is not None and response.status_code < 500:
             return response
         if response is not None:
@@ -3965,7 +3971,14 @@ async def _post_codex_elicitation_request(
             )
             return None
         await _elicitation_retry_sleep(backoff_s)
-        backoff_s = min(backoff_s * 2, _CODEX_ELICITATION_RETRY_MAX_BACKOFF_SECONDS)
+        if held_s >= _CODEX_ELICITATION_HELD_POLL_FLOOR_SECONDS:
+            # The gateway severed a held poll rather than a sick server refusing
+            # it: re-POST inside the server's re-park grace so the approval card
+            # survives the gap instead of clearing between polls. Growth is kept
+            # for fast failures, which are the ones worth backing off from.
+            backoff_s = _CODEX_ELICITATION_RETRY_INITIAL_BACKOFF_SECONDS
+        else:
+            backoff_s = min(backoff_s * 2, _CODEX_ELICITATION_RETRY_MAX_BACKOFF_SECONDS)
 
 
 def _note_native_plan_implementation_prompt(

--- a/omnigent/native/native_policy_hook.py
+++ b/omnigent/native/native_policy_hook.py
@@ -34,13 +34,24 @@ import httpx
 # How long to keep retrying transient 5xx / connect errors on the
 # policy evaluate POST before failing closed. Keeps the pre-execution
 # gate from blocking long on a sick server while still absorbing brief
-# DB hiccups on a hosted deployment.
+# DB hiccups on a hosted deployment. A gateway-severed held poll resets
+# it — see :func:`post_evaluate_with_retry`.
 _EVALUATE_POLICY_RETRY_BUDGET_S = 30.0
 _EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S = 1.0
 _EVALUATE_POLICY_RETRY_MAX_BACKOFF_S = 10.0
 # Fast connect budget so an unreachable server fails into the retry
 # loop quickly rather than blocking on the day-long read timeout.
 _EVALUATE_POLICY_CONNECT_TIMEOUT_S = 5.0
+# A 5xx or torn connection that arrives only after the POST was held at
+# least this long is a gateway severing a parked ASK long-poll (the
+# Databricks front door caps any request at 300s and answers 504), not a
+# sick server: it re-POSTs the same id at once and spends no budget.
+# Mirrors the PermissionRequest hook's held-poll floor.
+_EVALUATE_POLICY_HELD_POLL_FLOOR_S = 10.0
+# Transport errors that mean an established connection was torn down
+# mid-poll. A timeout is deliberately absent: a ReadTimeout fires only
+# after the server held the poll for the whole read budget.
+_HELD_POLL_SEVER_ERRORS = (httpx.RemoteProtocolError, httpx.ReadError)
 
 # Hook event names that gate tool execution and therefore carry policy
 # meaning. ``PreToolUse`` fires before the tool runs (can block);
@@ -586,6 +597,14 @@ def post_evaluate_with_retry(
     :data:`_EVALUATE_POLICY_RETRY_BUDGET_S`. Returns the successful response,
     or ``None`` if the budget is exhausted or a non-retryable error occurs.
 
+    A 5xx or torn connection that arrives only after the POST was held at
+    least :data:`_EVALUATE_POLICY_HELD_POLL_FLOOR_S` is not a fault but a
+    gateway severing a parked ASK long-poll (the Databricks front door caps
+    any request at 300s and answers 504). It re-POSTs the same id after the
+    initial backoff — inside the server's re-park grace, so the approval card
+    survives — and spends none of the transient budget, so a slow human is
+    never failed closed by the proxy.
+
     A stable ``_omnigent_elicitation_id`` is minted once and stamped on
     every attempt. When the server parks an ASK gate and the connection
     drops (5xx or :class:`httpx.ConnectError`), the retry re-POSTs the
@@ -595,13 +614,10 @@ def post_evaluate_with_retry(
     second approval card from appearing when the first was already
     published before the error.
 
-    4xx responses are final — a bad request won't succeed on retry. Other
-    mid-stream errors (e.g. :class:`httpx.ReadTimeout`) are also not retried:
-    a read timeout fires *after* the server received the request and may
-    mean the long-polling ASK gate was severed mid-wait; retrying with the
-    same id will re-park the existing elicitation (no duplicate card), but
-    the caller's fail-closed path is equivalent and simpler. The caller is
-    responsible for fail-closed handling on ``None``.
+    4xx responses are final — a bad request won't succeed on retry. A
+    :class:`httpx.ReadTimeout` is final too: it fires only after the server
+    held the poll for the whole read budget, i.e. the ask itself timed out.
+    The caller is responsible for fail-closed handling on ``None``.
 
     :param url: Absolute URL of the evaluate endpoint.
     :param headers: Auth headers for the Omnigent server.
@@ -618,7 +634,9 @@ def post_evaluate_with_retry(
         refresh-capable :class:`~omnigent.runner._entry._RunnerDatabricksAuth`.
         ``None`` (the default) keeps the legacy behavior for callers that have
         no token source. Returning ``None`` from it falls through to the
-        normal failure handling (the caller fails closed).
+        normal failure handling (the caller fails closed). A poll the server
+        held past the floor re-arms the one-shot, so a wait longer than the
+        token lifetime survives every lapse.
     :returns: ``(response, error)`` — on success, ``(response, None)``; on
         failure, ``(None, short_error_string)`` describing the last error so
         callers can surface it in the deny/block reason shown to the user.
@@ -635,6 +653,8 @@ def post_evaluate_with_retry(
     reauthed = False
     last_error: str = "unknown error"
     while True:
+        attempt_started = time.monotonic()
+        held_poll_severed = False
         try:
             with httpx.Client(headers=headers, timeout=timeout) as client:
                 resp = client.post(url, json=request_body)
@@ -693,8 +713,16 @@ def post_evaluate_with_retry(
                     file=sys.stderr,
                 )
                 return None, last_error
+            held_poll_severed = (
+                time.monotonic() - attempt_started >= _EVALUATE_POLICY_HELD_POLL_FLOOR_S
+            )
             print(
-                f"omnigent {hook_label}: Omnigent returned {status}; retrying",
+                f"omnigent {hook_label}: Omnigent returned {status}"
+                + (
+                    " after a held poll (gateway sever); re-parking"
+                    if held_poll_severed
+                    else "; retrying"
+                ),
                 file=sys.stderr,
             )
         except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
@@ -704,15 +732,33 @@ def post_evaluate_with_retry(
                 file=sys.stderr,
             )
         except httpx.HTTPError as exc:
-            # Other HTTP errors (ReadTimeout while a long ASK poll is in flight,
-            # etc.) are not retried — retrying a severed ASK would open a new
-            # elicitation and prompt the human twice.
             last_error = f"request error: {exc}"
+            # A connection the gateway tore down after holding the poll is a
+            # sever: the same id re-parks the elicitation. Anything else
+            # mid-stream (a ReadTimeout means the ask itself timed out) is final.
+            held_poll_severed = (
+                isinstance(exc, _HELD_POLL_SEVER_ERRORS)
+                and time.monotonic() - attempt_started >= _EVALUATE_POLICY_HELD_POLL_FLOOR_S
+            )
+            if not held_poll_severed:
+                print(
+                    f"omnigent {hook_label}: Omnigent request failed: {exc}",
+                    file=sys.stderr,
+                )
+                return None, last_error
             print(
-                f"omnigent {hook_label}: Omnigent request failed: {exc}",
+                f"omnigent {hook_label}: held poll severed by the gateway; re-parking: {exc}",
                 file=sys.stderr,
             )
-            return None, last_error
+        if held_poll_severed:
+            # The re-park mechanism working as intended, not a transient fault:
+            # the budget and backoff are for fast failures, and the accepted
+            # poll re-arms the one-shot re-mint for the next token lapse.
+            deadline = time.monotonic() + _EVALUATE_POLICY_RETRY_BUDGET_S
+            backoff_s = _EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S
+            reauthed = False
+            time.sleep(backoff_s)
+            continue
         if time.monotonic() + backoff_s >= deadline:
             print(
                 f"omnigent {hook_label}: retry budget exhausted",

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -11696,6 +11696,7 @@ def create_runner_app(
         and _pane_reaper_registry is not None
         and hasattr(_pane_reaper_registry, "native_panes")
     ):
+        from omnigent.harnesses.claude_native.bridge import approval_wait_is_fresh
         from omnigent.native.native_cost_popup import _list_tmux_clients, _tmux_window_activity_at
         from omnigent.runner.tool_dispatch import _publish_terminal_deleted_event
         from omnigent.terminals.pane_reaper import (
@@ -11721,6 +11722,11 @@ def create_runner_app(
             ):
                 return True
             if _native_pane_status.get(conv_id) == "running":
+                return True
+            # A pane parked on a permission prompt emits nothing and reports no
+            # active turn, so every signal above reads idle. Reaping it kills the
+            # prompt and strands its approval card unanswerable.
+            if approval_wait_is_fresh(conv_id):
                 return True
             clients = await asyncio.to_thread(_list_tmux_clients, str(pane.socket_path), "main")
             if clients:

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -426,7 +426,12 @@ _HARNESS_PRE_RESOLVED_ELICITATION_TTL_S = 300.0
 _HARNESS_PRE_RESOLVED_ELICITATION_MAX_ENTRIES = 1024
 
 
-_HARNESS_ELICITATION_REPARK_GRACE_S = 10.0
+# How long a severed elicitation's card survives before it is cleared, giving a
+# hook retry time to re-park the same id. Wide enough to absorb a slow re-POST
+# (a lapsed token costs a re-mint round trip) so a still-blocked prompt is not
+# flipped to "Resolved elsewhere" between polls; a hook that died for real just
+# leaves the card up this much longer.
+_HARNESS_ELICITATION_REPARK_GRACE_S = 30.0
 
 
 _HOOK_ELICITATION_ID_RE = re.compile(r"^elicit_[a-z]+_[0-9a-f]{32}$")

--- a/tests/terminals/test_pane_reaper.py
+++ b/tests/terminals/test_pane_reaper.py
@@ -9,6 +9,11 @@ from pathlib import Path
 
 import pytest
 
+from omnigent.entities.session_resources import terminal_resource_id
+from omnigent.harnesses.claude_native import bridge as claude_native_bridge
+from omnigent.native import native_cost_popup
+from omnigent.runner.app import create_runner_app
+from omnigent.runner.resource_registry import SessionResourceRegistry
 from omnigent.terminals.pane_reaper import (
     _DEFAULT_IDLE_TIMEOUT_S,
     _IDLE_TIMEOUT_ENV,
@@ -16,6 +21,8 @@ from omnigent.terminals.pane_reaper import (
     PaneRef,
     resolve_native_pane_idle_timeout_s,
 )
+from omnigent.terminals.registry import TerminalRegistry
+from tests.runner.helpers import NullServerClient
 
 
 def _pane(conv: str, name: str = "claude") -> PaneRef:
@@ -196,3 +203,41 @@ def test_kimi_is_exempt_from_pane_reaping() -> None:
 
     assert "kimi" not in NATIVE_PANE_TERMINAL_NAMES
     assert "claude" in NATIVE_PANE_TERMINAL_NAMES
+
+
+async def test_runner_busy_check_spares_a_pane_parked_on_an_approval(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The runner's busy check treats a fresh approval-wait marker as busy.
+
+    A pane parked on a permission prompt has no active turn, no ``running``
+    status, no attached client and no output, so every other signal reads idle
+    and the reaper would kill the prompt under a still-answerable card.
+    """
+    # Bound by name when the app is built, so stub before building: no tmux here.
+    monkeypatch.setattr(native_cost_popup, "_list_tmux_clients", lambda *_args: [])
+    monkeypatch.setattr(native_cost_popup, "_tmux_window_activity_at", lambda *_args: None)
+    monkeypatch.setattr(claude_native_bridge, "_APPROVAL_WAIT_ROOT", tmp_path / "approval-waits")
+    registry = TerminalRegistry()
+    app = create_runner_app(
+        terminal_registry=registry,
+        resource_registry=SessionResourceRegistry(terminal_registry=registry),
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    reaper = app.state.native_pane_reaper
+    assert reaper is not None
+    pane = PaneRef(
+        "conv_parked", terminal_resource_id("claude", "main"), "claude", tmp_path / "tmux.sock"
+    )
+
+    assert not await reaper._is_busy(pane)
+
+    marker = claude_native_bridge.approval_wait_marker_path("conv_parked")
+    marker.parent.mkdir(parents=True)
+    claude_native_bridge.touch_approval_wait_marker(marker)
+    assert await reaper._is_busy(pane)
+    # Another session's parked prompt does not spare this pane.
+    other = PaneRef("conv_other", pane.terminal_id, "claude", pane.socket_path)
+    assert not await reaper._is_busy(other)

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -10217,6 +10217,8 @@ def test_http_ingress_all_interfaces_opt_in_advertises_routable_host(
     finally:
         httpd.shutdown()
         httpd.server_close()
+
+
 def test_approval_wait_marker_tracks_a_parked_permission_hook(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -10247,13 +10249,22 @@ def test_approval_wait_marker_tracks_a_parked_permission_hook(
     # One session's parked prompt must not spare another session's pane.
     assert not claude_native_bridge.approval_wait_is_fresh("conv_other")
 
-    stale = time.time() - claude_native_bridge.APPROVAL_WAIT_MARKER_TTL_S - 1
-    os.utime(marker, (stale, stale))
-    assert not claude_native_bridge.approval_wait_is_fresh("conv_wait")
-
+    # Each hook owns its own marker, so one finishing (an AskUserQuestion beside
+    # a permission request, or parallel tool calls) leaves the other's evidence.
+    sibling = marker.with_name(marker.name.replace(f".{os.getpid()}.", f".{os.getpid() + 1}."))
+    assert sibling != marker
+    claude_native_bridge.touch_approval_wait_marker(sibling)
     claude_native_bridge.clear_approval_wait_marker(marker)
     assert not marker.exists()
-    # The hook clears in a finally, so a second clear must not raise.
+    assert claude_native_bridge.approval_wait_is_fresh("conv_wait")
+
+    # A stale marker (a hook killed mid-wait) reads idle and is pruned.
+    stale = time.time() - claude_native_bridge.APPROVAL_WAIT_MARKER_TTL_S - 1
+    os.utime(sibling, (stale, stale))
+    assert not claude_native_bridge.approval_wait_is_fresh("conv_wait")
+    assert not sibling.exists()
+
+    # The hook clears on exit, so clearing an absent marker must not raise.
     claude_native_bridge.clear_approval_wait_marker(marker)
 
     # A hook subprocess derives the root from the bridge dir it was handed,
@@ -10263,3 +10274,44 @@ def test_approval_wait_marker_tracks_a_parked_permission_hook(
         claude_native_bridge.approval_wait_marker_path("conv_wait", bridge_dir=bridge_dir)
         == marker
     )
+
+
+def test_hold_approval_wait_marker_refreshes_until_released(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    The held marker is re-touched on a timer and gone once the block exits.
+
+    A direct server holds one POST for the whole wait, so a marker touched
+    only at the start of the attempt read stale after the TTL and the reaper
+    killed the parked pane an hour later.
+    """
+    monkeypatch.setattr(claude_native_bridge, "APPROVAL_WAIT_MARKER_REFRESH_S", 0.02)
+    touches: list[Path] = []
+    real_touch = claude_native_bridge.touch_approval_wait_marker
+
+    def _counting_touch(marker: Path) -> None:
+        """
+        Record a touch, then perform it.
+
+        :param marker: Marker path being touched.
+        :returns: None.
+        """
+        touches.append(marker)
+        real_touch(marker)
+
+    monkeypatch.setattr(claude_native_bridge, "touch_approval_wait_marker", _counting_touch)
+    marker = tmp_path / "approval-waits" / "digest.1234.wait"
+    marker.parent.mkdir()
+
+    with claude_native_bridge.hold_approval_wait_marker(marker):
+        assert marker.exists(), "touched before the block starts"
+        deadline = time.monotonic() + 5.0
+        while len(touches) < 3 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert len(touches) >= 3, "the refresher must keep touching while the block runs"
+    assert not marker.exists()
+    settled = len(touches)
+    time.sleep(0.1)
+    assert len(touches) == settled, "the refresher must stop when the block exits"

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -10217,3 +10217,49 @@ def test_http_ingress_all_interfaces_opt_in_advertises_routable_host(
     finally:
         httpd.shutdown()
         httpd.server_close()
+def test_approval_wait_marker_tracks_a_parked_permission_hook(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A touched marker reads fresh, a stale one does not, and clearing removes it.
+
+    The idle pane reaper spares a native pane only while this marker is fresh,
+    so a marker that reads stale mid-wait reproduces the wedge where a reaped
+    pane strands its approval card unanswerable.
+    """
+    monkeypatch.setattr("omnigent.harnesses.claude_native.bridge._TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(
+        "omnigent.harnesses.claude_native.bridge._BRIDGE_ROOT_PARENT", tmp_path / "omnigent-test"
+    )
+    monkeypatch.setattr(
+        "omnigent.harnesses.claude_native.bridge._APPROVAL_WAIT_ROOT",
+        tmp_path / "omnigent-test" / "approval-parent" / "approval-waits",
+    )
+
+    assert not claude_native_bridge.approval_wait_is_fresh("conv_wait")
+
+    marker = claude_native_bridge.approval_wait_marker_path("conv_wait")
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    claude_native_bridge.touch_approval_wait_marker(marker)
+    assert marker.exists()
+    assert claude_native_bridge.approval_wait_is_fresh("conv_wait")
+    # One session's parked prompt must not spare another session's pane.
+    assert not claude_native_bridge.approval_wait_is_fresh("conv_other")
+
+    stale = time.time() - claude_native_bridge.APPROVAL_WAIT_MARKER_TTL_S - 1
+    os.utime(marker, (stale, stale))
+    assert not claude_native_bridge.approval_wait_is_fresh("conv_wait")
+
+    claude_native_bridge.clear_approval_wait_marker(marker)
+    assert not marker.exists()
+    # The hook clears in a finally, so a second clear must not raise.
+    claude_native_bridge.clear_approval_wait_marker(marker)
+
+    # A hook subprocess derives the root from the bridge dir it was handed,
+    # which must land on the same path the runner-side reaper checks.
+    bridge_dir = tmp_path / "omnigent-test" / "approval-parent" / "abc123"
+    assert (
+        claude_native_bridge.approval_wait_marker_path("conv_wait", bridge_dir=bridge_dir)
+        == marker
+    )

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -16,6 +16,8 @@ from omnigent.harnesses.claude_native import hook as claude_native_hook
 from omnigent.harnesses.claude_native.bridge import (
     OBSERVER_HOOK_STDERR_FILE,
     ClaudeNativeHookInterpreterMismatchError,
+    approval_wait_is_fresh,
+    approval_wait_marker_path,
     build_hook_settings,
     prepare_bridge_dir,
     read_transcript_path,
@@ -2524,6 +2526,66 @@ def test_reattach_held_poll_sever_resets_backoff(monkeypatch: pytest.MonkeyPatch
     initial = claude_native_hook._PERMISSION_RETRY_INITIAL_BACKOFF_S
     # Three hard failures double the wait; each held-poll sever resets it.
     assert sleeps == [initial, initial * 2, initial * 4, initial, initial]
+
+
+def test_reattach_holds_the_approval_wait_marker_until_the_wait_ends(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked hook keeps its approval-wait marker fresh on every attempt.
+
+    A pane parked on a permission prompt emits nothing and reports no active
+    turn, so the idle pane reaper reads it as abandoned and kills the prompt.
+    This marker is the pane's only evidence of the wait, so it must be fresh
+    for every re-POST across a severed poll — and gone once the wait ends, so
+    the pane returns to normal idle accounting instead of lingering.
+    """
+    monkeypatch.setattr(
+        "omnigent.harnesses.claude_native.bridge._APPROVAL_WAIT_ROOT", tmp_path / "approval-waits"
+    )
+    session_id = "conv_marked"
+    marker = approval_wait_marker_path(session_id)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    held = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S + 290.0
+    fresh_per_attempt: list[bool] = []
+    clock = {"t": 0.0}
+    monkeypatch.setattr(claude_native_hook.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(claude_native_hook.time, "sleep", lambda _s: None)
+
+    class _ObservingClient:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _ObservingClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            fresh_per_attempt.append(approval_wait_is_fresh(session_id))
+            req = httpx.Request("POST", url)
+            if len(fresh_per_attempt) <= 2:
+                clock["t"] += held
+                raise httpx.RemoteProtocolError("gateway severed the poll", request=req)
+            return httpx.Response(200, json={"ok": True}, request=req)
+
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _ObservingClient)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_marked/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+        wait_marker=marker,
+    )
+
+    assert resp is not None and resp.status_code == 200
+    assert fresh_per_attempt == [True, True, True], (
+        "the marker must read fresh on every attempt, including after a sever"
+    )
+    assert not approval_wait_marker_path(session_id).exists()
 
 
 def test_reattach_fast_flapping_connection_is_hard_failure(

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -7,6 +7,7 @@ import json
 import re
 import shlex
 import sys
+import time
 from pathlib import Path
 
 import httpx
@@ -2502,9 +2503,10 @@ def test_reattach_held_poll_sever_resets_backoff(monkeypatch: pytest.MonkeyPatch
     """After a held-poll sever the next re-POST waits only the initial backoff.
 
     The server clears the approval card ``_HARNESS_ELICITATION_REPARK_GRACE_S``
-    (10s) after a severed wait unless the same id re-parks first, so a
-    backoff that kept doubling past 10s flipped the card to "Resolved
-    elsewhere" on every proxy sever. Growth is reserved for hard failures.
+    (30s) after a severed wait unless the same id re-parks first, so a
+    backoff that kept doubling towards its 30s cap flipped the card to
+    "Resolved elsewhere" on every proxy sever. Growth is reserved for hard
+    failures.
     """
     floor = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S
     client = _scripted_client(
@@ -2586,6 +2588,131 @@ def test_reattach_holds_the_approval_wait_marker_until_the_wait_ends(
         "the marker must read fresh on every attempt, including after a sever"
     )
     assert not approval_wait_marker_path(session_id).exists()
+
+
+def test_reattach_marker_stays_fresh_through_an_unsevered_held_poll(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    One long held POST keeps the marker fresh past the TTL while in flight.
+
+    A direct server (no front door) holds the poll for the whole wait, so the
+    single touch a per-attempt refresh made went stale after the TTL and the
+    idle reaper killed the parked pane an hour later. Real clock, scaled TTL.
+    """
+    monkeypatch.setattr(
+        "omnigent.harnesses.claude_native.bridge._APPROVAL_WAIT_ROOT", tmp_path / "approval-waits"
+    )
+    monkeypatch.setattr(
+        "omnigent.harnesses.claude_native.bridge.APPROVAL_WAIT_MARKER_REFRESH_S", 0.05
+    )
+    monkeypatch.setattr("omnigent.harnesses.claude_native.bridge.APPROVAL_WAIT_MARKER_TTL_S", 0.5)
+    session_id = "conv_direct"
+    marker = approval_wait_marker_path(session_id)
+    marker.parent.mkdir(parents=True)
+    freshness: list[bool] = []
+
+    class _HoldingClient:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _HoldingClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            for _ in range(3):
+                time.sleep(0.5)  # each hold spans a whole TTL
+                freshness.append(approval_wait_is_fresh(session_id))
+            return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _HoldingClient)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_direct/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+        wait_marker=marker,
+    )
+
+    assert resp is not None and resp.status_code == 200
+    assert freshness == [True, True, True], "the marker must stay fresh for the whole held poll"
+    assert not marker.exists()
+
+
+def test_reattach_reauths_again_after_a_held_poll_sever(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Every token lapse across a long wait is re-minted, not only the first.
+
+    A parked approval outlives the ~1h token: the server bounces the lapsed
+    bearer, the hook re-mints once, the gateway severs the next held poll, and
+    an hour later the fresh token lapses too. The held poll must re-arm the
+    one-shot re-mint, or the second bounce fail-asks into the unwatched TUI.
+    """
+    floor = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S
+    clock = {"t": 0.0}
+    monkeypatch.setattr(claude_native_hook.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(claude_native_hook.time, "sleep", lambda _s: None)
+    # Per attempt: a bounce, a gateway sever after a held poll, a second bounce,
+    # then the verdict.
+    script = [("302", 0.0), ("severed", floor + 290.0), ("302", 0.0), ("ok", 0.0)]
+    seen_auth: list[str] = []
+
+    class _Client:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del timeout
+            self._headers = headers
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            seen_auth.append(self._headers.get("Authorization", ""))
+            kind, held_s = script[len(seen_auth) - 1]
+            clock["t"] += held_s
+            req = httpx.Request("POST", url)
+            if kind == "302":
+                return httpx.Response(
+                    302,
+                    headers={"Location": "https://w.example.com/oidc/oauth2/v2.0/authorize"},
+                    request=req,
+                )
+            if kind == "severed":
+                raise httpx.RemoteProtocolError("gateway severed the poll", request=req)
+            return httpx.Response(200, json={"ok": True}, request=req)
+
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _Client)
+    minted: list[int] = []
+
+    def _reauth() -> dict[str, str]:
+        """
+        Mint a distinguishable fresh bearer.
+
+        :returns: Headers carrying the new token.
+        """
+        minted.append(len(minted) + 1)
+        return {"Authorization": f"Bearer fresh{len(minted)}"}
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={"Authorization": "Bearer stale"},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+        reauth=_reauth,
+    )
+
+    assert resp is not None and resp.status_code == 200
+    assert minted == [1, 2], "the second lapse must be re-minted too"
+    assert seen_auth == ["Bearer stale", "Bearer fresh1", "Bearer fresh1", "Bearer fresh2"]
 
 
 def test_reattach_fast_flapping_connection_is_hard_failure(

--- a/tests/test_claude_native_hook.py
+++ b/tests/test_claude_native_hook.py
@@ -2273,7 +2273,9 @@ def _scripted_client(
       * ``"connect"`` — :class:`httpx.ConnectError` (server never reached: hard)
       * ``"severed"`` — :class:`httpx.RemoteProtocolError` (established then
         dropped: a held-poll sever iff ``held_s`` >= the floor)
-      * ``"5xx"``     — a 503 response (server sick: hard)
+      * ``"5xx"``     — a 503 response (hard iff ``held_s`` < the floor; a
+        gateway 5xx ending a held poll is a sever)
+      * ``"ok"``      — a 200 response (the human answered: final)
 
     :param script: Per-attempt ``(kind, held_s)`` plan.
     :param monkeypatch: Installs the fake clock + no-op sleep.
@@ -2310,6 +2312,8 @@ def _scripted_client(
                 raise httpx.RemoteProtocolError("server dropped the poll", request=req)
             if kind == "5xx":
                 return httpx.Response(503, text="upstream down", request=req)
+            if kind == "ok":
+                return httpx.Response(200, json={"ok": True}, request=req)
             raise AssertionError(f"unknown scripted kind {kind!r}")
 
     _ScriptedClient.calls = calls
@@ -2459,6 +2463,67 @@ def test_reattach_proxy_severed_held_poll_never_caps(monkeypatch: pytest.MonkeyP
         "a slow human behind a severing proxy was capped — the #1782 regression"
     )
     assert len(calls) == n_severs + 1  # retried through every sever, then answered
+
+
+def test_reattach_gateway_5xx_after_held_poll_never_caps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gateway 5xx that ends a HELD poll is a sever, not a sick server.
+
+    The Databricks front door answers an idle long-poll with 504 after 300s.
+    Counting those as hard failures fail-asked a parked approval into the
+    unwatched TUI after ``cap`` severs (40 minutes). Held past the floor, a
+    5xx must reset the counter exactly like a torn connection does.
+    """
+    cap = claude_native_hook._PERMISSION_MAX_CONSECUTIVE_FAILURES
+    held = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S + 290.0
+    client = _scripted_client(
+        script=[("5xx", held)] * (cap * 3) + [("ok", 0.0)],
+        monkeypatch=monkeypatch,
+    )
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", client)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is not None and resp.status_code == 200, (
+        "a slow human behind a 504-answering gateway was capped"
+    )
+    assert len(client.calls) == cap * 3 + 1
+
+
+def test_reattach_held_poll_sever_resets_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After a held-poll sever the next re-POST waits only the initial backoff.
+
+    The server clears the approval card ``_HARNESS_ELICITATION_REPARK_GRACE_S``
+    (10s) after a severed wait unless the same id re-parks first, so a
+    backoff that kept doubling past 10s flipped the card to "Resolved
+    elsewhere" on every proxy sever. Growth is reserved for hard failures.
+    """
+    floor = claude_native_hook._PERMISSION_HELD_POLL_FLOOR_S
+    client = _scripted_client(
+        script=[("connect", 0.0)] * 3 + [("severed", floor + 290.0)] * 2 + [("ok", 0.0)],
+        monkeypatch=monkeypatch,
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr(claude_native_hook.time, "sleep", sleeps.append)
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", client)
+
+    resp = claude_native_hook._post_hook_with_reattach(
+        url="http://127.0.0.1:8787/v1/sessions/conv_x/hooks/permission-request",
+        headers={},
+        payload={"hook_event_name": "PreToolUse"},
+        hook_label="permission",
+    )
+
+    assert resp is not None and resp.status_code == 200
+    initial = claude_native_hook._PERMISSION_RETRY_INITIAL_BACKOFF_S
+    # Three hard failures double the wait; each held-poll sever resets it.
+    assert sleeps == [initial, initial * 2, initial * 4, initial, initial]
 
 
 def test_reattach_fast_flapping_connection_is_hard_failure(

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -776,6 +776,91 @@ async def test_elicitation_post_reposts_after_transport_cut_with_same_envelope(
 
 
 @pytest.mark.asyncio
+async def test_elicitation_post_resets_backoff_after_a_gateway_severed_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A gateway-severed HELD poll resets the retry backoff; fast failures grow it.
+
+    The front door caps a request at 300s and answers with 504, so a parked
+    approval is severed every five minutes. A backoff that kept doubling
+    pushed the re-POST past the server's re-park grace, which cleared the
+    approval card to "Resolved elsewhere" between polls. Growth belongs to
+    fast failures (a sick or unreachable server), not to a poll the gateway
+    held for its full budget.
+    """
+    loop = asyncio.get_running_loop()
+    clock = {"t": 0.0}
+    monkeypatch.setattr(loop, "time", lambda: clock["t"])
+    sleeps: list[float] = []
+
+    async def _record_sleep(seconds: float) -> None:
+        """
+        Record the backoff instead of waiting it out.
+
+        :param seconds: Backoff the loop asked for.
+        :returns: None.
+        """
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(fwd, "_elicitation_retry_sleep", _record_sleep)
+    held = fwd._CODEX_ELICITATION_HELD_POLL_FLOOR_SECONDS + 290.0
+    # (held_s, outcome) per attempt: a gateway sever holds the poll for its
+    # full budget, a refused connection fails instantly.
+    script = [
+        (held, "5xx"),
+        (held, "5xx"),
+        (0.0, "cut"),
+        (0.0, "cut"),
+        (held, "5xx"),
+        (0.0, "ok"),
+    ]
+
+    class _ScriptedElicitationClient:
+        """Stub client whose POSTs follow *script*, advancing the fake clock."""
+
+        def __init__(self) -> None:
+            self.posts: list[tuple[str, dict]] = []
+
+        async def post(self, url: str, *, json: dict, timeout: httpx.Timeout) -> httpx.Response:
+            """
+            Fail or succeed per the script, charging the attempt's hold time.
+
+            :param url: Request URL.
+            :param json: Codex JSON-RPC request envelope.
+            :param timeout: Per-attempt budget (ignored by the stub).
+            :returns: 504 for a gateway sever, 200 once the script says so.
+            :raises httpx.ReadError: For an instantly refused connection.
+            """
+            del timeout
+            self.posts.append((url, json))
+            held_s, outcome = script[len(self.posts) - 1]
+            clock["t"] += held_s
+            request = httpx.Request("POST", url)
+            if outcome == "cut":
+                raise httpx.ReadError("connection refused", request=request)
+            if outcome == "5xx":
+                return httpx.Response(504, request=request)
+            return httpx.Response(200, json={"action": "accept"}, request=request)
+
+    client = _ScriptedElicitationClient()
+
+    response = await fwd._post_codex_elicitation_request(
+        client,  # type: ignore[arg-type]  # stub implements the one used method
+        "conv_x",
+        event=_ELICITATION_EVENT,
+    )
+
+    assert response is not None
+    assert response.status_code == 200
+    initial = fwd._CODEX_ELICITATION_RETRY_INITIAL_BACKOFF_SECONDS
+    assert sleeps == [initial, initial, initial, initial * 2, initial * 4], (
+        "a gateway-severed held poll must reset the backoff so the re-POST lands "
+        "inside the server's re-park grace; only fast failures may back off"
+    )
+
+
+@pytest.mark.asyncio
 async def test_elicitation_post_retries_gateway_5xx(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_native_policy_hook.py
+++ b/tests/test_native_policy_hook.py
@@ -532,6 +532,117 @@ def test_post_evaluate_with_retry_reauths_on_login_redirect(
     assert seen_headers[1]["Authorization"] == "Bearer fresh"  # retry: fresh token
 
 
+@pytest.mark.parametrize("sever", ["504", "torn"])
+def test_post_evaluate_with_retry_reparks_a_held_ask_poll_the_gateway_severed(
+    monkeypatch: pytest.MonkeyPatch,
+    sever: str,
+) -> None:
+    """
+    A held ASK poll the gateway severs re-POSTs the same id and spends no budget.
+
+    The Databricks front door caps any request at 300s and answers 504 (or
+    tears the connection down). The transient budget is 30s from the first
+    attempt, so counting that 504 as a fault exhausted it at once and an
+    unattended ASK gate failed closed after five minutes.
+    """
+    clock = {"t": 0.0}
+    monkeypatch.setattr(native_policy_hook.time, "monotonic", lambda: clock["t"])
+    sleeps: list[float] = []
+    monkeypatch.setattr(native_policy_hook.time, "sleep", sleeps.append)
+    held = native_policy_hook._EVALUATE_POLICY_HELD_POLL_FLOOR_S + 290.0
+    bodies: list[dict[str, object]] = []
+    ok = httpx.Response(
+        200,
+        text='{"result":"POLICY_ACTION_ALLOW"}',
+        request=httpx.Request("POST", "https://ap/x"),
+    )
+
+    class _Client:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            bodies.append(json)
+            if len(bodies) > 2:
+                return ok
+            clock["t"] += held  # the gateway held the poll for its full budget
+            req = httpx.Request("POST", url)
+            if sever == "504":
+                return httpx.Response(504, request=req)
+            raise httpx.RemoteProtocolError("gateway severed the poll", request=req)
+
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _Client)
+
+    resp, error = post_evaluate_with_retry(
+        "https://ap/x", {}, {"event": {}}, 86400.0, "evaluate-policy hook"
+    )
+
+    assert resp is ok
+    assert error is None
+    assert len(bodies) == 3
+    assert len({body["_omnigent_elicitation_id"] for body in bodies}) == 1, (
+        "every re-POST must re-park the same elicitation"
+    )
+    initial = native_policy_hook._EVALUATE_POLICY_RETRY_INITIAL_BACKOFF_S
+    assert sleeps == [initial, initial], "a severed held poll re-POSTs inside the re-park grace"
+
+
+def test_post_evaluate_with_retry_fast_5xx_still_exhausts_the_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A server answering 5xx at once is a fault bounded by the transient budget.
+
+    Only a poll held past the floor is a gateway sever; a sick server that
+    refuses quickly must still fail closed once the budget is spent.
+    """
+    clock = {"t": 0.0}
+    monkeypatch.setattr(native_policy_hook.time, "monotonic", lambda: clock["t"])
+
+    def _sleep(seconds: float) -> None:
+        """
+        Advance the fake clock instead of waiting.
+
+        :param seconds: Backoff the loop asked for.
+        :returns: None.
+        """
+        clock["t"] += seconds
+
+    monkeypatch.setattr(native_policy_hook.time, "sleep", _sleep)
+    posts: list[str] = []
+
+    class _Client:
+        def __init__(self, *, headers: dict[str, str], timeout: object) -> None:
+            del headers, timeout
+
+        def __enter__(self) -> _Client:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+        def post(self, url: str, *, json: dict[str, object]) -> httpx.Response:
+            del json
+            posts.append(url)
+            return httpx.Response(503, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(native_policy_hook.httpx, "Client", _Client)
+
+    resp, error = post_evaluate_with_retry(
+        "https://ap/x", {}, {"event": {}}, 86400.0, "evaluate-policy hook"
+    )
+
+    assert resp is None
+    assert error is not None and "retry budget exhausted" in error
+    assert 2 <= len(posts) <= 8, "retried within the budget, then gave up"
+
+
 def test_post_evaluate_with_retry_reauths_on_403_invalid_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

No tracked GitHub issue — this came from an internal report: a native-Claude session on a Databricks-hosted server (isaac, session `860572132071726`) that looked dead but was actually blocked on an unanswered permission prompt. Root-caused from the Omnigent debug logs.

Closes # <!-- none -->

## Summary

On Databricks-hosted servers, the workspace front door caps **every** HTTP request at ~300s of total duration, not idleness (measured: a session SSE stream with a keepalive every 15s was still cut at 300.2s), and returns a `504`. The native-Claude permission hook long-polls the server for a human's approval verdict, so it takes a `504` every five minutes and has to reconnect.

Two defects turned that routine cut into a wedged session:

- The hook counted **every** `5xx` as a sick-server hard failure and gave up after 8 in a row (~40 min), exiting with no decision so Claude Code fell back to a terminal prompt nobody watches. Its reconnect backoff (1→2→…→30s) also outgrew the server's 10s re-park grace, so the web approval card flipped to **"Resolved elsewhere"** between polls.
- Even with the retry loop fixed, the **idle pane reaper** kills the pane an hour later: a pane parked on a permission prompt emits no output, runs no active turn, has no client attached and no `running` status, so every busy signal reads idle.

This PR keeps the prompt answerable end to end:

1. Classify a `5xx` held past the floor as a **gateway sever**, not a sick server, and reset the backoff on every held sever so the re-POST lands inside the re-park grace. Fast failures still count toward the anti-spin cap (#1782).
2. A parked hook keeps a **freshness marker** the reaper honors, so a pane waiting on a prompt is spared. The marker root is derived from the runner-supplied `--bridge-dir`, so a hook subprocess can't disagree with the runner about `$TMPDIR`; it lives inside the bridge root (no `owner.pid`, so the orphan pruner skips it) and clears in a `finally`.
3. Widen the server re-park grace `10s → 30s` so a slow re-POST (a lapsed token costs a re-mint round trip) can't clear a still-blocked card.
4. Apply the same backoff reset to the **codex** elicitation forwarder, which flickered to "Resolved elsewhere" every five minutes for the same reason.
5. Hold the marker fresh for the **whole wait**, not once per POST: a parked hook re-touches it on a daemon thread every 60s, so a direct server that holds one POST for hours (no front door to sever it) reads as parked too. Markers are per hook process, so a permission request and an AskUserQuestion parked side by side never clear each other's, and the reaper's check prunes the stale marker a killed hook leaves behind.
6. Give the **policy ASK gate** the same classification: `post_evaluate_with_retry` had a 30s transient budget measured from the first attempt, so the 504 at 300s exhausted it instantly and the gate fail-asked into the unwatched TUI. A 5xx or torn connection after a held poll now re-POSTs the same id after 1s and spends no budget; a fast 5xx still fails closed after the budget.
7. Re-arm the one-shot token re-mint after every held poll in both hooks, so a wait longer than the ~1h token lifetime survives each lapse instead of fail-asking at the second bounce.

### ELI5

Claude asks "can I run this?" and the web page shows an Approve button. The messenger carrying that question has to reconnect every five minutes because the front door hangs up on long-idle requests. The messenger mistook those hang-ups for "the server is broken," gave up after 40 minutes, and handed the question to a terminal nobody is watching — and even before that, a janitor closed the idle-looking window the question lived in. Now the messenger knows a hang-up is routine, and the janitor leaves a window alone while someone's waiting on its prompt.

```mermaid
sequenceDiagram
    participant CC as Claude Code (hidden pane)
    participant H as Hook (per-prompt subprocess)
    participant FD as Databricks front door
    participant S as Omnigent server
    Note over FD: caps any request at ~300s → 504
    loop every 5 min
        H->>FD: POST permission-request (held-poll)
        FD-->>H: 504 after 300s
        Note over H: before — counted as failure (give up at 8)<br/>after — recognized as a sever, retry in 1s
    end
    Note over H: while waiting, refresh a marker the pane reaper honors
    S-->>H: verdict once the human clicks Approve
```

## Test Plan

- **Unit** — `pytest tests/test_claude_native_hook.py tests/test_claude_native_bridge.py tests/test_codex_native_forwarder.py tests/terminals/test_pane_reaper.py tests/test_native_policy_hook.py` all pass. New tests cover the 504-held-poll classification, the backoff reset (Claude and Codex), the pane-alive marker, the marker staying fresh through one unsevered held poll (real clock, scaled TTL), per-hook markers and stale-marker pruning, the refresher stopping on exit, the runner's `_native_pane_is_busy` honoring the marker, the ASK gate re-parking after a 504 / torn connection with the same elicitation id (and still failing closed on a fast 5xx), and a second token lapse being re-minted. Each was red-proofed (reverting the fix makes it fail, e.g. Codex backoff goes `[1,2,4,8,16]` where the test requires `[1,1,1,2,4]`; without the refresher the unsevered-poll test reads `[True, False, False]`).
- **Integration** — `pytest tests/server/integration/test_sessions_permission_request_hook.py` (61) passes with the widened grace.
- **Static** — `ruff format`/`check`, the repo lint scripts, and `pyrefly` are clean on the changed files.
- **Manual, pre-merge (needs a deploy to a Databricks-hosted server):** start a native-Claude session, request a shell command that needs approval, leave the card untouched for >70 min (past both the 5-min cuts and the 1-hour idle reap), then click Approve — the card should still be answerable and the command should run. In the debug-log table you should see one `claude_permission_request_hook start` ~1s after each 300s `ok`, and no `response.elicitation_resolved` until the click.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification so far covers the mechanism, not the full journey: I confirmed the front door's ~300s total-duration cap by holding a session SSE stream open through it (cut at 300.2s despite 15s keepalives), and confirmed the hook-side and reaper-side marker paths resolve to byte-identical locations via a live runner import. The full end-to-end check (park an approval >70 min on a deployed Databricks-hosted server, then approve) needs a deploy and is the pre-merge manual step in the Test Plan; it has not been run yet.

The `_native_pane_is_busy` reaper closure in `create_runner_app` is now covered directly (`tests/terminals/test_pane_reaper.py::test_runner_busy_check_spares_a_pane_parked_on_an_approval` builds the runner app and checks the busy verdict with and without a marker).

## Changelog

Native Claude and Codex approval prompts and policy ASK gates left unattended stay answerable in the web UI instead of silently reverting to the terminal after a few minutes, on direct and Databricks-hosted servers alike.

