### PR TITLE
feat(sandbox): clone multiple repos into a managed sandbox in parallel

### DIFF
--- a/omnigent/onboarding/sandboxes/__init__.py
+++ b/omnigent/onboarding/sandboxes/__init__.py
@@ -42,6 +42,7 @@ from omnigent.onboarding.sandboxes.registry import (
 )
 from omnigent.onboarding.sandboxes.types import (
     HostContext,
+    RepoWorkspace,
     SandboxCapabilities,
     SandboxCommandError,
     SandboxConfigError,
@@ -57,6 +58,7 @@ __all__ = [
     "HostContext",
     "RemoteCommandResult",
     "RemoteProcess",
+    "RepoWorkspace",
     "SandboxCapabilities",
     "SandboxCapabilityError",
     "SandboxCommandError",

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -34,8 +34,10 @@ from omnigent.host.identity import HOST_ID_ENV_VAR, HOST_NAME_ENV_VAR, HOST_TOKE
 from omnigent.onboarding.sandboxes import types as _sandbox_types
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable, Iterator, Sequence
     from pathlib import Path
+
+    from omnigent.onboarding.sandboxes.types import RepoWorkspace
 
 
 DEFAULT_HOST_IMAGE: str = "ghcr.io/omnigent-ai/omnigent-host:latest"
@@ -823,9 +825,7 @@ class SandboxHostLauncher(SandboxLifecycle):
         host_id: str,
         host_name: str,
         server_url: str,
-        repo_url: str | None = None,
-        repo_branch: str | None = None,
-        repo_name: str | None = None,
+        repos: Sequence[RepoWorkspace] = (),
         host_config: dict[str, object] | None = None,
         on_stage: Callable[[str], None] | None = None,
     ) -> str:
@@ -838,16 +838,16 @@ class SandboxHostLauncher(SandboxLifecycle):
         :param host_name: Server-chosen host display name, e.g.
             ``"managed-a1b2c3d4"``.
         :param server_url: URL of this server the host dials back to.
-        :param repo_url: Repository clone URL, or ``None`` for an empty
-            workspace.
-        :param repo_branch: Branch to clone, or ``None`` for the default branch.
-        :param repo_name: Directory the clone lands in under the workspace, or
-            ``None`` when *repo_url* is ``None``.
+        :param repos: Repositories to clone into ``<workspace>/<repo_name>``
+            (empty for an empty workspace). The returned path is the single
+            clone directory when exactly one repo is cloned, else the
+            workspace root that parents them all.
         :param host_config: Deployment-supplied ``~/.omnigent/config.yaml``
             content installed into the sandbox's config BEFORE the host starts.
         :param on_stage: Progress observer invoked with ``"cloning"`` and
             ``"starting"``.
-        :returns: The absolute in-sandbox workspace path.
+        :returns: The absolute in-sandbox workspace path — the working
+            directory the host starts the agent in.
         """
 
 
@@ -874,9 +874,7 @@ class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
         host_id: str,
         host_name: str,
         server_url: str,
-        repo_url: str | None = None,
-        repo_branch: str | None = None,
-        repo_name: str | None = None,
+        repos: Sequence[RepoWorkspace] = (),
         host_config: dict[str, object] | None = None,
         on_stage: Callable[[str], None] | None = None,
     ) -> str:
@@ -884,11 +882,16 @@ class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
         Start ``omnigent host`` in the sandbox and return the workspace path.
 
         The default is the EXEC model: probe ``$HOME``, create
-        ``<HOME>/workspace``, optionally materialize the repository into it (via
-        :meth:`materialize_workspace`, which clones by default), merge any
-        *host_config* into ``~/.omnigent/config.yaml``, and start the host
-        detached (``setsid``-backgrounded, identity + token in the process
+        ``<HOME>/workspace``, clone each requested repo into it (via
+        :meth:`materialize_workspace`), merge any *host_config* into
+        ``~/.omnigent/config.yaml``, and start the host detached
+        (``setsid``-backgrounded, identity + token in the process
         environment) — all driven through :meth:`run` / :meth:`run_background`.
+
+        The working directory is the single clone directory when exactly one
+        repo is cloned, else the workspace root parenting them all (or an empty
+        workspace when none are requested). Clones run sequentially here; the
+        entrypoint-as-host launchers (Kubernetes) clone in parallel.
 
         :returns: The absolute in-sandbox workspace path.
         """
@@ -900,15 +903,24 @@ class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
             )
         workspace = f"{home}/workspace"
         self.run(sandbox_id, f"mkdir -p {shlex.quote(workspace)}")
-        if repo_url is not None:
-            workspace = self.materialize_workspace(
-                sandbox_id,
-                workspace=workspace,
-                repo_url=repo_url,
-                repo_branch=repo_branch,
-                repo_name=repo_name,
-                on_stage=on_stage,
-            )
+        if repos:
+            if on_stage is not None:
+                on_stage("cloning")
+            # Distinct URLs can derive the same repo_name (e.g. two orgs' "api");
+            # disambiguate so they don't clone into one colliding directory.
+            clone_dirs = [
+                self.materialize_workspace(
+                    sandbox_id,
+                    workspace=workspace,
+                    repo_url=repo.url,
+                    repo_branch=repo.branch,
+                    repo_name=dirname,
+                )
+                for repo, dirname in zip(repos, _sandbox_types.clone_dir_names(repos), strict=True)
+            ]
+            # One repo → drop the agent straight into it; several → the
+            # workspace root that parents them all.
+            workspace = clone_dirs[0] if len(clone_dirs) == 1 else workspace
         if on_stage is not None:
             on_stage("starting")
         if host_config is not None or self.capabilities.resume_stopped:

--- a/omnigent/onboarding/sandboxes/islo.py
+++ b/omnigent/onboarding/sandboxes/islo.py
@@ -45,7 +45,7 @@ from omnigent.onboarding.sandboxes.base import (
     SandboxLauncher,
     host_image_wheel_install_command,
 )
-from omnigent.onboarding.sandboxes.types import SandboxCapabilities
+from omnigent.onboarding.sandboxes.types import RepoWorkspace, SandboxCapabilities
 
 API_BASE_URL_ENV_VAR: str = "ISLO_BASE_URL"
 """Optional Islo API base URL override. Defaults to
@@ -535,9 +535,7 @@ class IsloSandboxLauncher(SandboxLauncher):
         host_id: str,
         host_name: str,
         server_url: str,
-        repo_url: str | None = None,
-        repo_branch: str | None = None,
-        repo_name: str | None = None,
+        repos: Sequence[RepoWorkspace] = (),
         host_config: dict[str, object] | None = None,
         on_stage: Callable[[str], None] | None = None,
     ) -> str:
@@ -549,9 +547,7 @@ class IsloSandboxLauncher(SandboxLauncher):
             host_id=host_id,
             host_name=host_name,
             server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
+            repos=repos,
             host_config=host_config,
             on_stage=on_stage,
         )

--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -69,12 +69,14 @@ from omnigent.onboarding.sandboxes.base import (
     SandboxHostLauncher,
     render_host_config_write_command,
 )
-from omnigent.onboarding.sandboxes.types import SandboxCapabilities
+from omnigent.onboarding.sandboxes.types import SandboxCapabilities, clone_dir_names
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from kubernetes import client as k8s_client
+
+    from omnigent.onboarding.sandboxes.types import RepoWorkspace
 
 
 _logger = logging.getLogger(__name__)
@@ -471,9 +473,7 @@ def _token_secret_name(job_name: str) -> str:
 
 def _render_workspace_prep_command(
     workspace: str,
-    clone_dir: str | None,
-    repo_url: str | None,
-    repo_branch: str | None,
+    repos: Sequence[RepoWorkspace],
     server_url: str,
     host_id: str,
     host_config: dict[str, object] | None = None,
@@ -481,46 +481,61 @@ def _render_workspace_prep_command(
     """
     Render the init container command that prepares the workspace.
 
-    Creates ``<workspace>``, clones the repository into ``<clone_dir>`` when
-    requested, and merges *host_config* into ``config.yaml`` under
-    ``$OMNIGENT_CONFIG_HOME`` or the default ``~/.omnigent`` when set — all
-    BEFORE the host starts. Running in an init container means a failure
-    terminates the init container non-zero — surfaced fast by the start wait
-    with the error as the container log tail — rather than silently leaving the
-    host without its workspace or provider config.
+    Creates ``<workspace>``, clones each requested repository into
+    ``<workspace>/<repo_name>`` **in parallel**, and merges *host_config* into
+    ``config.yaml`` under ``$OMNIGENT_CONFIG_HOME`` or the default
+    ``~/.omnigent`` when set — all BEFORE the host starts. Running in an init
+    container means a failure terminates the init container non-zero — surfaced
+    fast by the start wait with the error as the container log tail — rather
+    than silently leaving the host without its workspace or provider config.
 
     :param workspace: The workspace root to create, e.g. ``"/home/omnigent/workspace"``.
-    :param clone_dir: Directory the clone lands in, or ``None`` for no clone.
-    :param repo_url: Repository clone URL, or ``None`` for an empty workspace.
-    :param repo_branch: Branch to clone (``--branch … --single-branch``), or
-        ``None`` for the default branch.
+    :param repos: Repositories to clone into ``<workspace>/<repo_name>``; empty
+        for an empty workspace.
     :param host_config: Deployment-supplied config content to merge in (lands
         under the same config directory seen by the host container), or
         ``None``.
     :returns: The ``["bash", "-lc", script]`` command.
     """
     script = f"set -e\nmkdir -p {shlex.quote(workspace)}\n"
-    if repo_url is not None and clone_dir is not None:
+    if repos:
         # Prefer the owner's per-user credential for the clone: when they've
         # connected GitHub, wire the broker as the sole github.com helper so a
-        # private clone authenticates as *them*. When they haven't connected this
-        # is a no-op that leaves the image's shared ``$GIT_TOKEN`` helper in
-        # place; ``|| true`` keeps a broker hiccup from failing the clone (it
-        # then falls back to ``$GIT_TOKEN``). Needs OMNIGENT_HOST_TOKEN in-env.
+        # private clone authenticates as *them*. Wired ONCE (it configures the
+        # global github.com helper for every clone below). When they haven't
+        # connected this is a no-op that leaves the image's shared ``$GIT_TOKEN``
+        # helper in place; ``|| true`` keeps a broker hiccup from failing the
+        # clone (it then falls back to ``$GIT_TOKEN``). Needs OMNIGENT_HOST_TOKEN.
         wire = (
             "from omnigent.git_credential_github import configure_clone_credentials; "
             f"configure_clone_credentials({server_url!r}, {host_id!r})"
         )
         script += f"python3 -c {shlex.quote(wire)} || true\n"
-        # ``--`` separates options from the (already-validated) URL so it can
-        # never be parsed as a flag; --single-branch keeps branch-pinned clones
-        # fast. Auth: the broker (above, if connected) else the image's GIT_TOKEN.
-        branch = (
-            f"--branch {shlex.quote(repo_branch)} --single-branch "
-            if repo_branch is not None
-            else ""
-        )
-        script += f"git clone {branch}-- {shlex.quote(repo_url)} {shlex.quote(clone_dir)}\n"
+        # Clone every repo concurrently, then wait on each and fail the init
+        # container if ANY clone failed — a half-populated workspace must abort
+        # the launch loudly, not boot the host on it. ``set -e`` stays on, but a
+        # backgrounded failure doesn't trip it; the explicit per-pid exit-code
+        # check below does. ``--`` separates options from the (already-validated)
+        # URL so it can never be parsed as a flag; --single-branch keeps
+        # branch-pinned clones fast.
+        # ponytail: unbounded fan-out; add `xargs -P <n>` if huge repo sets on a
+        # 2-vCPU pod ever thrash.
+        script += "pids=''\n"
+        # Distinct URLs can derive the same repo_name (e.g. two orgs' "api"); a
+        # shared clone dir would fail the concurrent clones, so disambiguate.
+        for repo, dirname in zip(repos, clone_dir_names(repos), strict=True):
+            clone_dir = f"{workspace}/{dirname}"
+            branch = (
+                f"--branch {shlex.quote(repo.branch)} --single-branch "
+                if repo.branch is not None
+                else ""
+            )
+            script += (
+                f"git clone {branch}-- {shlex.quote(repo.url)} "
+                f'{shlex.quote(clone_dir)} & pids="$pids $!"\n'
+            )
+        script += 'rc=0\nfor p in $pids; do wait "$p" || rc=1; done\n'
+        script += '[ "$rc" -eq 0 ]\n'
     if host_config is not None:
         script += render_host_config_write_command(host_config) + "\n"
     return ["bash", "-lc", script]
@@ -593,9 +608,7 @@ def build_job_manifest(
     env_literals: dict[str, str],
     node_selector: dict[str, str] | None,
     workspace: str,
-    clone_dir: str | None = None,
-    repo_url: str | None = None,
-    repo_branch: str | None = None,
+    repos: Sequence[RepoWorkspace] = (),
     host_config: dict[str, object] | None = None,
     resources: dict[str, object] | None = None,
     pvc_mounts: Sequence[Mapping[str, object]] | None = None,
@@ -696,9 +709,8 @@ def build_job_manifest(
         a default ``kubernetes.io/arch: amd64``; an operator-supplied
         ``kubernetes.io/arch`` entry overrides the default.
     :param workspace: Absolute workspace root created by the init container.
-    :param clone_dir: Directory the clone lands in, or ``None`` for no clone.
-    :param repo_url: Repository clone URL, or ``None`` for an empty workspace.
-    :param repo_branch: Branch to clone, or ``None`` for the default branch.
+    :param repos: Repositories the init container clones into
+        ``<workspace>/<repo_name>`` in parallel; empty for an empty workspace.
     :param host_config: Deployment-supplied config content merged in by the
         init container under the host's resolved config directory, or ``None``.
         Non-secret by design:
@@ -787,7 +799,7 @@ def build_job_manifest(
         )
 
     init_env: list[dict[str, object]] = [{"name": "HOME", "value": _HOME_DIR}]
-    if repo_url is not None:
+    if repos:
         # The clone wires the per-user broker when the owner has connected GitHub
         # (see _render_workspace_prep_command), which reads the launch token from
         # the env — project it the same way the host container does. Only added
@@ -833,7 +845,7 @@ def build_job_manifest(
         "image": image,
         "workingDir": _HOME_DIR,
         "command": _render_workspace_prep_command(
-            workspace, clone_dir, repo_url, repo_branch, server_url, host_id, host_config
+            workspace, repos, server_url, host_id, host_config
         ),
         "env": init_env,
         "resources": pod_resources,
@@ -1138,6 +1150,11 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
             resume_stopped=True,
             programmatic_terminate=True,
             classifies_runner_by_agent=True,
+            # The init container clones repos in parallel. agent-sandbox
+            # inherits this; managed Databricks launchers (Lakebox, Arca, …)
+            # are on the exec-model branch and stay single-repo until they
+            # opt in themselves.
+            multi_repo=True,
         )
 
     def __init__(
@@ -1409,9 +1426,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         host_id: str,
         host_name: str,
         server_url: str,
-        repo_url: str | None = None,
-        repo_branch: str | None = None,
-        repo_name: str | None = None,
+        repos: Sequence[RepoWorkspace] = (),
         host_config: dict[str, object] | None = None,
         agent_name: str | None = None,
         on_stage: Callable[[str], None] | None = None,
@@ -1424,9 +1439,10 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         :param host_id: Server-chosen host identity.
         :param host_name: Server-chosen host display name.
         :param server_url: URL the host dials back to.
-        :param repo_url: Repository clone URL, or ``None`` for an empty workspace.
-        :param repo_branch: Branch to clone, or ``None`` for the default branch.
-        :param repo_name: Directory the clone lands in, or ``None``.
+        :param repos: Repositories the init container clones into
+            ``<workspace>/<repo_name>`` in parallel; empty for an empty
+            workspace. The returned path is the single clone directory when one
+            repo is cloned, else the workspace root parenting them all.
         :param host_config: Deployment-supplied ``~/.omnigent/config.yaml``
             content the init container merges in before the host starts, or
             ``None``.
@@ -1447,7 +1463,6 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         env_literals = self._resolve_sandbox_env()
         secret_name = _token_secret_name(sandbox_id)
         workspace = f"{_HOME_DIR}/workspace"
-        clone_dir = f"{workspace}/{repo_name}" if repo_name else None
         if on_stage is not None:
             on_stage("starting")
         core = self._load_core()
@@ -1470,9 +1485,7 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
                     env_literals=env_literals,
                     node_selector=self._node_selector,
                     workspace=workspace,
-                    clone_dir=clone_dir,
-                    repo_url=repo_url,
-                    repo_branch=repo_branch,
+                    repos=repos,
                     host_config=host_config,
                     resources=self._resources,
                     pvc_mounts=self._pvc_mounts,
@@ -1510,7 +1523,9 @@ class KubernetesSandboxLauncher(SandboxHostLauncher):
         finally:
             self._close_clients()
         click.echo(f"  → {self.workload_kind} '{sandbox_id}' is starting the host")
-        return clone_dir or workspace
+        # One repo → drop the agent straight into it; several (or none) → the
+        # workspace root that parents every clone.
+        return f"{workspace}/{repos[0].repo_name}" if len(repos) == 1 else workspace
 
     def _create_workload(self, namespace: str, manifest: dict[str, object]) -> None:
         """

--- a/omnigent/onboarding/sandboxes/types.py
+++ b/omnigent/onboarding/sandboxes/types.py
@@ -8,11 +8,12 @@ interface and the newer pluggable surface in
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 
 class SandboxError(Exception):
@@ -87,6 +88,10 @@ class SandboxCapabilities:
         suspend-time snapshot (dependencies installed, caches warm)
         rather than cold-starting it. Only meaningful alongside
         ``resume_stopped``.
