### PR TITLE
Reduce Codex native forwarder backlog

### DIFF
--- a/omnigent/entities/conversation.py
+++ b/omnigent/entities/conversation.py
@@ -292,6 +292,9 @@ class MessageData(BaseModel):
         turn, e.g. Codex ``turn/completed`` with status
         ``"interrupted"``. Defaults to ``False`` and is omitted from
         serialized payloads in that case.
+    :param stream_message_id: Native live-preview stream finalized by
+        this assistant message. Persisted so reconnect snapshots can
+        suppress delayed preview chunks after the authoritative item.
     """
 
     role: Literal["user", "assistant"]
@@ -300,6 +303,7 @@ class MessageData(BaseModel):
     agent: str | None = Field(default=None, serialization_alias="model")
     is_meta: bool = Field(default=False, exclude_if=lambda value: value is False)
     interrupted: bool = Field(default=False, exclude_if=lambda value: value is False)
+    stream_message_id: str | None = None
 
     @model_validator(mode="after")
     def check_agent_for_assistant(self) -> MessageData:

--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -7,7 +7,7 @@ import contextlib
 import hashlib
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -2385,12 +2385,40 @@ async def _subscribe_until_ready(
     forwarder_state: _CodexForwarderState | None = None,
     ready_signal: asyncio.Event | None = None,
 ) -> None:
+    """Reserve authoritative delivery order while subscribing and replaying."""
+    async with _conversation_item_delivery_scope(session_id):
+        await _subscribe_until_ready_inner(
+            client,
+            ap_client,
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            thread_id=thread_id,
+            usage_coalescer=usage_coalescer,
+            elicitation_tracker=elicitation_tracker,
+            forwarder_state=forwarder_state,
+            ready_signal=ready_signal,
+        )
+
+
+async def _subscribe_until_ready_inner(
+    client: CodexAppServerClient,
+    ap_client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    thread_id: str,
+    usage_coalescer: _SessionUsageCoalescer,
+    elicitation_tracker: _CodexElicitationTaskTracker,
+    forwarder_state: _CodexForwarderState | None = None,
+    ready_signal: asyncio.Event | None = None,
+) -> None:
     """
     Subscribe this app-server connection to a Codex thread.
 
-    A resume session's thread already has a persisted rollout, so the
-    first ``thread/resume`` succeeds and any prior message items are
-    replayed immediately.
+    A resume session's thread already has a persisted rollout. Healthy idle
+    reconnects exclude old turns, while an interrupted forwarder replays from
+    the bridge's persisted active turn so completed items observed by Codex but
+    not acknowledged by Omnigent are recovered.
 
     A fresh TUI-created thread, however, has *no* rollout until its first
     turn runs — Codex defers materialization for a new thread, so
@@ -2421,11 +2449,17 @@ async def _subscribe_until_ready(
         signal).
     :returns: None.
     """
+    bridge_state = read_bridge_state(bridge_dir)
+    replay_from_turn_id = (
+        bridge_state.active_turn_id
+        if bridge_state is not None and bridge_state.thread_id == thread_id
+        else None
+    )
     saw_not_ready = False
     while True:
         try:
             params: _JsonObject = {"threadId": thread_id}
-            if not saw_not_ready:
+            if not saw_not_ready and replay_from_turn_id is None:
                 params["excludeTurns"] = True
             response = await client.request("thread/resume", params)
         except asyncio.CancelledError:
@@ -2488,6 +2522,7 @@ async def _subscribe_until_ready(
             usage_coalescer=usage_coalescer,
             elicitation_tracker=elicitation_tracker,
             forwarder_state=forwarder_state,
+            replay_from_turn_id=replay_from_turn_id,
         )
         return
 
@@ -2549,6 +2584,7 @@ async def _replay_resume_response(
     usage_coalescer: _SessionUsageCoalescer,
     elicitation_tracker: _CodexElicitationTaskTracker,
     forwarder_state: _CodexForwarderState | None = None,
+    replay_from_turn_id: str | None = None,
 ) -> None:
     """
     Mirror message items returned by ``thread/resume``.
