### PR TITLE
fix(runner): acknowledge a child's terminal status when the parent has no inbox here

### DIFF
--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2056,8 +2056,9 @@ def _deliver_subagent_completion(entry: _SubagentWorkEntry) -> _SubagentDelivery
         )
     inbox = _session_inboxes_ref.get(entry.parent_session_id)
     if inbox is None:
-        _logger.warning(
-            "Sub-agent work completed but parent inbox is missing; parent=%s child=%s",
+        _logger.info(
+            "Sub-agent work completed but parent inbox is missing; leaving it for "
+            "init-time recovery; parent=%s child=%s",
             entry.parent_session_id,
             entry.child_session_id,
         )
@@ -2311,42 +2312,44 @@ def _subagent_delivery_not_confirmed_response(
     is_runner_known_subagent: bool,
 ) -> JSONResponse | None:
     """
-    Build a 503 response when a known sub-agent result was not delivered.
+    Build a 503 response when a known sub-agent's handoff metadata is gone.
 
     Top-level sessions also post terminal status but have no parent inbox, so
     an untracked status remains a no-op unless the runner knows this session
-    was created as a sub-agent. For known sub-agents, Omnigent must not receive a
-    2xx acknowledgement unless the terminal payload is confirmed in the
-    parent's inbox.
+    was created as a sub-agent. A known sub-agent with no work entry (runner
+    state loss) must not be acknowledged: the 503 makes the forwarder retry
+    until the handoff metadata is recovered.
+
+    A tracked entry whose parent inbox is missing is acknowledged instead. The
+    parent has no session on this runner — a mirrored sub-agent that never
+    gets one, a closed parent, or one not yet re-initialized after a restart —
+    so nothing can drain the inbox now. The entry stays terminal and
+    undelivered, and the parent's initialization re-queues undrained results
+    from the server (``_recover_undrained_subagent_results``). A 503 here made
+    the forwarder retry every 30 s for as long as the runner lived.
 
     :param ack: Delivery acknowledgement returned by
         ``mark_subagent_work_terminal``.
     :param is_runner_known_subagent: Whether runner session state identifies
         the status sender as a sub-agent child.
-    :returns: A 503 JSON response when delivery is not confirmed, or ``None``
+    :returns: A 503 JSON response when the work entry is missing, or ``None``
         when the status can be acknowledged.
     """
     if ack.delivered:
         return None
-    if ack.entry is None and not is_runner_known_subagent:
+    if ack.entry is not None:
         return None
-    reason = _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY if ack.entry is None else ack.reason
-    detail_by_reason = {
-        _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY: (
-            "Sub-agent terminal status arrived, but the runner has no "
-            "tracked work entry to deliver to the parent inbox."
-        ),
-        _SUBAGENT_DELIVERY_MISSING_PARENT_INBOX: (
-            "Sub-agent terminal status arrived, but the parent inbox is missing on this runner."
-        ),
-    }
-    detail = detail_by_reason[reason]
+    if not is_runner_known_subagent:
+        return None
     return JSONResponse(
         status_code=503,
         content={
             "error": "subagent_delivery_not_confirmed",
-            "reason": reason,
-            "detail": detail,
+            "reason": _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY,
+            "detail": (
+                "Sub-agent terminal status arrived, but the runner has no "
+                "tracked work entry to deliver to the parent inbox."
+            ),
         },
     )
 

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2056,9 +2056,8 @@ def _deliver_subagent_completion(entry: _SubagentWorkEntry) -> _SubagentDelivery
         )
     inbox = _session_inboxes_ref.get(entry.parent_session_id)
     if inbox is None:
-        _logger.info(
-            "Sub-agent work completed but parent inbox is missing; leaving it for "
-            "init-time recovery; parent=%s child=%s",
+        _logger.warning(
+            "Sub-agent work completed but parent inbox is missing; parent=%s child=%s",
             entry.parent_session_id,
             entry.child_session_id,
         )
@@ -2312,44 +2311,42 @@ def _subagent_delivery_not_confirmed_response(
     is_runner_known_subagent: bool,
 ) -> JSONResponse | None:
     """
-    Build a 503 response when a known sub-agent's handoff metadata is gone.
+    Build a 503 response when a known sub-agent result was not delivered.
 
     Top-level sessions also post terminal status but have no parent inbox, so
     an untracked status remains a no-op unless the runner knows this session
-    was created as a sub-agent. A known sub-agent with no work entry (runner
-    state loss) must not be acknowledged: the 503 makes the forwarder retry
-    until the handoff metadata is recovered.
-
-    A tracked entry whose parent inbox is missing is acknowledged instead. The
-    parent has no session on this runner — a mirrored sub-agent that never
-    gets one, a closed parent, or one not yet re-initialized after a restart —
-    so nothing can drain the inbox now. The entry stays terminal and
-    undelivered, and the parent's initialization re-queues undrained results
-    from the server (``_recover_undrained_subagent_results``). A 503 here made
-    the forwarder retry every 30 s for as long as the runner lived.
+    was created as a sub-agent. For known sub-agents, Omnigent must not receive a
+    2xx acknowledgement unless the terminal payload is confirmed in the
+    parent's inbox.
 
     :param ack: Delivery acknowledgement returned by
         ``mark_subagent_work_terminal``.
     :param is_runner_known_subagent: Whether runner session state identifies
         the status sender as a sub-agent child.
-    :returns: A 503 JSON response when the work entry is missing, or ``None``
+    :returns: A 503 JSON response when delivery is not confirmed, or ``None``
         when the status can be acknowledged.
     """
     if ack.delivered:
         return None
-    if ack.entry is not None:
+    if ack.entry is None and not is_runner_known_subagent:
         return None
-    if not is_runner_known_subagent:
-        return None
+    reason = _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY if ack.entry is None else ack.reason
+    detail_by_reason = {
+        _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY: (
+            "Sub-agent terminal status arrived, but the runner has no "
+            "tracked work entry to deliver to the parent inbox."
+        ),
+        _SUBAGENT_DELIVERY_MISSING_PARENT_INBOX: (
+            "Sub-agent terminal status arrived, but the parent inbox is missing on this runner."
+        ),
+    }
+    detail = detail_by_reason[reason]
     return JSONResponse(
         status_code=503,
         content={
             "error": "subagent_delivery_not_confirmed",
-            "reason": _SUBAGENT_DELIVERY_MISSING_WORK_ENTRY,
-            "detail": (
-                "Sub-agent terminal status arrived, but the runner has no "
-                "tracked work entry to deliver to the parent inbox."
-            ),
+            "reason": reason,
+            "detail": detail,
         },
     )
 
@@ -4963,6 +4960,23 @@ def create_runner_app(
             agent=agent,
             title=snapshot.sub_agent_name or "",
         )
+
+    async def _parent_is_nested_subagent(entry: _SubagentWorkEntry) -> bool:
+        """
+        Return whether an undelivered result's parent is itself a sub-agent.
+
+        A sub-agent parent that has no inbox on this runner never gets one: a
+        mirrored claude-native child is never initialized here, and a
+        runner-launched one re-queues undrained results from the server when
+        it is re-initialized. Retrying its children's terminal status buys
+        nothing. An unreadable parent snapshot reads as a top-level parent, so
+        the retry contract still covers a parent that lives elsewhere.
+
+        :param entry: Terminal work entry whose parent inbox was missing.
+        :returns: ``True`` when the parent's snapshot names its own parent.
+        """
+        snapshot = await _session_snapshot(entry.parent_session_id)
+        return snapshot.ok and snapshot.parent_session_id is not None
 
     async def _recover_undrained_subagent_results(parent_id: str) -> None:
         """
@@ -8741,6 +8755,14 @@ def create_runner_app(
                     output=output or "Error: native sub-agent turn failed",
                 )
             if delivery_ack is not None:
+                if (
+                    delivery_ack.entry is not None
+                    and delivery_ack.reason == _SUBAGENT_DELIVERY_MISSING_PARENT_INBOX
+                    and await _parent_is_nested_subagent(delivery_ack.entry)
+                ):
+                    # No inbox will appear here for this result; the entry stays
+                    # terminal and undelivered for the parent's own recovery scan.
+                    return Response(status_code=204)
                 is_known = (
                     conversation_id in _session_sub_agent_names or recovered_entry is not None
                 )

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2318,8 +2318,9 @@ def _subagent_delivery_not_confirmed_response(
     was created as a sub-agent. For known sub-agents, Omnigent must not receive a
     2xx acknowledgement unless the terminal payload is confirmed in the
     parent's inbox — except a tracked entry whose parent is itself a
-    sub-agent, which ``post_session_events`` acknowledges before calling here
-    and retains for delivery when the parent's inbox is created.
+    sub-agent, which ``post_session_events`` acknowledges before calling here;
+    the entry is retained and delivered only if this runner ever creates that
+    parent's inbox.
 
     :param ack: Delivery acknowledgement returned by
         ``mark_subagent_work_terminal``.
@@ -4967,13 +4968,16 @@ def create_runner_app(
         """
         Return whether an undelivered result's parent is itself a sub-agent.
 
-        A sub-agent parent normally has no inbox on this runner: a mirrored
-        claude-native child is never initialized here. Retrying its children's
-        terminal status every 30 s buys nothing, so the status is acknowledged
-        and the entry kept; creating the parent's inbox later delivers it (see
-        ``_deliver_retained_subagent_results``). An unreadable parent snapshot
-        reads as a top-level parent, so the retry contract still covers a
-        parent that lives elsewhere or is re-initializing after a restart.
+        A mirrored claude-native sub-agent never runs on this runner, so its
+        inbox never exists here and retrying its children's terminal status
+        every 30 s buys nothing. The inbox record is redundant for that
+        topology: the child's result reaches the parent natively inside the
+        Claude process. The status is acknowledged and the entry kept, so a
+        sub-agent parent that does run here later still receives it when its
+        inbox is created (``_deliver_retained_subagent_results``). An unreadable
+        parent snapshot reads as a top-level parent, so the retry contract still
+        covers a parent that lives elsewhere or is re-initializing after a
+        restart.
 
         :param entry: Terminal work entry whose parent inbox was missing.
         :returns: ``True`` when the parent's snapshot names its own parent.
