### PR TITLE
Rebuild Codex cold resumes from server history

### DIFF
--- a/omnigent/harnesses/codex_native/main.py
+++ b/omnigent/harnesses/codex_native/main.py
@@ -17,7 +17,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import click
 import httpx
@@ -1881,16 +1881,18 @@ async def _ensure_local_codex_resume_rollout(
     terminal_launch_args: Sequence[str] | None = None,
 ) -> Path:
     """
-    Ensure Codex has a local rollout JSONL for cold resume.
+    Refresh Codex's local rollout JSONL for cold resume.
 
     Cross-machine resume has the Omnigent conversation and Codex thread id on
     the server, but not necessarily the app-server's local
     ``$CODEX_HOME/sessions/.../rollout-*-<thread>.jsonl`` file. Codex
     ``resume <thread>`` reads that local rollout, so before launching a
-    known-thread terminal we synthesize the rollout from committed AP
-    items when the local rollout is missing. Existing local rollout files
-    are left untouched because Codex treats them as append-only runtime
-    state, not a cache that Omnigent should rewrite.
+    known-thread terminal we rewrite it from committed Omnigent items. This
+    keeps the server transcript authoritative when a previous local rollout
+    has diverged. If server history is temporarily unavailable, a valid local
+    rollout remains a best-effort fallback. A successful server fetch wins
+    even when its committed history is empty or shorter than the local file;
+    local-only records are intentionally discarded.
 
     :param client: HTTP client pointed at the Omnigent server.
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
@@ -1913,21 +1915,33 @@ async def _ensure_local_codex_resume_rollout(
         rollout, but treats the value as informational, so a flaky probe
         must not cost the carried history.
     :param terminal_launch_args: Persisted Codex approval/sandbox launch args.
-    :returns: Path to the existing or written rollout.
-    :raises click.ClickException: If Omnigent history cannot be fetched or the
-        rollout cannot be written, or if the persisted Codex thread id is
-        unsafe for use in a rollout filename.
+    :returns: Path to the refreshed rollout, or to a valid local fallback when
+        server history is temporarily unavailable.
+    :raises click.ClickException: If Omnigent history cannot be fetched and no
+        valid local fallback exists, if the rollout cannot be written, or if
+        the persisted Codex thread id is unsafe for use in a rollout filename.
     """
     if not _CODEX_THREAD_ID_RE.fullmatch(external_session_id):
         raise click.ClickException(
             f"Cannot resume Codex session {session_id!r}: persisted thread id "
             f"{external_session_id!r} is not a safe Codex rollout id."
         )
-    existing = _find_codex_rollout(codex_home, external_session_id)
-    if existing is not None:
-        return existing
+    try:
+        items = await _fetch_all_session_items_for_codex_resume(client, session_id)
+    except _CodexResumeHistoryUnavailableError:
+        existing = _find_codex_rollout(codex_home, external_session_id)
+        if existing is not None and _is_resumable_codex_rollout(
+            existing, external_session_id=external_session_id
+        ):
+            _logger.warning(
+                "Could not fetch server history for %r; resuming from the "
+                "existing local Codex rollout %s",
+                session_id,
+                existing,
+            )
+            return existing
+        raise
     target = _codex_resume_rollout_path(codex_home, external_session_id)
-    items = await _fetch_all_session_items_for_codex_resume(client, session_id)
     cli_version = None
     if codex_path is not None:
         from omnigent.inner.codex_executor import _codex_cli_version
@@ -1945,19 +1959,37 @@ async def _ensure_local_codex_resume_rollout(
         terminal_launch_args=terminal_launch_args,
     )
     target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    tmp = target.with_suffix(".jsonl.tmp")
+    tmp: Path | None = None
     try:
-        with tmp.open("w", encoding="utf-8") as handle:
+        with NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            tmp = Path(handle.name)
             for record in records:
                 handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+        assert tmp is not None
         os.replace(tmp, target)
     except OSError as exc:
         raise click.ClickException(
             f"Failed to write Codex resume rollout {target}: {exc}"
         ) from exc
     finally:
-        with contextlib.suppress(FileNotFoundError):
-            tmp.unlink()
+        if tmp is not None:
+            with contextlib.suppress(FileNotFoundError):
+                tmp.unlink()
+    _logger.info(
+        "Refreshed Codex resume rollout from server history: "
+        "session=%s thread=%s items=%d target=%s",
+        session_id,
+        external_session_id,
+        len(items),
+        target,
+    )
     return target
 
 
@@ -1986,6 +2018,41 @@ def _codex_resume_rollout_path(codex_home: Path, external_session_id: str) -> Pa
     return partition / f"rollout-{stamp}-{external_session_id}.jsonl"
 
 
