### PR TITLE
fix(codex-native): preserve startup events on resume

### DIFF
--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -1858,10 +1858,9 @@ async def supervise_forwarder(
         state on thread rotation, so the executor keeps reaching the
         live app-server after a native ``/clear``.
     :param thread_id: Codex thread id to subscribe to.
-    :param client: Optional already-connected client. Fresh Codex
-        sessions pass the listener that observed ``thread/started``;
-        the forwarder still calls ``thread/resume`` once the id is
-        known so that connection receives turn/item notifications.
+    :param client: Optional client connected before thread creation or
+        resume, retaining startup notifications. The forwarder still calls
+        ``thread/resume`` so that connection receives turn/item notifications.
     :param auth: Optional HTTP auth for long-lived remote sessions.
     :param ap_transport: Optional HTTP transport for the Omnigent client,
         e.g. ``httpx.MockTransport(...)`` for tests.

--- a/omnigent/harnesses/codex_native/main.py
+++ b/omnigent/harnesses/codex_native/main.py
@@ -379,9 +379,8 @@ class PreparedCodexTerminal:
         the app-server directly.
     :param app_server: Running app-server process when this wrapper
         invocation owns it. ``None`` for reattached live terminals.
-    :param event_client: App-server client already listening for the
-        Codex thread. Fresh sessions keep this listener open after it
-        observes the TUI-created ``thread/started`` event.
+    :param event_client: App-server client connected before thread creation
+        or resume, retained by the forwarder to preserve startup events.
     :param reattached: ``True`` when an existing terminal was reused.
     """
 
@@ -1260,13 +1259,13 @@ async def _prepare_codex_terminal(
         launched_terminal: LaunchedCodexTerminal | None = None
         try:
             await app_server.start()
-            if thread_id is None:
-                event_client = client_for_transport(
-                    codex_ws_url,
-                    client_name="omnigent-codex-native",
-                )
-                await event_client.connect()
-            else:
+            event_client = client_for_transport(
+                codex_ws_url,
+                client_name="omnigent-codex-native",
+            )
+            # Buffer startup events before either the TUI or preload loads the thread.
+            await event_client.connect()
+            if thread_id is not None:
                 await preload_codex_thread_for_resume(
                     codex_ws_url,
                     thread_id,

--- a/omnigent/runner/native/orchestration.py
+++ b/omnigent/runner/native/orchestration.py
@@ -4431,6 +4431,17 @@ async def _auto_create_codex_terminal(
         ws_url=codex_ws_url,
         client_name="omnigent-codex-native-auto",
     )
+    try:
+        # Keep the listener connected through thread creation or preload so
+        # the forwarder receives the initial startup/status notifications.
+        await event_client.connect()
+    except Exception:
+        # connect() may have opened the socket before its handshake failed.
+        with contextlib.suppress(Exception):
+            await event_client.close()
+        await app_server.close()
+        _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+        raise
     if launch_config.external_session_id is not None:
         from omnigent.harnesses.codex_native.bridge import (
             CodexNativeBridgeState,
@@ -4448,6 +4459,8 @@ async def _auto_create_codex_terminal(
                 # The app-server started above must not outlive a refused resume:
                 # without this close, every retry stacked another live codex
                 # process (and only the newest stayed tracked for teardown).
+                with contextlib.suppress(Exception):
+                    await event_client.close()
                 with contextlib.suppress(Exception):
                     await app_server.close()
                 _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
@@ -4504,21 +4517,6 @@ async def _auto_create_codex_terminal(
                         exc_info=True,
                         extra={"session_id": session_id},
                     )
-    if launch_config.external_session_id is None:
-        try:
-            # Connect the listener BEFORE launching the TUI so it observes the
-            # ``thread/started`` the TUI emits on startup (the client buffers
-            # notifications, so there is no created-before-listening race).
-            await event_client.connect()
-        except Exception:
-            # connect() may have half-opened the ws before the initialize
-            # handshake failed, so close the listener too — not just the
-            # app-server.
-            with contextlib.suppress(Exception):
-                await event_client.close()
-            await app_server.close()
-            _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
-            raise
 
     # Register the Codex TUI as a streamable terminal resource attached to
     # the app-server started above (``--remote`` over its loopback ws
@@ -4660,6 +4658,7 @@ async def _auto_create_codex_terminal(
                 bridge_dir=bridge_dir,
                 codex_ws_url=codex_ws_url,
                 thread_id=launch_config.external_session_id,
+                event_client=event_client,
                 subagent_router=_codex_router,
                 turn_router=_codex_turn_router,
             )
@@ -4918,6 +4917,7 @@ async def _codex_forward_known_thread(
     bridge_dir: Path,
     codex_ws_url: str,
     thread_id: str,
+    event_client: CodexAppServerClient,
     subagent_router: SubagentRouter | None = None,
     turn_router: TurnRouter | None = None,
 ) -> None:
@@ -4930,6 +4930,7 @@ async def _codex_forward_known_thread(
         ``"ws://127.0.0.1:9876"``.
     :param thread_id: Existing Codex app-server thread id, e.g.
         ``"thread_abc123"``.
+    :param event_client: Listener connected before the thread was preloaded.
     :param subagent_router: Router this terminal launch started, torn down
         in the ``finally``. Passed so a late teardown cannot close the
         endpoint a re-created terminal has since installed.
@@ -4944,11 +4945,11 @@ async def _codex_forward_known_thread(
         _RunnerDatabricksAuth,
     )
 
-    server_url = _required_runner_env("RUNNER_SERVER_URL")
-    auth_factory = _make_auth_token_factory()
-    auth_token = auth_factory() if auth_factory is not None else None
-    headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
     try:
+        server_url = _required_runner_env("RUNNER_SERVER_URL")
+        auth_factory = _make_auth_token_factory()
+        auth_token = auth_factory() if auth_factory is not None else None
+        headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
         await supervise_forwarder(
             base_url=server_url,
             headers=headers,
@@ -4956,10 +4957,13 @@ async def _codex_forward_known_thread(
             bridge_dir=bridge_dir,
             app_server_url=codex_ws_url,
             thread_id=thread_id,
+            client=event_client,
             auth=_RunnerDatabricksAuth(auth_factory),
         )
     finally:
         leftover_app_server = _AUTO_CODEX_APP_SERVERS.pop(session_id, None)
+        with contextlib.suppress(Exception):
+            await event_client.close()
         if leftover_app_server is not None:
             with contextlib.suppress(Exception):
                 await leftover_app_server.close()

--- a/tests/e2e_ui/start_session/test_project_config_prefill.py
+++ b/tests/e2e_ui/start_session/test_project_config_prefill.py
@@ -785,7 +785,7 @@ def test_project_opt_out_wins_over_global_default(
     """A project's explicit ``use_worktree: false`` beats a global default of on.
 
     With the global default on but the project storing an explicit opt-out, the
-    composer must NOT seed a worktree: the branch chip stays blank ("Worktree")
+    composer must NOT seed a worktree: the branch chip shows "New worktree"
     and the create posts no ``git`` block (a plain launch in the workspace).
     """
     base_url, session_id = seeded_session
@@ -818,8 +818,8 @@ async def _drive_project_opt_out(base_url: str, session_id: str) -> None:
             await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
                 "omnigent", timeout=15_000
             )
-            await expect(page.get_by_test_id("new-chat-landing-branch-chip")).to_contain_text(
-                "Worktree", timeout=15_000
+            await expect(page.get_by_test_id("new-chat-landing-branch-chip")).to_have_text(
+                "New worktree", timeout=15_000
             )
 
             await page.get_by_test_id("new-chat-landing-input").fill("start here")

--- a/tests/runner/test_app_sessions_native_terminals_runtime.py
+++ b/tests/runner/test_app_sessions_native_terminals_runtime.py
@@ -518,14 +518,8 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
         app_server.codex_home = kwargs["codex_home"]
         return app_server
 
-    class _UnexpectedDiscoveryClient:
-        """
-        App-server client that must not connect on a known-thread resume.
-
-        Fresh sessions connect this listener to discover ``thread/started``.
-        Resume sessions already have ``external_session_id`` and should go
-        straight to the known-thread forwarder.
-        """
+    class _StartupEventClient:
+        """Listener retained across known-thread preload and forwarding."""
 
         def __init__(self, *, ws_url: str, client_name: str) -> None:
             """
@@ -536,12 +530,8 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
             self.client_name = client_name
 
         async def connect(self) -> None:
-            """
-            Fail if the resume path tries to discover a fresh thread.
-
-            :returns: None.
-            """
-            raise AssertionError("resume path must not connect discovery client")
+            """Record the connection established before preload."""
+            self.connected = True
 
         async def close(self) -> None:
             """:returns: None."""
@@ -620,7 +610,7 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
         "build_codex_native_server",
         _fake_build_codex_native_server,
     )