@@ -4985,10 +4989,13 @@ def create_runner_app(
         """
         Hand over results acknowledged while ``parent_id`` had no inbox here.
 
-        A terminal child whose parent inbox was missing is acknowledged with
-        its entry kept undelivered. Creating the parent's inbox delivers those
-        entries and wakes the parent, as the forwarder's pending retry used to
-        the moment the inbox appeared. Idempotent: delivered entries are skipped.
+        A terminal child whose sub-agent parent had no inbox here is
+        acknowledged with its entry kept undelivered. If that parent later
+        runs on this runner, creating its inbox delivers those entries and
+        wakes it, as the forwarder's pending retry used to the moment the inbox
+        appeared. A parent that never runs here keeps the entry undelivered;
+        for a claude-native mirror the result already reached it natively.
+        Idempotent: delivered entries are skipped.
 
         :param parent_id: Parent whose inbox now exists, e.g. ``"conv_parent123"``.
         :returns: None.
@@ -8783,9 +8790,9 @@ def create_runner_app(
                     and delivery_ack.reason == _SUBAGENT_DELIVERY_MISSING_PARENT_INBOX
                     and await _parent_is_nested_subagent(delivery_ack.entry)
                 ):
-                    # Acknowledge instead of asking the forwarder to poll; the
-                    # entry stays terminal and undelivered until this runner
-                    # creates the parent's inbox and hands it over.
+                    # Acknowledge instead of asking the forwarder to poll. The
+                    # entry stays terminal and undelivered; it is handed over
+                    # only if this runner ever creates the parent's inbox.
                     return Response(status_code=204)
                 is_known = (
                     conversation_id in _session_sub_agent_names or recovered_entry is not None

--- a/omnigent/runner/app.py
+++ b/omnigent/runner/app.py
@@ -2317,7 +2317,9 @@ def _subagent_delivery_not_confirmed_response(
     an untracked status remains a no-op unless the runner knows this session
     was created as a sub-agent. For known sub-agents, Omnigent must not receive a
     2xx acknowledgement unless the terminal payload is confirmed in the
-    parent's inbox.
+    parent's inbox — except a tracked entry whose parent is itself a
+    sub-agent, which ``post_session_events`` acknowledges before calling here
+    and retains for delivery when the parent's inbox is created.
 
     :param ack: Delivery acknowledgement returned by
         ``mark_subagent_work_terminal``.
@@ -4965,18 +4967,37 @@ def create_runner_app(
         """
         Return whether an undelivered result's parent is itself a sub-agent.
 
-        A sub-agent parent that has no inbox on this runner never gets one: a
-        mirrored claude-native child is never initialized here, and a
-        runner-launched one re-queues undrained results from the server when
-        it is re-initialized. Retrying its children's terminal status buys
-        nothing. An unreadable parent snapshot reads as a top-level parent, so
-        the retry contract still covers a parent that lives elsewhere.
+        A sub-agent parent normally has no inbox on this runner: a mirrored
+        claude-native child is never initialized here. Retrying its children's
+        terminal status every 30 s buys nothing, so the status is acknowledged
+        and the entry kept; creating the parent's inbox later delivers it (see
+        ``_deliver_retained_subagent_results``). An unreadable parent snapshot
+        reads as a top-level parent, so the retry contract still covers a
+        parent that lives elsewhere or is re-initializing after a restart.
 
         :param entry: Terminal work entry whose parent inbox was missing.
         :returns: ``True`` when the parent's snapshot names its own parent.
         """
         snapshot = await _session_snapshot(entry.parent_session_id)
         return snapshot.ok and snapshot.parent_session_id is not None
+
+    def _deliver_retained_subagent_results(parent_id: str) -> None:
+        """
+        Hand over results acknowledged while ``parent_id`` had no inbox here.
+
+        A terminal child whose parent inbox was missing is acknowledged with
+        its entry kept undelivered. Creating the parent's inbox delivers those
+        entries and wakes the parent, as the forwarder's pending retry used to
+        the moment the inbox appeared. Idempotent: delivered entries are skipped.
+
+        :param parent_id: Parent whose inbox now exists, e.g. ``"conv_parent123"``.
+        :returns: None.
+        """
+        for entry in list_subagent_work(parent_id):
+            if entry.status not in _SUBAGENT_TERMINAL_STATUSES or entry.delivered:
+                continue
+            if _deliver_subagent_completion(entry).delivered_now:
+                _schedule_subagent_wake(entry)
 
     async def _recover_undrained_subagent_results(parent_id: str) -> None:
         """
