### PR TITLE
ci(polly-review): let REVIEW_ALLOWLIST logins trigger /review

### DIFF
--- a/.github/workflows/polly-review.yml
+++ b/.github/workflows/polly-review.yml
@@ -8,7 +8,8 @@ name: Polly AI Review
 #
 # Triggers:
 #   - pull_request opened/reopened/ready_for_review (automatic, once per PR)
-#   - `/review` comment on a PR (manual retrigger by write-access users)
+#   - `/review` comment on a PR (manual retrigger by write-access users, or
+#     any login in the REVIEW_ALLOWLIST repo variable, a JSON array of strings)
 #   - workflow_dispatch with a PR number (manual retrigger from Actions tab,
 #     also used by the maintainer-approval relay)
 #
@@ -43,10 +44,10 @@ env:
 
 jobs:
   # Security precondition gate (security-gate.yml): untrusted PRs wait for
-  # the scan; trusted authors pass through. Only runs on pull_request events
-  # — issue_comment and workflow_dispatch are already gated by write-access
-  # (author_association check + GitHub's own dispatch auth) and never check
-  # out PR code, so the scan is not applicable.
+  # the scan; trusted authors pass through. Only runs on pull_request events.
+  # issue_comment and workflow_dispatch are gated by write-access or the
+  # REVIEW_ALLOWLIST (author_association / login check, plus GitHub's dispatch
+  # auth) and never check out PR code, so the scan is not applicable.
   gate:
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/security-gate.yml
@@ -54,9 +55,10 @@ jobs:
   review:
     name: Polly AI Review
     needs: gate
-    # Fire on non-draft PRs (after gate passes), `/review` comments by
-    # write-access users, or workflow_dispatch. The `!cancelled()` ensures
-    # the job runs when gate is skipped (non-PR events) but not when it fails.
+    # Fire on non-draft PRs (after gate passes), `/review` comments by write-
+    # access users or REVIEW_ALLOWLIST logins, or workflow_dispatch. The
+    # `!cancelled()` ensures the job runs when gate is skipped (non-PR events)
+    # but not when it fails.
     if: >-
       !cancelled() && (
         (
@@ -72,7 +74,8 @@ jobs:
           (
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||
-            github.event.comment.author_association == 'COLLABORATOR'
+            github.event.comment.author_association == 'COLLABORATOR' ||
+            contains(fromJSON(vars.REVIEW_ALLOWLIST || '[]'), github.event.comment.user.login)
           )
         ) ||
         github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Related issue

N/A, Test / CI change (no issue required per the PR template).

## Summary

The `/review` comment trigger in `polly-review.yml` is gated on GitHub `author_association` (`OWNER`/`MEMBER`/`COLLABORATOR`), which is equivalent to repo write access. Trusted OSS contributors without write access therefore cannot re-run a Polly review on their own PR after pushing new commits, and fork PRs get no automatic review at all (fork `pull_request` runs receive no gateway secrets, so the creds step no-ops).

This adds an optional `REVIEW_ALLOWLIST` repo variable (a JSON array of logins) OR'd into the existing gate, so maintainers can grant `/review` to named contributors without granting write access:

- Unset or empty resolves to an empty list via `fromJSON(vars.REVIEW_ALLOWLIST || '[]')`, so behavior is unchanged until the variable is populated.
- The `issue_comment` path still never checks out PR head code, and always runs the default-branch copy of this workflow, so a PR cannot edit the gate to add itself.

To use it: `gh variable set REVIEW_ALLOWLIST --repo omnigent-ai/omnigent --body '["login1","login2"]'`.

## Test Plan

- `yaml.safe_load` parses the edited workflow (pre-commit `check yaml syntax` passes).
- Reviewed the expression: an unset variable gives `fromJSON('[]')`, an empty list, so `contains([], login)` is false and the gate stays identical to today until the variable is set.
- Full end-to-end (an allowlisted, non-write user commenting `/review`) can only be exercised after this merges, because `issue_comment` always runs the workflow copy on the default branch. Post-merge check: set `REVIEW_ALLOWLIST` to a test login, have that user comment `/review` on an open PR, and confirm the "Polly AI Review" run starts.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is a GitHub Actions `if:` expression with no extractable script logic, so there is no unit-test surface in-repo. Verified manually that the workflow YAML parses and that the `fromJSON(vars.REVIEW_ALLOWLIST || '[]')` default keeps the gate unchanged when the variable is unset. The allowlist path can only be exercised end-to-end after merge (see Test Plan), since `issue_comment` runs the default-branch copy of the workflow.

This pull request and its description were written by Isaac.
