### PR TITLE
feat(web): undo after archiving a session

### DIFF
--- a/tests/e2e_ui/desktop/test_desktop_update.py
+++ b/tests/e2e_ui/desktop/test_desktop_update.py
@@ -151,8 +151,9 @@ def test_update_overlay_height_lifts_sonner_toaster(
     expect(page.locator(".app-shell")).to_be_visible(timeout=30_000)
     page.wait_for_function("() => window.__omniUpdate.hasOverlaySubscriber()")
 
-    # Archive is a provider-free, real UI path that emits showToast(). Sonner
-    # does not mount its positioned list until the first toast exists.
+    # Archive is a provider-free, real UI path that puts a toast on screen (the
+    # post-archive Undo pill). Sonner does not mount its positioned list until
+    # the first toast exists.
     row = page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
     expect(row).to_be_visible()
     row.hover()
@@ -160,7 +161,7 @@ def test_update_overlay_height_lifts_sonner_toaster(
     page.get_by_test_id("archive-conversation").click()
     page.wait_for_url(f"{base_url}/", timeout=10_000)
 
-    toast = page.get_by_test_id("toast")
+    toast = page.get_by_test_id("archive-undo-toast")
     expect(toast).to_be_visible(timeout=10_000)
     toast.hover()  # Pause Sonner's finite dismissal timer while measuring.
     toaster = page.locator("[data-sonner-toaster]")

--- a/tests/e2e_ui/sessions/test_sidebar_undo_archive.py
+++ b/tests/e2e_ui/sessions/test_sidebar_undo_archive.py
@@ -1,0 +1,119 @@
+"""Browser e2e for undoing a session archive from the sidebar.
+
+Archiving a session pops a floating Undo pill (a sonner toast, bottom-right
+like the old "View in Settings" pointer). Archiving again while it's still up
+merges into the SAME pill and resets its countdown, so a burst of archives is
+covered by one Undo that restores every session at once. The pill reads
+"Archived N session(s)." — singular for one, plural for more — with a bold,
+underlined **Undo** and a small "View in Settings" link.
+
+This asserts the headline behaviour: two archives in quick succession collapse
+into one pill whose Undo unarchives BOTH — durably, not just in the client
+cache. Undo replays ``PATCH /v1/sessions/{id}`` with ``archived: false`` for the
+whole batch, so the store rows flip back and the sidebar rows return.
+
+Copy/pluralisation and batch-merge/reset mechanics are unit-tested in
+``web/src/shell/archiveUndoToast.test.tsx``; this file proves the wiring across
+a real archive → toast → unarchive round-trip in the browser.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+from playwright.sync_api import Locator, Page, expect
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate the sidebar row (``<li>``) for *session_id* by its href."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _archive_from_row(page: Page, session_id: str) -> None:
+    """Open a sidebar row's kebab and click Archive."""
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+    # Hover first so the desktop hover-revealed kebab trigger is interactable.
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("archive-conversation").click()
+
+
+def _archived_flag(base_url: str, session_id: str) -> bool | None:
+    """Read the store's ``archived`` flag for *session_id* (None if missing)."""
+    resp = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+    if resp.status_code != 200:
+        return None
+    return resp.json()["archived"]
+
+
+def _wait_for_archived(base_url: str, session_id: str, want: bool) -> None:
+    """Poll until the store row reports ``archived == want`` (or time out).
+
+    The list refetch that repaints the sidebar can land marginally before the
+    single-session snapshot reflects the write, so this polls rather than
+    reading once.
+    """
+    deadline = time.monotonic() + 15.0
+    seen: bool | None = None
+    while time.monotonic() < deadline:
+        seen = _archived_flag(base_url, session_id)
+        if seen is want:
+            return
+        time.sleep(0.25)
+    raise AssertionError(f"session {session_id} should report archived={want}, got {seen}")
+
+
+def test_undo_restores_every_session_archived_in_succession(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Two quick archives merge into one pill whose Undo restores both.
+
+    Failure modes this catches:
+
+    - Archiving fires no toast, or a separate toast per archive, so a burst
+      can't be undone as one action.
+    - The pill miscounts (e.g. always "1 session", or the literal
+      "session(s)") instead of "Archived 2 sessions.".
+    - Undo only restores the last-archived session, or only un-hides rows in
+      the client cache while the store still reports ``archived: true`` (a
+      reload would re-hide them).
+
+    :param page: Playwright page fixture (fresh context per test).
+    :param seeded_session_pair: ``(base_url, session_a, session_b)`` for two
+        pre-created runner-bound sessions.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+
+    # Start on session A's chat surface, then archive both in succession. The
+    # first archive (of the active session) redirects home; B is archived from
+    # its sidebar row, which stays listed on "/".
+    page.goto(f"{base_url}/c/{session_a}")
+    _archive_from_row(page, session_a)
+    expect(page.locator(f'a[href="/c/{session_a}"]')).to_have_count(0)
+    page.wait_for_url(f"{base_url}/", timeout=10_000)
+
+    _archive_from_row(page, session_b)
+    expect(page.locator(f'a[href="/c/{session_b}"]')).to_have_count(0)
+
+    # One pill, covering both — merged rather than stacked, and pluralised.
+    pill = page.get_by_test_id("archive-undo-toast")
+    expect(pill).to_be_visible()
+    expect(pill).to_contain_text("Archived 2 sessions.")
+
+    _wait_for_archived(base_url, session_a, True)
+    _wait_for_archived(base_url, session_b, True)
+
+    # Undo restores the whole batch.
+    pill.get_by_test_id("archive-undo-button").click()
+
+    # Both rows return to the sidebar...
+    expect(page.locator(f'a[href="/c/{session_a}"]')).to_have_count(1)
+    expect(page.locator(f'a[href="/c/{session_b}"]')).to_have_count(1)
+
+    # ...and the un-archive is durable: the store rows carry archived: false,
+    # not just the client cache.
+    _wait_for_archived(base_url, session_a, False)
+    _wait_for_archived(base_url, session_b, False)

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -16,6 +16,7 @@ import {
   useBulkArchiveConversations,
   useBulkDeleteConversations,
   useBulkStopSessions,
+  undoArchiveConversations,
   useConversations,
   useDeleteProject,
   useProjects,
@@ -2754,5 +2755,52 @@ describe("useDeleteProject", () => {
       succeeded: ["conv_a"],
       total: 2,
     });
+  });
+});
+
+describe("undoArchiveConversations optimistic restore", () => {
+  it("re-injects evicted rows into cached lists before the unarchive PATCH settles", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // A refetch already evicted the archived row from the sidebar list, so the
+    // flag-flip overlay has nothing to un-hide — this exercises the injection.
+    queryClient.setQueryData(
+      ["conversations", "", false],
+      infinitePage([conversation({ id: "conv_keep" })]),
+    );
+    // Search lists have server-owned membership; the row must not land there.
+    queryClient.setQueryData(["conversations", "term", false], infinitePage([]));
+    // Hold the unarchive PATCH in flight so the assertions below can only be
+    // satisfied by the synchronous cache write, never the network round-trip.
+    let resolvePatch!: (value: Response) => void;
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+
+    const undo = undoArchiveConversations(queryClient, [
+      conversation({ id: "conv_a", archived: true }),
+    ]);
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<ConversationsInfiniteData>([
+        "conversations",
+        "",
+        false,
+      ]);
+      expect(data?.pages[0].data.map((c) => c.id)).toEqual(["conv_a", "conv_keep"]);
+    });
+    const data = queryClient.getQueryData<ConversationsInfiniteData>(["conversations", "", false]);
+    expect(data?.pages[0].data[0].archived).toBe(false);
+    const search = queryClient.getQueryData<ConversationsInfiniteData>([
+      "conversations",
+      "term",
+      false,
+    ]);
+    expect(search?.pages[0].data).toEqual([]);
+
+    resolvePatch(mockResponse(conversation({ id: "conv_a", archived: false, updated_at: 101 })));
+    await undo;
   });
 });

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -28,6 +28,7 @@ import { authenticatedFetch } from "@/lib/identity";
 import { startTimedInteraction } from "@/lib/analyticsEmit";
 import {
   filtersFromConversationQueryKey,
+  markRecentlyCreated,
   mergeItemsIntoPages,
   overlayArchivedIntoCaches,
   overlayTitleIntoCaches,
@@ -36,6 +37,7 @@ import {
   PROJECT_LABEL_KEY,
   recentlyCreatedSessions,
   removeIdsFromPages,
+  unmarkRecentlyCreated,
   type ConversationsInfiniteData,
   type SessionListWireItem,
 } from "@/lib/sessionListCache";
@@ -391,7 +393,10 @@ function applySessionTombstones(page: ConversationsPage, dropArchiving = false):
 // The recently-created keep-alive map + its mutators live in the leaf
 // `sessionListCache` module (so the chat store can arm it on optimistic create
 // without an import cycle); re-exported here for existing callers.
-export { markRecentlyCreated, clearRecentlyCreated } from "@/lib/sessionListCache";
+// `markRecentlyCreated` is imported above for the undo path, so re-export the
+// local binding; `unmarkRecentlyCreated` stays internal.
+export { markRecentlyCreated };
+export { clearRecentlyCreated } from "@/lib/sessionListCache";
 
 /**
  * Prepend recently-created rows the first page doesn't yet include (the index
@@ -1270,6 +1275,75 @@ export function useBulkArchiveConversations() {
       void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
     },
   });
+}
+
+/**
+ * Unarchive a batch of sessions imperatively — the "Undo" behind the
+ * post-archive toast. Runs the same optimistic overlay + reconcile as
+ * `useBulkArchiveConversations({ archived: false })`, but as a plain async
+ * function rather than a hook: the toast is rendered by the app-level Toaster,
+ * outside the row/header/selection component that did the archiving. That
+ * component unmounts the moment its row leaves the sidebar (the optimistic
+ * overlay), so a mutation observer created there is already gone by the time
+ * Undo is clicked and its callbacks would never fire.
+ *
+ * Takes the full `Conversation` rows, not just ids, because the flag-flip
+ * overlay can only un-hide a row that's still in the list cache — and by the
+ * time Undo is clicked, a `["conversations"]` refetch (which excludes archived
+ * rows) may already have evicted them. So we ALSO arm the recently-created
+ * keep-alive with each row (archived cleared), which re-injects it into page 0
+ * and holds it there until the lagging search index reflects the unarchive —
+ * the additive mirror of the archive tombstone. Archiving bumped `updated_at`,
+ * so page 0 is the row's correct home and the injection doesn't duplicate it.
+ *
+ * Any id whose PATCH fails is dropped from the keep-alive and re-hidden, and a
+ * failure toast is shown. Mirrors the bulk hook's partial-failure path.
+ */
+export async function undoArchiveConversations(
+  queryClient: QueryClient,
+  conversations: readonly Conversation[],
+): Promise<void> {
+  if (conversations.length === 0) return;
+  const ids = conversations.map((c) => c.id);
+  // Un-hide any rows still in the list cache (flag flip). Rows a refetch already
+  // evicted aren't here to flip — the keep-alive below covers those.
+  await paintConversationsArchived(queryClient, ids, false);
+  for (const conv of conversations) markRecentlyCreated({ ...conv, archived: false });
+  // Refetch the sidebar list so `withRecentlyCreated` re-injects the kept-alive
+  // rows into page 0 at once, instead of waiting for the periodic reconcile.
+  // The keep-alive holds them there until the search index reflects the
+  // unarchive, so a lagging refetch can't drop them.
+  void queryClient.invalidateQueries({ queryKey: ["conversations"] });
+  try {
+    const results = await Promise.allSettled(ids.map((id) => archiveConversation(id, false)));
+    const failed: string[] = [];
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === "fulfilled") markConversationSeen(ids[i], result.value.updated_at);
+      else failed.push(ids[i]);
+    }
+    if (failed.length > 0) {
+      // The ids that stayed archived: drop them from the keep-alive so they stop
+      // being re-injected, and overlay archived=true so they leave the list
+      // again. The ids that DID unarchive stay visible.
+      for (const id of failed) {
+        unmarkRecentlyCreated(id);
+        overlayArchivedIntoCaches(queryClient, id, true);
+      }
+      reapplyLiveSessionTombstones(queryClient);
+      showToast(
+        failed.length === ids.length
+          ? failed.length === 1
+            ? "Couldn't restore the session."
+            : "Couldn't restore the sessions."
+          : "Couldn't restore some sessions.",
+      );
+    }
+  } finally {
+    void queryClient.invalidateQueries({ queryKey: ["projects"] });
+    void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
+    void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });
+  }
 }
 
 /**

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -28,6 +28,7 @@ import { authenticatedFetch } from "@/lib/identity";
 import { startTimedInteraction } from "@/lib/analyticsEmit";
 import {
   filtersFromConversationQueryKey,
+  insertNewRowsIntoPages,
   markRecentlyCreated,
   mergeItemsIntoPages,
   overlayArchivedIntoCaches,
@@ -1308,10 +1309,28 @@ export async function undoArchiveConversations(
   // Un-hide any rows still in the list cache (flag flip). Rows a refetch already
   // evicted aren't here to flip — the keep-alive below covers those.
   await paintConversationsArchived(queryClient, ids, false);
-  for (const conv of conversations) markRecentlyCreated({ ...conv, archived: false });
-  // Refetch the sidebar list so `withRecentlyCreated` re-injects the kept-alive
-  // rows into page 0 at once, instead of waiting for the periodic reconcile.
-  // The keep-alive holds them there until the search index reflects the
+  const restored = conversations.map((conv) => ({ ...conv, archived: false }));
+  for (const conv of restored) markRecentlyCreated(conv);
+  // Optimistically write the evicted rows straight back into the cached lists
+  // so Undo's result is visible on the next frame — the flag flip above only
+  // covers rows a refetch hasn't evicted yet, and waiting on the refetch below
+  // leaves a visible gap where the user wonders whether Undo worked. Same
+  // filter-aware insertion the WS `session_added` path uses, so search lists
+  // and non-member variants are untouched.
+  const candidates = new Map(restored.map((conv) => [conv.id, conv]));
+  for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
+    queryKey: ["conversations"],
+  })) {
+    if (!data) continue;
+    const { data: next } = insertNewRowsIntoPages(
+      data,
+      candidates,
+      filtersFromConversationQueryKey(key),
+    );
+    if (next !== data) queryClient.setQueryData(key, next);
+  }
+  // Refetch the sidebar list to reconcile with the server. The keep-alive
+  // armed above holds the rows in page 0 until the search index reflects the
   // unarchive, so a lagging refetch can't drop them.
   void queryClient.invalidateQueries({ queryKey: ["conversations"] });
   try {

--- a/web/src/lib/sessionListCache.ts
+++ b/web/src/lib/sessionListCache.ts
@@ -340,6 +340,15 @@ export function clearRecentlyCreated(): void {
 }
 
 /**
+ * Drop one row from the keep-alive map — e.g. an optimistic unarchive whose
+ * PATCH failed, so the row must stop being re-injected and fall back to
+ * archived. Safe to call for an id that isn't tracked.
+ */
+export function unmarkRecentlyCreated(id: string): void {
+  recentlyCreatedSessions.delete(id);
+}
+
+/**
  * Prepend brand-new rows (a create here or elsewhere, a share) to page 0 so the
  * sidebar shows them the instant the push lands, instead of after the debounced
  * refetch (which lags the search index). A new row sorts newest-first, so page 0

--- a/web/src/shell/HeaderConversationMenu.test.tsx
+++ b/web/src/shell/HeaderConversationMenu.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Conversation } from "@/hooks/useConversations";
 import type * as ConversationsModule from "@/hooks/useConversations";
 import type * as UnseenConversationsModule from "@/hooks/useUnseenConversations";
@@ -70,18 +71,23 @@ const SECOND_CONVERSATION: Conversation = {
 };
 
 function menuTree(overrides: Partial<Parameters<typeof HeaderConversationMenu>[0]> = {}) {
+  // A QueryClientProvider is required: the menu reads useQueryClient() to hand
+  // the post-archive Undo toast a client for unarchiving.
+  const queryClient = new QueryClient();
   return (
-    <MemoryRouter initialEntries={[`/c/${overrides.conversation?.id ?? CONVERSATION.id}`]}>
-      <HeaderConversationMenu
-        conversation={CONVERSATION}
-        currentProject={null}
-        canShare
-        canFork
-        onShare={() => {}}
-        onFork={mocks.fork}
-        {...overrides}
-      />
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/c/${overrides.conversation?.id ?? CONVERSATION.id}`]}>
+        <HeaderConversationMenu
+          conversation={CONVERSATION}
+          currentProject={null}
+          canShare
+          canFork
+          onShare={() => {}}
+          onFork={mocks.fork}
+          {...overrides}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
@@ -182,9 +188,9 @@ describe("HeaderConversationMenu", () => {
 
     openMenu();
     fireEvent.click(screen.getByRole("menuitem", { name: "Archive" }));
-    // Just the flag: the optimistic overlay lives in the hook, and the
-    // "view archived" toast fires synchronously (navigating away unmounts this
-    // menu, so a mutate onSuccess callback wouldn't fire).
+    // Just the flag: the optimistic overlay lives in the hook, and the Undo
+    // toast fires synchronously (navigating away unmounts this menu, so a
+    // mutate onSuccess callback wouldn't fire).
     expect(mocks.archive).toHaveBeenCalledWith({ id: "conv-1", archived: true });
 
     view.unmount();

--- a/web/src/shell/HeaderConversationMenu.tsx
+++ b/web/src/shell/HeaderConversationMenu.tsx
@@ -41,6 +41,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   PINNED_LABEL_KEY,
   type Conversation,
@@ -54,9 +55,9 @@ import { ProjectPicker } from "./ProjectPicker";
 import { markConversationUnread } from "@/hooks/useUnseenConversations";
 import { useOmnigentAnalytics } from "@/lib/analytics";
 import { useIsMobileViewport } from "@/hooks/useIsMobileViewport";
-import { Link, useNavigate } from "@/lib/routing";
+import { useNavigate } from "@/lib/routing";
 import { USER_SESSION_TITLE_MAX_CHARS } from "@/lib/sessionTitles";
-import { showToast } from "@/components/ui/toast";
+import { showArchiveUndoToast } from "./archiveUndoToast";
 import { cn } from "@/lib/utils";
 import { MOBILE_GLASS_SURFACE } from "./mobileGlass";
 import { conversationDisplayLabel } from "./sidebarNav";
@@ -82,21 +83,6 @@ interface HeaderConversationMenuProps {
   workspaceItems?: ReactNode;
 }
 
-function ArchivedToast() {
-  return (
-    <span>
-      View archived sessions in{" "}
-      <Link to="/settings/archived" className="font-medium text-primary hover:underline">
-        Settings
-      </Link>
-    </span>
-  );
-}
-
-function showArchivedToast() {
-  showToast(<ArchivedToast />);
-}
-
 export function HeaderConversationMenu({
   conversation,
   currentProject,
@@ -112,6 +98,7 @@ export function HeaderConversationMenu({
   workspaceItems = null,
 }: HeaderConversationMenuProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const isMobile = useIsMobileViewport();
   const { trackClick } = useOmnigentAnalytics();
   const togglePinned = useTogglePinnedConversation();
@@ -194,7 +181,9 @@ export function HeaderConversationMenu({
     archive.mutate({ id: conversation.id, archived: true });
     // Fire NOW, not in a mutate onSuccess: navigating away unmounts this menu,
     // and per-call mutate callbacks don't fire once their observer unmounts.
-    showArchivedToast();
+    // The Undo toast is driven by module state + the app-level Toaster, so it
+    // survives this menu unmounting.
+    showArchiveUndoToast(queryClient, [conversation]);
   };
 
   const mainItems = (

--- a/web/src/shell/Sidebar.archive.test.tsx
+++ b/web/src/shell/Sidebar.archive.test.tsx
@@ -3,7 +3,7 @@
 // sidebar optimistically (useArchiveConversation flips the cached `archived`
 // flag in onMutate; the list filters archived rows out client-side), so there
 // is no "Archiving…" status row — the row simply unmounts, like delete's. The
-// only mutate-level callback is the success toast pointing at Settings.
+// only synchronous side effect is the Undo pill (which also links to Settings).
 // The runner stop is the server's job once the flag commits — a client stop
 // would race the server's against the same runner, and put the runner's stop
 // timeouts in front of the flag flip. The kebab's user-facing "Stop session"
@@ -167,16 +167,21 @@ describe("archive flow", () => {
     expect(screen.getByRole("link", { name: /My Session/ })).toBeInTheDocument();
   });
 
-  it("toasts a pointer to Settings on archive", async () => {
+  it("shows an Undo pill (with a Settings link) on archive", async () => {
     mockConversations([CONV]);
     renderSidebar();
     clickArchive();
 
     // The toast fires synchronously on click (the row is about to unmount, so
     // it can't wait for a mutate callback) — no need to drive onSuccess.
-    const toast = await screen.findByTestId("toast");
-    expect(within(toast).getByText(/View archived sessions in/)).toBeInTheDocument();
-    expect(within(toast).getByRole("link", { name: "Settings" })).toHaveAttribute(
+    const toast = await screen.findByTestId("archive-undo-toast");
+    // Singular copy for one session — never "session(s)".
+    expect(toast).toHaveTextContent("Archived 1 session.");
+    // Undo is the prominent action: bold + underlined per the design.
+    const undo = within(toast).getByTestId("archive-undo-button");
+    expect(undo).toHaveClass("font-bold", "underline");
+    // The Settings pointer is kept alongside Undo.
+    expect(within(toast).getByRole("link", { name: "View in Settings" })).toHaveAttribute(
       "href",
       "/settings/archived",
     );

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -143,6 +143,7 @@ import { useBranding } from "@/lib/branding";
 import { relativeTime } from "@/lib/relativeTime";
 import { USER_SESSION_TITLE_MAX_CHARS } from "@/lib/sessionTitles";
 import { showToast } from "@/components/ui/toast";
+import { showArchiveUndoToast } from "./archiveUndoToast";
 import { PermissionsModal } from "@/components/PermissionsModal";
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
 import { ProjectRowIcon } from "./ProjectPicker";
@@ -441,18 +442,6 @@ function useActiveNavItem(): {
  *     scrollback is fine; users typically want the conversations list
  *     to stay visible while they switch around.
  */
