### PR TITLE
fix(host): self-heal + name the cause on auth-rejected tunnel upgrades

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -411,6 +411,12 @@ _LOOPBACK_REFUSED_FATAL_ATTEMPTS = 100
 # keeps retrying and never exits.
 _AUTH_REJECT_ESCALATE_ATTEMPTS = 30
 
+# Min seconds between warnings when token acquisition raises. The reconnect
+# loop calls the token factory every few seconds, so a persistent failure is
+# logged at warning at most this often (debug in between) — visible without
+# flooding the log.
+_AUTH_TOKEN_ERROR_WARN_INTERVAL_S = 60.0
+
 # Consecutive accepted-then-silent connections (upgrade completed, then the
 # socket died without one inbound frame) before the reconnect loop treats the
 # endpoint as unhealthy: it stops using the prompt "recycle" cadence and
@@ -1460,9 +1466,20 @@ class HostProcess:
         body = " ".join(raw_body.decode("utf-8", "replace").split())
         if len(body) > _UPGRADE_BODY_MAX_CHARS:
             body = body[:_UPGRADE_BODY_MAX_CHARS] + "…"
-        return self._classify_http_status(exc.response.status_code, body)
+        # Databricks' workspace edge names the refusal reason in a response
+        # header (e.g. "Source IP address: … is blocked by Databricks IP ACL
+        # for workspace: …") — far more actionable than a bare status. Surface
+        # it so an IP-ACL block isn't mislabeled as a credential problem.
+        reason = ""
+        try:
+            reason = (exc.response.headers.get("x-databricks-reason-phrase") or "").strip()
+        except Exception:  # noqa: BLE001 — header extraction is best-effort
+            reason = ""
+        return self._classify_http_status(exc.response.status_code, body, reason=reason)
 
-    def _classify_http_status(self, status: int, body: str = "") -> HostConnectError | None:
+    def _classify_http_status(
+        self, status: int, body: str = "", *, reason: str = ""
+    ) -> HostConnectError | None:
         """Map a rejected-upgrade HTTP status to a fatal error, or ``None``.
 
         :param status: HTTP status on the failed WS upgrade response, e.g.
@@ -1471,6 +1488,10 @@ class HostProcess:
             (decoded, stripped). When present it is the authoritative,
             reason-specific explanation, so it is surfaced verbatim for statuses
             without their own client-actionable guidance.
+        :param reason: The edge's reason phrase (Databricks
+            ``x-databricks-reason-phrase`` header), when present. More specific
+            than ``body`` and preferred when naming the refusal cause — notably
+            a workspace IP-ACL block.
         :returns: A :class:`HostConnectError` for a permanent 4xx, or
             ``None`` for a transient status (retryable 4xx in
             :data:`_RETRYABLE_UPGRADE_STATUSES`, a 404 on a host that has
@@ -1478,6 +1499,12 @@ class HostProcess:
             non-4xx such as a 5xx server bounce) that the reconnect loop
             should retry.
         """
+        # The reason phrase (when present) is the most specific explanation;
+        # fall back to the body. An IP-ACL block is a network-location problem,
+        # not a credential one, so it retries and self-heals once the source IP
+        # is allowed — worth naming distinctly.
+        detail = (reason or body).strip()
+        ip_acl_blocked = "ip acl" in detail.lower() or "ip access" in detail.lower()
         if status in _RETRYABLE_UPGRADE_STATUSES or not (400 <= status < 500):
             return None
         if status == 404:
@@ -1485,19 +1512,36 @@ class HostProcess:
         if status in (401, 403):
             # Fresh hosts can race OAuth refresh; connected hosts preserve active sessions.
             self._auth_retry_streak += 1
-            cause = f"Connection refused (HTTP {status}): the host tunnel was rejected."
+            if ip_acl_blocked:
+                cause = f"Connection refused (HTTP {status}): {detail}."
+            else:
+                cause = f"Connection refused (HTTP {status}): the host tunnel was rejected."
             should_retry = self._ever_connected or (
                 self._auth_retry_streak < _MAX_CONSECUTIVE_AUTH_ERRORS
             )
             if should_retry:
