### PR TITLE
Revert "chore(cli): deprecate omni update" (#6362)

### DIFF
--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -1718,10 +1718,10 @@ _HARNESS_COMMANDS: frozenset[str] = frozenset(
 _ACCENT_RGB = (244, 59, 166)
 
 # Command names that are pure aliases of another command (the same Click
-# object registered under a second name, e.g. ``antigravity`` -> ``agy``).
+# object registered under a second name, e.g. ``update`` -> ``upgrade``).
 # Kept runnable/registered but omitted from the ``--help`` listing so the
 # alias isn't shown as a duplicate line.
-_ALIAS_COMMANDS: frozenset[str] = frozenset({"antigravity"})
+_ALIAS_COMMANDS: frozenset[str] = frozenset({"update", "antigravity"})
 
 
 def _harness_extra_checks() -> dict[str, Callable[[], bool]]:
@@ -1797,7 +1797,7 @@ class _OmnigentCLI(click.Group):
             cmd = self.get_command(ctx, subcommand)
             if cmd is None or cmd.hidden:
                 continue
-            # Skip pure aliases (e.g. ``antigravity`` -> ``agy``) so the
+            # Skip pure aliases (e.g. ``update`` -> ``upgrade``) so the
             # listing doesn't show a duplicate line; still runnable.
             if subcommand in _ALIAS_COMMANDS:
                 continue
@@ -2085,9 +2085,9 @@ def _should_skip_update_check(argv: list[str]) -> bool:
 
     Skipped for help / version requests, internal TUI subcommands
     (``pane-split`` / ``pane-picker``, invoked by the terminal UI rather
-    than the user), and ``upgrade`` (and its deprecated ``update`` spelling)
-    itself (pointing the user at ``omni upgrade`` while they are running it
-    is noise).
+    than the user), and ``upgrade`` (and its ``update`` alias) itself
+    (pointing the user at ``omni upgrade`` while they are running it is
+    noise).
 
     :param argv: CLI arguments without the program name, e.g.
         ``["run", "agent.yaml"]``.
@@ -5771,34 +5771,11 @@ def upgrade(
     )
 
 
-@click.pass_context
-def _update_deprecated(ctx: click.Context, **kwargs: object) -> None:
-    """Warn that ``update`` is deprecated, then run the ``upgrade`` flow.
-
-    :param ctx: The click context, used to invoke ``upgrade``.
-    :param kwargs: ``upgrade``'s own parsed options, forwarded verbatim.
-    :returns: None.
-    """
-    click.echo(
-        f"omnigent: `update` is deprecated; use `{cli_invocation(name='omni')} upgrade`.",
-        err=True,
-    )
-    ctx.invoke(upgrade, **kwargs)
-
-
-# Deprecated rather than deleted: the desktop About window shipped this same
-# ``omni update`` hint, and ``server start`` was deleted outright in v0.7.0
-# (#3105) then restored (#3578) when older clients hard-failed on it.
-cli.add_command(
-    click.Command(
-        "update",
-        params=list(upgrade.params),
-        callback=_update_deprecated,
-        hidden=True,
-        # Static: a module-level f-string would freeze the wrapper spelling.
-        help="Deprecated spelling of `upgrade`. Use `upgrade` instead.",
-    )
-)
+# ``omni update`` is an alias for ``omni upgrade`` — mistyping the latter as
+# the former is common, and silently doing nothing is annoying. Registering
+# the same Command object under a second name shares the exact callback,
+# options, and semantics; there is no duplicated implementation to drift.
+cli.add_command(upgrade, name="update")
 
 
 def _bundle(source: Path) -> bytes:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1096,14 +1096,16 @@ def test_help_groups_harnesses_and_other_commands() -> None:
     assert commands_at < result.output.index("server")
 
 
-def test_help_hides_deprecated_update_spelling_but_keeps_it_runnable() -> None:
-    """``update`` is omitted from --help but stays registered and runnable."""
+def test_help_hides_update_alias_but_keeps_it_runnable() -> None:
+    """The ``update`` alias is omitted from --help but stays registered."""
     result = CliRunner().invoke(cli, ["--help"])
 
     assert result.exit_code == 0, result.output
     assert "upgrade" in result.output
+    # The alias line is suppressed so it doesn't duplicate ``upgrade``...
     assert "\n  update " not in result.output
-    assert cli.commands["update"].hidden is True
+    # ...but it's still a real, invokable command.
+    assert cli.commands["update"] is cli.commands["upgrade"]
 
 
 def test_help_hides_extras_gated_harness_when_sdk_missing(

--- a/tests/cli/test_upgrade_command.py
+++ b/tests/cli/test_upgrade_command.py
@@ -8,7 +8,6 @@ import pytest
 from click.testing import CliRunner
 
 from omnigent.cli import cli
-from omnigent.cli_invocation import WRAPPER_COMMAND_ENV
 from omnigent.host.local_server import LocalServerInfo
 from omnigent.update_check import (
     _build_nightly_upgrade_suggestion,
@@ -333,29 +332,27 @@ def test_upgrade_pre_passes_prerelease_flag_to_installer(
     assert ran == ["uv tool upgrade omnigent --prerelease allow"]
 
 
-# ── deprecated ``omni update`` spelling ──────────────────────────────
+# ── ``omni update`` alias ────────────────────────────────────────────
 
 
-def test_update_is_hidden_and_shares_upgrade_options() -> None:
-    """``update`` is a hidden shim over ``upgrade``, not a second command.
+def test_update_is_alias_for_upgrade_same_callback() -> None:
+    """``update`` and ``upgrade`` resolve to the exact same Click command.
 
-    It has to be its own Click object to warn, so the guard is that it reuses
-    ``upgrade``'s parameter objects — the option surface cannot drift.
+    The alias is registered by handing the *same* Command object to the
+    group under a second name, so its callback, options and help must be
+    identical — there is no second implementation to drift from ``upgrade``.
     """
     update_cmd = cli.commands["update"]
     upgrade_cmd = cli.commands["upgrade"]
 
-    assert update_cmd is not upgrade_cmd
-    assert update_cmd.hidden is True
-    assert upgrade_cmd.hidden is False
-    # The very same Parameter objects, not merely equally-named ones.
-    assert all(a is b for a, b in zip(update_cmd.params, upgrade_cmd.params, strict=True))
+    assert update_cmd is upgrade_cmd
+    assert update_cmd.callback is upgrade_cmd.callback
+    # Same option surface (--check / --force / --pre).
+    assert [p.name for p in update_cmd.params] == [p.name for p in upgrade_cmd.params]
 
 
-def test_update_warns_then_runs_upgrade(
-    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
-) -> None:
-    """``omni update`` still works, but warns and names ``upgrade``."""
+def test_update_up_to_date(monkeypatch: pytest.MonkeyPatch, _wheel_install: None) -> None:
+    """``omni update`` runs the upgrade flow end-to-end (up-to-date path)."""
     monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.1.0")
 
     def _must_not_run(*_a: object, **_k: object) -> int:
@@ -366,31 +363,8 @@ def test_update_warns_then_runs_upgrade(
     result = CliRunner().invoke(cli, ["update"])
 
     assert result.exit_code == 0, result.output
-    assert "`update` is deprecated" in result.stderr
-    assert "upgrade" in result.stderr
-    assert "up to date" in result.stdout
-    assert "0.1.0" in result.stdout
-
-
-def test_update_deprecation_notice_honors_the_wrapper_command(
-    monkeypatch: pytest.MonkeyPatch, _wheel_install: None
-) -> None:
-    """Under a wrapper the notice says ``isaac omni upgrade``, not ``omni``.
-
-    The wrapper guard rejects naked ``omnigent`` calls, so a hint spelling the
-    naked binary would name a command that cannot run.
-    """
-    monkeypatch.setenv(WRAPPER_COMMAND_ENV, "isaac omni")
-    monkeypatch.setattr("omnigent.update_check.fetch_latest_version", lambda *_a, **_k: "0.1.0")
-    monkeypatch.setattr(
-        "omnigent.update_check._run_upgrade_command",
-        lambda *_a, **_k: pytest.fail("upgrade ran while already up to date"),
-    )
-
-    result = CliRunner().invoke(cli, ["update"])
-
-    assert result.exit_code == 0, result.output
-    assert "`isaac omni upgrade`" in result.stderr
+    assert "up to date" in result.output
+    assert "0.1.0" in result.output
 
 
 def test_update_check_matches_upgrade_check(
@@ -409,11 +383,8 @@ def test_update_check_matches_upgrade_check(
     upgrade_result = runner.invoke(cli, ["upgrade", "--check"])
 
     assert update_result.exit_code == upgrade_result.exit_code == 1
-    assert update_result.stdout == upgrade_result.stdout
-    assert "v0.1.0 → v0.2.0" in update_result.stdout
-    # The warning is the only difference between the two.
-    assert "`update` is deprecated" in update_result.stderr
-    assert "deprecated" not in upgrade_result.stderr
+    assert update_result.output == upgrade_result.output
+    assert "v0.1.0 → v0.2.0" in update_result.output
 
 
 def test_update_suppresses_update_check_like_upgrade() -> None:

--- a/tests/e2e_ui/desktop/test_about_dialog.py
+++ b/tests/e2e_ui/desktop/test_about_dialog.py
@@ -62,7 +62,7 @@ def test_about_dialog_update_flow(page: Page) -> None:
     expect(page.get_by_text("0.13.0", exact=True)).to_be_visible()
     expect(page.get_by_text("0.13.0.dev0", exact=True)).to_be_visible()
     expect(page.get_by_text("/Users/alice/.local/bin/omnigent", exact=True)).to_be_visible()
-    expect(page.get_by_text("omni upgrade", exact=True)).to_be_visible()
+    expect(page.get_by_text("omni update", exact=True)).to_be_visible()
 
     update_now = page.get_by_role("button", name="Update now")
     expect(update_now).to_be_visible()

--- a/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
+++ b/tests/e2e_ui/sessions/test_new_session_optimistic_title.py
@@ -147,12 +147,9 @@ def test_new_session_shows_first_prompt_optimistically(
 
     # Sanity: the real auto-send handoff ran (its POST was intercepted),
     # so a green run isn't a composer that silently never sent.
-    # Pump the driver with wait_for_timeout, not time.sleep: the sync API
-    # dispatches route handlers only inside Playwright calls, so a bare
-    # sleep loop never runs handle_events for a late-landing POST.
     deadline = time.monotonic() + 15
     while time.monotonic() < deadline and _PROMPT not in event_texts:
-        page.wait_for_timeout(50)
+        time.sleep(0.05)
     assert _PROMPT in event_texts, (
         f"the initial prompt was never POSTed to the session's /events "
         f"(observed: {event_texts}) — the auto-send path did not run"

--- a/web/electron/README.md
+++ b/web/electron/README.md
@@ -51,7 +51,7 @@ adds native niceties:
   native `Cmd+,` accelerator on macOS (`Ctrl+,` elsewhere) and routes the
   focused connected window through the SPA without reloading it. On macOS,
   **About Omnigent** opens a shell-owned modal showing the platform app and
-  detected CLI versions; the CLI section points users to `omni upgrade`.
+  detected CLI versions; the CLI section points users to `omni update`.
   **Check for Updates…** in
   the Server menu opens the same modal and starts a check. **Update now** in the
   shell update prompt opens the modal, hides the prompt, and starts the download;

--- a/web/electron/about/index.html
+++ b/web/electron/about/index.html
@@ -389,7 +389,7 @@
             <dt>Path</dt>
             <dd><code id="cli-path">Loading…</code></dd>
           </dl>
-          <p class="cli-update">Run <code>omni upgrade</code> to update.</p>
+          <p class="cli-update">Run <code>omni update</code> to update.</p>
         </section>
 
         <footer class="footer">

--- a/web/electron/test/about_window.test.js
+++ b/web/electron/test/about_window.test.js
@@ -244,7 +244,7 @@ describe("About window", () => {
     assert.match(html, /id="desktop-update-now"[^>]*>Update now<\/button>/);
     assert.match(html, /aria-label="Update download progress"/);
     assert.match(html, /id="desktop-restart"[^>]*>Restart to update<\/button>/);
-    assert.match(html, /Run <code>omni upgrade<\/code> to update\./);
+    assert.match(html, /Run <code>omni update<\/code> to update\./);
     assert.match(html, /id="close"[^>]*>Close<\/button>/);
     assert.match(script, /info\.appIconDataUrl\.startsWith\("data:image\/"\)/);
     assert.match(script, /desktopHeading\.textContent = `Omnigent \$\{platformName\} app`/);


### PR DESCRIPTION
## Related issue

Not required — Refactor / chore. Reverts #6362.

## Summary

- Restore `omni update` as a supported, silent alias of `omni upgrade` rather than a deprecated forwarding command.
- Restore the Electron About dialog's `omni update` hint, documentation, and original test expectations.
- Exactly reverse all eight files from commit `2ab561b9f43b4e95ef89593a129bd8083af2d132`, including its bundled optimistic-title E2E polling change, while preserving subsequent changes on `main`.

## Test Plan

- CLI tests: **376 passed** with the machine's wrapper environment removed so entry-point and wrapper-guard tests exercise their intended environments:
  ```sh
  env -u OMNIGENT_REQUIRE_WRAPPER -u OMNIGENT_WRAPPER_COMMAND -u OMNIGENT_WRAPPER_BYPASS \
    uv run --no-sync pytest tests/cli/test_cli.py tests/cli/test_upgrade_command.py -q
  ```
- Electron unit tests: **13 passed** with `(cd web/electron && node --test test/about_window.test.js)`.
- About dialog browser test: **1 passed** with `uv run --no-sync pytest tests/e2e_ui/desktop/test_about_dialog.py -q`.
- Verified the staged patch matches the original commit's exact inverse using zero-context stable patch IDs; `git diff --cached --check` passes.
- Ran `uv run --no-sync pre-commit run` on all staged changes. All applicable checks pass except a pre-existing Pyrefly error in `omnigent/harnesses/opencode_native/provider.py:363` (`object` passed to `WorkspaceClient(config=...)`). Reproduced the same error in a clean `origin/main` worktree; left that unrelated code unchanged.

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

About dialog captured by the passing Chromium E2E test using its mocked Electron preload bridge. The CLI hint reads **Run `omni update` to update.** The image lives on a separate evidence branch and is not part of the revert diff.

![About dialog with the restored omni update hint](https://raw.githubusercontent.com/yaoharry/omnigent/2036383f4e1dd1679c89b6eaaa8d3b822bba1654/about-dialog.png)

To verify manually, run `omni update --check` and confirm there is no deprecation warning, then open the desktop app's About dialog and confirm the `omni update` hint. `--check` does not install an update.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Restores tests asserting that `update` and `upgrade` are the same Click command, have identical output and exit status, and keep the alias out of root help. The About dialog test covers the restored hint and desktop update states without installing an update. The session optimistic-title E2E test's original polling loop is restored as part of the complete revert; that session-flow test was not rerun.

## Changelog

You can use `omni update` without a deprecation warning; it remains an alias of `omni upgrade`.
