### PR TITLE
fix(codex-native): extend configured-command startup timeout

### DIFF
--- a/omnigent/harnesses/codex_native/bridge.py
+++ b/omnigent/harnesses/codex_native/bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import json
+import math
 import os
 import secrets
 import stat
@@ -24,9 +25,22 @@ CODEX_NATIVE_BRIDGE_ID_LABEL_KEY = "omnigent.codex_native.bridge_id"
 CODEX_NATIVE_BRIDGE_DIR_ENV_VAR = "HARNESS_CODEX_NATIVE_BRIDGE_DIR"
 CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR = "HARNESS_CODEX_NATIVE_REQUEST_SESSION_ID"
 
+# Maximum time for a fresh TUI to emit ``thread/started``. Deliberately
+# generous because a host-spawned TUI cold-starts over the runner.
+CODEX_NATIVE_DIRECT_THREAD_START_TIMEOUT_SECONDS = 30.0
+# A configured command (for example ``codex-wrapper``) may do bounded setup
+# before it execs Codex. Direct launches retain the watchdog above; this
+# allowance is advertised only for an explicit command override.
+CODEX_NATIVE_CONFIGURED_COMMAND_STARTUP_TIMEOUT_SECONDS = 120.0
+# Give the runner time to publish bridge state or its startup error at the end
+# of the configured-command watchdog before the executor reports a generic miss.
+CODEX_NATIVE_STARTUP_PUBLICATION_GRACE_SECONDS = 5.0
+
 _STATE_FILE = "state.json"
 _STATE_LOCK_FILE = "state.lock"
 _STARTUP_ERROR_FILE = "startup_error.json"
+_STARTUP_TIMEOUT_FILE = "startup_timeout.json"
+_STARTUP_TIMEOUT_MAX_BYTES = 256
 # Per-MCP-server startup state mirrored from Codex's
 # ``mcpServer/startupStatus/updated`` notifications. Written by the
 # forwarder (and by ``wait_for_thread_started`` while it drains startup
@@ -822,6 +836,64 @@ def write_bridge_state(bridge_dir: Path, state: CodexNativeBridgeState) -> None:
         _write_bridge_state_unlocked(bridge_dir, state)
 
 