-/** Toast body shown after archiving a session — links to its new home. */
-function ArchivedToast() {
-  return (
-    <span>
-      View archived sessions in{" "}
-      <Link to="/settings/archived" className="font-medium text-primary hover:underline">
-        Settings
-      </Link>
-    </span>
-  );
-}
-
 /**
  * Compute the set of IDs to add for a shift-click range selection.
  * Returns null when the range can't be computed (missing anchor or id).
@@ -467,11 +456,6 @@ export function computeShiftSelectRange(
   if (anchorIdx === -1 || targetIdx === -1) return null;
   const [start, end] = anchorIdx < targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
   return visibleIds.slice(start, end + 1);
-}
-
-/** Fire the post-archive toast. Hoisted so it isn't a render-scoped closure. */
-function showArchivedToast() {
-  showToast(<ArchivedToast />);
 }
 
 /** Stable empty array for the pinned-conversations fallback (referential
@@ -3538,6 +3522,7 @@ function ConversationRowImpl({
     if (!isActive) return;
     rowRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
   }, [isActive]);
+  const queryClient = useQueryClient();
   const rename = useRenameConversation();
   const del = useStopAndDeleteConversation();
   const archive = useArchiveConversation();
@@ -3796,11 +3781,13 @@ function ConversationRowImpl({
     // session they'd switched to meanwhile. Mirrors confirmDelete.
     if (nextArchived && isActive) navigate("/", { replace: true });
     archive.mutate({ id: conversation.id, archived: nextArchived });
-    // Point the user at where the session went — fire NOW, not in a mutate
-    // onSuccess: the optimistic overlay unmounts this row on the next frame,
-    // and per-call mutate callbacks don't fire once their observer unmounts.
-    // A failed archive reconciles the row back with its own error toast.
-    if (nextArchived) showArchivedToast();
+    // Offer an Undo (and point at where the session went) — fire NOW, not in a
+    // mutate onSuccess: the optimistic overlay unmounts this row on the next
+    // frame, and per-call mutate callbacks don't fire once their observer
+    // unmounts. A failed archive reconciles the row back with its own error
+    // toast. The toast is driven imperatively (module state + app-level
+    // Toaster), so it survives this row unmounting.
+    if (nextArchived) showArchiveUndoToast(queryClient, [conversation]);
   }
 
   function runUnarchive() {
@@ -5175,6 +5162,7 @@ function BulkActionBar({
   onProjectAssigned?: (projectName: string) => void;
 }) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { conversationId: activeId } = useParams<{ conversationId: string }>();
   const bulkArchive = useBulkArchiveConversations();
   const bulkDelete = useBulkDeleteConversations();
@@ -5281,6 +5269,10 @@ function BulkActionBar({
       navigate("/", { replace: true });
     onDeselectAll();
     bulkArchive.mutate({ ids: nonArchivedSelected.map((c) => c.id), archived: true });
+    // Offer Undo for the whole batch. Fire now, before this bar unmounts with
+    // the cleared selection; the toast is driven by module state + the
+    // app-level Toaster, so it outlives this component.
+    showArchiveUndoToast(queryClient, nonArchivedSelected);
   }
 
   function handleUnarchive() {

--- a/web/src/shell/archiveUndoToast.test.tsx
+++ b/web/src/shell/archiveUndoToast.test.tsx
@@ -1,0 +1,130 @@
+// Tests for the post-archive Undo pill. Contract: archives in quick succession
+// merge into ONE pill whose count updates live, and Undo unarchives the whole
+// merged batch through undoArchiveConversations. The batch is module state, so
+// it's reset between cases and any leftover toast is dismissed.
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { Conversation } from "@/hooks/useConversations";
+
+const mocks = vi.hoisted(() => ({ undoArchiveConversations: vi.fn() }));
+
+// archiveUndoToast only pulls undoArchiveConversations from this module; a
+// partial mock keeps the toast logic isolated from cache/network behavior.
+vi.mock("@/hooks/useConversations", () => ({
+  undoArchiveConversations: mocks.undoArchiveConversations,
+}));
+
+import { showArchiveUndoToast, resetArchiveUndoBatchForTests } from "./archiveUndoToast";
+import { Toaster } from "@/components/ui/sonner";
+
+const queryClient = new QueryClient();
+
+/** Minimal Conversation rows keyed by id — the pill only needs id + count. */
+const conv = (id: string): Conversation =>
+  ({ id, object: "conversation", title: id, created_at: 0, updated_at: 0 }) as Conversation;
+
+const convs = (...ids: string[]) => ids.map(conv);
+
+function mountToaster() {
+  render(
+    <MemoryRouter>
+      <Toaster />
+    </MemoryRouter>,
+  );
+}
+
+const show = (ids: string[]) => act(() => showArchiveUndoToast(queryClient, convs(...ids)));
+
+beforeEach(() => {
+  mocks.undoArchiveConversations.mockReset().mockResolvedValue(undefined);
+  resetArchiveUndoBatchForTests();
+  toast.dismiss();
+});
+
+afterEach(() => cleanup());
+
+describe("showArchiveUndoToast", () => {
+  it("uses singular copy for a single session", async () => {
+    mountToaster();
+    await show(["a"]);
+
+    const pill = await screen.findByTestId("archive-undo-toast");
+    expect(pill).toHaveTextContent("Archived 1 session.");
+    // Never the literal "session(s)".
+    expect(pill.textContent).not.toContain("session(s)");
+  });
+
+  it("uses plural copy and keeps one pill when archives merge", async () => {
+    mountToaster();
+    await show(["a"]);
+    await show(["b", "c"]);
+
+    // Still a single pill, now covering all three.
+    const pills = await screen.findAllByTestId("archive-undo-toast");
+    expect(pills).toHaveLength(1);
+    expect(pills[0]).toHaveTextContent("Archived 3 sessions.");
+  });
+
+  it("de-dupes ids already in the batch", async () => {
+    mountToaster();
+    await show(["a"]);
+    await show(["a", "b"]);
+
+    expect(await screen.findByTestId("archive-undo-toast")).toHaveTextContent(
+      "Archived 2 sessions.",
+    );
+  });
+
+  it("undoes the whole merged batch and dismisses the pill", async () => {
+    mountToaster();
+    await show(["a"]);
+    await show(["b", "c"]);
+
+    const pill = await screen.findByTestId("archive-undo-toast");
+    act(() => {
+      fireEvent.click(within(pill).getByTestId("archive-undo-button"));
+    });
+
+    expect(mocks.undoArchiveConversations).toHaveBeenCalledTimes(1);
+    expect(mocks.undoArchiveConversations).toHaveBeenCalledWith(queryClient, convs("a", "b", "c"));
+    // The pill dismisses on Undo (sonner animates it out, so wait for removal).
+    await waitFor(() => expect(screen.queryByTestId("archive-undo-toast")).not.toBeInTheDocument());
+  });
+
+  it("starts a fresh batch after an Undo", async () => {
+    mountToaster();
+    await show(["a", "b"]);
+    const first = await screen.findByTestId("archive-undo-toast");
+    act(() => {
+      fireEvent.click(within(first).getByTestId("archive-undo-button"));
+    });
+    expect(mocks.undoArchiveConversations).toHaveBeenLastCalledWith(queryClient, convs("a", "b"));
+    // Let the dismissed pill finish animating out before reusing the toast id.
+    await waitFor(() => expect(screen.queryByTestId("archive-undo-toast")).not.toBeInTheDocument());
+
+    // A later archive is its own batch, not appended to the undone one: it reads
+    // "1 session" and undoing again restores only the new id.
+    await show(["x"]);
+    const second = await screen.findByTestId("archive-undo-toast");
+    expect(second).toHaveTextContent("Archived 1 session.");
+    act(() => {
+      fireEvent.click(within(second).getByTestId("archive-undo-button"));
+    });
+    expect(mocks.undoArchiveConversations).toHaveBeenLastCalledWith(queryClient, convs("x"));
+  });
+
+  it("links to the archived-sessions settings page", async () => {
+    mountToaster();
+    await show(["a"]);
+
+    const pill = await screen.findByTestId("archive-undo-toast");
+    expect(within(pill).getByRole("link", { name: "View in Settings" })).toHaveAttribute(
+      "href",
+      "/settings/archived",
+    );
+  });
+});

