### PR TITLE
fix(runner): recover incomplete agent bundle caches

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1262,6 +1262,9 @@ async def _resolve_agent_spec_from_server(
     :raises RuntimeError: If the server returns a non-200 status
         other than 404.
     """
+    import shutil
+    import tempfile
+
     from omnigent.runner.native import ResolvedSpec
     from omnigent.spec import load
 
@@ -1304,9 +1307,19 @@ async def _resolve_agent_spec_from_server(
     # unsupported sub-agent and launch the parent with what this runner
     # *does* support, rather than failing every dispatch of the agent.
     # See omnigent.spec.load.
-    if not dest.exists():
-        dest.mkdir(parents=True)
-        load(resp.content, dest=dest, expand_env=expand_env, prune_invalid_sub_agents=True)
+    if not (dest / "config.yaml").is_file():
+        spec_cache_root.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=spec_cache_root, prefix=".agent-bundle-") as staging:
+            staging_dir = Path(staging)
+            load(
+                resp.content,
+                dest=staging_dir,
+                expand_env=expand_env,
+                prune_invalid_sub_agents=True,
+            )
+            if dest.exists():
+                shutil.rmtree(dest)
+            staging_dir.rename(dest)
     spec = load(dest, expand_env=expand_env, prune_invalid_sub_agents=True)
     return ResolvedSpec(spec=spec, workdir=dest)
 

--- a/tests/e2e/test_agent_bundle_cache_recovery_e2e.py
+++ b/tests/e2e/test_agent_bundle_cache_recovery_e2e.py
@@ -1,0 +1,208 @@
+"""End-to-end regression coverage: incomplete agent bundle caches must heal.
+
+Guarded regression: if the runner's ``_resolve_agent_spec_from_server``
+treats an existing versioned cache directory as proof that an agent bundle
+was successfully extracted and loaded, a bundle whose load fails (e.g. the
+archive is missing ``config.yaml``) leaves an incomplete directory behind;
+every later resolve of the same agent version then skips extraction and
+fails with ``FileNotFoundError: config.yaml not found`` — native session
+startup stays broken even though the server is now serving a valid bundle.
+
+These tests drive the runner's **real** resolver code over a **real** TCP
+socket against a live session-scoped agent-contents endpoint. The only thing
+simulated is the fault *condition* — the bundle bytes the endpoint serves —
+which is exactly the trigger the report names:
+
+* ``test_valid_bundle_recovers_after_failed_extraction``: the endpoint serves
+  a partial tar (no ``config.yaml``) once, then a valid bundle for the same
+  agent version. The second resolve must succeed instead of reusing the
+  poisoned cache entry.
+* ``test_incomplete_cache_dir_is_rebuilt_from_valid_response``: a versioned
+  cache directory already exists holding an unrelated partial file and no
+  ``config.yaml`` (what an interrupted extraction leaves behind). A resolve
+  against a healthy endpoint must rebuild the entry from the fetched response
+  rather than trusting the leftover directory.
+
+No LLM, server subprocess, or runner tunnel is needed: the defect is entirely
+in the runner-side bundle resolution, so the tests own a tiny stub HTTP
+server for the single endpoint the resolver calls.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import threading
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.runner._entry import _resolve_agent_spec_from_server
+
+_AGENT_VERSION = "7"
+_AGENT_NAME = "cache-recovery-agent"
+_VALID_CONFIG = (
+    b"spec_version: 1\n"
+    b"name: cache-recovery-agent\n"
+    b"executor:\n"
+    b"  config:\n"
+    b"    harness: claude-sdk\n"
+)
+
+
+def _tar_bytes(files: dict[str, bytes]) -> bytes:
+    """Build an in-memory ``.tar.gz`` bundle from a name->bytes mapping.
+
+    :param files: Archive members, e.g. ``{"config.yaml": b"..."}``.
+    :returns: The gzipped tarball bytes.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+# A bundle whose extraction succeeds but whose load must fail: it carries a
+# stray file and no config.yaml, like a truncated/corrupted bundle body.
+_PARTIAL_BUNDLE = _tar_bytes({"partial.txt": b"truncated bundle placeholder\n"})
+_VALID_BUNDLE = _tar_bytes({"config.yaml": _VALID_CONFIG})
+
+
+@dataclass
+class _BundleEndpoint:
+    """A live agent-contents endpoint serving a scripted bundle sequence.
+
+    :param responses: Bundle payloads to serve in order; the last entry
+        repeats for any further requests.
+    :param requested_paths: URL paths of every request served, in order.
+    """
+
+    responses: list[bytes]
+    requested_paths: list[str] = field(default_factory=list)
+    base_url: str = ""
+
+
+@pytest.fixture()
+def bundle_endpoint(request: pytest.FixtureRequest) -> Iterator[_BundleEndpoint]:
+    """Serve ``GET /v1/sessions/{id}/agent/contents`` over a real TCP socket.
+
+    The bundle sequence is provided per-test via indirect parametrization or
+    by mutating ``endpoint.responses`` before the first request.
+
+    :param request: Pytest fixture request (unused; keeps signature uniform).
+    :returns: The running endpoint descriptor with its ``base_url`` filled in.
+    """
+    endpoint = _BundleEndpoint(responses=[_VALID_BUNDLE])
+
+    class _Handler(BaseHTTPRequestHandler):
+        """Request handler serving the scripted bundle sequence."""
+
+        def do_GET(self) -> None:  # noqa: N802 - http.server API name
+            """Serve the next scripted bundle with the fixed version header."""
+            index = min(len(endpoint.requested_paths), len(endpoint.responses) - 1)
+            endpoint.requested_paths.append(self.path)
+            body = endpoint.responses[index]
+            self.send_response(200)
+            self.send_header("X-Agent-Version", _AGENT_VERSION)
+            self.send_header("X-Agent-Session-Scoped", "true")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args: object) -> None:
+            """Silence per-request stderr logging."""
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint.base_url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        yield endpoint
+    finally:
+        server.shutdown()
+        thread.join(timeout=10)
+
+
+async def test_valid_bundle_recovers_after_failed_extraction(
+    bundle_endpoint: _BundleEndpoint,
+    tmp_path: Path,
+) -> None:
+    """A failed bundle load must not poison later resolves of the version.
+
+    The endpoint first serves a partial bundle (no ``config.yaml``) for agent
+    version 7 — that resolve fails, as the bundle is genuinely invalid. It
+    then serves a valid bundle under the same version header. The second
+    resolve must load the valid response instead of failing forever on the
+    leftover cache directory.
+
+    :param bundle_endpoint: Live stub agent-contents endpoint.
+    :param tmp_path: Runner-local spec cache root for extracted bundles.
+    :returns: None.
+    """
+    bundle_endpoint.responses = [_PARTIAL_BUNDLE, _VALID_BUNDLE]
+    async with httpx.AsyncClient(base_url=bundle_endpoint.base_url) as client:
+        # First resolve: the served bundle is invalid, so failing is correct.
+        with pytest.raises(FileNotFoundError, match="config.yaml not found"):
+            await _resolve_agent_spec_from_server(
+                client, tmp_path, "ag_recovery", session_id="conv_recovery"
+            )
+
+        # Second resolve: the server now serves a valid bundle for the same
+        # version. This must succeed; reusing the incomplete cache directory
+        # (FileNotFoundError again) is the regression under test.
+        resolved = await _resolve_agent_spec_from_server(
+            client, tmp_path, "ag_recovery", session_id="conv_recovery"
+        )
+
+    assert resolved is not None
+    assert resolved.name == _AGENT_NAME
+    assert resolved.workdir is not None
+    assert (resolved.workdir / "config.yaml").read_bytes() == _VALID_CONFIG
+    # Both resolves reached the server; the recovery came from the valid
+    # response, not from skipping the fetch.
+    assert bundle_endpoint.requested_paths == [
+        "/v1/sessions/conv_recovery/agent/contents",
+        "/v1/sessions/conv_recovery/agent/contents",
+    ]
+
+
+async def test_incomplete_cache_dir_is_rebuilt_from_valid_response(
+    bundle_endpoint: _BundleEndpoint,
+    tmp_path: Path,
+) -> None:
+    """An existing cache entry without ``config.yaml`` is rebuilt, not trusted.
+
+    Seeds the versioned cache directory with an unrelated partial file and no
+    ``config.yaml`` — the state an interrupted extraction leaves behind — and
+    resolves against an endpoint serving a valid bundle for that version. The
+    resolver must rebuild the entry from the fetched response without
+    preserving the leftover file.
+
+    :param bundle_endpoint: Live stub agent-contents endpoint.
+    :param tmp_path: Runner-local spec cache root for extracted bundles.
+    :returns: None.
+    """
+    poisoned = tmp_path / f"ag_recoveryb-v{_AGENT_VERSION}"
+    poisoned.mkdir(parents=True)
+    (poisoned / "leftover.txt").write_text("interrupted extraction leftover\n")
+
+    async with httpx.AsyncClient(base_url=bundle_endpoint.base_url) as client:
+        resolved = await _resolve_agent_spec_from_server(
+            client, tmp_path, "ag_recoveryb", session_id="conv_recoveryb"
+        )
+
+    assert resolved is not None
+    assert resolved.name == _AGENT_NAME
+    assert resolved.workdir is not None
+    assert (resolved.workdir / "config.yaml").read_bytes() == _VALID_CONFIG
+    assert not (resolved.workdir / "leftover.txt").exists()
+    assert bundle_endpoint.requested_paths == [
+        "/v1/sessions/conv_recoveryb/agent/contents",
+    ]

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -2391,6 +2391,65 @@ async def test_resolve_agent_spec_from_server_caches_success_by_agent_version(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cache_state", ["incomplete-directory", "failed-load"])
+async def test_resolve_agent_spec_from_server_recovers_incomplete_cache(
+    tmp_path: Path,
+    cache_state: str,
+) -> None:
+    """A failed bundle load must not turn later valid responses into cache hits."""
+    config_bytes = (
+        b"spec_version: 1\nname: recovered-agent\nexecutor:\n  config:\n    harness: claude-sdk\n"
+    )
+    bundles: dict[str, bytes] = {}
+    for entry_name, content in [("config.yaml", config_bytes), ("partial.txt", b"partial")]:
+        bundle_buffer = io.BytesIO()
+        with tarfile.open(fileobj=bundle_buffer, mode="w:gz") as archive:
+            entry = tarfile.TarInfo(name=entry_name)
+            entry.size = len(content)
+            archive.addfile(entry, io.BytesIO(content))
+        bundles[entry_name] = bundle_buffer.getvalue()
+
+    cache_dir = tmp_path / "ag_recover-v7"
+    if cache_state == "incomplete-directory":
+        cache_dir.mkdir()
+        (cache_dir / "partial.txt").write_text("partial")
+
+    response_contents = [bundles["config.yaml"]]
+    if cache_state == "failed-load":
+        response_contents.insert(0, bundles["partial.txt"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=response_contents.pop(0),
+            headers={"X-Agent-Version": "7"},
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://server.test",
+    ) as client:
+        if cache_state == "failed-load":
+            with pytest.raises(FileNotFoundError, match=r"config\.yaml not found"):
+                await _resolve_agent_spec_from_server(
+                    client, tmp_path, "ag_recover", session_id="conv_test"
+                )
+            assert not cache_dir.exists()
+
+        recovered = await _resolve_agent_spec_from_server(
+            client, tmp_path, "ag_recover", session_id="conv_test"
+        )
+
+    assert recovered is not None
+    assert recovered.name == "recovered-agent"
+    assert recovered.workdir == cache_dir
+    assert (cache_dir / "config.yaml").read_bytes() == config_bytes
+    assert not (cache_dir / "partial.txt").exists()
+    assert list(tmp_path.iterdir()) == [cache_dir]
+    assert response_contents == []
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("status_code", [401, 403, 500, 502])
 async def test_resolve_agent_spec_from_server_raises_for_non_404_errors(
     tmp_path: Path,


### PR DESCRIPTION
## Related issue

Closes #6975

## Summary

- Extract and validate agent bundles in a temporary sibling directory, then rename the successful result into the versioned cache.
- Repair older incomplete cache entries that lack `config.yaml`, replacing partial files only after the new bundle validates.
- Preserve valid-version cache reuse, session-scoped fetching, provenance-dependent environment expansion, and existing bundle validation.

ELI5: an empty cache directory is not a usable agent. A failed download/load must not prevent a later valid bundle from starting the session.

```text
bundle response → temporary extraction → validation → publish version cache
                                         failure ↳ clean temporary directory
```

## Test Plan

- Both new regression cases fail on unmodified `main`: an existing incomplete directory and a failed bundle load that leaves a cache directory behind.
- `.venv/bin/python -m pytest tests/runner/test_runner_entry.py -q`: 111 passed.
- Tests verify successful recovery, final workdir, removal of incomplete leftovers, cleanup of temporary directories, and reuse of valid cached versions.
- Changed-file pre-commit checks pass, including repository-wide Pyrefly, using the existing complete environment and this worktree's SDK import paths.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The real resolver and bundle loader run against a mocked HTTP transport and temporary filesystem. No production deployment or manual live-session validation. This repairs incomplete local caches; it does not make an invalid server bundle valid.

## Issues

Resolves [OMNI-7066](https://linear.app/omnigent/issue/OMNI-7066/bug-incomplete-agent-bundle-caches-keep-native-session-startup-broken)