-    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _StartupEventClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
     monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
 
@@ -688,12 +678,16 @@ async def test_auto_create_codex_terminal_uses_persisted_resume_launch_config(
     del forward_calls[0]["subagent_router"]
     assert "turn_router" in forward_calls[0]
     del forward_calls[0]["turn_router"]
+    event_client = forward_calls[0]["event_client"]
+    assert isinstance(event_client, _StartupEventClient)
+    assert event_client.connected
     assert forward_calls == [
         {
             "session_id": session_id,
             "bridge_dir": bridge_dir,
             "codex_ws_url": app_server.listen_url,
             "thread_id": thread_id,
+            "event_client": event_client,
         }
     ]
     bridge_state = codex_native_bridge.read_bridge_state(bridge_dir)
@@ -848,8 +842,8 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
         del kwargs
         return app_server
 
-    class _UnexpectedDiscoveryClient:
-        """Discovery client that must not connect on the resume path."""
+    class _StartupEventClient:
+        """No-op listener for the known-thread startup path."""
 
         def __init__(self, *, ws_url: str, client_name: str) -> None:
             """
@@ -860,8 +854,7 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
             self.client_name = client_name
 
         async def connect(self) -> None:
-            """:raises AssertionError: Always — the fork resumes a known thread."""
-            raise AssertionError("fork resume path must not connect discovery client")
+            """No-op connect."""
 
         async def close(self) -> None:
             """:returns: None."""
@@ -934,7 +927,7 @@ async def test_auto_create_codex_terminal_fork_clones_rollout_and_resumes(
     monkeypatch.setattr(
         codex_app_mod, "build_codex_native_server", _fake_build_codex_native_server
     )
-    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _StartupEventClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
     monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
 
@@ -1125,8 +1118,8 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
         del kwargs
         return app_server
 
-    class _UnexpectedDiscoveryClient:
-        """Discovery client that must not connect on the resume path."""
+    class _StartupEventClient:
+        """No-op listener for the known-thread startup path."""
 
         def __init__(self, *, ws_url: str, client_name: str) -> None:
             """:param ws_url: App-server URL. :param client_name: RPC client name."""
@@ -1134,8 +1127,7 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
             self.client_name = client_name
 
         async def connect(self) -> None:
-            """:raises AssertionError: Always — the fork resumes a known thread."""
-            raise AssertionError("fork resume path must not connect discovery client")
+            """No-op connect."""
 
         async def close(self) -> None:
             """:returns: None."""
@@ -1194,7 +1186,7 @@ async def test_auto_create_codex_terminal_fork_builds_rollout_from_items_and_res
     monkeypatch.setattr(
         codex_app_mod, "build_codex_native_server", _fake_build_codex_native_server
     )
-    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _StartupEventClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
     monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
 
@@ -3530,8 +3522,8 @@ async def test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog(
         app_server.codex_home = kwargs["codex_home"]
         return app_server
 
-    class _UnexpectedDiscoveryClient:
-        """App-server client that must not connect on a known-thread resume."""
+    class _StartupEventClient:
+        """No-op listener for the known-thread startup path."""
 
         def __init__(self, *, ws_url: str, client_name: str) -> None:
             """
@@ -3542,8 +3534,7 @@ async def test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog(
             self.client_name = client_name
 
         async def connect(self) -> None:
-            """Fail if the resume path tries to discover a fresh thread."""
-            raise AssertionError("resume path must not connect discovery client")
+            """No-op connect."""
 
         async def close(self) -> None:
             """No-op close."""
@@ -3606,7 +3597,7 @@ async def test_auto_create_codex_terminal_default_pin_requires_a_fresh_catalog(
     monkeypatch.setattr(
         codex_app_mod, "build_codex_native_server", _fake_build_codex_native_server
     )
-    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _StartupEventClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
     monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
 
@@ -3767,8 +3758,8 @@ async def test_auto_create_codex_terminal_accepts_gateway_spelled_override(
         app_server.codex_home = kwargs["codex_home"]
         return app_server
 
-    class _UnexpectedDiscoveryClient:
-        """App-server client that must not connect on a known-thread resume."""
+    class _StartupEventClient:
+        """No-op listener for the known-thread startup path."""
 
         def __init__(self, *, ws_url: str, client_name: str) -> None:
             """
@@ -3779,8 +3770,7 @@ async def test_auto_create_codex_terminal_accepts_gateway_spelled_override(
             self.client_name = client_name
 
         async def connect(self) -> None:
-            """Fail if the resume path tries to discover a fresh thread."""
-            raise AssertionError("resume path must not connect discovery client")
+            """No-op connect."""
 
         async def close(self) -> None:
             """No-op close."""
@@ -3823,7 +3813,7 @@ async def test_auto_create_codex_terminal_accepts_gateway_spelled_override(
     monkeypatch.setattr(
         codex_app_mod, "build_codex_native_server", _fake_build_codex_native_server
     )
-    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _StartupEventClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
     monkeypatch.setattr(runner_app_mod, "_codex_forward_known_thread", _fake_forward_known_thread)
 

--- a/tests/runner/test_app_sessions_native_wake_forwarders.py
+++ b/tests/runner/test_app_sessions_native_wake_forwarders.py
@@ -830,8 +830,8 @@ async def test_auto_create_codex_terminal_recreate_cancels_prior_forwarder(
         app_server.codex_home = kwargs["codex_home"]
         return app_server
 
-    class _UnexpectedDiscoveryClient:
-        """App-server client that must not connect on a known-thread resume."""
+    class _StartupEventClient:
+        """No-op listener for the known-thread startup path."""
 
         def __init__(self, *, ws_url: str, client_name: str) -> None:
             """
@@ -842,8 +842,7 @@ async def test_auto_create_codex_terminal_recreate_cancels_prior_forwarder(
             self.client_name = client_name
 
         async def connect(self) -> None:
-            """Fail if the resume path tries to discover a fresh thread."""
-            raise AssertionError("resume path must not connect discovery client")
+            """No-op connect."""
 
         async def close(self) -> None:
             """:returns: None."""
@@ -903,7 +902,7 @@ async def test_auto_create_codex_terminal_recreate_cancels_prior_forwarder(
         "build_codex_native_server",
         _fake_build_codex_native_server,
     )
-    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _UnexpectedDiscoveryClient)
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _StartupEventClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _fake_preload_thread)
     monkeypatch.setattr(
         runner_app_mod,
@@ -1112,8 +1111,10 @@ async def test_auto_create_codex_terminal_refused_resume_closes_app_server(
         app_server.codex_home = kwargs["codex_home"]
         return app_server
 
-    class _IdleClient:
-        """Event client that must never connect before the resume succeeds."""
+    listener_events: list[str] = []
+
+    class _StartupEventClient:
+        """Record cleanup of the listener when preload refuses the resume."""
 
         def __init__(self, *, ws_url: str, client_name: str) -> None:
             """
@@ -1124,11 +1125,12 @@ async def test_auto_create_codex_terminal_refused_resume_closes_app_server(
             self.client_name = client_name
 
         async def connect(self) -> None:
-            """Fail if the refused resume still wires the listener."""
-            raise AssertionError("refused resume must not connect the event client")
+            """Record the connection established before preload."""
+            listener_events.append("connected")
 
         async def close(self) -> None:
-            """:returns: None."""
+            """Record listener cleanup."""
+            listener_events.append("closed")
 
     async def _refusing_preload(
         transport: str,
@@ -1159,7 +1161,7 @@ async def test_auto_create_codex_terminal_refused_resume_closes_app_server(
         "build_codex_native_server",
         _fake_build_codex_native_server,
     )
-    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _IdleClient)
+    monkeypatch.setattr(codex_app_mod, "CodexAppServerClient", _StartupEventClient)
     monkeypatch.setattr(codex_app_mod, "preload_codex_thread_for_resume", _refusing_preload)
 
     agent_spec = AgentSpec(
@@ -1181,6 +1183,7 @@ async def test_auto_create_codex_terminal_refused_resume_closes_app_server(
                 server_client=_SnapshotServerClient(),  # type: ignore[arg-type]
             )
         assert closed == ["closed"], "refused resume left the app-server running"
+        assert listener_events == ["connected", "closed"]
         assert session_id not in runner_app_mod._AUTO_CODEX_APP_SERVERS, (
             "failed create left its app-server tracked; the next attempt would "
             "overwrite (and leak) it"

--- a/tests/runner/test_codex_startup_events.py
+++ b/tests/runner/test_codex_startup_events.py
@@ -1,0 +1,218 @@
+"""Fresh and resumed native launches retain the same startup event stream."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from omnigent.entities.session_resources import SessionResourceView
+from omnigent.harnesses.codex_native import app_server as codex_app
+from omnigent.harnesses.codex_native import bridge
+from omnigent.harnesses.codex_native import main as codex_main
+from omnigent.runner.native import orchestration as native
+from omnigent.spec.types import AgentSpec, ExecutorSpec
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entrypoint", ["runner", "local-cli"])
+@pytest.mark.parametrize("resumed", [False, True], ids=["fresh", "resume"])
+async def test_startup_status_is_retained_before_working(
+    entrypoint: str,
+    resumed: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The initial idle edge clears MCP using the unchanged forwarder policy."""
+    session_id = "00000000000040008000000000000001"
+    thread_id = "00000000-0000-4000-8000-000000000002"
+    loaded = False
+    clients: list[StartupClient] = []
+    subscribed = asyncio.Event()
+    working = asyncio.Event()
+    posts: list[dict[str, Any]] = []
+
+    def broadcast(method: str, params: dict[str, Any]) -> None:
+        for client in clients:
+            if client.connected:
+                client.events.put_nowait({"method": method, "params": params})
+
+    def load_thread(*, fresh: bool) -> None:
+        nonlocal loaded
+        if loaded:
+            return
+        loaded = True
+        if fresh:
+            broadcast("thread/started", {"thread": {"id": thread_id}})
+        # A status emitted during loading is not replayed to later listeners.
+        broadcast("thread/status/changed", {"threadId": thread_id, "status": {"type": "idle"}})
+
+    class StartupClient:
+        def __init__(self, *, ws_url: str, client_name: str) -> None:
+            self.connected = False
+            self.client_name = client_name
+            self.events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+            clients.append(self)
+
+        async def connect(self) -> None:
+            assert not self.connected
+            self.connected = True
+
+        async def close(self) -> None:
+            self.connected = False
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            assert self.connected
+            assert method == "thread/resume"
+            assert params["threadId"] == thread_id
+            load_thread(fresh=False)
+            if self.client_name != "omnigent-codex-native-preload":
+                subscribed.set()
+            return {"result": {"thread": {"id": thread_id, "turns": []}}}
+
+        async def iter_events(self) -> AsyncIterator[dict[str, Any]]:
+            while True:
+                yield await self.events.get()
+
+    app_server = SimpleNamespace(
+        codex_path="/test-bin/codex",
+        codex_cli_version=(0, 152, 1),
+        env={},
+        config_overrides=[],
+        start=AsyncMock(),
+        close=AsyncMock(),
+    )
+
+    def build_server(**kwargs: Any) -> SimpleNamespace:
+        app_server.codex_home = kwargs["codex_home"]
+        app_server.codex_home.mkdir(parents=True, exist_ok=True)
+        (app_server.codex_home / "config.toml").write_text(
+            '[mcp_servers.slow]\ncommand = "slow-mcp"\nstartup_timeout_sec = 120\n'
+        )
+        return app_server
+
+    async def launch_terminal(*_args: Any, **_kwargs: Any) -> Any:
+        load_thread(fresh=not resumed)
+        if entrypoint == "local-cli":
+            return codex_main.LaunchedCodexTerminal(
+                terminal_id="terminal_codex_main", tmux_socket=None, tmux_target=None
+            )
+        return SessionResourceView(
+            id="terminal_codex_main", type="terminal", session_id=session_id, name="Codex"
+        )
+
+    snapshot: dict[str, Any] = {
+        "labels": {codex_main._WRAPPER_LABEL_KEY: codex_main._WRAPPER_LABEL_VALUE},
+        "external_session_id": thread_id if resumed else None,
+    }
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/events"):
+            event = json.loads(request.content)
+            posts.append(event)
+            if event == {
+                "type": "external_session_status",
+                "data": {"status": "running", "response_id": "codex_turn_1"},
+            }:
+                working.set()
+        if request.method == "GET" and request.url.path.endswith("/items"):
+            return httpx.Response(200, json={"data": [], "has_more": False})
+        return httpx.Response(200, json=snapshot)
+
+    @contextlib.asynccontextmanager
+    async def server_client(*_args: Any, **_kwargs: Any) -> AsyncIterator[httpx.AsyncClient]:
+        async with httpx.AsyncClient(
+            base_url="http://startup.test", transport=httpx.MockTransport(handle_request)
+        ) as client:
+            yield client
+
+    monkeypatch.setattr(bridge, "_BRIDGE_ROOT", tmp_path / "bridges")
+    monkeypatch.setenv("RUNNER_SERVER_URL", "http://startup.test")
+    monkeypatch.setenv("OMNIGENT_RUNNER_WORKSPACE", str(tmp_path))
+    monkeypatch.setattr("omnigent.config.load_effective_config", dict)
+    monkeypatch.setattr("omnigent.cli_auth.open_server_client", server_client)
+    monkeypatch.setattr("omnigent.runner._entry._make_auth_token_factory", lambda: None)
+    monkeypatch.setattr("omnigent.inner.codex_executor._find_codex_cli", lambda: "/test-bin/codex")
+    monkeypatch.setattr(
+        "omnigent.inner.codex_executor.populate_codex_skills_from_bundle", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        "omnigent.harnesses.codex_native.process_registry.reap_codex_native_processes_for_state_dir",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(codex_app, "CodexAppServerClient", StartupClient)
+    for module in (codex_app, codex_main):
+        monkeypatch.setattr(module, "build_codex_native_server", build_server)
+        monkeypatch.setattr(
+            module,
+            "resolve_native_codex_launch",
+            lambda **_kwargs: codex_app.NativeCodexLaunch([], "test-model", None),
+        )
+    monkeypatch.setattr(codex_main, "_ensure_local_codex_resume_rollout", AsyncMock())
+    monkeypatch.setattr(codex_main, "_create_codex_session", AsyncMock(return_value=session_id))
+    monkeypatch.setattr(codex_main, "_find_running_codex_terminal", AsyncMock(return_value=None))
+    monkeypatch.setattr(codex_main, "_launch_codex_terminal", launch_terminal)
+    local_forwarder: asyncio.Task[None] | None = None
+    try:
+        if entrypoint == "runner":
+            async with server_client() as client:
+                await native._auto_create_codex_terminal(
+                    session_id,
+                    SimpleNamespace(launch_auxiliary_terminal=launch_terminal),  # type: ignore[arg-type]
+                    lambda _sid, _event: None,
+                    agent_spec=AgentSpec(
+                        spec_version=1,
+                        name="codex",
+                        executor=ExecutorSpec(config={"harness": "codex-native"}),
+                    ),
+                    server_client=client,
+                )
+        else:
+            prepared = await codex_main._prepare_codex_terminal(
+                base_url="http://startup.test",
+                headers={},
+                session_id=session_id if resumed else None,
+                runner_id=None,
+                session_bundle=b"test bundle",
+                codex_args=(),
+                command="/test-bin/codex",
+                model="test-model",
+            )
+            if not resumed:
+                prepared.thread_id = await codex_main._initialize_fresh_terminal_thread(
+                    base_url="http://startup.test", headers={}, prepared=prepared
+                )
+            local_forwarder = codex_main._start_codex_forwarder(
+                base_url="http://startup.test", headers={}, prepared=prepared, auth=None
+            )
+        await asyncio.wait_for(subscribed.wait(), timeout=2)
+        broadcast("turn/started", {"threadId": thread_id, "turn": {"id": "turn_1"}})
+        await asyncio.wait_for(working.wait(), timeout=2)
+
+        mcp_updates = [
+            event["data"]["servers"] for event in posts if event["type"] == "external_mcp_startup"
+        ]
+        assert mcp_updates == [
+            {"slow": {"status": "starting", "error": None}},
+            {},
+        ], (
+            "startup status must survive the listener handoff, "
+            "without waiting for MCP or model output"
+        )
+        assert posts[-1]["type"] == "external_session_status"
+    finally:
+        await native._cancel_auto_forwarder_task(session_id)
+        if local_forwarder is not None:
+            local_forwarder.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await local_forwarder
+        for client in clients:
+            await client.close()


### PR DESCRIPTION
## Related issue

Closes #7072

## Summary

Cold resume connected the Codex event forwarder after a temporary connection had already loaded the thread, losing the initial status notification that clears synthesized MCP startup state. Connect the listener before preload and retain it through the forwarder handoff, for both runner-managed and local CLI cold resumes; close it on failure and teardown.

The original new-session behavior, shared indicator policy, and `Working...` timing are unchanged. This adds no wait for MCP readiness.

CI also exposed an existing project-prefill test expecting the old "Worktree" placeholder. Update only that assertion to wait for the current "New worktree" label; the UI and the no-worktree request assertion stay unchanged.

ELI5: resume was turning on the listener after the startup announcement. Turn it on first, just as new sessions already do.

```text
Fresh (unchanged): listen -> start thread  -> forward buffered events
Resume (fixed):    listen -> resume thread -> forward buffered events
```

## Test Plan

- Required pre-commit hooks in a clean worktree, including the follow-up browser-test correction.
- 480 Python tests across native Codex, forwarding, model fallback, terminal runtime, wake/cleanup, and the new startup regression suite:

  ```bash
  uv run --no-sync python -m pytest tests/test_codex_native.py tests/test_codex_native_forwarder.py tests/runner/test_codex_model_pick_fallback.py tests/runner/test_codex_startup_events.py tests/runner/test_app_sessions_native_terminals_runtime.py tests/runner/test_app_sessions_native_wake_forwarders.py -q --tb=short
  ```

- Original-checkout verification also passed 212 existing frontend tests and four existing browser tests covering MCP startup/reconnect/failure indicators.
- Rebuilt the unchanged SPA and reran all six project-prefill browser tests plus the four MCP indicator tests after correcting the stale label assertion.
- Human check: run `omnidev`, open its displayed UI URL, create a native Codex session and send a prompt, then use the sidebar menu to stop it. Resume and send another prompt. With slow MCP startup, resume should match the fresh-session indicators, with no extra delay before `Working...`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

No frontend/rendering changes. The four parameterized regression cases exercise real startup/forwarding helpers through runner and local CLI entrypoints, with a scripted app-server event bus. Before the fix: both fresh cases passed, both resume cases failed. After the fix: all four pass, clearing synthesized MCP state before the running event without receiving MCP-ready events or model output.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

A controlled native Codex 0.152.1 probe with a slow local MCP handshake and dummy model endpoint confirmed that an early listener receives the initial idle status and a late listener misses it. Full provider-backed fresh/resume UI comparison remains a human check; the MCP browser tests were rerun unchanged. The only browser-test edit corrects the unrelated project-prefill label assertion exposed by CI. Fresh startup and hot reattach retain their existing behavior.

## Changelog

Resumed native Codex sessions clear stale MCP startup indicators like new sessions, without delaying `Working...`.