+    :param multi_repo: Provider can clone more than one repository into a
+        single session's workspace. Off by default, so a provider that
+        clones only one repo (and every out-of-tree provider) is never
+        handed a multi-repo request; providers opt in explicitly.
     """
 
     cli_bootstrap: bool = False
@@ -101,6 +106,7 @@ class SandboxCapabilities:
     # New fields append at the end to preserve positional-constructor
     # compatibility for out-of-tree providers.
     snapshot_restore: bool = False
+    multi_repo: bool = False
 
 
 @dataclass(frozen=True)
@@ -125,6 +131,79 @@ class SandboxInfo:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class RepoWorkspace:
+    """
+    A single repository to materialize in a managed sandbox's workspace.
+
+    Server code builds these via ``parse_repo_workspace`` (which validates
+    the URL and branch); the launcher surface only reads the fields. Lives
+    here rather than in the server package so a launcher can accept it
+    without importing ``omnigent.server`` (an onboarding→server dependency
+    the entrypoint-as-host launchers deliberately avoid).
+
+    :param url: The clone URL with any ``#<branch>`` fragment stripped,
+        e.g. ``"https://github.com/org/repo.git"`` or
+        ``"git@github.com:org/repo.git"``.
+    :param branch: Branch to clone (``--branch … --single-branch``), or
+        ``None`` for the default branch.
+    :param repo_name: Directory the clone lands in under the sandbox
+        workspace, derived from the URL's last path segment, e.g.
+        ``"repo"``.
+    """
+
+    url: str
+    branch: str | None
+    repo_name: str
+
+
+def _owner_segment(url: str) -> str:
+    """
+    The owner/org segment of a repo URL (second-to-last path segment), used to
+    disambiguate repos whose ``repo_name`` collides. Best-effort: ``""`` when
+    the URL has no owner segment.
+
+    ``https://github.com/org-a/api`` → ``"org-a"``;
+    ``git@github.com:org-b/api.git`` → ``"org-b"``.
+    """
+    parts = [p for p in re.split(r"[/:]", url.rstrip("/")) if p]
+    return parts[-2] if len(parts) >= 2 else ""
+
+
+def clone_dir_names(repos: Sequence[RepoWorkspace]) -> list[str]:
+    """
+    Unique clone-directory names for a list of repos, positionally aligned.
+
+    Each repo clones into ``<workspace>/<name>``. Distinct URLs can derive the
+    same ``repo_name`` (e.g. ``org-a/api`` and ``org-b/api`` → ``api``), which
+    would collide into one directory and fail the clone; those are qualified by
+    owner (``org-a__api``), with a numeric suffix as a last resort. A repo whose
+    name is already unique keeps the plain name, so the single-repo working
+    directory is unchanged.
+
+    :param repos: The repositories to clone, in order.
+    :returns: A directory name per repo, in the same order.
+    """
+    from collections import Counter
+
+    counts = Counter(r.repo_name for r in repos)
+    used: set[str] = set()
+    names: list[str] = []
+    for repo in repos:
+        if counts[repo.repo_name] > 1:
+            owner = _owner_segment(repo.url)
+            base = f"{owner}__{repo.repo_name}" if owner else repo.repo_name
+        else:
+            base = repo.repo_name
+        name, n = base, 2
+        while name in used:
+            name = f"{base}-{n}"
+            n += 1
+        used.add(name)
+        names.append(name)
+    return names
+
+
 @dataclass
 class HostContext:
     """Context handed to ``start_host`` when launching a managed host."""
@@ -133,8 +212,6 @@ class HostContext:
     host_id: str
     host_name: str
     server_url: str
-    repo_url: str | None = None
-    repo_branch: str | None = None
-    repo_name: str | None = None
+    repos: list[RepoWorkspace] = field(default_factory=list)
     host_config: dict[str, object] = field(default_factory=dict)
     on_stage: Callable[[str], None] | None = None

--- a/omnigent/server/app.py
+++ b/omnigent/server/app.py
@@ -152,6 +152,10 @@ class ServerInfoResponse(BaseModel):
     managed_sandboxes_enabled: bool
     sandbox_provider: str | None
     sandbox_providers: list[str]
+    # UI-relevant capability flags per launchable provider, e.g.
+    # ``{"agent_sandbox": {"multi_repo": true}}``. The web branches on these
+    # (multi-repo picker vs single). Providers absent from the map default off.
+    sandbox_provider_capabilities: dict[str, dict[str, bool]] = {}
     enabled_connections: list[str]
     sharing_mode: Literal["on", "read_only", "restricted_read_only", "off"]
     public_sharing_enabled: bool
@@ -2457,10 +2461,12 @@ def create_app(
         managed_sandboxes_enabled = False
         sandbox_provider = None
         sandbox_providers: list[str] = []
+        sandbox_provider_capabilities: dict[str, dict[str, bool]] = {}
         if sandbox_config is not None and sandbox_config.managed_launch_supported:
             managed_sandboxes_enabled = True
             sandbox_provider = sandbox_config.default.provider
             sandbox_providers = list(sandbox_config.launchable_providers())
+            sandbox_provider_capabilities = sandbox_config.provider_ui_capabilities()
         # enabled_connections lists the connection providers this deploy has
         # wired (config + store present), in a stable order. The web UI shows
         # the Sandbox Integrations nav when the list is non-empty and renders
@@ -2535,6 +2541,7 @@ def create_app(
                 "managed_sandboxes_enabled": managed_sandboxes_enabled,
                 "sandbox_provider": sandbox_provider,
                 "sandbox_providers": sandbox_providers,
+                "sandbox_provider_capabilities": sandbox_provider_capabilities,
                 "enabled_connections": enabled_connections,
                 "sharing_mode": sharing_mode.value,
                 "public_sharing_enabled": public_sharing_enabled,

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -164,7 +164,7 @@ import re
 import secrets
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import TYPE_CHECKING, cast
@@ -172,7 +172,13 @@ from typing import TYPE_CHECKING, cast
 import click
 from fastapi import HTTPException
 
+from omnigent.db.db_models import LABEL_VALUE_MAX_LEN
 from omnigent.db.utils import builtin_agent_id, now_epoch
+
+# RepoWorkspace lives in the launcher's own package so a launcher can accept it
+# without importing omnigent.server; re-exported here (its parser is here) so
+# existing `from omnigent.server.managed_hosts import RepoWorkspace` keeps working.
+from omnigent.onboarding.sandboxes.types import RepoWorkspace
 from omnigent.stores.host_store import Host, HostStore
 
 if TYPE_CHECKING:
@@ -310,15 +316,74 @@ MANAGED_LAUNCH_RENDEZVOUS_TIMEOUT_S = MANAGED_HOST_ONLINE_TIMEOUT_S + 120
 # create/patch reject any client label here, closing future keys by default.
 MANAGED_SANDBOX_LABEL_NAMESPACE = "omnigent.sandbox."
 
-# Session label recording the repository-URL workspace a managed
-# session was created with (the raw ``<url>[#<branch>]`` request
-# value). ``conversations.workspace`` is overwritten with the CLONED
-# path at bind time, so this label is what a sandbox RELAUNCH parses
-# to re-clone the repository into the fresh generation's workspace.
-# Per-session state: a fork never inherits it (the store drops it, and
-# the fork's own launch re-stamps whatever repository it resolves),
-# while an in-place agent switch keeps it — the sandbox is unchanged.
+# Base key for the labels recording the repository-URL workspaces a managed
+# session was created with (the raw ``<url>[#<branch>]`` request values).
+# ``conversations.workspace`` is overwritten with the CLONED path at bind time,
+# so these labels are what a sandbox RELAUNCH parses to re-clone the repos into
+# the fresh generation's workspace. Stored ONE PER REPO under ``<base>.<index>``
+# (``omnigent.sandbox.repo.0``, ``.1``, …): a single joined label would be
+# silently truncated at the 256-char label-value cap, losing repos on relaunch.
+# Per-session state: a fork never inherits them (the store drops the whole
+# ``<base>.`` family, and the fork's own launch re-stamps whatever it resolves),
+# while an in-place agent switch keeps them — the sandbox is unchanged.
 MANAGED_REPO_LABEL_KEY = "omnigent.sandbox.repo"
+
+
+def managed_repo_labels(workspaces: Sequence[str]) -> dict[str, str]:
+    """
+    Build the per-repo relaunch labels for a managed session's workspaces.
+
+    One label per repo, ``<base>.<index>`` → the raw ``<url>[#<branch>]`` value,
+    so each stays well under the 256-char label-value cap that would truncate a
+    single joined label (and lose repos on relaunch/fork). These indexed labels
+    are the source of truth :func:`read_managed_repo_workspaces` reads.
+
+    Backwards-compat shim: also write the legacy bare ``<base>`` key (the
+    space-joined value) so a server predating per-repo storage — e.g. after a
+    rollback against a shared database — still relaunches the repos through its
+    old bare-key read. It's written only when it fits the label-value cap (so a
+    truncated value is never stored); a larger set has no bare key and an old
+    server would relaunch it empty, but that is the rare many-repo case and only
+    a rolled-back reader. The current server ignores the bare key whenever the
+    indexed labels are present.
+
+    :param workspaces: The raw repository workspace strings, in order.
+    :returns: ``{f"{MANAGED_REPO_LABEL_KEY}.{i}": ws}`` for each, plus the bare
+        ``MANAGED_REPO_LABEL_KEY`` when the joined value fits; ``{}`` when
+        *workspaces* is empty.
+    """
+    labels = {f"{MANAGED_REPO_LABEL_KEY}.{i}": ws for i, ws in enumerate(workspaces)}
+    if labels:
+        joined = " ".join(workspaces)
+        if len(joined) <= LABEL_VALUE_MAX_LEN:
+            labels[MANAGED_REPO_LABEL_KEY] = joined
+    return labels
+
+
+def read_managed_repo_workspaces(labels: Mapping[str, str]) -> list[str]:
+    """
+    Recover the ordered repository workspaces from a session's labels.
+
+    Inverse of :func:`managed_repo_labels`: collect every ``<base>.<index>``
+    label and return the values ordered by their integer index. Falls back to
+    the legacy single space-joined ``<base>`` label so sessions created before
+    per-repo storage still relaunch/fork with their repositories.
+
+    :param labels: The session's labels.
+    :returns: The raw workspace strings in order; ``[]`` when none are recorded.
+    """
+    prefix = f"{MANAGED_REPO_LABEL_KEY}."
+    indexed: list[tuple[int, str]] = []
+    for key, value in labels.items():
+        if key.startswith(prefix):
+            suffix = key[len(prefix) :]
+            if suffix.isdigit():
+                indexed.append((int(suffix), value))
+    if indexed:
+        return [value for _, value in sorted(indexed)]
+    # Legacy: a single space-joined label from before per-repo storage.
+    legacy = labels.get(MANAGED_REPO_LABEL_KEY)
+    return legacy.split() if legacy else []
 
 
 def resolve_managed_agent_label(
@@ -696,6 +761,28 @@ class ManagedSandboxDeployment:
             if config.managed_launch_supported and config.provider is not None
         )
 
+    def provider_ui_capabilities(self) -> dict[str, dict[str, bool]]:
+        """
+        UI-relevant capability flags per launchable provider, for ``/v1/info``.
+
+        Only the flags the web branches on are exposed (not the full internal
+        :class:`SandboxCapabilities`), so the wire contract stays small — add an
+        inner key here to surface another flag. Instantiates each launchable
+        provider's launcher to read its declared capabilities.
+
+        ponytail: builds launchers on each call; memoize on the deployment only
+        if /v1/info shows up hot (provider count is tiny, __init__ does no I/O).
+
+        :returns: ``{provider: {"multi_repo": bool}}`` for each launchable
+            provider, in configured order.
+        """
+        caps: dict[str, dict[str, bool]] = {}
+        for config in self.configs:
+            if config.managed_launch_supported and config.provider is not None:
+                launcher = config.launcher_factory()
+                caps[config.provider] = {"multi_repo": launcher.capabilities.multi_repo}
+        return caps
+
 
 @dataclass
 class ManagedHostLaunch:
@@ -713,32 +800,6 @@ class ManagedHostLaunch:
 
     host_id: str
     workspace: str
-
-
-@dataclass
-class RepoWorkspace:
-    """
-    Parsed repository-URL workspace for a managed session.
-
-    A managed create's ``workspace`` is a git repository URL with an
-    optional ``#<branch>`` fragment (Docker build-context style): the
-    URL fully describes what the server materializes inside the
-    sandbox. Built by :func:`parse_repo_workspace` — construct via the
-    parser, not directly, so every field has been validated.
-
-    :param url: The clone URL with any fragment stripped, e.g.
-        ``"https://github.com/org/repo.git"`` or
-        ``"git@github.com:org/repo.git"``.
-    :param branch: Branch to clone (``--branch … --single-branch``),
-        e.g. ``"release-1.2"``, or ``None`` for the default branch.
-    :param repo_name: Directory name the clone lands in under the
-        sandbox workspace, derived from the URL's last path segment
-        with ``.git`` stripped, e.g. ``"repo"``.
-    """
-
-    url: str
-    branch: str | None
-    repo_name: str
 
 
 # A full 40-hex object id — rejected as a clone fragment: cloning a
@@ -848,15 +909,40 @@ def parse_repo_workspace(workspace: str) -> RepoWorkspace:
     url, sep, fragment = workspace.partition("#")
     if any(ch.isspace() for ch in workspace):
         raise ValueError("a repository workspace must not contain whitespace")
+    # Each workspace is stored verbatim in its own relaunch label, whose value
+    # column is capped; reject an over-long one at parse so it can't be silently
+    # truncated on write and relaunch/fork the wrong ref.
+    if len(workspace) > LABEL_VALUE_MAX_LEN:
+        raise ValueError(
+            f"a repository workspace must be at most {LABEL_VALUE_MAX_LEN} characters "
+            f"(got {len(workspace)}) — shorten the URL or branch"
+        )
+    # Reject embedded credentials (``user:token@host``) BEFORE any error that
+    # echoes the URL: the token would otherwise be persisted verbatim in a
+    # session label and the sandbox Pod spec, and leak into the error/logs. A
+    # well-formed URL of either form has no ``@`` after the scheme (https) or the
+    # ``git@`` user (ssh), so any ``@`` in the remainder is embedded userinfo —
+    # for both forms. The message must not echo the URL (it carries the secret);
+    # connect the account so the clone authenticates via the credential broker.
+    _cred_msg = (
+        "a repository URL must not embed credentials (user:token@host) — "
+        "connect the account instead of putting a token in the URL"
+    )
     if url.startswith("https://"):
-        host, slash, path = url[len("https://") :].partition("/")
+        rest = url[len("https://") :]
+        if "@" in rest:
+            raise ValueError(_cred_msg)
+        host, slash, path = rest.partition("/")
         if not host or not slash or not path.strip("/"):
             raise ValueError(
                 f"'{url}' is not a usable https repository URL — expected "
                 "'https://<host>/<org>/<repo>'"
             )
     elif url.startswith("git@"):
-        host, colon, path = url[len("git@") :].partition(":")
+        rest = url[len("git@") :]
+        if "@" in rest:
+            raise ValueError(_cred_msg)
+        host, colon, path = rest.partition(":")
         if not host or not colon or not path.strip("/"):
             raise ValueError(
                 f"'{url}' is not a usable ssh repository URL — expected 'git@<host>:<org>/<repo>'"
@@ -3109,7 +3195,7 @@ async def launch_managed_host(
     config: ManagedSandboxDeployment,
     owner: str,
     host_store: HostStore,
-    repo: RepoWorkspace | None = None,
+    repos: Sequence[RepoWorkspace] = (),
     provider: str | None = None,
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
@@ -3119,12 +3205,11 @@ async def launch_managed_host(
 
     Sequence: provision sandbox → pre-register the host row with its
     launch-token digest (so the credential resolves by the time the
-    host dials the tunnel) → optionally clone the requested repository
-    → start ``omnigent host`` inside the sandbox with the token +
-    identity in its environment → poll the hosts table until the host
-    is online. Any failure after provisioning terminates the sandbox
-    and deletes the host row (which revokes the token) before
-    re-raising.
+    host dials the tunnel) → clone the requested repositories → start
+    ``omnigent host`` inside the sandbox with the token + identity in its
+    environment → poll the hosts table until the host is online. Any
+    failure after provisioning terminates the sandbox and deletes the
+    host row (which revokes the token) before re-raising.
 
     :param config: The deployment's offered providers (YAML-parsed or
         wrapped around a directly-constructed embedding config).
@@ -3134,12 +3219,14 @@ async def launch_managed_host(
     :param host_store: Persistent host registrations — receives the
         pre-registered host row and is polled for the sandbox host
         coming online.
-    :param repo: Parsed repository-URL workspace to clone into the
-        sandbox as the session's working directory, or ``None`` for
-        an empty workspace. Private repositories authenticate via the
-        host image's git credential helper when the sandbox env
-        carries ``GIT_TOKEN`` (injected through Modal secrets — see
-        deploy/modal/README.md "Git credentials").
+    :param repos: Parsed repository-URL workspaces to clone into the
+        sandbox (empty for an empty workspace). One repo becomes the
+        session's working directory; several are cloned as siblings and
+        the working directory is the parent that holds them. Private
+        repositories authenticate via the host image's git credential
+        helper when the sandbox env carries ``GIT_TOKEN`` (injected
+        through Modal secrets — see deploy/modal/README.md "Git
+        credentials").
     :param provider: Which configured provider to launch on, e.g.
         ``"modal"``. ``None`` takes the deployment's default (first)
         provider — what a request that names none gets.
@@ -3182,7 +3269,7 @@ async def launch_managed_host(
         host_name=host_name,
         owner=owner,
         sandbox_id=sandbox_id,
-        repo=repo,
+        repos=repos,
         agent_name=agent_name,
         on_stage=on_stage,
     )
@@ -3194,7 +3281,7 @@ async def relaunch_managed_host(
     config: ManagedSandboxDeployment,
     host: Host,
     host_store: HostStore,
-    repo: RepoWorkspace | None = None,
+    repos: Sequence[RepoWorkspace] = (),
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
 ) -> ManagedHostLaunch:
@@ -3210,8 +3297,8 @@ async def relaunch_managed_host(
     atomically revokes the previous generation's token).
 
     The new sandbox starts from the image — workspace contents of the
-    dead generation are gone. Passing *repo* re-clones the session's
-    repository so the workspace is restored to its create-time state.
+    dead generation are gone. Passing *repos* re-clones the session's
+    repositories so the workspace is restored to its create-time state.
 
     Unlike a first launch, a failure here keeps the host row (only the
     new sandbox is torn down and the armed token revoked), so the
@@ -3221,8 +3308,8 @@ async def relaunch_managed_host(
     :param host: The existing managed host row to relaunch
         (``sandbox_provider`` set; callers guard on that).
     :param host_store: Persistent host registrations.
-    :param repo: Repository to re-clone as the workspace, or ``None``
-        for an empty workspace.
+    :param repos: Repositories to re-clone as the workspace (empty for an
+        empty workspace), matching the create-time selection.
     :param agent_name: Server-resolved built-in agent name the session runs,
         re-stamped as the new runner Pod's ``omnigent.ai/agent`` classifier
         (Kubernetes only), or ``None`` to leave it unstamped.
@@ -3273,7 +3360,7 @@ async def relaunch_managed_host(
             host_name=host.name,
             owner=host.user_id,
             sandbox_id=sandbox_id,
-            repo=repo,
+            repos=repos,
             agent_name=agent_name,
             on_stage=on_stage,
             keep_host_on_failure=True,
@@ -3294,9 +3381,7 @@ async def _start_sandbox_host(
     host_id: str,
     host_name: str,
     server_url: str,
-    repo_url: str | None,
-    repo_branch: str | None,
-    repo_name: str | None,
+    repos: Sequence[RepoWorkspace],
     host_config: dict[str, object] | None,
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
@@ -3319,9 +3404,7 @@ async def _start_sandbox_host(
             host_id=host_id,
             host_name=host_name,
             server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
+            repos=repos,
             host_config=host_config,
             on_stage=on_stage,
             agent_name=agent_name,
@@ -3334,9 +3417,7 @@ async def _start_sandbox_host(
             host_id=host_id,
             host_name=host_name,
             server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
+            repos=repos,
         )
     if host_config is None:
         return await asyncio.to_thread(
@@ -3346,9 +3427,7 @@ async def _start_sandbox_host(
             host_id=host_id,
             host_name=host_name,
             server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
+            repos=repos,
             on_stage=on_stage,
         )
     if on_stage is None:
@@ -3359,9 +3438,7 @@ async def _start_sandbox_host(
             host_id=host_id,
             host_name=host_name,
             server_url=server_url,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            repo_name=repo_name,
+            repos=repos,
             host_config=host_config,
         )
     return await asyncio.to_thread(
@@ -3371,9 +3448,7 @@ async def _start_sandbox_host(
         host_id=host_id,
         host_name=host_name,
         server_url=server_url,
-        repo_url=repo_url,
-        repo_branch=repo_branch,
-        repo_name=repo_name,
+        repos=repos,
         host_config=host_config,
         on_stage=on_stage,
     )
@@ -3388,7 +3463,7 @@ async def _register_and_start_host(
     host_name: str,
     owner: str,
     sandbox_id: str,
-    repo: RepoWorkspace | None = None,
+    repos: Sequence[RepoWorkspace] = (),
     agent_name: str | None = None,
     on_stage: Callable[[str], None] | None = None,
     keep_host_on_failure: bool = False,
@@ -3415,8 +3490,9 @@ async def _register_and_start_host(
     :param owner: User the managed host acts for, e.g.
         ``"alice@example.com"``.
     :param sandbox_id: The provisioned sandbox, e.g. ``"sb-a1b2c3"``.
-    :param repo: Repository to clone as the workspace, or ``None``
-        for an empty workspace.
+    :param repos: Repositories to clone into the workspace (empty for an
+        empty workspace). One repo → the agent's cwd is that clone dir;
+        several → the workspace root that parents them all.
     :param agent_name: Server-resolved built-in agent name the session runs,
         forwarded to ``start_host`` only for launchers that declare
         ``classifies_runner_by_agent`` (Kubernetes stamps it as the runner
@@ -3465,8 +3541,7 @@ async def _register_and_start_host(
         # Uniform across providers: provision() fixed the sandbox id and the
         # token was armed against it above, so start_host starts the host with
         # a token that already resolves. The exec-model default execs in; the
-        # entrypoint model (k8s) creates the Pod that boots the host. *repo* is
-        # unpacked into primitives — the launcher API takes no RepoWorkspace.
+        # entrypoint model (k8s) creates the Pod that boots the host.
         workspace = await _start_sandbox_host(
             launcher,
             sandbox_id,
@@ -3474,9 +3549,7 @@ async def _register_and_start_host(
             host_id=host_id,
             host_name=host_name,
             server_url=config.server_url,
-            repo_url=repo.url if repo is not None else None,
-            repo_branch=repo.branch if repo is not None else None,
-            repo_name=repo.repo_name if repo is not None else None,
+            repos=repos,
             host_config=config.host_config,
             agent_name=agent_name,
             on_stage=on_stage,
@@ -3752,9 +3825,7 @@ async def resume_managed_host(
                 host_id=host.host_id,
                 host_name=host.name,
                 server_url=entry.server_url,
-                repo_url=None,  # the persistent volume already holds the workspace
-                repo_branch=None,
-                repo_name=None,
+                repos=(),  # the persistent volume already holds the workspace
                 host_config=entry.host_config,
                 on_stage=on_stage,
                 agent_name=agent_name,

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -5471,7 +5471,7 @@ async def _provision_managed_sandbox(
     session_id: str,
     owner: str,
     sandbox_config: ManagedSandboxDeployment,
-    repo: RepoWorkspace | None,
+    repos: Sequence[RepoWorkspace],
     tracker: ManagedLaunchTracker,
     host_store: HostStore,
     relaunch_host: Host | None,
@@ -5489,7 +5489,7 @@ async def _provision_managed_sandbox(
     :param session_id: Session/conversation identifier.
     :param owner: User the managed host acts for.
     :param sandbox_config: The deployment's sandbox config.
-    :param repo: Repository workspace to clone, or ``None``.
+    :param repos: Repository workspaces to clone (empty for none).
     :param tracker: The app's launch tracker (failed here on error).
     :param host_store: Persistent host registrations.
     :param relaunch_host: Existing host row for a relaunch, or
@@ -5523,7 +5523,7 @@ async def _provision_managed_sandbox(
                 config=sandbox_config,
                 host=relaunch_host,
                 host_store=host_store,
-                repo=repo,
+                repos=repos,
                 agent_name=agent_name,
                 on_stage=_on_stage,
             )
@@ -5531,7 +5531,7 @@ async def _provision_managed_sandbox(
             config=sandbox_config,
             owner=owner,
             host_store=host_store,
-            repo=repo,
+            repos=repos,
             provider=provider,
             agent_name=agent_name,
             on_stage=_on_stage,

--- a/omnigent/server/routes/_sessions/orchestration.py
+++ b/omnigent/server/routes/_sessions/orchestration.py
@@ -129,12 +129,14 @@ from omnigent.server.background_session_titles import (
 from omnigent.server.bundles import bundle_location, validate_agent_bundle
 from omnigent.server.host_registry import HostConnection, HostRegistry, RunnerExitReports
 from omnigent.server.managed_hosts import (
+    MANAGED_REPO_LABEL_KEY,
     ManagedHostLaunch,
     ManagedLaunchTracker,
     ManagedSandboxDeployment,
     RepoWorkspace,
     host_resume_supported,
     host_sandbox_is_running,
+    read_managed_repo_workspaces,
 )
 from omnigent.server.routes._auth_helpers import (
     attribution_user as _attribution_user,
@@ -797,31 +799,41 @@ def _spawn_archive_stop(
 
 def _labels_for_viewer(labels: dict[str, str], user_id: str | None) -> dict[str, str]:
     """
