### PR TITLE
fix(codex): reuse fresh catalog selections at startup

### DIFF
--- a/omnigent/harnesses/codex_native/app_server.py
+++ b/omnigent/harnesses/codex_native/app_server.py
@@ -63,8 +63,11 @@ from omnigent.inner.codex_executor import (
     read_codex_model_catalog,
     write_codex_hooks_file,
 )
-from omnigent.inner.databricks_executor import _databricks_gateway_host
-from omnigent.models.codex_model_vocabulary import codex_spawn_model
+from omnigent.inner.databricks_executor import (
+    _databricks_gateway_host,
+    _read_databrickscfg_host,
+)
+from omnigent.models.codex_model_vocabulary import codex_reachable_model_slug, codex_spawn_model
 from omnigent.process_logging import log_info_once, log_once, redact_log_text
 
 _logger = logging.getLogger(__name__)
@@ -1110,7 +1113,10 @@ async def probe_codex_model_options(
     env = _clean_codex_env()
     if launch.profile is not None:
         databricks = await asyncio.to_thread(
-            _databricks_launch_materialization, model=launch.model, profile=launch.profile
+            _databricks_launch_materialization,
+            model=launch.model,
+            profile=launch.profile,
+            codex_path=resolved_codex,
         )
         config_overrides.extend(databricks.config_overrides)
         env["DATABRICKS_HOST"] = databricks.host
@@ -1154,7 +1160,8 @@ def codex_catalog_fingerprint(launch: NativeCodexLaunch, *, codex_path: str | No
     The Codex executable is part of the key. The catalog holds that
     binary's own answer, so an upgraded CLI must re-probe instead of
     serving model names the previous release printed. The binary is
-    resolved the same way the probe launches it.
+    resolved the same way the probe launches it. Databricks profile keys also
+    include the locally configured host, so repointing a profile is a miss.
 
     :param launch: The resolved launch (``resolve_native_codex_launch``).
     :param codex_path: Optional Codex executable override, matching the
@@ -1163,9 +1170,10 @@ def codex_catalog_fingerprint(launch: NativeCodexLaunch, *, codex_path: str | No
     """
     from omnigent.models.model_catalog_store import binary_identity, fingerprint_of
 
+    profile_host = _read_databrickscfg_host(launch.profile) if launch.profile is not None else None
     return fingerprint_of(
         "codex-native",
-        launch.profile,
+        (launch.profile, (profile_host or "").rstrip("/")) if launch.profile is not None else None,
         launch.model,
         tuple(launch.config_overrides),
         binary_identity(codex_path or _find_codex_cli()),
@@ -2327,7 +2335,7 @@ class _DatabricksLaunchMaterialization:
 
 
 def _databricks_launch_materialization(
-    *, model: str | None, profile: str
+    *, model: str | None, profile: str, codex_path: str | None = None
 ) -> _DatabricksLaunchMaterialization:
     """
     Resolve the Databricks-profile routing pieces of a Codex launch.
@@ -2339,6 +2347,7 @@ def _databricks_launch_materialization(
     :param model: Optional explicit model pin; ``None`` resolves the
         catalog default.
     :param profile: ``~/.databrickscfg`` profile name, e.g. ``"oss"``.
+    :param codex_path: Executable whose shared catalog may resolve the model.
     :returns: The materialized overrides, pinned model, and host.
     :raises OSError: When the profile resolves no workspace host.
     """
@@ -2350,10 +2359,7 @@ def _databricks_launch_materialization(
             "with a host visible to the runner process."
         )
     host = host.rstrip("/")
-    # Resolve against what the workspace actually serves (live UC listing →
-    # ucode state → bundled catalog), never the bundled catalog alone — its
-    # legacy ``databricks-`` spellings can 501 on today's gateway.
-    resolved_model = _resolve_databricks_codex_model(host, profile, model)
+    resolved_model = _resolve_databricks_codex_model(host, profile, model, codex_path=codex_path)
     return _DatabricksLaunchMaterialization(
         config_overrides=_databricks_codex_config_overrides(
             model=resolved_model,
@@ -2366,7 +2372,9 @@ def _databricks_launch_materialization(
 
 
 # DATABRICKS-PATCH(codex-live-model-discovery)
-def _resolve_databricks_codex_model(host: str, profile: str, requested: str | None) -> str:
+def _resolve_databricks_codex_model(
+    host: str, profile: str, requested: str | None, *, codex_path: str | None = None
+) -> str:
     """Resolve the codex launch model against what the workspace serves.
 
     Codex used to take its model from the bundled MLflow catalog — a
@@ -2378,7 +2386,9 @@ def _resolve_databricks_codex_model(host: str, profile: str, requested: str | No
     then ucode's cached copy of it, then the bundled catalog as the documented
     last resort.
 
-    An explicit model is matched against the servable ids, so a legacy
+    An explicit model first reuses its fresh shared Codex catalog row's model
+    for the same profile, workspace and executable. A miss keeps discovery.
+    The explicit model is matched against the servable ids, so a legacy
     ``model_override`` persisted before this change still launches; one the
     workspace does not serve passes through untouched, because the gateway's
     error beats a silent substitution.
@@ -2387,12 +2397,27 @@ def _resolve_databricks_codex_model(host: str, profile: str, requested: str | No
     :param profile: Databricks CLI profile backing the launch.
     :param requested: Explicit model id, or ``None`` to take the newest
         servable one.
+    :param codex_path: Executable whose shared catalog may resolve the model.
     :returns: The model id to pin on the codex launch.
     """
+    from omnigent.models import model_catalog_store
     from omnigent.models.databricks_model_discovery import (
         discover_databricks_codex_models,
         select_servable_model,
     )
+
+    if requested:
+        profile_host = _read_databrickscfg_host(profile)
+        if profile_host and profile_host.rstrip("/") == host.rstrip("/"):
+            fingerprint = codex_catalog_fingerprint(
+                NativeCodexLaunch([], None, profile), codex_path=codex_path
+            )
+            rows = model_catalog_store.read_catalog("codex-native", fingerprint)
+            if rows and not model_catalog_store.catalog_is_stale("codex-native", fingerprint):
+                slug = codex_reachable_model_slug(requested, rows)
+                model = next((row.get("model") for row in rows if row.get("id") == slug), None)
+                if isinstance(model, str) and model.strip():
+                    return model.strip()
 
     servable: tuple[str, ...] = ()
     try:
@@ -2514,7 +2539,9 @@ def build_codex_native_server(
     config_overrides: list[str] = []
     pinned_model = model
     if profile is not None:
-        databricks = _databricks_launch_materialization(model=model, profile=profile)
+        databricks = _databricks_launch_materialization(
+            model=model, profile=profile, codex_path=resolved_codex
+        )
         config_overrides.extend(databricks.config_overrides)
         env["DATABRICKS_HOST"] = databricks.host
         # A launch that names no model still routes through the profile's

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -5383,11 +5383,11 @@ def create_runner_app(
         # session — keeping the SHAPE's stored default (a session's own pin
         # must not become the host-wide default).
         asyncio.get_running_loop().create_task(
-            _write_back_codex_catalog([dict(row) for row in rows])
+            _write_back_codex_catalog(conv_id, [dict(row) for row in rows])
         )
         return marked
 
-    async def _write_back_codex_catalog(rows: list[_JsonObject]) -> None:
+    async def _write_back_codex_catalog(session_id: str, rows: list[_JsonObject]) -> None:
         try:
             from omnigent.harnesses.codex_native.app_server import (
                 codex_catalog_fingerprint,
@@ -5396,7 +5396,10 @@ def create_runner_app(
             )
             from omnigent.models import model_catalog_store
 
-            launch = await asyncio.to_thread(resolve_native_codex_launch, model=None)
+            spec = await _resolve_session_agent_spec(session_id)
+            if spec is None:
+                return
+            launch = await asyncio.to_thread(resolve_native_codex_launch, model=None, spec=spec)
             fingerprint = codex_catalog_fingerprint(launch)
             stored = model_catalog_store.read_catalog("codex-native", fingerprint)
             stored_default = next(
@@ -5413,7 +5416,7 @@ def create_runner_app(
             _logger.debug(
                 "codex model-catalog write-back skipped",
                 exc_info=True,
-                extra={"session_id": runner_primary_session_id()},
+                extra={"session_id": session_id},
             )
 
     async def _handle_pi_native_effort_change(

--- a/tests/runner/test_app_sessions_native_events_lifecycle.py
+++ b/tests/runner/test_app_sessions_native_events_lifecycle.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -1021,6 +1023,164 @@ async def test_codex_native_model_options_query_model_list(
     ]
     assert fake_client.connected
     assert fake_client.closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ["default", "other", "missing-spec", "invalid-config"])
+async def test_codex_model_catalog_writeback_uses_session_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, case: str
+) -> None:
+    """Session rows stay in their provider's shared cache, including across sessions."""
+    from omnigent.harnesses.codex_native import app_server as codex
+    from omnigent.models import model_catalog_store
+    from omnigent.runner.session_init_protocol import (
+        RunnerSessionInitEnvelope,
+        RunnerSessionInitSnapshot,
+    )
+    from omnigent.spec.types import DatabricksAuth
+
+    cfg = tmp_path / "databrickscfg"
+    cfg.write_text("[default]\nhost = https://a.example\n[other]\nhost = https://b.example\n")
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+    monkeypatch.setattr(codex, "_find_codex_cli", lambda: sys.executable)
+    monkeypatch.setattr(codex_native_bridge, "_BRIDGE_ROOT", tmp_path / "bridges")
+    profile = "default" if case == "default" else "other"
+    spec = AgentSpec(
+        spec_version=1,
+        name="codex",
+        executor=ExecutorSpec(
+            type="omnigent",
+            config={"harness": "codex-native"},
+            auth=DatabricksAuth(profile=profile),
+        ),
+    )
+
+    async def resolve_spec(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        return spec
+
+    def resolve_launch(
+        *, model: str | None, spec: AgentSpec | None = None
+    ) -> codex.NativeCodexLaunch:
+        if case == "invalid-config":
+            raise RuntimeError("provider configuration unavailable")
+        selected = spec.executor.auth.profile if spec is not None else "default"
+        return codex.NativeCodexLaunch([], model, selected)
+
+    launch_resolver = Mock(side_effect=resolve_launch)
+    monkeypatch.setattr(codex, "resolve_native_codex_launch", launch_resolver)
+    credentials = Mock(side_effect=AssertionError("cache reuse must not acquire credentials"))
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", credentials
+    )
+    catalogs = {}
+    fingerprints = {}
+    for provider in ("default", "other"):
+        rows = [
+            {"id": "shared-picker", "model": f"{provider}.schema.model", "isDefault": True},
+            {"id": "second-picker", "model": f"{provider}.schema.second"},
+        ]
+        fingerprint = codex.codex_catalog_fingerprint(codex.NativeCodexLaunch([], None, provider))
+        model_catalog_store.write_catalog("codex-native", fingerprint, rows)
+        catalogs[provider], fingerprints[provider] = rows, fingerprint
+    live_rows = [dict(row, displayName="Live model") for row in catalogs[profile]]
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text('model = "second-picker"\n')
+    fake_client = _RecordingCodexAppServerClient("ws://codex.test", "test")
+    monkeypatch.setattr(codex, "client_for_transport", lambda *args, **kwargs: fake_client)
+
+    async def fake_launch(session_id: str, *args: Any, **kwargs: Any) -> SessionResourceView:
+        return SessionResourceView(
+            id="terminal_codex_main",
+            type="terminal",
+            session_id=session_id,
+            name="codex:main",
+            metadata={"running": True},
+        )
+
+    monkeypatch.setattr(
+        "omnigent.runner.native.orchestration._auto_create_codex_terminal", fake_launch
+    )
+    app = create_runner_app(
+        process_manager=_FakeProcessManager(_ScriptedHarnessClient([])),  # type: ignore[arg-type]
+        spec_resolver=None if case == "missing-spec" else resolve_spec,
+        server_client=NullServerClient(),  # type: ignore[arg-type]
+    )
+    async with _runner_client(app) as client:
+        for session_id in (uuid.uuid4().hex, uuid.uuid4().hex):
+            codex_native_bridge.write_bridge_state(
+                codex_native_bridge.bridge_dir_for_bridge_id(session_id),
+                codex_native_bridge.CodexNativeBridgeState(
+                    session_id=session_id,
+                    socket_path="ws://codex.test",
+                    thread_id="test-thread",
+                    codex_home=str(codex_home),
+                ),
+            )
+            init = RunnerSessionInitEnvelope(
+                protocol_version=2,
+                server_version="0.14.0",
+                session_id=session_id,
+                agent_id="test-agent",
+                suppress_recovery_turn=True,
+                snapshot=RunnerSessionInitSnapshot(
+                    created_at=0,
+                    updated_at=0,
+                    harness_override="codex-native",
+                ),
+            )
+            created = await client.post(
+                "/v1/sessions",
+                json={
+                    "session_id": session_id,
+                    "agent_id": "test-agent",
+                    "session_init": init.model_dump(mode="json"),
+                },
+            )
+            assert created.status_code == 201, created.text
+            fake_client.model_list_responses = [{"result": {"data": live_rows}}]
+            response = await client.get(f"/v1/sessions/{session_id}/codex-model-options")
+            assert response.status_code == 200, response.text
+            assert response.json()["models"] == codex.mark_launch_default(
+                live_rows, "second-picker"
+            )
+            await asyncio.gather(
+                *[
+                    task
+                    for task in asyncio.all_tasks()
+                    if getattr(task.get_coro(), "__name__", "") == "_write_back_codex_catalog"
+                ]
+            )
+            for provider in ("default", "other"):
+                expected = (
+                    live_rows
+                    if provider == profile and case in {"default", "other"}
+                    else catalogs[provider]
+                )
+                assert (
+                    model_catalog_store.read_catalog("codex-native", fingerprints[provider])
+                    == expected
+                )
+            catalog_dir = model_catalog_store.catalog_path(
+                "codex-native", fingerprints[profile]
+            ).parent
+            assert len(list(catalog_dir.glob("*.json"))) == 2
+            for provider, host in (
+                ("default", "https://a.example"),
+                ("other", "https://b.example"),
+            ):
+                assert (
+                    codex._resolve_databricks_codex_model(
+                        host, provider, "shared-picker", codex_path=sys.executable
+                    )
+                    == f"{provider}.schema.model"
+                )
+            credentials.assert_not_called()
+    if case == "missing-spec":
+        launch_resolver.assert_not_called()
+    else:
+        assert launch_resolver.call_count == 2
+        launch_resolver.assert_called_with(model=None, spec=spec)
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_native_app_server.py
+++ b/tests/test_codex_native_app_server.py
@@ -10,7 +10,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from websockets.asyncio.client import ClientConnection
@@ -669,10 +669,12 @@ def test_build_codex_native_server_pins_profile_resolved_model(
     monkeypatch.setattr(
         codex_native_app_server,
         "_databricks_launch_materialization",
-        lambda *, model, profile: codex_native_app_server._DatabricksLaunchMaterialization(
-            config_overrides=[f'model="{model or "databricks-gpt-5-4-mini"}"'],
-            model=model or "databricks-gpt-5-4-mini",
-            host="https://ws.example",
+        lambda *, model, profile, codex_path: (
+            codex_native_app_server._DatabricksLaunchMaterialization(
+                config_overrides=[f'model="{model or "databricks-gpt-5-4-mini"}"'],
+                model=model or "databricks-gpt-5-4-mini",
+                host="https://ws.example",
+            )
         ),
     )
 
@@ -731,10 +733,12 @@ def test_launch_argv_and_config_pin_name_the_same_model(
     monkeypatch.setattr(
         codex_native_app_server,
         "_databricks_launch_materialization",
-        lambda *, model, profile: codex_native_app_server._DatabricksLaunchMaterialization(
-            config_overrides=[f'model="{model or "databricks-gpt-5-6-luna"}"'],
-            model=model or "databricks-gpt-5-6-luna",
-            host="https://ws.example",
+        lambda *, model, profile, codex_path: (
+            codex_native_app_server._DatabricksLaunchMaterialization(
+                config_overrides=[f'model="{model or "databricks-gpt-5-6-luna"}"'],
+                model=model or "databricks-gpt-5-6-luna",
+                host="https://ws.example",
+            )
         ),
     )
 
@@ -2686,13 +2690,15 @@ async def test_probe_codex_model_options_uses_launch_config_and_marks_default(
     monkeypatch.setattr(
         codex_native_app_server,
         "_databricks_launch_materialization",
-        lambda *, model, profile: codex_native_app_server._DatabricksLaunchMaterialization(
-            config_overrides=[
-                'model="databricks-gpt-5-4"',
-                'model_provider="omnigent_databricks"',
-            ],
-            model="databricks-gpt-5-4",
-            host="https://ws.example",
+        lambda *, model, profile, codex_path: (
+            codex_native_app_server._DatabricksLaunchMaterialization(
+                config_overrides=[
+                    'model="databricks-gpt-5-4"',
+                    'model_provider="omnigent_databricks"',
+                ],
+                model="databricks-gpt-5-4",
+                host="https://ws.example",
+            )
         ),
     )
     monkeypatch.setattr(codex_native_app_server, "_clean_codex_env", lambda: {"PATH": "/bin"})
@@ -2913,6 +2919,175 @@ async def test_probe_codex_model_options_probes_every_launch_shape(
         )
         assert ambient_fingerprint != fingerprint
         assert model_catalog_store.read_catalog("codex-native", ambient_fingerprint) is None
+
+
+@pytest.fixture
+def _databricks_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    from omnigent.harnesses.codex_native import app_server
+    from omnigent.models import model_catalog_store
+
+    cfg_path = tmp_path / "databrickscfg"
+    cfg_path.write_text("[prof]\nhost = https://h.example.com/\n")
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(tmp_path))
+    # The launch's explicit executable, not PATH's default, must key the lookup.
+    monkeypatch.setattr(app_server, "_find_codex_cli", lambda: "/other/codex")
+    fingerprint = app_server.codex_catalog_fingerprint(
+        NativeCodexLaunch([], None, "prof"), codex_path=sys.executable
+    )
+    model_catalog_store.write_catalog(
+        "codex-native",
+        fingerprint,
+        [
+            {"id": "gpt-1.2-test", "model": "system.ai.gpt-1-2-test"},
+            {"id": "custom-picker", "model": "custom_catalog.schema.model"},
+        ],
+    )
+    return fingerprint
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        ("system.ai.gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("databricks-gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("gpt-1.2-test", "system.ai.gpt-1-2-test"),
+        ("custom-picker", "custom_catalog.schema.model"),
+        ("custom_catalog.schema.model", "custom_catalog.schema.model"),
+    ],
+)
+def test_build_codex_native_server_reuses_catalog_model(
+    _databricks_catalog: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    requested: str,
+    expected: str,
+) -> None:
+    credentials = Mock(side_effect=RuntimeError("credentials unavailable"))
+    discovery = Mock(side_effect=RuntimeError("discovery unavailable"))
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", credentials
+    )
+    monkeypatch.setattr(
+        "omnigent.models.databricks_model_discovery.discover_databricks_codex_models", discovery
+    )
+    monkeypatch.setenv("DATABRICKS_HOST", "https://ambient.example.com")
+
+    server = build_codex_native_server(
+        socket_path=tmp_path / "codex.sock",
+        codex_home=tmp_path / "codex-home",
+        cwd=tmp_path,
+        model=requested,
+        profile="prof",
+        bridge_dir=tmp_path / "bridge",
+        codex_path=sys.executable,
+    )
+
+    credentials.assert_not_called()
+    discovery.assert_not_called()
+    assert f'model="{expected}"' in server.config_overrides
+    assert server.env["DATABRICKS_HOST"] == "https://h.example.com"
+    overrides = "\n".join(server.config_overrides)
+    assert "https://h.example.com/ai-gateway/codex/v1" in overrides
+    assert 'databricks auth token --profile \\"prof\\"' in overrides
+
+
+@pytest.mark.parametrize(
+    ("catalog_state", "requested", "expected"),
+    [
+        ("missing", "databricks-gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("damaged", "databricks-gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("stale", "databricks-gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("missing-model", "databricks-gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("blank-model", "databricks-gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("invalid-model", "databricks-gpt-1-2-test", "system.ai.gpt-1-2-test"),
+        ("missing", "gpt-1.2-test", "gpt-1.2-test"),
+        ("fresh", "unknown-model", "unknown-model"),
+        ("fresh", None, "system.ai.gpt-1-2-test"),
+    ],
+)
+def test_resolve_databricks_codex_model_catalog_miss_keeps_discovery(
+    _databricks_catalog: str,
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_state: str,
+    requested: str | None,
+    expected: str,
+) -> None:
+    from types import SimpleNamespace
+
+    from omnigent.harnesses.codex_native.app_server import _resolve_databricks_codex_model
+    from omnigent.models import model_catalog_store
+
+    path = model_catalog_store.catalog_path("codex-native", _databricks_catalog)
+    if catalog_state == "missing":
+        path.unlink()
+    elif catalog_state == "damaged":
+        path.write_text("not json")
+    elif catalog_state == "stale":
+        old = path.stat().st_mtime - model_catalog_store.CATALOG_STALE_AFTER_S - 60
+        os.utime(path, (old, old))
+    elif catalog_state.endswith("-model"):
+        row: dict[str, object] = {"id": "gpt-1.2-test"}
+        if catalog_state != "missing-model":
+            row["model"] = " " if catalog_state == "blank-model" else 123
+        model_catalog_store.write_catalog("codex-native", _databricks_catalog, [row])
+
+    credentials = Mock(return_value=SimpleNamespace(token="tok"))
+    discovery = Mock(return_value=("system.ai.gpt-1-2-test",))
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace", credentials
+    )
+    monkeypatch.setattr(
+        "omnigent.models.databricks_model_discovery.discover_databricks_codex_models", discovery
+    )
+
+    assert (
+        _resolve_databricks_codex_model(
+            "https://h.example.com", "prof", requested, codex_path=sys.executable
+        )
+        == expected
+    )
+    credentials.assert_called_once_with("prof")
+    discovery.assert_called_once_with("https://h.example.com", "tok")
+
+
+@pytest.mark.parametrize("changed", ["profile", "workspace", "host", "binary"])
+def test_resolve_databricks_codex_model_does_not_reuse_other_catalog(
+    _databricks_catalog: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    changed: str,
+) -> None:
+    from types import SimpleNamespace
+
+    from omnigent.harnesses.codex_native.app_server import _resolve_databricks_codex_model
+
+    profile = "other" if changed == "profile" else "prof"
+    host = (
+        "https://other.example.com"
+        if changed in {"workspace", "host"}
+        else "https://h.example.com"
+    )
+    profile_host = host if changed != "host" else "https://h.example.com"
+    (tmp_path / "databrickscfg").write_text(f"[{profile}]\nhost = {profile_host}\n")
+    codex_path = "/other/codex" if changed == "binary" else sys.executable
+    discovery = Mock(return_value=("system.ai.gpt-1-2-test",))
+    monkeypatch.setattr(
+        "omnigent.runtime.credentials.databricks.resolve_databricks_workspace",
+        lambda profile: SimpleNamespace(token="tok"),
+    )
+    monkeypatch.setattr(
+        "omnigent.models.databricks_model_discovery.discover_databricks_codex_models", discovery
+    )
+
+    assert (
+        _resolve_databricks_codex_model(
+            host, profile, "databricks-gpt-1-2-test", codex_path=codex_path
+        )
+        == "system.ai.gpt-1-2-test"
+    )
+    discovery.assert_called_once_with(host, "tok")
 
 
 def test_resolve_databricks_codex_model_matches_servable_ids() -> None:


### PR DESCRIPTION
## Related issue

Part of #6496 (OMNI-6295). Replaces the closed #7076; the runner responsiveness fix is already merged in #6497.

## Summary

Native Codex was acquiring credentials and looking up models again even when its existing catalog already knew the selected model.

In plain English: reuse the model we already know for the provider you chose. Later sessions with the same provider configuration share that answer.

- Reuse a fresh catalog row's `model` through the existing alias matcher. Match the profile, workspace, and actual Codex executable; include the locally configured workspace in the existing fingerprint.
- Write a live session's catalog back using its own provider configuration, not the machine-default provider. The session ID only retrieves its configuration; it is **not** part of the cache key. Missing or invalid configuration skips the background writeback without failing the live model-list request, and a session's model pin does not replace the shared default.
- Keep existing discovery and fallbacks for Default, cold/stale catalogs, unknown selections, and incomplete rows. Codex-only: two production files plus two test files, with no new API fields, flags, cache, persistent state, or model-prefix heuristics.

```text
Model selection
  |-- fresh catalog for this provider --> use its model
  `-- Default / cache miss -----------> existing discovery and fallbacks

Live session's models --> same provider's shared catalog --> later sessions
```

## Test Plan

- The startup regression failed before the original fix because it acquired credentials. It now covers canonical IDs, legacy aliases, bare/dotted names, and arbitrary provider IDs without credentials or discovery on a hit.
- All four new writeback cases failed before this follow-up and now pass: default profile, another profile, missing spec, and invalid configuration. They exercise the runner endpoint, real catalog store, fingerprint, and startup resolver with mocked transport/configuration. Two sessions share a provider cache, different profiles remain isolated, and the stored default survives a session-specific model pin.
- 306 tests passed: 254 across Codex startup, model vocabulary, catalog storage, runner model fallback, and native terminal creation; 52 across runner native events/model-options/lifecycle, including the new regression.
- Pre-commit passed on the staged follow-up, including Pyrefly, using the dependency set from `.github/workflows/lint.yml`: `uv sync --locked --group lint --extra hindsight --extra nimble --extra s3 --extra tracing`, then `.venv/bin/pre-commit run`.
- Earlier live E2E on `4a5966f40`: real UI/server/host/Codex/model replies succeeded. A new warm session bypassed an unconditional 10-second discovery delay with explicit cache-hit evidence; a separate empty-cache host probe reached the delay (10.005 seconds) and populated the catalog. This proves discovery was skipped, not that all session latency disappeared.

Focused reproduction after `uv sync --locked --extra all --group dev`:

```bash
uv run --no-sync pytest -q tests/runner/test_app_sessions_native_events_lifecycle.py \
  -k codex_model_catalog_writeback_uses_session_provider
uv run --no-sync pytest -q tests/test_codex_native_app_server.py \
  -k 'reuses_catalog_model or resolve_databricks_codex_model'
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A for visuals; no UI changes. Reproducible checks and live startup evidence are above.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The live E2E above verified startup cache reuse before this writeback follow-up. The follow-up's two-profile isolation and same-profile sharing are verified by the new automated regression; a live two-provider E2E was not run. The cold live control was a host catalog probe, not a session reply.

The broader runner lifecycle tests need isolated provider configuration on a configured workstation: otherwise existing model-list assertions receive extra `source` metadata from local provider detection. No source or existing test assertions were changed for this.

With all development extras installed, Pyrefly reports the previously verified OpenCode error (`opencode_native/provider.py:363`, `object` passed as SDK `Config`). No OpenCode code or dependency definitions were changed; checks pass with CI's dependency set.

Manual smoke check: select a listed model and launch two successive Databricks-backed Codex sessions with the same profile. Send `Reply exactly catalog-ok` in each; confirm both retain the selected model and reply successfully. The first/cold catalog lookup can still take time. Use the focused regression above to check profile isolation and cache sharing directly.

## Changelog

Databricks-backed Codex sessions reuse fresh model selections across sessions with the same provider configuration, without mixing different providers' catalogs.
