### PR TITLE
fix: bound managed sandbox reaper scans

### DIFF
--- a/omnigent/db/db_models.py
+++ b/omnigent/db/db_models.py
@@ -1367,7 +1367,7 @@ class SqlHost(OmnigentBase):
     sandbox_provider: Mapped[str | None] = mapped_column(String(32), nullable=True)
     sandbox_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
     terminating_sandbox_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
-    deleted_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    deleted_at: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     # Opaque; never SQL-filtered — stored compressed (CompressedText).
     configured_harnesses: Mapped[str | None] = mapped_column(CompressedText, nullable=True)
 
@@ -1381,6 +1381,13 @@ class SqlHost(OmnigentBase):
         # rotation) stays consistent.
         UniqueConstraint(
             "workspace_id", "user_id", "name", name="uq_hosts_workspace_user_id_name"
+        ),
+        Index("ix_hosts_sandbox_scan", "sandbox_id", "workspace_id", "host_id"),
+        Index(
+            "ix_hosts_terminating_sandbox_scan",
+            "terminating_sandbox_id",
+            "workspace_id",
+            "host_id",
         ),
     )
 

--- a/omnigent/db/migrations/versions/gg1b2c3d4e5f_widen_hosts_deleted_at_and_index_reaper_scans.py
+++ b/omnigent/db/migrations/versions/gg1b2c3d4e5f_widen_hosts_deleted_at_and_index_reaper_scans.py
@@ -1,0 +1,66 @@
+"""Widen hosts.deleted_at and index managed-sandbox reaper scans.
+
+Revision ID: gg1b2c3d4e5f
+Revises: gf1b2c3d4e5f
+Create Date: 2026-09-10 00:00:00.000000
+
+Unix epoch seconds exceed a signed 32-bit integer in 2038. Keep the logical
+deletion timestamp consistent with the other 64-bit host timestamps. Index
+the active and terminating sandbox-id slots so the reaper can traverse each
+slot in bounded keyset pages instead of running cross-column OR scans.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "gg1b2c3d4e5f"
+down_revision: str | None = "gf1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Widen the timestamp and add reaper traversal indexes."""
+    inspector = sa.inspect(op.get_bind())
+    deleted_at_type = next(
+        column["type"]
+        for column in inspector.get_columns("hosts")
+        if column["name"] == "deleted_at"
+    )
+    existing_indexes = {index["name"] for index in inspector.get_indexes("hosts")}
+
+    with op.batch_alter_table("hosts") as batch_op:
+        if not isinstance(deleted_at_type, sa.BigInteger):
+            batch_op.alter_column(
+                "deleted_at",
+                existing_type=sa.Integer(),
+                type_=sa.BigInteger(),
+                existing_nullable=True,
+            )
+        if "ix_hosts_sandbox_scan" not in existing_indexes:
+            batch_op.create_index(
+                "ix_hosts_sandbox_scan",
+                ["sandbox_id", "workspace_id", "host_id"],
+            )
+        if "ix_hosts_terminating_sandbox_scan" not in existing_indexes:
+            batch_op.create_index(
+                "ix_hosts_terminating_sandbox_scan",
+                ["terminating_sandbox_id", "workspace_id", "host_id"],
+            )
+
+
+def downgrade() -> None:
+    """Drop reaper indexes and restore the 32-bit timestamp."""
+    with op.batch_alter_table("hosts") as batch_op:
+        batch_op.drop_index("ix_hosts_terminating_sandbox_scan")
+        batch_op.drop_index("ix_hosts_sandbox_scan")
+        batch_op.alter_column(
+            "deleted_at",
+            existing_type=sa.BigInteger(),
+            type_=sa.Integer(),
+            existing_nullable=True,
+        )

--- a/omnigent/server/managed_sandbox_reaper.py
+++ b/omnigent/server/managed_sandbox_reaper.py
@@ -13,21 +13,28 @@ from omnigent.server.managed_hosts import (
     ManagedSandboxDeployment,
     _launcher_for_teardown,
 )
-from omnigent.stores.host_store import Host, HostStore, host_is_live
+from omnigent.stores.host_store import (
+    Host,
+    HostStore,
+    ManagedSandboxScanCursor,
+    ManagedSandboxScanRow,
+    host_is_live,
+)
 
 _logger = logging.getLogger(__name__)
 
 _SECONDS_PER_DAY = 24 * 60 * 60
