### PR TITLE
chore(terminal): correlate probe failures with lifecycle events

### DIFF
--- a/docs/terminal-lifecycle-diagnostics.md
+++ b/docs/terminal-lifecycle-diagnostics.md
@@ -1,0 +1,48 @@
+# Terminal lifecycle diagnostics
+
+Structured fields distinguish terminal disappearance from session failure.
+Error severity, terminal lifecycle behavior, and dashboard exclusions are
+unchanged. Deploy the updated runner before expecting these fields.
+
+The debug-log sink stores `event_name` separately and serializes non-null
+`attributes` values as strings. Booleans appear as `True` or `False`.
+
+## Events and correlation
+
+- `terminal_probe_failed`: the existing capture-pane warning.
+- `terminal_unavailable`: the existing three-probe error.
+- `terminal_exit_observed`: an informational lifecycle record with the owning
+  `session_id`, `terminal_lifecycle` (`required` or `auxiliary`),
+  `session_status_before_exit` (`idle`, `running`, or `unknown`),
+  `terminal_exit_status` when known, and `superseded`.
+- `terminal_close_requested`: an informational record before the explicit
+  terminal-close path runs. It does not assert who requested the close or that
+  cleanup succeeded.
+
+Join records by `attributes['terminal_instance_id']`. The identifier is unique
+to a terminal instance, so a replacement with the same name/key is distinguishable.
+Watcher logs may inherit a runner's primary session; the lifecycle record carries
+the actual owning session, including subagents.
+
+The probe error includes `consecutive_probe_failures`, `last_capture_age_ms`,
+`pane_output_seen`, `keep_alive_after_exit`, and `shutdown_requested`.
+An absent `terminal_exit_status` means unknown, not success. An auxiliary terminal
+exit does not by itself prove an agent failure. A required terminal exiting while
+idle differs from losing it during a turn. Check the subsequent turn-status
+event for the actual user-visible outcome.
+
+The new attributes contain no pane contents, command arguments, or filesystem
+paths. Existing human-readable errors remain unchanged. No extra tmux probes
+are introduced for diagnostics.
+
+## Verification
+
+```sh
+uv run --no-sync pytest -q tests/inner/test_terminal.py tests/runner/test_resource_registry.py
+```
+
+Run `omnidev` and explicitly close a disposable terminal. Verify that
+`terminal_close_requested` carries its session and terminal-instance identifiers
+in the debug-log table. For a naturally observed terminal disappearance, use the
+instance identifier to find the probe warning and lifecycle record. Compare
+required/auxiliary and prior session status against the subsequent turn outcome.

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -16,6 +16,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -23,6 +24,7 @@ from typing import Any, TypeAlias
 
 from omnigent._platform import IS_WINDOWS
 from omnigent.cli_invocation import cli_invocation
+from omnigent.debug_logging import debug_event
 from omnigent.runner.identity import strip_runner_auth_secrets
 from omnigent.util.tmux_compat import MIN_TMUX_VERSION, MIN_TMUX_VERSION_HINT, tmux_version
 
@@ -932,6 +934,8 @@ class TerminalInstance:
     # not read as agent activity. ``-inf`` until the first interaction.
     _last_client_interaction_at: float = field(default=float("-inf"), repr=False)
     _last_pane_snapshot: str | None = field(default=None, repr=False)
+    _last_capture_at: float | None = field(default=None, repr=False)
+    diagnostic_id: str = field(default_factory=lambda: uuid.uuid4().hex, init=False, repr=False)
     # Exit status of the pane's inner process, captured from tmux
     # ``#{pane_dead_status}`` the first time a dead pane is observed (only
     # meaningful with ``keep_alive_after_exit`` / ``remain-on-exit``). ``None``
@@ -980,6 +984,31 @@ class TerminalInstance:
     def _remember_pane_snapshot(self, snapshot: str) -> None:
         """Store a pane capture for later exit diagnostics."""
         self._last_pane_snapshot = snapshot
