### PR TITLE
fix(web): remove duplicate close button in working-directory picker

### DIFF
--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -6417,7 +6417,10 @@ export function NewChatLandingScreen() {
             />
           </form>
           <Dialog open={workspacePickerOpen} onOpenChange={setWorkspacePickerOpen}>
-            <DialogContent className="max-w-[min(64rem,calc(100vw-2rem))] border-0 bg-transparent p-0 shadow-none sm:max-w-[min(64rem,calc(100vw-2rem))]">
+            <DialogContent
+              showCloseButton={false}
+              className="max-w-[min(64rem,calc(100vw-2rem))] border-0 bg-transparent p-0 shadow-none sm:max-w-[min(64rem,calc(100vw-2rem))]"
+            >
               <DialogHeader className="sr-only">
                 <DialogTitle>Select working directory</DialogTitle>
                 <DialogDescription>Choose a folder for the new session.</DialogDescription>


### PR DESCRIPTION
## Summary

The **Select working directory** picker opened from the New Chat screen showed **two overlapping "x" close icons** in its top-right corner (next to the show/hide-hidden-files eye toggle).

`WorkspacePicker` renders its own close button in its header whenever it receives an `onClose` prop. In `NewChatDialog` the picker is hosted in a transparent, borderless `DialogContent` (`border-0 bg-transparent p-0 shadow-none`) — the DialogContent *is* the picker chrome — yet it still rendered shadcn's default close button (`showCloseButton` defaults to `true`), which lands in the exact same corner. Result: a duplicate "x".

Fix: pass `showCloseButton={false}` to that `DialogContent` so only `WorkspacePicker`'s own close button remains. The other WorkspacePicker call sites (Fork/SwitchHost/ProjectSettings/ResumeWithDirectory/CreateScheduledTask) embed the picker inside a bordered dialog body where the two buttons sit in different places and serve different purposes, so they are unaffected.

## Test Plan

- `cd web && npm test` — the only failures are two pre-existing, unrelated cases in `NewChatDialog.test.tsx` (host accessible name `machine-1` vs `This machine`); confirmed identical on the unmodified baseline.
- `cd web && npm run build` — passes (tsc + vite).
- Manual: New Chat → open the working-directory picker → confirm exactly one close "x" in the top-right (to the right of the eye toggle); it closes the picker, and Esc still closes it.

## Demo

<!-- UI change — add a before/after screenshot of the picker's top-right corner -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] UI / frontend change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation

## Test coverage

- [x] Manual verification completed
- [ ] Automated tests added/updated

## Coverage notes

Purely visual fix (removes a redundant duplicate close button); verified manually and via existing UI test + build gates. No behavior change beyond removing the extra button.

This pull request and its description were written by Isaac.
