### PR TITLE
Route pi gateway models by configured family, not name tokens

### DIFF
--- a/omnigent/inner/pi_executor.py
+++ b/omnigent/inner/pi_executor.py
@@ -863,6 +863,7 @@ def _build_models_json(
                 model,
                 wire_catalog.get(model.lower()),
                 generic_openai_wire_api=generic_openai_wire_api,
+                only_family=_only_configured_family(base_urls),
             )
         ]
         if not any(entry.get("id") == model for entry in provider["models"]):
@@ -910,15 +911,50 @@ def _pi_needs_responses_api(
     return "gpt" in lower
 
 
+def _only_configured_family(base_urls: Mapping[str, str] | None) -> str | None:
+    """Return the lone family key when a provider configures exactly one.
+
+    An empty URL counts as unconfigured — the reading
+    :func:`_build_models_json` itself gives the dict — so a lone family with
+    an empty URL is not "configured" and never pins routing.
+
+    :param base_urls: Provider base URLs keyed by family (``"claude"`` /
+        ``"openai"``), from ucode state or a provider entry.
+    :returns: The single configured family, or ``None`` when both families
+        (or neither) carry a URL.
+    """
+    families = [family for family, url in (base_urls or {}).items() if url]
+    if len(families) == 1:
+        return families[0]
+    return None
+
+
 def _pi_provider_for_model(
     model: str,
     wire_apis: frozenset[ModelWireAPI] | None = None,
     *,
     generic_openai_wire_api: str | None = None,
+    only_family: str | None = None,
 ) -> str:
-    """Return the Pi provider name to use for a given Databricks model."""
+    """Return the Pi provider name to use for a given Databricks model.
+
+    :param model: Model id to route.
+    :param wire_apis: Catalog-reported wire surfaces, when known.
+    :param generic_openai_wire_api: Configured wire for a generic
+        (non-Databricks) OpenAI-compatible provider.
+    :param only_family: The lone family a provider entry configures, from
+        :func:`_only_configured_family`. A one-family provider has no other
+        real endpoint, so every dynamically-registered model routes to that
+        family's surface regardless of name tokens; name heuristics would
+        otherwise pick a provider whose base URL was fabricated for the
+        Databricks workspace host and 404 at the vendor.
+    """
     lower = model.lower()
-    if "claude" in lower:
+    if "claude" in lower and only_family != "openai":
+        return "databricks-anthropic"
+    # A claude-only provider fronts non-Claude-named ids (e.g. moonshot
+    # serving kimi) on its anthropic wire, so they route there too.
+    if only_family == "claude":
         return "databricks-anthropic"
     if generic_openai_wire_api is not None:
         if generic_openai_wire_api == RESPONSES_WIRE_API:
@@ -2374,6 +2410,7 @@ class PiExecutor(Executor):
                 effective_model,
                 wire_catalog.get(effective_model.lower()),
                 generic_openai_wire_api=self._generic_openai_wire_api(),
+                only_family=_only_configured_family(self._base_urls_override),
             )
             pi_model = f"{provider}/{effective_model}"
         else:

--- a/tests/inner/test_pi_executor.py
+++ b/tests/inner/test_pi_executor.py
@@ -677,6 +677,49 @@ class TestBuildModelsJson(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+def test_anthropic_only_family_routes_non_claude_model_to_anthropic_surface():
+    # A provider configuring only an anthropic family (a vendor whose
+    # anthropic-wire endpoint also fronts non-Claude-named models, e.g.
+    # moonshot serving kimi at /anthropic) must route a non-claude model to
+    # that configured surface. Routing by name token instead sent the model
+    # to the completions provider against a fabricated /serving-endpoints
+    # path that only exists on a Databricks workspace, so the vendor
+    # answered 404 url.not_found.
+    result = _build_models_json(
+        "https://api.moonshot.ai",
+        "tok",
+        {"claude": "https://api.moonshot.ai/anthropic"},
+        model="kimi-k2.7-code",
+    )
+    p = result["providers"]
+    anthropic_ids = [e.get("id") for e in p["databricks-anthropic"]["models"]]
+    assert "kimi-k2.7-code" in anthropic_ids
+    assert p["databricks-anthropic"]["baseUrl"] == "https://api.moonshot.ai/anthropic"
+    for name, provider in p.items():
+        if name != "databricks-anthropic":
+            ids = [e.get("id") for e in provider.get("models", [])]
+            assert "kimi-k2.7-code" not in ids, name
+
+
+def test_openai_only_family_routes_claude_named_model_to_openai_surface():
+    # Symmetric: a provider configuring only an openai family that serves a
+    # Claude-named id (a LiteLLM-style passthrough) must keep that model on
+    # the configured openai surface. The name heuristic sent it to the
+    # anthropic provider against a fabricated /serving-endpoints/anthropic
+    # path. Configured families win over name tokens in both directions.
+    result = _build_models_json(
+        "https://gw.example.com",
+        "tok",
+        {"openai": "https://gw.example.com/v1"},
+        model="claude-k2.7",
+    )
+    p = result["providers"]
+    completions_ids = [e.get("id") for e in p["databricks-completions"]["models"]]
+    assert "claude-k2.7" in completions_ids
+    anthropic_ids = [e.get("id") for e in p["databricks-anthropic"]["models"]]
+    assert "claude-k2.7" not in anthropic_ids
+
+
 class TestGenerateExtensionJs(unittest.TestCase):
     def test_contains_tool_names(self):
         schemas = [


### PR DESCRIPTION
## Problem

A provider entry that configures only ONE family (e.g. a vendor whose
anthropic-wire endpoint also serves non-Claude-named models — Moonshot
serving `kimi-k2.7-code` at `api.moonshot.ai/anthropic`) cannot launch a
non-claude model through the pi gateway: `_pi_provider_for_model` routes by
name token (`"claude" in id` → anthropic provider, else a completions
provider), so `kimi-k2.7-code` lands on `databricks-completions` whose base
URL is fabricated for a Databricks workspace (`{origin}/serving-endpoints`)
— a path that only exists on a workspace. The vendor answers **404
`url.not_found`**.

The symmetric shape breaks too: an openai-only passthrough serving a
Claude-named id routes to `databricks-anthropic` with the fabricated
`{origin}/serving-endpoints/anthropic` base.

## Fix

When `base_urls` carries exactly one family (truthy URL), that family is the
only surface the vendor actually serves, so every dynamically-registered
model routes to it — family availability wins over name tokens, in both
directions. With both families (or neither) configured, routing is
unchanged. The family pin is applied at both decision points (models.json
registration and the launch-time `provider/<model>` selector in
`_ensure_rpc`) so they cannot disagree.

## Tests

Two new tests in `tests/inner/test_pi_executor.py` cover both single-family
shapes (anthropic-only + non-claude id; openai-only + claude-named id) and
assert the model lands on the configured family's provider with its real
base URL. Full file green (168 tests), ruff + pyrefly clean.

Possible follow-up (happy to send separately): catalog-model registration
inside `_build_models_json`'s loop still routes by name tokens under a
family pin — observable for the single-claude-family cli-config gateway
shape in `workflow.py` (`_apply_cli_config_databricks_to_pi`).

Fixes #7018