### PR TITLE
Support launcher prefixes in native resume hints

### DIFF
--- a/omnigent/native/_native_resume_hint.py
+++ b/omnigent/native/_native_resume_hint.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import shlex
 
 import click
+
+_RESUME_COMMAND_PREFIX_ENV_VAR = "OMNIGENT_RESUME_COMMAND_PREFIX"
 
 
 def format_native_resume_command(
@@ -21,10 +24,18 @@ def format_native_resume_command(
     :param session_id: Omnigent conversation id, e.g.
         ``"conv_abc123"``.
     :param server: Optional Omnigent server URL, e.g.
-        ``"https://example.databricks.com"``.
+        ``"https://example.databricks.com"``. Rendered only in the default
+        unprefixed form.
     :returns: Shell-quoted command string, e.g.
-        ``"omnigent claude --resume conv_abc123"``.
+        ``"omnigent claude --resume conv_abc123"``. When
+        ``OMNIGENT_RESUME_COMMAND_PREFIX`` is set, that multi-token command
+        replaces the leading ``omnigent`` token and the server is omitted.
     """
+    prefix = os.environ.get(_RESUME_COMMAND_PREFIX_ENV_VAR)
+    if prefix:
+        parts = [*shlex.split(prefix), native_command, "--resume", session_id]
+        return " ".join(shlex.quote(part) for part in parts)
+
     parts = ["omnigent", native_command]
     if server is not None:
         parts.extend(["--server", server])

--- a/omnigent/native/_native_resume_hint.py
+++ b/omnigent/native/_native_resume_hint.py
@@ -33,8 +33,13 @@ def format_native_resume_command(
     """
     prefix = os.environ.get(_RESUME_COMMAND_PREFIX_ENV_VAR)
     if prefix:
-        parts = [*shlex.split(prefix), native_command, "--resume", session_id]
-        return " ".join(shlex.quote(part) for part in parts)
+        try:
+            prefix_parts = shlex.split(prefix)
+        except ValueError:
+            prefix_parts = []
+        if prefix_parts:
+            parts = [*prefix_parts, native_command, "--resume", session_id]
+            return " ".join(shlex.quote(part) for part in parts)
 
     parts = ["omnigent", native_command]
     if server is not None:

--- a/tests/test_native_resume_hint.py
+++ b/tests/test_native_resume_hint.py
@@ -10,7 +10,9 @@ from omnigent.native._native_resume_hint import (
 )
 
 
-def test_format_native_resume_command_includes_remote_context() -> None:
+def test_format_native_resume_command_includes_remote_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """
     Remote native-wrapper hints include enough context to copy/paste.
 
@@ -22,6 +24,8 @@ def test_format_native_resume_command_includes_remote_context() -> None:
     hint containing it would tell the user to run a command that
     no longer parses.
     """
+    monkeypatch.delenv("OMNIGENT_RESUME_COMMAND_PREFIX", raising=False)
+
     command = format_native_resume_command(
         native_command="claude",
         server="https://example.databricks.com",
@@ -29,6 +33,41 @@ def test_format_native_resume_command_includes_remote_context() -> None:
     )
 
     assert command == ("omnigent claude --server https://example.databricks.com --resume conv_abc")
+
+
+def test_format_native_resume_command_uses_launcher_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A distribution wrapper can replace the executable and own routing."""
+    monkeypatch.setenv("OMNIGENT_RESUME_COMMAND_PREFIX", "acme-agent omnigent")
+
+    command = format_native_resume_command(
+        native_command="codex",
+        server="https://example.com/omnigent",
+        session_id="conv_abc",
+    )
+
+    assert command == "acme-agent omnigent codex --resume conv_abc"
+    assert "--server" not in command
+
+
+def test_format_native_resume_command_shell_quotes_prefixed_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prefix arguments and dynamic values remain safe to paste into a shell."""
+    monkeypatch.setenv(
+        "OMNIGENT_RESUME_COMMAND_PREFIX",
+        "acme-agent --profile 'example team' omnigent",
+    )
+
+    command = format_native_resume_command(
+        native_command="claude",
+        session_id="conversation with spaces",
+    )
+
+    assert command == (
+        "acme-agent --profile 'example team' omnigent claude --resume 'conversation with spaces'"
+    )
 
 
 def test_cold_resume_hint_not_restored_is_honest_on_stderr(

--- a/tests/test_native_resume_hint.py
+++ b/tests/test_native_resume_hint.py
@@ -70,6 +70,27 @@ def test_format_native_resume_command_shell_quotes_prefixed_tokens(
     )
 
 
+@pytest.mark.parametrize(
+    "prefix",
+    ["   ", "acme-agent 'unterminated"],
+    ids=["whitespace-only", "malformed"],
+)
+def test_format_native_resume_command_ignores_invalid_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    prefix: str,
+) -> None:
+    """An invalid launcher prefix falls back to the default resume command."""
+    monkeypatch.setenv("OMNIGENT_RESUME_COMMAND_PREFIX", prefix)
+
+    command = format_native_resume_command(
+        native_command="codex",
+        server="https://example.com/omnigent",
+        session_id="conv_abc",
+    )
+
+    assert command == ("omnigent codex --server https://example.com/omnigent --resume conv_abc")
+
+
 def test_cold_resume_hint_not_restored_is_honest_on_stderr(
     capsys: pytest.CaptureFixture[str],
 ) -> None:


### PR DESCRIPTION
## Related issue

Closes #7004

## Summary

- Add opt-in `OMNIGENT_RESUME_COMMAND_PREFIX` support for native resume hints.
- Parse multi-token prefixes with shell semantics and quote every emitted token.
- When a prefix is configured, omit `--server` because the launcher owns routing. Existing behavior is unchanged when the variable is unset.
- Fall back to that default behavior for malformed or whitespace-only prefix values.

## Test Plan

- `uv run pytest tests/test_native_resume_hint.py` (7 passed)
- Ruff check and format validation passed for both touched files.
- Full touched-file pre-commit validation passed, including Pyrefly with `--extra tracing`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Example output with a configured prefix:

```text
acme-agent omnigent codex --resume conv_abc
```

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover unchanged default behavior, multi-token prefixes, server omission, shell quoting, and fallback for malformed or whitespace-only prefixes.

## Changelog

Native resume hints can now use a distribution-provided launcher command prefix.