### PR TITLE
List key/gateway providers' live models in the Pi launch picker

### DIFF
--- a/omnigent/harnesses/pi_native/credentials.py
+++ b/omnigent/harnesses/pi_native/credentials.py
@@ -53,6 +53,7 @@ from omnigent.models.pi_model_compatibility import (
     unsupported_in_pi,
 )
 from omnigent.onboarding.provider_config import (
+    ANTHROPIC_FAMILY,
     CHAT_WIRE_API,
     CLI_CONFIG_KIND,
     DATABRICKS_KIND,
@@ -74,6 +75,8 @@ from omnigent.util.reasoning_effort import (
 )
 
 if TYPE_CHECKING:
+    import httpx
+
     # Annotation-only import (the runtime import is lazy inside the function,
     # since ``ambient`` pulls in onboarding-only deps this module avoids on the
     # runner's session-create hot path).
@@ -232,6 +235,11 @@ class PiProviderConfig:
         reachable with this provider's credential, keyed by surface. Set by the
         Databricks builders; lets a model the live catalog didn't list be routed
         by family instead of stranded on the Claude-only primary.
+    :param listing_provider: Model-catalog descriptor of the key/gateway/local
+        endpoint whose live model inventory the pre-launch picker enumerates.
+        Metadata for the picker only — never rendered into ``models.json`` — and
+        ``None`` for the Databricks / cli-config / subscription paths, which
+        resolve their models elsewhere.
     """
 
     provider_id: str
@@ -250,6 +258,11 @@ class PiProviderConfig:
     # Keys are provider ids; values are complete Pi provider config dicts.
     additional_providers: dict[str, _PiProviderPayload] = field(default_factory=dict, hash=False)
     databricks_surfaces: dict[DatabricksPiSurface, str] = field(default_factory=dict, hash=False)
+    # Excluded from __hash__/__eq__ too: two configs that render the same
+    # models.json are equal regardless of how the picker discovered the ids.
+    listing_provider: model_catalog.ResolvedModelProvider | None = field(
+        default=None, hash=False, compare=False
+    )
 
     @property
     def _primary_claude_only(self) -> bool:
@@ -474,16 +487,40 @@ def pi_own_login_model_arg(selection: str) -> str | None:
     return None if "/" in split[1] else split[1]
 
 
-def pi_native_model_options() -> list[dict[str, object]]:
+def pi_native_model_options(
+    *,
+    config_loader: Callable[[], dict[str, object]] | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> list[dict[str, object]]:
     """Return the pre-launch Pi model choices for this host.
 
-    Prefers the provider configured through ``omni setup``; when none is
-    configured the launched Pi runs on its own login, so that login's models
-    (:func:`pi_own_login_model_options`) are the honest catalog.
+    Prefers the provider configured through ``omni setup``; key/gateway/local
+    providers render their endpoint's live model listing, so the picker offers
+    the models the endpoint actually serves rather than only the configured
+    default. When none is configured the launched Pi runs on its own login, so
+    that login's models (:func:`pi_own_login_model_options`) are the honest
+    catalog.
+
+    :param config_loader: Injection seam for tests; ``None`` uses
+        :func:`load_config` through
+        :func:`resolve_pi_native_provider`.
+    :param transport: Optional httpx transport override for tests, forwarded to
+        the live listing fetch.
+    :returns: One pre-launch option per model, sorted by qualified id.
     """
-    provider = resolve_pi_native_provider()
+    # Forward only the config_loader seam: tests replace the module-level
+    # resolver with a zero-argument callable, so a bare picker call must stay
+    # bare. The transport is NOT threaded through resolution — the listing is
+    # fetched below, off the launch path.
+    if config_loader is None:
+        provider = resolve_pi_native_provider()
+    else:
+        provider = resolve_pi_native_provider(config_loader=config_loader)
     if provider is None:
         return pi_own_login_model_options()
+    provider = replace(
+        provider, extra_models=_live_family_model_entries(provider, transport=transport)
+    )
 
     options: dict[str, dict[str, object]] = {}
     for provider_id, payload in provider.to_models_config()["providers"].items():
@@ -1275,6 +1312,57 @@ def _catalog_entry_for_model(model_id: str) -> model_catalog.ModelEntry | None:
     return None
 
 
+def _live_family_model_entries(
+    provider: PiProviderConfig,
+    *,
+    transport: httpx.BaseTransport | None,
+) -> list[_PiModelEntry]:
+    """Enumerate a key/gateway endpoint's models for the pre-launch picker.
+
+    The rendered ``models.json`` otherwise carries only the configured default,
+    so the picker offered one row while the endpoint served several. Ask the
+    endpoint's own listing through the shared model-catalog fetchers — the lane
+    the Databricks paths already use — and keep the configured default first:
+    it still launches when the listing is unreachable.
+
+    :param provider: The resolved provider; its ``listing_provider`` names the
+        endpoint to list and ``extra_models`` holds the configured default.
+    :param transport: Optional httpx transport override for tests.
+    :returns: The configured entries followed by every live model id, deduped;
+        unchanged when the listing fails.
+    """
+    listing_provider = provider.listing_provider
+    if listing_provider is None:
+        return list(provider.extra_models)
+    try:
+        # Mirror the catalog's routing: only a real Anthropic key speaks the
+        # Anthropic models API; a gateway's family endpoint proxies messages,
+        # so its inventory comes from the OpenAI-compatible listing.
+        if listing_provider.kind == KEY_KIND and listing_provider.family == ANTHROPIC_FAMILY:
+            listing = model_catalog._fetch_anthropic_listing(listing_provider, transport=transport)
+        else:
+            listing = model_catalog._fetch_openai_compatible_listing(
+                listing_provider, transport=transport
+            )
+    except Exception:  # noqa: BLE001 — an unreachable listing must not break the picker
+        _LOGGER.info(
+            "pi-native: could not list models for provider %s; offering only the "
+            "configured default",
+            listing_provider.detail or listing_provider.kind,
+            exc_info=True,
+        )
+        return list(provider.extra_models)
+
+    entries = list(provider.extra_models)
+    seen = {entry.get("id") for entry in entries}
+    for model_entry in listing.models:
+        if model_entry.id in seen:
+            continue
+        seen.add(model_entry.id)
+        entries.append(_gateway_pi_model_entry(model_entry.id))
+    return entries
+
+
 def _inline_family_pi_provider(
     entry: ProviderEntry, *, model: str | None
 ) -> PiProviderConfig | None:
@@ -1342,6 +1430,16 @@ def _inline_family_pi_provider(
             # passthrough endpoint rejects it, and silence reads as a hang.
             credential_warning=_cross_family_routing_warning(entry, family_name, resolved_model),
             extra_models=[model_entry],
+            # Record the endpoint the pre-launch picker can enumerate live; no
+            # I/O happens here so session launch stays off the network.
+            listing_provider=model_catalog.ResolvedModelProvider(
+                kind=entry.kind,
+                family=family_name,
+                base_url=family.base_url,
+                api_key=family.api_key,
+                auth_command=family.auth_command,
+                detail=f"provider {entry.name!r}",
+            ),
         )
     return None
 

--- a/tests/test_pi_native_credentials.py
+++ b/tests/test_pi_native_credentials.py
@@ -7,6 +7,7 @@ import stat
 from pathlib import Path
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 from omnigent.harnesses.pi_native import credentials as creds
@@ -437,6 +438,118 @@ def test_provider_launch_rejects_unavailable_qualified_selection(tmp_path: Path)
         )
 
     assert not agent_dir.exists()
+
+
+def test_key_provider_model_options_list_the_live_anthropic_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key/gateway provider's picker rows come from its live model listing.
+
+    The pre-launch picker renders the resolved provider's ``models.json``;
+    for key/gateway providers that config carried only the configured
+    default (one row), so the picker offered exactly one model while the
+    endpoint serves several. The listing must be fetched live via the
+    model-catalog fetchers — the same lane the Databricks paths use — with
+    the configured default still present (it launches offline).
+    """
+    config = {
+        "providers": {
+            "zai": {
+                "kind": "gateway",
+                "default": True,
+                "anthropic": {
+                    "base_url": "https://gw.example.com/anthropic",
+                    "api_key": "sk-test-literal",
+                    "models": {"default": "glm-5.3"},
+                },
+            }
+        }
+    }
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "glm-5.3"}, {"id": "glm-5.3-flash"}, {"id": "glm-5.2"}]},
+        )
+
+    options = creds.pi_native_model_options(
+        config_loader=lambda: config, transport=httpx.MockTransport(_handler)
+    )
+
+    assert {o["model"] for o in options} == {
+        "omnigent/glm-5.3",
+        "omnigent/glm-5.3-flash",
+        "omnigent/glm-5.2",
+    }
+
+
+def test_key_provider_model_options_list_the_live_openai_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An openai-family key/gateway provider lists its /v1/models rows too."""
+    config = {
+        "providers": {
+            "deepseek": {
+                "kind": "key",
+                "default": True,
+                "openai": {
+                    "base_url": "https://gw.example.com/v1",
+                    "api_key": "sk-test-literal",
+                    "wire_api": "chat",
+                    "models": {"default": "deepseek-flash"},
+                },
+            }
+        }
+    }
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "deepseek-flash"}, {"id": "deepseek-v4-pro"}]},
+        )
+
+    options = creds.pi_native_model_options(
+        config_loader=lambda: config, transport=httpx.MockTransport(_handler)
+    )
+
+    assert {o["model"] for o in options} == {
+        "omnigent/deepseek-flash",
+        "omnigent/deepseek-v4-pro",
+    }
+
+
+def test_key_provider_model_options_degrade_to_default_when_listing_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable listing endpoint degrades to the configured default.
+
+    The launch picker must not hard-fail when the vendor's /models endpoint
+    is offline or rejects the key: the configured default model still
+    launches, exactly as it did before live listing existed.
+    """
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "bad key"})
+
+    config = {
+        "providers": {
+            "zai": {
+                "kind": "gateway",
+                "default": True,
+                "anthropic": {
+                    "base_url": "https://gw.example.com/anthropic",
+                    "api_key": "sk-test-literal",
+                    "models": {"default": "glm-5.3"},
+                },
+            }
+        }
+    }
+
+    options = creds.pi_native_model_options(
+        config_loader=lambda: config, transport=httpx.MockTransport(_handler)
+    )
+
+    assert {o["model"] for o in options} == {"omnigent/glm-5.3"}
 
 
 def test_pi_native_model_options_lists_only_managed_models(


### PR DESCRIPTION
## Problem

The pre-launch Pi model picker renders the resolved provider's
`models.json`. For key/gateway/local providers (`_inline_family_pi_provider`)
that config carries exactly one model entry — the configured default — so
the picker offers exactly one model while the endpoint serves several (z.ai
serves ten on both wire families). The Databricks paths already enumerate
live listings (`DATABRICKS-PATCH(pi-live-model-discovery)`); inline-family
providers never did.

## Fix

The inline-family builder records a `listing_provider` descriptor (a
model-catalog `ResolvedModelProvider`) on the resolved `PiProviderConfig` —
metadata only, excluded from hash/equality, and **no I/O at build time**, so
`resolve_pi_native_provider` stays offline and session launch/resume never
touch the network. `pi_native_model_options` enumerates the descriptor's
endpoint through the shared model-catalog fetchers
(`_fetch_anthropic_listing` / `_fetch_openai_compatible_listing` — the same
lane the Databricks paths use) and merges the live ids into the picker rows.

- Anthropic-family `key` providers are listed via the Anthropic models API;
  every other inline family via the OpenAI-compatible listing, mirroring how
  the catalog routes real keys vs gateway surfaces.
- The listing is best-effort: unreachable endpoint or rejected credential
  degrades to the configured default only — the picker never hard-fails, and
  the default (which launches without any listing) is kept and deduped.
- `pi_native_model_options` gains `config_loader`/`transport` injection
  seams following the established pattern; the host's existing
  `asyncio.to_thread` call site is unchanged.
- Databricks, cli-config, and subscription paths are unchanged.

## Tests

Three new tests in `tests/test_pi_native_credentials.py`: live listing via
the anthropic family, via an openai-completions family, and degradation to
the default when the listing endpoint rejects the credential. Full file
green (124 tests), ruff + format + pyrefly clean. Verified live against
z.ai's anthropic and OpenAI-compatible surfaces (both serve 10 ids; the
`/v4`-base listing URL needs the `_models_url` fix — sent as a separate PR).

Fixes #7019