+_DEFAULT_SCAN_BATCH_SIZE = 500
 
 
 class ManagedSandboxReaper:
     """Reap stale generations and retry pending provider cleanup.
 
-    Each loop covers the whole configured deployment. A sweep discovers every
-    workspace containing an active or pending managed sandbox, then queries
-    candidates within that workspace. Offline age comes from the host heartbeat
-    row, which is the persisted source of truth for when the sandbox was last
-    online.
+    Each loop traverses both persisted sandbox-id slots in bounded keyset pages.
+    The traversal is deterministic and complete rather than random: every
+    current or pending generation present when its page is reached is examined.
+    Offline age comes from the host heartbeat row, which is the persisted source
+    of truth for when the sandbox was last online.
 
     Reaping detaches only the stale provider generation. The session transcript
     and durable host row remain, allowing a fresh sandbox to launch while failed
@@ -40,10 +47,14 @@ class ManagedSandboxReaper:
         host_store: HostStore,
         sandbox_config: ManagedSandboxDeployment,
         clock: Callable[[], int] = now_epoch,
+        scan_batch_size: int = _DEFAULT_SCAN_BATCH_SIZE,
     ) -> None:
+        if scan_batch_size <= 0:
+            raise ValueError("scan_batch_size must be positive")
         self._host_store = host_store
         self._sandbox_config = sandbox_config
         self._clock = clock
+        self._scan_batch_size = scan_batch_size
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
@@ -68,23 +79,12 @@ class ManagedSandboxReaper:
     async def sweep_once(self, *, now: int | None = None) -> int:
         """Run one complete cross-workspace sweep and return the reap count."""
         reference_time = self._clock() if now is None else now
-        workspace_ids = await asyncio.to_thread(
-            self._host_store.list_managed_sandbox_workspace_ids
+        cutoff = (
+            reference_time
+            - self._sandbox_config.reaper.terminate_after_offline_days * _SECONDS_PER_DAY
         )
-        reaped = 0
-        for workspace_id in workspace_ids:
-            try:
-                reaped += await self._sweep_current_workspace(
-                    workspace_id,
-                    reference_time,
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                _logger.exception(
-                    "Managed sandbox reaper failed for workspace %s; continuing",
-                    workspace_id,
-                )
+        reaped = await self._sweep_terminating_slot(cutoff=cutoff, now=reference_time)
+        reaped += await self._sweep_current_slot(cutoff=cutoff, now=reference_time)
         return reaped
 
     async def _run(self) -> None:
@@ -99,22 +99,65 @@ class ManagedSandboxReaper:
                 _logger.exception("Managed sandbox reaper sweep failed; retrying later")
             await asyncio.sleep(self._sandbox_config.reaper.sweep_interval_s)
 
-    async def _sweep_current_workspace(self, workspace_id: int, now: int) -> int:
-        cutoff = now - self._sandbox_config.reaper.terminate_after_offline_days * _SECONDS_PER_DAY
-        hosts = await asyncio.to_thread(
-            self._list_stale_managed_sandbox_hosts,
-            workspace_id,
-            cutoff,
-        )
-        grouped: dict[str, list[Host]] = {}
-        for host in hosts:
+    async def _sweep_terminating_slot(self, *, cutoff: int, now: int) -> int:
+        cursor: ManagedSandboxScanCursor | None = None
+        reaped = 0
+        while True:
+            page = await asyncio.to_thread(
+                self._host_store.list_terminating_managed_sandbox_hosts_page,
+                after=cursor,
+                limit=self._scan_batch_size,
+            )
+            if not page:
+                break
+            workspace_id, last = page[-1]
+            terminating_sandbox_id = last.terminating_sandbox_id
+            assert terminating_sandbox_id is not None
+            cursor = (terminating_sandbox_id, workspace_id, last.host_id)
+            reaped += await self._reap_page(page, cutoff=cutoff, now=now, current_slot=False)
+            if len(page) < self._scan_batch_size:
+                break
+        return reaped
+
+    async def _sweep_current_slot(self, *, cutoff: int, now: int) -> int:
+        cursor: ManagedSandboxScanCursor | None = None
+        reaped = 0
+        while True:
+            page = await asyncio.to_thread(
+                self._host_store.list_current_managed_sandbox_hosts_page,
+                after=cursor,
+                limit=self._scan_batch_size,
+            )
+            if not page:
+                break
+            workspace_id, last = page[-1]
+            sandbox_id = last.sandbox_id
+            assert sandbox_id is not None
+            cursor = (sandbox_id, workspace_id, last.host_id)
+            reaped += await self._reap_page(page, cutoff=cutoff, now=now, current_slot=True)
+            if len(page) < self._scan_batch_size:
+                break
+        return reaped
+
+    async def _reap_page(
+        self,
+        page: list[ManagedSandboxScanRow],
+        *,
+        cutoff: int,
+        now: int,
+        current_slot: bool,
+    ) -> int:
+        grouped: dict[tuple[int, str], list[Host]] = {}
+        for workspace_id, host in sorted(page, key=self._page_reap_order):
+            if current_slot and host.terminating_sandbox_id is not None:
+                continue
             if not self._is_reap_candidate(host, cutoff=cutoff, now=now):
                 continue
             assert host.sandbox_provider is not None
-            grouped.setdefault(host.sandbox_provider, []).append(host)
+            grouped.setdefault((workspace_id, host.sandbox_provider), []).append(host)
 
         reaped = 0
-        for provider, candidates in grouped.items():
+        for (workspace_id, provider), candidates in grouped.items():
             try:
                 reaped += await asyncio.to_thread(
                     self._reap_group,
@@ -134,13 +177,11 @@ class ManagedSandboxReaper:
                 )
         return reaped
 
-    def _list_stale_managed_sandbox_hosts(
-        self,
-        workspace_id: int,
-        cutoff: int,
-    ) -> list[Host]:
-        with workspace_scope(workspace_id):
-            return self._host_store.list_stale_managed_sandbox_hosts(cutoff)
+    @staticmethod
+    def _page_reap_order(row: ManagedSandboxScanRow) -> tuple[int, int, str]:
+        workspace_id, host = row
+        relevant_at = host.deleted_at if host.deleted_at is not None else host.updated_at
+        return relevant_at, workspace_id, host.host_id
 
     def _reap_group(
         self,

--- a/omnigent/stores/host_store.py
+++ b/omnigent/stores/host_store.py
@@ -18,7 +18,7 @@ import logging
 from dataclasses import dataclass
 from typing import cast
 
-from sqlalchemy import Engine, and_, or_, select, update
+from sqlalchemy import Engine, or_, select, tuple_, update
 from sqlalchemy import delete as sql_delete
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
@@ -98,6 +98,10 @@ class Host:
     configured_harnesses: dict[str, HarnessAvailability] | None = None
     terminating_sandbox_id: str | None = None
     deleted_at: int | None = None
+
+
+ManagedSandboxScanCursor = tuple[str, int, str]
+ManagedSandboxScanRow = tuple[int, Host]
 
 
 def host_is_live(host: Host, now: int | None = None) -> bool:
@@ -726,58 +730,83 @@ class HostStore:
             )
             return [_row_to_host(row) for row in rows]
 
-    def list_managed_sandbox_workspace_ids(self) -> list[int]:
-        """List workspaces with active or pending managed sandbox generations.
+    def list_current_managed_sandbox_hosts_page(
+        self,
+        *,
+        after: ManagedSandboxScanCursor | None,
+        limit: int,
+    ) -> list[ManagedSandboxScanRow]:
+        """Page through hosts whose current sandbox-id slot is populated.
 
-        This is the privileged discovery query used by the server-wide managed
-        sandbox reaper. Unlike normal request-path store methods, it
-        intentionally spans workspace partitions; the reaper immediately enters
-        each returned :func:`workspace_scope` before reading sessions or hosts.
+        This privileged reaper scan intentionally spans workspaces. Ordering by
+        the indexed ``(sandbox_id, workspace_id, host_id)`` tuple makes every
+        query bounded while allowing a complete deterministic traversal.
 
-        :returns: Workspace ids in ascending order.
+        :param after: Exclusive keyset cursor from the prior page.
+        :param limit: Maximum rows returned by this query.
+        :returns: ``(workspace_id, host)`` rows in cursor order.
         """