@@ -2566,6 +2602,8 @@ async def _replay_resume_response(
     :param elicitation_tracker: Background Codex elicitation tracker.
     :param forwarder_state: Optional mutable state for dedup and
         sub-agent registration.
+    :param replay_from_turn_id: Optional first turn to replay after an
+        interrupted forwarder. Earlier acknowledged turns are skipped.
     :returns: None.
     """
     result = response.get("result")
@@ -2579,33 +2617,35 @@ async def _replay_resume_response(
         return
     thread_id = thread.get("id")
     thread_id = thread_id if isinstance(thread_id, str) and thread_id else None
-    for turn in turns:
-        if not isinstance(turn, dict):
-            continue
-        turn_id = _turn_id_from_payload(turn)
-        items = turn.get("items")
-        if not turn_id or not isinstance(items, list):
-            continue
-        for item in items:
-            if not isinstance(item, dict):
+    replay_turns = _resume_turns_from(turns, replay_from_turn_id)
+    async with _conversation_item_delivery_scope(session_id):
+        for turn in replay_turns:
+            if not isinstance(turn, dict):
                 continue
-            await _handle_event(
-                client,
-                session_id=session_id,
-                bridge_dir=bridge_dir,
-                event={
-                    "method": "item/completed",
-                    "params": {
-                        "threadId": thread_id,
-                        "turnId": turn_id,
-                        "item": item,
+            turn_id = _turn_id_from_payload(turn)
+            items = turn.get("items")
+            if not turn_id or not isinstance(items, list):
+                continue
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                await _handle_event(
+                    client,
+                    session_id=session_id,
+                    bridge_dir=bridge_dir,
+                    event={
+                        "method": "item/completed",
+                        "params": {
+                            "threadId": thread_id,
+                            "turnId": turn_id,
+                            "item": item,
+                        },
                     },
-                },
-                usage_coalescer=usage_coalescer,
-                elicitation_tracker=elicitation_tracker,
-                expected_thread_id=thread_id,
-                forwarder_state=forwarder_state,
-            )
+                    usage_coalescer=usage_coalescer,
+                    elicitation_tracker=elicitation_tracker,
+                    expected_thread_id=thread_id,
+                    forwarder_state=forwarder_state,
+                )
     await _post_resume_terminal_status(
         client,
         session_id=session_id,
@@ -2613,6 +2653,20 @@ async def _replay_resume_response(
         thread_id=thread_id,
         turns=turns,
     )
+
+
+def _resume_turns_from(turns: list[object], replay_from_turn_id: str | None) -> list[object]:
+    """Return the interrupted turn and every later Codex turn."""
+    if replay_from_turn_id is None:
+        return turns
+    for index, turn in enumerate(turns):
+        if isinstance(turn, dict) and _turn_id_from_payload(turn) == replay_from_turn_id:
+            return turns[index:]
+    _logger.warning(
+        "Codex active turn %s missing from resume response; replaying all turns",
+        replay_from_turn_id,
+    )
+    return turns
 
 
 async def _post_resume_terminal_status(
@@ -3342,61 +3396,65 @@ async def _maybe_handle_turn_event(
                 _turn_id_from_payload(params),
             )
             return True
-        if delta_coalescer is not None:
-            await delta_coalescer.flush()
-        error = _terminal_error_from_notification(params)
-        if error is None:
-            _logger.warning("Codex forwarder ignored malformed error notification")
-            return True
-        turn_id = _turn_id_from_payload(params)
-        if forwarder_state is not None and turn_id is not None:
-            if turn_id in forwarder_state.surfaced_terminal_error_turns:
-                _logger.info(
-                    "Codex forwarder ignored duplicate terminal error: turn_id=%s",
-                    turn_id,
-                )
+        async with _conversation_item_delivery_scope(session_id):
+            if delta_coalescer is not None:
+                await delta_coalescer.flush()
+            error = _terminal_error_from_notification(params)
+            if error is None:
+                _logger.warning("Codex forwarder ignored malformed error notification")
                 return True
-            forwarder_state.surfaced_terminal_error_turns.add(turn_id)
-            clear_active_turn_id_if_matches(bridge_dir, turn_id)
-        await _post_turn_status_edge(
-            client,
-            session_id,
-            _CodexTurnStatusEdge(
-                status="failed",
-                turn_id=turn_id,
-                source="error",
-                error=error,
-            ),
-        )
-        await usage_coalescer.flush()
+            turn_id = _turn_id_from_payload(params)
+            if forwarder_state is not None and turn_id is not None:
+                if turn_id in forwarder_state.surfaced_terminal_error_turns:
+                    _logger.info(
+                        "Codex forwarder ignored duplicate terminal error: turn_id=%s",
+                        turn_id,
+                    )
+                    return True
+                forwarder_state.surfaced_terminal_error_turns.add(turn_id)
+                clear_active_turn_id_if_matches(bridge_dir, turn_id)
+            await _post_turn_status_edge(
+                client,
+                session_id,
+                _CodexTurnStatusEdge(
+                    status="failed",
+                    turn_id=turn_id,
+                    source="error",
+                    error=error,
+                ),
+            )
+            await usage_coalescer.flush()
         return True
     if method == "turn/started":
-        if delta_coalescer is not None:
-            await delta_coalescer.flush()
-        await _handle_turn_started(client, session_id, bridge_dir, params)
-        if forwarder_state is not None:
-            # A new turn opens a fresh reasoning block: the next reasoning
-            # delta must emit ``response.reasoning.started`` again.
-            forwarder_state.reasoning_stream_item_id = None
-            # An in-TUI ``/model`` switch writes config.toml (the cost-policy
-            # source of truth) but emits no notification. Re-read it at turn
-            # start so a switch made since the last turn lands ``model_override``
-            # on Omnigent before this turn's first tool call reaches the cost gate.
-            _refresh_model_from_config(bridge_dir, forwarder_state)
-            _refresh_developer_instructions_from_config(bridge_dir, forwarder_state)
-            _refresh_effort_from_config(bridge_dir, forwarder_state)
-            await _sync_model_change(
-                client, session_id=session_id, forwarder_state=forwarder_state
-            )
-            # Only sync once config.toml has revealed an effort: without one the
-            # unseeded baseline would mirror a spurious ``None`` on every session.
-            # A fresh session's first turn/started posts the launch effort itself
-            # (baseline ``None`` → changed) — redundant but harmless, not the
-            # terminal-change path.
-            if forwarder_state.last_config_effort is not None:
-                await _sync_reasoning_effort_change(
+        async with _conversation_item_delivery_scope(session_id):
+            if delta_coalescer is not None:
+                await delta_coalescer.flush()
+            await _handle_turn_started(client, session_id, bridge_dir, params)
+            if forwarder_state is not None:
+                # A new turn opens a fresh reasoning block: the next reasoning
+                # delta must emit ``response.reasoning.started`` again.
+                forwarder_state.reasoning_stream_item_id = None
+                # An in-TUI ``/model`` switch writes config.toml (the cost-policy
+                # source of truth) but emits no notification. Re-read it at turn
+                # start so a switch made since the last turn lands ``model_override``
+                # on Omnigent before this turn's first tool call reaches the cost gate.
+                _refresh_model_from_config(bridge_dir, forwarder_state)
+                _refresh_developer_instructions_from_config(bridge_dir, forwarder_state)
+                _refresh_effort_from_config(bridge_dir, forwarder_state)
+                await _sync_model_change(
                     client, session_id=session_id, forwarder_state=forwarder_state
                 )
+                # Only sync once config.toml has revealed an effort: without one the
+                # unseeded baseline would mirror a spurious ``None`` on every session.
+                # A fresh session's first turn/started posts the launch effort itself
+                # (baseline ``None`` → changed) — redundant but harmless, not the
+                # terminal-change path.
+                if forwarder_state.last_config_effort is not None:
+                    await _sync_reasoning_effort_change(
+                        client,
+                        session_id=session_id,
+                        forwarder_state=forwarder_state,
+                    )
         return True
     if method in {"turn/completed", "turn/failed"}:
         await _handle_terminal_turn_boundary(
@@ -3576,6 +3634,35 @@ async def _handle_completed_event(
 
 
 async def _handle_terminal_turn_boundary(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    bridge_dir: Path,
+    method: str,
+    params: _JsonObject,
+    usage_coalescer: _SessionUsageCoalescer,
+    delta_coalescer: _OutputTextDeltaCoalescer | None,
+    elicitation_tracker: _CodexElicitationTaskTracker,
+    codex_client: CodexAppServerClient | None,
+    forwarder_state: _CodexForwarderState | None,
+) -> None:
+    """Serialize terminal cleanup behind any unfinished authoritative replay."""
+    async with _conversation_item_delivery_scope(session_id):
+        await _handle_terminal_turn_boundary_inner(
+            client,
+            session_id=session_id,
+            bridge_dir=bridge_dir,
+            method=method,
+            params=params,
+            usage_coalescer=usage_coalescer,
+            delta_coalescer=delta_coalescer,
+            elicitation_tracker=elicitation_tracker,
+            codex_client=codex_client,
+            forwarder_state=forwarder_state,
+        )
+
+
+async def _handle_terminal_turn_boundary_inner(
     client: httpx.AsyncClient,
     *,
     session_id: str,
@@ -4771,6 +4858,25 @@ async def _handle_completed_item(
     forwarder_state: _CodexForwarderState | None = None,
     bridge_dir: Path | None = None,
 ) -> None:
+    """Serialize and forward one completed Codex transcript item."""
+    async with _conversation_item_delivery_scope(session_id):
+        await _handle_completed_item_inner(
+            client,
+            session_id,
+            params,
+            forwarder_state=forwarder_state,
+            bridge_dir=bridge_dir,
+        )
+
+
+async def _handle_completed_item_inner(
+    client: httpx.AsyncClient,
+    session_id: str,
+    params: _JsonObject,
+    *,
+    forwarder_state: _CodexForwarderState | None = None,
+    bridge_dir: Path | None = None,
+) -> None:
     """
     Forward one Codex completed item event when it maps to Omnigent history.
 
@@ -5019,27 +5125,28 @@ async def _flush_turn_diff(
     call_id = f"codex_turn_diff_{turn_id}"
     thread_id = _thread_id_from_params(params) or "thread"
     source_id = f"{thread_id}:{turn_id}:turn-diff"
-    await _post_external_item(
-        client,
-        session_id,
-        item_type="function_call",
-        item_data={
-            "agent": _AGENT_NAME,
-            "name": "turn_diff",
-            "arguments": "{}",
-            "call_id": call_id,
-        },
-        response_id=response_id,
-        source_id=f"{source_id}:call",
-    )
-    await _post_external_item(
-        client,
-        session_id,
-        item_type="function_call_output",
-        item_data={"call_id": call_id, "output": diff},
-        response_id=response_id,
-        source_id=f"{source_id}:output",
-    )
+    async with _conversation_item_delivery_scope(session_id):
+        await _post_external_item(
+            client,
+            session_id,
+            item_type="function_call",
+            item_data={
+                "agent": _AGENT_NAME,
+                "name": "turn_diff",
+                "arguments": "{}",
+                "call_id": call_id,
+            },
+            response_id=response_id,
+            source_id=f"{source_id}:call",
+        )
+        await _post_external_item(
+            client,
+            session_id,
+            item_type="function_call_output",
+            item_data={"call_id": call_id, "output": diff},
+            response_id=response_id,
+            source_id=f"{source_id}:output",
+        )
 
 
 async def _handle_collab_item(
@@ -6291,8 +6398,6 @@ async def _post_external_item(
         data["message_id"] = message_id
     if source_id is not None:
         data["source_id"] = _bounded_source_id(source_id)
-    locks = _conversation_item_locks.get()
-    lock = locks.setdefault(session_id, asyncio.Lock()) if locks is not None else None
 
     async def _post() -> httpx.Response | None:
         return await _post_session_event(
@@ -6305,11 +6410,8 @@ async def _post_external_item(
         )
 
     try:
-        if lock is None:
+        async with _conversation_item_delivery_scope(session_id):
             response = await _post()
-        else:
-            async with lock:
-                response = await _post()
     except asyncio.CancelledError:
         if source_id is not None and (dl_dir := _dead_letter_dir.get()) is not None:
             append_dead_letter(
@@ -6889,11 +6991,55 @@ _forward_health = _ForwardHealth()
 
 # Bridge dir for dead-lettering undeliverable durable events; set per-forwarder (#1120).
 _dead_letter_dir: ContextVar[Path | None] = ContextVar("_codex_dead_letter_dir", default=None)
+
+
+class _ReentrantAsyncLock:
+    """Task-reentrant lock for one conversation's authoritative items."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._owner: asyncio.Task[object] | None = None
+        self._depth = 0
+
+    async def __aenter__(self) -> None:
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("conversation delivery requires an asyncio task")
+        if self._owner is task:
+            self._depth += 1
+            return
+        await self._lock.acquire()
+        self._owner = task
+        self._depth = 1
+
+    async def __aexit__(self, _exc_type: object, _exc: object, _traceback: object) -> None:
+        task = asyncio.current_task()
+        if task is None or self._owner is not task:
+            raise RuntimeError("conversation delivery lock released by non-owner")
+        self._depth -= 1
+        if self._depth == 0:
+            self._owner = None
+            self._lock.release()
+
+
 # Per-forwarder session locks keep resume backfill and live completed items in
 # server position order while an older idempotent delivery is retrying.
-_conversation_item_locks: ContextVar[dict[str, asyncio.Lock] | None] = ContextVar(
+_conversation_item_locks: ContextVar[dict[str, _ReentrantAsyncLock] | None] = ContextVar(
     "_codex_conversation_item_locks", default=None
 )
+
+
+@contextlib.asynccontextmanager
+async def _conversation_item_delivery_scope(session_id: str) -> AsyncIterator[None]:
+    """Hold one session's authoritative-item order across nested posts."""
+    locks = _conversation_item_locks.get()
+    if locks is None:
+        yield
+        return
+    lock = locks.setdefault(session_id, _ReentrantAsyncLock())
+    async with lock:
+        yield
+
 
 # Durable event types worth dead-lettering (not ephemeral deltas).
 _DEAD_LETTER_EVENT_TYPES = frozenset({"external_conversation_item", "external_session_usage"})

--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -90,7 +90,7 @@ _REPLAY_MAX_RECORDS = 500
 _REPLAY_POST_TIMEOUT_SECONDS = 5.0
 _REPLAY_DEADLINE_SECONDS = 30.0
 _DELTA_FLUSH_INTERVAL_SECONDS = 0.05
-_DELTA_FLUSH_CHAR_THRESHOLD = 64
+_DELTA_FLUSH_CHAR_THRESHOLD = 512
 # A worker cancelled at loop teardown can no longer resolve its queued markers, so an
 # unbounded wait parks the caller for good. Under the runner's 10s auto-forwarder cancel
 # budget so this resolves first.
@@ -1113,7 +1113,7 @@ _ToolItemBuilder = Callable[[str, _JsonObject], "_CodexToolCall | None"]
 @dataclass(frozen=True)
 class _DeltaChunk:
     """
-    One queued text delta with optional stream identity.
+    One queued transient delta with optional stream identity.
 
     :param message_id: Stable native message stream id, e.g.
         ``"codex:thread_123:turn_123:agentMessage:item_agent"``, or
@@ -1121,11 +1121,14 @@ class _DeltaChunk:
     :param delta: Text fragment, e.g. ``"hel"``.
     :param tool_call_id: Codex command item id when this is a live
         command-output chunk, otherwise ``None``.
+    :param reasoning_started: Whether this chunk opens a reasoning block,
+        or ``None`` when this is not a reasoning delta.
     """
 
     message_id: str | None
     delta: str
     tool_call_id: str | None = None
+    reasoning_started: bool | None = None
 
 
 def _resolve_marker(done: asyncio.Future[None]) -> None:
@@ -1169,9 +1172,9 @@ class _DeltaFlushStop:
 
 class _OutputTextDeltaCoalescer:
     """
-    Coalesce high-frequency Codex text and command-output deltas.
+    Coalesce high-frequency Codex text, reasoning, and command-output deltas.
 
-    Codex can emit many tiny text and command-output notifications.
+    Codex can emit many tiny transient notifications.
     Posting each one through Omnigent as an awaited HTTP request makes the
     forwarder drain behind Codex. This worker keeps event ingestion
     cheap while preserving the order of flushed text relative to
@@ -1201,7 +1204,7 @@ class _OutputTextDeltaCoalescer:
         :param flush_interval_seconds: Maximum buffering delay in
             seconds, e.g. ``0.05``.
         :param flush_char_threshold: Character threshold that triggers
-            an immediate flush, e.g. ``64``.
+            an immediate flush, e.g. ``512``.
         """
         self._client = client
         self._session_id = session_id
@@ -1239,6 +1242,15 @@ class _OutputTextDeltaCoalescer:
         self._ensure_worker()
         self._queue.put_nowait(_DeltaChunk(message_id=None, delta=delta, tool_call_id=call_id))
 
+    async def append_reasoning(self, delta: str, *, started: bool) -> None:
+        """Queue reasoning text for coalesced delivery."""
+        if not delta and not started:
+            return
+        self._ensure_worker()
+        self._queue.put_nowait(
+            _DeltaChunk(message_id=None, delta=delta, reasoning_started=started)
+        )
+
     async def flush(self) -> None:
         """
         Flush all deltas queued before this call.
@@ -1258,25 +1270,32 @@ class _OutputTextDeltaCoalescer:
 
         :returns: None after the worker has stopped.
         """
-        if self._worker_task is None:
+        worker = self._worker_task
+        if worker is None:
             return
         # A worker that already stopped will never read the marker, so skip
         # straight to reaping it rather than waiting out the bound.
-        if self._worker_task.done():
+        if worker.done():
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker
             self._worker_task = None
             return
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
         self._queue.put_nowait(_DeltaFlushStop(done=done))
         await self._await_marker(done, "stop marker")
-        # Only reap a worker that has actually finished; awaiting a wedged one
-        # would reintroduce the unbounded wait this method exists to remove.
-        if self._worker_task.done():
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._worker_task
-        self._worker_task = None
+        if not worker.done():
+            worker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker
+        if self._worker_task is worker:
+            self._worker_task = None
 
-    async def _await_marker(self, done: asyncio.Future[None], marker: str) -> None:
+    async def _await_marker(
+        self,
+        done: asyncio.Future[None],
+        marker: str,
+    ) -> None:
         """
         Wait for the worker to resolve a queue marker.
 
@@ -1347,8 +1366,14 @@ class _OutputTextDeltaCoalescer:
                     buffer
                     and buffer_chunk is not None
                     and (
-                        item.message_id != buffer_chunk.message_id
-                        or item.tool_call_id != buffer_chunk.tool_call_id
+                        item.tool_call_id != buffer_chunk.tool_call_id
+                        or (item.reasoning_started is None)
+                        != (buffer_chunk.reasoning_started is None)
+                        or (
+                            item.reasoning_started is None
+                            and item.message_id != buffer_chunk.message_id
+                        )
+                        or item.reasoning_started is True
                     )
                 ):
                     await self._flush_buffer(buffer, chunk=buffer_chunk)
@@ -1361,7 +1386,12 @@ class _OutputTextDeltaCoalescer:
                     buffer_chunk = item
                 buffer.append(item.delta)
                 buffered_chars += len(item.delta)
-                if "\n" in item.delta or buffered_chars >= self._flush_char_threshold:
+                flush_text_line = (
+                    item.tool_call_id is None
+                    and item.reasoning_started is None
+                    and "\n" in item.delta
+                )
+                if flush_text_line or buffered_chars >= self._flush_char_threshold:
                     await self._flush_buffer(buffer, chunk=buffer_chunk)
                     buffer = []
                     buffer_chunk = None
@@ -1397,6 +1427,17 @@ class _OutputTextDeltaCoalescer:
             return
         assert chunk is not None
         delta = "".join(buffer)
+        if chunk.reasoning_started is not None:
+            try:
+                await _post_output_reasoning_delta(
+                    self._client,
+                    self._session_id,
+                    delta,
+                    started=chunk.reasoning_started,
+                )
+            except Exception:  # noqa: BLE001 - preserve the long-lived forwarder.
+                _logger.warning("Codex forwarder reasoning delta flush failed", exc_info=True)
+            return
         if chunk.tool_call_id is not None:
             try:
                 await _post_tool_output_delta(
@@ -3367,11 +3408,9 @@ async def _maybe_handle_delta_event(
         await delta_coalescer.append_tool_output(delta, call_id=call_id)
         return True
     if method in {"item/reasoning/textDelta", "item/reasoning/summaryTextDelta"}:
-        # Flush any buffered assistant text first so a reasoning delta never
-        # jumps ahead of earlier-streamed answer text in arrival order.
-        if delta_coalescer is not None:
-            await delta_coalescer.flush()
-        await _handle_reasoning_delta(client, session_id, params, forwarder_state)
+        if delta_coalescer is None:
+            raise RuntimeError("Codex reasoning delta handling requires a text-delta coalescer")
+        await _handle_reasoning_delta(params, delta_coalescer, forwarder_state)
         return True
     return False
 
@@ -6442,9 +6481,8 @@ def _read_compacted_history(rollout_path: Path) -> dict[str, object] | None:
 
 
 async def _handle_reasoning_delta(
-    client: httpx.AsyncClient,
-    session_id: str,
     params: _JsonObject,
+    delta_coalescer: _OutputTextDeltaCoalescer,
     forwarder_state: _CodexForwarderState | None,
 ) -> None:
     """
@@ -6459,10 +6497,9 @@ async def _handle_reasoning_delta(
     executor's wire shape (#1254). The first delta of a reasoning item
     opens the block (``started=True`` → ``response.reasoning.started``).
 
-    :param client: HTTP client for Omnigent event posts.
-    :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param params: Codex reasoning delta params, e.g.
         ``{"turnId": "turn_123", "itemId": "item_r", "delta": "Let me"}``.
+    :param delta_coalescer: Shared transient-delta coalescer.
     :param forwarder_state: Optional forwarder state tracking which
         reasoning item is currently open (for the ``started`` edge).
     :returns: None.
@@ -6487,10 +6524,7 @@ async def _handle_reasoning_delta(
             # same block don't re-open it.
             started = forwarder_state.reasoning_stream_item_id is None
             forwarder_state.reasoning_stream_item_id = ""
-    # An empty, non-opening delta carries nothing to render.
-    if not delta and not started:
-        return
-    await _post_output_reasoning_delta(client, session_id, delta, started=started)
+    await delta_coalescer.append_reasoning(delta, started=started)
 
 
 async def _post_output_reasoning_delta(

--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -5809,6 +5809,7 @@ async def _post_agent_message(
             "content": [{"type": "output_text", "text": text}],
         },
         response_id=_response_id(params),
+        message_id=_completed_streaming_message_id(params, item, "agentMessage"),
     )
 
 
@@ -5915,6 +5916,7 @@ async def _post_plan_item(
             "content": [{"type": "output_text", "text": text}],
         },
         response_id=_response_id(params),
+        message_id=_completed_streaming_message_id(params, item, "plan"),
     )
 
 
@@ -6208,6 +6210,7 @@ async def _post_external_item(
     item_type: str,
     item_data: _JsonObject,
     response_id: str,
+    message_id: str | None = None,
 ) -> None:
     """
     Post one external conversation item to AP.
@@ -6221,17 +6224,21 @@ async def _post_external_item(
     :param item_type: Conversation item type, e.g. ``"message"``.
     :param item_data: Conversation item payload.
     :param response_id: Response id for the mirrored Codex turn.
+    :param message_id: Optional live-preview stream finalized by this item.
     :returns: None.
     """
+    data: _JsonObject = {
+        "item_type": item_type,
+        "item_data": item_data,
+        "response_id": response_id,
+    }
+    if message_id is not None:
+        data["message_id"] = message_id
     response = await _post_session_event(
         client,
         session_id,
         event_type="external_conversation_item",
-        data={
-            "item_type": item_type,
-            "item_data": item_data,
-            "response_id": response_id,
-        },
+        data=data,
     )
     if response is None:
         _logger.warning("failed to post Codex conversation item")
@@ -7434,6 +7441,17 @@ def _streaming_message_id(params: _JsonObject, item_type: str) -> str | None:
     if item_id is not None:
         parts.append(item_id)
     return ":".join(parts)
+
+
+def _completed_streaming_message_id(
+    params: _JsonObject,
+    item: _JsonObject,
+    item_type: str,
+) -> str | None:
+    """Build the live-preview id finalized by a completed Codex item."""
+    completed_params = dict(params)
+    completed_params["itemId"] = item.get("id")
+    return _streaming_message_id(completed_params, item_type)
 
 
 def _record_partial_text_delta(

--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -90,11 +90,17 @@ _REPLAY_MAX_RECORDS = 500
 _REPLAY_POST_TIMEOUT_SECONDS = 5.0
 _REPLAY_DEADLINE_SECONDS = 30.0
 _DELTA_FLUSH_INTERVAL_SECONDS = 0.05
-_DELTA_FLUSH_CHAR_THRESHOLD = 512
-# A worker cancelled at loop teardown can no longer resolve its queued markers, so an
-# unbounded wait parks the caller for good. Under the runner's 10s auto-forwarder cancel
-# budget so this resolves first.
-_DELTA_MARKER_TIMEOUT_SECONDS = 5.0
+_DELTA_FLUSH_CHAR_THRESHOLD = 8 * 1024
+# Transient output can be discarded because completed items are persisted
+# separately. Bound queued text so a slow relay cannot create hours of lag.
+_DELTA_QUEUE_CHAR_LIMIT = 256 * 1024
+_DELTA_POST_TIMEOUT_SECONDS = 5.0
+# Preserve healthy queued deltas briefly at ordering boundaries. If they do not
+# drain, shed the remaining previews and wait only for the current bounded POST.
+_DELTA_FLUSH_GRACE_SECONDS = 1.0
+# Bound the post-shedding wait below the runner's 10s cancellation budget and
+# above the delta POST deadline.
+_DELTA_MARKER_TIMEOUT_SECONDS = 6.0
 _EXTERNAL_REASONING_EFFORT_CHANGE_TYPE = "external_reasoning_effort_change"
 # Context-compaction progress edge. Publishes the same
 # ``response.compaction.in_progress`` / ``response.compaction.completed`` SSE
@@ -1204,7 +1210,7 @@ class _OutputTextDeltaCoalescer:
         :param flush_interval_seconds: Maximum buffering delay in
             seconds, e.g. ``0.05``.
         :param flush_char_threshold: Character threshold that triggers
-            an immediate flush, e.g. ``512``.
+            an immediate flush, e.g. ``8192``.
         """
         self._client = client
         self._session_id = session_id
@@ -1215,6 +1221,8 @@ class _OutputTextDeltaCoalescer:
         )
         self._worker_task: asyncio.Task[None] | None = None
         self._next_index_by_message_id: dict[str, int] = {}
+        self._queued_chars = 0
+        self._dropping_until_barrier = False
 
     async def append(self, delta: str, *, message_id: str | None = None) -> None:
         """
@@ -1227,8 +1235,7 @@ class _OutputTextDeltaCoalescer:
         """
         if not delta:
             return
-        self._ensure_worker()
-        self._queue.put_nowait(_DeltaChunk(message_id=message_id, delta=delta))
+        await self._enqueue(_DeltaChunk(message_id=message_id, delta=delta))
 
     async def append_tool_output(self, delta: str, *, call_id: str) -> None:
         """Queue command output for coalesced delivery.
@@ -1239,16 +1246,14 @@ class _OutputTextDeltaCoalescer:
         """
         if not delta or not call_id:
             return
-        self._ensure_worker()
-        self._queue.put_nowait(_DeltaChunk(message_id=None, delta=delta, tool_call_id=call_id))
+        await self._enqueue(_DeltaChunk(message_id=None, delta=delta, tool_call_id=call_id))
 
     async def append_reasoning(self, delta: str, *, started: bool) -> None:
         """Queue reasoning text for coalesced delivery."""
         if not delta and not started:
             return
-        self._ensure_worker()
-        self._queue.put_nowait(
-            _DeltaChunk(message_id=None, delta=delta, reasoning_started=started)
+        await self._enqueue(
+            _DeltaChunk(message_id=None, delta=delta, reasoning_started=started),
         )
 
     async def flush(self) -> None:
@@ -1257,12 +1262,33 @@ class _OutputTextDeltaCoalescer:
 
         :returns: None after all earlier deltas have been posted.
         """
-        if self._worker_task is None or self._worker_task.done():
+        if self._worker_task is None:
+            self._dropping_until_barrier = False
+            return
+        if self._worker_task.done():
+            self._reap_stopped_worker()
             return
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
         self._queue.put_nowait(_DeltaFlushBarrier(done=done))
-        await self._await_marker(done, "flush barrier")
+        if not self._dropping_until_barrier and await self._await_marker(
+            done,
+            "flush barrier",
+            timeout_seconds=_DELTA_FLUSH_GRACE_SECONDS,
+            log_timeout=False,
+        ):
+            return
+        if not self._dropping_until_barrier:
+            self._dropping_until_barrier = True
+            _logger.warning(
+                "Codex delta backlog did not drain within %.1fs; dropping transient "
+                "output until the flush boundary (session=%s)",
+                _DELTA_FLUSH_GRACE_SECONDS,
+                self._session_id,
+            )
+        if await self._await_marker(done, "flush barrier after shedding"):
+            return
+        await self._cancel_and_reap_worker()
 
     async def close(self) -> None:
         """
@@ -1276,26 +1302,24 @@ class _OutputTextDeltaCoalescer:
         # A worker that already stopped will never read the marker, so skip
         # straight to reaping it rather than waiting out the bound.
         if worker.done():
-            with contextlib.suppress(asyncio.CancelledError):
-                await worker
-            self._worker_task = None
+            self._reap_stopped_worker()
             return
         loop = asyncio.get_running_loop()
         done: asyncio.Future[None] = loop.create_future()
         self._queue.put_nowait(_DeltaFlushStop(done=done))
-        await self._await_marker(done, "stop marker")
-        if not worker.done():
-            worker.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await worker
-        if self._worker_task is worker:
-            self._worker_task = None
+        if not await self._await_marker(done, "stop marker"):
+            await self._cancel_and_reap_worker()
+        elif self._worker_task is worker:
+            self._reap_stopped_worker()
 
     async def _await_marker(
         self,
         done: asyncio.Future[None],
         marker: str,
-    ) -> None:
+        *,
+        timeout_seconds: float | None = None,
+        log_timeout: bool = True,
+    ) -> bool:
         """
         Wait for the worker to resolve a queue marker.
 
@@ -1306,8 +1330,12 @@ class _OutputTextDeltaCoalescer:
 
         :param done: Future the worker resolves for this marker.
         :param marker: Marker name used in the timeout log.
-        :returns: None once resolved, once the worker stops, or once the bound elapses.
+        :param timeout_seconds: Maximum seconds to wait.
+        :param log_timeout: Whether to warn when the bound elapses.
+        :returns: Whether the marker resolved or a stopped worker was reaped.
         """
+        if timeout_seconds is None:
+            timeout_seconds = _DELTA_MARKER_TIMEOUT_SECONDS
         worker = self._worker_task
         waiters: set[asyncio.Future[None] | asyncio.Task[None]] = {done}
         if worker is not None:
@@ -1315,15 +1343,32 @@ class _OutputTextDeltaCoalescer:
         await asyncio.wait(
             waiters,
             return_when=asyncio.FIRST_COMPLETED,
-            timeout=_DELTA_MARKER_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
-        if not done.done() and (worker is None or not worker.done()):
+        if done.done():
+            return True
+        if worker is None or worker.done():
+            self._reap_stopped_worker()
+            return True
+        if log_timeout:
             _logger.warning(
                 "codex delta coalescer %s timed out after %.1fs (session=%s)",
                 marker,
-                _DELTA_MARKER_TIMEOUT_SECONDS,
+                timeout_seconds,
                 self._session_id,
             )
+        return False
+
+    async def _cancel_and_reap_worker(self) -> None:
+        """Cancel an unresponsive worker and discard its stale queued deltas."""
+        worker = self._worker_task
+        if worker is None:
+            return
+        if not worker.done():
+            worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        if self._worker_task is worker:
+            self._reap_stopped_worker()
 
     def _ensure_worker(self) -> None:
         """
@@ -1331,10 +1376,76 @@ class _OutputTextDeltaCoalescer:
 
         :returns: None.
         """
+        if self._worker_task is not None and self._worker_task.done():
+            self._reap_stopped_worker()
         if self._worker_task is None:
             self._worker_task = asyncio.create_task(
                 self._run(),
                 name="codex-native-delta-coalescer",
+            )
+
+    async def _enqueue(self, chunk: _DeltaChunk) -> None:
+        """Queue one transient chunk unless this segment already exceeded its budget."""
+        if self._dropping_until_barrier:
+            return
+        queued_chars = self._queued_chars + len(chunk.delta)
+        if queued_chars > _DELTA_QUEUE_CHAR_LIMIT:
+            # A ready app-server socket can yield many events without giving a
+            # newly-created worker CPU. Let a healthy worker drain once before
+            # treating the full queue as relay backpressure.
+            self._ensure_worker()
+            await asyncio.sleep(0)
+            if self._dropping_until_barrier:
+                return
+            queued_chars = self._queued_chars + len(chunk.delta)
+        if queued_chars > _DELTA_QUEUE_CHAR_LIMIT:
+            self._dropping_until_barrier = True
+            _logger.warning(
+                "Codex delta backlog exceeded %d chars; dropping transient output "
+                "until the next flush boundary (session=%s)",
+                _DELTA_QUEUE_CHAR_LIMIT,
+                self._session_id,
+            )
+            return
+        self._ensure_worker()
+        self._queued_chars = queued_chars
+        self._queue.put_nowait(chunk)
+
+    def _reap_stopped_worker(self) -> None:
+        """Reap a stopped worker and discard transient data it can no longer order."""
+        worker = self._worker_task
+        if worker is None or not worker.done():
+            return
+        worker_error: BaseException | None = None
+        with contextlib.suppress(asyncio.CancelledError):
+            worker_error = worker.exception()
+        if worker_error is not None:
+            _logger.warning(
+                "Codex delta coalescer worker stopped unexpectedly; restarting",
+                exc_info=(type(worker_error), worker_error, worker_error.__traceback__),
+            )
+        self._worker_task = None
+        dropped_chunks = 0
+        dropped_chars = 0
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if isinstance(item, _DeltaChunk):
+                dropped_chunks += 1
+                dropped_chars += len(item.delta)
+            else:
+                _resolve_marker(item.done)
+        self._queued_chars = 0
+        self._dropping_until_barrier = False
+        if dropped_chunks:
+            _logger.warning(
+                "Codex delta coalescer discarded %d stale chunk(s) (%d chars) "
+                "after its worker stopped (session=%s)",
+                dropped_chunks,
+                dropped_chars,
+                self._session_id,
             )
 
     async def _run(self) -> None:
@@ -1355,13 +1466,21 @@ class _OutputTextDeltaCoalescer:
             try:
                 item = await asyncio.wait_for(self._queue.get(), timeout=timeout)
             except TimeoutError:
-                await self._flush_buffer(buffer, chunk=buffer_chunk)
+                if not self._dropping_until_barrier:
+                    await self._flush_buffer(buffer, chunk=buffer_chunk)
                 buffer = []
                 buffer_chunk = None
                 buffered_chars = 0
                 flush_deadline = None
                 continue
             if isinstance(item, _DeltaChunk):
+                self._queued_chars -= len(item.delta)
+                if self._dropping_until_barrier:
+                    buffer = []
+                    buffer_chunk = None
+                    buffered_chars = 0
+                    flush_deadline = None
+                    continue
                 if (
                     buffer
                     and buffer_chunk is not None
@@ -1399,14 +1518,18 @@ class _OutputTextDeltaCoalescer:
                     flush_deadline = None
                 continue
             if isinstance(item, _DeltaFlushBarrier):
-                await self._flush_buffer(buffer, chunk=buffer_chunk)
+                if not self._dropping_until_barrier:
+                    await self._flush_buffer(buffer, chunk=buffer_chunk)
                 buffer = []
                 buffer_chunk = None
                 buffered_chars = 0
                 flush_deadline = None
+                self._dropping_until_barrier = False
                 _resolve_marker(item.done)
                 continue
-            await self._flush_buffer(buffer, chunk=buffer_chunk)
+            if not self._dropping_until_barrier:
+                await self._flush_buffer(buffer, chunk=buffer_chunk)
+            self._dropping_until_barrier = False
             _resolve_marker(item.done)
             return
 
@@ -6296,6 +6419,8 @@ async def _post_output_text_delta(
         session_id,
         event_type="external_output_text_delta",
         data=data,
+        max_attempts=1,
+        timeout=_DELTA_POST_TIMEOUT_SECONDS,
     )
     _log_failed_session_event_post("external_output_text_delta", response)
 
@@ -6320,6 +6445,8 @@ async def _post_tool_output_delta(
         session_id,
         event_type="external_tool_output_delta",
         data={"call_id": call_id, "delta": delta},
+        max_attempts=1,
+        timeout=_DELTA_POST_TIMEOUT_SECONDS,
     )
     _log_failed_session_event_post("external_tool_output_delta", response)
 
@@ -6550,6 +6677,8 @@ async def _post_output_reasoning_delta(
         session_id,
         event_type=_EXTERNAL_OUTPUT_REASONING_DELTA_TYPE,
         data={"delta": delta, "started": started},
+        max_attempts=1,
+        timeout=_DELTA_POST_TIMEOUT_SECONDS,
     )
     _log_failed_session_event_post(_EXTERNAL_OUTPUT_REASONING_DELTA_TYPE, response)
 
@@ -6817,6 +6946,8 @@ async def _post_session_event(
     *,
     event_type: str,
     data: _JsonObject,
+    max_attempts: int = _POST_MAX_ATTEMPTS,
+    timeout: float | None = None,
 ) -> httpx.Response | None:
     """
     Post one Omnigent session event, tracking forward-sync health (#1120).
@@ -6833,10 +6964,19 @@ async def _post_session_event(
     :param event_type: Session event type, e.g.
         ``"external_conversation_item"``.
     :param data: Event data payload, e.g. ``{"status": "running"}``.
+    :param max_attempts: Maximum POST attempts, e.g. ``1`` for transient deltas.
+    :param timeout: Optional per-request timeout overriding the client default.
     :returns: The final HTTP response, or ``None`` (see
         :func:`_post_session_event_inner`).
     """
-    result = await _post_session_event_inner(client, session_id, event_type=event_type, data=data)
+    result = await _post_session_event_inner(
+        client,
+        session_id,
+        event_type=event_type,
+        data=data,
+        max_attempts=max_attempts,
+        timeout=timeout,
+    )
     response = result.response
     if response is not None and response.status_code < 400:
         _note_forward_success()

--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import logging
 from collections.abc import Callable
@@ -79,7 +80,10 @@ _NO_ROLLOUT_FRAGMENT = "no rollout found for thread id"
 _EMPTY_ROLLOUT_FRAGMENT = "is empty"
 _POST_MAX_ATTEMPTS = 3
 _POST_RETRY_DELAY_SECONDS = 0.1
+_POST_RETRY_MAX_DELAY_SECONDS = 30.0
 _POST_RETRY_STATUS_CODES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+_DURABLE_ITEM_POST_TIMEOUT_SECONDS = 5.0
+_SOURCE_ID_MAX_CHARS = 256
 # Startup dead-letter replay budget (#1579). Bounded so a large dead-letter file
 # or a slow/hung server cannot stall forwarder startup: each re-POST is a single
 # attempt (its natural retry is the next startup) with a short timeout (vs the
@@ -2042,6 +2046,9 @@ async def supervise_forwarder(
     """
     # Bind bridge dir so failed durable-event posts can be dead-lettered (#1120).
     _dead_letter_dir.set(bridge_dir)
+    # Resume backfill and live notifications can post concurrently. Serialize
+    # durable items per AP session so an older retry cannot land after a newer item.
+    _conversation_item_locks.set({})
     if client is None:
         client = client_for_transport(app_server_url, client_name="omnigent-codex-forwarder")
         await client.connect()
@@ -4725,36 +4732,35 @@ def _claim_completed_item(
     params: _JsonObject,
     item: _JsonObject,
     forwarder_state: _CodexForwarderState | None,
-) -> bool:
+) -> str | None:
     """
     Claim one completed Codex transcript item for Omnigent posting.
 
-    Returns ``True`` when the caller should post the item; ``False`` when
-    it was already posted this connection (dedup gate). Also advances the
+    Returns the stable source id when the caller should post the item; ``None``
+    when it was already posted this connection (dedup gate). Also advances the
     anonymous-item counter on a successful claim so the next anonymous
     item in the same (thread, turn) gets a fresh key.
 
-    When ``forwarder_state`` is ``None``, dedup is disabled and the
-    function always returns ``True`` (used in tests that bypass
-    ``supervise_forwarder``).
+    When ``forwarder_state`` is ``None``, dedup is disabled and the function
+    derives a source id directly (used in tests that bypass ``supervise_forwarder``).
 
     :param params: Codex ``item/completed`` params.
     :param item: Codex item payload.
     :param forwarder_state: Optional mutable state holding synced-item
         keys and anonymous-item counters.
-    :returns: ``True`` when the item should be posted to AP.
+    :returns: Stable source id when the item should be posted to AP, otherwise ``None``.
     """
     if forwarder_state is None:
-        return True
+        return _source_id(params, item)
     item_key, is_anon = _completed_item_key(params, item, forwarder_state)
     if not forwarder_state.claim_item_key(item_key):
-        return False
+        return None
     if is_anon:
         thread_id = _thread_id_from_params(params) or "thread"
         turn_id = params.get("turnId")
         turn_id = turn_id if isinstance(turn_id, str) and turn_id else "turn"
         forwarder_state.advance_anon_counter(thread_id, turn_id)
-    return True
+    return item_key
 
 
 async def _handle_completed_item(
@@ -4829,11 +4835,12 @@ async def _handle_completed_item(
                 if forwarder_state is not None:
                     forwarder_state.compaction_item_persisted = True
         return
-    if not _claim_completed_item(params, item, forwarder_state):
+    source_id = _claim_completed_item(params, item, forwarder_state)
+    if source_id is None:
         return
     if item_type == "userMessage":
-        await _post_user_message(client, session_id, params, item)
-        if forwarder_state is not None:
+        posted = await _post_user_message(client, session_id, params, item, source_id=source_id)
+        if posted and forwarder_state is not None:
             turn_id = _turn_id_from_payload(params)
             if turn_id:
                 forwarder_state.note_user_message_posted(turn_id)
@@ -4849,13 +4856,13 @@ async def _handle_completed_item(
         # bubbles. Recover and post the turn's user message first so it
         # always takes the earlier position.
         await _ensure_user_message_posted(client, session_id, params, forwarder_state)
-        await _post_agent_message(client, session_id, params, item)
+        await _post_agent_message(client, session_id, params, item, source_id=source_id)
         return
     if item_type == "plan":
-        await _post_plan_item(client, session_id, params, item)
+        await _post_plan_item(client, session_id, params, item, source_id=source_id)
         return
     if item_type in _REVIEW_MODE_ITEM_TYPES:
-        await _post_review_mode_marker(client, session_id, params, item)
+        await _post_review_mode_marker(client, session_id, params, item, source_id=source_id)
         return
     if item_type in _TOOL_ITEM_TYPES:
         await _post_tool_item(
@@ -4864,6 +4871,7 @@ async def _handle_completed_item(
             params,
             item,
             forwarder_state=forwarder_state,
+            source_id=source_id,
         )
 
 
@@ -4953,6 +4961,8 @@ async def _post_interrupted_partial_agent_message(
     :param text: Partial assistant text, e.g. ``"The answer is"``.
     :returns: None.
     """
+    thread_id = _thread_id_from_params(params) or "thread"
+    turn_id = _turn_id_from_payload(params) or "turn"
     await _post_external_item(
         client,
         session_id,
@@ -4964,6 +4974,7 @@ async def _post_interrupted_partial_agent_message(
             "content": [{"type": "output_text", "text": text}],
         },
         response_id=_response_id(params),
+        source_id=f"{thread_id}:{turn_id}:interrupted-partial",
     )
 
 
@@ -5006,6 +5017,8 @@ async def _flush_turn_diff(
         return
     response_id = _response_id(_params_with_turn_id(params, turn_id))
     call_id = f"codex_turn_diff_{turn_id}"
+    thread_id = _thread_id_from_params(params) or "thread"
+    source_id = f"{thread_id}:{turn_id}:turn-diff"
     await _post_external_item(
         client,
         session_id,
@@ -5017,6 +5030,7 @@ async def _flush_turn_diff(
             "call_id": call_id,
         },
         response_id=response_id,
+        source_id=f"{source_id}:call",
     )
     await _post_external_item(
         client,
@@ -5024,6 +5038,7 @@ async def _flush_turn_diff(
         item_type="function_call_output",
         item_data={"call_id": call_id, "output": diff},
         response_id=response_id,
+        source_id=f"{source_id}:output",
     )
 
 
@@ -5695,10 +5710,17 @@ async def _ensure_user_message_posted(
         "turnId": turn_id,
         "item": user_item,
     }
-    if not _claim_completed_item(recovered_params, user_item, forwarder_state):
+    source_id = _claim_completed_item(recovered_params, user_item, forwarder_state)
+    if source_id is None:
         return
-    await _post_user_message(client, session_id, recovered_params, user_item)
-    forwarder_state.note_user_message_posted(turn_id)
+    if await _post_user_message(
+        client,
+        session_id,
+        recovered_params,
+        user_item,
+        source_id=source_id,
+    ):
+        forwarder_state.note_user_message_posted(turn_id)
 
 
 def _find_turn_user_message(response: CodexMessage, turn_id: str) -> _JsonObject | None:
@@ -5737,7 +5759,9 @@ async def _post_user_message(
     session_id: str,
     params: _JsonObject,
     item: _JsonObject,
-) -> None:
+    *,
+    source_id: str | None = None,
+) -> bool:
     """
     Persist a Codex user message observed from the TUI.
 
@@ -5745,7 +5769,8 @@ async def _post_user_message(
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param params: Codex notification params.
     :param item: Codex ``userMessage`` item.
-    :returns: None.
+    :param source_id: Stable native item id used for server-side deduplication.
+    :returns: Whether the item was accepted by the server.
     """
     text = _user_message_text(item)
     # An image/file-only message has no text but must still be posted: the
@@ -5757,7 +5782,7 @@ async def _post_user_message(
     # message (no text, no file block) is skipped.
     has_file_block = _user_message_has_file_content(item)
     if not text and not has_file_block:
-        return
+        return False
     # Text-only / text+image post the text; image-only posts empty content and
     # relies on the server-side pending fold to supply the image block.
     content: list[_JsonObject] = [{"type": "input_text", "text": text}] if text else []
@@ -5772,12 +5797,13 @@ async def _post_user_message(
             session_id,
             _source_id(params, item),
         )
-    await _post_external_item(
+    return await _post_external_item(
         client,
         session_id,
         item_type="message",
         item_data=item_data,
         response_id=_response_id(params),
+        source_id=source_id or _source_id(params, item),
     )
 
 
@@ -5786,7 +5812,9 @@ async def _post_agent_message(
     session_id: str,
     params: _JsonObject,
     item: _JsonObject,
-) -> None:
+    *,
+    source_id: str | None = None,
+) -> bool:
     """
     Persist a Codex assistant message observed from the TUI/app-server.
 
@@ -5794,12 +5822,13 @@ async def _post_agent_message(
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param params: Codex notification params.
     :param item: Codex ``agentMessage`` item.
-    :returns: None.
+    :param source_id: Stable native item id used for server-side deduplication.
+    :returns: Whether the item was accepted by the server.
     """
     text = item.get("text")
     if not isinstance(text, str) or not text:
-        return
-    await _post_external_item(
+        return False
+    return await _post_external_item(
         client,
         session_id,
         item_type="message",
@@ -5810,6 +5839,7 @@ async def _post_agent_message(
         },
         response_id=_response_id(params),
         message_id=_completed_streaming_message_id(params, item, "agentMessage"),
+        source_id=source_id or _source_id(params, item),
     )
 
 
@@ -5818,6 +5848,8 @@ async def _post_tool_call_item(
     session_id: str,
     params: _JsonObject,
     item: _JsonObject,
+    *,
+    source_id: str | None = None,
 ) -> str | None:
     """Persist the function-call half of a Codex built-in tool item."""
     tool_call = _codex_tool_call_from_item(item)
@@ -5831,7 +5863,8 @@ async def _post_tool_call_item(
             tool_call.name,
         )
         return None
-    await _post_external_item(
+    source_id = source_id or _source_id(params, item)
+    posted = await _post_external_item(
         client,
         session_id,
         item_type="function_call",
@@ -5842,8 +5875,9 @@ async def _post_tool_call_item(
             "call_id": tool_call.call_id,
         },
         response_id=_response_id(params),
+        source_id=f"{source_id}:call",
     )
-    return tool_call.call_id
+    return tool_call.call_id if posted else None
 
 
 async def _post_tool_item(
@@ -5853,6 +5887,7 @@ async def _post_tool_item(
     item: _JsonObject,
     *,
     forwarder_state: _CodexForwarderState | None,
+    source_id: str,
 ) -> None:
     """
     Mirror one completed Codex built-in tool call into Omnigent history.
@@ -5877,7 +5912,16 @@ async def _post_tool_item(
     if tool_call is None:
         return
     if forwarder_state is None or not forwarder_state.take_posted_tool_call(tool_call.call_id):
-        if await _post_tool_call_item(client, session_id, params, item) is None:
+        if (
+            await _post_tool_call_item(
+                client,
+                session_id,
+                params,
+                item,
+                source_id=source_id,
+            )
+            is None
+        ):
             return
     await _post_external_item(
         client,
@@ -5885,6 +5929,7 @@ async def _post_tool_item(
         item_type="function_call_output",
         item_data={"call_id": tool_call.call_id, "output": tool_call.output},
         response_id=_response_id(params),
+        source_id=f"{source_id}:output",
     )
 
 
@@ -5893,7 +5938,9 @@ async def _post_plan_item(
     session_id: str,
     params: _JsonObject,
     item: _JsonObject,
-) -> None:
+    *,
+    source_id: str | None = None,
+) -> bool:
     """
     Persist one completed Codex plan item as assistant text.
 
@@ -5901,12 +5948,13 @@ async def _post_plan_item(
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :param params: Codex ``item/completed`` params.
     :param item: Codex ``plan`` thread item.
-    :returns: None.
+    :param source_id: Stable native item id used for server-side deduplication.
+    :returns: Whether the item was accepted by the server.
     """
     text = item.get("text")
     if not isinstance(text, str) or not text:
-        return
-    await _post_external_item(
+        return False
+    return await _post_external_item(
         client,
         session_id,
         item_type="message",
@@ -5917,6 +5965,7 @@ async def _post_plan_item(
         },
         response_id=_response_id(params),
         message_id=_completed_streaming_message_id(params, item, "plan"),
+        source_id=source_id or _source_id(params, item),
     )
 
 
@@ -5925,7 +5974,9 @@ async def _post_review_mode_marker(
     session_id: str,
     params: _JsonObject,
     item: _JsonObject,
-) -> None:
+    *,
+    source_id: str | None = None,
+) -> bool:
     """
     Mirror a Codex review-mode enter/exit transition into Omnigent history.
 
@@ -5943,7 +5994,8 @@ async def _post_review_mode_marker(
     :param item: Codex ``enteredReviewMode`` / ``exitedReviewMode`` item,
         e.g. ``{"type": "enteredReviewMode", "id": "rev_1",
         "review": "review the auth changes"}``.
-    :returns: None.
+    :param source_id: Stable native item id used for server-side deduplication.
+    :returns: Whether the item was accepted by the server.
     """
     entered = item.get("type") == "enteredReviewMode"
     header = "Entered review mode" if entered else "Exited review mode"
@@ -5952,7 +6004,7 @@ async def _post_review_mode_marker(
         text = f"{header}: {review.strip()}"
     else:
         text = header
-    await _post_external_item(
+    return await _post_external_item(
         client,
         session_id,
         item_type="message",
@@ -5962,6 +6014,7 @@ async def _post_review_mode_marker(
             "content": [{"type": "output_text", "text": text}],
         },
         response_id=_response_id(params),
+        source_id=source_id or _source_id(params, item),
     )
 
 
@@ -6211,13 +6264,14 @@ async def _post_external_item(
     item_data: _JsonObject,
     response_id: str,
     message_id: str | None = None,
-) -> None:
+    source_id: str | None = None,
+) -> bool:
     """
     Post one external conversation item to AP.
 
-    The forwarder does not send a dedup key to the server — items are
-    persisted with a random primary key. Avoiding re-posts on resume is
-    the producer's own responsibility.
+    Completed Codex items carry a stable ``source_id`` so the server derives
+    an idempotent item id. Their transient delivery retries can therefore
+    continue until recovery without creating duplicate transcript entries.
 
     :param client: HTTP client for Omnigent event posts.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
@@ -6225,7 +6279,8 @@ async def _post_external_item(
     :param item_data: Conversation item payload.
     :param response_id: Response id for the mirrored Codex turn.
     :param message_id: Optional live-preview stream finalized by this item.
-    :returns: None.
+    :param source_id: Stable native source id for server-side idempotency.
+    :returns: Whether the item was accepted by the server.
     """
     data: _JsonObject = {
         "item_type": item_type,
@@ -6234,21 +6289,49 @@ async def _post_external_item(
     }
     if message_id is not None:
         data["message_id"] = message_id
-    response = await _post_session_event(
-        client,
-        session_id,
-        event_type="external_conversation_item",
-        data=data,
-    )
+    if source_id is not None:
+        data["source_id"] = _bounded_source_id(source_id)
+    locks = _conversation_item_locks.get()
+    lock = locks.setdefault(session_id, asyncio.Lock()) if locks is not None else None
+
+    async def _post() -> httpx.Response | None:
+        return await _post_session_event(
+            client,
+            session_id,
+            event_type="external_conversation_item",
+            data=data,
+            max_attempts=None if source_id is not None else _POST_MAX_ATTEMPTS,
+            timeout=_DURABLE_ITEM_POST_TIMEOUT_SECONDS if source_id is not None else None,
+        )
+
+    try:
+        if lock is None:
+            response = await _post()
+        else:
+            async with lock:
+                response = await _post()
+    except asyncio.CancelledError:
+        if source_id is not None and (dl_dir := _dead_letter_dir.get()) is not None:
+            append_dead_letter(
+                dl_dir,
+                session_id=session_id,
+                event_type="external_conversation_item",
+                payload=data,
+                reason="delivery interrupted before acknowledgement",
+                delivered_ambiguous=True,
+            )
+        raise
     if response is None:
         _logger.warning("failed to post Codex conversation item")
-        return
+        return False
     if response.status_code >= 400:
         _logger.warning(
             "failed to post Codex conversation item: status=%s body=%s",
             response.status_code,
             response.text[:1000],
         )
+        return False
+    return True
 
 
 async def _post_status(
@@ -6784,11 +6867,9 @@ class _ForwardHealth:
     """
     Process-level health of Omnigent session-event forwarding (#1120).
 
-    Network failures (connect timeouts, 503s, resets) make
-    ``_post_session_event`` drop transcript/usage events after its bounded
-    retries, previously visible only as scattered per-item warnings. This
-    tracks consecutive permanent failures so a sustained outage escalates
-    to a single loud signal instead of staying effectively silent.
+    Non-idempotent or permanently rejected events can still fail after bounded
+    retries. This tracks consecutive terminal failures so a sustained problem
+    escalates to one loud signal instead of scattered per-event warnings.
 
     :param consecutive_failures: Permanent post failures since the last
         success.
@@ -6808,6 +6889,11 @@ _forward_health = _ForwardHealth()
 
 # Bridge dir for dead-lettering undeliverable durable events; set per-forwarder (#1120).
 _dead_letter_dir: ContextVar[Path | None] = ContextVar("_codex_dead_letter_dir", default=None)
+# Per-forwarder session locks keep resume backfill and live completed items in
+# server position order while an older idempotent delivery is retrying.
+_conversation_item_locks: ContextVar[dict[str, asyncio.Lock] | None] = ContextVar(
+    "_codex_conversation_item_locks", default=None
+)
 
 # Durable event types worth dead-lettering (not ephemeral deltas).
 _DEAD_LETTER_EVENT_TYPES = frozenset({"external_conversation_item", "external_session_usage"})
@@ -6953,7 +7039,7 @@ async def _post_session_event(
     *,
     event_type: str,
     data: _JsonObject,
-    max_attempts: int = _POST_MAX_ATTEMPTS,
+    max_attempts: int | None = _POST_MAX_ATTEMPTS,
     timeout: float | None = None,
 ) -> httpx.Response | None:
     """
@@ -6971,7 +7057,8 @@ async def _post_session_event(
     :param event_type: Session event type, e.g.
         ``"external_conversation_item"``.
     :param data: Event data payload, e.g. ``{"status": "running"}``.
-    :param max_attempts: Maximum POST attempts, e.g. ``1`` for transient deltas.
+    :param max_attempts: Maximum POST attempts, or ``None`` to retry transient
+        failures until recovery for an idempotent durable item.
     :param timeout: Optional per-request timeout overriding the client default.
     :returns: The final HTTP response, or ``None`` (see
         :func:`_post_session_event_inner`).
@@ -7017,7 +7104,7 @@ async def _post_session_event_inner(
     *,
     event_type: str,
     data: _JsonObject,
-    max_attempts: int = _POST_MAX_ATTEMPTS,
+    max_attempts: int | None = _POST_MAX_ATTEMPTS,
     timeout: float | None = None,
 ) -> _PostResult:
     """
@@ -7029,34 +7116,42 @@ async def _post_session_event_inner(
         ``"external_conversation_item"``.
     :param data: Event data payload, e.g.
         ``{"status": "running"}``.
-    :param max_attempts: Maximum POST attempts before giving up, e.g. ``3``.
+    :param max_attempts: Maximum POST attempts before giving up, e.g. ``3``;
+        ``None`` retries transient failures indefinitely and requires an
+        idempotent event payload.
         Startup dead-letter replay passes ``1`` — its natural retry cadence is
         the next startup, so an in-call retry loop only adds latency (#1579).
     :param timeout: Optional per-request timeout in seconds overriding the
         client default, e.g. ``5.0``. Replay passes a short value so a hung
         server fails fast instead of stalling startup on the 30s client default.
-    :returns: A :class:`_PostResult` carrying the final response, or — when no
-        response was seen — whether the POST was abandoned after an ambiguous
-        transport failure (``external_conversation_item`` only; the item may
-        already be committed, so retrying risks a duplicate) versus a
-        proven-undelivered transport failure after all retries.
+    :returns: A :class:`_PostResult` carrying the final response, or — for a
+        legacy conversation item without ``source_id`` — whether the POST was
+        abandoned after an ambiguous transport failure versus a proven-
+        undelivered transport failure after all retries.
     """
+    idempotent = _session_event_is_idempotent(event_type, data)
+    if max_attempts is None and not idempotent:
+        raise ValueError("unbounded session-event retries require an idempotent source_id")
     url = f"/v1/sessions/{url_component(session_id)}/events"
     payload = {"type": event_type, "data": data}
-    for attempt in range(1, max_attempts + 1):
+    attempt = 0
+    while max_attempts is None or attempt < max_attempts:
+        attempt += 1
         try:
             if timeout is None:
                 response = await client.post(url, json=payload)
             else:
                 response = await client.post(url, json=payload, timeout=timeout)
         except httpx.HTTPError as exc:
-            # Conversation items persist with a random primary key and no
-            # server-side dedup, so an ambiguous failure (request sent,
-            # response lost — the server may have committed it) must not
-            # be retried: a re-post would duplicate the item.
-            # Other event types are idempotent / transient, so retrying
-            # them on the same errors is safe and preserves delivery.
-            if event_type == "external_conversation_item" and post_may_have_been_delivered(exc):
+            # Legacy conversation items without a source id are not
+            # idempotent, so an ambiguous response-loss failure must not be
+            # retried. Completed Codex items carry a stable source id and are
+            # safe to retry until the relay recovers.
+            if (
+                event_type == "external_conversation_item"
+                and not idempotent
+                and post_may_have_been_delivered(exc)
+            ):
                 _logger.warning(
                     "skipping Codex session event after an ambiguous transport "
                     "failure (may already be committed); not retrying to avoid "
@@ -7072,6 +7167,7 @@ async def _post_session_event_inner(
             if _is_final_post_attempt(attempt, max_attempts):
                 _log_post_transport_failure(event_type, exc, max_attempts)
                 return _PostResult(response=None, transport_error=type(exc).__name__)
+            _log_unbounded_post_retry(event_type, session_id, attempt, exc=exc)
             await _sleep(_post_retry_delay(attempt))
             continue
         # An HTTP response (no transport error) proves the server is reachable,
@@ -7081,17 +7177,21 @@ async def _post_session_event_inner(
         note_native_post_success()
         if _post_response_is_final(response, attempt, max_attempts):
             return _PostResult(response=response)
+        _log_unbounded_post_retry(event_type, session_id, attempt, response=response)
         await _sleep(_post_retry_delay(attempt))
     return _PostResult(response=None)
 
 
-def _post_response_is_final(response: httpx.Response, attempt: int, max_attempts: int) -> bool:
+def _post_response_is_final(
+    response: httpx.Response, attempt: int, max_attempts: int | None
+) -> bool:
     """
     Return whether a session-event POST response should stop retries.
 
     :param response: HTTP response from AP.
     :param attempt: One-based attempt number, e.g. ``1``.
-    :param max_attempts: Maximum POST attempts allowed, e.g. ``3``.
+    :param max_attempts: Maximum POST attempts allowed, or ``None`` for
+        indefinite transient retries.
     :returns: ``True`` when the caller should return ``response``.
     """
     if response.status_code < 400:
@@ -7101,18 +7201,21 @@ def _post_response_is_final(response: httpx.Response, attempt: int, max_attempts
     return _is_final_post_attempt(attempt, max_attempts)
 
 
-def _is_final_post_attempt(attempt: int, max_attempts: int) -> bool:
+def _is_final_post_attempt(attempt: int, max_attempts: int | None) -> bool:
     """
     Return whether an Omnigent event POST attempt is the final try.
 
     :param attempt: One-based attempt number, e.g. ``3``.
-    :param max_attempts: Maximum POST attempts allowed, e.g. ``3``.
+    :param max_attempts: Maximum POST attempts allowed, or ``None`` for
+        indefinite transient retries.
     :returns: ``True`` when no further retry is allowed.
     """
-    return attempt >= max_attempts
+    return max_attempts is not None and attempt >= max_attempts
 
 
-def _log_post_transport_failure(event_type: str, exc: httpx.HTTPError, max_attempts: int) -> None:
+def _log_post_transport_failure(
+    event_type: str, exc: httpx.HTTPError, max_attempts: int | None
+) -> None:
     """
     Log an exhausted Omnigent session-event transport failure.
 
@@ -7133,6 +7236,38 @@ def _log_post_transport_failure(event_type: str, exc: httpx.HTTPError, max_attem
     # attaches this cause to the failure reason instead of a generic
     # "wedged LLM" message.
     record_native_post_failure(event_type, exc)
+
+
+def _session_event_is_idempotent(event_type: str, data: _JsonObject) -> bool:
+    """Return whether retrying this event cannot append a duplicate item."""
+    source_id = data.get("source_id")
+    return (
+        event_type == "external_conversation_item"
+        and isinstance(source_id, str)
+        and bool(source_id.strip())
+    )
+
+
+def _log_unbounded_post_retry(
+    event_type: str,
+    session_id: str,
+    attempt: int,
+    *,
+    exc: httpx.HTTPError | None = None,
+    response: httpx.Response | None = None,
+) -> None:
+    """Log sparse progress for a durable event retrying until recovery."""
+    if attempt != 1 and attempt % 10 != 0:
+        return
+    _logger.warning(
+        "retrying idempotent Codex session event until delivery: "
+        "session=%s type=%s attempt=%s http_status=%s error=%s",
+        session_id,
+        event_type,
+        attempt,
+        response.status_code if response is not None else None,
+        type(exc).__name__ if exc is not None else None,
+    )
 
 
 def _log_failed_session_event_post(
@@ -7177,7 +7312,8 @@ def _post_retry_delay(attempt: int) -> float:
     :param attempt: One-based failed attempt number, e.g. ``1``.
     :returns: Delay in seconds before the next attempt.
     """
-    return _POST_RETRY_DELAY_SECONDS * attempt
+    exponent = min(max(0, attempt - 1), 32)
+    return min(_POST_RETRY_DELAY_SECONDS * (2**exponent), _POST_RETRY_MAX_DELAY_SECONDS)
 
 
 def _turn_id_from_payload(payload: object) -> str | None:
@@ -7666,19 +7802,29 @@ def _source_id(params: _JsonObject, item: _JsonObject) -> str:
     """
     Build a stable per-record label for one Codex item.
 
-    Only used for debug-log correlation — it is not sent to the server
-    and is not a dedup key (the server persists external items with a
-    random primary key).
+    Sent as the external item's ``source_id`` so the server derives a stable
+    primary key. It is also used for debug-log correlation.
 
     :param params: Codex notification params.
     :param item: Codex item payload.
-    :returns: Record label, e.g. ``"turn_abc:item_xyz"``.
+    :returns: Record label, e.g. ``"thread_abc:turn_abc:item_xyz"``.
     """
+    thread_id = _thread_id_from_params(params)
     turn_id = params.get("turnId")
     item_id = item.get("id")
-    left = turn_id if isinstance(turn_id, str) and turn_id else "thread"
-    right = item_id if isinstance(item_id, str) and item_id else "item"
-    return f"{left}:{right}"
+    thread = thread_id if isinstance(thread_id, str) and thread_id else "thread"
+    turn = turn_id if isinstance(turn_id, str) and turn_id else "turn"
+    native_item = item_id if isinstance(item_id, str) and item_id else "item"
+    return f"{thread}:{turn}:{native_item}"
+
+
+def _bounded_source_id(source_id: str) -> str:
+    """Keep a stable source id within the Sessions API limit."""
+    stripped = source_id.strip()
+    if len(stripped) <= _SOURCE_ID_MAX_CHARS:
+        return stripped
+    digest = hashlib.sha256(stripped.encode("utf-8")).hexdigest()
+    return f"codex:{digest}"
 
 
 def _completed_item_key(

--- a/omnigent/native/_native_post_delivery.py
+++ b/omnigent/native/_native_post_delivery.py
@@ -2,13 +2,10 @@
 event POSTs.
 
 The claude-native, codex-native, and antigravity-native forwarders mirror
-transcript items into AP as ``external_conversation_item`` POSTs. The server
-persists those with a random primary key and does NOT dedupe them — producers
-are responsible for not re-posting items they have already sent. That makes a
-blind retry after a failed POST unsafe: if the server committed the item and
-published ``session.input.consumed`` but the response was lost, a retry appends
-a second copy and the web UI renders a duplicate bubble. The native tmux pane
-is unaffected, which is why the duplicate is web-only.
+transcript items into AP as ``external_conversation_item`` POSTs. Producers
+that include a stable ``source_id`` receive store-level idempotency; legacy
+payloads without one still use random item ids, so an ambiguous retry can
+append a duplicate bubble visible only in the web UI.
 
 :func:`post_may_have_been_delivered` is the shared classifier all forwarders
 use to decide whether a failed POST is safe to retry.
@@ -77,8 +74,8 @@ def append_dead_letter(
     :param reason: Short human-readable cause, e.g.
         ``"permanent HTTP failure after retries"``.
     :param delivered_ambiguous: Whether the failure was ambiguous (request sent,
-        response lost), so the server may have committed the item. Such records are
-        NEVER replayed — a re-POST risks a duplicate (no server-side dedup).
+        response lost), so the server may have committed the item. Replay is safe
+        only when the payload carries a stable server-side ``source_id``.
     :param http_status: Final HTTP status code when the server responded, e.g.
         ``503`` or ``400``; ``None`` for a transport failure that saw no response.
     :param transport_error: Transport-error class name when the POST raised without a
@@ -349,11 +346,11 @@ def _dead_letter_record_replayable(
     """
     Return whether a dead-letter record is safe to re-POST on startup (#1579).
 
-    Only *proven-undelivered* records are replayable: a transport failure that
-    never reached the server, or a retryable status (e.g. ``503``) exhausted
-    after the forwarder's bounded retries. Ambiguous failures (the server may
-    have committed the item) and permanent rejections (a 4xx the server will
-    just reject again) are never replayed.
+    Proven-undelivered records are replayable: a transport failure that never
+    reached the server, or a retryable status (e.g. ``503``) exhausted after
+    bounded retries. Ambiguous conversation-item failures are also replayable
+    when their payload carries a stable ``source_id`` because the server
+    deduplicates the retry. Permanent rejections remain forensic only.
 
     Records written before classification was added (#1579) lack the
     ``delivered_ambiguous`` field; they are treated as unsafe (forensic only)
@@ -380,11 +377,18 @@ def _dead_letter_record_replayable(
     if "delivered_ambiguous" not in record:
         return False
     if record.get("delivered_ambiguous"):
-        return False
+        payload = record.get("payload")
+        source_id = payload.get("source_id") if isinstance(payload, dict) else None
+        if not (
+            event_type == "external_conversation_item"
+            and isinstance(source_id, str)
+            and bool(source_id.strip())
+        ):
+            return False
     http_status = record.get("http_status")
     if http_status is None:
-        # Transport failure with no response (ambiguous already excluded above)
-        # — proven undelivered, so safe to re-POST.
+        # Either the request was proven undelivered, or it was ambiguous but
+        # carries a source id that makes the replay idempotent.
         return True
     # The server responded: only a retryable status is recoverable; a permanent
     # 4xx would just be rejected again.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2829,6 +2829,7 @@ def _publish_external_conversation_item(
     session_id: str,
     item: ConversationItem,
     cleared_pending_id: str | None = None,
+    message_id: str | None = None,
 ) -> None:
     """
     Broadcast a terminal-observed conversation item.
@@ -2847,6 +2848,7 @@ def _publish_external_conversation_item(
         at the persist site — see :func:`_persist_external_conversation_item`
         — because it also folds the entry's file blocks into the durable
         item before append.
+    :param message_id: Optional live-preview stream finalized by this item.
     :returns: None.
     """
     if item.type == "message" and isinstance(item.data, MessageData):
@@ -2858,7 +2860,10 @@ def _publish_external_conversation_item(
             # path that filters on the flag, so keep it off the stream.
             return
     event = OutputItemDoneEvent(type="response.output_item.done", item=item.to_api_dict())
-    session_stream.publish(session_id, event.model_dump())
+    payload = event.model_dump()
+    if message_id is not None:
+        payload["message_id"] = message_id
+    session_stream.publish(session_id, payload)
 
 
 def _publish_external_output_text_delta(session_id: str, body: SessionEventInput) -> None:
@@ -3181,6 +3186,12 @@ def _parse_external_conversation_item(
     if not isinstance(response_id, str) or not response_id.strip():
         raise OmnigentError(
             "external_conversation_item data.response_id must be a non-empty string",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    message_id = body.data.get("message_id")
+    if message_id is not None and (not isinstance(message_id, str) or not message_id):
+        raise OmnigentError(
+            "external_conversation_item data.message_id must be a non-empty string",
             code=ErrorCode.INVALID_INPUT,
         )
     # NOTE: producers that can re-post (the native transcript forwarders

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -3210,6 +3210,8 @@ def _parse_external_conversation_item(
             f"Invalid data payload for external item type {item_type!r}: {exc}",
             code=ErrorCode.INVALID_INPUT,
         ) from exc
+    if message_id is not None and isinstance(data, MessageData) and data.role == "assistant":
+        data = data.model_copy(update={"stream_message_id": message_id})
     return NewConversationItem(
         type=item_type,
         response_id=response_id.strip(),

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -2441,8 +2441,12 @@ async def _persist_external_conversation_item(
     await _seed_missing_title_from_user_message(conv, item, conversation_store)
     if pending_background_title is not None:
         pending_background_title.schedule(expected_seed_title=conv.title)
+    message_id = body.data.get("message_id")
     _publish_external_conversation_item(
-        session_id, persisted, cleared_pending_id=cleared_pending_id
+        session_id,
+        persisted,
+        cleared_pending_id=cleared_pending_id,
+        message_id=message_id if isinstance(message_id, str) else None,
     )
     _drive_terminal_resolved_elicitation(session_id, persisted)
     return persisted.id

--- a/openapi.json
+++ b/openapi.json
@@ -3172,6 +3172,18 @@
             ],
             "title": "Role",
             "type": "string"
+          },
+          "stream_message_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Native live-preview stream finalized by this assistant message. Persisted so reconnect snapshots can suppress delayed preview chunks after the authoritative item.",
+            "title": "Stream Message Id"
           }
         },
         "required": [

--- a/tests/e2e_ui/chat/test_codex_native_stream_backlog.py
+++ b/tests/e2e_ui/chat/test_codex_native_stream_backlog.py
@@ -1,0 +1,312 @@
+"""Codex web UI falls behind during high-volume native streaming.
+
+During a high-volume codex-native turn the TUI keeps producing output while
+the web transcript trickles in far behind, because the forwarder posts
+(nearly) one transcript-relay POST per streamed delta:
+
+- ``item/reasoning/textDelta`` bypasses the text coalescer entirely — one
+  awaited relay POST per delta.
+- ``item/commandExecution/outputDelta`` rides the coalescer but is flushed
+  on every newline — one POST per output line.
+- ``item/agentMessage/delta`` coalesces only up to a 64-character
+  threshold — one POST per ~64 characters of answer text.
+
+The relay POSTs are serialized (per-delta inline awaits and a single FIFO
+worker), so when the relay is transiently slow the backlog drains far more
+slowly than Codex emits, and the web UI looks stuck until it catches up.
+
+Journey driven here (mirroring ``test_codex_native_subagent_activity.py``):
+open the session page in the SPA, then feed the real forwarder
+(``_handle_event``) the exact notification stream shape a Codex TUI
+app-server emits for one high-volume turn — reasoning deltas, command
+output lines, and assistant text deltas — against the live spawned server.
+A small per-request latency on the forwarder's HTTP transport stands in for
+the reported transient relay slowness; the POST-count assertions are
+latency-independent, so the regression guard is deterministic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from omnigent.harnesses.codex_native import forwarder as codex_native_forwarder
+from omnigent.harnesses.codex_native.bridge import (
+    CodexNativeBridgeState,
+    write_bridge_state,
+)
+
+_THREAD_ID = "thread_hv_stream"
+_TURN_ID = "turn_hv_stream"
+
+# High-volume turn shape: tiny deltas, the way Codex streams them.
+_N_REASONING_DELTAS = 150
+_N_COMMAND_LINES = 150
+_N_TEXT_DELTAS = 240
+_MARKER = "HIGH-VOLUME-STREAM-END"
+
+# Simulated transient relay slowness per request. Only stretches the
+# user-visible drain time; every count asserted below is unaffected by it.
+_RELAY_LATENCY_SECONDS = 0.02
+
+# Aggregate relay budget for the whole scripted turn. Today's per-delta
+# behavior spends ~330 POSTs on it; coalesced streaming needs a few dozen.
+_TOTAL_RELAY_POST_BUDGET = 120
+
+
+class _CountingLatencyTransport(httpx.AsyncBaseTransport):
+    """Delegate to a real transport, counting and slowing relay event POSTs.
+
+    :param latency_seconds: Added delay per ``POST .../events`` request,
+        standing in for a transiently slow transcript relay.
+    :param counts: Counter keyed by posted event ``type``.
+    """
+
+    def __init__(self, latency_seconds: float, counts: Counter[str]) -> None:
+        self._inner = httpx.AsyncHTTPTransport()
+        self._latency_seconds = latency_seconds
+        self._counts = counts
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            try:
+                payload = json.loads(request.content.decode("utf-8"))
+                event_type = payload.get("type", "<untyped>")
+            except (ValueError, UnicodeDecodeError):
+                event_type = "<unparsed>"
+            self._counts[event_type] += 1
+            await asyncio.sleep(self._latency_seconds)
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+def _scripted_high_volume_turn() -> tuple[list[dict[str, object]], str]:
+    """Build the Codex app-server notification stream for one big turn.
+
+    :returns: ``(events, full_answer_text)`` where ``events`` is the ordered
+        notification list and ``full_answer_text`` the completed assistant
+        message the deltas add up to.
+    """
+    events: list[dict[str, object]] = [
+        {
+            "method": "turn/started",
+            "params": {
+                "threadId": _THREAD_ID,
+                "turn": {"id": _TURN_ID, "status": "inProgress"},
+            },
+        },
+        {
+            "method": "item/completed",
+            "params": {
+                "threadId": _THREAD_ID,
+                "turnId": _TURN_ID,
+                "item": {
+                    "type": "userMessage",
+                    "id": "item_user_hv_stream",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Run the full release build and summarize the output.",
+                        }
+                    ],
+                },
+            },
+        },
+    ]
+    for i in range(_N_REASONING_DELTAS):
+        events.append(
+            {
+                "method": "item/reasoning/textDelta",
+                "params": {
+                    "threadId": _THREAD_ID,
+                    "turnId": _TURN_ID,
+                    "itemId": "item_reasoning_hv_stream",
+                    "delta": f"considering step {i:03d} ",
+                },
+            }
+        )
+    for i in range(_N_COMMAND_LINES):
+        events.append(
+            {
+                "method": "item/commandExecution/outputDelta",
+                "params": {
+                    "threadId": _THREAD_ID,
+                    "turnId": _TURN_ID,
+                    "itemId": "call_build_hv_stream",
+                    "delta": f"compiling module {i:03d} ... ok\n",
+                },
+            }
+        )
+    words = [f"wd{i:04d} " for i in range(_N_TEXT_DELTAS)]
+    words.append(_MARKER)
+    for word in words:
+        events.append(
+            {
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "threadId": _THREAD_ID,
+                    "turnId": _TURN_ID,
+                    "itemId": "item_agent_hv_stream",
+                    "delta": word,
+                },
+            }
+        )
+    full_text = "".join(words)
+    events.append(
+        {
+            "method": "item/completed",
+            "params": {
+                "threadId": _THREAD_ID,
+                "turnId": _TURN_ID,
+                "item": {
+                    "type": "agentMessage",
+                    "id": "item_agent_hv_stream",
+                    "text": full_text,
+                },
+            },
+        }
+    )
+    events.append(
+        {
+            "method": "turn/completed",
+            "params": {
+                "threadId": _THREAD_ID,
+                "turn": {"id": _TURN_ID, "status": "completed", "items": []},
+            },
+        }
+    )
+    return events, full_text
+
+
+async def _drive_high_volume_turn(
+    base_url: str, session_id: str, bridge_dir: Path
+) -> dict[str, object]:
+    """Feed the scripted turn through the real forwarder against the server.
+
+    Seeds the bridge state exactly like a native Codex launch does, then
+    hands every notification to ``_handle_event`` with the production
+    coalescer configuration, over a latency-injected counting transport.
+
+    :param base_url: Live spawned server base URL.
+    :param session_id: Seeded session (conversation) id.
+    :param bridge_dir: Temp dir standing in for the native bridge dir.
+    :returns: Metrics: relay POST ``counts`` and the drain wall-clock.
+    """
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    codex_home = bridge_dir / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    write_bridge_state(
+        bridge_dir,
+        CodexNativeBridgeState(
+            session_id=session_id,
+            socket_path=str(bridge_dir / "codex.sock"),
+            thread_id=_THREAD_ID,
+            codex_home=str(codex_home),
+            active_turn_id=None,
+            cwd=None,
+        ),
+    )
+
+    counts: Counter[str] = Counter()
+    transport = _CountingLatencyTransport(_RELAY_LATENCY_SECONDS, counts)
+    state = codex_native_forwarder._CodexForwarderState(parent_session_id=session_id)
+    tracker = codex_native_forwarder._CodexElicitationTaskTracker()
+    events, _ = _scripted_high_volume_turn()
+
+    started = time.monotonic()
+    async with httpx.AsyncClient(base_url=base_url, transport=transport, timeout=30.0) as client:
+        usage_coalescer = codex_native_forwarder._SessionUsageCoalescer(client, session_id)
+        delta_coalescer = codex_native_forwarder._OutputTextDeltaCoalescer(client, session_id)
+        try:
+            for event in events:
+                await codex_native_forwarder._handle_event(
+                    client,
+                    session_id=session_id,
+                    bridge_dir=bridge_dir,
+                    event=event,
+                    usage_coalescer=usage_coalescer,
+                    elicitation_tracker=tracker,
+                    delta_coalescer=delta_coalescer,
+                    expected_thread_id=_THREAD_ID,
+                    forwarder_state=state,
+                )
+        finally:
+            await delta_coalescer.close()
+            await usage_coalescer.flush()
+            await tracker.close()
+    return {
+        "counts": counts,
+        "drain_seconds": time.monotonic() - started,
+        "n_events": len(events),
+    }
+
+
+def test_high_volume_codex_native_stream_is_coalesced(
+    page: Page,
+    seeded_session: tuple[str, str],
+    tmp_path: Path,
+) -> None:
+    """One high-volume Codex turn must not spend a relay POST per delta.
+
+    Fails on the per-delta relay posting behavior: ~1 POST per reasoning delta,
+    ~1 POST per command output line, and 64-char text batches make the
+    serialized relay queue (and therefore the web transcript) fall far
+    behind the TUI whenever the relay slows down.
+    """
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_label("Message the agent")).to_be_visible(timeout=30_000)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        metrics = executor.submit(
+            asyncio.run,
+            _drive_high_volume_turn(base_url, session_id, tmp_path / "bridge"),
+        ).result()
+
+    # Journey end state: the web transcript did (eventually) catch up and
+    # shows the completed answer — the report's symptom is lag, not loss.
+    expect(page.get_by_text(_MARKER).first).to_be_visible(timeout=30_000)
+
+    counts: Counter[str] = metrics["counts"]  # type: ignore[assignment]
+    reasoning_posts = counts.get("external_output_reasoning_delta", 0)
+    tool_output_posts = counts.get("external_tool_output_delta", 0)
+    text_posts = counts.get("external_output_text_delta", 0)
+    total_posts = sum(counts.values())
+    print(
+        "codex-native stream relay metrics: "
+        f"total_posts={total_posts} reasoning_posts={reasoning_posts} "
+        f"tool_output_posts={tool_output_posts} text_posts={text_posts} "
+        f"drain_seconds={metrics['drain_seconds']:.2f} "
+        f"n_events={metrics['n_events']} counts={dict(counts)}"
+    )
+
+    assert reasoning_posts <= _N_REASONING_DELTAS // 4, (
+        f"{reasoning_posts} relay POSTs for {_N_REASONING_DELTAS} reasoning deltas: "
+        "reasoning deltas are posted one-by-one instead of coalesced, so a slow "
+        f"relay backlogs the web UI (drain took {metrics['drain_seconds']:.2f}s "
+        f"at {_RELAY_LATENCY_SECONDS * 1000:.0f}ms simulated relay latency)"
+    )
+    assert tool_output_posts <= _N_COMMAND_LINES // 4, (
+        f"{tool_output_posts} relay POSTs for {_N_COMMAND_LINES} command output "
+        "lines: every newline forces a command-output flush, so line-oriented "
+        "output posts once per line and backlogs the web UI"
+    )
+    assert text_posts <= 12, (
+        f"{text_posts} relay POSTs for {_N_TEXT_DELTAS + 1} assistant text deltas: "
+        "the 64-character batch threshold posts once per ~64 chars of answer text"
+    )
+    assert total_posts <= _TOTAL_RELAY_POST_BUDGET, (
+        f"{total_posts} relay POSTs for one scripted high-volume turn "
+        f"(budget {_TOTAL_RELAY_POST_BUDGET}): per-delta posting amplifies "
+        "transient relay slowness into a client-visible transcript backlog"
+    )

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4153,6 +4153,7 @@ async def test_post_external_conversation_item_persists_and_streams_visible_item
             "item_type": "message",
             "response_id": "resp_terminal_assistant",
             "source_id": "src_terminal_assistant_2",
+            "message_id": "codex:thread_1:turn_1:agentMessage:item_1",
             "item_data": {
                 "role": "assistant",
                 "agent": "claude-native-ui",
@@ -4222,6 +4223,7 @@ async def test_post_external_conversation_item_persists_and_streams_visible_item
     assert published[1][1]["item"]["type"] == "function_call"
     assert published[2][1]["item"]["type"] == "function_call_output"
     assert published[3][1]["item"]["type"] == "message"
+    assert published[3][1]["message_id"] == "codex:thread_1:turn_1:agentMessage:item_1"
     assert published[4][1]["item"]["type"] == "terminal_command"
     assert published[5][1]["item"]["type"] == "terminal_command"
 

--- a/tests/server/routes/test_external_conversation_item.py
+++ b/tests/server/routes/test_external_conversation_item.py
@@ -1,0 +1,38 @@
+"""Tests for externally-forwarded conversation-item parsing."""
+
+from omnigent.entities import ConversationItem, MessageData
+from omnigent.server.routes.sessions import _parse_external_conversation_item
+from omnigent.server.schemas import SessionEventInput
+
+
+def test_native_message_stream_id_survives_snapshot_serialization() -> None:
+    """The completed item durably identifies the preview stream it replaces."""
+    parsed = _parse_external_conversation_item(
+        SessionEventInput(
+            type="external_conversation_item",
+            data={
+                "item_type": "message",
+                "item_data": {
+                    "role": "assistant",
+                    "agent": "codex",
+                    "content": [{"type": "output_text", "text": "done"}],
+                },
+                "response_id": "turn_1",
+                "message_id": "codex:thread_1:turn_1:agentMessage:item_1",
+            },
+        )
+    )
+
+    assert isinstance(parsed.data, MessageData)
+    assert parsed.data.stream_message_id == "codex:thread_1:turn_1:agentMessage:item_1"
+    persisted = ConversationItem(
+        id="item_1",
+        type=parsed.type,
+        status="completed",
+        response_id=parsed.response_id,
+        created_at=1,
+        data=parsed.data,
+    )
+    assert persisted.to_api_dict()["stream_message_id"] == (
+        "codex:thread_1:turn_1:agentMessage:item_1"
+    )

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -1971,6 +1971,22 @@ def test_subscribe_until_ready_replays_completed_turn_status(
                     "id": "thread_123",
                     "turns": [
                         {
+                            "id": "turn_122",
+                            "status": "completed",
+                            "items": [
+                                {
+                                    "type": "userMessage",
+                                    "id": "item_old_user",
+                                    "content": [{"type": "text", "text": "already synced"}],
+                                },
+                                {
+                                    "type": "agentMessage",
+                                    "id": "item_old_agent",
+                                    "text": "already synced reply",
+                                },
+                            ],
+                        },
+                        {
                             "id": "turn_123",
                             "status": "completed",
                             "items": [
@@ -1985,7 +2001,7 @@ def test_subscribe_until_ready_replays_completed_turn_status(
                                     "text": "reply",
                                 },
                             ],
-                        }
+                        },
                     ],
                 }
             }
@@ -2025,6 +2041,7 @@ def test_subscribe_until_ready_replays_completed_turn_status(
 
     asyncio.run(run())
 
+    assert fake_client.requests == [("thread/resume", {"threadId": "thread_123"})]
     assert [payload["type"] for payload in posted] == [
         "external_conversation_item",
         "external_conversation_item",
@@ -2935,6 +2952,7 @@ def test_forwarder_persists_interrupted_codex_partial_agent_message(tmp_path: Pa
                     "content": [{"type": "output_text", "text": "partial answer"}],
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:interrupted-partial",
             },
         },
         {
@@ -4004,6 +4022,8 @@ def test_forwarder_keeps_streaming_when_native_tui_answers_codex_elicitation(
                     "content": [{"type": "output_text", "text": "after approval"}],
                 },
                 "response_id": "codex_turn_123",
+                "message_id": "codex:thread_123:turn_123:agentMessage:item_agent",
+                "source_id": "thread_123:turn_123:item_agent",
             },
         },
     ]
@@ -5818,6 +5838,7 @@ def test_forwarder_posts_codex_user_and_agent_messages(tmp_path: Path) -> None:
                     "content": [{"type": "input_text", "text": "hello codex"}],
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:item_user",
             },
         },
         {
@@ -5830,6 +5851,8 @@ def test_forwarder_posts_codex_user_and_agent_messages(tmp_path: Path) -> None:
                     "content": [{"type": "output_text", "text": "hello from codex"}],
                 },
                 "response_id": "codex_turn_123",
+                "message_id": "codex:thread_123:turn_123:agentMessage:item_agent",
+                "source_id": "thread_123:turn_123:item_agent",
             },
         },
     ]
@@ -6132,6 +6155,8 @@ def test_forwarder_posts_completed_codex_plan_item() -> None:
                     ],
                 },
                 "response_id": "codex_turn_123",
+                "message_id": "codex:thread_123:turn_123:plan:plan_123",
+                "source_id": "thread_123:turn_123:plan_123",
             },
         }
     ]
@@ -6232,6 +6257,7 @@ def test_forwarder_posts_codex_command_execution_tool_call() -> None:
                     "call_id": "call_abc123",
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:call_abc123:call",
             },
         },
         {
@@ -6243,6 +6269,7 @@ def test_forwarder_posts_codex_command_execution_tool_call() -> None:
                     "output": "hello world\n",
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:call_abc123:output",
             },
         },
     ]
@@ -6356,6 +6383,7 @@ def test_forwarder_streams_codex_command_output_before_completed_item(tmp_path: 
             "output": "collecting tests...\n1 passed\n",
         },
         "response_id": "codex_turn_123",
+        "source_id": "thread_123:turn_123:call_abc123:output",
     }
 
 
@@ -6535,6 +6563,7 @@ def test_forwarder_posts_codex_image_view_tool_call() -> None:
                     "call_id": "img_view_1",
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:img_view_1:call",
             },
         },
         {
@@ -6546,6 +6575,7 @@ def test_forwarder_posts_codex_image_view_tool_call() -> None:
                     "output": "/repo/screenshot.png",
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:img_view_1:output",
             },
         },
     ]
@@ -6653,6 +6683,7 @@ def test_forwarder_posts_codex_entered_review_mode_marker() -> None:
                     ],
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:review_1",
             },
         }
     ]
