### PR TITLE
fix(web): keep a finished answer visible when a background task wakes the turn

### DIFF
--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2848,9 +2848,14 @@ def _publish_external_conversation_item(
         item before append.
     :returns: None.
     """
-    if item.type == "message" and isinstance(item.data, MessageData) and item.data.role == "user":
-        _publish_input_consumed(session_id, item, cleared_pending_id=cleared_pending_id)
-        return
+    if item.type == "message" and isinstance(item.data, MessageData):
+        if item.data.role == "user":
+            _publish_input_consumed(session_id, item, cleared_pending_id=cleared_pending_id)
+            return
+        if item.data.is_meta:
+            # Hidden context on a non-user message has no live rendering
+            # path that filters on the flag, so keep it off the stream.
+            return
     event = OutputItemDoneEvent(type="response.output_item.done", item=item.to_api_dict())
     session_stream.publish(session_id, event.model_dump())
 

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -1636,9 +1636,13 @@ def _publish_input_consumed(
         web message mirrored back from the transcript), that entry's
         id, e.g. ``"pending_a1b2c3"`` — so clients drop the optimistic
         bubble by id. ``None`` when nothing was drained.
+
+    Hidden context items (``is_meta``, e.g. injected skill text or a
+    Claude background-task notification) are published too, flagged in
+    ``data.is_meta``: subscribers hide or re-label them, and the web UI
+    shows the task notification as a system marker so the turn Claude
+    resumes on it starts a new bubble.
     """
-    if item.type == "message" and isinstance(item.data, MessageData) and item.data.is_meta:
-        return
     event = SessionInputConsumedEvent(
         type="session.input.consumed",
         data=SessionInputConsumedPayload(
@@ -2844,8 +2848,6 @@ def _publish_external_conversation_item(
         item before append.
     :returns: None.
     """
-    if item.type == "message" and isinstance(item.data, MessageData) and item.data.is_meta:
-        return
     if item.type == "message" and isinstance(item.data, MessageData) and item.data.role == "user":
         _publish_input_consumed(session_id, item, cleared_pending_id=cleared_pending_id)
         return

--- a/tests/e2e_ui/chat/test_working_indicator_reload.py
+++ b/tests/e2e_ui/chat/test_working_indicator_reload.py
@@ -849,3 +849,131 @@ def test_settled_fold_holds_through_scheduled_wake(
     expect(fold.nth(1)).to_be_visible(timeout=15_000)
     assert fold.count() == 2
     assert page.locator(_ASSISTANT_BUBBLE).count() == 2
+
+
+_LATENCY_QUESTION = (
+    "can you help me understand the definition of this latency? "
+    "what's the start time and what's the end time"
+)
+_LATENCY_ANSWER = (
+    "It is end-to-end launch latency: wall-clock seconds from asking to launch the "
+    "job to user code running on the GPU pod.\n\n"
+    "The start clock is captured in the Makefile right before it invokes `air run`; "
+    "the end clock is the first line of the job's command block on the remote pod."
+)
+_TASK_NOTIFICATION = "\n".join(
+    [
+        "<task-notification>",
+        "<task-id>b3f9a2c1d</task-id>",
+        "<tool-use-id>toolu_bdrk_01Xy7Q2PfLm8RkVn3Ws4Tz9A</tool-use-id>",
+        "<output-file>/tmp/claude/tasks/b3f9a2c1d.output</output-file>",
+        "<status>completed</status>",
+        '<summary>Background command "air run -f cases/latency_launch_hello_world/run.yml" '
+        "completed (exit code 0)</summary>",
+        "</task-notification>",
+    ]
+)
+_RUNS_SUMMARY = (
+    "Both additional runs succeeded.\n\n"
+    "**df1 latency_launch_hello_world (civ4) — 3 runs total**\n\n"
+    "| # | Launch latency (s) | Run |\n|---|---|---|\n"
+    "| 1 | 40 | 864427556073297 |\n| 2 | 35 | 60354668994037 |\n| 3 | 37 | 236213654141952 |"
+)
+
+
+def _assert_answer_outside_fold(page: Page) -> None:
+    """Assert the pre-wake answer and the wake marker render, with one fold.
+
+    :param page: Playwright page fixture.
+    :returns: None.
+    """
+    fold = page.locator(_FOLD)
+    expect(fold.first).to_be_visible(timeout=15_000)
+    expect(fold).to_have_count(1)
+    # The answer Claude finished BEFORE the wake must stay readable without
+    # expanding anything; folding it behind the follow-up work is the bug.
+    expect(page.get_by_text("It is end-to-end launch latency", exact=False)).to_be_visible()
+    marker = page.get_by_test_id("system-message")
+    expect(marker).to_be_visible()
+    expect(marker).to_contain_text("Background task completed")
+    expect(page.get_by_text("Both additional runs succeeded.", exact=False)).to_be_visible()
+    expect(page.locator(_ASSISTANT_BUBBLE)).to_have_count(2)
+
+
+def test_background_task_wake_keeps_prior_answer_visible(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """
+    A finished answer stays visible when Claude resumes on a background task.
+
+    Claude Code reports a finished background shell task by injecting a
+    ``<task-notification>`` user entry and starting a NEW turn on it, with
+    no human message in between. The claude-native forwarder mirrors that
+    entry as an ``is_meta`` user item. Grouping every assistant item after
+    the real user message into one bubble folded the already-complete
+    answer behind the follow-up work's "Worked for" row, so the chat showed
+    only the wrap-up text while the terminal showed the answer.
+
+    The wake must render as a muted system marker that starts a new bubble:
+    the answer keeps its own bubble and only the follow-up work folds. The
+    wire order below is the one observed live (answer, idle edge, hidden
+    notification, running edge, tool work, wrap-up, idle edge). Asserted
+    live and again after a reload, because both views must agree.
+
+    :param page: Playwright page fixture.
+    :param seeded_session: ``(base_url, session_id)`` from the local server.
+    :returns: None.
+    """
+    base_url, session_id = seeded_session
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=20_000)
+
+    _seed_user_message(base_url, session_id, text=_LATENCY_QUESTION, response_id="resp_q")
+    _publish_status(base_url, session_id, "running", response_id="resp_answer")
+    _seed_assistant_message(base_url, session_id, text=_LATENCY_ANSWER, response_id="resp_answer")
+    _publish_status(base_url, session_id, "idle", response_id="resp_answer")
+    expect(page.get_by_text("It is end-to-end launch latency", exact=False)).to_be_visible(
+        timeout=15_000
+    )
+
+    # Claude Code wakes on the finished background task: a hidden meta user
+    # entry, then a fresh turn's running edge and its tool work.
+    _seed_item(
+        base_url,
+        session_id,
+        item_type="message",
+        item_data={
+            "role": "user",
+            "is_meta": True,
+            "content": [{"type": "input_text", "text": _TASK_NOTIFICATION}],
+        },
+        response_id="resp_wake",
+    )
+    _publish_status(base_url, session_id, "running", response_id="resp_followup")
+    _seed_assistant_message(
+        base_url,
+        session_id,
+        text="Both background runs finished — pulling their launch metrics.",
+        response_id="resp_followup",
+    )
+    _seed_completed_tool_call(
+        base_url,
+        session_id,
+        response_id="resp_followup",
+        call_id="call_wake_runs",
+        arguments='{"command": "air runs list --latest 2 --format json"}',
+        output=(
+            '[{"run": "864427556073297", "launch_s": 40}, '
+            '{"run": "60354668994037", "launch_s": 35}]\n'
+        ),
+    )
+    _seed_assistant_message(base_url, session_id, text=_RUNS_SUMMARY, response_id="resp_followup")
+    _publish_status(base_url, session_id, "idle", response_id="resp_followup")
+
+    _assert_answer_outside_fold(page)
+
+    page.reload()
+    expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=20_000)
+    _assert_answer_outside_fold(page)

--- a/tests/e2e_ui/chat/test_working_indicator_reload.py
+++ b/tests/e2e_ui/chat/test_working_indicator_reload.py
@@ -868,8 +868,10 @@ _TASK_NOTIFICATION = "\n".join(
         "<tool-use-id>toolu_bdrk_01Xy7Q2PfLm8RkVn3Ws4Tz9A</tool-use-id>",
         "<output-file>/tmp/claude/tasks/b3f9a2c1d.output</output-file>",
         "<status>completed</status>",
-        '<summary>Background command "air run -f cases/latency_launch_hello_world/run.yml" '
-        "completed (exit code 0)</summary>",
+        (
+            '<summary>Background command "air run -f cases/latency_launch_hello_world/run.yml" '
+            + "completed (exit code 0)</summary>"
+        ),
         "</task-notification>",
     ]
 )

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -2141,6 +2141,49 @@ async def test_external_meta_user_message_persists_and_publishes_flagged_input_e
     assert consumed["cleared_pending_id"] is None
 
 
+async def test_external_meta_assistant_message_persists_without_live_event(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A meta message that is not a user message stays off the live stream.
+
+    ``response.output_item.done`` has no ``is_meta`` filter on the web
+    live path, so hidden context on an assistant item must be persisted
+    for history yet never published.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "message",
+                "item_data": {
+                    "role": "assistant",
+                    "agent": "claude-native-ui",
+                    "content": [{"type": "output_text", "text": "<hidden>context</hidden>"}],
+                    "is_meta": True,
+                },
+                "response_id": "resp_meta_assistant",
+                "source_id": "meta-assistant",
+            },
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    items = (await client.get(f"/v1/sessions/{session['id']}/items")).json()["data"]
+    assert [item["is_meta"] for item in items if item["type"] == "message"] == [True]
+    assert published == []
+
+
 async def test_external_user_message_folds_pending_image_into_durable_item(
     client: httpx.AsyncClient,
 ) -> None:

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -2085,18 +2085,19 @@ async def test_skill_slash_command_non_json_resolve_surfaces_controlled_error(
     assert "malformed skill resolution" in resp.json()["error"]["message"]
 
 
-async def test_external_meta_user_message_persists_without_live_input_event(
+async def test_external_meta_user_message_persists_and_publishes_flagged_input_event(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """
-    External bridge meta messages are durable but hidden from live UI.
+    External bridge meta messages are durable and reach live subscribers flagged.
 
     Codex-native mirrors ``<skill>`` wrappers via
     ``external_conversation_item``. The server must store those
-    messages so resume has the context, while suppressing
-    ``session.input.consumed`` so subscribers do not render raw skill
-    text.
+    messages so resume has the context, and publish
+    ``session.input.consumed`` with ``is_meta`` set so subscribers can
+    hide raw skill text yet still see a Claude background-task wake as a
+    turn boundary; it must not seed a title from the hidden text.
     """
     published: list[tuple[str, dict[str, Any]]] = []
     monkeypatch.setattr(
@@ -2131,7 +2132,13 @@ async def test_external_meta_user_message_persists_without_live_input_event(
     snap = await client.get(f"/v1/sessions/{session['id']}")
     assert snap.status_code == 200
     assert snap.json()["title"] is None
-    assert published == []
+    assert [(sid, ev["type"]) for sid, ev in published] == [
+        (session["id"], "session.input.consumed")
+    ]
+    consumed = published[0][1]["data"]
+    assert consumed["item_id"] == meta["id"]
+    assert consumed["data"]["is_meta"] is True
+    assert consumed["cleared_pending_id"] is None
 
 
 async def test_external_user_message_folds_pending_image_into_durable_item(

--- a/web/src/lib/itemsToBlocks.test.ts
+++ b/web/src/lib/itemsToBlocks.test.ts
@@ -105,7 +105,7 @@ describe("itemsToBlocks — flat shape", () => {
     ]);
   });
 
-  it("hides legacy Claude task notifications that predate is_meta", () => {
+  it("re-labels a Claude task notification as a system marker between real messages", () => {
     const items: ConversationItem[] = [
       userMessage("resp_before", "visible before", "msg_before"),
       userMessage(
@@ -129,10 +129,53 @@ describe("itemsToBlocks — flat shape", () => {
 
     const userBlocks = blocks.filter((b): b is UserMessageBlock => b.type === "user_message");
     const texts = userBlocks.map((b) => b.content.map((c) => ("text" in c ? c.text : "")).join(""));
-    expect(texts).toEqual(["visible before", "visible after"]);
+    // The wake keeps its place as a `[System: …]` marker: it is a turn
+    // boundary, so the answer before it cannot fold into the work after it.
+    expect(texts).toEqual([
+      "visible before",
+      '[System: background task a815d170defd74675 completed]\nAgent "Explore spec" finished',
+      "visible after",
+    ]);
+    expect(userBlocks[1]!.ctx.itemId).toBe("msg_legacy_task_notification");
   });
 
-  it("hides legacy Claude Monitor task notifications with optional fields omitted", () => {
+  it("re-labels an is_meta task notification (bridge-marked) as a system marker", () => {
+    const items: ConversationItem[] = [
+      {
+        id: "msg_wake",
+        response_id: "resp_wake",
+        type: "message",
+        status: "completed",
+        role: "user",
+        is_meta: true,
+        content: [
+          {
+            type: "input_text",
+            text: [
+              "<task-notification>",
+              "<task-id>b3f9a2c1d</task-id>",
+              "<status>failed</status>",
+              "<summary>Background command exited 1</summary>",
+              "</task-notification>",
+            ].join("\n"),
+          },
+        ],
+      },
+    ];
+
+    const blocks = itemsToBlocks(items);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.type).toBe("user_message");
+    expect((blocks[0] as UserMessageBlock).content).toEqual([
+      {
+        type: "input_text",
+        text: "[System: background task b3f9a2c1d failed]\nBackground command exited 1",
+      },
+    ]);
+  });
+
+  it("re-labels a Claude Monitor task notification with optional fields omitted", () => {
     const items: ConversationItem[] = [
       userMessage(
         "resp_task",
@@ -147,7 +190,17 @@ describe("itemsToBlocks — flat shape", () => {
       ),
     ];
 
-    expect(itemsToBlocks(items)).toEqual([]);
+    const blocks = itemsToBlocks(items);
+
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as UserMessageBlock).content).toEqual([
+      {
+        type: "input_text",
+        text:
+          "[System: background task b1mhekpmy finished]\n" +
+          'Monitor event: "PR 2086 E2E UI + npm test CI results"',
+      },
+    ]);
   });
 
   it("user + assistant items produce [UserMessageBlock, TextDone] in order", () => {

--- a/web/src/lib/itemsToBlocks.ts
+++ b/web/src/lib/itemsToBlocks.ts
@@ -61,6 +61,7 @@ import {
 } from "./conversationItems";
 import { nativePolicyNameForAgentName } from "./nativeCodingAgents";
 import { routingExtrasFromWire } from "./routingDecision";
+import { taskNotificationMarkerContent } from "./systemMessage";
 
 // Claude built-ins whose call is a question TO the user rather than work
 // the agent did on its own. The elicitation that carried the card is
@@ -214,6 +215,17 @@ function answersFromToolResult(
 }
 
 function itemToBlock(item: ConversationItem): AnyBlock | null {
+  if (isMessageItem(item) && item.role === "user") {
+    // Claude Code's background-task wake: the CLI injects a
+    // `<task-notification>` user entry (mirrored with `is_meta`) and
+    // starts a new turn on it. Render it as a muted system marker so the
+    // answer it interrupts keeps its own bubble instead of folding into
+    // the follow-up work's "Worked for" row.
+    const marker = taskNotificationMarkerContent(item.content);
+    if (marker !== null) {
+      return { ...userMessageToBlock(item), content: marker };
+    }
+  }
   if (isMessageItem(item) && item.is_meta === true) {
     return null;
   }
@@ -222,7 +234,7 @@ function itemToBlock(item: ConversationItem): AnyBlock | null {
     // after /compact. It starts with a distinctive prefix and is
     // part of the model's context (needed for resume) but should
     // not be shown as a chat bubble in the web UI.
-    if (isCompactionSummaryMessage(item) || isClaudeTaskNotificationMessage(item)) {
+    if (isCompactionSummaryMessage(item)) {
       return null;
     }
     return userMessageToBlock(item);
@@ -271,23 +283,6 @@ function isCompactionSummaryMessage(item: MessageItem): boolean {
   for (const block of item.content) {
     if (block.type === "input_text" && typeof block.text === "string") {
       if (block.text.startsWith(prefix)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-// Hide legacy Claude Task notifications persisted before the bridge marked them meta.
-function isClaudeTaskNotificationMessage(item: MessageItem): boolean {
-  const requiredMarkers = ["<task-notification>", "<task-id>", "</task-notification>"];
-  for (const block of item.content) {
-    if (block.type === "input_text" && typeof block.text === "string") {
-      const text = block.text.trimStart();
-      if (
-        text.startsWith("<task-notification>") &&
-        requiredMarkers.every((marker) => text.includes(marker))
-      ) {
         return true;
       }
     }

--- a/web/src/lib/renderItems.test.ts
+++ b/web/src/lib/renderItems.test.ts
@@ -534,6 +534,107 @@ describe("buildBubbles — bubble grouping", () => {
     expect(turn.items.map((i) => i.kind)).toEqual(["tool", "elicitation", "text"]);
   });
 
+  it("a Claude background-task wake splits the turn so the finished answer keeps its bubble", () => {
+    // Claude Code resumes on a `<task-notification>` (mirrored as a meta
+    // user item) with no human message in between. Grouping every
+    // assistant item after the real question into one bubble folded the
+    // finished answer behind the follow-up work's "Worked for" row; the
+    // wake must land as a system marker that starts a new bubble.
+    const items: ConversationItem[] = [
+      {
+        id: "u_q",
+        response_id: "resp_q",
+        type: "message",
+        status: "completed",
+        role: "user",
+        content: [{ type: "input_text", text: "what is this latency?" }],
+      },
+      {
+        id: "a_answer",
+        response_id: "resp_answer",
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        model: "claude-native-ui",
+        content: [{ type: "output_text", text: "It is end-to-end launch latency." }],
+      },
+      {
+        id: "u_wake",
+        response_id: "resp_wake",
+        type: "message",
+        status: "completed",
+        role: "user",
+        is_meta: true,
+        content: [
+          {
+            type: "input_text",
+            text: [
+              "<task-notification>",
+              "<task-id>b3f9a2c1d</task-id>",
+              "<status>completed</status>",
+              "<summary>Background command completed (exit code 0)</summary>",
+              "</task-notification>",
+            ].join("\n"),
+          },
+        ],
+      },
+      {
+        id: "a_followup_1",
+        response_id: "resp_followup",
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        model: "claude-native-ui",
+        content: [{ type: "output_text", text: "Both runs finished — checking metrics." }],
+      },
+      {
+        id: "fc_runs",
+        response_id: "resp_followup",
+        type: "function_call",
+        status: "completed",
+        model: "claude-native-ui",
+        name: "shell",
+        arguments: '{"command": "air runs list"}',
+        call_id: "call_runs",
+      },
+      {
+        id: "fo_runs",
+        response_id: "resp_followup",
+        type: "function_call_output",
+        status: "completed",
+        call_id: "call_runs",
+        output: "run 1: 40s\nrun 2: 35s\n",
+      },
+      {
+        id: "a_followup_2",
+        response_id: "resp_followup",
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        model: "claude-native-ui",
+        content: [{ type: "output_text", text: "Both additional runs succeeded." }],
+      },
+    ];
+
+    const bubbles = buildBubbles(itemsToBlocks(items), null);
+
+    expect(bubbles.map((b) => b.kind)).toEqual(["user", "assistant", "user", "assistant"]);
+    const answer = bubbles[1] as Extract<Bubble, { kind: "assistant" }>;
+    // Text only: nothing to fold, so the answer renders in full.
+    expect(answer.items.map((i) => i.kind)).toEqual(["text"]);
+    expect((answer.items[0] as Extract<RenderItem, { kind: "text" }>).text).toBe(
+      "It is end-to-end launch latency.",
+    );
+    const marker = bubbles[2] as Extract<Bubble, { kind: "user" }>;
+    expect(marker.itemId).toBe("u_wake");
+    expect((marker.content[0] as { text: string }).text).toBe(
+      "[System: background task b3f9a2c1d completed]\nBackground command completed (exit code 0)",
+    );
+    const followup = bubbles[3] as Extract<Bubble, { kind: "assistant" }>;
+    expect(followup.responseId).toBe("resp_followup");
+    expect(followup.items.some((i) => i.kind === "tool")).toBe(true);
+  });
+
   it("two response_ids produce two assistant bubbles in order", () => {
     const blocks: AnyBlock[] = [
       {

--- a/web/src/lib/systemMessage.test.ts
+++ b/web/src/lib/systemMessage.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { MessageContentBlock } from "@/lib/blocks";
-import { isSystemUserContent, parseSystemMessage } from "./systemMessage";
+import {
+  claudeTaskNotificationMarker,
+  isSystemUserContent,
+  parseSystemMessage,
+  taskNotificationMarkerContent,
+} from "./systemMessage";
 
 describe("parseSystemMessage", () => {
   it("returns null for plain user text", () => {
@@ -155,5 +160,63 @@ describe("isSystemUserContent", () => {
       { type: "input_image", file_id: "f1" },
     ];
     expect(isSystemUserContent(withImage)).toBe(false);
+  });
+});
+
+describe("Claude background-task notifications", () => {
+  const notification = [
+    "<task-notification>",
+    "<task-id>b3f9a2c1d</task-id>",
+    "<tool-use-id>toolu_bdrk_01Xy7Q2PfLm8RkVn3Ws4Tz9A</tool-use-id>",
+    "<output-file>/tmp/claude/tasks/b3f9a2c1d.output</output-file>",
+    "<status>completed</status>",
+    '<summary>Background command "air run" completed (exit code 0)</summary>',
+    "</task-notification>",
+  ].join("\n");
+
+  it("re-labels a notification as a marker whose header parses as a completed task", () => {
+    const marker = claudeTaskNotificationMarker(notification);
+    expect(marker).toBe(
+      "[System: background task b3f9a2c1d completed]\n" +
+        'Background command "air run" completed (exit code 0)',
+    );
+    expect(parseSystemMessage(marker!)).toEqual({
+      kind: "task_completed",
+      label: "Background task completed",
+      body: 'Background command "air run" completed (exit code 0)',
+    });
+    // Marker content is a system row, not a human turn.
+    expect(isSystemUserContent([{ type: "input_text", text: marker! }])).toBe(true);
+  });
+
+  it("maps failed and unknown statuses to the matching marker kinds", () => {
+    expect(
+      parseSystemMessage(
+        claudeTaskNotificationMarker(
+          "<task-notification>\n<task-id>t1</task-id>\n<status>failed</status>\n</task-notification>",
+        )!,
+      ),
+    ).toEqual({ kind: "task_failed", label: "Background task failed", body: "" });
+    expect(
+      parseSystemMessage(
+        claudeTaskNotificationMarker(
+          "<task-notification>\n<task-id>t2</task-id>\n<summary>Monitor event</summary>\n</task-notification>",
+        )!,
+      ),
+    ).toEqual({ kind: "generic", label: "Background task finished", body: "Monitor event" });
+  });
+
+  it("leaves ordinary user text and partial markup alone", () => {
+    expect(claudeTaskNotificationMarker("please run the tests")).toBeNull();
+    expect(claudeTaskNotificationMarker("<task-notification> unterminated")).toBeNull();
+    expect(taskNotificationMarkerContent([{ type: "input_text", text: "hi" }])).toBeNull();
+    expect(taskNotificationMarkerContent([{ type: "input_text", text: notification }])).toEqual([
+      {
+        type: "input_text",
+        text:
+          "[System: background task b3f9a2c1d completed]\n" +
+          'Background command "air run" completed (exit code 0)',
+      },
+    ]);
   });
 });

--- a/web/src/lib/systemMessage.test.ts
+++ b/web/src/lib/systemMessage.test.ts
@@ -206,6 +206,16 @@ describe("Claude background-task notifications", () => {
     ).toEqual({ kind: "generic", label: "Background task finished", body: "Monitor event" });
   });
 
+  it("falls back to an 'unknown' id when the task-id is empty or contains whitespace", () => {
+    for (const id of ["", "  ", "two words", "a\nb"]) {
+      const marker = claudeTaskNotificationMarker(
+        `<task-notification>\n<task-id>${id}</task-id>\n<status>completed</status>\n</task-notification>`,
+      );
+      expect(marker).toBe("[System: background task unknown completed]");
+      expect(parseSystemMessage(marker!)?.kind).toBe("task_completed");
+    }
+  });
+
   it("leaves ordinary user text and partial markup alone", () => {
     expect(claudeTaskNotificationMarker("please run the tests")).toBeNull();
     expect(claudeTaskNotificationMarker("<task-notification> unterminated")).toBeNull();

--- a/web/src/lib/systemMessage.ts
+++ b/web/src/lib/systemMessage.ts
@@ -40,6 +40,11 @@ const TERMINAL_RE = /^terminal (\S+) is idle$/;
 const SUBAGENT_WAKE_RE =
   /^sub-agent .+ finished \((completed|failed|cancelled)\) — \d+ results? waiting in inbox\. Call sys_read_inbox to collect\.$/;
 
+// Claude Code's background-task wake, re-labelled by the client from the raw
+// `<task-notification>` block the CLI injects (see `claudeTaskNotificationMarker`).
+const BACKGROUND_TASK_RE = /^background task (\S+) (completed|failed|cancelled|finished)$/;
+const TASK_NOTIFICATION_MARKERS = ["<task-notification>", "<task-id>", "</task-notification>"];
+
 const TASK_KIND_LABEL: Record<string, string> = {
   tool: "Tool",
   sub_agent: "Sub-agent",
@@ -88,6 +93,19 @@ export function parseSystemMessage(text: string): ParsedSystemMessage | null {
       label: `${kindLabel} ${taskId} cancelled`,
       body: "",
     };
+  }
+  const backgroundMatch = BACKGROUND_TASK_RE.exec(inner);
+  if (backgroundMatch) {
+    const status = backgroundMatch[2] ?? "finished";
+    const kind: SystemMessageKind =
+      status === "completed"
+        ? "task_completed"
+        : status === "failed"
+          ? "task_failed"
+          : status === "cancelled"
+            ? "task_cancelled"
+            : "generic";
+    return { kind, label: `Background task ${status}`, body };
   }
   const timerMatch = TIMER_RE.exec(inner);
   if (timerMatch) {
@@ -141,4 +159,60 @@ export function isSystemUserContent(content: MessageContentBlock[]): boolean {
     .replace(ATTACHED_RE, "")
     .trim();
   return parseSystemMessage(text) !== null;
+}
+
+/**
+ * Whether ``text`` is the ``<task-notification>`` block Claude Code injects as
+ * a user-role entry when a background task finishes.
+ *
+ * :param text: One user message text block.
+ * :returns: ``true`` for a task notification, ``false`` otherwise.
+ */
+export function isClaudeTaskNotificationText(text: string): boolean {
+  const trimmed = text.trimStart();
+  return (
+    trimmed.startsWith("<task-notification>") &&
+    TASK_NOTIFICATION_MARKERS.every((marker) => trimmed.includes(marker))
+  );
+}
+
+/**
+ * Re-label a Claude Code ``<task-notification>`` block as a ``[System: …]``
+ * marker. Claude resumes on the notification with no human message in
+ * between; the marker keeps that resume visible as a turn boundary, so the
+ * answer Claude had already finished is not folded into the follow-up work.
+ *
+ * :param text: One user message text block.
+ * :returns: Marker text (header plus the notification's summary as the
+ *   body), or ``null`` when ``text`` is not a task notification.
+ */
+export function claudeTaskNotificationMarker(text: string): string | null {
+  if (!isClaudeTaskNotificationText(text)) return null;
+  const taskId = /<task-id>([^<]*)<\/task-id>/.exec(text)?.[1]?.trim() || "unknown";
+  const rawStatus = /<status>([^<]*)<\/status>/.exec(text)?.[1]?.trim().toLowerCase();
+  const status =
+    rawStatus === "completed" || rawStatus === "failed" || rawStatus === "cancelled"
+      ? rawStatus
+      : "finished";
+  const summary = /<summary>([\s\S]*?)<\/summary>/.exec(text)?.[1]?.trim() ?? "";
+  const header = `[System: background task ${taskId} ${status}]`;
+  return summary ? `${header}\n${summary}` : header;
+}
+
+/**
+ * System-marker content for a user message that is a Claude task notification.
+ *
+ * :param content: A user message block's content array.
+ * :returns: One ``input_text`` block carrying the marker, or ``null`` for an
+ *   ordinary user message.
+ */
+export function taskNotificationMarkerContent(
+  content: MessageContentBlock[],
+): MessageContentBlock[] | null {
+  for (const block of content) {
+    if (!isTextBlock(block)) continue;
+    const marker = claudeTaskNotificationMarker(block.text);
+    if (marker !== null) return [{ type: "input_text", text: marker }];
+  }
+  return null;
 }

--- a/web/src/lib/systemMessage.ts
+++ b/web/src/lib/systemMessage.ts
@@ -188,7 +188,10 @@ export function isClaudeTaskNotificationText(text: string): boolean {
  */
 export function claudeTaskNotificationMarker(text: string): string | null {
   if (!isClaudeTaskNotificationText(text)) return null;
-  const taskId = /<task-id>([^<]*)<\/task-id>/.exec(text)?.[1]?.trim() || "unknown";
+  // The header regex takes the id as one token; an id with inner whitespace
+  // would otherwise stop the marker parsing as a background task.
+  const rawId = /<task-id>([^<]*)<\/task-id>/.exec(text)?.[1]?.trim() ?? "";
+  const taskId = rawId !== "" && !/\s/.test(rawId) ? rawId : "unknown";
   const rawStatus = /<status>([^<]*)<\/status>/.exec(text)?.[1]?.trim().toLowerCase();
   const status =
     rawStatus === "completed" || rawStatus === "failed" || rawStatus === "cancelled"

--- a/web/src/store/chatStore.test.ts
+++ b/web/src/store/chatStore.test.ts
@@ -5746,6 +5746,58 @@ describe("chatStore — handleSessionEvent (session.* events)", () => {
       ]);
     });
 
+    it("renders a meta background-task wake as a system marker without consuming pending", () => {
+      // Claude Code resumes on a finished background task with no human
+      // message; the forwarder mirrors the notification as a meta user
+      // item. It must land as a `[System: …]` boundary (so the finished
+      // answer keeps its own bubble) and must not pop a queued web message.
+      useChatStore.setState({
+        blocks: [],
+        pendingUserMessages: [
+          { tempId: "pend_1", content: [{ type: "input_text", text: "visible pending" }] },
+        ],
+      });
+
+      handleSessionEvent({
+        type: "session_input_consumed",
+        itemId: "msg_wake",
+        itemType: "message",
+        isMeta: true,
+        data: {
+          role: "user",
+          is_meta: true,
+          content: [
+            {
+              type: "input_text",
+              text: [
+                "<task-notification>",
+                "<task-id>b3f9a2c1d</task-id>",
+                "<status>completed</status>",
+                "<summary>Background command completed (exit code 0)</summary>",
+                "</task-notification>",
+              ].join("\n"),
+            },
+          ],
+        },
+      });
+
+      const after = useChatStore.getState();
+      expect(after.blocks).toHaveLength(1);
+      expect(after.blocks[0]!.type).toBe("user_message");
+      expect(after.blocks[0]!.ctx.itemId).toBe("msg_wake");
+      expect((after.blocks[0] as UserMessageBlock).content).toEqual([
+        {
+          type: "input_text",
+          text:
+            "[System: background task b3f9a2c1d completed]\n" +
+            "Background command completed (exit code 0)",
+        },
+      ]);
+      expect(after.pendingUserMessages).toEqual([
+        { tempId: "pend_1", content: [{ type: "input_text", text: "visible pending" }] },
+      ]);
+    });
+
     it("is a no-op for non-message item types (e.g. function_call_output from other client)", () => {
       const existingBlocks: AnyBlock[] = [];
       useChatStore.setState({ blocks: existingBlocks, pendingUserMessages: [] });

--- a/web/src/store/chatStore.ts
+++ b/web/src/store/chatStore.ts
@@ -141,7 +141,7 @@ import {
   onResponseStart,
 } from "./interactionTelemetry";
 import { getSessionHost } from "@/lib/sessionHost";
-import { isSystemUserContent } from "@/lib/systemMessage";
+import { isSystemUserContent, taskNotificationMarkerContent } from "@/lib/systemMessage";
 import { isNativeTerminalSession as isNativeTerminalSessionFn } from "@/lib/nativeCodingAgents";
 
 export interface SendOptions {
@@ -5411,18 +5411,24 @@ export async function pumpStreamEvents(
  * Returns `null` if the event does not describe a user message.
  */
 function userContentFromEvent(event: SessionInputConsumedEvent): MessageContentBlock[] | null {
-  if (event.isMeta === true) return null;
   if (event.itemType !== "message") return null;
   if (event.data.role !== "user") return null;
   const raw = event.data.content;
   if (!Array.isArray(raw)) return null;
-  return raw.filter(
+  const content = raw.filter(
     (b): b is MessageContentBlock =>
       typeof b === "object" &&
       b !== null &&
       "type" in b &&
       (b.type === "input_text" || b.type === "input_image" || b.type === "input_file"),
   );
+  // A Claude background-task wake is hidden context (`is_meta`) that still
+  // has to start a new turn on screen: render it as a system marker. Every
+  // other meta message (injected skill text) stays hidden.
+  const marker = taskNotificationMarkerContent(content);
+  if (marker !== null) return marker;
+  if (event.isMeta === true) return null;
+  return content;
 }
 
 function hasCommittedItem(blocks: AnyBlock[], itemId: string): boolean {
@@ -6164,7 +6170,9 @@ export function handleSessionEvent(event: StreamEvent, streamConversationId?: st
       return;
     }
     case "session_input_consumed":
-      if (event.isMeta === true) return;
+      // Hidden meta inputs stay hidden — except a background-task wake,
+      // which `userContentFromEvent` re-labels as a system marker.
+      if (event.isMeta === true && userContentFromEvent(event) === null) return;
       // Promote the matching optimistic bubble into committed history.
       // Three ways to find it, in order of precision:
       //   1. By id — the server tells us which pending-input entry this


### PR DESCRIPTION
## Related issue

Linear: [OMNI-6959](https://linear.app/omnigent/issue/OMNI-6959/claude-code-output-missing-in-chat-view-terminal-shows-it-fine) (reported in prod on 2026-09-10; no GitHub issue).

## Summary

Claude Code reports a finished background shell task by injecting a `<task-notification>` user entry and starting a **new turn on it with no human message in between**. The claude-native forwarder mirrors that entry as an `is_meta` user item. The server suppressed it from SSE and the web UI dropped it on reload, so every assistant item after the real question was grouped into one bubble, and the settled-turn fold hid the answer Claude had already finished behind the follow-up work's "Worked for" row. The chat showed only the wrap-up text while the terminal showed the answer. Reproduced from the prod session's SSE trace: answer committed 11:47:38, idle, wake 11:47:48, tool work, wrap-up 11:48:15, fold labelled "Worked for 37s" spanning exactly that range.

Fix: render the wake as a muted `[System: background task <id> completed]` marker, the same treatment scheduled, timer and sub-agent wakes already get. A marker starts a new bubble, so the answer keeps its own text-only bubble (nothing to fold) and only the follow-up work folds.

- **Reload path (web):** `itemsToBlocks` re-labels the notification instead of dropping it; `parseSystemMessage` learns the `background task … completed|failed|cancelled|finished` header and maps it onto the existing task marker kinds.
- **Live path (server + web):** `_publish_input_consumed` now publishes meta user items too, flagged `is_meta` (the web store and REPL already gate on that flag). The store re-labels task notifications, keeps other meta text (skill wrappers) hidden, and never pops a pending web message for a marker. Non-user meta messages stay off the stream, since `response.output_item.done` has no flag-aware live rendering path.
- **Conscious sign-off:** hidden skill-wrapper text now travels the SSE wire for the session's own subscribers (hidden in the UI). Those subscribers can already read the same items from session history, so this widens no authorization boundary.

ELI5: Claude finished answering, then a background job it had started earlier finished and Claude spoke again about that. The chat treated both as one reply and collapsed the first one under "Worked for 37s". Now the moment Claude resumed is shown as a small system row, so the first reply stays open.

```text
before:  [user Q] ─ [answer, wake(hidden), narration, tools…, wrap-up]  → fold hides answer
after:   [user Q] ─ [answer] ─ System: Background task completed ─ [narration, tools…, wrap-up] → only work folds
```

## Test Plan

- New e2e `test_background_task_wake_keeps_prior_answer_visible` in `tests/e2e_ui/chat/test_working_indicator_reload.py` replays the observed wire order through the same `/events` route the forwarder uses (answer, idle edge, `is_meta` notification, running edge, tool work, wrap-up, idle edge) and asserts the answer, the marker and a single fold, live and again after reload. **Fails on main** (fold forms, `get_by_text("It is end-to-end launch latency")` not found, no `system-message` marker) and **passes on this branch**; the other 9 non-nightly tests in the file still pass (`--ui-skip-build` against a fresh SPA build).
- `vitest run src/lib/systemMessage.test.ts src/lib/itemsToBlocks.test.ts src/lib/renderItems.test.ts src/store/chatStore.test.ts`: 622 passed (2 legacy "hidden notification" tests updated to assert the marker; new cases for the parser, the store's live path and the bubble split).
- `pytest tests/server/integration/test_sessions_endpoints.py tests/server/integration/test_sessions_child_sessions.py -k meta`: 4 passed (skill-wrapper test now asserts the flagged `session.input.consumed`).
- `pre-commit` on changed files: ruff, prettier, oxlint, tsc pass. pyrefly reports a pre-existing databricks-sdk typing error in untouched `omnigent/harnesses/opencode_native/provider.py` in this venv.
- Review follow-ups (Polly): a whitespace-bearing `<task-id>` now normalizes to `unknown` so the marker header always parses (unit test), and a meta message that is not a user message stays unpublished (server test).

## Demo

- [x] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Same seeded sequence (question, answer, hidden task notification, follow-up tool work, wrap-up), captured after reload. On `main` the finished answer is folded under "Worked for" and only the wrap-up table shows; on this branch the answer keeps its bubble, the wake shows as a muted system row, and only the follow-up work folds.

| `main` | this branch |
|---|---|
| ![Answer folded away on main](https://raw.githubusercontent.com/dbczumar/omnigent/assets/pr-7002/before-main.png) | ![Answer visible above the marker on the branch](https://raw.githubusercontent.com/dbczumar/omnigent/assets/pr-7002/after-fix.png) |

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The e2e test is the faithful reproduction (same route, same item shapes and order as the prod trace); unit tests pin the parser, the reload grouping and the live store path; the server test pins the flagged event.

## Changelog

A finished Claude answer no longer collapses into the "Worked for" fold when a background task wakes the turn; the wake shows as a "Background task completed" system row.
