### PR TITLE
ci: add a CockroachDB store test lane (min supported version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,57 @@ jobs:
           path: artifacts/
           retention-days: 14
 
+  # One lane on the minimum supported CockroachDB, mirroring the single-version
+  # postgres/mysql lanes. The full version matrix runs locally via `just crdb-test`.
+  stores-cockroachdb:
+    name: Pytest (stores-crdb-${{ matrix.crdb_version }})
+    needs: gate
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - crdb_version: "23.2.28"
+            crdb_service: crdb-23-2-28
+            crdb_port: 26323
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version-file: ".python-version"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
+        with:
+          enable-cache: true
+      - name: Start CockroachDB
+        run: |
+          docker compose -f deploy/cockroachdb/docker-compose.yml up \
+            --detach --wait --wait-timeout 90 "${{ matrix.crdb_service }}"
+          if [[ "${{ matrix.crdb_version }}" == "23.2.28" ]]; then
+            docker compose -f deploy/cockroachdb/docker-compose.yml exec -T \
+              "${{ matrix.crdb_service }}" cockroach sql --insecure \
+              --execute="SET CLUSTER SETTING sql.txn.read_committed_isolation.enabled = true"
+          fi
+      - name: Install dependencies
+        run: uv sync --locked --extra all --extra cockroachdb --group test
+      - name: Run store + DB tests against CockroachDB
+        env:
+          OMNIGENT_TEST_DB_URI: cockroachdb+psycopg://root@localhost:${{ matrix.crdb_port }}/defaultdb?sslmode=disable
+        run: |
+          uv run pytest tests/stores tests/db \
+            -m "not databricks" \
+            -n 4 \
+            --dist=loadfile \
+            --timeout=300 \
+            --junitxml=artifacts/pytest-stores-crdb.xml
+      - if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: pytest-stores-crdb-${{ matrix.crdb_version }}-${{ github.run_id }}
+          path: artifacts/
+          retention-days: 14
+
   stores-mysql:
     name: Pytest (stores-mysql)
     needs: gate


### PR DESCRIPTION
## Related issue

N/A (Test / CI change).

## Summary

- Adds a `stores-cockroachdb` CI lane that runs `tests/stores` and `tests/db` against CockroachDB **v23.2.28** (the minimum supported version), mirroring the existing single-version `stores-postgres` and `stores-mysql` lanes. The full four-version matrix stays local via `just crdb-test`.
- Why here and not in #6360: that PR is from a fork, and the fork-PR workflow sync pins `.github/workflows/` to `main`, so the job is stripped on every sync (it has been removed three times). A branch on the main repo persists.
- **Ordering: merge after #6360.** The lane depends on files that #6360 introduces (`deploy/cockroachdb/docker-compose.yml`, the `cockroachdb` extra in `pyproject.toml`, and `tests/db/test_cockroachdb.py`). Until #6360 is on `main`, the `stores-cockroachdb` check on this PR is expected to be red; every other check should pass. Rebase on `main` after #6360 lands and it goes green.

## Test Plan

The identical job ran green against live CockroachDB v23.2.28 on #6360's branch: **1109 tests, 0 failures, 6 skipped** (junit from run `34296887426`). 23.2.28 is chosen deliberately as the most version-gated path (it needs the `read_committed_isolation` cluster setting and lacks `autocommit_before_ddl`).

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [x] Not applicable

## Coverage notes

CI-only change (adds a test lane, no product code). The lane runs the existing `tests/stores` + `tests/db` suites against CockroachDB; it adds no new tests of its own. Its own check stays red until #6360 (which carries the CRDB compose file, extra, and tests) is on `main`.

This pull request and its description were written by Isaac.