@@ -6688,6 +6719,7 @@ def test_forwarder_posts_codex_exited_review_mode_marker() -> None:
                     "content": [{"type": "output_text", "text": "Exited review mode"}],
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:review_2",
             },
         }
     ]
@@ -6773,6 +6805,7 @@ def test_forwarder_coalesces_and_flushes_turn_diff(tmp_path: Path) -> None:
                     "call_id": "codex_turn_diff_turn_123",
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:turn-diff:call",
             },
         },
         {
@@ -6784,6 +6817,7 @@ def test_forwarder_coalesces_and_flushes_turn_diff(tmp_path: Path) -> None:
                     "output": latest_diff,
                 },
                 "response_id": "codex_turn_123",
+                "source_id": "thread_123:turn_123:turn-diff:output",
             },
         },
         {

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -1729,33 +1729,32 @@ async def test_reasoning_delta_opens_block_then_continues() -> None:
     """
     client = _RecordingClient()
     state = fwd._CodexForwarderState()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=1000,
+    )
 
     await fwd._handle_reasoning_delta(
-        client,
-        "conv_x",
         {"turnId": "turn_1", "itemId": "item_r", "delta": "Let me "},
+        coalescer,
         state,
     )
     await fwd._handle_reasoning_delta(
-        client,
-        "conv_x",
         {"turnId": "turn_1", "itemId": "item_r", "delta": "think."},
+        coalescer,
         state,
     )
+    await coalescer.flush()
+    await coalescer.close()
 
     assert client.posts == [
         (
             "/v1/sessions/conv_x/events",
             {
                 "type": "external_output_reasoning_delta",
-                "data": {"delta": "Let me ", "started": True},
-            },
-        ),
-        (
-            "/v1/sessions/conv_x/events",
-            {
-                "type": "external_output_reasoning_delta",
-                "data": {"delta": "think.", "started": False},
+                "data": {"delta": "Let me think.", "started": True},
             },
         ),
     ]
@@ -1772,13 +1771,17 @@ async def test_reasoning_delta_new_item_reopens_block() -> None:
     """
     client = _RecordingClient()
     state = fwd._CodexForwarderState()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=1000,
+    )
 
