### PR TITLE
feat(slack): let an operator pre-set the default agent and managed host for setup

### DIFF
--- a/integrations/slack/.env.example
+++ b/integrations/slack/.env.example
@@ -9,6 +9,24 @@ OMNIGENT_SERVER_URL=https://omnigent.example.com
 # when OMNIGENT_DATA_DIR is unset). Set this to override.
 # OMNIGENT_SLACK_DATABASE_PATH=
 
+# Optional workspace-wide setup defaults. Each pre-selects a choice in every
+# user's `/omnigent` setup modal instead of leaving it blank. The modal still
+# opens and still has to be submitted, and the user can change either choice —
+# this only removes the "pick two things you have no opinion on" step. Unset
+# (the default) leaves the picker exactly as it has always been.
+# The agent id to pre-select — one of the ids the server returns from
+# GET /v1/agents (the same list the picker is built from). If the server
+# doesn't offer that agent to a given user, their agent menu stays blank and
+# the modal says the configured default is unavailable; it never substitutes
+# a different agent.
+# OMNIGENT_SLACK_DEFAULT_AGENT_ID=
+# Pre-select the server-provisioned managed sandbox as the host. The only
+# accepted value is `managed`; anything else fails at startup. There is
+# deliberately no default for a specific external host: /v1/hosts is
+# owner-scoped, so one user's host is invisible to everyone else and could
+# never be pre-selected in a menu that never lists it.
+# OMNIGENT_SLACK_DEFAULT_HOST_TYPE=managed
+
 # Optional but strongly recommended: shared secret from Omnigent server
 # Set it to the SAME value as the Omnigent server's
 # OMNIGENT_DEVICE_CLIENT_SECRET; the bot then sends it on the device

--- a/integrations/slack/.env.example
+++ b/integrations/slack/.env.example
@@ -15,16 +15,16 @@ OMNIGENT_SERVER_URL=https://omnigent.example.com
 # this only removes the "pick two things you have no opinion on" step. Unset
 # (the default) leaves the picker exactly as it has always been.
 # The agent id to pre-select — one of the ids the server returns from
-# GET /v1/agents (the same list the picker is built from). If the server
-# doesn't offer that agent to a given user, their agent menu stays blank and
-# the modal says the configured default is unavailable; it never substitutes
-# a different agent.
+# GET /v1/agents (the same list the picker is built from). If that agent isn't
+# available in a given user's menu, their menu stays blank and the modal says
+# the configured default is unavailable; it never substitutes another agent.
+# Unset or blank means no default.
 # OMNIGENT_SLACK_DEFAULT_AGENT_ID=
-# Pre-select the server-provisioned managed sandbox as the host. The only
-# accepted value is `managed`; anything else fails at startup. There is
-# deliberately no default for a specific external host: /v1/hosts is
-# owner-scoped, so one user's host is invisible to everyone else and could
-# never be pre-selected in a menu that never lists it.
+# Pre-select the server-provisioned managed sandbox as the host. Accepted
+# values: unset or blank (no default), or `managed`. Any other non-blank value
+# fails at startup. There is deliberately no default for a specific external
+# host: on an authenticated server /v1/hosts is owner-scoped, so one user's
+# host is not listed for anyone else and could never be pre-selected.
 # OMNIGENT_SLACK_DEFAULT_HOST_TYPE=managed
 
 # Optional but strongly recommended: shared secret from Omnigent server

--- a/integrations/slack/.env.example
+++ b/integrations/slack/.env.example
@@ -9,7 +9,7 @@ OMNIGENT_SERVER_URL=https://omnigent.example.com
 # when OMNIGENT_DATA_DIR is unset). Set this to override.
 # OMNIGENT_SLACK_DATABASE_PATH=
 
-# Optional workspace-wide setup defaults. Each pre-selects a choice in every
+# Optional operator-set setup defaults. Each pre-selects a choice in every
 # user's `/omnigent` setup modal instead of leaving it blank. The modal still
 # opens and still has to be submitted, and the user can change either choice —
 # this only removes the "pick two things you have no opinion on" step. Unset

--- a/integrations/slack/README.md
+++ b/integrations/slack/README.md
@@ -96,8 +96,8 @@ while it's already up is a no-op that reports the existing process.
 ### Configuration
 
 All configuration (the two Slack tokens, `OMNIGENT_SERVER_URL`, and the
-optional `OMNIGENT_DEVICE_CLIENT_SECRET` / `OMNIGENT_SLACK_TOKEN_ENCRYPTION_KEY`)
-comes from **real environment variables** — the bot does **not** read a `.env`
+optional `OMNIGENT_DEVICE_CLIENT_SECRET` / `OMNIGENT_SLACK_TOKEN_ENCRYPTION_KEY`
+/ the setup defaults below) comes from **real environment variables** — the bot does **not** read a `.env`
 file itself. For local dev, either export the vars, or launch under a tool that
 injects a `.env` — e.g. `uv run --env-file .env omni integration slack`, or
 `export $(grep -v '^#' .env | xargs)` before running. In production the
@@ -137,6 +137,36 @@ URL to enter):
 
 The choice is saved per `(Slack workspace, user)`. After that, mentioning the
 bot (or DMing it) starts a session on the configured server.
+
+### Workspace-wide setup defaults (optional)
+
+A team standardized on one agent — or on the managed sandbox — can pre-select
+step 2's choices for everyone, so a new user submits the modal instead of
+making two decisions they have no opinion on:
+
+| Variable | Effect |
+| --- | --- |
+| `OMNIGENT_SLACK_DEFAULT_AGENT_ID` | Opens the **Agent** menu on this agent id. |
+| `OMNIGENT_SLACK_DEFAULT_HOST_TYPE` | Only `managed` — opens the **Host** menu on the server-provisioned sandbox. |
+
+Set them in the bot's environment like every other variable (see
+**Configuration** above); `.env.example` carries the same notes.
+
+Both are pre-selections, nothing more. The modal still opens, still shows the
+full menus, and still has to be submitted — either choice can be changed, and
+what the user submits is what is saved.
+
+Availability is checked per user, each time the modal is rendered, against the
+agents and hosts that user's own login can see. A default that isn't on offer
+— an agent id the server doesn't return for them, or `managed` on a server that
+provisions no sandbox — leaves **that** menu blank and says so in the modal. A
+different agent or host is never substituted, and a valid default in the other
+menu is still applied. A server that can't be reached is a login/retry failure
+as before, not an "unavailable default".
+
+There is deliberately **no** default for a specific external host id: `/v1/hosts`
+is owner-scoped, so one user's host is invisible to everyone else and could not
+be pre-selected in a menu that never lists it.
 
 ## Authentication
 

--- a/integrations/slack/README.md
+++ b/integrations/slack/README.md
@@ -149,6 +149,9 @@ making two decisions they have no opinion on:
 | `OMNIGENT_SLACK_DEFAULT_AGENT_ID` | Opens the **Agent** menu on this agent id. |
 | `OMNIGENT_SLACK_DEFAULT_HOST_TYPE` | Only `managed` — opens the **Host** menu on the server-provisioned sandbox. |
 
+Either variable may be left unset or blank for no default; any other non-blank
+value for `OMNIGENT_SLACK_DEFAULT_HOST_TYPE` fails at startup.
+
 Set them in the bot's environment like every other variable (see
 **Configuration** above); `.env.example` carries the same notes.
 
@@ -158,15 +161,24 @@ what the user submits is what is saved.
 
 Availability is checked per user, each time the modal is rendered, against the
 agents and hosts that user's own login can see. A default that isn't on offer
-— an agent id the server doesn't return for them, or `managed` on a server that
-provisions no sandbox — leaves **that** menu blank and says so in the modal. A
-different agent or host is never substituted, and a valid default in the other
-menu is still applied. A server that can't be reached is a login/retry failure
-as before, not an "unavailable default".
+— an agent id missing from their menu, or `managed` on a server that provisions
+no sandbox — leaves **that** menu blank and says so in the modal. A different
+agent or host is never substituted, and a valid default in the other menu is
+still applied.
 
-There is deliberately **no** default for a specific external host id: `/v1/hosts`
-is owner-scoped, so one user's host is invisible to everyone else and could not
-be pre-selected in a menu that never lists it.
+The modal distinguishes what it actually established from what it could not
+check. A server that can't be reached is a login/retry failure as before, not
+an "unavailable default"; a capability probe that fails says the check didn't
+complete, not that the server provisions no sandboxes; and an agent past the
+menu's 100-option cap is reported as missing from the menu, not from the
+server.
+
+There is deliberately **no** default for a specific external host id. On an
+authenticated server `/v1/hosts` is owner-scoped, so one user's host is not
+listed for anyone else and could not be pre-selected in a menu that never
+lists it. (On a server with auth disabled every caller shares the reserved
+`local` owner and does see the same hosts — but a default that only works for
+unauthenticated deployments is not one worth shipping.)
 
 ## Authentication
 

--- a/integrations/slack/README.md
+++ b/integrations/slack/README.md
@@ -138,7 +138,7 @@ URL to enter):
 The choice is saved per `(Slack workspace, user)`. After that, mentioning the
 bot (or DMing it) starts a session on the configured server.
 
-### Workspace-wide setup defaults (optional)
+### Operator-set setup defaults (optional)
 
 A team standardized on one agent — or on the managed sandbox — can pre-select
 step 2's choices for everyone, so a new user submits the modal instead of

--- a/integrations/slack/src/omnigent_slack/app.py
+++ b/integrations/slack/src/omnigent_slack/app.py
@@ -131,6 +131,8 @@ async def run() -> None:
         server_url=settings.server_url,
         auth_manager=auth_manager,
         enrollment_url=enrollment_url,
+        default_agent_id=settings.default_agent_id,
+        default_host_type=settings.default_host_type,
     )
     service = SlackOmnigentService(
         store=store,

--- a/integrations/slack/src/omnigent_slack/config.py
+++ b/integrations/slack/src/omnigent_slack/config.py
@@ -26,6 +26,14 @@ class ConfigError(Exception):
 # to the server. See ``docs/DATABRICKS_APP_WEBAUTH_DESIGN.md``.
 ServerAuthMode = Literal["auto", "databricks"]
 
+# Host kind an operator may pre-select for every user's setup modal. Only the
+# server-provisioned managed sandbox qualifies: it is the same choice for
+# everyone, so it can be named once in the deployment's config. A specific
+# external host id deliberately is NOT configurable — ``/v1/hosts`` is
+# owner-scoped, so one user's host is invisible to everyone else and could
+# never be pre-selected in a menu that never lists it.
+DefaultHostType = Literal["managed"]
+
 # Minimum length for the enrollment-state HMAC secret. 32 chars is a floor
 # against offline brute-forcing a weak operator value (which would let an
 # attacker forge a signed `state`); `openssl rand -hex 32` yields 64.
@@ -135,6 +143,26 @@ class Settings(BaseSettings):
     )
     log_level: str = Field(default="INFO", validation_alias="LOG_LEVEL")
 