--- a/web/src/shell/archiveUndoToast.tsx
+++ b/web/src/shell/archiveUndoToast.tsx
@@ -1,0 +1,110 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Link } from "@/lib/routing";
+import { undoArchiveConversations, type Conversation } from "@/hooks/useConversations";
+
+/**
+ * How long the post-archive Undo pill stays on screen, in milliseconds. 3s
+ * reads as long enough to catch and act on without lingering.
+ */
+const ARCHIVE_UNDO_DURATION_MS = 3000;
+
+/** Stable id so repeated archives update ONE pill (merge) and reset its timer. */
+const ARCHIVE_UNDO_TOAST_ID = "archive-undo";
+
+// The sessions the visible pill would undo. Archives in quick succession
+// (while the pill is still up) merge into this one batch; it's cleared when the
+// pill auto-closes, is dismissed, or Undo runs. Module-level so the three
+// archive entry points (row menu, header menu, bulk selection) share a single
+// pill rather than stacking one each. Full rows (not just ids) so Undo can
+// re-inject them into the sidebar even after a refetch evicted the archived
+// rows (see `undoArchiveConversations`).
+let batched: Conversation[] = [];
+// The most recent caller's QueryClient. Every entry point resolves the same
+// app-level client, so the latest one correctly unarchives the whole batch.
+let activeQueryClient: QueryClient | null = null;
+
+function clearBatch(): void {
+  batched = [];
+  activeQueryClient = null;
+}
+
+function runUndo(): void {
+  const conversations = batched;
+  const queryClient = activeQueryClient;
+  clearBatch();
+  toast.dismiss(ARCHIVE_UNDO_TOAST_ID);
+  if (queryClient && conversations.length > 0) {
+    void undoArchiveConversations(queryClient, conversations);
+  }
+}
+
+/** The pill body: "Archived N session(s). Undo" plus a small Settings link. */
+function ArchiveUndoToast({ count }: { count: number }) {
+  return (
+    <div
+      data-testid="archive-undo-toast"
+      className="flex items-center gap-3 rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground shadow-composer dark:bg-card-solid"
+    >
+      <span>
+        Archived {count} {count === 1 ? "session" : "sessions"}.{" "}
+        <button
+          type="button"
+          data-testid="archive-undo-button"
+          onClick={runUndo}
+          className="font-bold underline underline-offset-2 hover:text-primary"
+        >
+          Undo
+        </button>
+      </span>
+      <Link
+        to="/settings/archived"
+        onClick={() => toast.dismiss(ARCHIVE_UNDO_TOAST_ID)}
+        className="border-l border-border pl-3 text-xs text-muted-foreground hover:text-foreground hover:underline"
+      >
+        View in Settings
+      </Link>
+    </div>
+  );
+}
+
+/**
+ * Show (or extend) the post-archive Undo pill after archiving `conversations`.
+ *
+ * Fire it right after kicking off the archive — like the old Settings toast, it
+ * runs synchronously on the click because the archiving row unmounts on the
+ * next frame (optimistic overlay). Repeated calls merge their rows into the
+ * same pill and reset its countdown, so undoing restores every session archived
+ * since the pill first appeared. A failed archive reconciles its own row back
+ * and the extra row in the batch is harmless — unarchiving a session that never
+ * archived is a no-op.
+ */
+export function showArchiveUndoToast(
+  queryClient: QueryClient,
+  conversations: readonly Conversation[],
+): void {
+  if (conversations.length === 0) return;
+  activeQueryClient = queryClient;
+  const seen = new Set(batched.map((c) => c.id));
+  for (const conv of conversations) {
+    if (!seen.has(conv.id)) {
+      batched.push(conv);
+      seen.add(conv.id);
+    }
+  }
+  const count = batched.length;
+  toast.custom(() => <ArchiveUndoToast count={count} />, {
+    id: ARCHIVE_UNDO_TOAST_ID,
+    duration: ARCHIVE_UNDO_DURATION_MS,
+    unstyled: true,
+    testId: "archive-undo-toast-item",
+    onAutoClose: clearBatch,
+    onDismiss: clearBatch,
+  });
+}
+
+/** Test-only: drop the pending Undo batch so cases don't leak module state. */
+export function resetArchiveUndoBatchForTests(): void {
+  clearBatch();
+}