-    await fwd._handle_reasoning_delta(
-        client, "conv_x", {"itemId": "item_a", "delta": "first"}, state
-    )
-    await fwd._handle_reasoning_delta(
-        client, "conv_x", {"itemId": "item_b", "delta": "second"}, state
-    )
+    await fwd._handle_reasoning_delta({"itemId": "item_a", "delta": "first"}, coalescer, state)
+    await fwd._handle_reasoning_delta({"itemId": "item_b", "delta": "second"}, coalescer, state)
+    await coalescer.flush()
+    await coalescer.close()
 
     started_flags = [post[1]["data"]["started"] for post in client.posts]
     assert started_flags == [True, True]
@@ -1795,11 +1798,19 @@ async def test_reasoning_delta_skips_empty_non_opening_delta() -> None:
     """
     client = _RecordingClient()
     state = fwd._CodexForwarderState()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=1000,
+    )
 
     # Opening delta (empty) still posts to open the block.
-    await fwd._handle_reasoning_delta(client, "conv_x", {"itemId": "item_r", "delta": ""}, state)
+    await fwd._handle_reasoning_delta({"itemId": "item_r", "delta": ""}, coalescer, state)
     # Empty continuation for the same item is dropped.
-    await fwd._handle_reasoning_delta(client, "conv_x", {"itemId": "item_r", "delta": ""}, state)
+    await fwd._handle_reasoning_delta({"itemId": "item_r", "delta": ""}, coalescer, state)
+    await coalescer.flush()
+    await coalescer.close()
 
     assert len(client.posts) == 1
     assert client.posts[0][1]["data"] == {"delta": "", "started": True}
@@ -3032,21 +3043,25 @@ async def test_delta_coalescer_close_gives_up_on_a_wedged_worker(
     worker = coalescer._worker_task
     assert worker is not None
 
-    await asyncio.wait_for(coalescer.close(), timeout=fwd._DELTA_MARKER_TIMEOUT_SECONDS + 5.0)
+    try:
+        await asyncio.wait_for(coalescer.close(), timeout=fwd._DELTA_MARKER_TIMEOUT_SECONDS + 5.0)
 
-    # close() gave up on the bound rather than waiting out a worker still stuck in its post.
-    assert coalescer._worker_task is None
-    assert not worker.done()
-    worker.cancel()
+        # Once the close deadline expires, cancel and reap the worker so it
+        # cannot outlive the HTTP client that owns its in-flight POST.
+        assert coalescer._worker_task is None
+        assert worker.cancelled()
+    finally:
+        if not worker.done():
+            worker.cancel()
+            await asyncio.gather(worker, return_exceptions=True)
 
 
 @pytest.mark.asyncio
 async def test_delta_coalescer_worker_survives_an_already_settled_marker() -> None:
     """Resolving a marker whose future is already settled must not kill the worker.
 
