### PR TITLE
chore(deps): bump react-router-dom to 7.18.0 for Trivy findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
         specifier: ^9.2.1
         version: 9.2.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom:
-        specifier: 6.30.4
-        version: 6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 7.18.0
+        version: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^3.10.1
         version: 3.10.1(@types/react@19.2.17)(react-dom@18.3.1(react@18.3.1))(react-is@19.2.7)(react@18.3.1)(redux@5.0.1)
@@ -3492,10 +3492,6 @@ packages:
       react-redux:
         optional: true
 
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
-    engines: {node: '>=14.0.0'}
-
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4006,6 +4002,7 @@ packages:
   '@testing-library/jest-dom@6.10.0':
     resolution: {integrity: sha512-HQwu0KaB2zyT0iLzBL+8CLyZDL3KlZlZJ+2iyc9uCUnlJVskJU/UlPuVCyIPhtukjPQdT2QNoR5nCP5FqTmmDQ==}
     engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    deprecated: Incorrect minor release with breaking changes (Node >=22 and required @testing-library/dom peer). Use 6.9.1 for the 6.x line, or upgrade to 7.0.0.
     peerDependencies:
       '@testing-library/dom': '>=10 <11'
       vitest: '*'
@@ -8042,18 +8039,22 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  react-router-dom@6.30.4:
-    resolution: {integrity: sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==}
-    engines: {node: '>=14.0.0'}
+  react-router-dom@7.18.0:
+    resolution: {integrity: sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^18.2.0
+      react-dom: ^18.2.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -8382,6 +8383,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.2:
     resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
@@ -12787,8 +12791,6 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-redux: 9.3.0(@types/react@19.2.17)(react@18.3.1)(redux@5.0.1)
-
-  '@remix-run/router@1.23.3': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -18213,17 +18215,19 @@ snapshots:
       react-draggable: 4.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.6.2
 
-  react-router-dom@6.30.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-router-dom@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.30.4(react@18.3.1)
+      react-router: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  react-router@6.30.4(react@18.3.1):
+  react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.3
+      cookie: 1.1.1
       react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-style-singleton@2.2.3(@types/react@19.2.17)(react@18.3.1):
     dependencies:
@@ -18695,6 +18699,8 @@ snapshots:
       send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.2: {}
 

--- a/tests/e2e_ui/sessions/test_router_session_switch.py
+++ b/tests/e2e_ui/sessions/test_router_session_switch.py
@@ -1,0 +1,44 @@
+"""E2E: switching sessions changes routes in place without a document reload.
+
+This covers the user-facing SPA navigation contract around ``/c/<session_id>``
+routes. The React Router upgrade in this change set updates the client-side
+routing layer and removes the legacy ``future`` flag from ``BrowserRouter``;
+this test pins that navigating between two existing sessions through the
+sidebar still updates the URL in place and preserves the current document.
+
+No LLM turn is involved.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+_LOAD_MARKER_INIT_SCRIPT = """
+window.__documentLoadMarker = crypto.randomUUID();
+"""
+
+
+def test_sidebar_session_switch_navigates_in_place(
+    page: Page,
+    seeded_session_pair: tuple[str, str, str],
+) -> None:
+    """Sidebar session picks should route to another conversation without reload.
+
+    :param page: Fresh Playwright page.
+    :param seeded_session_pair: ``(base_url, session_a, session_b)`` for two
+        real sessions on the same live server.
+    """
+    base_url, session_a, session_b = seeded_session_pair
+    page.add_init_script(_LOAD_MARKER_INIT_SCRIPT)
+
+    page.goto(f"{base_url}/c/{session_a}")
+    expect(page).to_have_url(f"{base_url}/c/{session_a}")
+    load_marker = page.evaluate("window.__documentLoadMarker")
+
+    page.locator(f'a[href="/c/{session_b}"]').click()
+    expect(page).to_have_url(f"{base_url}/c/{session_b}", timeout=30_000)
+    assert page.evaluate("window.__documentLoadMarker") == load_marker
+
+    page.locator(f'a[href="/c/{session_a}"]').click()
+    expect(page).to_have_url(f"{base_url}/c/{session_a}", timeout=30_000)
+    assert page.evaluate("window.__documentLoadMarker") == load_marker

--- a/web/package.json
+++ b/web/package.json
@@ -84,7 +84,7 @@
     "react-hotkeys-hook": "^5.2.4",
     "react-markdown": "^10.1.0",
     "react-pdf": "^9.2.1",
-    "react-router-dom": "6.30.4",
+    "react-router-dom": "7.18.0",
     "recharts": "^3.10.1",
     "rehype-github-alerts": "^4.2.0",
     "rehype-raw": "^7.0.0",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -140,7 +140,7 @@ function RootApp({ initialInfo }: { initialInfo: ServerInfo | "loading" }) {
           <ThemeProvider>
             <TooltipProvider>
               <ImageLightboxProvider>
-                <BrowserRouter future={{ v7_startTransition: true }}>
+                <BrowserRouter>
                   <SessionUpdatesProvider>
                     <RunnerHealthProvider>
                       <QueueFlushProvider>


### PR DESCRIPTION
## Summary
Bump `react-router-dom` from `6.30.4` to `7.18.0`, refresh `pnpm-lock.yaml`, and remove the obsolete `future={{ v7_startTransition: true }}` prop from `BrowserRouter`.

This targets the remaining open Trivy repo findings reported in `trivy-repo-report.txt` / `trivy-repo-report.json` for:
- `CVE-2026-53666` on `react-router@6.30.4` (Trivy fixed version: `7.18.0`)
- `CVE-2026-53669` on `react-router@6.30.4`

Because `react-router` is resolved through `react-router-dom`, the package bump also refreshes the transitive `react-router` version in the lockfile.

Trivy report excerpt:
> `react-router` `6.30.4` — fixed version `7.18.0`

## Test Plan
- `pnpm install --lockfile-only`
- `pnpm -C web type-check`
- Re-run `trivy repo . --skip-version-check`

## Demo
N/A

## Type of change
- [x] Dependency update
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] UI / frontend change

## Test coverage
- [x] Manual verification completed
- [ ] Automated tests added
- [ ] Automated tests updated
- [ ] Not applicable

## Coverage notes
Validated that the web workspace still type-checks after the router upgrade. The only required source change was dropping the v6-to-v7 future flag that v7 no longer accepts.