-        with self._session("list_managed_sandbox_workspaces") as session:
-            return list(
-                session.execute(
-                    select(SqlHost.workspace_id)
-                    .where(
-                        SqlHost.sandbox_provider.is_not(None),
-                        or_(
-                            SqlHost.sandbox_id.is_not(None),
-                            SqlHost.terminating_sandbox_id.is_not(None),
-                        ),
-                    )
-                    .distinct()
-                    .order_by(SqlHost.workspace_id.asc())
-                ).scalars()
-            )
-
-    def list_stale_managed_sandbox_hosts(self, older_than_epoch: int) -> list[Host]:
-        """List stale active and pending managed sandboxes in this workspace.
-
-        :param older_than_epoch: Latest included host heartbeat timestamp.
-        :returns: Stale generations ordered from oldest to newest.
-        """
-        with self._session("list_stale_managed_sandbox_hosts") as session:
-            rows = (
-                session.query(SqlHost)
-                .filter(
-                    SqlHost.workspace_id == current_workspace_id(),
-                    SqlHost.sandbox_provider.is_not(None),
-                    or_(
-                        SqlHost.deleted_at.is_not(None),
-                        SqlHost.terminating_sandbox_id.is_not(None),
-                        and_(
-                            SqlHost.terminating_sandbox_id.is_(None),
-                            SqlHost.sandbox_id.is_not(None),
-                            SqlHost.updated_at <= older_than_epoch,
-                        ),
-                    ),
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        with self._session("list_current_managed_sandbox_hosts_page") as session:
+            stmt = (
+                select(SqlHost)
+                .where(SqlHost.sandbox_id.is_not(None))
+                .order_by(
+                    SqlHost.sandbox_id.asc(),
+                    SqlHost.workspace_id.asc(),
+                    SqlHost.host_id.asc(),
                 )
-                .order_by(SqlHost.updated_at.asc(), SqlHost.host_id.asc())
-                .all()
+                .limit(limit)
             )
-            return [_row_to_host(row) for row in rows]
+            if after is not None:
+                stmt = stmt.where(
+                    tuple_(SqlHost.sandbox_id, SqlHost.workspace_id, SqlHost.host_id) > after
+                )
+            rows = session.execute(stmt).scalars().all()
+            return [(row.workspace_id, _row_to_host(row)) for row in rows]
+
+    def list_terminating_managed_sandbox_hosts_page(
+        self,
+        *,
+        after: ManagedSandboxScanCursor | None,
+        limit: int,
+    ) -> list[ManagedSandboxScanRow]:
+        """Page through hosts whose terminating sandbox-id slot is populated.
+
+        This privileged reaper scan intentionally spans workspaces. Ordering by
+        the indexed ``(terminating_sandbox_id, workspace_id, host_id)`` tuple
+        makes every query bounded while allowing a complete deterministic
+        traversal.
+
+        :param after: Exclusive keyset cursor from the prior page.
+        :param limit: Maximum rows returned by this query.
+        :returns: ``(workspace_id, host)`` rows in cursor order.
+        """
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        with self._session("list_terminating_managed_sandbox_hosts_page") as session:
+            stmt = (
+                select(SqlHost)
+                .where(SqlHost.terminating_sandbox_id.is_not(None))
+                .order_by(
+                    SqlHost.terminating_sandbox_id.asc(),
+                    SqlHost.workspace_id.asc(),
+                    SqlHost.host_id.asc(),
+                )
+                .limit(limit)
+            )
+            if after is not None:
+                stmt = stmt.where(
+                    tuple_(
+                        SqlHost.terminating_sandbox_id,
+                        SqlHost.workspace_id,
+                        SqlHost.host_id,
+                    )
+                    > after
+                )
+            rows = session.execute(stmt).scalars().all()
+            return [(row.workspace_id, _row_to_host(row)) for row in rows]
 
     def get_host(self, host_id: str) -> Host | None:
         """

--- a/tests/db/test_migration_connections.py
+++ b/tests/db/test_migration_connections.py
@@ -34,7 +34,7 @@ def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
 def test_single_alembic_head() -> None:
     script = ScriptDirectory.from_config(_build_alembic_config("sqlite://"))
     heads = script.get_heads()
-    assert heads == ["gf1b2c3d4e5f"], f"expected a single head, got {heads!r}"
+    assert heads == ["gg1b2c3d4e5f"], f"expected a single head, got {heads!r}"
 
 
 def test_upgrade_creates_table_downgrade_drops_it(tmp_path: Path) -> None:

--- a/tests/db/test_migration_managed_sandbox_deleted_at.py
+++ b/tests/db/test_migration_managed_sandbox_deleted_at.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sqlalchemy as sa
 from alembic import command
 
+from omnigent.db.db_models import SqlHost
 from omnigent.db.utils import _build_alembic_config, clear_engine_cache
 
 
@@ -22,6 +23,14 @@ def _downgrade(uri: str, engine: sa.Engine, revision: str) -> None:
     with engine.begin() as connection:
         config.attributes["connection"] = connection
         command.downgrade(config, revision)
+
+
+def test_hosts_deleted_at_model_uses_big_integer() -> None:
+    assert isinstance(SqlHost.__table__.c.deleted_at.type, sa.BigInteger)
+    assert {
+        "ix_hosts_sandbox_scan",
+        "ix_hosts_terminating_sandbox_scan",
+    }.issubset({index.name for index in SqlHost.__table__.indexes})
 
 
 def test_upgrade_adds_hosts_deleted_at_and_downgrade_removes_it(tmp_path: Path) -> None:
@@ -42,6 +51,87 @@ def test_upgrade_adds_hosts_deleted_at_and_downgrade_removes_it(tmp_path: Path) 
     assert "deleted_at" not in {
         column["name"] for column in sa.inspect(engine).get_columns("hosts")
     }
+
+    engine.dispose()
+    clear_engine_cache()
+
+
+def test_upgrade_widens_hosts_deleted_at_and_preserves_data(tmp_path: Path) -> None:
+    uri = f"sqlite:///{tmp_path / 'managed-sandbox-deleted-at-bigint.db'}"
+    engine = sa.create_engine(uri)
+
+    _migrate(uri, engine, "ge1b2c3d4e5f")
+    columns = {column["name"]: column for column in sa.inspect(engine).get_columns("hosts")}
+    assert isinstance(columns["deleted_at"]["type"], sa.Integer)
+    assert not isinstance(columns["deleted_at"]["type"], sa.BigInteger)
+
+    deleted_at = 2_147_483_647
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO hosts (
+                    workspace_id, host_id, user_id, name, status,
+                    created_at, updated_at, deleted_at
+                ) VALUES (
+                    :workspace_id, :host_id, :user_id, :name, :status,
+                    :created_at, :updated_at, :deleted_at
+                )
+                """
+            ),
+            {
+                "workspace_id": 0,
+                "host_id": bytes.fromhex("0123456789abcdef0123456789abcdef"),
+                "user_id": "alice@example.com",
+                "name": "managed-bigint",
+                "status": 2,
+                "created_at": 1,
+                "updated_at": 1,
+                "deleted_at": deleted_at,
+            },
+        )
+
+    _migrate(uri, engine, "gg1b2c3d4e5f")
+    columns = {column["name"]: column for column in sa.inspect(engine).get_columns("hosts")}
+    assert isinstance(columns["deleted_at"]["type"], sa.BigInteger)
+    assert {
+        "ix_hosts_sandbox_scan",
+        "ix_hosts_terminating_sandbox_scan",
+    }.issubset({index["name"] for index in sa.inspect(engine).get_indexes("hosts")})
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text("SELECT deleted_at FROM hosts")) == deleted_at
+
+    _downgrade(uri, engine, "ge1b2c3d4e5f")
+    columns = {column["name"]: column for column in sa.inspect(engine).get_columns("hosts")}
+    assert isinstance(columns["deleted_at"]["type"], sa.Integer)
+    assert not isinstance(columns["deleted_at"]["type"], sa.BigInteger)
+    assert {
+        "ix_hosts_sandbox_scan",
+        "ix_hosts_terminating_sandbox_scan",
+    }.isdisjoint({index["name"] for index in sa.inspect(engine).get_indexes("hosts")})
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text("SELECT deleted_at FROM hosts")) == deleted_at
+
+    engine.dispose()
+    clear_engine_cache()
+
+
+def test_upgrade_tolerates_current_schema_stamped_at_crdb_baseline(tmp_path: Path) -> None:
+    uri = f"sqlite:///{tmp_path / 'managed-sandbox-current-schema.db'}"
+    engine = sa.create_engine(uri)
+
+    _migrate(uri, engine, "gg1b2c3d4e5f")
+    with engine.begin() as connection:
+        connection.execute(sa.text("UPDATE alembic_version SET version_num = 'gf1b2c3d4e5f'"))
+
+    _migrate(uri, engine, "gg1b2c3d4e5f")
+
+    columns = {column["name"]: column for column in sa.inspect(engine).get_columns("hosts")}
+    assert isinstance(columns["deleted_at"]["type"], sa.BigInteger)
+    assert {
+        "ix_hosts_sandbox_scan",
+        "ix_hosts_terminating_sandbox_scan",
+    }.issubset({index["name"] for index in sa.inspect(engine).get_indexes("hosts")})
 
     engine.dispose()
     clear_engine_cache()

