### PR TITLE
feat(attachments): accept large images and compress them under the model limit

### DIFF
--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -133,13 +133,12 @@ _COMPRESSIBLE_IMAGE_MIMES: frozenset[str] = frozenset(
 
 # Pillow format names that legitimately back each compressible MIME. Used to
 # reject a spoofed extension (e.g. a TIFF/BMP labeled image/png) before we hand
-# 50 MB of untrusted bytes to an unintended decoder. Multi-picture JPEG (MPO)
-# is deliberately excluded: it reports n_frames >= 2, so admitting it would only
-# route it to the animation rejection with a confusing message — asking for a
-# plain JPEG here is clearer.
+# 50 MB of untrusted bytes to an unintended decoder. MPO (multi-picture JPEG,
+# common from phone/stereo cameras) is admitted for image/jpeg and flattened to
+# its primary frame — see the animation gate in compress_image_attachment.
 _ALLOWED_PIL_FORMATS: dict[str, frozenset[str]] = {
     "image/png": frozenset({"PNG"}),
-    "image/jpeg": frozenset({"JPEG"}),
+    "image/jpeg": frozenset({"JPEG", "MPO"}),
     "image/webp": frozenset({"WEBP"}),
     "image/gif": frozenset({"GIF"}),
 }
@@ -294,11 +293,12 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
 
     Already-small images (``<=`` budget) and non-raster types we don't compress
     (SVG, …) are returned unchanged. For still images we search largest-first:
-    alpha images try lossy then lossless WebP then PNG; opaque images try
-    descending-quality JPEG, downscaling the canvas when quality alone isn't
-    enough. An **animated** image over the budget is rejected: we can't
-    re-encode animation, and storing it uncompressed would just fail at the
-    provider at turn time.
+    alpha images try lossy then lossless WebP then PNG; opaque images try WebP
+    (crisper on text than JPEG) then fall back to JPEG, downscaling the canvas
+    when quality alone isn't enough. A multi-picture JPEG (MPO) is flattened to
+    its primary frame. A truly **animated** image over the budget is rejected:
+    we can't re-encode animation, and storing it uncompressed would just fail at
+    the provider at turn time.
 
     :param content: Raw uploaded image bytes.
     :param content_type: The resolved image MIME (``image/*``).
@@ -333,10 +333,13 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
             # ~89 MP warning), so no warnings.catch_warnings() is needed.
             if probe.width * probe.height > IMAGE_MAX_DECODED_PIXELS:
                 raise ImageCompressionError("the image's dimensions are too large to process")
+            probe_format = probe.format
             n_frames = int(getattr(probe, "n_frames", 1))
-        # Animation can't be re-encoded here, and it's over budget, so it
-        # would be rejected by the provider at turn time — reject cleanly now.
-        if n_frames != 1:
+        # True animation can't be re-encoded here and would be rejected by the
+        # provider at turn time — reject cleanly now. MPO is multi-frame but not
+        # animation (its extra frames are alternate stills), so we keep its
+        # primary frame (Image.open positions at frame 0) and compress that.
+        if n_frames != 1 and probe_format != "MPO":
             raise ImageCompressionError(
                 "this animated image is too large to attach; upload a smaller "
                 "or static image instead"
@@ -374,9 +377,13 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
             )
         else:
             base = image.convert("RGB")
-            _encodings = tuple(
-                ("JPEG", "image/jpeg", {"quality": q, "optimize": True, "progressive": True})
-                for q in (85, 70, 55)
+            # WebP first: at a comparable budget it keeps fine text/UI detail
+            # crisper than JPEG (which rings on screenshots), and providers
+            # accept WebP. JPEG is the final fallback.
+            _encodings = (
+                ("WEBP", "image/webp", {"quality": 82, "method": 4}),
+                ("WEBP", "image/webp", {"quality": 68, "method": 4}),
+                ("JPEG", "image/jpeg", {"quality": 75, "optimize": True, "progressive": True}),
             )
 
         # Pre-shrink an oversized canvas to the edge cap before the quality search.

--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -111,6 +111,20 @@ MAX_PDF_UPLOAD_BYTES: int = 20 * 1024 * 1024
 MAX_TEXT_UPLOAD_BYTES: int = 10 * 1024 * 1024
 MAX_ATTACHMENT_UPLOAD_BYTES: int = 50 * 1024 * 1024
 
+# The larger image cap only applies to raster formats we can actually shrink
+# (see _COMPRESSIBLE_IMAGE_MIMES). Other image types — SVG and any vector /
+# exotic format Pillow can't re-encode for us — keep this conservative cap and
+# skip compression: raising their cap would let an oversized one slip through
+# to the provider uncompressed. This is the pre-compression image limit.
+IMAGE_UNCOMPRESSED_UPLOAD_BYTES: int = 5 * 1024 * 1024
+
+# Raster image MIMEs compress_image_attachment can decode and re-encode. Only
+# these get MAX_IMAGE_UPLOAD_BYTES; everything else image/* is capped at
+# IMAGE_UNCOMPRESSED_UPLOAD_BYTES and passed through untouched.
+_COMPRESSIBLE_IMAGE_MIMES: frozenset[str] = frozenset(
+    {"image/png", "image/jpeg", "image/webp", "image/gif"}
+)
+
 # Budget an image's stored/inlined bytes must fit after compression. Kept
 # under Anthropic's ~5 MB per-image ceiling with headroom for the data-URI
 # wrapper and base64 metadata. Large uploads are downscaled / re-encoded to
@@ -166,6 +180,12 @@ def attachment_upload_limit(content_type: str) -> int | None:
     them only produces garbled UTF-8 or — for large files — an oversized,
     context-blowing request. Callers reject ``None`` with HTTP 415.
 
+    Compressible raster images (PNG, JPEG, WebP, GIF) get the large
+    :data:`MAX_IMAGE_UPLOAD_BYTES` cap because an oversized one is shrunk
+    under the model budget at upload; other image types (SVG, …) keep the
+    smaller :data:`IMAGE_UNCOMPRESSED_UPLOAD_BYTES` cap since we can't shrink
+    them.
+
     :param content_type: The resolved MIME type, e.g. ``"image/png"``.
         Use :func:`_resolve_content_type` to derive it from the upload's
         declared type + filename first.
@@ -174,7 +194,9 @@ def attachment_upload_limit(content_type: str) -> int | None:
         not an allowed attachment.
     """
     if content_type.startswith("image/"):
-        return MAX_IMAGE_UPLOAD_BYTES
+        if content_type in _COMPRESSIBLE_IMAGE_MIMES:
+            return MAX_IMAGE_UPLOAD_BYTES
+        return IMAGE_UNCOMPRESSED_UPLOAD_BYTES
     if content_type == "application/pdf":
         return MAX_PDF_UPLOAD_BYTES
     if content_type.startswith("text/") or content_type in _TEXT_LIKE_APPLICATION_MIMES:
@@ -237,27 +259,32 @@ def _encode_image(image: Any, image_format: str, **params: Any) -> bytes:
 def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes, str]:
     """Shrink a raster image so its bytes fit :data:`IMAGE_MODEL_BUDGET_BYTES`.
 
-    Images upload at the larger :data:`MAX_IMAGE_UPLOAD_BYTES`, but every
-    attachment is inlined as base64 into each turn's request, so a big image
-    would blow past the provider's per-image limit. This downscales and/or
-    re-encodes the image to fit the model budget, keeping it a valid in-place
-    attachment (the compressed bytes are what get stored).
+    Compressible raster images upload at the larger
+    :data:`MAX_IMAGE_UPLOAD_BYTES`, but every attachment is inlined as base64
+    into each turn's request, so a big image would blow past the provider's
+    per-image limit. This downscales and/or re-encodes the image to fit the
+    model budget, keeping it a valid in-place attachment (the compressed bytes
+    are what get stored).
 
-    Already-small images (``<=`` budget) and animated images (multi-frame
-    GIF/WebP — re-encoding animation safely is out of scope) are returned
-    unchanged. For still images we search largest-first: alpha images try
-    lossy then lossless WebP then PNG; opaque images try descending-quality
-    JPEG, downscaling the canvas when quality alone isn't enough.
+    Already-small images (``<=`` budget) and non-raster types we don't compress
+    (SVG, …) are returned unchanged. For still images we search largest-first:
+    alpha images try lossy then lossless WebP then PNG; opaque images try
+    descending-quality JPEG, downscaling the canvas when quality alone isn't
+    enough. An **animated** image over the budget is rejected: we can't
+    re-encode animation, and storing it uncompressed would just fail at the
+    provider at turn time.
 
     :param content: Raw uploaded image bytes.
     :param content_type: The resolved image MIME (``image/*``).
     :returns: ``(bytes, content_type)`` — the (possibly re-encoded) image and
         its MIME. For a decodable still image the bytes are ``<=`` the budget;
         the content_type may change (e.g. ``image/png`` → ``image/jpeg``).
-    :raises ImageCompressionError: If the bytes don't decode as an image, or
-        can't be brought under the budget.
+    :raises ImageCompressionError: If the bytes don't decode as an image, are
+        an oversized animation, or can't be brought under the budget. The
+        message is safe to surface to the client (no raw decoder text).
     """
-    if len(content) <= IMAGE_MODEL_BUDGET_BYTES:
+    # Small enough already, or a type we don't compress (SVG etc.): leave as-is.
+    if len(content) <= IMAGE_MODEL_BUDGET_BYTES or content_type not in _COMPRESSIBLE_IMAGE_MIMES:
         return content, content_type
 
     import warnings
@@ -271,11 +298,14 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
             with Image.open(BytesIO(content)) as probe:
                 n_frames = int(getattr(probe, "n_frames", 1))
                 if probe.width * probe.height > IMAGE_MAX_DECODED_PIXELS:
-                    raise ImageCompressionError("image dimensions are too large to process")
-            # Multi-frame (animated) images are left untouched; the upload cap
-            # still bounds them.
+                    raise ImageCompressionError("the image's dimensions are too large to process")
+            # Animation can't be re-encoded here, and it's over budget, so it
+            # would be rejected by the provider at turn time — reject cleanly now.
             if n_frames != 1:
-                return content, content_type
+                raise ImageCompressionError(
+                    "this animated image is too large to attach; upload a smaller "
+                    "or static image instead"
+                )
             with Image.open(BytesIO(content)) as opened:
                 image = ImageOps.exif_transpose(opened)
                 image.load()
@@ -289,7 +319,7 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
         SyntaxError,
         ValueError,
     ) as exc:
-        raise ImageCompressionError(f"could not decode image: {exc}") from exc
+        raise ImageCompressionError("the file is not a readable image") from exc
 
     has_alpha = image.mode in ("RGBA", "LA") or (
         image.mode == "P" and "transparency" in image.info
@@ -299,8 +329,8 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
 
         def _candidates(frame: Any) -> list[tuple[bytes, str]]:
             return [
-                (_encode_image(frame, "WEBP", quality=85, method=4), "image/webp"),
-                (_encode_image(frame, "WEBP", quality=70, method=4), "image/webp"),
+                (_encode_image(frame, "WEBP", quality=80, method=4), "image/webp"),
+                (_encode_image(frame, "WEBP", quality=60, method=4), "image/webp"),
                 (_encode_image(frame, "PNG", optimize=True), "image/png"),
             ]
     else:
@@ -312,7 +342,7 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
                     _encode_image(frame, "JPEG", quality=q, optimize=True, progressive=True),
                     "image/jpeg",
                 )
-                for q in (88, 80, 72, 62, 50)
+                for q in (85, 70, 55)
             ]
 
     # Pre-shrink an oversized canvas to the edge cap before the quality search.
@@ -324,7 +354,9 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
             Image.Resampling.LANCZOS,
         )
 
-    for scale in (1.0, 0.75, 0.5, 0.375, 0.25):
+    # Largest-first over a small scale/quality grid (≤ 3 scales × 3 encodings)
+    # so a worst-case (incompressible) upload can't fan out into many encodes.
+    for scale in (1.0, 0.5, 0.25):
         if scale == 1.0:
             frame = base
         else:
@@ -336,7 +368,7 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
             if len(data) <= IMAGE_MODEL_BUDGET_BYTES:
                 return data, mime
 
-    raise ImageCompressionError("image could not be compressed under the model size budget")
+    raise ImageCompressionError("the image couldn't be compressed to a supported size")
 
 
 # Extensions accepted as text/code attachments even when the upload's

--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -127,10 +127,13 @@ _COMPRESSIBLE_IMAGE_MIMES: frozenset[str] = frozenset(
 
 # Pillow format names that legitimately back each compressible MIME. Used to
 # reject a spoofed extension (e.g. a TIFF/BMP labeled image/png) before we hand
-# 50 MB of untrusted bytes to an unintended decoder. MPO is multi-picture JPEG.
+# 50 MB of untrusted bytes to an unintended decoder. Multi-picture JPEG (MPO)
+# is deliberately excluded: it reports n_frames >= 2, so admitting it would only
+# route it to the animation rejection with a confusing message — asking for a
+# plain JPEG here is clearer.
 _ALLOWED_PIL_FORMATS: dict[str, frozenset[str]] = {
     "image/png": frozenset({"PNG"}),
-    "image/jpeg": frozenset({"JPEG", "MPO"}),
+    "image/jpeg": frozenset({"JPEG"}),
     "image/webp": frozenset({"WEBP"}),
     "image/gif": frozenset({"GIF"}),
 }
@@ -305,40 +308,40 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
     if len(content) <= IMAGE_MODEL_BUDGET_BYTES or content_type not in _COMPRESSIBLE_IMAGE_MIMES:
         return content, content_type
 
-    import warnings
     from io import BytesIO
 
     from PIL import Image, ImageOps, UnidentifiedImageError
 
     try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", Image.DecompressionBombWarning)
-            with Image.open(BytesIO(content)) as probe:
-                # Reject a spoofed extension before decoding: the real container
-                # (probe.format, from the header) must match the declared MIME,
-                # so a TIFF/BMP-as-png can't select an unintended 50 MB decoder.
-                if probe.format not in _ALLOWED_PIL_FORMATS.get(content_type, frozenset()):
-                    raise ImageCompressionError("the file is not a readable image")
-                # Cheap header dimensions first — bail before walking frames
-                # (n_frames enumerates every GIF frame).
-                if probe.width * probe.height > IMAGE_MAX_DECODED_PIXELS:
-                    raise ImageCompressionError("the image's dimensions are too large to process")
-                n_frames = int(getattr(probe, "n_frames", 1))
-            # Animation can't be re-encoded here, and it's over budget, so it
-            # would be rejected by the provider at turn time — reject cleanly now.
-            if n_frames != 1:
+        with Image.open(BytesIO(content)) as probe:
+            # Reject a spoofed extension before decoding: the real container
+            # (probe.format, from the header) must match the declared MIME,
+            # so a TIFF/BMP-as-png can't select an unintended 50 MB decoder.
+            if probe.format not in _ALLOWED_PIL_FORMATS.get(content_type, frozenset()):
                 raise ImageCompressionError(
-                    "this animated image is too large to attach; upload a smaller "
-                    "or static image instead"
+                    "this image format can't be resized; upload a PNG, JPEG, WebP, or GIF"
                 )
-            with Image.open(BytesIO(content)) as opened:
-                image = ImageOps.exif_transpose(opened)
-                image.load()
+            # Cheap header dimensions first — bail before walking frames
+            # (n_frames enumerates every GIF frame). This deterministic area
+            # check is the decompression-bomb guard (fires below Pillow's own
+            # ~89 MP warning), so no warnings.catch_warnings() is needed.
+            if probe.width * probe.height > IMAGE_MAX_DECODED_PIXELS:
+                raise ImageCompressionError("the image's dimensions are too large to process")
+            n_frames = int(getattr(probe, "n_frames", 1))
+        # Animation can't be re-encoded here, and it's over budget, so it
+        # would be rejected by the provider at turn time — reject cleanly now.
+        if n_frames != 1:
+            raise ImageCompressionError(
+                "this animated image is too large to attach; upload a smaller "
+                "or static image instead"
+            )
+        with Image.open(BytesIO(content)) as opened:
+            image = ImageOps.exif_transpose(opened)
+            image.load()
     except ImageCompressionError:
         raise
     except (
         Image.DecompressionBombError,
-        Image.DecompressionBombWarning,
         UnidentifiedImageError,
         OSError,
         SyntaxError,

--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -125,6 +125,16 @@ _COMPRESSIBLE_IMAGE_MIMES: frozenset[str] = frozenset(
     {"image/png", "image/jpeg", "image/webp", "image/gif"}
 )
 
+# Pillow format names that legitimately back each compressible MIME. Used to
+# reject a spoofed extension (e.g. a TIFF/BMP labeled image/png) before we hand
+# 50 MB of untrusted bytes to an unintended decoder. MPO is multi-picture JPEG.
+_ALLOWED_PIL_FORMATS: dict[str, frozenset[str]] = {
+    "image/png": frozenset({"PNG"}),
+    "image/jpeg": frozenset({"JPEG", "MPO"}),
+    "image/webp": frozenset({"WEBP"}),
+    "image/gif": frozenset({"GIF"}),
+}
+
 # Budget for an image's RAW stored bytes after compression. The stored blob is
 # re-encoded as a base64 data URI on every turn (see _resolve_file_id_block),
 # which inflates it ~4/3, and providers apply the ~5 MB per-image ceiling to
@@ -247,7 +257,11 @@ def image_filename_for_content_type(filename: str, content_type: str) -> str:
     path = PurePosixPath(filename)
     if path.suffix.lower() == target:
         return filename
-    return str(path.with_suffix(target))
+    try:
+        return str(path.with_suffix(target))
+    except ValueError:
+        # Names like "." / ".." have no stem for with_suffix; keep as-is.
+        return filename
 
 
 def _encode_image(image: Any, image_format: str, **params: Any) -> bytes:
@@ -280,8 +294,9 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
     :param content: Raw uploaded image bytes.
     :param content_type: The resolved image MIME (``image/*``).
     :returns: ``(bytes, content_type)`` — the (possibly re-encoded) image and
-        its MIME. For a decodable still image the bytes are ``<=`` the budget;
-        the content_type may change (e.g. ``image/png`` → ``image/jpeg``).
+        its MIME, with the bytes ``<=`` the budget; the content_type may change
+        (e.g. ``image/png`` → ``image/jpeg``). A high-entropy image that can't
+        reach the budget even at the smallest scale/quality raises instead.
     :raises ImageCompressionError: If the bytes don't decode as an image, are
         an oversized animation, or can't be brought under the budget. The
         message is safe to surface to the client (no raw decoder text).
@@ -299,9 +314,16 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
         with warnings.catch_warnings():
             warnings.simplefilter("error", Image.DecompressionBombWarning)
             with Image.open(BytesIO(content)) as probe:
-                n_frames = int(getattr(probe, "n_frames", 1))
+                # Reject a spoofed extension before decoding: the real container
+                # (probe.format, from the header) must match the declared MIME,
+                # so a TIFF/BMP-as-png can't select an unintended 50 MB decoder.
+                if probe.format not in _ALLOWED_PIL_FORMATS.get(content_type, frozenset()):
+                    raise ImageCompressionError("the file is not a readable image")
+                # Cheap header dimensions first — bail before walking frames
+                # (n_frames enumerates every GIF frame).
                 if probe.width * probe.height > IMAGE_MAX_DECODED_PIXELS:
                     raise ImageCompressionError("the image's dimensions are too large to process")
+                n_frames = int(getattr(probe, "n_frames", 1))
             # Animation can't be re-encoded here, and it's over budget, so it
             # would be rejected by the provider at turn time — reject cleanly now.
             if n_frames != 1:
@@ -324,9 +346,11 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
     ) as exc:
         raise ImageCompressionError("the file is not a readable image") from exc
 
-    has_alpha = image.mode in ("RGBA", "LA") or (
-        image.mode == "P" and "transparency" in image.info
-    )
+    # Detect alpha broadly: RGBA/LA modes, and RGB/L/P images carrying a tRNS
+    # chunk (Pillow exposes it as image.info["transparency"] without changing
+    # the mode) — routing them through the alpha branch avoids flattening
+    # transparency to JPEG.
+    has_alpha = image.mode in ("RGBA", "LA") or "transparency" in image.info
     if has_alpha:
         base = image.convert("RGBA")
         # Alpha-preserving encoders, best-compression first. Generated lazily so

--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -97,8 +97,7 @@ _EXTRA_MIME_TYPES: dict[str, str] = {
 # bounded well under the model's context budget and the provider's API
 # limits — Anthropic accepts images up to ~5 MB, PDFs up to ~32 MB / 100
 # pages, and ~32 MB per request total. The per-type caps below keep a
-# single attachment usable across a multi-turn conversation; the global
-# ceiling backstops the total request size after base64 inflation (~1.33x).
+# single attachment usable across a multi-turn conversation.
 #
 # Images are the exception: we accept a much larger upload (screenshots,
 # retina captures) and shrink it under the provider's per-image limit at
@@ -109,13 +108,20 @@ _EXTRA_MIME_TYPES: dict[str, str] = {
 MAX_IMAGE_UPLOAD_BYTES: int = 50 * 1024 * 1024
 MAX_PDF_UPLOAD_BYTES: int = 20 * 1024 * 1024
 MAX_TEXT_UPLOAD_BYTES: int = 10 * 1024 * 1024
+# Per-attachment read cap, not an aggregate one. It is applied as
+# ``min(type_limit, MAX_ATTACHMENT_UPLOAD_BYTES)``: only compressible images
+# reach 50 MB (then shrink to <= IMAGE_MODEL_BUDGET_BYTES before storage);
+# PDF/text keep their smaller per-type caps. So this is no longer a sub-32 MB
+# request backstop — nothing oversized is stored because images are compressed.
 MAX_ATTACHMENT_UPLOAD_BYTES: int = 50 * 1024 * 1024
 
 # The larger image cap only applies to raster formats we can actually shrink
-# (see _COMPRESSIBLE_IMAGE_MIMES). Other image types — SVG and any vector /
-# exotic format Pillow can't re-encode for us — keep this conservative cap and
-# skip compression: raising their cap would let an oversized one slip through
-# to the provider uncompressed. This is the pre-compression image limit.
+# (see _COMPRESSIBLE_IMAGE_MIMES). Other image types (SVG, and raster formats we
+# don't re-encode like BMP/TIFF) keep this smaller cap and skip compression, so
+# raising the image cap can't let an oversized uncompressed one through. Note a
+# file near this cap still inflates to ~6.6 MB base64 — over the provider's
+# per-image ceiling — but these formats generally aren't valid model image
+# inputs anyway; this is the pre-existing behavior for uncompressed images.
 IMAGE_UNCOMPRESSED_UPLOAD_BYTES: int = 5 * 1024 * 1024
 
 # Raster image MIMEs compress_image_attachment can decode and re-encode. Only
@@ -349,40 +355,42 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
     ) as exc:
         raise ImageCompressionError("the file is not a readable image") from exc
 
-    # Detect alpha broadly: RGBA/LA modes, and RGB/L/P images carrying a tRNS
-    # chunk (Pillow exposes it as image.info["transparency"] without changing
-    # the mode) — routing them through the alpha branch avoids flattening
-    # transparency to JPEG.
-    has_alpha = image.mode in ("RGBA", "LA") or "transparency" in image.info
-    if has_alpha:
-        base = image.convert("RGBA")
-        # Alpha-preserving encoders, best-compression first. Generated lazily so
-        # the search stops at the first candidate that fits.
-        _encodings: tuple[tuple[str, str, dict[str, Any]], ...] = (
-            ("WEBP", "image/webp", {"quality": 80, "method": 4}),
-            ("WEBP", "image/webp", {"quality": 60, "method": 4}),
-            ("PNG", "image/png", {"optimize": True}),
-        )
-    else:
-        base = image.convert("RGB")
-        _encodings = tuple(
-            ("JPEG", "image/jpeg", {"quality": q, "optimize": True, "progressive": True})
-            for q in (85, 70, 55)
-        )
-
-    # Pre-shrink an oversized canvas to the edge cap before the quality search.
-    longest = max(base.width, base.height)
-    if longest > IMAGE_MAX_EDGE_PX:
-        factor = IMAGE_MAX_EDGE_PX / longest
-        base = base.resize(
-            (max(1, round(base.width * factor)), max(1, round(base.height * factor))),
-            Image.Resampling.LANCZOS,
-        )
-
-    # Largest-first over a small scale/quality grid (≤ 3 scales × 3 encodings),
-    # encoding one candidate at a time and returning at the first that fits, so a
-    # worst-case (incompressible) upload can't fan out into many eager encodes.
+    # convert(), the pre-shrink resize(), and every encode share one try so a
+    # Pillow error anywhere in re-encoding becomes a clean 413, never a 500.
     try:
+        # Detect alpha broadly: RGBA/LA modes, and RGB/L/P images carrying a
+        # tRNS chunk (Pillow exposes it as image.info["transparency"] without
+        # changing the mode) — routing them through the alpha branch avoids
+        # flattening transparency to JPEG.
+        has_alpha = image.mode in ("RGBA", "LA") or "transparency" in image.info
+        if has_alpha:
+            base = image.convert("RGBA")
+            # Alpha-preserving encoders, best-compression first. Tried lazily so
+            # the search stops at the first candidate that fits.
+            _encodings: tuple[tuple[str, str, dict[str, Any]], ...] = (
+                ("WEBP", "image/webp", {"quality": 80, "method": 4}),
+                ("WEBP", "image/webp", {"quality": 60, "method": 4}),
+                ("PNG", "image/png", {"optimize": True}),
+            )
+        else:
+            base = image.convert("RGB")
+            _encodings = tuple(
+                ("JPEG", "image/jpeg", {"quality": q, "optimize": True, "progressive": True})
+                for q in (85, 70, 55)
+            )
+
+        # Pre-shrink an oversized canvas to the edge cap before the quality search.
+        longest = max(base.width, base.height)
+        if longest > IMAGE_MAX_EDGE_PX:
+            factor = IMAGE_MAX_EDGE_PX / longest
+            base = base.resize(
+                (max(1, round(base.width * factor)), max(1, round(base.height * factor))),
+                Image.Resampling.LANCZOS,
+            )
+
+        # Largest-first over a small scale/quality grid (≤ 3 scales × 3 encodings),
+        # encoding one candidate at a time and returning at the first that fits, so
+        # a worst-case (incompressible) upload can't fan out into many eager encodes.
         for scale in (1.0, 0.5, 0.25):
             if scale == 1.0:
                 frame = base
@@ -396,7 +404,7 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
                 if len(data) <= IMAGE_MODEL_BUDGET_BYTES:
                     return data, mime
     except (OSError, ValueError) as exc:
-        # A Pillow encode error becomes a clean 413, not an unhandled 500.
+        # A Pillow convert/resize/encode error becomes a clean 413, not a 500.
         raise ImageCompressionError("the image couldn't be re-encoded") from exc
 
     raise ImageCompressionError("the image couldn't be compressed to a supported size")

--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -125,16 +125,19 @@ _COMPRESSIBLE_IMAGE_MIMES: frozenset[str] = frozenset(
     {"image/png", "image/jpeg", "image/webp", "image/gif"}
 )
 
-# Budget an image's stored/inlined bytes must fit after compression. Kept
-# under Anthropic's ~5 MB per-image ceiling with headroom for the data-URI
-# wrapper and base64 metadata. Large uploads are downscaled / re-encoded to
-# land under this; a decodable still image always ends up at or below it.
-IMAGE_MODEL_BUDGET_BYTES: int = 4_500_000
+# Budget for an image's RAW stored bytes after compression. The stored blob is
+# re-encoded as a base64 data URI on every turn (see _resolve_file_id_block),
+# which inflates it ~4/3, and providers apply the ~5 MB per-image ceiling to
+# that encoded payload. So the raw budget is 5 MB / (4/3) with headroom for the
+# data-URI wrapper: 3.5 MB raw → ~4.7 MB encoded, safely under 5 MB. A decodable
+# still image always ends up at or below the raw budget.
+IMAGE_MODEL_BUDGET_BYTES: int = 3_500_000
 
 # Longest-edge cap applied before the quality search when re-encoding an
-# oversized image. 8K covers 5K/retina screenshots at full resolution;
-# anything larger is scaled down to this first.
-IMAGE_MAX_EDGE_PX: int = 8192
+# oversized image. Matches the provider's documented 8000 px max edge (an image
+# already under this is left at native resolution); anything larger is scaled
+# down to this first.
+IMAGE_MAX_EDGE_PX: int = 8000
 
 # Decompression-bomb guard: refuse to decode images whose pixel area is
 # implausibly large for a real screenshot/photo.
@@ -326,24 +329,19 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
     )
     if has_alpha:
         base = image.convert("RGBA")
-
-        def _candidates(frame: Any) -> list[tuple[bytes, str]]:
-            return [
-                (_encode_image(frame, "WEBP", quality=80, method=4), "image/webp"),
-                (_encode_image(frame, "WEBP", quality=60, method=4), "image/webp"),
-                (_encode_image(frame, "PNG", optimize=True), "image/png"),
-            ]
+        # Alpha-preserving encoders, best-compression first. Generated lazily so
+        # the search stops at the first candidate that fits.
+        _encodings: tuple[tuple[str, str, dict[str, Any]], ...] = (
+            ("WEBP", "image/webp", {"quality": 80, "method": 4}),
+            ("WEBP", "image/webp", {"quality": 60, "method": 4}),
+            ("PNG", "image/png", {"optimize": True}),
+        )
     else:
         base = image.convert("RGB")
-
-        def _candidates(frame: Any) -> list[tuple[bytes, str]]:
-            return [
-                (
-                    _encode_image(frame, "JPEG", quality=q, optimize=True, progressive=True),
-                    "image/jpeg",
-                )
-                for q in (85, 70, 55)
-            ]
+        _encodings = tuple(
+            ("JPEG", "image/jpeg", {"quality": q, "optimize": True, "progressive": True})
+            for q in (85, 70, 55)
+        )
 
     # Pre-shrink an oversized canvas to the edge cap before the quality search.
     longest = max(base.width, base.height)
@@ -354,19 +352,25 @@ def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes,
             Image.Resampling.LANCZOS,
         )
 
-    # Largest-first over a small scale/quality grid (≤ 3 scales × 3 encodings)
-    # so a worst-case (incompressible) upload can't fan out into many encodes.
-    for scale in (1.0, 0.5, 0.25):
-        if scale == 1.0:
-            frame = base
-        else:
-            frame = base.resize(
-                (max(1, round(base.width * scale)), max(1, round(base.height * scale))),
-                Image.Resampling.LANCZOS,
-            )
-        for data, mime in _candidates(frame):
-            if len(data) <= IMAGE_MODEL_BUDGET_BYTES:
-                return data, mime
+    # Largest-first over a small scale/quality grid (≤ 3 scales × 3 encodings),
+    # encoding one candidate at a time and returning at the first that fits, so a
+    # worst-case (incompressible) upload can't fan out into many eager encodes.
+    try:
+        for scale in (1.0, 0.5, 0.25):
+            if scale == 1.0:
+                frame = base
+            else:
+                frame = base.resize(
+                    (max(1, round(base.width * scale)), max(1, round(base.height * scale))),
+                    Image.Resampling.LANCZOS,
+                )
+            for image_format, mime, params in _encodings:
+                data = _encode_image(frame, image_format, **params)
+                if len(data) <= IMAGE_MODEL_BUDGET_BYTES:
+                    return data, mime
+    except (OSError, ValueError) as exc:
+        # A Pillow encode error becomes a clean 413, not an unhandled 500.
+        raise ImageCompressionError("the image couldn't be re-encoded") from exc
 
     raise ImageCompressionError("the image couldn't be compressed to a supported size")
 

--- a/omnigent/runtime/content_resolver.py
+++ b/omnigent/runtime/content_resolver.py
@@ -99,11 +99,32 @@ _EXTRA_MIME_TYPES: dict[str, str] = {
 # pages, and ~32 MB per request total. The per-type caps below keep a
 # single attachment usable across a multi-turn conversation; the global
 # ceiling backstops the total request size after base64 inflation (~1.33x).
+#
+# Images are the exception: we accept a much larger upload (screenshots,
+# retina captures) and shrink it under the provider's per-image limit at
+# upload time via :func:`compress_image_attachment`, so the stored blob —
+# and the base64 re-sent every turn — always fits. The compressed result is
+# what lands in the file store (see the ``files`` upload route).
 # Mirrored client-side in web/src/lib/attachments.ts — keep in sync.
-MAX_IMAGE_UPLOAD_BYTES: int = 5 * 1024 * 1024
+MAX_IMAGE_UPLOAD_BYTES: int = 50 * 1024 * 1024
 MAX_PDF_UPLOAD_BYTES: int = 20 * 1024 * 1024
 MAX_TEXT_UPLOAD_BYTES: int = 10 * 1024 * 1024
-MAX_ATTACHMENT_UPLOAD_BYTES: int = 25 * 1024 * 1024
+MAX_ATTACHMENT_UPLOAD_BYTES: int = 50 * 1024 * 1024
+
+# Budget an image's stored/inlined bytes must fit after compression. Kept
+# under Anthropic's ~5 MB per-image ceiling with headroom for the data-URI
+# wrapper and base64 metadata. Large uploads are downscaled / re-encoded to
+# land under this; a decodable still image always ends up at or below it.
+IMAGE_MODEL_BUDGET_BYTES: int = 4_500_000
+
+# Longest-edge cap applied before the quality search when re-encoding an
+# oversized image. 8K covers 5K/retina screenshots at full resolution;
+# anything larger is scaled down to this first.
+IMAGE_MAX_EDGE_PX: int = 8192
+
+# Decompression-bomb guard: refuse to decode images whose pixel area is
+# implausibly large for a real screenshot/photo.
+IMAGE_MAX_DECODED_PIXELS: int = 64 * 1024 * 1024
 
 # Copy-at-spawn limits (see the ``files:copy`` endpoint). A parent forwarding
 # files to a subagent copies them through the server, which reads each source
@@ -159,6 +180,163 @@ def attachment_upload_limit(content_type: str) -> int | None:
     if content_type.startswith("text/") or content_type in _TEXT_LIKE_APPLICATION_MIMES:
         return MAX_TEXT_UPLOAD_BYTES
     return None
+
+
+class ImageCompressionError(ValueError):
+    """An image attachment could not be shrunk under the model size budget.
+
+    Raised when the bytes don't decode as an image, or when even the smallest
+    downscale/quality still exceeds :data:`IMAGE_MODEL_BUDGET_BYTES`. Callers
+    reject it with HTTP 413.
+    """
+
+
+# Filename extension for each image type we emit from compression, so a
+# re-encoded attachment's name matches its bytes.
+_IMAGE_CONTENT_TYPE_EXTENSIONS: dict[str, str] = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
+
+
+def image_filename_for_content_type(filename: str, content_type: str) -> str:
+    """Return *filename* with an extension matching *content_type*.
+
+    :func:`compress_image_attachment` may re-encode an image (e.g. PNG →
+    JPEG), leaving the original name's extension inconsistent with the stored
+    bytes. Swapping it keeps name, bytes, and MIME aligned. An unknown image
+    type, or a name already carrying the right extension, is returned
+    unchanged.
+
+    :param filename: The original upload filename, e.g. ``"shot.png"``.
+    :param content_type: The re-encoded image MIME, e.g. ``"image/jpeg"``.
+    :returns: The filename with the matching extension, e.g. ``"shot.jpg"``.
+    """
+    from pathlib import PurePosixPath
+
+    target = _IMAGE_CONTENT_TYPE_EXTENSIONS.get(content_type)
+    if target is None:
+        return filename
+    path = PurePosixPath(filename)
+    if path.suffix.lower() == target:
+        return filename
+    return str(path.with_suffix(target))
+
+
+def _encode_image(image: Any, image_format: str, **params: Any) -> bytes:
+    """Encode *image* to *image_format*, returning the bytes."""
+    from io import BytesIO
+
+    buffer = BytesIO()
+    image.save(buffer, format=image_format, **params)
+    return buffer.getvalue()
+
+
+def compress_image_attachment(content: bytes, content_type: str) -> tuple[bytes, str]:
+    """Shrink a raster image so its bytes fit :data:`IMAGE_MODEL_BUDGET_BYTES`.
+
+    Images upload at the larger :data:`MAX_IMAGE_UPLOAD_BYTES`, but every
+    attachment is inlined as base64 into each turn's request, so a big image
+    would blow past the provider's per-image limit. This downscales and/or
+    re-encodes the image to fit the model budget, keeping it a valid in-place
+    attachment (the compressed bytes are what get stored).
+
+    Already-small images (``<=`` budget) and animated images (multi-frame
+    GIF/WebP — re-encoding animation safely is out of scope) are returned
+    unchanged. For still images we search largest-first: alpha images try
+    lossy then lossless WebP then PNG; opaque images try descending-quality
+    JPEG, downscaling the canvas when quality alone isn't enough.
+
+    :param content: Raw uploaded image bytes.
+    :param content_type: The resolved image MIME (``image/*``).
+    :returns: ``(bytes, content_type)`` — the (possibly re-encoded) image and
+        its MIME. For a decodable still image the bytes are ``<=`` the budget;
+        the content_type may change (e.g. ``image/png`` → ``image/jpeg``).
+    :raises ImageCompressionError: If the bytes don't decode as an image, or
+        can't be brought under the budget.
+    """
+    if len(content) <= IMAGE_MODEL_BUDGET_BYTES:
+        return content, content_type
+
+    import warnings
+    from io import BytesIO
+
+    from PIL import Image, ImageOps, UnidentifiedImageError
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(BytesIO(content)) as probe:
+                n_frames = int(getattr(probe, "n_frames", 1))
+                if probe.width * probe.height > IMAGE_MAX_DECODED_PIXELS:
+                    raise ImageCompressionError("image dimensions are too large to process")
+            # Multi-frame (animated) images are left untouched; the upload cap
+            # still bounds them.
+            if n_frames != 1:
+                return content, content_type
+            with Image.open(BytesIO(content)) as opened:
+                image = ImageOps.exif_transpose(opened)
+                image.load()
+    except ImageCompressionError:
+        raise
+    except (
+        Image.DecompressionBombError,
+        Image.DecompressionBombWarning,
+        UnidentifiedImageError,
+        OSError,
+        SyntaxError,
+        ValueError,
+    ) as exc:
+        raise ImageCompressionError(f"could not decode image: {exc}") from exc
+
+    has_alpha = image.mode in ("RGBA", "LA") or (
+        image.mode == "P" and "transparency" in image.info
+    )
+    if has_alpha:
+        base = image.convert("RGBA")
+
+        def _candidates(frame: Any) -> list[tuple[bytes, str]]:
+            return [
+                (_encode_image(frame, "WEBP", quality=85, method=4), "image/webp"),
+                (_encode_image(frame, "WEBP", quality=70, method=4), "image/webp"),
+                (_encode_image(frame, "PNG", optimize=True), "image/png"),
+            ]
+    else:
+        base = image.convert("RGB")
+
+        def _candidates(frame: Any) -> list[tuple[bytes, str]]:
+            return [
+                (
+                    _encode_image(frame, "JPEG", quality=q, optimize=True, progressive=True),
+                    "image/jpeg",
+                )
+                for q in (88, 80, 72, 62, 50)
+            ]
+
+    # Pre-shrink an oversized canvas to the edge cap before the quality search.
+    longest = max(base.width, base.height)
+    if longest > IMAGE_MAX_EDGE_PX:
+        factor = IMAGE_MAX_EDGE_PX / longest
+        base = base.resize(
+            (max(1, round(base.width * factor)), max(1, round(base.height * factor))),
+            Image.Resampling.LANCZOS,
+        )
+
+    for scale in (1.0, 0.75, 0.5, 0.375, 0.25):
+        if scale == 1.0:
+            frame = base
+        else:
+            frame = base.resize(
+                (max(1, round(base.width * scale)), max(1, round(base.height * scale))),
+                Image.Resampling.LANCZOS,
+            )
+        for data, mime in _candidates(frame):
+            if len(data) <= IMAGE_MODEL_BUDGET_BYTES:
+                return data, mime
+
+    raise ImageCompressionError("image could not be compressed under the model size budget")
 
 
 # Extensions accepted as text/code attachments even when the upload's

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -1569,7 +1569,11 @@ def register_resources_routes(
         filename = file.filename
         if content_type.startswith("image/"):
             try:
-                compressed, resolved_type = compress_image_attachment(content, content_type)
+                # Compression decodes + re-encodes (CPU/memory heavy); run it off
+                # the event loop so one large upload can't stall other requests.
+                compressed, resolved_type = await asyncio.to_thread(
+                    compress_image_attachment, content, content_type
+                )
             except ImageCompressionError as exc:
                 raise HTTPException(status_code=413, detail=str(exc)) from exc
             # A re-encode (e.g. PNG → JPEG) changes the type; realign the

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -1523,9 +1523,12 @@ def register_resources_routes(
             )
         from omnigent.runtime.content_resolver import (
             MAX_ATTACHMENT_UPLOAD_BYTES,
+            ImageCompressionError,
             _resolve_content_type,
             attachment_text_type_for_extension,
             attachment_upload_limit,
+            compress_image_attachment,
+            image_filename_for_content_type,
         )
 
         # Resolve the type from the declared MIME + filename BEFORE reading
@@ -1560,9 +1563,23 @@ def register_resources_routes(
             file,
             min(type_limit, MAX_ATTACHMENT_UPLOAD_BYTES),
         )
+        # Images upload at the larger image cap; shrink an oversized one under
+        # the provider's per-image limit before storing, so the base64 inlined
+        # every turn always fits. Non-images pass through untouched.
+        filename = file.filename
+        if content_type.startswith("image/"):
+            try:
+                compressed, resolved_type = compress_image_attachment(content, content_type)
+            except ImageCompressionError as exc:
+                raise HTTPException(status_code=413, detail=str(exc)) from exc
+            # A re-encode (e.g. PNG → JPEG) changes the type; realign the
+            # filename extension so name, bytes, and MIME stay consistent.
+            if resolved_type != content_type:
+                filename = image_filename_for_content_type(file.filename, resolved_type)
+            content, content_type = compressed, resolved_type
         stored = file_store.create(
             session_id=session_id,
-            filename=file.filename,
+            filename=filename,
             bytes=len(content),
             content_type=content_type,
         )

--- a/omnigent/server/routes/sessions/routes_resources.py
+++ b/omnigent/server/routes/sessions/routes_resources.py
@@ -120,6 +120,13 @@ class _RunnerStreamResponse(StreamingResponse):
             await self._upstream.aclose()
 
 
+# Bounds how many image compressions run concurrently across the worker.
+# Each decodes/re-encodes a raster (up to IMAGE_MAX_DECODED_PIXELS, several
+# full buffers live at once), so an unbounded burst of large uploads could
+# spike peak memory even with the to_thread offload keeping the loop responsive.
+_IMAGE_COMPRESSION_CONCURRENCY = asyncio.Semaphore(4)
+
+
 def register_resources_routes(
     router: APIRouter,
     *,
@@ -1569,11 +1576,13 @@ def register_resources_routes(
         filename = file.filename
         if content_type.startswith("image/"):
             try:
-                # Compression decodes + re-encodes (CPU/memory heavy); run it off
-                # the event loop so one large upload can't stall other requests.
-                compressed, resolved_type = await asyncio.to_thread(
-                    compress_image_attachment, content, content_type
-                )
+                # Compression decodes + re-encodes (CPU/memory heavy). Run it off
+                # the event loop, and bound concurrency so a burst of large
+                # uploads can't drive peak memory unbounded.
+                async with _IMAGE_COMPRESSION_CONCURRENCY:
+                    compressed, resolved_type = await asyncio.to_thread(
+                        compress_image_attachment, content, content_type
+                    )
             except ImageCompressionError as exc:
                 raise HTTPException(status_code=413, detail=str(exc)) from exc
             # A re-encode (e.g. PNG → JPEG) changes the type; realign the

--- a/tests/runtime/test_content_resolver.py
+++ b/tests/runtime/test_content_resolver.py
@@ -1032,7 +1032,7 @@ def test_compress_image_leaves_small_image_untouched() -> None:
 
 
 def test_compress_image_shrinks_opaque_png_under_budget() -> None:
-    """A large opaque PNG is re-encoded (to JPEG) under the budget."""
+    """A large opaque PNG is re-encoded (WebP or JPEG) under the budget."""
     from omnigent.runtime.content_resolver import (
         IMAGE_MODEL_BUDGET_BYTES,
         compress_image_attachment,
@@ -1041,7 +1041,7 @@ def test_compress_image_shrinks_opaque_png_under_budget() -> None:
     result, content_type = compress_image_attachment(_png_bytes_over_budget(), "image/png")
 
     assert len(result) <= IMAGE_MODEL_BUDGET_BYTES
-    assert content_type == "image/jpeg"
+    assert content_type in ("image/webp", "image/jpeg")
     # The stored blob is base64-inlined every turn; the encoded payload must
     # stay under the provider's ~5 MB per-image ceiling.
     assert len(base64.b64encode(result)) < 5 * 1024 * 1024
@@ -1149,6 +1149,35 @@ def test_compress_image_rejects_format_mismatch() -> None:
 
     with pytest.raises(ImageCompressionError):
         compress_image_attachment(bmp, "image/png")
+
+
+def test_compress_image_flattens_mpo_to_primary_frame() -> None:
+    """A multi-picture JPEG (MPO) over budget is compressed, not rejected."""
+    import os
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime.content_resolver import (
+        IMAGE_MODEL_BUDGET_BYTES,
+        compress_image_attachment,
+    )
+
+    # High-entropy frames so the MPO's JPEG-compressed frames still exceed the
+    # budget and actually enter compression.
+    side = 2400
+    frames = [Image.frombytes("RGB", (side, side), os.urandom(side * side * 3)) for _ in range(2)]
+    buffer = BytesIO()
+    frames[0].save(buffer, format="MPO", save_all=True, append_images=frames[1:])
+    mpo = buffer.getvalue()
+    assert len(mpo) > IMAGE_MODEL_BUDGET_BYTES
+
+    # Declared image/jpeg (as browsers/OS label MPO photos); should compress the
+    # primary frame rather than 413 as "animated".
+    result, content_type = compress_image_attachment(mpo, "image/jpeg")
+
+    assert len(result) <= IMAGE_MODEL_BUDGET_BYTES
+    assert content_type in ("image/webp", "image/jpeg")
 
 
 def test_compress_image_rejects_oversized_animated(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/runtime/test_content_resolver.py
+++ b/tests/runtime/test_content_resolver.py
@@ -1099,6 +1099,58 @@ def test_compress_image_skips_non_raster_type() -> None:
     assert content_type == "image/svg+xml"
 
 
+def test_compress_image_preserves_rgb_trns_transparency() -> None:
+    """An RGB PNG with a tRNS chunk is treated as alpha (not flattened to JPEG)."""
+    import os
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime.content_resolver import (
+        IMAGE_MODEL_BUDGET_BYTES,
+        compress_image_attachment,
+    )
+
+    side = 1600
+    image = Image.frombytes("RGB", (side, side), os.urandom(side * side * 3))
+    buffer = BytesIO()
+    # tRNS transparency on a truecolor image: Pillow keeps mode "RGB" and exposes
+    # it via info["transparency"] on reopen.
+    image.save(buffer, format="PNG", transparency=(0, 0, 0))
+    original = buffer.getvalue()
+    assert len(original) > IMAGE_MODEL_BUDGET_BYTES
+
+    result, content_type = compress_image_attachment(original, "image/png")
+
+    assert len(result) <= IMAGE_MODEL_BUDGET_BYTES
+    # Alpha-capable branch, never lossy JPEG.
+    assert content_type in ("image/webp", "image/png")
+
+
+def test_compress_image_rejects_format_mismatch() -> None:
+    """Bytes whose real format differs from the declared MIME are rejected."""
+    import os
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime.content_resolver import (
+        IMAGE_MODEL_BUDGET_BYTES,
+        ImageCompressionError,
+        compress_image_attachment,
+    )
+
+    # A real (uncompressed) BMP, but declared as image/png.
+    side = 1200
+    buffer = BytesIO()
+    Image.frombytes("RGB", (side, side), os.urandom(side * side * 3)).save(buffer, format="BMP")
+    bmp = buffer.getvalue()
+    assert len(bmp) > IMAGE_MODEL_BUDGET_BYTES
+
+    with pytest.raises(ImageCompressionError):
+        compress_image_attachment(bmp, "image/png")
+
+
 def test_compress_image_rejects_oversized_animated(monkeypatch: pytest.MonkeyPatch) -> None:
     """An animated image over the budget is rejected (can't be re-encoded)."""
     from io import BytesIO
@@ -1132,6 +1184,7 @@ def test_compress_image_rejects_oversized_animated(monkeypatch: pytest.MonkeyPat
         ("shot.jpg", "image/jpeg", "shot.jpg"),  # already matches → unchanged
         ("shot.PNG", "image/png", "shot.PNG"),  # case-insensitive match → unchanged
         ("shot.png", "image/svg+xml", "shot.png"),  # unknown emit type → unchanged
+        (".", "image/jpeg", "."),  # no stem for with_suffix → unchanged, not 500
     ],
 )
 def test_image_filename_for_content_type(filename: str, content_type: str, expected: str) -> None:

--- a/tests/runtime/test_content_resolver.py
+++ b/tests/runtime/test_content_resolver.py
@@ -939,6 +939,8 @@ def test_resolve_image_file_keeps_specific_mime(
         ("image/png", 50),
         ("image/jpeg", 50),
         ("image/webp", 50),
+        ("image/gif", 50),
+        ("image/svg+xml", 5),  # non-raster: not compressed, keeps the small cap
         ("application/pdf", 20),
         ("text/plain", 10),
         ("text/markdown", 10),
@@ -1078,6 +1080,43 @@ def test_compress_image_rejects_undecodable_over_budget() -> None:
     garbage = b"\x00" * (IMAGE_MODEL_BUDGET_BYTES + 1)
     with pytest.raises(ImageCompressionError):
         compress_image_attachment(garbage, "image/png")
+
+
+def test_compress_image_skips_non_raster_type() -> None:
+    """A non-raster image type (SVG) over the budget is passed through, not 413'd."""
+    from omnigent.runtime.content_resolver import (
+        IMAGE_MODEL_BUDGET_BYTES,
+        compress_image_attachment,
+    )
+
+    svg = b"<svg xmlns='http://www.w3.org/2000/svg'>" + b" " * (IMAGE_MODEL_BUDGET_BYTES + 1)
+    result, content_type = compress_image_attachment(svg, "image/svg+xml")
+
+    assert result is svg
+    assert content_type == "image/svg+xml"
+
+
+def test_compress_image_rejects_oversized_animated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An animated image over the budget is rejected (can't be re-encoded)."""
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime import content_resolver as cr
+
+    # Tiny budget so a small animated GIF counts as oversized without building
+    # a multi-megabyte fixture.
+    monkeypatch.setattr(cr, "IMAGE_MODEL_BUDGET_BYTES", 50)
+    frames = [Image.new("RGB", (16, 16), (i * 40, 0, 0)) for i in range(4)]
+    buffer = BytesIO()
+    frames[0].save(
+        buffer, format="GIF", save_all=True, append_images=frames[1:], duration=80, loop=0
+    )
+    animated = buffer.getvalue()
+    assert len(animated) > 50
+
+    with pytest.raises(cr.ImageCompressionError):
+        cr.compress_image_attachment(animated, "image/gif")
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/test_content_resolver.py
+++ b/tests/runtime/test_content_resolver.py
@@ -1042,6 +1042,9 @@ def test_compress_image_shrinks_opaque_png_under_budget() -> None:
 
     assert len(result) <= IMAGE_MODEL_BUDGET_BYTES
     assert content_type == "image/jpeg"
+    # The stored blob is base64-inlined every turn; the encoded payload must
+    # stay under the provider's ~5 MB per-image ceiling.
+    assert len(base64.b64encode(result)) < 5 * 1024 * 1024
 
 
 def test_compress_image_shrinks_alpha_png_under_budget() -> None:

--- a/tests/runtime/test_content_resolver.py
+++ b/tests/runtime/test_content_resolver.py
@@ -936,9 +936,9 @@ def test_resolve_image_file_keeps_specific_mime(
 @pytest.mark.parametrize(
     ("content_type", "expected_mb"),
     [
-        ("image/png", 5),
-        ("image/jpeg", 5),
-        ("image/webp", 5),
+        ("image/png", 50),
+        ("image/jpeg", 50),
+        ("image/webp", 50),
         ("application/pdf", 20),
         ("text/plain", 10),
         ("text/markdown", 10),
@@ -986,6 +986,117 @@ def test_attachment_upload_limits_are_under_global_ceiling() -> None:
     assert MAX_IMAGE_UPLOAD_BYTES <= MAX_ATTACHMENT_UPLOAD_BYTES
     assert MAX_PDF_UPLOAD_BYTES <= MAX_ATTACHMENT_UPLOAD_BYTES
     assert MAX_TEXT_UPLOAD_BYTES <= MAX_ATTACHMENT_UPLOAD_BYTES
+
+
+# ── Image attachment compression ──────────────────────────────────────
+
+
+def _png_bytes_over_budget() -> bytes:
+    """A valid opaque PNG whose encoded size exceeds the model budget."""
+    import os
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime.content_resolver import IMAGE_MODEL_BUDGET_BYTES
+
+    # Random noise resists PNG compression, so the encoded size ~ the raw
+    # pixel count. Size it comfortably above the budget.
+    side = 1600
+    image = Image.frombytes("RGB", (side, side), os.urandom(side * side * 3))
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    data = buffer.getvalue()
+    assert len(data) > IMAGE_MODEL_BUDGET_BYTES
+    return data
+
+
+def test_compress_image_leaves_small_image_untouched() -> None:
+    """An image already under the budget is returned byte-for-byte."""
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime.content_resolver import compress_image_attachment
+
+    buffer = BytesIO()
+    Image.new("RGB", (32, 32), (10, 20, 30)).save(buffer, format="PNG")
+    original = buffer.getvalue()
+
+    result, content_type = compress_image_attachment(original, "image/png")
+
+    assert result is original
+    assert content_type == "image/png"
+
+
+def test_compress_image_shrinks_opaque_png_under_budget() -> None:
+    """A large opaque PNG is re-encoded (to JPEG) under the budget."""
+    from omnigent.runtime.content_resolver import (
+        IMAGE_MODEL_BUDGET_BYTES,
+        compress_image_attachment,
+    )
+
+    result, content_type = compress_image_attachment(_png_bytes_over_budget(), "image/png")
+
+    assert len(result) <= IMAGE_MODEL_BUDGET_BYTES
+    assert content_type == "image/jpeg"
+
+
+def test_compress_image_shrinks_alpha_png_under_budget() -> None:
+    """A large image with alpha stays lossless/alpha-capable under the budget."""
+    import os
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime.content_resolver import (
+        IMAGE_MODEL_BUDGET_BYTES,
+        compress_image_attachment,
+    )
+
+    side = 1500
+    image = Image.frombytes("RGBA", (side, side), os.urandom(side * side * 4))
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    original = buffer.getvalue()
+    assert len(original) > IMAGE_MODEL_BUDGET_BYTES
+
+    result, content_type = compress_image_attachment(original, "image/png")
+
+    assert len(result) <= IMAGE_MODEL_BUDGET_BYTES
+    assert content_type in ("image/webp", "image/png")
+
+
+def test_compress_image_rejects_undecodable_over_budget() -> None:
+    """Bytes over the budget that don't decode as an image are rejected."""
+    from omnigent.runtime.content_resolver import (
+        IMAGE_MODEL_BUDGET_BYTES,
+        ImageCompressionError,
+        compress_image_attachment,
+    )
+
+    garbage = b"\x00" * (IMAGE_MODEL_BUDGET_BYTES + 1)
+    with pytest.raises(ImageCompressionError):
+        compress_image_attachment(garbage, "image/png")
+
+
+@pytest.mark.parametrize(
+    ("filename", "content_type", "expected"),
+    [
+        ("shot.png", "image/jpeg", "shot.jpg"),  # re-encoded PNG → JPEG
+        ("shot.png", "image/webp", "shot.webp"),  # alpha kept, WebP
+        ("my.screen.png", "image/jpeg", "my.screen.jpg"),  # dotted stem preserved
+        ("noext", "image/jpeg", "noext.jpg"),  # no extension → appended
+        ("shot.jpg", "image/jpeg", "shot.jpg"),  # already matches → unchanged
+        ("shot.PNG", "image/png", "shot.PNG"),  # case-insensitive match → unchanged
+        ("shot.png", "image/svg+xml", "shot.png"),  # unknown emit type → unchanged
+    ],
+)
+def test_image_filename_for_content_type(filename: str, content_type: str, expected: str) -> None:
+    """The stored filename's extension is realigned to the (re-)encoded type."""
+    from omnigent.runtime.content_resolver import image_filename_for_content_type
+
+    assert image_filename_for_content_type(filename, content_type) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/server/routes/test_sessions_upload_limits.py
+++ b/tests/server/routes/test_sessions_upload_limits.py
@@ -131,8 +131,9 @@ def test_upload_large_image_is_compressed_under_budget(
     assert resp.status_code in (200, 201), resp.text
     body = resp.json()
     assert body["metadata"]["bytes"] <= IMAGE_MODEL_BUDGET_BYTES
-    # Opaque image re-encodes to JPEG, so the stored name is realigned.
-    assert body["name"] == "screenshot.jpg"
+    # Opaque image re-encodes (WebP preferred, JPEG fallback), so the stored
+    # name is realigned to match the new type.
+    assert body["name"] in ("screenshot.webp", "screenshot.jpg")
 
 
 def test_upload_csv_mislabeled_as_excel_is_accepted(

--- a/tests/server/routes/test_sessions_upload_limits.py
+++ b/tests/server/routes/test_sessions_upload_limits.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 
 from omnigent.errors import OmnigentError
 from omnigent.runtime.content_resolver import (
-    MAX_IMAGE_UPLOAD_BYTES,
     MAX_TEXT_UPLOAD_BYTES,
 )
 from omnigent.server.routes.sessions import create_sessions_router
@@ -87,16 +86,53 @@ def test_upload_rejects_unsupported_type(upload_client: tuple[TestClient, str]) 
     assert "Unsupported attachment type" in resp.text
 
 
-def test_upload_rejects_oversized_image(upload_client: tuple[TestClient, str]) -> None:
-    """An image over the per-type limit is rejected with 413."""
+def test_upload_rejects_undecodable_oversized_image(
+    upload_client: tuple[TestClient, str],
+) -> None:
+    """Image bytes over the model budget that don't decode are rejected 413.
+
+    Real images are downscaled under the budget; garbage that only claims to
+    be an image can't be compressed, so the route surfaces a 413 instead of
+    storing an oversized attachment.
+    """
+    from omnigent.runtime.content_resolver import IMAGE_MODEL_BUDGET_BYTES
+
     client, session_id = upload_client
-    oversized = b"\x00" * (MAX_IMAGE_UPLOAD_BYTES + 1)
+    oversized = b"\x00" * (IMAGE_MODEL_BUDGET_BYTES + 1)
     resp = client.post(
         f"/v1/sessions/{session_id}/resources/files",
         files={"file": ("huge.png", oversized, "image/png")},
     )
     assert resp.status_code == 413, resp.status_code
-    assert "limit" in resp.text.lower()
+
+
+def test_upload_large_image_is_compressed_under_budget(
+    upload_client: tuple[TestClient, str],
+) -> None:
+    """A large but valid image uploads and is stored shrunk under the model budget."""
+    import os
+    from io import BytesIO
+
+    from PIL import Image
+
+    from omnigent.runtime.content_resolver import IMAGE_MODEL_BUDGET_BYTES
+
+    client, session_id = upload_client
+    side = 1600
+    buffer = BytesIO()
+    Image.frombytes("RGB", (side, side), os.urandom(side * side * 3)).save(buffer, format="PNG")
+    payload = buffer.getvalue()
+    assert len(payload) > IMAGE_MODEL_BUDGET_BYTES
+
+    resp = client.post(
+        f"/v1/sessions/{session_id}/resources/files",
+        files={"file": ("screenshot.png", payload, "image/png")},
+    )
+    assert resp.status_code in (200, 201), resp.text
+    body = resp.json()
+    assert body["metadata"]["bytes"] <= IMAGE_MODEL_BUDGET_BYTES
+    # Opaque image re-encodes to JPEG, so the stored name is realigned.
+    assert body["name"] == "screenshot.jpg"
 
 
 def test_upload_csv_mislabeled_as_excel_is_accepted(

--- a/web/src/lib/attachments.test.ts
+++ b/web/src/lib/attachments.test.ts
@@ -77,6 +77,19 @@ describe("validateAttachments", () => {
     expect(errors[0]).toContain("too large");
   });
 
+  it("caps non-compressible images (SVG) at the smaller limit", () => {
+    // Under 5 MB: accepted. A raster PNG the same size would be fine too, but
+    // SVG can't be compressed server-side, so it keeps the small cap.
+    const smallSvg = makeFile("icon.svg", "image/svg+xml", 4 * MB);
+    expect(validateAttachments([smallSvg]).accepted).toHaveLength(1);
+
+    // Between the SVG cap (5 MB) and the raster image cap (50 MB): rejected.
+    const bigSvg = makeFile("big.svg", "image/svg+xml", 6 * MB);
+    const { accepted, errors } = validateAttachments([bigSvg]);
+    expect(accepted).toHaveLength(0);
+    expect(errors[0]).toContain("too large");
+  });
+
   it("partitions a mixed batch into accepted + errors", () => {
     const ok = makeFile("a.png", "image/png");
     const badType = makeFile("a.zip", "application/zip");

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -10,9 +10,15 @@
  * UX only. Keep the limits in sync with the Python constants.
  */
 
-/** Per-type upload size limits, in megabytes. Mirrors the server caps. */
+/**
+ * Per-type upload size limits, in megabytes. Mirrors the server caps.
+ *
+ * Images accept a large upload — the server downscales/re-encodes an oversized
+ * image under the provider's per-image limit before storing it, so screenshots
+ * and retina captures no longer need to be shrunk by hand.
+ */
 export const ATTACHMENT_SIZE_LIMITS_MB = {
-  image: 5,
+  image: 50,
   pdf: 20,
   text: 10,
 } as const;

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -13,15 +13,25 @@
 /**
  * Per-type upload size limits, in megabytes. Mirrors the server caps.
  *
- * Images accept a large upload — the server downscales/re-encodes an oversized
- * image under the provider's per-image limit before storing it, so screenshots
- * and retina captures no longer need to be shrunk by hand.
+ * Compressible raster images accept a large upload — the server
+ * downscales/re-encodes an oversized one under the provider's per-image limit
+ * before storing it, so screenshots and retina captures no longer need to be
+ * shrunk by hand. Other image types (SVG, …) can't be shrunk, so they keep the
+ * smaller `UNCOMPRESSED_IMAGE_LIMIT_MB` cap (see `validateAttachments`).
  */
 export const ATTACHMENT_SIZE_LIMITS_MB = {
   image: 50,
   pdf: 20,
   text: 10,
 } as const;
+
+// Raster image types the server can compress under the model limit; only these
+// get the large image cap. Mirrors _COMPRESSIBLE_IMAGE_MIMES on the server.
+const COMPRESSIBLE_IMAGE_MIMES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+
+// Image types we don't compress (SVG, …) keep this smaller cap. Mirrors
+// IMAGE_UNCOMPRESSED_UPLOAD_BYTES on the server.
+const UNCOMPRESSED_IMAGE_LIMIT_MB = 5;
 
 export type AttachmentCategory = keyof typeof ATTACHMENT_SIZE_LIMITS_MB;
 
@@ -170,7 +180,12 @@ export function validateAttachments(files: File[]): AttachmentValidation {
       );
       continue;
     }
-    const limitMb = ATTACHMENT_SIZE_LIMITS_MB[category];
+    // Non-compressible images (SVG, …) can't be shrunk server-side, so they
+    // keep the smaller cap; compressible raster images get the large cap.
+    const limitMb =
+      category === "image" && !COMPRESSIBLE_IMAGE_MIMES.has(file.type || "")
+        ? UNCOMPRESSED_IMAGE_LIMIT_MB
+        : ATTACHMENT_SIZE_LIMITS_MB[category];
     if (file.size > limitMb * 1024 * 1024) {
       errors.push(`"${name}" is too large — the limit for ${category} files is ${limitMb} MB.`);
       continue;


### PR DESCRIPTION
## Related issue

Linear: [OMNI-2754 — allow larger file uploads](https://linear.app/omnigent/issue/OMNI-2754/allow-larger-file-uplaods) (no GitHub issue; tracked in Linear).

## Summary

- Screenshot-heavy workflows hit the **5 MB image upload cap** on managed servers, even though a full-screen/retina PNG that large is routine.
- Every attachment is base64-inlined into the model context each turn, so simply raising the number would just move the failure downstream (Anthropic rejects images over ~5 MB).
- This **accepts images up to 50 MB and compresses an oversized one under a ~3.5 MB model budget (≈4.7 MB after base64, under the provider ~5 MB/image ceiling) at upload time**, so the stored blob — and the base64 re-sent every turn — always fits. PDF (20 MB) and text (10 MB) caps are unchanged.

**ELI5:** You can now drop in a big screenshot. The server quietly shrinks it to a size the model accepts before storing it, instead of rejecting it at 5 MB.

```mermaid
flowchart LR
    U[Drop image up to 50MB] --> R[Upload route]
    R --> C{"&gt; 3.5MB budget?"}
    C -- no --> S[Store as-is]
    C -- yes --> K[compress_image_attachment<br/>downscale + re-encode]
    K -- fits --> S2[Store compressed<br/>realign .png to .jpg/.webp]
    K -- undecodable --> E[413]
    S --> M[base64 inlined every turn]
    S2 --> M
```

Compression searches largest-first: opaque images re-encode WebP-first (JPEG fallback); images with alpha (including RGB/L images carrying a tRNS chunk) go to WebP/PNG; the canvas is downscaled when quality alone isn't enough. The decoded container is validated against the declared MIME (a spoofed TIFF/BMP-as-png is rejected), compression runs off the event loop under a bounded semaphore, and undecodable/unsupported oversized bytes return **413** instead of storing a broken attachment. On a re-encode the stored filename's extension is realigned (`screenshot.png` → `screenshot.webp`/`.jpg`) so name, bytes, and MIME stay consistent. The web client limit mirror is kept in sync.

**Behavior notes:**
- Only compressible raster types (PNG/JPEG/WebP/GIF) get the 50 MB cap; other image types (SVG, …) keep the previous 5 MB cap and pass through untouched.
- **Memory-bounded**: an oversized image is downscaled to a 2048 px edge before the re-encode, JPEGs are DCT-decoded at reduced scale via `draft()`, EXIF orientation is applied in place, and concurrent compressions are gated by a configurable semaphore. Peak memory for a 6400×6400 JPEG drops from ~1.4 GiB to ~230 MiB, keeping the ~1 GiB deployments safe.
- **Animated** images in the ~3.5–5 MB band that previously uploaded are now rejected at upload. This is a deliberate trade-off: we can't re-encode animation, and such an image would be rejected by the provider at turn time anyway — failing cleanly at upload is the better UX.

## Test Plan

- `pytest tests/runtime/test_content_resolver.py tests/server/routes/test_sessions_upload_limits.py` — **119 passed** (compression: opaque/alpha/small/undecodable, format-spoof, MPO, tRNS, animated-reject, injected decoder errors, edge-cap downscale, format-aware pixel cap, filename realignment, concurrency config; plus the end-to-end upload route).
- `web`: `npm run build` ✅; `vitest` — attachments tests pass. The only failing vitest file (`NewChatDialog.test.tsx`, 2 tests) fails identically on the unmodified base, so it's pre-existing and unrelated.
- Manual: on a managed harness, drop an 8–15 MB retina screenshot into the composer → attaches (previously blocked), agent can read it, and the chip shows `.webp`/`.jpg`. A renamed binary as `.png` → clean 413.

## Demo

Before
<img width="781" height="192" alt="image" src="https://github.com/user-attachments/assets/37e785b2-d5f7-4198-90e3-3872aedcf427" />

After
<img width="801" height="585" alt="image" src="https://github.com/user-attachments/assets/76eed4d5-79ea-462a-a86b-87359d973a46" />

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the compression paths (opaque→WebP/JPEG, alpha→WebP/PNG, small-passthrough, undecodable→413) and the filename realignment, plus a route test asserting a large PNG is stored under the model budget with a realigned extension. Manual verification is the drag-drop UX on a managed harness (large screenshot accepted + readable; renamed binary rejected), which is best confirmed by a human.

## Changelog

Large image uploads (screenshots, retina captures) up to 50 MB are now accepted and compressed to fit automatically, instead of being rejected at 5 MB.

This pull request and its description were written by Isaac.

