### PR TITLE
ci: retry stalled UI preview provisioning

### DIFF
--- a/.github/ui-preview/README.md
+++ b/.github/ui-preview/README.md
@@ -16,6 +16,29 @@ when a PR changes the frontend (`web/`).
 3. A comment with the preview URL is posted on the PR and updated on each push.
 4. The app is deleted automatically when the PR is closed.
 
+## Provisioning retries
+
+Initial compute provisioning gets up to three attempts, each polling for about
+10 minutes. The logs include the compute state and Databricks' status message.
+If compute stays `STARTING` or enters `ERROR` / `STOPPED`, the workflow can
+delete the undeployed app and recreate it with the **same name**. It confirms
+deletion first, then backs off for 15 seconds before the second attempt and
+30 seconds before the third. An undeployed app left by an earlier failed run
+can also be recovered this way.
+
+Recreation is restricted to the same app ID, deployment principal, and preview
+description, with no deployments, source path, resources, or pending updates.
+Existing deployed previews are reused, never deleted by provisioning retries.
+API/authentication errors, identity changes, and unconfirmed deletions fail the
+step instead of triggering recreation. The final failed app is left for
+inspection; closing the PR still cleans it up.
+
+To verify the retry behavior without touching Databricks, run
+`uv run --no-sync python -m pytest tests/test_ui_preview_workflow.py`.
+These tests execute the workflow's shell with a fake CLI and no real sleeps.
+After a live deployment, check the `Create or update app` log for the attempt
+number and confirm the preview URL posted on the PR opens successfully.
+
 ## Fork PR safety
 
 `ui-preview.yml` runs its build/deploy on `pull_request_target`, so the label is

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -394,7 +394,32 @@ jobs:
             sleep "$((attempt * 15))"
           done
 