+    # ── Operator-set setup defaults ───────────────────────────────────────
+    #
+    # Pre-select a choice in every user's ``/omnigent`` setup modal, for a
+    # workspace standardized on one agent (or on the managed sandbox). Purely
+    # additive: unset, the picker opens blank exactly as it always has. Set,
+    # the menu opens on that choice — still changeable, and setup still
+    # requires a submit. A default the server doesn't offer that user leaves
+    # its menu blank with an in-modal note (setup.py), never a substitute.
+    default_agent_id: str | None = Field(
+        default=None,
+        validation_alias="OMNIGENT_SLACK_DEFAULT_AGENT_ID",
+    )
+    # ``managed`` (the server-provisioned sandbox) or unset — see
+    # ``DefaultHostType`` for why no external host id is accepted. Anything
+    # else fails at startup rather than silently doing nothing.
+    default_host_type: DefaultHostType | None = Field(
+        default=None,
+        validation_alias="OMNIGENT_SLACK_DEFAULT_HOST_TYPE",
+    )
+
     # Fernet key (urlsafe-base64, 32 bytes) that encrypts the delegated
     # Omnigent access/refresh tokens at rest in the local SQLite store.
     # Generate with ``python -c "from cryptography.fernet import Fernet;
@@ -204,6 +232,23 @@ class Settings(BaseSettings):
         default=None,
         validation_alias="OMNIGENT_SLACK_DATABRICKS_APP_URL",
     )
+
+    @field_validator("default_agent_id", "default_host_type", mode="before")
+    @classmethod
+    def _blank_default_is_unset(cls, value: object) -> object:
+        """Treat a blank setup default as unset rather than as a bad value.
+
+        ``OMNIGENT_SLACK_DEFAULT_HOST_TYPE=`` is how a compose file / deploy
+        template spells "leave this off", so an empty or whitespace-only value
+        must mean "no default" — not a startup failure, and not a literal ""
+        agent id the modal could only report as unavailable. A non-blank value
+        is still validated strictly (an unknown host type fails startup). The
+        web prefill treats a blank stored agent id the same way
+        (web/src/shell/projectPrefill.ts).
+        """
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value.strip() if isinstance(value, str) else value
 
     @field_validator("server_url")
     @classmethod

--- a/integrations/slack/src/omnigent_slack/config.py
+++ b/integrations/slack/src/omnigent_slack/config.py
@@ -26,12 +26,9 @@ class ConfigError(Exception):
 # to the server. See ``docs/DATABRICKS_APP_WEBAUTH_DESIGN.md``.
 ServerAuthMode = Literal["auto", "databricks"]
 
-# Host kind an operator may pre-select for every user's setup modal. Only the
-# server-provisioned managed sandbox qualifies: it is the same choice for
-# everyone, so it can be named once in the deployment's config. A specific
-# external host id deliberately is NOT configurable — ``/v1/hosts`` is
-# owner-scoped, so one user's host is invisible to everyone else and could
-# never be pre-selected in a menu that never lists it.
+# Host kind an operator may pre-select for every user. Only the managed sandbox
+# qualifies: on an authenticated server ``/v1/hosts`` is owner-scoped, so a
+# specific external host id could never be pre-selected. See the README.
 DefaultHostType = Literal["managed"]
 
 # Minimum length for the enrollment-state HMAC secret. 32 chars is a floor
@@ -144,20 +141,15 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", validation_alias="LOG_LEVEL")
 
     # ── Operator-set setup defaults ───────────────────────────────────────
-    #
-    # Pre-select a choice in every user's ``/omnigent`` setup modal, for a
-    # workspace standardized on one agent (or on the managed sandbox). Purely
-    # additive: unset, the picker opens blank exactly as it always has. Set,
-    # the menu opens on that choice — still changeable, and setup still
-    # requires a submit. A default the server doesn't offer that user leaves
-    # its menu blank with an in-modal note (setup.py), never a substitute.
+    # Pre-select a choice in every user's ``/omnigent`` setup modal. Unset, the
+    # picker opens blank exactly as it always has; set, the menu opens on that
+    # choice and the user can still change it. See the README for the behaviour.
     default_agent_id: str | None = Field(
         default=None,
         validation_alias="OMNIGENT_SLACK_DEFAULT_AGENT_ID",
     )
-    # ``managed`` (the server-provisioned sandbox) or unset — see
-    # ``DefaultHostType`` for why no external host id is accepted. Anything
-    # else fails at startup rather than silently doing nothing.
+    # ``managed`` (see ``DefaultHostType``), or unset/blank for no default. Any
+    # other non-blank value fails startup rather than silently doing nothing.
     default_host_type: DefaultHostType | None = Field(
         default=None,
         validation_alias="OMNIGENT_SLACK_DEFAULT_HOST_TYPE",
@@ -238,13 +230,15 @@ class Settings(BaseSettings):
     def _blank_default_is_unset(cls, value: object) -> object:
         """Treat a blank setup default as unset rather than as a bad value.
 
-        ``OMNIGENT_SLACK_DEFAULT_HOST_TYPE=`` is how a compose file / deploy
-        template spells "leave this off", so an empty or whitespace-only value
-        must mean "no default" — not a startup failure, and not a literal ""
-        agent id the modal could only report as unavailable. A non-blank value
-        is still validated strictly (an unknown host type fails startup). The
-        web prefill treats a blank stored agent id the same way
-        (web/src/shell/projectPrefill.ts).
+        ``OMNIGENT_SLACK_DEFAULT_HOST_TYPE=`` is one way a compose file spells
+        "leave this off", so an empty or whitespace-only value means "no
+        default" — not a startup failure, and not a literal "" agent id the
+        modal could only report as unavailable. A non-blank value is still
+        validated strictly (an unknown host type fails startup).
+
+        Deliberately NOT the rule for every field here: ``server_auth_mode``
+        rejects a blank value. These two are optional pre-selections whose
+        absence is the normal case, which is what makes blank-means-off safe.
         """
         if isinstance(value, str) and not value.strip():
             return None

--- a/integrations/slack/src/omnigent_slack/omnigent.py
+++ b/integrations/slack/src/omnigent_slack/omnigent.py
@@ -193,12 +193,18 @@ class ValidatedServer:
     runs no host of their own. ``managed_host_provider`` names the backing
     provider (e.g. ``"modal"``) for the menu label, and is ``None`` when the
     server doesn't name one.
+
+    ``managed_support_known`` is whether the capability probe was actually
+    readable. A failed probe leaves ``managed_hosts`` False — the option is
+    still withheld — but callers must not then tell a user the server
+    provisions no sandboxes, which is a claim we never established.
     """
 
     agents: list[dict[str, Any]]
     online_hosts: list[dict[str, Any]]
     managed_hosts: bool = False
     managed_host_provider: str | None = None
+    managed_support_known: bool = True
 
 
 class ClientAuth:
@@ -371,28 +377,34 @@ class OmnigentClient:
         agents = await self.list_agents()
         hosts = await self.list_hosts()
         online_hosts = [host for host in hosts if _is_host_online(host)]
-        managed_hosts, provider = await self.managed_host_support()
+        managed_supported, provider = await self.managed_host_support()
         return ValidatedServer(
             agents=agents,
             online_hosts=online_hosts,
-            managed_hosts=managed_hosts,
+            # An unreadable probe withholds the option exactly as a "no" does;
+            # only ``managed_support_known`` tells the two apart.
+            managed_hosts=managed_supported is True,
             managed_host_provider=provider,
+            managed_support_known=managed_supported is not None,
         )
 
-    async def managed_host_support(self) -> tuple[bool, str | None]:
+    async def managed_host_support(self) -> tuple[bool | None, str | None]:
         """Whether the server provisions managed sandboxes, and which provider.
 
         Reads ``managed_sandboxes_enabled`` / ``sandbox_provider`` off the
         unauthenticated ``GET /v1/info`` — the same gate the web UI's
         new-session sandbox option uses, so a server whose ``sandbox:`` config
         is missing or can't actually launch never advertises the option.
-        Best-effort: an unreadable probe reports "not supported", so setup
-        offers a managed session only when the create would be accepted.
+
+        ``None`` means the probe could not be READ (``_get_json`` swallows
+        transport/HTTP/JSON errors), which is not the same answer as ``False``.
+        Callers must still withhold the option — offering one the server would
+        422 is worse — but must not report non-support as a fact.
         """
         info = await self._get_json("/v1/info")
         if info is None:
             self._logger.info("Omnigent server info unavailable; managed sandboxes not offered")
-            return False, None
+            return None, None
         enabled = info.get("managed_sandboxes_enabled") is True
         provider = info.get("sandbox_provider")
         self._logger.debug("Omnigent managed sandboxes enabled=%s provider=%s", enabled, provider)

--- a/integrations/slack/src/omnigent_slack/setup.py
+++ b/integrations/slack/src/omnigent_slack/setup.py
@@ -1033,7 +1033,7 @@ def select_modal(
     if default_agent_id and agent_initial is None:
         blocks.append(
             _unavailable_default_block(
-                f"The default agent set for this workspace "
+                "Your Omnigent operator's default agent "
                 f"(`{truncate_option(default_agent_id)}`) isn't among the agents "
                 "this server offers you — pick one below."
             )
@@ -1067,8 +1067,8 @@ def select_modal(
     if default_host_type == "managed" and host_initial is None:
         blocks.append(
             _unavailable_default_block(
-                "This workspace defaults to a managed sandbox, but this server "
-                "doesn't provision one — pick a host below."
+                "Your Omnigent operator's default host is a managed sandbox, "
+                "but this server doesn't provision one — pick a host below."
             )
         )
     workspace_element: dict[str, Any] = {

--- a/integrations/slack/src/omnigent_slack/setup.py
+++ b/integrations/slack/src/omnigent_slack/setup.py
@@ -104,11 +104,18 @@ class SetupFlow:
         server_url: str,
         auth_manager: AuthManager | None = None,
         enrollment_url: Callable[[str, str, str, str], str | None] | None = None,
+        default_agent_id: str | None = None,
+        default_host_type: str | None = None,
     ) -> None:
         self._store = store
         self._pool = pool
         self._server_url = server_url
         self._auth = auth_manager
+        # Operator-set picker defaults (unset = today's blank picker). They are
+        # only ever pre-selections: applied against what this user is actually
+        # offered, and never substituted for something else if unavailable.
+        self._default_agent_id = default_agent_id
+        self._default_host_type = default_host_type
         # In Databricks web-auth mode, returns the signed enrollment link for a
         # (team, user, email) or ``None`` if the web server isn't configured.
         # ``None`` here means the historical device-grant / OIDC-ticket login
@@ -393,9 +400,18 @@ class SetupFlow:
             if validated.online_hosts
             else None
         )
+        # Resolved here, against the listing fetched as this authenticated user,
+        # so an operator default is only pre-selected when it is genuinely on
+        # offer. The submit handler stays network-free.
         await ack(
             response_action="update",
-            view=select_modal(server_url, validated, workspace_default=workspace_default),
+            view=select_modal(
+                server_url,
+                validated,
+                workspace_default=workspace_default,
+                default_agent_id=self._default_agent_id,
+                default_host_type=self._default_host_type,
+            ),
         )
 
     async def _revalidate_and_advance(
@@ -978,38 +994,83 @@ def select_modal(
     server_url: str,
     validated: ValidatedServer,
     workspace_default: str | None = None,
+    *,
+    default_agent_id: str | None = None,
+    default_host_type: str | None = None,
 ) -> dict[str, Any]:
+    """Build the agent/host/workspace picker.
+
+    ``default_agent_id`` / ``default_host_type`` are the operator's optional
+    pre-selections. Each is applied only when it names an option this user is
+    actually being offered; an unavailable one leaves its menu blank and adds a
+    note saying so, rather than quietly selecting something else. Unset (the
+    normal case) renders exactly the picker this always rendered.
+    """
     blocks: list[dict[str, Any]] = [
         {
             "type": "section",
             "text": {"type": "mrkdwn", "text": f"Connected to *{server_url}*."},
         },
+    ]
+    agent_options = _agent_options(validated.agents)
+    agent_initial = _option_with_value(agent_options, default_agent_id)
+    agent_element: dict[str, Any] = {
+        "type": "static_select",
+        "action_id": AGENT_ACTION,
+        "placeholder": {"type": "plain_text", "text": "Choose an agent"},
+        "options": agent_options,
+    }
+    if agent_initial is not None:
+        agent_element["initial_option"] = agent_initial
+    blocks.append(
         {
             "type": "input",
             "block_id": AGENT_BLOCK,
             "label": {"type": "plain_text", "text": "Agent"},
-            "element": {
-                "type": "static_select",
-                "action_id": AGENT_ACTION,
-                "placeholder": {"type": "plain_text", "text": "Choose an agent"},
-                "options": _agent_options(validated.agents),
-            },
-        },
-    ]
+            "element": agent_element,
+        }
+    )
+    if default_agent_id and agent_initial is None:
+        blocks.append(
+            _unavailable_default_block(
+                f"The default agent set for this workspace "
+                f"(`{truncate_option(default_agent_id)}`) isn't among the agents "
+                "this server offers you — pick one below."
+            )
+        )
+
     host_options = _host_options(validated)
+    # Only the managed sandbox is defaultable, so the sentinel is the whole
+    # lookup; ``_host_options`` omits it when the server provisions none, which
+    # is exactly the "configured default unavailable" case.
+    host_initial = (
+        _option_with_value(host_options, MANAGED_HOST_VALUE)
+        if default_host_type == "managed"
+        else None
+    )
+    host_element: dict[str, Any] = {
+        "type": "static_select",
+        "action_id": HOST_ACTION,
+        "placeholder": {"type": "plain_text", "text": "Choose a host"},
+        "options": host_options,
+    }
+    if host_initial is not None:
+        host_element["initial_option"] = host_initial
     blocks.append(
         {
             "type": "input",
             "block_id": HOST_BLOCK,
             "label": {"type": "plain_text", "text": "Host"},
-            "element": {
-                "type": "static_select",
-                "action_id": HOST_ACTION,
-                "placeholder": {"type": "plain_text", "text": "Choose a host"},
-                "options": host_options,
-            },
+            "element": host_element,
         }
     )
+    if default_host_type == "managed" and host_initial is None:
+        blocks.append(
+            _unavailable_default_block(
+                "This workspace defaults to a managed sandbox, but this server "
+                "doesn't provision one — pick a host below."
+            )
+        )
     workspace_element: dict[str, Any] = {
         "type": "plain_text_input",
         "action_id": WORKSPACE_ACTION,
@@ -1096,6 +1157,23 @@ def managed_host_label(provider: str | None) -> str:
 
 def _option(text: str, value: str) -> dict[str, Any]:
     return {"text": {"type": "plain_text", "text": text}, "value": value}
+
+
+def _option_with_value(options: list[dict[str, Any]], value: str | None) -> dict[str, Any] | None:
+    """Return the offered option carrying ``value``, or ``None`` if there is none.
+
+    Slack rejects an ``initial_option`` that isn't one of the menu's own
+    options, so the pre-selection is looked up in the built list (identity
+    included) rather than constructed from the configured value.
+    """
+    if not value:
+        return None
+    return next((option for option in options if option.get("value") == value), None)
+
+
+def _unavailable_default_block(text: str) -> dict[str, Any]:
+    """Context note under a picker whose configured default can't be offered."""
+    return {"type": "context", "elements": [{"type": "mrkdwn", "text": f":warning: {text}"}]}
 
 
 def _input_value(view: dict[str, Any], block_id: str, action_id: str) -> str:

--- a/integrations/slack/src/omnigent_slack/setup.py
+++ b/integrations/slack/src/omnigent_slack/setup.py
@@ -1031,11 +1031,19 @@ def select_modal(
         }
     )
     if default_agent_id and agent_initial is None:
