### PR TITLE
fix: exclude PR reads and comments from session tracking

### DIFF
--- a/omnigent/harnesses/opencode_native/provider.py
+++ b/omnigent/harnesses/opencode_native/provider.py
@@ -32,6 +32,8 @@ from typing import TYPE_CHECKING
 from omnigent.models import model_catalog
 
 if TYPE_CHECKING:
+    from databricks.sdk.core import Config
+
     from omnigent.spec.types import MCPServerConfig
 
 _logger = logging.getLogger(__name__)
@@ -345,7 +347,7 @@ def resolve_databricks_gateway(
     )
 
 
-def _list_gateway_models(config: object) -> tuple[str, ...]:
+def _list_gateway_models(config: Config) -> tuple[str, ...]:
     """
     List the workspace's chat-capable ``databricks-*`` serving endpoints.
 

--- a/omnigent/runner/pr_observer.py
+++ b/omnigent/runner/pr_observer.py
@@ -437,6 +437,19 @@ def _content_only(tokens: list[str]) -> bool:
     )
 
 
+def _created_pr_metadata(result: object) -> PullRequestRef | None:
+    """Read Claude's creation identity from tool metadata, never rendered stdout."""
+    if not isinstance(result, dict):
+        return None
+    operation = result.get("gitOperation")
+    if not isinstance(operation, dict):
+        return None
+    pr = operation.get("pr")
+    if not isinstance(pr, dict) or pr.get("action") != "created":
+        return None
+    return _reference(pr.get("url"))
+
+
 def _mcp_prs(
     arguments: dict[str, object], result: object, *, created: bool
 ) -> list[PullRequestRef]:
@@ -494,10 +507,18 @@ def extract_prs(
         if not commands:
             return [], False
         text = _output_text(result)
-        if re.search(r"\[exit code: [1-9]|Process exited with code [1-9]", text):
+        if re.search(
+            r"(?:^|\n)(?:\[exit code: -?[1-9][0-9]*\]"
+            r"|Process exited with code -?[1-9][0-9]*)\s*\Z",
+            text,
+        ):
             return [], False
         created = all(_creates_pr(tokens) for tokens in commands)
         references = [ref for tokens in commands if (ref := _command_target(tokens))]
+        if any(_creates_pr(tokens) for tokens in commands) and (
+            ref := _created_pr_metadata(result)
+        ):
+            references.append(ref)
         # Shared stdout cannot attribute a result to a write when reads/comments also ran.
         if len(commands) == len(gh_commands) and (
             len(commands) > 1 or not _content_only(commands[0])

--- a/omnigent/runner/pr_observer.py
+++ b/omnigent/runner/pr_observer.py
@@ -17,14 +17,28 @@ from omnigent.policies.builtins._shell import (
 from omnigent.runner.session_prs import PullRequestRef, SessionPrRegistry, observation_key
 
 _logger = logging.getLogger(__name__)
+_PR_WRITES = {
+    "create",
+    "edit",
+    "merge",
+    "close",
+    "reopen",
+    "ready",
+    "lock",
+    "unlock",
+    "update-branch",
+}
+_MCP_REVIEWS = {
+    "create_pull_request_review",
+    "submit_pending_pull_request_review",
+    "pull_request_review_write",
+}
 _MCP_ACTIONS = {
     "create_pull_request",
     "update_pull_request",
     "merge_pull_request",
     "update_pull_request_branch",
-    "create_pull_request_review",
-    "submit_pending_pull_request_review",
-    "pull_request_review_write",
+    *_MCP_REVIEWS,
 }
 
 
@@ -241,16 +255,67 @@ def _api_endpoint(tokens: list[str]) -> str | None:
     return None
 
 
+def _api_method(tokens: list[str]) -> str:
+    method = _flag(tokens, "--method", "-X")
+    if method is None:
+        method = (
+            "POST" if _flag(tokens, "--field", "--raw-field", "-f", "-F", "--input") else "GET"
+        )
+    return method.upper()
+
+
+def _api_field(tokens: list[str], field: str) -> str | None:
+    flags = ("--field", "--raw-field", "-f", "-F")
+    index = 0
+    while index < len(tokens):
+        value = _flag(tokens[index : index + 2], *flags)
+        if value is not None:
+            key, separator, content = value.partition("=")
+            if key == field and separator:
+                return content
+            if tokens[index] in flags:
+                index += 1
+        index += 1
+    return None
+
+
+def _changes_review_state(event: object) -> bool:
+    return isinstance(event, str) and event.upper() in {"APPROVE", "REQUEST_CHANGES"}
+
+
+def _tracks_pr(tokens: list[str]) -> bool:
+    """Track PR changes, excluding reads and comment-only interactions."""
+    if tokens[0] == "pr":
+        if len(tokens) < 2:
+            return False
+        if tokens[1] == "review":
+            return bool({"--approve", "-a", "--request-changes", "-r"}.intersection(tokens[2:]))
+        return tokens[1] in _PR_WRITES
+    if tokens[0] != "api" or _api_method(tokens) not in {"POST", "PATCH", "PUT", "DELETE"}:
+        return False
+    endpoint = (_api_endpoint(tokens[1:]) or "").split("?", 1)[0]
+    path = endpoint.strip("/").split("/")
+    # GraphQL POSTs can be queries or comment mutations; HTTP method alone is insufficient.
+    if path[0] != "repos" or len(path) < 4:
+        return False
+    resource = path[3:]
+    if "comments" in resource:
+        return False
+    if "reviews" in resource:
+        return _changes_review_state(_api_field(tokens, "event"))
+    return True
+
+
 def _creates_pr(tokens: list[str]) -> bool:
     if tokens[:2] == ["pr", "create"]:
         return True
     if tokens[0] != "api":
         return False
-    method = _flag(tokens, "--method", "-X")
-    if method is None:
-        method = "POST" if _flag(tokens, "--field", "--raw-field", "-f", "-F") else "GET"
     endpoint = (_api_endpoint(tokens[1:]) or "").split("?", 1)[0]
-    return method == "POST" and re.fullmatch(r"/?repos/[^/]+/[^/]+/pulls/?", endpoint) is not None
+    return (
+        _api_method(tokens) == "POST"
+        and re.fullmatch(r"/?repos/[^/]+/[^/]+/pulls/?", endpoint) is not None
+    )
 
 
 def _positional_target(tokens: list[str]) -> str | None:
@@ -422,18 +487,21 @@ def extract_prs(
         if not isinstance(command, str) or len(command) > 100_000:
             return [], False
         # Unrelated setup commands do not affect PR associations.
-        commands = [
+        gh_commands = [
             tokens for tokens in _gh_commands(command) if tokens and tokens[0] in {"pr", "api"}
         ]
+        commands = [tokens for tokens in gh_commands if _tracks_pr(tokens)]
         if not commands:
             return [], False
         text = _output_text(result)
         if re.search(r"\[exit code: [1-9]|Process exited with code [1-9]", text):
             return [], False
-        # Mixed reads/writes still associate PRs, but cannot establish creation.
         created = all(_creates_pr(tokens) for tokens in commands)
         references = [ref for tokens in commands if (ref := _command_target(tokens))]
-        if len(commands) > 1 or not _content_only(commands[0]):
+        # Shared stdout cannot attribute a result to a write when reads/comments also ran.
+        if len(commands) == len(gh_commands) and (
+            len(commands) > 1 or not _content_only(commands[0])
+        ):
             for obj in _objects(result):
                 if ref := _reference(obj.get("html_url", obj.get("url"))):
                     references.append(ref)
@@ -459,6 +527,8 @@ def extract_prs(
             if isinstance(params, dict):
                 arguments = {**params, "owner": params.get("owner", params.get("org"))}
         if name not in _MCP_ACTIONS:
+            return [], False
+        if name in _MCP_REVIEWS and not _changes_review_state(arguments.get("event")):
             return [], False
         created = name == "create_pull_request"
         references = _mcp_prs(arguments, result, created=created)

--- a/tests/e2e/test_session_pr_tracking_e2e.py
+++ b/tests/e2e/test_session_pr_tracking_e2e.py
@@ -87,8 +87,8 @@ async def test_native_session_tracks_prs_across_repositories(
             ["/bin/sh", "-c", rest_command], text=True, cwd=workspace
         )
         mixed_command = (
-            "gh api /repos/example/five/issues/42/comments -f body=fixture; "
-            "gh pr view 42 -R example/one --json url"
+            "gh api /repos/example/commented/issues/42/comments -f body=fixture; "
+            "gh pr view 42 -R example/read --json url"
         )
         mixed_output = subprocess.check_output(
             ["/bin/sh", "-c", mixed_command], text=True, cwd=workspace
@@ -154,6 +154,21 @@ async def test_native_session_tracks_prs_across_repositories(
                 "tool_input": {"command": mixed_command},
                 "tool_response": {"stdout": mixed_output, "exit_code": 0},
             },
+            {
+                "tool_name": "mcp__custom__create_pull_request_review",
+                "tool_input": {
+                    "owner": "example",
+                    "repo": "commented",
+                    "pullNumber": 42,
+                    "event": "COMMENT",
+                },
+                "tool_response": {"html_url": "https://github.com/example/commented/pull/42"},
+            },
+            {
+                "tool_name": "mcp__custom__update_pull_request",
+                "tool_input": {"owner": "example", "repo": "five", "pullNumber": 42},
+                "tool_response": {"html_url": "https://github.com/example/five/pull/42"},
+            },
         ]
         for index, payload in enumerate(payloads):
             payload.update(
@@ -184,7 +199,7 @@ async def test_native_session_tracks_prs_across_repositories(
         }
         registry.remove("https://github.com/example/five/pull/42")
         # A new observation, as well as hook replay, must respect explicit unlinking.
-        for call_id in (payloads[-1]["tool_use_id"], "new-comment"):
+        for call_id in (payloads[-1]["tool_use_id"], "new-update"):
             completed = await asyncio.to_thread(
                 subprocess.run,
                 command,

--- a/tests/e2e/test_session_pr_tracking_e2e.py
+++ b/tests/e2e/test_session_pr_tracking_e2e.py
@@ -70,11 +70,21 @@ async def test_native_session_tracks_prs_across_repositories(
     try:
         shell_command = (
             "gh auth switch --user example-user; gh repo set-default example/one && "
-            "gh pr create -R example/one; gh config set pager cat"
+            + ("gh pr diff 42 -R example/read && " if harness == "claude_native" else "")
+            + "gh pr create -R example/one; gh config set pager cat"
         )
         output = subprocess.check_output(
             ["/bin/sh", "-c", shell_command], text=True, cwd=workspace
         )
+        shell_response: dict[str, object] = {"stdout": output, "exit_code": 0}
+        if harness == "claude_native":
+            # Claude retains creation metadata when a long diff truncates stdout.
+            url = "https://github.com/example/one/pull/42"
+            shell_response = {
+                "stdout": output[: output.index(url)],
+                "interrupted": False,
+                "gitOperation": {"pr": {"number": 42, "url": url, "action": "created"}},
+            }
         rest_command = (
             "gh auth switch --user example-user; "
             "printf 'HEAD SHA: fixture\\n' && gh api /repos/example/three/pulls \\\n"
@@ -101,7 +111,7 @@ async def test_native_session_tracks_prs_across_repositories(
             {
                 "tool_name": "Bash",
                 "tool_input": {"command": shell_command},
-                "tool_response": {"stdout": output, "exit_code": 0},
+                "tool_response": shell_response,
             },
             {
                 "tool_name": "Bash",

--- a/tests/e2e_ui/github/test_pr_read_comment_no_association.py
+++ b/tests/e2e_ui/github/test_pr_read_comment_no_association.py
@@ -1,0 +1,314 @@
+"""PR reads and comments must not create session PR associations.
+
+Session PR tracking observes completed shell calls on the runner
+(``omnigent/runner/pr_observer.py``) and surfaces associated PRs in the
+web UI: the workspace rail's GitHub tab shows a "Session pull request"
+picker and the composer status line links the selected PR. Reported bug:
+tool completions that merely *read* a pull request (``gh pr view``, a
+``gh api`` GET) or *comment* on one (``gh pr comment``) associate that PR
+with the session, so unrelated review activity pollutes the session's PR
+selector. Only creation, edits, merges, and approvals should be tracked.
+
+These tests drive the real journey end to end — a live server + runner
+executes the agent's shell command for real (a PATH-stubbed ``gh`` prints
+gh's canonical output for each subcommand, so no GitHub access is needed;
+the observer only ever sees the command string and its output) — and
+assert the *correct* behavior: a session that only reads or comments on a
+PR has no PR associations afterwards. The three read/comment shapes fail
+on the affected build (the picker lists ``example/one #42``); the
+``gh pr create`` control passes, pinning that the fix must suppress
+reads/comments without also suppressing creation tracking.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+from tests.e2e_ui.conftest import (
+    _ensure_runner_online,
+    configure_mock_llm,
+    open_right_rail,
+    set_fallback_mock_llm,
+)
+
+_PR_URL = "https://github.com/example/one/pull/42"
+_COMPOSER = "Send a message…"
+_ASSISTANT = '[data-testid="message-bubble"][data-role="assistant"]'
+_WORKING = '[data-testid="working-indicator"]'
+
+# The per-fixture model gives each test an isolated mock-LLM queue.
+_AGENT_YAML = """\
+name: {name}
+prompt: |
+  You are a deterministic test assistant. When asked about a pull request
+  you run a shell command against it, then confirm.
+
+executor:
+  model: {model}
+  harness: openai-agents
+
+os_env:
+  type: caller_process
+  cwd: {cwd}
+  sandbox:
+    type: none
+"""
+
+# Stands in for the real gh CLI on PATH: prints gh's canonical output for
+# each subcommand the tests exercise — the PR URL for ``pr view`` and
+# ``pr create``, the comment permalink for ``pr comment``, and the pull
+# request JSON for an ``api`` read — and succeeds, exactly what a real
+# successful call shows.
+_GH_STUB = f"""\
+#!/bin/sh
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  echo "{_PR_URL}"
+elif [ "$1" = "pr" ] && [ "$2" = "comment" ]; then
+  echo "{_PR_URL}#issuecomment-1"
+elif [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  echo "{_PR_URL}"
+elif [ "$1" = "api" ]; then
+  echo '{{"url": "https://api.github.com/repos/example/one/pulls/42", \
+"html_url": "{_PR_URL}", "number": 42, "state": "open"}}'
+fi
+exit 0
+"""
+
+# The reported read/comment shapes that must not associate the PR, plus the
+# creation shape that must keep associating it. The leading PATH export only
+# makes the stubbed gh resolvable; it adds no gh clause.
+_PREFIX = 'export PATH="{stub}:$PATH"; cd {worktree} && '
+_READ_COMMENT_COMMANDS = {
+    "read-pr-view": _PREFIX + "gh pr view 42 -R example/one",
+    "comment-pr-comment": _PREFIX + "gh pr comment 42 -R example/one --body 'Looks good'",
+    "read-rest-api-get": _PREFIX + "gh api repos/example/one/pulls/42",
+}
+_CREATE_COMMAND = _PREFIX + "gh pr create --title 'Example' --body 'Example'"
+
+
+def _agent_bundle(name: str, model: str, cwd: str) -> bytes:
+    """Gzip-tar the agent YAML for multipart upload."""
+    yaml_text = _AGENT_YAML.format(name=name, model=model, cwd=cwd)
+    buf = io.BytesIO()
+    with (
+        gzip.GzipFile(fileobj=buf, mode="wb", mtime=0) as gz,
+        tarfile.open(fileobj=gz, mode="w") as tar,
+    ):
+        data = yaml_text.encode()
+        info = tarfile.TarInfo(name=f"{name}.yaml")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _git(*args: str) -> None:
+    subprocess.run(["git", *args], check=True, capture_output=True)
+
+
+@pytest.fixture
+def pr_probe_runner_id(
+    live_server: str,
+    runner_id: str,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[str]:
+    """Recover the shared runner after an earlier crash test in the shard."""
+    respawned = _ensure_runner_online(live_server, tmp_path_factory)
+    try:
+        yield runner_id
+    finally:
+        if respawned is not None:
+            respawned.terminate()
+            try:
+                respawned.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                respawned.kill()
+                respawned.wait(timeout=5)
+
+
+@pytest.fixture
+def pr_probe_session(
+    live_server: str,
+    pr_probe_runner_id: str,
+    mock_llm_server_url: str,
+) -> Iterator[tuple[str, str, str, Path, Path]]:
+    """An isolated runner-bound session whose workspace can run the commands.
+
+    The workspace holds a ``stub-bin/gh`` for PATH and a ``worktree`` git
+    repo, so the agent's command runs from a realistic checkout without any
+    GitHub access.
+    """
+    ws = Path(tempfile.mkdtemp(prefix="omnigent-e2e-pr-read-comment-"))
+    stub = ws / "stub-bin"
+    stub.mkdir()
+    (stub / "gh").write_text(_GH_STUB)
+    (stub / "gh").chmod(0o755)
+    worktree = ws / "worktree"
+    _git("init", "-q", "-b", "topic", str(worktree))
+    _git(
+        "-C",
+        str(worktree),
+        "-c",
+        "user.email=e2e@example.com",
+        "-c",
+        "user.name=e2e",
+        "commit",
+        "--allow-empty",
+        "-q",
+        "-m",
+        "init",
+    )
+
+    name = f"pr_assoc_probe_{uuid.uuid4().hex[:8]}"
+    model = f"pr-assoc-probe-{uuid.uuid4().hex[:8]}"
+    create_resp = httpx.post(
+        f"{live_server}/v1/sessions",
+        data={"metadata": json.dumps({})},
+        files={
+            "bundle": (
+                "agent.tar.gz",
+                _agent_bundle(name, model, str(ws)),
+                "application/gzip",
+            )
+        },
+        timeout=30.0,
+    )
+    create_resp.raise_for_status()
+    session_id = create_resp.json()["session_id"]
+    try:
+        httpx.patch(
+            f"{live_server}/v1/sessions/{session_id}",
+            json={"runner_id": pr_probe_runner_id},
+            timeout=10.0,
+        ).raise_for_status()
+        yield (live_server, session_id, model, stub, worktree)
+    finally:
+        httpx.delete(f"{live_server}/v1/sessions/{session_id}", timeout=10.0)
+        shutil.rmtree(ws, ignore_errors=True)
+
+
+def _drive_shell_turn(
+    page: Page,
+    base_url: str,
+    session_id: str,
+    model: str,
+    mock_url: str,
+    command: str,
+    prompt: str,
+    reply: str,
+) -> None:
+    """Run one agent turn whose only tool call executes *command* for real."""
+    # Configure both responses together because reconfiguring a queue resets it.
+    configure_mock_llm(
+        mock_url,
+        [
+            {
+                "tool_calls": [
+                    {
+                        "call_id": "call_gh",
+                        "name": "sys_os_shell",
+                        "arguments": json.dumps({"command": command}),
+                    }
+                ]
+            },
+            {"text": reply},
+        ],
+        key=model,
+    )
+    set_fallback_mock_llm(mock_url, model, "Done.")
+
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = page.get_by_placeholder(_COMPOSER)
+    expect(composer).to_be_visible(timeout=30_000)
+    composer.fill(prompt)
+    page.get_by_role("button", name="Send", exact=True).click()
+    expect(page.locator(_ASSISTANT).last).to_contain_text(reply, timeout=60_000)
+    expect(page.locator(_WORKING)).to_have_count(0, timeout=60_000)
+
+
+def _open_github_panel(page: Page) -> Locator:
+    """Reload like a returning user, open the rail, and select the GitHub tab."""
+    page.reload()
+    expect(page.get_by_placeholder(_COMPOSER)).to_be_visible(timeout=30_000)
+    open_right_rail(page)
+    rail = page.get_by_role("complementary", name="Workspace")
+    rail.get_by_role("tab", name="GitHub").click()
+    # The "Link a PR" affordance renders once the panel's info request has
+    # settled (with or without tracked PRs), so waiting on it keeps negative
+    # assertions from passing vacuously against a still-loading panel.
+    expect(rail.get_by_role("button", name="Link a PR").first).to_be_visible(timeout=30_000)
+    return rail
+
+
+@pytest.mark.parametrize("shape", list(_READ_COMMENT_COMMANDS), ids=list(_READ_COMMENT_COMMANDS))
+def test_read_or_comment_does_not_associate_pr(
+    page: Page,
+    pr_probe_session: tuple[str, str, str, Path, Path],
+    mock_llm_server_url: str,
+    shape: str,
+) -> None:
+    """Reading or commenting on a PR leaves the session without associations."""
+    base_url, session_id, model, stub, worktree = pr_probe_session
+    command = _READ_COMMENT_COMMANDS[shape].format(stub=stub, worktree=worktree)
+    _drive_shell_turn(
+        page,
+        base_url,
+        session_id,
+        model,
+        mock_llm_server_url,
+        command,
+        "Take a look at PR 42 in example/one.",
+        "Reviewed the pull request.",
+    )
+
+    rail = _open_github_panel(page)
+    # A read/comment must leave the session unassociated: no session-PR
+    # picker in the GitHub tab and no composer status-line PR link.
+    expect(rail.get_by_role("combobox", name="Session pull request")).to_have_count(0)
+    expect(page.get_by_test_id("composer-pr-link")).to_have_count(0)
+    # The registry itself must stay empty — a hidden association would still
+    # resurface in pickers and defaults later.
+    info = httpx.get(
+        f"{base_url}/v1/sessions/{session_id}/resources/github",
+        timeout=30.0,
+    )
+    info.raise_for_status()
+    prs = info.json().get("prs", [])
+    assert prs == [], f"read/comment associated PRs: {[pr['url'] for pr in prs]}"
+
+
+def test_created_pr_remains_tracked(
+    page: Page,
+    pr_probe_session: tuple[str, str, str, Path, Path],
+    mock_llm_server_url: str,
+) -> None:
+    """Control: ``gh pr create`` still associates its PR with the session."""
+    base_url, session_id, model, stub, worktree = pr_probe_session
+    command = _CREATE_COMMAND.format(stub=stub, worktree=worktree)
+    _drive_shell_turn(
+        page,
+        base_url,
+        session_id,
+        model,
+        mock_llm_server_url,
+        command,
+        "Open a pull request for this change.",
+        "Opened the pull request.",
+    )
+
+    rail = _open_github_panel(page)
+    picker = rail.get_by_role("combobox", name="Session pull request")
+    expect(picker).to_have_text("example/one #42", timeout=30_000)
+    expect(page.get_by_test_id("composer-pr-link")).to_have_accessible_name("#42")

--- a/tests/runner/test_session_prs.py
+++ b/tests/runner/test_session_prs.py
@@ -122,8 +122,8 @@ def test_reference_accepts_dns_hostname(host: str) -> None:
         ("Bash", {"command": "gh pr create"}, {"stdout": A, "exit_code": 1}, []),
         ("Bash", {"command": "gh pr create"}, A + "\n[exit code: 1]", []),
         ("Bash", {"command": f"echo '{A}'"}, A, []),
-        ("Bash", {"command": "gh pr list"}, A + "\n" + B, [A, B]),
-        ("Bash", {"command": "gh pr view 42"}, A, [A]),
+        ("Bash", {"command": "gh pr list"}, A + "\n" + B, []),
+        ("Bash", {"command": "gh pr view 42"}, A, []),
         (
             "mcp__custom__create_pull_request",
             {"owner": "example", "repo": "one"},
@@ -158,6 +158,156 @@ def test_extract_completed_operations(
 ) -> None:
     references, _ = extract_prs(name, args, result)
     assert [ref.url for ref in references] == urls
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh pr view 42 -R example/one --comments",
+        "gh pr diff 42 -R example/one",
+        "gh pr checks 42 -R example/one",
+        "gh pr list --json url",
+        "gh pr status --json url",
+        "gh pr checkout 42 -R example/one",
+        "gh pr comment 42 -R example/one --body test",
+        "gh pr review 42 -R example/one --comment --body test",
+        "gh pr review -c -R example/one 42 --body test",
+        "gh api repos/example/one/pulls/42",
+        "gh api repos/example/one/pulls --method GET -f state=open",
+        "gh api repos/example/one/pulls/42 -X HEAD",
+        "gh api graphql -f query='{ viewer { pullRequests(first: 10) { nodes { url } } } }'",
+        "gh api repos/example/one/issues/42/comments -f body=test",
+        "gh api repos/example/one/issues/comments/123 -X PATCH -f body=test",
+        "gh api repos/example/one/pulls/42/comments -f body=test",
+        "gh api repos/example/one/pulls/42/comments/123/replies -f body=test",
+        "gh api repos/example/one/pulls/comments/123 -X DELETE",
+        "gh api repos/example/one/pulls/42/reviews -f body=test -f event=COMMENT",
+        "gh api repos/example/one/pulls/42/reviews/123/events -f event=COMMENT",
+        "gh api repos/example/one/pulls/42/reviews -f body=test",
+    ],
+)
+@pytest.mark.parametrize("structured", [False, True])
+def test_reads_and_comments_do_not_attach_prs(command: str, structured: bool) -> None:
+    result = {"html_url": A, "body": B} if structured else A + "\n" + B
+    assert extract_prs("Bash", {"command": command}, result) == ([], False)
+
+
+@pytest.mark.parametrize(
+    "name,extra",
+    [
+        ("pull_request_read", {"method": "get"}),
+        ("get_pull_request", {}),
+        ("add_issue_comment", {}),
+        ("add_comment_to_pending_review", {}),
+        ("create_pull_request_review", {"event": "COMMENT"}),
+        ("submit_pending_pull_request_review", {"event": "COMMENT"}),
+        ("pull_request_review_write", {"method": "submit_pending", "event": "COMMENT"}),
+        ("pull_request_review_write", {"method": "create"}),
+    ],
+)
+def test_mcp_reads_and_comments_do_not_attach_prs(name: str, extra: dict) -> None:
+    refs, created = extract_prs(
+        f"mcp__github__{name}",
+        {"owner": "example", "repo": "one", "pullNumber": 42, **extra},
+        {"structuredContent": {"html_url": A}},
+    )
+    assert refs == []
+    assert not created
+
+
+@pytest.mark.parametrize(
+    "ignored",
+    [
+        "gh pr view 42 -R example/one --json url",
+        "gh pr list --json url",
+        "gh pr comment 42 -R example/one --body test",
+        "gh api repos/example/one/issues/42/comments -f body=test",
+    ],
+)
+@pytest.mark.parametrize("reverse", [False, True])
+def test_mixed_reads_and_writes_use_only_write_targets(ignored: str, reverse: bool) -> None:
+    commands = [ignored, "gh pr edit 42 -R example/two --title test"]
+    refs, created = extract_prs(
+        "Bash",
+        {"command": "; ".join(reversed(commands) if reverse else commands)},
+        {"stdout": json.dumps({"url": A}) + "\n" + B},
+    )
+    assert [ref.url for ref in refs] == [B]
+    assert not created
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh pr close 42 -R example/one",
+        "gh pr reopen 42 -R example/one",
+        "gh pr ready 42 -R example/one",
+        "gh pr merge 42 -R example/one --squash",
+        "gh pr update-branch 42 -R example/one",
+        "gh pr review 42 -R example/one --approve",
+        "gh pr review 42 -R example/one -r --body test",
+        "gh api repos/example/one/pulls/42 -X PATCH -f title=test",
+        "gh api repos/example/one/pulls/42/merge -X PUT",
+        "gh api repos/example/one/pulls/42/reviews -f body=test -f event=APPROVE",
+        "gh api repos/example/one/pulls/42/reviews "
+        "--raw-field=body=test --field=event=REQUEST_CHANGES",
+        "gh api repos/example/one/pulls/42/reviews/123/events -fevent=APPROVE",
+    ],
+)
+def test_pr_changes_still_use_command_targets(command: str) -> None:
+    refs, created = extract_prs("Bash", {"command": command}, "Done.")
+    assert [ref.url for ref in refs] == [A]
+    assert not created
+
+
+@pytest.mark.parametrize("repo", ["comments", "reviews"])
+def test_repository_name_does_not_classify_rest_operation(repo: str) -> None:
+    url = f"https://github.com/example/{repo}/pull/42"
+    refs, created = extract_prs(
+        "Bash", {"command": f"gh api repos/example/{repo}/pulls --input request.json"}, url
+    )
+    assert [ref.url for ref in refs] == [url]
+    assert created
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "create_pull_request_review",
+        "submit_pending_pull_request_review",
+        "pull_request_review_write",
+    ],
+)
+@pytest.mark.parametrize("event", ["APPROVE", "REQUEST_CHANGES"])
+def test_mcp_review_state_changes_still_attach_prs(name: str, event: str) -> None:
+    refs, created = extract_prs(
+        f"mcp__github__{name}",
+        {"owner": "example", "repo": "one", "pullNumber": 42, "event": event},
+        "Done.",
+    )
+    assert [ref.url for ref in refs] == [A]
+    assert not created
+
+
+def test_reads_and_comments_do_not_refresh_existing_associations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+    store = SessionPrRegistry("conv_ignored")
+    store.record([PullRequestRef.from_url(A)], relationship="created", source="test", timestamp=10)
+    original = store.list()
+    for index, command in enumerate((f"gh pr view {A}", f"gh pr comment {A} --body test")):
+        observe_hook(
+            "conv_ignored",
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "tool_response": {"stdout": A + "\n" + B, "exit_code": 0},
+                "tool_use_id": f"ignored-{index}",
+            },
+        )
+    assert store.list() == original
 
 
 def test_independent_repos_and_restart(tmp_path: Path) -> None:
@@ -241,7 +391,7 @@ def test_hook_uses_bound_omnigent_session(tmp_path: Path, monkeypatch: pytest.Mo
         ("gh pr view || gh pr create", A, []),
         ("gh pr create", {"stdout": A, "metadata": {"exit_code": 1}}, []),
         ("gh pr create", {"output": A, "session_id": 12, "exit_code": None}, []),
-        ("gh pr comment -R example/one 42 -b test", "Posted", [A]),
+        ("gh pr comment -R example/one 42 -b test", "Posted", []),
     ],
 )
 def test_ambiguous_and_nonterminal_commands(command: str, result: object, urls: list[str]) -> None:
@@ -317,13 +467,13 @@ EOF
             True,
         ),
         ("gh auth status", A, [], False),
-        ("gh auth switch --user example-user; gh pr list", A, [A], False),
-        ("gh auth switch --user example-user; gh pr view; gh pr create", A, [A], False),
+        ("gh auth switch --user example-user; gh pr list", A, [], False),
+        ("gh auth switch --user example-user; gh pr view; gh pr create", A, [], True),
         (
             "gh auth switch --user example-user; gh api repos/example/one/pulls/42; gh pr create",
             A,
-            [A],
-            False,
+            [],
+            True,
         ),
         ("gh auth switch --user example-user; gh pr create || true", A, [], False),
         (
@@ -596,56 +746,58 @@ def test_background_or_interrupted_shell_does_not_attach_target(result: dict) ->
 
 
 @pytest.mark.parametrize(
-    "commands,created",
+    "commands,urls,created",
     [
-        (["gh api repos/example/one/pulls/42 --jq .html_url", "gh pr create"], False),
-        (["gh pr view 42 --repo example/one", "gh pr create"], False),
-        (["gh api repos/example/one/pulls -X POST", "gh pr edit 42"], False),
+        (["gh api repos/example/one/pulls/42 --jq .html_url", "gh pr create"], [], True),
+        (["gh pr view 42 --repo example/one", "gh pr create"], [], True),
+        (["gh api repos/example/one/pulls -X POST", "gh pr edit 42"], [A, B], False),
         (
             ["gh api repos/example/one/pulls -X POST", "gh api repos/example/two/pulls/42"],
-            False,
+            [],
+            True,
         ),
         (
             ["gh api repos/example/one/pulls -X POST", "gh api repos/example/two/pulls -X POST"],
+            [A, B],
             True,
         ),
-        (["gh api repos/example/one/pulls -X POST", "gh pr create"], True),
+        (["gh api repos/example/one/pulls -X POST", "gh pr create"], [A, B], True),
     ],
 )
 @pytest.mark.parametrize("reverse", [False, True])
 def test_combined_operations_keep_prs_without_misattributing_creation(
-    commands: list[str], created: bool, reverse: bool
+    commands: list[str], urls: list[str], created: bool, reverse: bool
 ) -> None:
     refs, was_created = extract_prs(
         "Bash",
         {"command": "; ".join(reversed(commands) if reverse else commands)},
         A + "\n" + B,
     )
-    assert {ref.url for ref in refs} == {A, B}
+    assert {ref.url for ref in refs} == set(urls)
     assert was_created is created
 
 
 @pytest.mark.parametrize(
-    "result,urls",
+    "result",
     [
-        ({"html_url": A + "#issuecomment-123", "body": B}, [A]),
-        ({"stdout": json.dumps({"html_url": A + "#issuecomment-123", "body": B})}, [A]),
-        (A + "#issuecomment-123", [A]),
-        (f"Comment posted: [view]({A}#issuecomment-123)", []),
-        ({"body": B}, []),
-        ({"html_url": A.replace("/pull/", "/issues/") + "#issuecomment-123"}, []),
-        ({"stdout": A, "exit_code": 1}, []),
-        ({"stdout": A, "interrupted": True}, []),
-        ({"stdout": A, "backgroundTaskId": "pending"}, []),
+        {"html_url": A + "#issuecomment-123", "body": B},
+        {"stdout": json.dumps({"html_url": A + "#issuecomment-123", "body": B})},
+        A + "#issuecomment-123",
+        f"Comment posted: [view]({A}#issuecomment-123)",
+        {"body": B},
+        {"html_url": A.replace("/pull/", "/issues/") + "#issuecomment-123"},
+        {"stdout": A, "exit_code": 1},
+        {"stdout": A, "interrupted": True},
+        {"stdout": A, "backgroundTaskId": "pending"},
     ],
 )
-def test_rest_comment_tracks_pr_identity(result: object, urls: list[str]) -> None:
+def test_rest_comment_ignores_pr_identity(result: object) -> None:
     refs, created = extract_prs(
         "Bash",
         {"command": f"gh api repos/example/one/issues/42/comments -f body='{B}'"},
         result,
     )
-    assert [ref.url for ref in refs] == urls
+    assert refs == []
     assert not created
 
 
@@ -653,11 +805,11 @@ def test_rest_comment_tracks_pr_identity(result: object, urls: list[str]) -> Non
     "command",
     ["gh pr view 42 --json url,body", "gh api repos/example/one/pulls/42"],
 )
-def test_pr_reads_use_structured_identity(command: str) -> None:
+def test_pr_reads_ignore_structured_identity(command: str) -> None:
     refs, created = extract_prs(
         "Bash", {"command": command}, {"stdout": json.dumps({"url": A, "body": B})}
     )
-    assert [ref.url for ref in refs] == [A]
+    assert refs == []
     assert not created
 
 
@@ -670,7 +822,7 @@ def test_pr_reads_use_structured_identity(command: str) -> None:
     ],
 )
 def test_rendered_output_requires_complete_url_line(result: str, urls: list[str]) -> None:
-    refs, created = extract_prs("Bash", {"command": "gh pr view 42"}, result)
+    refs, created = extract_prs("Bash", {"command": "gh pr edit 42 --title test"}, result)
     assert [ref.url for ref in refs] == urls
     assert not created
 
@@ -678,13 +830,12 @@ def test_rendered_output_requires_complete_url_line(result: str, urls: list[str]
 @pytest.mark.parametrize(
     "command",
     [
-        "gh pr view 42 -R example/one",
-        f"gh pr view {A} --comments",
-        "gh auth status; gh pr view --comments -R example/one 42; gh config set pager cat",
-        "gh pr view --json body -q .body 42 -R example/one",
-        "gh pr diff --color never 42 -R example/one",
-        "gh api repos/example/one/pulls/42 --jq .body",
-        "gh api repos/example/one/pulls/42/reviews",
+        "gh pr edit 42 -R example/one --title test",
+        f"gh pr merge {A} --squash",
+        "gh auth status; gh pr edit -R example/one 42 --title test; gh config set pager cat",
+        "gh pr review 42 -R example/one --approve",
+        "gh api repos/example/one/pulls/42 -X PATCH --jq .body",
+        "gh api repos/example/one/pulls/42/reviews -f event=APPROVE",
     ],
 )
 def test_known_target_excludes_prs_mentioned_in_output(command: str) -> None:
@@ -728,7 +879,7 @@ def test_single_operation_prefers_structured_identity_over_text() -> None:
 def test_plain_text_fallback_accepts_only_complete_url_lines() -> None:
     refs, _ = extract_prs(
         "Bash",
-        {"command": "gh pr view 42; gh pr create"},
+        {"command": "gh pr edit 42 --title test; gh pr create"},
         {
             "stdout": (
                 f"Supersedes {A}\n+{A}\n[view]({A})\n"
@@ -791,9 +942,9 @@ def test_rest_create_with_jq_and_multiline_shell(envelope: bool) -> None:
             True,
         ),
         ("gh api /repos/example/one/pulls/42 -X PATCH --jq .html_url", A, [A], False),
-        ("gh api /repos/example/one/pulls/42 --jq .html_url", A, [A], False),
-        ("gh api /repos/example/one/pulls -X GET -f title=test --jq .html_url", A, [A], False),
-        ("gh api /repos/example/one/pulls --jq '.[].html_url'", A + "\n" + B, [A, B], False),
+        ("gh api /repos/example/one/pulls/42 --jq .html_url", A, [], False),
+        ("gh api /repos/example/one/pulls -X GET -f title=test --jq .html_url", A, [], False),
+        ("gh api /repos/example/one/pulls --jq '.[].html_url'", A + "\n" + B, [], False),
         (
             "gh api /repos/example/one/pulls/99 -X PATCH --jq .body",
             A,

--- a/tests/runner/test_session_prs.py
+++ b/tests/runner/test_session_prs.py
@@ -237,6 +237,141 @@ def test_mixed_reads_and_writes_use_only_write_targets(ignored: str, reverse: bo
 
 
 @pytest.mark.parametrize(
+    "read",
+    [
+        "gh pr diff 42 -R example/one",
+        "gh pr view 42 -R example/one",
+        "gh pr comment 42 -R example/one --body test",
+        "gh api repos/example/one/pulls/42",
+    ],
+)
+@pytest.mark.parametrize("truncated", [False, True])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_mixed_creation_uses_native_metadata(read: str, truncated: bool, reverse: bool) -> None:
+    commands = [read, "gh pr create --title test --body test"]
+    stdout = f"diff --git a/README b/README\n@@ -1 +1,2 @@\n {A}\n+fixture = '[exit code: 1]'\n"
+    if not truncated:
+        stdout += B + "\n"
+    refs, created = extract_prs(
+        "Bash",
+        {
+            "command": "cd /workspace && "
+            + " && ".join(reversed(commands) if reverse else commands)
+        },
+        {
+            "stdout": stdout,
+            "stderr": "",
+            "interrupted": False,
+            "gitOperation": {"pr": {"number": 42, "url": B, "action": "created"}},
+        },
+    )
+    assert [ref.url for ref in refs] == [B]
+    assert created
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        "created",
+        {"pr": None},
+        {"pr": [B]},
+        {"pr": {"url": B}},
+        {"pr": {"url": B, "action": "updated"}},
+        {"pr": {"url": "not-a-pr", "action": "created"}},
+    ],
+)
+def test_mixed_creation_requires_explicit_metadata(metadata: object) -> None:
+    refs, _ = extract_prs(
+        "Bash",
+        {"command": "gh pr diff 42 && gh pr create"},
+        {"stdout": A + "\n" + B, "gitOperation": metadata},
+    )
+    assert refs == []
+
+
+@pytest.mark.parametrize("command", ["gh pr view 42", "gh pr comment 42 --body test"])
+def test_creation_metadata_does_not_enable_excluded_commands(command: str) -> None:
+    refs, created = extract_prs(
+        "Bash",
+        {"command": command},
+        {"gitOperation": {"pr": {"url": A, "action": "created"}}},
+    )
+    assert refs == []
+    assert not created
+
+
+def test_creation_metadata_requires_a_creation_command() -> None:
+    refs, created = extract_prs(
+        "Bash",
+        {"command": "gh pr edit 42 -R example/two --title test"},
+        {"gitOperation": {"pr": {"url": A, "action": "created"}}},
+    )
+    assert [ref.url for ref in refs] == [B]
+    assert not created
+
+
+def test_mixed_creation_metadata_preserves_explicit_write_targets() -> None:
+    refs, created = extract_prs(
+        "Bash",
+        {"command": "gh pr diff 7; gh pr edit 42 -R example/one; gh pr create"},
+        {"gitOperation": {"pr": {"url": B, "action": "created"}}},
+    )
+    assert {ref.url for ref in refs} == {A, B}
+    assert not created
+
+
+@pytest.mark.parametrize("as_text", [False, True])
+def test_creation_metadata_in_stdout_is_not_tool_metadata(as_text: bool) -> None:
+    stdout = json.dumps({"gitOperation": {"pr": {"url": A, "action": "created"}}})
+    refs, _ = extract_prs(
+        "Bash",
+        {"command": "gh pr diff 42 && gh pr create"},
+        stdout if as_text else {"stdout": stdout},
+    )
+    assert refs == []
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        {"exit_code": 1},
+        {"exitCode": -9},
+        {"interrupted": True},
+        {"isError": True},
+        {"cancelled": True},
+        {"session_id": 12, "exit_code": None},
+    ],
+)
+def test_creation_metadata_does_not_override_failed_or_unfinished_calls(status: dict) -> None:
+    assert extract_prs(
+        "Bash",
+        {"command": "gh pr diff 42 && gh pr create"},
+        {"gitOperation": {"pr": {"url": A, "action": "created"}}, **status},
+    ) == ([], False)
+
+
+@pytest.mark.parametrize(
+    "marker", ["[exit code: 1]", "Process exited with code 2", "[exit code: -9]"]
+)
+@pytest.mark.parametrize("footer", [False, True])
+def test_shell_exit_markers_must_be_footers(marker: str, footer: bool) -> None:
+    stdout = f"{B}\n{marker}\n" if footer else f"fixture = '{marker}'\n{B}\n"
+    refs, _ = extract_prs("Bash", {"command": "gh pr create"}, {"stdout": stdout})
+    assert [ref.url for ref in refs] == ([] if footer else [B])
+
+
+def test_creation_metadata_preserves_other_write_identities() -> None:
+    refs, created = extract_prs(
+        "Bash",
+        {"command": "gh pr create -R example/one; gh pr create -R example/two"},
+        {"stdout": A + "\n" + B, "gitOperation": {"pr": {"url": B, "action": "created"}}},
+    )
+    assert {ref.url for ref in refs} == {A, B}
+    assert created
+
+
+@pytest.mark.parametrize(
     "command",
     [
         "gh pr close 42 -R example/one",

--- a/tests/runner/test_session_prs.py
+++ b/tests/runner/test_session_prs.py
@@ -385,7 +385,7 @@ def test_creation_metadata_preserves_other_write_identities() -> None:
         "gh api repos/example/one/pulls/42/merge -X PUT",
         "gh api repos/example/one/pulls/42/reviews -f body=test -f event=APPROVE",
         "gh api repos/example/one/pulls/42/reviews "
-        "--raw-field=body=test --field=event=REQUEST_CHANGES",
+        + "--raw-field=body=test --field=event=REQUEST_CHANGES",
         "gh api repos/example/one/pulls/42/reviews/123/events -fevent=APPROVE",
     ],
 )


### PR DESCRIPTION
## Related issue

Closes #7056

## Summary

Reading or commenting on an unrelated PR currently adds it to the session's PR selector. Filter CLI and MCP operations before extracting identities so reads and comments, including comment-only reviews, no longer add or refresh associations. Creation, edits, merges, approvals, and change requests remain eligible.

For mixed calls such as `gh pr diff 42 && gh pr create ...`, use Claude's direct `tool_response.gitOperation.pr` creation metadata to identify the new PR, even when a long diff truncates its URL out of stdout. Metadata is accepted only alongside an eligible creation command; rendered diff/body text cannot supply it. Explicit failure, cancellation, and unfinished-call checks remain in place, and textual exit-code detection now requires a terminal footer so literals in diffs do not reject successful calls.

A PR joins the session when the agent changes it. Reads and comments are ignored; mixed calls use explicit write targets and confirmed creation metadata because combined stdout cannot attribute each URL to a command. Account switching and ordinary setup commands still allow creation detection.

```text
Completed tool call → classify operation → identify eligible PRs → session registry
                              └─ read/comment → ignore
Mixed read + creation → explicit creation metadata → created PR only
```

Also correct an existing OpenCode gateway parameter annotation from `object` to `Config`, with a type-only import, to clear the pre-commit type-check failure. Codex mixed-call attribution is tracked separately in #7071.

## Test Plan

- 396 tests passed: `.venv/bin/python -m pytest tests/runner/test_session_prs.py tests/runner/test_session_pr_resources.py tests/e2e/test_session_pr_tracking_e2e.py tests/test_opencode_native_provider.py -q --tb=short`.
- All 4 browser tests passed: `.venv/bin/python -m pytest tests/e2e_ui/github/test_pr_read_comment_no_association.py --ui-skip-build -q --tb=short`. A live server and runner execute stubbed `gh` calls and verify that reads/comments leave the selector empty while creation remains tracked.
- Replayed the captured live Claude PostToolUse payload through extraction and an isolated session registry: only created PR #7066 was recorded, despite its URL being absent from truncated stdout. Duplicate replay stayed idempotent. The earlier transcript result likewise identified only created PR #7060.
- New metadata and footer regressions failed before the fix. Coverage includes mixed operations in either order, truncated stdout, malformed metadata, metadata rendered inside stdout, failed/incomplete calls, explicit write targets, and multiple creations.
- Native hook subprocess tests verify relay delivery, Claude mixed creation with truncated output, cross-repository tracking, ignored reads/comments, replay deduplication, unlinking, and host resource reads.
- Pre-commit passed, including formatting, lint, and full Python type checking.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A — backend tracking change; reproducible evidence is in Test Plan.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Native tests use real hook subprocesses and an authenticated relay with a stubbed GitHub CLI. Captured-payload replay uses actual Claude metadata, but no live vendor agent was launched after the fix and no remote PR was created during validation. Codex tests cover the existing hook transport; they do not establish that Codex emits Claude's metadata.

Mixed read/write calls without explicit targets or creation metadata still cannot infer a new PR from shared stdout; creation in a separate tool call is the workaround. REST classification is limited to repository endpoints; GraphQL calls are excluded because POST alone does not establish a PR mutation. Existing stored links are retained and can be unlinked manually.

To verify manually, run `omnidev` from this branch and start a fresh Claude native session with a test branch ready for a PR. Ask the agent to run `gh pr diff <unrelated-pr> && gh pr create ...` in one tool call. The selector should contain only the newly created PR. In another fresh session, viewing or commenting on an unrelated PR should leave the selector empty; editing it should add it.

## Changelog

Reading or commenting on a PR no longer links it to the session; mixed Claude read/create calls still track the created PR.

## Issues

Resolves [OMNI-7216](https://linear.app/omnigent/issue/OMNI-7216/bug-pr-reads-and-comments-add-unwanted-session-associations)
