### PR TITLE
fix(pi): end a turn at agent_settled and carry declared model limits

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -646,9 +646,9 @@ _RPC_SESSION_CLOSE_REAP_TIMEOUT_S = 2.0
 # EOF does. Module-level so tests can patch it.
 _TURN_STDOUT_IDLE_TIMEOUT_S = 120.0
 
-# Post-error drain budget: after an errored message the only line left to
-# consume is the already-emitted ``agent_end``. Module-level so tests can
-# patch it.
+# Post-error drain budget: after an errored message the only lines left to
+# consume are the already-emitted ``agent_end``/``agent_settled``. Applies to
+# each such read. Module-level so tests can patch it.
 _TURN_STDOUT_ERROR_DRAIN_TIMEOUT_S = 10.0
 
 # CLI flags whose values are sensitive (e.g. the full system prompt) and must
@@ -2487,22 +2487,29 @@ class PiExecutor(Executor):
             yield ExecutorError(message=f"Failed to send prompt to Pi: {exc}")
             return
 
-        # Read events until agent_end.
+        # Read events until agent_settled.
         response_text = ""
         streamed_any = False
         # Per-LLM-call token usage captured from each assistant message pi
-        # forwards (``message_end`` is the capture site; ``agent_end`` is a
-        # fallback). Summed into a turn-level usage dict at completion so a
-        # multi-step (tool-loop) turn bills for every call, not just the
-        # last. Empty when pi reports no usage — cost tracking is skipped.
+        # forwards (``message_end`` is the capture site; ``agent_settled``
+        # is a fallback). Summed into a turn-level usage dict at completion
+        # so a multi-step (tool-loop) turn bills for every call, not just
+        # the last. Empty when pi reports no usage — cost tracking is skipped.
         message_usages: list[_PiMessageUsage] = []
         # Error reported by a ``message_end`` (stopReason=error); surfaced at
-        # ``agent_end`` so the terminal event is consumed off the RPC stream.
+        # ``agent_settled`` so the terminal event is consumed off the RPC
+        # stream.
         pending_error: str | None = None
+        # Messages from the most recent ``agent_end``. A turn may contain
+        # several low-level agent runs (retry, compaction, queued
+        # continuation), so this is overwritten each time and read once at
+        # ``agent_settled``.
+        end_messages: list[Any] = []
 
         while True:
             # After an errored message the only thing left to drain is the
-            # already-emitted agent_end, so don't wait the full idle budget.
+            # already-emitted agent_end/agent_settled, so don't wait the full
+            # idle budget.
             line = await rpc.read_line(
                 timeout=_TURN_STDOUT_IDLE_TIMEOUT_S
                 if pending_error is None
@@ -2653,12 +2660,27 @@ class PiExecutor(Executor):
                 )
                 continue
 
-            # Agent ended — the turn is complete.
+            # One low-level agent run ended — NOT necessarily the turn. Pi
+            # may still auto-retry, compact, or drain queued continuations
+            # after this, each emitting its own ``agent_end``: the event is
+            # documented as "may still be followed by retry, compaction, or
+            # queued continuations" (pi ``docs/rpc.md``). Capture this run's
+            # messages and keep reading — ``agent_settled`` is the real
+            # terminator.
             if event_type == "agent_end":
+                raw_end_messages = event.get("messages", [])
+                if isinstance(raw_end_messages, list):
+                    end_messages = raw_end_messages
+                continue
+
+            # The agent run is fully settled: "no automatic retry, compaction
+            # retry, or queued continuation remains" (pi ``docs/rpc.md``), so
+            # the turn is complete. Pi's own RPC client waits for this event
+            # rather than ``agent_end`` (``dist/modes/rpc/rpc-client.js``).
+            if event_type == "agent_settled":
                 if pending_error is not None:
                     yield ExecutorError(message=pending_error)
                     return
-                end_messages = event.get("messages", [])
                 if not response_text:
                     for m in reversed(end_messages):
                         if m.get("role") == "assistant":
@@ -2679,7 +2701,7 @@ class PiExecutor(Executor):
                 # usage, pull it from the last assistant message in
                 # ``messages`` (only the last — ``messages`` may hold the
                 # whole conversation, so summing it would overcount).
-                if not message_usages and isinstance(end_messages, list):
+                if not message_usages:
                     for m in reversed(end_messages):
                         captured = _extract_pi_turn_usage(m, model)
                         if captured is not None:
@@ -2709,11 +2731,11 @@ class PiExecutor(Executor):
                         yield ExecutorError(message=str(err))
                         return
                     if stop == "error":
-                        # Pi emits the turn-terminal ``agent_end`` after an
-                        # errored LLM call; returning here would leave it
+                        # Pi emits the turn-terminal ``agent_settled`` after
+                        # an errored LLM call; returning here would leave it
                         # queued, so the next turn on this RPC session reads
                         # the stale event as its own end. Record the error
-                        # and keep draining until ``agent_end``.
+                        # and keep draining until ``agent_settled``.
                         pending_error = str(msg.get("errorMessage", stop))
                 continue
 

--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -693,6 +693,68 @@ def _redact_argv_for_log(args: Sequence[str]) -> list[str]:
     return redacted
 
 
+# Limit keys carried from the user's global Pi ``models.json`` onto entries
+# this module registers dynamically.
+_PI_LIMIT_KEYS: tuple[str, ...] = ("contextWindow", "maxTokens")
+
+
+def _global_pi_model_limits(
+    global_agent_dir: pathlib.Path | None = None,
+) -> dict[str, _JsonObject]:
+    """Index declared context/output limits from the user's global ``models.json``.
+
+    A dynamically-registered entry declares no limits, so Pi falls back to its
+    own defaults (``contextWindow`` 128000, ``maxTokens`` 16384) and begins
+    auto-compacting at ``contextWindow - maxTokens`` (~111.6k tokens) — far
+    below what these gateway models actually accept. The user's global
+    ``~/.pi/agent/models.json`` declares the real numbers, so reuse them.
+    Gateway mode relocates Pi's agent root to a per-session temp dir and
+    :func:`~omnigent.inner.pi_settings.prepare_managed_pi_agent_dir` copies
+    only ``settings.json``, so the generated ``models.json`` is the sole
+    carrier of these limits.
+
+    Ids are matched exactly across *every* provider in that file: the provider
+    name there is unrelated to the generated one (e.g. ``moose`` there vs.
+    ``databricks-completions`` here). First provider declaring an id wins.
+
+    Never raises: an absent, unreadable or malformed file yields ``{}``, which
+    leaves callers on Pi's default behaviour rather than blocking a spawn.
+
+    :param global_agent_dir: Override for tests; defaults to
+        :data:`~omnigent.inner.pi_settings.DEFAULT_PI_AGENT_DIR`.
+    :returns: Model id → whichever of ``contextWindow``/``maxTokens`` are
+        present as positive integers.
+    """
+    from omnigent.inner.pi_settings import DEFAULT_PI_AGENT_DIR, _read_settings_file
+
+    agent_root = global_agent_dir if global_agent_dir is not None else DEFAULT_PI_AGENT_DIR
+    providers = _read_settings_file(agent_root / "models.json").get("providers")
+    if not isinstance(providers, dict):
+        return {}
+    limits: dict[str, _JsonObject] = {}
+    for provider in providers.values():
+        if not isinstance(provider, dict):
+            continue
+        declared_models = provider.get("models")
+        if not isinstance(declared_models, list):
+            continue
+        for declared in declared_models:
+            if not isinstance(declared, dict):
+                continue
+            model_id = declared.get("id")
+            if not isinstance(model_id, str):
+                continue
+            declared_limits: _JsonObject = {}
+            for key in _PI_LIMIT_KEYS:
+                value = declared.get(key)
+                # ``bool`` is an ``int`` subclass; a JSON ``true`` is not a limit.
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    declared_limits[key] = value
+            if declared_limits:
+                limits.setdefault(model_id, declared_limits)
+    return limits
+
+
 def _build_models_json(
     host: str,
     token: str,
@@ -701,6 +763,8 @@ def _build_models_json(
     catalog_models: Sequence[model_catalog.ModelEntry] = (),
     model_wire_apis: Mapping[str, frozenset[ModelWireAPI]] | None = None,
     openai_wire_api: str | None = None,
+    *,
+    global_agent_dir: pathlib.Path | None = None,
 ) -> _PiModelsConfig:
     # Pi's models.json mixes str/int/bool/list/dict across provider configs;
     """Build a Pi ``models.json`` with protocol-specific gateway providers.
@@ -728,6 +792,9 @@ def _build_models_json(
         wire surfaces. Missing GPT metadata defaults to Responses.
     :param openai_wire_api: Configured wire for a generic OpenAI-compatible
         provider. ``None`` defaults generic providers to Chat Completions.
+    :param global_agent_dir: Override for tests; where the user's global Pi
+        ``models.json`` is read from for declared limits. Defaults to
+        :data:`~omnigent.inner.pi_settings.DEFAULT_PI_AGENT_DIR`.
     :returns: Pi ``models.json`` contents.
     """
     h = host.rstrip("/")
@@ -878,6 +945,13 @@ def _build_models_json(
             entry: _JsonObject = {"id": model, "input": ["text", "image"]}
             if pi_model_is_reasoning(model):
                 entry["reasoning"] = True
+            # Carry any limits the user's global models.json declares for this
+            # id. Catalog entries already get theirs via
+            # ``pi_model_json_entry``; without the same treatment here Pi
+            # applies 128000/16384 and starts auto-compacting at
+            # ``contextWindow - maxTokens`` (~111.6k), truncating long runs on
+            # models that accept far more. A no-op when the id is absent.
+            entry.update(_global_pi_model_limits(global_agent_dir).get(model, {}))
             provider["models"] = [*provider["models"], entry]
     return config
 

--- a/tests/e2e/test_pi_interrupt_reap_budget_race_e2e.py
+++ b/tests/e2e/test_pi_interrupt_reap_budget_race_e2e.py
@@ -165,6 +165,7 @@ async def test_rpc_prompt_command_sets_streaming_behavior() -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         captured["proc"] = proc

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -1965,6 +1965,7 @@ class TestRunTurn(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2026,6 +2027,7 @@ class TestRunTurn(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2163,6 +2165,7 @@ class TestRunTurn(unittest.TestCase):
                         }
                     ),
                     json.dumps({"type": "agent_end", "messages": []}),
+                    json.dumps({"type": "agent_settled"}),
                 ):
                     fake_rpc._line_queue.put_nowait(line)
 
@@ -2240,8 +2243,10 @@ class TestRunTurn(unittest.TestCase):
 
         _run(_test())
 
-    def test_agent_end_extracts_response_from_messages(self):
-        """When no text deltas were streamed, response is extracted from agent_end messages."""
+    def test_agent_settled_extracts_response_from_agent_end_messages(self):
+        """When no text deltas were streamed, the response is extracted at
+        ``agent_settled`` from the messages the preceding ``agent_end`` carried.
+        """
 
         async def _test():
             executor = self._make_executor()
@@ -2266,6 +2271,7 @@ class TestRunTurn(unittest.TestCase):
                         ],
                     }
                 ),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2312,6 +2318,7 @@ class TestRunTurn(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2357,8 +2364,10 @@ class TestRunTurn(unittest.TestCase):
             lines = [
                 json.dumps({"type": "response", "success": True}),
                 json.dumps({"type": "message_end", "message": errored}),
-                # Pi's agent loop always emits agent_end after an errored call.
+                # Pi's agent loop always emits agent_end then agent_settled
+                # after an errored call.
                 json.dumps({"type": "agent_end", "messages": [errored]}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2384,9 +2393,10 @@ class TestRunTurn(unittest.TestCase):
         _run(_test())
 
     def test_message_end_error_with_stream_eof_fails_with_real_error(self):
-        """If pi dies after reporting the errored message (no agent_end ever
-        arrives), the turn still fails with pi's error message rather than
-        the generic ended-without-response fallback.
+        """If pi dies after reporting the errored message (no terminal
+        ``agent_end``/``agent_settled`` ever arrives), the turn still fails
+        with pi's error message rather than the generic
+        ended-without-response fallback.
         """
 
         async def _test():
@@ -2413,7 +2423,7 @@ class TestRunTurn(unittest.TestCase):
                 del timeout
                 if lines:
                     return lines.pop(0)
-                return None  # EOF: process died without agent_end.
+                return None  # EOF: process died without a terminal event.
 
             fake_rpc.read_line = fake_read_line
 
@@ -2437,11 +2447,12 @@ class TestRunTurn(unittest.TestCase):
 
         _run(_test())
 
-    def test_post_tool_error_drains_agent_end_before_failing(self):
+    def test_post_tool_error_drains_terminal_events_before_failing(self):
         """A message_end error after a successful tool call fails the turn
         with pi's error message, but only after consuming the trailing
-        ``agent_end`` — leaving it queued would make the next turn on the
-        same RPC session read the stale terminal event as its own end.
+        ``agent_end``/``agent_settled`` — leaving them queued would make the
+        next turn on the same RPC session read a stale terminal event as its
+        own end.
         """
 
         async def _test():
@@ -2478,8 +2489,10 @@ class TestRunTurn(unittest.TestCase):
                     }
                 ),
                 # Pi always emits agent_end after the errored LLM call ends
-                # the agent loop; it carries the errored message.
+                # the agent loop (it carries the errored message), then
+                # agent_settled once no retry remains.
                 json.dumps({"type": "agent_end", "messages": [errored_assistant]}),
+                json.dumps({"type": "agent_settled"}),
             ]
             for line in lines:
                 fake_rpc._line_queue.put_nowait(line)
@@ -2507,8 +2520,8 @@ class TestRunTurn(unittest.TestCase):
             self.assertEqual([e.message for e in errors], [parse_error])
             self.assertFalse(any(isinstance(e, TurnComplete) for e in events))
             self.assertFalse(any(isinstance(e, TextChunk) for e in events))
-            # The trailing agent_end was consumed: nothing stale is left for
-            # the next turn on this RPC session.
+            # The trailing agent_end/agent_settled were consumed: nothing
+            # stale is left for the next turn on this RPC session.
             self.assertTrue(fake_rpc._line_queue.empty())
 
         _run(_test())
@@ -2622,6 +2635,7 @@ def test_pi_thinking_deltas_stream_as_reasoning_chunks() -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -2686,6 +2700,7 @@ def test_pi_thinking_and_text_delta_ordering_preserved() -> None:
                 _update({"type": "thinking_delta", "contentIndex": 2, "delta": "revise"}),
                 _update({"type": "text_delta", "contentIndex": 3, "delta": " step two"}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -2921,6 +2936,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -2943,6 +2959,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -2964,6 +2981,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -2989,6 +3007,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -3010,6 +3029,7 @@ class TestBlockedToolDetection(unittest.TestCase):
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
         tool_completes = [e for e in events if isinstance(e, ToolCallComplete)]
@@ -3915,6 +3935,7 @@ def test_run_turn_spawn_log_redacts_system_prompt_end_to_end(monkeypatch, caplog
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -3987,6 +4008,7 @@ def test_run_turn_spawn_env_has_no_host_secrets(monkeypatch) -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -4046,6 +4068,7 @@ def test_run_turn_spawn_env_honors_spec_env_passthrough(monkeypatch) -> None:
             stdout_lines=[
                 json.dumps({"type": "response", "success": True}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -4177,6 +4200,7 @@ def test_run_turn_bridge_extension_carries_live_server_token(monkeypatch) -> Non
             stdout_lines=[
                 json.dumps({"type": "response", "success": True}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             stderr_lines=[],
         )
@@ -4293,6 +4317,7 @@ def test_pi_usage_captured_from_message_end() -> None:
                 ),
                 json.dumps({"type": "message_end", "message": _pi_assistant_message_with_usage()}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -4327,8 +4352,9 @@ def test_pi_usage_captured_from_message_end() -> None:
 
 def test_pi_usage_fallback_from_agent_end() -> None:
     """
-    When no ``message_end`` carried usage, the ``agent_end`` handler falls
-    back to the last assistant message in ``event["messages"]``. Asserts
+    When no ``message_end`` carried usage, the ``agent_settled`` handler
+    falls back to the last assistant message in the ``messages`` the
+    preceding ``agent_end`` carried. Asserts
     the mapped numbers so the fallback path is proven to map, not just to
     set a non-None dict.
     """
@@ -4337,7 +4363,8 @@ def test_pi_usage_fallback_from_agent_end() -> None:
         executor = _executor_with_scripted_rpc(
             [
                 json.dumps({"type": "response", "success": True}),
-                # No message_end frame — usage must come from agent_end.
+                # No message_end frame — usage must come from the
+                # agent_end messages.
                 json.dumps(
                     {
                         "type": "agent_end",
@@ -4354,6 +4381,7 @@ def test_pi_usage_fallback_from_agent_end() -> None:
                         ],
                     }
                 ),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -4384,6 +4412,78 @@ def test_pi_usage_fallback_from_agent_end() -> None:
     _run(_test())
 
 
+def test_pi_turn_completes_at_agent_settled_not_at_a_retried_agent_end() -> None:
+    """
+    A turn ends at ``agent_settled``, not at the first ``agent_end``.
+
+    Pi documents ``agent_end`` as "one low-level agent run completes (may
+    still be followed by retry, compaction, or queued continuations)" and
+    ``agent_settled`` as "agent run is fully settled; no automatic retry,
+    compaction retry, or queued continuation remains" (``docs/rpc.md``).
+    Ending the turn on the first ``agent_end`` therefore truncates a run pi
+    is still working on, and — because ``agent_end`` carries no error — the
+    truncated turn is reported as a normal completion.
+
+    Scripts a retried run: an ``agent_end`` with ``willRetry`` set carrying
+    only partial text, the retry's ``agent_end`` carrying the real answer,
+    then ``agent_settled``. Exactly one ``TurnComplete`` must be emitted and
+    it must carry the retry's answer; treating the first ``agent_end`` as
+    terminal yields ``"Partial"`` instead.
+    """
+
+    async def _test() -> None:
+        executor = _executor_with_scripted_rpc(
+            [
+                json.dumps({"type": "response", "success": True}),
+                # First low-level run ends mid-work; pi will retry it.
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "content": [{"type": "text", "text": "Partial"}],
+                            },
+                        ],
+                        "willRetry": True,
+                    }
+                ),
+                # The retry is a second agent run with its own agent_end.
+                json.dumps(
+                    {
+                        "type": "agent_end",
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "content": [{"type": "text", "text": "Final answer"}],
+                            },
+                        ],
+                    }
+                ),
+                # Only now is the run fully settled.
+                json.dumps({"type": "agent_settled"}),
+            ]
+        )
+
+        events = [
+            e
+            async for e in executor.run_turn(
+                [{"role": "user", "content": "hello"}],
+                [],
+                "system",
+            )
+        ]
+
+        turn_complete = [e for e in events if isinstance(e, TurnComplete)]
+        assert len(turn_complete) == 1, "turn must complete once, at agent_settled"
+        assert turn_complete[0].response == "Final answer"
+        # The turn must not fail, and must not end before the retry ran.
+        assert not [e for e in events if isinstance(e, ExecutorError)]
+        assert isinstance(events[-1], TurnComplete)
+
+    _run(_test())
+
+
 def test_pi_usage_model_falls_back_to_configured_model() -> None:
     """
     When the assistant message omits ``model``, the usage ``model`` falls
@@ -4402,6 +4502,7 @@ def test_pi_usage_model_falls_back_to_configured_model() -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ],
             model="databricks-claude-sonnet-4-6",
         )
