### PR TITLE
fix(codex-native): keep a session alive when the TUI parks on a startup prompt

### DIFF
--- a/dev/repro_codex_startup_prompt.py
+++ b/dev/repro_codex_startup_prompt.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python
+"""Reproduce a Codex-native session blocked on a startup prompt.
+
+Boots a throwaway local Omnigent server + runner and creates a real
+``codex-native`` session, then makes the detached Codex TUI park its startup on
+an interactive box a human must answer — a directory-trust / hook-review screen
+(the reliable ``--trigger trust-box`` default) or a ``TERM`` "Continue anyway?"
+gate (``--trigger term-dumb``). This is the state that used to make the session
+hang for 30s and then die with::
+
+    Codex native thread never started: Codex app-server never started a thread
+    (startup timed out: TimeoutError). ...
+
+- BEFORE the readiness fix: the turn hangs, then fails with the "never started"
+  error and the terminal vanishes.
+- AFTER the fix: the session stays alive, shows an "answer it in the Terminal"
+  banner (with the web UI built) / records an actionable notice, and recovers
+  once you attach the pane and answer the box.
+
+Requirements: the ``codex`` CLI on PATH and a usable Codex credential in your
+environment (a configured provider or an ``auth.json`` login), so the startup
+box is the *only* thing blocking startup. Uses your real ``$HOME`` /
+``$CODEX_HOME`` so the credential is picked up; everything else (config, state,
+DB) is a temp dir wiped on exit.
+
+To see the banner visually the web UI must be built into
+``omnigent/server/static/web-ui`` (``cd web && npm ci --legacy-peer-deps &&
+npm run build``); otherwise use the UI-free checks the script prints.
+
+Usage::
+
+    python dev/repro_codex_startup_prompt.py                    # reliable trust box
+    python dev/repro_codex_startup_prompt.py --trigger term-dumb # TERM box (flaky)
+    python dev/repro_codex_startup_prompt.py --trigger none      # clean control run
+
+Ctrl-C to tear the stack down.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import secrets
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from pathlib import Path
+
+import httpx
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HEALTH_TIMEOUT_S = 60.0
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _create_codex_session(base_url: str, runner_id: str) -> str:
+    """Register the ``omnigent codex`` wrapper spec and bind its session."""
+    from omnigent._wrapper_labels import (
+        CODEX_NATIVE_WRAPPER_VALUE,
+        UI_MODE_LABEL_KEY,
+        UI_MODE_TERMINAL_VALUE,
+        WRAPPER_LABEL_KEY,
+    )
+    from omnigent.harnesses.codex_native.main import _materialize_codex_agent_spec
+
+    with tempfile.TemporaryDirectory() as tmp:
+        spec_path = _materialize_codex_agent_spec(Path(tmp), model=None)
+        yaml_text = spec_path.read_text()
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        data = yaml_text.encode()
+        info = tarfile.TarInfo("codex-native-ui.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    metadata = {
+        "labels": {
+            UI_MODE_LABEL_KEY: UI_MODE_TERMINAL_VALUE,
+            WRAPPER_LABEL_KEY: CODEX_NATIVE_WRAPPER_VALUE,
+        },
+        # Runner-owned codex terminals hard-require a workspace.
+        "workspace": str(_REPO_ROOT),
+    }
+    create = httpx.post(
+        f"{base_url}/v1/sessions",
+        data={"metadata": json.dumps(metadata)},
+        files={"bundle": ("codex-native-ui.tar.gz", buf.getvalue(), "application/gzip")},
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    patch = httpx.patch(
+        f"{base_url}/v1/sessions/{session_id}",
+        json={"runner_id": runner_id},
+        timeout=10.0,
+    )
+    patch.raise_for_status()
+    return session_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--trigger",
+        choices=("trust-box", "term-dumb", "none"),
+        default="trust-box",
+        help="How to make the pane park on a startup box. 'trust-box' (default, "
+        "reliable): force Codex's real directory-trust/hook-review box by "
+        "disabling the runner's auto-acknowledgements. 'term-dumb': set the "
+        "runner TERM to dumb (only bites if the browser terminal is attached "
+        "during codex boot — not reliable for the detached auto-create pane). "
+        "'none': clean control run.",
+    )
+    args = parser.parse_args()
+
+    if shutil.which("codex") is None:
+        print("error: the `codex` CLI must be on PATH for this repro.", file=sys.stderr)
+        return 2
+
+    work = Path(tempfile.mkdtemp(prefix="codex-startup-repro-"))
+    config_home = work / "config-home"
+    state_dir = work / "codex-native-state"
+    artifacts = work / "artifacts"
+    for path in (config_home, state_dir, artifacts):
+        path.mkdir(parents=True, exist_ok=True)
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    binding_token = secrets.token_urlsafe(32)
+
+    from omnigent.runner.identity import token_bound_runner_id
+
+    runner_id = token_bound_runner_id(binding_token)
+
+    # Inherit the real environment (so $HOME / $CODEX_HOME credentials are found)
+    # and pin the isolated config/state dirs on top.
+    shared_env = {
+        **os.environ,
+        "PYTHONPATH": f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+        "OMNIGENT_CONFIG_HOME": str(config_home),
+        "OMNIGENT_CODEX_NATIVE_STATE_DIR": str(state_dir),
+    }
+    server_env = {**shared_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token}
+    runner_env = {
+        **shared_env,
+        "OMNIGENT_RUNNER_ID": runner_id,
+        "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+        "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+        "RUNNER_SERVER_URL": base_url,
+    }
+    if args.trigger == "trust-box":
+        # Force Codex's real trust/hook-review box in the detached pane, so the
+        # thread never starts and the recovery path engages regardless of
+        # whether a browser is attached (see _force_startup_trust_prompt).
+        runner_env["OMNIGENT_CODEX_FORCE_STARTUP_TRUST_PROMPT"] = "1"
+    elif args.trigger == "term-dumb":
+        # A non-interactive TERM. Only trips the box if the browser terminal is
+        # attached during codex boot; the detached auto-create pane usually
+        # starts clean, so this is the less-reliable trigger.
+        runner_env["TERM"] = "dumb"
+
+    server_log = work / "server.log"
+    runner_log = work / "runner.log"
+    server_handle = server_log.open("w")
+    runner_handle = runner_log.open("w")
+    server_proc: subprocess.Popen[bytes] | None = None
+    runner_proc: subprocess.Popen[bytes] | None = None
+    session_id: str | None = None
+    client = httpx.Client()
+    try:
+        server_proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "omnigent.cli",
+                "server",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--database-uri",
+                f"sqlite:///{work}/repro.db",
+                "--artifact-location",
+                str(artifacts),
+            ],
+            env=server_env,
+            stdout=server_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+        runner_proc = subprocess.Popen(
+            [sys.executable, "-m", "omnigent.runner._entry"],
+            env=runner_env,
+            stdout=runner_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+        online = False
+        while time.monotonic() < deadline:
+            if server_proc.poll() is not None or runner_proc.poll() is not None:
+                break
+            try:
+                if client.get(f"{base_url}/health", timeout=2).status_code == 200:
+                    status = client.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+                    if status.status_code == 200 and status.json().get("online"):
+                        online = True
+                        break
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.5)
+        if not online:
+            print(
+                "stack did not come online:\n"
+                f"  server log: {server_log}\n  runner log: {runner_log}",
+                file=sys.stderr,
+            )
+            return 1
+
+        session_id = _create_codex_session(base_url, runner_id)
+        url = f"{base_url}/c/{session_id}"
+        snapshot = f"{base_url}/v1/sessions/{session_id}"
+        # The server serves the SPA only when it is built into
+        # omnigent/server/static/web-ui; a fresh worktree has none, so the URL
+        # would render the API-only landing ("web UI isn't installed"). Detect
+        # that and steer the user to the build step or the UI-free checks.
+        web_ui_built = (_REPO_ROOT / "omnigent/server/static/web-ui/index.html").is_file()
+        print("\n" + "=" * 72)
+        print(f"  trigger={args.trigger!r}  codex-native session is up.")
+        print(f"  Session: {session_id}")
+        if web_ui_built:
+            print(f"  Open in browser:  {url}")
+            print("  Send a chat message; the 'answer it in the Terminal' banner")
+            print("  appears while the pane is blocked and clears once you answer it.")
+        else:
+            print("  The web UI is NOT built, so the browser URL shows the API-only")
+            print("  landing. To see the banner visually, build it once:")
+            print("      (cd web && npm ci --legacy-peer-deps && npm run build)")
+            print("  then re-run this script. Or verify without the UI below.")
+        print("")
+        print("  --- verify WITHOUT the browser UI ---")
+        print("  1) Readiness fix (runner keeps the session alive):")
+        print(f"     grep -E 'parked on|never started' {runner_log}")
+        print("     Fixed  -> 'parked on a terminal-compatibility prompt ...'")
+        print("     Broken -> 'never started a thread (startup timed out)'")
+        print("  2) GUI banner state (server snapshot field):")
+        print(f"     curl -s {snapshot} | python -m json.tool | grep codex_startup_prompt")
+        print("     Blocked -> a prompt string; recovered/clear -> null")
+        print("  3) Turn behaviour (fails fast with guidance, not a 30s hang):")
+        print(f"     curl -s -XPOST {snapshot}/events \\")
+        print('       -H "content-type: application/json" \\')
+        print(
+            '       -d \'{"type":"message","data":{"role":"user",'
+            '"content":[{"type":"input_text","text":"hi"}]}}\''
+        )
+        print("     then re-open the session or GET its items and read the turn error.")
+        print("")
+        print("  To clear the box and confirm recovery: attach the pane and answer it:")
+        print(f"     tmux -S <socket> attach   (socket/target are in {runner_log})")
+        print("  Ctrl-C to tear down.")
+        print("=" * 72 + "\n")
+        signal.pause()
+        return 0
+    except KeyboardInterrupt:
+        print("\ntearing down...")
+        return 0
+    finally:
+        if session_id is not None:
+            with httpx.Client() as c, contextlib.suppress(httpx.HTTPError):
+                c.delete(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+        for proc in (runner_proc, server_proc):
+            if proc is not None and proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+        for proc in (runner_proc, server_proc):
+            if proc is not None:
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+        client.close()
+        server_handle.close()
+        runner_handle.close()
+        shutil.rmtree(work, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4284,6 +4284,15 @@ async def _auto_create_codex_terminal(
         )
         or None
     )
+    # Dev/testing override: force Codex's real startup trust/hook-review box to
+    # appear by skipping the runner's auto-acknowledgements (below) and the
+    # hook-trust bypass flag. Lets the startup-prompt recovery path be exercised
+    # end to end (a detached pane parks on the box regardless of client attach),
+    # unlike TERM=dumb, which only bites when a client is attached during boot.
+    # Off in production; set only by dev/repro_codex_startup_prompt.py.
+    _force_startup_trust_prompt = (
+        os.environ.get("OMNIGENT_CODEX_FORCE_STARTUP_TRUST_PROMPT") == "1"
+    )
     # SDK initialization can block on DNS/auth before model discovery times out.
     # Keep it off the runner loop so heartbeats and other sessions can progress.
     app_server = await asyncio.to_thread(
@@ -4303,13 +4312,15 @@ async def _auto_create_codex_terminal(
         # Codex can show project-trust and legacy-model migration prompts before
         # creating a thread. This TUI runs detached for the web UI, so persist
         # the runner-owned acknowledgements in the private session config.
-        trust_project=True,
+        # (Disabled by the dev-only startup-prompt override so the real box can
+        # be exercised — see _force_startup_trust_prompt.)
+        trust_project=not _force_startup_trust_prompt,
         # Codex ignores --dangerously-bypass-hook-trust for the startup
         # hook-review screen on a persistent ``resume`` attach, which strands a
         # resumed web session behind the interactive "Hooks need review" prompt.
         # Persist trust for every merged hook so the review finds nothing to
         # review. See trust_all_codex_hooks.
-        trust_all_hooks=True,
+        trust_all_hooks=not _force_startup_trust_prompt,
     )
     # Generate routing hooks.json (and bypass codex's hook-trust prompt): the
     # app-server reads the endpoint out of its own process env at start, and
@@ -4483,8 +4494,11 @@ async def _auto_create_codex_terminal(
             # this flag. Otherwise a transient ``codex --version`` failure strands
             # the queued web message behind the terminal-only review screen.
             bypass_hook_trust=(
-                app_server.codex_cli_version is None
-                or app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
+                not _force_startup_trust_prompt
+                and (
+                    app_server.codex_cli_version is None
+                    or app_server.codex_cli_version >= _MIN_BYPASS_HOOK_TRUST_CODEX_VERSION
+                )
             ),
         )
         # Apply the per-harness startup command/args override from config
@@ -4562,6 +4576,12 @@ async def _auto_create_codex_terminal(
 
     # Adopt the thread the fresh TUI creates and run the forwarder in the
     # background, so session creation never blocks on TUI startup.
+    # Resolve the pane so the fresh-launch path can tell a recoverable startup
+    # prompt (directory-trust, hook-review, TERM "Continue anyway?") from a
+    # genuine failure when the thread-start wait times out.
+    _codex_tmux_socket, _codex_tmux_target = _terminal_tmux_pane(
+        resource_registry, session_id, "codex", "main"
+    )
     _forwarder_task = asyncio.create_task(
         (
             _codex_discover_thread_and_forward(
@@ -4573,6 +4593,8 @@ async def _auto_create_codex_terminal(
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
                 login_required=_codex_launch.login_required,
+                tmux_socket=_codex_tmux_socket,
+                tmux_target=_codex_tmux_target,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4621,6 +4643,57 @@ async def _auto_create_codex_terminal(
     return terminal_view
 
 
+# Substrings that identify an interactive prompt Codex parks its startup on
+# in the detached pane — one a human at the terminal can answer, but which no
+# thread-start deadline can. Each maps to a short, user-facing description of
+# what the pane is waiting for. Matched case-insensitively against the captured
+# pane text. Ordered most- to least-specific; the first hit wins.
+_CODEX_STARTUP_PROMPT_MARKERS: tuple[tuple[str, str], ...] = (
+    ("hooks need review", "a hook-review prompt"),
+    ("do you trust the contents", "a directory-trust prompt"),
+    ("continue anyway", "a terminal-compatibility prompt"),
+    ("term is set to", "a terminal-compatibility prompt"),
+)
+
+
+async def _codex_pane_interactive_prompt(
+    tmux_socket: Path | None,
+    tmux_target: str | None,
+) -> str | None:
+    """
+    Describe the interactive prompt a Codex pane is parked on, if any.
+
+    Captures the detached Codex pane and matches its text against
+    :data:`_CODEX_STARTUP_PROMPT_MARKERS`. A hit means the TUI is blocked on a
+    prompt a human can answer from the terminal — a directory-trust screen, a
+    hook-review screen, or a ``TERM``-compatibility "Continue anyway?" gate — so
+    the caller keeps the terminal alive instead of reaping it on the
+    thread-start timeout. Fully defensive: any capture failure returns ``None``
+    (treat as "no recoverable prompt").
+
+    :param tmux_socket: The pane's tmux socket, or ``None`` when the terminal
+        is not locally reachable.
+    :param tmux_target: The pane's tmux target, or ``None``.
+    :returns: A short description of the prompt (e.g. ``"a hook-review
+        prompt"``), or ``None`` when no known prompt is visible.
+    """
+    if tmux_socket is None or tmux_target is None:
+        return None
+    from omnigent.terminals.control_bridge import _run_tmux_capture
+
+    try:
+        raw = await _run_tmux_capture(str(tmux_socket), tmux_target)
+    except Exception:  # noqa: BLE001 - detection must never sink the launch
+        return None
+    if not raw:
+        return None
+    text = raw.decode("utf-8", errors="replace").lower()
+    for marker, description in _CODEX_STARTUP_PROMPT_MARKERS:
+        if marker in text:
+            return description
+    return None
+
+
 async def _codex_discover_thread_and_forward(
     *,
     session_id: str,
@@ -4631,6 +4704,8 @@ async def _codex_discover_thread_and_forward(
     event_client: CodexAppServerClient,
     routing_summary: str,
     login_required: bool = False,
+    tmux_socket: Path | None = None,
+    tmux_target: str | None = None,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4667,6 +4742,13 @@ async def _codex_discover_thread_and_forward(
         the thread-start timeout), while thread discovery keeps listening
         so an interactive sign-in from the terminal still recovers the
         session.
+    :param tmux_socket: The Codex pane's tmux socket, used to capture the pane
+        when the thread-start wait times out so a recoverable interactive
+        prompt (directory-trust, hook-review, ``TERM`` "Continue anyway?") is
+        distinguished from a genuine startup failure. ``None`` when the pane is
+        not locally reachable (the timeout then stays fatal as before).
+    :param tmux_target: The Codex pane's tmux target, paired with
+        ``tmux_socket``.
     :param subagent_router: Router this terminal launch started, torn down
         in the ``finally``. Passed so a late teardown cannot close the
         endpoint a re-created terminal has since installed.
@@ -4719,7 +4801,35 @@ async def _codex_discover_thread_and_forward(
                 # so this wait only serves a possible interactive sign-in.
                 thread_id = await wait_for_thread_started(event_client, timeout=None)
             else:
-                thread_id = await wait_for_thread_started(event_client)
+                try:
+                    thread_id = await wait_for_thread_started(event_client)
+                except TimeoutError:
+                    # The bounded wait elapsed. If the pane is parked on an
+                    # interactive prompt a human can answer (directory-trust,
+                    # hook-review, or a TERM "Continue anyway?" gate), don't
+                    # reap the terminal: record an actionable fail-fast notice
+                    # so a headless turn fails immediately with guidance, then
+                    # keep listening with no deadline so answering the prompt in
+                    # the terminal recovers the session. A timeout with no such
+                    # prompt is a genuine startup failure and falls through to
+                    # the fatal path below.
+                    prompt = await _codex_pane_interactive_prompt(tmux_socket, tmux_target)
+                    if prompt is None:
+                        raise
+                    _logger.warning(
+                        "Codex TUI for %s is parked on %s in its terminal; keeping "
+                        "the terminal attachable instead of failing the session on "
+                        "the thread-start timeout",
+                        session_id,
+                        prompt,
+                    )
+                    write_bridge_startup_error(
+                        bridge_dir,
+                        f"Codex is waiting on {prompt} in its terminal and cannot "
+                        "start this turn yet. Open the Terminal for this session and "
+                        f"answer the prompt to continue. Launch routing: {routing_summary}.",
+                    )
+                    thread_id = await wait_for_thread_started(event_client, timeout=None)
         except (TimeoutError, RuntimeError) as exc:
             # Expected failure modes of wait_for_thread_started: the TUI exited
             # at startup, or the event stream ended before a thread was
@@ -4743,10 +4853,11 @@ async def _codex_discover_thread_and_forward(
             )
             return
 
-        if login_required:
-            # The user signed in (or the TUI otherwise started a thread):
-            # the pre-recorded fail-fast cause no longer applies.
-            clear_bridge_startup_error(bridge_dir)
+        # The thread started, so any pre-recorded fail-fast cause no longer
+        # applies — whether it was the login-fallback notice recorded up front
+        # or the interactive-prompt notice recorded on the thread-start
+        # timeout. Clearing when nothing was recorded is a harmless no-op.
+        clear_bridge_startup_error(bridge_dir)
         write_bridge_state(
             bridge_dir,
             CodexNativeBridgeState(

--- a/tests/runner/test_codex_native_startup_prompt.py
+++ b/tests/runner/test_codex_native_startup_prompt.py
@@ -1,0 +1,216 @@
+"""Codex-native startup-prompt detection and thread-start recovery.
+
+A runner-owned Codex TUI runs detached in a tmux pane. When it parks its
+startup on an interactive prompt a human can answer — a directory-trust
+screen, a hook-review screen, or a ``TERM`` "Continue anyway?" gate — the old
+behaviour reaped the terminal on the 30s thread-start timeout and failed every
+chat turn with "Codex native thread never started (startup timed out)". These
+tests cover the fix: detect that prompt from the pane, record an actionable
+fail-fast notice instead, and keep listening so answering the prompt recovers
+the session — while a genuine startup failure (no prompt, or the event stream
+ending) stays fatal as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from omnigent.harnesses.codex_native import forwarder as codex_native_forwarder
+from omnigent.harnesses.codex_native.bridge import read_bridge_startup_error
+from omnigent.runner.native import orchestration
+
+
+class _FakeEventClient:
+    """Minimal stand-in for the app-server listener the discover task closes."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+# Sentinel marking "called without an explicit timeout" (the bounded wait).
+_DEFAULT = object()
+
+
+class _WaitStub:
+    """Scripted ``wait_for_thread_started`` recording the timeout of each call."""
+
+    def __init__(self, results: list[Any]) -> None:
+        self._results = list(results)
+        self.timeouts: list[Any] = []
+
+    async def __call__(self, client: Any, *, timeout: Any = _DEFAULT) -> str:
+        self.timeouts.append(timeout)
+        result = self._results.pop(0)
+        if result == "timeout":
+            raise TimeoutError
+        if result == "runtime":
+            raise RuntimeError("event stream ended")
+        if result == "cancel":
+            raise asyncio.CancelledError
+        return result
+
+
+async def _run_discover(bridge_dir: Path) -> _FakeEventClient:
+    event_client = _FakeEventClient()
+    await orchestration._codex_discover_thread_and_forward(
+        session_id="conv_test",
+        bridge_dir=bridge_dir,
+        codex_ws_url="ws://127.0.0.1:0",
+        codex_home=bridge_dir / "codex-home",
+        workspace=str(bridge_dir),
+        event_client=event_client,  # type: ignore[arg-type]
+        routing_summary="provider 'x' via cli-config",
+        tmux_socket=Path("/tmp/fake.sock"),
+        tmux_target="%1",
+    )
+    return event_client
+
+
+@pytest.mark.parametrize(
+    ("pane_text", "expected"),
+    [
+        ("... Hooks need review\n1. Review hooks", "a hook-review prompt"),
+        (
+            "You are in /home/me\nDo you trust the contents of this directory?",
+            "a directory-trust prompt",
+        ),
+        (
+            'WARNING: TERM is set to "dumb" ... Continue anyway? [y/N]',
+            "a terminal-compatibility prompt",
+        ),
+        ("just some ordinary model output, nothing blocking", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_pane_interactive_prompt_classifies_known_screens(
+    monkeypatch: pytest.MonkeyPatch, pane_text: str, expected: str | None
+) -> None:
+    async def _fake_capture(socket_path: str, tmux_target: str) -> bytes:
+        return pane_text.encode()
+
+    monkeypatch.setattr("omnigent.terminals.control_bridge._run_tmux_capture", _fake_capture)
+    result = await orchestration._codex_pane_interactive_prompt(Path("/s"), "%1")
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_pane_interactive_prompt_none_without_pane() -> None:
+    assert await orchestration._codex_pane_interactive_prompt(None, None) is None
+    assert await orchestration._codex_pane_interactive_prompt(Path("/s"), None) is None
+
+
+@pytest.mark.asyncio
+async def test_pane_interactive_prompt_swallows_capture_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _boom(socket_path: str, tmux_target: str) -> bytes:
+        raise RuntimeError("tmux gone")
+
+    monkeypatch.setattr("omnigent.terminals.control_bridge._run_tmux_capture", _boom)
+    assert await orchestration._codex_pane_interactive_prompt(Path("/s"), "%1") is None
+
+
+@pytest.mark.asyncio
+async def test_thread_start_timeout_on_prompt_records_recoverable_notice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A timeout while a prompt is up keeps waiting and records an actionable notice."""
+    # Bounded wait times out; the second, unbounded wait is interrupted by a
+    # teardown cancel (stands in for the session being torn down while a human
+    # had not yet answered the prompt).
+    wait = _WaitStub(["timeout", "cancel"])
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", wait)
+
+    async def _prompt(socket: Any, target: Any) -> str:
+        return "a hook-review prompt"
+
+    monkeypatch.setattr(orchestration, "_codex_pane_interactive_prompt", _prompt)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_discover(tmp_path)
+
+    # It retried without a deadline rather than reaping the terminal.
+    assert wait.timeouts == [_DEFAULT, None]
+    recorded = read_bridge_startup_error(tmp_path)
+    assert recorded is not None
+    assert "hook-review prompt" in recorded
+    assert "Open the Terminal" in recorded
+    # The fatal timeout marker the executor keys "never started" on is absent.
+    assert "never started" not in recorded
+    assert "startup timed out" not in recorded
+
+
+@pytest.mark.asyncio
+async def test_thread_start_timeout_clears_notice_once_thread_starts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Answering the prompt (thread starts on the retry) clears the notice."""
+    wait = _WaitStub(["timeout", "thread-abc"])
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", wait)
+
+    async def _prompt(socket: Any, target: Any) -> str:
+        return "a directory-trust prompt"
+
+    monkeypatch.setattr(orchestration, "_codex_pane_interactive_prompt", _prompt)
+
+    # Once the thread starts the notice is cleared, then the task moves on to
+    # record external_session_id — which needs RUNNER_SERVER_URL. Leaving it
+    # unset raises right after the clear, so the test asserts the clear without
+    # standing up a live server.
+    monkeypatch.delenv("RUNNER_SERVER_URL", raising=False)
+
+    with pytest.raises(RuntimeError, match="RUNNER_SERVER_URL"):
+        await _run_discover(tmp_path)
+
+    assert wait.timeouts == [_DEFAULT, None]
+    assert read_bridge_startup_error(tmp_path) is None
+
+
+@pytest.mark.asyncio
+async def test_thread_start_timeout_without_prompt_stays_fatal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A timeout with no interactive prompt keeps the fatal 'never started' error."""
+    wait = _WaitStub(["timeout"])
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", wait)
+
+    async def _no_prompt(socket: Any, target: Any) -> None:
+        return None
+
+    monkeypatch.setattr(orchestration, "_codex_pane_interactive_prompt", _no_prompt)
+
+    event_client = await _run_discover(tmp_path)
+
+    assert wait.timeouts == [_DEFAULT]  # did not retry
+    recorded = read_bridge_startup_error(tmp_path)
+    assert recorded is not None
+    assert "never started" in recorded
+    assert event_client.closed  # terminal/listener torn down as before
+
+
+@pytest.mark.asyncio
+async def test_event_stream_end_stays_fatal_even_with_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A crashed TUI (stream ends) is fatal regardless of any stale pane text."""
+    wait = _WaitStub(["runtime"])
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", wait)
+
+    async def _prompt(socket: Any, target: Any) -> str:
+        return "a hook-review prompt"
+
+    monkeypatch.setattr(orchestration, "_codex_pane_interactive_prompt", _prompt)
+
+    await _run_discover(tmp_path)
+
+    assert wait.timeouts == [_DEFAULT]  # RuntimeError is not the timeout retry path
+    recorded = read_bridge_startup_error(tmp_path)
+    assert recorded is not None
+    assert "never started" in recorded


### PR DESCRIPTION
## Related issue

No tracked issue — found while working the recurring "Codex terminal crashing" reports (Sid, earlier Samraj/Kasey) from the Slack thread. Happy to file one if preferred.

Closes #

## Summary

- A runner-owned Codex TUI runs **detached** in a tmux pane. When it parks its startup on an interactive prompt a human can answer — a directory-trust screen, a hook-review screen (the "codex review hook"), or a `TERM` "Continue anyway?" gate — **no thread-start deadline can clear it**. The 30s `wait_for_thread_started` timed out, the runner recorded a **fatal** `Codex native thread never started (startup timed out)` error, and the terminal was reaped. Every chat turn then failed and the box stayed invisible behind a dead chat.
- Fix: on the thread-start timeout, **capture the pane and classify it**. If it shows a known interactive prompt, record an *actionable, non-timeout* notice (so a headless turn still fails fast — now with guidance to open the Terminal and answer it) and **keep listening with no deadline**, so answering the prompt recovers the session. The notice is cleared once the thread starts. A timeout with **no** such prompt, or the event stream ending (a real crash), stays **fatal exactly as before**.
- This reuses the established `login_required` pattern (record a fail-fast cause up front, keep listening for an interactive recovery).

ELI5: Codex sometimes stops at a yes/no box in its terminal before it's ready. We used to give up after 30s and kill the whole session, hiding the box. Now we notice the box, tell the user to go answer it, and keep the session alive so it picks up the moment they do.

```
thread-start times out
  ├─ pane shows a known prompt (trust / hooks / TERM)  ──► record "answer it in the Terminal", keep listening (no deadline) ──► user answers ──► thread starts ──► notice cleared
  └─ no prompt (real crash / stream ended)             ──► fatal "never started" (unchanged)
```

## Test Plan

- New unit suite `tests/runner/test_codex_native_startup_prompt.py` (10 cases): pane classification for each known prompt + no-match/no-pane/capture-failure; the timeout-with-prompt branch records the recoverable notice and retries with no deadline; the notice is cleared once the thread starts; a timeout with no prompt and an event-stream-end both stay fatal.
- Existing `test_codex_native.py` discover/timeout tests (incl. `..._writes_routing_summary_on_timeout`, `..._login_required_records_error_before_waiting`) still pass — 293 passed.
- Manual repro: `python dev/repro_codex_startup_prompt.py` boots a throwaway local stack with `TERM=dumb` so the real "Continue anyway?" box blocks a real codex TUI; open the printed URL and send a message. Before the fix the turn dies with "never started" and the terminal vanishes; after, it fails fast with the actionable notice and recovers once you answer the box in the Terminal tab. Pass `--term xterm-256color` for a clean control run.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The unit suite drives `_codex_discover_thread_and_forward` directly with a scripted `wait_for_thread_started` and a stubbed pane capture, asserting the recorded bridge-startup-error text and the wait timeouts ([default, None]) on each branch — this is the decisive link between the pane state and whether the session is reaped or recovered. A full browser+codex end-to-end additionally needs a runner launched with `TERM=dumb` (or a real trust/hook box), which is what `dev/repro_codex_startup_prompt.py` sets up.

## Changelog

Codex sessions no longer die when the terminal is waiting on a trust / hook-review / terminal-compatibility prompt — they surface the prompt to answer and recover once you do.

This pull request and its description were written by Isaac.
