### PR TITLE
docs(repro-agent): teach needs_manual_review and likely_repro verdicts

### DIFF
--- a/dev/repro-agent/AGENTS.md
+++ b/dev/repro-agent/AGENTS.md
@@ -214,22 +214,22 @@ system-browser OIDC hop, the native setup screen).
 The surface picks the kind of test you author (Step 3) and the recorder that
 captures it (Step 4).
 
-**When the reported surface is a native one you cannot drive here, say so —
+**When the reported surface is a native one you cannot drive here, defer it —
 never clear it.** This runner drives the web SPA (including at a phone
 viewport), the terminal/CLI, and the Electron desktop shell — it has **no**
 iOS/Android device and no native macOS chrome. So for a native-chrome-only bug
 (safe-area insets, the system-browser OIDC hop, the native setup screen, or any
 native mobile rendering the phone-viewport SPA does not exercise), the most you
-can drive is the web SPA **standing in** for the native app. That substitute is
-not the reported surface: a `not_reproduced` you reach on it says nothing about
-the native app, and reporting it as a plain verdict wrongly clears the ticket.
-When you could only drive a stand-in for the reported surface, set
-`environment_fidelity` to name both — e.g. `stand-in: web SPA at a phone
-profile — could not drive the native iOS app` — and say the same in `journey`
-and `evidence`. This applies to `not_reproduced` too: a negative on a stand-in
-is a stand-in verdict, and the workflow routes such a ticket to a human on the
-reported device rather than out of the reproduction queue. Set
-`environment_fidelity: real` when you did drive the surface the ticket reports.
+can drive is the web SPA **standing in** for the native app — a substitute that
+can never exhibit the native failure. Do **not** call that `not_reproduced`: a
+stand-in that could not show the bug has not cleared it. The verdict is
+**`needs_manual_review`** (Step 2), which routes the ticket to a human on the
+real device. Name the engine/device profile you actually drove — e.g. "desktop
+Chromium at an iPhone viewport" — in the facet's `evidence`; a `mobile` facet
+you verdict `not_reproduced` or `needs_manual_review` that omits it is rejected.
+This is distinct from a stand-in on which you *did* reproduce the failure
+(that is `likely_repro`, with the stand-in named in `environment_fidelity`).
+Set `environment_fidelity: real` when you drove the surface the ticket reports.
 
 **Prefer a user-facing surface — reserve `api` for the genuinely invisible.**
 If a user encounters the failure on *any* interactive surface — a screen in the
@@ -310,19 +310,35 @@ unavailable compute/browser/app access, sandbox restrictions, timeout, crash, or
 any other execution problem. Those are workflow failures and must remain
 retryable rather than becoming a product verdict.
 
-- Failure reproduces → **`reproduced`**. Capture the evidence (snapshot, response,
-  log excerpt).
-- Behaves correctly on the running build → that sub-symptom does **not** reproduce
-  here. If the report was against an older version and a later commit clearly
-  fixed it, hunt for the fixing commit (`git log`) and mark it **`already_fixed`**
-  with the commit. Otherwise **`not_reproduced`** and what you'd need to see it
-  (often a `needs_more_info`-style gap).
+- Failure reproduces on the environment the ticket reports → **`reproduced`**.
+  Capture the evidence (snapshot, response, log excerpt).
+- Failure reproduces, but only against a **stand-in** for the reported
+  environment you could not drive (for example the CI egress proxy standing in
+  for a Databricks-network host) → **`likely_repro`**. Name the stand-in in
+  `environment_fidelity` (see below). It still dispatches the fix workflow.
+- The failure depends on **native behaviour this environment cannot exercise**
+  (the iOS soft keyboard, WebKit-only rendering, a native-chrome layout) and the
+  stand-in you can drive — desktop Chromium at a phone viewport — cannot exhibit
+  it either way → **`needs_manual_review`**. This is *not* `not_reproduced`: a
+  substitute that can never show the failure has not cleared it; a human on the
+  real device must decide. Name the engine/device profile you drove in
+  `evidence` (e.g. "desktop Chromium at an iPhone viewport").
+- Behaves correctly on the running build, on an environment that *can* exhibit
+  the reported failure → that sub-symptom does **not** reproduce here. If the
+  report was against an older version and a later commit clearly fixed it, hunt
+  for the fixing commit (`git log`) and mark it **`already_fixed`** with the
+  commit. Otherwise **`not_reproduced`** and what you'd need to see it (often a
+  `needs_more_info`-style gap).
 
 **Roll up to an overall verdict, but never let it hide a live sub-symptom.** If