--- a/web/src/shell/archiveUndoToast.tsx
+++ b/web/src/shell/archiveUndoToast.tsx
@@ -53,7 +53,7 @@ function ArchiveUndoToast({ count }: { count: number }) {
           type="button"
           data-testid="archive-undo-button"
           onClick={runUndo}
-          className="font-bold underline underline-offset-2 hover:text-primary"
+          className="cursor-pointer font-bold underline underline-offset-2 hover:text-primary"
         >
           Undo
         </button>


### PR DESCRIPTION
## Related issue

Closes #6966

## Summary

Adds a brief Undo after archiving a session, so a semi-destructive action has a
quick way back.

- After archiving, a small floating pill appears near the bottom: "Archived 1
  session. Undo" (plural by count), styled like the composer (card surface + drop
  shadow, fully rounded). It sits bottom-right, same placement as the previous
  "View archived in Settings" toast, which is now folded into the pill as a small
  "View in Settings" link.
- Archives in quick succession merge into one pill whose count updates live, so a
  single **Undo** restores the whole batch. It stays up for 3s.
- Wired into all three archive entry points: the sidebar row menu, the chat
  header menu, and bulk selection (which previously showed no toast at all).

Undo runs through an imperative `undoArchiveConversations` rather than a mutation
hook, because the pill is rendered by the app-level Toaster, outside the component
that archived. That component unmounts with its row (optimistic overlay), so a
mutation observer created there would never fire its callbacks. Rows a refetch has
already evicted are re-shown at once via the recently-created keep-alive rather
than waiting on the periodic reconcile.

