### PR TITLE
test(e2e-ui): fix stale branch-chip assertion in worktree opt-out test

### DIFF
--- a/tests/e2e_ui/start_session/test_project_config_prefill.py
+++ b/tests/e2e_ui/start_session/test_project_config_prefill.py
@@ -785,8 +785,9 @@ def test_project_opt_out_wins_over_global_default(
     """A project's explicit ``use_worktree: false`` beats a global default of on.
 
     With the global default on but the project storing an explicit opt-out, the
-    composer must NOT seed a worktree: the branch chip stays blank ("Worktree")
-    and the create posts no ``git`` block (a plain launch in the workspace).
+    composer must NOT seed a worktree: the branch chip shows the unseeded
+    "New worktree" invite (never an auto-named ``worktree-<hex>`` branch) and the
+    create posts no ``git`` block (a plain launch in the workspace).
     """
     base_url, session_id = seeded_session
     _run_in_fresh_loop(_drive_project_opt_out(base_url, session_id))
@@ -818,8 +819,12 @@ async def _drive_project_opt_out(base_url: str, session_id: str) -> None:
             await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_contain_text(
                 "omnigent", timeout=15_000
             )
+            # A git-repo main tree with no seed shows the "New worktree" invite
+            # (the resolved steady state) — not an auto-named worktree-<hex>
+            # branch. Asserting the resolved label avoids racing the transient
+            # "Worktree" worktrees-loading placeholder.
             await expect(page.get_by_test_id("new-chat-landing-branch-chip")).to_contain_text(
-                "Worktree", timeout=15_000
+                "New worktree", timeout=15_000
             )
 
             await page.get_by_test_id("new-chat-landing-input").fill("start here")


### PR DESCRIPTION
## Summary

Fixes a test that flips between pass and fail on CI depending on load timing — surfaced by the E2E UI shard on #7077, where it failed with `unexpected value "New worktree"`.

`test_project_opt_out_wins_over_global_default` asserts the new-chat **branch chip** contains `"Worktree"`. The composer redesign (#6345) renamed that chip's resolved label to **`"New worktree"`** for a workspace that is a git repo's main tree — which is exactly what this test stubs (`workspace = /work/omnigent`, `is_main: true`). The assertion was never updated.

It's not genuinely nondeterministic — the assertion is simply stale. It *appeared* flaky because `"Worktree"` is also the transient label shown **while the worktrees list is still loading** (`!worktreesResolved` in `NewChatDialog.tsx`):

- worktrees resolve **slower** than the assertion → poll catches the `"Worktree"` loading placeholder → false pass;
- worktrees resolve **promptly** → label is `"New worktree"` throughout → assertion times out and fails.

The behaviour under test is correct — the opt-out seeds no worktree and the create posts no `git` block (asserted separately, unchanged). Only the UI-label proxy was wrong.

Fix: assert the resolved `"New worktree"` invite. It's deterministic (the poll waits through the loading placeholder) and still proves no auto-named `worktree-<hex>` branch was seeded.

## Test Plan

- Static: label logic in `web/src/shell/NewChatDialog.tsx:598-607` (`is_main` → `"New worktree"`) vs the loading placeholder at `:562-568` (`"Worktree"`); confirmed via `git log` that `"New worktree"` was introduced by #6345 (2026-09-10), after this test (#5547, 2026-08-26).
- `python -m py_compile` and `ruff check` pass on the edited file; pre-commit hooks green.
- The sibling seeded-worktree assertion (line 762, `worktree-<hex>` regex) is unaffected — it asserts a stable seeded state.

> The `e2e_ui` suite needs a live server+runner stack to execute; this change was verified statically against the label logic and git history rather than by a local run.

## Demo

N/A — test-only change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI / frontend change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation

## Test coverage

- [x] Automated tests added/updated
- [x] Manual verification completed

## Coverage notes

Test-only fix: updates the stale assertion in `test_project_opt_out_wins_over_global_default` and its docstring/comment. The real opt-out invariants (`project_id`, no `workspace`, `git is None`) are unchanged. Not run in a live e2e stack locally (requires server+runner); verified statically against the composer label logic and git history.

This pull request and its description were written by Isaac.