-    Collapse per-user pin keys to the canonical pin label for one viewer.
+    Collapse the dynamic-suffix label families to their canonical bare keys.
 
-    Pins are stored per-user as ``omnigent.pinned.<user>`` (see
-    :func:`pinned_label_key`). On the wire we present a single canonical
-    ``omnigent.pinned`` key — set iff THIS viewer pinned the session — and drop
-    every ``omnigent.pinned.*`` key. That keeps the per-user dimension server-
-    side (a viewer never sees who else pinned a shared session, and the client
-    reads the same bare key it writes) and stops other users' pin keys from
-    bloating the payload.
+    Two families are stored under indexed/per-user keys but presented on the
+    wire as one bare key, so the client reads the same key it writes:
+
+    - Pins are stored per-user as ``omnigent.pinned.<user>`` (see
+      :func:`pinned_label_key`); we present a single ``omnigent.pinned`` set iff
+      THIS viewer pinned the session, and drop every ``omnigent.pinned.*`` key.
+      That keeps the per-user dimension server-side and stops other users' pins
+      from bloating the payload.
+    - Sandbox repos are stored one per repo as ``omnigent.sandbox.repo.<index>``
+      (avoiding the 256-char label-value cap); we present the canonical
+      ``omnigent.sandbox.repo`` as the space-joined list so clients that read
+      the bare key (e.g. the fork dialog) see every repo.
 
     :param labels: The stored conversation labels.
     :param user_id: The requesting viewer, or ``None`` in single-user mode.
-    :returns: A copy with all ``omnigent.pinned.*`` keys removed and the
-        canonical ``omnigent.pinned`` key added when the viewer's own pin
-        is present.
+    :returns: A copy with the pin and sandbox-repo families collapsed to their
+        canonical bare keys.
     """
     my_key = pinned_label_key(user_id)
     my_pin = labels.get(my_key)
+    repos = read_managed_repo_workspaces(labels)
     cleaned = {
         k: v
         for k, v in labels.items()
-        if k != PINNED_LABEL_KEY and not k.startswith(f"{PINNED_LABEL_KEY}.")
+        if k != PINNED_LABEL_KEY
+        and not k.startswith(f"{PINNED_LABEL_KEY}.")
+        and k != MANAGED_REPO_LABEL_KEY
+        and not k.startswith(f"{MANAGED_REPO_LABEL_KEY}.")
     }
     if my_pin is not None:
         cleaned[PINNED_LABEL_KEY] = my_pin
+    if repos:
+        cleaned[MANAGED_REPO_LABEL_KEY] = " ".join(repos)
     return cleaned
 
 
@@ -2944,7 +2956,7 @@ async def _run_managed_launch(
     session_id: str,
     owner: str,
     sandbox_config: ManagedSandboxDeployment,
-    repo: RepoWorkspace | None,
+    repos: Sequence[RepoWorkspace],
     tracker: ManagedLaunchTracker,
     conversation_store: ConversationStore,
     host_store: HostStore,
@@ -3033,7 +3045,7 @@ async def _run_managed_launch(
         session_id=session_id,
         owner=owner,
         sandbox_config=sandbox_config,
-        repo=repo,
+        repos=repos,
         tracker=tracker,
         host_store=host_store,
         relaunch_host=relaunch_host,
@@ -3616,29 +3628,29 @@ def _kick_managed_relaunch(
         agent store the classifier is re-derived from.
     """
     from omnigent.server.managed_hosts import (
-        MANAGED_REPO_LABEL_KEY,
         parse_repo_workspace,
+        read_managed_repo_workspaces,
     )
 
-    # Re-clone the repository the session was created with so the
-    # fresh generation's workspace matches the create-time state.
-    # The label holds the raw create-time value, already validated
-    # by the create's parse — a parse failure here means the label
-    # was tampered with, and the relaunch proceeds with an empty
-    # workspace rather than dying.
-    repo = None
-    raw_repo = conv.labels.get(MANAGED_REPO_LABEL_KEY)
-    if raw_repo is not None:
+    # Re-clone the repositories the session was created with so the fresh
+    # generation's workspace matches the create-time state. The per-repo labels
+    # hold the raw create-time values, already validated by the create's parse —
+    # a parse failure here means a label was tampered with, and the relaunch
+    # proceeds with an empty workspace rather than dying.
+    repos: list[RepoWorkspace] = []
+    raw_workspaces = read_managed_repo_workspaces(conv.labels)
+    if raw_workspaces:
         try:
-            repo = parse_repo_workspace(raw_repo)
+            repos = [parse_repo_workspace(w) for w in raw_workspaces]
         except ValueError:
             _logger.warning(
-                "Session %s has an unparseable %s label (%r); relaunching with an empty workspace",
+                "Session %s has an unparseable sandbox repo label (%r); "
+                "relaunching with an empty workspace",
                 session_id,
-                MANAGED_REPO_LABEL_KEY,
-                raw_repo,
+                raw_workspaces,
                 extra={"session_id": session_id},
             )
+            repos = []
     _logger.info(
         "Managed sandbox for session %s (host %s) is gone; relaunching a new generation",
         session_id,
@@ -3661,7 +3673,7 @@ def _kick_managed_relaunch(
             session_id=session_id,
             owner=host.user_id,
             sandbox_config=sandbox_config,
-            repo=repo,
+            repos=repos,
             tracker=tracker,
             conversation_store=conversation_store,
             host_store=host_store,

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -247,7 +247,7 @@ def register_core_routes(
         agent_id: str | None,
         user_id: str | None,
         sandbox_provider: str | None,
-        workspace: str | None,
+        workspaces: list[str],
     ) -> None:
         """
         Provision a managed sandbox host for a just-created session.
@@ -276,9 +276,11 @@ def register_core_routes(
             owner).
         :param sandbox_provider: Provider to provision, or ``None`` for
             the server's first configured provider.
-        :param workspace: Managed workspace — a git repository URL
-            (optionally ``#<branch>``) cloned into the sandbox, or
-            ``None`` for an empty sandbox.
+        :param workspaces: Managed workspaces — git repository URLs
+            (each optionally ``#<branch>``) cloned into the sandbox in
+            parallel; empty for an empty sandbox. One repo becomes the
+            session's working directory; several are cloned as siblings
+            and the working directory is the parent that holds them.
         :raises OmnigentError: If managed hosts aren't configured or the
             provider isn't offered.
         """
@@ -293,7 +295,7 @@ def register_core_routes(
             )
         from omnigent.server.auth import RESERVED_USER_LOCAL
         from omnigent.server.managed_hosts import (
-            MANAGED_REPO_LABEL_KEY,
+            managed_repo_labels,
             parse_repo_workspace,
         )
 
@@ -306,18 +308,32 @@ def register_core_routes(
                 f"on this server — available: {offered}",
                 code=ErrorCode.INVALID_INPUT,
             )
+        # Reject several repos on a provider that clones only one, with a clear
+        # 4xx (the web picker already caps this per provider; this guards direct
+        # API callers). Resolve the provider the launch will actually use.
+        if len(workspaces) > 1:
+            resolved = sandbox_provider or sandbox_config.default.provider
+            caps = sandbox_config.provider_ui_capabilities().get(resolved or "", {})
+            if not caps.get("multi_repo", False):
+                raise OmnigentError(
+                    f"sandbox provider '{resolved}' clones only one repository; "
+                    "select a single repository or choose a provider that supports several",
+                    code=ErrorCode.INVALID_INPUT,
+                )
         # A managed workspace is a repository URL (schema-validated) the
-        # launch clones inside the sandbox; parse it now so a malformed
+        # launch clones inside the sandbox; parse each now so a malformed
         # URL is a synchronous 4xx, not a background failure.
-        repo = parse_repo_workspace(workspace) if workspace is not None else None
-        if workspace is not None:
-            # The session row's workspace is overwritten with the CLONED
-            # path at bind time; record the raw request value so a
-            # sandbox relaunch can re-clone the same repository.
+        repos = [parse_repo_workspace(w) for w in workspaces]
+        if workspaces:
+            # The session row's workspace is overwritten with the CLONED path at
+            # bind time; record the raw request value(s) so a sandbox relaunch
+            # can re-clone the same repositories. Stored one label per repo (not
+            # a single joined value) so the 256-char label-value cap can't
+            # silently truncate the list and drop repos on relaunch.
             await asyncio.to_thread(
                 conversation_store.set_labels,
                 session_id,
-                {MANAGED_REPO_LABEL_KEY: workspace},
+                managed_repo_labels(workspaces),
             )
         managed_launches.begin(session_id)
         # Seed the launch-progress indicator before the background task
@@ -332,7 +348,7 @@ def register_core_routes(
                 # host registers under the reserved local owner.
                 owner=user_id if user_id is not None else RESERVED_USER_LOCAL,
                 sandbox_config=sandbox_config,
-                repo=repo,
+                repos=repos,
                 tracker=managed_launches,
                 conversation_store=conversation_store,
                 host_store=host_store_for_managed,
@@ -673,7 +689,7 @@ def register_core_routes(
                 agent_id=conv.agent_id if conv is not None else None,
                 user_id=user_id,
                 sandbox_provider=body.sandbox_provider,
-                workspace=body.workspace,
+                workspaces=body.managed_repo_workspaces(),
             )
 
         # Host launch: if a host is targeted (caller-supplied or
@@ -846,7 +862,11 @@ def register_core_routes(
                 agent_id=result.agent_id,
                 user_id=user_id,
                 sandbox_provider=parsed_metadata.sandbox_provider,
-                workspace=parsed_metadata.workspace,
+                # Bundle metadata carries a single repo; multi-repo is a
+                # web-picker (JSON) feature. Empty list = no repo.
+                workspaces=[parsed_metadata.workspace]
+                if parsed_metadata.workspace is not None
+                else [],
             )
         # Caller-supplied external host: bind + launch a runner on it,
         # exactly like the JSON create form (same authorization, atomic
@@ -2916,16 +2936,21 @@ def register_core_routes(
         # Push the forked session to this user's other open tabs.
         _announce_session_added(user_id, new_conv.id)
 
-        from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+        from omnigent.server.managed_hosts import read_managed_repo_workspaces
 
         # Managed host: schedule the fork's own BACKGROUND sandbox provision
         # and return immediately, exactly like a managed create. The host is
         # registered to the forking caller, so the sandbox resolves THEIR
-        # credentials, never the source owner's. An omitted workspace
-        # inherits the repository the source recorded (read off the SOURCE,
-        # since a fork never inherits the label itself), so cloning a sandbox
-        # session lands the fork in the same checkout.
+        # credentials, never the source owner's. An omitted workspace inherits
+        # ALL of the repositories the source recorded (read off the SOURCE,
+        # since a fork never inherits the labels itself), so cloning a
+        # multi-repo sandbox session lands the fork with every repo.
         if body.host_type == "managed":
+            fork_workspaces = (
+                ([body.workspace] if body.workspace is not None else [])
+                if workspace_set
+                else read_managed_repo_workspaces(source.labels)
+            )
             await _schedule_managed_launch(
                 request,
                 session_id=new_conv.id,
@@ -2935,9 +2960,7 @@ def register_core_routes(
                 agent_id=new_conv.agent_id,
                 user_id=user_id,
                 sandbox_provider=body.sandbox_provider,
-                workspace=(
-                    body.workspace if workspace_set else source.labels.get(MANAGED_REPO_LABEL_KEY)
-                ),
+                workspaces=fork_workspaces,
             )
 
         # Bound the response like the GET-session snapshot: newest item page,

--- a/omnigent/server/schemas.py
+++ b/omnigent/server/schemas.py
@@ -1341,6 +1341,15 @@ class SessionGitOptions(BaseModel):
         return self
 
 
+# Upper bound on repositories a single managed session may clone. Generous for
+# the realistic multi-repo case (a handful) while bounding three things a larger
+# set would grow: the sandbox's parallel git-clone fan-out on a small node, the
+# per-repo relaunch labels (one each, carried in every session snapshot), and an
+# abusive request.
+# ponytail: bump this one constant if larger repo sets ever need supporting.
+_MAX_MANAGED_WORKSPACES = 10
+
+
 class _SessionCreateRequestBase(BaseModel):
     """
     JSON request body for ``POST /v1/sessions``.
@@ -1407,6 +1416,14 @@ class _SessionCreateRequestBase(BaseModel):
         inside the sandbox and the cloned directory becomes the
         stored session workspace (paths are rejected; ``None``
         gives an empty server-created workspace).
+    :param workspaces: ``host_type: "managed"`` only — clone SEVERAL
+        repositories into one sandbox. A list of git repository URLs
+        (each optionally ``#<branch>``), same grammar as ``workspace``.
+        The server clones them in parallel as siblings under the
+        sandbox workspace; the agent starts in that parent directory
+        (or, when the list has exactly one entry, directly inside that
+        repo — matching single-``workspace`` behaviour). Mutually
+        exclusive with ``workspace``; ``None`` or ``[]`` means no repo.
     :param git: Optional git worktree options. When set, the server
         creates a worktree for a new branch on the host and starts
         the runner in it; ``workspace`` is then interpreted as the
@@ -1487,6 +1504,7 @@ class _SessionCreateRequestBase(BaseModel):
     host_id: str | None = None
     sandbox_provider: str | None = None
     workspace: str | None = None
+    workspaces: list[str] | None = None
     git: SessionGitOptions | None = None
     terminal_launch_args: list[str] | None = None
     model_override: str | None = None
@@ -1531,8 +1549,9 @@ class _SessionCreateRequestBase(BaseModel):
 
         :returns: The validated instance.
         :raises ValueError: On ``"managed"`` + ``host_id``, a managed
-            workspace that isn't a valid repository URL, or an
-            external repository-URL workspace.
+            workspace/workspaces that isn't a valid repository URL,
+            ``workspace`` and ``workspaces`` set together, too many
+            ``workspaces``, or an external repository-URL workspace.
         """
         # Lazy import: schemas is imported by nearly every module, so
         # pulling the (FastAPI/click-importing) managed-hosts module in
@@ -1545,13 +1564,23 @@ class _SessionCreateRequestBase(BaseModel):
                     "host_type 'managed' lets the server provision the host; "
                     "host_id must not be set"
                 )
-            if self.workspace is not None:
+            if self.workspace is not None and self.workspaces is not None:
+                raise ValueError(
+                    "set either 'workspace' (one repository) or 'workspaces' "
+                    "(several) for host_type 'managed', not both"
+                )
+            if self.workspaces is not None and len(self.workspaces) > _MAX_MANAGED_WORKSPACES:
+                raise ValueError(
+                    f"host_type 'managed' takes at most {_MAX_MANAGED_WORKSPACES} "
+                    f"repositories in 'workspaces' (got {len(self.workspaces)})"
+                )
+            for candidate in self.managed_repo_workspaces():
                 try:
-                    parse_repo_workspace(self.workspace)
+                    parse_repo_workspace(candidate)
                 except ValueError as exc:
                     raise ValueError(
-                        "host_type 'managed' takes a git repository URL "
-                        f"(optionally '#<branch>') as workspace: {exc}"
+                        "host_type 'managed' takes git repository URLs "
+                        f"(optionally '#<branch>') as workspace(s): {exc}"
                     ) from exc
             return self
         if self.sandbox_provider is not None:
@@ -1559,12 +1588,37 @@ class _SessionCreateRequestBase(BaseModel):
                 "sandbox_provider only applies to host_type 'managed' — "
                 "external hosts are not server-provisioned"
             )
+        if self.workspaces:
+            raise ValueError(
+                "'workspaces' (multi-repo clone) requires host_type 'managed' — "
+                "external hosts take a single absolute path in 'workspace'"
+            )
         if self.workspace is not None and is_repo_workspace(self.workspace):
             raise ValueError(
                 "a repository-URL workspace requires host_type 'managed' — "
                 "external hosts take an absolute path on the host"
             )
         return self
+
+    def managed_repo_workspaces(self) -> list[str]:
+        """
+        The managed session's repository workspaces as a normalized list.
+
+        ``workspaces`` when given, else the single ``workspace`` as a
+        one-element list, else empty. ``workspace`` and ``workspaces``
+        are mutually exclusive (:meth:`_check_managed_host_fields`), so at
+        most one source is populated. Meaningful only for
+        ``host_type: "managed"`` (an external ``workspace`` is a host path,
+        not a repo URL); callers gate on that.
+
+        :returns: Raw repository-URL strings (each optionally
+            ``#<branch>``); empty for an empty sandbox workspace.
+        """
+        if self.workspaces:
+            return list(self.workspaces)
+        if self.workspace is not None:
+            return [self.workspace]
+        return []
 
 
 class SessionCreateRequest(_SessionCreateRequestBase):

--- a/omnigent/stores/conversation_store/__init__.py
+++ b/omnigent/stores/conversation_store/__init__.py
@@ -185,13 +185,19 @@ _INSTANCE_SCOPED_LABEL_KEYS = frozenset(
 # repository records what THIS session's sandbox was built from and a relaunch
 # re-clones from it, so a fork that asked for an empty sandbox would otherwise
 # have the source's repo re-cloned into it on the first relaunch; the fork's own
-# managed launch re-stamps whatever repository it resolves. The repo literal
-# mirrors the server's ``MANAGED_REPO_LABEL_KEY``; a store test cross-checks it
-# so a rename there fails loudly here. Unlike runtime instance labels, these
-# survive an in-place agent switch but never a fork.
+# managed launch re-stamps whatever repository it resolves. Unlike runtime
+# instance labels, these survive an in-place agent switch but never a fork.
+#
+# Recorded one label PER repo (``omnigent.sandbox.repo.<index>``), a
+# dynamic-suffix family like the per-user pins, so a fork drops the whole family
+# by prefix in ``fork_conversation`` (this bare base key still covers any legacy
+# single-label session). The literal mirrors the server's
+# ``MANAGED_REPO_LABEL_KEY``; a store test cross-checks it so a rename there
+# fails loudly here.
+_SANDBOX_REPO_LABEL_KEY = "omnigent.sandbox.repo"
 _FORK_ONLY_DROPPED_LABEL_KEYS = IMPORT_PROVENANCE_LABEL_KEYS | {
     ARCHIVED_AT_LABEL_KEY,
-    "omnigent.sandbox.repo",
+    _SANDBOX_REPO_LABEL_KEY,
 }
 
 

--- a/omnigent/stores/conversation_store/sqlalchemy_store.py
+++ b/omnigent/stores/conversation_store/sqlalchemy_store.py
@@ -83,6 +83,7 @@ from omnigent.session_import.models import IMPORT_SOURCE_LABEL_KEY
 from omnigent.stores.conversation_store import (
     _FORK_ONLY_DROPPED_LABEL_KEYS,
     _INSTANCE_SCOPED_LABEL_KEYS,
+    _SANDBOX_REPO_LABEL_KEY,
     ARCHIVED_AT_LABEL_KEY,
     FORK_CARRY_HISTORY_LABEL_KEY,
     FORK_SOURCE_EXTERNAL_SESSION_LABEL_KEY,
@@ -4285,11 +4286,13 @@ class SqlAlchemyConversationStore(ConversationStore):
             # that combination reflects lost metadata, not a chat-only
             # session. Other workspace-less sources resume in-process like
             # a brand-new chat session.
-            # Per-user pin keys (``omnigent.pinned.<user>``) are dynamic-suffix,
-            # so they're never in the exact-match drop sets — drop them by prefix
+            # Per-user pin keys (``omnigent.pinned.<user>``) and per-repo sandbox
+            # labels (``omnigent.sandbox.repo.<index>``) are dynamic-suffix, so
+            # they're never in the exact-match drop sets — drop them by prefix
             # instead. A fork is a NEW conversation; inheriting the source's pins
             # would show the clone as pinned for the forker AND carry every other
-            # user's pin key along as dead data.
+            # user's pin key along as dead data, and inheriting the repo labels
+            # would re-clone the source's repos even into a fork asked for empty.
             source_labels = _fetch_labels(session, source_conversation_id)
             fork_labels = {
                 key: value
@@ -4301,6 +4304,7 @@ class SqlAlchemyConversationStore(ConversationStore):
                     | dropped_label_keys
                 )
                 and not key.startswith(f"{PINNED_LABEL_KEY}.")
+                and not key.startswith(f"{_SANDBOX_REPO_LABEL_KEY}.")
             }
             source_workspace = source_meta_ref.workspace if source_meta_ref else None
             source_ext_session = source_meta_ref.external_session_id if source_meta_ref else None

--- a/openapi.json
+++ b/openapi.json
@@ -4550,6 +4550,17 @@
             ],
             "title": "Sandbox Provider"
           },
+          "sandbox_provider_capabilities": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            },
+            "default": {},
+            "title": "Sandbox Provider Capabilities",
+            "type": "object"
+          },
           "sandbox_providers": {
             "items": {
               "type": "string"

--- a/tests/onboarding/sandboxes/test_agent_sandbox.py
+++ b/tests/onboarding/sandboxes/test_agent_sandbox.py
@@ -181,6 +181,13 @@ def _launcher() -> AgentSandboxLauncher:
     )
 
 
+def test_agent_sandbox_inherits_multi_repo_capability() -> None:
+    """agent-sandbox declares multi_repo via KubernetesSandboxLauncher, so the
+    picker offers the multi-repo menu for it and the launch accepts N repos.
+    Managed Databricks launchers are on the exec-model branch and stay off."""
+    assert _launcher().capabilities.multi_repo is True
+
+
 # ── manifest conversion ────────────────────────────────
 
 

--- a/tests/onboarding/sandboxes/test_base.py
+++ b/tests/onboarding/sandboxes/test_base.py
@@ -26,6 +26,7 @@ from omnigent.onboarding.sandboxes.base import (
     render_host_config_write_command,
     supervise_host_command,
 )
+from omnigent.onboarding.sandboxes.types import RepoWorkspace
 
 _HOST_LAUNCH = "FOO=bar omnigent host --server https://srv"
 
@@ -225,15 +226,44 @@ def test_start_host_default_materialize_clones_repo() -> None:
         host_id="host_abc",
         host_name="managed-abc",
         server_url="https://srv",
-        repo_url="https://github.com/org/repo",
-        repo_branch="release-1.2",
-        repo_name="repo",
+        repos=[
+            RepoWorkspace(
+                url="https://github.com/org/repo", branch="release-1.2", repo_name="repo"
+            )
+        ],
     )
 
     assert workspace == "/root/workspace/repo"
     assert (
         "git clone --branch release-1.2 --single-branch -- "
         "https://github.com/org/repo /root/workspace/repo"
+    ) in launcher.commands
+
+
+def test_start_host_clones_multiple_repos_into_sibling_dirs() -> None:
+    """
+    Several repos → the exec-model default clones each into
+    ``<workspace>/<repo_name>`` and returns the parent workspace (the working
+    directory that holds them all), matching the entrypoint (k8s) rule.
+    """
+    launcher = _RecordingLauncher()
+
+    workspace = launcher.start_host(
+        "sb-1",
+        token="tok-123",
+        host_id="host_abc",
+        host_name="managed-abc",
+        server_url="https://srv",
+        repos=[
+            RepoWorkspace(url="https://github.com/org/api", branch=None, repo_name="api"),
+            RepoWorkspace(url="https://github.com/org/web", branch="dev", repo_name="web"),
+        ],
+    )
+
+    assert workspace == "/root/workspace"
+    assert "git clone -- https://github.com/org/api /root/workspace/api" in launcher.commands
+    assert (
+        "git clone --branch dev --single-branch -- https://github.com/org/web /root/workspace/web"
     ) in launcher.commands
 
 