-    ``set_result`` on a settled future raises ``InvalidStateError``, and
-    ``_ensure_worker`` only replaces a ``None`` task, so a worker lost this way is
-    never restarted and every later delta is dropped without a word.
+    ``set_result`` on a settled future raises ``InvalidStateError`` inside the
+    worker, so every later delta would otherwise be dropped without a word.
     """
     client = _RecordingClient()
     coalescer = _coalescer(client)
@@ -3073,10 +3088,9 @@ async def test_delta_coalescer_worker_survives_an_already_settled_marker() -> No
 async def test_delta_coalescer_survives_a_cancelled_flush_caller() -> None:
     """A cancelled ``flush()`` caller must not kill the worker.
 
-    The caller's cancellation settles its own future. Resolving it again raises
-    ``InvalidStateError`` inside the worker, and ``_ensure_worker`` only replaces a
-    ``None`` task, so the dead worker was never restarted and every later delta was
-    silently dropped.
+    The caller's cancellation can settle its own future. Resolving it again raises
+    ``InvalidStateError`` inside the worker, so every later delta would otherwise
+    be silently dropped.
     """
     client = _RecordingClient()
     coalescer = _coalescer(client)
@@ -3098,6 +3112,137 @@ async def test_delta_coalescer_survives_a_cancelled_flush_caller() -> None:
     )
     await asyncio.wait_for(coalescer.flush(), timeout=5.0)
     assert len(client.posts) > posts_before
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_batches_newline_heavy_tool_output() -> None:
+    """Line-oriented command output is batched instead of POSTed per line."""
+    client = _RecordingClient()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=100_000,
+    )
+    chunks = [f"line {index}\n" for index in range(200)]
+
+    for chunk in chunks:
+        await coalescer.append_tool_output(chunk, call_id="call_1")
+    await coalescer.flush()
+    await coalescer.close()
+
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_tool_output_delta",
+                "data": {"call_id": "call_1", "delta": "".join(chunks)},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_preserves_mixed_stream_order() -> None:
+    """Assistant and reasoning batches retain their Codex arrival order."""
+    client = _RecordingClient()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=100_000,
+    )
+
+    await coalescer.append("answer one", message_id="message_1")
+    await coalescer.append_reasoning("think ", started=True)
+    await coalescer.append_reasoning("more", started=False)
+    await coalescer.append("answer two", message_id="message_2")
+    await coalescer.flush()
+    await coalescer.close()
+
+    assert [post[1]["type"] for post in client.posts] == [
+        "external_output_text_delta",
+        "external_output_reasoning_delta",
+        "external_output_text_delta",
+    ]
+    assert [post[1]["data"]["delta"] for post in client.posts] == [
+        "answer one",
+        "think more",
+        "answer two",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_timeout_preserves_backlog_until_post_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timeout keeps queued deltas and later flushes ordered behind the slow POST."""
+
+    class _HangingFirstClient:
+        """Hold the first POST until the test releases the simulated stall."""
+
+        def __init__(self) -> None:
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+            self.posts: list[tuple[str, dict]] = []
+            self.calls = 0
+
+        async def post(self, url: str, *, json: dict) -> httpx.Response:
+            self.calls += 1
+            if self.calls == 1:
+                self.entered.set()
+                await self.release.wait()
+            self.posts.append((url, json))
+            return httpx.Response(200, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(fwd, "_DELTA_MARKER_TIMEOUT_SECONDS", 0.05)
+    client = _HangingFirstClient()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=1,
+    )
+
+    await coalescer.append("stale", message_id="old")
+    await asyncio.wait_for(client.entered.wait(), timeout=5.0)
+    await coalescer.flush()
+
+    await coalescer.append("fresh", message_id="new")
+    later_flush = asyncio.create_task(coalescer.flush())
+    await asyncio.sleep(0.01)
+    assert not later_flush.done()
+    client.release.set()
+    await later_flush
+    await coalescer.close()
+
+    assert client.calls == 2
+    assert client.posts == [
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_output_text_delta",
+                "data": {
+                    "delta": "stale",
+                    "message_id": "old",
+                    "index": 0,
+                    "final": False,
+                },
+            },
+        ),
+        (
+            "/v1/sessions/conv_x/events",
+            {
+                "type": "external_output_text_delta",
+                "data": {
+                    "delta": "fresh",
+                    "message_id": "new",
+                    "index": 0,
+                    "final": False,
+                },
+            },
+        ),
+    ]
 
 
 def test_default_collaboration_mode_refuses_when_developer_instructions_never_confirmed() -> None:

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -44,13 +44,20 @@ class _RecordingClient:
         """Initialize with an empty record of posts."""
         self.posts: list[tuple[str, dict]] = []
 
