### PR TITLE
fix(host): canonicalize daemon server URL keys

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2841,10 +2841,15 @@ def _find_daemon_record(target: str) -> _HostDaemonRecord | None:
     Find a daemon record by target.
 
     :param target: Normalized daemon target, e.g. ``"local"``.
-    :returns: Matching daemon record, or ``None``.
+    :returns: Matching daemon record, including a pre-canonicalization record,
+        or ``None``.
     """
-    for record in _list_daemon_records():
+    records = _list_daemon_records()
+    for record in records:
         if record.target == target:
+            return record
+    for record in records:
+        if _normalize_daemon_target(record.target) == target:
             return record
     return None
 
@@ -3035,7 +3040,7 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
     existing = _find_daemon_record(target)
     if existing is None:
         return _DaemonReuseDecision(reuse=False, config_changed=False)
-    if not _daemon_owner_is_live(existing, target):
+    if not _daemon_owner_is_live(existing, existing.target):
         _delete_daemon_record(existing)
         return _DaemonReuseDecision(reuse=False, config_changed=False)
 
@@ -3144,7 +3149,7 @@ def _wait_for_daemon_claim(
     deadline = time.monotonic() + timeout_s
     while True:
         record = _find_daemon_record(target)
-        if record is not None and _daemon_owner_is_live(record, target):
+        if record is not None and _daemon_owner_is_live(record, record.target):
             return record
         if time.monotonic() >= deadline:
             return None

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -2990,7 +2990,7 @@ class _DaemonReuseDecision:
     config_changed: bool
 
 
-def _daemon_owner_is_live(record: _HostDaemonRecord, target: str) -> bool:
+def _daemon_owner_is_live(record: _HostDaemonRecord) -> bool:
     """Whether the daemon that wrote *record* is still alive.
 
     A held record flock is a definitive live owner (the kernel drops it on
@@ -3002,11 +3002,11 @@ def _daemon_owner_is_live(record: _HostDaemonRecord, target: str) -> bool:
     process is. Reaping therefore requires a free lock and a dead-or-foreign
     PID.
 
-    :param record: Existing daemon record for *target*.
-    :param target: Normalized daemon target, e.g. ``"local"``.
+    :param record: Existing daemon record whose original target identifies the
+        lock path held by its owner.
     :returns: ``True`` if the daemon should be treated as alive.
     """
-    if _record_flock_is_held(_daemon_record_path(target)) is True:
+    if _record_flock_is_held(_daemon_record_path(record.target)) is True:
         return True
     return _pid_is_recorded_daemon(record)
 
@@ -3040,7 +3040,7 @@ def _reuse_existing_daemon_record(target: str) -> _DaemonReuseDecision:
     existing = _find_daemon_record(target)
     if existing is None:
         return _DaemonReuseDecision(reuse=False, config_changed=False)
-    if not _daemon_owner_is_live(existing, existing.target):
+    if not _daemon_owner_is_live(existing):
         _delete_daemon_record(existing)
         return _DaemonReuseDecision(reuse=False, config_changed=False)
 
@@ -3149,7 +3149,7 @@ def _wait_for_daemon_claim(
     deadline = time.monotonic() + timeout_s
     while True:
         record = _find_daemon_record(target)
-        if record is not None and _daemon_owner_is_live(record, record.target):
+        if record is not None and _daemon_owner_is_live(record):
             return record
         if time.monotonic() >= deadline:
             return None
@@ -3244,7 +3244,7 @@ def _live_daemon_conflict(record: _HostDaemonRecord) -> _HostDaemonRecord | None
     """
     existing = _find_daemon_record(record.target)
     if existing is not None and existing.pid != record.pid:
-        if _daemon_owner_is_live(existing, record.target):
+        if _daemon_owner_is_live(existing):
             return existing
         # Dead, or alive but not our daemon (pid recycled after a reboot):
         # the record is stale, not a conflict — prune it and start normally.
@@ -3260,14 +3260,14 @@ def _live_daemon_conflict(record: _HostDaemonRecord) -> _HostDaemonRecord | None
         if (
             local_record is not None
             and local_record.pid != record.pid
-            and _daemon_owner_is_live(local_record, _LOCAL_DAEMON_MARKER)
+            and _daemon_owner_is_live(local_record)
             and local_record.resolved_server_url == record.server_url.rstrip("/")
         ):
             return local_record
         if (
             local_record is not None
             and local_record.pid != record.pid
-            and not _daemon_owner_is_live(local_record, _LOCAL_DAEMON_MARKER)
+            and not _daemon_owner_is_live(local_record)
         ):
             _delete_daemon_record(local_record)
     return None

--- a/omnigent/host/daemon_lifecycle.py
+++ b/omnigent/host/daemon_lifecycle.py
@@ -25,6 +25,7 @@ import logging
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from omnigent.process_logging import data_dir
 
@@ -69,9 +70,34 @@ def normalize_daemon_target(server_url: str | None) -> str:
     """Return the registry key for a daemon target.
 
     :param server_url: Requested server URL, or ``None`` / empty for local mode.
-    :returns: ``"local"`` for local mode, else the URL without a trailing slash.
+    :returns: ``"local"`` for local mode, else a canonical server URL.
     """
-    return _LOCAL_DAEMON_MARKER if not server_url else server_url.rstrip("/")
+    if not server_url:
+        return _LOCAL_DAEMON_MARKER
+
+    target = server_url.rstrip("/")
+    try:
+        parsed = urlsplit(target)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return target
+    if not parsed.scheme or hostname is None:
+        return target
+
+    scheme = parsed.scheme.lower()
+    hostname = hostname.lower()
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    if port is None or (scheme, port) in {("http", 80), ("https", 443)}:
+        port_suffix = ""
+    else:
+        port_suffix = f":{port}"
+
+    raw_userinfo, separator, _ = parsed.netloc.rpartition("@")
+    userinfo = f"{raw_userinfo}@" if separator else ""
+    netloc = f"{userinfo}{hostname}{port_suffix}"
+    return urlunsplit((scheme, netloc, parsed.path, parsed.query, parsed.fragment))
 
 
 def _target_digest(target: str) -> str:

--- a/omnigent/host/daemon_lifecycle.py
+++ b/omnigent/host/daemon_lifecycle.py
@@ -75,15 +75,15 @@ def normalize_daemon_target(server_url: str | None) -> str:
     if not server_url:
         return _LOCAL_DAEMON_MARKER
 
-    target = server_url.rstrip("/")
+    fallback_target = server_url.rstrip("/")
     try:
-        parsed = urlsplit(target)
+        parsed = urlsplit(server_url)
         hostname = parsed.hostname
         port = parsed.port
     except ValueError:
-        return target
+        return fallback_target
     if not parsed.scheme or hostname is None:
-        return target
+        return fallback_target
 
     scheme = parsed.scheme.lower()
     hostname = hostname.lower()
@@ -97,7 +97,8 @@ def normalize_daemon_target(server_url: str | None) -> str:
     raw_userinfo, separator, _ = parsed.netloc.rpartition("@")
     userinfo = f"{raw_userinfo}@" if separator else ""
     netloc = f"{userinfo}{hostname}{port_suffix}"
-    return urlunsplit((scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+    path = parsed.path.rstrip("/")
+    return urlunsplit((scheme, netloc, path, parsed.query, parsed.fragment))
 
 
 def _target_digest(target: str) -> str:

--- a/tests/host/test_daemon_lifecycle.py
+++ b/tests/host/test_daemon_lifecycle.py
@@ -37,6 +37,11 @@ def _write_record(path: Path, pid: int) -> None:
         ("HTTPS://X.Example.COM:443/api/", "https://x.example.com/api"),
         ("http://X.Example.COM:80/", "http://x.example.com"),
         ("http://X.Example.COM:8080/Path/", "http://x.example.com:8080/Path"),
+        (
+            "https://X.Example.COM/api/?next=/",
+            "https://x.example.com/api?next=/",
+        ),
+        ("https://X.Example.COM/api/#/", "https://x.example.com/api#/"),
         ("https://[2001:DB8::1]:443/", "https://[2001:db8::1]"),
         ("unix:///tmp/omnigent.sock/", "unix:///tmp/omnigent.sock"),
     ],
@@ -304,18 +309,18 @@ def test_daemon_owner_is_live_flock_then_pid(
     lock = DaemonLifecycleLock.for_target(target, base_dir=tmp_path, pid=999)
     assert lock.acquire() is True
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: False)
-    assert cli._daemon_owner_is_live(_record(target, 999), target) is True
+    assert cli._daemon_owner_is_live(_record(target, 999)) is True
     lock.release()
 
     # Free lock → fall back to pid identity: a pid that is still the
     # recorded daemon (e.g. mid-startup, lock not yet grabbed) → alive.
     monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: True)
-    assert cli._daemon_owner_is_live(_record(target, 999), target) is True
+    assert cli._daemon_owner_is_live(_record(target, 999)) is True
 
     # Free lock + a pid that is no longer the recorded daemon (dead, or
     # recycled to an unrelated process after a reboot) → dead (reapable).
     monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: False)