@@ -272,9 +302,7 @@ def test_materialize_workspace_override_resolves_local_checkout_without_cloning(
         host_id="host_abc",
         host_name="managed-abc",
         server_url="https://srv",
-        repo_url="https://github.com/org/repo",
-        repo_branch="main",
-        repo_name="repo",
+        repos=[RepoWorkspace(url="https://github.com/org/repo", branch="main", repo_name="repo")],
     )
 
     assert workspace == "/checkouts/repo"

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -32,6 +32,7 @@ from omnigent.onboarding.sandboxes.kubernetes import (
     build_job_manifest,
     build_token_secret_manifest,
 )
+from omnigent.onboarding.sandboxes.types import RepoWorkspace
 
 _TOKEN = "launch-token-xyz"
 _MANIFEST_KW = {
@@ -104,9 +105,10 @@ def test_build_job_manifest_has_no_liveness_probe() -> None:
 def test_build_job_manifest_init_container_prepares_and_clones_workspace() -> None:
     """The init container makes the workspace and clones the repo before the host."""
     manifest = build_job_manifest(
-        **{**_MANIFEST_KW, "clone_dir": "/home/omnigent/workspace/repo"},
-        repo_url="https://github.com/org/repo.git",
-        repo_branch="main",
+        **_MANIFEST_KW,
+        repos=[
+            RepoWorkspace(url="https://github.com/org/repo.git", branch="main", repo_name="repo")
+        ],
     )
     init = _pod_spec(manifest)["initContainers"]
     assert len(init) == 1
@@ -126,6 +128,44 @@ def test_build_job_manifest_init_container_prepares_and_clones_workspace() -> No
     )
 
 
+def test_build_job_manifest_clones_multiple_repos_as_parallel_siblings() -> None:
+    """Several repos → each clones into its own sibling dir, backgrounded (parallel)."""
+    manifest = build_job_manifest(
+        **_MANIFEST_KW,
+        repos=[
+            RepoWorkspace(url="https://github.com/org/a.git", branch=None, repo_name="a"),
+            RepoWorkspace(url="https://github.com/org/b.git", branch="main", repo_name="b"),
+        ],
+    )
+    script = _pod_spec(manifest)["initContainers"][0]["command"][2]
+    assert "https://github.com/org/a.git /home/omnigent/workspace/a" in script
+    assert (
+        "--branch main --single-branch -- https://github.com/org/b.git "
+        "/home/omnigent/workspace/b" in script
+    )
+    # Both clones are backgrounded and joined, and the broker is wired ONCE
+    # (a single `python3 -c` line configures the helper for every clone).
+    assert script.count(" & pids=") == 2
+    assert 'for p in $pids; do wait "$p" || rc=1; done' in script
+    assert script.count("python3 -c") == 1
+
+
+def test_build_job_manifest_disambiguates_same_named_repos() -> None:
+    """Two repos with the same last-segment name clone into owner-qualified dirs,
+    not one colliding directory that would fail the concurrent clone."""
+    manifest = build_job_manifest(
+        **_MANIFEST_KW,
+        repos=[
+            RepoWorkspace(url="https://github.com/org-a/api", branch=None, repo_name="api"),
+            RepoWorkspace(url="https://github.com/org-b/api", branch=None, repo_name="api"),
+        ],
+    )
+    script = _pod_spec(manifest)["initContainers"][0]["command"][2]
+    assert "https://github.com/org-a/api /home/omnigent/workspace/org-a__api" in script
+    assert "https://github.com/org-b/api /home/omnigent/workspace/org-b__api" in script
+    assert "workspace/api " not in script  # no plain colliding dir
+
+
 def test_build_job_manifest_without_repo_has_no_clone() -> None:
     """No repo → the init container only makes the workspace, no git clone."""
     manifest = build_job_manifest(**_MANIFEST_KW)
@@ -142,8 +182,10 @@ def test_build_job_manifest_without_repo_has_no_clone() -> None:
 def test_build_job_manifest_host_config_is_written_by_init_container() -> None:
     """host_config rides the init container script, after mkdir/clone, before the host."""
     manifest = build_job_manifest(
-        **{**_MANIFEST_KW, "clone_dir": "/home/omnigent/workspace/repo"},
-        repo_url="https://github.com/org/repo.git",
+        **_MANIFEST_KW,
+        repos=[
+            RepoWorkspace(url="https://github.com/org/repo.git", branch=None, repo_name="repo")
+        ],
         host_config=_HOST_CONFIG,
     )
     spec = _pod_spec(manifest)
@@ -553,23 +595,21 @@ def test_build_job_manifest_is_restricted_and_least_privilege() -> None:
 
 
 @pytest.mark.parametrize(
-    ("clone_dir", "repo_url", "repo_branch", "expect_clone", "expect_branch"),
+    ("repos", "expect_clone", "expect_branch"),
     [
-        (None, None, None, False, False),
-        ("/ws/repo", "https://x/y.git", None, True, False),
-        ("/ws/repo", "https://x/y.git", "release-1.2", True, True),
+        ([], False, False),
+        ([RepoWorkspace(url="https://x/y.git", branch=None, repo_name="y")], True, False),
+        ([RepoWorkspace(url="https://x/y.git", branch="release-1.2", repo_name="y")], True, True),
     ],
 )
 def test_render_workspace_prep_command(
-    clone_dir: str | None,
-    repo_url: str | None,
-    repo_branch: str | None,
+    repos: list[RepoWorkspace],
     expect_clone: bool,
     expect_branch: bool,
 ) -> None:
     """The init command always mkdir's the workspace and clones only when asked."""
     command = k8s._render_workspace_prep_command(
-        "/ws", clone_dir, repo_url, repo_branch, "http://srv.example.com", "host_abc"
+        "/ws", repos, "http://srv.example.com", "host_abc"
     )
     script = command[2]
     assert "mkdir -p /ws" in script
