### PR TITLE
docs(readme): change agents to assistants in tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # <img src="https://raw.githubusercontent.com/omnigent-ai/omnigent/main/docs/images/omnigent-logo.svg" alt="" height="38" valign="middle" /> Omnigent
 
-### The open-source meta-harness for all your AI agents.
+### The open-source meta-harness for all your AI assistants.
 
 Omnigent is an open-source **meta-harness** that gives you a common orchestration layer over Claude Code, Codex, Cursor, OpenCode, Hermes, Pi, and the agents you write yourself: swap or combine harnesses without rewriting, enforce policies and sandboxing, and collaborate in real time from any device — terminal, browser, phone, or the native desktop app.
 


### PR DESCRIPTION
## Summary
- Changed one word in the README tagline: "agents" → "assistants"

## Test Plan
- N/A (docs-only change)

## Demo
N/A

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] UI / frontend change

## Test coverage
- [x] Not applicable

## Coverage notes
Documentation-only change.

This pull request and its description were written by Isaac.