+        self._last_capture_at = time.monotonic()
+
+    def _probe_log_extra(
+        self, event_name: str, consecutive_failures: int | None = None
+    ) -> dict[str, object]:
+        """Correlate probe failures with lifecycle events without recording pane contents."""
+        return debug_event(
+            event_name,
+            terminal_instance_id=self.diagnostic_id,
+            terminal_name=self.name,
+            terminal_key=self.session_key,
+            consecutive_probe_failures=consecutive_failures,
+            keep_alive_after_exit=self.keep_alive_after_exit,
+            last_capture_age_ms=(
+                round((time.monotonic() - self._last_capture_at) * 1000)
+                if self._last_capture_at is not None
+                else None
+            ),
+            pane_output_seen=bool(self._last_pane_snapshot),
+            terminal_exit_status=self._last_exit_status,
+            shutdown_requested=(
+                not self.running
+                or (self._idle_stop_event is not None and self._idle_stop_event.is_set())
+            ),
+        )
 
     def last_exit_status(self) -> int | None:
         """Return the inner process's exit code, if the pane has died.
@@ -1449,6 +1478,7 @@ class TerminalInstance:
                     self.name,
                     self.session_key,
                     exc,
+                    extra=self._probe_log_extra("terminal_probe_failed"),
                 )
                 if await self._tmux_session_exists_async():
                     consecutive_capture_failures = 0
@@ -1461,6 +1491,9 @@ class TerminalInstance:
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
+                    extra=self._probe_log_extra(
+                        "terminal_unavailable", consecutive_capture_failures
+                    ),
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1644,6 +1677,9 @@ class TerminalInstance:
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
+                    extra=self._probe_log_extra(
+                        "terminal_unavailable", consecutive_capture_failures
+                    ),
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1712,6 +1748,7 @@ class TerminalInstance:
                 self.name,
                 self.session_key,
                 exc,
+                extra=self._probe_log_extra("terminal_probe_failed"),
             )
             return None
 

--- a/omnigent/runner/resource_registry.py
+++ b/omnigent/runner/resource_registry.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Literal
 
 from cachetools import TTLCache
 
-from omnigent.debug_logging import runner_primary_session_id
+from omnigent.debug_logging import debug_event, runner_primary_session_id
 from omnigent.entities.pagination import PagedList
 from omnigent.entities.session_resources import (
     DEFAULT_ENVIRONMENT_ID,
@@ -1438,7 +1438,8 @@ class SessionResourceRegistry:
         command, args_count, cwd, last_output, exit_status = _terminal_exit_diagnostics(instance)
         # Idle = clean shutdown after the turn finished. Anything else (running,
         # or never observed → boot failure) stays a failure.
-        session_was_idle = self._take_session_status_memo(session_id) == "idle"
+        session_status_before_exit = self._take_session_status_memo(session_id)
+        session_was_idle = session_status_before_exit == "idle"
 
         superseded_by: TerminalInstance | None = None
         if self._terminal_registry is not None:
@@ -1459,6 +1460,28 @@ class SessionResourceRegistry:
                     superseded_by = current
 
         publisher = self._terminal_exit_publisher
+        _logger.info(
+            "Terminal exit observed: session=%s terminal=%s:%s "
+            "lifecycle=%s status=%s superseded=%s",
+            session_id,
+            terminal_name,
+            session_key,
+            lifecycle.value,
+            session_status_before_exit or "unknown",
+            superseded_by is not None,
+            extra=debug_event(
+                "terminal_exit_observed",
+                session_id=session_id,
+                terminal_instance_id=instance.diagnostic_id if instance is not None else None,
+                terminal_id=terminal_id,
+                terminal_name=terminal_name,
+                terminal_key=session_key,
+                terminal_lifecycle=lifecycle.value,
+                session_status_before_exit=session_status_before_exit or "unknown",
+                terminal_exit_status=exit_status,
+                superseded=superseded_by is not None,
+            ),
+        )
         if superseded_by is not None:
             _logger.info(
                 "Skipping exit event for superseded terminal: session=%s terminal=%s:%s",
@@ -1501,6 +1524,17 @@ class SessionResourceRegistry:
             session_id,
         ):
             if terminal_resource_id(entry.terminal_name, entry.session_key) == terminal_id:
+                _logger.info(
+                    "Terminal close requested: session=%s terminal=%s",
+                    session_id,
+                    terminal_id,
+                    extra=debug_event(
+                        "terminal_close_requested",
+                        session_id=session_id,
+                        terminal_id=terminal_id,
+                        terminal_instance_id=entry.instance.diagnostic_id,
+                    ),
+                )
                 closed = await self._terminal_registry.close(
                     session_id,
                     entry.terminal_name,

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -62,7 +62,9 @@ def contains_subsequence(values: list[str], expected: list[str]) -> bool:
     )
 
 
-def test_threaded_idle_watcher_reports_terminal_exit(tmp_path: Path) -> None:
+def test_threaded_idle_watcher_reports_terminal_exit(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """
     The threaded watcher reports tmux disappearance instead of exiting silently.
 