+        # "not in this menu", not "not on this server": an agent past the option
+        # cap exists and is usable, it just didn't fit — so name that when it is
+        # what happened, and never claim more than the menu can tell us.
+        why = (
+            f", which lists only the first {_MAX_SELECT_OPTIONS} of {len(validated.agents)} agents"
+            if len(validated.agents) > _MAX_SELECT_OPTIONS
+            else ""
+        )
         blocks.append(
             _unavailable_default_block(
                 "Your Omnigent operator's default agent "
-                f"(`{truncate_option(default_agent_id)}`) isn't among the agents "
-                "this server offers you — pick one below."
+                f"(`{truncate_option(default_agent_id)}`) isn't available in this "
+                f"menu{why} — pick one above."
             )
         )
 
@@ -1065,10 +1073,18 @@ def select_modal(
         }
     )
     if default_host_type == "managed" and host_initial is None:
+        # A capability probe that could not be READ is not a server that answered
+        # "no" — withhold the option either way, but never report the failure to
+        # ask as a finding about the operator's server.
         blocks.append(
             _unavailable_default_block(
-                "Your Omnigent operator's default host is a managed sandbox, "
-                "but this server doesn't provision one — pick a host below."
+                "Your Omnigent operator's default host is a managed sandbox, but "
+                + (
+                    "this server doesn't provision one"
+                    if validated.managed_support_known
+                    else "whether this server provisions one couldn't be checked just now"
+                )
+                + " — pick a host above."
             )
         )
     workspace_element: dict[str, Any] = {

--- a/integrations/slack/tests/test_app.py
+++ b/integrations/slack/tests/test_app.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
+from typing import Any
 
 import pytest
+from omnigent_slack import app as app_module
 from omnigent_slack.app import _register_error_handler
 from slack_bolt.async_app import AsyncApp
+
+
+class _StartupReached(Exception):
+    """Raised in place of connecting to Slack, to stop ``run()`` after wiring."""
 
 
 @pytest.mark.asyncio
@@ -54,3 +61,45 @@ async def test_error_handler_logs_exception_without_active_traceback(
     assert "created outside an except block" in record.message
     assert record.exc_info == (ValueError, error, None)
     assert "NoneType: None" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_passes_the_operator_setup_defaults_to_the_setup_flow(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``run()`` hands the configured defaults to SetupFlow.
+
+    Without this the two env vars parse fine and do nothing. The socket handler
+    is replaced so startup stops just after wiring, before any Slack call.
+    """
+    for key in ("OMNIGENT_SLACK_DEFAULT_AGENT_ID", "OMNIGENT_SLACK_DEFAULT_HOST_TYPE"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OMNIGENT_SLACK_BOT_TOKEN", "xoxb-dummy")
+    monkeypatch.setenv("OMNIGENT_SLACK_APP_TOKEN", "xapp-dummy")
+    monkeypatch.setenv("OMNIGENT_SERVER_URL", "https://omnigent.example.com")
+    monkeypatch.setenv("OMNIGENT_SLACK_DATABASE_PATH", str(tmp_path / "bot.sqlite3"))
+    monkeypatch.setenv("OMNIGENT_SLACK_DEFAULT_AGENT_ID", "ag_standard")
+    monkeypatch.setenv("OMNIGENT_SLACK_DEFAULT_HOST_TYPE", "managed")
+
+    captured: dict[str, Any] = {}
+    real_setup_flow = app_module.SetupFlow
+
+    def _record(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return real_setup_flow(**kwargs)
+
+    class _StopHandler:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def start_async(self) -> None:
+            raise _StartupReached
+
+    monkeypatch.setattr(app_module, "SetupFlow", _record)
+    monkeypatch.setattr(app_module, "AsyncSocketModeHandler", _StopHandler)
+
+    with pytest.raises(_StartupReached):
+        await app_module.run()
+
+    assert captured["default_agent_id"] == "ag_standard"
+    assert captured["default_host_type"] == "managed"

--- a/integrations/slack/tests/test_config.py
+++ b/integrations/slack/tests/test_config.py
@@ -34,6 +34,8 @@ def _set_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
         "OMNIGENT_SLACK_DATABRICKS_CLIENT_SECRET",
         "OMNIGENT_SLACK_DATABRICKS_SCOPES",
         "OMNIGENT_SLACK_DATABRICKS_APP_URL",
+        "OMNIGENT_SLACK_DEFAULT_AGENT_ID",
+        "OMNIGENT_SLACK_DEFAULT_HOST_TYPE",
         "DATABRICKS_HOST",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -299,3 +301,62 @@ def test_webauth_port_defaults_to_8000(monkeypatch: pytest.MonkeyPatch) -> None:
     # Laptop run without the platform var: fall back to the 8000 convention.
     _set_env(monkeypatch)
     assert _load().databricks_webauth_port == 8000
+
+
+# ── Operator-set setup defaults ──────────────────────────────────────
+
+
+def test_setup_defaults_are_unset_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deployment that sets neither var gets no defaults at all."""
+    _set_env(monkeypatch)
+    settings = _load()
+    assert settings.default_agent_id is None
+    assert settings.default_host_type is None
+
+
+def test_setup_defaults_read_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(
+        monkeypatch,
+        OMNIGENT_SLACK_DEFAULT_AGENT_ID="ag_standard",
+        OMNIGENT_SLACK_DEFAULT_HOST_TYPE="managed",
+    )
+    settings = _load()
+    assert settings.default_agent_id == "ag_standard"
+    assert settings.default_host_type == "managed"
+
+
+def test_setup_defaults_strip_surrounding_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A deploy template that pads the value must still name a real agent id.
+    _set_env(monkeypatch, OMNIGENT_SLACK_DEFAULT_AGENT_ID="  ag_standard  ")
+    assert _load().default_agent_id == "ag_standard"
+
+
+def test_blank_setup_defaults_are_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `OMNIGENT_SLACK_DEFAULT_HOST_TYPE=` in a compose file means "off", not a
+    # bad value — and a blank agent id is no agent, not one named "".
+    _set_env(
+        monkeypatch,
+        OMNIGENT_SLACK_DEFAULT_AGENT_ID="   ",
+        OMNIGENT_SLACK_DEFAULT_HOST_TYPE="",
+    )
+    settings = _load()
+    assert settings.default_agent_id is None
+    assert settings.default_host_type is None
+
+
+def test_unknown_default_host_type_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the managed sandbox is defaultable; anything else is a config error.
+
+    An external host id can't be honored (``/v1/hosts`` is owner-scoped, so one
+    user's host is invisible to the rest), so a value naming one must fail loudly
+    at startup rather than be silently ignored for every user.
+    """
+    _set_env(monkeypatch, OMNIGENT_SLACK_DEFAULT_HOST_TYPE="external")
+
+    with pytest.raises(ConfigError) as excinfo:
+        load_settings()
+
+    msg = str(excinfo.value)
+    assert "Invalid configuration" in msg
+    assert "OMNIGENT_SLACK_DEFAULT_HOST_TYPE" in msg
+    assert "managed" in msg

--- a/integrations/slack/tests/test_omnigent.py
+++ b/integrations/slack/tests/test_omnigent.py
@@ -227,9 +227,11 @@ async def test_managed_host_support_reads_the_server_capability_probe() -> None:
 
 
 @respx.mock
-async def test_managed_host_support_reports_unsupported_when_probe_fails() -> None:
+async def test_managed_host_support_reports_unknown_when_probe_fails() -> None:
     # An unreadable /v1/info must NOT advertise managed sandboxes: setup would
-    # then offer an option the server rejects with a 422 at first message.
+    # then offer an option the server rejects with a 422 at first message. It
+    # reports ``None``, not ``False`` — we never learned the server's answer, and
+    # callers must not repeat the failure to ask as a finding about the server.
     respx.get("http://omnigent.test/v1/info").mock(return_value=httpx.Response(500))
     client = OmnigentClient("http://omnigent.test")
 
@@ -238,7 +240,57 @@ async def test_managed_host_support_reports_unsupported_when_probe_fails() -> No
     finally:
         await client.aclose()
 
-    assert supported == (False, None)
+    assert supported == (None, None)
+
+
+@respx.mock
+async def test_validate_withholds_managed_but_records_an_unread_probe() -> None:
+    respx.get("http://omnigent.test/health").mock(
+        return_value=httpx.Response(200, json={"status": "ok"})
+    )
+    respx.get("http://omnigent.test/v1/agents").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "ag_1"}]})
+    )
+    respx.get("http://omnigent.test/v1/hosts").mock(
+        return_value=httpx.Response(200, json={"hosts": [{"host_id": "h1", "status": "online"}]})
+    )
+    respx.get("http://omnigent.test/v1/info").mock(return_value=httpx.Response(500))
+    client = OmnigentClient("http://omnigent.test")
+
+    try:
+        validated = await client.validate()
+    finally:
+        await client.aclose()
+
+    # Withheld, exactly as before…
+    assert validated.managed_hosts is False
+    # …but flagged as never established, so no caller can report it as a "no".
+    assert validated.managed_support_known is False
+
+
+@respx.mock
+async def test_validate_records_a_readable_probe_as_known() -> None:
+    respx.get("http://omnigent.test/health").mock(
+        return_value=httpx.Response(200, json={"status": "ok"})
+    )
+    respx.get("http://omnigent.test/v1/agents").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "ag_1"}]})
+    )
+    respx.get("http://omnigent.test/v1/hosts").mock(
+        return_value=httpx.Response(200, json={"hosts": [{"host_id": "h1", "status": "online"}]})
+    )
+    respx.get("http://omnigent.test/v1/info").mock(
+        return_value=httpx.Response(200, json={"managed_sandboxes_enabled": False})
+    )
+    client = OmnigentClient("http://omnigent.test")
+
+    try:
+        validated = await client.validate()
+    finally:
+        await client.aclose()
+
+    assert validated.managed_hosts is False
+    assert validated.managed_support_known is True
 
 
 @respx.mock

--- a/integrations/slack/tests/test_setup.py
+++ b/integrations/slack/tests/test_setup.py
@@ -1154,7 +1154,12 @@ async def test_prompt_relogin_reports_when_dm_cannot_open(tmp_path: Path) -> Non
 # ── Operator-set setup defaults ──────────────────────────────────────
 
 
-def _validated(*, agents: list[dict[str, Any]] | None = None, managed: bool = False) -> Any:
+def _validated(
+    *,
+    agents: list[dict[str, Any]] | None = None,
+    managed: bool = False,
+    managed_support_known: bool = True,
+) -> Any:
     from omnigent_slack.omnigent import ValidatedServer
 
     return ValidatedServer(
@@ -1162,6 +1167,7 @@ def _validated(*, agents: list[dict[str, Any]] | None = None, managed: bool = Fa
         online_hosts=[{"host_id": "h1", "name": "Host One"}],
         managed_hosts=managed,
         managed_host_provider="modal" if managed else None,
+        managed_support_known=managed_support_known,
     )
 
 
@@ -1267,7 +1273,8 @@ def test_select_modal_leaves_host_blank_when_the_server_provisions_no_sandbox() 
     element = _element(view, HOST_BLOCK)
     assert "initial_option" not in element
     assert MANAGED_HOST_VALUE not in [o["value"] for o in element["options"]]
-    assert any("managed sandbox" in note.lower() for note in _notes(view))
+    # The server answered "no", so saying so is a fact we established.
+    assert any("doesn't provision one" in note for note in _notes(view))
 
 
 def test_select_modal_keeps_the_usable_default_when_the_other_is_unavailable() -> None:
@@ -1571,3 +1578,92 @@ async def test_switching_off_the_managed_default_still_requires_a_workspace_path
     assert ack.calls[-1]["response_action"] == "errors"
     assert WORKSPACE_BLOCK in ack.calls[-1]["errors"]
     assert await store.get_user_config("T1", "U1") is None
+
+
+def test_an_unreadable_capability_probe_is_not_reported_as_non_support() -> None:
+    # `/v1/info` being unreadable is not the server answering "no": _get_json
+    # swallows transport, HTTP and JSON errors alike. The option is still
+    # withheld (offering one the server would 422 is worse), but the modal must
+    # not tell the user their operator's server provisions no sandboxes when we
+    # simply failed to ask.
+    view = select_modal(
+        _SERVER,
+        _validated(managed=False, managed_support_known=False),
+        default_host_type="managed",
+    )
+    element = _element(view, HOST_BLOCK)
+    assert "initial_option" not in element
+    assert MANAGED_HOST_VALUE not in [o["value"] for o in element["options"]]
+    notes = _notes(view)
+    assert any("couldn't be checked" in note for note in notes)
+    assert not any("doesn't provision one" in note for note in notes)
+
+
+def test_an_agent_past_the_option_cap_is_named_as_a_menu_limit() -> None:
+    # Agent 101 exists on the server and is perfectly usable — it just didn't fit
+    # the menu. Saying "this server doesn't offer it" would be a false diagnosis.
+    agents = [{"id": f"ag_{n}", "name": f"Agent {n}"} for n in range(101)]
+    view = select_modal(_SERVER, _validated(agents=agents), default_agent_id="ag_100")
+    note = next(n for n in _notes(view) if "ag_100" in n)
+    assert "isn't available in this menu" in note
+    assert "first 100 of 101 agents" in note
+
+
+def test_an_unavailable_default_points_at_the_menu_above_it() -> None:
+    # Both notes are appended AFTER their input block, so "below" would send the
+    # reader past the picker they need.
+    view = select_modal(
+        _SERVER,
+        _validated(managed=False),
+        default_agent_id="ag_missing",
+        default_host_type="managed",
+    )
+    assert len(_notes(view)) == 2
+    assert all("above" in note and "below" not in note for note in _notes(view))
+    # Each note really does follow its own picker.
+    types = [b.get("block_id") or b["type"] for b in view["blocks"]]
+    assert types.index(AGENT_BLOCK) < types.index("context")
+    assert types.index(HOST_BLOCK) < len(types) - 1
+
+
+@respx.mock
+async def test_an_unreachable_capability_probe_does_not_claim_non_support(
+    tmp_path: Path,
+) -> None:
+    """The reviewer's reproduction: everything works except `/v1/info`.
+
+    Health, agents and an online external host all succeed, so setup reaches the
+    picker — but the managed capability was never established. The modal must
+    not diagnose the operator's server from a probe we could not read.
+    """
+    respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
+    respx.get(_SERVER + "/v1/agents").mock(
+        return_value=httpx.Response(200, json={"data": [{"id": "ag_1", "name": "Helper"}]})
+    )
+    respx.get(_SERVER + "/v1/hosts").mock(
+        return_value=httpx.Response(
+            200, json={"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]}
+        )
+    )
+    respx.get(_SERVER + "/v1/hosts/h1/filesystem").mock(
+        return_value=httpx.Response(
+            200, json={"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
+        )
+    )
+    respx.get(_SERVER + "/v1/info").mock(return_value=httpx.Response(500))
+    pool = OmnigentClientPool()
+    flow = _flow(await _store(tmp_path), pool, default_host_type="managed")
+    client = FakeSetupClient()
+
+    try:
+        await flow._begin_setup(client, team_id="T1", user_id="U1", view_id="V1")
+    finally:
+        await pool.aclose_all()
+
+    view = _last_update(client)
+    assert view["callback_id"] == "omnigent_setup_select"
+    notes = _notes(view)
+    assert any("couldn't be checked" in note for note in notes)
+    assert not any("doesn't provision one" in note for note in notes)
+    # The option is still withheld — a create against it would 422.
+    assert MANAGED_HOST_VALUE not in [o["value"] for o in _element(view, HOST_BLOCK)["options"]]

--- a/integrations/slack/tests/test_setup.py
+++ b/integrations/slack/tests/test_setup.py
@@ -1187,11 +1187,9 @@ def _notes(view: dict[str, Any]) -> list[str]:
     ]
 
 
-# The token the setup tests authenticate with. The pool builds a client with
-# ``auth=None`` whenever no resolver is wired or no token is stored
-# (omnigent.py), and against a fake that ignores credentials an unauthenticated
-# client is indistinguishable from an authenticated one — so listings that are
-# auth-gated on the real server are gated here too.
+# The token the setup tests authenticate with. Against a fake that ignores
+# credentials an unauthenticated client (the pool's ``auth=None`` path) is
+# indistinguishable from a real one, so auth-gated listings are gated here too.
 _BEARER = "at"
 
 
@@ -1628,11 +1626,9 @@ async def test_switching_off_the_managed_default_still_requires_a_workspace_path
 
 
 def test_an_unreadable_capability_probe_is_not_reported_as_non_support() -> None:
-    # `/v1/info` being unreadable is not the server answering "no": _get_json
-    # swallows transport, HTTP and JSON errors alike. The option is still
-    # withheld (offering one the server would 422 is worse), but the modal must
-    # not tell the user their operator's server provisions no sandboxes when we
-    # simply failed to ask.
+    # An unreadable `/v1/info` is not the server answering "no". The option is
+    # still withheld (offering one the server would 422 is worse), but the modal
+    # must not report the failure to ask as a finding about the server.
     view = select_modal(
         _SERVER,
         _validated(managed=False, managed_support_known=False),
@@ -1656,9 +1652,9 @@ def test_an_agent_past_the_option_cap_is_named_as_a_menu_limit() -> None:
     assert "first 100 of 101 agents" in note
 
 
-def test_an_unavailable_default_points_at_the_menu_above_it() -> None:
-    # Both notes are appended AFTER their input block, so "below" would send the
-    # reader past the picker they need.
+def test_each_unavailable_default_note_follows_its_own_picker() -> None:
+    # Each note says "above", so each must sit AFTER the picker it refers to and
+    # before the next one — otherwise the wording sends the reader the wrong way.
     view = select_modal(
         _SERVER,
         _validated(managed=False),
@@ -1667,10 +1663,23 @@ def test_an_unavailable_default_points_at_the_menu_above_it() -> None:
     )
     assert len(_notes(view)) == 2
     assert all("above" in note and "below" not in note for note in _notes(view))
-    # Each note really does follow its own picker.
-    types = [b.get("block_id") or b["type"] for b in view["blocks"]]
-    assert types.index(AGENT_BLOCK) < types.index("context")
-    assert types.index(HOST_BLOCK) < len(types) - 1
+
+    def _at(predicate: Any) -> int:
+        return next(i for i, block in enumerate(view["blocks"]) if predicate(block))
+
+    def _note_saying(text: str) -> Any:
+        return lambda b: b["type"] == "context" and text in str(b)
+
+    agent_picker = _at(lambda b: b.get("block_id") == AGENT_BLOCK)
+    host_picker = _at(lambda b: b.get("block_id") == HOST_BLOCK)
+    agent_note = _at(_note_saying("ag_missing"))
+    host_note = _at(_note_saying("managed sandbox"))
+    # Each note is below its own picker…
+    assert agent_picker < agent_note
+    assert host_picker < host_note
+    # …and the agent's note stays above the host picker, so it can't be read as
+    # belonging to the menu underneath it.
+    assert agent_note < host_picker
 
 
 @respx.mock

--- a/integrations/slack/tests/test_setup.py
+++ b/integrations/slack/tests/test_setup.py
@@ -7,10 +7,13 @@ from omnigent_slack.models import ThreadKey, UserConfig
 from omnigent_slack.omnigent import OmnigentClientPool
 from omnigent_slack.setup import (
     ACTION_SETUP_START,
+    AGENT_ACTION,
     AGENT_BLOCK,
     CALLBACK_SETUP_INFO,
+    HOST_ACTION,
     HOST_BLOCK,
     MANAGED_HOST_VALUE,
+    WORKSPACE_ACTION,
     WORKSPACE_BLOCK,
     SetupFlow,
     connecting_modal,
@@ -113,8 +116,22 @@ async def _store(tmp_path: Path) -> SQLiteStore:
     return store
 
 
-def _flow(store: SQLiteStore, pool: OmnigentClientPool, auth: Any = None) -> SetupFlow:
-    return SetupFlow(store=store, pool=pool, server_url=_SERVER, auth_manager=auth)
+def _flow(
+    store: SQLiteStore,
+    pool: OmnigentClientPool,
+    auth: Any = None,
+    *,
+    default_agent_id: str | None = None,
+    default_host_type: str | None = None,
+) -> SetupFlow:
+    return SetupFlow(
+        store=store,
+        pool=pool,
+        server_url=_SERVER,
+        auth_manager=auth,
+        default_agent_id=default_agent_id,
+        default_host_type=default_host_type,
+    )
 
 
 def test_select_modal_lists_agents_and_hosts() -> None:
@@ -1132,3 +1149,425 @@ async def test_prompt_relogin_reports_when_dm_cannot_open(tmp_path: Path) -> Non
 
     assert delivered is False
     assert client.posts == []
+
+
+# ── Operator-set setup defaults ──────────────────────────────────────
+
+
+def _validated(*, agents: list[dict[str, Any]] | None = None, managed: bool = False) -> Any:
+    from omnigent_slack.omnigent import ValidatedServer
+
+    return ValidatedServer(
+        agents=agents if agents is not None else [{"id": "ag_1", "name": "Helper"}],
+        online_hosts=[{"host_id": "h1", "name": "Host One"}],
+        managed_hosts=managed,
+        managed_host_provider="modal" if managed else None,
+    )
+
+
+def _element(view: dict[str, Any], block_id: str) -> dict[str, Any]:
+    blocks = {b["block_id"]: b for b in view["blocks"] if "block_id" in b}
+    element: dict[str, Any] = blocks[block_id]["element"]
+    return element
+
+
+def _notes(view: dict[str, Any]) -> list[str]:
+    """Text of every context note the modal carries (the unavailable-default ones)."""
+    return [
+        str(element.get("text", ""))
+        for block in view["blocks"]
+        if block.get("type") == "context"
+        for element in block.get("elements", [])
+    ]
+
+
+def _state_as_submitted(
+    view: dict[str, Any],
+    *,
+    agent: dict[str, Any] | None = None,
+    host: dict[str, Any] | None = None,
+    workspace: str | None = None,
+) -> dict[str, Any]:
+    """The ``view.state`` Slack posts back for ``view``, honoring its pre-selections.
+
+    An untouched ``static_select`` submits its ``initial_option``; ``agent`` /
+    ``host`` stand in for the user picking something else instead. Derived from
+    the rendered view rather than hand-written, so a lost pre-selection shows up
+    here as an empty submission instead of passing anyway.
+    """
+    values: dict[str, Any] = {}
+    for block_id, action_id, override in (
+        (AGENT_BLOCK, AGENT_ACTION, agent),
+        (HOST_BLOCK, HOST_ACTION, host),
+    ):
+        values[block_id] = {
+            action_id: {
+                "selected_option": override or _element(view, block_id).get("initial_option")
+            }
+        }
+    typed = (
+        workspace
+        if workspace is not None
+        else _element(view, WORKSPACE_BLOCK).get("initial_value", "")
+    )
+    values[WORKSPACE_BLOCK] = {WORKSPACE_ACTION: {"value": typed}}
+    return {"state": {"values": values}}
+
+
+def test_select_modal_preselects_nothing_when_no_defaults_are_configured() -> None:
+    # The regression guard that matters most: a deployment that configures no
+    # defaults must get byte-identical picker behaviour.
+    view = select_modal(_SERVER, _validated(managed=True))
+    assert "initial_option" not in _element(view, AGENT_BLOCK)
+    assert "initial_option" not in _element(view, HOST_BLOCK)
+    assert _notes(view) == []
+
+
+def test_select_modal_preselects_the_configured_default_agent() -> None:
+    view = select_modal(
+        _SERVER,
+        _validated(agents=[{"id": "ag_1", "name": "Helper"}, {"id": "ag_2", "name": "Other"}]),
+        default_agent_id="ag_2",
+    )
+    element = _element(view, AGENT_BLOCK)
+    assert element["initial_option"]["value"] == "ag_2"
+    # Slack only accepts an initial_option that is one of the menu's options.
+    assert element["initial_option"] in element["options"]
+    # Nothing is skipped or removed — the user can still pick the other agent.
+    assert [o["value"] for o in element["options"]] == ["ag_1", "ag_2"]
+    assert view["submit"]["text"] == "Save"
+    assert _notes(view) == []
+
+
+def test_select_modal_preselects_the_managed_sandbox_when_configured() -> None:
+    view = select_modal(_SERVER, _validated(managed=True), default_host_type="managed")
+    element = _element(view, HOST_BLOCK)
+    assert element["initial_option"]["value"] == MANAGED_HOST_VALUE
+    assert element["initial_option"] in element["options"]
+    # The user's own host is still on offer.
+    assert [o["value"] for o in element["options"]] == [MANAGED_HOST_VALUE, "h1"]
+    assert _notes(view) == []
+
+
+def test_select_modal_leaves_agent_blank_when_the_default_is_not_offered() -> None:
+    # The configured agent isn't among the ones this user is offered: say so and
+    # leave the menu blank. Substituting a different agent would silently put
+    # someone on the wrong one.
+    view = select_modal(_SERVER, _validated(), default_agent_id="ag_missing")
+    element = _element(view, AGENT_BLOCK)
+    assert "initial_option" not in element
+    assert [o["value"] for o in element["options"]] == ["ag_1"]
+    assert any("ag_missing" in note for note in _notes(view))
+
+
+def test_select_modal_leaves_host_blank_when_the_server_provisions_no_sandbox() -> None:
+    # Managed capability gates the pre-selection: a server with no managed
+    # sandboxes offers no such option, so there is nothing to pre-select.
+    view = select_modal(_SERVER, _validated(managed=False), default_host_type="managed")
+    element = _element(view, HOST_BLOCK)
+    assert "initial_option" not in element
+    assert MANAGED_HOST_VALUE not in [o["value"] for o in element["options"]]
+    assert any("managed sandbox" in note.lower() for note in _notes(view))
+
+
+def test_select_modal_keeps_the_usable_default_when_the_other_is_unavailable() -> None:
+    # A partly-honorable config still honors the part it can.
+    view = select_modal(
+        _SERVER,
+        _validated(managed=False),
+        default_agent_id="ag_1",
+        default_host_type="managed",
+    )
+    assert _element(view, AGENT_BLOCK)["initial_option"]["value"] == "ag_1"
+    assert "initial_option" not in _element(view, HOST_BLOCK)
+    assert len(_notes(view)) == 1
+
+
+def test_select_modal_does_not_preselect_an_agent_beyond_the_option_cap() -> None:
+    # Slack caps a static_select at 100 options, so agent 101 is not in the menu
+    # and cannot be pre-selected. That is the unavailable case (blank + a note),
+    # not a silent no-op the operator has no way to notice.
+    agents = [{"id": f"ag_{n}", "name": f"Agent {n}"} for n in range(101)]
+    view = select_modal(_SERVER, _validated(agents=agents), default_agent_id="ag_100")
+    element = _element(view, AGENT_BLOCK)
+    assert len(element["options"]) == 100
+    assert "initial_option" not in element
+    assert any("ag_100" in note for note in _notes(view))
+
+
+@respx.mock
+async def test_setup_preselects_defaults_resolved_as_the_authenticated_user(
+    tmp_path: Path,
+) -> None:
+    respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
+    respx.get(_SERVER + "/v1/agents").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": [{"id": "ag_1", "name": "Helper"}, {"id": "ag_2", "name": "Other"}]},
+        )
+    )
+    respx.get(_SERVER + "/v1/hosts").mock(
+        return_value=httpx.Response(
+            200, json={"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]}
+        )
+    )
+    respx.get(_SERVER + "/v1/hosts/h1/filesystem").mock(
+        return_value=httpx.Response(
+            200, json={"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
+        )
+    )
+    _mock_info(managed=True, provider="modal")
+    pool = OmnigentClientPool()
+    flow = _flow(
+        await _store(tmp_path), pool, default_agent_id="ag_2", default_host_type="managed"
+    )
+    client = FakeSetupClient()
+
+    try:
+        await flow._begin_setup(client, team_id="T1", user_id="U1", view_id="V1")
+    finally:
+        await pool.aclose_all()
+
+    view = _last_update(client)
+    assert view["callback_id"] == "omnigent_setup_select"
+    assert _element(view, AGENT_BLOCK)["initial_option"]["value"] == "ag_2"
+    assert _element(view, HOST_BLOCK)["initial_option"]["value"] == MANAGED_HOST_VALUE
+
+
+@respx.mock
+async def test_setup_defaults_are_resolved_after_the_user_logs_in(tmp_path: Path) -> None:
+    """The default is matched against the listing fetched as the logged-in user.
+
+    The pre-login probe 401s and lists nothing, so a default resolved before
+    auth could only ever come back "unavailable". Pre-selection appearing after
+    approval is what proves it is resolved on the post-login listing.
+    """
+    import asyncio
+
+    respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
+    respx.get(_SERVER + "/v1/me").mock(
+        return_value=httpx.Response(401, json={"login_url": "/login"})
+    )
+    agents_calls = {"n": 0}
+
+    def _agents(request: httpx.Request) -> httpx.Response:
+        agents_calls["n"] += 1
+        if agents_calls["n"] == 1:
+            return httpx.Response(401)
+        return httpx.Response(200, json={"data": [{"id": "ag_1", "name": "Helper"}]})
+
+    respx.get(_SERVER + "/v1/agents").mock(side_effect=_agents)
+    respx.get(_SERVER + "/v1/hosts").mock(
+        return_value=httpx.Response(
+            200, json={"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]}
+        )
+    )
+    respx.get(_SERVER + "/v1/hosts/h1/filesystem").mock(
+        return_value=httpx.Response(
+            200, json={"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
+        )
+    )
+    _mock_info()
+    respx.post(_SERVER + "/oauth/device/authorize").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "device_code": "dc",
+                "user_code": "ABCD-2345",
+                "verification_uri": _SERVER + "/oauth/device",
+                "verification_uri_complete": (_SERVER + "/oauth/device?user_code=ABCD-2345"),
+                "expires_in": 600,
+                "interval": 0,
+            },
+        )
+    )
+    respx.post(_SERVER + "/oauth/token").mock(
+        return_value=httpx.Response(
+            200, json={"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+        )
+    )
+    from cryptography.fernet import Fernet
+    from omnigent_slack.auth_manager import AuthManager
+    from omnigent_slack.tokens import EncryptedTokenStore
+
+    token_store = EncryptedTokenStore(tmp_path / "tok.sqlite3", Fernet.generate_key().decode())
+    await token_store.initialize()
+    pool = OmnigentClientPool()
+    auth = AuthManager(token_store)
+    pool.set_auth_resolver(auth.resolve_auth)
+    flow = _flow(await _store(tmp_path), pool, auth, default_agent_id="ag_1")
+    client = FakeSetupClient()
+
+    try:
+        await flow._begin_setup(client, team_id="T1", user_id="U1", view_id="V1")
+        for _ in range(50):
+            if len(client.updated_views) >= 2:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        await pool.aclose_all()
+
+    view = _last_update(client)
+    assert view["callback_id"] == "omnigent_setup_select"
+    assert _element(view, AGENT_BLOCK)["initial_option"]["value"] == "ag_1"
+    assert _notes(view) == []
+
+
+@respx.mock
+async def test_unreachable_server_is_not_reported_as_an_unavailable_default(
+    tmp_path: Path,
+) -> None:
+    # A network failure says nothing about whether the configured agent exists,
+    # so it must still be the try-again screen — never "your default is gone".
+    respx.get(_SERVER + "/health").mock(return_value=httpx.Response(500))
+    pool = OmnigentClientPool()
+    flow = _flow(
+        await _store(tmp_path), pool, default_agent_id="ag_1", default_host_type="managed"
+    )
+    client = FakeSetupClient()
+
+    try:
+        await flow._begin_setup(client, team_id="T1", user_id="U1", view_id="V1")
+    finally:
+        await pool.aclose_all()
+
+    view = _last_update(client)
+    assert view["callback_id"] == CALLBACK_SETUP_INFO
+    body = view["blocks"][0]["text"]["text"]
+    assert "reach" in body.lower()
+    assert "ag_1" not in str(view)
+
+
+@respx.mock
+async def test_a_server_with_no_agents_still_shows_the_no_agents_screen(tmp_path: Path) -> None:
+    # Nothing to pick means nothing to default to: keep the existing guidance
+    # screen rather than a picker whose only content is a warning.
+    respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
+    respx.get(_SERVER + "/v1/agents").mock(return_value=httpx.Response(200, json={"data": []}))
+    respx.get(_SERVER + "/v1/hosts").mock(
+        return_value=httpx.Response(
+            200, json={"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]}
+        )
+    )
+    _mock_info()
+    pool = OmnigentClientPool()
+    flow = _flow(await _store(tmp_path), pool, default_agent_id="ag_1")
+    client = FakeSetupClient()
+
+    try:
+        await flow._begin_setup(client, team_id="T1", user_id="U1", view_id="V1")
+    finally:
+        await pool.aclose_all()
+
+    view = _last_update(client)
+    assert view["callback_id"] == CALLBACK_SETUP_INFO
+    assert "no agents available" in view["blocks"][0]["text"]["text"]
+
+
+async def test_submitting_the_preselected_managed_default_stores_no_host_or_workspace(
+    tmp_path: Path,
+) -> None:
+    # Accepting both defaults untouched must persist exactly what a hand-picked
+    # managed sandbox does: no host id, no workspace (the server owns both).
+    store = await _store(tmp_path)
+    pool = OmnigentClientPool()
+    flow = _flow(store, pool)
+    view = select_modal(
+        _SERVER,
+        _validated(managed=True),
+        workspace_default="/home/bob",
+        default_agent_id="ag_1",
+        default_host_type="managed",
+    )
+    ack = FakeAck()
+    client = FakeSetupClient()
+
+    try:
+        await flow._handle_select_submit(
+            ack, {"team": {"id": "T1"}, "user": {"id": "U1"}}, _state_as_submitted(view), client
+        )
+    finally:
+        await pool.aclose_all()
+
+    config = await store.get_user_config("T1", "U1")
+    assert config is not None
+    assert config.agent_id == "ag_1"
+    assert config.host_type == "managed"
+    assert config.host_id is None
+    assert config.workspace == ""
+
+
+async def test_an_explicit_user_choice_wins_over_the_preselected_defaults(
+    tmp_path: Path,
+) -> None:
+    # The pre-selection is only a starting point: whatever the user submits is
+    # what gets stored.
+    store = await _store(tmp_path)
+    pool = OmnigentClientPool()
+    flow = _flow(store, pool)
+    view = select_modal(
+        _SERVER,
+        _validated(
+            agents=[{"id": "ag_1", "name": "Helper"}, {"id": "ag_2", "name": "Other"}],
+            managed=True,
+        ),
+        default_agent_id="ag_1",
+        default_host_type="managed",
+    )
+    agent_options = _element(view, AGENT_BLOCK)["options"]
+    host_options = _element(view, HOST_BLOCK)["options"]
+    state = _state_as_submitted(
+        view,
+        agent=next(o for o in agent_options if o["value"] == "ag_2"),
+        host=next(o for o in host_options if o["value"] == "h1"),
+        workspace="/home/me/project",
+    )
+    ack = FakeAck()
+    client = FakeSetupClient()
+
+    try:
+        await flow._handle_select_submit(
+            ack, {"team": {"id": "T1"}, "user": {"id": "U1"}}, state, client
+        )
+    finally:
+        await pool.aclose_all()
+
+    config = await store.get_user_config("T1", "U1")
+    assert config is not None
+    assert config.agent_id == "ag_2"
+    assert config.host_id == "h1"
+    assert config.host_type == "external"
+    assert config.workspace == "/home/me/project"
+
+
+async def test_switching_off_the_managed_default_still_requires_a_workspace_path(
+    tmp_path: Path,
+) -> None:
+    # Moving off the pre-selected sandbox to a real host re-imposes the absolute
+    # path requirement; the defaults path must not loosen it.
+    store = await _store(tmp_path)
+    pool = OmnigentClientPool()
+    flow = _flow(store, pool)
+    view = select_modal(
+        _SERVER,
+        _validated(managed=True),
+        default_agent_id="ag_1",
+        default_host_type="managed",
+    )
+    host_options = _element(view, HOST_BLOCK)["options"]
+    state = _state_as_submitted(
+        view, host=next(o for o in host_options if o["value"] == "h1"), workspace="relative/path"
+    )
+    ack = FakeAck()
+    client = FakeSetupClient()
+
+    try:
+        await flow._handle_select_submit(
+            ack, {"team": {"id": "T1"}, "user": {"id": "U1"}}, state, client
+        )
+    finally:
+        await pool.aclose_all()
+
+    assert ack.calls[-1]["response_action"] == "errors"
+    assert WORKSPACE_BLOCK in ack.calls[-1]["errors"]
+    assert await store.get_user_config("T1", "U1") is None

--- a/integrations/slack/tests/test_setup.py
+++ b/integrations/slack/tests/test_setup.py
@@ -1187,6 +1187,41 @@ def _notes(view: dict[str, Any]) -> list[str]:
     ]
 
 
+# The token the setup tests authenticate with. The pool builds a client with
+# ``auth=None`` whenever no resolver is wired or no token is stored
+# (omnigent.py), and against a fake that ignores credentials an unauthenticated
+# client is indistinguishable from an authenticated one — so listings that are
+# auth-gated on the real server are gated here too.
+_BEARER = "at"
+
+
+def _bearer_gated(payload: dict[str, Any]) -> Any:
+    """respx side_effect serving ``payload`` only to a request carrying ``_BEARER``."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.headers.get("authorization") != f"Bearer {_BEARER}":
+            return httpx.Response(401)
+        return httpx.Response(200, json=payload)
+
+    return _handler
+
+
+async def _authenticated_pool(tmp_path: Path, *, token: str | None = _BEARER) -> Any:
+    """A pool whose resolver hands out ``token`` for (T1, U1) on ``_SERVER``."""
+    from cryptography.fernet import Fernet
+    from omnigent_slack.auth_manager import AuthManager
+    from omnigent_slack.tokens import EncryptedTokenStore
+
+    token_store = EncryptedTokenStore(tmp_path / "tok.sqlite3", Fernet.generate_key().decode())
+    await token_store.initialize()
+    if token is not None:
+        await token_store.put("T1", "U1", _SERVER, access_token=token, refresh_token="rt")
+    pool = OmnigentClientPool()
+    auth = AuthManager(token_store)
+    pool.set_auth_resolver(auth.resolve_auth)
+    return pool, auth
+
+
 def _state_as_submitted(
     view: dict[str, Any],
     *,
@@ -1220,12 +1255,25 @@ def _state_as_submitted(
     return {"state": {"values": values}}
 
 
-def test_select_modal_preselects_nothing_when_no_defaults_are_configured() -> None:
-    # The regression guard that matters most: a deployment that configures no
-    # defaults must get byte-identical picker behaviour.
+def test_select_modal_renders_the_unchanged_payload_when_no_defaults_are_set() -> None:
+    """The guard that matters most: configuring nothing changes nothing.
+
+    Checked as payload equivalence, not just "no initial_option" — the block
+    sequence, the modal's own keys, and the absence of the string anywhere in
+    the serialized view, so any block this feature might add shows up here.
+    """
+    import json
+
     view = select_modal(_SERVER, _validated(managed=True))
-    assert "initial_option" not in _element(view, AGENT_BLOCK)
-    assert "initial_option" not in _element(view, HOST_BLOCK)
+    assert [b["type"] for b in view["blocks"]] == ["section", "input", "input", "input"]
+    assert [b.get("block_id") for b in view["blocks"]] == [
+        None,
+        AGENT_BLOCK,
+        HOST_BLOCK,
+        WORKSPACE_BLOCK,
+    ]
+    assert set(view) == {"type", "callback_id", "title", "submit", "close", "blocks"}
+    assert "initial_option" not in json.dumps(view)
     assert _notes(view) == []
 
 
@@ -1307,26 +1355,26 @@ async def test_setup_preselects_defaults_resolved_as_the_authenticated_user(
     tmp_path: Path,
 ) -> None:
     respx.get(_SERVER + "/health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
+    # Auth-gated exactly as the real listing endpoints are: an unauthenticated
+    # client sees a 401, so reaching the picker at all proves the user's own
+    # token resolved before the defaults were matched against anything.
     respx.get(_SERVER + "/v1/agents").mock(
-        return_value=httpx.Response(
-            200,
-            json={"data": [{"id": "ag_1", "name": "Helper"}, {"id": "ag_2", "name": "Other"}]},
+        side_effect=_bearer_gated(
+            {"data": [{"id": "ag_1", "name": "Helper"}, {"id": "ag_2", "name": "Other"}]}
         )
     )
     respx.get(_SERVER + "/v1/hosts").mock(
-        return_value=httpx.Response(
-            200, json={"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]}
-        )
+        side_effect=_bearer_gated({"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]})
     )
     respx.get(_SERVER + "/v1/hosts/h1/filesystem").mock(
-        return_value=httpx.Response(
-            200, json={"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
+        side_effect=_bearer_gated(
+            {"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
         )
     )
     _mock_info(managed=True, provider="modal")
-    pool = OmnigentClientPool()
+    pool, auth = await _authenticated_pool(tmp_path)
     flow = _flow(
-        await _store(tmp_path), pool, default_agent_id="ag_2", default_host_type="managed"
+        await _store(tmp_path), pool, auth, default_agent_id="ag_2", default_host_type="managed"
     )
     client = FakeSetupClient()
 
@@ -1355,23 +1403,19 @@ async def test_setup_defaults_are_resolved_after_the_user_logs_in(tmp_path: Path
     respx.get(_SERVER + "/v1/me").mock(
         return_value=httpx.Response(401, json={"login_url": "/login"})
     )
-    agents_calls = {"n": 0}
-
-    def _agents(request: httpx.Request) -> httpx.Response:
-        agents_calls["n"] += 1
-        if agents_calls["n"] == 1:
-            return httpx.Response(401)
-        return httpx.Response(200, json={"data": [{"id": "ag_1", "name": "Helper"}]})
-
-    respx.get(_SERVER + "/v1/agents").mock(side_effect=_agents)
+    # Gated on the bearer rather than on call ordering: the pre-login probe 401s
+    # because it carries no token, and the post-login listing succeeds because
+    # the device grant stored one. A fake that ignored credentials would pass
+    # even if the pooled client were never given the user's auth at all.
+    respx.get(_SERVER + "/v1/agents").mock(
+        side_effect=_bearer_gated({"data": [{"id": "ag_1", "name": "Helper"}]})
+    )
     respx.get(_SERVER + "/v1/hosts").mock(
-        return_value=httpx.Response(
-            200, json={"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]}
-        )
+        side_effect=_bearer_gated({"hosts": [{"host_id": "h1", "name": "H", "status": "online"}]})
     )
     respx.get(_SERVER + "/v1/hosts/h1/filesystem").mock(
-        return_value=httpx.Response(
-            200, json={"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
+        side_effect=_bearer_gated(
+            {"data": [{"name": ".x", "path": "/home/bob/.x", "type": "file"}]}
         )
     )
     _mock_info()
@@ -1390,18 +1434,11 @@ async def test_setup_defaults_are_resolved_after_the_user_logs_in(tmp_path: Path
     )
     respx.post(_SERVER + "/oauth/token").mock(
         return_value=httpx.Response(
-            200, json={"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+            200, json={"access_token": _BEARER, "refresh_token": "rt", "expires_in": 3600}
         )
     )
-    from cryptography.fernet import Fernet
-    from omnigent_slack.auth_manager import AuthManager
-    from omnigent_slack.tokens import EncryptedTokenStore
-
-    token_store = EncryptedTokenStore(tmp_path / "tok.sqlite3", Fernet.generate_key().decode())
-    await token_store.initialize()
-    pool = OmnigentClientPool()
-    auth = AuthManager(token_store)
-    pool.set_auth_resolver(auth.resolve_auth)
+    # No token stored up front — the device grant above is what puts one there.
+    pool, auth = await _authenticated_pool(tmp_path, token=None)
     flow = _flow(await _store(tmp_path), pool, auth, default_agent_id="ag_1")
     client = FakeSetupClient()
 
@@ -1478,13 +1515,13 @@ async def test_submitting_the_preselected_managed_default_stores_no_host_or_work
     # managed sandbox does: no host id, no workspace (the server owns both).
     store = await _store(tmp_path)
     pool = OmnigentClientPool()
-    flow = _flow(store, pool)
+    flow = _flow(store, pool, default_agent_id="ag_1", default_host_type="managed")
     view = select_modal(
         _SERVER,
         _validated(managed=True),
         workspace_default="/home/bob",
-        default_agent_id="ag_1",
-        default_host_type="managed",
+        default_agent_id=flow._default_agent_id,
+        default_host_type=flow._default_host_type,
     )
     ack = FakeAck()
     client = FakeSetupClient()
@@ -1507,20 +1544,30 @@ async def test_submitting_the_preselected_managed_default_stores_no_host_or_work
 async def test_an_explicit_user_choice_wins_over_the_preselected_defaults(
     tmp_path: Path,
 ) -> None:
-    # The pre-selection is only a starting point: whatever the user submits is
-    # what gets stored.
+    """A submitted choice beats the operator's default — on a flow that HAS one.
+
+    The flow itself is configured with both defaults, so a submit handler that
+    preferred ``self._default_agent_id`` over the submitted option would have
+    something to prefer, and this test would catch it. Built without them, it
+    could not.
+    """
     store = await _store(tmp_path)
     pool = OmnigentClientPool()
-    flow = _flow(store, pool)
+    flow = _flow(store, pool, default_agent_id="ag_1", default_host_type="managed")
     view = select_modal(
         _SERVER,
         _validated(
             agents=[{"id": "ag_1", "name": "Helper"}, {"id": "ag_2", "name": "Other"}],
             managed=True,
         ),
-        default_agent_id="ag_1",
-        default_host_type="managed",
+        default_agent_id=flow._default_agent_id,
+        default_host_type=flow._default_host_type,
     )
+    # The defaults really are pre-selected — otherwise "the user overrode them"
+    # would be a claim about a modal that never offered them.
+    assert _element(view, AGENT_BLOCK)["initial_option"]["value"] == "ag_1"
+    assert _element(view, HOST_BLOCK)["initial_option"]["value"] == MANAGED_HOST_VALUE
+
     agent_options = _element(view, AGENT_BLOCK)["options"]
     host_options = _element(view, HOST_BLOCK)["options"]
     state = _state_as_submitted(
@@ -1554,12 +1601,12 @@ async def test_switching_off_the_managed_default_still_requires_a_workspace_path
     # path requirement; the defaults path must not loosen it.
     store = await _store(tmp_path)
     pool = OmnigentClientPool()
-    flow = _flow(store, pool)
+    flow = _flow(store, pool, default_agent_id="ag_1", default_host_type="managed")
     view = select_modal(
         _SERVER,
         _validated(managed=True),
-        default_agent_id="ag_1",
-        default_host_type="managed",
+        default_agent_id=flow._default_agent_id,
+        default_host_type=flow._default_host_type,
     )
     host_options = _element(view, HOST_BLOCK)["options"]
     state = _state_as_submitted(


### PR DESCRIPTION
## Related issue

Closes #6840

## Summary

Two optional env vars let an operator pre-select the Slack setup modal's
choices for everyone, so a new user submits the modal instead of making two
decisions they usually have no opinion on:

| Variable | Effect |
| --- | --- |
| `OMNIGENT_SLACK_DEFAULT_AGENT_ID` | Opens the **Agent** menu on this agent id. |
| `OMNIGENT_SLACK_DEFAULT_HOST_TYPE` | Only `managed` — opens the **Host** menu on the server-provisioned sandbox. |

Either may be left unset **or blank** for no default; any other non-blank
`OMNIGENT_SLACK_DEFAULT_HOST_TYPE` fails at startup (`SystemExit(2)`).

Strictly additive: **a deployment that sets neither behaves exactly as it does
today.** With neither variable configured the new branch is unreachable, so the
rendered modal payload is byte-identical; a dedicated test pins that (block
sequence, block ids, modal key set, and no `initial_option` anywhere in the
serialized view).

Of the 374 pre-existing tests, 373 pass untouched. One was deliberately
changed: `test_managed_host_support_reports_unsupported_when_probe_fails` is
renamed to `..._reports_unknown_when_probe_fails` and its expectation moved
from `(False, None)` to `(None, None)` — that *is* the tri-state fix below. The
guarantee it encoded (an unreadable probe must never advertise the sandbox) is
preserved and strengthened by a new companion test asserting `validate()` still
sets `managed_hosts=False` in that case.

These are pre-selections and nothing more. The modal still opens, still shows
the full menus, still requires a submit, and whatever the user submits is what
is saved. Nothing is skipped.

What that test proves, precisely: the block sequence, the block ids, the
modal's top-level key set, and that `initial_option` appears nowhere. It is not
a full snapshot — a changed placeholder or workspace hint would still pass — so
it is a structural guard, not a byte-for-byte assertion about every string.

### Saying only what we actually established

The modal never converts a failure to check into a finding about the operator's
server. Four distinct cases, four distinct messages:

| Situation | What the modal says |
| --- | --- |
| Server unreachable / auth failure | today's reach-the-server or login screen — unchanged, no mention of defaults |
| `/v1/info` readable, sandboxes off | "this server doesn't provision one" |
| `/v1/info` **unreadable** | "whether this server provisions one couldn't be checked just now" |
| Agent exists but past the menu's 100-option cap | "isn't available in this menu, which lists only the first 100 of N agents" |

That third row required a small upstream change, described below.

### `managed_host_support()` now distinguishes unsupported from unverified

`managed_host_support()` (`omnigent.py:382`) returned `(False, None)` both when
the server answered "no sandboxes" and when `/v1/info` could not be read at all
— `_get_json` (`omnigent.py:1036`) swallows transport, HTTP (including auth),
and JSON errors alike. With a configured managed default, the first draft of
this PR turned that into "this server doesn't provision one": a false diagnosis
of the operator's configuration when the truth was that we never asked.

Reproduces with health, agents and one online external host all succeeding and
`/v1/info` returning 500.

The probe now returns `None` for "unread", and `ValidatedServer` carries
`managed_support_known` beside `managed_hosts`. **The option is still withheld
either way** — offering one the server would 422 is worse — so a deployment
configuring neither variable sees no change; only the wording of the
configured-default note distinguishes the two. `_get_json`'s swallowing is
untouched: this stops presenting its result as affirmative evidence, it does
not try to fix it.

Covered by five tests: the client's tri-state return, `validate()` recording it
for an unread probe, `validate()` recording it for a readable one, the modal's
wording, and the full flow with `/v1/info` returning 500 while everything else
succeeds.

### Unavailable-default policy

Availability is resolved **at render time**, against the agent/host listing
fetched as the authenticated Slack user — after per-user login, not before. No
network call is added to the submit handler.

A configured default that is not among that user's offered options leaves
**that** menu blank and adds a context note below it, pointing back up at the
menu. A different agent or host is **never** substituted, and a valid default in
the other menu is still applied. This follows
`web/src/shell/projectPrefill.ts` (`:99` no substitution, `:144` managed gated
on server support, `:158` never override the user).

**One deliberate divergence from that precedent:** `projectPrefill.ts:105` seeds
a configured agent verbatim without checking the picker list, on the grounds
that absence from the list doesn't prove the id is unusable. The Slack modal
cannot do that — Block Kit requires a `static_select`'s `initial_option` to be
one of the options it was given. So here, absence from the menu is the only
signal available, and it produces the blank + note state. The note names the
configured id, and names truncation when that is the cause, so the user can tell
their operator something accurate.

Managed submission is untouched: `host_id=None`, `workspace=""` (the server
rejects managed with a non-None host id, `omnigent/server/schemas.py:1542`).
No storage migration — `UserConfig` already carries these fields.

### Option-cap behavior

`_agent_options` takes the first 100 agents (Slack's `static_select` cap). The
pre-selection is looked up in the **built option list**, so a configured agent
that exists on the server but falls outside the cap is the unavailable case:
blank menu + a note. The note says "isn't available in this menu, which lists
only the first 100 of N agents" — the agent is on the server and usable, it just
didn't fit, and the note must not imply otherwise.

Chosen over hoisting the agent into the menu, which would reorder the list for a
case the code already calls "far below 100 in practice"; hoisting would be a
reasonable follow-up if a large-fleet deployment hits it.

### Deliberately not implemented: `OMNIGENT_SLACK_DEFAULT_HOST_ID`

The issue's "possible shape" mentions defaulting a host. A default for a
*specific external host id* is deliberately out of scope: on an authenticated
server `/v1/hosts` is owner-scoped (`omnigent/server/routes/hosts.py:599`), so
one user's host is not listed for anyone else and could not be pre-selected in a
menu that never lists it. (With auth disabled every caller shares the reserved
`local` owner and does see the same hosts — but a default that only works on
unauthenticated deployments isn't worth shipping.) Rather than accept a value
that silently does nothing for most users,
`OMNIGENT_SLACK_DEFAULT_HOST_TYPE` accepts only unset/blank or `managed` — the
one host choice that means the same thing for every user — and fails at startup
on any other non-blank value.

### Judgment call: a blank value means "unset"

`OMNIGENT_SLACK_DEFAULT_HOST_TYPE=` (empty) is normalized to unset rather than
rejected — that spelling is one way a compose file says "leave this off", and
failing startup on it would turn a benign idiom into a crash loop. A blank agent
id is likewise no agent, not one named `""`. A **non-blank** value is still
validated strictly. Values are also stripped of surrounding whitespace.

This is **not** a universal rule in this file and isn't claimed as one: the
existing `ServerAuthMode` literal (`config.py`) rejects a blank value. It is
consistent with the optional-field handling nearby (`webauth_base_url`, the
empty-encryption-key path in `app.py`), and it fits these two specifically
because they are optional pre-selections whose absence is the normal case. The
docstring records that as an exception rather than a convention.

### Scope notes

- **The `comp:tui` label is not substantiated.** A search found no equivalent
  agent/host picker in the TUI to apply a default to, so no TUI change is in
  this PR. If a maintainer knows the surface the label refers to, please point
  at it and it can be a follow-up — inventing a TUI change to satisfy the label
  seemed worse than saying so.
- Out of scope: web UI, resolving an agent id the picker does not offer. The
  `omnigent.py` client change is limited to the tri-state above.
- **Possible rebase.** #6907 (unmerged) also adds fields to
  `integrations/slack/src/omnigent_slack/config.py` and lines to
  `integrations/slack/.env.example`; #6891 (unmerged) rewrites the same submit
  handler region in `setup.py`. Whichever of the three lands later may need a
  rebase. This branch is based on `origin/main` and has not been merged with
  either.

## Test Plan

`integrations/slack` is its own package with its own `pyproject.toml`; the
pytest invocation runs from the repo root, whose `pyproject.toml` supplies the
`asyncio_mode = "auto"` these tests rely on.

```
ruff check integrations/slack                 # clean
ruff format --check integrations/slack        # clean (52 files)
pytest integrations/slack/tests               # 400 collected, 400 passed
```

Baseline before this branch: **374 collected, 374 passed**. This PR adds 26
cases. It changes exactly one pre-existing test — the renamed probe test
described under Summary — and leaves the other 373 untouched.

### Mutation testing

Every new test was mutation-checked, and every one has a row in the table
below: the thing it claims to test was broken in production code, the test
confirmed RED, then the change was reverted and the tree verified clean.
**40 mutations run: 39 RED, plus one deliberate control that PASSES** (`S7b`,
confirming two flow tests guard different code paths rather than duplicating
each other).

<details>
<summary>Mutation table (40 mutations)</summary>

| # | Mutation to production code | Test that must fail | Result |
| --- | --- | --- | --- |
| M1 | `default_agent_id` defaults to `"ag_leak"` | `defaults_are_unset_by_default` | RED |
| M2 | `validation_alias` renamed | `defaults_read_from_env` | RED |
| M3 | drop `.strip()` in the normalizer | `defaults_strip_surrounding_whitespace` | RED |
| M4 | drop the blank→None branch | `blank_defaults_are_treated_as_unset` | RED |
| M5 | `DefaultHostType` → `str` | `unknown_default_host_type_fails_startup` | RED |
| B1a | probe failure returns `(False, None)` again | `managed_host_support_reports_unknown_when_probe_fails` | RED |
| B1b | `validate()` always reports the probe as known | `validate_withholds_managed_but_records_an_unread_probe` | RED |
| B1c | modal always says "doesn't provision one" | `unreadable_capability_probe_is_not_reported_as_non_support` | RED |
| B1d | same | `unreachable_capability_probe_does_not_claim_non_support` (flow, `/v1/info` 500) | RED |
| B1e | an unread probe *offers* the managed option | same flow test | RED |
| B1f | `validate()` always reports the probe as unknown | `validate_records_a_readable_probe_as_known` | RED |
| S1 | never set agent `initial_option` | `preselects_the_configured_default_agent` | RED |
| S1b | same | `explicit_user_choice_wins_over_the_preselected_defaults` | RED |
| S2 | never set host `initial_option` | `preselects_the_managed_sandbox_when_configured` | RED |
| S2b | same | `explicit_user_choice_wins_over_the_preselected_defaults` | RED |
| S3 | drop the agent unavailable note | `leaves_agent_blank_when_the_default_is_not_offered` | RED |
| S4 | drop the host unavailable note | `leaves_host_blank_when_the_server_provisions_no_sandbox` | RED |
| S4b | same | `keeps_the_usable_default_when_the_other_is_unavailable` | RED |
| S5 | `_option_with_value` falls back to `options[0]` (auto-substitute) | `leaves_agent_blank...` | RED |
| S5b | same | `leaves_host_blank...` | RED |
| S5c | same | `does_not_preselect_an_agent_beyond_the_option_cap` | RED |
| S6 | `_advance_to_select` passes `None` instead of the defaults | pre-login flow | RED |
| S6b | same | post-login flow | RED |
| S7 | post-login `_revalidate_and_advance` drops the default | post-login flow | RED |
| **S7b** | *(control)* same mutation | pre-login flow | **PASS**, as intended — the two flow tests guard different paths |
| S8 | change the unreachable-server copy | `unreachable_server_is_not_reported_as_an_unavailable_default` | RED |
| S8b | unreachable branch falls through to the picker with defaults applied | same | RED |
| S9 | remove the 100-option cap | `does_not_preselect_an_agent_beyond_the_option_cap` | RED |
| S11 | managed submit stores `host_value` as the host id | `managed_default_stores_no_host_or_workspace` | RED |
| S13 | remove the absolute-path check | `still_requires_a_workspace_path` | RED |
| S14 | remove the no-agents guard | `no_agents_screen` | RED |
| W1 | never name the truncation | `agent_past_the_option_cap_is_named_as_a_menu_limit` | RED |
| W2 | notes point "below" again | `each_unavailable_default_note_follows_its_own_picker` | RED |
| W3 | host note moved *above* its own picker | same | RED |
| P1 | append one extra block to the payload | `renders_the_unchanged_payload_when_no_defaults_are_set` | RED |
| P2 | `select_modal` params default to real values | same | RED |
| R1 | submit prefers `self._default_agent_id` over the submitted option | `explicit_user_choice_wins_over_the_preselected_defaults` | RED |
| R4 | pool builds clients with `auth=None` | pre-login flow | RED |
| R5 | same | post-login flow | RED |
| A1 | `run()` stops passing the defaults to `SetupFlow` | `run_passes_the_operator_setup_defaults_to_the_setup_flow` | RED |

</details>

Three of those (`R1`, `R4`, `R5`) **passed** against the first draft of these
tests and only fail now, because the tests were rebuilt to require what their
names claim:

- `explicit_user_choice_wins_...` ran on a `SetupFlow` with *no* configured
  defaults, so a handler preferring `self._default_agent_id` had nothing to
  prefer. It now configures the flow, asserts both pre-selections really render,
  then overrides them.
- both flow tests accepted any client — no auth resolver, no stored token, and a
  server fake that granted access by request count. The listing routes are now
  gated on the user's bearer, so reaching the picker requires the pooled client
  to have carried that user's token.

All three submit tests build `view.state.values` from the **rendered** modal
rather than hand-writing it, but they lean on the pre-selections differently.
Only the untouched-managed-default test derives *both* submitted selections
from the rendered `initial_option`s; the workspace-path test derives only the
agent one (it overrides the host); and the override test derives neither — it
supplies both selections itself, and instead asserts both `initial_option`s are
present before overriding them, which is what `S1b`/`S2b` catch.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Manual reproduction (needs a Slack app + an Omnigent server).

**Setup first — every case below needs a picker to render at all.** Setup
short-circuits to an information screen when the server offers no agents, or
when the user has neither an online host nor a managed sandbox
(`setup.py:373`). So: use a server that returns at least one agent from
`GET /v1/agents`, and bring up an external host with
`omni host --server <url>` before starting. Without that host, the
`/v1/info`-failure case below dead-ends on the no-host screen and you never see
the warning.

```bash
export OMNIGENT_SLACK_DEFAULT_AGENT_ID=<an id from GET /v1/agents>
export OMNIGENT_SLACK_DEFAULT_HOST_TYPE=managed   # only on a server with sandboxes
omni integration slack
```

Then in Slack run `/omnigent`: the Agent menu opens on that agent and the Host
menu on the managed sandbox, both still changeable. Worth checking each
message separately:

| Change | Expected |
| --- | --- |
| both unset | today's picker, nothing pre-selected |
| nonexistent `OMNIGENT_SLACK_DEFAULT_AGENT_ID` | blank Agent menu + "isn't available in this menu" |
| `managed` on a server with sandboxes off | "this server doesn't provision one" |
| `managed` while `/v1/info` is blocked (agent + online host still available) | "couldn't be checked just now" — and *not* the line above |
| `OMNIGENT_SLACK_DEFAULT_HOST_TYPE=external` | startup config error, exit 2 |
| server unreachable entirely | today's reach-the-server screen, no mention of defaults |

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

**Not verified in this PR, stated plainly:**

- **No live Slack render.** This sandbox has no Slack app or Omnigent server, so
  the modal was never opened in a real client. The round-trip these tests assume
  — a `static_select`'s `initial_option` must be one of its offered options, is
  selected on load, and is returned in the submission payload (Slack's 2020
  full-state change sends all stateful elements) — is documented behaviour, and
  this very modal already relies on the analogous `initial_value` round-trip for
  the workspace input (`setup.py:1102`). Documented, not observed here; the
  manual steps above are the check a reviewer should run.
- **The `comp:tui` label**, as above — no TUI picker was found; not disproven,
  just unsubstantiated.
- **Type checking**: `pyrefly` (the repo's pre-commit type gate) is scoped to
  `omnigent/` and `sdks/python-client/`, so it does not cover
  `integrations/slack`. Run manually against the touched files it reports one
  error, pre-existing and unrelated (`app.py`, the `DatabricksOAuthClient`
  rotator type), on a line this PR does not touch.
- **`pre-commit` itself was not run** — its hooks invoke `.venv/bin/*`, which
  does not exist in this environment. The ruff hooks' equivalents were run
  directly.

## Changelog

Slack setup can pre-select an agent and the managed sandbox for everyone via `OMNIGENT_SLACK_DEFAULT_AGENT_ID` / `OMNIGENT_SLACK_DEFAULT_HOST_TYPE`
