### PR TITLE
chore(claude-native): annotate prompt-readiness timeouts

### DIFF
--- a/docs/claude-readiness-diagnostics.md
+++ b/docs/claude-readiness-diagnostics.md
@@ -1,0 +1,43 @@
+# Claude prompt-readiness diagnostics
+
+The existing prompt-delivery timeout error gains structured diagnostics. Timeout
+length, error severity, cleanup behavior, and dashboard exclusions are unchanged.
+Deploy the updated runner/harness code before expecting these fields; historical
+logs are unchanged.
+
+The debug-log sink stores `event_name` separately and serializes non-null
+`attributes` values as strings. Booleans appear as `True` or `False`.
+
+## Event and fields
+
+`harness_prompt_delivery_timeout` includes:
+
+- The owning `session_id` and `harness`.
+- `delivery_operation`: `model_switch` or `message_delivery`.
+- `message_delivered` and `cleanup_succeeded`.
+- `readiness_stage`, `readiness_timeout_s`, `readiness_elapsed_ms`,
+  `readiness_polls`, `readiness_empty_captures`, and
+  `readiness_last_capture_empty`.
+- `readiness_*_visible` signals for config setup, authentication flows, fullscreen
+  prompts, external-import prompts, confirmation dialogs, and a dead pane.
+
+Visibility signals describe the last nonempty capture observed during the wait.
+They can overlap and are clues, not proven causes: text may still be visible after
+a setup step completed. No extra capture or subprocess runs at timeout. For
+example, all-empty captures differ from a consistently visible setup dialog.
+`cleanup_succeeded=True` also covers a terminal that was already absent.
+
+The new attributes contain no terminal text, user prompts, or credentials.
+Existing human-readable error messages and exception tails are unchanged.
+
+## Verification
+
+```sh
+uv run --no-sync pytest -q tests/inner/test_claude_native_executor.py tests/test_claude_native_bridge.py
+```
+
+For a manual check, start `omnidev` and use a disposable session. If Claude is
+waiting on a startup/login dialog, send a web-chat message and let the readiness
+timeout occur. Inspect `harness_prompt_delivery_timeout` in the debug-log table:
+verify the session, delivery operation, poll counts, visibility signals, and
+cleanup result. Do not dismiss approval dialogs automatically just to test logs.