@@ -4472,6 +4573,7 @@ def test_pi_usage_sums_across_multiple_message_end() -> None:
                     }
                 ),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -4520,9 +4622,11 @@ def test_pi_turn_without_usage_leaves_usage_none() -> None:
                         "assistantMessageEvent": {"type": "text_delta", "delta": "Hi there"},
                     }
                 ),
-                # message_end with no usage object, then a usage-less agent_end.
+                # message_end with no usage object, then a usage-less
+                # agent_end/agent_settled pair.
                 json.dumps({"type": "message_end", "message": {"stopReason": "stop"}}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -4621,6 +4725,7 @@ def test_run_turn_spawns_pi_with_thinking_flag(monkeypatch) -> None:
                 _levels_response(["off", "low", "medium", "high", "xhigh", "max"]),
                 json.dumps({"type": "response", "command": "prompt", "success": True}),
                 json.dumps({"type": "agent_end", "messages": []}),
+                json.dumps({"type": "agent_settled"}),
             ]
         )
 
@@ -4656,6 +4761,7 @@ def test_midsession_effort_change_sets_thinking_level_before_prompt() -> None:
             _levels_response(["off", "low", "medium", "high", "xhigh", "max"]),
             json.dumps({"type": "response", "command": "prompt", "success": True}),
             json.dumps({"type": "agent_end", "messages": []}),