-          if ! URL=$(jq -er '.url | select(type == "string" and startswith("https://"))' <<< "$APP_JSON"); then
+          if ! URL=$(python3 -c '
+          import json
+          import sys
+          from urllib.parse import urlsplit
+
+          url = json.load(sys.stdin).get("url")
+          if not isinstance(url, str) or any(
+              char.isspace() or ord(char) < 32 or ord(char) == 127 or char == "\\"
+              for char in url
+          ):
+              sys.exit(1)
+          try:
+              parsed = urlsplit(url)
+              valid = (
+                  parsed.scheme == "https"
+                  and bool(parsed.hostname)
+                  and parsed.username is None
+                  and parsed.password is None
+                  and (parsed.port is None or parsed.port > 0)
+              )
+          except ValueError:
+              sys.exit(1)
+          if not valid:
+              sys.exit(1)
+          print(url)
+          ' <<< "$APP_JSON"); then
             echo "::error::App has no usable preview URL"
             exit 1
           fi

--- a/.github/workflows/ui-preview.yml
+++ b/.github/workflows/ui-preview.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Download app files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -294,6 +294,7 @@ jobs:
 
       - name: Create or update app
         id: app
+        timeout-minutes: 40
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
@@ -302,31 +303,101 @@ jobs:
           APP_NAME: ${{ github.event_name == 'push' && 'omnigent-ui-preview-dev' || format('omnigent-ui-preview-pr-{0}', github.event.pull_request.number) }}
           APP_DESCRIPTION: ${{ github.event.pull_request.html_url || format('{0}/{1}', github.server_url, github.repository) }}
         run: |
-          if databricks apps get "$APP_NAME" > /dev/null 2>&1; then
-            echo "App already exists"
-          else
-            echo "Creating app..."
-            databricks apps create \
-              --json "{\"name\": \"$APP_NAME\", \"description\": \"$APP_DESCRIPTION\"}" \
-              --no-wait
-            for i in $(seq 1 40); do
-              STATE=$(databricks apps get "$APP_NAME" -o json | jq -r '.compute_status.state')
-              echo "Compute state: $STATE"
-              if [ "$STATE" = "ACTIVE" ]; then
+          refresh_app() {
+            APP_JSON=$(databricks apps get "$APP_NAME" -o json)
+            if ! jq -e --arg id "$APP_ID" --arg name "$APP_NAME" \
+              '.id == $id and .name == $name' <<< "$APP_JSON" > /dev/null; then
+              echo "::error::App identity changed while provisioning; refusing to continue"
+              exit 1
+            fi
+            APP_STATE=$(jq -er '.compute_status.state' <<< "$APP_JSON")
+            jq -r '"Compute state: \(.compute_status.state): \(.compute_status.message // "no details")"' \
+              <<< "$APP_JSON"
+          }
+
+          # A failed lookup must not turn an auth/API error into a create attempt.
+          APP_JSON=$(databricks apps list -o json | jq -c --arg name "$APP_NAME" \
+            '.[] | select(.name == $name)')
+          if [ -n "$APP_JSON" ]; then
+            APP_JSON=$(databricks apps get "$APP_NAME" -o json)
+          fi
+
+          for attempt in $(seq 1 3); do
+            echo "Provisioning attempt $attempt/3"
+            if [ -z "$APP_JSON" ]; then
+              APP_JSON=$(databricks apps create \
+                --json "$(jq -cn --arg name "$APP_NAME" --arg description "$APP_DESCRIPTION" \
+                  '{name: $name, description: $description}')" --no-wait -o json)
+            fi
+            APP_ID=$(jq -er '.id | select(type == "string" and length > 0)' <<< "$APP_JSON")
+
+            # Existing deployments retain their app identity, permissions, and URL.
+            if jq -e '.active_deployment != null or .pending_deployment != null
+              or (.default_source_code_path // "") != ""' <<< "$APP_JSON" > /dev/null; then
+              echo "App already has a deployment; reusing without recreation"
+              break
+            fi
+
+            for poll in $(seq 1 40); do
+              refresh_app
+              if [ "$APP_STATE" = "ACTIVE" ]; then
                 break
-              elif [ "$STATE" = "ERROR" ] || [ "$STATE" = "STOPPED" ]; then
-                echo "::error::Compute entered $STATE state"
-                exit 1
+              elif [ "$APP_STATE" = "ERROR" ] || [ "$APP_STATE" = "STOPPED" ]; then
+                break
               fi
               sleep 15
             done
-            if [ "$STATE" != "ACTIVE" ]; then
-              echo "::error::Timed out waiting for compute to become ACTIVE (last state: $STATE)"
+
+            # Provisioning may have finished during the last polling interval.
+            if [ "$APP_STATE" != "ACTIVE" ]; then
+              refresh_app
+            fi
+            if [ "$APP_STATE" = "ACTIVE" ]; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Compute did not become ACTIVE after 3 attempts (last state: $APP_STATE)"
               exit 1
             fi
-          fi
 
-          URL=$(databricks apps get "$APP_NAME" -o json | jq -r '.url')
+            # Only an undeployed preview owned by this workflow is disposable.
+            if ! jq -e --arg creator "$DATABRICKS_CLIENT_ID" --arg description "$APP_DESCRIPTION" \
+              '.creator == $creator and .description == $description
+              and .active_deployment == null and .pending_deployment == null
+              and .pending_update == null
+              and (.default_source_code_path // "") == ""
+              and ((.resources // []) | length == 0)
+              and (.compute_status.state | IN("STARTING", "ERROR", "STOPPED"))' \
+              <<< "$APP_JSON" > /dev/null; then
+              echo "::error::App is not an unchanged, undeployed preview; refusing to recreate"
+              exit 1
+            fi
+
+            echo "::warning::Compute did not become ACTIVE (last state: $APP_STATE); recreating $APP_NAME"
+            databricks apps delete "$APP_NAME" --auto-approve
+            for poll in $(seq 1 20); do
+              APP_JSON=$(databricks apps list -o json | jq -c --arg name "$APP_NAME" \
+                '.[] | select(.name == $name)')
+              if [ -z "$APP_JSON" ]; then
+                break
+              fi
+              if ! jq -e --arg id "$APP_ID" '.id == $id' <<< "$APP_JSON" > /dev/null; then
+                echo "::error::App identity changed during deletion; refusing to continue"
+                exit 1
+              fi
+              sleep 3
+            done
+            if [ -n "$APP_JSON" ]; then
+              echo "::error::App still exists after deletion; refusing to create another app"
+              exit 1
+            fi
+            sleep "$((attempt * 15))"
+          done
+
+          if ! URL=$(jq -er '.url | select(type == "string" and startswith("https://"))' <<< "$APP_JSON"); then
+            echo "::error::App has no usable preview URL"
+            exit 1
+          fi
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Upload files and deploy

--- a/tests/test_ui_preview_workflow.py
+++ b/tests/test_ui_preview_workflow.py
@@ -1,6 +1,328 @@
+import json
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
+import yaml
+
 WORKFLOW = Path(".github/workflows/ui-preview.yml").read_text()
+DEPLOY_JOB = yaml.safe_load(WORKFLOW)["jobs"]["deploy"]
+PROVISION_STEP = next(step for step in DEPLOY_JOB["steps"] if step.get("id") == "app")
+APP_NAME = "omnigent-ui-preview-pr-123"
+APP_DESCRIPTION = "https://github.com/omnigent-ai/omnigent/pull/123"
+APP_CREATOR = "preview-deployer"
+APP_URL = "https://preview.example.com"
+
+Reply = tuple[str, object, int]
+
+
+def _app(state: str = "STARTING", **fields: object) -> dict[str, object]:
+    return {
+        "id": "app-1",
+        "name": APP_NAME,
+        "description": APP_DESCRIPTION,
+        "creator": APP_CREATOR,
+        "compute_status": {"state": state, "message": "Provisioning app dependencies"},
+        "url": APP_URL,
+        **fields,
+    }
+
+
+def _reply(command: str, output: object = None, code: int = 0) -> Reply:
+    return command, output, code
+
+
+def _run_provision(
+    tmp_path: Path, replies: list[Reply]
+) -> tuple[subprocess.CompletedProcess[str], list[str], str]:
+    if not shutil.which("bash") or not shutil.which("jq"):
+        pytest.skip("Workflow execution requires bash and jq")
+
+    for index, (command, output, code) in enumerate(replies):
+        (tmp_path / f"{index}.command").write_text(command)
+        (tmp_path / f"{index}.output").write_text(
+            output if isinstance(output, str) else json.dumps(output)
+        )
+        (tmp_path / f"{index}.code").write_text(str(code))
+    (tmp_path / "index").write_text("0")
+
+    cli = tmp_path / "databricks"
+    cli.write_text(
+        r"""#!/usr/bin/env bash
+set -euo pipefail
+index=$(<"$PREVIEW_TEST_DIR/index")
+printf '%s\n' "$((index + 1))" > "$PREVIEW_TEST_DIR/index"
+printf '%s\n' "$*" >> "$PREVIEW_TEST_DIR/commands"
+if [[ ! -f "$PREVIEW_TEST_DIR/$index.command" ]]; then
+  echo "Unexpected Databricks call: $*" >&2
+  exit 99
+fi
+expected=$(<"$PREVIEW_TEST_DIR/$index.command")
+if [[ "$1 $2" != "apps $expected" ]]; then
+  echo "Expected apps $expected, got $*" >&2
+  exit 99
+fi
+code=$(<"$PREVIEW_TEST_DIR/$index.code")
+if [[ "$code" == 0 ]]; then
+  printf '%s\n' "$(<"$PREVIEW_TEST_DIR/$index.output")"
+else
+  printf '%s\n' "$(<"$PREVIEW_TEST_DIR/$index.output")" >&2
+fi
+exit "$code"
+"""
+    )
+    cli.chmod(0o755)
+    sleep = tmp_path / "sleep"
+    sleep.write_text('#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "$PREVIEW_TEST_DIR/sleeps"\n')
+    sleep.chmod(0o755)
+
+    env = {key: value for key, value in os.environ.items() if not key.startswith("DATABRICKS_")}
+    env.pop("BASH_ENV", None)
+    env.update(
+        {
+            "PATH": f"{tmp_path}{os.pathsep}{env['PATH']}",
+            "PREVIEW_TEST_DIR": str(tmp_path),
+            "APP_NAME": APP_NAME,
+            "APP_DESCRIPTION": APP_DESCRIPTION,
+            "DATABRICKS_CLIENT_ID": APP_CREATOR,
+            "GITHUB_OUTPUT": str(tmp_path / "github-output"),
+        }
+    )
+    result = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", PROVISION_STEP["run"]],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+    commands = (tmp_path / "commands").read_text().splitlines()
+    output_path = tmp_path / "github-output"
+    output = output_path.read_text() if output_path.exists() else ""
+    return result, commands, output
+
+
+def test_provision_new_app(tmp_path: Path) -> None:
+    result, commands, output = _run_provision(
+        tmp_path, [_reply("list", []), _reply("create", _app()), _reply("get", _app("ACTIVE"))]
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output == f"url={APP_URL}\n"
+    create = next(command for command in commands if command.startswith("apps create "))
+    payload = json.loads(create.split("--json ", 1)[1].split(" --no-wait", 1)[0])
+    assert payload == {"name": APP_NAME, "description": APP_DESCRIPTION}
+    assert not any(command.startswith("apps delete") for command in commands)
+
+
+def test_provision_recreates_timed_out_app_after_deletion_finishes(tmp_path: Path) -> None:
+    result, commands, output = _run_provision(
+        tmp_path,
+        [
+            _reply("list", []),
+            _reply("create", _app()),
+            *[_reply("get", _app())] * 41,
+            _reply("delete"),
+            _reply("list", [_app()]),
+            _reply("list", []),
+            _reply("create", _app(id="app-2")),
+            _reply("get", _app("ACTIVE", id="app-2", url="https://retry.example.com")),
+        ],
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output == "url=https://retry.example.com\n"
+    assert "Provisioning app dependencies" in result.stdout
+    assert "Provisioning attempt 2/3" in result.stdout
+    assert f"apps delete {APP_NAME} --auto-approve" in commands
+    assert sum(command.startswith("apps create") for command in commands) == 2
+    assert (tmp_path / "sleeps").read_text().splitlines() == ["15"] * 40 + ["3", "15"]
+
+
+def test_provision_stops_after_three_attempts(tmp_path: Path) -> None:
+    replies = [_reply("list", [])]
+    for attempt in range(3):
+        app = _app(id=f"app-{attempt}")
+        replies.extend([_reply("create", app), *[_reply("get", app)] * 41])
+        if attempt < 2:
+            replies.extend([_reply("delete"), _reply("list", [])])
+    result, commands, output = _run_provision(tmp_path, replies)
+    assert result.returncode != 0
+    assert "after 3 attempts" in result.stdout
+    assert sum(command.startswith("apps create") for command in commands) == 3
+    assert sum(command.startswith("apps delete") for command in commands) == 2
+    assert output == ""
+
+
+def test_provision_recovers_undeployed_app_from_previous_run(tmp_path: Path) -> None:
+    result, commands, output = _run_provision(
+        tmp_path,
+        [
+            _reply("list", [_app()]),
+            _reply("get", _app()),
+            *[_reply("get", _app())] * 41,
+            _reply("delete"),
+            _reply("list", []),
+            _reply("create", _app(id="app-2")),
+            _reply("get", _app("ACTIVE", id="app-2")),
+        ],
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output == f"url={APP_URL}\n"
+    assert sum(command.startswith("apps create") for command in commands) == 1
+
+
+@pytest.mark.parametrize("state", ["ACTIVE", "STARTING", "STOPPED"])
+def test_provision_preserves_existing_deployed_app(tmp_path: Path, state: str) -> None:
+    app = _app(state, active_deployment={"deployment_id": "deployed"})
+    result, commands, output = _run_provision(
+        tmp_path, [_reply("list", [app]), _reply("get", app)]
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output == f"url={APP_URL}\n"
+    assert commands == ["apps list -o json", f"apps get {APP_NAME} -o json"]
+
+
+@pytest.mark.parametrize("state", ["ERROR", "STOPPED"])
+def test_provision_retries_terminal_compute_states(tmp_path: Path, state: str) -> None:
+    result, commands, _ = _run_provision(
+        tmp_path,
+        [
+            _reply("list", []),
+            _reply("create", _app()),
+            _reply("get", _app(state)),
+            _reply("get", _app(state)),
+            _reply("delete"),
+            _reply("list", []),
+            _reply("create", _app(id="app-2")),
+            _reply("get", _app("ACTIVE", id="app-2")),
+        ],
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert sum(command.startswith("apps create") for command in commands) == 2
+
+
+def test_provision_rechecks_readiness_before_deleting(tmp_path: Path) -> None:
+    result, commands, output = _run_provision(
+        tmp_path,
+        [
+            _reply("list", []),
+            _reply("create", _app()),
+            *[_reply("get", _app())] * 40,
+            _reply("get", _app("ACTIVE")),
+        ],
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output == f"url={APP_URL}\n"
+    assert not any(command.startswith("apps delete") for command in commands)
+
+
+@pytest.mark.parametrize(
+    "changed_fields",
+    [
+        {"creator": "another-principal"},
+        {"description": "another-app"},
+        {"resources": [{"name": "database"}]},
+        {"active_deployment": {"deployment_id": "deployed"}},
+        {"pending_deployment": {"deployment_id": "deploying"}},
+        {"pending_update": {"update_id": "updating"}},
+        {"default_source_code_path": "/Workspace/another-app"},
+    ],
+)
+def test_provision_refuses_to_delete_configured_or_foreign_app(
+    tmp_path: Path, changed_fields: dict[str, object]
+) -> None:
+    result, commands, output = _run_provision(
+        tmp_path,
+        [
+            _reply("list", []),
+            _reply("create", _app()),
+            _reply("get", _app("ERROR")),
+            _reply("get", _app("ERROR", **changed_fields)),
+        ],
+    )
+    assert result.returncode != 0
+    assert "refusing to recreate" in result.stdout
+    assert not any(command.startswith("apps delete") for command in commands)
+    assert output == ""
+
+
+@pytest.mark.parametrize("replacement_timing", ["provisioning", "deletion"])
+def test_provision_aborts_if_app_identity_changes(tmp_path: Path, replacement_timing: str) -> None:
+    replies = [_reply("list", []), _reply("create", _app())]
+    if replacement_timing == "provisioning":
+        replies.append(_reply("get", _app("ACTIVE", id="replacement")))
+    else:
+        replies.extend(
+            [
+                _reply("get", _app("ERROR")),
+                _reply("get", _app("ERROR")),
+                _reply("delete"),
+                _reply("list", [_app(id="replacement")]),
+            ]
+        )
+    result, commands, output = _run_provision(tmp_path, replies)
+    assert result.returncode != 0
+    assert "App identity changed" in result.stdout
+    assert sum(command.startswith("apps create") for command in commands) == 1
+    assert output == ""
+
+
+def test_provision_does_not_create_until_deletion_is_confirmed(tmp_path: Path) -> None:
+    result, commands, output = _run_provision(
+        tmp_path,
+        [
+            _reply("list", []),
+            _reply("create", _app()),
+            _reply("get", _app("ERROR")),
+            _reply("get", _app("ERROR")),
+            _reply("delete"),
+            *[_reply("list", [_app()])] * 20,
+        ],
+    )
+    assert result.returncode != 0
+    assert "App still exists after deletion" in result.stdout
+    assert sum(command.startswith("apps create") for command in commands) == 1
+    assert output == ""
+
+
+@pytest.mark.parametrize("failing_call", range(6))
+def test_provision_does_not_retry_cli_errors(tmp_path: Path, failing_call: int) -> None:
+    replies = [
+        _reply("list", []),
+        _reply("create", _app()),
+        _reply("get", _app("ERROR")),
+        _reply("get", _app("ERROR")),
+        _reply("delete"),
+        _reply("list", []),
+    ][: failing_call + 1]
+    replies[-1] = _reply(replies[-1][0], "Permission denied", code=1)
+    result, commands, output = _run_provision(tmp_path, replies)
+    assert result.returncode != 0
+    assert "Permission denied" in result.stderr
+    assert len(commands) == failing_call + 1
+    assert output == ""
+
+
+def test_provision_timeout_fits_within_deploy_job() -> None:
+    assert PROVISION_STEP["timeout-minutes"] == 40
+    assert DEPLOY_JOB["timeout-minutes"] == 60
+
+
+@pytest.mark.parametrize("url", [None, "", "Unavailable"])
+def test_provision_rejects_unavailable_url(tmp_path: Path, url: str | None) -> None:
+    result, commands, output = _run_provision(
+        tmp_path,
+        [
+            _reply("list", []),
+            _reply("create", _app()),
+            _reply("get", _app("ACTIVE", url=url)),
+        ],
+    )
+    assert result.returncode != 0
+    assert "App has no usable preview URL" in result.stdout
+    assert not any(command.startswith("apps delete") for command in commands)
+    assert output == ""
 
 
 def test_cleanup_worker_requires_reconciler_identity_fields() -> None:

--- a/tests/test_ui_preview_workflow.py
+++ b/tests/test_ui_preview_workflow.py
@@ -309,7 +309,32 @@ def test_provision_timeout_fits_within_deploy_job() -> None:
     assert DEPLOY_JOB["timeout-minutes"] == 60
 
 
-@pytest.mark.parametrize("url", [None, "", "Unavailable"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        None,
+        "",
+        "Unavailable",
+        "https://",
+        "https:///missing-host",
+        "http://preview.example.com",
+        "https://preview.example.com/\nurl=other",
+        "https://preview.example.com/\r",
+        "https://preview.example.com/\t",
+        "https://pre view.example.com",
+        "https://preview.example.com/\x00",
+        "https://preview.example.com/\x1f",
+        "https://preview.example.com/\x7f",
+        " https://preview.example.com",
+        "https://preview.example.com/\u00a0",
+        "https://preview.example.com:invalid",
+        "https://preview.example.com:70000",
+        "https://preview.example.com:0",
+        "https://[invalid",
+        "https://user@preview.example.com",
+        "https://preview.example.com\\extra",
+    ],
+)
 def test_provision_rejects_unavailable_url(tmp_path: Path, url: str | None) -> None:
     result, commands, output = _run_provision(
         tmp_path,
@@ -323,6 +348,27 @@ def test_provision_rejects_unavailable_url(tmp_path: Path, url: str | None) -> N
     assert "App has no usable preview URL" in result.stdout
     assert not any(command.startswith("apps delete") for command in commands)
     assert output == ""
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://preview.example.com/",
+        "https://preview.example.com:443/path?view=1#preview",
+        "https://[2001:db8::1]:8443/preview",
+    ],
+)
+def test_provision_preserves_valid_https_url(tmp_path: Path, url: str) -> None:
+    result, _, output = _run_provision(
+        tmp_path,
+        [
+            _reply("list", []),
+            _reply("create", _app()),
+            _reply("get", _app("ACTIVE", url=url)),
+        ],
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output == f"url={url}\n"
 
 
 def test_cleanup_worker_requires_reconciler_identity_fields() -> None:


### PR DESCRIPTION
## Related issue

N/A — Test / CI change. Motivated by [this failed UI Preview job](https://github.com/omnigent-ai/omnigent/actions/runs/34552362365/job/103117914786), which timed out before the PR's code was uploaded.

## Summary

A preview app could remain `STARTING` for ten minutes and abort the workflow. Give initial provisioning up to three attempts instead.

- Recreate only verified, undeployed previews under the same name, confirm deletion, and back off 15/30 seconds between attempts. Recover undeployed apps left by earlier failed runs too.
- Preserve deployed apps and apps with resources; stop on identity changes, API/authentication errors, or unconfirmed deletion. Recheck readiness immediately before considering recreation.
- Validate the preview URL before publishing it, rejecting malformed URLs, credentials, whitespace, and control characters.
- Log Databricks' compute-status message and allow 40 minutes for provisioning within a 60-minute deploy job.

ELI5: Give a brand-new preview two fresh tries if it gets stuck starting, without replacing an app that already has a deployment.

```text
Existing deployment -> reuse
Undeployed preview  -> provision -> ACTIVE -> deploy
                           |
                      timeout/error
                           |
               attempts left + safety checks
                           |
             delete -> confirm absent -> retry
```

## Test Plan

- `uv run --no-sync python -m pytest tests/test_ui_preview_workflow.py -q` — 56 passed.
- `.venv/bin/pre-commit run` on staged changed files — passed.
- Shell regression tests cover the original all-`STARTING` timeout, successful recreation, the three-attempt limit, delayed deletion, stale undeployed apps, readiness at the deadline, protected resources/deployments, changed identity, CLI errors, malformed/control-character URLs, and valid HTTPS URL preservation.
- After merge, run UI Preview for a fresh labeled PR, inspect `Create or update app` for attempt numbers/status messages, and open the posted preview URL. The `pull_request_target` workflow must land on the base branch before this live check uses the new logic.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A for visual media — this changes CI provisioning only; reproducible non-visual evidence is in Test Plan.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests execute the workflow's actual Bash with a fake Databricks CLI and no real sleeps. No live Databricks apps were created, stopped, or deleted during verification.

## Changelog

N/A — CI-only reliability change.