-*any* sub-symptom still reproduces, the overall verdict is **`reproduced`** — even
+*any* sub-symptom still reproduces, the overall verdict is **`reproduced`** (or
+**`likely_repro`** when every live one was only reproduced on a stand-in) — even
 when other facets are already fixed. Report the per-facet breakdown in the output
-(see below) so a partial fix is visible, not averaged away. Only when *every*
-sub-symptom is fixed is the overall verdict `already_fixed`.
+(see below) so a partial fix is visible, not averaged away. When nothing
+reproduced but a sub-symptom is **`needs_manual_review`** (a native-only failure
+you could not exercise), the overall verdict is `needs_manual_review` — a
+`not_reproduced` you could confirm never outranks a facet you could not. Only
+when *every* sub-symptom is fixed is the overall verdict `already_fixed`.
 
 ## Step 3 — Author the durable e2e test
 
@@ -429,10 +445,18 @@ choice:
   object.
 - Include **every** key below, always, even when a value is empty (`""`, `[]`) —
   the parser expects a fixed shape.
-- `verdict` must be **exactly one** of the four string literals
-  `"reproduced"`, `"not_reproduced"`, `"already_fixed"`, `"needs_more_info"` —
-  lowercase, no other wording. This is the field the caller reads to label the
-  issue, so it must match verbatim.
+- `verdict` must be **exactly one** of the six string literals
+  `"reproduced"`, `"likely_repro"`, `"not_reproduced"`, `"already_fixed"`,
+  `"needs_more_info"`, `"needs_manual_review"` — lowercase, no other wording.
+  This is the field the caller reads to label the issue, so it must match
+  verbatim. `reproduced`/`likely_repro`/`not_reproduced`/`already_fixed`/
+  `needs_more_info` are defined in Step 2; `needs_manual_review` is allowed
+  **only** when a facet's failure depends on native behaviour this environment
+  cannot exercise (for example the iOS soft keyboard, or WebKit-only rendering
+  when only desktop Chromium is available) so you can neither confirm nor clear
+  it — state that native dependency in `evidence`. It is not a substitute for
+  finishing the investigation, and never stands in for a workflow failure
+  (those stay retryable, per the `needs_more_info` rule).
 
 ```json
 {
@@ -464,17 +488,22 @@ Field meanings:
   overall `reproduced`; only when *every* sub-symptom is fixed is it
   `already_fixed`).
 - `facets` — an array of the per-sub-symptom breakdown from Steps 1–2, each an
-  object with `symptom`, its own `verdict` (same four literals), its `surface`
+  object with `symptom`, its own `verdict` (same six literals), its `surface`
   (`web` / `terminal` / `cli` / `desktop` / `mobile` / `api`, from Step 1), and one line of
   `evidence`. Always a list, even for a single-symptom bug (then it's one
   element). This is what stops a partially-landed fix from being averaged into a
-  misleading single verdict.
+  misleading single verdict. A `mobile` facet you verdict `not_reproduced` or
+  `needs_manual_review` **must** name the browser engine and device profile you
+  actually drove (e.g. "desktop Chromium at an iPhone viewport") in its
+  `evidence`, so a real negative is distinguishable from a stand-in that could
+  never show the failure; such a facet without it is rejected.
 - `test_path` — the e2e test you authored (the durable regression test), repo-
   relative. When multiple facets still reproduce, cover each live one; if you
   authored more than one file, make this an array of paths. Empty string if you
   authored none (e.g. `needs_more_info`).
-- `missing_information` — `[]` for `reproduced`, `not_reproduced`, and
-  `already_fixed`. For `needs_more_info`, a non-empty list of the concrete
+- `missing_information` — `[]` for every verdict except `needs_more_info`
+  (`reproduced`, `likely_repro`, `not_reproduced`, `already_fixed`, and
+  `needs_manual_review` all take `[]`). For `needs_more_info`, a non-empty list of the concrete
   product details absent from the full ticket and linked reports that prevent a
   reproduction, such as the triggering user action, required input, expected
   behavior, or affected surface. Operational failures, incomplete work, and
@@ -482,14 +511,14 @@ Field meanings:
   not produce this verdict.
 - `environment_fidelity` — which environment you actually drove. `real` when you
   drove the surface the ticket reports (or the bug is environment-independent and
-  reproduced here). When you could only drive a **stand-in** for the reported
-  surface — most importantly a native surface this runner cannot drive (see the
-  Step 1 native-surface note), but also a substituted network/host — set
+  reproduced here). When you reproduced the failure only against a **stand-in**
+  for the reported environment — the verdict is then `likely_repro` — set
   `stand-in: <what you drove> — could not drive <the reported surface>`, e.g.
-  `stand-in: web SPA at a phone profile — could not drive the native iOS app`.
-  Applies to **every** verdict, `not_reproduced` included: a negative reached on
-  a stand-in is a stand-in verdict, and naming the stand-in here is what stops
-  the workflow from clearing a native-surface ticket the runner never touched.
+  `stand-in: CI egress proxy — could not drive the Databricks-network host`, and
+  say the same in `journey` and `evidence`. (When the stand-in *cannot exhibit*
+  the reported failure at all — a native-chrome bug on the web SPA — you do not
+  get a verdict from it: that is `needs_manual_review`, and you name the
+  engine/device profile driven in the facet `evidence` rather than here.)
 - `session_id` — **this session** (in the app), from `sys_session_get_info`, so
   the fix step can replay how you reproduced it and you can browse it at
   `<server>/c/<session_id>`.


### PR DESCRIPTION
## Summary

The repro-agent contract (`dev/repro-agent/AGENTS.md`) tells the agent to emit **exactly one of four** verdicts — `reproduced`, `not_reproduced`, `already_fixed`, `needs_more_info`. But the omnigent-internal handoff validator and finalizer accept **six**: they also handle `likely_repro` and `needs_manual_review`. Those two literals appear **nowhere** in the omnigent repo, so the agent has no way to emit them on the normal path.

### Concrete cost (OMNI-6120)

"Queued follow-up prompt overlaps composer text" is a native-mobile layout issue. The CI runner has no iOS device, so it can only drive the desktop-Chromium web SPA standing in for the native app — a surface that can **never** exhibit the failure. With `needs_manual_review` not on the menu, the agent picked `not_reproduced`, which cleared the ticket instead of routing it to a human on the real device.

## What this changes (docs only)

Teach the contract the two missing verdicts and when to use them, matching the validator so handoffs pass:

- **`needs_manual_review`** — the failure depends on native behaviour this environment cannot exercise (iOS soft keyboard, WebKit-only rendering when only desktop Chromium is available), so it can be neither confirmed nor cleared here. Not a substitute for finishing the investigation, and never for a workflow failure. A `mobile` facet you verdict `not_reproduced` or `needs_manual_review` must name the engine/device profile actually driven (e.g. "desktop Chromium at an iPhone viewport") in its `evidence`, or the handoff is rejected.
- **`likely_repro`** — the failure reproduced, but only against a stand-in for the reported environment (e.g. the CI egress proxy for a Databricks-network host); name the stand-in in `environment_fidelity`. Still dispatches the fix workflow.

Updated: the verdict literal list, the Step 2 decision list, the roll-up rule, the `facets`/`environment_fidelity`/`missing_information` field meanings, and the Step 1 native-surface note (which now points at `needs_manual_review` rather than a stand-in `not_reproduced`).

## Why this is the right layer

This fixes the problem at the source — the agent's own verdict — rather than papering over a wrong `not_reproduced` downstream in the finalizer. It builds on omnigent PR #6939 (`environment_fidelity`) and pairs with the omnigent-internal side (PR #520 / #486), where the label and human-pickup already exist.

## Validation

- Contract now references all six verdicts; no remaining "four string literals" / "same four literals" wording.
- Example bug: https://linear.app/omnigent/issue/OMNI-6120/queued-follow-up-prompt-overlaps-composer-text

This pull request and its description were written by Isaac.