### PR TITLE
chore(databricks-connect): bump the ucode pin to the merged broker-mint SHA

### DIFF
--- a/omnigent/onboarding/ucode_setup.py
+++ b/omnigent/onboarding/ucode_setup.py
@@ -33,7 +33,7 @@ _UCODE_AGENT_NAMES: tuple[str, ...] = ("claude", "codex", "pi")
 # break setup unexpectedly). A full SHA is immutable, so uvx caches the built
 # wheel by ref and reuses it across runs — no ``--refresh-package`` needed to
 # defeat a mutable branch's stale cache.
-_UCODE_GIT_REF = "94271a78c7139220b7333bcae91e522f95ef3af3"
+_UCODE_GIT_REF = "304e4a29c5ca73b3bfaaf1911e38d0080833fda4"
 _UCODE_UVX_SOURCE = f"git+https://github.com/databricks/ucode@{_UCODE_GIT_REF}"
 
 

--- a/tests/onboarding/test_ucode_setup.py
+++ b/tests/onboarding/test_ucode_setup.py
@@ -33,7 +33,7 @@ def test_find_ucode_command_prefers_uvx_pinned_commit() -> None:
         assert find_ucode_command() == [
             "/usr/bin/uvx",
             "--from",
-            "git+https://github.com/databricks/ucode@94271a78c7139220b7333bcae91e522f95ef3af3",
+            "git+https://github.com/databricks/ucode@304e4a29c5ca73b3bfaaf1911e38d0080833fda4",
             "ucode",
         ]
 
@@ -89,7 +89,7 @@ def test_build_ucode_configure_command_supports_uvx_prefix() -> None:
         (
             "/usr/bin/uvx",
             "--from",
-            "git+https://github.com/databricks/ucode@94271a78c7139220b7333bcae91e522f95ef3af3",
+            "git+https://github.com/databricks/ucode@304e4a29c5ca73b3bfaaf1911e38d0080833fda4",
             "ucode",
         ),
         workspace_urls=("https://one.example.databricks.com",),
@@ -98,7 +98,7 @@ def test_build_ucode_configure_command_supports_uvx_prefix() -> None:
     assert command == [
         "/usr/bin/uvx",
         "--from",
-        "git+https://github.com/databricks/ucode@94271a78c7139220b7333bcae91e522f95ef3af3",
+        "git+https://github.com/databricks/ucode@304e4a29c5ca73b3bfaaf1911e38d0080833fda4",
         "ucode",
         "configure",
         "--workspaces",


### PR DESCRIPTION
## Related issue

Closes #6984

## Summary

- `databricks/ucode` #531 (`DATABRICKS_BEARER_COMMAND`) and #532 (Pi per-request auth) have merged to `databricks/ucode` main. Bump `_UCODE_GIT_REF` from the earlier pre-feature commit to `304e4a29c5ca73b3bfaaf1911e38d0080833fda4` (current upstream main).
- That commit carries every capability the managed-connect harness paths call: the broker token command (`DATABRICKS_BEARER_COMMAND`), Pi's per-request auth (`ucode auth-token`), the `ucode configure --profiles/--use-pat/--skip-unavailable` sandbox flags, and opencode config generation. The managed-connect Databricks AI gateway path is now **live** rather than inert (it was gated on these ucode features landing).
- Still a pinned full SHA on `databricks/ucode` (immutable, uvx-cacheable) — no fork dependency.

## Test Plan

- Verified `304e4a29c5ca73b3bfaaf1911e38d0080833fda4` on `databricks/ucode` contains all four capability markers: `DATABRICKS_BEARER_COMMAND`, `src/ucode/agents/pi.py` minting via `ucode auth-token`, the `--profiles`/`--use-pat`/`--skip-unavailable` configure flags, and `src/ucode/agents/opencode.py`.
- `uv run ruff format/check` clean.
- `uv run pytest tests/onboarding/test_ucode_setup.py` → 12 passed (the three assertions that pin the exact uvx source string were updated to the new SHA).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification = confirming the pinned upstream SHA actually contains the four ucode capabilities the managed-connect paths invoke (grep at that commit, listed in Test Plan). The unit tests in `tests/onboarding/test_ucode_setup.py` assert the exact uvx source string, so they lock the new pin. End-to-end in an agent-sandbox lab is tracked separately; the harness routing itself is unit-tested against mocked ucode state.

This pull request and its description were written by Isaac.