--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -418,6 +418,10 @@ def validate_claude_hook_interpreter_compatibility(
 class ClaudePromptTimeout(RuntimeError):
     """Claude Code's input box did not render before delivery timed out."""
 
+    def __init__(self, message: str, *, diagnostics: dict[str, object] | None = None) -> None:
+        super().__init__(message)
+        self.diagnostics = dict(diagnostics or {})
+
 
 class TmuxSessionNotAdvertised(RuntimeError):
     """The bridge's tmux target was not advertised before the deadline."""
@@ -4884,6 +4888,29 @@ def _format_terminal_failure_tail(pane: str) -> str:
     return f" Last terminal output:\n{tail}"
 
 
+def _readiness_observations(pane: str) -> dict[str, object]:
+    """Return bounded visibility signals, not inferred causes or terminal text."""
+    normalized = pane.casefold()
+    return {
+        "readiness_config_setup_visible": any(
+            marker in normalized
+            for marker in ("generating claude-code mcp client config", "managed settings drift")
+        ),
+        "readiness_auth_flow_visible": any(
+            marker in normalized
+            for marker in ("dbcert:", "logging in via sso", "oauth2/v1/authorize")
+        ),
+        "readiness_fullscreen_prompt_visible": "try the new fullscreen renderer?" in normalized,
+        "readiness_external_import_prompt_visible": (
+            "allow external claude.md file imports?" in normalized
+        ),
+        "readiness_dialog_visible": any(
+            marker in normalized for marker in ("enter to confirm", "enter to continue")
+        ),
+        "readiness_dead_pane_visible": "pane is dead" in normalized,
+    }
+
+
 def _wait_for_claude_prompt_ready(
     socket_path: str,
     tmux_target: str,
@@ -4919,7 +4946,8 @@ def _wait_for_claude_prompt_ready(
         a startup crash, a torn/empty capture under a mid-turn repaint, or
         a box that never appeared — is diagnosable from the error alone.
     """
-    deadline = time.monotonic() + timeout_s
+    started_at = time.monotonic()
+    deadline = started_at + timeout_s
     polls = 0
     empty_polls = 0
     # Keep the last non-empty capture the loop actually saw, not a fresh
@@ -4952,7 +4980,16 @@ def _wait_for_claude_prompt_ready(
         f"Claude Code terminal did not become ready within {timeout_s}s "
         f"(input prompt never rendered in {polls} polls, "
         f"{empty_polls} empty captures). The message was not delivered."
-        + _format_terminal_failure_tail(last_nonempty)
+        + _format_terminal_failure_tail(last_nonempty),
+        diagnostics={
+            "readiness_stage": "input_prompt",
+            "readiness_timeout_s": timeout_s,
+            "readiness_elapsed_ms": round((time.monotonic() - started_at) * 1000),
+            "readiness_polls": polls,
+            "readiness_empty_captures": empty_polls,
+            "readiness_last_capture_empty": not bool(pane.strip()),
+            **_readiness_observations(last_nonempty),
+        },
     )
 
 

--- a/omnigent/inner/claude_native_executor.py
+++ b/omnigent/inner/claude_native_executor.py
@@ -200,6 +200,7 @@ class ClaudeNativeExecutor(Executor):
         # ``/model`` only accepts this session's aliases / custom slot; a
         # bare catalog id is ignored and the pane keeps its old model.
         wanted_model_arg = self._model_command_arg(wanted_model)
+        delivery_operation = "model_switch" if wanted_model_arg is not None else "message_delivery"
         try:
             with telemetry.span("claude_native.inject"):
                 async with self._inject_lock:
@@ -219,17 +220,28 @@ class ClaudeNativeExecutor(Executor):
                         # Track the routed id, not the alias: the next turn's
                         # comparison is against what routing asked for.
                         self._applied_model = wanted_model
+                    delivery_operation = "message_delivery"
                     await asyncio.to_thread(
                         inject_user_message,
                         self._bridge_dir,
                         content=text,
                     )
         except ClaudePromptTimeout as exc:
+            cleanup_error = self._reap_failed_turn()
             _logger.exception(
                 "claude-native: prompt delivery to harness timed out",
-                extra={"session_id": self._request_session_id},
+                extra={
+                    "event_name": "harness_prompt_delivery_timeout",
+                    "session_id": self._request_session_id,
+                    "attributes": {
+                        **exc.diagnostics,
+                        "harness": "claude-native",
+                        "delivery_operation": delivery_operation,
+                        "message_delivered": False,
+                        "cleanup_succeeded": cleanup_error is None,
+                    },
+                },
             )
-            cleanup_error = self._reap_failed_turn()
             message = describe_exception(exc)
             if cleanup_error is not None:
                 message = f"{message} Cleanup also failed: {cleanup_error}"

--- a/tests/inner/test_claude_native_executor.py
+++ b/tests/inner/test_claude_native_executor.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 import threading
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from omnigent.debug_logging import record_to_row
 from omnigent.harnesses.claude_native.bridge import (
     REQUEST_SESSION_ID_ENV_VAR,
     ClaudePromptTimeout,
@@ -1334,19 +1336,29 @@ async def test_a_routed_first_message_switches_the_model_exactly_once(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("delivery_operation", ["message_delivery", "model_switch"])
 async def test_run_turn_reaps_tmux_before_reporting_prompt_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    delivery_operation: str,
 ) -> None:
     """A readiness timeout cannot leave a failed turn's pane alive."""
     bridge_dir = tmp_path / "bridge"
     killed: list[Path] = []
 
-    def fail_inject(bridge_dir_arg: Path, *, content: str, timeout_s: float = 30.0) -> None:
-        del bridge_dir_arg, content, timeout_s
-        raise ClaudePromptTimeout("terminal did not become ready")
+    def fail_inject(bridge_dir_arg: Path, **kwargs: object) -> None:
+        del bridge_dir_arg, kwargs
+        raise ClaudePromptTimeout(
+            "terminal did not become ready",
+            diagnostics={"readiness_polls": 199, "readiness_timeout_s": 30.0},
+        )
 
     monkeypatch.setattr(claude_native_executor, "inject_user_message", fail_inject)
+    monkeypatch.setenv(REQUEST_SESSION_ID_ENV_VAR, "conv_timeout")
+    if delivery_operation == "model_switch":
+        monkeypatch.setattr(claude_native_executor, "inject_slash_command", fail_inject)
+        monkeypatch.setattr(ClaudeNativeExecutor, "_model_command_arg", lambda self, model: "test")
     monkeypatch.setattr(
         claude_native_executor,
         "kill_session",
@@ -1366,6 +1378,18 @@ async def test_run_turn_reaps_tmux_before_reporting_prompt_timeout(
     assert killed == [bridge_dir]
     assert len(events) == 1
     assert isinstance(events[0], ExecutorError)
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert len(errors) == 1
+    row = record_to_row(errors[0], "harness")
+    assert row["event_name"] == "harness_prompt_delivery_timeout"
+    assert row["session_id"] == "conv_timeout"
+    attributes = row["attributes"]
+    assert isinstance(attributes, dict)
+    assert attributes["delivery_operation"] == delivery_operation
+    assert attributes["message_delivered"] == "False"
+    assert attributes["cleanup_succeeded"] == "True"
+    assert attributes["readiness_polls"] == "199"
+    assert attributes["readiness_timeout_s"] == "30.0"
 
 
 @pytest.mark.asyncio
@@ -1405,6 +1429,7 @@ async def test_run_turn_does_not_reap_unrelated_runtime_error(
 async def test_run_turn_reports_reap_failure_with_prompt_timeout(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A failed hard-stop remains visible beside the delivery error."""
 
@@ -1432,6 +1457,12 @@ async def test_run_turn_reports_reap_failure_with_prompt_timeout(
     assert isinstance(events[0], ExecutorError)
     assert "terminal did not become ready" in events[0].message
     assert "Cleanup also failed: tmux kill failed" in events[0].message
+    timeout_record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event_name", None) == "harness_prompt_delivery_timeout"
+    )
+    assert timeout_record.attributes["cleanup_succeeded"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -8143,6 +8143,43 @@ def test_format_terminal_failure_tail_caps_length(monkeypatch: pytest.MonkeyPatc
     assert len(body) <= 51
 
 
+@pytest.mark.parametrize(
+    ("pane", "signal"),
+    [
+        ("Generating claude-code MCP client config...", "readiness_config_setup_visible"),
+        ("Managed settings drift detected", "readiness_config_setup_visible"),
+        ("dbcert: Logging in via SSO...", "readiness_auth_flow_visible"),
+        ("Try the new fullscreen renderer?", "readiness_fullscreen_prompt_visible"),
+        ("Allow external CLAUDE.md file imports?", "readiness_external_import_prompt_visible"),
+        ("Enter to confirm", "readiness_dialog_visible"),
+        ("Pane is dead (status 0)", "readiness_dead_pane_visible"),
+    ],
+)
+def test_readiness_timeout_has_structured_observations_without_pane_contents(
+    monkeypatch: pytest.MonkeyPatch, pane: str, signal: str
+) -> None:
+    monkeypatch.setattr(
+        claude_native_bridge,
+        "_capture_pane",
+        lambda socket_path, tmux_target: pane + "\nprivate-terminal-content",
+    )
+    with pytest.raises(claude_native_bridge.ClaudePromptTimeout) as excinfo:
+        claude_native_bridge._wait_for_claude_prompt_ready(
+            "/tmp/example/tmux.sock", "main", timeout_s=0.0
+        )
+
+    diagnostics = excinfo.value.diagnostics
+    assert diagnostics["readiness_stage"] == "input_prompt"
+    assert diagnostics["readiness_polls"] == 1
+    assert diagnostics["readiness_empty_captures"] == 0
+    assert diagnostics["readiness_last_capture_empty"] is False
+    assert diagnostics["readiness_timeout_s"] == 0.0
+    assert diagnostics["readiness_elapsed_ms"] >= 0
+    assert diagnostics[signal] is True
+    assert "private-terminal-content" not in str(diagnostics)
+    assert pane not in str(diagnostics)
+
+
 def test_wait_for_claude_prompt_ready_surfaces_terminal_output_on_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -8198,7 +8235,7 @@ def test_wait_for_claude_prompt_ready_reports_empty_capture_count(
         "omnigent.harnesses.claude_native.bridge._capture_pane",
         lambda socket_path, tmux_target: "",
     )
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(claude_native_bridge.ClaudePromptTimeout) as excinfo:
         claude_native_bridge._wait_for_claude_prompt_ready(
             "/tmp/example/tmux.sock",
             "claude:0.0",
@@ -8210,6 +8247,9 @@ def test_wait_for_claude_prompt_ready_reports_empty_capture_count(
     assert "1 polls, 1 empty captures" in message
     # No pane text to surface when every capture was empty.
     assert "Last terminal output:" not in message
+    assert excinfo.value.diagnostics["readiness_polls"] == 1
+    assert excinfo.value.diagnostics["readiness_empty_captures"] == 1
+    assert excinfo.value.diagnostics["readiness_last_capture_empty"] is True
 
 
 def test_wait_for_claude_prompt_ready_tail_is_observed_not_recaptured(


### PR DESCRIPTION
## Related issue

N/A — diagnostic logging chore.

## Summary

- Prompt-readiness timeouts currently require reading terminal tails to distinguish blank captures, startup/config work, authentication, and blocking dialogs. Attach bounded visibility signals and poll/timing counters to the timeout exception.
- Annotate the existing executor error with delivery operation and cleanup outcome. Use only captures already observed during the wait; preserve the timeout and error text, and add no raw prompt/terminal/credential attributes.

ELI5: explain what the bridge observed while waiting, without copying more private terminal output into logs.

```text
observed pane + poll counters -> readiness timeout
                                    |
                                    v
                   delivery operation + cleanup outcome -> structured error
```

## Test Plan

- `uv run --no-sync pytest -q tests/inner/test_claude_native_executor.py tests/test_claude_native_bridge.py` — 400 passed.
- Cover setup/auth/dialog/dead-pane observations, empty captures, model-switch versus message delivery, cleanup failure, and serialization into the debug-log attributes map.
- Ruff and changed-file Pyrefly checks pass.
- `pre-commit run` was run before committing. Its full-project Pyrefly check is blocked by the existing `object` versus `Config | None` error at `omnigent/harnesses/opencode_native/provider.py:363`; the file is unchanged and checking it separately reproduces the error. Other applicable hooks pass. Keeping this PR draft until that baseline issue is resolved.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — no UI changes. Tests assert serialized fields and existing error behavior; the guide describes inspecting a timeout in a disposable development session.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The complete bridge/executor suites pass on this independent branch. Visibility signals can overlap and describe observations, not proven root causes. Existing exception tails are unchanged. No live login flow was interrupted and the logging is not deployed.

## Changelog

Claude prompt-delivery errors now expose readiness observations, poll counts, and cleanup outcome.