-    async def post(self, url: str, *, json: dict) -> httpx.Response:
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict,
+        timeout: float | None = None,
+    ) -> httpx.Response:
         """
         Record ``(url, json)`` and return a 200 response.
 
         :param url: Request URL, e.g. ``"/v1/sessions/conv_x/events"``.
         :param json: JSON body, e.g.
             ``{"type": "external_model_change", "data": {"model": "gpt-5.4"}}``.
+        :param timeout: Ignored request timeout used by transient delta posts.
         :returns: A real ``httpx.Response`` with status 200.
         """
         self.posts.append((url, json))
@@ -2011,7 +2018,7 @@ async def test_post_session_event_dead_letters_durable_event_on_permanent_failur
 
     fwd._reset_forward_health()
 
-    async def _failing_inner(client, session_id, *, event_type, data):
+    async def _failing_inner(client, session_id, *, event_type, data, max_attempts, timeout):
         return fwd._PostResult(
             response=httpx.Response(500, request=httpx.Request("POST", "http://test"))
         )
@@ -2051,7 +2058,7 @@ async def test_post_session_event_does_not_dead_letter_ephemeral_event(
     """
     fwd._reset_forward_health()
 
-    async def _failing_inner(client, session_id, *, event_type, data):
+    async def _failing_inner(client, session_id, *, event_type, data, max_attempts, timeout):
         return fwd._PostResult(
             response=httpx.Response(500, request=httpx.Request("POST", "http://test"))
         )
@@ -2089,7 +2096,7 @@ async def test_post_session_event_dead_letters_usage_on_permanent_failure(
 
     fwd._reset_forward_health()
 
-    async def _failing_inner(client, session_id, *, event_type, data):
+    async def _failing_inner(client, session_id, *, event_type, data, max_attempts, timeout):
         return fwd._PostResult(
             response=httpx.Response(500, request=httpx.Request("POST", "http://test"))
         )
@@ -2191,7 +2198,7 @@ async def test_post_session_event_dead_letters_ambiguous_classification(
 
     fwd._reset_forward_health()
 
-    async def _ambiguous_inner(client, session_id, *, event_type, data):
+    async def _ambiguous_inner(client, session_id, *, event_type, data, max_attempts, timeout):
         return fwd._PostResult(
             response=None, delivered_ambiguous=True, transport_error="ReadTimeout"
         )
@@ -2229,7 +2236,7 @@ async def test_post_session_event_dead_letters_records_http_status(
 
     fwd._reset_forward_health()
 
-    async def _failing_inner(client, session_id, *, event_type, data):
+    async def _failing_inner(client, session_id, *, event_type, data, max_attempts, timeout):
         return fwd._PostResult(
             response=httpx.Response(503, request=httpx.Request("POST", "http://test"))
         )
@@ -3037,8 +3044,7 @@ async def test_delta_coalescer_close_gives_up_on_a_wedged_worker(
     monkeypatch.setattr(fwd, "_DELTA_MARKER_TIMEOUT_SECONDS", 0.1)
     client = _HangingClient()
     coalescer = _coalescer(client)
-    coalescer._ensure_worker()
-    coalescer._queue.put_nowait(fwd._DeltaChunk(message_id="m1", tool_call_id=None, delta="x"))
+    await coalescer.append("x", message_id="m1")
     await asyncio.wait_for(client.entered.wait(), timeout=5.0)
     worker = coalescer._worker_task
     assert worker is not None
@@ -3077,9 +3083,7 @@ async def test_delta_coalescer_worker_survives_an_already_settled_marker() -> No
     assert not coalescer._worker_task.done()
 
     posts_before = len(client.posts)
-    coalescer._queue.put_nowait(
-        fwd._DeltaChunk(message_id="m1", tool_call_id=None, delta="still here")
-    )
+    await coalescer.append("still here", message_id="m1")
     await asyncio.wait_for(coalescer.flush(), timeout=5.0)
     assert len(client.posts) > posts_before
 
@@ -3107,11 +3111,31 @@ async def test_delta_coalescer_survives_a_cancelled_flush_caller() -> None:
     assert not coalescer._worker_task.done()
 
     posts_before = len(client.posts)
-    coalescer._queue.put_nowait(
-        fwd._DeltaChunk(message_id="m1", tool_call_id=None, delta="still here")
-    )
+    await coalescer.append("still here", message_id="m1")
     await asyncio.wait_for(coalescer.flush(), timeout=5.0)
     assert len(client.posts) > posts_before
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_restarts_an_unexpectedly_stopped_worker() -> None:
+    """A dead worker drops its stale queue before later streaming restarts."""
+    client = _RecordingClient()
+    coalescer = _coalescer(client)
+    coalescer._ensure_worker()
+    worker = coalescer._worker_task
+    assert worker is not None
+
+    worker.cancel()
+    await asyncio.gather(worker, return_exceptions=True)
+    stale = fwd._DeltaChunk(message_id="old", tool_call_id=None, delta="stale")
+    coalescer._queue.put_nowait(stale)
+    coalescer._queued_chars = len(stale.delta)
+    await coalescer.flush()
+    await coalescer.append("recovered", message_id="m1")
+    await coalescer.flush()
+    await coalescer.close()
+
+    assert [post[1]["data"]["delta"] for post in client.posts] == ["recovered"]
 
 
 @pytest.mark.asyncio
@@ -3173,30 +3197,57 @@ async def test_delta_coalescer_preserves_mixed_stream_order() -> None:
 
 
 @pytest.mark.asyncio
-async def test_delta_coalescer_timeout_preserves_backlog_until_post_recovers(
+async def test_delta_coalescer_does_not_drop_healthy_burst_at_queue_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A timeout keeps queued deltas and later flushes ordered behind the slow POST."""
+    """A ready worker gets a chance to drain before the queue sheds output."""
+    monkeypatch.setattr(fwd, "_DELTA_QUEUE_CHAR_LIMIT", 10)
+    client = _RecordingClient()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=100,
+    )
 