@@ -87,6 +89,51 @@ def test_threaded_idle_watcher_reports_terminal_exit(tmp_path: Path) -> None:
 
     assert exited.wait(timeout=1.0)
     assert instance.running is False
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(errors) == 1
+    assert errors[0].event_name == "terminal_unavailable"
+    assert errors[0].attributes["terminal_instance_id"] == instance.diagnostic_id
+    assert errors[0].attributes["consecutive_probe_failures"] == 3
+    assert errors[0].attributes["pane_output_seen"] is False
+    assert errors[0].attributes["shutdown_requested"] is False
+
+
+async def test_async_idle_watcher_logs_correlated_probe_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    instance = TerminalInstance(
+        name="runtime",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+        keep_alive_after_exit=True,
+    )
+    instance._remember_pane_snapshot("private-terminal-output")
+
+    async def fail_probe(*args: str) -> str:
+        raise RuntimeError("no server running")
+
+    async def session_missing() -> bool:
+        return False
+
+    monkeypatch.setattr(instance, "_tmux_output", fail_probe)
+    monkeypatch.setattr(instance, "_tmux_session_exists_async", session_missing)
+    monkeypatch.setattr(terminal_mod, "_IDLE_POLL_INTERVAL_SECONDS", 0.001)
+    await asyncio.wait_for(instance._idle_watch_loop(lambda: None), timeout=1.0)
+
+    records = [record for record in caplog.records if record.name == terminal_mod.__name__]
+    assert len(records) == 4
+    assert {record.attributes["terminal_instance_id"] for record in records} == {
+        instance.diagnostic_id
+    }
+    attributes = records[-1].attributes
+    assert attributes["consecutive_probe_failures"] == 3
+    assert attributes["keep_alive_after_exit"] is True
+    assert attributes["pane_output_seen"] is True
+    assert attributes["last_capture_age_ms"] >= 0
+    assert "private-terminal-output" not in str(attributes)
+    assert str(tmp_path) not in str(attributes)
 
 
 def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> None:
@@ -249,6 +296,9 @@ def test_capture_probe_logs_command_return_code_and_stderr(
     assert str(instance.socket_path) in message
     assert "capture-pane -t main -p -e" in message
     assert "fork failed: resource temporarily unavailable" in message
+    record = next(record for record in caplog.records if record.name == terminal_mod.__name__)
+    assert record.event_name == "terminal_probe_failed"
+    assert record.attributes["terminal_instance_id"] == instance.diagnostic_id
 
 
 def test_threaded_idle_watcher_fires_on_tick_each_poll(tmp_path: Path) -> None:

--- a/tests/runner/test_resource_registry.py
+++ b/tests/runner/test_resource_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -151,6 +152,7 @@ def test_list_resources_filters_by_type(tmp_path: Path) -> None:
 async def test_terminal_resource_role_is_private_and_cleared_on_close(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """
     Terminal role markers stay private and follow close lifecycle.
@@ -222,10 +224,19 @@ async def test_terminal_resource_role_is_private_and_cleared_on_close(
     assert "command" not in view.metadata
     assert "args" not in view.metadata
 
-    closed = await registry.close_terminal("conv_codex", view.id)
+    with caplog.at_level(logging.INFO, logger="omnigent.runner.resource_registry"):
+        closed = await registry.close_terminal("conv_codex", view.id)
 
     assert closed is True
     assert registry.terminal_resource_role("conv_codex", view.id) is None
+    record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event_name", None) == "terminal_close_requested"
+    )
+    assert record.session_id == "conv_codex"
+    assert record.attributes["terminal_id"] == view.id
+    assert record.attributes["terminal_instance_id"] == instance.diagnostic_id
 
 
 @pytest.mark.asyncio
@@ -311,8 +322,11 @@ async def test_terminal_lifecycle_cannot_change_after_observe(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_auxiliary_terminal_exit_publishes_resource_exit_only(tmp_path: Path) -> None:
+async def test_auxiliary_terminal_exit_publishes_resource_exit_only(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Auxiliary terminal exit is reported with auxiliary lifecycle metadata."""
+    caplog.set_level(logging.INFO, logger="omnigent.runner.resource_registry")
     terminal_registry = TerminalRegistry()
     registry = SessionResourceRegistry(terminal_registry=terminal_registry)
     instance = make_test_terminal_instance("sidecar", "s1", tmp_path)
@@ -359,6 +373,18 @@ async def test_auxiliary_terminal_exit_publishes_resource_exit_only(tmp_path: Pa
     assert exits[0].cwd == str(tmp_path)
     assert exits[0].last_output == "startup failed\nretry login"
     assert terminal_registry.get("conv_exit", "sidecar", "s1") is None
+    record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event_name", None) == "terminal_exit_observed"
+    )
+    assert record.session_id == "conv_exit"
+    assert record.attributes["terminal_lifecycle"] == "auxiliary"
+    assert record.attributes["terminal_instance_id"] == instance.diagnostic_id
+    assert record.attributes["session_status_before_exit"] == "unknown"
+    assert record.attributes["superseded"] is False
+    assert "startup failed" not in str(record.attributes)
+    assert str(tmp_path) not in str(record.attributes)
 
 
 async def _observe_native_agent_terminal_and_capture(
@@ -675,7 +701,9 @@ async def test_pty_edges_drive_status_when_poller_inactive(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_required_terminal_exit_while_idle_is_clean_shutdown(tmp_path: Path) -> None:
+async def test_required_terminal_exit_while_idle_is_clean_shutdown(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """A required terminal that exits after going idle is not a failure.
 
     The native agent terminal is long-lived: it goes ``idle`` when its turn
@@ -689,6 +717,7 @@ async def test_required_terminal_exit_while_idle_is_clean_shutdown(tmp_path: Pat
     terminal_registry = TerminalRegistry()
     registry = SessionResourceRegistry(terminal_registry=terminal_registry)
     instance = make_test_terminal_instance("claude", "main", tmp_path)
+    caplog.set_level(logging.INFO, logger="omnigent.runner.resource_registry")
     terminal_registry._by_conversation.setdefault("conv_idle", {})[("claude", "main")] = instance
     exits: list[TerminalExitEvent] = []
     exit_published = asyncio.Event()
@@ -717,10 +746,20 @@ async def test_required_terminal_exit_while_idle_is_clean_shutdown(tmp_path: Pat
     assert len(exits) == 1
     assert exits[0].lifecycle == TerminalLifecycle.REQUIRED
     assert exits[0].session_was_idle is True
+    record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event_name", None) == "terminal_exit_observed"
+    )
+    assert record.session_id == "conv_idle"
+    assert record.attributes["terminal_lifecycle"] == "required"
+    assert record.attributes["session_status_before_exit"] == "idle"
 
 
 @pytest.mark.asyncio
-async def test_required_terminal_exit_while_running_is_failure(tmp_path: Path) -> None:
+async def test_required_terminal_exit_while_running_is_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """A required terminal that vanishes mid-turn is still a failure.
 
     When the last PTY-status edge was ``running``, the pane disappeared while
@@ -732,6 +771,7 @@ async def test_required_terminal_exit_while_running_is_failure(tmp_path: Path) -
     terminal_registry = TerminalRegistry()
     registry = SessionResourceRegistry(terminal_registry=terminal_registry)
     instance = make_test_terminal_instance("claude", "main", tmp_path)
+    caplog.set_level(logging.INFO, logger="omnigent.runner.resource_registry")
     terminal_registry._by_conversation.setdefault("conv_run", {})[("claude", "main")] = instance
     exits: list[TerminalExitEvent] = []
     exit_published = asyncio.Event()
@@ -755,6 +795,12 @@ async def test_required_terminal_exit_while_running_is_failure(tmp_path: Path) -
 
     assert len(exits) == 1
     assert exits[0].session_was_idle is False
+    record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event_name", None) == "terminal_exit_observed"
+    )
+    assert record.attributes["session_status_before_exit"] == "running"
 
 
 def test_trim_terminal_output_drops_whole_leading_lines() -> None:


### PR DESCRIPTION
## Related issue

N/A — diagnostic logging chore.

## Summary

A tmux probe failure alone does not say whether a required agent terminal disappeared, an auxiliary terminal closed, or an old instance was replaced. Correlate probe warnings with main's terminal-unavailable diagnostics and add owning-session lifecycle records for observed exits and explicit close requests. Record required/auxiliary lifecycle, prior session status, exit status when known, and replacement state.

The shared instance identifier ties these records together, including child sessions:

```text
probe warning -> terminal unavailable
                         | same terminal_instance_id
                         v
              owning session + lifecycle + prior status
```

## Test Plan

- `uv run --no-sync pytest tests/inner/test_terminal.py tests/runner/test_resource_registry.py -q` — 130 passed against main `06c5ea016cd350260105e1696769f69aa5cca83e`.
- Coverage includes async/threaded probes, required/auxiliary terminals, idle/running state, replacements, explicit closes, and attribute privacy.
- All applicable pre-commit hooks passed, including full-project Pyrefly. The worktree has its own dependency environment.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A for visual media. Follow `docs/terminal-lifecycle-diagnostics.md`: run `omnidev`, close a disposable terminal, and find its `terminal_close_requested` record. Correlate naturally occurring probe failures and `terminal_exit_observed` records by `attributes['terminal_instance_id']`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The refresh preserves main's richer probe-history diagnostics and adds no probes or severity changes. Watcher rows can inherit a primary session; the lifecycle record supplies the actual owning session. New attributes contain no raw pane text or command arguments. No production deployment or live-session interruption was performed.

## Changelog

N/A — diagnostic logging and documentation only.