-                # A sustained streak (vs. a brief VPN blip) means the credential
-                # is very likely permanently rejected: escalate the operator
-                # signal and name re-auth, but keep retrying so a real outage
-                # self-heals.
-                if (
+                escalate = (
                     self._auth_retry_streak >= _AUTH_REJECT_ESCALATE_ATTEMPTS
                     and self._auth_retry_streak % _AUTH_REJECT_ESCALATE_ATTEMPTS == 0
-                ):
+                )
+                if ip_acl_blocked:
+                    # A network-location block, not a credential problem:
+                    # connecting from an allowed IP (the VPN) heals it on the
+                    # next dial, so name the real cause and keep retrying.
+                    msg = (
+                        f"{cause} Your machine's source IP is not on the "
+                        "workspace's allow-list — connect to the VPN / an "
+                        "allowed network; it reconnects automatically once the "
+                        "IP is permitted."
+                    )
+                    _logger.warning("%s", msg)
+                    if escalate or self._auth_retry_streak == 1:
+                        print(f"⚠ {msg}", file=sys.stderr, flush=True)
+                elif escalate:
+                    # A sustained streak (vs. a brief VPN blip) means the
+                    # credential is very likely permanently rejected: escalate
+                    # the operator signal and name re-auth, but keep retrying so
+                    # a real outage self-heals.
                     escalated = (
                         f"{cause} The server has rejected it "
                         f"{self._auth_retry_streak} times in a row — this is no "
@@ -1531,6 +1575,12 @@ class HostProcess:
                 + self._login_fix_hint()
             )
         if status == 403:
+            if ip_acl_blocked:
+                return HostConnectError(
+                    f"Connection refused (HTTP 403): {detail}. Your machine's "
+                    "source IP is not on the workspace's allow-list. Connect to "
+                    "the VPN / an allowed network and retry."
+                )
             # An expired stored login is the common way to land here: the
             # token loader yields nothing, the dial goes out
             # unauthenticated, and the server's refusal looks like an
@@ -3869,7 +3919,22 @@ class HostProcess:
             if self._auth_token_factory is not None:
                 return self._auth_token_factory()
         except Exception:  # noqa: BLE001