-    class _HangingFirstClient:
-        """Hold the first POST until the test releases the simulated stall."""
+    await coalescer.append("first!", message_id="m1")
+    await coalescer.append("second", message_id="m1")
+    await coalescer.flush()
+    await coalescer.close()
+
+    assert [post[1]["data"]["delta"] for post in client.posts] == ["first!second"]
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_overflow_drops_backlog_before_durable_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow relay sheds queued previews but preserves the completion boundary."""
+
+    class _SlowFirstClient(_RecordingClient):
+        """Hold the first delta POST while the queue crosses its byte budget."""
 
         def __init__(self) -> None:
+            super().__init__()
             self.entered = asyncio.Event()
             self.release = asyncio.Event()
-            self.posts: list[tuple[str, dict]] = []
             self.calls = 0
 
-        async def post(self, url: str, *, json: dict) -> httpx.Response:
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict,
+            timeout: float | None = None,
+        ) -> httpx.Response:
             self.calls += 1
             if self.calls == 1:
                 self.entered.set()
                 await self.release.wait()
-            self.posts.append((url, json))
-            return httpx.Response(200, request=httpx.Request("POST", url))
+            return await super().post(url, json=json, timeout=timeout)
 
-    monkeypatch.setattr(fwd, "_DELTA_MARKER_TIMEOUT_SECONDS", 0.05)
-    client = _HangingFirstClient()
+    monkeypatch.setattr(fwd, "_DELTA_QUEUE_CHAR_LIMIT", 19)
+    client = _SlowFirstClient()
     coalescer = fwd._OutputTextDeltaCoalescer(
         client,
         "conv_x",
@@ -3206,17 +3257,31 @@ async def test_delta_coalescer_timeout_preserves_backlog_until_post_recovers(
 
     await coalescer.append("stale", message_id="old")
     await asyncio.wait_for(client.entered.wait(), timeout=5.0)
-    await coalescer.flush()
+    await coalescer.append("queued stale", message_id="old")
+    await coalescer.append("overflow", message_id="old")
+    completed = asyncio.create_task(
+        fwd._handle_completed_event(
+            client,  # type: ignore[arg-type]
+            session_id="conv_x",
+            params={
+                "threadId": "thread_1",
+                "turnId": "turn_1",
+                "item": {"id": "item_1", "type": "agentMessage", "text": "final answer"},
+            },
+            delta_coalescer=coalescer,
+            forwarder_state=None,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not completed.done()
+    client.release.set()
+    await asyncio.wait_for(completed, timeout=5.0)
 
     await coalescer.append("fresh", message_id="new")
-    later_flush = asyncio.create_task(coalescer.flush())
-    await asyncio.sleep(0.01)
-    assert not later_flush.done()
-    client.release.set()
-    await later_flush
+    await coalescer.flush()
     await coalescer.close()
 
-    assert client.calls == 2
+    assert client.calls == 3
     assert client.posts == [
         (
             "/v1/sessions/conv_x/events",
@@ -3233,6 +3298,21 @@ async def test_delta_coalescer_timeout_preserves_backlog_until_post_recovers(
         (
             "/v1/sessions/conv_x/events",
             {
+                "type": "external_conversation_item",
+                "data": {
+                    "item_type": "message",
+                    "item_data": {
+                        "role": "assistant",
+                        "agent": "codex-native-ui",
+                        "content": [{"type": "output_text", "text": "final answer"}],
+                    },
+                    "response_id": "codex_turn_1",
+                },
+            },
+        ),
+        (
+            "/v1/sessions/conv_x/events",
+            {
                 "type": "external_output_text_delta",
                 "data": {
                     "delta": "fresh",
@@ -3243,6 +3323,93 @@ async def test_delta_coalescer_timeout_preserves_backlog_until_post_recovers(
             },
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_delta_coalescer_sheds_small_slow_backlog_before_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sub-limit backlog cannot continue posting after the durable item."""
+
+    class _SlowDeltaClient(_RecordingClient):
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            if json["type"] == "external_output_text_delta":
+                await asyncio.sleep(0.04)
+            return await super().post(url, json=json, timeout=timeout)
+
+    monkeypatch.setattr(fwd, "_DELTA_FLUSH_GRACE_SECONDS", 0.02)
+    monkeypatch.setattr(fwd, "_DELTA_MARKER_TIMEOUT_SECONDS", 0.1)
+    client = _SlowDeltaClient()
+    coalescer = fwd._OutputTextDeltaCoalescer(
+        client,
+        "conv_x",
+        flush_interval_seconds=60.0,
+        flush_char_threshold=5,
+    )
+
+    await coalescer.append("first", message_id="old")
+    await asyncio.sleep(0)
+    await coalescer.append("second", message_id="old")
+    await fwd._handle_completed_event(
+        client,  # type: ignore[arg-type]
+        session_id="conv_x",
+        params={
+            "threadId": "thread_1",
+            "turnId": "turn_1",
+            "item": {"id": "item_1", "type": "agentMessage", "text": "final answer"},
+        },
+        delta_coalescer=coalescer,
+        forwarder_state=None,
+    )
+    await asyncio.sleep(0.05)
+    await coalescer.close()
+
+    assert [post[1]["type"] for post in client.posts] == [
+        "external_output_text_delta",
+        "external_conversation_item",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transient_delta_post_uses_one_short_attempt() -> None:
+    """Lossy previews fail fast instead of retrying behind durable events."""
+
+    class _FailingClient:
+        def __init__(self) -> None:
+            self.timeouts: list[float | None] = []
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            self.timeouts.append(timeout)
+            return httpx.Response(503, request=httpx.Request("POST", url))
+
+    fwd._reset_forward_health()
+    try:
+        client = _FailingClient()
+
+        await fwd._post_output_text_delta(
+            client,  # type: ignore[arg-type]
+            "conv_x",
+            "preview",
+            message_id="m1",
+            index=0,
+            final=False,
+        )
+
+        assert client.timeouts == [fwd._DELTA_POST_TIMEOUT_SECONDS]
+    finally:
+        fwd._reset_forward_health()
 
 
 def test_default_collaboration_mode_refuses_when_developer_instructions_never_confirmed() -> None:

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -2300,6 +2300,345 @@ async def test_idempotent_conversation_items_keep_order_while_older_post_is_slow
 
 
 @pytest.mark.asyncio
+async def test_resume_replay_keeps_tool_pair_ahead_of_live_completion() -> None:
+    """Replay holds one delivery scope so live items cannot split a tool pair."""
+
+    class _BlockingFirstPostClient(_RecordingClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            if not self.posts:
+                self.entered.set()
+                await self.release.wait()
+            return await super().post(url, json=json, timeout=timeout)
+
+    client = _BlockingFirstPostClient()
+    state = fwd._CodexForwarderState()
+    tracker = fwd._CodexElicitationTaskTracker()
+    locks_token = fwd._conversation_item_locks.set({})
+    try:
+        replay = asyncio.create_task(
+            fwd._replay_resume_response(
+                client,  # type: ignore[arg-type]
+                session_id="conv_x",
+                bridge_dir=Path(),
+                response={
+                    "result": {
+                        "thread": {
+                            "id": "thread_1",
+                            "turns": [
+                                {
+                                    "id": "turn_1",
+                                    "items": [
+                                        {
+                                            "type": "commandExecution",
+                                            "id": "call_1",
+                                            "command": "pwd",
+                                            "aggregatedOutput": "/repo\n",
+                                            "exitCode": 0,
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    }
+                },
+                usage_coalescer=fwd._SessionUsageCoalescer(client, "conv_x"),  # type: ignore[arg-type]
+                elicitation_tracker=tracker,
+                forwarder_state=state,
+            )
+        )
+        await asyncio.wait_for(client.entered.wait(), timeout=5.0)
+        live = asyncio.create_task(
+            fwd._handle_completed_item(
+                client,  # type: ignore[arg-type]
+                "conv_x",
+                {
+                    "threadId": "thread_1",
+                    "turnId": "turn_2",
+                    "item": {"type": "agentMessage", "id": "item_2", "text": "new reply"},
+                },
+                forwarder_state=state,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not live.done()
+
+        client.release.set()
+        await asyncio.gather(replay, live)
+    finally:
+        fwd._conversation_item_locks.reset(locks_token)
+        await tracker.close()
+
+    assert [body["data"]["source_id"] for _url, body in client.posts] == [
+        "thread_1:turn_1:call_1:call",
+        "thread_1:turn_1:call_1:output",
+        "thread_1:turn_2:item_2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_reserves_delivery_order_before_post_resume_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A live completion cannot overtake replay while resume metadata sync waits."""
+
+    class _ResumeClient:
+        async def request(self, _method: str, _params: dict) -> dict:
+            return {
+                "result": {
+                    "thread": {
+                        "id": "thread_1",
+                        "turns": [
+                            {
+                                "id": "turn_1",
+                                "items": [
+                                    {
+                                        "type": "agentMessage",
+                                        "id": "item_1",
+                                        "text": "replayed",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                }
+            }
+
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_x",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_1",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_1",
+        ),
+    )
+    sync_entered = asyncio.Event()
+    release_sync = asyncio.Event()
+
+    async def blocking_model_sync(*_args: object, **_kwargs: object) -> None:
+        sync_entered.set()
+        await release_sync.wait()
+
+    monkeypatch.setattr(fwd, "_sync_model_change", blocking_model_sync)
+    monkeypatch.setattr(fwd, "_sync_codex_approval_mode_change", AsyncMock())
+    monkeypatch.setattr(fwd, "_refresh_model_from_config", MagicMock())
+    monkeypatch.setattr(fwd, "_refresh_developer_instructions_from_config", MagicMock())
+
+    client = _RecordingClient()
+    state = fwd._CodexForwarderState()
+    tracker = fwd._CodexElicitationTaskTracker()
+    usage = fwd._SessionUsageCoalescer(client, "conv_x")  # type: ignore[arg-type]
+    locks_token = fwd._conversation_item_locks.set({})
+    try:
+        subscribe = asyncio.create_task(
+            fwd._subscribe_until_ready(
+                _ResumeClient(),  # type: ignore[arg-type]
+                client,  # type: ignore[arg-type]
+                session_id="conv_x",
+                bridge_dir=tmp_path,
+                thread_id="thread_1",
+                usage_coalescer=usage,
+                elicitation_tracker=tracker,
+                forwarder_state=state,
+            )
+        )
+        await asyncio.wait_for(sync_entered.wait(), timeout=5.0)
+        live = asyncio.create_task(
+            fwd._handle_completed_item(
+                client,  # type: ignore[arg-type]
+                "conv_x",
+                {
+                    "threadId": "thread_1",
+                    "turnId": "turn_2",
+                    "item": {"type": "agentMessage", "id": "item_2", "text": "live"},
+                },
+                forwarder_state=state,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not live.done()
+        assert client.posts == []
+
+        release_sync.set()
+        await asyncio.gather(subscribe, live)
+    finally:
+        fwd._conversation_item_locks.reset(locks_token)
+        await usage.close()
+        await tracker.close()
+
+    assert [body["data"]["source_id"] for _url, body in client.posts] == [
+        "thread_1:turn_1:item_1",
+        "thread_1:turn_2:item_2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_terminal_boundary_waits_for_replay_before_clearing_active_turn(
+    tmp_path: Path,
+) -> None:
+    """A blocked replay keeps the crash journal until its item is acknowledged."""
+
+    class _BlockingFirstPostClient(_RecordingClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            if not self.posts:
+                self.entered.set()
+                await self.release.wait()
+            return await super().post(url, json=json, timeout=timeout)
+
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_x",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_1",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_1",
+        ),
+    )
+    client = _BlockingFirstPostClient()
+    tracker = fwd._CodexElicitationTaskTracker()
+    usage = fwd._SessionUsageCoalescer(client, "conv_x")  # type: ignore[arg-type]
+    locks_token = fwd._conversation_item_locks.set({})
+    try:
+        replay = asyncio.create_task(
+            fwd._replay_resume_response(
+                client,  # type: ignore[arg-type]
+                session_id="conv_x",
+                bridge_dir=tmp_path,
+                response={
+                    "result": {
+                        "thread": {
+                            "id": "thread_1",
+                            "turns": [
+                                {
+                                    "id": "turn_1",
+                                    "items": [
+                                        {
+                                            "type": "agentMessage",
+                                            "id": "item_1",
+                                            "text": "replayed",
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    }
+                },
+                usage_coalescer=usage,
+                elicitation_tracker=tracker,
+            )
+        )
+        await asyncio.wait_for(client.entered.wait(), timeout=5.0)
+        terminal = asyncio.create_task(
+            fwd._handle_terminal_turn_boundary(
+                client,  # type: ignore[arg-type]
+                session_id="conv_x",
+                bridge_dir=tmp_path,
+                method="turn/completed",
+                params={"turn": {"id": "turn_1", "status": "completed", "items": []}},
+                usage_coalescer=usage,
+                delta_coalescer=None,
+                elicitation_tracker=tracker,
+                codex_client=None,
+                forwarder_state=None,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not terminal.done()
+        assert read_bridge_state(tmp_path).active_turn_id == "turn_1"  # type: ignore[union-attr]
+
+        client.release.set()
+        await asyncio.gather(replay, terminal)
+    finally:
+        fwd._conversation_item_locks.reset(locks_token)
+        await usage.close()
+        await tracker.close()
+
+    assert read_bridge_state(tmp_path).active_turn_id is None  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_turn_started_waits_for_replay_before_replacing_active_turn(tmp_path: Path) -> None:
+    """A newer turn cannot overwrite the interrupted-turn crash journal."""
+    write_bridge_state(
+        tmp_path,
+        CodexNativeBridgeState(
+            session_id="conv_x",
+            socket_path=str(tmp_path / "app-server.sock"),
+            thread_id="thread_1",
+            codex_home=str(tmp_path / "codex-home"),
+            active_turn_id="turn_1",
+        ),
+    )
+    client = _RecordingClient()
+    tracker = fwd._CodexElicitationTaskTracker()
+    usage = fwd._SessionUsageCoalescer(client, "conv_x")  # type: ignore[arg-type]
+    lock_entered = asyncio.Event()
+    release_lock = asyncio.Event()
+
+    async def hold_replay_scope() -> None:
+        async with fwd._conversation_item_delivery_scope("conv_x"):
+            lock_entered.set()
+            await release_lock.wait()
+
+    locks_token = fwd._conversation_item_locks.set({})
+    try:
+        replay = asyncio.create_task(hold_replay_scope())
+        await asyncio.wait_for(lock_entered.wait(), timeout=5.0)
+        turn_started = asyncio.create_task(
+            fwd._maybe_handle_turn_event(
+                client,  # type: ignore[arg-type]
+                session_id="conv_x",
+                bridge_dir=tmp_path,
+                method="turn/started",
+                params={"turn": {"id": "turn_2"}},
+                usage_coalescer=usage,
+                delta_coalescer=None,
+                elicitation_tracker=tracker,
+                codex_client=None,
+                forwarder_state=None,
+            )
+        )
+        await asyncio.sleep(0)
+        assert not turn_started.done()
+        assert read_bridge_state(tmp_path).active_turn_id == "turn_1"  # type: ignore[union-attr]
+
+        release_lock.set()
+        assert await turn_started is True
+        await replay
+    finally:
+        fwd._conversation_item_locks.reset(locks_token)
+        await usage.close()
+        await tracker.close()
+
+    assert read_bridge_state(tmp_path).active_turn_id == "turn_2"  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
 async def test_cancelled_idempotent_item_is_dead_lettered_for_safe_replay(tmp_path: Path) -> None:
     """Shutdown during an in-flight completion keeps a replayable disk record."""
 

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -3307,6 +3307,7 @@ async def test_delta_coalescer_overflow_drops_backlog_before_durable_completion(
                         "content": [{"type": "output_text", "text": "final answer"}],
                     },
                     "response_id": "codex_turn_1",
+                    "message_id": "codex:thread_1:turn_1:agentMessage:item_1",
                 },
             },
         ),

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -2136,6 +2136,27 @@ class _RaisingPostClient:
         raise self._exc
 
 
+class _SequencedPostClient:
+    """Return or raise configured POST outcomes in order."""
+
+    def __init__(self, outcomes: list[httpx.Response | httpx.HTTPError]) -> None:
+        self._outcomes = outcomes
+        self.calls: list[tuple[str, object, float | None]] = []
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: object,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        self.calls.append((url, json, timeout))
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, httpx.HTTPError):
+            raise outcome
+        return outcome
+
+
 @pytest.mark.asyncio
 async def test_post_session_event_inner_classifies_ambiguous_skip() -> None:
     """
@@ -2158,6 +2179,172 @@ async def test_post_session_event_inner_classifies_ambiguous_skip() -> None:
     assert result.transport_error == "ReadTimeout"
     # Ambiguous items are abandoned immediately — no retries.
     assert client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_conversation_item_retries_ambiguous_failure_until_delivered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stable source id makes response-loss retries duplicate-safe."""
+    monkeypatch.setattr(fwd, "_sleep", AsyncMock())
+    request = httpx.Request("POST", "http://test")
+    client = _SequencedPostClient(
+        [
+            httpx.ReadTimeout("response lost", request=request),
+            httpx.Response(503, request=request),
+            httpx.Response(202, request=request),
+        ]
+    )
+    data = {
+        "item_type": "message",
+        "item_data": {"role": "assistant"},
+        "source_id": "thread_1:turn_1:item_1",
+    }
+
+    result = await fwd._post_session_event_inner(
+        client,  # type: ignore[arg-type]
+        "conv_codex1",
+        event_type="external_conversation_item",
+        data=data,
+        max_attempts=None,
+        timeout=5.0,
+    )
+
+    assert result.response is not None
+    assert result.response.status_code == 202
+    assert [call[1] for call in client.calls] == [
+        {"type": "external_conversation_item", "data": data},
+    ] * 3
+    assert [call[2] for call in client.calls] == [5.0, 5.0, 5.0]
+
+
+@pytest.mark.asyncio
+async def test_idempotent_conversation_item_bounds_long_source_id() -> None:
+    """Long native ids are hashed into the server's source-id limit."""
+    client = _RecordingClient()
+
+    posted = await fwd._post_external_item(
+        client,  # type: ignore[arg-type]
+        "conv_x",
+        item_type="message",
+        item_data={"role": "assistant", "content": []},
+        response_id="codex_turn_1",
+        source_id="source:" + ("x" * 300),
+    )
+
+    assert posted is True
+    source_id = client.posts[0][1]["data"]["source_id"]
+    assert isinstance(source_id, str)
+    assert source_id.startswith("codex:")
+    assert len(source_id) <= 256
+
+
+@pytest.mark.asyncio
+async def test_idempotent_conversation_items_keep_order_while_older_post_is_slow() -> None:
+    """Concurrent resume/live delivery cannot let a newer item overtake an older one."""
+
+    class _BlockingFirstPostClient(_RecordingClient):
+        def __init__(self) -> None:
+            super().__init__()
+            self.entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            if not self.posts:
+                self.entered.set()
+                await self.release.wait()
+            return await super().post(url, json=json, timeout=timeout)
+
+    client = _BlockingFirstPostClient()
+    token = fwd._conversation_item_locks.set({})
+    try:
+        older = asyncio.create_task(
+            fwd._post_external_item(
+                client,  # type: ignore[arg-type]
+                "conv_x",
+                item_type="message",
+                item_data={"role": "assistant", "content": []},
+                response_id="codex_turn_1",
+                source_id="thread_1:turn_1:item_1",
+            )
+        )
+        await asyncio.wait_for(client.entered.wait(), timeout=5.0)
+        newer = asyncio.create_task(
+            fwd._post_external_item(
+                client,  # type: ignore[arg-type]
+                "conv_x",
+                item_type="message",
+                item_data={"role": "assistant", "content": []},
+                response_id="codex_turn_2",
+                source_id="thread_1:turn_2:item_2",
+            )
+        )
+        await asyncio.sleep(0)
+        assert client.posts == []
+
+        client.release.set()
+        assert await asyncio.gather(older, newer) == [True, True]
+    finally:
+        fwd._conversation_item_locks.reset(token)
+
+    assert [body["data"]["source_id"] for _url, body in client.posts] == [
+        "thread_1:turn_1:item_1",
+        "thread_1:turn_2:item_2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_idempotent_item_is_dead_lettered_for_safe_replay(tmp_path: Path) -> None:
+    """Shutdown during an in-flight completion keeps a replayable disk record."""
+
+    class _BlockingPostClient:
+        def __init__(self) -> None:
+            self.entered = asyncio.Event()
+
+        async def post(
+            self,
+            url: str,
+            *,
+            json: dict,
+            timeout: float | None = None,
+        ) -> httpx.Response:
+            self.entered.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+    client = _BlockingPostClient()
+    dead_letter_token = fwd._dead_letter_dir.set(tmp_path)
+    locks_token = fwd._conversation_item_locks.set({})
+    try:
+        task = asyncio.create_task(
+            fwd._post_external_item(
+                client,  # type: ignore[arg-type]
+                "conv_x",
+                item_type="message",
+                item_data={"role": "assistant", "content": []},
+                response_id="codex_turn_1",
+                source_id="thread_1:turn_1:item_1",
+            )
+        )
+        await asyncio.wait_for(client.entered.wait(), timeout=5.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        fwd._conversation_item_locks.reset(locks_token)
+        fwd._dead_letter_dir.reset(dead_letter_token)
+
+    import json as _json
+
+    record = _json.loads((tmp_path / "dead_letter.jsonl").read_text().splitlines()[0])
+    assert record["delivered_ambiguous"] is True
+    assert record["payload"]["source_id"] == "thread_1:turn_1:item_1"
 
 
 @pytest.mark.asyncio
@@ -3308,6 +3495,7 @@ async def test_delta_coalescer_overflow_drops_backlog_before_durable_completion(
                     },
                     "response_id": "codex_turn_1",
                     "message_id": "codex:thread_1:turn_1:agentMessage:item_1",
+                    "source_id": "thread_1:turn_1:item_1",
                 },
             },
         ),

--- a/tests/test_native_post_delivery.py
+++ b/tests/test_native_post_delivery.py
@@ -245,8 +245,16 @@ def test_append_dead_letter_classification_defaults(tmp_path: Path) -> None:
         (_dead_letter_record(), True),
         # Retryable status exhausted after the forwarder's bounded retries.
         (_dead_letter_record(http_status=503), True),
-        # Ambiguous: the server may have committed it — never replay.
+        # Legacy ambiguous item: no idempotency key, so never replay.
         (_dead_letter_record(delivered_ambiguous=True), False),
+        # Idempotent ambiguous item: source_id makes a replay duplicate-safe.
+        (
+            _dead_letter_record(
+                delivered_ambiguous=True,
+                payload={"item_type": "message", "source_id": "thread:turn:item"},
+            ),
+            True,
+        ),
         # Permanent 4xx: the server rejected it; a replay just re-rejects.
         (_dead_letter_record(http_status=400), False),
         # Non-retryable 5xx that is not in the retry set is also not recoverable.
@@ -271,7 +279,7 @@ def test_append_dead_letter_classification_defaults(tmp_path: Path) -> None:
 )
 def test_dead_letter_record_replayable_classification(record: object, replayable: bool) -> None:
     """
-    Only proven-undelivered records are replayable; everything else is forensic.
+    Proven-undelivered records and source-idempotent ambiguous items are replayable.
 
     A wrong classification either duplicates a committed item (ambiguous or
     permanent record wrongly replayed) or re-rejects forever.

--- a/web/src/lib/conversationItems.ts
+++ b/web/src/lib/conversationItems.ts
@@ -36,6 +36,8 @@ export interface MessageItem extends BaseItem {
   is_meta?: boolean;
   /** Assistant-only marker for durable partial text from an interrupted turn. */
   interrupted?: boolean;
+  /** Native live-preview stream finalized by this persisted assistant message. */
+  stream_message_id?: string;
 }
 
 export interface FunctionCallItem extends BaseItem {

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -322,6 +322,8 @@ export interface MessageDone {
   content: Record<string, unknown>[];
   itemId: string;
   responseId: string;
+  /** Native live-preview stream finalized by this item. */
+  messageId?: string;
 }
 
 /**

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseEvent, withStallGuard } from "./sse";
 import type {
   ElicitationResolved,
+  MessageDone,
   ReasoningDone,
   SessionStatusEvent,
   SessionSupersededEvent,
@@ -136,6 +137,27 @@ describe("parseEvent — response.output_text.delta", () => {
 
   it("returns null when delta is not a string", () => {
     expect(parseEvent("response.output_text.delta", { delta: { text: "bad" } })).toBeNull();
+  });
+});
+
+describe("parseEvent — response.output_item.done (message)", () => {
+  it("carries the native preview id finalized by the item", () => {
+    const ev = parseEvent("response.output_item.done", {
+      message_id: "codex:thread_1:turn_1:agentMessage:item_1",
+      item: {
+        id: "it_1",
+        type: "message",
+        response_id: "resp_1",
+        content: [{ type: "output_text", text: "done" }],
+      },
+    });
+    expect(ev).toEqual({
+      type: "message_done",
+      content: [{ type: "output_text", text: "done" }],
+      itemId: "it_1",
+      responseId: "resp_1",
+      messageId: "codex:thread_1:turn_1:agentMessage:item_1",
+    } satisfies MessageDone);
   });
 });
 

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -1179,6 +1179,7 @@ function parseOutputItem(data: Record<string, unknown>): StreamEvent | null {
   const itemType = String(rec.type ?? "");
   const itemId = String(rec.id ?? "");
   const responseId = String(rec.response_id ?? "");
+  const messageId = typeof data.message_id === "string" ? data.message_id : undefined;
 
   if (itemType === "function_call") {
     const argsStr = String(rec.arguments ?? "{}");
@@ -1218,6 +1219,7 @@ function parseOutputItem(data: Record<string, unknown>): StreamEvent | null {
       content: Array.isArray(content) ? (content as Record<string, unknown>[]) : [],
       itemId,
       responseId,
+      ...(messageId !== undefined ? { messageId } : {}),
     } satisfies MessageDone;
   }
 

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -10517,8 +10517,14 @@ describe("chatStore — live delta streaming (claude-native)", () => {
   }
 
   /** A finalized assistant message `output_item.done` frame. */
-  function messageDone(itemId: string, responseId: string, text: string): string {
+  function messageDone(
+    itemId: string,
+    responseId: string,
+    text: string,
+    messageId?: string,
+  ): string {
     return sse("response.output_item.done", {
+      ...(messageId !== undefined ? { message_id: messageId } : {}),
       item: {
         type: "message",
         role: "assistant",
@@ -10598,6 +10604,31 @@ describe("chatStore — live delta streaming (claude-native)", () => {
     controller.abort();
   });
 
+  it("drops the first preview chunk when its authoritative item arrived first", async () => {
+    useChatStore.setState({
+      conversationId: "conv_live_late",
+      blocks: [],
+      isNativeTerminalSession: true,
+    });
+    const { sink, controller } = startPump("conv_live_late");
+
+    sink.push(sse("response.created", { id: "resp_l", status: "in_progress", output: [] }));
+    sink.push(messageDone("ci_1", "resp_l", "Hello world", "m1"));
+    await tick();
+
+    sink.push(nativeDelta("m1", 0, "Hello world", true));
+    await tick();
+
+    expect(provisional()).toBeUndefined();
+    const dones = useChatStore
+      .getState()
+      .blocks.filter((b): b is Extract<AnyBlock, { type: "text_done" }> => b.type === "text_done");
+    expect(dones.map((b) => b.ctx.itemId)).toEqual(["ci_1"]);
+    expect(dones[0]!.fullText).toBe("Hello world");
+
+    controller.abort();
+  });
+
   it("gives the provisional the LIVE TURN's response id so it shares that bubble", async () => {
     // `walkBubbles` groups by response id, so a synthetic preview id split
     // one native turn into several fragment bubbles while streaming that
@@ -10669,6 +10700,18 @@ describe("chatStore — live delta streaming (claude-native)", () => {
     expect(dones).toHaveLength(1);
     expect(dones[0]!.ctx.itemId).toBe("ci_1");
     expect(dones[0]!.fullText).toBe("Hello world");
+
+    // A preview POST can time out client-side but still reach the server
+    // after the durable item. It must not recreate a trailing live bubble.
+    sink.push(nativeDelta("m1", 1, " late", true));
+    await tick();
+    expect(provisional()).toBeUndefined();
+    expect(
+      useChatStore
+        .getState()
+        .blocks.filter((b) => b.type === "text_done")
+        .map((b) => b.ctx.itemId),
+    ).toEqual(["ci_1"]);
 
     controller.abort();
   });
@@ -10930,6 +10973,15 @@ describe("chatStore — live delta streaming (claude-native)", () => {
     // Turn ends with no committed item for m1 (interrupt before the
     // partial transcript record was forwarded).
     sink.push(sse("response.completed", { id: "resp_l", status: "completed", output: [] }));
+    await tick();
+    expect(provisional()).toBeUndefined();
+
+    // A late chunk for the interrupted message must stay dropped after the
+    // terminal cleanup rather than reappearing after the completed turn.
+    sink.push(nativeDelta("m1", 1, " stale", true));
+    await tick();
+    expect(provisional()).toBeUndefined();
+
     sink.close();
     await tick();
     await tick();

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -115,7 +115,11 @@ function userMessage(responseId: string, text: string): ConversationItem {
   };
 }
 
-function assistantMessage(responseId: string, text: string): ConversationItem {
+function assistantMessage(
+  responseId: string,
+  text: string,
+  streamMessageId?: string,
+): ConversationItem {
   return {
     id: `msg_${responseId}_asst`,
     response_id: responseId,
@@ -124,6 +128,7 @@ function assistantMessage(responseId: string, text: string): ConversationItem {
     status: "completed",
     model: "test-agent",
     content: [{ type: "output_text", text }],
+    ...(streamMessageId !== undefined ? { stream_message_id: streamMessageId } : {}),
   };
 }
 
@@ -705,6 +710,54 @@ describe("chatStore — switchTo", () => {
         .map((b) => b.fullText);
       expect(texts).toContain("Worker result ready.");
     });
+  });
+
+  it("shares snapshot completion tombstones with a retained live stream", async () => {
+    const sink = pushableStream();
+    seedSession("conv_native_revisit", []);
+    seedSession("conv_other", []);
+    const base = fetchMock.getMockImplementation()!;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url === "/v1/sessions/conv_native_revisit/stream") {
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      return base(input, init);
+    });
+
+    await useChatStore.getState().switchTo("conv_native_revisit");
+    sink.push(
+      sse("response.output_text.delta", {
+        delta: "stale preview",
+        message_id: "message_revisit",
+        index: 0,
+      }),
+    );
+    await tick();
+    expect(useChatStore.getState().blocks.map((block) => block.ctx.itemId)).toContain(
+      "live:message_revisit",
+    );
+
+    await useChatStore.getState().switchTo("conv_other");
+    const completed = assistantMessage("resp_revisit", "authoritative", "message_revisit");
+    seedSession("conv_native_revisit", [completed]);
+
+    await useChatStore.getState().switchTo("conv_native_revisit");
+    await vi.waitFor(() => {
+      expect(useChatStore.getState().blocks.map((block) => block.ctx.itemId)).toEqual([
+        completed.id,
+      ]);
+    });
+
+    sink.push(
+      sse("response.output_text.delta", {
+        delta: "late preview",
+        message_id: "message_revisit",
+        index: 1,
+      }),
+    );
+    await tick();
+    expect(useChatStore.getState().blocks.map((block) => block.ctx.itemId)).toEqual([completed.id]);
   });
 
   it("commits a message sent in a backgrounded conversation, in transcript order", async () => {
@@ -9149,6 +9202,65 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     await loop;
   });
 
+  it("suppresses delayed previews after snapshot-only completion recovery", async () => {
+    seedSession("conv_native_tombstone", []);
+    const sinks = routeStreamOpens();
+    const controller = new AbortController();
+    useChatStore.setState({
+      conversationId: "conv_native_tombstone",
+      abortController: controller,
+      blocks: [],
+      isNativeTerminalSession: true,
+    });
+
+    const loop = startStreamPump("conv_native_tombstone", controller, setState, getState);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(sinks).toHaveLength(1);
+
+    sinks[0]!.push(
+      sse("response.output_text.delta", {
+        delta: "stale preview",
+        message_id: "message_1",
+        index: 0,
+        final: true,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(20);
+    expect(useChatStore.getState().blocks.map((block) => block.ctx.itemId)).toContain(
+      "live:message_1",
+    );
+
+    seedSessionItems("conv_native_tombstone", [
+      assistantMessage("response_1", "authoritative", "message_1"),
+    ]);
+
+    sinks[0]!.error();
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(sinks).toHaveLength(2);
+    expect(useChatStore.getState().blocks.map((block) => block.ctx.itemId)).toEqual([
+      "msg_response_1_asst",
+    ]);
+
+    sinks[1]!.push(
+      sse("response.output_text.delta", {
+        delta: "late preview",
+        message_id: "message_1",
+        index: 0,
+        final: true,
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(20);
+    expect(
+      useChatStore.getState().blocks.some((block) => block.ctx.itemId === "live:message_1"),
+    ).toBe(false);
+
+    sinks[1]!.push("data: [DONE]\n\n");
+    sinks[1]!.close();
+    await vi.advanceTimersByTimeAsync(20);
+    controller.abort();
+    await loop;
+  });
+
   it("stops reconnecting (and clears the binding) when aborted after a drop", async () => {
     seedSession("conv_abrt3", []);
     const sinks = routeStreamOpens();
@@ -10001,6 +10113,68 @@ describe("chatStore — startStreamPump reconnect loop", () => {
     const last = sinks[1]!;
     last.push("data: [DONE]\n\n");
     last.close();
+    await drainAsync(2);
+    await loop;
+  });
+
+  it("tombstones native previews found only by capped re-hydration", async () => {
+    const preGap = Array.from({ length: 30 }, (_, i) => gapUser("npre", i));
+    const windowItems = preGap.slice(-SESSION_HISTORY_PAGE_SIZE);
+    const gap = Array.from({ length: 100 }, (_, i) => gapUser("ngap", i));
+    const completed = assistantMessage("resp_cap", "authoritative", "message_cap");
+    seedSession("conv_native_cap", preGap);
+
+    const sinks: StreamSink[] = [];
+    let injectedFreshCompletion = false;
+    fetchMock.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (/\/v1\/sessions\/[^/]+\/stream$/.test(url)) {
+        const sink = pushableStream();
+        sinks.push(sink);
+        return mockResponse(null, { bodyStream: sink.stream });
+      }
+      if (
+        url.includes("/v1/sessions/conv_native_cap/items") &&
+        new URL(url, "http://test.local").searchParams.get("limit") ===
+          String(INITIAL_WINDOW_ITEMS) &&
+        !injectedFreshCompletion
+      ) {
+        injectedFreshCompletion = true;
+        seedSessionItems("conv_native_cap", [...preGap, ...gap, completed]);
+      }
+      return defaultFetchHandler(input, init);
+    });
+
+    const controller = new AbortController();
+    useChatStore.setState({
+      conversationId: "conv_native_cap",
+      abortController: controller,
+      blocks: itemsToBlocks(windowItems),
+      hasMoreHistory: true,
+      oldestItemId: windowItems[0]!.id,
+    });
+    const loop = startStreamPump("conv_native_cap", controller, setState, getState);
+    await drainAsync();
+    expect(sinks).toHaveLength(1);
+
+    sinks[0]!.push(nativeDeltaFrame("message_cap", 0, "stale preview"));
+    await drainAsync();
+    expect(livePreviews().map((block) => block.ctx.itemId)).toEqual(["live:message_cap"]);
+
+    seedSessionItems("conv_native_cap", [...preGap, ...gap]);
+    sinks[0]!.error();
+    await drainAsync();
+    expect(sinks).toHaveLength(2);
+    expect(injectedFreshCompletion).toBe(true);
+    expect(livePreviews()).toEqual([]);
+    expect(useChatStore.getState().blocks.map((block) => block.ctx.itemId)).toContain(completed.id);
+
+    sinks[1]!.push(nativeDeltaFrame("message_cap", 1, "late preview"));
+    await drainAsync();
+    expect(livePreviews()).toEqual([]);
+
+    sinks[1]!.push("data: [DONE]\n\n");
+    sinks[1]!.close();
     await drainAsync(2);
     await loop;
   });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -57,6 +57,7 @@ import { userInputElicitationKey } from "@/lib/askUserQuestion";
 import { LIVE_ITEM_PREFIX, PENDING_FILE_PREFIX, structuredErrorFields } from "@/lib/blocks";
 import { BlockStream } from "@/lib/blockStream";
 import { itemsToBlocks } from "@/lib/itemsToBlocks";
+import { isMessageItem, type ConversationItem, type MessageItem } from "@/lib/conversationItems";
 import { buildBubbles } from "@/lib/renderItems";
 import { emitBrowserActionRequest } from "@/lib/browserActionBus";
 import {
@@ -1122,6 +1123,10 @@ let queryClient: QueryClient | null = null;
 // stale. Heartbeats are filtered before this revision is bumped.
 const streamEventRevisions = new Map<string, number>();
 conversationRegistry.subscribeDisposed((id) => streamEventRevisions.delete(id));
+
+// Snapshot reconciliation must teach the already-running stream pump which
+// native preview messages have finalized, including warm session revisits.
+const nativePreviewTombstonesByController = new WeakMap<AbortController, Set<string>>();
 
 /**
  * Evict a conversation from the live registry.
@@ -2422,7 +2427,13 @@ export const useChatStore = create<ChatState>((_rootSet, get) => ({
       // controller too. Verify the instantly-painted transcript against the
       // committed snapshot in the background; item-id dedupe makes this a
       // no-op when the entry really is current.
-      void reconcileOnReconnect(conversationId, entrySetter(entry), entryGetter(entry));
+      const controller = entry.getState().abortController;
+      void reconcileOnReconnect(
+        conversationId,
+        entrySetter(entry),
+        entryGetter(entry),
+        controller === null ? undefined : nativePreviewTombstonesByController.get(controller),
+      );
       return;
     }
 
@@ -3516,6 +3527,8 @@ async function bindStream(
 ): Promise<void> {
   racedNativeModelOptions.delete(id);
   const controller = new AbortController();
+  const ignoredNativeMessageIds = new Set<string>();
+  nativePreviewTombstonesByController.set(controller, ignoredNativeMessageIds);
   // Take an origin-wide stream slot before opening the connection, evicting our
   // own LRU background stream to make room. A fresh tab that finds every slot
   // held by other tabs opens over budget (no slot) and raises the banner.
@@ -3557,7 +3570,9 @@ async function bindStream(
 
   // The slot is held for the pump's whole lifetime; released when it exits (a
   // terminal close, an abort from switchTo/dispose, or eviction).
-  void startStreamPump(id, controller, set, get).finally(() => releaseStreamSlot(id));
+  void startStreamPump(id, controller, set, get, ignoredNativeMessageIds).finally(() =>
+    releaseStreamSlot(id),
+  );
 
   // Background tabs can miss the `response.elicitation_resolved` SSE event
   // (browser throttling), so a pending ApprovalCard that was answered on
@@ -3603,6 +3618,8 @@ async function bindStream(
     ]);
     if (isConversationDisposed(id)) return;
     const items = page.items;
+    const snapshotNativeMessageIds = nativeCompletedMessageIds(items);
+    snapshotNativeMessageIds.forEach((messageId) => ignoredNativeMessageIds.add(messageId));
 
     // Sticky-pref handoff for CLI-created sessions with no override.
     // Binding-derived fields (isNativeTerminalSession, bound agent,
@@ -3648,6 +3665,7 @@ async function bindStream(
     // inside the updater because it depends on the catalog bind race.
     let resolvedStickyModel: string | null = null;
     set((state) => {
+      const currentBlocks = withoutNativePreviews(state.blocks, snapshotNativeMessageIds);
       const racedOptions = racedNativeModelOptions.get(id);
       const catalogWonBindRace =
         bindingPatch.codexModelOptions.length === 0 && (racedOptions?.length ?? 0) > 0;
@@ -3655,14 +3673,14 @@ async function bindStream(
         ? { ...bindingPatch, codexModelOptions: racedOptions! }
         : bindingPatch;
       const seenItemIds = new Set(
-        state.blocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
+        currentBlocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
       );
       const unique = snapshotBlocks.filter((b) => !b.ctx.itemId || !seenItemIds.has(b.ctx.itemId));
       // Dedupe against any elicitation blocks already produced by
       // the live pump (the snapshot may race ahead of or behind
       // the SSE event — match by elicitationId).
       const seenElicitationIds = new Set(
-        state.blocks
+        currentBlocks
           .filter((b): b is typeof b & { type: "elicitation" } => b.type === "elicitation")
           .map((b) => b.elicitationId),
       );
@@ -3687,7 +3705,7 @@ async function bindStream(
       // re-binds.)
       const allBlocks = [
         ...unique,
-        ...withoutRebuiltUserInputCards(state.blocks, unique),
+        ...withoutRebuiltUserInputCards(currentBlocks, unique),
         ...uniquePendingElicitations,
       ];
       const hasErrorBlock = allBlocks.some((b) => b.type === "error");
@@ -4277,6 +4295,7 @@ async function rehydrateWindowOnReconnect(
   preGapElicitations: { pending: Set<string>; autoResolved: Set<string> },
   set: Setter,
   get: Getter,
+  ignoredNativeMessageIds: Set<string>,
 ): Promise<void> {
   // Pinned at entry (still the caller's generation — its guards just passed).
   const generation = get().historyGeneration;
@@ -4287,11 +4306,14 @@ async function rehydrateWindowOnReconnect(
     return;
   }
   if (isConversationDisposed(id) || get().historyGeneration !== generation) return;
+  const snapshotNativeMessageIds = nativeCompletedMessageIds(fresh.items);
+  snapshotNativeMessageIds.forEach((messageId) => ignoredNativeMessageIds.add(messageId));
   const freshBlocks = itemsToBlocks(fresh.items);
   const snapshotPending = pendingElicitationBlocksFromSnapshot(session);
   set((s) => {
     const rid = s.activeResponse?.state === "streaming" ? s.activeResponse.responseId : null;
-    const tail = s.blocks.filter((b) => {
+    const currentBlocks = withoutNativePreviews(s.blocks, snapshotNativeMessageIds);
+    const tail = currentBlocks.filter((b) => {
       if (b.ctx.itemId) return !preGapIds.has(b.ctx.itemId);
       // Elicitation/error blocks aren't items, so the fresh fetch can't recreate them.
       if (b.type === "elicitation" || b.type === "error") return true;
@@ -4350,7 +4372,12 @@ async function rehydrateWindowOnReconnect(
  * failure just means the next reconnect retries. All writes are
  * `historyGeneration`-guarded so a window reset mid-fetch voids them.
  */
-async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promise<void> {
+async function reconcileOnReconnect(
+  id: string,
+  set: Setter,
+  get: Getter,
+  ignoredNativeMessageIds: Set<string> = new Set<string>(),
+): Promise<void> {
   if (queryClient === null) return;
   // Captured before any await: the ids rendered BEFORE the gap. The overlap
   // check below must not be satisfied by items the reconnected pump appends
@@ -4410,16 +4437,27 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
     if (older.items.length === 0) break; // no progress; avoid refetching the same cursor
   }
   /* oxlint-enable no-await-in-loop */
+  const snapshotNativeMessageIds = nativeCompletedMessageIds(items);
+  snapshotNativeMessageIds.forEach((messageId) => ignoredNativeMessageIds.add(messageId));
   if (!covered) {
-    await rehydrateWindowOnReconnect(id, session, preGapIds, preGapElicitations, set, get);
+    await rehydrateWindowOnReconnect(
+      id,
+      session,
+      preGapIds,
+      preGapElicitations,
+      set,
+      get,
+      ignoredNativeMessageIds,
+    );
     return;
   }
 
   const snapshotBlocks = itemsToBlocks(items);
   const snapshotPending = pendingElicitationBlocksFromSnapshot(session);
   set((s) => {
+    const currentBlocks = withoutNativePreviews(s.blocks, snapshotNativeMessageIds);
     const seen = new Set(
-      s.blocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
+      currentBlocks.map((b) => b.ctx.itemId).filter((iid): iid is string => Boolean(iid)),
     );
     const unseen = snapshotBlocks.filter((b) => b.ctx.itemId && !seen.has(b.ctx.itemId));
     const patch: Partial<ChatState> = reconnectStatusPatch(session, s);
@@ -4431,7 +4469,7 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
     if (recoveredUserInputs > 0) {
       patch.pendingUserMessages = s.pendingUserMessages.slice(recoveredUserInputs);
     }
-    let nextBlocks = s.blocks;
+    let nextBlocks = currentBlocks;
     if (unseen.length > 0) {
       // Splice the gap's committed items ahead of the active turn's
       // replayed in-flight region (its itemId-less blocks, rebuilt by the
@@ -4442,7 +4480,7 @@ async function reconcileOnReconnect(id: string, set: Setter, get: Getter): Promi
       const rid = s.activeResponse?.state === "streaming" ? s.activeResponse.responseId : null;
       // A card answered before the gap whose call the gap persisted comes
       // back rebuilt in `unseen` — drop the live copy before anchoring.
-      const kept = withoutRebuiltUserInputCards(s.blocks, unseen);
+      const kept = withoutRebuiltUserInputCards(currentBlocks, unseen);
       let at = -1;
       if (rid) {
         at = kept.findIndex((b) => b.ctx.responseId === rid && !b.ctx.itemId);
@@ -4559,7 +4597,9 @@ export async function startStreamPump(
   controller: AbortController,
   set: Setter,
   get: Getter,
+  ignoredNativeMessageIds: Set<string> = new Set<string>(),
 ): Promise<void> {
+  nativePreviewTombstonesByController.set(controller, ignoredNativeMessageIds);
   let failedOpens = 0;
   let statusReconcileInFlight = false;
   const statusReconcileTimer =
@@ -4719,9 +4759,17 @@ export async function startStreamPump(
         });
         // Start the pump, then reconcile the snapshot concurrently (race-safe
         // via itemId dedup) — mirrors bindStream's stream-then-snapshot order.
-        const pumpPromise = pumpStreamEvents(id, guardedBody, controller, set, get);
+        const pumpPromise = pumpStreamEvents(
+          id,
+          guardedBody,
+          controller,
+          set,
+          get,
+          undefined,
+          ignoredNativeMessageIds,
+        );
         if (reconnecting) {
-          await reconcileOnReconnect(id, set, get);
+          await reconcileOnReconnect(id, set, get, ignoredNativeMessageIds);
         }
         let reason = await pumpPromise;
 
@@ -4858,6 +4906,33 @@ function ignoreLivePreview(block: AnyBlock | undefined, ignoredMessageIds: Set<s
   const itemId = block?.ctx.itemId;
   if (!itemId?.startsWith(LIVE_ITEM_PREFIX)) return;
   ignoredMessageIds.add(itemId.slice(LIVE_ITEM_PREFIX.length));
+}
+
+/** Return persisted native preview ids finalized by assistant messages. */
+function nativeCompletedMessageIds(items: ConversationItem[]): Set<string> {
+  return new Set(
+    items
+      .filter(
+        (item): item is MessageItem =>
+          isMessageItem(item) &&
+          item.role === "assistant" &&
+          typeof item.stream_message_id === "string" &&
+          item.stream_message_id.length > 0,
+      )
+      .map((item) => item.stream_message_id!),
+  );
+}
+
+/** Remove provisional previews whose authoritative snapshot item is present. */
+function withoutNativePreviews(blocks: AnyBlock[], messageIds: Set<string>): AnyBlock[] {
+  if (messageIds.size === 0) return blocks;
+  return blocks.filter((block) => {
+    const itemId = block.ctx.itemId;
+    return (
+      !itemId?.startsWith(LIVE_ITEM_PREFIX) ||
+      !messageIds.has(itemId.slice(LIVE_ITEM_PREFIX.length))
+    );
+  });
 }
 
 /**
@@ -5124,6 +5199,7 @@ export async function pumpStreamEvents(
   set: Setter,
   get: Getter,
   scheduler: FrameScheduler = createRafScheduler(),
+  ignoredMessages: Set<string> = new Set<string>(),
 ): Promise<StreamEndReason> {
   const stream = new BlockStream();
   const sseResult: SseStreamResult = { sawDone: false };
@@ -5140,7 +5216,6 @@ export async function pumpStreamEvents(
   // the reducer's internal state. See migration plan §5.3.
   // Ignore the rest of messages whose previews are stale or already replaced
   // by authoritative items, so late transport delivery cannot recreate them.
-  const ignoredMessages = new Set<string>();
   const events = tapLiveDeltas(
     tapSessionEvents(rawEvents, id, (elicitationId) => {
       // A fast native approval can resolve in the few milliseconds between

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -4853,6 +4853,13 @@ function isLiveProvisionalBlock(b: AnyBlock): boolean {
   return b.ctx.itemId?.startsWith(LIVE_ITEM_PREFIX) ?? false;
 }
 
+/** Suppress future chunks for a provisional preview that is no longer valid. */
+function ignoreLivePreview(block: AnyBlock | undefined, ignoredMessageIds: Set<string>): void {
+  const itemId = block?.ctx.itemId;
+  if (!itemId?.startsWith(LIVE_ITEM_PREFIX)) return;
+  ignoredMessageIds.add(itemId.slice(LIVE_ITEM_PREFIX.length));
+}
+
 /**
  * Build a provisional in-flight assistant-text block for live streaming.
  *
@@ -4997,6 +5004,9 @@ async function* tapLiveDeltas(
   get: Getter,
 ): AsyncIterable<StreamEvent> {
   for await (const ev of events) {
+    if (ev.type === "message_done" && ev.messageId !== undefined) {
+      ignored.add(ev.messageId);
+    }
     if (ev.type === "text_delta" && ev.messageId !== undefined) {
       if (!isConversationDisposed(id) && !ignored.has(ev.messageId)) {
         // A scheduled wake streams its first deltas ahead of the batch
@@ -5128,9 +5138,9 @@ export async function pumpStreamEvents(
   // to the BlockStream reducer. The reducer is intentionally pure
   // (block factory) — session-scoped state lives on the store, not in
   // the reducer's internal state. See migration plan §5.3.
-  // A scheduled wake can stream before its new turn id arrives. Ignore the
-  // rest of that message so it cannot attach to the completed prior turn.
-  const ignoredWakeMessages = new Set<string>();
+  // Ignore the rest of messages whose previews are stale or already replaced
+  // by authoritative items, so late transport delivery cannot recreate them.
+  const ignoredMessages = new Set<string>();
   const events = tapLiveDeltas(
     tapSessionEvents(rawEvents, id, (elicitationId) => {
       // A fast native approval can resolve in the few milliseconds between
@@ -5152,7 +5162,7 @@ export async function pumpStreamEvents(
       };
     }),
     id,
-    ignoredWakeMessages,
+    ignoredMessages,
     set,
     get,
   );
@@ -5240,6 +5250,7 @@ export async function pumpStreamEvents(
       ) {
         const provIdx = get().blocks.findIndex(isLiveProvisionalBlock);
         if (provIdx !== -1) {
+          ignoreLivePreview(get().blocks[provIdx], ignoredMessages);
           flush();
           set((s) => {
             const at = s.blocks.findIndex(isLiveProvisionalBlock);
@@ -5323,6 +5334,7 @@ export async function pumpStreamEvents(
       if (block.type === "text_done" && get().isNativeTerminalSession) {
         const provIdx = get().blocks.findIndex(isLiveProvisionalBlock);
         if (provIdx !== -1) {
+          ignoreLivePreview(get().blocks[provIdx], ignoredMessages);
           // The done item has no message id. Native messages are sequential,
           // so remove the oldest preview and let the committed item follow
           // the normal reducer path.
@@ -5370,6 +5382,7 @@ export async function pumpStreamEvents(
         // after this event, or a stream drop). Normal messages already
         // had their preview replaced when their `text_done` committed, so
         // this is usually a no-op.
+        get().blocks.forEach((candidate) => ignoreLivePreview(candidate, ignoredMessages));
         set((s) => ({
           status: "idle",
           blocks: s.blocks.some(isLiveProvisionalBlock)


### PR DESCRIPTION
## Related issue

Closes [OMNI-7088](https://linear.app/omnigent/issue/OMNI-7088/codex-web-ui-falls-behind-during-high-volume-native-streaming)

Related transcript-retention fix: [#6904](https://github.com/omnigent-ai/omnigent/pull/6904)

## Summary

### Problem

When the relay slowed down, Codex's many small serialized preview POSTs accumulated faster than they drained. The TUI stayed current because it reads Codex directly, but the Web UI replayed stale preview work and delayed the authoritative completed items behind it. A preview request whose response timed out could also arrive after completion and recreate an out-of-order provisional message.

### Solution

- **Lossy, bounded previews:** retain the 50 ms low-volume flush timer, raise the immediate batch threshold from 64 characters to 8 KiB, cap queued preview text at 256 Ki characters, and give every preview POST a five-second deadline. At completion boundaries, briefly drain healthy work, then shed stale queued previews rather than let animation backlog block the transcript.
- **Durable, idempotent completed items:** attach a deterministic Codex `source_id` to each completed item so the server derives a stable item ID. Retry transient and ambiguous failures until acknowledgement, serialize authoritative delivery per session, and keep multi-record tool/diff pairs together so later items cannot interleave.
- **Crash recovery from Codex's journal:** if the forwarder restarts with a persisted active turn, resume the retained Codex rollout from that turn onward and replay its completed items through the same idempotent path before live completions or a newer turn can overtake it. Healthy idle reconnects still exclude old turns. This recovery relies on #6904 retaining `codex-home`; this PR does not change transcript storage.
- **No late-preview resurrection:** persist the preview `message_id` on its authoritative completed assistant item. Cold hydration, incremental reconnect repair, capped-window rehydration, and warm session revisits all tombstone that ID in the live pump, remove any matching provisional block, and ignore later chunks for the finalized message.

Status edges and usage bypass the preview queue, but keep their existing best-effort semantics; the durable guarantee in this PR is specifically for Codex completed conversation items.

### Claude-native parity

This uses the same reliability boundary as [#6792](https://github.com/omnigent-ai/omnigent/pull/6792): backlog work must not block authoritative transcript progress, stable source IDs make retries idempotent, and durable progress advances only after complete records are acknowledged. Claude-native applies that boundary with separate parent/child lanes, bounded event batches, and JSONL cursors. Codex-native applies it with best-effort preview deltas plus app-server completed items and the retained rollout as the authoritative journal.

```text
Codex app-server
    ├── preview deltas ── 50 ms / 8 KiB batches ── bounded queue ──> Web animation
    │                                                   └─ shed on relay slowness
    └── completed items ── stable source_id ── ordered retries ───> durable transcript
                               └─ rollout replay after interrupted forwarding
```

## Test Plan

- `uv run pytest -q tests/test_codex_native.py tests/test_codex_native_forwarder.py tests/test_native_post_delivery.py tests/server/integration/test_sessions_endpoints.py tests/server/routes/test_external_conversation_item.py tests/e2e_ui/chat/test_codex_native_stream_backlog.py` — 708 passed.
- `cd web && pnpm vitest run src/lib/sse.test.ts src/store/chatStore.test.ts` — 446 passed.
- `cd web && npm run type-check` — passed.
- `OMNIGENT_E2E_CODEX_NATIVE=1 uv run pytest -q tests/e2e/test_host_codex_native_e2e.py -k test_codex_native_builtin_session_round_trip` — 1 passed (real browser → runner → Codex app-server → shell journey).
- Changed-file pre-commit hooks — Ruff format/check, asyncio guard, model guard, Prettier, Oxlint, Web TypeScript, whitespace, YAML/conflict/case/line-ending checks passed. Full-project Pyrefly still reports the known unrelated `omnigent/harnesses/opencode_native/provider.py:363` error.

Regression coverage verifies healthy low-volume latency, 8 KiB batching, reasoning/tool-output coalescing, mixed-stream ordering, queue overflow and slow-backlog shedding, bounded preview POSTs, authoritative progress after relay stalls, deterministic server idempotency, ambiguous-failure retries, restart replay from the interrupted turn, replay-vs-live/new-turn ordering, atomic tool pairs, and late-preview suppression across cold hydration, incremental reconnect, capped rehydration, and warm live-session revisits.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The behavior is a relay-backpressure and recovery failure path covered deterministically in tests; there is no normal-state visual layout change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated tests use deterministic blocked transports and explicit release gates to verify queue shedding, completion durability, idempotent retry, restart replay, authoritative ordering, and reconnect-safe preview suppression. The real Codex native E2E additionally verifies the complete browser-to-shell user journey.

## Changelog

Codex Web sessions keep authoritative completed messages synchronized during relay slowness: preview animation may be shed under backpressure, while completed items retry idempotently, recover after interrupted forwarding, and cannot be followed by stale previews.