@@ -1006,7 +1046,7 @@ def test_launch_host_without_agent_label_keeps_reserved_labels(
 def test_launch_host_with_repo_returns_clone_dir(
     fake_clients: tuple[_FakeCore, _FakeBatch],
 ) -> None:
-    """With a repo, the returned workspace is the cloned directory under the workspace."""
+    """With one repo, the returned workspace is the cloned directory under the workspace."""
     core, _batch = fake_clients
     _setup_pod_discovery(core)
     workspace = _launcher().start_host(
@@ -1015,10 +1055,31 @@ def test_launch_host_with_repo_returns_clone_dir(
         host_id="host_2",
         host_name="managed-2",
         server_url="http://srv.example.com",
-        repo_url="https://github.com/org/repo.git",
-        repo_name="repo",
+        repos=[
+            RepoWorkspace(url="https://github.com/org/repo.git", branch=None, repo_name="repo")
+        ],
     )
     assert workspace == "/home/omnigent/workspace/repo"
+
+
+def test_launch_host_with_multiple_repos_returns_parent_workspace(
+    fake_clients: tuple[_FakeCore, _FakeBatch],
+) -> None:
+    """With several repos, the returned workspace is the parent that holds them all."""
+    core, _batch = fake_clients
+    _setup_pod_discovery(core)
+    workspace = _launcher().start_host(
+        "omnigent-job-2b",
+        token=_TOKEN,
+        host_id="host_2b",
+        host_name="managed-2b",
+        server_url="http://srv.example.com",
+        repos=[
+            RepoWorkspace(url="https://github.com/org/a.git", branch=None, repo_name="a"),
+            RepoWorkspace(url="https://github.com/org/b.git", branch=None, repo_name="b"),
+        ],
+    )
+    assert workspace == "/home/omnigent/workspace"
 
 
 def test_launch_host_cleans_up_on_create_failure(
@@ -1087,8 +1148,7 @@ def test_launch_host_fast_fails_on_clone_failure_with_log_tail(
             host_id="host_4",
             host_name="managed-4",
             server_url="http://srv.example.com",
-            repo_url="https://x/y.git",
-            repo_name="y",
+            repos=[RepoWorkspace(url="https://x/y.git", branch=None, repo_name="y")],
         )
     assert "workspace prep failed (exit 128" in exc.value.message
     assert "repository 'https://x/y.git' not found" in exc.value.message

--- a/tests/onboarding/sandboxes/test_types.py
+++ b/tests/onboarding/sandboxes/test_types.py
@@ -7,13 +7,43 @@ import pytest
 
 from omnigent.onboarding.sandboxes.types import (
     HostContext,
+    RepoWorkspace,
     SandboxCapabilities,
     SandboxCommandError,
     SandboxConfigError,
     SandboxError,
     SandboxInfo,
     SandboxSpec,
+    clone_dir_names,
 )
+
+
+def _repo(url: str, name: str) -> RepoWorkspace:
+    return RepoWorkspace(url=url, branch=None, repo_name=name)
+
+
+def test_clone_dir_names_disambiguates_collisions_by_owner() -> None:
+    """Distinct URLs deriving the same repo_name get owner-qualified dirs; a
+    unique name stays plain (so the single-repo working directory is unchanged)."""
+    repos = [
+        _repo("https://github.com/org-a/api", "api"),
+        _repo("git@github.com:org-b/api.git", "api"),
+        _repo("https://github.com/org-c/web", "web"),
+    ]
+    assert clone_dir_names(repos) == ["org-a__api", "org-b__api", "web"]
+    # A single repo never collides — plain name.
+    assert clone_dir_names([_repo("https://github.com/o/solo", "solo")]) == ["solo"]
+
+
+def test_clone_dir_names_suffixes_residual_collisions() -> None:
+    """If even the owner-qualified name repeats (same owner+name), a numeric
+    suffix guarantees uniqueness so no two repos share a clone directory."""
+    repos = [
+        _repo("https://github.com/org/api", "api"),
+        _repo("https://github.com/org/api", "api"),
+    ]
+    names = clone_dir_names(repos)
+    assert len(set(names)) == 2, names
 
 
 def test_capabilities_defaults() -> None:
@@ -28,6 +58,9 @@ def test_capabilities_defaults() -> None:
     assert caps.file_copy is False
     assert caps.streaming_exec is False
     assert caps.foreground_exec is False
+    # Off by default so a single-repo provider (and every out-of-tree one) is
+    # never handed a multi-repo request; providers opt in explicitly.
+    assert caps.multi_repo is False
 
 
 def test_capabilities_custom() -> None:
@@ -65,7 +98,7 @@ def test_host_context_defaults() -> None:
     assert ctx.host_id == "hid"
     assert ctx.host_name == "hname"
     assert ctx.server_url == "https://srv"
-    assert ctx.repo_url is None
+    assert ctx.repos == []
     assert ctx.on_stage is None
     assert ctx.host_config == {}
 

--- a/tests/server/integration/test_host_session_binding.py
+++ b/tests/server/integration/test_host_session_binding.py
@@ -667,7 +667,7 @@ async def test_managed_session_create_validator_errors_serialize_as_422(
     # The list-of-errors shape with a human-readable msg is what
     # describeCreateError picks the message from.
     assert isinstance(detail, list) and len(detail) == 1
-    assert "takes a git repository URL" in detail[0]["msg"]
+    assert "git repository URL" in detail[0]["msg"]
 
 
 async def test_managed_session_create_rejects_unconfigured_provider(

--- a/tests/server/routes/test_labels_for_viewer.py
+++ b/tests/server/routes/test_labels_for_viewer.py
@@ -1,0 +1,50 @@
+"""Unit tests for ``_labels_for_viewer`` label-family collapsing.
+
+Two dynamic-suffix families are stored under indexed/per-user keys but presented
+on the wire as one canonical bare key so clients read the same key they write:
+per-user pins (``omnigent.pinned.<user>``) and per-repo sandbox workspaces
+(``omnigent.sandbox.repo.<index>``). The repo collapse is load-bearing for the
+fork dialog, which reads the bare key — without it, forking a session created
+after per-repo storage would see no repo and clone an empty sandbox.
+"""
+
+from __future__ import annotations
+
+from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+from omnigent.server.routes._sessions.orchestration import _labels_for_viewer
+from omnigent.stores.conversation_store import pinned_label_key
+
+
+def test_collapses_per_repo_labels_to_the_bare_space_joined_key() -> None:
+    """Per-index repo labels present as one bare key, ordered, space-joined."""
+    labels = {
+        f"{MANAGED_REPO_LABEL_KEY}.0": "https://github.com/org/api#main",
+        f"{MANAGED_REPO_LABEL_KEY}.1": "https://github.com/org/web",
+        "kept": "yes",
+    }
+    viewer = _labels_for_viewer(labels, "alice@example.com")
+    assert viewer[MANAGED_REPO_LABEL_KEY] == (
+        "https://github.com/org/api#main https://github.com/org/web"
+    )
+    # The internal per-index keys never reach the wire.
+    assert not any(k.startswith(f"{MANAGED_REPO_LABEL_KEY}.") for k in viewer)
+    assert viewer["kept"] == "yes"
+
+
+def test_no_repo_labels_leaves_no_bare_key() -> None:
+    """A session with no sandbox repos exposes no sandbox-repo label."""
+    viewer = _labels_for_viewer({"kept": "yes"}, None)
+    assert MANAGED_REPO_LABEL_KEY not in viewer
+    assert viewer == {"kept": "yes"}
+
+
+def test_still_collapses_the_pin_family() -> None:
+    """The added repo collapse doesn't regress the per-user pin collapse."""
+    labels = {
+        pinned_label_key("alice@example.com"): "1721760000000",
+        pinned_label_key("bob@example.com"): "1721760001000",
+    }
+    viewer = _labels_for_viewer(labels, "alice@example.com")
+    # This viewer's pin surfaces as the canonical bare key; others' don't leak.
+    assert viewer.get("omnigent.pinned") == "1721760000000"
+    assert not any(k.startswith("omnigent.pinned.") for k in viewer)

--- a/tests/server/routes/test_sessions_fork.py
+++ b/tests/server/routes/test_sessions_fork.py
@@ -1486,7 +1486,9 @@ async def test_fork_reversed_native_spelling_carry_gating(
 # ── Managed-sandbox fork ─────────────────────────────────────────
 
 
-def _arm_managed_app(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+def _arm_managed_app(
+    app: FastAPI, monkeypatch: pytest.MonkeyPatch, *, provider: str = "modal"
+) -> list[dict[str, Any]]:
     """
     Wire the app for managed forks and capture the scheduled launches.
 
@@ -1497,10 +1499,12 @@ def _arm_managed_app(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> list[dict
 
     :param app: The app under test.
     :param monkeypatch: Fixture used to swap the background launch.
+    :param provider: Sandbox provider to configure. ``"modal"`` (default) is
+        single-repo; pass ``"kubernetes"`` for a multi-repo provider.
     :returns: The list the recorder appends each launch's kwargs to.
     """
     app.state.sandbox_config = parse_sandbox_config(
-        {"provider": "modal", "server_url": "https://managed-test.example.com"}
+        {"provider": provider, "server_url": "https://managed-test.example.com"}
     )
     # Never dereferenced: the recorder replaces the only consumer.
     app.state.host_store = object()
@@ -1543,7 +1547,7 @@ async def test_fork_managed_schedules_sandbox_launch(
     assert launch["session_id"] == body["id"]
     assert launch["provider"] == "modal"
     # No repository on either side, so the clone gets an empty sandbox.
-    assert launch["repo"] is None
+    assert launch["repos"] == []
     assert conv_store.label_writes == []
 
 
@@ -1676,15 +1680,68 @@ async def test_fork_managed_inherits_source_repository(
     )
 
     assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
-    repo = launches[0]["repo"]
-    assert repo is not None
-    assert repo.url == "https://github.com/org/repo"
-    assert repo.branch == "release-1.2"
-    # Recorded on the FORK too, so its own sandbox relaunch re-clones it.
+    repos = launches[0]["repos"]
+    assert len(repos) == 1
+    assert repos[0].url == "https://github.com/org/repo"
+    assert repos[0].branch == "release-1.2"
+    # Recorded on the FORK too (one label per repo, plus the bare compat key),
+    # so its own sandbox relaunch re-clones it. The source here uses the legacy
+    # single-value label, exercising the read fallback.
     assert conv_store.label_writes == [
         (
             resp.json()["id"],
-            {MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo#release-1.2"},
+            {
+                f"{MANAGED_REPO_LABEL_KEY}.0": "https://github.com/org/repo#release-1.2",
+                MANAGED_REPO_LABEL_KEY: "https://github.com/org/repo#release-1.2",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_inherits_all_source_repositories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A multi-repo source hands the fork EVERY repository it recorded.
+
+    The source records one label per repo; the fork reads them all back and
+    re-stamps its own per-repo labels — cloning a multi-repo sandbox session
+    lands the fork with all of its checkouts, not just the first.
+    """
+    conv = _make_conversation(
+        labels={
+            f"{MANAGED_REPO_LABEL_KEY}.0": "https://github.com/org/api#main",
+            f"{MANAGED_REPO_LABEL_KEY}.1": "https://github.com/org/web",
+        }
+    )
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    # Multi-repo provider — inheriting several repos is only allowed where the
+    # provider supports it (a single-repo provider rejects it; see the guard test).
+    launches = _arm_managed_app(app, monkeypatch, provider="kubernetes")
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed"},
+    )
+
+    assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
+    repos = launches[0]["repos"]
+    assert [(r.url, r.branch) for r in repos] == [
+        ("https://github.com/org/api", "main"),
+        ("https://github.com/org/web", None),
+    ]
+    # The fork re-stamps its own per-repo labels (plus the bare compat key) for
+    # relaunch.
+    assert conv_store.label_writes == [
+        (
+            resp.json()["id"],
+            {
+                f"{MANAGED_REPO_LABEL_KEY}.0": "https://github.com/org/api#main",
+                f"{MANAGED_REPO_LABEL_KEY}.1": "https://github.com/org/web",
+                MANAGED_REPO_LABEL_KEY: "https://github.com/org/api#main https://github.com/org/web",
+            },
         )
     ]
 
@@ -1716,8 +1773,8 @@ async def test_fork_managed_explicit_workspace_overrides_inherited(
 
     assert chosen.status_code == 201, f"got {chosen.status_code}: {chosen.text}"
     assert emptied.status_code == 201, f"got {emptied.status_code}: {emptied.text}"
-    assert launches[0]["repo"].url == "https://github.com/org/other"
-    assert launches[1]["repo"] is None, "an explicit null workspace means an empty sandbox"
+    assert [r.url for r in launches[0]["repos"]] == ["https://github.com/org/other"]
+    assert launches[1]["repos"] == [], "an explicit null workspace means an empty sandbox"
 
 
 @pytest.mark.asyncio
@@ -1783,7 +1840,7 @@ async def test_fork_managed_restamps_resolved_repository(
     assert resp.status_code == 201, f"got {resp.status_code}: {resp.text}"
     fork = conv_store.get_conversation(resp.json()["id"])
     assert fork is not None
-    assert fork.labels[MANAGED_REPO_LABEL_KEY] == "https://github.com/org/other#dev"
+    assert fork.labels[f"{MANAGED_REPO_LABEL_KEY}.0"] == "https://github.com/org/other#dev"
 
 
 @pytest.mark.asyncio
@@ -1846,6 +1903,34 @@ async def test_fork_managed_rejects_unoffered_provider(
     assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
     assert "is not configured on this server" in resp.json()["error"]["message"]
     assert launches == []
+
+
+@pytest.mark.asyncio
+async def test_fork_managed_rejects_multiple_repos_on_single_repo_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A multi-repo source forked onto a single-repo provider fails the POST with
+    a clear 400 (modal is exec-model → single-repo), rather than a background
+    clone failure. The web picker caps this per provider; this guards the API."""
+    conv = _make_conversation(
+        labels={
+            f"{MANAGED_REPO_LABEL_KEY}.0": "https://github.com/org/api#main",
+            f"{MANAGED_REPO_LABEL_KEY}.1": "https://github.com/org/web",
+        }
+    )
+    conv_store = _ConversationStore(conversations={"e9f8f58523cec9a57d3bdf93be543e8c": conv})
+    app = _build_app(conv_store)
+    launches = _arm_managed_app(app, monkeypatch)  # provider "modal" (single-repo)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/v1/sessions/e9f8f58523cec9a57d3bdf93be543e8c/fork",
+        json={"host_type": "managed"},
+    )
+
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+    assert "clones only one repository" in resp.json()["error"]["message"]
+    assert launches == [], "a rejected multi-repo fork must schedule no launch"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -8,6 +8,7 @@ import re
 import sys
 import types
 import uuid
+from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -51,8 +52,10 @@ from omnigent.server.managed_hosts import (
     RepoWorkspace,
     host_resume_supported,
     launch_managed_host,
+    managed_repo_labels,
     parse_repo_workspace,
     parse_sandbox_config,
+    read_managed_repo_workspaces,
     relaunch_managed_host,
     resolve_managed_agent_label,
     resume_managed_host,
@@ -2053,6 +2056,10 @@ def test_parse_repo_workspace_accepts_url_forms(workspace: str, expected: RepoWo
         # unsupported in the fragment form.
         ("https://github.com/org/repo#a#b", "not a valid git branch name"),
         ("https://github.com/org/repo#a b", "must not contain whitespace"),
+        # Embedded credentials would be persisted verbatim in a label + Pod spec —
+        # rejected in the https AND the ssh (scp-form) branch.
+        ("https://user:token@github.com/org/repo", "must not embed credentials"),
+        ("git@x-access-token:tok@github.com:org/repo.git", "must not embed credentials"),
     ],
 )
 def test_parse_repo_workspace_rejects_malformed(workspace: str, expected_fragment: str) -> None:
@@ -2064,6 +2071,98 @@ def test_parse_repo_workspace_rejects_malformed(workspace: str, expected_fragmen
     with pytest.raises(ValueError, match="") as exc:
         parse_repo_workspace(workspace)
     assert expected_fragment in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "workspace",
+    [
+        "https://x-access-token:s3cr3t@github.com/org/repo",
+        # No path → trips the shape guard; the secret must still not be echoed
+        # (the credential check runs before any URL-echoing error).
+        "https://user:s3cr3t@github.com",
+        "git@x-access-token:s3cr3t@github.com:org/repo.git",
+    ],
+)
+def test_credential_rejection_does_not_echo_the_token(workspace: str) -> None:
+    """The credential-URL error must not include the URL — that carries the secret."""
+    with pytest.raises(ValueError) as exc:
+        parse_repo_workspace(workspace)
+    assert "s3cr3t" not in str(exc.value)
+
+
+def test_managed_repo_labels_round_trip() -> None:
+    """Per-repo labels avoid the 256-char single-label cap and read back in order.
+
+    A bare space-joined key rides along as a rollback compat shim (it fits here),
+    but the indexed labels are what the current reader uses.
+    """
+    workspaces = ["https://github.com/org/api#main", "https://github.com/org/web"]
+    labels = managed_repo_labels(workspaces)
+    assert labels == {
+        "omnigent.sandbox.repo.0": "https://github.com/org/api#main",
+        "omnigent.sandbox.repo.1": "https://github.com/org/web",
+        # Legacy bare key for a rolled-back/older reader (written only when it fits).
+        "omnigent.sandbox.repo": "https://github.com/org/api#main https://github.com/org/web",
+    }
+    assert read_managed_repo_workspaces(labels) == workspaces
+    assert managed_repo_labels([]) == {}
+
+
+def test_managed_repo_labels_omit_bare_key_when_over_cap() -> None:
+    """The compat bare key is skipped (never truncated) when the joined value
+    would exceed the label-value cap; the indexed labels still carry every repo."""
+    # Enough long URLs that the space-joined value exceeds 256 chars.
+    workspaces = [f"https://github.com/some-long-org-name/repository-number-{i}" for i in range(6)]
+    labels = managed_repo_labels(workspaces)
+    assert "omnigent.sandbox.repo" not in labels  # no truncated bare value stored
+    assert read_managed_repo_workspaces(labels) == workspaces  # indexed labels intact
+
+
+def test_read_managed_repo_workspaces_orders_numerically_and_falls_back() -> None:
+    """Indices order numerically (not lexically), and the legacy single label still reads."""
+    # .10 must sort after .2, not before it (lexical order would break past 9).
+    many = {f"omnigent.sandbox.repo.{i}": f"https://github.com/o/r{i}" for i in range(11)}
+    assert read_managed_repo_workspaces(many)[-1] == "https://github.com/o/r10"
+    # Legacy single space-joined label (pre-per-repo storage) still round-trips.
+    legacy = {"omnigent.sandbox.repo": "https://github.com/o/a https://github.com/o/b"}
+    assert read_managed_repo_workspaces(legacy) == [
+        "https://github.com/o/a",
+        "https://github.com/o/b",
+    ]
+    assert read_managed_repo_workspaces({}) == []
+
+
+def test_provider_ui_capabilities_reports_multi_repo_per_provider() -> None:
+    """The /v1/info map reflects each launchable provider's declared multi_repo,
+    keyed by provider name; a provider declaring nothing stays off."""
+
+    class _MultiRepoFake(FakeSandboxLauncher):
+        @property
+        def capabilities(self) -> Any:
+            return replace(super().capabilities, multi_repo=True)
+
+    single = FakeSandboxLauncher()  # exec-model default → multi_repo False
+    multi = _MultiRepoFake()
+    deployment = ManagedSandboxDeployment(
+        configs=(
+            ManagedSandboxConfig(
+                server_url="https://s",
+                provider="single",
+                token_ttl_s=3600,
+                launcher_factory=lambda: single,
+            ),
+            ManagedSandboxConfig(
+                server_url="https://s",
+                provider="multi",
+                token_ttl_s=3600,
+                launcher_factory=lambda: multi,
+            ),
+        )
+    )
+    assert deployment.provider_ui_capabilities() == {
+        "single": {"multi_repo": False},
+        "multi": {"multi_repo": True},
+    }
 
 
 # ── GET /v1/info: managed_sandboxes_enabled ─────────────────
@@ -2457,9 +2556,7 @@ async def test_launch_and_resume_without_optional_kwargs_support_legacy_start_ho
             host_id: str,
             host_name: str,
             server_url: str,
-            repo_url: str | None = None,
-            repo_branch: str | None = None,
-            repo_name: str | None = None,
+            repos: Sequence[RepoWorkspace] = (),
         ) -> str:
             return super().start_host(
                 sandbox_id,
@@ -2467,9 +2564,7 @@ async def test_launch_and_resume_without_optional_kwargs_support_legacy_start_ho
                 host_id=host_id,
                 host_name=host_name,
                 server_url=server_url,
-                repo_url=repo_url,
-                repo_branch=repo_branch,
-                repo_name=repo_name,
+                repos=repos,
             )
 
     fake = _LegacySignatureLauncher(on_host_start=_register, can_resume=True)
@@ -2668,7 +2763,7 @@ async def test_launch_with_repo_clones_into_workspace(db_uri: str) -> None:
         config=_injected_config(fake),
         owner=_OWNER,
         host_store=host_store,
-        repo=parse_repo_workspace("https://github.com/org/myrepo.git#release-1.2"),
+        repos=[parse_repo_workspace("https://github.com/org/myrepo.git#release-1.2")],
     )
 
     # The session workspace is the clone directory, named after the repo.
@@ -2704,7 +2799,7 @@ async def test_launch_clone_failure_terminates_and_deletes_host(db_uri: str) -> 
             config=_injected_config(fake),
             owner=_OWNER,
             host_store=host_store,
-            repo=parse_repo_workspace("https://github.com/org/private#main"),
+            repos=[parse_repo_workspace("https://github.com/org/private#main")],
         )
     assert exc.value.status_code == 502
     assert "failed to clone repository 'https://github.com/org/private'" in exc.value.detail
@@ -2751,9 +2846,7 @@ class _EntrypointFakeLauncher(FakeSandboxLauncher):
         host_id: str,
         host_name: str,
         server_url: str,
-        repo_url: str | None = None,
-        repo_branch: str | None = None,
-        repo_name: str | None = None,
+        repos: Sequence[RepoWorkspace] = (),
         host_config: dict[str, object] | None = None,
         on_stage=None,
     ) -> str:
@@ -2764,8 +2857,7 @@ class _EntrypointFakeLauncher(FakeSandboxLauncher):
                 "token": token,
                 "host_id": host_id,
                 "server_url": server_url,
-                "repo_url": repo_url,
-                "repo_name": repo_name,
+                "repos": list(repos),
             }
         )
         # The token was registered before start_host, so it resolves now.
@@ -2774,7 +2866,12 @@ class _EntrypointFakeLauncher(FakeSandboxLauncher):
         )
         # Simulate the host's entrypoint dialing back over the tunnel.
         self._host_store.upsert_on_connect(host_id=host_id, name=host_name, user_id=_OWNER)
-        return f"/home/omnigent/workspace/{repo_name}" if repo_name else "/home/omnigent/workspace"
+        # One repo → its clone dir; none or several → the workspace parent.
+        return (
+            f"/home/omnigent/workspace/{repos[0].repo_name}"
+            if len(repos) == 1
+            else "/home/omnigent/workspace"
+        )
 
 
 async def test_launch_entrypoint_provider_arms_token_before_launch_host(db_uri: str) -> None:
@@ -2790,7 +2887,7 @@ async def test_launch_entrypoint_provider_arms_token_before_launch_host(db_uri: 
         config=_injected_config(fake),
         owner=_OWNER,
         host_store=host_store,
-        repo=parse_repo_workspace("https://github.com/org/repo.git#main"),
+        repos=[parse_repo_workspace("https://github.com/org/repo.git#main")],
     )
 
     # start_host ran once, with the reserved id and repo info.
@@ -2798,8 +2895,8 @@ async def test_launch_entrypoint_provider_arms_token_before_launch_host(db_uri: 
     call = fake.start_calls[0]
     assert call["sandbox_id"] == "omnigent-pod-1"
     assert call["server_url"] == "https://srv.example.com"
-    assert call["repo_url"] == "https://github.com/org/repo.git"
-    assert call["repo_name"] == "repo"
+    assert [r.url for r in call["repos"]] == ["https://github.com/org/repo.git"]
+    assert [r.repo_name for r in call["repos"]] == ["repo"]
     # The token was already resolvable when start_host ran (no dial-back race).
     assert fake.token_resolved_at_start is True
     # The workspace (cloned dir) is returned and the host is online + bound.
@@ -4348,7 +4445,7 @@ async def test_run_managed_launch_leaves_the_runner_unclassified(
         session_id="conv_1",
         owner=_OWNER,
         sandbox_config=SimpleNamespace(),
-        repo=None,
+        repos=[],
         tracker=ManagedLaunchTracker(),
         conversation_store=SimpleNamespace(),
         host_store=SimpleNamespace(),
@@ -4391,7 +4488,7 @@ async def test_run_managed_launch_resolves_the_classifier_on_its_own_task(
         session_id="conv_1",
         owner=_OWNER,
         sandbox_config=SimpleNamespace(),
-        repo=None,
+        repos=[],
         tracker=ManagedLaunchTracker(),
         conversation_store=SimpleNamespace(),
         host_store=SimpleNamespace(),
@@ -4430,7 +4527,7 @@ async def test_run_managed_launch_omits_the_classifier_for_a_session_scoped_impo
         session_id="conv_1",
         owner=_OWNER,
         sandbox_config=SimpleNamespace(),
-        repo=None,
+        repos=[],
         tracker=ManagedLaunchTracker(),
         conversation_store=SimpleNamespace(),
         host_store=SimpleNamespace(),

--- a/tests/server/test_schemas.py
+++ b/tests/server/test_schemas.py
@@ -846,7 +846,7 @@ def test_session_create_managed_rejects_path_workspace() -> None:
     """
     from omnigent.server.schemas import SessionCreateRequest
 
-    with pytest.raises(ValidationError, match="takes a git repository URL"):
+    with pytest.raises(ValidationError, match="git repository URL"):
         SessionCreateRequest(agent_id="ag_x", host_type="managed", workspace="/tmp/w")
 
 
@@ -911,6 +911,77 @@ def test_session_create_external_rejects_repo_url_workspace() -> None:
             agent_id="ag_x",
             host_id="host_abc",
             workspace="https://github.com/org/repo",
+        )
+
+
+def test_session_create_managed_accepts_multiple_workspaces() -> None:
+    """
+    ``host_type="managed"`` + ``workspaces`` accepts several repository
+    URLs; ``managed_repo_workspaces`` returns them verbatim for the launch
+    path to clone in parallel.
+    """
+    from omnigent.server.schemas import SessionCreateRequest
+
+    repos = ["https://github.com/org/api#main", "git@github.com:org/web.git"]
+    req = SessionCreateRequest(agent_id="ag_x", host_type="managed", workspaces=repos)
+    assert req.managed_repo_workspaces() == repos
+
+
+def test_managed_repo_workspaces_normalizes_single_and_empty() -> None:
+    """A single ``workspace`` yields a one-element list; neither field yields []."""
+    from omnigent.server.schemas import SessionCreateRequest
+
+    single = SessionCreateRequest(
+        agent_id="ag_x", host_type="managed", workspace="https://github.com/org/repo"
+    )
+    assert single.managed_repo_workspaces() == ["https://github.com/org/repo"]
+    empty = SessionCreateRequest(agent_id="ag_x", host_type="managed")
+    assert empty.managed_repo_workspaces() == []
+
+
+def test_session_create_managed_rejects_workspace_and_workspaces_together() -> None:
+    """``workspace`` and ``workspaces`` are mutually exclusive — set one, not both."""
+    from omnigent.server.schemas import SessionCreateRequest
+
+    with pytest.raises(ValidationError, match="not both"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            host_type="managed",
+            workspace="https://github.com/org/a",
+            workspaces=["https://github.com/org/b"],
+        )
+
+
+def test_session_create_managed_rejects_too_many_workspaces() -> None:
+    """The multi-repo list is bounded so an abusive request can't fan out unbounded clones."""
+    from omnigent.server.schemas import _MAX_MANAGED_WORKSPACES, SessionCreateRequest
+
+    too_many = [f"https://github.com/org/r{i}" for i in range(_MAX_MANAGED_WORKSPACES + 1)]
+    with pytest.raises(ValidationError, match="at most"):
+        SessionCreateRequest(agent_id="ag_x", host_type="managed", workspaces=too_many)
+
+
+def test_session_create_managed_rejects_malformed_workspaces_entry() -> None:
+    """Every ``workspaces`` entry must parse as a repository URL, else 422 at validation."""
+    from omnigent.server.schemas import SessionCreateRequest
+
+    with pytest.raises(ValidationError, match="not a supported repository URL"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            host_type="managed",
+            workspaces=["https://github.com/org/ok", "org/bad-shorthand"],
+        )
+
+
+def test_session_create_external_rejects_workspaces() -> None:
+    """``workspaces`` (multi-repo clone) is managed-only — rejected on an external host."""
+    from omnigent.server.schemas import SessionCreateRequest
+
+    with pytest.raises(ValidationError, match="requires host_type 'managed'"):
+        SessionCreateRequest(
+            agent_id="ag_x",
+            host_id="host_abc",
+            workspaces=["https://github.com/org/repo"],
         )
 
 

--- a/tests/stores/test_conversation_store.py
+++ b/tests/stores/test_conversation_store.py
@@ -108,6 +108,31 @@ def test_fork_drops_sandbox_repo_label(
     assert MANAGED_REPO_LABEL_KEY not in fork.labels
 
 
+def test_fork_drops_per_repo_sandbox_labels(
+    conversation_store: SqlAlchemyConversationStore,
+) -> None:
+    """The per-repo family (``omnigent.sandbox.repo.<index>``) is dropped by
+    prefix on a fork, for the same reason as the legacy single label: the fork's
+    own launch re-stamps whatever it resolves, so inheriting the source's would
+    re-clone them even into a fork that asked for an empty sandbox."""
+    from omnigent.server.managed_hosts import MANAGED_REPO_LABEL_KEY
+
+    source = conversation_store.create_conversation()
+    conversation_store.set_labels(
+        source.id,
+        {
+            f"{MANAGED_REPO_LABEL_KEY}.0": "https://github.com/org/api#main",
+            f"{MANAGED_REPO_LABEL_KEY}.1": "https://github.com/org/web",
+            "kept": "yes",
+        },
+    )
+
+    fork = conversation_store.fork_conversation(source.id)
+
+    assert fork.labels["kept"] == "yes"
+    assert not any(k.startswith(f"{MANAGED_REPO_LABEL_KEY}.") for k in fork.labels)
+
+
 def test_fork_drops_per_user_pin_labels(
     conversation_store: SqlAlchemyConversationStore,
 ) -> None:

--- a/web/src/lib/capabilities.ts
+++ b/web/src/lib/capabilities.ts
@@ -115,6 +115,13 @@ export interface ServerInfo {
    */
   sandbox_providers?: string[];
   /**
+   * UI-relevant capability flags per launch-capable provider, e.g.
+   * ``{ agent_sandbox: { multi_repo: true } }``. The new-session repo picker
+   * branches on these (multi-repo list vs single). A provider absent from the
+   * map, or the map absent entirely, defaults every flag off.
+   */
+  sandbox_provider_capabilities?: Record<string, { multi_repo?: boolean }>;
+  /**
    * Connection providers this deploy has wired (config + store present),
    * e.g. ``["github"]`` or ``["github", "databricks"]``. Non-empty shows the
    * Sandbox Integrations nav; the SPA renders one panel per provider via
@@ -231,6 +238,7 @@ export const FALLBACK_SERVER_INFO: ServerInfo = {
   managed_sandboxes_enabled: false,
   sandbox_provider: null,
   sandbox_providers: [],
+  sandbox_provider_capabilities: {},
   enabled_connections: [],
   // Sharing fails OPEN (opposite of the other caps): a failed probe must
   // not silently disable sharing, so the sentinel is the permissive "on".
@@ -316,6 +324,14 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
           sandbox_providers: Array.isArray(data.sandbox_providers)
             ? data.sandbox_providers.filter((p): p is string => typeof p === "string")
             : [],
+          // Plain-object guard only; consumers read `?.[p]?.multi_repo === true`,
+          // so any stray shape reads as "unset" (off) rather than throwing.
+          sandbox_provider_capabilities:
+            data.sandbox_provider_capabilities !== null &&
+            typeof data.sandbox_provider_capabilities === "object" &&
+            !Array.isArray(data.sandbox_provider_capabilities)
+              ? (data.sandbox_provider_capabilities as Record<string, { multi_repo?: boolean }>)
+              : {},
           enabled_connections: Array.isArray(data.enabled_connections)
             ? data.enabled_connections.filter((p): p is string => typeof p === "string")
             : [],

--- a/web/src/lib/repoPreferences.test.ts
+++ b/web/src/lib/repoPreferences.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { readLastSandboxRepo, writeLastSandboxRepo } from "./repoPreferences";
+import { readLastSandboxRepos, writeLastSandboxRepos } from "./repoPreferences";
+
+const KEY = "omnigent:last-sandbox-repos";
+const LEGACY_KEY = "omnigent:last-sandbox-repo";
 
 afterEach(() => {
   localStorage.clear();
@@ -7,57 +10,64 @@ afterEach(() => {
 });
 
 describe("repoPreferences", () => {
-  it("returns null when nothing is stored", () => {
-    expect(readLastSandboxRepo()).toBeNull();
+  it("returns [] when nothing is stored", () => {
+    expect(readLastSandboxRepos()).toEqual([]);
   });
 
-  it("round-trips a written repo + branch", () => {
-    writeLastSandboxRepo("https://github.com/org/repo.git", "main");
-    expect(readLastSandboxRepo()).toEqual({
-      url: "https://github.com/org/repo.git",
-      branch: "main",
-    });
+  it("round-trips a list of repos + branches", () => {
+    writeLastSandboxRepos([
+      { url: "https://github.com/org/a.git", branch: "main" },
+      { url: "https://github.com/org/b.git", branch: "" },
+    ]);
+    expect(readLastSandboxRepos()).toEqual([
+      { url: "https://github.com/org/a.git", branch: "main" },
+      { url: "https://github.com/org/b.git", branch: "" },
+    ]);
   });
 
-  it("keeps a repo with no branch (default-branch case)", () => {
-    writeLastSandboxRepo("https://github.com/org/repo.git", "");
-    expect(readLastSandboxRepo()).toEqual({
-      url: "https://github.com/org/repo.git",
-      branch: "",
-    });
+  it("trims surrounding whitespace and drops blank-url entries before storing", () => {
+    writeLastSandboxRepos([
+      { url: "  https://github.com/org/repo.git  ", branch: "  dev  " },
+      { url: "   ", branch: "main" },
+    ]);
+    expect(readLastSandboxRepos()).toEqual([
+      { url: "https://github.com/org/repo.git", branch: "dev" },
+    ]);
   });
 
-  it("trims surrounding whitespace before storing", () => {
-    writeLastSandboxRepo("  https://github.com/org/repo.git  ", "  dev  ");
-    expect(readLastSandboxRepo()).toEqual({
-      url: "https://github.com/org/repo.git",
-      branch: "dev",
-    });
+  it("clears the preference when the list is empty (or all-blank)", () => {
+    writeLastSandboxRepos([{ url: "https://github.com/org/repo.git", branch: "main" }]);
+    writeLastSandboxRepos([]);
+    expect(readLastSandboxRepos()).toEqual([]);
+    expect(localStorage.getItem(KEY)).toBeNull();
   });
 
-  it("clears the preference when the url is blank", () => {
-    writeLastSandboxRepo("https://github.com/org/repo.git", "main");
-    writeLastSandboxRepo("   ", "main");
-    expect(readLastSandboxRepo()).toBeNull();
+  it("overwrites the previous list", () => {
+    writeLastSandboxRepos([{ url: "https://github.com/org/a.git", branch: "main" }]);
+    writeLastSandboxRepos([{ url: "https://github.com/org/b.git", branch: "dev" }]);
+    expect(readLastSandboxRepos()).toEqual([
+      { url: "https://github.com/org/b.git", branch: "dev" },
+    ]);
   });
 
-  it("overwrites the previous value", () => {
-    writeLastSandboxRepo("https://github.com/org/a.git", "main");
-    writeLastSandboxRepo("https://github.com/org/b.git", "dev");
-    expect(readLastSandboxRepo()).toEqual({
-      url: "https://github.com/org/b.git",
-      branch: "dev",
-    });
+  it("migrates a single-repo preference written by an older build", () => {
+    localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({ url: "https://github.com/org/legacy.git", branch: "main" }),
+    );
+    expect(readLastSandboxRepos()).toEqual([
+      { url: "https://github.com/org/legacy.git", branch: "main" },
+    ]);
   });
 
-  it("returns null for a stored entry with a blank url (defensive)", () => {
-    localStorage.setItem("omnigent:last-sandbox-repo", JSON.stringify({ url: "  ", branch: "x" }));
-    expect(readLastSandboxRepo()).toBeNull();
+  it("drops entries with a blank url (defensive)", () => {
+    localStorage.setItem(KEY, JSON.stringify([{ url: "  ", branch: "x" }]));
+    expect(readLastSandboxRepos()).toEqual([]);
   });
 
-  it("returns null for malformed stored json (defensive)", () => {
-    localStorage.setItem("omnigent:last-sandbox-repo", "not json");
-    expect(readLastSandboxRepo()).toBeNull();
+  it("returns [] for malformed stored json (defensive)", () => {
+    localStorage.setItem(KEY, "not json");
+    expect(readLastSandboxRepos()).toEqual([]);
   });
 
   it("never throws when storage is inaccessible", () => {
@@ -67,27 +77,29 @@ describe("repoPreferences", () => {
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new Error("access denied");
     });
-    expect(() => writeLastSandboxRepo("https://github.com/org/repo.git", "main")).not.toThrow();
-    expect(readLastSandboxRepo()).toBeNull();
+    expect(() =>
+      writeLastSandboxRepos([{ url: "https://github.com/org/repo.git", branch: "main" }]),
+    ).not.toThrow();
+    expect(readLastSandboxRepos()).toEqual([]);
   });
 
   it("strips URL userinfo so a tokenized URL is not persisted (secret at rest)", () => {
-    writeLastSandboxRepo("https://x-access-token:s3cr3tpat@github.com/org/repo.git", "main");
-    expect(readLastSandboxRepo()).toEqual({
-      url: "https://github.com/org/repo.git",
-      branch: "main",
-    });
-    expect(localStorage.getItem("omnigent:last-sandbox-repo") ?? "").not.toContain("s3cr3tpat");
+    writeLastSandboxRepos([
+      { url: "https://x-access-token:s3cr3tpat@github.com/org/repo.git", branch: "main" },
+    ]);
+    expect(readLastSandboxRepos()).toEqual([
+      { url: "https://github.com/org/repo.git", branch: "main" },
+    ]);
+    expect(localStorage.getItem(KEY) ?? "").not.toContain("s3cr3tpat");
   });
 
-  it("strips userinfo from a legacy stored tokenized URL on read (defensive)", () => {
+  it("strips userinfo from a stored tokenized URL on read (defensive)", () => {
     localStorage.setItem(
-      "omnigent:last-sandbox-repo",
-      JSON.stringify({ url: "https://user:PAT@github.com/org/repo.git", branch: "dev" }),
+      KEY,
+      JSON.stringify([{ url: "https://user:PAT@github.com/org/repo.git", branch: "dev" }]),
     );
-    expect(readLastSandboxRepo()).toEqual({
-      url: "https://github.com/org/repo.git",
-      branch: "dev",
-    });
+    expect(readLastSandboxRepos()).toEqual([
+      { url: "https://github.com/org/repo.git", branch: "dev" },
+    ]);
   });
 });

--- a/web/src/lib/repoPreferences.ts
+++ b/web/src/lib/repoPreferences.ts
@@ -1,14 +1,16 @@
-// Persisted, app-global preference for the last GitHub repo (and branch) the
+// Persisted, app-global preference for the last GitHub repos (and branches) the
 // user launched a sandbox session with.
 //
 // Mirrors baseBranchPreferences: the landing composer reads this to seed the
-// repo URL + branch fields when there's no in-session draft, so returning users
-// don't re-pick the same repo every time. The stored URL is the source of
-// truth the free-text field shows; the repo combobox derives its selection from
-// it, so a stored repo the account can no longer access simply shows unselected
-// (no stale entry is forced into the picker). Written on session create.
+// repo list when there's no in-session draft, so returning users don't re-pick
+// the same repos every time. The stored URLs are the source of truth; the repo
+// combobox derives its selection from them, so a stored repo the account can no
+// longer access simply shows unselected (no stale entry is forced into the
+// picker). Written on session create.
 
-const STORAGE_KEY = "omnigent:last-sandbox-repo";
+const STORAGE_KEY = "omnigent:last-sandbox-repos";
+// Single-repo key written by builds before multi-repo; read once for migration.
+const LEGACY_STORAGE_KEY = "omnigent:last-sandbox-repo";
 
 /**
  * Strip any userinfo (`user[:secret]@`) from an http(s) URL, so a pasted
@@ -20,7 +22,7 @@ function stripUrlUserinfo(url: string): string {
   return url.replace(/^(https?:\/\/)[^/@]*@/i, "$1");
 }
 
-/** The last repo the user launched with: its clone URL and branch (may be ""). */
+/** A repo the user launched with: its clone URL and branch (may be ""). */
 export interface LastSandboxRepo {
   /** Repo URL, e.g. ``https://github.com/org/repo.git`` (never blank). */
   url: string;
@@ -28,45 +30,58 @@ export interface LastSandboxRepo {
   branch: string;
 }
 
+/** Trim + userinfo-strip one stored entry, or ``null`` when its URL is blank. */
+function normalizeEntry(value: unknown): LastSandboxRepo | null {
+  if (typeof value !== "object" || value === null) return null;
+  const url = stripUrlUserinfo(String((value as { url?: unknown }).url ?? "").trim());
+  const branch = String((value as { branch?: unknown }).branch ?? "").trim();
+  return url === "" ? null : { url, branch };
+}
+
 /**
- * Read the last repo the user launched a sandbox with: the stored
- * ``{url, branch}``, or ``null`` when nothing is stored, on a server render (no
- * ``window``), when storage is inaccessible, or when the stored value is
- * malformed / has a blank URL — never throws. Trims on read so a hand-edited or
- * stale entry can't seed an un-normalized value.
+ * Read the last repos the user launched a sandbox with: the stored list, or
+ * ``[]`` when nothing is stored, on a server render (no ``window``), when
+ * storage is inaccessible, or when the stored value is malformed — never
+ * throws. Trims on read so a hand-edited or stale entry can't seed an
+ * un-normalized value. Falls back once to the single-repo key an older build
+ * wrote, so a returning user's last repo still seeds the picker.
  */
-export function readLastSandboxRepo(): LastSandboxRepo | null {
-  if (typeof window === "undefined") return null;
+export function readLastSandboxRepos(): LastSandboxRepo[] {
+  if (typeof window === "undefined") return [];
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as unknown;
-    if (typeof parsed !== "object" || parsed === null) return null;
-    const url = stripUrlUserinfo(String((parsed as { url?: unknown }).url ?? "").trim());
-    const branch = String((parsed as { branch?: unknown }).branch ?? "").trim();
-    return url === "" ? null : { url, branch };
+    if (raw) {
+      const parsed = JSON.parse(raw) as unknown;
+      if (!Array.isArray(parsed)) return [];
+      return parsed.map(normalizeEntry).filter((r): r is LastSandboxRepo => r !== null);
+    }
+    const legacy = window.localStorage.getItem(LEGACY_STORAGE_KEY);
+    if (legacy) {
+      const one = normalizeEntry(JSON.parse(legacy) as unknown);
+      return one ? [one] : [];
+    }
+    return [];
   } catch {
-    return null;
+    return [];
   }
 }
 
 /**
- * Persist ``url`` (+ optional ``branch``) as the last repo launched with. A
- * blank (or whitespace-only) URL clears the preference. Swallows quota/access
- * errors so a failed write can't break session creation.
+ * Persist ``repos`` as the last repos launched with. Entries with a blank
+ * (or whitespace-only) URL are dropped; an empty result clears the preference.
+ * Swallows quota/access errors so a failed write can't break session creation.
  */
-export function writeLastSandboxRepo(url: string, branch: string): void {
+export function writeLastSandboxRepos(repos: LastSandboxRepo[]): void {
   if (typeof window === "undefined") return;
   try {
-    const trimmedUrl = stripUrlUserinfo(url.trim());
-    if (trimmedUrl === "") {
+    const cleaned = repos
+      .map((r) => ({ url: stripUrlUserinfo(r.url.trim()), branch: r.branch.trim() }))
+      .filter((r) => r.url !== "");
+    if (cleaned.length === 0) {
       window.localStorage.removeItem(STORAGE_KEY);
       return;
     }
-    window.localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({ url: trimmedUrl, branch: branch.trim() }),
-    );
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(cleaned));
   } catch {
     // localStorage quota or access errors shouldn't break session creation.
   }

--- a/web/src/shell/ForkSessionDialog.test.tsx
+++ b/web/src/shell/ForkSessionDialog.test.tsx
@@ -1281,6 +1281,84 @@ describe("ForkSessionDialog", () => {
       await waitFor(() => expect(navigateMock).toHaveBeenCalledWith("/c/conv_fork"));
     });
 
+    it("inherits ALL repositories from a multi-repo sandbox source", async () => {
+      // A source with several repos records them space-joined; the single
+      // URL/branch fields can't represent that, so the fork shows a read-only
+      // list and inherits every repo (workspace omitted) instead of seeding a
+      // broken URL that would grey the submit button.
+      useSessionMock.mockReturnValue({
+        session: {
+          labels: {
+            [SANDBOX_REPO_LABEL_KEY]: "https://github.com/org/api#main https://github.com/org/web",
+          },
+        },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof useSession>);
+      forkSessionMock.mockResolvedValue({
+        id: "conv_fork",
+      } as unknown as Awaited<ReturnType<typeof forkSession>>);
+      // A multi-repo source can only inherit all repos onto a multi-repo dest.
+      renderDialog({
+        ...CODING,
+        info: {
+          managed_sandboxes_enabled: true,
+          sandbox_provider: "agent_sandbox",
+          sandbox_providers: ["agent_sandbox"],
+          sandbox_provider_capabilities: { agent_sandbox: { multi_repo: true } },
+        },
+      });
+
+      selectSandbox();
+      openAdvanced();
+      // No editable single-repo field — a read-only list of every source repo.
+      expect(screen.queryByTestId("fork-session-sandbox-repo-input")).toBeNull();
+      const readonly = screen.getByTestId("fork-session-sandbox-repos-readonly");
+      expect(readonly.textContent).toContain("api#main");
+      expect(readonly.textContent).toContain("web");
+
+      // The space-joined label no longer greys the button on a multi-repo dest.
+      const submit = screen.getByTestId("fork-session-submit") as HTMLButtonElement;
+      expect(submit.disabled).toBe(false);
+      fireEvent.click(submit);
+
+      await waitFor(() => expect(forkSessionMock).toHaveBeenCalledTimes(1));
+      const call = forkSessionMock.mock.calls[0][1];
+      expect(call?.sandbox?.provider).toBe("agent_sandbox");
+      // workspace omitted (undefined) → the server re-clones ALL source repos.
+      expect(call?.sandbox?.workspace).toBeUndefined();
+    });
+
+    it("blocks forking a multi-repo source onto a single-repo provider", async () => {
+      // modal is single-repo; a source with several repos can't inherit them
+      // there, so the fork is blocked in the UI (not 422'd after creation).
+      useSessionMock.mockReturnValue({
+        session: {
+          labels: {
+            [SANDBOX_REPO_LABEL_KEY]: "https://github.com/org/api#main https://github.com/org/web",
+          },
+        },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof useSession>);
+      renderDialog({
+        ...CODING,
+        info: {
+          managed_sandboxes_enabled: true,
+          sandbox_provider: "modal",
+          sandbox_providers: ["modal"],
+          sandbox_provider_capabilities: { modal: { multi_repo: false } },
+        },
+      });
+
+      selectSandbox();
+      openAdvanced();
+      // The read-only list warns the destination can't take them, and submit
+      // is blocked rather than deferring to a server-side 422.
+      expect(screen.getByTestId("fork-session-repos-unsupported")).toBeInTheDocument();
+      expect((screen.getByTestId("fork-session-submit") as HTMLButtonElement).disabled).toBe(true);
+    });
+
     it("sends an explicit null workspace when the repository is cleared", async () => {
       // Clearing the prefill is a real choice (an empty sandbox), so it must
       // reach the server as an explicit null — omitting the key would make the

--- a/web/src/shell/ForkSessionDialog.tsx
+++ b/web/src/shell/ForkSessionDialog.tsx
@@ -962,6 +962,12 @@ export function ForkSessionForm({
   // Repository the SOURCE ran in, when it was itself a sandbox session.
   // Recorded by the server on the managed create and copied onto the fork.
   const sourceSandboxRepo = sourceSession?.labels?.[SANDBOX_REPO_LABEL_KEY] ?? null;
+  // The source's repo label is space-joined when it had several repos. The
+  // single URL/branch fields below can't represent more than one, so a
+  // multi-repo source inherits ALL of them wholesale (the fork omits its own
+  // workspace, and the server re-clones every repo the source recorded).
+  const sourceSandboxRepos = (sourceSandboxRepo ?? "").split(/\s+/).filter(Boolean);
+  const multiRepoSource = sourceSandboxRepos.length > 1;
 
   // Prefill the sandbox repository from the source's, so cloning a sandbox
   // session onto a fresh sandbox lands in the same checkout. A ref keeps it
@@ -970,10 +976,14 @@ export function ForkSessionForm({
   useEffect(() => {
     if (!sandboxSelected || sandboxRepoSeededRef.current || sourceSandboxRepo === null) return;
     sandboxRepoSeededRef.current = true;
+    // A multi-repo source can't be edited through the single URL/branch pair,
+    // so leave them blank and inherit every repo (see the submit below);
+    // splitting the space-joined label here would seed an invalid URL.
+    if (multiRepoSource) return;
     const { url, branch } = splitSandboxWorkspace(sourceSandboxRepo);
     setSandboxRepoUrl(url);
     setSandboxRepoBranch(branch);
-  }, [sandboxSelected, sourceSandboxRepo]);
+  }, [sandboxSelected, sourceSandboxRepo, multiRepoSource]);
 
   // Resolve a typed "~/…" path to its absolute form against the host's home,
   // so it's directly submittable without opening the tree browser (the server
@@ -1006,8 +1016,20 @@ export function ForkSessionForm({
   // A blank repository is legal — the clone then gets an empty sandbox —
   // but a branch without one, or a malformed URL, greys the button instead
   // of surfacing as a 422. Mirrors NewChatDialog's sandbox validity rule.
-  const sandboxRepoValid =
-    sandboxRepoUrl.trim() === ""
+  // The destination provider the fork launches on (server default when none is
+  // picked yet) and whether it clones several repos.
+  const forkEffectiveProvider =
+    sandboxProvider ?? (info !== "loading" ? info.sandbox_provider : null);
+  const forkProviderMultiRepo =
+    info !== "loading" &&
+    forkEffectiveProvider !== null &&
+    info.sandbox_provider_capabilities?.[forkEffectiveProvider]?.multi_repo === true;
+  // A multi-repo source inherits every repo, so it needs a multi-repo
+  // destination; onto a single-repo provider it would be rejected server-side
+  // after the fork is created and announced, so block submit here instead.
+  const sandboxRepoValid = multiRepoSource
+    ? forkProviderMultiRepo
+    : sandboxRepoUrl.trim() === ""
       ? sandboxRepoBranch.trim() === ""
       : isValidSandboxRepoUrl(sandboxRepoUrl);
   // Short "repo" / "repo#branch" form for the sandbox hint — the same name
@@ -1174,7 +1196,12 @@ export function ForkSessionForm({
         sandbox: sandboxSelected
           ? {
               provider: sandboxProvider,
-              workspace: composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch) ?? null,
+              // Omit the workspace for a multi-repo source so the server
+              // inherits ALL of the source's repositories; otherwise send the
+              // single repo the fields resolve to (blank → empty sandbox).
+              workspace: multiRepoSource
+                ? undefined
+                : (composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch) ?? null),
             }
           : undefined,
       });
@@ -1453,9 +1480,11 @@ export function ForkSessionForm({
               The repository fields themselves live under Advanced. */}
         {sandboxSelected && (
           <p className="text-sm text-muted-foreground" data-testid="fork-session-sandbox-hint">
-            {sandboxRepoUrl.trim() === ""
-              ? "The clone starts in a fresh, empty sandbox. Name a repository under Advanced settings to clone one into it."
-              : `The clone starts in a fresh sandbox with ${sandboxRepoLabel} cloned into it. Open Advanced settings to change it.`}
+            {multiRepoSource
+              ? `The clone starts in a fresh sandbox with all ${sourceSandboxRepos.length} of the source's repositories cloned into it.`
+              : sandboxRepoUrl.trim() === ""
+                ? "The clone starts in a fresh, empty sandbox. Name a repository under Advanced settings to clone one into it."
+                : `The clone starts in a fresh sandbox with ${sandboxRepoLabel} cloned into it. Open Advanced settings to change it.`}
           </p>
         )}
 
@@ -1552,7 +1581,41 @@ export function ForkSessionForm({
                   directory. The sandbox doesn't exist yet, so there is no
                   path to browse: the workspace is specified as a repository
                   the server clones into it. */}
-              {isCodingSource && sandboxSelected && (
+              {isCodingSource && sandboxSelected && multiRepoSource && (
+                <div
+                  className="flex flex-col gap-1"
+                  data-testid="fork-session-sandbox-repos-readonly"
+                >
+                  <span className="text-sm font-medium text-muted-foreground">Repositories</span>
+                  <ul className="flex flex-col gap-1 rounded-md border border-input bg-background px-3 py-2">
+                    {sourceSandboxRepos.map((w) => {
+                      const { url, branch } = splitSandboxWorkspace(w);
+                      const name = deriveRepoName(url) ?? url;
+                      return (
+                        <li key={w} className="truncate font-mono text-sm" title={w}>
+                          {branch.trim() !== "" ? `${name}#${branch}` : name}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                  {forkProviderMultiRepo ? (
+                    <p className="text-sm text-muted-foreground">
+                      All of the source's repositories are cloned into the fork's sandbox as
+                      siblings; the agent starts in the parent directory that holds them.
+                    </p>
+                  ) : (
+                    <p
+                      className="text-sm text-warning"
+                      data-testid="fork-session-repos-unsupported"
+                    >
+                      This provider clones only one repository, but the source has{" "}
+                      {sourceSandboxRepos.length}. Choose a provider that supports several to fork
+                      with all of them.
+                    </p>
+                  )}
+                </div>
+              )}
+              {isCodingSource && sandboxSelected && !multiRepoSource && (
                 <>
                   <div className="flex flex-col gap-1">
                     <label

--- a/web/src/shell/NewChatDialog.projectPrefill.test.tsx
+++ b/web/src/shell/NewChatDialog.projectPrefill.test.tsx
@@ -519,27 +519,25 @@ describe("NewChatLandingScreen project prefill", () => {
     fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
       target: { value: "https://github.com/org/alpha-repo" },
     });
-    fireEvent.change(screen.getByTestId("new-chat-landing-repo-branch-input"), {
-      target: { value: "alpha-main" },
-    });
-    expect(screen.getByTestId("new-chat-landing-repo-chip").textContent).toContain(
-      "alpha-repo#alpha-main",
-    );
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-add"));
+    await screen.findByTestId("new-chat-landing-repo-row");
+    expect(screen.getByTestId("new-chat-landing-repo-chip").textContent).toContain("alpha-repo");
 
     // Click project Beta's pencil: the param changes in place.
     searchParams = new URLSearchParams("project=Beta");
     rerender(<NewChatLandingScreen />);
 
     // The sticky host pick re-selects the sandbox, but Alpha's staged repo
-    // inputs are gone.
+    // is gone.
     await waitFor(() =>
       expect(screen.getByTestId("new-chat-landing-repo-chip").textContent).toContain("Repository"),
     );
     const body = await submitAndReadBody();
     expect(body.host_type).toBe("managed");
-    // Blank repo inputs pin workspace to explicit null under Beta's
-    // project_id (a managed create rejects a default-filled path) — not
-    // Alpha's repo#branch.
+    // No repos carried over → an empty workspaces list; workspace stays pinned
+    // to explicit null under Beta's project_id (a managed create rejects a
+    // default-filled path) — not Alpha's repo.
+    expect(body.workspaces).toEqual([]);
     expect(body.workspace).toBeNull();
   });
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import {
   composeSandboxWorkspace,
+  composeSandboxWorkspaces,
   composerWorktreeHeaderState,
   deriveHomeDir,
   deriveRepoName,
@@ -580,6 +581,18 @@ describe("sandbox repository helpers", () => {
     ["  https://github.com/org/repo  ", " main ", "https://github.com/org/repo#main"],
   ])("composeSandboxWorkspace(%j, %j) === %j", (url, branch, expected) => {
     expect(composeSandboxWorkspace(url, branch)).toBe(expected);
+  });
+
+  it("composeSandboxWorkspaces maps each selection and drops blank-url entries", () => {
+    expect(
+      composeSandboxWorkspaces([
+        { url: "https://github.com/org/api", branch: "main" },
+        { url: "https://github.com/org/web", branch: "" },
+        // A stray blank-URL entry contributes nothing (never invents "#main").
+        { url: "   ", branch: "dev" },
+      ]),
+    ).toEqual(["https://github.com/org/api#main", "https://github.com/org/web"]);
+    expect(composeSandboxWorkspaces([])).toEqual([]);
   });
 
   it.each<[string, string | null]>([
@@ -2145,20 +2158,21 @@ describe("NewChatLandingScreen", () => {
     await waitFor(() => expect(screen.queryByTestId("new-chat-landing-branch-input")).toBeNull());
   });
 
-  it("keeps the responsive sandbox repository trigger accessibly named", () => {
+  it("keeps the responsive sandbox repository trigger accessibly named", async () => {
     renderLanding({ managed_sandboxes_enabled: true });
 
     const repositoryTrigger = screen.getByTestId("new-chat-landing-repo-chip");
-    expect(repositoryTrigger).toHaveAccessibleName("Sandbox repository: Not selected");
+    expect(repositoryTrigger).toHaveAccessibleName("Sandbox repositories: None selected");
     expect(within(repositoryTrigger).getByText("Repository")).toHaveClass("hidden", "lg:block");
     fireEvent.click(repositoryTrigger);
+    // Paste a URL and add it — the chip's accessible name reflects the single
+    // pick using the server's clone-dir naming.
     fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
       target: { value: "https://github.com/omnigent-ai/omnigent.git" },
     });
-    fireEvent.change(screen.getByTestId("new-chat-landing-repo-branch-input"), {
-      target: { value: "feature" },
-    });
-    expect(repositoryTrigger).toHaveAccessibleName("Sandbox repository: omnigent#feature");
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-add"));
+    await screen.findByTestId("new-chat-landing-repo-row");
+    expect(repositoryTrigger).toHaveAccessibleName("Sandbox repositories: omnigent");
   });
 
   it("names Claude and Codex model and effort details in the harness trigger", () => {
@@ -3832,7 +3846,7 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("new-chat-landing-branch-chip")).toBeNull();
   });
 
-  it("offers a GitHub repo picker that fills the sandbox repo URL + branch", async () => {
+  it("adds a GitHub repo from the picker with a branch", async () => {
     // enabled_connections has github + a connected /repos response → the picker renders
     // inside the repo chip and drives the same URL/branch state as the
     // free-text fields.
@@ -3872,25 +3886,24 @@ describe("NewChatLandingScreen", () => {
     );
 
     fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
-    // Open the searchable repo combobox, filter by typing, then pick the repo.
+    // Open the "Add repository" combobox, filter by typing, then pick the repo.
     fireEvent.click(await screen.findByTestId("new-chat-landing-repo-select"));
     fireEvent.change(await screen.findByTestId("new-chat-landing-repo-search"), {
       target: { value: "hello" },
     });
     fireEvent.click(await screen.findByRole("option", { name: /octo\/hello/ }));
 
-    // Picking the repo composes the clone URL into the shared URL field.
-    expect((screen.getByTestId("new-chat-landing-repo-input") as HTMLInputElement).value).toBe(
-      "https://github.com/octo/hello.git",
-    );
+    // Picking the repo adds it as a row; the chip reflects the single pick using
+    // the server's clone-dir naming.
+    const row = await screen.findByTestId("new-chat-landing-repo-row");
+    expect(row.textContent).toContain("octo/hello");
+    expect(screen.getByTestId("new-chat-landing-repo-chip").textContent).toContain("hello");
 
-    // Its branches load into the searchable branch combobox; open it, wait for
-    // the async list, then choosing one fills the branch.
+    // The row's branches load into a searchable branch combobox; open it, wait
+    // for the async list, then choosing one updates the chip label.
     fireEvent.click(await screen.findByTestId("new-chat-landing-repo-branch-select"));
     fireEvent.click(await screen.findByRole("option", { name: "dev" }));
-    expect(
-      (screen.getByTestId("new-chat-landing-repo-branch-input") as HTMLInputElement).value,
-    ).toBe("dev");
+    expect(screen.getByTestId("new-chat-landing-repo-chip").textContent).toContain("hello#dev");
   });
 
   it("hides the GitHub repo picker when the GitHub App is disabled", async () => {
@@ -4104,49 +4117,103 @@ describe("NewChatLandingScreen", () => {
     expect(screen.queryByTestId("new-chat-landing-provisioning")).toBeNull();
   });
 
-  it("sends the repository inputs as the managed workspace string", async () => {
+  it("sends the added repositories as the managed workspaces list", async () => {
     authenticatedFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ id: "conv_new" }),
     } as unknown as Response);
-    renderLanding({ managed_sandboxes_enabled: true });
+    // The multi-repo picker only shows for a provider that declares the
+    // capability; agent_sandbox does.
+    renderLanding({
+      managed_sandboxes_enabled: true,
+      sandbox_provider: "agent_sandbox",
+      sandbox_provider_capabilities: { agent_sandbox: { multi_repo: true } },
+    });
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
     // The repository chip replaces the file-browser workspace chip in
     // sandbox mode.
     fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
-    fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
-      target: { value: "https://github.com/org/myrepo" },
-    });
-    fireEvent.change(screen.getByTestId("new-chat-landing-repo-branch-input"), {
-      target: { value: "release-1.2" },
-    });
-    // The chip reflects the pick using the server's clone-dir naming.
+    // Paste two URLs and add each — they become sibling rows the server clones
+    // in parallel; the chip shows the count.
+    const paste = screen.getByTestId("new-chat-landing-repo-input");
+    fireEvent.change(paste, { target: { value: "https://github.com/org/api" } });
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-add"));
+    fireEvent.change(paste, { target: { value: "https://github.com/org/web" } });
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-add"));
+    await waitFor(() => expect(screen.getAllByTestId("new-chat-landing-repo-row")).toHaveLength(2));
     expect(screen.getByTestId("new-chat-landing-repo-chip").textContent).toContain(
-      "myrepo#release-1.2",
+      "2 repositories",
     );
     fireEvent.change(screen.getByTestId("new-chat-landing-input"), {
-      target: { value: "audit the repo" },
+      target: { value: "audit the repos" },
     });
     fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
     await waitFor(() => expect(authenticatedFetchMock).toHaveBeenCalledTimes(1));
     const [, init] = authenticatedFetchMock.mock.calls[0];
     const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
-    // One composed string — the Docker-build-context-style form the
-    // server parses and clones. host_id/git stay absent (422 otherwise).
-    expect(body.workspace).toBe("https://github.com/org/myrepo#release-1.2");
+    // A list of Docker-build-context-style strings the server parses and clones
+    // in parallel. host_id/git stay absent (422 otherwise).
+    expect(body.workspaces).toEqual(["https://github.com/org/api", "https://github.com/org/web"]);
     expect(body.host_type).toBe("managed");
     expect("host_id" in body).toBe(false);
     expect("git" in body).toBe(false);
   });
 
-  it("clears a drafted sandbox repository when remounting under another project", async () => {
+  it("caps the picker at one repository for a single-repo provider", async () => {
+    // A provider that doesn't declare multi_repo gets a single-repo picker: once
+    // one repo is added, the add controls disappear so no second can be picked.
+    renderLanding({
+      managed_sandboxes_enabled: true,
+      sandbox_provider: "modal",
+      sandbox_provider_capabilities: { modal: { multi_repo: false } },
+    });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
+      target: { value: "https://github.com/org/api" },
+    });
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-add"));
+    await screen.findByTestId("new-chat-landing-repo-row");
+    // At the cap: the add controls (paste input included) are gone.
+    expect(screen.queryByTestId("new-chat-landing-repo-input")).toBeNull();
+    expect(screen.getAllByTestId("new-chat-landing-repo-row")).toHaveLength(1);
+  });
+
+  it("blocks submit when remembered repos exceed a single-repo provider's cap", async () => {
+    // Two repos remembered from a prior multi-repo session seed the picker; on a
+    // single-repo provider they're over cap, so submit is blocked (with a
+    // warning) rather than 422'd after the session row is created.
+    localStorage.setItem(
+      "omnigent:last-sandbox-repos",
+      JSON.stringify([
+        { url: "https://github.com/org/api", branch: "" },
+        { url: "https://github.com/org/web", branch: "" },
+      ]),
+    );
+    renderLanding({
+      managed_sandboxes_enabled: true,
+      sandbox_provider: "modal",
+      sandbox_provider_capabilities: { modal: { multi_repo: false } },
+    });
+    fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
+    fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
+    fireEvent.change(screen.getByTestId("new-chat-landing-input"), { target: { value: "go" } });
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
+    expect(screen.getByTestId("new-chat-landing-repo-overcap")).toBeInTheDocument();
+    expect((screen.getByTestId("new-chat-landing-submit") as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
+  it("clears drafted sandbox repositories when remounting under another project", async () => {
     authenticatedFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ id: "conv_new" }),
     } as unknown as Response);
-    // Project Alpha's composer: stage a sandbox repo + branch, then navigate
-    // away (unmount parks them in the module-scoped landing draft).
+    // Project Alpha's composer: stage a sandbox repo, then navigate away
+    // (unmount parks the selections in the module-scoped landing draft).
     renderLanding({ managed_sandboxes_enabled: true }, "/?project=Alpha");
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
@@ -4154,15 +4221,14 @@ describe("NewChatLandingScreen", () => {
     fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
       target: { value: "https://github.com/org/alpha-repo" },
     });
-    fireEvent.change(screen.getByTestId("new-chat-landing-repo-branch-input"), {
-      target: { value: "alpha-main" },
-    });
+    fireEvent.click(screen.getByTestId("new-chat-landing-repo-add"));
+    await screen.findByTestId("new-chat-landing-repo-row");
     // Unmount WITHOUT resetting the draft — the leak under test rides in it.
     cleanup();
 
-    // Project Beta's composer: the repo inputs compose the managed create's
-    // workspace string, so Alpha's repo/branch must not survive — otherwise
-    // Beta's sandbox silently clones another project's repository.
+    // Project Beta's composer: the selections compose the managed create's
+    // workspaces, so Alpha's repo must not survive — otherwise Beta's sandbox
+    // silently clones another project's repository.
     renderLanding({ managed_sandboxes_enabled: true }, "/?project=Beta");
     await waitFor(() =>
       expect(screen.getByTestId("new-chat-landing-repo-chip")).toHaveTextContent("Repository"),
@@ -4175,9 +4241,9 @@ describe("NewChatLandingScreen", () => {
     const [, init] = authenticatedFetchMock.mock.calls[0];
     const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>;
     expect(body.host_type).toBe("managed");
-    // Blank repo inputs compose to an omitted workspace (empty server-created
-    // one) — not Alpha's repo#branch.
-    expect(body.workspace).toBeUndefined();
+    // No selections carried over → an empty workspaces list (empty server-created
+    // workspace), not Alpha's repo.
+    expect(body.workspaces).toEqual([]);
   });
 
   it("carries the picked provider in the managed create when several are offered", async () => {
@@ -4267,7 +4333,7 @@ describe("NewChatLandingScreen", () => {
     );
   });
 
-  it("blocks submit on an invalid repository URL or a dangling branch", () => {
+  it("gates the add-repository button on a valid URL; submit stays enabled", async () => {
     renderLanding({ managed_sandboxes_enabled: true });
     fireEvent.pointerDown(screen.getByTestId("new-chat-landing-host-chip"), { button: 0 });
     fireEvent.click(screen.getByTestId("new-chat-landing-sandbox-option"));
@@ -4278,20 +4344,21 @@ describe("NewChatLandingScreen", () => {
     // No repo at all is a valid sandbox create (empty workspace).
     expect(submit.disabled).toBe(false);
     fireEvent.click(screen.getByTestId("new-chat-landing-repo-chip"));
-    // A branch with no repository is dangling — nothing to clone it from.
-    fireEvent.change(screen.getByTestId("new-chat-landing-repo-branch-input"), {
-      target: { value: "main" },
-    });
-    expect(submit.disabled).toBe(true);
-    // An unusable URL shape would 422 server-side; gate it inline.
+    const add = screen.getByTestId("new-chat-landing-repo-add") as HTMLButtonElement;
+    // An unusable URL shape can't be added (it would 422 server-side); the
+    // half-typed input is not a selection, so submit stays enabled.
     fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
       target: { value: "org/repo" },
     });
-    expect(submit.disabled).toBe(true);
-    // Completing a valid URL re-enables submit.
+    expect(add.disabled).toBe(true);
+    expect(submit.disabled).toBe(false);
+    // A valid URL enables Add; adding it keeps submit enabled.
     fireEvent.change(screen.getByTestId("new-chat-landing-repo-input"), {
       target: { value: "https://github.com/org/repo" },
     });
+    expect(add.disabled).toBe(false);
+    fireEvent.click(add);
+    await screen.findByTestId("new-chat-landing-repo-row");
     expect(submit.disabled).toBe(false);
   });
 });

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -146,7 +146,11 @@ import { readLastHarness, writeLastHarness } from "@/lib/harnessPreferences";
 import { readHideUnconfiguredHarnesses } from "@/lib/harnessVisibilityPreferences";
 import { readDefaultBaseBranch } from "@/lib/baseBranchPreferences";
 import { readAlwaysUseWorktree } from "@/lib/worktreeDefaultPreferences";
-import { readLastSandboxRepo, writeLastSandboxRepo } from "@/lib/repoPreferences";
+import {
+  type LastSandboxRepo,
+  readLastSandboxRepos,
+  writeLastSandboxRepos,
+} from "@/lib/repoPreferences";
 import { readHarnessOptions, writeHarnessOption, type HarnessOptions } from "@/lib/modePreferences";
 import {
   AUTO_HARNESS_DESCRIPTION,
@@ -929,6 +933,26 @@ export function splitSandboxWorkspace(workspace: string | null): {
   if (hash === -1) return { url: workspace, branch: "" };
   return { url: workspace.slice(0, hash), branch: workspace.slice(hash + 1) };
 }
+
+/**
+ * Compose the managed session's ``workspaces`` list from the selected repos.
+ *
+ * Each ``{url, branch}`` becomes a ``<url>[#<branch>]`` string; blank-URL
+ * entries are dropped. The API clones them in parallel and starts the agent in
+ * the single repo (one entry) or the parent that holds them all (several).
+ *
+ * @param repos The selected repos, in the order the user added them.
+ * @returns The composed workspace strings (may be empty for no repo).
+ */
+export function composeSandboxWorkspaces(repos: LastSandboxRepo[]): string[] {
+  return repos
+    .map((r) => composeSandboxWorkspace(r.url, r.branch))
+    .filter((w): w is string => w !== undefined);
+}
+
+// Max repos a managed sandbox may clone — mirrors the server's
+// `_MAX_MANAGED_WORKSPACES` so the picker stops adding before a create 422s.
+const MAX_SANDBOX_REPOS = 10;
 
 /**
  * Derive a repository's display name from its URL.
@@ -2223,8 +2247,7 @@ interface LandingDraft {
   selectedHostId: string | null;
   sandboxSelected: boolean;
   sandboxProvider: string | null;
-  sandboxRepoUrl: string;
-  sandboxRepoBranch: string;
+  sandboxRepoSelections: LastSandboxRepo[];
   workspace: string;
   branchName: string;
   autoSeededBranch: string;
@@ -2392,8 +2415,7 @@ export function NewChatLandingScreen() {
           // The repo inputs compose the managed create's workspace string, so
           // they are location state too — keeping them would clone another
           // project's repository into this project's sandbox.
-          sandboxRepoUrl: "",
-          sandboxRepoBranch: "",
+          sandboxRepoSelections: [],
           workspace: "",
           branchName: "",
           // The branch may be the worktree-default's auto-seed, generated for
@@ -2585,16 +2607,50 @@ export function NewChatLandingScreen() {
   // Sandbox repository inputs — composed into the managed create's
   // `workspace` string (`<url>[#<branch>]`); both blank = empty
   // server-created workspace.
-  // Seed from the in-session draft, else the last repo the user launched with
-  // (remembered across visits) so returning users don't re-pick it. The repo
-  // combobox derives its selection from the URL, so a remembered repo the
+  // Seed from the in-session draft, else the last repos the user launched with
+  // (remembered across visits) so returning users don't re-pick them. The repo
+  // combobox derives its selection from each URL, so a remembered repo the
   // account can no longer access just shows unselected.
-  const [sandboxRepoUrl, setSandboxRepoUrl] = useState<string>(
-    () => restoredDraft?.sandboxRepoUrl ?? readLastSandboxRepo()?.url ?? "",
+  const [sandboxRepoSelections, setSandboxRepoSelections] = useState<LastSandboxRepo[]>(
+    () => restoredDraft?.sandboxRepoSelections ?? readLastSandboxRepos(),
   );
-  const [sandboxRepoBranch, setSandboxRepoBranch] = useState<string>(
-    () => restoredDraft?.sandboxRepoBranch ?? readLastSandboxRepo()?.branch ?? "",
+  // Whether the launch provider clones several repos (server-declared per
+  // provider via /v1/info). A single-repo provider caps the picker at one, so
+  // it reads as a plain single-repo picker and never offers a multi-repo menu.
+  // Falls back to the server's default provider when none is picked yet, which
+  // is what the launch will use.
+  const effectiveSandboxProvider =
+    sandboxProvider ?? (info !== "loading" ? info.sandbox_provider : null);
+  const sandboxMultiRepo =
+    info !== "loading" &&
+    effectiveSandboxProvider !== null &&
+    info.sandbox_provider_capabilities?.[effectiveSandboxProvider]?.multi_repo === true;
+  const maxSandboxRepos = sandboxMultiRepo ? MAX_SANDBOX_REPOS : 1;
+  // Append a repo (deduped by URL — adding one already picked is a no-op),
+  // remove one, or repoint its branch. Order is preserved so the list reads
+  // the way the user built it.
+  const addSandboxRepo = useCallback(
+    (url: string, branch = ""): void => {
+      const u = url.trim();
+      if (u === "") return;
+      setSandboxRepoSelections((prev) =>
+        // Cap at the provider's limit so a selection can't only fail with a 422
+        // at create; a duplicate URL is a no-op.
+        prev.some((r) => r.url === u) || prev.length >= maxSandboxRepos
+          ? prev
+          : [...prev, { url: u, branch: branch.trim() }],
+      );
+    },
+    [maxSandboxRepos],
   );
+  const removeSandboxRepo = useCallback((url: string): void => {
+    setSandboxRepoSelections((prev) => prev.filter((r) => r.url !== url));
+  }, []);
+  const setSandboxRepoBranch = useCallback((url: string, branch: string): void => {
+    setSandboxRepoSelections((prev) => prev.map((r) => (r.url === url ? { ...r, branch } : r)));
+  }, []);
+  // Free-text URL being typed into the "paste a URL" adder (not yet added).
+  const [pendingRepoUrl, setPendingRepoUrl] = useState<string>("");
   // When the server advertises the GitHub App and the caller has connected
   // their account, offer a picker over their repos instead of only the
   // free-text URL. The /repos endpoint returns `connected: false` when the
@@ -2756,8 +2812,7 @@ export function NewChatLandingScreen() {
     selectedHostId,
     sandboxSelected,
     sandboxProvider,
-    sandboxRepoUrl,
-    sandboxRepoBranch,
+    sandboxRepoSelections,
     workspace,
     branchName,
     autoSeededBranch,
@@ -2892,8 +2947,8 @@ export function NewChatLandingScreen() {
     setAutoSeededBranch("");
     // Drafted sandbox repo fields are location state too — left in place they
     // would clone the previous project's repo into this project's sandbox.
-    setSandboxRepoUrl("");
-    setSandboxRepoBranch("");
+    setSandboxRepoSelections([]);
+    setPendingRepoUrl("");
     setPrefilledBranch("");
     agentFromConfigRef.current = false;
     workspaceFromConfigRef.current = false;
@@ -4133,12 +4188,17 @@ export function NewChatLandingScreen() {
     worktreeSeededForRef.current = null;
   }, [prefillConfig, branchName, autoSeededBranch]);
 
-  // Sandbox repo inputs are valid when blank (empty workspace), or when
-  // the URL passes the shape check; a branch without a URL is dangling.
+  // Sandbox repo inputs are valid when empty (empty workspace) or when every
+  // selected repo's URL passes the shape check. A half-typed URL in the paste
+  // adder never blocks submit — it isn't a selection until the user adds it.
+  // ...AND the count fits the provider's limit. The count guard matters on a
+  // stale selection the per-insert cap can't stop after the fact: repos
+  // remembered/drafted under a multi-repo provider, then the provider switched
+  // to a single-repo one. Without it the create would submit and be rejected
+  // server-side only after the session row is announced.
+  const sandboxRepoOverCap = sandboxRepoSelections.length > maxSandboxRepos;
   const sandboxRepoValid =
-    sandboxRepoUrl.trim() === ""
-      ? sandboxRepoBranch.trim() === ""
-      : isValidSandboxRepoUrl(sandboxRepoUrl);
+    sandboxRepoSelections.every((r) => isValidSandboxRepoUrl(r.url)) && !sandboxRepoOverCap;
 
   // Sandbox creates need no host or path workspace — the server
   // provisions both; only the message, agent, and (optional) repo
@@ -4292,15 +4352,19 @@ export function NewChatLandingScreen() {
   // actionable (submitting, or mid-create).
   const submitDisabledReason = canSubmit
     ? null
-    : sandboxSelected && !sandboxRepoValid
-      ? "Please enter a valid repository URL"
-      : !sandboxSelected && (!selectedHostId || !workspaceValid)
-        ? "Please choose a host and working directory"
-        : configuredAgentUnavailable && selectedAgent == null
-          ? "This project's configured agent is unavailable — pick an agent to continue"
-          : message.trim().length === 0
-            ? "Enter a message to get started"
-            : null;
+    : sandboxSelected && sandboxRepoOverCap
+      ? `This sandbox provider clones at most ${maxSandboxRepos} ${
+          maxSandboxRepos === 1 ? "repository" : "repositories"
+        } — remove the extras`
+      : sandboxSelected && !sandboxRepoValid
+        ? "Please enter a valid repository URL"
+        : !sandboxSelected && (!selectedHostId || !workspaceValid)
+          ? "Please choose a host and working directory"
+          : configuredAgentUnavailable && selectedAgent == null
+            ? "This project's configured agent is unavailable — pick an agent to continue"
+            : message.trim().length === 0
+              ? "Enter a message to get started"
+              : null;
 
   // Chip display labels.
   const worktreeHeader = composerWorktreeHeaderState({
@@ -4337,21 +4401,33 @@ export function NewChatLandingScreen() {
     !sandboxSelected &&
     (branchName.trim() !== "" ||
       (worktreesEnabled && (hostWorktrees === undefined || hostWorktrees.length > 0)));
-  // Sandbox repository chip label: repo name (server's clone-dir rule)
-  // plus the pinned branch, e.g. "repo#main"; placeholder when unset.
-  const sandboxRepoName = deriveRepoName(sandboxRepoUrl);
-  // The connected-GitHub repo (if any) whose clone URL matches the current
-  // free-text value, so the picker <select> stays in sync with the URL field
-  // and we can offer the matching branch list.
-  const selectedSandboxRepo = sandboxRepos.find(
-    (r) => (r.clone_url ?? `https://github.com/${r.full_name}.git`) === sandboxRepoUrl.trim(),
-  );
   const showGithubRepoPicker = githubReposEnabled && sandboxRepoPickerConnected;
-  const sandboxRepoLabel = sandboxRepoName
-    ? sandboxRepoBranch.trim()
-      ? `${sandboxRepoName}#${sandboxRepoBranch.trim()}`
-      : sandboxRepoName
-    : "Repository";
+  // The connected-GitHub repo (if any) a selection URL names, so its row can
+  // offer that repo's branch list. Repos not in the picker (pasted URLs, or a
+  // repo the account lost access to) resolve to undefined and fall back to a
+  // free-text branch input.
+  const repoForUrl = (url: string): GithubRepo | undefined =>
+    sandboxRepos.find(
+      (r) => (r.clone_url ?? `https://github.com/${r.full_name}.git`) === url.trim(),
+    );
+  // The clone URL of a connected repo, matching the server's derivation.
+  const repoCloneUrl = (r: GithubRepo): string =>
+    r.clone_url ?? `https://github.com/${r.full_name}.git`;
+  // Repos not yet selected — the "Add repository" combobox offers only these.
+  const unselectedRepos = sandboxRepos.filter(
+    (r) => !sandboxRepoSelections.some((s) => s.url === repoCloneUrl(r)),
+  );
+  // Sandbox repository chip label: the single repo's name[#branch] (server's
+  // clone-dir rule), a count when several, or a placeholder when none.
+  const sandboxRepoLabel =
+    sandboxRepoSelections.length === 0
+      ? "Repository"
+      : sandboxRepoSelections.length === 1
+        ? ((only) => {
+            const name = deriveRepoName(only.url) ?? "repository";
+            return only.branch.trim() ? `${name}#${only.branch.trim()}` : name;
+          })(sandboxRepoSelections[0])
+        : `${sandboxRepoSelections.length} repositories`;
   // The trigger label is just the agent name; the run-config knobs live in
   // the picker's per-entry submenu, so duplicating their values here would be
   // redundant. Top-level Smart Routing is the exception: it has no agent of its
@@ -4606,11 +4682,11 @@ export function NewChatLandingScreen() {
     // after the user has navigated elsewhere while this component is still
     // mounted in the outgoing transition tree.
     const createLocation = window.location.href;
-    // Remember the repo/branch for next time (seeds the picker on the next
+    // Remember the repos/branches for next time (seeds the picker on the next
     // visit). Only when a repo is actually set — a no-repo session leaves the
-    // remembered repo untouched rather than clearing it.
-    if (sandboxRepoUrl.trim()) {
-      writeLastSandboxRepo(sandboxRepoUrl, sandboxRepoBranch);
+    // remembered repos untouched rather than clearing them.
+    if (sandboxRepoSelections.length > 0) {
+      writeLastSandboxRepos(sandboxRepoSelections);
     }
     setCreating(true);
     setCreateError(null);
@@ -4812,16 +4888,17 @@ export function NewChatLandingScreen() {
             ...(sandboxSelected
               ? {
                   host_type: "managed",
-                  // On a `project_id` create an ABSENT workspace would be
+                  // The repos to clone in parallel; the agent starts in the one
+                  // repo, or the parent that holds them all. Empty = empty
+                  // sandbox workspace.
+                  workspaces: composeSandboxWorkspaces(sandboxRepoSelections),
+                  // On a `project_id` create an ABSENT (path) workspace would be
                   // default-filled with the config's path workspace, which a
-                  // managed create rejects — pin an explicit null instead
-                  // (explicit values are never replaced by project hints).
-                  workspace:
-                    composeSandboxWorkspace(sandboxRepoUrl, sandboxRepoBranch) ??
-                    (createProjectId !== null ? null : undefined),
-                  // Same guard for a config-stored `git` block: a sandbox has
-                  // no host for the server to create a worktree on.
-                  ...(createProjectId !== null ? { git: null } : {}),
+                  // managed create rejects — pin an explicit null (explicit
+                  // values are never replaced by project hints). Same guard for
+                  // a config-stored `git` block: a sandbox has no host for the
+                  // server to create a worktree on.
+                  ...(createProjectId !== null ? { workspace: null, git: null } : {}),
                   // Omitted when null so a default create is unchanged.
                   ...(sandboxProvider !== null ? { sandbox_provider: sandboxProvider } : {}),
                 }
@@ -5842,8 +5919,8 @@ export function NewChatLandingScreen() {
                         <PopoverTrigger asChild>
                           <button
                             type="button"
-                            aria-label={`Sandbox repository: ${
-                              sandboxRepoName ? sandboxRepoLabel : "Not selected"
+                            aria-label={`Sandbox repositories: ${
+                              sandboxRepoSelections.length > 0 ? sandboxRepoLabel : "None selected"
                             }`}
                             className="flex h-6 cursor-pointer items-center gap-1 rounded-full px-2.5 text-sm font-normal text-muted-foreground transition-colors hover:text-foreground"
                             data-testid="new-chat-landing-repo-chip"
@@ -5858,12 +5935,9 @@ export function NewChatLandingScreen() {
                         <PopoverContent align="start" className="w-96 p-3">
                           <div className="flex flex-col gap-2">
                             <div className="flex items-center gap-1.5">
-                              <label
-                                htmlFor="landing-repo-url"
-                                className="text-sm font-medium text-foreground"
-                              >
-                                Repository (optional)
-                              </label>
+                              <span className="text-sm font-medium text-foreground">
+                                Repositories (optional)
+                              </span>
                               {databricksGitCredentialsTooltipContent && (
                                 <Tooltip>
                                   <TooltipTrigger asChild>
@@ -5881,88 +5955,164 @@ export function NewChatLandingScreen() {
                                 </Tooltip>
                               )}
                             </div>
-                            {/* Connected-GitHub picker: choose one of the caller's
-                          repos + a branch, which fills the same URL/branch state
-                          the free-text inputs below drive. Only shown when the
-                          server advertises the GitHub App and the account is
-                          linked; otherwise the free-text URL is the only path. */}
-                            {showGithubRepoPicker && (
-                              <>
-                                <SandboxRepoCombobox
-                                  repos={sandboxRepos}
-                                  value={selectedSandboxRepo?.full_name ?? ""}
-                                  onSelect={(repo) => {
-                                    setSandboxRepoUrl(
-                                      repo
-                                        ? (repo.clone_url ??
-                                            `https://github.com/${repo.full_name}.git`)
-                                        : "",
-                                    );
-                                    // A new repo has its own branches — reset so a
-                                    // stale branch never rides along.
-                                    setSandboxRepoBranch("");
-                                  }}
-                                />
-                                {sandboxReposTruncated && (
-                                  <p
-                                    className="text-sm text-muted-foreground"
-                                    data-testid="new-chat-landing-repo-truncated"
-                                  >
-                                    Showing your most recently pushed repositories. Don't see one?
-                                    Paste its URL below.
-                                  </p>
-                                )}
-                                {selectedSandboxRepo && (
-                                  <SandboxRepoBranchSelect
-                                    fullName={selectedSandboxRepo.full_name}
-                                    value={sandboxRepoBranch}
-                                    defaultBranch={selectedSandboxRepo.default_branch}
-                                    onChange={setSandboxRepoBranch}
-                                  />
-                                )}
-                                <p className="text-sm text-muted-foreground">
-                                  or paste a repository URL:
-                                </p>
-                              </>
-                            )}
-                            {/* Connected but the repo list failed to load: say so
-                          explicitly, so a transient error isn't mistaken for
-                          "GitHub not connected" (the picker just wouldn't render). */}
-                            {githubReposEnabled && sandboxReposErrored && !showGithubRepoPicker && (
+                            {/* Stale over-cap selection (repos remembered/added under
+                          a multi-repo provider, then switched to a single-repo one):
+                          warn and block submit rather than 422 after the session row
+                          is created. */}
+                            {sandboxRepoOverCap && (
                               <p
-                                className="text-sm text-destructive"
-                                data-testid="new-chat-landing-repo-error"
+                                className="text-sm text-warning"
+                                data-testid="new-chat-landing-repo-overcap"
                               >
-                                Couldn't load your GitHub repositories. Paste a repository URL
-                                below.
+                                This sandbox provider clones at most {maxSandboxRepos}{" "}
+                                {maxSandboxRepos === 1 ? "repository" : "repositories"}. Remove the
+                                extra {maxSandboxRepos === 1 ? "repositories" : "ones"} to continue.
                               </p>
                             )}
-                            <input
-                              id="landing-repo-url"
-                              type="text"
-                              value={sandboxRepoUrl}
-                              onChange={(e) => {
-                                // Editing the repo invalidates a branch picked for the
-                                // previous repo, so clear it (mirrors the repo select).
-                                setSandboxRepoUrl(e.target.value);
-                                setSandboxRepoBranch("");
-                              }}
-                              placeholder="https://github.com/org/repo"
-                              className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
-                              data-testid="new-chat-landing-repo-input"
-                            />
-                            <input
-                              type="text"
-                              value={sandboxRepoBranch}
-                              onChange={(e) => setSandboxRepoBranch(e.target.value)}
-                              placeholder="Branch (defaults to the repo's default)"
-                              aria-label="Repository branch"
-                              className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
-                              data-testid="new-chat-landing-repo-branch-input"
-                            />
+                            {/* Selected repos: each clones into its own sibling dir.
+                          A connected repo gets its branch combobox; a pasted URL a
+                          free-text branch. The remove button drops it. */}
+                            {sandboxRepoSelections.map((sel) => {
+                              const repo = repoForUrl(sel.url);
+                              const name = repo?.full_name ?? deriveRepoName(sel.url) ?? sel.url;
+                              return (
+                                <div
+                                  key={sel.url}
+                                  className="flex items-center gap-2"
+                                  data-testid="new-chat-landing-repo-row"
+                                >
+                                  <span className="min-w-0 flex-1 truncate text-sm" title={sel.url}>
+                                    {name}
+                                  </span>
+                                  {repo ? (
+                                    <div className="w-36 shrink-0">
+                                      <SandboxRepoBranchSelect
+                                        fullName={repo.full_name}
+                                        value={sel.branch}
+                                        defaultBranch={repo.default_branch}
+                                        onChange={(b) => setSandboxRepoBranch(sel.url, b)}
+                                      />
+                                    </div>
+                                  ) : (
+                                    <input
+                                      type="text"
+                                      value={sel.branch}
+                                      onChange={(e) =>
+                                        setSandboxRepoBranch(sel.url, e.target.value)
+                                      }
+                                      placeholder="branch"
+                                      aria-label={`Branch for ${name}`}
+                                      className="w-28 shrink-0 rounded-md border border-input bg-background px-2 py-1 text-xs outline-none transition-colors focus-visible:border-ring"
+                                    />
+                                  )}
+                                  <button
+                                    type="button"
+                                    onClick={() => removeSandboxRepo(sel.url)}
+                                    aria-label={`Remove ${name}`}
+                                    className="shrink-0 rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground"
+                                    data-testid="new-chat-landing-repo-remove"
+                                  >
+                                    <XIcon className="size-3.5" />
+                                  </button>
+                                </div>
+                              );
+                            })}
+                            {sandboxRepoSelections.length > 0 && (
+                              <div className="my-0.5 border-t border-border" />
+                            )}
+                            {/* Add-repository controls, hidden once the provider's
+                          repo cap is reached — so a single-repo provider shows one
+                          slot and no multi-repo affordance. */}
+                            {sandboxRepoSelections.length < maxSandboxRepos && (
+                              <>
+                                {/* Add from the connected account's repos (only those
+                              not already picked); the free-text URL below is the
+                              fallback for a repo not in the list or no GitHub link. */}
+                                {showGithubRepoPicker && (
+                                  <>
+                                    <SandboxRepoCombobox
+                                      repos={unselectedRepos}
+                                      value=""
+                                      onSelect={(repo) => {
+                                        if (repo) {
+                                          addSandboxRepo(
+                                            repo.clone_url ??
+                                              `https://github.com/${repo.full_name}.git`,
+                                          );
+                                        }
+                                      }}
+                                    />
+                                    {sandboxReposTruncated && (
+                                      <p
+                                        className="text-sm text-muted-foreground"
+                                        data-testid="new-chat-landing-repo-truncated"
+                                      >
+                                        Showing your most recently pushed repositories. Don't see
+                                        one? Paste its URL below.
+                                      </p>
+                                    )}
+                                    <p className="text-sm text-muted-foreground">
+                                      or paste a repository URL:
+                                    </p>
+                                  </>
+                                )}
+                                {/* Connected but the repo list failed to load: say so
+                              explicitly, so a transient error isn't mistaken for
+                              "GitHub not connected" (the picker just wouldn't render). */}
+                                {githubReposEnabled &&
+                                  sandboxReposErrored &&
+                                  !showGithubRepoPicker && (
+                                    <p
+                                      className="text-sm text-destructive"
+                                      data-testid="new-chat-landing-repo-error"
+                                    >
+                                      Couldn't load your GitHub repositories. Paste a repository URL
+                                      below.
+                                    </p>
+                                  )}
+                                <div className="flex items-center gap-2">
+                                  <input
+                                    id="landing-repo-url"
+                                    type="text"
+                                    value={pendingRepoUrl}
+                                    onChange={(e) => setPendingRepoUrl(e.target.value)}
+                                    onKeyDown={(e) => {
+                                      // Enter adds the repo (same as the Add button), so a
+                                      // paste-then-Enter flow never needs the mouse.
+                                      if (
+                                        e.key === "Enter" &&
+                                        isValidSandboxRepoUrl(pendingRepoUrl)
+                                      ) {
+                                        e.preventDefault();
+                                        addSandboxRepo(pendingRepoUrl);
+                                        setPendingRepoUrl("");
+                                      }
+                                    }}
+                                    placeholder="https://github.com/org/repo"
+                                    aria-label="Repository URL"
+                                    className="min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors focus-visible:border-ring"
+                                    data-testid="new-chat-landing-repo-input"
+                                  />
+                                  <button
+                                    type="button"
+                                    disabled={!isValidSandboxRepoUrl(pendingRepoUrl)}
+                                    onClick={() => {
+                                      addSandboxRepo(pendingRepoUrl);
+                                      setPendingRepoUrl("");
+                                    }}
+                                    className="flex shrink-0 items-center gap-1 rounded-md border border-input px-2.5 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
+                                    data-testid="new-chat-landing-repo-add"
+                                  >
+                                    <PlusIcon className="size-3.5" />
+                                    Add
+                                  </button>
+                                </div>
+                              </>
+                            )}
                             <p className="text-sm text-muted-foreground">
-                              Cloned into the sandbox as the session's working directory. Leave
-                              blank to start in an empty workspace.
+                              {maxSandboxRepos > 1
+                                ? "Cloned into the sandbox at startup. Several repos are cloned side by side and the agent starts in the parent that holds them; pick one and it starts directly inside it. Leave empty for a blank workspace."
+                                : "Cloned into the sandbox at startup as the working directory. Leave empty for a blank workspace."}
                             </p>
                           </div>
                         </PopoverContent>


### PR DESCRIPTION
## Related issue

N/A (maintainer feature request; no tracking issue). Happy to link one if there is an existing issue.

## Summary

The New Chat repo picker only took a single GitHub repo. This lets a user pick as many as they want when starting a managed sandbox (`k8s` / `agent-sandbox`):

- **Multi-select picker** (New Chat): an added-repo list, each row a repo + its branch + a remove button, with an "Add repository" combobox and a URL-paste fallback. Bounded at 10 repos.
- **Parallel clone**: the k8s / agent-sandbox init container backgrounds every `git clone` and joins them, failing fast if any clone fails. The per-user credential helper is wired once.
- **Working directory**: the agent starts in the parent directory that holds all the clones, or directly inside the repo when exactly one is picked (identical to today's single-repo behaviour).

Under the hood a list of `RepoWorkspace` threads through the whole launch chain (`schemas` -> `managed_hosts` -> `start_host`). `RepoWorkspace` moved to `onboarding/sandboxes/types` so a launcher needs no `server` import. The session-create API gains a `workspaces: [...]` field next to the still-accepted single `workspace`, and a relaunch re-clones every repo from the (space-joined) create-time label.

### ELI5

Before: "pick one repo, we clone it, you start inside it."
Now: "pick a few repos, we clone them all at once, and you start in the folder that contains them (or inside the one repo if you only picked one)."

### Flow

```mermaid
flowchart LR
  P["New Chat picker (repo list)"] --> API["POST /v1/sessions (workspaces)"]
  API --> MH["managed_hosts (list of RepoWorkspace)"]
  MH --> SH["start_host(repos=...)"]
  SH --> INIT["init container: clone A and clone B in parallel, then wait"]
  INIT --> CWD{"how many repos?"}
  CWD -->|one| R["cwd = workspace/repo"]
  CWD -->|several| W["cwd = workspace (parent of all)"]
```

## Test Plan

Backend (run locally against this branch):

- `pytest tests/onboarding/sandboxes/test_kubernetes.py` — 92 passed, including new multi-repo manifest + parallel-clone-script tests and the "1 repo -> clone dir / N repos -> parent" cwd rule.
- `pytest tests/server/test_managed_hosts.py` — 324 passed (launch / relaunch / entrypoint fakes updated to the `repos` contract).
- `pytest tests/server/test_schemas.py -k "workspace or managed"` — 22 passed (new `workspaces` validation: multi, mutual-exclusion with `workspace`, 10-repo cap, malformed entry, external-host rejection).
- `pytest tests/onboarding/sandboxes/test_base.py -k "start_host or materialize"` — exec-model multi-repo clone + cwd rule.
- Rendered the real init script and ran it through a shell with a stub `git`: two 0.3s clones finished in **0.32s** (parallel, not 0.6s serial); a failing clone made the script exit non-zero after both had started.

Web:

- `web/src/lib/repoPreferences.test.ts` and the `NewChatDialog` helper tests updated for the list shape (`composeSandboxWorkspaces`, list prefs with legacy-key migration). Web typecheck + vitest run in CI — this worktree has no web toolchain installed, so those are CI-watch items.

Manual verification (recommended before merge):

1. Start a server with a `k8s` or `agent-sandbox` provider configured and GitHub connected, then open New Chat.
2. Open the repository chip, add two repos (each with a branch), and create.
3. Confirm both cloned in parallel and the agent's cwd is the parent workspace (e.g. `/home/omnigent/workspace`) with both repos as siblings.
4. Repeat with a single repo and confirm cwd is that repo's directory.
5. Kill the sandbox, send a message, and confirm the relaunch re-clones both repos.

## Demo

- [x] Visual demo attached below

New Chat repository chip -> popover (the approved "added-repo list" layout):

```
chip:  [ (branch)  2 repositories  v ]

+- Repositories (optional) ------------+
| acme/api        [ main    v ]     X  |
| acme/web        [ Default v ]     X  |
| ------------------------------------ |
| Add: [ Choose a repository...   v ]  |
| or paste a URL: [____________]  [+]  |
|                                      |
| Cloned into the sandbox at startup.  |
| Several repos are cloned side by     |
| side; the agent starts in the parent |
| that holds them (or inside the repo  |
| when you pick one).                  |
+--------------------------------------+
```

> Note: this is the approved layout mockup. A live screenshot / recording from the running web app still needs capturing (the CI worktree has no web toolchain to launch it); I'm happy to add one, or it can be attached before merge.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Backend is fully unit-covered (launcher manifest + init script, managed-hosts launch/relaunch chain, session-schema validation), and the parallel-clone shell logic was exercised live with a stub `git`. Web logic (list preferences + workspace compose) has unit tests; the picker UI itself and the web typecheck/vitest run in CI, since this worktree has no web toolchain to run them locally.

## Changelog

Start a sandbox with multiple GitHub repositories, cloned in parallel

---

This pull request and its description were written by Isaac.