## Test Plan

- **Unit (Vitest):** new `web/src/shell/archiveUndoToast.test.tsx` covers
  singular/plural copy, merge + de-dupe, "Undo restores the whole batch", the
  fresh-batch-after-undo reset, and the Settings link. Updated
  `Sidebar.archive.test.tsx` and `HeaderConversationMenu.test.tsx` for the new
  pill. 161 tests pass across the touched suites.
- **E2E (Playwright):** new
  `tests/e2e_ui/sessions/test_sidebar_undo_archive.py` archives two sessions in
  succession, asserts one pill reads "Archived 2 sessions.", clicks Undo, and
  verifies both rows return to the sidebar and the store reports `archived:
  false` for both (durable, not just a cache splice). Passes.
- **Manual:** ran the local stack (server + host + Vite) and drove the real UI in
  Chromium. Archived single, multiple-in-succession, and bulk; the pill copy and
  count were correct; Undo restored the sessions (~0.3s to reappear) and the
  store confirmed `archived: false`. Verified the composer-matched styling in
  light and dark.
- `tsc -b`, `oxlint`, and `pre-commit run` are clean on all changed files.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<img width="1232" height="720" alt="omnigent-undo-archive" src="https://github.com/user-attachments/assets/aedc1358-01a4-44e5-8785-17f928a50349" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified against a local stack (server + host + Vite) in a real browser:
archived from the row menu, header menu, and bulk selection; confirmed the pill
copy/count, that Undo restores every session archived in the burst, that the
restore is durable (the session store flips back to `archived: false`), and that
the pill matches the composer surface in light and dark. Automated unit + e2e
coverage backs the happy path and the copy/merge/undo logic.

## Changelog

Archiving a session now shows a brief Undo to bring it (and any others archived in quick succession) back.

This pull request and its description were written by Claude Code.