-            _logger.debug("Could not obtain auth token", exc_info=True)
+            # Don't stay silent: a raised token-acquisition error otherwise
+            # returns None, the tunnel dials unauthenticated, and the server's
+            # refusal looks like an opaque 403/redirect with no breadcrumb.
+            # Rate-limit so a persistent failure on the ~3s reconnect loop
+            # surfaces without flooding the log.
+            now = time.monotonic()
+            last = getattr(self, "_auth_token_error_warned_at", 0.0)
+            if now - last >= _AUTH_TOKEN_ERROR_WARN_INTERVAL_S:
+                self._auth_token_error_warned_at = now
+                _logger.warning(
+                    "Could not obtain an auth token — dialing the tunnel "
+                    "unauthenticated; the server will likely reject it.",
+                    exc_info=True,
+                )
+            else:
+                _logger.debug("Could not obtain auth token", exc_info=True)
         return None
 
     async def _serve_frames(self, ws: websockets.asyncio.client.ClientConnection) -> None:

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -679,7 +679,14 @@ def _make_auth_token_factory(
                     sdk_auth, _host = _resolve_databricks_auth()
             except (DatabricksAuthError, ImportError, ValueError):
                 sdk_auth = None
-            sdk_auth_resolved = True
+            # Cache only a SUCCESSFUL resolution. A transient failure
+            # (a databricks CLI hiccup, the network down across a laptop
+            # suspend, a workspace IP-ACL window) must not latch ``None`` for
+            # the life of the factory — that wedges the process into dialing
+            # unauthenticated forever and only a restart clears it. Leaving the
+            # flag False re-resolves (a fresh ``Config``) on the next call, so
+            # the factory self-heals once credentials resolve again.
+            sdk_auth_resolved = sdk_auth is not None
         if sdk_auth is None:
             return None
         try:

--- a/tests/host/test_connect.py
+++ b/tests/host/test_connect.py
@@ -5286,6 +5286,79 @@ def test_post_connect_auth_rejection_escalates_without_going_fatal(
     assert host._auth_retry_streak == _AUTH_REJECT_ESCALATE_ATTEMPTS
 
 
+_IP_ACL_REASON = "Source IP address: 1.2.3.4 is blocked by Databricks IP ACL for workspace: 999"
+
+
+def test_ip_acl_403_names_reason_and_retries(capsys: pytest.CaptureFixture[str]) -> None:
+    """A 403 carrying a Databricks IP-ACL reason phrase is named, not mislabeled.
+
+    An IP-ACL block is a network-location problem — connecting from an allowed
+    IP heals it on the next dial — so it stays retryable (None) and the
+    operator message names the allow-list, not the generic "check your
+    VPN/network" credential hint.
+    """
+    host = _make_host_process()
+    host._ever_connected = True
+
+    assert host._classify_http_status(403, reason=_IP_ACL_REASON) is None
+    err = capsys.readouterr().err
+    assert "IP ACL" in err
+    assert "allow-list" in err
+    assert "network dropped" not in err  # not the generic credential message
+
+
+def test_ip_acl_403_fatal_message_names_allowlist_when_never_connected() -> None:
+    """A never-connected host that exhausts its retry budget on an IP-ACL 403
+    fails with a message naming the allow-list, not a credential/version guess.
+    """
+    from omnigent.host.connect import _MAX_CONSECUTIVE_AUTH_ERRORS, HostConnectError
+
+    host = _make_host_process()
+    host._ever_connected = False
+
+    result: HostConnectError | None = None
+    for _ in range(_MAX_CONSECUTIVE_AUTH_ERRORS):
+        result = host._classify_http_status(403, reason=_IP_ACL_REASON)
+    assert isinstance(result, HostConnectError)
+    assert "allow-list" in str(result)
+    assert "IP ACL" in str(result)
+
+
+def test_current_auth_token_warns_once_when_factory_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A raised token-acquisition error must surface (not stay debug-silent),
+    rate-limited so the ~3s reconnect loop doesn't flood the log.
+
+    Silence here is what turned a wedged host into an opaque 403 loop with no
+    breadcrumb — the factory error was swallowed at debug while the daemon ran
+    at info.
+    """
+    import logging
+
+    from omnigent.host.identity import HOST_TOKEN_ENV_VAR
+
+    monkeypatch.delenv(HOST_TOKEN_ENV_VAR, raising=False)
+    host = _make_host_process()
+
+    def _boom() -> str | None:
+        raise RuntimeError("token mint failed")
+
+    host._auth_token_factory = _boom
+    host._auth_token_factory_resolved = True
+
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        assert host._current_auth_token() is None
+    assert any("Could not obtain an auth token" in r.getMessage() for r in caplog.records)
+
+    # Rate-limited: an immediate second failure does not emit another warning.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="omnigent.host.connect"):
+        assert host._current_auth_token() is None
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
 async def test_launch_harness_probe_runs_off_the_event_loop(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/runner/test_runner_entry.py
+++ b/tests/runner/test_runner_entry.py
@@ -199,6 +199,67 @@ def test_make_auth_token_factory_returns_none_without_databricks_creds(
     assert _make_auth_token_factory() is None
 
 
+def test_sdk_token_resolution_failure_is_not_latched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient SDK-auth resolution failure must not latch ``None`` forever.
+
+    The factory is built while a stored OIDC token satisfies the probe, so the
+    Databricks ``_sdk_token`` path is not exercised at build. When the OIDC
+    token later lapses and the first fallback to ``_sdk_token`` hits a
+    transient resolution error, the NEXT call must re-resolve (build a fresh
+    ``Config``) rather than return ``None`` for the life of the factory — that
+    is what lets a long-lived host self-heal without a restart.
+    """
+    from omnigent.inner.databricks_executor import DatabricksAuthError, _DatabricksBearerAuth
+
+    server = "https://ws.example.com/api/2.0/omnigent"
+    for var in (
+        "RUNNER_SERVER_URL",
+        "RUNNER_INITIAL_AUTH_TOKEN",
+        "RUNNER_DELEGATED_AUTH",
+        "RUNNER_TUNNEL_BINDING_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    # OIDC token present at build (probe succeeds without _sdk_token), then
+    # lapses so later calls fall through to the Databricks SDK path.
+    oidc: dict[str, str | None] = {"token": "oidc-token"}
+
+    def _load_token(url: str, *, min_remaining_seconds: float = 0) -> str | None:
+        return oidc["token"]
+
+    monkeypatch.setattr("omnigent.cli_auth.load_token", _load_token)
+    monkeypatch.setattr("omnigent.cli_auth.refresh_stored_token", lambda url: None)
+    monkeypatch.setattr("omnigent.cli_auth.load_databricks_workspace_host", lambda url: None)
+
+    class _Cfg:
+        def authenticate(self) -> dict[str, str]:
+            return {"Authorization": "Bearer sdk-token"}
+
+    calls = {"n": 0}
+
+    def _resolve(profile: str | None = None) -> tuple[Any, str]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise DatabricksAuthError("transient resolution failure")
+        return _DatabricksBearerAuth(_Cfg(), profile_name=None), "https://ws.example.com"
+
+    monkeypatch.setattr("omnigent.inner.databricks_executor._resolve_databricks_auth", _resolve)
+
+    factory = _make_auth_token_factory(server_url=server)
+    assert factory is not None
+    assert factory() == "oidc-token"  # OIDC path; _sdk_token untouched
+
+    # OIDC lapses → fall to _sdk_token.
+    oidc["token"] = None
+    # First fallback resolution fails transiently...
+    assert factory() is None
+    # ...and it is NOT latched: the next call re-resolves and succeeds.
+    assert factory() == "sdk-token"
+    assert calls["n"] == 2
+
+
 def test_make_auth_token_factory_uses_managed_mint_when_only_binding_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Related issue

<!-- Surfaced while diagnosing a host daemon stuck in a 403 loop against a
Databricks-fronted server. No single tracked issue owns all three; related to
the 403-loop investigation (OMNI-6909). -->

N/A — hardening surfaced during a 403-loop investigation.

## Summary

When a host daemon's tunnel upgrade is rejected, three things went wrong that
this PR fixes independently:

1. **The real cause was hidden.** A Databricks workspace **IP-ACL block** (the
   edge rejecting your machine's source IP) arrives as a 403 with
   `x-databricks-reason-phrase: Source IP address … is blocked by Databricks IP
   ACL …`, but the daemon logged the generic *"check your VPN/network"* and
   never showed the header. `_fatal_upgrade_error` now reads that header and
   `_classify_http_status` names the block — and, because an IP-ACL block heals
   on the next dial from an allowed IP, keeps retrying with a message pointing
   at the VPN/allow-list. A never-connected host that exhausts its retry budget
   fails with the same named cause instead of a credential/version guess.

2. **A transient auth-resolution failure latched forever.**
   `_make_auth_token_factory._sdk_token` set `sdk_auth_resolved = True` even
   when `_resolve_databricks_auth` raised, pinning `None` for the life of the
   factory — so a process that hit a transient failure (CLI hiccup, network
   down across a laptop suspend, an IP-ACL window at first fallback) dialed
   unauthenticated **forever until restart**. Now it caches only a *successful*
   resolution, so the next call re-resolves a fresh `Config` and the factory
   self-heals.

3. **The token error was swallowed.** `_current_auth_token` caught any factory
   error at `debug` and returned `None`, so a wedged host looped on an opaque
   403 with no breadcrumb (the daemon runs at INFO). It now logs at `warning`,
   rate-limited to once per 60s, so the real cause is visible without flooding
   the ~3s reconnect loop.

Note on scope: the interactive `UserPromptSubmit` policy hook is a **fresh
subprocess per prompt** that builds a fresh token factory, so change #2 does
not apply to it — #2 targets the long-lived host daemon. #1 and #3 improve
diagnosis for both.

## Test Plan

- `pytest tests/host/test_connect.py -k "ip_acl or current_auth_token_warns"` —
  3 new tests: IP-ACL 403 is named + retried (not the generic hint), the
  never-connected fatal message names the allow-list, and a raised factory
  error warns once (rate-limited).
- `pytest tests/runner/test_runner_entry.py -k not_latched` — a transient
  `_sdk_token` resolution failure is retried on the next call, not latched.
- Full regression: `pytest tests/runner/test_runner_entry.py` (110 passed) and
  `tests/host/test_connect.py -k "classify or auth or upgrade or 403 or 404 or
  redirect or fatal"` (34 passed) — the `_classify_http_status` signature and
  retry-branch restructure don't regress existing behavior.
- ruff format + ruff check clean.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Before (INFO log, IP-ACL 403):

```
WARN host.connect …ify_http_status | Connection refused (HTTP 403): the host tunnel was rejected. Retrying — check your VPN/network.
```

After:

```
WARN host.connect …ify_http_status | Connection refused (HTTP 403): Source IP address: … is blocked by Databricks IP ACL for workspace: …. Your machine's source IP is not on the workspace's allow-list — connect to the VPN / an allowed network; it reconnects automatically once the IP is permitted.
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification: against the live `dbc-a5d4177a-49dc` workspace, confirmed
the 403 carried `x-databricks-reason-phrase: Source IP address … blocked by
Databricks IP ACL` (captured under `OMNIGENT_LOG_LEVEL=DEBUG`), that the block
self-heals once the source IP is allow-listed (a fresh token + allowed IP got
HTTP 101), and that token minting itself was never the problem — which is what
motivated naming the cause (#1) rather than blaming credentials.

## Changelog

Host daemon now names a Databricks IP-ACL block on a rejected tunnel (instead of a generic VPN hint), re-resolves credentials after a transient auth failure instead of staying wedged until restart, and no longer swallows the token error that caused an opaque 403 loop.

This pull request and its description were written by Isaac.
