### PR TITLE
docs: change "agents" to "assistants" in README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # <img src="https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg" alt="" height="38" valign="middle" /> Omnigent
 
-### The open-source meta-harness for all your AI agents.
+### The open-source meta-harness for all your AI assistants.
 
 Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
 


### PR DESCRIPTION
## Summary

Changed "agents" to "assistants" in the README tagline. This is a test PR for session PR tracking behavior.

## Test Plan

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

N/A — one-word doc change.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Not applicable

## Coverage notes

One-word README change; no code modified.

This pull request and its description were written by Isaac.