### PR TITLE
fix(web): make post-archive Undo instant and flicker-free on a multi-user server

### DIFF
--- a/tests/e2e_ui/sessions/test_undo_archive_multi_user.py
+++ b/tests/e2e_ui/sessions/test_undo_archive_multi_user.py
@@ -1,0 +1,616 @@
+"""Browser e2e for post-archive Undo against a multi-user (owner-scoped) server.
+
+``tests/e2e_ui/sessions/test_sidebar_undo_archive.py`` proves the archive →
+Undo round-trip on the shared single-user server, where every row's ``owner``
+is null and the ownership checks pass vacuously. On a real multi-user server
+(header-auth, like a Databricks Apps / SSO-proxy install) each row carries the
+creator's user id in ``owner``, the sidebar's "My sessions" tab renders from an
+owner-scoped list cache, and the update stream / list reads can lag writes.
+That deployment shape breaks Undo in ways the single-user suite can't see:
+
+1. **"My sessions" doesn't restore optimistically.** Archiving evicts the row
+   from the owner-scoped ("mine") cache outright (``violatesKnownMembership``),
+   so Undo can only bring it back through ``insertNewRowsIntoPages`` — which,
+   unlike the WS ``session_added`` path, is called without a ``viewerId``. The
+   ownership check ``owner == null || owner === viewerId`` then fails for the
+   viewer's OWN sessions and the "mine" cache is skipped: the restored rows
+   only reappear after a server list read completes (seconds on a lagging
+   deployment). The "All sessions" tab restores instantly.
+
+2. **A stale update-stream frame un-restores the row.** The session-updates
+   stream re-reads watched rows on an interval, so a rapid archive → Undo can
+   deliver a ``changed`` frame carrying ``archived: true`` *after* Undo already
+   painted the row back. Nothing guards the merge against that stale flag (the
+   archive tombstone is cleared by the unarchive, and the recently-created
+   keep-alive skips rows whose cached copy reads archived), so the restored row
+   vanishes until the next tick/refetch brings it back — the flicker.
+
+3. **Restored rows briefly read as unread.** Unarchiving bumps ``updated_at``
+   server-side (and archiving pruned the per-viewer read-state), but Undo only
+   calls ``markConversationSeen`` after ALL unarchive PATCHes settle. Any row
+   whose refreshed ``updated_at`` reaches the client before the whole batch
+   settles lights the unread dot for a session the viewer just restored
+   themselves.
+
+The tests run against a dedicated multi-user server (the shared ``live_server``
+is single-user). Chromium does not attach ``extra_http_headers`` to WebSocket
+handshakes, so the sessions-updates socket cannot authenticate the way plain
+fetches do; where a test needs the live stream it bridges the socket through a
+Python WebSocket client that attaches the identity header — standing in for
+the SSO front door that forwards identity on a real deployment — which also
+gives the test frame-level delivery control to reproduce the lag
+deterministically.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json as _json
+import os
+import queue
+import threading
+import time
+from collections import deque
+from collections.abc import Callable, Iterator
+from urllib.parse import urlsplit
+
+import httpx
+import pytest
+from playwright.sync_api import Browser, BrowserContext, Locator, Page, Route, expect
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
+from tests.e2e_ui.collaboration._multi_user_server import (
+    ADMIN_EMAIL,
+    MultiUserServer,
+    spawn_multi_user_server,
+)
+from tests.e2e_ui.conftest import _build_hello_world_bundle
+
+_ADMIN_HEADERS = {"X-Forwarded-Email": ADMIN_EMAIL}
+
+# One interval of the server's session-updates rescan loop
+# (_SESSION_UPDATES_RESCAN_INTERVAL_S = 4.0) plus slack: how long a test waits
+# for the stream to emit a frame reflecting a just-committed write.
+_UPDATES_TICK_TIMEOUT_S = 8.0
+
+
+@pytest.fixture(scope="module")
+def multi_user_server(
+    built_spa: None,
+    mock_llm_server_url: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[MultiUserServer]:
+    """A NON-single-user server, so list rows carry ``owner`` and the sidebar
+    shows the ownership-scoped filter tabs."""
+    server_tmp = tmp_path_factory.mktemp("e2e_ui_undo_archive_multi_user")
+    yield from spawn_multi_user_server(mock_llm_server_url, server_tmp)
+
+
+def _create_admin_session(server: MultiUserServer, title: str) -> str:
+    """Create an admin-owned hello_world session named *title*; return its id."""
+    bundle = _build_hello_world_bundle()
+    create = httpx.post(
+        f"{server.base_url}/v1/sessions",
+        data={"metadata": _json.dumps({})},
+        files={"bundle": ("agent.tar.gz", bundle, "application/gzip")},
+        headers=_ADMIN_HEADERS,
+        timeout=30.0,
+    )
+    create.raise_for_status()
+    session_id = str(create.json()["session_id"])
+    rename = httpx.patch(
+        f"{server.base_url}/v1/sessions/{session_id}",
+        json={"title": title},
+        headers=_ADMIN_HEADERS,
+        timeout=30.0,
+    )
+    rename.raise_for_status()
+    return session_id
+
+
+def _wait_archived(server: MultiUserServer, session_id: str, want: bool) -> None:
+    """Poll the store until *session_id* reports ``archived == want``."""
+    deadline = time.monotonic() + 15.0
+    seen: bool | None = None
+    while time.monotonic() < deadline:
+        resp = httpx.get(
+            f"{server.base_url}/v1/sessions/{session_id}",
+            headers=_ADMIN_HEADERS,
+            timeout=10.0,
+        )
+        seen = resp.json()["archived"] if resp.status_code == 200 else None
+        if seen is want:
+            return
+        time.sleep(0.2)
+    raise AssertionError(f"session {session_id} should report archived={want}, got {seen}")
+
+
+def _link(page: Page, session_id: str) -> Locator:
+    """The sidebar link for *session_id* (present iff the row is listed)."""
+    return page.locator(f'a[href="/c/{session_id}"]')
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """The sidebar row (``<li>``) for *session_id*."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _archive_from_row(page: Page, session_id: str) -> None:
+    """Open a sidebar row's kebab and click Archive."""
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("archive-conversation").click()
+    expect(_link(page, session_id)).to_have_count(0)
+
+
+def _select_filter(page: Page, value: str) -> None:
+    """Switch the sidebar's session filter (``all`` / ``mine`` / ...).
+
+    A click that lands while the previous menu instance is still animating
+    closed can be swallowed (Radix treats it as the closing toggle), so retry
+    the trigger once if the menu didn't open.
+    """
+    trigger = page.get_by_test_id("session-filter")
+    item = page.get_by_test_id(f"session-filter-{value}")
+    trigger.click()
+    try:
+        item.wait_for(state="visible", timeout=3_000)
+    except PlaywrightTimeoutError:
+        trigger.click()
+        item.wait_for(state="visible", timeout=5_000)
+    item.click()
+    expect(item).to_be_hidden(timeout=5_000)
+
+
+class _HeldRoutes:
+    """Park matching requests unanswered until :meth:`release` — the client-
+    observable equivalent of a backend whose reads/writes lag."""
+
+    def __init__(self) -> None:
+        self._held: list[Route] = []
+
+    def hold_session_lists(self, route: Route) -> None:
+        """Route handler: park every ``GET /v1/sessions`` list read."""
+        req = route.request
+        if req.method == "GET" and urlsplit(req.url).path.endswith("/v1/sessions"):
+            self._held.append(route)
+            return
+        route.fallback()
+
+    def hold_patch_for(self, session_id: str) -> Callable[[Route], None]:
+        """Route handler: park ``PATCH /v1/sessions/{session_id}`` only."""
+
+        def handler(route: Route) -> None:
+            req = route.request
+            if req.method == "PATCH" and urlsplit(req.url).path.endswith(
+                f"/v1/sessions/{session_id}"
+            ):
+                self._held.append(route)
+                return
+            route.fallback()
+
+        return handler
+
+    def release(self) -> None:
+        """Let every parked request proceed (best-effort; the page may have
+        aborted some while they were parked)."""
+        held, self._held = self._held, []
+        for route in held:
+            with contextlib.suppress(Exception):
+                route.continue_()
+
+
+class _SessionUpdatesBridge:
+    """Authenticated relay for the ``/v1/sessions/updates`` socket.
+
+    Chromium omits ``extra_http_headers`` from WebSocket handshakes, so on a
+    header-auth multi-user server the page's updates socket is rejected (403)
+    and the sidebar loses live updates entirely. On a real deployment the SSO
+    front door injects the identity header on every request, WebSocket
+    handshakes included; this bridge reproduces that: the page's socket is
+    served by the test, which relays frames over a Python WebSocket connection
+    that carries ``X-Forwarded-Email``.
+
+    Relaying also hands the test the server→client frame schedule. With
+    ``hold_from_server`` set, frames queue in :attr:`held` instead of reaching
+    the page — the update stream "lagging" — until :meth:`release_held`
+    delivers them. Frames only move server→page on :meth:`pump`, which must be
+    called from the test thread (Playwright sync objects are not thread-safe).
+    """
+
+    def __init__(self, server: MultiUserServer) -> None:
+        self._ws_url = f"{server.base_url}/v1/sessions/updates".replace("http", "ws", 1)
+        self._to_server: queue.Queue[str | bytes | None] = queue.Queue()
+        self._from_server: deque[str | bytes] = deque()
+        self._lock = threading.Lock()
+        self._page_ws = None
+        self._closed = threading.Event()
+        self.connect_error: str | None = None
+        self.hold_from_server = False
+        self.held: list[str | bytes] = []
+
+    def handler(self, ws) -> None:  # ws: playwright WebSocketRoute
+        """``page.route_web_socket`` handler: serve the page's socket."""
+        self._page_ws = ws
+        ws.on_message(self._to_server.put)
+        ws.on_close(lambda code=None, reason=None: self.close())
+        threading.Thread(target=self._run, daemon=True).start()
+
+    def _run(self) -> None:
+        from websockets.sync.client import connect as ws_connect
+
+        try:
+            conn = ws_connect(
+                self._ws_url,
+                additional_headers=_ADMIN_HEADERS,
+                open_timeout=15,
+            )
+        except Exception as exc:  # surfaced by the test's pump loop
+            self.connect_error = f"{type(exc).__name__}: {exc}"
+            return
+        try:
+
+            def send_loop() -> None:
+                while True:
+                    msg = self._to_server.get()
+                    if msg is None:
+                        return
+                    conn.send(msg)
+
+            threading.Thread(target=send_loop, daemon=True).start()
+            while not self._closed.is_set():
+                try:
+                    msg = conn.recv(timeout=0.25)
+                except TimeoutError:
+                    continue
+                except Exception:
+                    return
+                with self._lock:
+                    self._from_server.append(msg)
+        finally:
+            with contextlib.suppress(Exception):
+                conn.close()
+
+    def pump(self) -> None:
+        """Deliver (or hold) any frames the relay has received so far."""
+        assert self.connect_error is None, (
+            f"authenticated updates-stream relay failed to connect: {self.connect_error}"
+        )
+        with self._lock:
+            frames = list(self._from_server)
+            self._from_server.clear()
+        for frame in frames:
+            if self.hold_from_server:
+                self.held.append(frame)
+            else:
+                self._page_ws.send(frame)
+
+    def release_held(self) -> None:
+        """Deliver every held frame to the page, oldest first."""
+        held, self.held = self.held, []
+        for frame in held:
+            self._page_ws.send(frame)
+
+    def close(self) -> None:
+        self._closed.set()
+        self._to_server.put(None)
+
+
+def _new_admin_page(
+    browser: Browser,
+    server: MultiUserServer,
+    *,
+    sidebar_filter: str,
+    updates_bridge: _SessionUpdatesBridge | None = None,
+) -> tuple[BrowserContext, Page]:
+    """An admin-identified page on the sidebar's *sidebar_filter* tab.
+
+    When *updates_bridge* is given, the sessions-updates socket is routed
+    through it (installed before navigation, so the app's first connection
+    attempt is already bridged).
+    """
+    # Film the journey when the recording harness asks for it. The conftest's
+    # OMNIGENT_E2E_RECORD_DIR hook instruments the async API only, and these
+    # tests drive the sync `browser` fixture, so honor the env var directly.
+    record_dir = os.environ.get("OMNIGENT_E2E_RECORD_DIR")
+    ctx = browser.new_context(
+        extra_http_headers=_ADMIN_HEADERS,
+        **({"record_video_dir": record_dir} if record_dir else {}),
+    )
+    ctx.add_init_script(
+        f'window.localStorage.setItem("omnigent:session-filter", {_json.dumps(sidebar_filter)})'
+    )
+    page = ctx.new_page()
+    if updates_bridge is not None:
+        page.route_web_socket(lambda url: "/v1/sessions/updates" in url, updates_bridge.handler)
+    page.goto(f"{server.public_url}/")
+    expect(page.get_by_test_id("session-filter")).to_be_visible(timeout=30_000)
+    return ctx, page
+
+
+def _pump_until(
+    page: Page,
+    bridge: _SessionUpdatesBridge,
+    timeout_s: float,
+    *,
+    predicate: Callable[[], bool] | None = None,
+    probe: Callable[[], None] | None = None,
+) -> bool:
+    """Pump the bridge (and *probe*) until *predicate* holds or time runs out."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        bridge.pump()
+        if probe is not None:
+            probe()
+        if predicate is not None and predicate():
+            return True
+        page.wait_for_timeout(40)
+    return predicate() if predicate is not None else False
+
+
+def _frame_reports_archived(frame: str | bytes, session_id: str, archived: bool) -> bool:
+    """True when a stream frame carries *session_id* with the given flag."""
+    try:
+        payload = _json.loads(frame)
+    except (ValueError, TypeError):
+        return False
+    return any(
+        item.get("id") == session_id and item.get("archived", False) is archived
+        for item in payload.get("items") or []
+    )
+
+
+def test_undo_restores_optimistically_on_my_sessions_tab(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """Undo must repaint restored rows on "My sessions" without a server trip.
+
+    Journey (all on the default "My sessions" tab, as the sessions' owner):
+    archive sessions A and B from their row menus — both merge into one Undo
+    pill — then, with every ``GET /v1/sessions`` list read parked (the lagging
+    backend), click Undo.
+
+    Archiving evicted both rows from the owner-scoped "mine" cache, so only
+    Undo's optimistic re-insert can repaint them there — and that insert is
+    exactly what skips owner-scoped caches when no viewer id is supplied. On
+    the broken build the rows come back instantly on "All sessions" (whose
+    cache keeps archived rows and needs only the flag flip) but stay missing
+    from "My sessions" until a list read completes — which on a real deployment
+    means seconds of the user wondering whether Undo worked. The final
+    assertions are the regression guard: A and B must be visible on
+    "My sessions" while list reads are still parked.
+    """
+    server = multi_user_server
+    session_a = _create_admin_session(server, "Undo repro A (mine-tab restore)")
+    session_b = _create_admin_session(server, "Undo repro B (mine-tab restore)")
+    list_holds = _HeldRoutes()
+    ctx, page = _new_admin_page(browser, server, sidebar_filter="mine")
+    try:
+        expect(_link(page, session_a)).to_be_visible(timeout=30_000)
+        expect(_link(page, session_b)).to_be_visible(timeout=30_000)
+
+        # Archive both; the second merges into the first's pill.
+        _archive_from_row(page, session_a)
+        _archive_from_row(page, session_b)
+        _wait_archived(server, session_a, True)
+        _wait_archived(server, session_b, True)
+        pill = page.get_by_test_id("archive-undo-toast")
+        expect(pill).to_be_visible()
+        expect(pill).to_contain_text("Archived 2 sessions.")
+
+        # Park every list read: the client is now on its own, exactly as it is
+        # inside a real deployment's index-lag window. Undo's restore must not
+        # depend on a fetch completing.
+        page.route("**/v1/sessions**", list_holds.hold_session_lists)
+        pill.get_by_test_id("archive-undo-button").click()
+        expect(pill).to_be_hidden(timeout=5_000)
+
+        # Control: the "All sessions" tab restored both rows instantly (its
+        # cache kept the archived rows, so the optimistic flag flip repaints
+        # them) — the undo itself worked.
+        _select_filter(page, "all")
+        expect(_link(page, session_a)).to_be_visible(timeout=5_000)
+        expect(_link(page, session_b)).to_be_visible(timeout=5_000)
+
+        # THE BUG: back on "My sessions", the same rows must be there just as
+        # instantly — no list read has completed, so only the optimistic
+        # restore can have put them there. On the broken build this times out:
+        # the re-insert skipped the owner-scoped cache, and the user watches
+        # their restored sessions stay missing from "My sessions" until the
+        # backend catches up.
+        _select_filter(page, "mine")
+        expect(_link(page, session_a)).to_be_visible(timeout=4_000)
+        expect(_link(page, session_b)).to_be_visible(timeout=4_000)
+    finally:
+        # Let the parked reads land so the journey's tail is the (slow) restore
+        # completing, then confirm the store agrees before tearing down.
+        list_holds.release()
+        try:
+            expect(_link(page, session_a)).to_be_visible(timeout=15_000)
+            _wait_archived(server, session_a, False)
+            _wait_archived(server, session_b, False)
+        except (AssertionError, PlaywrightTimeoutError):
+            pass
+        ctx.close()
+
+
+def test_rapid_archive_undo_does_not_flicker_restored_row(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """A stale update-stream frame must not un-restore a just-undone archive.
+
+    Journey (on "All sessions", where Undo's repaint works): archive session C,
+    click Undo about a second later — the row pops straight back — while the
+    sessions-updates stream runs a beat behind. Its rescan read the row between
+    the archive and the unarchive, so the frame it delivers carries
+    ``archived: true`` and lands only *after* Undo already restored the row —
+    routine on a shared deployment, reproduced here by holding the relay's
+    server→client frames (and the unarchive PATCH) until that stale frame is
+    captured. List reads are parked for the window so the sidebar shows purely
+    what the client believes.
+
+    The restored row must stay put. On the broken build the stale frame's merge
+    re-flags the row archived and it vanishes from the sidebar — the appear →
+    disappear → reappear flicker — until the stream's next tick reports the
+    unarchive and brings it back.
+    """
+    server = multi_user_server
+    session_c = _create_admin_session(server, "Undo repro C (rapid archive undo)")
+    bridge = _SessionUpdatesBridge(server)
+    patch_holds = _HeldRoutes()
+    list_holds = _HeldRoutes()
+    ctx, page = _new_admin_page(browser, server, sidebar_filter="all", updates_bridge=bridge)
+    try:
+        expect(_link(page, session_c)).to_be_visible(timeout=30_000)
+        # Let the stream hand-shake and deliver its snapshot, then lag it.
+        _pump_until(page, bridge, 1.0)
+        bridge.hold_from_server = True
+
+        # Archive C; the write commits, and the stream's next rescan (held by
+        # the relay) will report it archived.
+        _archive_from_row(page, session_c)
+        _wait_archived(server, session_c, True)
+        pill = page.get_by_test_id("archive-undo-toast")
+        expect(pill).to_be_visible()
+
+        # Park C's unarchive PATCH so the rescan tick reads the row while it is
+        # still archived — the stale frame a laggy stream delivers after Undo —
+        # and park list reads so a refetch can't repaint ahead of the stream.
+        page.route("**/v1/sessions**", patch_holds.hold_patch_for(session_c))
+        page.route("**/v1/sessions**", list_holds.hold_session_lists)
+        pill.get_by_test_id("archive-undo-button").click()
+        # Undo's optimistic restore: C pops straight back.
+        expect(_link(page, session_c)).to_be_visible(timeout=5_000)
+
+        # Capture the stale archived:true frame from the (held) stream.
+        got_stale_frame = _pump_until(
+            page,
+            bridge,
+            _UPDATES_TICK_TIMEOUT_S,
+            predicate=lambda: any(
+                _frame_reports_archived(f, session_c, True) for f in bridge.held
+            ),
+        )
+        assert got_stale_frame, (
+            "updates stream never reported the archived row; cannot exercise the "
+            "stale-frame window"
+        )
+
+        # Let the unarchive commit (the user's Undo has long since happened),
+        # then deliver the stale frame — the moment the laggy stream catches up
+        # with the page.
+        patch_holds.release()
+        _wait_archived(server, session_c, False)
+        bridge.hold_from_server = False
+        bridge.release_held()
+
+        # THE BUG: the restored row must not vanish. Sample its presence while
+        # the stream's next tick (which reports archived: false) makes its way
+        # over; on the broken build the stale frame re-archives the row and it
+        # disappears for seconds before that tick restores it.
+        vanished: list[float] = []
+        recovered: list[float] = []
+        start = time.monotonic()
+
+        def probe() -> None:
+            if _link(page, session_c).count() == 0:
+                vanished.append(time.monotonic() - start)
+            elif vanished:
+                recovered.append(time.monotonic() - start)
+
+        _pump_until(page, bridge, _UPDATES_TICK_TIMEOUT_S, probe=probe)
+        assert not vanished, (
+            "restored row flickered away after Undo: a stale updates frame "
+            f"re-archived it (hidden from {vanished[0]:.2f}s to {vanished[-1]:.2f}s; "
+            + (
+                f"reappeared at {recovered[0]:.2f}s"
+                if recovered
+                else "still missing when sampling ended"
+            )
+            + ")"
+        )
+    finally:
+        patch_holds.release()
+        list_holds.release()
+        bridge.close()
+        with contextlib.suppress(AssertionError):
+            _wait_archived(server, session_c, False)
+        ctx.close()
+
+
+def test_undo_does_not_light_unread_dot_on_restored_rows(
+    browser: Browser,
+    multi_user_server: MultiUserServer,
+) -> None:
+    """Rows the viewer just restored must not light the unread dot.
+
+    Journey (on "All sessions", where Undo's repaint works): archive sessions D
+    and E, click Undo. Each unarchive PATCH bumps the row's ``updated_at`` (and
+    archiving pruned its per-viewer read-state), but Undo marks the rows seen
+    only after the WHOLE batch of PATCHes settles. Park E's PATCH (one slow
+    write in a batch — routine on a shared server): D's refreshed row then
+    reaches the page — via the update stream's next tick — while the batch is
+    still pending. On the broken build D, a session the viewer restored
+    themselves with no new activity, lights the "New messages" dot.
+    """
+    server = multi_user_server
+    session_d = _create_admin_session(server, "Undo repro D (unread dot)")
+    session_e = _create_admin_session(server, "Undo repro E (unread dot)")
+    bridge = _SessionUpdatesBridge(server)
+    patch_holds = _HeldRoutes()
+    list_holds = _HeldRoutes()
+    ctx, page = _new_admin_page(browser, server, sidebar_filter="all", updates_bridge=bridge)
+    try:
+        expect(_link(page, session_d)).to_be_visible(timeout=30_000)
+        expect(_link(page, session_e)).to_be_visible(timeout=30_000)
+        _pump_until(page, bridge, 1.0)
+
+        # No dot before the journey starts: the rows were seeded read-as-of-load.
+        unseen_dot_d = _row(page, session_d).locator(
+            '[data-testid="session-state-badge"][data-state="unseen"]'
+        )
+        expect(unseen_dot_d).to_have_count(0)
+
+        _archive_from_row(page, session_d)
+        _archive_from_row(page, session_e)
+        _wait_archived(server, session_d, True)
+        _wait_archived(server, session_e, True)
+        pill = page.get_by_test_id("archive-undo-toast")
+        expect(pill).to_be_visible()
+        expect(pill).to_contain_text("Archived 2 sessions.")
+
+        # One slow unarchive in the batch: park E's PATCH; D's commits at once.
+        # List reads are parked too, so D's refreshed row arrives the way it
+        # does on a live deployment — over the update stream.
+        page.route("**/v1/sessions**", patch_holds.hold_patch_for(session_e))
+        page.route("**/v1/sessions**", list_holds.hold_session_lists)
+        pill.get_by_test_id("archive-undo-button").click()
+        expect(_link(page, session_d)).to_be_visible(timeout=5_000)
+        _wait_archived(server, session_d, False)
+
+        # THE BUG: as soon as D's refreshed row (bumped updated_at) reaches the
+        # page over the stream, its row lights the unread dot, because the
+        # batch's mark-seen is still parked behind E.
+        lit: list[float] = []
+        start = time.monotonic()
+
+        def probe() -> None:
+            if unseen_dot_d.count() > 0:
+                lit.append(time.monotonic() - start)
+
+        _pump_until(page, bridge, _UPDATES_TICK_TIMEOUT_S, probe=probe)
+        assert not lit, (
+            "Undo lit the unread dot on a row the viewer restored themselves "
+            f"(first seen {lit[0]:.2f}s after Undo)"
+        )
+    finally:
+        patch_holds.release()
+        list_holds.release()
+        bridge.close()
+        with contextlib.suppress(AssertionError):
+            _wait_archived(server, session_e, False)
+        ctx.close()

--- a/web/src/hooks/SessionUpdatesProvider.test.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.test.tsx
@@ -12,7 +12,9 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  clearRecentlyCreated,
   clearSessionTombstones,
+  undoArchiveConversations,
   useArchiveConversation,
   type Conversation,
   type ConversationsPage,
@@ -98,6 +100,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   clearSessionTombstones();
+  clearRecentlyCreated();
 });
 
 describe("SessionUpdatesProvider watch-set", () => {
@@ -375,6 +378,52 @@ describe("SessionUpdatesProvider archive tombstone", () => {
         .pages[0].data.find((row) => row.id === "conv_a"),
     ).toMatchObject({ title: "Late edit", archived: true });
     await waitFor(() => expect(archive.result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("SessionUpdatesProvider unarchive tombstone", () => {
+  it("does not let a stale archived frame re-hide a row the user just restored", async () => {
+    // Mirror of the archive tombstone above, for Undo. The user archived a
+    // session then clicked Undo; the restore un-hides the row. But the archive's
+    // own `changed` frame (archived=true) is still in flight and lands AFTER Undo
+    // cleared the archiving mark. Without a symmetric unarchive guard the frame
+    // flips the row back to archived and it's evicted from the non-archived list —
+    // the row flashes: appear (undo) → disappear (stale frame) → appear (the
+    // unarchive frame lands). It must stay put instead.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ...conv("conv_a"), archived: false, updated_at: 101 }),
+      }),
+    );
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    // "My sessions" tab: visibility="mine", includeArchived=false — the archived
+    // row was evicted, so only the optimistic restore brings it back.
+    client.setQueryData<ConversationsInfiniteData>(["conversations", "", false, null, "mine"], {
+      pages: [{ data: [conv("conv_b")], first_id: "conv_b", last_id: "conv_b", has_more: false }],
+      pageParams: [undefined],
+    });
+    renderProvider(client, ["/"]);
+    const handler = frameHandler();
+    const mineIds = () =>
+      client
+        .getQueryData<ConversationsInfiniteData>(["conversations", "", false, null, "mine"])!
+        .pages[0].data.map((row) => row.id);
+
+    // Undo restores conv_a (the toast holds the archived row).
+    await act(async () => {
+      await undoArchiveConversations(client, [{ ...conv("conv_a"), archived: true }]);
+    });
+    expect(mineIds()).toEqual(["conv_a", "conv_b"]);
+
+    // The archive's WS frame (archived=true) arrives after Undo cleared the mark.
+    act(() => handler({ type: "changed", items: [{ ...conv("conv_a"), archived: true }] }));
+
+    // The row must remain — no flash. Without the unarchive tombstone it is
+    // dropped here (violatesKnownMembership evicts the archived row).
+    expect(mineIds()).toEqual(["conv_a", "conv_b"]);
   });
 });
 

--- a/web/src/hooks/SessionUpdatesProvider.tsx
+++ b/web/src/hooks/SessionUpdatesProvider.tsx
@@ -23,6 +23,7 @@ import { childSessionsQueryKey, type ChildSessionInfo } from "@/hooks/useChildSe
 import {
   isSessionArchiving,
   isSessionDeleting,
+  isSessionUnarchiving,
   markRecentlyCreated,
 } from "@/hooks/useConversations";
 import {
@@ -72,10 +73,13 @@ function applyItemsToCache(
   const itemsById = new Map<string, SessionListWireItem>();
   for (const item of items) {
     if (isSessionDeleting(item.id)) continue;
-    itemsById.set(
-      item.id,
-      nullsToUndefined(isSessionArchiving(item.id) ? { ...item, archived: true } : item),
-    );
+    // An optimistic archive/unarchive in flight owns the row's archived flag:
+    // coerce a stale frame to match so a lagging server signal can't flip the
+    // row out from under the pending mutation (either direction flashes).
+    let coerced = item;
+    if (isSessionArchiving(item.id)) coerced = { ...item, archived: true };
+    else if (isSessionUnarchiving(item.id)) coerced = { ...item, archived: false };
+    itemsById.set(item.id, nullsToUndefined(coerced));
   }
   const foundAnywhere = new Set<string>();
   let needsRefetch = false;

--- a/web/src/hooks/useConversations.test.ts
+++ b/web/src/hooks/useConversations.test.ts
@@ -39,8 +39,17 @@ import {
 } from "./useConversations";
 import { PINNED_LABEL_KEY } from "@/lib/sessionListCache";
 import { PINNED_CONVERSATION_IDS_STORAGE_KEY } from "@/shell/sidebarNav";
+import type * as IdentityModule from "@/lib/identity";
 
 vi.mock("./useSessionUpdatesConnected", () => ({ useSessionUpdatesConnected: vi.fn() }));
+
+// Resolve the viewer id so ownership-aware list insertion (visibility="mine")
+// can admit the viewer's own rows; authenticatedFetch etc. stay real.
+const MOCK_VIEWER_ID = "user_me";
+vi.mock("@/lib/identity", async (importOriginal) => ({
+  ...(await importOriginal<typeof IdentityModule>()),
+  getCurrentUserId: () => MOCK_VIEWER_ID,
+}));
 
 function mockResponse(body: unknown, init?: { ok?: boolean; status?: number }): Response {
   return {
@@ -2801,6 +2810,58 @@ describe("undoArchiveConversations optimistic restore", () => {
     expect(search?.pages[0].data).toEqual([]);
 
     resolvePatch(mockResponse(conversation({ id: "conv_a", archived: false, updated_at: 101 })));
+    await undo;
+  });
+
+  it("re-injects the viewer's own row into the visibility='mine' list (multi-user)", async () => {
+    // The "My sessions" tab query is visibility="mine" + includeArchived=false, so
+    // the archived row was evicted and only the ownership-aware insert can restore
+    // it. On a multi-user server the row carries an explicit owner; without the
+    // viewer id the insert's ownedByViewer check fails and the row is dropped back
+    // onto the slow post-PATCH refetch. This asserts the synchronous insert lands.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    queryClient.setQueryData(
+      ["conversations", "", false, null, "mine"],
+      infinitePage([conversation({ id: "conv_keep", owner: MOCK_VIEWER_ID })]),
+    );
+    // Hold the unarchive PATCH in flight so only the synchronous cache write can
+    // satisfy the assertion, never the network round-trip.
+    let resolvePatch!: (value: Response) => void;
+    fetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+
+    const undo = undoArchiveConversations(queryClient, [
+      conversation({ id: "conv_a", archived: true, owner: MOCK_VIEWER_ID }),
+    ]);
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<ConversationsInfiniteData>([
+        "conversations",
+        "",
+        false,
+        null,
+        "mine",
+      ]);
+      expect(data?.pages[0].data.map((c) => c.id)).toEqual(["conv_a", "conv_keep"]);
+    });
+    const mine = queryClient.getQueryData<ConversationsInfiniteData>([
+      "conversations",
+      "",
+      false,
+      null,
+      "mine",
+    ]);
+    expect(mine?.pages[0].data[0].archived).toBe(false);
+
+    resolvePatch(
+      mockResponse(
+        conversation({ id: "conv_a", archived: false, owner: MOCK_VIEWER_ID, updated_at: 101 }),
+      ),
+    );
     await undo;
   });
 });

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -59,7 +59,11 @@ import {
 import { releaseConversation, useChatStore } from "@/store/chatStore";
 import type { Session } from "@/lib/types";
 import { useSessionUpdatesConnected } from "./useSessionUpdatesConnected";
-import { markConversationSeen } from "./useUnseenConversations";
+import {
+  beginUnseenSuppression,
+  endUnseenSuppression,
+  markConversationSeen,
+} from "./useUnseenConversations";
 
 export const CONNECTED_STREAM_REFETCH_INTERVAL_MS = 60_000;
 export const DISCONNECTED_STREAM_REFETCH_INTERVAL_MS = 45_000;
@@ -1391,6 +1395,11 @@ export async function undoArchiveConversations(
 ): Promise<void> {
   if (conversations.length === 0) return;
   const ids = conversations.map((c) => c.id);
+  // Hold the unread dot off every restored row until this settles. The unarchive
+  // bumps each session's updated_at (a self-initiated write), which the WS push
+  // surfaces before the seen-anchor below lands, so the row would otherwise
+  // flash an unread badge on the way back in. Released in `finally`.
+  for (const id of ids) beginUnseenSuppression(id);
   // Un-hide any rows still in the list cache (flag flip). Rows a refetch already
   // evicted aren't here to flip; the keep-alive below covers those. The paint
   // also arms the unarchive tombstone (`marked`), which coerces a lagging
@@ -1462,6 +1471,9 @@ export async function undoArchiveConversations(
       );
     }
   } finally {
+    // Restore settled: the seen-anchor for the ids that came back has landed
+    // (marked seen in the loop above), so the dot can read normally again.
+    for (const id of ids) endUnseenSuppression(id);
     void queryClient.invalidateQueries({ queryKey: ["projects"] });
     void queryClient.invalidateQueries({ queryKey: ["project-sessions"] });
     void queryClient.invalidateQueries({ queryKey: ARCHIVED_PROJECT_NAMES_KEY });

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -24,7 +24,7 @@ import {
   useQueryClient,
   type QueryClient,
 } from "@tanstack/react-query";
-import { authenticatedFetch } from "@/lib/identity";
+import { authenticatedFetch, getCurrentUserId } from "@/lib/identity";
 import { startTimedInteraction } from "@/lib/analyticsEmit";
 import {
   filtersFromConversationQueryKey,
@@ -1315,8 +1315,12 @@ export async function undoArchiveConversations(
   // so Undo's result is visible on the next frame — the flag flip above only
   // covers rows a refetch hasn't evicted yet, and waiting on the refetch below
   // leaves a visible gap where the user wonders whether Undo worked. Same
-  // filter-aware insertion the WS `session_added` path uses, so search lists
-  // and non-member variants are untouched.
+  // filter-aware insertion the WS `session_added` path uses (with the viewer id
+  // and delete-tombstone skip), so the "My sessions" tab (visibility="mine")
+  // still admits the owner's rows on a multi-user server — omitting the viewer
+  // id there fails the ownership check and drops the restore back onto the slow
+  // refetch. Search lists and non-member variants stay untouched.
+  const viewerId = getCurrentUserId();
   const candidates = new Map(restored.map((conv) => [conv.id, conv]));
   for (const [key, data] of queryClient.getQueriesData<ConversationsInfiniteData>({
     queryKey: ["conversations"],
@@ -1326,6 +1330,8 @@ export async function undoArchiveConversations(
       data,
       candidates,
       filtersFromConversationQueryKey(key),
+      isSessionDeleting,
+      viewerId,
     );
     if (next !== data) queryClient.setQueryData(key, next);
   }

--- a/web/src/hooks/useConversations.ts
+++ b/web/src/hooks/useConversations.ts
@@ -314,6 +314,9 @@ function markSessionsArchiving(ids: Iterable<string>): Map<string, ArchiveTombst
   for (const id of ids) {
     const previous = archivingSessions.get(id);
     if (previous?.timer !== undefined) clearTimeout(previous.timer);
+    // A session is either archiving or unarchiving, never both: a re-archive
+    // supersedes an in-flight unarchive guard so the row can leave the list.
+    unmarkSessionsUnarchiving([id]);
     const entry = {};
     archivingSessions.set(id, entry);
     marked.set(id, entry);
@@ -351,23 +354,92 @@ export function isSessionArchiving(id: string): boolean {
   return archivingSessions.has(id);
 }
 
+// The mirror of `archivingSessions` for the unarchive/undo direction. Archiving
+// holds a row's `archived` flag TRUE against a lagging server signal (a WS frame
+// or a search-index-lagged fetch) so it stays out of the sidebar; unarchiving
+// holds it FALSE for the same window so a just-restored row can't be re-hidden
+// by the archive's own late signals. That late re-hide is the flash Undo shows.
+const unarchivingSessions = new Map<string, ArchiveTombstone>();
+
+function markSessionsUnarchiving(ids: Iterable<string>): Map<string, ArchiveTombstone> {
+  const marked = new Map<string, ArchiveTombstone>();
+  for (const id of ids) {
+    const previous = unarchivingSessions.get(id);
+    if (previous?.timer !== undefined) clearTimeout(previous.timer);
+    // Supersede any in-flight archive guard: this row is coming back.
+    unmarkSessionsArchiving([id]);
+    const entry = {};
+    unarchivingSessions.set(id, entry);
+    marked.set(id, entry);
+  }
+  return marked;
+}
+
+function unmarkSessionsUnarchiving(
+  ids?: Iterable<string>,
+  marked?: Map<string, ArchiveTombstone>,
+): void {
+  const targets = ids ?? unarchivingSessions.keys();
+  for (const id of targets) {
+    const entry = unarchivingSessions.get(id);
+    if (entry === undefined || (marked !== undefined && marked.get(id) !== entry)) continue;
+    if (entry.timer !== undefined) clearTimeout(entry.timer);
+    unarchivingSessions.delete(id);
+  }
+}
+
+function expireSessionsUnarchiving(
+  marked: Map<string, ArchiveTombstone>,
+  ids: Iterable<string>,
+): void {
+  for (const id of ids) {
+    const entry = marked.get(id);
+    if (entry === undefined || unarchivingSessions.get(id) !== entry) continue;
+    entry.timer = setTimeout(() => {
+      if (unarchivingSessions.get(id) === entry) unarchivingSessions.delete(id);
+    }, DELETED_TOMBSTONE_MS);
+  }
+}
+
+export function isSessionUnarchiving(id: string): boolean {
+  return unarchivingSessions.has(id);
+}
+
 /** Wipe module-level tombstones between tests. */
 export function clearSessionTombstones(): void {
   unmarkSessionsDeleting();
   unmarkSessionsArchiving();
+  unmarkSessionsUnarchiving();
 }
 
 /**
  * Apply optimistic delete/archive state to a freshly fetched page.
  */
 function applySessionTombstones(page: ConversationsPage, dropArchiving = false): ConversationsPage {
-  if (deletingSessionIds.size === 0 && archivingSessions.size === 0) return page;
+  if (
+    deletingSessionIds.size === 0 &&
+    archivingSessions.size === 0 &&
+    unarchivingSessions.size === 0
+  ) {
+    return page;
+  }
   let changed = false;
   let lastArchivingId: string | null = null;
   const data: Conversation[] = [];
   for (const conv of page.data) {
     if (isSessionDeleting(conv.id)) {
       changed = true;
+      continue;
+    }
+    if (isSessionUnarchiving(conv.id)) {
+      // Undo/unarchive in flight: keep the row active even if a search-index
+      // read still reports it archived (mirrors the archiving coercion below).
+      if (conv.archived === true) {
+        changed = true;
+        data.push({ ...conv, archived: false });
+      } else {
+        data.push(conv);
+      }
       continue;
     }
     if (!isSessionArchiving(conv.id)) {
@@ -868,13 +940,14 @@ async function paintConversationsArchived(
   queryClient: QueryClient,
   ids: readonly string[],
   archived: boolean,
-): Promise<{ snapshot: ArchiveListsSnapshot; marked?: Map<string, ArchiveTombstone> }> {
+): Promise<{ snapshot: ArchiveListsSnapshot; marked: Map<string, ArchiveTombstone> }> {
   await Promise.all([
     queryClient.cancelQueries({ queryKey: ["conversations"] }),
     queryClient.cancelQueries({ queryKey: ["project-sessions"] }),
   ]);
-  const marked = archived ? markSessionsArchiving(ids) : undefined;
-  if (!archived) unmarkSessionsArchiving(ids);
+  // Arm the matching tombstone: archiving holds the row hidden, unarchiving
+  // holds it visible. Each mark supersedes the opposite one for these ids.
+  const marked = archived ? markSessionsArchiving(ids) : markSessionsUnarchiving(ids);
   const snapshot = snapshotArchiveLists(queryClient);
   for (const id of ids) overlayArchivedIntoCaches(queryClient, id, archived);
   if (archived) dropFromPinnedCache(queryClient, ids);
@@ -888,11 +961,14 @@ export function useArchiveConversation() {
       archiveConversation(id, archived),
     onMutate: ({ id, archived }) => paintConversationsArchived(queryClient, [id], archived),
     onError: (_err, { id, archived }, context) => {
-      if (archived && context?.marked !== undefined) {
+      if (context?.marked !== undefined) {
         const marked = context.marked.get(id);
-        const live = archivingSessions.get(id);
+        // A newer op of the same kind (archive/unarchive) replaced this row's
+        // mark, so leave its state alone rather than rolling back over it.
+        const live = (archived ? archivingSessions : unarchivingSessions).get(id);
         if (live !== undefined && live !== marked) return;
-        unmarkSessionsArchiving([id], context.marked);
+        if (archived) unmarkSessionsArchiving([id], context.marked);
+        else unmarkSessionsUnarchiving([id], context.marked);
       }
       // Roll back to exactly the pre-archive caches, synchronously — so the
       // row (and any dropped pin) returns at once, rather than waiting on a
@@ -907,8 +983,9 @@ export function useArchiveConversation() {
     },
     onSuccess: (updated, { archived }, context) => {
       markConversationSeen(updated.id, updated.updated_at);
-      if (archived && context?.marked !== undefined) {
-        expireSessionsArchiving(context.marked, [updated.id]);
+      if (context?.marked !== undefined) {
+        if (archived) expireSessionsArchiving(context.marked, [updated.id]);
+        else expireSessionsUnarchiving(context.marked, [updated.id]);
       }
       // Archiving/unarchiving the last (or first) non-archived member of a
       // project removes/restores it from the server's project list, and adds
@@ -1252,9 +1329,16 @@ export function useBulkArchiveConversations() {
       if (!context?.snapshot) return;
       const failed = new Set(err instanceof BulkConversationMutationError ? err.failed : ids);
       const succeeded = ids.filter((id) => !failed.has(id));
-      if (archived && context.marked !== undefined) {
-        unmarkSessionsArchiving(failed, context.marked);
-        expireSessionsArchiving(context.marked, succeeded);
+      if (context.marked !== undefined) {
+        // Drop the guard for the ids that didn't move (they revert), keep it
+        // through the propagation window for the ids that did.
+        if (archived) {
+          unmarkSessionsArchiving(failed, context.marked);
+          expireSessionsArchiving(context.marked, succeeded);
+        } else {
+          unmarkSessionsUnarchiving(failed, context.marked);
+          expireSessionsUnarchiving(context.marked, succeeded);
+        }
       }
       restoreArchiveLists(queryClient, context.snapshot);
       if (!archived) {
@@ -1263,8 +1347,9 @@ export function useBulkArchiveConversations() {
       reapplyLiveSessionTombstones(queryClient);
     },
     onSuccess: (_data, { ids, archived }, context) => {
-      if (archived && context?.marked !== undefined) {
-        expireSessionsArchiving(context.marked, ids);
+      if (context?.marked !== undefined) {
+        if (archived) expireSessionsArchiving(context.marked, ids);
+        else expireSessionsUnarchiving(context.marked, ids);
       }
     },
     onSettled: () => {
@@ -1307,8 +1392,11 @@ export async function undoArchiveConversations(
   if (conversations.length === 0) return;
   const ids = conversations.map((c) => c.id);
   // Un-hide any rows still in the list cache (flag flip). Rows a refetch already
-  // evicted aren't here to flip — the keep-alive below covers those.
-  await paintConversationsArchived(queryClient, ids, false);
+  // evicted aren't here to flip; the keep-alive below covers those. The paint
+  // also arms the unarchive tombstone (`marked`), which coerces a lagging
+  // archived=true signal (the just-issued archive's own WS frame, or a
+  // search-index refetch) back to false so the restored row can't flash out.
+  const { marked } = await paintConversationsArchived(queryClient, ids, false);
   const restored = conversations.map((conv) => ({ ...conv, archived: false }));
   for (const conv of restored) markRecentlyCreated(conv);
   // Optimistically write the evicted rows straight back into the cached lists
@@ -1347,10 +1435,19 @@ export async function undoArchiveConversations(
       if (result.status === "fulfilled") markConversationSeen(ids[i], result.value.updated_at);
       else failed.push(ids[i]);
     }
+    // Hold the unarchive guard through the propagation window for the ids that
+    // restored (it expires itself after), so a lagging archived=true signal
+    // can't re-hide them in the meantime.
+    const failedSet = new Set(failed);
+    expireSessionsUnarchiving(
+      marked,
+      ids.filter((id) => !failedSet.has(id)),
+    );
     if (failed.length > 0) {
-      // The ids that stayed archived: drop them from the keep-alive so they stop
-      // being re-injected, and overlay archived=true so they leave the list
-      // again. The ids that DID unarchive stay visible.
+      // The ids that stayed archived: drop the unarchive guard and the
+      // keep-alive so they stop being re-injected, and overlay archived=true so
+      // they leave the list again. The ids that DID unarchive stay visible.
+      unmarkSessionsUnarchiving(failed, marked);
       for (const id of failed) {
         unmarkRecentlyCreated(id);
         overlayArchivedIntoCaches(queryClient, id, true);

--- a/web/src/hooks/useUnseenConversations.test.ts
+++ b/web/src/hooks/useUnseenConversations.test.ts
@@ -124,6 +124,25 @@ describe("isConversationUnseen", () => {
   });
 });
 
+describe("unseen suppression during Undo restore", () => {
+  it("holds the dot off while a restore is in flight, then reads normally again", async () => {
+    const mod = await loadFresh();
+    mod.seedReadState([{ id: "conv-1", viewer_last_seen: 1_000 }]);
+    // The unarchive bumps updated_at past the baseline, which normally reads unseen.
+    expect(mod.isConversationUnseen("conv-1", 2_000, "idle")).toBe(true);
+    // While Undo's restore is in flight, that self-initiated bump is held off so
+    // the row doesn't flash an unread dot on the way back in.
+    mod.beginUnseenSuppression("conv-1");
+    expect(mod.isConversationUnseen("conv-1", 2_000, "idle")).toBe(false);
+    // Other sessions are unaffected by the hold.
+    mod.seedReadState([{ id: "conv-2", viewer_last_seen: 1_000 }]);
+    expect(mod.isConversationUnseen("conv-2", 2_000, "idle")).toBe(true);
+    // Once the restore settles (the seen-anchor has landed), the dot reads normally.
+    mod.endUnseenSuppression("conv-1");
+    expect(mod.isConversationUnseen("conv-1", 2_000, "idle")).toBe(true);
+  });
+});
+
 describe("markConversationSeen", () => {
   it("does nothing before the first seed (reload-clobber guard)", async () => {
     const mod = await loadFresh();

--- a/web/src/hooks/useUnseenConversations.ts
+++ b/web/src/hooks/useUnseenConversations.ts
@@ -42,6 +42,14 @@ type LastSeenMap = Record<string, number>;
 let lastSeenMap: LastSeenMap = {};
 const explicitlyUnread = new Set<string>();
 
+// Sessions with an Undo-restore in flight. Unarchiving is a self-initiated
+// write that bumps the server's `updated_at`, which the WS push surfaces before
+// the restore's seen-anchor lands, so the row would briefly read as unseen and
+// flash an unread dot. Hold the dot off for that in-flight window (see
+// `beginUnseenSuppression`). Kept sub-second: released the moment the restore
+// settles, not for the archived-flag propagation window.
+const restoringSessions = new Set<string>();
+
 // localStorage persistence. Best-effort everywhere: storage can be
 // missing (SSR), full, or blocked — the in-memory mirror always works.
 const STORAGE_KEY = "omnigent.readState.v1";
@@ -201,6 +209,7 @@ export function useSeedReadState(conversations: readonly ReadStateSeed[] | undef
 export function resetReadStateForTests(): void {
   lastSeenMap = {};
   explicitlyUnread.clear();
+  restoringSessions.clear();
   seeded.clear();
   hydrated = false;
   try {
@@ -285,6 +294,25 @@ export function markConversationUnread(conversationId: string, updatedAt: number
 }
 
 /**
+ * Hold the unseen dot off a session while an Undo-restore is in flight — the
+ * unarchive's own `updated_at` bump is self-initiated and shouldn't read as new
+ * activity before the seen-anchor lands. Paired with {@link endUnseenSuppression},
+ * which the restore calls once it settles (a sub-second window, not the full
+ * archived-flag propagation window). Explicitly-unread rows are left alone: the
+ * dot condition already short-circuits on those, and the user's intent wins.
+ */
+export function beginUnseenSuppression(conversationId: string): void {
+  if (restoringSessions.has(conversationId)) return;
+  restoringSessions.add(conversationId);
+  notifySubscribers();
+}
+
+/** Release the {@link beginUnseenSuppression} hold once the restore settles. */
+export function endUnseenSuppression(conversationId: string): void {
+  if (restoringSessions.delete(conversationId)) notifySubscribers();
+}
+
+/**
  * Subscribes the caller to read-state mirror writes and returns the current
  * write version, so a component re-renders (and recomputes
  * `isConversationUnseen`) the instant the user marks a row read/unread — not
@@ -336,6 +364,9 @@ export function isConversationUnseen(
   status: string | undefined,
 ): boolean {
   if (status === "running" || status === undefined) return false;
+  // An Undo-restore in flight owns this row's updated_at bump (its own
+  // unarchive write); don't read that self-initiated bump as new activity.
+  if (restoringSessions.has(conversationId)) return false;
   const stored = lastSeenMap[conversationId];
   if (stored === undefined) return false;
   return updatedAt > stored;


### PR DESCRIPTION
## Related issue

Closes #7032

## Summary

Follow-up to the post-archive **Undo** (#6967). On a real multi-user / search-indexed server the restore was slow and flickery (none of it reproduces on a single-user local server). Three focused fixes, one per commit:

- **Instant restore on the "My sessions" tab.** Undo's optimistic insert omitted the viewer id (and the delete-tombstone skip) that the WS `session_added` path passes, so on the owner-scoped `visibility="mine"` list the ownership check dropped the owned rows and the restore fell back to the slow post-PATCH refetch. Pass `getCurrentUserId()` + `isSessionDeleting` so the rows paint on the next frame.
- **No flicker on rapid archive/undo.** Archiving arms a tombstone that pins a row's `archived` flag TRUE against a lagging server signal (a stale WS frame, a search-index refetch). Undo had no symmetric guard, so the just-issued archive's own late `archived=true` frame re-hid the restored row and the unarchive frame then showed it again (appear, disappear, appear). Add the mirror tombstone `unarchivingSessions` that pins it FALSE for the same window, honored in both the fetch path (`applySessionTombstones`) and the WS overlay (`applyItemsToCache`).
- **No unread-dot flash.** Unarchiving bumps `updated_at` (a self-initiated write), which the WS push surfaces before Undo's seen-anchor lands, so a restored row briefly read as unseen. Hold the dot off each restored row for the in-flight window, released once the seen-anchor lands.

**Known minor, intentionally left as-is:** the transient sub-order churn among restored rows. The sidebar sort is server-owned by `updated_at` and the parallel unarchive writes commit in nondeterministic order, so the rows correctly float to the top and only their relative order settles when the refetch lands. Stabilizing it would mean serializing the undo writes, which reintroduces the per-session latency this PR removes.

## Test Plan

- `pnpm exec vitest run`: green for every file this PR touches. New deterministic tests, each of which fails without its fix:
  - `useConversations.test.ts`: the viewer's own row is re-injected into the `visibility="mine"` list on a multi-user server.
  - `SessionUpdatesProvider.test.tsx`: a stale `archived=true` frame arriving after Undo must not re-hide the restored row.
  - `useUnseenConversations.test.ts`: the unread dot is held off a session while its restore is in flight, then reads normally once it settles.
- `pre-commit run` (prettier, oxlint, tsc): clean.
- Manual verification on a shared multi-user server (see Coverage notes).
- Note: two pre-existing failures in `src/shell/NewChatDialog.test.tsx` (composer layout / accessible-name) also fail on clean `main` and are unrelated to this change.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

<img width="1232" height="720" alt="omni-undo-fix" src="https://github.com/user-attachments/assets/f8195a80-96e0-4da7-b3cd-c8544cfbdaf4" />


## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manually verified against a shared multi-user Omnigent server (a single-user local server reproduces none of the three symptoms). On the **My sessions** tab: archived 3 to 5 sessions and clicked Undo, including rapid archive/undo cycles on the same sessions. Restore is now instant, with no flicker and no unread-dot flash. Each of the three symptoms is also covered by a deterministic unit test that fails without its fix.

## Changelog

Undo after archiving restores sessions instantly and without flicker, even on a busy multi-user server

This pull request and its description were written by Isaac.

## Issues

Resolves [OMNI-7194](https://linear.app/omnigent/issue/OMNI-7194/undo-after-archiving-is-slow-and-flickers-on-a-multi-user-server)
