### PR TITLE
Prevent split Codex recovery thread bindings

### DIFF
--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4419,6 +4419,8 @@ async def _auto_create_codex_terminal(
         ws_url=codex_ws_url,
         client_name="omnigent-codex-native-auto",
     )
+    replace_external_session_id_from: str | None = None
+    thread_reset_error: str | None = None
     if launch_config.external_session_id is not None:
         from omnigent.harnesses.codex_native.bridge import (
             CodexNativeBridgeState,
@@ -4451,13 +4453,11 @@ async def _auto_create_codex_terminal(
                 exc,
                 extra={"session_id": session_id},
             )
-            codex_error = (
+            replace_external_session_id_from = launch_config.external_session_id
+            thread_reset_error = (
                 exc.message
                 if isinstance(exc, CodexAppServerResponseError) and exc.message
                 else str(exc)
-            )
-            await _post_codex_thread_reset_notice(
-                session_id=session_id, server_client=server_client, codex_error=codex_error
             )
             launch_config = dataclasses.replace(launch_config, external_session_id=None)
         else:
@@ -4641,6 +4641,14 @@ async def _auto_create_codex_terminal(
                 login_required=_codex_launch.login_required,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
+                **(
+                    {
+                        "replace_external_session_id_from": replace_external_session_id_from,
+                        "thread_reset_error": thread_reset_error,
+                    }
+                    if replace_external_session_id_from is not None
+                    else {}
+                ),
             )
             if launch_config.external_session_id is None
             else _codex_forward_known_thread(
@@ -4699,6 +4707,8 @@ async def _codex_discover_thread_and_forward(
     login_required: bool = False,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
+    replace_external_session_id_from: str | None = None,
+    thread_reset_error: str | None = None,
 ) -> None:
     """
     Adopt the fresh Codex TUI's thread, then mirror it into the Omnigent session.
@@ -4738,6 +4748,10 @@ async def _codex_discover_thread_and_forward(
         endpoint a re-created terminal has since installed.
     :param turn_router: First-message routing endpoint this launch
         started, torn down alongside the subagent one.
+    :param replace_external_session_id_from: Persisted unreadable thread id
+        that must still be current before binding the discovered replacement.
+    :param thread_reset_error: Codex error to log after a replacement id is
+        safely bound.
     """
     from omnigent.harnesses.codex_native.bridge import (
         CodexNativeBridgeState,
@@ -4813,23 +4827,28 @@ async def _codex_discover_thread_and_forward(
             # The user signed in (or the TUI otherwise started a thread):
             # the pre-recorded fail-fast cause no longer applies.
             clear_bridge_startup_error(bridge_dir)
-        write_bridge_state(
-            bridge_dir,
-            CodexNativeBridgeState(
-                session_id=session_id,
-                socket_path=codex_ws_url,
-                thread_id=thread_id,
-                codex_home=str(codex_home),
-                # The session workspace: without it the executor falls back
-                # to the runner process's own cwd when starting turns.
-                cwd=workspace,
-            ),
-        )
-
         server_url = _required_runner_env("RUNNER_SERVER_URL")
         auth_factory = _make_auth_token_factory()
         auth_token = auth_factory() if auth_factory is not None else None
         headers: dict[str, str] = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+        from omnigent.runner._entry import _runner_tunnel_binding_token_from_env
+        from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER
+
+        binding_token = _runner_tunnel_binding_token_from_env()
+        if binding_token is not None:
+            headers[RUNNER_TUNNEL_TOKEN_HEADER] = binding_token
+
+        if replace_external_session_id_from is None:
+            write_bridge_state(
+                bridge_dir,
+                CodexNativeBridgeState(
+                    session_id=session_id,
+                    socket_path=codex_ws_url,
+                    thread_id=thread_id,
+                    codex_home=str(codex_home),
+                    cwd=workspace,
+                ),
+            )
 
         # Mirror the discovered Codex thread id onto the Omnigent session as its
         # external_session_id, the same way claude-native records its
@@ -4839,9 +4858,9 @@ async def _codex_discover_thread_and_forward(
         # external_session_id, and the forked clone's runner clones this
         # thread's rollout from it (see _clone_codex_rollout). Without it a
         # host-spawned codex session has no recorded thread id, so a fork
-        # would resume fresh. Best-effort: a transient Omnigent failure here still
-        # leaves chat streaming working — only fork-history carry-over
-        # degrades.
+        # would resume fresh. Fresh-thread discovery records this best-effort;
+        # unreadable-thread replacement must bind it before bridge publication
+        # so a stale runner cannot split the web chat from the terminal.
         from omnigent.cli_auth import open_server_client
 
         try:
@@ -4851,10 +4870,31 @@ async def _codex_discover_thread_and_forward(
                 auth=_RunnerDatabricksAuth(auth_factory),
                 timeout=httpx.Timeout(10.0),
             ) as _ext_client:
+                patch_body = {"external_session_id": thread_id}
+                if replace_external_session_id_from is not None:
+                    patch_body["expected_external_session_id"] = replace_external_session_id_from
                 _ext_resp = await _ext_client.patch(
                     f"/v1/sessions/{urllib.parse.quote(session_id, safe='')}",
-                    json={"external_session_id": thread_id},
+                    json=patch_body,
                 )
+                if replace_external_session_id_from is not None:
+                    _ext_resp.raise_for_status()
+                    write_bridge_state(
+                        bridge_dir,
+                        CodexNativeBridgeState(
+                            session_id=session_id,
+                            socket_path=codex_ws_url,
+                            thread_id=thread_id,
+                            codex_home=str(codex_home),
+                            cwd=workspace,
+                        ),
+                    )
+                    if thread_reset_error is not None:
+                        await _post_codex_thread_reset_notice(
+                            session_id=session_id,
+                            server_client=_ext_client,
+                            codex_error=thread_reset_error,
+                        )
             if _ext_resp.status_code >= 400:
                 _logger.warning(
                     "AP rejected codex external_session_id PATCH (%s); session=%s thread=%s — "
@@ -4865,6 +4905,14 @@ async def _codex_discover_thread_and_forward(
                     extra={"session_id": session_id},
                 )
         except httpx.HTTPError:
+            if replace_external_session_id_from is not None:
+                _logger.error(
+                    "Could not compare-and-swap codex external_session_id for %s; "
+                    "closing the replacement thread to avoid web/TUI divergence",
+                    session_id,
+                    exc_info=True,
+                )
+                raise
             _logger.warning(
                 "Could not record codex external_session_id for %s; a fork of this "
                 "session will resume fresh",

--- a/omnigent/server/API.md
+++ b/omnigent/server/API.md
@@ -827,12 +827,19 @@ Request body:
     400 `invalid_input`. Wrapper bridges should write the value once
     when they first observe it from the underlying runtime.
 
+  expected_external_session_id (string, optional)
+    Compare-and-swap guard for runtime recovery. When present, both it
+    and `external_session_id` must be non-empty. The replacement succeeds
+    only when the stored id still equals the expected value. Multi-user
+    servers also require proof from the session's currently bound runner;
+    retrying after a successful replacement is idempotent.
+
 200 OK - body matches the `SessionResponse` shape above, with
 `runner_id` set to the newly bound value when `runner_id` was present.
 
 400 Bad Request - runner is not currently registered; `collaboration_mode`
 is used on a non-Codex-native session; or `external_session_id` would
-overwrite a different existing value
+overwrite a different existing value or fail its compare-and-swap guard
 404 Not Found - no session with that id
 
 This is the mutable affinity primitive for Alpha. The same endpoint

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -42,6 +42,7 @@ from omnigent.errors import ErrorCategory, ErrorCode, ErrorImpact, ErrorPhase, O
 from omnigent.models.model_override import validate_model_override
 from omnigent.runner.identity import (
     RUNNER_TUNNEL_TOKEN_HEADER,
+    token_bound_runner_id,
 )
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runner.session_init_protocol import build_runner_session_init_payload
@@ -1976,6 +1977,46 @@ def register_core_routes(
                     f"To fork this session instead, run: omnigent run --fork {session_id}",
                     code=ErrorCode.FORBIDDEN,
                 )
+        replace_external_session_id = "expected_external_session_id" in body.model_fields_set
+        replacement_runner_id: str | None = None
+        if replace_external_session_id and (
+            body.expected_external_session_id is None
+            or not body.expected_external_session_id.strip()
+            or body.external_session_id is None
+            or not body.external_session_id.strip()
+        ):
+            raise OmnigentError(
+                "expected_external_session_id requires a non-empty external_session_id and "
+                "expected value",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        if replace_external_session_id and permission_store is not None:
+            tunnel_token = (request.headers.get(RUNNER_TUNNEL_TOKEN_HEADER) or "").strip()
+            if not tunnel_token:
+                raise OmnigentError(
+                    "Replacing external_session_id requires proof from the session's "
+                    "currently bound runner",
+                    code=ErrorCode.FORBIDDEN,
+                )
+            current = await asyncio.to_thread(
+                conversation_store.get_conversation,
+                session_id,
+            )
+            if current is None:
+                raise _session_not_found()
+            bound_runner_id = current.runner_id
+            authorized_runner = (
+                runner_tunnel_tokens is not None and tunnel_token in runner_tunnel_tokens
+            ) or (
+                bound_runner_id is not None
+                and token_bound_runner_id(tunnel_token) == bound_runner_id
+            )
+            if bound_runner_id is None or not authorized_runner:
+                raise OmnigentError(
+                    "Only the session's currently bound runner may replace external_session_id",
+                    code=ErrorCode.FORBIDDEN,
+                )
+            replacement_runner_id = bound_runner_id
         if body.labels:
             _reject_server_reserved_label_seed(body.labels)
             # Advisor-owned cost_control.* labels are written only by the
@@ -2457,20 +2498,28 @@ def register_core_routes(
             )
         if body.external_session_id is not None:
             try:
-                await asyncio.to_thread(
-                    conversation_store.set_external_session_id,
-                    session_id,
-                    body.external_session_id,
-                )
+                if replace_external_session_id:
+                    assert body.expected_external_session_id is not None
+                    await asyncio.to_thread(
+                        conversation_store.replace_external_session_id,
+                        session_id,
+                        expected_value=body.expected_external_session_id,
+                        value=body.external_session_id,
+                        expected_runner_id=replacement_runner_id,
+                    )
+                else:
+                    await asyncio.to_thread(
+                        conversation_store.set_external_session_id,
+                        session_id,
+                        body.external_session_id,
+                    )
             except ConversationNotFoundError as exc:
                 # Race: row vanished between the update above and this
                 # write. Reuse the NOT_FOUND code for consistency.
                 raise _session_not_found() from exc
             except ValueError as exc:
-                # Store raises ValueError on attempted overwrite of an
-                # already-set external_session_id — surface as
-                # invalid_input so the caller (a wrapper bridge) sees a
-                # 400 with the conflict explained.
+                # Store raises ValueError on an unguarded overwrite or a
+                # failed compare-and-swap. Surface the conflict to the caller.
                 raise OmnigentError(
                     str(exc),
                     code=ErrorCode.INVALID_INPUT,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -2244,6 +2244,11 @@ class UpdateSessionRequest(BaseModel):
         writes; the server rejects attempts to overwrite an
         already-set different value with ``invalid_input`` to
         surface programmer errors. ``None`` leaves unchanged.
+    :param expected_external_session_id: Optional compare-and-swap guard for
+        recovery. When present, ``external_session_id`` replaces the stored
+        value only if it still equals this expected id; multi-user servers
+        additionally require proof from the currently bound runner. Omitted
+        for ordinary first-write and idempotent bridge updates.
     :param terminal_launch_args: Per-session native-terminal
         pass-through args, e.g. ``["--dangerously-skip-permissions"]``.
         A list (including ``[]``) replaces the stored value wholesale
@@ -2286,6 +2291,7 @@ class UpdateSessionRequest(BaseModel):
     subagent_routing_override: str | None = None
     share_workspace_files: bool | None = None
     external_session_id: str | None = None
+    expected_external_session_id: str | None = None
     terminal_launch_args: list[str] | None = None
     archived: bool | None = None
     project_id: str | None = None

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -1531,6 +1531,33 @@ class ConversationStore(ABC):
         ...
 
     @abstractmethod
+    def replace_external_session_id(
+        self,
+        conversation_id: str,
+        *,
+        expected_value: str,
+        value: str,
+        expected_runner_id: str | None = None,
+    ) -> Conversation:
+        """Compare-and-swap the runtime-native session id.
+
+        Recovery code uses this when the persisted native thread is unreadable
+        and the runtime creates a replacement. Retrying is idempotent when the
+        row already contains ``value``; a stale runner cannot replace a newer
+        binding.
+
+        :param conversation_id: Conversation to update.
+        :param expected_value: Native session id the caller observed.
+        :param value: Replacement native session id.
+        :param expected_runner_id: Optional runner binding that must still own
+            the conversation when the replacement lands.
+        :returns: The updated :class:`Conversation`.
+        :raises ConversationNotFoundError: If the conversation does not exist.
+        :raises ValueError: If the current id matches neither expected nor new.
+        """
+        ...
+
+    @abstractmethod
     def create_session_with_agent(
         self,
         *,

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -3688,6 +3688,66 @@ class SqlAlchemyConversationStore(ConversationStore):
         )
         return _to_conversation(ap_row, meta, labels)
 
+    def replace_external_session_id(
+        self,
+        conversation_id: str,
+        *,
+        expected_value: str,
+        value: str,
+        expected_runner_id: str | None = None,
+    ) -> Conversation:
+        """Compare-and-swap a runtime-native session id during recovery."""
+        with self._session("replace_external_session_id") as session:
+            predicates = [
+                SqlConversationMetadata.workspace_id == current_workspace_id(),
+                SqlConversationMetadata.id == conversation_id,
+                SqlConversationMetadata.external_session_id == expected_value,
+            ]
+            if expected_runner_id is not None:
+                predicates.append(SqlConversationMetadata.runner_id == expected_runner_id)
+            result = cast(
+                _RowCountResult,
+                session.execute(
+                    update(SqlConversationMetadata)
+                    .where(*predicates)
+                    .values(external_session_id=value)
+                    .execution_options(synchronize_session=False)
+                ),
+            )
+            changed = result.rowcount == 1
+            meta = session.get(
+                SqlConversationMetadata,
+                (current_workspace_id(), conversation_id),
+                populate_existing=True,
+            )
+            if meta is None:
+                raise ConversationNotFoundError(
+                    f"conversation {conversation_id!r} does not exist",
+                )
+            runner_matches = expected_runner_id is None or meta.runner_id == expected_runner_id
+            if not changed and (meta.external_session_id != value or not runner_matches):
+                raise ValueError(
+                    f"conversation {conversation_id!r} has "
+                    f"external_session_id={meta.external_session_id!r} and "
+                    f"runner_id={meta.runner_id!r}; expected {expected_value!r}"
+                    + (
+                        f" on runner {expected_runner_id!r}"
+                        if expected_runner_id is not None
+                        else ""
+                    )
+                    + f" before replacing it with {value!r}",
+                )
+        with self._conv_session("replace_external_session_id") as ap_sess:
+            ap_row = ap_sess.get(SqlConversation, (current_workspace_id(), conversation_id))
+            if ap_row is None:
+                raise ConversationNotFoundError(
+                    f"conversation {conversation_id!r} does not exist",
+                )
+            if changed:
+                ap_row.updated_at = now_epoch()
+            labels = _fetch_labels(ap_sess, conversation_id)
+        return _to_conversation(ap_row, meta, labels)
+
     def create_session_with_agent(
         self,
         *,

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -707,6 +707,169 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
 
 
 @pytest.mark.asyncio
+async def test_auto_create_codex_terminal_recovers_unreadable_resume_with_cas_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreadable persisted thread launches fresh and carries its CAS guard."""
+    from omnigent.harnesses.codex_native import app_server as codex_app_mod
+    from omnigent.runner import app as runner_app_mod
+
+    session_id = "56d0e57c1a154fe4b79fbb7b88b2d330"
+    old_thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "codex-bridge")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path / "workspace"))
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    class _SnapshotServerClient:
+        async def get(self, url: str, **kwargs: Any) -> httpx.Response:
+            del kwargs
+            if url == f"/v1/sessions/{session_id}/items":
+                return httpx.Response(
+                    200,
+                    json={"data": [], "has_more": False},
+                    request=httpx.Request("GET", url),
+                )
+            return httpx.Response(
+                200,
+                json={"external_session_id": old_thread_id},
+                request=httpx.Request("GET", url),
+            )
+
+    class _FakeCodexAppServer:
+        codex_path = "/opt/codex/bin/codex"
+        codex_cli_version: tuple[int, int, int] | None = None
+
+        def __init__(self) -> None:
+            self.env = {"OPENAI_API_KEY": "sk-test"}
+            self.codex_home = tmp_path / "unconfigured-codex-home"
+            self.listen_url: str | None = None
+            self.config_overrides: list[str] = []
+
+        async def start(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    app_server = _FakeCodexAppServer()
+
+    def _fake_build_codex_native_server(**kwargs: Any) -> _FakeCodexAppServer:
+        app_server.codex_home = kwargs["codex_home"]
+        return app_server
+
+    event_client_connected = False
+
+    class _DiscoveryClient:
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            self.ws_url = ws_url
+            self.client_name = client_name
+
+        async def connect(self) -> None:
+            nonlocal event_client_connected
+            event_client_connected = True
+
+        async def close(self) -> None:
+            return None
+
+    async def _unreadable_preload(
+        transport: str,
+        loaded_thread_id: str,
+        *,
+        terminal_launch_args: list[str] | None = None,
+    ) -> None:
+        del transport, terminal_launch_args
+        assert loaded_thread_id == old_thread_id
+        raise codex_app_mod.CodexAppServerResponseError(
+            {
+                "code": -32603,
+                "message": "thread-store internal error: malformed rollout",
+            }
+        )
+
+    launched_specs: list[Any] = []
+
+    class _FakeResourceRegistry:
+        async def launch_auxiliary_terminal(
+            self,
+            *,
+            session_id: str,
+            terminal_name: str,
+            session_key: str,
+            spec: Any,
+            resource_role: str | None = None,
+            parent_os_env: Any = None,
+        ) -> SessionResourceView:
+            del terminal_name, session_key, resource_role, parent_os_env
+            launched_specs.append(spec)
+            return SessionResourceView(
+                id="terminal_codex_main",
+                type="terminal",
+                session_id=session_id,
+                name="Codex",
+            )
+
+    discovery_calls: list[dict[str, Any]] = []
+
+    async def _fake_discover_thread_and_forward(**kwargs: Any) -> None:
+        discovery_calls.append(kwargs)
+
+    async def _unexpected_known_thread_forwarder(**kwargs: Any) -> None:
+        raise AssertionError(f"unreadable resume used known-thread forwarding: {kwargs}")
+
+    monkeypatch.setattr(
+        codex_app_mod,
+        "build_codex_native_server",
+        _fake_build_codex_native_server,
+    )
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _DiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _unreadable_preload)
+    monkeypatch.setattr(
+        runner_app_mod,
+        "_codex_discover_thread_and_forward",
+        _fake_discover_thread_and_forward,
+    )
+    monkeypatch.setattr(
+        runner_app_mod,
+        "_codex_forward_known_thread",
+        _unexpected_known_thread_forwarder,
+    )
+
+    agent_spec = AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex-native", "model": "gpt-5-default"},
+        ),
+    )
+
+    try:
+        await _auto_create_codex_terminal(
+            session_id,
+            _FakeResourceRegistry(),  # type: ignore[arg-type]
+            lambda _sid, _event: None,
+            agent_spec=agent_spec,
+            server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
+        )
+        await asyncio.sleep(0)
+    finally:
+        runner_app_mod._AUTO_FORWARDER_TASKS.pop(session_id, None)
+        runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+
+    assert event_client_connected is True
+    assert len(launched_specs) == 1
+    assert "resume" not in launched_specs[0].args
+    assert len(discovery_calls) == 1
+    assert discovery_calls[0]["replace_external_session_id_from"] == old_thread_id
+    assert discovery_calls[0]["thread_reset_error"] == (
+        "thread-store internal error: malformed rollout"
+    )
+
+
+@pytest.mark.asyncio
 async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3287,6 +3450,170 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
     assert state is not None
     assert state.thread_id == thread_id
     assert state.cwd == str(workspace)
+
+
+@pytest.mark.asyncio
+async def test_codex_discover_thread_and_forward_compare_and_swaps_replacement_thread(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unreadable-thread recovery binds the replacement before forwarding."""
+    from omnigent import cli_auth
+    from omnigent.harnesses.codex_native import forwarder as codex_native_forwarder
+    from omnigent.runner.app import (
+        _AUTO_CODEX_APP_SERVERS,
+        _codex_discover_thread_and_forward,
+    )
+
+    old_thread_id = "019e96aa-old0-7343-8d3b-6f914d60936b"
+    new_thread_id = "019e96aa-new0-7343-8d3b-6f914d60936b"
+    requests: list[tuple[str, dict[str, Any]]] = []
+    client_headers: list[dict[str, str]] = []
+    supervised: list[str] = []
+
+    async def _fake_wait(*_args: object, **_kwargs: object) -> str:
+        return new_thread_id
+
+    async def _fake_supervise(**kwargs: object) -> None:
+        supervised.append(cast(str, kwargs["thread_id"]))
+
+    class _Response:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class _ServerClient:
+        async def patch(self, url: str, *, json: dict[str, Any]) -> _Response:
+            requests.append((url, json))
+            return _Response()
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict[str, Any],
+            timeout: float,
+        ) -> _Response:
+            del timeout
+            requests.append((url, json))
+            return _Response()
+
+    @contextlib.asynccontextmanager
+    async def _fake_open_server_client(*_args: object, **kwargs: object):
+        client_headers.append(cast(dict[str, str], kwargs["headers"]))
+        yield _ServerClient()
+
+    class _EventClient:
+        async def close(self) -> None:
+            return None
+
+    class _AppServer:
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _fake_wait)
+    monkeypatch.setattr(codex_native_forwarder, "supervise_forwarder", _fake_supervise)
+    monkeypatch.setattr(cli_auth, "open_server_client", _fake_open_server_client)
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.setenv("OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN", "runner-proof")
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    session_id = "cas-replacement-session"
+    _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
+    await _codex_discover_thread_and_forward(
+        session_id=session_id,
+        bridge_dir=tmp_path,
+        codex_ws_url="ws://127.0.0.1:1",
+        codex_home=tmp_path / "codex-home",
+        workspace=str(tmp_path / "workspace"),
+        event_client=_EventClient(),  # type: ignore[arg-type]
+        routing_summary="provider 'test' (model=gpt-test)",
+        replace_external_session_id_from=old_thread_id,
+        thread_reset_error="thread-store internal error: malformed rollout",
+    )
+
+    assert requests[0] == (
+        f"/v1/sessions/{session_id}",
+        {
+            "external_session_id": new_thread_id,
+            "expected_external_session_id": old_thread_id,
+        },
+    )
+    assert client_headers == [{"X-Omnigent-Runner-Tunnel-Token": "runner-proof"}]
+    notice_data = requests[1][1]["data"]["item_data"]
+    assert notice_data["code"] == "codex_thread_reset"
+    assert notice_data["level"] == "info"
+    assert (
+        "Codex reported: thread-store internal error: malformed rollout" in notice_data["message"]
+    )
+    assert supervised == [new_thread_id]
+    state = codex_native_bridge.read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.thread_id == new_thread_id
+
+
+@pytest.mark.asyncio
+async def test_codex_discover_thread_and_forward_closes_on_replacement_cas_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed replacement CAS stops the native thread instead of diverging."""
+    from omnigent import cli_auth
+    from omnigent.harnesses.codex_native import forwarder as codex_native_forwarder
+    from omnigent.runner.app import (
+        _AUTO_CODEX_APP_SERVERS,
+        _codex_discover_thread_and_forward,
+    )
+
+    async def _fake_wait(*_args: object, **_kwargs: object) -> str:
+        return "019e96aa-new0-7343-8d3b-6f914d60936b"
+
+    class _ServerClient:
+        async def patch(self, url: str, *, json: dict[str, Any]) -> httpx.Response:
+            return httpx.Response(400, request=httpx.Request("PATCH", url), json={"error": json})
+
+    @contextlib.asynccontextmanager
+    async def _fake_open_server_client(*_args: object, **_kwargs: object):
+        yield _ServerClient()
+
+    class _EventClient:
+        async def close(self) -> None:
+            return None
+
+    class _AppServer:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def close(self) -> None:
+            self.closed = True
+
+    async def _unexpected_supervise(**_kwargs: object) -> None:
+        raise AssertionError("forwarder must not start after a failed replacement CAS")
+
+    monkeypatch.setattr(codex_native_forwarder, "wait_for_thread_started", _fake_wait)
+    monkeypatch.setattr(codex_native_forwarder, "supervise_forwarder", _unexpected_supervise)
+    monkeypatch.setattr(cli_auth, "open_server_client", _fake_open_server_client)
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+
+    session_id = "cas-conflict-session"
+    app_server = _AppServer()
+    _AUTO_CODEX_APP_SERVERS[session_id] = app_server
+    with pytest.raises(httpx.HTTPStatusError):
+        await _codex_discover_thread_and_forward(
+            session_id=session_id,
+            bridge_dir=tmp_path,
+            codex_ws_url="ws://127.0.0.1:1",
+            codex_home=tmp_path / "codex-home",
+            workspace=str(tmp_path / "workspace"),
+            event_client=_EventClient(),  # type: ignore[arg-type]
+            routing_summary="provider 'test' (model=gpt-test)",
+            replace_external_session_id_from="019e96aa-old0-7343-8d3b-6f914d60936b",
+        )
+
+    assert app_server.closed is True
+    assert codex_native_bridge.read_bridge_state(tmp_path) is None
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -1363,10 +1363,11 @@ async def test_auto_create_codex_terminal_unreadable_thread_starts_fresh(
             )
 
     runs: list[_ForwarderRun] = []
+    discovery_calls: list[dict[str, Any]] = []
 
     async def _parking_discover_thread(**kwargs: Any) -> None:
         """Park forever in place of the fresh-thread discovery forwarder."""
-        del kwargs
+        discovery_calls.append(kwargs)
         run = _ForwarderRun(task=asyncio.current_task())
         runs.append(run)
         try:
@@ -1413,17 +1414,12 @@ async def test_auto_create_codex_terminal_unreadable_thread_starts_fresh(
         await asyncio.sleep(0)
 
         assert closed == [], "the fallback must keep the app-server for the fresh thread"
-        assert [p["url"] for p in posted] == [f"/v1/sessions/{session_id}/events"], (
-            "the fallback must surface exactly one notice into the session"
+        assert posted == [], (
+            "the recovery notice must wait until the replacement thread is discovered and bound"
         )
-        notice = posted[0]["json"]
-        assert notice["type"] == "external_conversation_item"
-        assert notice["data"]["item_type"] == "error"
-        assert notice["data"]["item_data"]["code"] == "codex_thread_reset"
-        assert notice["data"]["item_data"]["level"] == "info"
-        # The body names codex as the source and quotes its own error text.
-        assert "Codex reported an internal error" in notice["data"]["item_data"]["message"]
-        assert "stream did not contain valid UTF-8" in notice["data"]["item_data"]["message"]
+        assert len(discovery_calls) == 1
+        assert discovery_calls[0]["replace_external_session_id_from"] == thread_id
+        assert "stream did not contain valid UTF-8" in discovery_calls[0]["thread_reset_error"]
         assert connected == ["omnigent-codex-native-auto"], (
             "the fresh-thread path must connect the discovery listener"
         )

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -3201,6 +3201,74 @@ async def test_patch_session_external_session_id_rejects_overwrite(
     assert after.json()["external_session_id"] == "sid-1"
 
 
+async def test_patch_session_external_session_id_compare_and_swap(
+    client: httpx.AsyncClient,
+) -> None:
+    """A guarded recovery PATCH replaces only the observed native thread id."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    first = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={"external_session_id": "sid-old"},
+    )
+    assert first.status_code == 200, first.text
+
+    replaced = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={
+            "external_session_id": "sid-new",
+            "expected_external_session_id": "sid-old",
+        },
+    )
+
+    assert replaced.status_code == 200, replaced.text
+    assert replaced.json()["external_session_id"] == "sid-new"
+
+
+async def test_patch_session_external_session_id_compare_and_swap_rejects_stale_runner(
+    client: httpx.AsyncClient,
+) -> None:
+    """A stale expected id returns 400 and preserves the newer binding."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    first = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={"external_session_id": "sid-current"},
+    )
+    assert first.status_code == 200, first.text
+
+    rejected = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={
+            "external_session_id": "sid-stale-runner",
+            "expected_external_session_id": "sid-old",
+        },
+    )
+
+    assert rejected.status_code == 400
+    after = await client.get(f"/v1/sessions/{session['id']}")
+    assert after.status_code == 200
+    assert after.json()["external_session_id"] == "sid-current"
+
+
+async def test_patch_session_external_session_id_compare_and_swap_requires_both_values(
+    client: httpx.AsyncClient,
+) -> None:
+    """An invalid CAS fails before any other requested mutation is applied."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    rejected = await client.patch(
+        f"/v1/sessions/{session['id']}",
+        json={"title": "must not persist", "expected_external_session_id": "sid-old"},
+    )
+
+    assert rejected.status_code == 400
+    after = await client.get(f"/v1/sessions/{session['id']}")
+    assert after.status_code == 200
+    assert after.json()["title"] != "must not persist"
+
+
 async def test_create_session_returns_null_external_session_id(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/server/routes/test_sessions_cost_labels.py
+++ b/tests/server/routes/test_sessions_cost_labels.py
@@ -385,6 +385,76 @@ def test_single_user_server_skips_the_gate(
     assert COST_CONTROL_PLAN_LABEL in conv.labels
 
 
+# ── PATCH: recovery CAS uses the same runner proof ───────────────────────────
+
+
+def test_token_bound_runner_authorizes_external_session_id_rebind(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore, SqlAlchemyPermissionStore],
+) -> None:
+    """A token-bound runner can atomically bind its replacement Codex thread."""
+    conversation_store = stores[0]
+    app = _multi_user_app(stores, runner_tunnel_tokens=frozenset({"pool-token"}))
+    conv_id = _seed_session(stores, runner_id=token_bound_runner_id(_RUNNER_TOKEN))
+    conversation_store.set_external_session_id(conv_id, "thread-old")
+
+    resp = TestClient(app).patch(
+        f"/v1/sessions/{conv_id}",
+        json={
+            "external_session_id": "thread-new",
+            "expected_external_session_id": "thread-old",
+        },
+        headers={
+            "X-Forwarded-Email": ALICE,
+            RUNNER_TUNNEL_TOKEN_HEADER: _RUNNER_TOKEN,
+        },
+    )
+
+    assert resp.status_code == 200
+    conv = conversation_store.get_conversation(conv_id)
+    assert conv is not None
+    assert conv.external_session_id == "thread-new"
+
+
+def test_allowlisted_stable_runner_authorizes_external_session_id_rebind(
+    stores: tuple[SqlAlchemyConversationStore, SqlAlchemyAgentStore, SqlAlchemyPermissionStore],
+) -> None:
+    """An allow-listed pool token can rebind a session using a stable runner id."""
+    conversation_store = stores[0]
+    app = _multi_user_app(stores, runner_tunnel_tokens=frozenset({"pool-token"}))
+    conv_id = _seed_session(stores, runner_id="runner_stable_pool_1")
+    conversation_store.set_external_session_id(conv_id, "thread-old")
+
+    rejected = TestClient(app).patch(
+        f"/v1/sessions/{conv_id}",
+        json={
+            "external_session_id": "thread-untrusted",
+            "expected_external_session_id": "thread-old",
+        },
+        headers={
+            "X-Forwarded-Email": ALICE,
+            RUNNER_TUNNEL_TOKEN_HEADER: "not-allowlisted",
+        },
+    )
+    assert rejected.status_code == 403
+
+    resp = TestClient(app).patch(
+        f"/v1/sessions/{conv_id}",
+        json={
+            "external_session_id": "thread-new",
+            "expected_external_session_id": "thread-old",
+        },
+        headers={
+            "X-Forwarded-Email": ALICE,
+            RUNNER_TUNNEL_TOKEN_HEADER: "pool-token",
+        },
+    )
+
+    assert resp.status_code == 200
+    conv = conversation_store.get_conversation(conv_id)
+    assert conv is not None
+    assert conv.external_session_id == "thread-new"
+
+
 # ── Create: no client may seed the namespace ─────────────────────────────────
 
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -3887,6 +3887,103 @@ def test_set_external_session_id_rejects_overwrite_with_different_value(
     assert fetched.external_session_id == "sid-1"
 
 
+def test_replace_external_session_id_compare_and_swap(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Recovery can replace exactly the stale native id it observed."""
+    conv = conversation_store.create_conversation()
+    conversation_store.set_external_session_id(conv.id, "sid-old")
+
+    updated = conversation_store.replace_external_session_id(
+        conv.id,
+        expected_value="sid-old",
+        value="sid-new",
+    )
+
+    assert updated.external_session_id == "sid-new"
+    fetched = conversation_store.get_conversation(conv.id)
+    assert fetched is not None
+    assert fetched.external_session_id == "sid-new"
+
+
+def test_replace_external_session_id_retry_is_idempotent(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A lost CAS response may be retried after the new id is already stored."""
+    conv = conversation_store.create_conversation()
+    conversation_store.set_external_session_id(conv.id, "sid-old")
+    conversation_store.replace_external_session_id(
+        conv.id,
+        expected_value="sid-old",
+        value="sid-new",
+    )
+
+    updated = conversation_store.replace_external_session_id(
+        conv.id,
+        expected_value="sid-old",
+        value="sid-new",
+    )
+
+    assert updated.external_session_id == "sid-new"
+
+
+def test_replace_external_session_id_same_expected_and_new_still_requires_match(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """Equal expected/new values cannot turn CAS into a first-write operation."""
+    conv = conversation_store.create_conversation()
+
+    with pytest.raises(ValueError, match="expected 'sid-new'"):
+        conversation_store.replace_external_session_id(
+            conv.id,
+            expected_value="sid-new",
+            value="sid-new",
+        )
+
+    fetched = conversation_store.get_conversation(conv.id)
+    assert fetched is not None
+    assert fetched.external_session_id is None
+
+
+def test_replace_external_session_id_rejects_stale_expected_value(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A stale runner cannot overwrite a newer native thread binding."""
+    conv = conversation_store.create_conversation()
+    conversation_store.set_external_session_id(conv.id, "sid-newer")
+
+    with pytest.raises(ValueError, match="expected 'sid-old'"):
+        conversation_store.replace_external_session_id(
+            conv.id,
+            expected_value="sid-old",
+            value="sid-stale-runner",
+        )
+
+    fetched = conversation_store.get_conversation(conv.id)
+    assert fetched is not None
+    assert fetched.external_session_id == "sid-newer"
+
+
+def test_replace_external_session_id_rejects_stale_runner(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """A recovery CAS cannot land after the conversation moves runners."""
+    conv = conversation_store.create_conversation(runner_id="runner-current")
+    conversation_store.set_external_session_id(conv.id, "sid-old")
+
+    with pytest.raises(ValueError, match="runner-current"):
+        conversation_store.replace_external_session_id(
+            conv.id,
+            expected_value="sid-old",
+            value="sid-stale-runner",
+            expected_runner_id="runner-stale",
+        )
+
+    fetched = conversation_store.get_conversation(conv.id)
+    assert fetched is not None
+    assert fetched.external_session_id == "sid-old"
+
+
 def test_set_external_session_id_missing_conversation_raises(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes [OMNI-6995](https://linear.app/omnigent/issue/OMNI-6995/codex-gui-and-tui-out-of-sync)

## Summary

- When Codex cannot read the recorded thread and starts a replacement, compare-and-swap `external_session_id` from the observed old thread to the new thread.
- Require proof from the session's currently bound runner on multi-user servers. Both token-bound runners and allow-listed stable pool runners are supported, and the SQL CAS checks the expected thread and runner atomically.
- Publish replacement bridge state and the reset notice only after the CAS succeeds; a losing recovery closes its replacement Codex thread instead of splitting terminal and Web UI history.

**ELI5:** if two recovery runners both open a replacement notebook, only the runner still assigned to the session may swap it in, and only one swap can win.

```text
stored thread A unreadable
        |
        +-- runner starts B
        |
        +-- CAS(expected=A, runner=current)
                 | success -> publish B to bridge
                 └ conflict -> close B
```

This PR does not change transcript cleanup or forwarder batching.

## Test Plan

- Focused runner, API, store, token-bound, and allow-listed CAS tests — 12 passed.
- Post-rebase adjacent suite — 592 passed, 1 skipped; one unrelated concurrent-usage test hit cross-test config state and passed immediately in isolation.
- `SKIP=pyrefly .venv/bin/pre-commit run --from-ref origin/main --to-ref HEAD` — passed. Full Pyrefly passed before the final rebase; current `main` has one unrelated baseline error in `omnigent/harnesses/opencode_native/provider.py:363`.
- Repeated critical subagent review found no remaining correctness or regression blockers.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The tests simulate competing recovery runners and verify token-bound and allow-listed authorization, stale-thread rejection, atomic runner predicates, delayed bridge publication, and replacement-thread cleanup after conflict.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Coverage exercises the runner-to-server request headers, multi-user authorization, SQL compare-and-swap behavior, and the native recovery lifecycle without requiring a live Codex process.

## Changelog

Codex recovery no longer splits terminal and Web UI history when it must replace an unreadable thread.
