### PR TITLE
feat(codex-native): report Omnigent as the codex originator

### DIFF
--- a/omnigent/harnesses/codex_native/app_server.py
+++ b/omnigent/harnesses/codex_native/app_server.py
@@ -45,6 +45,7 @@ from omnigent.harnesses.codex_native.process_registry import (
 from omnigent.inner import _proc
 from omnigent.inner.codex_executor import (
     _CODEX_ROUTER_HOOK_MODULE,
+    CODEX_ORIGINATOR_ENV_VAR,
     _clean_codex_env,
     _codex_cli_version,
     _codex_home_config_source_from_env,
@@ -3456,13 +3457,23 @@ def codex_terminal_env(app_server: CodexNativeAppServer) -> dict[str, str]:
     """
     Build terminal env overrides for the native Codex TUI.
 
+    The TUI is a separate process from the app-server, so
+    :data:`CODEX_ORIGINATOR_ENV_VAR` has to survive this allowlist too or the
+    terminal half of a session reports codex's own ``codex-tui`` default.
+
     :param app_server: Running app-server wrapper.
     :returns: Environment variables for the terminal process.
     """
     return {
         key: value
         for key, value in {**app_server.env, "CODEX_HOME": str(app_server.codex_home)}.items()
-        if key in {"CODEX_HOME", "DATABRICKS_HOST", "DATABRICKS_CODEX_TOKEN"}
+        if key
+        in {
+            "CODEX_HOME",
+            "DATABRICKS_HOST",
+            "DATABRICKS_CODEX_TOKEN",
+            CODEX_ORIGINATOR_ENV_VAR,
+        }
         or key.startswith(("OPENAI_", "HTTP_", "HTTPS_", "NO_PROXY", "ALL_PROXY"))
     }
 

--- a/omnigent/inner/codex_executor.py
+++ b/omnigent/inner/codex_executor.py
@@ -174,6 +174,15 @@ _CODEX_PROVIDER_CONFIG_PREFIX = "model_providers."
 # developer API key that would charge separately.
 _CODEX_ENV_DENY_EXACT: frozenset[str] = frozenset({"OPENAI_API_KEY"})
 
+# Codex derives the ``originator`` it reports — on its API user agent and its
+# own telemetry — from this variable, falling back to a built-in per-surface
+# value (``codex-tui`` for the TUI, ``codex_vscode`` for the extension). Left
+# unset, a codex process Omnigent launched reports the same originator as one
+# the user started themselves, so the two cannot be told apart downstream.
+CODEX_ORIGINATOR_ENV_VAR = "CODEX_INTERNAL_ORIGINATOR_OVERRIDE"
+#: Value reported by codex processes Omnigent launches.
+CODEX_ORIGINATOR = "omnigent"
+
 # The codex CLI logs a rejected gateway request to stderr as
 # ``unexpected status <code> <reason>: {...}, url: <url>`` and precedes it with
 # ``Reconnecting... N/5`` retry lines. These parse that shape so the head can
@@ -498,9 +507,12 @@ def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
     codex signals back out of it, so those names have to survive the filter
     (see :data:`_CODEX_OMNIGENT_LAUNCH_ENV_VARS`).
 
+    Also stamps :data:`CODEX_ORIGINATOR_ENV_VAR` so codex attributes the
+    process to Omnigent instead of its own per-surface default.
+
     :returns: Filtered environment dict.
     """
-    return clean_agent_env(
+    env = clean_agent_env(
         allow_prefixes=("OPENAI_", "REQUESTS_", "CODEX_HOME"),
         allow_exact=(
             "PYTHONUTF8",
@@ -520,6 +532,11 @@ def _clean_codex_env(extra_allow: Iterable[str] = ()) -> dict[str, str]:
         deny_exact=_CODEX_ENV_DENY_EXACT,
         extra_allowed=extra_allow,
     )
+    # Set after the filter, not allowed through it: a host value would
+    # otherwise survive into the child and mis-attribute an Omnigent session
+    # as whatever launched the outer process.
+    env[CODEX_ORIGINATOR_ENV_VAR] = CODEX_ORIGINATOR
+    return env
 
 
 def codex_skill_sources(

--- a/tests/inner/test_codex_executor.py
+++ b/tests/inner/test_codex_executor.py
@@ -3504,6 +3504,40 @@ def test_clean_codex_env_includes_omnigent_session_marker(monkeypatch) -> None:
     assert env.get(OMNIGENT_SESSION_ENV_VAR) == OMNIGENT_SESSION_ENV_VALUE
 
 
+def test_clean_codex_env_stamps_omnigent_originator(monkeypatch) -> None:
+    """Every codex subprocess is tagged as Omnigent-originated.
+
+    Without the stamp codex falls back to a per-surface default
+    (``codex-tui``), which is also what a user's own codex run reports.
+    """
+    from omnigent.inner.codex_executor import (
+        CODEX_ORIGINATOR,
+        CODEX_ORIGINATOR_ENV_VAR,
+        _clean_codex_env,
+    )
+
+    monkeypatch.delenv(CODEX_ORIGINATOR_ENV_VAR, raising=False)
+
+    assert _clean_codex_env()[CODEX_ORIGINATOR_ENV_VAR] == CODEX_ORIGINATOR
+
+
+def test_clean_codex_env_originator_overrides_host_value(monkeypatch) -> None:
+    """A host originator must not survive into the codex subprocess.
+
+    An Omnigent session launched from inside another agent would otherwise
+    inherit that outer process's originator and be attributed to it.
+    """
+    from omnigent.inner.codex_executor import (
+        CODEX_ORIGINATOR,
+        CODEX_ORIGINATOR_ENV_VAR,
+        _clean_codex_env,
+    )
+
+    monkeypatch.setenv(CODEX_ORIGINATOR_ENV_VAR, "some-other-harness")
+
+    assert _clean_codex_env()[CODEX_ORIGINATOR_ENV_VAR] == CODEX_ORIGINATOR
+
+
 # ---------------------------------------------------------------------------
 # Tests for _to_codex_input_items — input_file → inline text conversion
 # ---------------------------------------------------------------------------

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -3103,3 +3103,34 @@ async def test_discovery_early_exit_without_stderr_keeps_plain_error() -> None:
     )
     with pytest.raises(RuntimeError, match=r"^Codex model discovery exited early \(1\)$"):
         await codex_native_app_server._wait_for_discovery_listener(discovery, port=1)
+
+
+def test_codex_terminal_env_keeps_omnigent_originator(tmp_path) -> None:
+    """The TUI keeps the originator stamp; unrelated host vars stay filtered.
+
+    ``codex_terminal_env`` is an allowlist, so a new env var that the
+    app-server sets is dropped from the terminal unless it is listed there.
+    """
+    from omnigent.harnesses.codex_native.app_server import codex_terminal_env
+    from omnigent.inner.codex_executor import (
+        CODEX_ORIGINATOR,
+        CODEX_ORIGINATOR_ENV_VAR,
+    )
+
+    class _FakeAppServer:
+        """Minimal app-server object used by ``codex_terminal_env``."""
+
+        def __init__(self) -> None:
+            """:returns: None."""
+            self.env = {
+                CODEX_ORIGINATOR_ENV_VAR: CODEX_ORIGINATOR,
+                "DATABRICKS_HOST": "https://example.invalid",
+                "UNRELATED": "dropped",
+            }
+            self.codex_home = tmp_path / "codex-home"
+
+    env = codex_terminal_env(cast(Any, _FakeAppServer()))
+
+    assert env[CODEX_ORIGINATOR_ENV_VAR] == CODEX_ORIGINATOR
+    assert env["DATABRICKS_HOST"] == "https://example.invalid"
+    assert "UNRELATED" not in env


### PR DESCRIPTION
## Related issue

Closes #

<!-- No issue linked: this was found while auditing how each native harness is
attributable in codex's own telemetry. Happy to file one if maintainers want the
queue entry. -->

## Summary

- Codex derives the `originator` it reports — on its API user agent and its own
  telemetry — from `CODEX_INTERNAL_ORIGINATOR_OVERRIDE`, falling back to a
  built-in per-surface value (`codex-tui` for the TUI, `codex_vscode` for the
  extension). Omnigent never set it, so a codex process Omnigent launched
  reported the same originator as one the user started themselves, and nothing
  downstream could tell the two apart.
- Stamp the variable in `_clean_codex_env`, the single choke point every codex
  subprocess env goes through. It is set *after* the filter rather than
  allowlisted through it: a host value would otherwise survive into the child
  and attribute an Omnigent session to whatever launched the outer process.
- `codex_terminal_env` is a second, separate allowlist for the TUI half of a
  session, so the name has to be listed there too or the terminal keeps
  reporting `codex-tui`.

## Test Plan

- `pytest tests/inner/test_codex_executor.py tests/test_codex_native_app_server.py
  tests/test_agent_spawn_env_canary.py tests/inner/test_codex_hooks_generation.py`
  → 305 passed, including the three added below.
- `pytest tests/runner/test_app_sessions_native_terminals_runtime.py
  tests/runner/test_app_sessions_native_wake_forwarders.py
  tests/runner/test_background_session_title.py` → 96 passed, 2 failed.
  Both failures (`test_auto_create_codex_terminal_uses_persisted_resume_launch_config`,
  `..._uses_worktree_workspace_not_bundle_dir`) reproduce identically on an
  unmodified `main` worktree — they read the machine's real effective config, so
  they fail wherever a `harness.codex-native.command` override is configured.
  Not caused by this change.
- `ruff check` / `ruff format --check` clean on all four files.
- The env var itself is codex-side: verified that `CODEX_INTERNAL_ORIGINATOR_OVERRIDE`
  is present in the shipped codex binary (0.153.4) in the same module that builds
  the originator and user agent, alongside the `codex-tui` / `codex_vscode`
  defaults and the "Falling back to default Codex originator" path.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Three unit tests cover the part this PR owns: the stamp is present in
`_clean_codex_env`'s output, it wins over a pre-set host value, and it survives
`codex_terminal_env`'s allowlist while an unrelated var is still dropped.

Manual verification stopped short of a live originator capture. Redirecting codex
at a local endpoint to read the outgoing header needs a provider override, and on
the machine used here a managed provider config pins the provider and ignores
`-c model_provider=...`, so the request never reached the local listener. The
codex-side half is therefore evidenced by the binary inspection noted in the Test
Plan rather than an end-to-end capture; a reviewer on an unmanaged setup can
confirm it in one run.

## Changelog

Codex sessions launched by Omnigent now identify themselves as `omnigent` instead of reporting codex's default originator.

This pull request and its description were written by Isaac.