-    assert cli._daemon_owner_is_live(_record(target, 999), target) is False
+    assert cli._daemon_owner_is_live(_record(target, 999)) is False
 
 
 def test_live_daemon_conflict_uses_flock_then_pid(
@@ -338,6 +343,30 @@ def test_live_daemon_conflict_uses_flock_then_pid(
     # Free lock + dead PID → the owner is gone, so not a conflict.
     monkeypatch.setattr(cli, "_pid_alive", lambda pid: False)
     assert cli._live_daemon_conflict(claimer) is None
+
+
+def test_live_daemon_conflict_probes_legacy_record_lock_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from omnigent import cli
+
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    legacy_target = "https://X.Example.COM:443/api"
+    existing = _record(legacy_target, 222)
+    cli._write_daemon_record(existing)
+    probed_paths: list[Path] = []
+    monkeypatch.setattr(
+        cli,
+        "_record_flock_is_held",
+        lambda path: probed_paths.append(path) or True,
+    )
+    monkeypatch.setattr(cli, "_pid_is_recorded_daemon", lambda record: False)
+
+    canonical_target = normalize_daemon_target("https://x.example.com/api")
+    conflict = cli._live_daemon_conflict(_record(canonical_target, 111))
+
+    assert conflict == existing
+    assert probed_paths == [cli._daemon_record_path(legacy_target)]
 
 
 def _host_with_lock(lock: DaemonLifecycleLock) -> HostProcess:

--- a/tests/host/test_daemon_lifecycle.py
+++ b/tests/host/test_daemon_lifecycle.py
@@ -14,6 +14,7 @@ from omnigent.host import connect
 from omnigent.host.connect import HostProcess
 from omnigent.host.daemon_lifecycle import (
     DaemonLifecycleLock,
+    HostDaemonRecord,
     daemon_record_path,
     normalize_daemon_target,
     record_flock_is_held,
@@ -27,10 +28,87 @@ def _write_record(path: Path, pid: int) -> None:
     path.write_text(json.dumps({"pid": pid, "target": "local", "mode": "local"}))
 
 
-def test_normalize_daemon_target() -> None:
-    assert normalize_daemon_target(None) == "local"
-    assert normalize_daemon_target("") == "local"
-    assert normalize_daemon_target("https://x.example.com/") == "https://x.example.com"
+@pytest.mark.parametrize(
+    ("server_url", "expected"),
+    [
+        (None, "local"),
+        ("", "local"),
+        ("https://x.example.com/", "https://x.example.com"),
+        ("HTTPS://X.Example.COM:443/api/", "https://x.example.com/api"),
+        ("http://X.Example.COM:80/", "http://x.example.com"),
+        ("http://X.Example.COM:8080/Path/", "http://x.example.com:8080/Path"),
+        ("https://[2001:DB8::1]:443/", "https://[2001:db8::1]"),
+        ("unix:///tmp/omnigent.sock/", "unix:///tmp/omnigent.sock"),
+    ],
+)
+def test_normalize_daemon_target(server_url: str | None, expected: str) -> None:
+    assert normalize_daemon_target(server_url) == expected
+
+
+def test_equivalent_server_urls_share_record_path(tmp_path: Path) -> None:
+    canonical = normalize_daemon_target("https://x.example.com/api")
+    equivalent = normalize_daemon_target("HTTPS://X.EXAMPLE.COM:443/api/")
+
+    assert canonical == equivalent
+    assert daemon_record_path(canonical, base_dir=tmp_path) == daemon_record_path(
+        equivalent, base_dir=tmp_path
+    )
+
+
+def test_find_daemon_record_reuses_legacy_url_spelling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from omnigent import cli
+
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    legacy_target = "https://X.Example.COM:443/api"
+    legacy_record = cli._HostDaemonRecord(
+        pid=4242,
+        target=legacy_target,
+        mode="server",
+        server_url=legacy_target,
+        log_path="daemon.log",
+        started_at=100,
+    )
+    cli._write_daemon_record(legacy_record)
+
+    canonical_target = normalize_daemon_target("https://x.example.com/api")
+    found = cli._find_daemon_record(canonical_target)
+
+    assert found == legacy_record
+
+
+def test_reuse_legacy_record_probes_its_original_lock_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from omnigent import cli
+
+    monkeypatch.setattr(cli, "_HOST_PID_PATH", tmp_path / "host.pid")
+    legacy_target = "https://X.Example.COM:443/api"
+    cli._write_daemon_record(
+        cli._HostDaemonRecord(
+            pid=4242,
+            target=legacy_target,
+            mode="server",
+            server_url=legacy_target,
+            log_path="daemon.log",
+            started_at=100,
+        )
+    )
+    probed_paths: list[Path] = []
+    monkeypatch.setattr(
+        cli,
+        "_record_flock_is_held",
+        lambda path: probed_paths.append(path) or True,
+    )
+    monkeypatch.setattr(cli, "_daemon_host_identity_changed", lambda record: False)
+
+    decision = cli._reuse_existing_daemon_record(
+        normalize_daemon_target("https://x.example.com/api")
+    )
+
+    assert decision.reuse is True
+    assert probed_paths == [cli._daemon_record_path(legacy_target)]
 
 
 def test_record_path_uses_digest(tmp_path: Path) -> None:
@@ -199,7 +277,7 @@ def test_background_daemon_loser_exits_before_connecting(
         owner.release()
 
 
-def _record(target: str, pid: int) -> object:
+def _record(target: str, pid: int) -> HostDaemonRecord:
     from omnigent import cli
 
     return cli._HostDaemonRecord(


### PR DESCRIPTION
## Related issue

Related to #3967

## Summary

Daemon election is keyed by a normalized server URL, but normalization previously only removed a trailing slash. Equivalent URLs such as `HTTPS://X.EXAMPLE.COM:443/api` and `https://x.example.com/api` therefore created different record locks, allowing two host daemons with the same host identity to connect to one server and replace each other.

This change canonicalizes the URL scheme and hostname, removes default HTTP/HTTPS ports, and preserves paths, non-default ports, and IPv6 addresses. Record lookup also recognizes pre-canonicalization spellings and probes the original record's lock path, so an upgrade reuses a live legacy daemon.

ELI5:

```text
Before: URL spelling A -> lock A -> daemon A --+
                                                 +-> one server / host identity
        URL spelling B -> lock B -> daemon B --+    (connections replace each other)

After:  URL spelling A --+
                         +-> canonical key -> one lock -> one daemon
        URL spelling B --+
```

## Test Plan

- `env -u OMNIGENT_WRAPPER_COMMAND -u OMNIGENT_REQUIRE_WRAPPER .venv/bin/python -m pytest tests/host/test_daemon_lifecycle.py tests/host/test_daemon_launch.py tests/host/test_cli_host.py -q` — 78 passed.
- `.venv/bin/pre-commit run --files omnigent/cli.py omnigent/host/daemon_lifecycle.py tests/host/test_daemon_lifecycle.py` — passed, including Ruff and full-project Pyrefly.
- Regression coverage verifies canonical record paths, IPv6 and non-default-port preservation, legacy-record discovery, and legacy lock-path probing.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — this is a host-daemon lifecycle fix with no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new unit cases exercise URL canonicalization and backward-compatible daemon reuse; the existing host CLI and daemon launch suites cover unchanged lifecycle behavior.

## Changelog

Omnigent no longer starts duplicate host daemons when the same server URL differs only by casing or an explicit default port.