@@ -4988,15 +5009,17 @@ def create_runner_app(
         before the next ``sys_read_inbox`` drain. The inbox is created here
         when missing: after a reconnect the server can dispatch a pending
         message before it re-initializes the session, and that turn's drain
-        must still see the recovered results.
+        must still see the recovered results. Results acknowledged while this
+        parent had no inbox here are handed over first, on every call.
 
         :param parent_id: Parent session whose inbox was recreated, e.g.
             ``"conv_parent123"``.
         :returns: None.
         """
+        _session_inboxes.setdefault(parent_id, asyncio.Queue())
+        _deliver_retained_subagent_results(parent_id)
         if parent_id in _subagent_recovery_done:
             return
-        _session_inboxes.setdefault(parent_id, asyncio.Queue())
         lock = _subagent_recovery_locks.setdefault(parent_id, asyncio.Lock())
         async with lock:
             if parent_id in _subagent_recovery_done:
@@ -8760,8 +8783,9 @@ def create_runner_app(
                     and delivery_ack.reason == _SUBAGENT_DELIVERY_MISSING_PARENT_INBOX
                     and await _parent_is_nested_subagent(delivery_ack.entry)
                 ):
-                    # No inbox will appear here for this result; the entry stays
-                    # terminal and undelivered for the parent's own recovery scan.
+                    # Acknowledge instead of asking the forwarder to poll; the
+                    # entry stays terminal and undelivered until this runner
+                    # creates the parent's inbox and hands it over.
                     return Response(status_code=204)
                 is_known = (
                     conversation_id in _session_sub_agent_names or recovered_entry is not None

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -988,14 +988,15 @@ async def test_external_status_for_untracked_session_does_not_wake() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tracked_subagent_status_without_parent_inbox_returns_503() -> None:
+async def test_tracked_subagent_status_without_parent_inbox_is_acked() -> None:
     """
-    A tracked sub-agent terminal status is not ACKed without parent delivery.
+    A tracked sub-agent terminal status is ACKed when the parent has no inbox here.
 
-    The parent inbox is the durable handoff point for async sub-agent results.
-    If the runner has a child work entry but the parent inbox is missing, a
-    204 would tell AP/the forwarder the completion was delivered even though
-    the parent can never drain it.
+    The parent has no session on this runner (a mirrored sub-agent, a closed
+    parent, or one not yet re-initialized after a restart), so nothing can
+    drain the inbox now; a 503 only made the forwarder retry every 30 s for
+    the life of the runner. The entry stays terminal and undelivered so the
+    parent's initialization can still re-queue the result.
     """
     from omnigent.runner import app as runner_app
 
@@ -1026,11 +1027,10 @@ async def test_tracked_subagent_status_without_parent_inbox_returns_503() -> Non
     finally:
         runner_app.unregister_subagent_work(child_id)
 
-    assert resp.status_code == 503, resp.text
-    assert resp.json()["reason"] == "missing_parent_inbox"
+    assert resp.status_code == 204, resp.text
     assert entry is not None
-    # The child is terminal, but not delivered; if delivered were True here,
-    # the runner would have ACKed a result the parent cannot read.
+    # Terminal but undelivered: recovery at parent init still has a result to
+    # deliver, and nothing was ACKed as read.
     assert entry.status == "completed"
     assert entry.delivered is False
 

--- a/tests/runner/test_app_sessions_native_supervision.py
+++ b/tests/runner/test_app_sessions_native_supervision.py
@@ -988,15 +988,14 @@ async def test_external_status_for_untracked_session_does_not_wake() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tracked_subagent_status_without_parent_inbox_is_acked() -> None:
+async def test_tracked_subagent_status_without_parent_inbox_returns_503() -> None:
     """
-    A tracked sub-agent terminal status is ACKed when the parent has no inbox here.
+    A tracked sub-agent terminal status is not ACKed without parent delivery.
 
-    The parent has no session on this runner (a mirrored sub-agent, a closed
-    parent, or one not yet re-initialized after a restart), so nothing can
-    drain the inbox now; a 503 only made the forwarder retry every 30 s for
-    the life of the runner. The entry stays terminal and undelivered so the
-    parent's initialization can still re-queue the result.
+    The parent inbox is the durable handoff point for async sub-agent results.
+    If the runner has a child work entry but the parent inbox is missing, a
+    204 would tell AP/the forwarder the completion was delivered even though
+    the parent can never drain it.
     """
     from omnigent.runner import app as runner_app
 
@@ -1027,10 +1026,11 @@ async def test_tracked_subagent_status_without_parent_inbox_is_acked() -> None:
     finally:
         runner_app.unregister_subagent_work(child_id)
 
-    assert resp.status_code == 204, resp.text
+    assert resp.status_code == 503, resp.text
+    assert resp.json()["reason"] == "missing_parent_inbox"
     assert entry is not None
-    # Terminal but undelivered: recovery at parent init still has a result to
-    # deliver, and nothing was ACKed as read.
+    # The child is terminal, but not delivered; if delivered were True here,
+    # the runner would have ACKed a result the parent cannot read.
     assert entry.status == "completed"
     assert entry.delivered is False
 

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -420,6 +420,57 @@ async def test_nested_subagent_parent_without_inbox_is_acked(
 
 
 @pytest.mark.asyncio
+async def test_retained_result_is_delivered_when_parent_inbox_is_created(
+    _clean_subagent_registry: None,
+) -> None:
+    """A result acknowledged without a parent inbox is delivered once the inbox exists.
+
+    After the nested-parent 204 the forwarder never resends, so the runner must
+    hand the retained result over itself when it creates the parent's inbox
+    (session init or a drain), the way the pending retry used to the moment
+    the inbox appeared. Delivered exactly once.
+    """
+    child_body = _child_snapshot(sub_agent_name="reviewer", parent_session_id=PARENT_SESSION_ID)
+    pm = _FakeProcessManager(_ScriptedHarnessClient([]))
+
+    async def _resolver(agent_id: str, session_id: str | None = None) -> AgentSpec:
+        del agent_id, session_id
+        return AgentSpec(
+            spec_version=1,
+            name="reviewer",
+            executor=ExecutorSpec(type="omnigent", config={"harness": "claude-native"}),
+        )
+
+    app = create_runner_app(
+        process_manager=pm,  # type: ignore[arg-type]
+        spec_resolver=_resolver,
+        server_client=_SnapshotServerClient(  # type: ignore[arg-type]
+            child_body, _parent_snapshot(parent_session_id="conv_top_level")
+        ),
+    )
+    async with _runner_client(app) as client:
+        acked = await client.post(
+            f"/v1/sessions/{CHILD_SESSION_ID}/events",
+            json={"type": "external_session_status", "data": {"status": "idle", "output": "x"}},
+        )
+        assert acked.status_code == 204
+        assert PARENT_SESSION_ID not in runner_app._session_inboxes_ref
+
+        # The parent's inbox appears on this process; a second creation is a no-op.
+        await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+        await app.state.recover_undrained_subagent_results(PARENT_SESSION_ID)
+
+    inbox = runner_app._session_inboxes_ref[PARENT_SESSION_ID]
+    assert inbox.qsize() == 1
+    delivered = inbox.get_nowait()
+    assert delivered["task_id"] == CHILD_SESSION_ID
+    assert delivered["status"] == "completed"
+    entry = runner_app.get_subagent_work(CHILD_SESSION_ID)
+    assert entry is not None
+    assert entry.delivered is True
+
+
+@pytest.mark.asyncio
 async def test_replayed_idle_after_drain_does_not_redeliver(
     _clean_subagent_registry: None,
 ) -> None:

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -89,9 +89,12 @@ class _SnapshotServerClient(NullServerClient):
     parent). All other endpoints fall through to the empty-200 base.
     """
 
-    def __init__(self, child_body: dict[str, Any]) -> None:
-        """Configure the JSON body returned for the child session GET."""
+    def __init__(
+        self, child_body: dict[str, Any], parent_body: dict[str, Any] | None = None
+    ) -> None:
+        """Configure the bodies returned for the child and parent session GETs."""
         self._child_body = child_body
+        self._parent_body = parent_body
 
     class _Resp:
         def __init__(self, payload: dict[str, Any]) -> None:
@@ -108,6 +111,8 @@ class _SnapshotServerClient(NullServerClient):
         del kwargs
         if url.rstrip("/").endswith(CHILD_SESSION_ID):
             return self._Resp(self._child_body)
+        if self._parent_body is not None and url.rstrip("/").endswith(PARENT_SESSION_ID):
+            return self._Resp(self._parent_body)
         if url.rstrip("/").endswith("/items"):
             return self._Resp({"data": [], "has_more": False})
         return self._Response()
@@ -216,12 +221,26 @@ def _child_snapshot(
     }
 
 
+def _parent_snapshot(*, parent_session_id: str | None) -> dict[str, Any]:
+    """Build the parent's ``SessionResponse``-shaped body."""
+    return {
+        "id": PARENT_SESSION_ID,
+        "agent_id": "ag_orchestrator",
+        "agent_name": "claude-native-ui",
+        "sub_agent_name": "explorer" if parent_session_id else None,
+        "parent_session_id": parent_session_id,
+        "created_at": 0,
+        "workspace": None,
+    }
+
+
 async def _post_native_idle(
     *,
     child_body: dict[str, Any],
     seed_parent_inbox: bool,
     register_work: bool,
     output: str = "review complete: LGTM",
+    parent_body: dict[str, Any] | None = None,
 ) -> tuple[int, list[dict[str, Any]]]:
     """POST a native ``external_session_status: idle`` and return (http, inbox items).
 
@@ -229,7 +248,8 @@ async def _post_native_idle(
     ``register_work`` seeds the in-memory work entry (the healthy case); leaving
     it ``False`` models a reconnect-wiped map or a ``sys_session_create`` child
     the dispatch never registered. ``seed_parent_inbox`` controls whether the
-    parent's inbox queue is present on this runner.
+    parent's inbox queue is present on this runner. ``parent_body`` is the
+    parent's session snapshot; when omitted the parent reads as top-level.
     """
     if seed_parent_inbox:
         runner_app._session_inboxes_ref[PARENT_SESSION_ID] = asyncio.Queue()
@@ -254,7 +274,7 @@ async def _post_native_idle(
     app = create_runner_app(
         process_manager=pm,  # type: ignore[arg-type]
         spec_resolver=_resolver,
-        server_client=_SnapshotServerClient(child_body),  # type: ignore[arg-type]
+        server_client=_SnapshotServerClient(child_body, parent_body),  # type: ignore[arg-type]
     )
 
     async with _runner_client(app) as client:
@@ -370,6 +390,33 @@ async def test_undeliverable_native_completion_returns_503_not_silent_204(
         "an undeliverable native sub-agent completion was acked with "
         f"http={http}; expected 503 so the forwarder retries. Items={items!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_nested_subagent_parent_without_inbox_is_acked(
+    _clean_subagent_registry: None,
+) -> None:
+    """A completion whose parent is itself a sub-agent is ACKed without an inbox.
+
+    Claude Code sub-agents can fan out further, and the forwarder mirrors the
+    grandchildren under the mid-level child. That parent is never initialized
+    on the runner, so its inbox never exists and a 503 only made the forwarder
+    retry every 30 s for the life of the runner. The entry stays terminal and
+    undelivered for the parent's own recovery scan.
+    """
+    http, items = await _post_native_idle(
+        child_body=_child_snapshot(sub_agent_name="reviewer", parent_session_id=PARENT_SESSION_ID),
+        seed_parent_inbox=False,
+        register_work=False,
+        parent_body=_parent_snapshot(parent_session_id="conv_top_level"),
+    )
+
+    assert http == 204
+    assert items == []
+    entry = runner_app.get_subagent_work(CHILD_SESSION_ID)
+    assert entry is not None
+    assert entry.status == "completed"
+    assert entry.delivered is False
 
 
 @pytest.mark.asyncio

--- a/tests/runner/test_native_subagent_inbox_delivery.py
+++ b/tests/runner/test_native_subagent_inbox_delivery.py
@@ -401,8 +401,9 @@ async def test_nested_subagent_parent_without_inbox_is_acked(
     Claude Code sub-agents can fan out further, and the forwarder mirrors the
     grandchildren under the mid-level child. That parent is never initialized
     on the runner, so its inbox never exists and a 503 only made the forwarder
-    retry every 30 s for the life of the runner. The entry stays terminal and
-    undelivered for the parent's own recovery scan.
+    retry every 30 s for the life of the runner; the result reaches the parent
+    natively inside the Claude process. The entry stays terminal and
+    undelivered so a parent that does run here later can still receive it.
     """
     http, items = await _post_native_idle(
         child_body=_child_snapshot(sub_agent_name="reviewer", parent_session_id=PARENT_SESSION_ID),


### PR DESCRIPTION
## Related issue

No linked issue. This is a separate runner defect found in the prod debug logs on 2026-09-10 while investigating chat-lag reports; it is not the fix for any existing ticket.

## Summary

When a claude-native sub-agent finishes, its forwarder posts `external_session_status idle`; the server forwards that to the child's runner, which must confirm delivery of the result into the **parent's** runner inbox. If the parent has no inbox on that runner, the runner answers `503 subagent_delivery_not_confirmed` so the forwarder keeps retrying until the inbox appears. That contract is right for a top-level parent that re-initializes after a restart or lives on another runner.

It never resolves for one parent shape: a parent that is itself a mirrored claude-native sub-agent. Claude Code sub-agents can fan out further (top session → mid-level child → grandchildren), the forwarder mirrors the grandchildren under the mid-level child, and mirrored children never go through `_initialize_session`, so that inbox never exists. Every sustained loop in prod on 2026-09-10 had this shape: one user's runner retried under a single mid-level parent for 7.3 h (6,005 attempts, still running at 17:30 PT), another had five such parents looping for 2.6 h each; ~11k attempts/day across 7 users, each a server + runner round trip, with `claude-native forward sync degraded` flapping 164 times in 13 sessions. The server also wraps the runner's 503 as `runner_unavailable`, so the forwarder's not-confirmed retry budget never engages and the loop runs for the life of the runner.

Fix, in two parts:

- When a tracked child's result cannot be delivered because the parent inbox is missing **and the parent's own snapshot names a parent** (it is a sub-agent), acknowledge with 204 and keep the work entry terminal and undelivered. A top-level parent, or an unreadable parent snapshot, keeps the 503 so the forwarder retries as before (restart, or a parent on another runner).
- If this runner later creates that parent's inbox (session init, or a `sys_read_inbox` drain), hand the retained terminal entries over and schedule the wake (`_deliver_retained_subagent_results`, called from `_recover_undrained_subagent_results`). That is what the forwarder's pending retry used to accomplish the moment the inbox appeared; restart recovery alone would not, because mirrored children carry no dispatch-id label and the recovery scan skips children that still have a local work entry.

What this deliberately does **not** do: a pure mirrored mid-level parent never runs on this runner, so its inbox never exists here and its grandchildren's retained entries are never delivered through the inbox path. That is acceptable for this topology because the inbox record is redundant: a nested claude-native sub-agent's result reaches its parent natively inside the single Claude process. The change drops a redundant mirror record and the retry storm, not user-visible data. The entry also lives only in process memory, so a runner restart loses it; the pre-fix retry died with the process too, so nothing that previously survived a restart is lost.

```text
before:  grandchild idle → server → runner: mid-level parent has no inbox → 503 → forwarder retries every 30s … forever
after:   grandchild idle → server → runner: parent is itself a sub-agent, no inbox here → 204 (entry kept terminal+undelivered)
         parent inbox created on this runner later (if ever) → retained entries delivered + wake, once
         top-level parent without inbox (restart / other runner) → 503 → retry, unchanged
```

ELI5: when a helper's helper finished, the runner refused to say "got it" until it could hand the result to the middle manager, but the middle manager never has a desk on that runner, so the messenger knocked every 30 seconds forever. Now the runner says "got it" for that case only; real bosses still get the retry.

## Test Plan

- New `test_nested_subagent_parent_without_inbox_is_acked` in `tests/runner/test_native_subagent_inbox_delivery.py`: parent snapshot names its own parent, no inbox, no registered work → 204, no inbox items, entry stays `completed` / `delivered=False`. New `test_retained_result_is_delivered_when_parent_inbox_is_created`: after that 204, creating the parent inbox on the same process delivers the result exactly once (a second creation is a no-op) and marks the entry delivered. The neighbouring `test_undeliverable_native_completion_returns_503_not_silent_204` (top-level parent elsewhere) still passes unchanged, as does `test_known_subagent_status_without_work_entry_returns_503`.
- `pytest tests/runner/test_native_subagent_inbox_delivery.py`: 18 passed on the final head; the supervision and terminal-routing suites passed on the previous head, and CI runs the full runner shard.
- `pre-commit` on the changed files: ruff, pyrefly, policy hooks pass.
- Prod verification after rollout: the runner line `Sub-agent work completed but parent inbox is missing` should appear at most once per grandchild completion, and the forwarder's `Failed to forward claude-native sub-agent status … http_status=503` should stop repeating:
  ```sql
  SELECT session_id, COUNT(*) FROM ai_devtools_prod.default.omnigent_debug_logs
  WHERE source = 'runner' AND message LIKE 'Sub-agent work completed but parent inbox is missing%'
    AND client_time > current_timestamp() - INTERVAL 1 HOUR GROUP BY 1 ORDER BY 2 DESC
  ```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Prod runner log, one grandchild, attempt counter climbing at the 30 s cap:

```text
13:42:41 _deliver_subagent_completion  Sub-agent work completed but parent inbox is missing; parent=860572132071721 child=1848829237704717
13:42:41 _forward_one_subagent         Failed to forward claude-native sub-agent status; child=1848829237704717 status=idle attempt=12 next_retry_s=30.000 http_status=503
13:43:11 … attempt=13 … 13:43:45 … attempt=14 … 13:44:16 … attempt=15 …  (continues until the runner exits)
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The new test drives the exact HTTP path the forwarder hits (`POST /v1/sessions/{child}/events` with `external_session_status idle`) through the runner's snapshot recovery, and the existing tests in the same file keep the retained 503 (top-level parent elsewhere, missing work entry) and the deliver-after-inbox-appears paths pinned.

## Changelog

A sub-agent finishing under a parent that is itself a sub-agent no longer makes the forwarder retry its status every 30 seconds indefinitely.
