### PR TITLE
ci(areas): add an examples area so example PRs get a real owner

### DIFF
--- a/.github/areas.json
+++ b/.github/areas.json
@@ -714,6 +714,23 @@
         "TomeHirata",
         "dhruv0811"
       ]
+    },
+    {
+      "key": "examples",
+      "label": "comp:infra",
+      "priority_label": "comp:infra",
+      "weight": 1.0,
+      "weight_source": "editorial",
+      "definition": "Bundled agent examples under examples/ -- polly, debby, remy, scribe, sentinel, aws_analyst, deep-research, the hello-page extension and the top-level kimi_hello.yaml spec: their config.yaml, agents/ sub-agent specs, skills/ and MCP tool configs. polly and debby ship inside the wheel and polly is the first-run default agent, so this is not sample-only code.",
+      "paths": [
+        "examples/"
+      ],
+      "owners": [
+        "PattaraS",
+        "TomeHirata",
+        "dhruv0811",
+        "dbczumar"
+      ]
     }
   ]
 }

--- a/.github/workflows/areas.test.js
+++ b/.github/workflows/areas.test.js
@@ -88,6 +88,10 @@ const cases = [
   ["web/electron/main.ts", "desktop-app"],
   ["omnigent/server/api.py", "server"],
   ["omnigent/server/auth.py", "auth"],
+  ["examples/polly/config.yaml", "examples"],
+  ["examples/extensions/hello-page/web/src/main.ts", "examples"],
+  ["examples/kimi_hello.yaml", "examples"],
+  ["omnigent/resources/examples/polly", "resources"],
 ];
 for (const [fn, key] of cases) {
   const m = resolve(fn);

--- a/.github/workflows/auto-assign-reviewer-test.yml
+++ b/.github/workflows/auto-assign-reviewer-test.yml
@@ -2,7 +2,7 @@ name: Auto-assign Reviewer Test
 
 # Offline unit test for the reviewer-assignment logic: runs
 # auto-assign-reviewer.test.js (mocked GitHub client, real .github/areas.json +
-# .github/MAINTAINER). Triggers only when the assigner, its test, or the
+# .github/MAINTAINER). Triggers only when the assigner, either test, or the
 # area/codeowner map change. Runs on `pull_request` (PR head checkout)
 # so it tests the PR's own version. No secrets, no network.
 
@@ -11,6 +11,7 @@ on:
     paths:
       - .github/workflows/auto-assign-reviewer.js
       - .github/workflows/auto-assign-reviewer.test.js
+      - .github/workflows/areas.test.js
       - .github/areas.json
   workflow_dispatch:
 


### PR DESCRIPTION
## Related issue

Closes #6991

## Summary

- `examples/` matches no path rule in `.github/areas.json`, so example PRs resolve to no area and `auto-assign-reviewer.js` takes its `areaOwners.size ? areaOwners : poolSet` fallback — load-balancing across all 8 owners instead of picking someone who owns the area.
- Adds an `examples` area. **Every owner is already in the managed pool**, so nothing outside `examples/` routing moves: pool stays at 8 logins, and `comp:infra`'s label-owner set (read by `review-sla.js` `pickSecondAssignee`) is identical to before.
- @dbczumar is included because he authored every commit under `examples/extensions/hello-page` (3/3, all 13 files). Without him the area would exclude that sub-tree's only author from candidates he already reached via the fallback.
- Weight 1.0, not the lowest band: `setup.py:_bundle_examples` ships `polly` and `debby` into every wheel, `omnigent/resources/examples/{polly,debby}` are tracked symlinks into this tree, and `polly` is the first-run default agent. 1.0 matches the `resources` area that owns the same bytes.
- Appended rather than inserted at index 0 — `issue-triage.yml` builds its prompt in document order, so index 0 would reorder the live AREAS block for no benefit.
- Also lists `areas.test.js` in `auto-assign-reviewer-test.yml`'s `paths:` filter: that workflow runs the suite but never triggered on changes to it.

## Test Plan

Four routing cases added to `areas.test.js`, each verified to actually fail:

| mutation | result |
|---|---|
| remove the `examples` area | 3 positive cases fail → `(unmatched)` |
| typo the prefix (`examples/` → `example/`) | same 3 fail |
| over-claim `omnigent/resources/examples/` | negative case fails → `resources -- examples` |
| unmodified | exit 0 |

`examples/extensions/hello-page/web/src/main.ts -> examples` is the case worth having — it is the only place a `web/` segment sits beneath another area's prefix, i.e. the carve-out class this suite exists to guard.

All three suites, unmodified: `areas.test.js` 407 PASS / 0 FAIL, `auto-assign-reviewer.test.js` 38/38, `review-sla.test.js` 47/47.

Invariants checked differentially against `main`: owner pool 8 → 8 with no newly-managed login; `comp:infra` label-owners `PattaraS, TomeHirata, dbczumar, dhruv0811` both sides.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The schema constraints are already enforced by `areas.test.js` (owners in `MAINTAINER`, label among the 8 real `comp:*`, `priority_label` declared, ≥2 owners, weight band, `weight_source`, non-empty definition, ≥1 path) and pass unchanged. The new behaviour — `examples/` path routing — was previously asserted by nothing, so the four cases above cover it, and each was mutation-tested rather than trusted on a pass count. Manual verification covers the two differential invariants (owner pool and `comp:infra` label-owners), which no test asserts.

## Known trade-offs, not addressed here

Flagging these rather than smuggling them in — happy to follow up on any:

1. **Union with core areas.** 26 of 41 commits touching `examples/` also touch `omnigent/`, so a spec rename that mechanically updates every `config.yaml` unions examples owners onto a core PR. Inherent to the union rule for any multi-area PR, not specific to this area.
2. **`comp:infra` reuse.** Only 8 `comp:*` labels exist and there is no label-sync, so examples shares CI's label. A distinct `priority_label` would separate the queues if you want one.
3. **`tests/resources/examples/`** carries ~20 further shipped specs (`test_examples_coverage_sync.py` scans both roots) and still matches no rule. Claiming a `tests/` subtree felt like a bigger decision than this PR should make.
4. **`sdks/web-extension` PRs are forced to touch `examples/`.** `.pre-commit-config.yaml` rebuilds and diff-checks the committed `dist` bundle under `examples/extensions/hello-page/`, so such a PR unions examples owners in unavoidably. A one-line carve-out under the `sdks` area would fix it.
5. **No `web` owner** for `examples/extensions/hello-page/`, which has its own `web/` subtree and a committed bundle. `serena-ruan` / `daniellok-db` are already in the pool if you would rather they be on it.
6. **@SabhyaC26 is the top `examples/` contributor** (8 commits) and a listed maintainer, but is in no area's owners today. Adding him would grow the managed pool 8→9, which makes him the zero-load candidate that wins the load tiebreak for every unmatched path and newly subjects him to reviewer reconcile-removal — so I left that to you.