+def _validated_startup_timeout(value: object) -> float | None:
+    """Return a bounded configured-command timeout, or ``None`` if invalid."""
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or value <= 0
+        or value > CODEX_NATIVE_CONFIGURED_COMMAND_STARTUP_TIMEOUT_SECONDS
+        or not math.isfinite(value)
+    ):
+        return None
+    return float(value)
+
+
+def write_bridge_startup_timeout(bridge_dir: Path, timeout_seconds: float) -> None:
+    """Advertise a bounded configured-command startup wait to the executor.
+
+    This is launch policy, not a completion claim. It remains beside successful
+    state or a startup error until :func:`clear_bridge_state` starts the next
+    launch, so a retiring forwarder cannot erase a successor's newer marker.
+    """
+    timeout = _validated_startup_timeout(timeout_seconds)
+    if timeout is None:
+        raise ValueError(
+            "timeout_seconds must be finite, positive, and no greater than "
+            f"{CODEX_NATIVE_CONFIGURED_COMMAND_STARTUP_TIMEOUT_SECONDS:g}"
+        )
+    with _bridge_state_lock(bridge_dir):
+        path = bridge_dir / _STARTUP_TIMEOUT_FILE
+        fd, tmp_name = tempfile.mkstemp(prefix=f"{_STARTUP_TIMEOUT_FILE}.", dir=str(bridge_dir))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump({"timeout_seconds": timeout}, handle, allow_nan=False, sort_keys=True)
+                handle.write("\n")
+            os.replace(tmp_name, path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+
+
+def read_bridge_startup_timeout(bridge_dir: Path) -> float | None:
+    """Read the configured-command startup wait, ignoring malformed input."""
+    path = bridge_dir / _STARTUP_TIMEOUT_FILE
+    try:
+        with path.open("rb") as handle:
+            payload = handle.read(_STARTUP_TIMEOUT_MAX_BYTES + 1)
+    except OSError:
+        return None
+    if len(payload) > _STARTUP_TIMEOUT_MAX_BYTES:
+        return None
+    try:
+        raw = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, ValueError, RecursionError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return _validated_startup_timeout(raw.get("timeout_seconds"))
+
+
 def clear_bridge_state(bridge_dir: Path) -> None:
     """
     Remove stale native Codex runtime state for a bridge directory.
@@ -840,6 +912,7 @@ def clear_bridge_state(bridge_dir: Path) -> None:
         for name in (
             _STATE_FILE,
             _STARTUP_ERROR_FILE,
+            _STARTUP_TIMEOUT_FILE,
             _MCP_STARTUP_FILE,
         ):
             try:

--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -24,6 +24,7 @@ from omnigent.harnesses.codex_native.app_server import (
 )
 from omnigent.harnesses.codex_native.bridge import (
     CODEX_NATIVE_BRIDGE_ID_LABEL_KEY,
+    CODEX_NATIVE_DIRECT_THREAD_START_TIMEOUT_SECONDS,
     MCP_STARTUP_STARTING,
     MCP_STARTUP_STATES,
     CodexNativeBridgeState,
@@ -66,10 +67,6 @@ _logger = logging.getLogger(__name__)
 
 _AGENT_NAME = "codex-native-ui"
 _SUBSCRIBE_RETRY_DELAY_SECONDS = 0.2
-# How long to wait for a freshly launched Codex TUI to create its
-# app-server thread (emit ``thread/started``) before giving up. Generous
-# because a host-spawned TUI cold-starts over the runner.
-_THREAD_START_TIMEOUT_SECONDS = 30.0
 _NO_ROLLOUT_FRAGMENT = "no rollout found for thread id"
 # A freshly created thread passes through a second transient state: its rollout
 # file exists but is still empty (the TUI created the thread but no turn has
@@ -7611,7 +7608,7 @@ def _thread_started_is_ephemeral(event: CodexMessage) -> bool:
 async def wait_for_thread_started(
     client: CodexAppServerClient,
     *,
-    timeout: float | None = _THREAD_START_TIMEOUT_SECONDS,
+    timeout: float | None = CODEX_NATIVE_DIRECT_THREAD_START_TIMEOUT_SECONDS,
 ) -> str:
     """
     Wait for a freshly launched Codex TUI to create its app-server thread.

--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -7,6 +7,7 @@ import base64
 import binascii
 import json
 import logging
+import math
 import os
 from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
@@ -20,11 +21,13 @@ from omnigent.harnesses.codex_native.app_server import (
 from omnigent.harnesses.codex_native.bridge import (
     CODEX_NATIVE_BRIDGE_DIR_ENV_VAR,
     CODEX_NATIVE_REQUEST_SESSION_ID_ENV_VAR,
+    CODEX_NATIVE_STARTUP_PUBLICATION_GRACE_SECONDS,
     CodexNativeBridgeState,
     cancel_pending_mcp_startup,
     clear_active_turn_id_if_matches,
     mcp_startup_waiting_detail,
     read_bridge_startup_error,
+    read_bridge_startup_timeout,
     read_bridge_state,
     read_mcp_startup,
     update_active_turn_id,
@@ -61,6 +64,18 @@ _logger = logging.getLogger(__name__)
 _NO_ACTIVE_TURN_ERROR_CODE = -32600
 _NO_ACTIVE_TURN_ERROR_MESSAGE = "no active turn to steer"
 _ACTIVE_TURN_MISMATCH_MARKERS = ("expected active turn id", "but found")
+_LEGACY_BRIDGE_STATE_POLL_COUNT = 60
+
+
+def _bridge_state_wait_poll_count(bridge_dir: Path) -> int:
+    """Return 60 legacy polls or the advertised configured-command budget."""
+    configured_timeout = read_bridge_startup_timeout(bridge_dir)
+    if configured_timeout is None:
+        return _LEGACY_BRIDGE_STATE_POLL_COUNT
+    return max(
+        _LEGACY_BRIDGE_STATE_POLL_COUNT,
+        math.ceil(configured_timeout + CODEX_NATIVE_STARTUP_PUBLICATION_GRACE_SECONDS),
+    )
 
 
 def _is_no_active_turn_to_steer(error: CodexAppServerResponseError) -> bool:
@@ -428,75 +443,131 @@ class CodexNativeExecutor(Executor):
         # Wait for the bridge to boot OUTSIDE the injection lock: this is a
         # one-time poll for the state file to appear (first turn, app-server
         # starting), with no shared-state mutation, so holding the lock
-        # across its up-to-60s wait would needlessly block concurrent
+        # across its bounded startup wait would needlessly block concurrent
         # steering (enqueue_session_message). Once the state exists, the
         # decision/RPC/write below runs under the lock — re-reading state so
         # it's atomic with respect to a steer that landed during the wait.
         state = read_bridge_state(self._bridge_dir)
+        poll_count = 0
+        max_poll_count = _LEGACY_BRIDGE_STATE_POLL_COUNT
+        startup_timeout_observed = False
         if state is None:
-            for _ in range(60):
+            max_poll_count = _bridge_state_wait_poll_count(self._bridge_dir)
+            startup_timeout_observed = max_poll_count > _LEGACY_BRIDGE_STATE_POLL_COUNT
+            if startup_timeout_observed:
+                _logger.debug(
+                    "Codex bridge-state wait extended from %d to %d polls by startup marker",
+                    _LEGACY_BRIDGE_STATE_POLL_COUNT,
+                    max_poll_count,
+                )
+
+        error_msg: str | None = None
+        while True:
+            while state is None and poll_count < max_poll_count:
                 # Startup already failed; the runner recorded the cause — stop waiting.
                 if read_bridge_startup_error(self._bridge_dir) is not None:
                     break
                 await asyncio.sleep(1.0)
+                poll_count += 1
                 state = read_bridge_state(self._bridge_dir)
                 if state is not None:
                     break
-
-        # No client-side wait for Codex MCP startup: the app-server accepts
-        # ``turn/start`` mid-startup and defers execution until the round
-        # settles (verified against codex 0.142.5), so sending immediately
-        # is safe. The web UI's MCP-startup band explains the wait.
-
-        # Serialized against enqueue_session_message: the
-        # turn/start-vs-turn/steer decision, the RPC, and the
-        # active_turn_id write must be atomic with respect to mid-turn
-        # steering. The terminal event is yielded after the lock releases.
-        error_msg: str | None = None
-        async with self._inject_lock:
-            state = read_bridge_state(self._bridge_dir)
-            if state is None:
-                startup_error = read_bridge_startup_error(self._bridge_dir)
-                error_msg = (
-                    f"Codex native thread never started: {startup_error}"
-                    if startup_error
-                    else "Codex native bridge state is missing"
-                )
-            elif not _session_is_active(state.session_id, self._request_session_id):
-                error_msg = "Codex native session is no longer active"
-            else:
-                client = client_for_transport(
-                    state.socket_path,
-                    client_name="omnigent-codex-native",
-                )
-                await client.connect()
-                try:
-                    if goal_objective is not None:
-                        await client.request(
-                            "thread/goal/set",
-                            {
-                                "threadId": state.thread_id,
-                                "objective": goal_objective,
-                            },
+                # The runner may publish the configured-command marker after
+                # this first-turn wait begins. Grant its full bounded allowance
+                # once from when it is first observed.
+                if not startup_timeout_observed:
+                    advertised_poll_count = _bridge_state_wait_poll_count(self._bridge_dir)
+                    if advertised_poll_count > _LEGACY_BRIDGE_STATE_POLL_COUNT:
+                        extended_poll_count = max(
+                            max_poll_count,
+                            poll_count + advertised_poll_count,
                         )
-                    await _inject_codex_turn(
-                        client,
-                        bridge_dir=self._bridge_dir,
-                        state=state,
-                        input_items=input_items,
-                        settings_overrides=settings_overrides,
+                        _logger.debug(
+                            "Codex bridge-state wait extended from %d to %d polls "
+                            "by startup marker",
+                            max_poll_count,
+                            extended_poll_count,
+                        )
+                        max_poll_count = extended_poll_count
+                        startup_timeout_observed = True
+
+            # No client-side wait for Codex MCP startup: the app-server accepts
+            # ``turn/start`` mid-startup and defers execution until the round
+            # settles (verified against codex 0.142.5), so sending immediately
+            # is safe. The web UI's MCP-startup band explains the wait.
+
+            # Serialized against enqueue_session_message: the
+            # turn/start-vs-turn/steer decision, the RPC, and the
+            # active_turn_id write must be atomic with respect to mid-turn
+            # steering. The terminal event is yielded after the lock releases.
+            async with self._inject_lock:
+                state = read_bridge_state(self._bridge_dir)
+                if state is None:
+                    startup_error = read_bridge_startup_error(self._bridge_dir)
+                    if startup_error is None and not startup_timeout_observed:
+                        # The runner may publish the configured-command marker
+                        # in the instant after the wait's final re-read, or
+                        # while a steer held this lock. Re-read once more
+                        # before surfacing the generic miss and resume the
+                        # bounded wait — the allowance is still granted at
+                        # most once — so the executor keeps outwaiting a
+                        # forwarder healthily inside its advertised budget.
+                        advertised_poll_count = _bridge_state_wait_poll_count(self._bridge_dir)
+                        if advertised_poll_count > _LEGACY_BRIDGE_STATE_POLL_COUNT:
+                            extended_poll_count = max(
+                                max_poll_count,
+                                poll_count + advertised_poll_count,
+                            )
+                            _logger.debug(
+                                "Codex bridge-state wait extended from %d to %d "
+                                "polls by startup marker",
+                                max_poll_count,
+                                extended_poll_count,
+                            )
+                            max_poll_count = extended_poll_count
+                            startup_timeout_observed = True
+                            continue
+                    error_msg = (
+                        f"Codex native thread never started: {startup_error}"
+                        if startup_error
+                        else "Codex native bridge state is missing"
                     )
-                except Exception as exc:
-                    _logger.exception("Codex native turn injection failed")
-                    error_msg = f"Codex native executor error: {exc}"
-                    # Name the servers a still-unsettled MCP startup is
-                    # blocked on — the most common cause of an injection
-                    # failure this early in the session's life.
-                    waiting = mcp_startup_waiting_detail(read_mcp_startup(self._bridge_dir))
-                    if waiting:
-                        error_msg = f"{error_msg} ({waiting})"
-                finally:
-                    await client.close()
+                elif not _session_is_active(state.session_id, self._request_session_id):
+                    error_msg = "Codex native session is no longer active"
+                else:
+                    client = client_for_transport(
+                        state.socket_path,
+                        client_name="omnigent-codex-native",
+                    )
+                    await client.connect()
+                    try:
+                        if goal_objective is not None:
+                            await client.request(
+                                "thread/goal/set",
+                                {
+                                    "threadId": state.thread_id,
+                                    "objective": goal_objective,
+                                },
+                            )
+                        await _inject_codex_turn(
+                            client,
+                            bridge_dir=self._bridge_dir,
+                            state=state,
+                            input_items=input_items,
+                            settings_overrides=settings_overrides,
+                        )
+                    except Exception as exc:
+                        _logger.exception("Codex native turn injection failed")
+                        error_msg = f"Codex native executor error: {exc}"
+                        # Name the servers a still-unsettled MCP startup is
+                        # blocked on — the most common cause of an injection
+                        # failure this early in the session's life.
+                        waiting = mcp_startup_waiting_detail(read_mcp_startup(self._bridge_dir))
+                        if waiting:
+                            error_msg = f"{error_msg} ({waiting})"
+                    finally:
+                        await client.close()
+            break
         if error_msg is not None:
             yield ExecutorError(message=error_msg)
         else:

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4581,6 +4581,10 @@ async def _auto_create_codex_terminal(
             resolve_harness_args,
             resolve_harness_config,
         )
+        from omnigent.harnesses.codex_native.bridge import (  # noqa: FlagLocalImports
+            CODEX_NATIVE_CONFIGURED_COMMAND_STARTUP_TIMEOUT_SECONDS,
+            write_bridge_startup_timeout,
+        )
 
         _codex_harness_cfg = load_effective_config()
         # Config-only command resolve: the managed host provisions
@@ -4590,11 +4594,41 @@ async def _auto_create_codex_terminal(
         # overrides are deliberately not consulted on this managed-host path.
         _, _codex_overrides = resolve_harness_config(_codex_harness_cfg)
         _codex_cmd_override = (_codex_overrides.get("codex-native") or {}).get("command")
-        codex_command = (
+        configured_codex_command = (
             _codex_cmd_override.strip()
             if isinstance(_codex_cmd_override, str) and _codex_cmd_override.strip()
-            else app_server.codex_path
+            else None
         )
+        codex_command = configured_codex_command or app_server.codex_path
+        thread_start_timeout_seconds = (
+            CODEX_NATIVE_CONFIGURED_COMMAND_STARTUP_TIMEOUT_SECONDS
+            if configured_codex_command is not None and not _codex_launch.login_required
+            else None
+        )
+        if configured_codex_command is not None:
+            if launch_config.external_session_id is not None:
+                _logger.info(
+                    "Codex resume: bridge state is preloaded before configured "
+                    "command %r starts; no bridge-state wait extension is needed "
+                    "(session %s)",
+                    configured_codex_command,
+                    session_id,
+                )
+            elif _codex_launch.login_required:
+                _logger.info(
+                    "Codex startup: configured command %r requires interactive "
+                    "login; preserving the unbounded sign-in wait (session %s)",
+                    configured_codex_command,
+                    session_id,
+                )
+            elif thread_start_timeout_seconds is not None:
+                _logger.info(
+                    "Codex startup: configured command %r gets a %.0fs "
+                    "thread-start budget (session %s)",
+                    configured_codex_command,
+                    thread_start_timeout_seconds,
+                    session_id,
+                )
         codex_launch_args = resolve_harness_args(
             "codex-native", tuple(codex_remote_args), cfg=_codex_harness_cfg
         )
@@ -4645,6 +4679,27 @@ async def _auto_create_codex_terminal(
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
         raise
 
+    # Known-thread resumes publish bridge state before the terminal starts;
+    # only fresh discovery needs to extend the executor's state wait.
+    if launch_config.external_session_id is None and thread_start_timeout_seconds is not None:
+        try:
+            write_bridge_startup_timeout(bridge_dir, thread_start_timeout_seconds)
+        except OSError:
+            # The marker only extends the executor's legacy wait. A write
+            # failure must not strand the terminal before its forwarder owns
+            # it, and the forwarder must not keep waiting past the executor's
+            # legacy deadline that the marker can no longer extend: fall both
+            # sides back to the legacy timeout so the forwarder's precise
+            # startup error lands while the executor is still reporting.
+            thread_start_timeout_seconds = None
+            _logger.warning(
+                "Could not publish Codex startup timeout for session %s; "
+                "falling back to the legacy startup timeout for the executor "
+                "and the forwarder",
+                session_id,
+                exc_info=True,
+            )
+
     # Adopt the thread the fresh TUI creates and run the forwarder in the
     # background, so session creation never blocks on TUI startup.
     _forwarder_task = asyncio.create_task(
@@ -4658,6 +4713,7 @@ async def _auto_create_codex_terminal(
                 event_client=event_client,
                 routing_summary=_codex_launch.summary,
                 login_required=_codex_launch.login_required,
+                thread_start_timeout_seconds=thread_start_timeout_seconds,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4717,6 +4773,7 @@ async def _codex_discover_thread_and_forward(
     event_client: CodexAppServerClient,
     routing_summary: str,
     login_required: bool = False,
+    thread_start_timeout_seconds: float | None = None,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4753,6 +4810,9 @@ async def _codex_discover_thread_and_forward(
         the thread-start timeout), while thread discovery keeps listening
         so an interactive sign-in from the terminal still recovers the
         session.
+    :param thread_start_timeout_seconds: Configured-command thread-start
+        allowance. ``None`` preserves the forwarder's ordinary 30-second
+        default.
     :param subagent_router: Router this terminal launch started, torn down
         in the ``finally``. Passed so a late teardown cannot close the
         endpoint a re-created terminal has since installed.
@@ -4760,6 +4820,7 @@ async def _codex_discover_thread_and_forward(
         started, torn down alongside the subagent one.
     """
     from omnigent.harnesses.codex_native.bridge import (
+        CODEX_NATIVE_DIRECT_THREAD_START_TIMEOUT_SECONDS,
         CodexNativeBridgeState,
         clear_bridge_startup_error,
         write_bridge_startup_error,
@@ -4804,6 +4865,11 @@ async def _codex_discover_thread_and_forward(
                 # No deadline: the turn-facing failure is already recorded,
                 # so this wait only serves a possible interactive sign-in.
                 thread_id = await wait_for_thread_started(event_client, timeout=None)
+            elif thread_start_timeout_seconds is not None:
+                thread_id = await wait_for_thread_started(
+                    event_client,
+                    timeout=thread_start_timeout_seconds,
+                )
             else:
                 thread_id = await wait_for_thread_started(event_client)
         except (TimeoutError, RuntimeError) as exc:
@@ -4816,11 +4882,15 @@ async def _codex_discover_thread_and_forward(
                 session_id,
             )
             # Bridge state is never written here; leave the real cause for the executor (#59).
-            cause = (
-                "startup timed out"
-                if isinstance(exc, TimeoutError)
-                else "event stream ended before a thread was created"
-            )
+            if isinstance(exc, TimeoutError):
+                timeout_seconds = (
+                    thread_start_timeout_seconds
+                    if thread_start_timeout_seconds is not None
+                    else CODEX_NATIVE_DIRECT_THREAD_START_TIMEOUT_SECONDS
+                )
+                cause = f"startup timed out after {timeout_seconds:g}s"
+            else:
+                cause = "event stream ended before a thread was created"
             write_bridge_startup_error(
                 bridge_dir,
                 f"Codex app-server never started a thread ({cause}: "

--- a/tests/e2e_ui/chat/test_codex_native_configured_command_startup_timeout.py
+++ b/tests/e2e_ui/chat/test_codex_native_configured_command_startup_timeout.py
@@ -1,0 +1,394 @@
+"""E2E: a configured codex-native command's setup must not trip the launch watchdog.
+
+Regression test: an explicit
+``harness.codex-native.command`` wrapper may perform cold-start setup before
+launching Codex, so a *healthy* launch can emit ``thread/started`` after the
+direct-launch 30s watchdog
+(``bridge.CODEX_NATIVE_DIRECT_THREAD_START_TIMEOUT_SECONDS``) expires. The
+runner then records::
+
+    Codex app-server never started a thread (startup timed out: TimeoutError). ...
+
+into the bridge startup error, and the user's first chat message dies with
+that error even though the wrapper is still progressing and Codex starts
+shortly afterward. Expected: configured commands get a larger bounded startup
+allowance, while direct Codex launches keep their existing timeout.
+
+Journey (all user-observable):
+
+1. configure ``harness.codex-native.command`` with a wrapper that performs
+   cold-start setup before launching Codex;
+2. create a fresh codex-native session and send its first prompt immediately;
+3. the turn dies at the 30s ``thread/started`` deadline with the startup
+   timeout error, even though Codex starts a few seconds later.
+
+The rig mirrors ``test_codex_native_headless_login_timeout.py`` (own server +
+runner so the mock ``OMNIGENT_CONFIG_HOME`` / ``CODEX_HOME`` cannot leak into
+other tests), with a mock openai Responses provider routed so the launch is
+credentialed (``login_required=False`` — the watchdog path, not the login
+fail-fast path). The wrapper's setup is simulated with a sleep just past the
+watchdog to reproduce the boundary deterministically; a marker file written at
+``exec codex`` time proves the launch was healthy, so the failing assertion can
+only be the premature watchdog. The assertions encode the DESIRED behavior —
+the first turn completes with no startup-timeout error — so this test FAILS
+while the bug is live and passes once configured commands get their larger
+bounded allowance.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import secrets
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from tests.e2e_ui.conftest import (
+    _create_native_codex_session,
+    configure_mock_llm,
+    reset_mock_llm,
+    set_fallback_mock_llm,
+)
+from tests.e2e_ui.messages.test_message_render_parity import _ensure_chat_view, _send
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("codex") is None or shutil.which("tmux") is None,
+    reason="codex-native e2e needs the `codex` CLI and `tmux` on PATH.",
+)
+
+# Boot budget for the spawned server + runner pair.
+_HEALTH_TIMEOUT_S = 60.0
+# The buggy path errors at the 30s thread-start watchdog plus the executor's
+# bridge-state poll; the fixed path completes after the wrapper's setup delay
+# plus a mock model turn. Cold CI runners are slow, so stay generous.
+_TURN_OUTCOME_TIMEOUT_S = 240.0
+_ERROR_PILL = '[data-testid="error-pill"]'
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+
+# Wrapper setup delay: just past the direct-launch 30s thread-start watchdog
+# (``bridge.CODEX_NATIVE_DIRECT_THREAD_START_TIMEOUT_SECONDS``). Codex's own
+# boot adds a few seconds on top before ``thread/started``.
+_WRAPPER_SETUP_DELAY_S = 45
+
+# Must match the model in the mock openai provider config written below.
+_CODEX_MOCK_MODEL = "gpt-4o"
+
+# Markers of the regression failure in the turn's executor error text (the
+# runner's bridge startup error, surfaced verbatim by the codex-native
+# executor as "Codex native thread never started: ...").
+_STARTUP_TIMEOUT_MARKER = "startup timed out"
+_NEVER_STARTED_MARKER = "never started a thread"
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+# Proxy-blind client: CI forces an egress proxy via HTTP(S)_PROXY env vars
+# that must not intercept loopback requests to the spawned server.
+_client = httpx.Client(trust_env=False)
+
+# Shared fixtures/helpers (e.g. the conftest session factory) use ambient
+# ``httpx`` calls that DO trust env, so also exclude loopback from any forced
+# proxy at import time.
+for _var in ("NO_PROXY", "no_proxy"):
+    os.environ[_var] = ",".join(filter(None, [os.environ.get(_var, ""), "127.0.0.1,localhost"]))
+
+
+def _clean_env() -> dict[str, str]:
+    """Ambient env with loopback proxy-excluded and runner/host vars stripped.
+
+    Stripping ``OMNIGENT_RUNNER_*`` / ``OMNIGENT_HOST_*`` matters when the
+    test itself runs inside a server-spawned runner: leaked zygote/tunnel
+    vars make the spawned child runner take the zygote-fork path and hang.
+    ``OMNIGENT_PROCESS_LOG_FILE`` / ``OMNIGENT_DATA_DIR`` are host-owned
+    write paths; the spawned pair must not write into (or crash on) the
+    calling host's log/data locations.
+    """
+    env = os.environ.copy()
+    for var in ("NO_PROXY", "no_proxy"):
+        existing = env.get(var, "")
+        env[var] = ",".join(filter(None, [existing, "127.0.0.1,localhost"]))
+    for key in list(env):
+        if key.startswith(("OMNIGENT_RUNNER_", "OMNIGENT_HOST_")):
+            del env[key]
+    for key in ("RUNNER_SERVER_URL", "OMNIGENT_PROCESS_LOG_FILE", "OMNIGENT_DATA_DIR"):
+        env.pop(key, None)
+    return env
+
+
+@pytest.fixture
+def wrapped_codex_session(
+    built_spa: None,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[str, str, Path]]:
+    """A codex-native session launched through a slow configured wrapper command.
+
+    Spawns a dedicated server + runner whose ``OMNIGENT_CONFIG_HOME`` carries
+    (a) a mock openai Responses provider (so the codex launch routes with a
+    usable credential and arms the thread-start watchdog, not the login
+    fail-fast path) and (b) ``harness.codex-native.command`` pointing at a
+    wrapper that sleeps ``_WRAPPER_SETUP_DELAY_S`` (simulated cold-start
+    setup) before ``exec``-ing the real Codex CLI with the runner's launch
+    args. The wrapper stamps marker files so the test can prove the launch
+    was healthy (Codex really started, just late).
+
+    :returns: ``(base_url, session_id, markers_dir)``.
+    """
+    codex_path = shutil.which("codex")
+    assert codex_path is not None  # pytestmark guards this
+
+    work = tmp_path_factory.mktemp("codex_wrapped_startup")
+    config_home = work / "config-home"
+    codex_home = work / "codex-home"
+    home_dir = work / "home"
+    state_dir = work / "codex-native-state"
+    artifacts = work / "artifacts"
+    markers = work / "markers"
+    for path in (config_home, codex_home, home_dir, state_dir, artifacts, markers):
+        path.mkdir(parents=True, exist_ok=True)
+
+    wrapper = work / "codex-setup-wrapper.sh"
+    wrapper.write_text(
+        f"""#!/usr/bin/env bash
+# A configured codex-native command that performs cold-start setup before
+# launching Codex (the representative shape). The setup is simulated with a sleep
+# so the timing boundary is deterministic; the launch itself is healthy.
+set -eu
+date +%s > "{markers}/wrapper-started"
+sleep {_WRAPPER_SETUP_DELAY_S}
+date +%s > "{markers}/codex-exec"
+exec "{codex_path}" "$@"
+""",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+    (config_home / "config.yaml").write_text(
+        f"""\
+providers:
+  mock-codex:
+    kind: key
+    default: [openai]
+    openai:
+      base_url: "{mock_llm_server_url}/v1"
+      api_key: "mock-key"
+      wire_api: responses
+      models:
+        default: {_CODEX_MOCK_MODEL}
+harness:
+  codex-native:
+    command: {wrapper}
+""",
+        encoding="utf-8",
+    )
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    binding_token = secrets.token_urlsafe(32)
+
+    from omnigent.runner.identity import token_bound_runner_id
+
+    runner_id = token_bound_runner_id(binding_token)
+
+    shared_env = {
+        **_clean_env(),
+        "PYTHONPATH": f"{_REPO_ROOT}{os.pathsep}{os.environ.get('PYTHONPATH', '')}",
+        "OMNIGENT_CONFIG_HOME": str(config_home),
+        "OMNIGENT_CODEX_NATIVE_STATE_DIR": str(state_dir),
+        "CODEX_HOME": str(codex_home),
+        "HOME": str(home_dir),
+    }
+    server_env = {**shared_env, "OMNIGENT_RUNNER_TUNNEL_TOKEN": binding_token}
+    runner_env = {
+        **shared_env,
+        "OMNIGENT_RUNNER_ID": runner_id,
+        "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN": binding_token,
+        "OMNIGENT_RUNNER_PARENT_PID": str(os.getpid()),
+        "RUNNER_SERVER_URL": base_url,
+    }
+
+    server_log = work / "server.log"
+    runner_log = work / "runner.log"
+    server_handle = server_log.open("w")
+    runner_handle = runner_log.open("w")
+    server_proc: subprocess.Popen[bytes] | None = None
+    runner_proc: subprocess.Popen[bytes] | None = None
+    session_id: str | None = None
+    try:
+        server_proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "omnigent.cli",
+                "server",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--database-uri",
+                f"sqlite:///{work}/test.db",
+                "--artifact-location",
+                str(artifacts),
+            ],
+            env=server_env,
+            stdout=server_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+        runner_proc = subprocess.Popen(
+            [sys.executable, "-m", "omnigent.runner._entry"],
+            env=runner_env,
+            stdout=runner_handle,
+            stderr=subprocess.STDOUT,
+            cwd=str(_REPO_ROOT),
+        )
+
+        deadline = time.monotonic() + _HEALTH_TIMEOUT_S
+        online = False
+        while time.monotonic() < deadline:
+            if server_proc.poll() is not None or runner_proc.poll() is not None:
+                break
+            try:
+                if _client.get(f"{base_url}/health", timeout=2).status_code == 200:
+                    status = _client.get(f"{base_url}/v1/runners/{runner_id}/status", timeout=2)
+                    if status.status_code == 200 and status.json().get("online"):
+                        online = True
+                        break
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.5)
+        if not online:
+            raise RuntimeError(
+                "wrapped codex rig did not come online within "
+                f"{_HEALTH_TIMEOUT_S:.0f}s.\nServer log:\n{server_log.read_text()[-3000:]}\n"
+                f"Runner log:\n{runner_log.read_text()[-3000:]}"
+            )
+
+        session_id = _create_native_codex_session(base_url, runner_id)
+        yield (base_url, session_id, markers)
+    finally:
+        if session_id is not None:
+            with contextlib.suppress(httpx.HTTPError):
+                _client.delete(f"{base_url}/v1/sessions/{session_id}", timeout=10.0)
+        for proc in (runner_proc, server_proc):
+            if proc is not None and proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+        for proc in (runner_proc, server_proc):
+            if proc is not None:
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=5)
+        server_handle.close()
+        runner_handle.close()
+
+
+@pytest.mark.timeout(600)
+def test_configured_codex_command_setup_survives_startup_watchdog(
+    page: Page,
+    wrapped_codex_session: tuple[str, str, Path],
+    mock_llm_server_url: str,
+) -> None:
+    """A healthy wrapped codex launch must not die at the 30s watchdog.
+
+    Journey under test: a codex-native session whose configured
+    ``codex-native.command`` performs cold-start setup gets its first prompt
+    immediately after creation. While the bug is live, the runner's 30s
+    ``thread/started`` watchdog fires mid-setup, records the startup error,
+    and the turn dies with ``Codex native thread never started: Codex
+    app-server never started a thread (startup timed out: TimeoutError)`` —
+    rendered by the SPA as an error pill — even though the wrapper execs
+    Codex a few seconds later (proven via the marker file).
+    """
+    base_url, session_id, markers = wrapped_codex_session
+
+    nonce = uuid.uuid4().hex[:8]
+    user_marker = f"wrapped-start-{nonce}"
+    assistant_token = f"wrapped-start-done-{nonce}"
+
+    reset_mock_llm(mock_llm_server_url)
+    # Main-turn script for the fixed path: the mock model completes the turn
+    # with the token. Internal requests embedding the transcript (helper
+    # threads, title generation) also match the marker queue, so pad with
+    # extra entries — a stray consumer must not starve the main completion.
+    configure_mock_llm(
+        mock_llm_server_url,
+        [{"text": assistant_token}] * 8,
+        key=user_marker,
+        match=user_marker,
+    )
+    # Stray internal Codex calls (model-routed, no transcript) must not stall.
+    set_fallback_mock_llm(mock_llm_server_url, _CODEX_MOCK_MODEL, "")
+
+    page.goto(f"{base_url}/c/{session_id}")
+    _ensure_chat_view(page)
+    _send(
+        page,
+        f"Context marker {user_marker}. Reply with exactly: {assistant_token}",
+    )
+    sent_at = time.monotonic()
+
+    # Wait for the first turn to reach a terminal, user-visible outcome:
+    # either an assistant reply (thread started, model responded) or an
+    # error pill (the premature startup failure).
+    outcome = page.locator(_ERROR_PILL).or_(page.locator(_ASSISTANT))
+    expect(outcome.first).to_be_visible(timeout=int(_TURN_OUTCOME_TIMEOUT_S * 1000))
+    elapsed = time.monotonic() - sent_at
+
+    # Rig validity: the wrapped launch must be HEALTHY — the wrapper really
+    # exec'd Codex after its setup delay. Without this, a startup-timeout
+    # error could come from a broken wrapper instead of the premature
+    # watchdog, and the regression assertion below would be meaningless.
+    exec_marker = markers / "codex-exec"
+    marker_deadline = time.monotonic() + _WRAPPER_SETUP_DELAY_S + 90.0
+    while not exec_marker.exists() and time.monotonic() < marker_deadline:
+        time.sleep(1.0)
+    assert exec_marker.exists(), (
+        "the configured wrapper never exec'd Codex — the rig is broken "
+        f"(wrapper markers: {sorted(p.name for p in markers.iterdir())})"
+    )
+
+    # THE BUG: the durable assertion runs against the canonical transcript.
+    # No error item of this turn may be the thread-start watchdog timeout —
+    # the launch was healthy, merely slower than the direct-launch budget.
+    items = _client.get(f"{base_url}/v1/sessions/{session_id}/items?limit=50", timeout=10.0)
+    items.raise_for_status()
+    error_messages = [
+        str(item.get("message", ""))
+        for item in items.json()["data"]
+        if item.get("type") == "error"
+    ]
+    premature = [
+        message
+        for message in error_messages
+        if _STARTUP_TIMEOUT_MARKER in message or _NEVER_STARTED_MARKER in message
+    ]
+    assert not premature, (
+        "codex-native configured-command launch died at the direct-launch "
+        f"thread-start watchdog (after {elapsed:.0f}s) even though the wrapper "
+        "exec'd Codex shortly afterward — configured commands need a larger "
+        f"bounded startup allowance: {premature[0][:500]}"
+    )
+
+    # And the journey must actually complete: the wrapped launch's thread
+    # serves the first turn once the allowance covers the setup delay.
+    reply = page.locator(_ASSISTANT, has_text=assistant_token)
+    expect(reply.first).to_be_visible(timeout=120_000)

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+import omnigent.inner.codex_native_executor as codex_native_executor
 from omnigent.harnesses.codex_native.app_server import CodexAppServerResponseError
 from omnigent.harnesses.codex_native.bridge import (
     CodexNativeBridgeState,
@@ -16,6 +18,7 @@ from omnigent.harnesses.codex_native.bridge import (
     read_codex_config_effort,
     read_codex_config_model,
     write_bridge_startup_error,
+    write_bridge_startup_timeout,
     write_bridge_state,
 )
 from omnigent.inner.codex_native_executor import CodexNativeExecutor
@@ -1342,8 +1345,12 @@ def test_run_turn_surfaces_recorded_startup_error(
     generic "bridge state is missing" (issue #59).
     """
 
+    sleep_calls = 0
+
     async def _no_sleep(_seconds: float) -> None:
         """No-op the poll backoff so the missing-state path is fast."""
+        nonlocal sleep_calls
+        sleep_calls += 1
 
     # asyncio.run does not depend on asyncio.sleep, so patching it is safe.
     monkeypatch.setattr(asyncio, "sleep", _no_sleep)
@@ -1351,6 +1358,7 @@ def test_run_turn_surfaces_recorded_startup_error(
         tmp_path,
         "Codex app-server never started a thread within the startup timeout.",
     )
+    write_bridge_startup_timeout(tmp_path, 120.0)
     executor = CodexNativeExecutor(bridge_dir=tmp_path)
 
     events = _collect_turn_events(executor, "hello")
@@ -1361,6 +1369,238 @@ def test_run_turn_surfaces_recorded_startup_error(
     assert "never started" in error.message
     assert "startup timeout" in error.message
     assert error.message != "Codex native bridge state is missing"
+    assert sleep_calls == 0
+
+
+def test_bridge_state_wait_preserves_legacy_and_configured_command_contracts(
+    tmp_path: Path,
+) -> None:
+    """Only an advertised configured-command launch extends the legacy 60s wait."""
+    assert codex_native_executor._bridge_state_wait_poll_count(tmp_path) == 60
+
+    write_bridge_startup_timeout(tmp_path, 120.0)
+
+    assert codex_native_executor._bridge_state_wait_poll_count(tmp_path) == 125
+
+
+def test_run_turn_without_marker_keeps_exact_legacy_poll_count(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The ordinary path remains the existing 60 one-second polls."""
+    sleep_calls = 0
+
+    async def _count_sleep(seconds: float) -> None:
+        nonlocal sleep_calls
+        assert seconds == 1.0
+        sleep_calls += 1
+
+    monkeypatch.setattr(asyncio, "sleep", _count_sleep)
+    events = _collect_turn_events(CodexNativeExecutor(bridge_dir=tmp_path), "hello")
+
+    assert sleep_calls == 60
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+
+
+@pytest.mark.asyncio
+async def test_extended_bridge_wait_does_not_block_concurrent_enqueue(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The configured-command wait remains outside the injection lock."""
+    write_bridge_startup_timeout(tmp_path, 120.0)
+    sleep_entered = asyncio.Event()
+    release_sleep = asyncio.Event()
+    sleep_calls = 0
+
+    async def _block_first_sleep(seconds: float) -> None:
+        nonlocal sleep_calls
+        assert seconds == 1.0
+        sleep_calls += 1
+        if sleep_calls == 1:
+            sleep_entered.set()
+            await release_sleep.wait()
+
+    async def _drive_run_turn(executor: CodexNativeExecutor) -> list[Any]:
+        events: list[Any] = []
+        async for event in executor.run_turn(
+            [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            [],
+            "",
+        ):
+            events.append(event)
+        return events
+
+    monkeypatch.setattr(asyncio, "sleep", _block_first_sleep)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+    run_turn_task = asyncio.create_task(_drive_run_turn(executor))
+    await asyncio.wait_for(sleep_entered.wait(), timeout=5.0)
+
+    accepted = await asyncio.wait_for(
+        executor.enqueue_session_message("session", "steer"),
+        timeout=5.0,
+    )
+    write_bridge_startup_error(tmp_path, "test completed")
+    release_sleep.set()
+    events = await asyncio.wait_for(run_turn_task, timeout=5.0)
+
+    assert accepted is False
+    assert sleep_calls == 1
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+
+
+def test_run_turn_honors_marker_published_after_wait_starts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A late persistent marker grants its full allowance exactly once."""
+    sleep_calls = 0
+
+    async def _publish_marker_during_wait(seconds: float) -> None:
+        nonlocal sleep_calls
+        assert seconds == 1.0
+        sleep_calls += 1
+        if sleep_calls == 3:
+            write_bridge_startup_timeout(tmp_path, 120.0)
+
+    monkeypatch.setattr(asyncio, "sleep", _publish_marker_during_wait)
+    caplog.set_level(logging.DEBUG, logger=codex_native_executor.__name__)
+    events = _collect_turn_events(CodexNativeExecutor(bridge_dir=tmp_path), "hello")
+
+    assert sleep_calls == 128
+    assert "bridge-state wait extended from 60 to 128 polls" in caplog.text
+    assert len(events) == 1
+    assert isinstance(events[0], ExecutorError)
+
+
+def test_run_turn_rechecks_marker_before_reporting_the_generic_miss(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A marker first observed after the wait exhausts still extends it once.
+
+    Boundary race: the runner can publish ``startup_timeout.json`` in the
+    instant after the wait loop's final re-read (for example while a steer
+    holds the injection lock). The executor must re-read the marker
+    immediately before surfacing the generic bridge-state miss and resume its
+    bounded wait, instead of reporting the false "never started" failure
+    while the forwarder is still inside its advertised budget.
+    """
+    sleep_calls = 0
+
+    async def _count_sleep(seconds: float) -> None:
+        nonlocal sleep_calls
+        assert seconds == 1.0
+        sleep_calls += 1
+
+    real_read_startup_error = codex_native_executor.read_bridge_startup_error
+    marker_published = False
+
+    def _publish_marker_at_the_locked_recheck(bridge_dir: Path) -> str | None:
+        # The wait loop's last startup-error read happens before its 60th
+        # sleep, so the first read at sleep_calls == 60 is the locked miss
+        # pre-check — after the legacy wait exhausted, before surfacing.
+        nonlocal marker_published
+        if sleep_calls == 60 and not marker_published:
+            write_bridge_startup_timeout(tmp_path, 120.0)
+            marker_published = True
+        return real_read_startup_error(bridge_dir)
+
+    monkeypatch.setattr(asyncio, "sleep", _count_sleep)
+    monkeypatch.setattr(
+        codex_native_executor,
+        "read_bridge_startup_error",
+        _publish_marker_at_the_locked_recheck,
+    )
+    caplog.set_level(logging.DEBUG, logger=codex_native_executor.__name__)
+    events = _collect_turn_events(CodexNativeExecutor(bridge_dir=tmp_path), "hello")
+
+    assert marker_published
+    assert sleep_calls == 185
+    assert "bridge-state wait extended from 60 to 185 polls" in caplog.text
+    assert len(events) == 1
+    error = events[0]
+    assert isinstance(error, ExecutorError)
+    assert error.message == "Codex native bridge state is missing"
+
+
+@pytest.mark.asyncio
+async def test_late_marker_allows_state_after_absolute_advertised_poll_count(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A marker first seen at poll 10 still permits state published at poll 126."""
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.harnesses.codex_native.app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+    sleep_calls = 0
+
+    async def _publish_marker_then_state(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 10:
+            write_bridge_startup_timeout(tmp_path, 120.0)
+        if sleep_calls == 126:
+            _start_state(tmp_path)
+
+    monkeypatch.setattr(asyncio, "sleep", _publish_marker_then_state)
+    events: list[Any] = []
+    async for event in executor.run_turn(
+        [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        [],
+        "",
+    ):
+        events.append(event)
+
+    assert sleep_calls == 126
+    assert any(isinstance(event, TurnComplete) for event in events)
+    assert [method for method, _params in _FakeCodexNativeClient.requests] == ["turn/start"]
+
+
+@pytest.mark.asyncio
+async def test_run_turn_honors_configured_command_wait_past_legacy_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A delayed wrapped launch can publish state after the legacy wait expires."""
+    _FakeCodexNativeClient.requests = []
+    _FakeCodexNativeClient.created = []
+    _FakeCodexNativeClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.harnesses.codex_native.app_server.CodexAppServerClient",
+        _FakeCodexNativeClient,
+    )
+    write_bridge_startup_timeout(tmp_path, 120.0)
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+    sleep_calls = 0
+
+    async def _publish_after_legacy_deadline(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 61:
+            _start_state(tmp_path)
+
+    monkeypatch.setattr(asyncio, "sleep", _publish_after_legacy_deadline)
+    events: list[Any] = []
+    async for event in executor.run_turn(
+        [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        [],
+        "",
+    ):
+        events.append(event)
+
+    assert sleep_calls == 61
+    assert any(isinstance(event, TurnComplete) for event in events)
+    assert [method for method, _params in _FakeCodexNativeClient.requests] == ["turn/start"]
 
 
 # ── MCP startup: no client-side gate + Stop cancel (issue #2058) ────────

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import shutil
 import threading
 import uuid
@@ -409,6 +410,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     permission_args: list[str],
     retain_subscription: bool,
     cancel_launch: bool,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     Runner-owned Codex launch consumes persisted args and thread id.
@@ -425,6 +427,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
+    import omnigent.harness_startup_config as startup_config_mod
     import omnigent.harnesses.codex_native.app_server as codex_app_mod
     from omnigent.runner import app as runner_app_mod
 
@@ -435,6 +438,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+    caplog.set_level(logging.INFO, logger="omnigent.runner.app")
     bridge_dir = codex_native_bridge.bridge_dir_for_bridge_id(session_id)
     codex_native_bridge.write_bridge_state(
         bridge_dir,
@@ -598,6 +602,9 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
             assert session_key == "main"
             assert resource_role == CODEX_NATIVE_TERMINAL_ROLE
             assert not retained_client.closed
+            preloaded_state = codex_native_bridge.read_bridge_state(bridge_dir)
+            assert preloaded_state is not None
+            assert preloaded_state.thread_id == thread_id
             launched_specs.append(spec)
             if cancel_launch:
                 raise asyncio.CancelledError
@@ -651,6 +658,16 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
     monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
+    monkeypatch.setattr(
+        startup_config_mod,
+        "resolve_harness_config",
+        lambda _cfg: (None, {"codex-native": {"command": "codex-wrapper"}}),
+    )
+    monkeypatch.setattr(
+        startup_config_mod,
+        "resolve_harness_args",
+        lambda _harness, args, *, cfg: ["codex", "--", *args],
+    )
 
     agent_spec = AgentSpec(
         spec_version=1,
@@ -700,9 +717,11 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     assert build_calls[0]["developer_instructions"] == "Be a concise, careful coding assistant."
     assert len(launched_specs) == 1
     launched = launched_specs[0]
-    assert launched.command == "/opt/codex/bin/codex"
+    assert launched.command == "codex-wrapper"
     # Older TUIs still need permission flags; Codex 0.154+ rejects them.
     assert launched.args == [
+        "codex",
+        "--",
         "--dangerously-bypass-hook-trust",
         *permission_args,
         "resume",
@@ -749,6 +768,11 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     # Codex executor starts turns with the runner process's own cwd, so
     # web-driven shell tools run from the wrong directory.
     assert bridge_state.cwd == str(tmp_path / "workspace")
+    # Resume state is published before the configured wrapper starts, so the
+    # executor never needs a startup-timeout marker for this path.
+    assert codex_native_bridge.read_bridge_startup_timeout(bridge_dir) is None
+    assert "bridge state is preloaded" in caplog.text
+    assert "no bridge-state wait extension is needed" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1320,6 +1344,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
+    import omnigent.harness_startup_config as startup_config_mod
     import omnigent.harnesses.codex_native.app_server as codex_app_mod
     from omnigent.inner.datamodel import OSEnvSandboxSpec, OSEnvSpec
     from omnigent.runner import app as runner_app_mod
@@ -1351,6 +1376,7 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
             codex_home=str(tmp_path / "stale-codex-home"),
         ),
     )
+    codex_native_bridge.write_bridge_startup_timeout(bridge_dir, 120.0)
 
     class _WorktreeSnapshotClient:
         """Server client whose session snapshot carries a worktree workspace."""
@@ -1429,6 +1455,8 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
         async def close(self) -> None:
             """:returns: None."""
 
+    discovery_observations: list[tuple[dict[str, Any], Any, float | None]] = []
+
     async def _fake_discover_thread_and_forward(**kwargs: Any) -> None:
         """
         Stand in for the fresh-session discovery forwarder.
@@ -1436,10 +1464,12 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
         :param kwargs: Forwarder keyword arguments.
         :returns: None.
         """
-        assert kwargs["bridge_dir"] == bridge_dir
-        assert codex_native_bridge.read_bridge_state(bridge_dir) is None, (
-            "fresh Codex launch must clear stale bridge state before the "
-            "discovery forwarder publishes the new thread"
+        discovery_observations.append(
+            (
+                kwargs,
+                codex_native_bridge.read_bridge_state(bridge_dir),
+                codex_native_bridge.read_bridge_startup_timeout(bridge_dir),
+            )
         )
 
     launch_captured: dict[str, Any] = {}
@@ -1490,6 +1520,16 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
         "_codex_discover_thread_and_forward",
         _fake_discover_thread_and_forward,
     )
+    monkeypatch.setattr(
+        startup_config_mod,
+        "resolve_harness_config",
+        lambda _cfg: (None, {}),
+    )
+    monkeypatch.setattr(
+        startup_config_mod,
+        "resolve_harness_args",
+        lambda _harness, args, *, cfg: list(args),
+    )
 
     # agent_spec is a ResolvedSpec whose workdir is the bundle dir — the
     # exact value the old code wrongly used as the cwd. Its os_env declares
@@ -1526,6 +1566,16 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
     finally:
         runner_app_mod._AUTO_CODEX_APP_SERVERS.pop(session_id, None)
 
+    assert len(discovery_observations) == 1
+    discover_kwargs, observed_state, observed_timeout = discovery_observations[0]
+    assert discover_kwargs["bridge_dir"] == bridge_dir
+    assert observed_state is None, (
+        "fresh Codex launch must clear stale bridge state before the "
+        "discovery forwarder publishes the new thread"
+    )
+    assert observed_timeout is None
+    assert discover_kwargs["thread_start_timeout_seconds"] is None
+
     # The Codex app-server cwd must be the worktree (resolved — the launch
     # config normalizes with expanduser().resolve()). A failure here means
     # the workspace resolution regressed: the bundle dir means the old
@@ -1556,9 +1606,20 @@ async def test_auto_create_codex_terminal_uses_worktree_workspace_not_bundle_dir
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("marker_write_fails", "login_required"),
+    [
+        pytest.param(False, False, id="marker-published"),
+        pytest.param(True, False, id="marker-write-fails"),
+        pytest.param(False, True, id="login-required"),
+    ],
+)
 async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    marker_write_fails: bool,
+    login_required: bool,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """The tool relay is started at session creation, non-blocking.
 
@@ -1580,6 +1641,7 @@ async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
     :param monkeypatch: Pytest monkeypatch fixture.
     :returns: None.
     """
+    import omnigent.harness_startup_config as startup_config_mod
     import omnigent.harnesses.codex_native.app_server as codex_app_mod
     from omnigent.runner import app as runner_app_mod
 
@@ -1589,6 +1651,7 @@ async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
     monkeypatch.setenv("RUNNER_SERVER_URL", "http://ap.example")
     monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+    caplog.set_level(logging.INFO, logger="omnigent.runner.app")
 
     class _SnapshotClient:
         """Fresh-session snapshot (no external thread → discovery path)."""
@@ -1662,15 +1725,48 @@ async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
                 name="Codex",
             )
 
+    discover_calls: list[dict[str, Any]] = []
+
     async def _fake_discover(**kwargs: Any) -> None:
         """:returns: None — stands in for the discovery forwarder."""
-        del kwargs
+        discover_calls.append(kwargs)
 
     monkeypatch.setattr(
         codex_app_mod, "build_codex_native_server", lambda **k: _FakeCodexAppServer()
     )
+    monkeypatch.setattr(
+        codex_app_mod,
+        "resolve_native_codex_launch",
+        lambda **_kwargs: codex_app_mod.NativeCodexLaunch(
+            config_overrides=[],
+            model="gpt-5-default",
+            profile=None,
+            summary="test route",
+            login_required=login_required,
+        ),
+    )
     monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _FakeDiscoveryClient)
     monkeypatch.setattr(runner_app_mod, "_codex_discover_thread_and_forward", _fake_discover)
+    monkeypatch.setattr(
+        startup_config_mod,
+        "resolve_harness_config",
+        lambda _cfg: (None, {"codex-native": {"command": "codex-wrapper"}}),
+    )
+    monkeypatch.setattr(
+        startup_config_mod,
+        "resolve_harness_args",
+        lambda _harness, args, *, cfg: list(args),
+    )
+    if marker_write_fails:
+
+        def _raise_marker_write_error(_bridge_dir: Path, _timeout: float) -> None:
+            raise OSError("read-only bridge directory")
+
+        monkeypatch.setattr(
+            codex_native_bridge,
+            "write_bridge_startup_timeout",
+            _raise_marker_write_error,
+        )
 
     relay_calls: list[dict[str, Any]] = []
 
@@ -1708,6 +1804,19 @@ async def test_auto_create_codex_terminal_starts_relay_at_session_creation(
         session_id
     )
     assert relay_calls[0]["await_notify"] is False
+    assert len(discover_calls) == 1
+    # A failed marker write falls the forwarder back to the legacy timeout
+    # too, keeping it aligned with the executor's unextended legacy wait.
+    expected_timeout = None if marker_write_fails or login_required else 120.0
+    assert discover_calls[0]["thread_start_timeout_seconds"] == expected_timeout
+    assert codex_native_bridge.read_bridge_startup_timeout(
+        codex_native_bridge.bridge_dir_for_bridge_id(session_id)
+    ) == (None if marker_write_fails or login_required else 120.0)
+    if login_required:
+        assert "requires interactive login" in caplog.text
+        assert "preserving the unbounded sign-in wait" in caplog.text
+    else:
+        assert "configured command 'codex-wrapper' gets a 120s thread-start budget" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -3235,7 +3344,7 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
         async def close(self) -> None:
             closed["app_server"] = True
 
-    async def _raise_no_thread(*_args: object, **_kwargs: object) -> str:
+    async def _raise_no_thread(_client: object) -> str:
         raise TimeoutError("no thread/started observed")
 
     # The helper lazily imports wait_for_thread_started from the forwarder
@@ -3266,11 +3375,13 @@ async def test_codex_discover_thread_and_forward_cleans_up_on_discovery_failure(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("exc", "expected_cause"),
+    ("exc", "thread_start_timeout_seconds", "expected_cause"),
     [
-        (TimeoutError("no thread/started observed"), "startup timed out"),
+        (TimeoutError("no thread/started observed"), None, "startup timed out after 30s"),
+        (TimeoutError("no thread/started observed"), 120.0, "startup timed out after 120s"),
         (
             RuntimeError("event stream ended"),
+            None,
             "event stream ended before a thread was created",
         ),
     ],
@@ -3279,6 +3390,7 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     exc: Exception,
+    thread_start_timeout_seconds: float | None,
     expected_cause: str,
 ) -> None:
     """
@@ -3317,6 +3429,7 @@ async def test_codex_discover_thread_and_forward_records_accurate_startup_error(
             workspace=str(tmp_path / "workspace"),
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
+            thread_start_timeout_seconds=thread_start_timeout_seconds,
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -3352,8 +3465,10 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
 
     thread_id = "019e96aa-abcd-7343-8d3b-6f914d60936b"
     workspace = tmp_path / "selected-workspace"
+    wait_calls: list[dict[str, object]] = []
 
-    async def _fake_wait(*_args: object, **_kwargs: object) -> str:
+    async def _fake_wait(*_args: object, **kwargs: object) -> str:
+        wait_calls.append(kwargs)
         return thread_id
 
     async def _fake_supervise(**_kwargs: object) -> None:
@@ -3373,6 +3488,7 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
     monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
 
     session_id = "9f1f7f7bd7f24f80a621d9a3ba3fbc10"
+    codex_native_bridge.write_bridge_startup_timeout(tmp_path, 120.0)
     _AUTO_CODEX_APP_SERVERS[session_id] = _AppServer()
     try:
         await _codex_discover_thread_and_forward(
@@ -3383,6 +3499,7 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
             workspace=str(workspace),
             event_client=_Client(),  # type: ignore[arg-type]
             routing_summary="provider 'test' (model=gpt-test)",
+            thread_start_timeout_seconds=120.0,
         )
     finally:
         _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -3391,6 +3508,8 @@ async def test_codex_discover_thread_and_forward_persists_workspace_as_bridge_cw
     assert state is not None
     assert state.thread_id == thread_id
     assert state.cwd == str(workspace)
+    assert wait_calls == [{"timeout": 120.0}]
+    assert codex_native_bridge.read_bridge_startup_timeout(tmp_path) == 120.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_native_bridge.py
+++ b/tests/test_codex_native_bridge.py
@@ -21,6 +21,7 @@ from omnigent.harnesses.codex_native.bridge import (
     pending_mcp_servers,
     prepare_bridge_dir,
     read_bridge_startup_error,
+    read_bridge_startup_timeout,
     read_bridge_state,
     read_codex_config_effort,
     read_codex_config_model,
@@ -32,6 +33,7 @@ from omnigent.harnesses.codex_native.bridge import (
     update_active_turn_id,
     update_mcp_server_startup,
     write_bridge_startup_error,
+    write_bridge_startup_timeout,
     write_bridge_state,
     write_codex_config_effort,
     write_codex_config_model,
@@ -548,6 +550,72 @@ def test_bridge_startup_error_round_trips_and_is_cleared(bridge_dir: Path) -> No
 
     clear_bridge_state(bridge_dir)
     assert read_bridge_startup_error(bridge_dir) is None
+
+
+def test_bridge_startup_timeout_round_trips_and_is_cleared(bridge_dir: Path) -> None:
+    """The configured-command marker is bounded and cleared before a new launch."""
+    assert read_bridge_startup_timeout(bridge_dir) is None
+
+    write_bridge_startup_timeout(bridge_dir, 120.0)
+    assert read_bridge_startup_timeout(bridge_dir) == 120.0
+
+    clear_bridge_state(bridge_dir)
+    assert read_bridge_startup_timeout(bridge_dir) is None
+
+
+@pytest.mark.parametrize("timeout", [0.0, -1.0, 120.1, float("inf"), float("nan")])
+def test_bridge_startup_timeout_rejects_unbounded_values(
+    bridge_dir: Path,
+    timeout: float,
+) -> None:
+    """Invalid marker values cannot weaken the executor's bounded wait."""
+    with pytest.raises(ValueError, match="finite, positive"):
+        write_bridge_startup_timeout(bridge_dir, timeout)
+
+
+@pytest.mark.parametrize("value", [True, "120", 120.1, 10**1000, None])
+def test_bridge_startup_timeout_ignores_malformed_file_values(
+    bridge_dir: Path,
+    value: object,
+) -> None:
+    """Executor-visible marker parsing fails closed to the legacy wait."""
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    (bridge_dir / "startup_timeout.json").write_text(
+        json.dumps({"timeout_seconds": value}),
+        encoding="utf-8",
+    )
+
+    assert read_bridge_startup_timeout(bridge_dir) is None
+
+
+def test_bridge_startup_timeout_ignores_invalid_utf8(bridge_dir: Path) -> None:
+    """A marker that is not UTF-8 fails closed to the legacy wait."""
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    (bridge_dir / "startup_timeout.json").write_bytes(b"\xff")
+
+    assert read_bridge_startup_timeout(bridge_dir) is None
+
+
+def test_bridge_startup_timeout_ignores_overlong_integer(bridge_dir: Path) -> None:
+    """A marker larger than the payload cap fails closed."""
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    (bridge_dir / "startup_timeout.json").write_text(
+        '{"timeout_seconds": ' + "1" * 5000 + "}",
+        encoding="utf-8",
+    )
+
+    assert read_bridge_startup_timeout(bridge_dir) is None
+
+
+def test_bridge_startup_timeout_ignores_deeply_nested_json(bridge_dir: Path) -> None:
+    """A recursively nested marker cannot escape the fail-closed boundary."""
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    (bridge_dir / "startup_timeout.json").write_text(
+        "[" * 10_000 + "0" + "]" * 10_000,
+        encoding="utf-8",
+    )
+
+    assert read_bridge_startup_timeout(bridge_dir) is None
 
 
 def test_mcp_startup_updates_round_trip(bridge_dir: Path) -> None:


### PR DESCRIPTION
## Related issue

Closes #6989

## Summary

Omnigent can start Codex directly or through a configured command that performs setup first. Today both paths get 30 seconds to emit `thread/started`. The setup path can still be healthy when that timer expires, causing a false “Codex never started” error while Codex is still starting.

- Allow fresh launches through a configured command up to 120 seconds.
- Keep direct Codex launches unchanged at 30 seconds.
- Share that bounded budget with the executor, plus 5 seconds for the runner to publish thread state or the exact startup error.
- Preserve resume, interactive-login, and early-exit behavior. Do not retry a launch that is still progressing, because that could start two competing Codex processes.

### Latest manual reproduction

This was an ordinary workspace using an explicit `codex-native.command` wrapper on 2026-09-09 PDT; no artificial delay was injected.

- `17:29:35.293` — runner started.
- `17:29:41.654` — runner WebSocket connected.
- `17:29:50.657` — Codex app-server WebSocket began listening and accepted clients.
- `17:29:51.073` — the thread-start watchdog began.
- `17:29:51–17:30:13` — the configured command continued startup preparation before executing Codex.
- `17:30:21.083` — the watchdog timed out exactly **30.010 seconds** after it began.

The app-server stayed alive throughout the watchdog window. No `thread/start` request occurred and Codex's state database contained no thread, so this was not a missed `thread/started` event. Setup consumed about **22 of the 30 seconds**, leaving roughly **8 seconds** for Codex to create the thread before the old watchdog cancelled a launch that was still progressing.

**Before**

```mermaid
flowchart TD
  A[Configured command performs setup] --> B[30-second cutoff]
  B --> C[False startup failure]
```

**After**

```mermaid
flowchart TD
  D[Configured command performs setup] --> E[Runner allows up to 120 seconds]
  E --> F[Publishes a bounded timeout marker]
  F --> G[Executor honors that budget plus 5 seconds]
  G --> H[Thread state or precise startup error]
```

Direct Codex launches remain unchanged at 30 seconds / 60 executor polls.

## Test Plan

- Focused bridge, executor, and runner suite: **112 passed**.
- Exact slow configured-command browser journey: **1 passed**; a 45-second setup crossed the old 30-second deadline and completed the first turn without a startup-timeout error.
- Repository-wide `pre-commit run --all-files`: **passed**.
- `git diff --check`: **passed**.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The diagrams above show the behavioral boundary; there is no UI change.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover configured and direct launches, resume and login paths, late marker publication, malformed or stale markers, precise startup errors, concurrent steering during the wait, and the delayed-command path through a completed first turn.

## Changelog

Codex sessions launched through configured commands no longer fail at the direct-launch timeout while setup is still progressing.