+def _is_resumable_codex_rollout(path: Path, *, external_session_id: str) -> bool:
+    """
+    Return whether *path* starts with matching Codex session metadata.
+
+    Codex rejects empty, binary, malformed, or mismatched rollouts on
+    ``resume``. Validate the local fallback before preferring it over a
+    temporarily unavailable server transcript.
+
+    :param path: Candidate ``rollout-*.jsonl`` path.
+    :param external_session_id: Expected Codex thread id.
+    :returns: ``True`` when the first non-empty record is matching
+        ``session_meta``.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except ValueError:
+                    return False
+                if not isinstance(record, dict) or record.get("type") != "session_meta":
+                    return False
+                payload = record.get("payload")
+                return isinstance(payload, dict) and payload.get("id") == external_session_id
+    except (OSError, UnicodeDecodeError):
+        return False
+    return False
+
+
+class _CodexResumeHistoryUnavailableError(click.ClickException):
+    """Server history is temporarily unavailable for Codex cold resume."""
+
+
 async def _fetch_all_session_items_for_codex_resume(
     client: httpx.AsyncClient,
     session_id: str,
@@ -1997,8 +2064,10 @@ async def _fetch_all_session_items_for_codex_resume(
     :param session_id: Omnigent conversation id, e.g. ``"conv_abc123"``.
     :returns: Flat API item dicts from
         ``GET /v1/sessions/{id}/items``.
-    :raises click.ClickException: If an item page cannot be fetched or
-        parsed.
+    :raises _CodexResumeHistoryUnavailableError: If transport or server errors
+        prevent fetching an item page.
+    :raises click.ClickException: If the server rejects the request or returns
+        an invalid page.
     """
     items: list[_JsonObject] = []
     after: str | None = None
