### PR TITLE
chore(host): add structured tunnel failure diagnostics

### DIFF
--- a/docs/host-connection-diagnostics.md
+++ b/docs/host-connection-diagnostics.md
@@ -1,0 +1,42 @@
+# Host connection diagnostics
+
+Structured fields annotate the existing reconnect warnings and accepted-but-silent
+connection errors. Retry policy, severity, and dashboard exclusions are unchanged.
+Deploy the updated host before expecting these fields; historical logs are unchanged.
+
+The debug-log sink stores `event_name` separately and serializes non-null
+`attributes` values as strings. Booleans appear as `True` or `False`.
+
+## Events and fields
+
+- `host_tunnel_unresponsive`: the existing accepted-but-silent connection error.
+- `host_tunnel_reconnecting`: the existing reconnect warning.
+- `host_tunnel_responsive`: one informational event when an application frame
+  arrives after a silent-connection streak. This proves a response, not that the
+  session or backend is otherwise healthy.
+
+Use `host_id`, `host_process_id`, `connection_attempt`, `connection_phase`, and
+`connection_elapsed_ms` to distinguish upgrade, owner lookup, hello transmission,
+runner-exit reporting, and receive-loop failures. Attempt numbers are local to
+one host process; include timestamps and process identity across restarts.
+
+`upgrade_accepted`, `hello_sent`, `frame_received`, `exception_type`,
+`disconnect_reason`, `websocket_close_code`, and `http_status` describe the last
+attempt. `consecutive_silent_connections` and `reconnect_delay_s` explain retry
+cadence. `tracked_runner_count` is not a count of failed or healthy sessions.
+
+The new attributes contain no URLs, headers, credentials, or peer-provided text.
+Existing human-readable error messages remain unchanged.
+
+## Verification
+
+```sh
+uv run --no-sync pytest -q tests/host/test_connect.py -k 'silent_connect or silent_connection_diagnostics or inbound_frame_resets or suspend'
+```
+
+For a naturally occurring reconnect, inspect its `event_name` and `attributes`
+in the debug-log table. Group by host/process and attempt; check whether the
+connection got through upgrade and hello transmission, its close/status code,
+and the selected retry delay. Look for `host_tunnel_responsive` to confirm a
+subsequent response. Do not interrupt a shared endpoint to test these logs;
+the unit tests exercise the failure paths with simulated connections.

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -146,6 +146,7 @@ from omnigent.runner.transports.ws_tunnel.limits import (
     TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
 )
 from omnigent.runtime.websocket_metrics import (
+    classify_disconnect_reason,
     record_websocket_connected,
     record_websocket_disconnected,
     websocket_close_code,
@@ -1045,6 +1046,10 @@ class HostProcess:
         # Per-connection markers feeding the silent-connect streak.
         self._conn_upgrade_accepted = False
         self._conn_frame_received = False
+        self._conn_started_at: float | None = None
+        self._conn_attempt = 0
+        self._conn_phase = "not_started"
+        self._conn_hello_sent = False
         # Live tunnel connection, set by _serve_frames for the watcher
         # tasks (which outlive any single connection) to report on.
         self._ws: websockets.asyncio.client.ClientConnection | None = None
@@ -3529,6 +3534,7 @@ class HostProcess:
                                 "%s Treating the endpoint as unhealthy; "
                                 "reconnecting on slow backoff until it responds.",
                                 cause,
+                                extra=self._connection_log_extra("host_tunnel_unresponsive", exc),
                             )
                             print(
                                 f"⚠ {cause} The server may be unhealthy. "
@@ -3600,6 +3606,12 @@ class HostProcess:
                         " (resumed from suspend — prompt reconnect)"
                         if woke
                         else (" (recycle — prompt reconnect)" if recycle else ""),
+                        extra=self._connection_log_extra(
+                            "host_tunnel_reconnecting",
+                            exc,
+                            reconnect_delay_s=wait_s,
+                            resumed_from_suspend=woke,
+                        ),
                     )
                     # Interruptible backoff: wake early if the lifecycle
                     # monitor loses ownership mid-backoff so the top-of-loop
@@ -3714,6 +3726,42 @@ class HostProcess:
                 handle.proc.kill()
         self._runners.clear()
 