+            json.dumps({"type": "agent_settled"}),
         ],
         applied_thinking="low",
     )
@@ -4690,6 +4796,7 @@ def test_unsupported_thinking_level_clamps_with_warning(caplog) -> None:
             _levels_response(["off", "low", "high"]),
             json.dumps({"type": "response", "command": "prompt", "success": True}),
             json.dumps({"type": "agent_end", "messages": []}),
+            json.dumps({"type": "agent_settled"}),
         ],
         applied_thinking=None,
     )
@@ -4724,6 +4831,7 @@ def test_midsession_effort_clear_leaves_level_untouched() -> None:
         [
             json.dumps({"type": "response", "command": "prompt", "success": True}),
             json.dumps({"type": "agent_end", "messages": []}),
+            json.dumps({"type": "agent_settled"}),
         ],
         applied_thinking="high",
     )
@@ -4796,6 +4904,7 @@ def test_run_turn_prompt_command_includes_streaming_behavior():
             }
         ),
         json.dumps({"type": "agent_end", "messages": []}),
+        json.dumps({"type": "agent_settled"}),
     ]:
         fake_rpc._line_queue.put_nowait(line)
 

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -32,6 +32,7 @@ from omnigent.inner.pi_executor import (
     _build_models_json,
     _databricks_model_wire_catalog,
     _generate_extension_js,
+    _global_pi_model_limits,
     _pi_provider_for_model,
     _PiRpcSession,
     _redact_argv_for_log,
@@ -3559,7 +3560,7 @@ if __name__ == "__main__":
 # ---------------------------------------------------------------------------
 
 
-def test_build_models_json_registers_unknown_model_with_routed_provider() -> None:
+def test_build_models_json_registers_unknown_model_with_routed_provider(tmp_path: Path) -> None:
     """A model outside the static Databricks lists is registered so Pi resolves it.
 
     Reproduces the OpenRouter failure: ``moonshotai/kimi-k2.6`` routes to
@@ -3575,6 +3576,9 @@ def test_build_models_json_registers_unknown_model_with_routed_provider() -> Non
         "or-key",
         {"openai": "https://openrouter.ai/api/v1"},
         model="moonshotai/kimi-k2.6",
+        # Empty agent dir: the entry below is asserted exactly, so it must not
+        # pick up limits from the developer's real ~/.pi/agent/models.json.
+        global_agent_dir=tmp_path,
     )
     completions = result["providers"]["databricks-completions"]
     # The run model is registered (so Pi resolves it) under the provider
@@ -3593,6 +3597,121 @@ def test_build_models_json_registers_unknown_model_with_routed_provider() -> Non
         for name in ("databricks", "databricks-anthropic")
         for m in result["providers"][name]["models"]
     )
+
+
+def _write_global_models_json(agent_dir: Path, providers: dict[str, object]) -> None:
+    """Write a global Pi ``models.json`` into *agent_dir*.
+
+    :param agent_dir: Stands in for ``~/.pi/agent``.
+    :param providers: The ``providers`` mapping to serialize.
+    """
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "models.json").write_text(
+        json.dumps({"providers": providers}), encoding="utf-8"
+    )
+
+
+def test_dynamic_model_carries_limits_from_global_models_json(tmp_path: Path) -> None:
+    """A dynamically-registered entry adopts the limits the user declared.
+
+    Catalog entries already carry ``contextWindow``/``maxTokens`` via
+    ``pi_model_json_entry``; the dynamic-registration path did not, so Pi
+    applied its own 128000/16384 defaults and began auto-compacting at
+    ``contextWindow - maxTokens`` (~111.6k tokens) against a gateway
+    declaring far more. The provider name in the user's file is deliberately
+    unrelated to the generated one, so ids are matched across all providers.
+    """
+    _write_global_models_json(
+        tmp_path,
+        {
+            "moose": {
+                "models": [
+                    {"id": "glm-5.2", "contextWindow": 1_048_576, "maxTokens": 1_048_576},
+                ]
+            }
+        },
+    )
+    result = _build_models_json(
+        "https://unused.example.com",
+        "key",
+        {"openai": "https://gateway.example.com/v1"},
+        model="glm-5.2",
+        global_agent_dir=tmp_path,
+    )
+    entry = next(
+        e for e in result["providers"]["databricks-completions"]["models"] if e["id"] == "glm-5.2"
+    )
+    assert entry["contextWindow"] == 1_048_576
+    assert entry["maxTokens"] == 1_048_576
+
+
+def test_dynamic_model_absent_from_global_models_json_declares_no_limits(
+    tmp_path: Path,
+) -> None:
+    """An id the user never declared is left on Pi's defaults, not guessed."""
+    _write_global_models_json(
+        tmp_path, {"moose": {"models": [{"id": "other-model", "contextWindow": 999}]}}
+    )
+    result = _build_models_json(
+        "https://unused.example.com",
+        "key",
+        {"openai": "https://gateway.example.com/v1"},
+        model="glm-5.2",
+        global_agent_dir=tmp_path,
+    )
+    entry = next(
+        e for e in result["providers"]["databricks-completions"]["models"] if e["id"] == "glm-5.2"
+    )
+    assert "contextWindow" not in entry
+    assert "maxTokens" not in entry
+
+
+def test_global_pi_model_limits_missing_file_is_empty(tmp_path: Path) -> None:
+    """No global models.json degrades to current behaviour rather than raising."""
+    assert _global_pi_model_limits(tmp_path) == {}
+
+
+def test_global_pi_model_limits_ignores_malformed_declarations(tmp_path: Path) -> None:
+    """Malformed shapes and non-positive/boolean values are skipped, not carried."""
+    _write_global_models_json(
+        tmp_path,
+        {
+            "not-a-dict": [],
+            "bad-models": {"models": "nope"},
+            "mixed": {
+                "models": [
+                    "not-a-dict",
+                    {"no": "id"},
+                    {"id": 17, "contextWindow": 10},
+                    # ``bool`` is an ``int`` subclass — must not be read as a limit.
+                    {"id": "bool-limits", "contextWindow": True, "maxTokens": 0},
+                    {"id": "partial", "maxTokens": 8192},
+                ]
+            },
+        },
+    )
+    limits = _global_pi_model_limits(tmp_path)
+    # Only the one usable declaration survives, and only its usable key.
+    assert limits == {"partial": {"maxTokens": 8192}}
+
+
+def test_global_pi_model_limits_unreadable_file_is_empty(tmp_path: Path) -> None:
+    """Invalid JSON yields no limits instead of blocking a spawn."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "models.json").write_text("{not json", encoding="utf-8")
+    assert _global_pi_model_limits(tmp_path) == {}
+
+
+def test_global_pi_model_limits_first_provider_declaring_an_id_wins(tmp_path: Path) -> None:
+    """A duplicated id resolves to the first provider that declared it."""
+    _write_global_models_json(
+        tmp_path,
+        {
+            "first": {"models": [{"id": "dup", "contextWindow": 111}]},
+            "second": {"models": [{"id": "dup", "contextWindow": 222}]},
+        },
+    )
+    assert _global_pi_model_limits(tmp_path)["dup"]["contextWindow"] == 111
 
 
 def test_build_models_json_known_catalog_model_not_duplicated() -> None:


### PR DESCRIPTION
## Related issue

Closes #

No issue is filed for either bug yet — both were observed while running
sub-agents through the Pi harness, and I wrote them up directly. Happy to
file one issue per fix if you'd prefer the tracker to lead; flagging it
because CONTRIBUTING asks bug fixes to reference one.

**Two independent fixes, one commit each**, in case you want only one:

| Commit | Fix |
| --- | --- |
| `fix(pi): end a turn at agent_settled, not at the first agent_end` | A — turn terminator |
| `fix(pi): carry declared model limits onto dynamically-registered entries` | B — model limits |

Adjacent context, **not the same bug**: #6315 (closed,
`validated:already_fixed`, `comp:harness-t2`) covered the 120 s idle-read
timeout in this same file being indistinguishable from EOF. That is a
different failure mode from either fix below; I mention it only because it
is the nearest prior art in `pi_executor.py`'s turn loop.

## Summary

### A — `agent_end` is not the end of a turn

`PiExecutor`'s RPC turn loop ended the turn on Pi's `agent_end`. Pi's own
`docs/rpc.md` distinguishes the two terminal events:

> | `agent_end` | One low-level agent run completes (may still be followed by retry, compaction, or queued continuations) |
> | `agent_settled` | Agent run is fully settled; no automatic retry, compaction retry, or queued continuation remains |

and Pi's own RPC client waits for `agent_settled`
(`dist/modes/rpc/rpc-client.js`), not `agent_end`.

So whenever Pi retried, compacted, or drained a queued continuation, the
executor stopped reading while Pi was still working. Because `agent_end`
carries no error, the truncated turn was yielded as an ordinary
`TurnComplete`: **the run was reported `completed`, not failed.** The
leftover events also stayed queued on the RPC session, where the next turn
could read one as its own terminator.

Observed symptom: roughly **10 sub-agent runs truncated in a single
session, every one of them reported `completed`**. The most legible case was
a sub-agent that had deliberately broken its own implementation to prove a
test was meaningful — it was cut off after the break and before it restored
the code, and still reported success.

The fix reads until `agent_settled`. `agent_end` now only captures that
run's `messages` (overwritten per run, since a turn may contain several) and
keeps reading; the response-text and usage fallbacks, the pending
`message_end` error, and the `TurnComplete` all move to `agent_settled`, so
they observe the final run rather than the first.

Compatibility: Pi has emitted `agent_settled` since **0.80.4**
(`earendil-works/pi#6363`); this repo's CI pins `0.84.2`
(`.github/ci-deps/package.json`). Against a Pi older than 0.80.4 a turn
would fall back to ending at stdout EOF, so it's worth a maintainer call
whether a floor should be documented.

Deliberately out of scope: `omnigent_pi_native_extension.js` also uses its
`agent_end` hook for loop-state/idle edges. That's the extension lifecycle,
not the RPC turn terminator, and I left it alone.

### B — dynamic model entries drop the declared token limits

`_build_models_json` registers the resolved run model as
`{"id", "input"}` when the live catalog doesn't list it. That entry declares
no `contextWindow`/`maxTokens`, so Pi applies its own defaults of
**128000 / 16384** and begins auto-compacting at `contextWindow -
maxTokens`:

```
128000 - 16384 = 111616  (~111.6k tokens)
```

against a gateway declaring `1048576 / 1048576`. Long runs compact — and
lose context — an order of magnitude early.

**The strongest argument for this one is that it's an internal
inconsistency, not a new feature.**
`pi_model_compatibility.pi_model_json_entry` documents those same Pi
defaults in its own docstring:

> Pi defaults an entry with no `contextWindow`/`maxTokens` to 128000/16384,
> which silently truncates the 1M-context gateway models, so limits are
> carried whenever the catalog reports them.

…and it already carries limits onto every catalog-sourced entry for exactly
this reason. Only the dynamic-registration path lacked the same treatment.

The fix indexes the ids declared in the user's global
`~/.pi/agent/models.json` and carries any `contextWindow`/`maxTokens` onto
the entry. It **reads configuration the user already maintains for Pi
itself — no new Omnigent setting.** It matters on the gateway path
specifically because that path relocates Pi's agent root to a per-session
temp dir where `prepare_managed_pi_agent_dir` copies only `settings.json`,
leaving the generated `models.json` as the sole carrier of these limits.

Ids are matched across every provider in that file, since the provider name
there is unrelated to the generated one. The lookup never raises: absent,
unreadable, or malformed input yields no limits and leaves the entry on Pi's
current default behaviour.

## Test Plan

**Both fixes are running in my own installed Omnigent** — that is where they
were written and where the truncation symptom above stopped. This branch is
a hand-port of them onto current `main` (the install is 715 commits behind);
the two sites had drifted only in line numbers, not in shape.

Automated coverage added:

- A: `test_pi_turn_completes_at_agent_settled_not_at_a_retried_agent_end`
  scripts a retried run — an `agent_end` with `willRetry` carrying partial
  text, the retry's `agent_end` carrying the real answer, then
  `agent_settled` — and asserts exactly one `TurnComplete` carrying the
  retry's answer. On the old code it yields `"Partial"`.
- A: the 27 existing scripted turns across `tests/inner/test_pi_executor.py`
  and `tests/e2e/test_pi_interrupt_reap_budget_race_e2e.py` gain the
  `agent_settled` their real Pi counterparts emit.
- B: limits carried; id absent from the file; first provider wins a
  duplicated id; missing / unreadable / malformed file; a JSON `true` not
  read as a limit (`bool` is an `int` subclass).
- B: `test_build_models_json_registers_unknown_model_with_routed_provider`
  asserts a dynamic entry exactly, so it now passes an empty
  `global_agent_dir` rather than reading the developer's real
  `~/.pi/agent/models.json`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change

## Coverage notes

**I have not executed this test suite against this branch** — I don't have a
dev environment for this checkout and didn't want to build one on the
machine that is currently running Omnigent from the installed package, so
**CI is the first real run.** Please treat the suite as unverified until it
goes green; that is the main reason this PR is a draft. What I did verify
locally: both files byte-compile, and `_global_pi_model_limits` was executed
in isolation against all six fixture shapes asserted in the new tests
(missing, happy path, malformed mix, invalid JSON, duplicate id, absent id),
each matching its assertion.

The `agent_settled` fixture change is broad by necessity: it touches every
scripted turn in the Pi executor tests, because the terminator those
fixtures emit is the thing being fixed.

## Changelog

Sub-agent turns on the Pi harness no longer end early — and get reported as
completed — when Pi retries, compacts, or drains a queued continuation.