@@ -2006,10 +2075,20 @@ async def _fetch_all_session_items_for_codex_resume(
         params: dict[str, str | int] = {"limit": 1000, "order": "asc"}
         if after is not None:
             params["after"] = after
-        resp = await client.get(
-            f"/v1/sessions/{url_component(session_id)}/items",
-            params=params,
-        )
+        try:
+            resp = await client.get(
+                f"/v1/sessions/{url_component(session_id)}/items",
+                params=params,
+            )
+        except httpx.TransportError as exc:
+            raise _CodexResumeHistoryUnavailableError(
+                f"Failed to fetch history for {session_id!r}: {exc}"
+            ) from exc
+        if resp.status_code >= 500:
+            raise _CodexResumeHistoryUnavailableError(
+                f"Failed to fetch history for {session_id!r} "
+                f"({resp.status_code}): {error_text(resp)}"
+            )
         if resp.status_code >= 400:
             raise click.ClickException(
                 f"Failed to fetch history for {session_id!r} "
@@ -2026,9 +2105,13 @@ async def _fetch_all_session_items_for_codex_resume(
             raise click.ClickException(
                 f"History fetch for {session_id!r} returned an invalid item list."
             )
-        for item in data:
-            if isinstance(item, dict):
-                items.append(item)
+        for index, item in enumerate(data):
+            if not isinstance(item, dict):
+                raise click.ClickException(
+                    f"History fetch for {session_id!r} returned a non-object "
+                    f"item at index {index}."
+                )
+            items.append(item)
         if not payload.get("has_more"):
             return items
         last_id = payload.get("last_id")
@@ -2385,17 +2468,24 @@ def _codex_function_call_payload_from_session_item(
     Convert an Omnigent function call item into a Codex function call payload.
 
     :param item: Omnigent function call item.
-    :returns: Codex function call payload, or ``None`` when optional
-        routing fields are absent.
+    :returns: Codex function call payload.
     :raises click.ClickException: If the Omnigent item violates required tool
         history fields.
     """
     name = item.get("name")
     call_id = item.get("call_id")
     if not isinstance(name, str) or not name:
-        return None
+        item_id = item.get("id")
+        raise click.ClickException(
+            "Cannot synthesize Codex resume rollout: Omnigent function_call "
+            f"{item_id!r} has an invalid name."
+        )
     if not isinstance(call_id, str) or not call_id:
-        return None
+        item_id = item.get("id")
+        raise click.ClickException(
+            "Cannot synthesize Codex resume rollout: Omnigent function_call "
+            f"{item_id!r} has an invalid call_id."
+        )
     arguments = item.get("arguments")
     if not isinstance(arguments, str):
         item_id = item.get("id")
@@ -2418,14 +2508,17 @@ def _codex_function_call_output_payload_from_session_item(
     Convert an Omnigent function output item into a Codex function output payload.
 
     :param item: Omnigent function output item.
-    :returns: Codex function output payload, or ``None`` when optional
-        routing fields are absent.
+    :returns: Codex function output payload.
     :raises click.ClickException: If the Omnigent item violates required tool
         output fields.
     """
     call_id = item.get("call_id")
     if not isinstance(call_id, str) or not call_id:
-        return None
+        item_id = item.get("id")
+        raise click.ClickException(
+            "Cannot synthesize Codex resume rollout: Omnigent function_call_output "
+            f"{item_id!r} has an invalid call_id."
+        )
     output = item.get("output")
     if not isinstance(output, str):
         item_id = item.get("id")

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -10817,15 +10817,15 @@ async def test_ensure_local_codex_resume_rollout_synthesizes_omnigent_history(
 
 
 @pytest.mark.asyncio
-async def test_ensure_local_codex_resume_rollout_preserves_existing_rollout(
+async def test_ensure_local_codex_resume_rollout_refreshes_existing_from_server(
     tmp_path: Path,
 ) -> None:
     """
-    Codex cold resume does not rewrite an existing local rollout.
+    Codex cold resume refreshes an existing rollout from server history.
 
-    A local rollout is Codex runtime state, not a cache. If it already
-    exists, the helper must return it untouched instead of fetching AP
-    history and rewriting the file.
+    The server transcript is authoritative on cold resume. A stale local
+    rollout must be atomically replaced with the committed Omnigent items
+    instead of silently preserving divergent history.
 
     :param tmp_path: Temporary directory for isolated ``CODEX_HOME``.
     """
@@ -10837,16 +10837,166 @@ async def test_ensure_local_codex_resume_rollout_preserves_existing_rollout(
         source_cwd="/stale/cwd",
     )
     before = existing.read_bytes()
+    workspace = (tmp_path / "workspace").resolve()
+    requested = False
 
     def handler(request: httpx.Request) -> httpx.Response:
         """
-        Fail if Omnigent history is fetched despite a local rollout.
+        Serve the authoritative Omnigent history.
 
         :param request: Incoming mock HTTP request.
-        :returns: Mock Omnigent response.
+        :returns: Mock Omnigent item page.
         """
-        del request
-        raise AssertionError("existing rollout should avoid Omnigent history fetch")
+        nonlocal requested
+        requested = True
+        assert request.url.path == "/v1/sessions/conv_codex/items"
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "msg_server",
+                        "response_id": "codex_turn_server",
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "authoritative server history"}
+                        ],
+                    }
+                ],
+                "has_more": False,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        rollout = await codex_native._ensure_local_codex_resume_rollout(
+            client,
+            session_id="conv_codex",
+            external_session_id=thread_id,
+            codex_home=codex_home,
+            workspace=workspace,
+            model_provider="omnigent_databricks",
+            codex_path=None,
+        )
+
+    assert requested
+    assert rollout == existing
+    assert existing.read_bytes() != before
+    records = [json.loads(line) for line in existing.read_text().splitlines()]
+    assert records[0]["payload"]["cwd"] == str(workspace)
+    assert "authoritative server history" in json.dumps(records)
+    assert "/stale/cwd" not in json.dumps(records)
+
+
+@pytest.mark.asyncio
+async def test_ensure_local_codex_resume_rollout_empty_server_history_wins(
+    tmp_path: Path,
+) -> None:
+    """A successful empty server history replaces divergent local-only records."""
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    codex_home = tmp_path / "codex-home"
+    existing = _write_source_rollout(
+        codex_home=codex_home,
+        thread_id=thread_id,
+        source_cwd="/local/only",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/sessions/conv_codex/items"
+        return httpx.Response(200, json={"data": [], "has_more": False})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        rollout = await codex_native._ensure_local_codex_resume_rollout(
+            client,
+            session_id="conv_codex",
+            external_session_id=thread_id,
+            codex_home=codex_home,
+            workspace=(tmp_path / "workspace").resolve(),
+            model_provider="omnigent_databricks",
+            codex_path=None,
+        )
+
+    assert rollout == existing
+    records = [json.loads(line) for line in existing.read_text().splitlines()]
+    assert [record["type"] for record in records] == ["session_meta"]
+    assert "/local/only" not in json.dumps(records)
+
+
+@pytest.mark.asyncio
+async def test_ensure_local_codex_resume_rollout_uses_unique_atomic_temp_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Separate cold-resume writers never share a temporary rollout path."""
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    codex_home = tmp_path / "codex-home"
+    replaced_from: list[Path] = []
+    real_replace = os.replace
+
+    def recording_replace(source: os.PathLike[str], target: os.PathLike[str]) -> None:
+        replaced_from.append(Path(source))
+        real_replace(source, target)
+
+    monkeypatch.setattr(codex_native.os, "replace", recording_replace)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/sessions/conv_codex/items"
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "msg_server",
+                        "response_id": "codex_turn_server",
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "server history"}],
+                    }
+                ],
+                "has_more": False,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(2):
+            await codex_native._ensure_local_codex_resume_rollout(
+                client,
+                session_id="conv_codex",
+                external_session_id=thread_id,
+                codex_home=codex_home,
+                workspace=(tmp_path / "workspace").resolve(),
+                model_provider="omnigent_databricks",
+                codex_path=None,
+            )
+
+    assert len(replaced_from) == 2
+    assert replaced_from[0] != replaced_from[1]
+    assert all(path.suffix == ".tmp" for path in replaced_from)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["server", "transport"])
+async def test_ensure_local_codex_resume_rollout_falls_back_when_server_unavailable(
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    """A transient server failure falls back to a valid local rollout."""
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    codex_home = tmp_path / "codex-home"
+    existing = _write_source_rollout(
+        codex_home=codex_home,
+        thread_id=thread_id,
+        source_cwd="/local/fallback",
+    )
+    before = existing.read_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if failure == "transport":
+            raise httpx.ReadError("connection dropped", request=request)
+        return httpx.Response(503, json={"error": {"code": "unavailable"}})
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
@@ -10865,9 +11015,137 @@ async def test_ensure_local_codex_resume_rollout_preserves_existing_rollout(
 
 
 @pytest.mark.asyncio
+async def test_ensure_local_codex_resume_rollout_does_not_fallback_on_4xx(
+    tmp_path: Path,
+) -> None:
+    """A server contract rejection cannot revive a local Codex rollout."""
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    codex_home = tmp_path / "codex-home"
+    existing = _write_source_rollout(
+        codex_home=codex_home,
+        thread_id=thread_id,
+        source_cwd="/local/fallback",
+    )
+    before = existing.read_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(404, json={"error": {"code": "not_found"}})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(click.ClickException, match="Failed to fetch history"):
+            await codex_native._ensure_local_codex_resume_rollout(
+                client,
+                session_id="conv_codex",
+                external_session_id=thread_id,
+                codex_home=codex_home,
+                workspace=(tmp_path / "workspace").resolve(),
+                model_provider="omnigent_databricks",
+                codex_path=None,
+            )
+
+    assert existing.read_bytes() == before
+
+
+@pytest.mark.asyncio
+async def test_ensure_local_codex_resume_rollout_rejects_invalid_local_fallback(
+    tmp_path: Path,
+) -> None:
+    """An unavailable server cannot fall back to a malformed local rollout."""
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    codex_home = tmp_path / "codex-home"
+    invalid = (
+        codex_home
+        / "sessions"
+        / "2026"
+        / "09"
+        / "11"
+        / f"rollout-2026-09-11T00-00-00-{thread_id}.jsonl"
+    )
+    invalid.parent.mkdir(parents=True)
+    invalid.write_text("not json\n", encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(503, json={"error": {"code": "unavailable"}})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(click.ClickException, match="Failed to fetch history"):
+            await codex_native._ensure_local_codex_resume_rollout(
+                client,
+                session_id="conv_codex",
+                external_session_id=thread_id,
+                codex_home=codex_home,
+                workspace=(tmp_path / "workspace").resolve(),
+                model_provider="omnigent_databricks",
+                codex_path=None,
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_item", [None, "not an object", 42])
+async def test_ensure_local_codex_resume_rollout_rejects_non_object_server_item(
+    tmp_path: Path,
+    bad_item: object,
+) -> None:
+    """Malformed entries in a successful server page fail closed."""
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    codex_home = tmp_path / "codex-home"
+    existing = _write_source_rollout(
+        codex_home=codex_home,
+        thread_id=thread_id,
+        source_cwd="/local/fallback",
+    )
+    before = existing.read_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        del request
+        return httpx.Response(200, json={"data": [bad_item], "has_more": False})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(click.ClickException, match="non-object item at index 0"):
+            await codex_native._ensure_local_codex_resume_rollout(
+                client,
+                session_id="conv_codex",
+                external_session_id=thread_id,
+                codex_home=codex_home,
+                workspace=(tmp_path / "workspace").resolve(),
+                model_provider="omnigent_databricks",
+                codex_path=None,
+            )
+
+    assert existing.read_bytes() == before
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("bad_item", "message"),
     [
+        (
+            {
+                "id": "fc_bad",
+                "response_id": "codex_turn_1",
+                "type": "function_call",
+                "name": "",
+                "call_id": "call_shell_1",
+                "arguments": "{}",
+            },
+            "function_call 'fc_bad' has an invalid name",
+        ),
+        (
+            {
+                "id": "fc_bad",
+                "response_id": "codex_turn_1",
+                "type": "function_call",
+                "name": "shell",
+                "call_id": "",
+                "arguments": "{}",
+            },
+            "function_call 'fc_bad' has an invalid call_id",
+        ),
         (
             {
                 "id": "fc_bad",
@@ -10877,6 +11155,16 @@ async def test_ensure_local_codex_resume_rollout_preserves_existing_rollout(
                 "call_id": "call_shell_1",
             },
             "function_call 'fc_bad' has non-string arguments",
+        ),
+        (
+            {
+                "id": "fco_bad",
+                "response_id": "codex_turn_1",
+                "type": "function_call_output",
+                "call_id": "",
+                "output": "done",
+            },
+            "function_call_output 'fco_bad' has an invalid call_id",
         ),
         (
             {


### PR DESCRIPTION
## Related issue

Follow-up to #6904 and OMNI-6996.

## Summary

- Make committed Omnigent server items the authoritative transcript for Codex cold resumes, rewriting the matching local rollout before launching `codex resume`.
- Fall back to an existing valid local rollout only when the server is temporarily unavailable (transport errors or HTTP 5xx); explicit 4xx responses and malformed history still fail closed.
- Use unique same-directory temporary files for atomic rollout replacement, and reject malformed page entries or incomplete tool identity fields before touching the local rollout.
- Keep warm/live terminal reattachment unchanged. This PR does not alter purging, locking, forwarding, or thread-binding behavior.

**ELI5:** A restarted Codex session now reloads its conversation from Omnigent first. Its local transcript is an emergency backup, not the primary copy.

```text
cold resume
    |
    v
fetch server history ---- success ----> atomically rewrite local rollout ----> codex resume
    |
 transport / 5xx
    v
validate local rollout --- valid ------> codex resume
    |
  invalid / absent
    v
fail with the server-history error
```

## Test Plan

- `.venv/bin/python -m pytest -q tests/test_codex_native.py` — 264 passed.
- `.venv/bin/python -m pytest -q tests/test_codex_native.py -k 'ensure_local_codex_resume_rollout'` — 17 passed.
- `.venv/bin/ruff format --check omnigent/harnesses/codex_native/main.py tests/test_codex_native.py`
- `.venv/bin/ruff check omnigent/harnesses/codex_native/main.py tests/test_codex_native.py`
- `.venv/bin/pyrefly check omnigent/harnesses/codex_native/main.py` — 0 errors.
- `git diff --check`
- Full pre-commit remains blocked by an unrelated existing Pyrefly error in `omnigent/harnesses/opencode_native/provider.py:363`.

Real CUJs on September 11, 2026, using an isolated `HOME`, a real local
Omnigent server/host/runner, Codex CLI 0.147.0, and the Databricks AI Gateway:

- Created a native Codex session and committed a `CUJ_SERVER_V1` user/assistant turn to the real local server.
- Replaced every local-rollout occurrence with `CUJ_LOCAL_STALE` while keeping valid JSONL. The production resume helper fetched the real server items, rewrote the same rollout atomically, restored `CUJ_SERVER_V1`, and removed every stale marker. Real `codex exec resume` then recalled `CUJ_SERVER_V1` from the rebuilt thread.
- Stopped the host/runner and ran the top-level `omnigent codex --resume` cold-start flow. The new runner logged `Refreshed Codex resume rollout from server history`, the TUI replayed the original turn, and its follow-up answer was `CUJ_SERVER_V1`.
- Stopped the server and reran the production helper. It emitted the local-fallback warning, returned the existing rollout byte-for-byte, and real Codex resumed it and recalled `CUJ_SERVER_V1`.
- Current `main` reaped the prior bridge during the full host restart, so the full cold-resume CUJ exercised server reconstruction. The fallback CUJ used the valid rollout created by that reconstruction; #6904 makes that backup survive ordinary restarts for seven days.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Unit tests cover authoritative overwrite (including empty server history), unique atomic temporary files, HTTP 5xx and transport fallback, 4xx refusal, invalid local fallback rejection, malformed page and tool history, and unsafe thread IDs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The change is isolated to Codex cold-resume rollout preparation. The complete
Codex-native unit suite passed, and the manual CUJs exercised both server-first
reconstruction and local fallback with real processes rather than an E2E pytest.

## Changelog

Codex cold resumes now rebuild from the server transcript and use a valid local transcript only during temporary server outages.