--- a/tests/e2e/omnigent/conftest.py
+++ b/tests/e2e/omnigent/conftest.py
@@ -135,6 +135,7 @@ def mock_credentials_env(
     # Strip vars that could interfere with the mock path.
     for stale in (
         "ANTHROPIC_API_KEY",
+        "DATABRICKS_HOST",
         "DATABRICKS_TOKEN",
         "CLAUDE_CODE",
         "CLAUDECODE",

--- a/tests/e2e/omnigent/test_repl_session_lifecycle.py
+++ b/tests/e2e/omnigent/test_repl_session_lifecycle.py
@@ -33,7 +33,7 @@ from tests.e2e.omnigent._pexpect_harness import (
     ensure_repl_test_theme_env,
     submit_prompt,
 )
-from tests.e2e.omnigent.conftest import configure_mock_llm
+from tests.e2e.omnigent.conftest import configure_mock_llm, set_fallback_mock_llm
 
 _MODEL = "mock-session-lifecycle"
 _HARNESS = "openai-agents"
@@ -887,6 +887,7 @@ async def test_repl_reasoning_effort_threads_through(
         [{"text": "SESSION_REASONING_OK"}],
         key=_MODEL,
     )
+    set_fallback_mock_llm(mock_llm_server_url, _MODEL, "SESSION_REASONING_OK")
     with _running_server(omnigent_python, omnigent_repo_root, env, tmp_path) as server:
         from omnigent.cli import _bundle
 
@@ -896,7 +897,10 @@ async def test_repl_reasoning_effort_threads_through(
             omnigent_repo_root,
             yaml_path,
             tmp_path,
-            extra_env={k: env[k] for k in ("OPENAI_BASE_URL", "OPENAI_API_KEY") if k in env},
+            extra_env={
+                key: env[key]
+                for key in ("OPENAI_BASE_URL", "OPENAI_API_KEY", "OMNIGENT_CONFIG_HOME")
+            },
         ) as runner_id:
             async with OmnigentClient(base_url=server.base_url) as client:
                 created = await client.sessions.create(bundle, reasoning_effort="high")

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -3688,7 +3688,13 @@ async def test_terminate_managed_host_retries_tombstone_after_terminate_fails(
     assert (
         host_store.resolve_launch_token("057e7fa3f1cdb40c0ec393a3d42affc7", "tok-term-2") is None
     )
-    tombstones = host_store.list_stale_managed_sandbox_hosts(now_epoch())
+    tombstones = [
+        host
+        for _, host in host_store.list_current_managed_sandbox_hosts_page(
+            after=None,
+            limit=10,
+        )
+    ]
     assert len(tombstones) == 1
     assert tombstones[0].deleted_at is not None
     assert tombstones[0].sandbox_id == "sb-term-2"
@@ -3700,7 +3706,8 @@ async def test_terminate_managed_host_retries_tombstone_after_terminate_fails(
     )
     assert await reaper.sweep_once() == 1
     assert fake.terminated == ["sb-term-2"]
-    assert host_store.list_stale_managed_sandbox_hosts(now_epoch()) == []
+    assert host_store.list_current_managed_sandbox_hosts_page(after=None, limit=10) == []
+    assert host_store.list_terminating_managed_sandbox_hosts_page(after=None, limit=10) == []
 
 
 async def test_terminate_managed_host_retains_only_failed_generation(
@@ -3745,7 +3752,13 @@ async def test_terminate_managed_host_retains_only_failed_generation(
     await terminate_managed_host(host, host_store, _injected_config(fake))
 
     assert attempts == ["sb-term-new-partial", "sb-term-old-partial"]
-    tombstones = host_store.list_stale_managed_sandbox_hosts(now_epoch())
+    tombstones = [
+        host
+        for _, host in host_store.list_current_managed_sandbox_hosts_page(
+            after=None,
+            limit=10,
+        )
+    ]
     assert len(tombstones) == 1
     assert tombstones[0].sandbox_id == "sb-term-new-partial"
     assert tombstones[0].terminating_sandbox_id is None
@@ -3757,7 +3770,8 @@ async def test_terminate_managed_host_retains_only_failed_generation(
     )
     assert await reaper.sweep_once() == 1
     assert fake.terminated == ["sb-term-old-partial", "sb-term-new-partial"]
-    assert host_store.list_stale_managed_sandbox_hosts(now_epoch()) == []
+    assert host_store.list_current_managed_sandbox_hosts_page(after=None, limit=10) == []
+    assert host_store.list_terminating_managed_sandbox_hosts_page(after=None, limit=10) == []
 
 
 async def test_terminate_managed_host_skips_mismatched_provider(db_uri: str) -> None:

--- a/tests/server/test_managed_sandbox_reaper.py
+++ b/tests/server/test_managed_sandbox_reaper.py
@@ -16,7 +16,7 @@ from omnigent.server.managed_hosts import (
     ManagedSandboxReaperConfig,
 )
 from omnigent.server.managed_sandbox_reaper import ManagedSandboxReaper
-from omnigent.stores.host_store import Host
+from omnigent.stores.host_store import Host, ManagedSandboxScanCursor, ManagedSandboxScanRow
 
 pytestmark = pytest.mark.asyncio
 
@@ -68,33 +68,48 @@ class _FakeHostStore:
         self.detached: list[tuple[int, str, str]] = []
         self.cleared: list[tuple[int, str, str]] = []
         self.refresh_on_detach: set[str] = set()
-        self.stale_queries: list[tuple[int, int]] = []
+        self.current_page_queries: list[tuple[ManagedSandboxScanCursor | None, int]] = []
+        self.terminating_page_queries: list[tuple[ManagedSandboxScanCursor | None, int]] = []
 
-    def list_managed_sandbox_workspace_ids(self) -> list[int]:
-        return sorted(
-            workspace_id
-            for workspace_id, hosts in self.hosts.items()
-            if any(
-                host.sandbox_provider is not None
-                and (host.sandbox_id is not None or host.terminating_sandbox_id is not None)
+    def list_current_managed_sandbox_hosts_page(
+        self,
+        *,
+        after: ManagedSandboxScanCursor | None,
+        limit: int,
+    ) -> list[ManagedSandboxScanRow]:
+        self.current_page_queries.append((after, limit))
+        rows = sorted(
+            (
+                (host.sandbox_id, workspace_id, host.host_id, host)
+                for workspace_id, hosts in self.hosts.items()
                 for host in hosts.values()
-            )
+                if host.sandbox_id is not None
+            ),
+            key=lambda row: row[:3],
         )
+        if after is not None:
+            rows = [row for row in rows if row[:3] > after]
+        return [(workspace_id, host) for _, workspace_id, _, host in rows[:limit]]
 
-    def list_stale_managed_sandbox_hosts(self, older_than_epoch: int) -> list[Host]:
-        workspace_id = current_workspace_id()
-        self.stale_queries.append((workspace_id, older_than_epoch))
-        hosts = [
-            host
-            for host in self.hosts[workspace_id].values()
-            if host.sandbox_provider is not None
-            and (
-                host.deleted_at is not None
-                or host.terminating_sandbox_id is not None
-                or (host.sandbox_id is not None and host.updated_at <= older_than_epoch)
-            )
-        ]
-        return sorted(hosts, key=lambda host: (host.updated_at, host.host_id))
+    def list_terminating_managed_sandbox_hosts_page(
+        self,
+        *,
+        after: ManagedSandboxScanCursor | None,
+        limit: int,
+    ) -> list[ManagedSandboxScanRow]:
+        self.terminating_page_queries.append((after, limit))
+        rows = sorted(
+            (
+                (host.terminating_sandbox_id, workspace_id, host.host_id, host)
+                for workspace_id, hosts in self.hosts.items()
+                for host in hosts.values()
+                if host.terminating_sandbox_id is not None
+            ),
+            key=lambda row: row[:3],
+        )
+        if after is not None:
+            rows = [row for row in rows if row[:3] > after]
+        return [(workspace_id, host) for _, workspace_id, _, host in rows[:limit]]
 
     def detach_stale_managed_sandbox(
         self,
@@ -277,7 +292,81 @@ async def test_sweep_reaps_stale_host_rows_without_scanning_sessions() -> None:
     assert hosts.hosts[7]["host_modal"].sandbox_id is None
     assert hosts.hosts[7]["host_modal"].terminating_sandbox_id is None
     assert hosts.hosts[7]["host_recent"].sandbox_id == "sb-recent"
-    assert hosts.stale_queries == [(7, now - _DAY_S), (9, now - _DAY_S)]
+    assert hosts.terminating_page_queries == [(None, 500)]
+    assert hosts.current_page_queries == [(None, 500)]
+
+
+async def test_sweep_completely_traverses_bounded_slot_pages() -> None:
+    now = 4_000_000
+    modal = _RecordingLauncher("modal")
+    hosts = _FakeHostStore(
+        {
+            7: [
+                _host(
+                    "host_current_a",
+                    provider="modal",
+                    sandbox_id="sb-current-a",
+                    updated_at=now - 2 * _DAY_S,
+                ),
+                _host(
+                    "host_current_b",
+                    provider="modal",
+                    sandbox_id="sb-current-b",
+                    updated_at=now - 3 * _DAY_S,
+                ),
+                _host(
+                    "host_current_c",
+                    provider="modal",
+                    sandbox_id="sb-current-c",
+                    updated_at=now - 4 * _DAY_S,
+                ),
+                _host(
+                    "host_pending_a",
+                    provider="modal",
+                    sandbox_id=None,
+                    terminating_sandbox_id="sb-pending-a",
+                    updated_at=now,
+                ),
+                _host(
+                    "host_pending_b",
+                    provider="modal",
+                    sandbox_id=None,
+                    terminating_sandbox_id="sb-pending-b",
+                    updated_at=now,
+                ),
+                _host(
+                    "host_pending_c",
+                    provider="modal",
+                    sandbox_id=None,
+                    terminating_sandbox_id="sb-pending-c",
+                    updated_at=now,
+                ),
+            ]
+        }
+    )
+    reaper = ManagedSandboxReaper(
+        host_store=hosts,  # type: ignore[arg-type]
+        sandbox_config=_deployment([modal]),
+        scan_batch_size=2,
+    )
+
+    assert await reaper.sweep_once(now=now) == 6
+    assert set(modal.terminated) == {
+        "sb-current-a",
+        "sb-current-b",
+        "sb-current-c",
+        "sb-pending-a",
+        "sb-pending-b",
+        "sb-pending-c",
+    }
+    assert hosts.terminating_page_queries == [
+        (None, 2),
+        (("sb-pending-b", 7, "host_pending_b"), 2),
+    ]
+    assert hosts.current_page_queries == [
+        (None, 2),
+        (("sb-current-b", 7, "host_current_b"), 2),
+    ]
 
 
 async def test_provider_failure_does_not_stop_other_sandboxes() -> None:

--- a/tests/stores/test_host_store.py
+++ b/tests/stores/test_host_store.py
@@ -857,14 +857,17 @@ def test_delete_host_hides_row_and_retains_cleanup_tombstone(db_uri: str) -> Non
     assert retry.deleted_at is not None
     assert retry.sandbox_id == "sb-m5"
 
-    cleanup = store.list_stale_managed_sandbox_hosts(now_epoch())
+    cleanup = [
+        host for _, host in store.list_current_managed_sandbox_hosts_page(after=None, limit=10)
+    ]
     assert [host.host_id for host in cleanup] == ["dcf4eb5fc0b04985ec45f79cfda95566"]
     assert cleanup[0].deleted_at == retry.deleted_at
     assert store.mark_sandbox_terminated(
         "dcf4eb5fc0b04985ec45f79cfda95566",
         sandbox_id="sb-m5",
     )
-    assert store.list_stale_managed_sandbox_hosts(now_epoch()) == []
+    assert store.list_current_managed_sandbox_hosts_page(after=None, limit=10) == []
+    assert store.list_terminating_managed_sandbox_hosts_page(after=None, limit=10) == []
 
     engine = get_or_create_engine(db_uri)
     with Session(engine) as session:
@@ -945,7 +948,9 @@ def test_replace_managed_host_sandbox_cannot_revive_deleted_tombstone(db_uri: st
         )
         is None
     )
-    tombstones = store.list_stale_managed_sandbox_hosts(now_epoch())
+    tombstones = [
+        host for _, host in store.list_current_managed_sandbox_hosts_page(after=None, limit=10)
+    ]
     assert [(host.host_id, host.sandbox_id) for host in tombstones] == [
         (host_id, "original-sandbox")
     ]
@@ -1054,10 +1059,10 @@ def test_delete_host_serializes_with_sandbox_replacement(db_uri: str) -> None:
     assert store.get_host(host_id) is None
 
 
-def test_managed_sandbox_reaper_queries_and_compare_clear_span_workspaces(
+def test_managed_sandbox_reaper_pages_and_compare_clear_span_workspaces(
     db_uri: str,
 ) -> None:
-    """The reaper discovers workspaces, scopes stale reads, and clears one generation."""
+    """The reaper keyset spans workspaces and clears one exact generation."""
     store = HostStore(db_uri)
     host_11 = "d6cb45e67d3d4bdbbff1b45d5c408e11"
     host_22 = "60a41477758b4b4c9f3072dd47009522"
@@ -1082,12 +1087,25 @@ def test_managed_sandbox_reaper_queries_and_compare_clear_span_workspaces(
             token_expires_at=now_epoch() + 3600,
         )
 
-    assert store.list_managed_sandbox_workspace_ids() == [11, 22]
+    first_page = store.list_current_managed_sandbox_hosts_page(after=None, limit=1)
+    assert [(workspace_id, host.host_id) for workspace_id, host in first_page] == [(11, host_11)]
+    first_host = first_page[0][1]
+    assert first_host.sandbox_id == "sb-11"
+    second_page = store.list_current_managed_sandbox_hosts_page(
+        after=("sb-11", 11, host_11),
+        limit=1,
+    )
+    assert [(workspace_id, host.host_id) for workspace_id, host in second_page] == [(22, host_22)]
+    assert (
+        store.list_current_managed_sandbox_hosts_page(
+            after=("sb-22", 22, host_22),
+            limit=1,
+        )
+        == []
+    )
+
     with workspace_scope(11):
-        assert store.list_stale_managed_sandbox_hosts(0) == []
-        listed = store.list_stale_managed_sandbox_hosts(now_epoch() + 1)
-        assert [host.host_id for host in listed] == [host_11]
-        last_seen_at = listed[0].updated_at
+        last_seen_at = first_host.updated_at
         assert (
             store.detach_stale_managed_sandbox(
                 host_11,
@@ -1112,7 +1130,6 @@ def test_managed_sandbox_reaper_queries_and_compare_clear_span_workspaces(
         assert detached.sandbox_id is None
         assert detached.terminating_sandbox_id == "sb-11"
         assert store.resolve_launch_token(host_11, "token-11") is None
-        assert store.list_managed_sandbox_workspace_ids() == [11, 22]
         assert (
             store.mark_sandbox_terminated(
                 host_11,
@@ -1132,10 +1149,9 @@ def test_managed_sandbox_reaper_queries_and_compare_clear_span_workspaces(
         assert reaped.sandbox_id is None
         assert reaped.terminating_sandbox_id is None
 
-    assert store.list_managed_sandbox_workspace_ids() == [22]
-    with workspace_scope(22):
-        listed = store.list_stale_managed_sandbox_hosts(now_epoch() + 1)
-        assert [host.host_id for host in listed] == [host_22]
+    assert store.list_terminating_managed_sandbox_hosts_page(after=None, limit=1) == []
+    remaining = store.list_current_managed_sandbox_hosts_page(after=None, limit=1)
+    assert [(workspace_id, host.host_id) for workspace_id, host in remaining] == [(22, host_22)]
 
 
 def test_detach_and_resume_rearm_are_atomic_competitors(db_uri: str) -> None:


### PR DESCRIPTION
## Related issue

N/A — reviewer follow-up on the managed-sandbox schema change.

## Summary

- Widen `hosts.deleted_at` from 32-bit `INTEGER` to 64-bit `BIGINT` so epoch timestamps cannot overflow in 2038.
- Replace the reaper's unbounded workspace discovery and cross-column `OR` scan with separate keyset-paginated scans for `terminating_sandbox_id` and `sandbox_id`, each capped at 500 rows per query.
- Add matching `(sandbox_id, workspace_id, host_id)` and `(terminating_sandbox_id, workspace_id, host_id)` indexes. The terminating slot is traversed first, then the current slot; traversal is deterministic and complete across pages, with oldest candidates handled first within each page.

**ELI5:** Instead of asking the database for every sandbox host at once, the reaper now walks two indexed lists 500 rows at a time until both lists are exhausted.

```text
terminating_sandbox_id index ──> page of 500 ──> reap candidates ──> next cursor
sandbox_id index             ──> page of 500 ──> reap candidates ──> next cursor
```

This PR does not change the user-host listing API or add host-row GC.

## Test Plan

- `uv run --group test pytest -q tests/server/test_managed_sandbox_reaper.py tests/stores/test_host_store.py tests/server/test_managed_hosts.py tests/db/test_migration_managed_sandbox_deleted_at.py tests/db/test_migration_connections.py` — 381 passed.
- `uv run --group lint ruff check ...` and `ruff format --check ...` on all changed files.
- `uv run --group lint pyrefly check` — 0 errors.
- `.venv/bin/pre-commit run --all-files` — all hooks passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The migration test verifies the type/index changes and data preservation. Reaper tests force a two-row page size to prove that both sandbox-id slots are traversed completely across multiple bounded queries.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Focused tests cover migration upgrade/downgrade, index presence, page cursors, complete multi-page traversal, provider isolation, and stale-host reaping behavior.

## Changelog

Managed sandbox cleanup now avoids unbounded database scans and uses 64-bit deletion timestamps.