+    def _connection_log_extra(
+        self,
+        event_name: str,
+        error: BaseException | None = None,
+        *,
+        reconnect_delay_s: float | None = None,
+        resumed_from_suspend: bool = False,
+    ) -> dict[str, object]:
+        """Describe the connection attempt without headers, URLs, or peer-provided text."""
+        return debug_event(
+            event_name,
+            host_id=self._identity.host_id,
+            host_process_id=os.getpid(),
+            connection_attempt=self._conn_attempt,
+            connection_phase=self._conn_phase,
+            connection_elapsed_ms=(
+                round((time.monotonic() - self._conn_started_at) * 1000)
+                if self._conn_started_at is not None
+                else None
+            ),
+            upgrade_accepted=self._conn_upgrade_accepted,
+            hello_sent=self._conn_hello_sent,
+            frame_received=self._conn_frame_received,
+            consecutive_silent_connections=self._silent_connect_streak,
+            tracked_runner_count=len(self._runners),
+            exception_type=type(error).__name__ if error is not None else None,
+            websocket_close_code=websocket_close_code(error),
+            disconnect_reason=(
+                classify_disconnect_reason(error, resumed_from_suspend=resumed_from_suspend)
+                if error is not None
+                else None
+            ),
+            http_status=error.response.status_code if isinstance(error, InvalidStatus) else None,
+            reconnect_delay_s=reconnect_delay_s,
+        )
+
     async def _connect_and_serve(self) -> None:
         """Single connection attempt: connect, hello, serve.
 
@@ -3723,6 +3771,10 @@ class HostProcess:
         # Fresh per-connection markers for the silent-connect streak.
         self._conn_upgrade_accepted = False
         self._conn_frame_received = False
+        self._conn_started_at = time.monotonic()
+        self._conn_attempt += 1
+        self._conn_phase = "prepare"
+        self._conn_hello_sent = False
         url = self._tunnel_url()
         headers = self._build_connect_headers()
 
@@ -3750,6 +3802,7 @@ class HostProcess:
                 ping_interval=TUNNEL_KEEPALIVE_PING_INTERVAL_S,
                 ping_timeout=TUNNEL_KEEPALIVE_PING_TIMEOUT_S,
             )
+            self._conn_phase = "upgrade"
             ws = await ws_cm.__aenter__()
         except (InvalidURI, InvalidStatus) as exc:
             # The upgrade itself was rejected. Fail loud on permanent
@@ -3774,6 +3827,7 @@ class HostProcess:
         record_websocket_connected("host", reconnect=reconnect)
         disconnect_error: BaseException | None = None
         try:
+            self._conn_phase = "owner_lookup"
             await self._ensure_owner_user_id()
             await self._serve_frames(ws)
         except BaseException as exc:
@@ -3935,7 +3989,10 @@ class HostProcess:
             encoded_hello = encode_host_frame(hello)
         except Exception as exc:
             raise HostConnectError(f"Could not encode host.hello: {exc}") from exc
+        self._conn_phase = "send_hello"
         await ws.send(encoded_hello)
+        self._conn_hello_sent = True
+        self._conn_phase = "report_runner_exits"
         self._ws = ws
         # Reports raised while disconnected must wait until registration; the
         # server cannot route them before this connection owns the host.
@@ -3962,9 +4019,17 @@ class HostProcess:
             self._prewarm_model_options(), name="host-model-options-prewarm"
         )
         try:
+            self._conn_phase = "receive"
             while True:
                 raw = await ws.recv()
+                recovered = not self._conn_frame_received and self._silent_connect_streak > 0
                 self._conn_frame_received = True
+                if recovered:
+                    _logger.info(
+                        "Host tunnel received a frame after %d silent connections",
+                        self._silent_connect_streak,
+                        extra=self._connection_log_extra("host_tunnel_responsive"),
+                    )
                 if isinstance(raw, str):
                     # Connection-control frames decide whether this receive
                     # loop exits or reconnects, so handle them inline. Ordinary

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -4640,6 +4640,17 @@ async def test_silent_connect_streak_escalates_and_slows_reconnects(
     errors = [record for record in caplog.records if record.levelno == logging.ERROR]
     assert len(errors) == 1
     assert "3 consecutive connections but never responded" in errors[0].message
+    assert errors[0].event_name == "host_tunnel_unresponsive"
+    attributes = errors[0].attributes
+    assert attributes["host_id"] == host._identity.host_id
+    assert attributes["connection_attempt"] == 3
+    assert attributes["connection_phase"] == "receive"
+    assert attributes["upgrade_accepted"] is True
+    assert attributes["hello_sent"] is True
+    assert attributes["frame_received"] is False
+    assert attributes["consecutive_silent_connections"] == 3
+    assert attributes["connection_elapsed_ms"] >= 0
+    assert attributes["disconnect_reason"] == "transport_error"
     assert capsys.readouterr().err.count("never responded") == 1
     reconnects = [
         record.message for record in caplog.records if "Reconnecting in" in record.message
@@ -4663,11 +4674,48 @@ async def test_inbound_frame_resets_silent_connect_streak(
     _patch_connect(monkeypatch, spy)
     host = _host()
 
-    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+    with caplog.at_level(logging.INFO, logger="omnigent.host.connect"):
         await host.run()
 
     assert host._silent_connect_streak == 2
     assert not [record for record in caplog.records if record.levelno == logging.ERROR]
+    recovered = [
+        record
+        for record in caplog.records
+        if getattr(record, "event_name", None) == "host_tunnel_responsive"
+    ]
+    assert len(recovered) == 1
+    assert recovered[0].attributes["connection_attempt"] == 3
+    assert recovered[0].attributes["consecutive_silent_connections"] == 2
+    assert recovered[0].attributes["frame_received"] is True
+
+
+async def test_silent_connection_diagnostics_distinguish_owner_lookup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_BASE_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._RECONNECT_CAP_S", 0.0)
+    monkeypatch.setattr("omnigent.host.connect._SILENT_CONNECT_ESCALATE_ATTEMPTS", 1)
+    spy = _ConnectSpy([None, asyncio.CancelledError()])
+    _patch_connect(monkeypatch, spy)
+    host = _host()
+
+    async def fail_owner_lookup() -> None:
+        raise RuntimeError("private-owner-lookup-detail")
+
+    monkeypatch.setattr(host, "_ensure_owner_user_id", fail_owner_lookup)
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        await host.run()
+
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(errors) == 1
+    attributes = errors[0].attributes
+    assert attributes["connection_phase"] == "owner_lookup"
+    assert attributes["hello_sent"] is False
+    assert attributes["exception_type"] == "RuntimeError"
+    assert "private-owner-lookup-detail" not in str(attributes)
+    assert host._server_url not in str(attributes)
 
 
 async def test_connection_error_frame_fails_loudly_on_live_receive_path() -> None:


### PR DESCRIPTION
## Related issue

N/A — diagnostic logging chore.

## Summary

- Accepted-but-silent tunnel errors do not currently say whether failure happened before hello, during owner lookup, or in the receive loop. Add bounded stage, timing, process/attempt, close-code, and retry attributes to the existing error and reconnect warning.
- Emit one informational recovery event when the host receives an application frame after a silent streak. No retry, severity, or dashboard-exclusion changes; no new URL/header/peer-text logging.

ELI5: record which step the connection reached, rather than only saying it stopped responding.

```text
upgrade -> owner lookup -> hello -> receive
                        failure -> stage + timing + retry diagnostics
                  later response -> one recovery event
```

## Test Plan

- `uv run --no-sync pytest -q tests/host/test_connect.py -k 'silent_connect or silent_connection_diagnostics or inbound_frame_resets or suspend'` — 6 passed.
- Cover silent escalation, recovery, owner-lookup failure, suspend/reconnect behavior, and keeping private details out of attributes.
- Ruff and changed-file Pyrefly checks pass.
- `pre-commit run` was run before committing. Its full-project Pyrefly check is blocked by the existing `object` versus `Config | None` error at `omnigent/harnesses/opencode_native/provider.py:363`; the file is unchanged and checking it separately reproduces the error. Other applicable hooks pass. Keeping this PR draft until that baseline issue is resolved.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — no UI changes. Tests validate event fields and unchanged reconnect behavior; the diagnostic guide gives an operator check for a naturally occurring reconnect.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No production endpoint was interrupted and the logging is not deployed. A broader combined suite had 12 unrelated host-test failures involving model-source metadata and CLI wording; all 12 also reproduced with the pre-change production modules. The six targeted connection tests pass on this branch.

## Changelog

Host connection logs now identify the failed stage, retry context, and subsequent response.
